### PR TITLE
fetch: do not touch JSCells in the Response Weak finalizer during GC sweep

### DIFF
--- a/src/runtime/webcore/ResumableSink.rs
+++ b/src/runtime/webcore/ResumableSink.rs
@@ -438,9 +438,10 @@ impl<Js: ResumableSinkJs, Context: ResumableSinkContext> ResumableSink<Js, Conte
     /// slots and downgrade `js_this` from a strong to a weak handle so the
     /// wrapper (and the `drainReaderIntoSink` closure it caches, which captures
     /// the reader/stream graph) becomes collectible. Unlike [`Self::cancel`]
-    /// this does NOT run any JS callbacks or invoke `on_end`, so it is safe to
-    /// call from contexts where executing JS is not allowed (e.g. teardown /
-    /// finalizers).
+    /// this does NOT run any JS callbacks or invoke `on_end`.
+    ///
+    /// NOT safe during GC sweep (Weak/cell finalizers): the cached-value
+    /// setters downcast the wrapper cell and issue a write barrier.
     pub fn detach_js(&mut self) {
         if let Some(js_this) = self.js_this.try_get() {
             let global = self.global_this;

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1599,7 +1599,7 @@ impl FetchTasklet {
         if this.signal_store.body_receive_mode() == BodyReceiveMode::Ignore {
             return;
         }
-        this.ignore_remaining_response_body();
+        this.ignore_remaining_response_body(false);
     }
 
     fn on_stream_drained_callback(ctx: Option<*mut c_void>) {
@@ -1723,17 +1723,23 @@ impl FetchTasklet {
         )
     }
 
-    fn ignore_remaining_response_body(&mut self) {
+    fn ignore_remaining_response_body(&mut self, from_finalizer: bool) {
         bun_output::scoped_log!(FetchTasklet, "ignoreRemainingResponseBody");
         // The response is being abandoned. If the request body is still uploading
         // through a ResumableSink, detach its JS wrapper so the cached
         // `ondrain` closure (and the reader/stream graph it captures) becomes
-        // collectible instead of leaking. `detach_js` runs no JS callbacks, so it
-        // is safe even on the GC-finalizer caller (`on_response_finalize`); the
-        // sink's own teardown (`Drop`/`finalize`) handles the rest once its refs
-        // drain.
-        if let Some(sink) = self.sink_mut() {
-            sink.detach_js();
+        // collectible instead of leaking.
+        //
+        // When reached from `on_response_finalize` (a JSC Weak finalizer inside
+        // `WeakBlock::sweep`), `detach_js()` and `clear_stream_handlers()` must be
+        // skipped: both reach `JSCell::classInfo()` via generated cached-value
+        // setters / `ReadableStreamTag__tagged`, and touching any cell during
+        // `MutatorState::Sweeping` is forbidden. `clear_sink()` in `deinit()` (an
+        // event-loop task, outside sweep) performs the deferred detach.
+        if !from_finalizer {
+            if let Some(sink) = self.sink_mut() {
+                sink.detach_js();
+            }
         }
         // enabling streaming will make the http thread to drain into the main thread (aka stop buffering)
         // without a stream ref, response body or response instance alive it will just ignore the result
@@ -1750,7 +1756,9 @@ impl FetchTasklet {
         let _ = self.javascript_vm;
         self.poll_ref.unref(bun_io::js_vm_ctx());
         // clean any remaining references
-        self.clear_stream_handlers();
+        if !from_finalizer {
+            self.clear_stream_handlers();
+        }
         self.readable_stream_ref.deinit();
         self.response.clear();
 
@@ -2461,11 +2469,11 @@ impl FetchTasklet {
                 if let Some(promise) = locked.promise {
                     if promise.is_empty_or_undefined_or_null() {
                         // Scenario 2b.
-                        this.ignore_remaining_response_body();
+                        this.ignore_remaining_response_body(true);
                     }
                 } else {
                     // Scenario 3.
-                    this.ignore_remaining_response_body();
+                    this.ignore_remaining_response_body(true);
                 }
             }
         }

--- a/test/js/web/fetch/fetch-response-finalizer-sweep.test.ts
+++ b/test/js/web/fetch/fetch-response-finalizer-sweep.test.ts
@@ -96,11 +96,7 @@ describe.skipIf(isWindows)("fetch Response Weak finalizer during GC sweep", () =
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // On failure the process aborts inside WeakBlock::sweep before reaching
     // the print; asserting the combined shape gives a readable diff. stderr
     // is included for diagnostics only (debug/ASAN builds emit benign

--- a/test/js/web/fetch/fetch-response-finalizer-sweep.test.ts
+++ b/test/js/web/fetch/fetch-response-finalizer-sweep.test.ts
@@ -1,0 +1,114 @@
+// fetch(): the JSResponse Weak finalizer (WeakBlock::sweep) reaches
+// FetchTasklet::ignore_remaining_response_body. That path used to call
+// ResumableSink::detach_js(), which writes the wrapper's cached ondrain/
+// oncancel/stream slots via generated *SetCachedValue helpers. Those helpers
+// uncheckedDowncast<JSResumableFetchSink>(...) -> JSCell::classInfo(), and
+// touching any JSCell while MutatorState == Sweeping trips
+// validateIsNotSweeping() (assert builds) or silently corrupts the heap
+// (release builds).
+//
+// Scenario: POST with a user-constructed ReadableStream body (so the sink
+// takes the JS route and holds a Strong js_this), server replies with headers
+// but leaves the body open (response body = Locked with no promise), drop the
+// Response unconsumed, force a synchronous sweep.
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+const fixture = /* js */ `
+  const net = require("node:net");
+
+  let sockets = [];
+  const server = net.createServer(socket => {
+    sockets.push(socket);
+    socket.on("error", () => {});
+    // Reply once request headers (and the first body chunk) have arrived so
+    // the client has already entered start_request_stream() and created the
+    // ResumableSink. Then send response headers + one partial chunk so
+    // fetch() resolves with is_waiting_body = true (BodyValue::Locked).
+    let replied = false;
+    socket.on("data", () => {
+      if (replied) return;
+      replied = true;
+      socket.write(
+        "HTTP/1.1 200 OK\\r\\n" +
+          "Transfer-Encoding: chunked\\r\\n" +
+          "Connection: close\\r\\n" +
+          "\\r\\n" +
+          "5\\r\\nhello\\r\\n",
+      );
+      // Do NOT send the terminating 0-chunk; keep the body pending.
+    });
+  });
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+
+  async function once() {
+    let pullAgain;
+    const body = new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("abc"));
+      },
+      pull() {
+        // Never resolve: keep the upload sink alive with a Strong js_this
+        // so detach_js() has a live wrapper to downcast.
+        return new Promise(r => { pullAgain = r; });
+      },
+    });
+    const res = await fetch("http://127.0.0.1:" + port + "/", {
+      method: "POST",
+      body,
+      duplex: "half",
+    });
+    if (res.status !== 200) throw new Error("status " + res.status);
+    // Drop the Response without touching .body / .text() etc.
+    return pullAgain;
+  }
+
+  // A few iterations so at least one Response lands in a block that the
+  // allocation slow-path sweeps while the collector thread is running.
+  const keep = [];
+  for (let i = 0; i < 12; i++) {
+    keep.push(await once());
+    // Allocation between Bun.gc calls gives LocalAllocator::allocateSlowCase
+    // a reason to sweep the block the dead Response sits in.
+    new Error("alloc");
+    Bun.gc(true);
+    new Error("alloc");
+    Bun.gc(true);
+  }
+
+  for (const s of sockets) s.destroy();
+  server.close();
+  console.log("ok");
+`;
+
+// collectContinuously is slow under Windows CI and the code path is identical
+// across platforms; the assertion this guards is platform-independent.
+describe.skipIf(isWindows)("fetch Response Weak finalizer during GC sweep", () => {
+  test("dropping an unconsumed streaming-upload Response does not touch JSCells in the finalizer", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    // On failure the process aborts inside WeakBlock::sweep before reaching
+    // the print; asserting the combined shape gives a readable diff. stderr
+    // is included for diagnostics only (debug/ASAN builds emit benign
+    // warnings there, so it is not required to be empty).
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toEqual({
+      stdout: "ok",
+      exitCode: 0,
+      stderr: expect.any(String),
+    });
+  }, 120_000);
+});


### PR DESCRIPTION
### Crash

```
ASSERTION FAILED: vm().currentThreadIsHoldingAPILock() => vm().heap.mutatorState() != MutatorState::Sweeping
vendor/WebKit/Source/JavaScriptCore/runtime/JSCell.cpp(179) : bool JSC::JSCell::validateIsNotSweeping() const
```

Backtrace (from a release-asan build with asserts):

```
#3  JSC::JSCell::validateIsNotSweeping()
#4  JSC::JSCell::classInfo() const
#5  WTF::uncheckedDowncast<WebCore::JSResumableFetchSink>(JSValue const&)
#6  ResumableFetchSinkPrototype__ondrainSetCachedValue
#7  bun_runtime::webcore::fetch::fetch_tasklet::FetchTasklet::ignore_remaining_response_body
#8  JSC::WeakBlock::sweep()          <- inside GC sweep (Weak finalizer)
#9  JSC::WeakSet::sweep()
#10 JSC::PreciseAllocation::sweep()
#12 JSC::Heap::finalize()
#21 JSC::LocalAllocator::allocateSlowCase
#23 JSC::ErrorInstance::create        <- ordinary allocation kicked off GC
```

Found by the syscall fault-injection fuzzer's client-side grammar scenario (fetch/node:http with abort + transient errno on the client socket). Reproduces ~4/5 under `BUN_JSC_collectContinuously=1`.

### Cause

`FetchTasklet::on_response_finalize` is the `WeakRefOwner<FetchResponse>::finalize` callback and runs inside `WeakBlock::sweep` while `MutatorState == Sweeping`. When the response body is `Locked` without a pending promise or stream it calls `ignore_remaining_response_body()`, which called:

- `ResumableSink::detach_js()`: writes the sink wrapper's cached `ondrain` / `oncancel` / `stream` slots via the generated `ResumableFetchSinkPrototype__*SetCachedValue` helpers. Each does `uncheckedDowncast<JSResumableFetchSink>(thisValue)`, which reaches `JSCell::classInfo()` and then issues a write barrier on the wrapper cell.
- `clear_stream_handlers()`: reaches `ReadableStreamTag__tagged` -> `object->inherits<JSReadableStream>()` (guarded today, but one boolean away).

Calling `classInfo()` on any cell while the mutator is sweeping is forbidden: the cell's `Structure` may already have been swept. Assert builds catch it; release builds corrupt the heap.

### Fix

Thread a `from_finalizer` flag through `ignore_remaining_response_body`. When `true` (the `on_response_finalize` caller) skip `detach_js()` and `clear_stream_handlers()`; only native state is touched. The sink's JS-side detach still happens from `clear_sink()` in `FetchTasklet::deinit()`, which runs as an event-loop `ConcurrentTask` outside any sweep, so nothing leaks.

The `on_stream_cancelled_callback` caller (reader `.cancel()`, runs from JS on the event loop) passes `false` and keeps the immediate detach.

Also corrects the `ResumableSink::detach_js` doc comment that claimed finalizer safety.

### Verification

New test at `test/js/web/fetch/fetch-response-finalizer-sweep.test.ts`: a child process under `BUN_JSC_collectContinuously=1` does 12 iterations of `fetch()` with a user-constructed `ReadableStream` body (so the sink takes the JS route with a Strong `js_this`) against a raw TCP server that sends headers + a partial chunked body and never terminates it, then drops the `Response` unconsumed and runs `Bun.gc(true)`.

Without the fix (`bun bd`, src/ stashed):

```
exitCode: 134
stderr: ASSERTION FAILED: vm().currentThreadIsHoldingAPILock() => vm().heap.mutatorState() != MutatorState::Sweeping
```

With the fix: `stdout: "ok"`, `exitCode: 0`.

`test/js/web/fetch/fetch-backpressure.test.ts` (exercises the `on_stream_cancelled_callback` path) passes unchanged.