### PR TITLE
fs.readdir: release pending_err mutex in recursive subtask error path

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2426,7 +2426,7 @@ mod _async_tasks {
                                 <$T as ReaddirEntry>::destroy_entry(item);
                             }
                             {
-                                let _lock = self.pending_err_mutex.lock();
+                                let _lock = self.pending_err_mutex.lock_guard();
                                 if self.pending_err.is_none() {
                                     let err_path: &[u8] = if !err.path.is_empty() {
                                         &err.path[..]

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1224,6 +1224,51 @@ it.skipIf(isWindows)(
   },
 );
 
+// The per-task pending_err mutex was acquired via `lock()` (returns `()`) instead of
+// `lock_guard()`, so it was never released: the next failing subtask on the same worker
+// panicked "Deadlock detected" (debug) or blocked forever and the promise never settled.
+it.skipIf(isWindows)(
+  "promises.readdir({recursive: true}) settles when multiple subtasks fail",
+  async () => {
+    using dir = tempDir("readdir-recursive-multi-error", {
+      "keep.txt": "x",
+    });
+    // Self-referencing symlinks: opening one with O_DIRECTORY fails with
+    // ELOOP, which is not swallowed by the recursive walker, so every
+    // enqueued subtask hits the pending_err path.
+    for (let i = 0; i < 64; i++) {
+      const link = join(String(dir), `loop${i}`);
+      fs.symlinkSync(link, link);
+    }
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("fs");
+          fs.promises.readdir(${JSON.stringify(String(dir))}, { recursive: true }).then(
+            r => console.log("resolved", r.length),
+            e => console.log("rejected", e.code),
+          );
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+      timeout: 10_000,
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "rejected ELOOP",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+);
+
 describe("readSync", () => {
   it("rejects the read when the length argument detaches the destination buffer during coercion", () => {
     const fd = openSync(import.meta.dir + "/readFileSync.txt", "r");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1227,47 +1227,44 @@ it.skipIf(isWindows)(
 // The per-task pending_err mutex was acquired via `lock()` (returns `()`) instead of
 // `lock_guard()`, so it was never released: the next failing subtask on the same worker
 // panicked "Deadlock detected" (debug) or blocked forever and the promise never settled.
-it.skipIf(isWindows)(
-  "promises.readdir({recursive: true}) settles when multiple subtasks fail",
-  async () => {
-    using dir = tempDir("readdir-recursive-multi-error", {
-      "keep.txt": "x",
-    });
-    // Self-referencing symlinks: opening one with O_DIRECTORY fails with
-    // ELOOP, which is not swallowed by the recursive walker, so every
-    // enqueued subtask hits the pending_err path.
-    for (let i = 0; i < 64; i++) {
-      const link = join(String(dir), `loop${i}`);
-      fs.symlinkSync(link, link);
-    }
+it.skipIf(isWindows)("promises.readdir({recursive: true}) settles when multiple subtasks fail", async () => {
+  using dir = tempDir("readdir-recursive-multi-error", {
+    "keep.txt": "x",
+  });
+  // Self-referencing symlinks: opening one with O_DIRECTORY fails with
+  // ELOOP, which is not swallowed by the recursive walker, so every
+  // enqueued subtask hits the pending_err path.
+  for (let i = 0; i < 64; i++) {
+    const link = join(String(dir), `loop${i}`);
+    fs.symlinkSync(link, link);
+  }
 
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
           const fs = require("fs");
           fs.promises.readdir(${JSON.stringify(String(dir))}, { recursive: true }).then(
             r => console.log("resolved", r.length),
             e => console.log("rejected", e.code),
           );
         `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "inherit",
-      timeout: 10_000,
-    });
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+    timeout: 10_000,
+  });
 
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "rejected ELOOP",
-      exitCode: 0,
-      signalCode: null,
-    });
-  },
-);
+  expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "rejected ELOOP",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
 
 describe("readSync", () => {
   it("rejects the read when the length argument detaches the destination buffer during coercion", () => {


### PR DESCRIPTION
## Problem

`fs.promises.readdir(path, { recursive: true })` hangs forever (release) or panics `Deadlock detected` on a thread-pool worker (debug) when two or more of its per-directory subtasks fail. The returned promise never settles, with nothing on stderr in a release build.

```
panic: Deadlock detected
  <bun_threading::mutex::Mutex>::lock                      src/threading/Mutex.rs:181
  <bun_runtime::node::fs::_async_tasks::AsyncReaddirRecursiveTask>::perform_work
  <bun_runtime::node::fs::_async_tasks::ReaddirSubtask>::run_owned
  <bun_threading::thread_pool::Thread>::run
```

## Cause

`AsyncReaddirRecursiveTask::perform_work` takes the per-task `pending_err_mutex` on the error path with

```rust
let _lock = self.pending_err_mutex.lock();
```

`bun_threading::Mutex::lock()` returns `()`, not a guard, so `_lock` is the unit value and the mutex is never released. The first failing subtask locks it and decrements `subtask_count`; the next failing subtask on the same worker trips the debug deadlock detector (`locking_thread == current_thread_id`), and on any other worker blocks forever in `FutexImpl::lock_slow`. `subtask_count` never reaches zero, so `finish_concurrently` never runs and the user-facing promise never settles.

This is the only site in the tree where a raw `bun_threading::Mutex::lock()` result was bound to a variable; every other `let _g = x.lock()` pattern is on `Guarded<T>`, `bun_core::Mutex<T>`, or `bun_alloc::Mutex`, all of which return a real guard.

## Fix

Use `lock_guard()` so the mutex is released when the scope exits.

## Verification

New test in `test/js/node/fs/fs.test.ts` creates 64 self-referencing symlinks (each subtask's `openat(..., O_DIRECTORY)` fails with `ELOOP`, which is not in the walker's swallowed set of `ENOENT`/`ENOTDIR`/`EPERM`) and asserts the spawned child rejects with `ELOOP` and exits 0. Without the fix the child panics in debug and hangs in release; with it the promise rejects in well under a second.