### PR TITLE
verify-baseline: allowlist llint_op_enter_wide32 data-in-.text false positive

### DIFF
--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -966,3 +966,21 @@ _ZN9bun_image9N_AVX3_DLL18NearestPaletteImplEPKhjiiii  [AVX]
 _ZN9bun_image9N_AVX3_DLL8VertPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VNNI, BMI1, FMA]
 _ZN9bun_image9N_AVX3_DLL9FlipHImplEPKhmmPh  [AVX, AVX2, AVX512F]
 _ZN9bun_image9N_AVX3_DLL9HorizPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL, AVX512_VNNI]
+
+
+# ----------------------------------------------------------------------------
+# JSC LLInt. Data-in-.text false positive, NOT a gate.
+#
+# ENABLE(LLINT_EMBEDDED_OPCODE_ID) is on for x86_64 (WTF/wtf/PlatformEnable.h),
+# so every LLInt opcode handler starts with a raw 4-byte ".int <opcode_id>"
+# (LowLevelInterpreter.cpp: EMBED_OPCODE_ID_IF_NEEDED). The linear-sweep
+# decoder desyncs on those embedded ints and, depending on how preceding .text
+# code aligns, can decode a stray VEX-encoded instruction out of the garbage.
+# offlineasm's x86 backend emits SSE2 (not VEX), and the Intel SDE Nehalem
+# emulation step in this same job exercises the LLInt and passes, so any
+# single-digit hit here is decode noise. Ceiling [AVX] so a multi-feature leak
+# still fails. On ELF each opcode handler has its own symbol, so layout shifts
+# can move the desync between llint_op_* siblings; add them here as they trip.
+# (1 symbol)
+# ----------------------------------------------------------------------------
+llint_op_enter_wide32  [AVX]


### PR DESCRIPTION
The Linux x64 baseline static instruction scan is reporting a single AVX hit:

```
llint_op_enter_wide32  [AVX]  (1 insns)
    0x000166e969  Vcvtsd2ss  (AVX)
```

This is a data-in-.text false positive from the linear-sweep decoder, not a real AVX leak.

### Why it is a false positive

- `ENABLE(LLINT_EMBEDDED_OPCODE_ID)` is on for x86_64 (`WTF/wtf/PlatformEnable.h:1050`), so every LLInt opcode handler is prefixed with a raw 4-byte `.int <opcode_id>` via `EMBED_OPCODE_ID_IF_NEEDED` in `LowLevelInterpreter.cpp`. With hundreds of handlers, the linear-sweep disassembler periodically desyncs on those data words and decodes a stray VEX encoding out of the resynced byte stream.
- `llint_op_enter_wide32` is `noWide(llint_op_enter)` which expands to a single `call _llint_crash`; it contains no floating point at all.
- offlineasm's x86 backend emits the SSE2 mnemonic `cvtsd2ss` (`offlineasm/x86.rb:1218`), never the VEX form, and GAS does not promote SSE mnemonics to VEX.
- The reported address `0x166e969` is misaligned for a function entry, consistent with a desynced decode.
- The Windows allowlist already carries the same suppression as `llint_entry [AVX]` (on PE the whole LLInt lives under one symbol); on ELF each handler has its own symbol so the desync surfaces per `llint_op_*`.
- The Intel SDE Nehalem emulation step in the same CI job exercises the LLInt and passes.

### Fix

Add `llint_op_enter_wide32  [AVX]` to `scripts/verify-baseline-static/allowlist-x64.txt` under a new "JSC LLInt data-in-.text" group mirroring the Windows entry. The `[AVX]` ceiling keeps the check sensitive: if a real multi-feature leak (AVX2/AVX512/BMI) ever lands in this symbol, the scan still fails.

Verified the allowlist parses cleanly with the built scanner.