### PR TITLE
crash_handler: re-raise original signal instead of terminating with SIGILL

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -645,6 +645,29 @@ mod draft {
         OutOfMemory,
     }
 
+    impl CrashReason {
+        /// Signal to terminate the process with after the crash report has
+        /// been printed. Signal-originated crashes re-raise the original
+        /// fault so the parent process (and core-dump analyzers) see the
+        /// real cause instead of a misleading SIGILL/SIGTRAP from a trap
+        /// instruction; everything else (panics, OOM) uses SIGABRT.
+        #[cfg(unix)]
+        fn terminal_signal(&self) -> c_int {
+            match self {
+                CrashReason::SegmentationFault(_) => libc::SIGSEGV,
+                CrashReason::IllegalInstruction(_) => libc::SIGILL,
+                CrashReason::BusError(_) => libc::SIGBUS,
+                CrashReason::FloatingPointError(_) => libc::SIGFPE,
+                CrashReason::Panic(_)
+                | CrashReason::Unreachable
+                | CrashReason::DatatypeMisalignment
+                | CrashReason::StackOverflow
+                | CrashReason::ZigError(_)
+                | CrashReason::OutOfMemory => libc::SIGABRT,
+            }
+        }
+    }
+
     impl fmt::Display for CrashReason {
         fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
@@ -1302,7 +1325,7 @@ mod draft {
             }
         }
 
-        crash();
+        crash(reason);
     }
 
     /// This is called when `main` returns an error.
@@ -1913,7 +1936,7 @@ mod draft {
         // A Rust `panic!` is a bug. The process must not continue — with
         // `panic = "abort"` no unwind starts, so `catch_unwind` boundaries are
         // unreachable for Rust panics.
-        crash();
+        crash(reason);
     }
 
     /// Adapter for non-fatal `bun_core::dump_current_stack_trace` callers
@@ -2887,11 +2910,15 @@ mod draft {
     }
 
     /// Crash. Make sure segfault handlers are off so that this doesnt trigger the crash handler.
-    /// This causes a segfault on posix systems to try to get a core dump.
-    fn crash() -> ! {
+    /// On POSIX this re-raises the signal that caused the crash (or SIGABRT
+    /// for panics) so the parent sees the real fault and core dumps are
+    /// attributed correctly.
+    fn crash(reason: CrashReason) -> ! {
         #[cfg(not(windows))]
         {
-            // Install default handler so that the tkill below will terminate.
+            let sig = reason.terminal_signal();
+
+            // Install default handler so that the raise below will terminate.
             // bun_sys::posix has no Sigaction yet — use libc directly (async-signal-safe).
             // SAFETY: all-zero is a valid sigaction (handler = SIG_DFL = 0, flags = 0).
             let mut sigact: libc::sigaction = bun_core::ffi::zeroed();
@@ -2900,7 +2927,7 @@ mod draft {
             unsafe {
                 libc::sigemptyset(&raw mut sigact.sa_mask);
             }
-            for sig in [
+            for s in [
                 libc::SIGSEGV,
                 libc::SIGILL,
                 libc::SIGBUS,
@@ -2908,28 +2935,42 @@ mod draft {
                 libc::SIGFPE,
                 libc::SIGHUP,
                 libc::SIGTERM,
-                // The trap below raises SIGTRAP on aarch64 (`brk`), not the
-                // SIGILL of x86_64's `ud2`. If JS registered a SIGTRAP
-                // listener (`process.on("SIGTRAP")` — npm's `signal-exit`
-                // package does), the forwarding sigaction returns after
-                // enqueueing, the trap instruction re-executes, and the
-                // process spins in signal delivery forever instead of dying.
-                // Reset it so the first trap is lethal.
+                // Keep SIGTRAP reset so the `core::intrinsics::abort()`
+                // fallback (brk on aarch64) is lethal even when JS installed
+                // a SIGTRAP listener via `process.on("SIGTRAP")` (npm's
+                // `signal-exit` package does).
                 libc::SIGTRAP,
             ] {
                 // SAFETY: &sigact is a valid sigaction; null oldact is permitted.
                 unsafe {
-                    libc::sigaction(sig, &raw const sigact, core::ptr::null_mut());
+                    libc::sigaction(s, &raw const sigact, core::ptr::null_mut());
                 }
             }
-            // `core::intrinsics::abort()` lowers to a trap instruction —
-            // ud2 (x86_64 → SIGILL) / brk (aarch64 → SIGTRAP).
-            // Do NOT use `libc::abort()` here — that raises SIGABRT
-            // (exit 134), which is the *Windows* path's behaviour.
+
+            // We may be running inside the signal handler for `sig`, in which
+            // case the kernel added it to this thread's mask and a re-raise
+            // would sit pending forever. Unblock it (and SIGABRT for the
+            // fallback below). pthread_sigmask is async-signal-safe.
+            // SAFETY: zeroed sigset is valid; sigemptyset/sigaddset initialize it.
+            unsafe {
+                let mut set: libc::sigset_t = bun_core::ffi::zeroed();
+                libc::sigemptyset(&raw mut set);
+                libc::sigaddset(&raw mut set, sig);
+                libc::sigaddset(&raw mut set, libc::SIGABRT);
+                libc::pthread_sigmask(libc::SIG_UNBLOCK, &raw const set, core::ptr::null_mut());
+            }
+
+            // SAFETY: raise has no preconditions; with SIG_DFL installed and
+            // the signal unblocked this terminates the process.
+            unsafe {
+                libc::raise(sig);
+            }
+            // If we somehow get here, fall through to a guaranteed-fatal trap.
             core::intrinsics::abort();
         }
         #[cfg(windows)]
         {
+            let _ = reason;
             // Node.js exits with code 134 (128 + SIGABRT) instead. We use abort() as it
             // includes a breakpoint which makes crashes easier to debug.
             //

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2949,14 +2949,13 @@ mod draft {
 
             // We may be running inside the signal handler for `sig`, in which
             // case the kernel added it to this thread's mask and a re-raise
-            // would sit pending forever. Unblock it (and SIGABRT for the
-            // fallback below). pthread_sigmask is async-signal-safe.
+            // would sit pending forever. Unblock it so the raise below is
+            // delivered. pthread_sigmask is async-signal-safe.
             // SAFETY: zeroed sigset is valid; sigemptyset/sigaddset initialize it.
             unsafe {
                 let mut set: libc::sigset_t = bun_core::ffi::zeroed();
                 libc::sigemptyset(&raw mut set);
                 libc::sigaddset(&raw mut set, sig);
-                libc::sigaddset(&raw mut set, libc::SIGABRT);
                 libc::pthread_sigmask(libc::SIG_UNBLOCK, &raw const set, core::ptr::null_mut());
             }
 

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -477,9 +477,9 @@ impl<'a> Coordinator<'a> {
             // A worker dying mid-file is never silently retried. If a test
             // intentionally exits (process.exit) that file is marked failed
             // and the run continues in a fresh worker. If the worker was
-            // killed by a fatal signal — SIGILL/SIGTRAP from Bun's own panic
-            // handler, SIGSEGV/SIGBUS/SIGFPE from native code, SIGABRT from a
-            // JSC/WTF assertion — that's a Bun or addon bug and must not be
+            // killed by a fatal signal — SIGABRT from Bun's own panic handler
+            // or a JSC/WTF assertion, SIGSEGV/SIGBUS/SIGFPE/SIGILL from native
+            // code — that's a Bun or addon bug and must not be
             // masked by the rest of the suite passing: abort the whole run so
             // the exit status reflects the crash. SIGKILL is treated as a
             // regular failure (commonly the OOM killer or the user).
@@ -683,8 +683,9 @@ impl<'a> Coordinator<'a> {
 
 /// Fatal signals that indicate Bun itself (or a native addon) crashed,
 /// as opposed to the test calling process.exit() or being SIGKILL'd by
-/// the OOM killer. Bun's panic handler ends in @trap() → SIGILL on
-/// POSIX; JSC/WTF assertion failures abort() → SIGABRT. On Windows
+/// the OOM killer. Bun's panic handler re-raises the original fault
+/// (SIGSEGV/SIGBUS/SIGFPE/SIGILL) or SIGABRT for panics; JSC/WTF
+/// assertion failures abort() → SIGABRT. On Windows
 /// neither surfaces as a signal — abort() is exit code 3 and NTSTATUS
 /// fault codes arrive as a plain exit status, both indistinguishable
 /// from process.exit(N) — so this classification is effectively

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -37,14 +37,12 @@ test.if(isDebug && isLinux && hasSymbolizer)(
   60_000, // symbolizing the debug binary takes several seconds
 );
 
-// The crash handler's final trap raises SIGILL on x86_64 (ud2) but SIGTRAP on
-// aarch64 (brk). `crash()` resets trap-signal dispositions to SIG_DFL right
-// before trapping so that the first trap is lethal — SIGTRAP was missing from
-// that list. A JS-registered listener (`process.on("SIGTRAP")`, which npm's
-// widely-used signal-exit package installs) is backed by a real sigaction that
-// enqueues to the JS thread and returns; returning from a synchronous trap
-// re-executes the trap instruction, so on aarch64 a crashing process would
-// spin in signal delivery forever (pinning a core) instead of dying.
+// `crash()` resets fatal-signal dispositions to SIG_DFL before re-raising so
+// that JS-registered listeners (`process.on("SIGABRT")` etc., installed by
+// npm's widely-used signal-exit package) cannot swallow the termination. A
+// JS listener's backing sigaction enqueues to the JS thread and returns;
+// without the reset the process would survive the raise and fall through to
+// the trap fallback, which on aarch64 (brk → SIGTRAP) used to spin forever.
 test.if(isPosix)(
   "panic terminates the process even when JS registered trap-signal listeners",
   async () => {
@@ -54,6 +52,7 @@ test.if(isPosix)(
         "-e",
         `process.on("SIGTRAP", () => {});
          process.on("SIGILL", () => {});
+         process.on("SIGABRT", () => {});
          require("bun:internal-for-testing").crash_handler.panic();`,
         // Make debug builds take the fast trace-string path instead of
         // spawning llvm-symbolizer, which can take tens of seconds.
@@ -82,6 +81,41 @@ test.if(isPosix)(
   },
   20_000,
 );
+
+// After printing the crash report the handler must terminate with a signal
+// that reflects the crash cause: panics abort (SIGABRT), a caught fault is
+// re-raised as the original signal. Previously the handler ended in a trap
+// instruction (ud2 → SIGILL on x86_64, brk → SIGTRAP on aarch64) so shells
+// reported "illegal hardware instruction" for every crash and parent
+// processes could not distinguish a panic from a CPU/codegen fault.
+describe.if(isPosix)("terminal signal reflects the crash cause", () => {
+  test.each([
+    ["panic", "SIGABRT"],
+    ["outOfMemory", "SIGABRT"],
+    ["segfault", "SIGSEGV"],
+  ] as const)("%s terminates with %s", async (approach, expectedSignal) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        path.join(import.meta.dir, "fixture-crash.js"),
+        approach,
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (approach === "segfault") {
+      expect(stderr).toContain("Segmentation fault at address");
+    } else if (approach === "panic") {
+      expect(stderr).toContain("invoked crashByPanic() handler");
+    }
+    expect(proc.signalCode).toBe(expectedSignal);
+    expect(exitCode).not.toBe(0);
+    void stdout;
+  });
+});
 
 test.if(process.platform === "darwin")("macOS has the assumed image offset", () => {
   // If this fails, then https://bun.report will be incorrect and the stack


### PR DESCRIPTION
## Problem

After printing the crash report, Bun's panic handler terminated via `core::intrinsics::abort()`, which lowers to a trap instruction: `ud2` on x86_64 (SIGILL) and `brk` on aarch64 (SIGTRAP). So every crash, regardless of cause, looked like an illegal instruction to the parent:

```console
$ bun -e 'require("bun:internal-for-testing").crash_handler.panic()'
…
panic(main thread): invoked crashByPanic() handler
…
Illegal instruction (core dumped)
$ echo $?
132
```

Shells report "illegal hardware instruction", orchestrators see signal 4, and when the crash was a caught SIGSEGV the original fault is masked entirely. Users and tooling assume a CPU/codegen bug.

## Fix

`crash()` now takes the `CrashReason` and, on POSIX:

- Re-raises the original signal when the crash was signal-originated (`SIGSEGV` / `SIGILL` / `SIGBUS` / `SIGFPE`).
- Raises `SIGABRT` for panics, `unreachable`, OOM, and `main`-error crashes.

Before raising, the target signal and `SIGABRT` are unblocked via `pthread_sigmask(SIG_UNBLOCK, …)`: when running inside the handler for a signal (no `SA_NODEFER`), the kernel has it masked and a re-raise would sit pending forever. Dispositions are still reset to `SIG_DFL` first so JS-installed listeners (`process.on("SIGABRT")`, npm's `signal-exit`) cannot swallow the termination. `core::intrinsics::abort()` stays as the last-resort fallback after `raise()`.

All of `SIGABRT`/`SIGSEGV`/`SIGBUS`/`SIGFPE`/`SIGILL` have default action *core*, so core dumps are still produced. Windows is unchanged (`ExitProcess(3)`).

After:

```console
$ bun -e '…crash_handler.panic()'     # → SIGABRT, exit 134
$ bun -e '…crash_handler.segfault()'  # → SIGSEGV, exit 139
```

## Verification

New `describe("terminal signal reflects the crash cause")` in `test/cli/run/run-crash-handler.test.ts` spawns the crash fixture for `panic` / `outOfMemory` / `segfault` and asserts `signalCode` is `SIGABRT` / `SIGABRT` / `SIGSEGV` respectively. All three fail with `SIGILL` on the unfixed build.

The existing "panic terminates even with JS trap-signal listeners" test now also installs a `SIGABRT` listener to cover the new primary termination path.

`bun run rust:check-all`: 10/10 targets clean (Linux/macOS/Windows, x64/aarch64, musl, FreeBSD, Android).