### PR TITLE
node:http: skip non-cell onWritable/onData/onAborted in drain/data/abort dispatch

### DIFF
--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -945,19 +945,21 @@ impl NodeHTTPResponse {
             js_value
         };
         if let Some(on_aborted) = js::on_aborted_get_cached(js_this) {
-            let vm = vm_get();
-            let global_this = vm.global();
-            let event_loop = vm.event_loop_ref();
+            if on_aborted.is_cell() {
+                let vm = vm_get();
+                let global_this = vm.global();
+                let event_loop = vm.event_loop_ref();
 
-            event_loop.run_callback(
-                on_aborted,
-                global_this,
-                js_this,
-                &[JSValue::js_number_from_int32(EVENT as u8 as i32)],
-            );
+                event_loop.run_callback(
+                    on_aborted,
+                    global_this,
+                    js_this,
+                    &[JSValue::js_number_from_int32(EVENT as u8 as i32)],
+                );
 
-            if EVENT == AbortEvent::Abort {
-                js::on_aborted_set_cached(js_this, global_this, JSValue::ZERO);
+                if EVENT == AbortEvent::Abort {
+                    js::on_aborted_set_cached(js_this, global_this, JSValue::ZERO);
+                }
             }
         }
 
@@ -1292,7 +1294,7 @@ impl NodeHTTPResponse {
         // defer { if last { ... } } — moved to tail.
 
         if let Some(callback) = js::on_data_get_cached(this_value) {
-            if !callback.is_undefined() {
+            if callback.is_cell() {
                 let vm = vm_get();
                 let global_this = vm.global();
                 let event_loop = vm.event_loop_ref();
@@ -1343,7 +1345,10 @@ impl NodeHTTPResponse {
             self.deref();
             return;
         };
-        if on_writable.is_undefined() {
+        // Slot may hold UNDEFINED (WantMore) or anything the `.onwritable`
+        // setter stored; non-cells can't be callable or AsyncContextFrame,
+        // so skip instead of surfacing a spurious "not a function" uncaught.
+        if !on_writable.is_cell() {
             self.deref();
             return;
         }
@@ -1608,8 +1613,8 @@ impl NodeHTTPResponse {
         global_object: &JSGlobalObject,
         value: JSValue,
     ) {
-        if self.is_done() || value.is_undefined() {
-            js::on_writable_set_cached(this_value, global_object, JSValue::UNDEFINED);
+        if self.is_done() || value.is_undefined_or_null() {
+            js::on_writable_set_cached(this_value, global_object, JSValue::ZERO);
         } else {
             js::on_writable_set_cached(
                 this_value,
@@ -1642,7 +1647,7 @@ impl NodeHTTPResponse {
             return;
         }
 
-        if self.is_requested_completed_or_ended() || value.is_undefined() {
+        if self.is_requested_completed_or_ended() || value.is_undefined_or_null() {
             js::on_aborted_set_cached(this_value, global_object, JSValue::ZERO);
         } else {
             js::on_aborted_set_cached(
@@ -1698,7 +1703,7 @@ impl NodeHTTPResponse {
         // previously cleared `ondata` (which already called clearOnData()); either way, there is no
         // more body to read, so don't re-register with uSockets or churn refs.
         let flags = self.flags.get();
-        if value.is_undefined()
+        if value.is_undefined_or_null()
             || flags.contains(Flags::ENDED)
             || flags.contains(Flags::SOCKET_CLOSED)
             || self.body_read_state.get() != BodyReadState::Pending

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -22,18 +22,26 @@ function uafTest(fixture, iterations = 2) {
   });
 }
 
-test("should not crash when drain fires after the onWritable slot was cleared", async () => {
+test.concurrent.each([
+  ["undefined", "undefined"],
+  ["null", "null"],
+  ["0", "0"],
+  ["false", "false"],
+])("should not crash when drain fires after onWritable slot is set to %s", async (_, slotExpr) => {
   const src = /* js */ `
     import http from "node:http";
     import net from "node:net";
     import { once } from "node:events";
+
+    let caught;
+    process.on("uncaughtException", err => { caught = String(err); });
 
     const server = http.createServer(async (req, res) => {
       res.writeHead(200, { "Content-Type": "application/octet-stream" });
       res.write(Buffer.alloc(8 * 1024 * 1024, "a"));
       const sym = Object.getOwnPropertySymbols(res).find(s => s.description === "handle");
       const handle = res[sym];
-      handle.onwritable = undefined;
+      handle.onwritable = ${slotExpr};
       while (handle.bufferedAmount > 0) await new Promise(r => setImmediate(r));
       res.end();
     });
@@ -45,7 +53,7 @@ test("should not crash when drain fires after the onWritable slot was cleared", 
     let received = 0;
     sock.on("data", d => (received += d.length));
     await once(sock, "close");
-    console.log(JSON.stringify({ received }));
+    console.log(JSON.stringify({ received, caught }));
     server.close();
   `;
   await using proc = Bun.spawn({


### PR DESCRIPTION
Follow-up to #32661.

The fuzzer's coverage-guided syscall campaign hit `ASSERTION FAILED: isCell()` in `JSCJSValue.h` under `Bun__JSValue__call` from the `NodeHTTPResponse::on_drain` path. The fuzz run was on a branch commit that predates #32661, so the literal assert it observed is the one that PR already fixed, but the analysis is correct that the guard is incomplete.

## Cause

`on_drain_corked` reads the cached `onWritable` slot and only skips when it is `undefined`:

```rust
let Some(on_writable) = js::on_writable_get_cached(this_value) else { return };
if on_writable.is_undefined() { return }
vm.event_loop_ref().run_callback(on_writable, ...);
```

The slot is populated by `write_or_end` (which stores `UNDEFINED` or a validated callable) and by the `.onwritable` JS setter, which stores the assigned value unvalidated. Assigning `null`, a number, or a boolean to `handle.onwritable` while a uWS writable handler is registered means the next drain passes the `is_undefined()` check and hands a non-cell to `run_callback`. After #32661 that no longer asserts; instead `Bun__JSValue__call` throws `TypeError: <value> is not a function`, which `run_callback` reports as an uncaught exception.

The sibling data/abort paths share the same shape: `on_data_or_aborted` checks `!callback.is_undefined()` and the abort path only checks `Some(_)`.

## Fix

- `on_drain_corked` / `on_data_or_aborted` / the abort dispatch now gate on `is_cell()` instead of `!is_undefined()`. A non-cell value cannot be callable and cannot be an `AsyncContextFrame` wrapper, so there is nothing useful `run_callback` can do with it.
- `set_on_writable` / `set_on_abort` / `set_on_data` treat `null` the same as `undefined` and clear the slot, matching the usual JS convention for clearing a callback.

## Test

The #32661 regression test is parameterised over `{undefined, null, 0, false}`. On `main` the `undefined` case passes and the other three surface:

```
stdout: { caught: "TypeError: null is not a function", received: 8388766 }
```

With this change all four pass and no uncaught exception is reported.