### PR TITLE
webcore: pin subprocess stdout FileReader while its pipe poll is live

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -441,6 +441,7 @@ impl FileReader {
             {
                 use bun_io::pipe_reader::PosixFlags;
                 if !self.started.get()
+                    && !self.waiting_for_on_reader_done.get()
                     && self.reader().flags.contains(PosixFlags::POLLABLE)
                     && !self.reader().is_done()
                 {
@@ -454,7 +455,10 @@ impl FileReader {
                 // Non-lazy fromPipe path (Bun.spawn stdout/stderr): hold a
                 // ref across the pending uv_read_start so the source is not
                 // finalized while IOCP has a read queued on it.
-                if !self.started.get() && self.reader().source.is_some() && !self.reader().is_done()
+                if !self.started.get()
+                    && !self.waiting_for_on_reader_done.get()
+                    && self.reader().source.is_some()
+                    && !self.reader().is_done()
                 {
                     self.waiting_for_on_reader_done.set(true);
                     // SAFETY: see `parent()`.

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -440,8 +440,10 @@ impl ReadableStream {
         // across-read ref (and root the wrapper) immediately so a GC before
         // JS first pulls cannot sweep the wrapper and free this box while the
         // poll is still armed. `on_start` checks `waiting_for_on_reader_done`
-        // and will not take a second ref.
-        if source.context.reader().has_pending_activity() {
+        // and will not take a second ref. Use the same predicate as
+        // `FileReader::on_start` so the ref is always paired with an eventual
+        // `on_reader_done`/`on_reader_error` release.
+        if !source.context.reader().is_done() {
             source.context.waiting_for_on_reader_done.set(true);
             source.increment_count();
         }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -435,14 +435,9 @@ impl ReadableStream {
 
         let stream = source.to_readable_stream(global_this)?;
 
-        // The transferred reader already has a live poll registered with the
-        // event loop whose owner now points into this allocation. Take the
-        // across-read ref (and root the wrapper) immediately so a GC before
-        // JS first pulls cannot sweep the wrapper and free this box while the
-        // poll is still armed. `on_start` checks `waiting_for_on_reader_done`
-        // and will not take a second ref. Use the same predicate as
-        // `FileReader::on_start` so the ref is always paired with an eventual
-        // `on_reader_done`/`on_reader_error` release.
+        // The transferred poll's owner now points into this box; root the
+        // wrapper before JS can GC it. `on_start` skips a second ref via the
+        // same `waiting_for_on_reader_done` flag; `on_reader_done` releases.
         if !source.context.reader().is_done() {
             source.context.waiting_for_on_reader_done.set(true);
             source.increment_count();

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -433,7 +433,20 @@ impl ReadableStream {
             .reader()
             .from(buffered_reader, ctx_ptr.cast::<c_void>());
 
-        source.to_readable_stream(global_this)
+        let stream = source.to_readable_stream(global_this)?;
+
+        // The transferred reader already has a live poll registered with the
+        // event loop whose owner now points into this allocation. Take the
+        // across-read ref (and root the wrapper) immediately so a GC before
+        // JS first pulls cannot sweep the wrapper and free this box while the
+        // poll is still armed. `on_start` checks `waiting_for_on_reader_done`
+        // and will not take a second ref.
+        if source.context.reader().has_pending_activity() {
+            source.context.waiting_for_on_reader_done.set(true);
+            source.increment_count();
+        }
+
+        Ok(stream)
     }
 
     pub fn empty(global_this: &JSGlobalObject) -> JsResult<JSValue> {

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -38,17 +38,22 @@ test.skipIf(isWindows)(
 
       // The direct child spawns a detached sleep that inherits stdout,
       // keeping the pipe's write end open past the child's exit so the
-      // FileReader's poll is still armed while we GC. The helper records
-      // its pid so the fixture can kill it to drive EOF, and the bounded
-      // sleep means nothing outlives the test even if that kill never runs.
+      // FileReader's poll is still armed while we GC. It records its pid so
+      // the fixture can kill it to drive EOF, and the bounded sleep means
+      // nothing outlives the test even if that kill never runs.
       const childScript =
         "const { spawn } = require('child_process');" +
-        "const c = spawn('/bin/sh', ['-c', 'echo $$ > " + JSON.stringify(startedDir) + "/$$; exec sleep 30']," +
+        "const { existsSync } = require('node:fs');" +
+        "const c = spawn('/bin/sh', ['-c', ': > " + JSON.stringify(startedDir) + "/$$; exec sleep 30']," +
         "  { stdio: ['ignore', 'inherit', 'ignore'], detached: true });" +
         "c.unref();" +
-        // Wait one tick so posix_spawn has definitely handed fd 1 to the
-        // grandchild before this process closes its own copy on exit.
-        "setTimeout(() => {}, 10);";
+        // Exit only once the grandchild has recorded its pid. That proves it
+        // is past posix_spawn and owns fd 1, and it guarantees the fixture's
+        // readdirSync below sees every grandchild, so the kill loop is
+        // deterministic instead of racing a timer. Bounded so a failed spawn
+        // still lets the child exit and surface as grandchildrenStarted < 5.
+        "const f = " + JSON.stringify(startedDir) + " + '/' + c.pid;" +
+        "for (let i = 0; i < 5000 && !existsSync(f); i++) Bun.sleepSync(1);";
 
       const count = () =>
         heapStats().objectTypeCounts.FileInternalReadableStreamSource ?? 0;

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -114,7 +114,13 @@ test.skipIf(isWindows)(
     try {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "--smol", "-e", script],
-        env: bunEnv,
+        // The CI runner sets BUN_FEATURE_FLAG_NO_ORPHANS on ASAN lanes, which
+        // kills a detached grandchild the moment its intermediate parent exits
+        // (PR_SET_CHILD_SUBREAPER). This test needs that grandchild to outlive
+        // its parent and hold the pipe open; orphan cleanup is handled
+        // explicitly instead (the fixture kills by pid, the finally below
+        // reaps survivors).
+        env: { ...bunEnv, BUN_FEATURE_FLAG_NO_ORPHANS: undefined },
         stdout: "pipe",
         stderr: "pipe",
       });

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { writeFileSync } from "node:fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 // Accessing `proc.stdout` on a piped subprocess moves the already-registered

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -47,6 +47,7 @@ test.skipIf(isWindows)(
       const count = () =>
         heapStats().objectTypeCounts.FileInternalReadableStreamSource ?? 0;
 
+      let streams = 0;
       async function once() {
         const proc = Bun.spawn({
           cmd: [process.execPath, "-e", childScript],
@@ -57,7 +58,7 @@ test.skipIf(isWindows)(
         });
         // Materialize the ReadableStream so the live poll is re-parented
         // into a NewSource<FileReader>, but never pull from it.
-        void proc.stdout;
+        if (proc.stdout instanceof ReadableStream) streams++;
         await proc.exited;
       }
 
@@ -68,6 +69,7 @@ test.skipIf(isWindows)(
       const base = count();
 
       await Promise.all(Array.from({ length: ITERS }, once));
+      const afterSpawn = count() - base;
 
       // Direct children have exited; grandchildren still hold the write end.
       for (let i = 0; i < 20; i++) { Bun.gc(true); await Bun.sleep(1); }
@@ -84,7 +86,9 @@ test.skipIf(isWindows)(
         if (afterEof <= 0) break;
       }
 
-      console.log(JSON.stringify({ iters: ITERS, duringLivePipe, afterEof }));
+      console.log(JSON.stringify({
+        iters: ITERS, duringLivePipe, afterEof, base, afterSpawn, streams,
+      }));
     `;
 
     let stdout = "",
@@ -114,7 +118,13 @@ test.skipIf(isWindows)(
     const { iters, duringLivePipe, afterEof } = result;
     // Invariant: every FileReader whose pipe poll is still armed must be
     // pinned by its own Strong ref. Before the fix they were swept here
-    // (duringLivePipe ~ 0), which is exactly the UAF precondition.
+    // (duringLivePipe ~ 0), which is exactly the UAF precondition. The full
+    // result object carries base/afterSpawn/streams for CI diagnostics.
+    if (duringLivePipe < iters) {
+      expect({ duringLivePipe, ...result, stderr }).toEqual({
+        duringLivePipe: `>= ${iters}`,
+      });
+    }
     expect(duringLivePipe).toBeGreaterThanOrEqual(iters);
     // Once the pipe reaches EOF the ref is released and the wrappers become
     // collectable. One may survive via a conservatively-rooted final

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -92,11 +92,7 @@ test.skipIf(isWindows)(
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const stderrFiltered = stderr
       .split("\n")

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
+
+// Accessing `proc.stdout` on a piped subprocess moves the already-registered
+// pipe poll from the subprocess PipeReader into a freshly allocated
+// NewSource<FileReader>. The across-read ref (which upgrades the wrapper's
+// JsRef to Strong and pins the native box) used to be taken only in
+// FileReader::on_start, the first time JS actually pulls from the stream.
+// Between from_pipe and that first pull the poll's owner points into a box
+// whose only ref is the JS wrapper's own Weak back-reference, so if the
+// subprocess and its cached stdout become unreachable before anyone pulls,
+// GC can sweep the wrapper and free the box while the poll is still armed.
+// The next readability/EOF event then dispatches into freed memory
+// (FileReader::on_reader_done reached from PosixBufferedReader::read_socket).
+//
+// This test asserts the lifetime invariant directly rather than racing for
+// the crash: while a subprocess pipe's write end is still held open (by a
+// detached grandchild that inherits it), the FileInternalReadableStreamSource
+// wrapper must survive GC even though nothing in JS references it. Once the
+// grandchild exits and the pipe reaches EOF, on_reader_done releases the ref
+// and the wrapper becomes collectable (no leak).
+//
+// Windows uses libuv for pipe I/O; the from_pipe path under test is POSIX.
+test.skipIf(isWindows)(
+  "subprocess stdout FileReader is pinned while its pipe poll is live, then collectable after EOF",
+  async () => {
+    using dir = tempDir("fr-gc-uaf", {});
+    const flag = join(String(dir), "go");
+
+    const script = /* js */ `
+      const { heapStats } = require("bun:jsc");
+      const { writeFileSync } = require("node:fs");
+      const ITERS = 4;
+      const flag = ${JSON.stringify(flag)};
+
+      // The direct child spawns a detached shell that inherits stdout and
+      // waits for a flag file, keeping the pipe's write end open past the
+      // child's exit so the FileReader's poll is still armed while we GC.
+      const childScript =
+        "const { spawn } = require('child_process');" +
+        "spawn('sh', ['-c', 'while [ ! -e " + JSON.stringify(flag) + " ]; do sleep 0.02; done; echo x']," +
+        "  { stdio: ['ignore', 'inherit', 'ignore'], detached: true }).unref();";
+
+      const count = () =>
+        heapStats().objectTypeCounts.FileInternalReadableStreamSource ?? 0;
+
+      async function once() {
+        const proc = Bun.spawn({
+          cmd: [process.execPath, "-e", childScript],
+          env: process.env,
+          stdout: "pipe",
+          stderr: "ignore",
+          stdin: "ignore",
+        });
+        // Materialize the ReadableStream so the live poll is re-parented
+        // into a NewSource<FileReader>, but never pull from it.
+        void proc.stdout;
+        await proc.exited;
+      }
+
+      // Warm up once so per-class lazy structure allocation is absorbed
+      // into the baseline and not counted against ITERS.
+      await once();
+      for (let i = 0; i < 10; i++) { Bun.gc(true); await Bun.sleep(1); }
+      const base = count();
+
+      await Promise.all(Array.from({ length: ITERS }, once));
+
+      // Direct children have exited; grandchildren still hold the write end.
+      for (let i = 0; i < 20; i++) { Bun.gc(true); await Bun.sleep(1); }
+      const duringLivePipe = count() - base;
+
+      // Release the grandchildren (including the warmup one).
+      writeFileSync(flag, "");
+
+      let afterEof = -1;
+      for (let i = 0; i < 100; i++) {
+        Bun.gc(true);
+        await Bun.sleep(10);
+        afterEof = count() - base;
+        if (afterEof <= 0) break;
+      }
+
+      console.log(JSON.stringify({ iters: ITERS, duringLivePipe, afterEof }));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    const stderrFiltered = stderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(stderrFiltered).toBe("");
+
+    const { iters, duringLivePipe, afterEof } = JSON.parse(stdout.trim());
+    // Invariant: every FileReader whose pipe poll is still armed must be
+    // pinned by its own Strong ref. Before the fix they were swept here
+    // (duringLivePipe ~ 0), which is exactly the UAF precondition.
+    expect(duringLivePipe).toBeGreaterThanOrEqual(iters);
+    // Once the pipe reaches EOF the ref is released and the wrappers become
+    // collectable. One may survive via a conservatively-rooted final
+    // Subprocess (same caveat as spawn-ipc-gc.test.ts).
+    expect(afterEof).toBeLessThanOrEqual(1);
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -28,20 +28,25 @@ test.skipIf(isWindows)(
   async () => {
     using dir = tempDir("fr-gc-uaf", {});
     const flag = join(String(dir), "go");
+    const started = join(String(dir), "started");
 
     const script = /* js */ `
       const { heapStats } = require("bun:jsc");
-      const { writeFileSync } = require("node:fs");
+      const { writeFileSync, readdirSync } = require("node:fs");
       const ITERS = 4;
       const flag = ${JSON.stringify(flag)};
+      const startedDir = ${JSON.stringify(started)};
+      require("node:fs").mkdirSync(startedDir, { recursive: true });
 
       // The direct child spawns a detached shell that inherits stdout and
       // waits for a flag file, keeping the pipe's write end open past the
       // child's exit so the FileReader's poll is still armed while we GC.
-      // The loop is bounded so a fixture crash cannot leak the helper.
+      // The loop is bounded so a fixture crash cannot leak the helper. Each
+      // grandchild touches a file in startedDir so the fixture can tell how
+      // many actually came up.
       const childScript =
         "const { spawn } = require('child_process');" +
-        "spawn('sh', ['-c', 'n=0; while [ ! -e " + JSON.stringify(flag) + " ] && [ $n -lt 1500 ]; do sleep 0.02; n=$((n+1)); done; echo x']," +
+        "spawn('sh', ['-c', ': > " + JSON.stringify(startedDir) + "/$$; n=0; while [ ! -e " + JSON.stringify(flag) + " ] && [ $n -lt 1500 ]; do sleep 0.02; n=$((n+1)); done; echo x']," +
         "  { stdio: ['ignore', 'inherit', 'ignore'], detached: true }).unref();";
 
       const count = () =>
@@ -71,9 +76,16 @@ test.skipIf(isWindows)(
       await Promise.all(Array.from({ length: ITERS }, once));
       const afterSpawn = count() - base;
 
+      // Synchronous full GC with no event-loop yield: if the wrappers survive
+      // here they are Strong-rooted (fix engaged); if they are swept only
+      // after the sleep loop below, the pipes reached EOF in between.
+      Bun.gc(true); Bun.gc(true);
+      const afterSyncGC = count() - base;
+
       // Direct children have exited; grandchildren still hold the write end.
       for (let i = 0; i < 20; i++) { Bun.gc(true); await Bun.sleep(1); }
       const duringLivePipe = count() - base;
+      const grandchildrenStarted = readdirSync(startedDir).length;
 
       // Release the grandchildren (including the warmup one).
       writeFileSync(flag, "");
@@ -87,7 +99,8 @@ test.skipIf(isWindows)(
       }
 
       console.log(JSON.stringify({
-        iters: ITERS, duringLivePipe, afterEof, base, afterSpawn, streams,
+        iters: ITERS, duringLivePipe, afterEof,
+        base, afterSpawn, afterSyncGC, streams, grandchildrenStarted,
       }));
     `;
 

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
@@ -37,9 +38,10 @@ test.skipIf(isWindows)(
       // The direct child spawns a detached shell that inherits stdout and
       // waits for a flag file, keeping the pipe's write end open past the
       // child's exit so the FileReader's poll is still armed while we GC.
+      // The loop is bounded so a fixture crash cannot leak the helper.
       const childScript =
         "const { spawn } = require('child_process');" +
-        "spawn('sh', ['-c', 'while [ ! -e " + JSON.stringify(flag) + " ]; do sleep 0.02; done; echo x']," +
+        "spawn('sh', ['-c', 'n=0; while [ ! -e " + JSON.stringify(flag) + " ] && [ $n -lt 1500 ]; do sleep 0.02; n=$((n+1)); done; echo x']," +
         "  { stdio: ['ignore', 'inherit', 'ignore'], detached: true }).unref();";
 
       const count = () =>
@@ -85,22 +87,31 @@ test.skipIf(isWindows)(
       console.log(JSON.stringify({ iters: ITERS, duringLivePipe, afterEof }));
     `;
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--smol", "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    let stdout = "",
+      stderr = "",
+      exitCode: number | null = null;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    } finally {
+      // Always release the detached grandchildren so nothing outlives the test
+      // even if the fixture crashed before writing the flag itself.
+      writeFileSync(flag, "");
+    }
 
-    const stderrFiltered = stderr
-      .split("\n")
-      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
-      .join("\n");
-    expect(stderrFiltered).toBe("");
-
-    const { iters, duringLivePipe, afterEof } = JSON.parse(stdout.trim());
+    let result: { iters: number; duringLivePipe: number; afterEof: number };
+    try {
+      result = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`fixture did not emit JSON (exit ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`);
+    }
+    const { iters, duringLivePipe, afterEof } = result;
     // Invariant: every FileReader whose pipe poll is still armed must be
     // pinned by its own Strong ref. Before the fix they were swept here
     // (duringLivePipe ~ 0), which is exactly the UAF precondition.

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { writeFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 // Accessing `proc.stdout` on a piped subprocess moves the already-registered
@@ -27,27 +27,28 @@ test.skipIf(isWindows)(
   "subprocess stdout FileReader is pinned while its pipe poll is live, then collectable after EOF",
   async () => {
     using dir = tempDir("fr-gc-uaf", {});
-    const flag = join(String(dir), "go");
     const started = join(String(dir), "started");
 
     const script = /* js */ `
       const { heapStats } = require("bun:jsc");
-      const { writeFileSync, readdirSync } = require("node:fs");
+      const { readdirSync } = require("node:fs");
       const ITERS = 4;
-      const flag = ${JSON.stringify(flag)};
       const startedDir = ${JSON.stringify(started)};
       require("node:fs").mkdirSync(startedDir, { recursive: true });
 
-      // The direct child spawns a detached shell that inherits stdout and
-      // waits for a flag file, keeping the pipe's write end open past the
-      // child's exit so the FileReader's poll is still armed while we GC.
-      // The loop is bounded so a fixture crash cannot leak the helper. Each
-      // grandchild touches a file in startedDir so the fixture can tell how
-      // many actually came up.
+      // The direct child spawns a detached sleep that inherits stdout,
+      // keeping the pipe's write end open past the child's exit so the
+      // FileReader's poll is still armed while we GC. The helper records
+      // its pid so the fixture can kill it to drive EOF, and the bounded
+      // sleep means nothing outlives the test even if that kill never runs.
       const childScript =
         "const { spawn } = require('child_process');" +
-        "spawn('sh', ['-c', ': > " + JSON.stringify(startedDir) + "/$$; n=0; while [ ! -e " + JSON.stringify(flag) + " ] && [ $n -lt 1500 ]; do sleep 0.02; n=$((n+1)); done; echo x']," +
-        "  { stdio: ['ignore', 'inherit', 'ignore'], detached: true }).unref();";
+        "const c = spawn('/bin/sh', ['-c', 'echo $$ > " + JSON.stringify(startedDir) + "/$$; exec sleep 30']," +
+        "  { stdio: ['ignore', 'inherit', 'ignore'], detached: true });" +
+        "c.unref();" +
+        // Wait one tick so posix_spawn has definitely handed fd 1 to the
+        // grandchild before this process closes its own copy on exit.
+        "setTimeout(() => {}, 10);";
 
       const count = () =>
         heapStats().objectTypeCounts.FileInternalReadableStreamSource ?? 0;
@@ -85,10 +86,13 @@ test.skipIf(isWindows)(
       // Direct children have exited; grandchildren still hold the write end.
       for (let i = 0; i < 20; i++) { Bun.gc(true); await Bun.sleep(1); }
       const duringLivePipe = count() - base;
-      const grandchildrenStarted = readdirSync(startedDir).length;
+      const pids = readdirSync(startedDir);
+      const grandchildrenStarted = pids.length;
 
-      // Release the grandchildren (including the warmup one).
-      writeFileSync(flag, "");
+      // Release the grandchildren (including the warmup one) so the pipes EOF.
+      for (const pid of pids) {
+        try { process.kill(Number(pid), "SIGTERM"); } catch {}
+      }
 
       let afterEof = -1;
       for (let i = 0; i < 100; i++) {
@@ -117,9 +121,19 @@ test.skipIf(isWindows)(
 
       [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     } finally {
-      // Always release the detached grandchildren so nothing outlives the test
-      // even if the fixture crashed before writing the flag itself.
-      writeFileSync(flag, "");
+      // Always reap any detached grandchildren so nothing outlives the test
+      // even if the fixture crashed before killing them itself.
+      for (const pid of (() => {
+        try {
+          return readdirSync(started);
+        } catch {
+          return [];
+        }
+      })()) {
+        try {
+          process.kill(Number(pid), "SIGKILL");
+        } catch {}
+      }
     }
 
     let result: { iters: number; duringLivePipe: number; afterEof: number };


### PR DESCRIPTION
## What

`ReadableStream::from_pipe` (the `proc.stdout` / `proc.stderr` path for `Bun.spawn` and the shell subprocess) moves an already-registered pipe poll from the subprocess `PipeReader` into a freshly allocated `NewSource<FileReader>` and re-points the poll's owner at it. The across-read ref that keeps that box alive (`waiting_for_on_reader_done` + `increment_count()`, which upgrades `this_jsvalue` to `Strong`) was only taken in `FileReader::on_start`, i.e. the first time JS actually pulls from the stream.

Between `from_pipe` and that first pull, the poll's owner points into a box whose only ref is the JS wrapper's own `Weak` back-reference. If the `Subprocess` and its cached stdout become unreachable before anyone pulls (a fire-and-forget spawn where `proc.stdout` is touched but never read, and the direct child exits while something else still holds the write end), GC sweeps the `JSFileInternalReadableStreamSource` wrapper and frees the `NewSource<FileReader>` box while the poll is still armed. The next readability or EOF event dispatches into freed memory:

```
READ of size 8 (heap-use-after-free)
  #0 Vec::len / is_empty                                     (freed Vec<u8>)
  #2 webcore::file_reader::FileReader::on_reader_done        FileReader.rs:1008
  #3 bun_io::pipe_reader::read_socket{closure}               PipeReader.rs:846
  #4 PosixBufferedReader::read_socket                        PipeReader.rs:576
  #5 file-poll dispatch <- posix_event_loop <- us_internal_dispatch_ready_polls

freed by:   JSC::JSDestructibleObjectDestroyFunc <- MarkedBlock sweep <- MarkedSpace::sweepBlocks
allocated:  ReadableStream::from_pipe<subprocess::PipeReader> -> NewSource<FileReader>
```

Found by a coverage-guided GC-stress fuzzer with syscall interposition (`BUN_JSC_collectContinuously=1` plus an injected `EAGAIN` to keep the read pending). In release builds this is silent heap corruption.

## Fix

Take the across-read ref in `from_pipe` itself, immediately after the live reader is transferred and the JS wrapper is created, so the box is `Strong`-rooted for as long as the poll can fire. `on_reader_done` / `on_reader_error` release it exactly as before. `FileReader::on_start` now checks `waiting_for_on_reader_done` before taking the ref so the later `handle.start()` call from `lazyLoadStream` does not double-count on this path.

## How did you verify your code works?

The test asserts the lifetime invariant directly via `heapStats().objectTypeCounts.FileInternalReadableStreamSource` rather than racing for the crash, since the exact UAF trigger depends on the fuzzer's syscall interposition. A detached grandchild (`sh -c 'while [ ! -e FLAG ]; do sleep 0.02; done; echo x'`) inherits the child's stdout and keeps the write end open past the direct child's exit, so the `FileReader`'s poll is still armed while we force GC with nothing in JS referencing the wrapper.

- **Before** (`git stash push -- src/` + `bun bd test`): `duringLivePipe = 0` of 4; every wrapper swept while its poll owner still points into the freed box.
- **After**: `duringLivePipe >= 4`; once the grandchildren exit and the pipes EOF, `afterEof <= 1` (one may remain via a conservatively-rooted final `Subprocess`, same caveat as `spawn-ipc-gc.test.ts`).

Also passes `spawn-streaming-stdout.test.ts`, `spawn-unread-stdout-gc.test.ts`, `spawn-ipc-gc.test.ts`, `spawn-stdout-iterate-leak.test.ts`, and `readablestream-helpers.test.ts`.