### PR TITLE
Bun.indexOfLine: fix O(n^2) scan on buffers containing a non-ASCII byte

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1319,7 +1319,7 @@ pub fn github_action_writer(writer: &mut impl fmt::Write, self_: &[u8]) -> fmt::
             let i = i as usize;
             let byte = self_[i];
             if byte > 0x7F {
-                offset += (strings::wtf8_byte_sequence_length(byte) as usize).max(1);
+                offset = i + (strings::wtf8_byte_sequence_length(byte) as usize).max(1);
                 continue;
             }
             if i > 0 {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1529,7 +1529,8 @@ pub(crate) fn index_of_line(
         if let Some(i) = strings::index_of_newline_or_non_ascii(bytes, current_offset as u32) {
             let byte = bytes[i as usize];
             if byte > 0x7F {
-                current_offset += (strings::wtf8_byte_sequence_length(byte) as usize).max(1);
+                current_offset =
+                    i as usize + (strings::wtf8_byte_sequence_length(byte) as usize).max(1);
                 continue;
             }
 

--- a/test/js/bun/util/index-of-line.test.ts
+++ b/test/js/bun/util/index-of-line.test.ts
@@ -53,13 +53,9 @@ test("indexOfLine", () => {
   }
 });
 
-// The non-ASCII arm of the scan loop advanced `offset` by the code-point
-// width from the previous search start rather than from the match index,
-// so a single byte >=0x80 late in the buffer was re-discovered O(n) times,
-// each time re-scanning O(n) bytes. 500KB with one multi-byte character
-// near the end took >2 minutes in a debug build; the linear scan finishes
-// in well under a second. Size is chosen so the quadratic loop cannot
-// complete inside the spawn timeout.
+// A single byte >=0x80 late in the buffer used to trigger an O(n^2) rescan.
+// Size chosen so the quadratic loop cannot complete inside the spawn timeout
+// while the linear scan finishes in well under a second.
 test("indexOfLine is linear on large input with a non-ASCII byte", async () => {
   const n = 500_000;
   const fixture = `

--- a/test/js/bun/util/index-of-line.test.ts
+++ b/test/js/bun/util/index-of-line.test.ts
@@ -1,5 +1,6 @@
 import { indexOfLine } from "bun";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("indexOfLine handles non-number offset", () => {
   // Regression test: passing a non-number offset should not crash
@@ -50,4 +51,53 @@ test("indexOfLine", () => {
     expect(i++ - delta).toBe(j++);
     nonEmptyLineCount++;
   }
+});
+
+// The non-ASCII arm of the scan loop advanced `offset` by the code-point
+// width from the previous search start rather than from the match index,
+// so a single byte >=0x80 late in the buffer was re-discovered O(n) times,
+// each time re-scanning O(n) bytes. 500KB with one multi-byte character
+// near the end took >2 minutes in a debug build; the linear scan finishes
+// in well under a second. Size is chosen so the quadratic loop cannot
+// complete inside the spawn timeout.
+test("indexOfLine is linear on large input with a non-ASCII byte", async () => {
+  const n = 500_000;
+  const fixture = `
+    const n = ${n};
+    const buf = Buffer.alloc(n + 3, "a");
+    buf[n] = 0xc3; buf[n + 1] = 0xa9; // 'é'
+    buf[n + 2] = 0x0a;                // '\\n'
+    const i = Bun.indexOfLine(buf);
+    console.log(JSON.stringify({ i, len: buf.length }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 30_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), stderr: /error|panic|assert|abort/i.test(stderr) ? stderr : "", exitCode }).toEqual({
+    stdout: JSON.stringify({ i: n + 2, len: n + 3 }),
+    stderr: "",
+    exitCode: 0,
+  });
+  expect(proc.signalCode).toBeNull();
+}, 60_000);
+
+test("indexOfLine skips multi-byte sequences correctly", () => {
+  // ascii prefix, multi-byte char, ascii, newline
+  const buf = Buffer.from("abé d\n");
+  expect(indexOfLine(buf)).toBe(buf.length - 1);
+  // newline immediately after a multi-byte char
+  const buf2 = Buffer.from("é\n");
+  expect(indexOfLine(buf2)).toBe(2);
+  // search starting mid-buffer with non-ASCII before the offset
+  const buf3 = Buffer.from("é\nabc\néé\n");
+  expect(indexOfLine(buf3, 3)).toBe(6);
+  expect(indexOfLine(buf3, 7)).toBe(11);
 });


### PR DESCRIPTION
## Repro

```js
Bun.indexOfLine(Buffer.from("a".repeat(60000) + "\n"));   // ~0.01 ms
Bun.indexOfLine(Buffer.from("a".repeat(60000) + "é\n"));  // ~15 ms release, ~18 s debug
```

A single byte >= 0x80 anywhere in the buffer made the scan quadratic in the distance from the start offset to that byte.

## Cause

`strings::index_of_newline_or_non_ascii(bytes, offset)` returns an **absolute** index `i` into `bytes`. When `bytes[i] > 0x7F`, the loop at `src/runtime/api/BunObject.rs` in `index_of_line` advanced with

```rust
current_offset += wtf8_byte_sequence_length(byte).max(1);
```

which moves from the previous search start, not from `i`. The same non-ASCII byte at `i` is re-found on the next iteration, so the SIMD scan from `current_offset` to `i` runs O(n) times. The sibling arm two lines down already does `current_offset = i + 1`, which shows the intended shape.

The identical pattern existed in `github_action_writer` (`src/bun_core/fmt.rs`) and is fixed the same way; output is unchanged there, only the scan is now linear.

## Fix

```rust
current_offset = i as usize + wtf8_byte_sequence_length(byte).max(1);
```

## Verification

Added to `test/js/bun/util/index-of-line.test.ts`:

- A subprocess runs `Bun.indexOfLine` on a 500 KB buffer ending in `é\n` with a 30 s spawn timeout. Before the fix the debug build takes over 2 minutes and the subprocess is SIGKILLed (exit 137, empty stdout); after the fix it returns the correct index in well under a second.
- Correctness cases for the non-ASCII skip path (newline immediately after a multi-byte char, non-zero start offset with preceding multi-byte data).