### PR TITLE
node:net: handle socket.connect() on a socket that still has a live native handle

### DIFF
--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1111,7 +1111,6 @@ impl Listener {
                     let tls: *mut TLSSocket = if let Some(prev_ptr) = prev_maybe_tls {
                         // SAFETY: caller passes a live TLSSocket
                         let prev = unsafe { &*prev_ptr };
-                        prev.detach_for_reconnect();
                         if let Some(prev_handlers) = prev.handlers.get() {
                             if prev.flags.get().contains(SocketFlags::OWNS_HANDLERS)
                                 // SAFETY: prev_handlers was heap-allocated; shared
@@ -1214,7 +1213,6 @@ impl Listener {
                         // SAFETY: caller passes a live TCPSocket
                         let prev = unsafe { &*prev_ptr };
                         debug_assert!(!prev.this_value.get().is_empty());
-                        prev.detach_for_reconnect();
                         if let Some(prev_handlers) = prev.handlers.get() {
                             if prev.flags.get().contains(SocketFlags::OWNS_HANDLERS)
                                 // SAFETY: prev_handlers was heap-allocated; shared

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1111,6 +1111,7 @@ impl Listener {
                     let tls: *mut TLSSocket = if let Some(prev_ptr) = prev_maybe_tls {
                         // SAFETY: caller passes a live TLSSocket
                         let prev = unsafe { &*prev_ptr };
+                        prev.detach_for_reconnect();
                         if let Some(prev_handlers) = prev.handlers.get() {
                             if prev.flags.get().contains(SocketFlags::OWNS_HANDLERS)
                                 // SAFETY: prev_handlers was heap-allocated; shared
@@ -1213,6 +1214,7 @@ impl Listener {
                         // SAFETY: caller passes a live TCPSocket
                         let prev = unsafe { &*prev_ptr };
                         debug_assert!(!prev.this_value.get().is_empty());
+                        prev.detach_for_reconnect();
                         if let Some(prev_handlers) = prev.handlers.get() {
                             if prev.flags.get().contains(SocketFlags::OWNS_HANDLERS)
                                 // SAFETY: prev_handlers was heap-allocated; shared
@@ -1469,6 +1471,11 @@ fn connect_finish<const IS_SSL: bool>(
         // SAFETY: caller passes a live NewSocket<IS_SSL>
         let prev = unsafe { &*prev_ptr };
         debug_assert!(prev.this_value.get().is_not_empty());
+        // `node:net` allows `socket.connect()` on an already-connected /
+        // still-connecting socket. Close the previous native socket before
+        // reusing this wrapper so `do_connect` does not alias two native
+        // sockets onto one ext slot.
+        prev.detach_for_reconnect();
         if let Some(prev_handlers) = prev.handlers.get() {
             // Only free the previous Handlers when no callback scope is still
             // holding it. If a `data`/`close` handler synchronously re-entered

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1201,6 +1201,43 @@ impl<const SSL: bool> NewSocket<SSL> {
         socket.close(code);
     }
 
+    /// Discard a still-live native socket so this wrapper can be reused for a
+    /// fresh connect. `node:net` permits `socket.connect()` on an
+    /// already-connected socket; without this the previous `us_socket_t`'s
+    /// ext slot keeps pointing at `self` while `do_connect` overwrites
+    /// `self.socket`, aliasing two native sockets onto one wrapper. The ext
+    /// slot is nulled before closing so the synchronous `on_close` /
+    /// `on_connecting_error` dispatch early-returns and no JS callback fires;
+    /// `mark_inactive`/`deref` balance the refs the previous `connect_finish`
+    /// took. Caller must hold an independent +1 across this call.
+    pub fn detach_for_reconnect(&self) {
+        let old = self.socket.get();
+        if old.is_detached() {
+            return;
+        }
+        if let Some(ext) = old.ext::<*mut c_void>() {
+            // SAFETY: ext slot is sized for `*mut c_void`; single-threaded.
+            unsafe { *ext = core::ptr::null_mut() };
+        }
+        self.socket.set(SocketHandler::<SSL>::DETACHED);
+        self.buffered_data_for_node_net
+            .with_mut(|b| b.clear_and_free());
+        self.detach_native_callback();
+        old.close(uws::CloseCode::Failure);
+        self.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
+        if self.flags.get().contains(Flags::IS_ACTIVE) {
+            self.update_flags(|f| f.remove(Flags::IS_ACTIVE));
+            if let Some(h) = self.handlers.get() {
+                // SAFETY: `h` is the live client-mode `Handlers` box; see
+                // `Handlers::mark_inactive` contract.
+                if unsafe { Handlers::mark_inactive(h.as_ptr()) } {
+                    self.handlers.set(None);
+                }
+            }
+        }
+        self.deref();
+    }
+
     pub fn mark_inactive(&self) {
         if self.flags.get().contains(Flags::IS_ACTIVE) {
             // we have to close the socket before the socket context is closed
@@ -1463,7 +1500,11 @@ impl<const SSL: bool> NewSocket<SSL> {
                 }
             }
         }
-        if scope.exit() {
+        // Only null if the cell still points at the Handlers `exit()` just
+        // freed; a synchronous reconnect from inside the open callback
+        // repoints it at a fresh allocation (same guard as `on_close`).
+        let captured_handlers = handlers.as_ptr();
+        if scope.exit() && this.handlers.get().map(|n| n.as_ptr()) == Some(captured_handlers) {
             this.handlers.set(None);
         }
         this.deref();

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -117,9 +117,7 @@ extern "C" fn select_alpn_callback(
             let buffer = match JSValue::create_buffer_from_length(&global, wire_len) {
                 Ok(b) => b,
                 Err(_) => {
-                    if scope.exit() {
-                        this.handlers.set(None);
-                    }
+                    this.exit_scope(scope, handlers);
                     return boringssl_sys::SSL_TLSEXT_ERR_ALERT_FATAL;
                 }
             };
@@ -160,17 +158,13 @@ extern "C" fn select_alpn_callback(
                 tls_socket_functions::ffi::us_internal_ssl_loop_state_restore(
                     saved_loop_state.as_mut_ptr(),
                 );
-                if scope.exit() {
-                    this.handlers.set(None);
-                }
+                this.exit_scope(scope, handlers);
                 return boringssl_sys::SSL_TLSEXT_ERR_ALERT_FATAL;
             }
             tls_socket_functions::ffi::us_internal_ssl_loop_state_restore(
                 saved_loop_state.as_mut_ptr(),
             );
-            if scope.exit() {
-                this.handlers.set(None);
-            }
+            this.exit_scope(scope, handlers);
             if !result.is_boolean() || result.to_boolean() {
                 // The server has an ALPNCallback and it answered: a string
                 // selects that protocol for this connection; anything else
@@ -763,9 +757,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let global = handlers.global_object;
         let this_value = self.get_this_value(&global);
         let _ = handlers.call_error_handler(this_value, &[this_value, err_value]);
-        if scope.exit() {
-            self.handlers.set(None);
-        }
+        self.exit_scope(scope, handlers);
     }
 
     /// Noalias re-entrancy: takes `this: *mut Self`, NOT
@@ -840,9 +832,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if let Err(err) = callback.call(&global, this_value, &[this_value]) {
             let _ = handlers.call_error_handler(this_value, &[this_value, global.take_error(err)]);
         }
-        if scope.exit() {
-            this.handlers.set(None);
-        }
+        this.exit_scope(scope, handlers);
         this.deref();
     }
 
@@ -890,9 +880,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if let Err(err) = callback.call(&global, this_value, &[this_value]) {
             let _ = handlers.call_error_handler(this_value, &[this_value, global.take_error(err)]);
         }
-        if scope.exit() {
-            this.handlers.set(None);
-        }
+        this.exit_scope(scope, handlers);
     }
 
     /// Returns the raw, freely-aliased
@@ -919,6 +907,17 @@ impl<const SSL: bool> NewSocket<SSL> {
             .get()
             .expect("No handlers set on Socket")
             .into()
+    }
+
+    /// `scope.exit()` drains microtasks, during which a synchronous
+    /// reconnect may repoint `self.handlers` at a fresh allocation; only
+    /// null the cell when it still holds the `Handlers` that `exit` freed.
+    #[inline]
+    fn exit_scope(&self, scope: super::handlers::Scope, entered: bun_ptr::BackRef<Handlers>) {
+        let captured = entered.as_ptr();
+        if scope.exit() && self.handlers.get().map(|n| n.as_ptr()) == Some(captured) {
+            self.handlers.set(None);
+        }
     }
 
     /// `*mut Self` for the same noalias-reentry reason as `on_writable` —
@@ -1501,13 +1500,7 @@ impl<const SSL: bool> NewSocket<SSL> {
                 }
             }
         }
-        // Only null if the cell still points at the Handlers `exit()` just
-        // freed; a synchronous reconnect from inside the open callback
-        // repoints it at a fresh allocation (same guard as `on_close`).
-        let captured_handlers = handlers.as_ptr();
-        if scope.exit() && this.handlers.get().map(|n| n.as_ptr()) == Some(captured_handlers) {
-            this.handlers.set(None);
-        }
+        this.exit_scope(scope, handlers);
         this.deref();
     }
 
@@ -1577,9 +1570,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if let Err(err) = callback.call(&global, this_value, &[this_value]) {
             let _ = handlers.call_error_handler(this_value, &[this_value, global.take_error(err)]);
         }
-        if scope.exit() {
-            this.handlers.set(None);
-        }
+        this.exit_scope(scope, handlers);
         this.deref();
     }
 
@@ -1704,9 +1695,7 @@ impl<const SSL: bool> NewSocket<SSL> {
                     Err(e) => {
                         // `Scope` has no Drop — balance event_loop().enter() and
                         // active_connections before propagating.
-                        if scope.exit() {
-                            this.handlers.set(None);
-                        }
+                        this.exit_scope(scope, handlers);
                         return Err(e);
                     }
                 }
@@ -1725,9 +1714,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if let Some(err_value) = result.to_error() {
             let _ = handlers.call_error_handler(this_value, &[this_value, err_value]);
         }
-        if scope.exit() {
-            this.handlers.set(None);
-        }
+        this.exit_scope(scope, handlers);
         Ok(())
     }
 
@@ -1765,9 +1752,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let buffer = match JSValue::create_buffer_from_length(&global, session.len()) {
             Ok(b) => b,
             Err(e) => {
-                if scope.exit() {
-                    this.handlers.set(None);
-                }
+                this.exit_scope(scope, handlers);
                 return Err(e);
             }
         };
@@ -1785,9 +1770,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if let Some(err_value) = result.to_error() {
             let _ = handlers.call_error_handler(this_value, &[this_value, err_value]);
         }
-        if scope.exit() {
-            this.handlers.set(None);
-        }
+        this.exit_scope(scope, handlers);
         Ok(())
     }
 
@@ -1821,9 +1804,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let buffer = match JSValue::create_buffer_from_length(&global, line.len()) {
             Ok(b) => b,
             Err(e) => {
-                if scope.exit() {
-                    this.handlers.set(None);
-                }
+                this.exit_scope(scope, handlers);
                 return Err(e);
             }
         };
@@ -1841,9 +1822,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if let Some(err_value) = result.to_error() {
             let _ = handlers.call_error_handler(this_value, &[this_value, err_value]);
         }
-        if scope.exit() {
-            this.handlers.set(None);
-        }
+        this.exit_scope(scope, handlers);
         Ok(())
     }
 
@@ -2064,9 +2043,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if let Err(err) = callback.call(&global, this_value, &[this_value, output_value]) {
             let _ = handlers.call_error_handler(this_value, &[this_value, global.take_error(err)]);
         }
-        if scope.exit() {
-            this.handlers.set(None);
-        }
+        this.exit_scope(scope, handlers);
     }
 
     #[bun_jsc::host_fn(getter)]

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1209,16 +1209,17 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// slot is nulled before closing so the synchronous `on_close` /
     /// `on_connecting_error` dispatch early-returns and no JS callback fires;
     /// `mark_inactive`/`deref` balance the refs the previous `connect_finish`
-    /// took. Caller must hold an independent +1 across this call.
+    /// took. Caller must hold an independent +1 across this call. Only
+    /// handles Connected/Connecting; Pipe/UpgradedDuplex back-pointers do
+    /// not live in the ext slot so those are left for the caller's existing
+    /// `debug_assert!` to catch.
     pub fn detach_for_reconnect(&self) {
         let old = self.socket.get();
-        if old.is_detached() {
+        let Some(ext) = old.ext::<*mut c_void>() else {
             return;
-        }
-        if let Some(ext) = old.ext::<*mut c_void>() {
-            // SAFETY: ext slot is sized for `*mut c_void`; single-threaded.
-            unsafe { *ext = core::ptr::null_mut() };
-        }
+        };
+        // SAFETY: ext slot is sized for `*mut c_void`; single-threaded.
+        unsafe { *ext = core::ptr::null_mut() };
         self.socket.set(SocketHandler::<SSL>::DETACHED);
         self.buffered_data_for_node_net
             .with_mut(|b| b.clear_and_free());

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// `Socket.prototype.connect` on a socket that still has a live native handle
+// used to trip `debug_assert!(prev.socket.get().is_detached())` in
+// connect_finish (assert builds) and, on release builds, silently aliased two
+// native sockets onto one wrapper (the old us_socket_t's ext slot kept
+// pointing at the wrapper while `do_connect` overwrote `self.socket`).
+describe("socket.connect() on an already-connected socket", () => {
+  it("does not crash and emits connect for the new connection", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { createServer, connect } = require("node:net");
+          const srv = createServer(c => c.on("error", () => {})).listen(0, "127.0.0.1", () => {
+            const port = srv.address().port;
+            const s = connect(port, "127.0.0.1", () => {
+              process.stdout.write("first ");
+              s.once("connect", () => {
+                process.stdout.write("second");
+                s.destroy();
+                srv.close();
+              });
+              s.once("error", e => {
+                process.stdout.write("err:" + e.code);
+                srv.close();
+              });
+              s.connect(port, "127.0.0.1");
+            });
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "first second", exitCode: 0 });
+    expect(stderr).not.toContain("assertion failed");
+  });
+
+  it("does not crash when reconnecting while the first connect is still in flight", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { createServer, connect } = require("node:net");
+          const srv = createServer(c => c.on("error", () => {})).listen(0, "127.0.0.1", () => {
+            const port = srv.address().port;
+            const s = connect(port, "127.0.0.1");
+            // Second connect while the first is still connecting.
+            s.connect(port, "127.0.0.1");
+            s.once("connect", () => {
+              process.stdout.write("connect");
+              s.destroy();
+              srv.close();
+            });
+            s.once("error", e => {
+              process.stdout.write("err:" + e.code);
+              s.destroy();
+              srv.close();
+            });
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Node emits EALREADY here; Bun drops the first in-flight connect and
+    // completes the second. Either is acceptable so long as the process
+    // exits cleanly.
+    expect(exitCode).toBe(0);
+    expect(["connect", "err:EALREADY"]).toContain(stdout);
+    expect(stderr).not.toContain("assertion failed");
+  });
+});

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// `Socket.prototype.connect` on a socket that still has a live native handle
-// used to trip `debug_assert!(prev.socket.get().is_detached())` in
-// connect_finish (assert builds) and, on release builds, silently aliased two
-// native sockets onto one wrapper (the old us_socket_t's ext slot kept
-// pointing at the wrapper while `do_connect` overwrote `self.socket`).
+// connect_finish must tear down a still-live previous native socket before
+// reusing the wrapper, not alias two native sockets onto one ext slot.
 describe("socket.connect() on an already-connected socket", () => {
   it("does not crash and emits connect for the new connection", async () => {
     await using proc = Bun.spawn({

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -37,8 +37,7 @@ describe("socket.connect() on an already-connected socket", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({ stdout: "first second", exitCode: 0 });
-    expect(stderr).not.toContain("assertion failed");
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "first second", stderr, exitCode: 0 });
   });
 
   it("does not crash when reconnecting while the first connect is still in flight", async () => {
@@ -74,8 +73,7 @@ describe("socket.connect() on an already-connected socket", () => {
     // Node emits EALREADY here; Bun drops the first in-flight connect and
     // completes the second. Either is acceptable so long as the process
     // exits cleanly.
-    expect(exitCode).toBe(0);
     expect(["connect", "err:EALREADY"]).toContain(stdout);
-    expect(stderr).not.toContain("assertion failed");
+    expect({ stderr, exitCode }).toEqual({ stderr, exitCode: 0 });
   });
 });

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -3,7 +3,7 @@ import { bunEnv, bunExe } from "harness";
 
 // connect_finish must tear down a still-live previous native socket before
 // reusing the wrapper, not alias two native sockets onto one ext slot.
-describe("socket.connect() on an already-connected socket", () => {
+describe.concurrent("socket.connect() on an already-connected socket", () => {
   it("does not crash and emits connect for the new connection", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
### Repro

```js
import { createServer, connect } from "node:net";
const srv = createServer(() => {}).listen(0, "127.0.0.1", () => {
  const s = connect(srv.address().port, "127.0.0.1", () => {
    s.connect(srv.address().port, "127.0.0.1");   // second connect on a live socket
  });
});
```

Assert/debug builds:

```
panic: assertion failed: prev.socket.get().is_detached()
    bun_runtime::socket::listener::connect_finish (src/runtime/socket/Listener.rs:1494)
    Listener::connect_inner
    node_net_binding::do_connect
```

Release builds do not panic (the `debug_assert!` compiles out), so `do_connect` overwrites `self.socket` while the previous `us_socket_t`'s ext slot still points at the same `NewSocket`, aliasing two native sockets onto one wrapper.

### Cause

`connect_finish`'s reuse-previous-wrapper path is written for the reconnect-after-close case (MongoDB driver pattern), where `on_close` has already detached the native socket and cleared the lifecycle refs. `node:net` also allows `socket.connect()` on a socket that is still connected or mid-connect; Node reuses the same `uv_tcp_t` and lets `uv_tcp_connect` re-run on it, so there is no equivalent of a previous native socket to tear down. Bun's `do_connect` always creates a fresh uSockets socket, so the previous one has to be released first.

A secondary issue surfaced once the first is fixed: `on_open`'s `scope.exit()` drains microtasks, which is where the reconnect runs when issued from inside the `'connect'` listener. After the drain, `on_open` nulled `this.handlers` unconditionally, wiping the fresh `Handlers` that `connect_finish` had just installed, so the second connection's `on_open` early-returned on `handlers == None` and the socket never emitted `'connect'`. `on_close` already guards against this with a captured-handlers comparison.

### Fix

- `NewSocket::detach_for_reconnect`: when the wrapper still holds a live Connected/Connecting uSockets socket, null its ext slot (so the synchronous close dispatch early-returns without reaching JS), close it, and release the `ref_()`/`poll_ref`/`IS_ACTIVE` state the previous `connect_finish`/`on_open` established. Called from `connect_finish` before the existing `prev` setup runs. Pipe/UpgradedDuplex variants are left alone (their back-pointer is not the ext slot; the Windows named-pipe reuse arms keep their pre-existing `debug_assert!`).
- `on_open`: only null `this.handlers` after `scope.exit()` when it still points at the captured allocation, mirroring `on_close`.

### Verification

`test/js/node/net/socket-reconnect-live.test.ts` covers both the already-connected and still-connecting cases. Without the src/ change each subprocess hits the assertion panic above; with it both emit `'connect'` for the fresh connection and exit 0.

`test/js/node/net/net-mongodb-pattern-leak.test.ts` (reconnect-after-close, the path this reuse branch was written for) continues to pass.
