### PR TITLE
Deflake streams-leak pull-buffer test by pacing writes on consumer progress

### DIFF
--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -11,6 +11,18 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
   // the scavenger releases them, so commit charge ran ahead of RSS
   // until VirtualAlloc(MEM_COMMIT) failed in
   // pas_compact_heap_reservation_try_allocate.
+  //
+  // The server and the consumer below share one event loop, so the pull
+  // callback paces itself on the consumer's progress: it writes chunk i+1
+  // only once the consumer has read every byte of chunk i. At most one
+  // write is ever in flight, so writes cannot coalesce on the wire and
+  // the consumer observes at least one small read per write regardless
+  // of machine load (unpaced, a lagging consumer on a busy CI runner saw
+  // the 2000 bytes coalesce into as few as 10 reads, starving the
+  // sample-size assertion below).
+  const CHUNKS_TO_WRITE = 64;
+  let bytesRead = 0;
+  let wakeProducer = () => {};
   using server = Bun.serve({
     port: 0,
     fetch() {
@@ -18,10 +30,16 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
         new ReadableStream({
           type: "direct",
           async pull(controller) {
-            for (let i = 0; i < 1000; i++) {
+            let bytesWritten = 0;
+            for (let i = 0; i < CHUNKS_TO_WRITE; i++) {
               controller.write("x\n");
+              bytesWritten += 2;
               await controller.flush();
-              await Bun.sleep(0);
+              while (bytesRead < bytesWritten) {
+                const { promise, resolve } = Promise.withResolvers<void>();
+                wakeProducer = resolve;
+                await promise;
+              }
             }
             controller.close();
           },
@@ -32,14 +50,18 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
 
   const resp = await fetch(server.url);
   const chunks: Uint8Array[] = [];
-  for await (const chunk of resp.body!) chunks.push(chunk);
+  for await (const chunk of resp.body!) {
+    chunks.push(chunk);
+    bytesRead += chunk.length;
+    wakeProducer();
+  }
 
-  // Some chunks coalesce on the wire; we just need a meaningful sample
-  // of small reads through the native pull path.
-  expect(chunks.length).toBeGreaterThan(20);
+  // At least one read per paced write; a meaningful sample of small reads
+  // through the native pull path.
+  expect(chunks.length).toBeGreaterThanOrEqual(CHUNKS_TO_WRITE);
 
   // Consecutive small reads should land in the same backing buffer (the
-  // tail subarray is reused until a read fills it). 2KB of ~few-byte
+  // tail subarray is reused until a read fills it). 128 bytes of 2-byte
   // chunks fits well inside one 256KB buffer, so the whole stream should
   // share a handful at most. Pre-fix every chunk had its own 256KB
   // buffer, so this was ~chunks.length.
@@ -48,7 +70,7 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
 
   let backingBytes = 0;
   for (const buf of distinctBuffers) backingBytes += buf.byteLength;
-  // Pre-fix this was ~chunks.length * 256KB ≈ 25–250 MB.
+  // Pre-fix this was ~chunks.length * 256KB ≈ 16 MB.
   expect(backingBytes).toBeLessThan(4 * 1024 * 1024);
 });
 


### PR DESCRIPTION
Fixes #32190

### Problem

`test/js/web/streams/streams-leak.test.ts` › "native ReadableStream reuses the pull buffer across small reads" flakes on loaded Linux CI runners, failing all 4 retry attempts when it triggers:

```
error: expect(received).toBeGreaterThan(expected)
Expected: > 20
Received: 14   (also 10, 11, 13, 19 across occurrences)
```

The fixture had the server write `"x\n"` 1000 times with only `flush()` + `sleep(0)` between writes and relied on the client keeping up so each write became its own read. On a busy runner the consumer lags, the flushed writes pile up in the TCP buffer and coalesce, and the 2000 bytes arrive in as few as 10 reads — starving the `chunks.length > 20` sample-size precondition. The buffer-reuse assertions (the point of the test, from #30593) were never the ones failing. This is easy to reproduce locally: with 8 busy-loop cores pinned alongside it, the old fixture fails 2/5 runs (`Received: 10`, `18`). 81dfd5996700 (fetch receive backpressure coupled to JS body consumption) deliberately leaves bytes in the socket between JS reads, so coalescing — and this flake — only get more likely.

Lowering the threshold (#31355's approach) guts the test: nothing bounds how far the 2000 bytes can coalesce, and below ~8 reads the `distinctBuffers.size < 8` assertion stops discriminating the pre-#30593 bug at all.

### Fix

Strengthen the fixture instead of weakening the assertions. The server and the consumer share one event loop, so the `pull` callback now paces itself on the consumer's byte progress: it writes chunk *i+1* only once the consumer has read every byte of chunk *i*. At most one write is ever in flight, so reads can never coalesce across writes regardless of machine load, and the read count is guaranteed by construction. The chunk-count assertion is strengthened from `> 20` to `>= CHUNKS_TO_WRITE` (64) so a future regression in the pacing is loud rather than silently eroding the sample back toward the old threshold; the buffer-reuse assertions are unchanged. Pre-fix (`#getInternalBuffer` rotating to a fresh 256KB buffer on every pull), `distinctBuffers.size` is ~64 — a much stronger signal than the previous marginal ~10.

Pacing on **bytes** rather than on a per-read ack is deliberate: a read-counting ack assumes exactly one read per write, so a *split* read (the dual of the coalescing being fixed) would double-fire it, let two writes get in flight, and convert the next coalesce into a producer hang instead of an assertion failure. Byte accounting tolerates both splits and coalescing. The test also got faster: 64 acked round trips instead of 1000 `sleep(0)` turns.

Relative to #32192 (same diagnosis, per-read ack): this version is robust to split reads, drops the `ack!()` non-null assertion / shared single-resolver slot, and asserts the deterministic chunk count. Happy to close this in favor of that one if preferred; one of the three (#31355, #32192, this) should land — the flake blocks unrelated PRs.

### How did you verify your code works?

- Old fixture under 8 busy-loop cores: fails 2/5 (`chunks.length` 10, 18).
- New fixture: 15/15 with the release binary under the same load, 5/5 with the debug build under load, 5/5 idle (debug + release), all with the strengthened `>= 64` assertion.
- The deflake is fixture-only; the assertions that detect the #30593 regression are unchanged or stronger.