### PR TITLE
glob: fix brace depth overflow when skipping a deeply nested branch

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -67,7 +67,7 @@ struct State {
     wildcard: Wildcard,
     globstar: Wildcard,
 
-    brace_depth: u32,
+    brace_depth: u8,
 }
 
 impl State {
@@ -104,7 +104,7 @@ struct Wildcard {
     // Using u32 rather than usize for these results in 10% faster performance.
     glob_index: u32,
     path_index: u32,
-    brace_depth: u32,
+    brace_depth: u8,
 }
 
 /// This function checks returns a boolean value if the pathname `path` matches
@@ -530,7 +530,7 @@ fn match_brace_branch(
     // Clone state
     let mut branch_state = *state;
     branch_state.glob_index = branch_index;
-    branch_state.brace_depth = brace_stack.len() as u32;
+    branch_state.brace_depth = u8::try_from(brace_stack.len()).expect("int cast");
 
     let matched = glob_match_impl(
         &mut branch_state,
@@ -548,21 +548,24 @@ fn match_brace_branch(
 
 fn skip_branch(state: &mut State, glob: &[u8]) {
     let mut in_brackets = false;
-    let end_brace_depth = state.brace_depth - 1;
+    // `state.brace_depth` only counts groups entered via `match_brace_branch`,
+    // so nesting merely scanned over while skipping is tracked locally, not in state.
+    let mut nested: u32 = 0;
     while (state.glob_index as usize) < glob.len() {
         match glob[state.glob_index as usize] {
             b'{' => {
                 if !in_brackets {
-                    state.brace_depth += 1;
+                    nested += 1;
                 }
             }
             b'}' => {
                 if !in_brackets {
-                    state.brace_depth -= 1;
-                    if state.brace_depth == end_brace_depth {
+                    if nested == 0 {
+                        state.brace_depth -= 1;
                         state.glob_index += 1;
                         return;
                     }
+                    nested -= 1;
                 }
             }
             b'[' => {

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -67,7 +67,7 @@ struct State {
     wildcard: Wildcard,
     globstar: Wildcard,
 
-    brace_depth: u8,
+    brace_depth: u32,
 }
 
 impl State {
@@ -104,7 +104,7 @@ struct Wildcard {
     // Using u32 rather than usize for these results in 10% faster performance.
     glob_index: u32,
     path_index: u32,
-    brace_depth: u8,
+    brace_depth: u32,
 }
 
 /// This function checks returns a boolean value if the pathname `path` matches
@@ -435,7 +435,7 @@ fn match_brace(
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
 ) -> bool {
-    let mut brace_depth: i16 = 0;
+    let mut brace_depth: i32 = 0;
     let mut in_brackets = false;
 
     let open_brace_index = state.glob_index;
@@ -530,7 +530,7 @@ fn match_brace_branch(
     // Clone state
     let mut branch_state = *state;
     branch_state.glob_index = branch_index;
-    branch_state.brace_depth = u8::try_from(brace_stack.len()).expect("int cast");
+    branch_state.brace_depth = brace_stack.len() as u32;
 
     let matched = glob_match_impl(
         &mut branch_state,

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -329,6 +329,31 @@ describe("Glob.match", () => {
     expect(glob.match("bde")).toBeTrue();
   });
 
+  test("deeply nested braces in skipped branch do not overflow depth counter", () => {
+    const opens = Buffer.alloc(300, "{").toString();
+    const closes = Buffer.alloc(300, "}").toString();
+
+    // First branch matches; skip_branch must scan past >255 nested braces to
+    // find the closing brace of the outer group.
+    let glob = new Glob("{a," + opens + closes + "}");
+    expect(glob.match("a")).toBeTrue();
+    expect(glob.match("b")).toBeFalse();
+
+    // Deeply nested braces in the first (non-matching) branch, second branch matches.
+    glob = new Glob("{" + opens + closes + ",a}");
+    expect(glob.match("a")).toBeTrue();
+
+    // Deep nest with content, surrounded by matching branches on both sides.
+    glob = new Glob("{a," + opens + "x" + closes + ",b}");
+    expect(glob.match("a")).toBeTrue();
+    expect(glob.match("b")).toBeTrue();
+    expect(glob.match("y")).toBeFalse();
+
+    // Same shape inside a wildcard backtrack.
+    glob = new Glob("*{a," + opens + closes + "}");
+    expect(glob.match("za")).toBeTrue();
+  });
+
   // Most of the potential bugs when dealing with non-ASCII patterns is when the
   // pattern matching algorithm wants to deal with single chars, for example
   // using the `[...]` syntax, it tries to match each char in the brackets. With

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -329,7 +329,7 @@ describe("Glob.match", () => {
     expect(glob.match("bde")).toBeTrue();
   });
 
-  test("deeply nested braces in skipped branch do not overflow depth counter", () => {
+  test("deeply nested braces do not overflow depth counters", () => {
     const opens = Buffer.alloc(300, "{").toString();
     const closes = Buffer.alloc(300, "}").toString();
 
@@ -352,6 +352,12 @@ describe("Glob.match", () => {
     // Same shape inside a wildcard backtrack.
     glob = new Glob("*{a," + opens + closes + "}");
     expect(glob.match("za")).toBeTrue();
+
+    // >32767 consecutive `{` overflows match_brace's group pre-scan counter.
+    // The group never closes, so nothing matches.
+    glob = new Glob(Buffer.alloc(40_000, "{").toString());
+    expect(glob.match("a")).toBeFalse();
+    expect(glob.match("{")).toBeFalse();
   });
 
   // Most of the potential bugs when dealing with non-ASCII patterns is when the


### PR DESCRIPTION
## Reproduction

```js
new Bun.Glob("{a," + "{".repeat(300) + "}".repeat(301)).match("a")
// expected: true
// release:  false  (silent wrap)
// debug:    panic: attempt to add with overflow
```

## Cause

`skip_branch` in `src/glob/matcher.rs` used `state.brace_depth` as its scan cursor while looking for the `}` that closes the current brace group, incrementing it for every `{` it passed and decrementing it for every `}`.

`state.brace_depth` is meant to count the groups the matcher has actually *entered* via `match_brace_branch`. Every other writer is bounded by the `BraceStack` cap of 10, which is why it is a `u8`. Braces inside a branch that is only being *skipped over* were never validated against that cap, so 255 or more consecutive `{` inside a skipped branch wrap the `u8`. `skip_branch` then satisfies its exit condition at the wrong `}` and the matcher resumes mid-group, returning the wrong result. Debug builds panic on the checked overflow instead.

## Fix

Per @Jarred-Sumner's suggestion, `skip_branch` no longer writes the braces it merely scans over into `state.brace_depth`. It tracks the relative nesting of the skipped region in a local counter and decrements `state.brace_depth` exactly once, at the group's real closing `}`. That is all the old code ever did to it net (it always exited at `original - 1`); the intermediate inflated values were pure scratch and are what overflowed. `State.brace_depth` and `Wildcard.brace_depth` stay `u8`.

`match_brace`'s forward pre-scan has the same class of bug in its (already local) `i16` counter, which overflows with 32768 or more consecutive `{`. Widened it to `i32`.

## Verification

Added a regression test in `test/js/bun/glob/match.test.ts` covering deeply nested braces in a skipped branch (before and after the matching branch, and under wildcard backtracking), plus a 40000-brace pattern for the `match_brace` counter. The first assertion returns `false` on the released build and `true` with this change. All 26 existing `match.test.ts` tests continue to pass.
