### PR TITLE
bundler: don't rewrite `..` to `_.._` in compiled entrypoint paths

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4151,7 +4151,9 @@ pub mod bv2_impl {
                                     .into_boxed_slice();
                             }
                             let mut v = Vec::new();
-                            template.print(&mut v).expect("oom");
+                            template
+                                .print(&mut v, !self.transpiler.options.compile)
+                                .expect("oom");
                             v.into_boxed_slice()
                         };
 

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -363,9 +363,11 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             // routing through `Display`/`write!` goes via `from_utf8_lossy`,
             // which would replace non-UTF-8 dir bytes with U+FFFD and corrupt
             // the output path.
+            // Disk output sanitizes leading `..`; `--compile` keeps it so
+            // runtime bunfs references to out-of-root entrypoints resolve.
             chunk
                 .template
-                .print(&mut rel_path)
+                .print(&mut rel_path, !c.options.compile)
                 .expect("write to Vec<u8>");
             path::resolve_path::platform_to_posix_in_place::<u8>(&mut rel_path);
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2503,6 +2503,7 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
     ext: &[u8],
     hash: Option<u64>,
     target: &[u8],
+    sanitize_parent_dirs: bool,
 ) -> bun_io::Result<()> {
     let mut remain: &[u8] = data;
     while let Some(j) = strings::index_of_char(remain, b'[') {
@@ -2543,9 +2544,10 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
             PlaceholderField::Dir => {
                 if dir.is_empty() {
                     writer.write_all(b".")?;
-                } else {
-                    // Sanitize leading `..` segments so `[dir]` cannot place output
-                    // above outdir when a source resolves outside `root`.
+                } else if sanitize_parent_dirs {
+                    // Sanitize leading `..` so `[dir]` can't escape outdir for an
+                    // out-of-root source. `--compile` skips this: bunfs entries keep
+                    // `..` so runtime references to them resolve.
                     let mut d: &[u8] = dir;
                     while matches!(d, [b'.', b'.', b'/' | b'\\', ..]) {
                         PathTemplate::write_replacing_slashes_on_windows(writer, b"_.._/")?;
@@ -2555,6 +2557,8 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
                         writer,
                         if d == b".." { b"_.._" } else { d },
                     )?;
+                } else {
+                    PathTemplate::write_replacing_slashes_on_windows(writer, dir)?;
                 }
             }
             PlaceholderField::Name => {
@@ -2645,7 +2649,11 @@ impl PathTemplate {
         placeholder: PlaceholderConst::DEFAULT,
     };
 
-    pub fn print<W: bun_io::Write>(&self, writer: &mut W) -> bun_io::Result<()> {
+    pub fn print<W: bun_io::Write>(
+        &self,
+        writer: &mut W,
+        sanitize_parent_dirs: bool,
+    ) -> bun_io::Result<()> {
         path_template_print(
             writer,
             &self.data,
@@ -2654,6 +2662,7 @@ impl PathTemplate {
             &self.placeholder.ext,
             self.placeholder.hash,
             &self.placeholder.target,
+            sanitize_parent_dirs,
         )
     }
 }
@@ -2709,7 +2718,11 @@ impl PathTemplateConst {
     /// Kept as an inherent method so callers writing
     /// to `Vec<u8>` via `write!(.., "{}", template)` resolve through the
     /// blanket [`core::fmt::Display`] impl below.
-    pub fn print<W: bun_io::Write>(&self, writer: &mut W) -> bun_io::Result<()> {
+    pub fn print<W: bun_io::Write>(
+        &self,
+        writer: &mut W,
+        sanitize_parent_dirs: bool,
+    ) -> bun_io::Result<()> {
         path_template_print(
             writer,
             self.data,
@@ -2718,6 +2731,7 @@ impl PathTemplateConst {
             self.placeholder.ext,
             self.placeholder.hash,
             self.placeholder.target,
+            sanitize_parent_dirs,
         )
     }
 
@@ -2729,7 +2743,7 @@ impl PathTemplateConst {
 impl core::fmt::Display for PathTemplateConst {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut buf = Vec::<u8>::new();
-        self.print(&mut buf).map_err(|_| core::fmt::Error)?;
+        self.print(&mut buf, true).map_err(|_| core::fmt::Error)?;
         write!(f, "{}", bstr::BStr::new(&buf))
     }
 }
@@ -2737,7 +2751,7 @@ impl core::fmt::Display for PathTemplateConst {
 impl core::fmt::Display for PathTemplate {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut buf = Vec::<u8>::new();
-        self.print(&mut buf).map_err(|_| core::fmt::Error)?;
+        self.print(&mut buf, true).map_err(|_| core::fmt::Error)?;
         write!(f, "{}", bstr::BStr::new(&buf))
     }
 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2545,7 +2545,7 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
                 if dir.is_empty() {
                     writer.write_all(b".")?;
                 } else if sanitize_parent_dirs {
-                    // Rewrite leading `..` so `[dir]` can't escape outdir for an
+                    // Rewrite `..` segments so `[dir]` can't escape outdir for an
                     // out-of-root source. `--compile` skips this: bunfs entries keep
                     // `..` so runtime references to them resolve.
                     write_sanitized_parent_dirs(writer, dir)?;
@@ -2572,19 +2572,22 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
     PathTemplate::write_replacing_slashes_on_windows(writer, remain)
 }
 
-/// Rewrite leading `..` path segments to `_.._` so a relative dir cannot escape
+/// Rewrite every `..` path segment to `_.._` so the path cannot traverse above
 /// its base directory on disk. Separators become native on Windows, matching
 /// the rest of the path template output.
 pub fn write_sanitized_parent_dirs<W: bun_io::Write>(
     writer: &mut W,
     dir: &[u8],
 ) -> bun_io::Result<()> {
-    let mut d: &[u8] = dir;
-    while matches!(d, [b'.', b'.', b'/' | b'\\', ..]) {
-        PathTemplate::write_replacing_slashes_on_windows(writer, b"_.._/")?;
-        d = &d[3..];
+    let mut rest: &[u8] = dir;
+    loop {
+        let sep = rest.iter().position(|&b| b == b'/' || b == b'\\');
+        let seg = sep.map_or(rest, |i| &rest[..i]);
+        PathTemplate::write_replacing_slashes_on_windows(writer, if seg == b".." { b"_.._" } else { seg })?;
+        let Some(i) = sep else { return Ok(()) };
+        PathTemplate::write_replacing_slashes_on_windows(writer, b"/")?;
+        rest = &rest[i + 1..];
     }
-    PathTemplate::write_replacing_slashes_on_windows(writer, if d == b".." { b"_.._" } else { d })
 }
 
 impl PathTemplate {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2545,18 +2545,10 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
                 if dir.is_empty() {
                     writer.write_all(b".")?;
                 } else if sanitize_parent_dirs {
-                    // Sanitize leading `..` so `[dir]` can't escape outdir for an
+                    // Rewrite leading `..` so `[dir]` can't escape outdir for an
                     // out-of-root source. `--compile` skips this: bunfs entries keep
                     // `..` so runtime references to them resolve.
-                    let mut d: &[u8] = dir;
-                    while matches!(d, [b'.', b'.', b'/' | b'\\', ..]) {
-                        PathTemplate::write_replacing_slashes_on_windows(writer, b"_.._/")?;
-                        d = &d[3..];
-                    }
-                    PathTemplate::write_replacing_slashes_on_windows(
-                        writer,
-                        if d == b".." { b"_.._" } else { d },
-                    )?;
+                    write_sanitized_parent_dirs(writer, dir)?;
                 } else {
                     PathTemplate::write_replacing_slashes_on_windows(writer, dir)?;
                 }
@@ -2578,6 +2570,21 @@ pub(crate) fn path_template_print<W: bun_io::Write>(
     }
 
     PathTemplate::write_replacing_slashes_on_windows(writer, remain)
+}
+
+/// Rewrite leading `..` path segments to `_.._` so a relative dir cannot escape
+/// its base directory on disk. Separators become native on Windows, matching
+/// the rest of the path template output.
+pub fn write_sanitized_parent_dirs<W: bun_io::Write>(
+    writer: &mut W,
+    dir: &[u8],
+) -> bun_io::Result<()> {
+    let mut d: &[u8] = dir;
+    while matches!(d, [b'.', b'.', b'/' | b'\\', ..]) {
+        PathTemplate::write_replacing_slashes_on_windows(writer, b"_.._/")?;
+        d = &d[3..];
+    }
+    PathTemplate::write_replacing_slashes_on_windows(writer, if d == b".." { b"_.._" } else { d })
 }
 
 impl PathTemplate {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2583,7 +2583,10 @@ pub fn write_sanitized_parent_dirs<W: bun_io::Write>(
     loop {
         let sep = rest.iter().position(|&b| b == b'/' || b == b'\\');
         let seg = sep.map_or(rest, |i| &rest[..i]);
-        PathTemplate::write_replacing_slashes_on_windows(writer, if seg == b".." { b"_.._" } else { seg })?;
+        PathTemplate::write_replacing_slashes_on_windows(
+            writer,
+            if seg == b".." { b"_.._" } else { seg },
+        )?;
         let Some(i) = sep else { return Ok(()) };
         PathTemplate::write_replacing_slashes_on_windows(writer, b"/")?;
         rest = &rest[i + 1..];

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2581,7 +2581,11 @@ pub fn write_sanitized_parent_dirs<W: bun_io::Write>(
 ) -> bun_io::Result<()> {
     let mut rest: &[u8] = dir;
     loop {
-        let sep = rest.iter().position(|&b| b == b'/' || b == b'\\');
+        // On POSIX `\` is a legal filename byte, not a separator, so only split
+        // on it under Windows (matches `write_replacing_slashes_on_windows`).
+        let sep = rest
+            .iter()
+            .position(|&b| b == b'/' || (cfg!(windows) && b == b'\\'));
         let seg = sep.map_or(rest, |i| &rest[..i]);
         PathTemplate::write_replacing_slashes_on_windows(
             writer,
@@ -2591,6 +2595,27 @@ pub fn write_sanitized_parent_dirs<W: bun_io::Write>(
         PathTemplate::write_replacing_slashes_on_windows(writer, b"/")?;
         rest = &rest[i + 1..];
     }
+}
+
+#[cfg(test)]
+#[test]
+fn write_sanitized_parent_dirs_rewrites_every_dotdot_segment() {
+    fn run(dir: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        write_sanitized_parent_dirs(&mut out, dir).unwrap();
+        out
+    }
+    // Leading `..` (the `[dir]` placeholder shape).
+    assert_eq!(run(b".."), b"_.._");
+    assert_eq!(run(b"../../worker.js"), b"_.._/_.._/worker.js");
+    // Non-leading `..` from a custom `--entry-naming` prefix before `[dir]`.
+    assert_eq!(run(b"out/../../worker.js"), b"out/_.._/_.._/worker.js");
+    // No traversal passes through; `..foo` is a filename, not a parent segment.
+    assert_eq!(run(b"a/b/c.js"), b"a/b/c.js");
+    assert_eq!(run(b"..foo/x.js"), b"..foo/x.js");
+    // POSIX: `\` is an ordinary filename byte, not a separator.
+    #[cfg(not(windows))]
+    assert_eq!(run(br"weird\dir/x.js"), br"weird\dir/x.js");
 }
 
 impl PathTemplate {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -865,8 +865,8 @@ pub(crate) fn to_bytes(
         if Environment::IS_CANARY || Environment::IS_DEBUG {
             if let Some(dump_code_dir) = bun_core::env_var::BUN_FEATURE_FLAG_DUMP_CODE.get() {
                 // `dest_path` keeps `..` for the embedded bunfs key below; neutralize
-                // leading `..` here so the on-disk dump can't escape `dump_code_dir`
-                // (the join normalizes `..` away, resolving above the dump dir).
+                // every `..` segment here so the on-disk dump can't escape
+                // `dump_code_dir` (the join would otherwise normalize `..` above it).
                 let mut dump_rel: Vec<u8> = Vec::new();
                 options::write_sanitized_parent_dirs(&mut dump_rel, dest_path)
                     .expect("write to Vec<u8>");

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -864,11 +864,17 @@ pub(crate) fn to_bytes(
 
         if Environment::IS_CANARY || Environment::IS_DEBUG {
             if let Some(dump_code_dir) = bun_core::env_var::BUN_FEATURE_FLAG_DUMP_CODE.get() {
+                // `dest_path` keeps `..` for the embedded bunfs key below; neutralize
+                // leading `..` here so the on-disk dump can't escape `dump_code_dir`
+                // (the join normalizes `..` away, resolving above the dump dir).
+                let mut dump_rel: Vec<u8> = Vec::new();
+                options::write_sanitized_parent_dirs(&mut dump_rel, dest_path)
+                    .expect("write to Vec<u8>");
                 let mut path_buf = bun_paths::path_buffer_pool::get();
                 let dest_z = path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
                     dump_code_dir,
                     &mut path_buf[..],
-                    &[dest_path],
+                    &[&dump_rel],
                 );
 
                 // Scoped block to handle dump failures without skipping module emission

--- a/test/regression/issue/32728.test.ts
+++ b/test/regression/issue/32728.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import path from "node:path";
+
+// https://github.com/oven-sh/bun/issues/32728
+// `bun build --compile` must keep the `..` parent segment in an out-of-root
+// entrypoint's embedded bunfs name. Sanitizing it to `_.._` (correct for
+// `--outdir` disk output) breaks runtime `new Worker("/$bunfs/root/../x.js")`
+// references, which still use `..`, with ModuleNotFound.
+test("compile preserves parent-segment entrypoint path for Worker resolution", async () => {
+  using dir = tempDir("compile-parent-entrypoint", {
+    "worker.js": `postMessage("worker started");`,
+    "app/index.js": `
+      const w = new Worker(process.env.WORKER_PATH);
+      w.onmessage = e => { console.log("RESULT:" + e.data); process.exit(0); };
+      w.onerror = e => { console.log("RESULT:error:" + (e && e.message ? e.message : String(e))); process.exit(1); };
+    `,
+  });
+
+  const appDir = path.join(String(dir), "app");
+  const exe = path.join(appDir, isWindows ? "app.exe" : "app");
+
+  // The worker sits one directory above the main entrypoint, so its `[dir]`
+  // placeholder resolves to `..` relative to the compile root.
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "./index.js", "../worker.js", "--outfile", "app"],
+    cwd: appDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [buildOut, buildErr, buildExit] = await Promise.all([
+    build.stdout.text(),
+    build.stderr.text(),
+    build.exited,
+  ]);
+  expect(buildErr).not.toContain("error:");
+  expect(buildExit).toBe(0);
+
+  // A plain-string bunfs path reaches the standalone graph lookup verbatim
+  // (no `..` normalization), so it must match the embedded key byte-for-byte.
+  const prefix = isWindows ? "B:/~BUN/root/" : "/$bunfs/root/";
+  await using run = Bun.spawn({
+    cmd: [exe],
+    cwd: appDir,
+    env: { ...bunEnv, WORKER_PATH: prefix + "../worker.js" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [runOut, runErr, runExit] = await Promise.all([
+    run.stdout.text(),
+    run.stderr.text(),
+    run.exited,
+  ]);
+  expect(runOut).toContain("RESULT:worker started");
+  expect(runErr).not.toContain("ModuleNotFound");
+  expect(runExit).toBe(0);
+});

--- a/test/regression/issue/32728.test.ts
+++ b/test/regression/issue/32728.test.ts
@@ -79,3 +79,42 @@ test.skipIf(!isDebug)("compile code dump stays within BUN_FEATURE_FLAG_DUMP_CODE
   expect(existsSync(path.join(appDir, "worker.js"))).toBe(false);
   expect(existsSync(path.join(dumpDir, "_.._", "worker.js"))).toBe(true);
 });
+
+// A custom `--entry-naming` can place a literal prefix before `[dir]`, so the
+// rendered path carries a non-leading `..` (e.g. `out/../../worker.js`). The
+// dump sanitizer must neutralize every `..` segment, not just leading ones.
+test.skipIf(!isDebug)("compile code dump stays contained under a custom entry-naming prefix", async () => {
+  using dir = tempDir("compile-dump-escape-naming", {
+    "worker.js": `postMessage("worker started");`,
+    "app/nested/index.js": `console.log("main");`,
+  });
+
+  const rootDir = path.join(String(dir), "app", "nested");
+  const dumpDir = path.join(rootDir, "dump");
+
+  await using build = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "build",
+      "--compile",
+      "--entry-naming",
+      "out/[dir]/[name].[ext]",
+      "./index.js",
+      "../../worker.js",
+      "--outfile",
+      "app",
+    ],
+    cwd: rootDir,
+    env: { ...bunEnv, BUN_FEATURE_FLAG_DUMP_CODE: dumpDir },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+  expect(buildErr).not.toContain("error:");
+  expect(buildExit).toBe(0);
+
+  // `out/../../worker.js` would normalize to `<rootDir>/worker.js` (one level
+  // above the dump dir); sanitizing every `..` keeps it inside the dump dir.
+  expect(existsSync(path.join(rootDir, "worker.js"))).toBe(false);
+  expect(existsSync(path.join(dumpDir, "out", "_.._", "_.._", "worker.js"))).toBe(true);
+});

--- a/test/regression/issue/32728.test.ts
+++ b/test/regression/issue/32728.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "node:path";
 
@@ -29,11 +29,7 @@ test("compile preserves parent-segment entrypoint path for Worker resolution", a
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [buildOut, buildErr, buildExit] = await Promise.all([
-    build.stdout.text(),
-    build.stderr.text(),
-    build.exited,
-  ]);
+  const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
   expect(buildErr).not.toContain("error:");
   expect(buildExit).toBe(0);
 
@@ -47,11 +43,7 @@ test("compile preserves parent-segment entrypoint path for Worker resolution", a
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [runOut, runErr, runExit] = await Promise.all([
-    run.stdout.text(),
-    run.stderr.text(),
-    run.exited,
-  ]);
+  const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
   expect(runOut).toContain("RESULT:worker started");
   expect(runErr).not.toContain("ModuleNotFound");
   expect(runExit).toBe(0);

--- a/test/regression/issue/32728.test.ts
+++ b/test/regression/issue/32728.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 // https://github.com/oven-sh/bun/issues/32728
@@ -47,4 +48,34 @@ test("compile preserves parent-segment entrypoint path for Worker resolution", a
   expect(runOut).toContain("RESULT:worker started");
   expect(runErr).not.toContain("ModuleNotFound");
   expect(runExit).toBe(0);
+});
+
+// Keeping `..` in the embedded name must not let the debug-only
+// `BUN_FEATURE_FLAG_DUMP_CODE` dump escape its directory: joining `../worker.js`
+// with the dump dir normalizes one level above it. The dump site re-sanitizes
+// independently of the embedded key. Feature is gated to canary/debug builds.
+test.skipIf(!isDebug)("compile code dump stays within BUN_FEATURE_FLAG_DUMP_CODE dir", async () => {
+  using dir = tempDir("compile-dump-escape", {
+    "worker.js": `postMessage("worker started");`,
+    "app/index.js": `console.log("main");`,
+  });
+
+  const appDir = path.join(String(dir), "app");
+  const dumpDir = path.join(appDir, "dump");
+
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "./index.js", "../worker.js", "--outfile", "app"],
+    cwd: appDir,
+    env: { ...bunEnv, BUN_FEATURE_FLAG_DUMP_CODE: dumpDir },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+  expect(buildErr).not.toContain("error:");
+  expect(buildExit).toBe(0);
+
+  // The out-of-root worker dumps to `<dumpDir>/_.._/worker.js` (contained), not
+  // `<dumpDir>/../worker.js` which normalizes to `<appDir>/worker.js`.
+  expect(existsSync(path.join(appDir, "worker.js"))).toBe(false);
+  expect(existsSync(path.join(dumpDir, "_.._", "worker.js"))).toBe(true);
 });


### PR DESCRIPTION
## What

Fixes #32728. A Bun 1.4 regression: `bun build --compile` rewrites the leading `..` parent segment of an out-of-root entrypoint's embedded name to `_.._`, while runtime references to that entrypoint still use `../`. The two no longer match, so the entrypoint (e.g. a `new Worker(...)` target) fails to resolve with `ModuleNotFound`.

Regressed in #31129, which added unconditional `..` → `_.._` sanitization to the `[dir]` path-template printer. Last good in 1.3.14.

## Repro

```
repro/
  worker.js      postMessage("worker started")
  app/index.js   new Worker(process.env.WORKER_PATH)
```

```console
$ cd app && bun build --compile ./index.js ../worker.js --outfile app
$ strings app | grep worker.js
/$bunfs/root/_.._/worker.js        # embedded entrypoint name
$ WORKER_PATH='/$bunfs/root/../worker.js' ./app
RESULT:error:BuildMessage: ModuleNotFound resolving "/$bunfs/root/../worker.js" (entry point)
```

Configured runtime path is `/$bunfs/root/../worker.js`; the embedded module is named `/$bunfs/root/_.._/worker.js`. `_.._` is a literal directory (does not normalize), so the two diverge. On 1.3.14 the embedded name was `/$bunfs/root/../worker.js` and resolved fine.

## Cause

The `PlaceholderField::Dir` arm in `path_template_print` (`src/bundler/options.rs`) rewrites leading `..` segments to `_.._` for every build mode. This is correct for `--outdir`: it stops `[dir]` from placing files above the output directory on disk. But `--compile` has no real output directory, it embeds entries into the virtual bunfs under `/$bunfs/root/`, and a plain-string specifier reaches the standalone-graph lookup verbatim (no `..` normalization), so the embedded key must keep its original `..`.

## Fix

Thread a `sanitize_parent_dirs` flag into the path-template printer and skip the `_.._` rewrite when compiling (`!options.compile`) at the two embed sites (chunk names and copied assets). Disk output, including the `--outdir` path-traversal hardening, is unchanged.

## Verification

New regression test `test/regression/issue/32728.test.ts` compiles an out-of-root worker entrypoint and runs the binary with the `../` bunfs path.

- Fails before the fix: `RESULT:error:BuildMessage: ModuleNotFound resolving "/$bunfs/root/../worker.js" (entry point)`
- Passes after: `RESULT:worker started`

`test/bundler/bundler_naming.test.ts` (outdir `_.._` sanitization, incl. `WithPathTraversal`) still passes. The non-bytecode compile worker tests (`WorkerRelativePathTSExtension`, `WorkerBytecodeESM`) pass. The 6 failing tests in `bundler_compile.test.ts` on the debug build are pre-existing and unrelated: they assert exact stderr (broken by a debug-only `hintSourcePagesDontNeed` warning) or an unstripped `-debug` version suffix, neither involving `..` entrypoints.