### PR TITLE
pm pack: drop the leading newline from --quiet and --silent output

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2417,9 +2417,13 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         );
 
         if !FOR_PUBLISH {
+            // Quiet/silent output must be only the tarball path so `$(bun pm pack --quiet)` works.
+            if log_level != LogLevel::Silent && log_level != LogLevel::Quiet {
+                bun_core::pretty!("\n");
+            }
             if opt_pack_destination(manager).is_empty() && opt_pack_filename(manager).is_empty() {
                 bun_core::pretty!(
-                    "\n{}\n",
+                    "{}\n",
                     fmt_tarball_filename(
                         package_name,
                         package_version,
@@ -2436,7 +2440,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     package_version,
                     &mut dest_buf[..],
                 );
-                bun_core::pretty!("\n{}\n", bstr::BStr::new(abs_tarball_dest.as_bytes()));
+                bun_core::pretty!("{}\n", bstr::BStr::new(abs_tarball_dest.as_bytes()));
             }
         }
 
@@ -2911,13 +2915,17 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     );
 
     if !FOR_PUBLISH {
+        // Quiet/silent output must be only the tarball path so `$(bun pm pack --quiet)` works.
+        if log_level != LogLevel::Silent && log_level != LogLevel::Quiet {
+            bun_core::pretty!("\n");
+        }
         if opt_pack_destination(manager).is_empty() && opt_pack_filename(manager).is_empty() {
             bun_core::pretty!(
-                "\n{}\n",
+                "{}\n",
                 fmt_tarball_filename(package_name, package_version, TarballNameStyle::Normalize)
             );
         } else {
-            bun_core::pretty!("\n{}\n", bstr::BStr::new(abs_tarball_dest.as_bytes()));
+            bun_core::pretty!("{}\n", bstr::BStr::new(abs_tarball_dest.as_bytes()));
         }
     }
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -184,6 +184,14 @@ impl<'a> Context<'a> {
             }
         }
     }
+
+    pub fn print_tarball_path(path: impl fmt::Display, log_level: LogLevel) {
+        // Quiet/silent output must be only the tarball path so `$(bun pm pack --quiet)` works.
+        if log_level != LogLevel::Silent && log_level != LogLevel::Quiet {
+            bun_core::pretty!("\n");
+        }
+        bun_core::pretty!("{}\n", path);
+    }
 }
 
 #[derive(Clone)]
@@ -2417,18 +2425,14 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         );
 
         if !FOR_PUBLISH {
-            // Quiet/silent output must be only the tarball path so `$(bun pm pack --quiet)` works.
-            if log_level != LogLevel::Silent && log_level != LogLevel::Quiet {
-                bun_core::pretty!("\n");
-            }
             if opt_pack_destination(manager).is_empty() && opt_pack_filename(manager).is_empty() {
-                bun_core::pretty!(
-                    "{}\n",
+                Context::print_tarball_path(
                     fmt_tarball_filename(
                         package_name,
                         package_version,
-                        TarballNameStyle::Normalize
-                    )
+                        TarballNameStyle::Normalize,
+                    ),
+                    log_level,
                 );
             } else {
                 let mut dest_buf = PathBuffer::uninit();
@@ -2440,7 +2444,10 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     package_version,
                     &mut dest_buf[..],
                 );
-                bun_core::pretty!("{}\n", bstr::BStr::new(abs_tarball_dest.as_bytes()));
+                Context::print_tarball_path(
+                    bstr::BStr::new(abs_tarball_dest.as_bytes()),
+                    log_level,
+                );
             }
         }
 
@@ -2915,17 +2922,13 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     );
 
     if !FOR_PUBLISH {
-        // Quiet/silent output must be only the tarball path so `$(bun pm pack --quiet)` works.
-        if log_level != LogLevel::Silent && log_level != LogLevel::Quiet {
-            bun_core::pretty!("\n");
-        }
         if opt_pack_destination(manager).is_empty() && opt_pack_filename(manager).is_empty() {
-            bun_core::pretty!(
-                "{}\n",
-                fmt_tarball_filename(package_name, package_version, TarballNameStyle::Normalize)
+            Context::print_tarball_path(
+                fmt_tarball_filename(package_name, package_version, TarballNameStyle::Normalize),
+                log_level,
             );
         } else {
-            bun_core::pretty!("{}\n", bstr::BStr::new(abs_tarball_dest.as_bytes()));
+            Context::print_tarball_path(bstr::BStr::new(abs_tarball_dest.as_bytes()), log_level);
         }
     }
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3088,7 +3088,8 @@ fn tarball_destination<'a>(
         let mut cursor = std::io::Cursor::new(&mut dest_buf[dir_len_trimmed..]);
         let res = write!(
             &mut cursor,
-            "/{}\x00",
+            "{}{}\x00",
+            SEP_STR,
             fmt_tarball_filename(package_name, package_version, TarballNameStyle::Normalize),
         );
         if res.is_err() {

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -469,6 +469,67 @@ describe("flags", () => {
     // Should still create the tarball
     expect(await exists(join(packageDir, "pack-quiet-test-1.1.1.tgz"))).toBeTrue();
   });
+
+  test("--silent", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-silent-test",
+          version: "1.1.1",
+        }),
+      ),
+      write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
+    ]);
+
+    const { out } = await pack(packageDir, bunEnv, "--silent");
+
+    expect(out).toBe("pack-silent-test-1.1.1.tgz\n");
+    expect(await exists(join(packageDir, "pack-silent-test-1.1.1.tgz"))).toBeTrue();
+  });
+
+  test("--quiet with --destination", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-quiet-dest-test",
+          version: "1.1.1",
+        }),
+      ),
+      write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
+    ]);
+
+    const dest = join(packageDir, "out");
+    const { out } = await pack(packageDir, bunEnv, "--quiet", `--destination=${dest}`);
+
+    const tarballPath = join(dest, "pack-quiet-dest-test-1.1.1.tgz");
+    expect(out).toBe(`${tarballPath}\n`);
+    expect(await exists(tarballPath)).toBeTrue();
+  });
+
+  test("--quiet with --dry-run", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-quiet-dry-test",
+          version: "1.1.1",
+        }),
+      ),
+      write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
+    ]);
+
+    const { out } = await pack(packageDir, bunEnv, "--quiet", "--dry-run");
+    expect(out).toBe("pack-quiet-dry-test-1.1.1.tgz\n");
+
+    const dest = join(packageDir, "out");
+    const { out: destOut } = await pack(packageDir, bunEnv, "--quiet", "--dry-run", `--destination=${dest}`);
+    expect(destOut).toBe(`${join(dest, "pack-quiet-dry-test-1.1.1.tgz")}\n`);
+
+    // --dry-run never writes the tarball.
+    expect(await exists(join(packageDir, "pack-quiet-dry-test-1.1.1.tgz"))).toBeFalse();
+  });
 });
 
 test("shasum and integrity are consistent", async () => {

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -463,8 +463,8 @@ describe("flags", () => {
     expect(out).not.toContain("Packed size:");
     expect(out).not.toContain("bun pack v");
 
-    // Should only contain the tarball name
-    expect(out.trim()).toBe("pack-quiet-test-1.1.1.tgz");
+    // Exactly the tarball name with no leading newline, so `$(bun pm pack --quiet)` works.
+    expect(out).toBe("pack-quiet-test-1.1.1.tgz\n");
 
     // Should still create the tarball
     expect(await exists(join(packageDir, "pack-quiet-test-1.1.1.tgz"))).toBeTrue();


### PR DESCRIPTION
Re-lands #25173 by @pxseu on the current tree. The original PR fixed `src/cli/pack_command.zig`, which no longer exists after the Rust rewrite, so it was closed as unmergeable; this ports the same change to `src/runtime/cli/pack_command.rs`. The fix commit is authored by @pxseu so the contribution credit lands with the merge.

### What does this PR do?

`bun pm pack --quiet` prints the tarball name with a leading newline:

```sh
$ bun pm pack --quiet | jq -Rs .
"\npack-repro-1.0.0.tgz\n"
```

so `FILE=$(bun pm pack --quiet)` captures the newline and anything expecting a single line breaks. The original report was writing it to `$GITHUB_ENV`:

```
Error: Unable to process file command 'env' successfully.
Error: Invalid format 'fami-1.0.11.tgz'
```

`--silent`, `--dry-run`, and `--destination` all have the same leading newline.

The `\n` is the blank line that separates the tarball name from the file listing. Quiet/silent suppress the listing (and every other line) while the name is printed unconditionally, so the separator has nothing to separate and just corrupts the one line of output. The fix only prints the separator when the listing is actually shown; default (non-quiet) output is byte-for-byte unchanged.

The exact-output assertions also caught a second, Windows-only bug in the same output: `tarball_destination` joins the directory with the native separator but appended the filename with a literal `/`, so `bun pm pack --destination=X` printed a mixed-separator path (`C:\...\out/name.tgz`). The Windows x64 CI lane failed on exactly that character, and the fix uses the platform separator there instead.

### How did you verify your code works?

The existing `--quiet` test now asserts the exact stdout (the previous `out.trim()` is what let this through), and new tests cover `--silent`, `--quiet --destination`, and `--quiet --dry-run` with and without `--destination`, so every print site the fix touches is asserted directly. All of them fail on bun 1.4.0 and pass with the fix:

```
(pass) flags > --quiet
(pass) flags > --silent
(pass) flags > --quiet with --destination
(pass) flags > --quiet with --dry-run
```
