### PR TITLE
net: validate setTypeOfService argument on the native TCPSocket prototype

### DIFF
--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -695,8 +695,14 @@ impl<const SSL: bool> NewSocket<SSL> {
         jsc::mark_binding!();
         let args = callframe.arguments_old::<1>();
         let tos: i32 = if args.len >= 1 {
+            let arg = args.ptr[0];
+            // validate_integer_range maps NaN to the default; node:net rejects
+            // it with ERR_INVALID_ARG_TYPE, so do that explicitly here.
+            if arg.is_number() && arg.as_number().is_nan() {
+                return Err(global.throw_invalid_property_type_value(b"tos", b"number", arg));
+            }
             global.validate_integer_range(
-                args.ptr[0],
+                arg,
                 0i32,
                 bun_sql_jsc::jsc::IntegerRange {
                     min: 0,

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -689,13 +689,22 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[bun_jsc::host_fn(method)]
     pub fn set_type_of_service(
         this: &Self,
-        _global: &JSGlobalObject,
+        global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         jsc::mark_binding!();
         let args = callframe.arguments_old::<1>();
         let tos: i32 = if args.len >= 1 {
-            args.ptr[0].to_int32()
+            global.validate_integer_range(
+                args.ptr[0],
+                0i32,
+                bun_sql_jsc::jsc::IntegerRange {
+                    min: 0,
+                    max: 255,
+                    field_name: b"tos",
+                    ..Default::default()
+                },
+            )?
         } else {
             0
         };

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -699,7 +699,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             // validate_integer_range maps NaN to the default; node:net rejects
             // it with ERR_INVALID_ARG_TYPE, so do that explicitly here.
             if arg.is_number() && arg.as_number().is_nan() {
-                return Err(global.throw_invalid_property_type_value(b"tos", b"number", arg));
+                return Err(global.throw_invalid_property_type_value(b"tos", b"integer", arg));
             }
             global.validate_integer_range(
                 arg,

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1558,3 +1558,76 @@ it("node:net connect() reusing a server-accepted handle keeps the listener's han
   expect(exitCode).toBe(0);
   void stderr;
 });
+
+it.concurrent("setTypeOfService validates its argument instead of asserting", async () => {
+  // The unfixed native binding called JSValue::asInt32() on the raw argument,
+  // which asserts isInt32() on assert builds and silently feeds garbage to
+  // setsockopt on release builds. It must throw a TypeError/RangeError.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        using listener = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: { open() {}, data() {}, close() {}, error() {} },
+        });
+        const done = Promise.withResolvers();
+        const client = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: listener.port,
+          socket: {
+            open(s) {
+              const results = [];
+              const check = (label, fn) => {
+                try {
+                  fn();
+                  results.push(label + "=no-throw");
+                } catch (e) {
+                  results.push(label + "=" + (e?.code ?? e?.constructor?.name));
+                }
+              };
+              check("object", () => s.setTypeOfService({}));
+              check("string", () => s.setTypeOfService("x"));
+              check("neg", () => s.setTypeOfService(-1));
+              check("big", () => s.setTypeOfService(256));
+              check("float", () => s.setTypeOfService(1.5));
+              check("ok", () => s.setTypeOfService(0x10));
+              check("get", () => {
+                const v = s.getTypeOfService();
+                if (!Number.isInteger(v)) throw new TypeError("not an int");
+              });
+              console.log(results.join("\\n"));
+              done.resolve();
+            },
+            data() {},
+            close() {},
+            error(_s, e) { done.reject(e); },
+            connectError(_s, e) { done.reject(e); },
+          },
+        });
+        await done.promise;
+        client.end();
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+    stdout: [
+      "object=ERR_INVALID_ARG_TYPE",
+      "string=ERR_INVALID_ARG_TYPE",
+      "neg=ERR_OUT_OF_RANGE",
+      "big=ERR_OUT_OF_RANGE",
+      "float=ERR_INVALID_ARG_TYPE",
+      "ok=no-throw",
+      "get=no-throw",
+    ],
+    exitCode: 0,
+  });
+  void stderr;
+});

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1590,6 +1590,7 @@ it.concurrent("setTypeOfService validates its argument instead of asserting", as
               };
               check("object", () => s.setTypeOfService({}));
               check("string", () => s.setTypeOfService("x"));
+              check("nan", () => s.setTypeOfService(NaN));
               check("neg", () => s.setTypeOfService(-1));
               check("big", () => s.setTypeOfService(256));
               check("float", () => s.setTypeOfService(1.5));
@@ -1621,6 +1622,7 @@ it.concurrent("setTypeOfService validates its argument instead of asserting", as
     stdout: [
       "object=ERR_INVALID_ARG_TYPE",
       "string=ERR_INVALID_ARG_TYPE",
+      "nan=ERR_INVALID_ARG_TYPE",
       "neg=ERR_OUT_OF_RANGE",
       "big=ERR_OUT_OF_RANGE",
       "float=ERR_INVALID_ARG_TYPE",


### PR DESCRIPTION
### Repro

```js
using listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
await Bun.connect({
  hostname: "127.0.0.1",
  port: listener.port,
  socket: { open(s) { s.setTypeOfService({}); } },
});
```

On any assert build (debug, release-asan):

```
ASSERTION FAILED: isInt32()
  #4 JSC__JSValue__toInt32
  #5 TCPSocketPrototype__setTypeOfService
  #6 WebCore::TCPSocketPrototype__setTypeOfServiceCallback
```

On plain release the assert compiles out and the NaN-boxed bits of the object handle are passed to `setsockopt(IP_TOS)` as the TOS byte.

### Cause

`set_type_of_service` in `src/runtime/socket/socket_body.rs` called `args.ptr[0].to_int32()` on the raw argument. For non-numeric values that falls through to the C++ `JSC__JSValue__toInt32`, which is `JSC::JSValue::asInt32()` (the unchecked accessor that asserts `isInt32()`), not a coercing conversion. The `node:net` wrapper validates `tos` in JS before calling the handle, but the Bun-native `Bun.connect` socket exposes this prototype method directly with no JS validation layer.

### Fix

Route the argument through `validate_integer_range` with `min: 0, max: 255, field_name: "tos"`, the same pattern the sibling `setKeepAlive` already uses for `initialDelay`. Non-numbers now throw `ERR_INVALID_ARG_TYPE`, out-of-range integers throw `ERR_OUT_OF_RANGE`, and non-integral numbers throw `ERR_INVALID_ARG_TYPE`, matching the `node:net` surface.

I audited the other numeric setters on the TCPSocket/TLSSocket prototype (`timeout`, `setMaxSendFragment`, `write` offset/length) and the remaining `to_int32()` / `to_int64()` callers in `src/runtime/socket/`: each is already gated by `is_number()` / `is_any_int()` or routes through `coerce`. `setTypeOfService` was the only unguarded one.

### Verification

New test in `test/js/bun/net/socket.test.ts` spawns a subprocess that calls `setTypeOfService` on a connected `Bun.connect` socket with `{}`, `"x"`, `-1`, `256`, `1.5`, and `0x10`, and asserts the error code for each plus that `getTypeOfService()` returns an integer. Without the fix the subprocess aborts (exit 134) on the first call; with the fix all seven checks pass. `test/js/node/test/parallel/test-net-socket-tos.js` continues to pass.

Found by the bun-sys-fuzz API-grammar layer.