### PR TITLE
GitHub Actions annotations: preserve non-ASCII bytes in title and body

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1319,10 +1319,15 @@ pub fn github_action_writer(writer: &mut impl fmt::Write, self_: &[u8]) -> fmt::
             let i = i as usize;
             let byte = self_[i];
             if byte > 0x7F {
-                let seq_len = (strings::wtf8_byte_sequence_length(byte) as usize).max(1);
-                let next = (i + seq_len).min(end as usize);
-                write_bytes(writer, &self_[offset..next])?;
-                offset = next;
+                let seq_len = strings::wtf8_byte_sequence_length(byte) as usize;
+                if i + seq_len > end as usize {
+                    // Truncated trailing sequence; emit the pending ASCII and stop
+                    // rather than hand an invalid slice to from_utf8_unchecked.
+                    write_bytes(writer, &self_[offset..i])?;
+                    break;
+                }
+                write_bytes(writer, &self_[offset..i + seq_len])?;
+                offset = i + seq_len;
                 continue;
             }
             if i > 0 {

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1319,7 +1319,10 @@ pub fn github_action_writer(writer: &mut impl fmt::Write, self_: &[u8]) -> fmt::
             let i = i as usize;
             let byte = self_[i];
             if byte > 0x7F {
-                offset += (strings::wtf8_byte_sequence_length(byte) as usize).max(1);
+                let seq_len = (strings::wtf8_byte_sequence_length(byte) as usize).max(1);
+                let next = (i + seq_len).min(end as usize);
+                write_bytes(writer, &self_[offset..next])?;
+                offset = next;
                 continue;
             }
             if i > 0 {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6247,14 +6247,11 @@ impl VirtualMachine {
             let message_slice = message.to_utf8();
             let msg = message_slice.slice();
             let mut cursor: u32 = 0;
-            let mut printed_first_line = false;
             if let Some(i) = bun_core::strings::index_of_char(msg, b'\n') {
                 cursor = i + 1;
                 let first_line = bun_core::String::borrow_utf8(&msg[..i as usize]);
                 let _ = write!(writer, ": {}::", first_line.github_action());
-                printed_first_line = true;
-            }
-            if !printed_first_line {
+            } else {
                 let _ = write!(writer, ": {}::", message.github_action());
             }
             // Skip past the next newline.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6248,28 +6248,18 @@ impl VirtualMachine {
             let msg = message_slice.slice();
             let mut cursor: u32 = 0;
             let mut printed_first_line = false;
-            while let Some(i) =
-                bun_core::strings::index_of_newline_or_non_ascii_or_ansi(msg, cursor)
-            {
+            if let Some(i) = bun_core::strings::index_of_char(msg, b'\n') {
                 cursor = i + 1;
-                if msg[i as usize] == b'\n' {
-                    let first_line = bun_core::String::borrow_utf8(&msg[..i as usize]);
-                    let _ = write!(writer, ": {}::", first_line.github_action());
-                    printed_first_line = true;
-                    break;
-                }
+                let first_line = bun_core::String::borrow_utf8(&msg[..i as usize]);
+                let _ = write!(writer, ": {}::", first_line.github_action());
+                printed_first_line = true;
             }
             if !printed_first_line {
                 let _ = write!(writer, ": {}::", message.github_action());
             }
             // Skip past the next newline.
-            while let Some(i) =
-                bun_core::strings::index_of_newline_or_non_ascii_or_ansi(msg, cursor)
-            {
-                cursor = i + 1;
-                if msg[i as usize] == b'\n' {
-                    break;
-                }
+            if let Some(i) = bun_core::strings::index_of_char(&msg[cursor as usize..], b'\n') {
+                cursor += i + 1;
             }
             if cursor > 0 {
                 let body = jsc::ZigString::init_utf8(&msg[cursor as usize..]);

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -620,7 +620,8 @@ describe("bun test", () => {
           GITHUB_ACTIONS: "true",
         },
       });
-      expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error: hello é world::/m);
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+      expect(annotation).toMatch(/^::error file=.*,line=\d+,col=\d+,title=error: hello é world::%0A {6}at /);
     });
     test("should annotate an error message containing emoji and newlines", () => {
       const stderr = runTest({
@@ -635,7 +636,10 @@ describe("bun test", () => {
           GITHUB_ACTIONS: "true",
         },
       });
-      expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error: before 😋 after::/m);
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+      expect(annotation).toMatch(
+        /^::error file=.*,line=\d+,col=\d+,title=error: before 😋 after::second 😋 line%0A {6}at /,
+      );
     });
     test("should annotate a test timeout", () => {
       const stderr = runTest({

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -607,6 +607,36 @@ describe("bun test", () => {
       });
       expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error: Oops!::/m);
     });
+    test("should annotate an error message containing non-ASCII bytes", () => {
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          test("fail", () => {
+            throw "hello é world";
+          });
+        `,
+        env: {
+          FORCE_COLOR: "1",
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error: hello é world::/m);
+    });
+    test("should annotate an error message containing emoji and newlines", () => {
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          test("fail", () => {
+            throw "before 😋 after\\nsecond 😋 line";
+          });
+        `,
+        env: {
+          FORCE_COLOR: "1",
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error: before 😋 after::/m);
+    });
     test("should annotate a test timeout", () => {
       const stderr = runTest({
         input: `


### PR DESCRIPTION
Split out from #32732 per review.

## Repro

```
$ cat fail.test.ts
import { test } from "bun:test";
test("fail", () => { throw "hello é world"; });

$ GITHUB_ACTIONS=true bun test fail.test.ts 2>&1 | grep ::error
::error file=fail.test.ts,line=2,col=22,title=error:  world:: world%0A...
```

The `hello é` prefix is dropped from the annotation title, and a spurious ` world` fragment appears after `::` as the body.

## Cause

Two sites dropped bytes around non-ASCII characters:

- `github_action_writer` (`src/bun_core/fmt.rs`) scans with `index_of_newline_or_non_ascii_or_ansi`; the non-ASCII arm advanced `offset` past the multi-byte sequence and `continue`d without writing the pending `self_[offset..i]` run or the sequence itself.
- `print_github_annotation` (`src/jsc/VirtualMachine.rs`) split the message into title/body using the same scanner to find the first and second `\n`. Because the scanner also returns hits for every byte `>= 0x80`, `cursor` ended up past the last non-ASCII byte rather than at the intended line boundary. A single-line message with a non-ASCII character emitted a spurious truncated body; a multi-line one lost everything up to the last non-ASCII byte of the second line.

## Fix

- `github_action_writer`: flush `self_[offset..i + seq_len]` before advancing. A truncated trailing lead byte writes only the pending ASCII and stops, rather than handing an incomplete sequence to `from_utf8_unchecked`.
- `print_github_annotation`: use `strings::index_of_char(.., b'\n')` for the title/body split; the loops only ever acted on `\n` anyway.

This also removes the quadratic rescan from `github_action_writer`; #32732 fixes the same shape in `Bun.indexOfLine` and will have a small textual overlap on the fmt.rs block with whichever lands second.

## Verification

Added two cases to the `support for Github Actions` block in `test/cli/test/bun-test.test.ts`: a single-line message with a 2-byte `é` and a two-line message with 4-byte emoji on both lines. Both assert the full annotation line: `title=error: hello é world::%0A      at ...` (no body fragment) and `title=error: before 😋 after::second 😋 line%0A      at ...` respectively. Before the fix they emitted `title=error:  world:: world%0A` and `title=error:  after:: line%0A`.
