### PR TITLE
yaml: combine `\uD8xx\uDCxx` surrogate-pair escapes in double-quoted scalars

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5465,25 +5465,46 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         }
     }
 
-    // TODO: should this append replacement characters instead of erroring?
-    fn decode_hex_code_point(
-        &mut self,
-        escape: Escape,
-        text: &mut Vec<Enc::Unit>,
-    ) -> Result<(), ParseError> {
+    fn read_hex_digits(&mut self, count: u8) -> Result<u32, ParseError> {
         let mut value: u32 = 0;
-        for _ in 0..(escape as u8) {
+        for _ in 0..count {
             self.inc(1);
             let digit = Enc::wide(self.next());
             let num =
                 bun_core::fmt::hex_digit_value_u32(digit).ok_or(ParseError::UnexpectedCharacter)?;
             value = value * 16 + num as u32;
         }
+        Ok(value)
+    }
 
-        if value > 0x10_FFFF {
+    fn decode_hex_code_point(
+        &mut self,
+        escape: Escape,
+        text: &mut Vec<Enc::Unit>,
+    ) -> Result<(), ParseError> {
+        let mut cp = self.read_hex_digits(escape as u8)?;
+
+        if cp > 0x10_FFFF {
             return Err(ParseError::UnexpectedCharacter);
         }
-        let cp = value;
+
+        // JSON encodes supplementary code points as a `\uD8xx\uDCxx` surrogate
+        // pair; YAML 1.2 is a JSON superset. Lone surrogates remain an error.
+        if (0xD800..=0xDFFF).contains(&cp) {
+            if !bun_core::strings::u16_is_lead(cp as u16)
+                || Enc::wide(self.peek(1)) != 0x5C /* '\\' */
+                || Enc::wide(self.peek(2)) != 0x75
+            /* 'u' */
+            {
+                return Err(ParseError::UnexpectedCharacter);
+            }
+            self.inc(2);
+            let low = self.read_hex_digits(Escape::LowerU as u8)?;
+            if !bun_core::strings::u16_is_trail(low as u16) {
+                return Err(ParseError::UnexpectedCharacter);
+            }
+            cp = bun_core::strings::u16_get_supplementary(cp as u16, low as u16);
+        }
 
         match Enc::KIND {
             EncodingKind::Utf8 => {
@@ -5495,10 +5516,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
             }
             EncodingKind::Utf16 => {
-                // Surrogate code points are rejected.
-                if (0xD800..=0xDFFF).contains(&cp) {
-                    return Err(ParseError::UnexpectedCharacter);
-                }
                 if cp < 0x10000 {
                     text.push(Enc::unit_from_u16(cp as u16));
                 } else {

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5491,7 +5491,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         // JSON encodes supplementary code points as a `\uD8xx\uDCxx` surrogate
         // pair; YAML 1.2 is a JSON superset. Lone surrogates remain an error.
         if (0xD800..=0xDFFF).contains(&cp) {
-            if !bun_core::strings::u16_is_lead(cp as u16)
+            if !matches!(escape, Escape::LowerU)
+                || !bun_core::strings::u16_is_lead(cp as u16)
                 || Enc::wide(self.peek(1)) != 0x5C /* '\\' */
                 || Enc::wide(self.peek(2)) != 0x75
             /* 'u' */

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1897,7 +1897,11 @@ folded: >
           expect(() => YAML.parse('"\\uD83D\\uD83D"')).toThrow(SyntaxError);
           expect(() => YAML.parse('"\\uD83D\\u0041"')).toThrow(SyntaxError);
           expect(() => YAML.parse('"\\uD83D\\n"')).toThrow(SyntaxError);
+          // `\U` ([60] ns-esc-32-bit) names a Unicode character; surrogate
+          // code points are not characters and are never combined.
           expect(() => YAML.parse('"\\U0000D83D"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\U0000D83D\\uDE00"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\U0000D83D\\U0000DE00"')).toThrow(SyntaxError);
         });
 
         test.todo("s-separate required after tag ([97] c-ns-tag-property)", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1875,10 +1875,29 @@ folded: >
           expect(() => YAML.parse("!!float 0x1f")).toThrow();
         });
 
-        test.todo("`\\uXXXX` surrogate pairs combine ([57] ns-esc-16-bit)", () => {
-          // js-yaml/eemeli combine surrogate halves to the supplementary code
-          // point. Currently rejected.
+        test("`\\uXXXX` surrogate pairs combine ([57] ns-esc-16-bit)", () => {
+          // YAML 1.2 is a JSON superset; JSON encodes supplementary code
+          // points as `\uD8xx\uDCxx` surrogate pairs.
           expect(YAML.parse('"\\uD834\\uDD1E"')).toBe("𝄞");
+          expect(YAML.parse('"\\uD83D\\uDE00"')).toBe("😀");
+          expect(YAML.parse('"\\ud83d\\ude00"')).toBe("😀");
+          expect(YAML.parse('"a\\uD83D\\uDE00b"')).toBe("a😀b");
+          expect(YAML.parse('"\\uD83D\\uDE00\\uD83D\\uDE01"')).toBe("😀😁");
+          expect(YAML.parse('"\\uDBFF\\uDFFF"')).toBe("\u{10FFFF}");
+          // Matches JSON.parse on the same document.
+          const doc = '{"k": "\\uD83D\\uDE00"}';
+          expect(YAML.parse(doc)).toEqual(JSON.parse(doc));
+          // `\U` 32-bit escapes for the same code point still work.
+          expect(YAML.parse('"\\U0001F600"')).toBe("😀");
+          // Lone or mis-ordered surrogates are rejected.
+          expect(() => YAML.parse('"\\uD83D"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\uD83Dx"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\uDE00"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\uDE00\\uD83D"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\uD83D\\uD83D"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\uD83D\\u0041"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\uD83D\\n"')).toThrow(SyntaxError);
+          expect(() => YAML.parse('"\\U0000D83D"')).toThrow(SyntaxError);
         });
 
         test.todo("s-separate required after tag ([97] c-ns-tag-property)", () => {


### PR DESCRIPTION
## What

`Bun.YAML.parse` rejected valid JSON documents containing astral-plane characters encoded as UTF-16 surrogate pairs:

```js
const s = '"\\uD83D\\uDE00"';
JSON.parse(s)      // "😀"
Bun.YAML.parse(s)  // SyntaxError: YAML Parse error: Unexpected character
```

YAML 1.2 is a strict superset of JSON, so every valid JSON document must parse as YAML. JSON encodes code points above U+FFFF as a high/low surrogate pair of `\u` escapes. js-yaml, PyYAML, and libyaml all accept this input.

## Why

In `decode_hex_code_point` (src/parsers/yaml.rs), the UTF-8 arm called `char::from_u32(cp)`, which returns `None` for every surrogate code point (0xD800..=0xDFFF), so the first `\uD83D` was rejected before the second half was ever read. There was no surrogate-pair combining anywhere in the escape decoder, so astral characters could not be expressed via `\u` escapes at all.

## How

When a hex escape decodes to a high surrogate (0xD800..=0xDBFF), peek for an immediately following `\u` escape; if it decodes to a low surrogate (0xDC00..=0xDFFF), combine the two via `bun_core::strings::u16_get_supplementary` into the supplementary code point before encoding. A lone or mis-ordered surrogate remains a parse error.

The hex-digit reading loop is extracted into `read_hex_digits` so the low-surrogate half reuses it. The explicit surrogate-range check in the UTF-16 arm is removed since the combining step now runs before the encoding `match` and covers all encodings.

## Tests

Un-skipped the existing `test.todo` for this case in `test/js/bun/yaml/yaml.test.ts` and expanded it to cover:

- `"\uD834\uDD1E"` → `"𝄞"`, `"\uD83D\uDE00"` → `"😀"` (upper- and lowercase hex)
- Adjacent text and back-to-back pairs
- `"\uDBFF\uDFFF"` → U+10FFFF (upper bound)
- Equivalence with `JSON.parse` on the same document
- `\U0001F600` 32-bit escape still works
- Lone high, lone low, high+high, low+high, high+BMP, and `\U0000D83D` all still throw `SyntaxError`

All 630 tests in `yaml.test.ts`, 402 in `yaml-test-suite.test.ts`, and the block-scalar matrix continue to pass.