### PR TITLE
http: never pool a proxy tunnel with a fatal TLS error or pending I/O

### DIFF
--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -670,6 +670,7 @@ unsafe extern "C" {
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
     pub fn SSL_do_handshake(ssl: *mut SSL) -> c_int;
     pub fn SSL_read(ssl: *mut SSL, buf: *mut c_void, num: c_int) -> c_int;
+    pub fn SSL_pending(ssl: *const SSL) -> c_int;
     pub fn SSL_write(ssl: *mut SSL, buf: *const c_void, num: c_int) -> c_int;
     pub fn SSL_shutdown(ssl: *mut SSL) -> c_int;
     pub fn SSL_get_error(ssl: *const SSL, ret_code: c_int) -> c_int;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3930,7 +3930,9 @@ impl<'a> HTTPClient<'a> {
                     && t.write_buffer.is_empty()
                     && t.wrapper
                         .as_ref()
-                        .map(|w| !w.is_shutdown())
+                        .map(|w| {
+                            !w.is_shutdown() && !w.flags.fatal_error() && !w.has_pending_data()
+                        })
                         .unwrap_or(false)
             } else {
                 true

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -158,7 +158,7 @@ pub mod ssl_wrapper {
             SSL_ERROR_SSL, SSL_ERROR_SYSCALL, SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE,
             SSL_ERROR_WANT_WRITE, SSL_ERROR_ZERO_RETURN, SSL_RECEIVED_SHUTDOWN, SSL_VERIFY_NONE,
             SSL_VERIFY_PEER, SSL_do_handshake, SSL_free, SSL_get_error, SSL_get_rbio,
-            SSL_get_shutdown, SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_read,
+            SSL_get_shutdown, SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_pending, SSL_read,
             SSL_renegotiate, SSL_set_accept_state, SSL_set_bio, SSL_set_connect_state,
             SSL_set_renegotiate_mode, SSL_set_verify, SSL_set0_verify_cert_store, SSL_shutdown,
             SSL_write, X509_STORE, X509_STORE_CTX, ssl_renegotiate_explicit, ssl_renegotiate_never,
@@ -672,12 +672,15 @@ pub mod ssl_wrapper {
             unsafe { boring_sys::BIO_ctrl_pending(boring_sys::SSL_get_wbio(ssl.as_ptr())) }
         }
 
-        /// Return if we have pending data to be read or write
+        /// Return if we have pending data to be read or write. Covers both
+        /// BIOs and `SSL_pending` — decrypted bytes of a partially-returned
+        /// record are buffered inside the SSL, invisible to either BIO.
         pub fn has_pending_data(&self) -> bool {
             let Some(ssl) = self.ssl else { return false };
             // SAFETY: ssl is a live SSL*; rbio/wbio bound in init_with_ctx.
             unsafe {
-                boring_sys::BIO_ctrl_pending(boring_sys::SSL_get_wbio(ssl.as_ptr())) > 0
+                boring_sys::SSL_pending(ssl.as_ptr()) > 0
+                    || boring_sys::BIO_ctrl_pending(boring_sys::SSL_get_wbio(ssl.as_ptr())) > 0
                     || boring_sys::BIO_ctrl_pending(boring_sys::SSL_get_rbio(ssl.as_ptr())) > 0
             }
         }

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1036,6 +1036,113 @@ test.skipIf(!isASAN)(
   },
 );
 
+test("response + corrupt TLS record in one packet via pooled HTTPS proxy tunnel does not use-after-free the client", async () => {
+  const fixture = `
+      const net = require("node:net");
+      const tlsCert = ${JSON.stringify({ cert: tlsCert.cert, key: tlsCert.key })};
+
+      const body = Buffer.alloc(4096, 0x42);
+      const origin = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: tlsCert,
+        socket: {
+          data(socket) {
+            socket.write("HTTP/1.1 200 OK\\r\\nContent-Length: 4096\\r\\nConnection: keep-alive\\r\\n\\r\\n");
+            socket.write(body);
+          },
+          error() {},
+        },
+      });
+
+      const poison = Buffer.alloc(64, 0x41);
+      const proxy = net.createServer(client => {
+        let upstream = null;
+        let clientFlights = 0;
+        let head = Buffer.alloc(0);
+        let held = Buffer.alloc(0);
+        let poisoned = false;
+        const tryFlush = () => {
+          let o = 0;
+          let hasResponseRecord = false;
+          while (o + 5 <= held.length) {
+            const len = held.readUInt16BE(o + 3);
+            if (o + 5 + len > held.length) return;
+            if (len >= 2048) hasResponseRecord = true;
+            o += 5 + len;
+          }
+          if (o !== held.length || !hasResponseRecord) return;
+          poisoned = true;
+          client.write(Buffer.concat([held, poison]));
+          held = Buffer.alloc(0);
+        };
+        client.on("error", () => {});
+        client.on("close", () => upstream?.destroy());
+        client.on("data", chunk => {
+          if (!upstream) {
+            head = Buffer.concat([head, chunk]);
+            const end = head.indexOf("\\r\\n\\r\\n");
+            if (end === -1) return;
+            const leftover = head.subarray(end + 4);
+            upstream = net.connect(origin.port, "127.0.0.1", () => {
+              client.write("HTTP/1.1 200 Connection Established\\r\\n\\r\\n");
+              if (leftover.length) upstream.write(leftover);
+            });
+            upstream.on("error", () => {});
+            upstream.on("data", data => {
+              if (poisoned) return;
+              if (clientFlights >= 2) {
+                held = Buffer.concat([held, data]);
+                tryFlush();
+              } else {
+                client.write(data);
+              }
+            });
+            return;
+          }
+          clientFlights++;
+          upstream.write(chunk);
+        });
+      });
+
+      proxy.listen(0, "127.0.0.1", async () => {
+        const res = await fetch("https://localhost:" + origin.port + "/", {
+          proxy: "http://127.0.0.1:" + proxy.address().port,
+          keepalive: true,
+          tls: { ca: tlsCert.cert, rejectUnauthorized: false },
+        });
+        const text = await res.text();
+        // a second round-trip can only complete if the HTTP client thread
+        // survived the first one; without it, process.exit(0) wins the race
+        // against the ASAN abort on that thread and the bug goes unobserved
+        const probe = await fetch("https://localhost:" + origin.port + "/", {
+          tls: { ca: tlsCert.cert, rejectUnauthorized: false },
+        });
+        await probe.bytes();
+        console.log(text.length, res.status, probe.status);
+        process.exit(0);
+      });
+    `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: {
+      ...bunEnv,
+      NO_PROXY: undefined,
+      no_proxy: undefined,
+      HTTP_PROXY: undefined,
+      http_proxy: undefined,
+      HTTPS_PROXY: undefined,
+      https_proxy: undefined,
+    },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error("stderr:", stderr);
+  expect(stdout).toBe("4096 200 200\n");
+  expect(exitCode).toBe(0);
+});
+
 // Sentry BUN-2V7Z: debug_assert!(!socket.is_shutdown()/is_closed()) in the
 // ProxyHeaders arm of on_writable (and the matching assert in
 // send_initial_request_payload) fired when the outer proxy socket died


### PR DESCRIPTION
### What does this PR do?

Fixes a use-after-free in the HTTP client's CONNECT proxy tunnel, caught by ASAN:

```
READ of size 8 at 0x61e00001fe80 thread T6
  #0 Option<RefPtr<ProxyTunnel>>::as_ref
  #1 proxy_tunnel::on_close            ProxyTunnel.rs:525
  #2 SSLWrapper::trigger_close_callback uws/lib.rs:833
  #3 SSLWrapper::handle_reading         uws/lib.rs:1053
  ...
freed by thread T6 here (same stack, same `handle_reading` call):
  #5 AsyncHTTP::on_async_http_callback_raw            AsyncHTTP.rs:819
  #7 HTTPClient::send_progress_update_without_stage_check
  #9 proxy_tunnel::on_data              ProxyTunnel.rs:350
  #11 SSLWrapper::trigger_data_callback uws/lib.rs:824
  #12 SSLWrapper::handle_reading        uws/lib.rs:1046
```

`SSLWrapper::handle_reading` flushes pending decrypted bytes to the data callback, then runs the close callback, guarded only by `closed_notified`:

1. The flushed data callback completes a keep-alive response through the tunnel. A fatal TLS record error sets only `fatal_error` — none of the shutdown flags — so the wrapper passed `tunnel_poolable`'s `!is_shutdown()` check and the tunnel was handed to the keep-alive pool. Nothing called `wrapper.shutdown()`, so `closed_notified` was never latched. Dispatching the final result then freed the `ThreadlocalAsyncHTTP` that embeds the `HTTPClient`.
2. The guard (`ssl.is_none() || closed_notified()`) passes.
3. `trigger_close_callback()` invokes `on_close(handlers.ctx)` with `ctx` pointing at the freed client.

The pooling branch is the only terminal path that doesn't go through `close_proxy_tunnel(true)` → `wrapper.shutdown()` → `closed_notified`, which is the latch the read loop relies on. `SSLWrapper::shutdown` already special-cases the *close_notify* flavor of this for exactly that reason; the fatal-error flavor never reaches `shutdown()`.

The fix is one predicate: a tunnel whose wrapper has a fatal error or pending unconsumed input/output is not poolable. That routes it through the orderly teardown that latches `closed_notified`, and the pending-I/O half closes the same hole for a tunnel pooled from a mid-loop data callback while more decrypted bytes or queued output remain. Both are also required for the pool to be correct on its own terms — a poisoned or dirty TLS session must not be handed to the next request.

### How did you verify your code works?

New regression test in `test/js/bun/http/proxy.test.ts` (next to the existing close_notify sibling): an HTTPS keep-alive response through a CONNECT proxy with a corrupt TLS record appended to the same TCP burst, followed by a second request that can only complete if the HTTP client thread survived the first.

Against an unfixed ASAN debug build the fixture aborts every run:

```
==20981==ERROR: AddressSanitizer: heap-use-after-free on address 0x61e00001fe80
READ of size 8 at 0x61e00001fe80 thread T6
...
exit=134
```

With this change it prints `4096 200 200` and exits 0 with no ASAN report. `test/js/bun/http/proxy.test.ts` (49/49), `fetch-proxy-connect-tunnel-split-envelope.test.ts`, `fetch-proxy-tls-intern-race.test.ts`, and `fetch-keepalive.test.ts` all pass.