### PR TITLE
http: emit 'close' on node:http upgrade sockets when the WebSocket peer closes

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1070,7 +1070,10 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
 
   [kEnableStreaming](enable: boolean) {
-    this[kIsTunnel] = enable;
+    // kIsTunnel latches: once a socket is detached into CONNECT/upgrade tunnel
+    // mode it never returns to normal request handling, and #onClose relies on
+    // it to emit 'close' on native close.
+    if (enable) this[kIsTunnel] = true;
     const handle = this[kHandle];
     if (handle) {
       if (enable) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1018,6 +1018,7 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
 
 const kBytesWritten = Symbol("kBytesWritten");
 const kEnableStreaming = Symbol("kEnableStreaming");
+const kIsTunnel = Symbol("kIsTunnel");
 function onServerSocketError(this: any, _err) {
   // Default 'error' listener so socket-level errors (e.g. res.destroy(err)
   // forwarding the error to the socket) do not crash the process as
@@ -1035,6 +1036,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   connecting = false;
   timeout = 0;
   [kBytesWritten] = 0;
+  [kIsTunnel] = false;
   [kHandle];
   server: Server;
   _httpMessage;
@@ -1068,6 +1070,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
 
   [kEnableStreaming](enable: boolean) {
+    this[kIsTunnel] = enable;
     const handle = this[kHandle];
     if (handle) {
       if (enable) {
@@ -1154,6 +1157,13 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     // onServerResponseClose socket listener does.
     if (message && !message._closed) {
       process.nextTick(emitCloseNT, message);
+    }
+
+    // A tunneled/upgraded connection (CONNECT or WebSocket upgrade) is detached
+    // from the request/response lifecycle, so end the Duplex on native close to
+    // emit 'close' for the upgrade handler and user listeners, like Node.js.
+    if (this[kIsTunnel] && !this.destroyed) {
+      this.destroy();
     }
   }
   #onCloseForDestroy(closeCallback, err?: Error) {

--- a/test/regression/issue/32734.test.ts
+++ b/test/regression/issue/32734.test.ts
@@ -17,10 +17,13 @@ test("node:http upgrade socket emits 'close' when the WebSocket peer closes", as
   const rawSocketClosed = Promise.withResolvers<void>();
 
   server.on("upgrade", (req, socket, head) => {
-    socket.once("error", rawSocketClosed.reject);
+    socket.once("error", err => rawSocketClosed.reject(err));
     socket.once("close", () => rawSocketClosed.resolve());
     wss.handleUpgrade(req, socket, head, ws => {
-      ws.on("error", err => (wsClosed.reject(err), echoed.reject(err)));
+      ws.on("error", err => {
+        echoed.reject(err);
+        wsClosed.reject(err);
+      });
       ws.on("message", m => ws.send("echo:" + String(m)));
       ws.on("close", () => wsClosed.resolve());
       ws.send("protocol:hi");
@@ -35,7 +38,9 @@ test("node:http upgrade socket emits 'close' when the WebSocket peer closes", as
     client = new WebSocket(`ws://127.0.0.1:${port}/`);
     client.addEventListener("error", () => {
       const err = new Error("client WebSocket error");
-      (echoed.reject(err), wsClosed.reject(err), rawSocketClosed.reject(err));
+      echoed.reject(err);
+      wsClosed.reject(err);
+      rawSocketClosed.reject(err);
     });
     client.addEventListener("message", e => {
       if (String(e.data).startsWith("protocol:")) client!.send("hello");
@@ -67,7 +72,7 @@ test("node:http CONNECT tunnel socket emits 'close' when the peer closes", async
   const connectClosed = Promise.withResolvers<void>();
 
   server.on("connect", (req, socket) => {
-    socket.once("error", connectClosed.reject);
+    socket.once("error", err => connectClosed.reject(err));
     socket.once("close", () => connectClosed.resolve());
     socket.write("HTTP/1.1 200 Connection established\r\n\r\n");
   });
@@ -76,15 +81,34 @@ test("node:http CONNECT tunnel socket emits 'close' when the peer closes", async
   const port = (server.address() as AddressInfo).port;
 
   let client: net.Socket | undefined;
+  let tunnelEstablished = false;
   try {
     client = net.connect(port, "127.0.0.1", () => {
       client!.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n");
     });
-    client.on("error", err => (established.reject(err), connectClosed.reject(err)));
+    client.on("error", err => {
+      established.reject(err);
+      connectClosed.reject(err);
+    });
+    client.on("close", () => {
+      if (!tunnelEstablished) {
+        established.reject(new Error("CONNECT socket closed before the tunnel was established"));
+      }
+    });
+
+    // Buffer raw TCP chunks until the full CONNECT response header arrives, then
+    // inspect the status line instead of searching each chunk independently.
+    let response = "";
     client.on("data", d => {
-      if (d.toString().includes("200")) {
+      response += d.toString();
+      if (!response.includes("\r\n\r\n")) return;
+      const statusLine = response.slice(0, response.indexOf("\r\n"));
+      if (statusLine.includes(" 200 ")) {
+        tunnelEstablished = true;
         established.resolve();
         client!.destroy(); // peer tears down -> server tunnel socket must 'close'
+      } else {
+        established.reject(new Error(`unexpected CONNECT response: ${statusLine}`));
       }
     });
 

--- a/test/regression/issue/32734.test.ts
+++ b/test/regression/issue/32734.test.ts
@@ -1,7 +1,7 @@
 // https://github.com/oven-sh/bun/issues/32734
 import { expect, test } from "bun:test";
 import http from "node:http";
-import type { AddressInfo } from "node:net";
+import net, { type AddressInfo } from "node:net";
 import { WebSocketServer } from "ws";
 
 // After an HTTP upgrade is handed to the native WebSocket server (server.upgrade),
@@ -12,12 +12,15 @@ test("node:http upgrade socket emits 'close' when the WebSocket peer closes", as
   const server = http.createServer();
   const wss = new WebSocketServer({ noServer: true });
 
-  const rawSocketClosed = Promise.withResolvers<void>();
+  const echoed = Promise.withResolvers<void>();
   const wsClosed = Promise.withResolvers<void>();
+  const rawSocketClosed = Promise.withResolvers<void>();
 
   server.on("upgrade", (req, socket, head) => {
+    socket.once("error", rawSocketClosed.reject);
     socket.once("close", () => rawSocketClosed.resolve());
     wss.handleUpgrade(req, socket, head, ws => {
+      ws.on("error", err => (wsClosed.reject(err), echoed.reject(err)));
       ws.on("message", m => ws.send("echo:" + String(m)));
       ws.on("close", () => wsClosed.resolve());
       ws.send("protocol:hi");
@@ -27,12 +30,15 @@ test("node:http upgrade socket emits 'close' when the WebSocket peer closes", as
   await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
   const port = (server.address() as AddressInfo).port;
 
+  let client: WebSocket | undefined;
   try {
-    const client = new WebSocket(`ws://127.0.0.1:${port}/`);
-    const echoed = Promise.withResolvers<void>();
-    client.addEventListener("error", echoed.reject);
+    client = new WebSocket(`ws://127.0.0.1:${port}/`);
+    client.addEventListener("error", () => {
+      const err = new Error("client WebSocket error");
+      echoed.reject(err), wsClosed.reject(err), rawSocketClosed.reject(err);
+    });
     client.addEventListener("message", e => {
-      if (String(e.data).startsWith("protocol:")) client.send("hello");
+      if (String(e.data).startsWith("protocol:")) client!.send("hello");
       if (e.data === "echo:hello") echoed.resolve();
     });
 
@@ -46,7 +52,46 @@ test("node:http upgrade socket emits 'close' when the WebSocket peer closes", as
     await rawSocketClosed.promise;
     expect(wss.clients.size).toBe(0);
   } finally {
+    client?.close();
     wss.close();
+    server.close();
+  }
+});
+
+// The same fix covers CONNECT tunnels: a detached node:http CONNECT socket must
+// emit 'close' when the peer tears down the connection.
+test("node:http CONNECT tunnel socket emits 'close' when the peer closes", async () => {
+  const server = http.createServer();
+
+  const established = Promise.withResolvers<void>();
+  const connectClosed = Promise.withResolvers<void>();
+
+  server.on("connect", (req, socket) => {
+    socket.once("error", connectClosed.reject);
+    socket.once("close", () => connectClosed.resolve());
+    socket.write("HTTP/1.1 200 Connection established\r\n\r\n");
+  });
+
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+  const port = (server.address() as AddressInfo).port;
+
+  let client: net.Socket | undefined;
+  try {
+    client = net.connect(port, "127.0.0.1", () => {
+      client!.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n");
+    });
+    client.on("error", err => (established.reject(err), connectClosed.reject(err)));
+    client.on("data", d => {
+      if (d.toString().includes("200")) {
+        established.resolve();
+        client!.destroy(); // peer tears down -> server tunnel socket must 'close'
+      }
+    });
+
+    await established.promise;
+    await connectClosed.promise; // hangs without the fix
+  } finally {
+    client?.destroy();
     server.close();
   }
 });

--- a/test/regression/issue/32734.test.ts
+++ b/test/regression/issue/32734.test.ts
@@ -1,0 +1,52 @@
+// https://github.com/oven-sh/bun/issues/32734
+import { expect, test } from "bun:test";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { WebSocketServer } from "ws";
+
+// After an HTTP upgrade is handed to the native WebSocket server (server.upgrade),
+// the node:http socket from the 'upgrade' event must still emit 'close' when the
+// WebSocket peer closes. Regressed in 1.4.0-canary.1: the raw socket 'close'
+// never fired, hanging any code that waits on it (e.g. a WebSocket proxy scope).
+test("node:http upgrade socket emits 'close' when the WebSocket peer closes", async () => {
+  const server = http.createServer();
+  const wss = new WebSocketServer({ noServer: true });
+
+  const rawSocketClosed = Promise.withResolvers<void>();
+  const wsClosed = Promise.withResolvers<void>();
+
+  server.on("upgrade", (req, socket, head) => {
+    socket.once("close", () => rawSocketClosed.resolve());
+    wss.handleUpgrade(req, socket, head, ws => {
+      ws.on("message", m => ws.send("echo:" + String(m)));
+      ws.on("close", () => wsClosed.resolve());
+      ws.send("protocol:hi");
+    });
+  });
+
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+  const port = (server.address() as AddressInfo).port;
+
+  try {
+    const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+    const echoed = Promise.withResolvers<void>();
+    client.addEventListener("error", echoed.reject);
+    client.addEventListener("message", e => {
+      if (String(e.data).startsWith("protocol:")) client.send("hello");
+      if (e.data === "echo:hello") echoed.resolve();
+    });
+
+    await echoed.promise;
+    client.close(1000);
+
+    // The ws-level 'close' fires in both 1.3.14 and 1.4; the raw node:http
+    // socket 'close' is the one that regressed. Awaiting it hangs without the
+    // fix until the test times out.
+    await wsClosed.promise;
+    await rawSocketClosed.promise;
+    expect(wss.clients.size).toBe(0);
+  } finally {
+    wss.close();
+    server.close();
+  }
+});

--- a/test/regression/issue/32734.test.ts
+++ b/test/regression/issue/32734.test.ts
@@ -35,7 +35,7 @@ test("node:http upgrade socket emits 'close' when the WebSocket peer closes", as
     client = new WebSocket(`ws://127.0.0.1:${port}/`);
     client.addEventListener("error", () => {
       const err = new Error("client WebSocket error");
-      echoed.reject(err), wsClosed.reject(err), rawSocketClosed.reject(err);
+      (echoed.reject(err), wsClosed.reject(err), rawSocketClosed.reject(err));
     });
     client.addEventListener("message", e => {
       if (String(e.data).startsWith("protocol:")) client!.send("hello");

--- a/test/regression/issue/32734.test.ts
+++ b/test/regression/issue/32734.test.ts
@@ -19,6 +19,10 @@ test("node:http upgrade socket emits 'close' when the WebSocket peer closes", as
   server.on("upgrade", (req, socket, head) => {
     socket.once("error", err => rawSocketClosed.reject(err));
     socket.once("close", () => rawSocketClosed.resolve());
+    // `ws` is load-bearing, not incidental: only its graceful bidirectional
+    // close handshake (close frame -> reply -> both FIN) reaches the native
+    // socket-closed callback. A raw client `destroy()` takes the abort path,
+    // which already emitted 'close' before the fix, so it does not reproduce.
     wss.handleUpgrade(req, socket, head, ws => {
       ws.on("error", err => {
         echoed.reject(err);


### PR DESCRIPTION
## What

Fixes #32734. After a bidirectional WebSocket proxy exchanges messages successfully, the scoped proxy/server fibers never settle and the test hangs until timeout. Regressed in `1.4.0-canary.1` (passes in `1.3.14`).

## Repro

```ts
import { WebSocketServer } from "ws";
import http from "node:http";

const server = http.createServer();
const wss = new WebSocketServer({ noServer: true });
server.on("upgrade", (req, socket, head) => {
  socket.once("close", () => console.log("raw socket closed")); // never fires on 1.4
  wss.handleUpgrade(req, socket, head, ws => {
    ws.on("message", m => ws.send("echo:" + String(m)));
    ws.send("protocol:hi");
  });
});
```

The ws-level `'close'` fires, but the raw node:http socket from the `'upgrade'` event never emits `'close'`, so anything waiting on it (e.g. `effect`'s `NodeHttpServer`, which interrupts the request fiber on `socket.on("close")`) hangs forever.

## Cause

`src/js/thirdparty/ws.js` hands the connection to the native WebSocket server via `server.upgrade(req, { data })`, which adopts the socket into the WebSocket context. The native socket-closed callback still fires on the node:http side, but nothing ends the `NodeHTTPServerSocket` Duplex.

In 1.3.14 the upgrade socket's `'close'` was driven indirectly by the request-abort chain (`onServerRequestEvent` -> `socket.destroy()`). PR #31587 rewrote `IncomingMessage`, and for a body-less upgrade GET the request now completes, which runs `IncomingMessage._destroy` -> clears `handle.onabort` and sets `REQUEST_HAS_COMPLETED`, disarming that chain. Once disarmed, the WebSocket close reaches the handle but no longer destroys the socket, so `'close'` never fires. CONNECT tunnels shared the same latent gap.

## Fix

`NodeHTTPServerSocket.#onClose` is the authoritative signal that the native connection is gone, so it now ends the Duplex for tunneled/upgraded sockets. A `kIsTunnel` flag is set when raw streaming mode is enabled (CONNECT at the `connect` dispatch, and the WebSocket upgrade path), scoping the change to detached sockets so normal request handling is untouched.

## Verification

```
# without the fix (release 1.4.0): raw socket 'close' never fires, test times out at 5000ms
# with the fix:
(pass) node:http upgrade socket emits 'close' when the WebSocket peer closes [476ms]
```

Regression test added at `test/regression/issue/32734.test.ts` (fails by timing out before the fix, passes after).

Also verified unchanged: `test-ws-bidir-proxy`, `websocket-proxy-tunnel-upgrade-leak`, `websocket-proxy-tunnel-client-leak`, `websocket-server` (93), `node-http-with-ws`, and the upgrade/connect/close subsets of `node-http.test.ts`.
