### PR TITLE
tls: buffer duplex data that arrives before the SSL engine is created

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1285,9 +1285,13 @@ function onDuplexTLSData(state, chunk) {
 
 function flushPendingDuplexTLS(state) {
   const { events, pending: chunks } = state;
+  if (!chunks) return;
+  // Keep buffering until the replay finishes: a chunk the engine's output
+  // synchronously echoes back into the duplex must not overtake queued ones.
+  // It lands on `chunks` itself, so the loop delivers it in arrival order.
+  for (let i = 0; i < chunks.length; i++) events[0](chunks[i]);
   state.pending = null;
   state.self[kflushPendingDuplexTLS] = undefined;
-  for (let i = 0; i < chunks.length; i++) events[0](chunks[i]);
 }
 
 // The native SSL engine behind an upgraded Duplex is created by a deferred

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1295,6 +1295,9 @@ function flushPendingDuplexTLS(state) {
   for (let i = 0; i < chunks.length; i++) events[0](chunks[i]);
   state.pending = null;
   state.self[kflushPendingDuplexTLS] = undefined;
+  // Drop the back-reference: the duplex's long-lived 'data' listener holds
+  // `state`, which must not pin the wrapping socket after the flush.
+  state.self = undefined;
 }
 
 // The native SSL engine behind an upgraded Duplex is created by a deferred

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1394,6 +1394,7 @@ function Socket(options?) {
   this._parentWrap = null;
   this[kpendingRead] = undefined;
   this[kupgraded] = null;
+  this[kflushPendingDuplexTLS] = undefined;
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -731,8 +731,11 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     const handle = self._handle || socket.listener;
     if (handle && typeof handle.onconnection === "function") {
       handle.onconnection(0, socket);
+    } else {
+      // Only the standalone wrap lands here, where `self` is the wrapping
+      // Socket (never a Server) and so the only receiver that can hold this.
+      self[kflushPendingDuplexTLS]?.();
     }
-    self[kflushPendingDuplexTLS]?.();
   },
   handshake(socket, success, verifyError) {
     const self = socket.data;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -138,6 +138,7 @@ const kAttach = Symbol("kAttach");
 const kCloseRawConnection = Symbol("kCloseRawConnection");
 const kpendingRead = Symbol("kpendingRead");
 const kupgraded = Symbol("kupgraded");
+const kflushPendingDuplexTLS = Symbol("kflushPendingDuplexTLS");
 const ksocket = Symbol("ksocket");
 const khandlers = Symbol("khandlers");
 const kclosed = Symbol("closed");
@@ -731,6 +732,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     if (handle && typeof handle.onconnection === "function") {
       handle.onconnection(0, socket);
     }
+    self[kflushPendingDuplexTLS]?.();
   },
   handshake(socket, success, verifyError) {
     const self = socket.data;
@@ -1014,6 +1016,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     if (self[kupgraded]) {
       self.connecting = false;
       SocketHandlers2.drain!(socket);
+      self[kflushPendingDuplexTLS]?.();
     }
   },
   data(socket, buffer) {
@@ -1272,6 +1275,26 @@ function traceConnectEnd(req) {
     req[kTraceConnectActive] = false;
     traceEvents.emitEvent("e", kNetTraceCat, "connect");
   }
+}
+
+// The native SSL engine behind an upgraded Duplex is created by a deferred
+// event-loop task. Buffer 'data' that arrives before it exists (as the
+// GC-owned Buffers they already are) and replay it from the `open` handler.
+function wireDuplexToTLS(self, connection, events) {
+  let pending: Buffer[] | null = [];
+  connection.on("data", chunk => {
+    if (pending) pending.push(chunk);
+    else events[0](chunk);
+  });
+  connection.on("end", events[1]);
+  connection.on("drain", events[2]);
+  connection.on("close", events[3]);
+  self[kflushPendingDuplexTLS] = function flushPendingDuplexTLS() {
+    const chunks = pending!;
+    pending = null;
+    self[kflushPendingDuplexTLS] = undefined;
+    for (let i = 0; i < chunks.length; i++) events[0](chunks[i]);
+  };
 }
 
 function kConnectTcp(self, addressType, req, address, port) {
@@ -1712,10 +1735,7 @@ Socket.prototype.connect = function connect(...args) {
             tls,
             socket: this[khandlers],
           });
-          connection.on("data", events[0]);
-          connection.on("end", events[1]);
-          connection.on("drain", events[2]);
-          connection.on("close", events[3]);
+          wireDuplexToTLS(this, connection, events);
           this._handle = result;
         } else {
           // upgradeTLS requires an established socket; a socket that is still
@@ -1762,10 +1782,7 @@ Socket.prototype.connect = function connect(...args) {
                   tls,
                   socket: this[khandlers],
                 });
-                connection.on("data", events[0]);
-                connection.on("end", events[1]);
-                connection.on("drain", events[2]);
-                connection.on("close", events[3]);
+                wireDuplexToTLS(this, connection, events);
                 this._handle = result;
               } else {
                 this[kupgraded] = connection;
@@ -2031,10 +2048,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
       socket: serverHandlersFor(this),
       isServer: true,
     });
-    connection.on("data", events[0]);
-    connection.on("end", events[1]);
-    connection.on("drain", events[2]);
-    connection.on("close", events[3]);
+    wireDuplexToTLS(this, connection, events);
     this[kupgraded] = connection;
     this._handle = result;
     return;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1278,15 +1278,16 @@ function traceConnectEnd(req) {
 }
 
 function onDuplexTLSData(state, chunk) {
-  if (state.pending) state.pending.push(chunk);
+  const { pending } = state;
+  if (pending) pending.push(chunk);
   else state.events[0](chunk);
 }
 
 function flushPendingDuplexTLS(state) {
-  const chunks = state.pending;
+  const { events, pending: chunks } = state;
   state.pending = null;
   state.self[kflushPendingDuplexTLS] = undefined;
-  for (let i = 0; i < chunks.length; i++) state.events[0](chunks[i]);
+  for (let i = 0; i < chunks.length; i++) events[0](chunks[i]);
 }
 
 // The native SSL engine behind an upgraded Duplex is created by a deferred

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1277,24 +1277,28 @@ function traceConnectEnd(req) {
   }
 }
 
+function onDuplexTLSData(state, chunk) {
+  if (state.pending) state.pending.push(chunk);
+  else state.events[0](chunk);
+}
+
+function flushPendingDuplexTLS(state) {
+  const chunks = state.pending;
+  state.pending = null;
+  state.self[kflushPendingDuplexTLS] = undefined;
+  for (let i = 0; i < chunks.length; i++) state.events[0](chunks[i]);
+}
+
 // The native SSL engine behind an upgraded Duplex is created by a deferred
 // event-loop task. Buffer 'data' that arrives before it exists (as the
 // GC-owned Buffers they already are) and replay it from the `open` handler.
 function wireDuplexToTLS(self, connection, events) {
-  let pending: Buffer[] | null = [];
-  connection.on("data", chunk => {
-    if (pending) pending.push(chunk);
-    else events[0](chunk);
-  });
+  const state = { self, events, pending: [] as Buffer[] | null };
+  connection.on("data", onDuplexTLSData.bind(null, state));
   connection.on("end", events[1]);
   connection.on("drain", events[2]);
   connection.on("close", events[3]);
-  self[kflushPendingDuplexTLS] = function flushPendingDuplexTLS() {
-    const chunks = pending!;
-    pending = null;
-    self[kflushPendingDuplexTLS] = undefined;
-    for (let i = 0; i < chunks.length; i++) events[0](chunks[i]);
-  };
+  self[kflushPendingDuplexTLS] = flushPendingDuplexTLS.bind(null, state);
 }
 
 function kConnectTcp(self, addressType, req, address, port) {

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -26,6 +26,9 @@ bun_output::declare_scope!(UpgradedDuplex, visible);
 
 pub(crate) struct UpgradedDuplex {
     pub wrapper: Option<WrapperType>,
+    /// Bytes that arrived via the duplex's `'data'` event before the deferred
+    /// StartTLS task created `wrapper`. Drained by `start_wrapper`.
+    pub pending_data: Vec<u8>,
     pub origin: StrongOptional, // any duplex
     // JSC_BORROW per LIFETIMES.tsv.
     pub global: Option<GlobalRef>,
@@ -227,6 +230,10 @@ impl UpgradedDuplex {
             if let Some(wrapper) = &mut self.wrapper {
                 wrapper.receive_data(data);
             }
+        } else {
+            // StartTLS hasn't run yet; buffer so the handshake sees these
+            // bytes instead of silently dropping them.
+            self.pending_data.extend_from_slice(data);
         }
     }
 
@@ -258,6 +265,7 @@ impl UpgradedDuplex {
             origin: StrongOptional::create(origin, global),
             global: Some(GlobalRef::from(global)),
             wrapper: None,
+            pending_data: Vec::new(),
             handlers,
             ssl_error: CertError::default(),
             on_data_callback: StrongOptional::empty(),
@@ -338,7 +346,7 @@ impl UpgradedDuplex {
             },
         )?);
 
-        self.wrapper.as_mut().unwrap().start();
+        self.start_wrapper();
         Ok(())
     }
 
@@ -375,8 +383,21 @@ impl UpgradedDuplex {
         // Success: disarm the errdefer.
         scopeguard::ScopeGuard::into_inner(ctx_guard);
 
-        self.wrapper.as_mut().unwrap().start();
+        self.start_wrapper();
         Ok(())
+    }
+
+    /// Kick the freshly-created wrapper, feeding in any bytes the duplex
+    /// delivered while the StartTLS task was still queued.
+    fn start_wrapper(&mut self) {
+        let pending = core::mem::take(&mut self.pending_data);
+        let wrapper = self.wrapper.as_mut().unwrap();
+        if pending.is_empty() {
+            wrapper.start();
+        } else {
+            bun_output::scoped_log!(UpgradedDuplex, "start ({} buffered bytes)", pending.len());
+            wrapper.start_with_payload(&pending);
+        }
     }
 
     #[uws_callback(export = "UpgradedDuplex__encode_and_write")]
@@ -535,6 +556,7 @@ impl UpgradedDuplex {
             host_fn::set_function_data(callback, None);
             self.on_close_callback.deinit();
         }
+        self.pending_data = Vec::new();
         self.ssl_error = CertError::default();
     }
 }

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -26,9 +26,6 @@ bun_output::declare_scope!(UpgradedDuplex, visible);
 
 pub(crate) struct UpgradedDuplex {
     pub wrapper: Option<WrapperType>,
-    /// Bytes that arrived via the duplex's `'data'` event before the deferred
-    /// StartTLS task created `wrapper`. Drained by `start_wrapper`.
-    pub pending_data: Vec<u8>,
     pub origin: StrongOptional, // any duplex
     // JSC_BORROW per LIFETIMES.tsv.
     pub global: Option<GlobalRef>,
@@ -230,10 +227,6 @@ impl UpgradedDuplex {
             if let Some(wrapper) = &mut self.wrapper {
                 wrapper.receive_data(data);
             }
-        } else {
-            // StartTLS hasn't run yet; buffer so the handshake sees these
-            // bytes instead of silently dropping them.
-            self.pending_data.extend_from_slice(data);
         }
     }
 
@@ -265,7 +258,6 @@ impl UpgradedDuplex {
             origin: StrongOptional::create(origin, global),
             global: Some(GlobalRef::from(global)),
             wrapper: None,
-            pending_data: Vec::new(),
             handlers,
             ssl_error: CertError::default(),
             on_data_callback: StrongOptional::empty(),
@@ -346,7 +338,7 @@ impl UpgradedDuplex {
             },
         )?);
 
-        self.start_wrapper();
+        self.wrapper.as_mut().unwrap().start();
         Ok(())
     }
 
@@ -383,21 +375,8 @@ impl UpgradedDuplex {
         // Success: disarm the errdefer.
         scopeguard::ScopeGuard::into_inner(ctx_guard);
 
-        self.start_wrapper();
+        self.wrapper.as_mut().unwrap().start();
         Ok(())
-    }
-
-    /// Kick the freshly-created wrapper, feeding in any bytes the duplex
-    /// delivered while the StartTLS task was still queued.
-    fn start_wrapper(&mut self) {
-        let pending = core::mem::take(&mut self.pending_data);
-        let wrapper = self.wrapper.as_mut().unwrap();
-        if pending.is_empty() {
-            wrapper.start();
-        } else {
-            bun_output::scoped_log!(UpgradedDuplex, "start ({} buffered bytes)", pending.len());
-            wrapper.start_with_payload(&pending);
-        }
     }
 
     #[uws_callback(export = "UpgradedDuplex__encode_and_write")]
@@ -556,7 +535,6 @@ impl UpgradedDuplex {
             host_fn::set_function_data(callback, None);
             self.on_close_callback.deinit();
         }
-        self.pending_data = Vec::new();
         self.ssl_error = CertError::default();
     }
 }

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { once } from "events";
 import { tls as certs } from "harness";
 import net from "net";
+import { Duplex, duplexPair } from "stream";
 import tls from "tls";
 
 test("should be able to upgrade a paused socket and also have backpressure on it #15438", async () => {
@@ -59,4 +60,93 @@ test("should be able to upgrade a paused socket and also have backpressure on it
   }
 
   expect().pass();
+});
+
+// The SSL engine for a TLS socket built over a generic Duplex is created by a
+// deferred event-loop task. Creating the client first makes its ClientHello
+// land on the server half of the pair before the server's engine exists; those
+// bytes must be buffered, not dropped, or the handshake never completes.
+test("server-side TLSSocket over a duplexPair handshakes when the client is created first", async () => {
+  const [clientSide, serverSide] = duplexPair();
+
+  const client = tls.connect({ socket: clientSide, ca: certs.cert, servername: "localhost" });
+  const server = new tls.TLSSocket(serverSide, {
+    isServer: true,
+    secureContext: tls.createSecureContext(certs),
+  });
+
+  const data = Promise.withResolvers<string>();
+  client.on("data", chunk => data.resolve(chunk.toString()));
+  client.on("error", data.reject);
+  server.on("error", data.reject);
+
+  await Promise.all([once(server, "secure"), once(client, "secureConnect")]);
+  server.end("pong");
+  expect(await data.promise).toBe("pong");
+  client.end();
+});
+
+// Nested TLS sessions, each layer wrapped in a generic Duplex shim. The outer
+// server decrypts and pushes the inner ClientHello in the same tick its
+// connection callback creates the inner server TLSSocket, so the inner server's
+// engine does not exist yet when those bytes arrive.
+test("TLS in TLS over a generic Duplex completes the inner handshake", async () => {
+  function wrapAsDuplex(underlying: tls.TLSSocket) {
+    const d = new Duplex({
+      read() {},
+      write(chunk, _enc, cb) {
+        underlying.write(chunk, cb);
+      },
+      final(cb) {
+        underlying.end();
+        cb();
+      },
+    });
+    underlying.on("data", chunk => d.push(chunk));
+    underlying.on("end", () => d.push(null));
+    underlying.on("error", e => d.destroy(e));
+    return d;
+  }
+
+  const innerServerSecure = Promise.withResolvers<void>();
+  const innerClientData = Promise.withResolvers<string>();
+
+  const outerServer = tls.createServer(certs, outerSocket => {
+    const innerServer = new tls.TLSSocket(wrapAsDuplex(outerSocket), {
+      isServer: true,
+      secureContext: tls.createSecureContext(certs),
+    });
+    innerServer.on("secure", () => {
+      innerServerSecure.resolve();
+      innerServer.end("hello from inner");
+    });
+    innerServer.on("error", e => {
+      innerServerSecure.reject(e);
+      innerClientData.reject(e);
+    });
+  });
+
+  let outerClient: tls.TLSSocket | undefined;
+  try {
+    await once(outerServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = outerServer.address() as net.AddressInfo;
+
+    outerClient = tls.connect({ port, host: "127.0.0.1", ca: certs.cert, servername: "localhost" });
+    outerClient.on("error", innerClientData.reject);
+    await once(outerClient, "secureConnect");
+
+    const innerClient = tls.connect({
+      socket: wrapAsDuplex(outerClient),
+      ca: certs.cert,
+      servername: "localhost",
+    });
+    innerClient.on("data", chunk => innerClientData.resolve(chunk.toString()));
+    innerClient.on("error", innerClientData.reject);
+
+    await innerServerSecure.promise;
+    expect(await innerClientData.promise).toBe("hello from inner");
+  } finally {
+    outerClient?.destroy();
+    outerServer.close();
+  }
 });

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -80,10 +80,14 @@ test("server-side TLSSocket over a duplexPair handshakes when the client is crea
   client.on("error", data.reject);
   server.on("error", data.reject);
 
-  await Promise.all([once(server, "secure"), once(client, "secureConnect")]);
-  server.end("pong");
-  expect(await data.promise).toBe("pong");
-  client.end();
+  try {
+    await Promise.all([once(server, "secure"), once(client, "secureConnect")]);
+    server.end("pong");
+    expect(await data.promise).toBe("pong");
+  } finally {
+    client.destroy();
+    server.destroy();
+  }
 });
 
 // Nested TLS sessions, each layer wrapped in a generic Duplex shim. The outer


### PR DESCRIPTION
### Problem

A server-side TLS socket over a generic `Duplex` (`new tls.TLSSocket(duplex, { isServer: true, secureContext })`) silently stalls: it never writes a ServerHello and never emits `'secure'` or an error. Node completes the handshake.

Minimal repro, hangs with no output:

```js
const tls = require("tls");
const { duplexPair } = require("stream");
const [clientSide, serverSide] = duplexPair();

// Client FIRST: its deferred TLS-start task runs before the server's.
const client = tls.connect({ socket: clientSide, ca, servername: "localhost" });
const server = new tls.TLSSocket(serverSide, {
  isServer: true,
  secureContext: tls.createSecureContext({ key, cert }),
});
server.on("secure", () => console.log("never reached"));
```

The originally reported form is TLS in TLS: an inner `tls.TLSSocket(duplex, { isServer: true })` where the duplex is a shim over an outer TLS socket. The outer session decrypts and pushes the inner ClientHello in the same tick the inner server TLSSocket is constructed.

### Cause

`upgradeDuplexToTLS` (used for every non-`net.Socket` `Duplex` transport) registers the duplex's `'data'` listener synchronously but defers creation of the `SSLWrapper` to an enqueued event-loop task (`DuplexUpgradeContext` / `EventState::StartTLS`). Bytes the duplex delivered in that window reached `UpgradedDuplex::on_internal_receive_data` while `self.wrapper` was still `None`, which did nothing:

```rust
fn on_internal_receive_data(&mut self, data: &[u8]) {
    if self.wrapper.is_some() { ... wrapper.receive_data(data) }
    // else: silently dropped
}
```

The server then waits forever for a ClientHello it will never see again. An accepted real `net.Socket` is unaffected because that path goes through `socket.upgradeTLS` and hands already-buffered bytes in via `initialData`; the duplex path had no equivalent.

### Fix

In `node:net`, hold the chunks the Duplex delivers before the engine exists in a per-socket JS array (they stay the GC-owned `Buffer`s they arrived as), and replay them into the engine from the `open` socket handler, which the native side dispatches from `SSLWrapper::start()` only after the wrapper has been created. `SocketHandlers2.open` already has an `if (self[kupgraded])` branch that flushes the pending write side at exactly that point; this adds the symmetric read side. A small `wireDuplexToTLS` helper replaces the `connection.on(...)` block that was previously repeated at all three `upgradeDuplexToTLS` call sites.

No native change. (A first iteration buffered in a Rust `Vec<u8>` on `UpgradedDuplex`; that was reverted per review since it held memory the GC could not see, and the JS array avoids the copy entirely.)

### Verification

Two tests added to `test/js/node/tls/node-tls-upgrade.test.ts`, both of which hang on an unfixed build (5s test timeout) and pass with the fix:

- `server-side TLSSocket over a duplexPair handshakes when the client is created first`: the minimal deterministic trigger (client created first so its StartTLS task writes the ClientHello before the server's engine exists).
- `TLS in TLS over a generic Duplex completes the inner handshake`: the reported scenario over a real connection.

The rest of `test/js/node/tls/` is unchanged (145 pass; the three failures it reports also fail or time out without this change).
