### PR TITLE
AbortSignal: emit write barrier when storing abort reason

### DIFF
--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -122,7 +122,7 @@ JSValue AbortSignal::jsReason(JSC::JSGlobalObject& globalObject)
         if (m_commonReason != CommonAbortReason::None) {
             existingValue = toJS(&globalObject, m_commonReason);
             m_commonReason = CommonAbortReason::None;
-            m_reason.setWeakly(existingValue);
+            m_reason.set(globalObject.vm(), wrapper(), existingValue);
         }
     }
 
@@ -159,10 +159,11 @@ void AbortSignal::markAborted(JSC::JSValue reason)
     applyFlags(static_cast<uint8_t>(AbortSignalFlags::Aborted) | static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners));
     m_sourceSignals.clear();
 
-    // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
-    // https://bugs.webkit.org/show_bug.cgi?id=236353
     ASSERT(reason);
-    m_reason.setWeakly(reason);
+    if (auto* context = scriptExecutionContext())
+        m_reason.set(context->vm(), wrapper(), reason);
+    else
+        m_reason.setWeakly(reason);
 
     cancelTimer();
 }

--- a/src/jsc/bindings/webcore/JSAbortController.cpp
+++ b/src/jsc/bindings/webcore/JSAbortController.cpp
@@ -242,10 +242,30 @@ void JSAbortController::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     addWebCoreOpaqueRoot(visitor, thisObject->wrapped().opaqueRoot());
-    thisObject->wrapped().signal().reason().visit(visitor);
+    thisObject->visitAdditionalChildrenInGCThread(visitor);
 }
 
 DEFINE_VISIT_CHILDREN(JSAbortController);
+
+template<typename Visitor>
+void JSAbortController::visitOutputConstraints(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSAbortController>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitOutputConstraints(thisObject, visitor);
+    thisObject->visitAdditionalChildrenInGCThread(visitor);
+}
+
+template void JSAbortController::visitOutputConstraints(JSCell*, AbstractSlotVisitor&);
+template void JSAbortController::visitOutputConstraints(JSCell*, SlotVisitor&);
+
+template<typename Visitor>
+void JSAbortController::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    wrapped().signal().reason().visit(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAbortController);
 
 void JSAbortController::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {

--- a/src/jsc/bindings/webcore/JSAbortController.h
+++ b/src/jsc/bindings/webcore/JSAbortController.h
@@ -58,7 +58,9 @@ public:
     }
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm);
     DECLARE_VISIT_CHILDREN;
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
+    template<typename Visitor> static void visitOutputConstraints(JSCell*, Visitor&);
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
 protected:

--- a/src/jsc/bindings/webcore/JSValueInWrappedObject.h
+++ b/src/jsc/bindings/webcore/JSValueInWrappedObject.h
@@ -98,7 +98,8 @@ inline void JSValueInWrappedObject::setWeakly(JSC::JSValue value)
 inline void JSValueInWrappedObject::set(JSC::VM& vm, const JSC::JSCell* owner, JSC::JSValue value)
 {
     setWeakly(value);
-    vm.writeBarrier(owner, value);
+    if (owner)
+        vm.writeBarrier(owner, value);
 }
 
 inline void JSValueInWrappedObject::clear()

--- a/test/js/web/abort/abort-controller-gc-reason.test.ts
+++ b/test/js/web/abort/abort-controller-gc-reason.test.ts
@@ -10,12 +10,9 @@ describe("AbortController GC", () => {
   test.skipIf(isWindows)(
     "reason is marked across concurrent GC (write barrier / output constraint)",
     async () => {
-      // verifyGC re-marks the world single-threaded at the end of each cycle
-      // and asserts on any reachable cell the real concurrent collector left
-      // unmarked. Before the fix, the abort reason was stored via setWeakly()
-      // with no write barrier and JSAbortController had no visitOutputConstraints,
-      // so a controller.abort(err) that ran after the controller was already
-      // scanned left the Error unmarked.
+      // verifyGC asserts on reachable cells the concurrent collector missed.
+      // Before the fix, abort() after the controller was scanned stored the
+      // reason with no write barrier / output constraint, leaving it unmarked.
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),

--- a/test/js/web/abort/abort-controller-gc-reason.test.ts
+++ b/test/js/web/abort/abort-controller-gc-reason.test.ts
@@ -1,9 +1,67 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 // https://bugs.webkit.org/show_bug.cgi?id=293319
 // AbortController.signal.reason is lost after garbage collection
 describe("AbortController GC", () => {
+  // https://bugs.webkit.org/show_bug.cgi?id=236353
+  // verifyGC + collectContinuously is prohibitively slow under Windows CI and
+  // the code path under test is platform-independent.
+  test.skipIf(isWindows)(
+    "reason is marked across concurrent GC (write barrier / output constraint)",
+    async () => {
+      // verifyGC re-marks the world single-threaded at the end of each cycle
+      // and asserts on any reachable cell the real concurrent collector left
+      // unmarked. Before the fix, the abort reason was stored via setWeakly()
+      // with no write barrier and JSAbortController had no visitOutputConstraints,
+      // so a controller.abort(err) that ran after the controller was already
+      // scanned left the Error unmarked.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const controllers = [];
+            for (let iter = 0; iter < 500; iter++) {
+              const c = new AbortController();
+              controllers.push(c);
+              const garbage = [];
+              for (let j = 0; j < 50; j++) garbage.push({ a: j, b: new Array(10).fill(j) });
+              c.abort(new Error("reason-" + iter));
+            }
+            let lost = 0;
+            for (const c of controllers) {
+              if (!(c.signal.reason instanceof Error)) lost++;
+            }
+            console.log("PASS lost=" + lost);
+          `,
+        ],
+        env: {
+          ...bunEnv,
+          BUN_JSC_verifyGC: "1",
+          BUN_JSC_collectContinuously: "1",
+          // `bun -e` sets numberOfGCMarkers=1 for one-shot startup, which
+          // serializes marking and hides the race. Restore parallel marking.
+          BUN_JSC_numberOfGCMarkers: "8",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // On failure verifyGC prints "GC Verifier: ERROR cell ... was not marked"
+      // to stderr and aborts before stdout is reached. stderr is included for
+      // diagnostics only; debug/ASAN builds may emit benign warnings there.
+      expect({ stdout: stdout.trim(), exitCode, stderr }).toEqual({
+        stdout: "PASS lost=0",
+        exitCode: 0,
+        stderr: expect.not.stringContaining("was not marked"),
+      });
+    },
+    120_000,
+  );
+
   test("signal.reason survives GC when only controller is retained", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
## Problem

`AbortSignal::markAborted` stored `m_reason` via `JSValueInWrappedObject::setWeakly()` without emitting a write barrier (the old code had a `FIXME` admitting it). `JSAbortController::visitChildren` visits `signal().reason()` but had no `visitOutputConstraints`, so once the concurrent collector had already scanned a controller, a later `controller.abort(err)` on the mutator thread was invisible to the GC: the controller was never rescanned and the `Error` passed as the reason was left unmarked.

JSC's GC verifier catches this directly:

```
GC Verifier: ERROR cell 0x7bfb390721c8 was not marked
  Object 0x7bfb390721c8 ... (Structure: Error, {message})
  In the real GC, this cell was NOT marked.
  In the verifier GC, it was visited via:
    0x7bfb393d1a98 (Structure: AbortController)
ASSERTION FAILED: this->isMarked(cell)   JavaScriptCore/heap/Heap.cpp:3469 (Heap::verifyGC)
```

Without the verifier the observable effect is that `signal.reason` silently becomes `undefined` while the controller is still reachable (the `Weak<>` in `JSValueInWrappedObject` is cleared). Any downstream consumer that holds the controller then reads a freed-and-possibly-reused cell.

## Reproduction

```sh
BUN_JSC_verifyGC=1 BUN_JSC_collectContinuously=1 BUN_JSC_numberOfGCMarkers=8 bun -e '
  const controllers = [];
  for (let iter = 0; iter < 500; iter++) {
    const c = new AbortController();
    controllers.push(c);
    const garbage = [];
    for (let j = 0; j < 50; j++) garbage.push({ a: j, b: new Array(10).fill(j) });
    c.abort(new Error("reason-" + iter));
  }
  let lost = 0;
  for (const c of controllers) if (!(c.signal.reason instanceof Error)) lost++;
  console.log("PASS lost=" + lost);
'
```

On current `main` this either asserts inside `Heap::verifyGC` or prints `lost > 0`.

## Fix

Match upstream WebKit (https://bugs.webkit.org/show_bug.cgi?id=236353):

- `AbortSignal::markAborted` / `AbortSignal::jsReason`: store `m_reason` via `set(vm, wrapper(), reason)` so a write barrier fires on the `JSAbortSignal` wrapper.
- `JSAbortController`: add `visitOutputConstraints` / `visitAdditionalChildrenInGCThread` so its subspace is registered as an output-constraint space and the DOMGCOutputConstraint re-visits the controller after the mutator has run. This covers the case where no `JSAbortSignal` wrapper exists yet (only the controller).
- `JSValueInWrappedObject::set`: null-check `owner` before the barrier, matching upstream, since `wrapper()` is null before a JS wrapper is created.

## Verification

- `bun bd test test/js/web/abort/` : 13 pass / 0 fail
- New test fails 5/5 on an unfixed `bun bd` build (verifier asserts) and passes 5/5 with the fix.