### PR TITLE
install: compare stored scope name and folder path, not just their hash

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -211,7 +211,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.
 
 use crate::lockfile_real::package as Package;
 use crate::package_manager_task as Task;
-use crate::resolvers::folder_resolver::FolderResolution;
+use crate::resolvers::folder_resolver::{Entry as FolderResolutionEntry, FolderResolution};
 use bun_install::lockfile::{self, Lockfile};
 use bun_install::{
     Dependency, DependencyID, Features, NetworkTask, PackageID, PackageManifestMap,
@@ -314,7 +314,7 @@ type ResolveTaskQueue = UnboundedQueue<Task::Task<'static> /* , .next */>;
 
 type RepositoryMap = HashMap<Task::Id, Fd /* , IdentityContext<Task::Id>, 80 */>;
 pub(crate) type FolderResolutionMap =
-    HashMap<u64, FolderResolution /* , IdentityContext<u64>, 80 */>;
+    HashMap<u64, FolderResolutionEntry /* , IdentityContext<u64>, 80 */>;
 pub(crate) type NpmAliasMap =
     HashMap<PackageNameHash, crate::dependency::Version /* , IdentityContext<u64>, 80 */>;
 
@@ -2072,7 +2072,10 @@ pub fn init(
         // SAFETY: singleton fully initialized; main thread, no workers yet.
         unsafe { &mut *manager_ptr }.folders.put(
             crate::resolvers::folder_resolver::hash(normalized),
-            crate::resolvers::folder_resolver::FolderResolution::PackageId(0),
+            FolderResolutionEntry {
+                abs_path: Box::<[u8]>::from(&*normalized),
+                resolution: FolderResolution::PackageId(0),
+            },
         )?;
         // normalized.deinit() → Drop (stack buffer)
     }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -240,11 +240,14 @@ impl Options {
         if name.is_empty() || name[0] != b'@' {
             return &self.scope;
         }
-        self.registries
-            .get(&Npm::registry::Scope::hash(Npm::registry::Scope::get_name(
-                name,
-            )))
-            .unwrap_or(&self.scope)
+        let scope_name = Npm::registry::Scope::get_name(name);
+        // Compare the stored scope name, not just its hash: a different scope
+        // whose hash collides must not inherit this scope's registry or token.
+        // Fall back to the default registry on a mismatch.
+        match self.registries.get(&Npm::registry::Scope::hash(scope_name)) {
+            Some(scope) if *scope.name == *scope_name => scope,
+            _ => &self.scope,
+        }
     }
 }
 

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -82,9 +82,18 @@ impl<'a> fmt::Display for PackageWorkspaceSearchPathFormatter<'a> {
     }
 }
 
+/// Value stored in the folder-resolution map: the resolution plus the
+/// normalized absolute `package.json` path the key hash was computed from.
+/// Lookups compare the path, since a different path whose hash collides must
+/// not reuse this resolution.
+pub struct Entry {
+    pub abs_path: Box<[u8]>,
+    pub resolution: FolderResolution,
+}
+
 // bun_collections::HashMap currently ignores the context/load-factor
 // type params (backed by std HashMap); identity hashing is a TODO(perf).
-pub type Map = HashMap<u64, FolderResolution, IdentityContext<u64>>;
+pub type Map = HashMap<u64, Entry, IdentityContext<u64>>;
 
 pub(crate) fn normalize(path: &[u8]) -> &[u8] {
     FileSystem::instance().normalize(path)
@@ -418,10 +427,14 @@ pub fn get_or_put(
     let abs_hash = hash(abs.as_bytes());
 
     // Check first, compute, then insert, because read_package_json_from_disk
-    // needs &mut manager.
-    if let Some(existing) = manager.folders.get(&abs_hash) {
-        return *existing;
-    }
+    // needs &mut manager. Compare the stored path, not just its hash: a
+    // different path whose hash collides must not reuse this resolution. On a
+    // collision, resolve fresh without caching so the first path's entry stays.
+    let hash_collision = match manager.folders.get(&abs_hash) {
+        Some(existing) if *existing.abs_path == *abs.as_bytes() => return existing.resolution,
+        Some(_) => true,
+        None => false,
+    };
 
     let result: Result<LockfilePackage, bun_core::Error> = match global_or_relative {
         GlobalOrRelative::Global(_) => 'global: {
@@ -487,13 +500,27 @@ pub fn get_or_put(
             } else {
                 FolderResolution::Err(err)
             };
-            manager.folders.insert(abs_hash, stored);
+            if !hash_collision {
+                manager.folders.insert(
+                    abs_hash,
+                    Entry {
+                        abs_path: abs.as_bytes().into(),
+                        resolution: stored,
+                    },
+                );
+            }
             return stored;
         }
     };
 
-    manager
-        .folders
-        .insert(abs_hash, FolderResolution::PackageId(package.meta.id));
+    if !hash_collision {
+        manager.folders.insert(
+            abs_hash,
+            Entry {
+                abs_path: abs.as_bytes().into(),
+                resolution: FolderResolution::PackageId(package.meta.id),
+            },
+        );
+    }
     FolderResolution::NewPackageId(package.meta.id)
 }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -18,6 +18,7 @@ import {
   toHaveBins,
 } from "harness";
 import { join, resolve, sep } from "path";
+import { realpathSync } from "fs";
 import {
   createTestContext,
   destroyTestContext,
@@ -27,6 +28,7 @@ import {
   setContextHandler,
   type TestContext,
 } from "./dummy.registry.js";
+import { constructStdCollision } from "./wyhash-std-collision.js";
 
 expect.extend({
   toBeWorkspaceLink,
@@ -9704,4 +9706,61 @@ it("does not create a cache index entry outside the cache directory for a depend
   expect(errOk).not.toContain("error:");
   expect(outOk).toContain("1 package installed");
   expect(exitCodeOk).toBe(0);
+});
+
+// Two distinct local `file:` dependencies whose absolute package.json paths
+// collide under the seed-0 std.Wyhash that keys the folder-resolution dedupe
+// map must each resolve to their own package, not share one identity.
+// https://github.com/oven-sh/bun/issues/32741
+it.skipIf(isWindows)("file: deps with colliding abs-path hashes resolve to distinct packages", async () => {
+  using dir = tempDir("folder-resolution-collision", {
+    "package.json": JSON.stringify({ name: "victim", version: "0.0.0" }),
+  });
+  // Use the canonical path so the folder resolver hashes the same bytes we
+  // construct the collision from (macOS /tmp -> /private/var symlink, etc.).
+  const victimDir = realpathSync(String(dir));
+  const prefix = `${victimDir}/`;
+  const suffix = "/package.json";
+
+  const collision = constructStdCollision({ seed: 0n, prefixStr: prefix, suffixStr: suffix });
+  const name1 = collision.str1.slice(prefix.length, collision.str1.length - suffix.length);
+  const name2 = collision.str2.slice(prefix.length, collision.str2.length - suffix.length);
+
+  // Confirm the collision holds against the exact hash the resolver uses before
+  // relying on it (Bun.hash.wyhash == bun.hash seed 0 == FolderResolution key).
+  const abs1 = `${victimDir}/${name1}/package.json`;
+  const abs2 = `${victimDir}/${name2}/package.json`;
+  expect(name1).not.toBe(name2);
+  expect(name1.includes("/")).toBe(false);
+  expect(name2.includes("/")).toBe(false);
+  expect(Bun.hash.wyhash(abs1, 0n)).toBe(Bun.hash.wyhash(abs2, 0n));
+
+  await write(join(victimDir, name1, "package.json"), JSON.stringify({ name: "pkg-alpha", version: "1.0.0" }));
+  await write(join(victimDir, name1, "index.js"), "module.exports = 'ALPHA';");
+  await write(join(victimDir, name2, "package.json"), JSON.stringify({ name: "pkg-beta", version: "2.0.0" }));
+  await write(join(victimDir, name2, "index.js"), "module.exports = 'BETA';");
+  await write(
+    join(victimDir, "package.json"),
+    JSON.stringify({
+      name: "victim",
+      version: "0.0.0",
+      dependencies: { alphadep: `file:./${name1}`, betadep: `file:./${name2}` },
+    }),
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: victimDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  // Each alias must carry its own package's identity despite the hash collision.
+  const alpha = await file(join(victimDir, "node_modules", "alphadep", "package.json")).json();
+  const beta = await file(join(victimDir, "node_modules", "betadep", "package.json")).json();
+  expect({ alpha: alpha.name, beta: beta.name }).toEqual({ alpha: "pkg-alpha", beta: "pkg-beta" });
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,6 +1,6 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
-import { readlinkSync } from "fs";
+import { readlinkSync, realpathSync } from "fs";
 import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
@@ -18,7 +18,6 @@ import {
   toHaveBins,
 } from "harness";
 import { join, resolve, sep } from "path";
-import { realpathSync } from "fs";
 import {
   createTestContext,
   destroyTestContext,

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1,7 +1,7 @@
 import { write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { rm } from "fs/promises";
-import { VerdaccioRegistry, bunExe, bunEnv as env, stderrForInstall } from "harness";
+import { VerdaccioRegistry, bunExe, bunEnv as env, stderrForInstall, tempDir } from "harness";
 import { join } from "path";
 const { iniInternals } = require("bun:internal-for-testing");
 const { loadNpmrc } = iniInternals;
@@ -492,5 +492,84 @@ registry=https://somehost.com/org1/npm/registry/
     expect(result.default_registry_url).toEqual("https://somehost.com/org1/npm/registry/");
     // Should be empty since there's no matching token for /org1/npm/registry/
     expect(result.default_registry_token).toBe("");
+  });
+});
+
+describe("scoped registry routing", () => {
+  // A request for a @scope package must be sent only to that scope's configured
+  // registry with that scope's token. The registry map was keyed by a bare
+  // Wyhash11 hash of the scope name, so a different scope whose name hashed to
+  // the same value would overwrite it and silently inherit its registry + token.
+  // https://github.com/oven-sh/bun/issues/32741
+  test("does not route to a hash-colliding scope's registry or token", async () => {
+    // scopeA and scopeB collide under Bun's internal scope-name hash
+    // (Wyhash11(0) == 0xd2c80616f46b9bf2) but are distinct strings.
+    const scopeA = "cuxk74rj1jlebf5o-cigmevrqk5-74swpkgcollapkgcollbaaaaaaaa8k0b-p2s";
+    const scopeB = "cuxk74rj1jlebf5o-cigmevrqk5-74swpkgcollapkgcollbbbbbbbbb8k0b-p2s";
+
+    type Req = { path: string; auth: string | null };
+    const reqsA: Req[] = [];
+    const reqsB: Req[] = [];
+    const notFound = () =>
+      new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+
+    await using serverA = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        reqsA.push({ path: new URL(req.url).pathname, auth: req.headers.get("authorization") });
+        return notFound();
+      },
+    });
+    await using serverB = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        reqsB.push({ path: new URL(req.url).pathname, auth: req.headers.get("authorization") });
+        return notFound();
+      },
+    });
+
+    const portA = serverA.port;
+    const portB = serverB.port;
+    const urlA = `http://127.0.0.1:${portA}/`;
+    const urlB = `http://127.0.0.1:${portB}/`;
+
+    // scopeA is declared first, so scopeB's colliding entry overwrites it in the
+    // hash-keyed registry map. The default registry also points at A so that a
+    // correct fallback stays offline instead of reaching the public registry.
+    using dir = tempDir("npmrc-scope-collision", {
+      ".npmrc":
+        `registry=${urlA}\n` +
+        `@${scopeA}:registry=${urlA}\n` +
+        `//127.0.0.1:${portA}/:_authToken=scope-A-SECRET-token\n` +
+        `@${scopeB}:registry=${urlB}\n` +
+        `//127.0.0.1:${portB}/:_authToken=scope-B-SECRET-token\n`,
+      "package.json": JSON.stringify({
+        name: "victim",
+        version: "0.0.0",
+        dependencies: { [`@${scopeA}/probe`]: "^1.0.0" },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-cache"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // The install fails (probe does not exist); we only care where it asked.
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).not.toBe(0);
+
+    // scopeB's registry must never see the @scopeA/probe request, and must
+    // never be handed scopeB's secret token for it.
+    expect(reqsB).toEqual([]);
+    // The request must have been attempted against scopeA's own registry.
+    expect(reqsA.some(r => r.path.includes("probe"))).toBe(true);
   });
 });

--- a/test/cli/install/wyhash-std-collision.ts
+++ b/test/cli/install/wyhash-std-collision.ts
@@ -1,0 +1,180 @@
+// Helper for constructing Zig std.hash.Wyhash (== `Bun.hash.wyhash` == the
+// `bun.hash` seed-0 function used to key the folder-resolution dedupe map)
+// collisions at runtime. Two inputs that share a prefix aligned to a 48-byte
+// round boundary and an identical tail, differing only in a "free" 8-byte word,
+// hash identically because one round lane is driven to a zero operand. Callers
+// must self-verify the returned pair against `Bun.hash.wyhash` before relying
+// on it. Ported from the reporter's proof of concept for
+// https://github.com/oven-sh/bun/issues/32741.
+
+const MASK = (1n << 64n) - 1n;
+const M128 = (1n << 128n) - 1n;
+const SECRET = [0xa0761d6478bd642fn, 0xe7037ed1a0b428dbn, 0x8ebc6af09c88c6e3n, 0x589965cc75374cc3n];
+
+function mumLoHi(a: bigint, b: bigint) {
+  const x = (a * b) & M128;
+  return { lo: x & MASK, hi: (x >> 64n) & MASK };
+}
+function mix(a: bigint, b: bigint): bigint {
+  const { lo, hi } = mumLoHi(a & MASK, b & MASK);
+  return (lo ^ hi) & MASK;
+}
+function read(n: number, data: Uint8Array, off: number): bigint {
+  let r = 0n;
+  for (let i = 0; i < n; i++) r |= BigInt(data[off + i]) << BigInt(8 * i);
+  return r;
+}
+function initState0(seed: bigint): bigint {
+  seed &= MASK;
+  return (seed ^ mix((seed ^ SECRET[0]) & MASK, SECRET[1])) & MASK;
+}
+function wyhashStd(seed: bigint, bytes: Uint8Array): bigint {
+  seed = BigInt(seed) & MASK;
+  const len = bytes.length;
+  const s0 = initState0(seed);
+  const state = [s0, s0, s0];
+  let a = 0n;
+  let b = 0n;
+  if (len <= 16) {
+    if (len >= 4) {
+      const end = len - 4;
+      const quarter = (len >> 3) << 2;
+      a = ((read(4, bytes, 0) << 32n) | read(4, bytes, quarter)) & MASK;
+      b = ((read(4, bytes, end) << 32n) | read(4, bytes, end - quarter)) & MASK;
+    } else if (len > 0) {
+      a = ((BigInt(bytes[0]) << 16n) | (BigInt(bytes[len >> 1]) << 8n) | BigInt(bytes[len - 1])) & MASK;
+      b = 0n;
+    }
+  } else {
+    let i = 0;
+    if (len >= 48) {
+      while (i + 48 < len) {
+        for (let j = 0; j < 3; j++) {
+          const av = read(8, bytes, i + 16 * j);
+          const bv = read(8, bytes, i + 16 * j + 8);
+          state[j] = mix((av ^ SECRET[j + 1]) & MASK, (bv ^ state[j]) & MASK);
+        }
+        i += 48;
+      }
+      state[0] = (state[0] ^ state[1] ^ state[2]) & MASK;
+    }
+    let k = i;
+    while (k + 16 < len) {
+      state[0] = mix((read(8, bytes, k) ^ SECRET[1]) & MASK, (read(8, bytes, k + 8) ^ state[0]) & MASK);
+      k += 16;
+    }
+    a = read(8, bytes, len - 16);
+    b = read(8, bytes, len - 8);
+  }
+  a = (a ^ SECRET[1]) & MASK;
+  b = (b ^ state[0]) & MASK;
+  const { lo, hi } = mumLoHi(a, b);
+  return mix((lo ^ SECRET[0] ^ BigInt(len)) & MASK, (hi ^ SECRET[1]) & MASK);
+}
+function roundsOver(seed: bigint, bytes: Uint8Array, count: number): bigint[] {
+  const s0 = initState0(BigInt(seed) & MASK);
+  const state = [s0, s0, s0];
+  for (let r = 0; r < count; r++) {
+    const off = r * 48;
+    for (let j = 0; j < 3; j++) {
+      const av = read(8, bytes, off + 16 * j);
+      const bv = read(8, bytes, off + 16 * j + 8);
+      state[j] = mix((av ^ SECRET[j + 1]) & MASK, (bv ^ state[j]) & MASK);
+    }
+  }
+  return state;
+}
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const u64le = (v: bigint) => {
+  const b = new Uint8Array(8);
+  for (let i = 0; i < 8; i++) b[i] = Number((v >> BigInt(8 * i)) & 0xffn);
+  return b;
+};
+
+// Build two byte arrays of the form `${prefixStr}<steerable bytes>${suffixStr}`
+// that collide under std.Wyhash(seed). The steerable region stays within
+// `charset` so it remains a valid path component.
+export function constructStdCollision(opts: {
+  seed?: bigint;
+  prefixStr: string;
+  suffixStr: string;
+  charset?: string;
+  freeA?: string;
+  freeB?: string;
+  padFillCh?: string;
+  maxSteer?: number;
+}): { bytes1: Uint8Array; bytes2: Uint8Array; str1: string; str2: string; hash: bigint } {
+  const {
+    seed = 0n,
+    prefixStr,
+    suffixStr,
+    // A wider charset means the derived kill word lands in-set sooner, so the
+    // search needs fewer iterations. Every char here is valid in a `file:` dep
+    // folder name (verified) and round-trips through a JS string.
+    charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=+,.~@!()[]{}^&$;'",
+    freeA = "AAAAAAAA",
+    freeB = "BBBBBBBB",
+    padFillCh = "x",
+    maxSteer = 5_000_000,
+  } = opts;
+  if (freeA.length !== 8 || freeB.length !== 8) throw new Error("free words must be 8 bytes");
+  const csBytes = [...charset].map(c => c.charCodeAt(0));
+  const inSet = new Set(csBytes);
+  const padCode = padFillCh.charCodeAt(0);
+  const prefix = enc(prefixStr);
+  const suffix = enc(suffixStr);
+  const basePad = (48 - (prefix.length % 48)) % 48;
+  const lane12 = enc("klmnopqrstuvwxyzABCDEFGHIJKLMNOP");
+  const steerTail = enc("qrstuvwxyzABCDEFGHIJKLMNOPqrstuv");
+
+  // `prefix + pad` is aligned to a 48-byte boundary, so its rounds are fixed
+  // across the search. Process them once and vary only the steer round whose
+  // lane-0 output (state[0]) becomes the required "kill" word. Recomputing just
+  // that one lane per candidate keeps the search allocation-free and fast.
+  const baseBlock = new Uint8Array(prefix.length + basePad);
+  baseBlock.set(prefix, 0);
+  baseBlock.fill(padCode, prefix.length);
+  const baseState0 = roundsOver(seed, baseBlock, baseBlock.length / 48)[0];
+
+  const steer = new Uint8Array(48);
+  steer.set(steerTail, 16);
+  for (let extra = 0; extra < maxSteer; extra++) {
+    let t = extra;
+    for (let i = 0; i < 8; i++) {
+      steer[i] = csBytes[t % csBytes.length];
+      t = Math.floor(t / csBytes.length);
+    }
+    for (let i = 8; i < 16; i++) steer[i] = csBytes[(i * 7 + extra) % csBytes.length];
+    // state[0] after the steer round; == the kill word the control lane needs.
+    const state0 = mix((read(8, steer, 0) ^ SECRET[1]) & MASK, (read(8, steer, 8) ^ baseState0) & MASK);
+    const killBytes = u64le(state0);
+    if (!killBytes.every(bb => inSet.has(bb))) continue;
+
+    const preBlock = new Uint8Array(baseBlock.length + 48);
+    preBlock.set(baseBlock, 0);
+    preBlock.set(steer, baseBlock.length);
+    const total = preBlock.length + 48 + suffix.length;
+    const build = (free: string) => {
+      const out = new Uint8Array(total);
+      out.set(preBlock, 0);
+      out.set(enc(free), preBlock.length);
+      out.set(killBytes, preBlock.length + 8);
+      out.set(lane12, preBlock.length + 16);
+      out.set(suffix, preBlock.length + 48);
+      return out;
+    };
+    const b1 = build(freeA);
+    const b2 = build(freeB);
+    if (wyhashStd(seed, b1) === wyhashStd(seed, b2) && Buffer.compare(Buffer.from(b1), Buffer.from(b2)) !== 0) {
+      return {
+        bytes1: b1,
+        bytes2: b2,
+        str1: new TextDecoder().decode(b1),
+        str2: new TextDecoder().decode(b2),
+        hash: wyhashStd(seed, b1),
+      };
+    }
+  }
+  throw new Error("failed to steer kill word in-charset within budget");
+}


### PR DESCRIPTION
Fixes two install-path sites from #32741 where a fixed-seed non-cryptographic hash is used as an identity key with no comparison of the bytes it was computed from, so a constructed hash collision confuses two distinct inputs. Both follow the store-the-bytes-and-compare invariant established by #31218 for `trustedDependencies`.

The headline of the report (trustedDependencies lifecycle-script RCE) is already fixed on main by #31218 and is not touched here.

## 1. Scoped-registry token leak

The registry map is keyed by `Scope::hash(scope_name)` (Wyhash11) and `scope_for_package_name` returned whatever scope sat in that slot without checking the name. Two scope names that collide overwrite each other, so a request for one scope was routed to the other scope's registry with the other scope's token.

```jsonc
// .npmrc: scopeA and scopeB collide under Scope::hash (== 0xd2c80616f46b9bf2)
@cuxk...aaaaaaaa...p2s:registry=http://registryA/   // token scope-A-SECRET
@cuxk...bbbbbbbbb...p2s:registry=http://registryB/  // token scope-B-SECRET
// package.json depends only on @cuxk...aaaaaaaa...p2s/probe
```

Before this change, installing `@scopeA/probe` sent the request to registry B with `Authorization: Bearer scope-B-SECRET-token`.

Fix: compare the stored `scope.name` against the requested scope, and fall back to the default registry on a mismatch.

## 2. Folder-resolution package confusion

`FolderResolution::get_or_put` keyed its dedupe map on `hash(absolute_package_json_path)` (seed-0 Wyhash) and stored only a package id. Two local `file:` dependencies whose absolute `package.json` paths collide shared one entry, so the second dependency resolved to the first package's contents:

```
node_modules/alphadep -> pkg-alpha 1.0.0
node_modules/betadep  -> pkg-alpha 1.0.0   // expected pkg-beta 2.0.0
```

Fix: store the absolute path alongside the resolution and compare it on lookup; on a hash collision, resolve fresh without evicting the existing entry.

## Scope

The same "hash as identity, no byte comparison" pattern exists in a few other install maps from the report (remote tarball URL dedup via `Task::Id`, `PackageNameHash`). Those are lower severity (they need the attacker to control both colliding remote URLs, or they fail loudly with a duplicate-dependency error) and touch a shared identity type, so they are left for a focused follow-up rather than widening this change.

## Verification

Both tests fail on the unfixed build and pass with the fix.

- `test/cli/install/npmrc.test.ts` stands up two in-process registries, configures the colliding scopes, and asserts the colliding scope's registry never receives the request or its token.
- `test/cli/install/bun-install.test.ts` constructs the path collision at runtime (self-verified against `Bun.hash.wyhash`, which is the exact function keying the map) and asserts each `file:` dependency keeps its own identity. Gated to POSIX.

```
$ bun bd test test/cli/install/npmrc.test.ts -t "hash-colliding"
(pass) scoped registry routing > does not route to a hash-colliding scope's registry or token

$ bun bd test test/cli/install/bun-install.test.ts -t "colliding abs-path"
(pass) file: deps with colliding abs-path hashes resolve to distinct packages
```
