### PR TITLE
install: validate bun.lockb slice descriptors and ids at load time

### DIFF
--- a/src/install/lockfile/Buffers.rs
+++ b/src/install/lockfile/Buffers.rs
@@ -474,6 +474,12 @@ pub(crate) fn load(
 
     // Legacy tree structure stores package IDs instead of dependency IDs
     if !this.trees.is_empty() && this.trees[0].dependency_id != tree::ROOT_DEP_ID {
+        // The remap scans `resolutions` and marks the dependency ids it claims
+        // in a bitset sized by `dependencies`. The two are parallel buffers,
+        // but nothing has validated that yet at this point.
+        if this.resolutions.len() != this.dependencies.len() {
+            return Err(bun_core::err!("InvalidLockfile"));
+        }
         let mut visited = Bitset::init_empty(this.dependencies.len())?;
         // Iterate by index so
         // `legacy_package_to_dependency_id` can borrow `&self` while we hold

--- a/src/install/lockfile/Buffers.rs
+++ b/src/install/lockfile/Buffers.rs
@@ -478,7 +478,7 @@ pub(crate) fn load(
         // in a bitset sized by `dependencies`. The two are parallel buffers,
         // but nothing has validated that yet at this point.
         if this.resolutions.len() != this.dependencies.len() {
-            return Err(bun_core::err!("InvalidLockfile"));
+            return Err(crate::Error::InvalidLockfile);
         }
         let mut visited = Bitset::init_empty(this.dependencies.len())?;
         // Iterate by index so

--- a/src/install/lockfile/Buffers.rs
+++ b/src/install/lockfile/Buffers.rs
@@ -474,9 +474,8 @@ pub(crate) fn load(
 
     // Legacy tree structure stores package IDs instead of dependency IDs
     if !this.trees.is_empty() && this.trees[0].dependency_id != tree::ROOT_DEP_ID {
-        // The remap scans `resolutions` and marks the dependency ids it claims
-        // in a bitset sized by `dependencies`. The two are parallel buffers,
-        // but nothing has validated that yet at this point.
+        // The remap indexes a `dependencies`-sized bitset with positions in
+        // `resolutions`, before `validate_buffer_ranges` has run.
         if this.resolutions.len() != this.dependencies.len() {
             return Err(crate::Error::InvalidLockfile);
         }

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -932,13 +932,14 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
 
     // `bin` is a tagged union; the `Map` arm is an `(off, len)` window into
     // `extern_strings` (the tag byte itself is validated by the package
-    // deserializer).
+    // deserializer). The window holds `[name, target]` pairs and every
+    // consumer walks it two at a time, so its length must also be even.
     let extern_strings_len = buffers.extern_strings.len();
     for package_bin in lockfile.packages.items_bin() {
         if package_bin.tag == bin::Tag::Map {
             // SAFETY: `tag == Map` discriminates the active union field.
             let map = unsafe { package_bin.value.map };
-            if !slice_in_bounds(map.off, map.len, extern_strings_len) {
+            if !slice_in_bounds(map.off, map.len, extern_strings_len) || map.len % 2 != 0 {
                 return Err(bun_core::err!("InvalidLockfile"));
             }
         }
@@ -960,12 +961,15 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
     let trees_len = buffers.trees.len();
     let hoisted_len = buffers.hoisted_dependencies.len();
     for (tree_index, tree) in buffers.trees.iter().enumerate() {
-        // `invalid_dependency_id` is the only sentinel the consumers handle
-        // (`Tree::folder_name`); `ROOT_DEP_ID` is only ever written on the
-        // root node, which nothing takes the folder name of.
+        // Only the root node carries a sentinel (`ROOT_DEP_ID`, or
+        // `invalid_dependency_id` from `Tree::default`). Every other node was
+        // created for a dependency, and the consumers (`Tree::folder_name`,
+        // `Lockfile::is_workspace_tree_id`) index `buffers.dependencies`
+        // with its id.
         let dependency_id_valid = (tree.dependency_id as usize) < dependencies_len
-            || tree.dependency_id == invalid_dependency_id
-            || (tree_index == 0 && tree.dependency_id == Tree::ROOT_DEP_ID);
+            || (tree_index == 0
+                && (tree.dependency_id == Tree::ROOT_DEP_ID
+                    || tree.dependency_id == invalid_dependency_id));
         if !dependency_id_valid
             || (tree.parent != Tree::INVALID_ID && tree.parent as usize >= trees_len)
             || !slice_in_bounds(tree.dependencies.off, tree.dependencies.len, hoisted_len)

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -20,9 +20,9 @@ use crate::dependency;
 use crate::dependency::{Behavior, Dependency};
 use crate::package_manager_real::Options as PackageManagerOptions;
 use crate::resolution_real::Tag as ResolutionTag;
+use crate::{invalid_dependency_id, invalid_package_id};
 use bun_ast::Log;
 use bun_core::strings;
-use crate::{invalid_dependency_id, invalid_package_id};
 use bun_install::{PackageID, PackageManager, PackageNameAndVersionHash, PackageNameHash};
 use bun_semver::{self as semver, String as SemverString};
 

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -953,9 +953,14 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
             || (tree_index == 0
                 && (tree.dependency_id == super::tree::ROOT_DEP_ID
                     || tree.dependency_id == invalid_dependency_id));
-        // The builder appends each tree after its parent: ids are positions
-        // and a parent precedes its child, which also rules out parent cycles.
-        let parent_valid = tree.parent == Tree::INVALID_ID || (tree.parent as usize) < tree_index;
+        // The builder appends each tree after its parent: ids are positions,
+        // only the root has no parent, and a parent precedes its child, which
+        // also rules out parent cycles.
+        let parent_valid = if tree_index == 0 {
+            tree.parent == Tree::INVALID_ID
+        } else {
+            (tree.parent as usize) < tree_index
+        };
         if tree.id as usize != tree_index
             || !dependency_id_valid
             || !parent_valid

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -20,7 +20,7 @@ use crate::dependency;
 use crate::dependency::{Behavior, Dependency};
 use crate::package_manager_real::Options as PackageManagerOptions;
 use crate::resolution_real::Tag as ResolutionTag;
-use crate::{invalid_dependency_id, invalid_package_id};
+use crate::{bin, invalid_dependency_id, invalid_package_id};
 use bun_ast::Log;
 use bun_core::strings;
 use bun_install::{PackageID, PackageManager, PackageNameAndVersionHash, PackageNameHash};
@@ -893,12 +893,15 @@ fn slice_in_bounds(off: u32, len: u32, buffer_len: usize) -> bool {
     off as usize + len as usize <= buffer_len
 }
 
-/// `package::serializer::load` and `buffers::load` memcpy slice descriptors
-/// (`(off, len)` pairs) and element ids verbatim from disk, and their
-/// consumers (`ExternalSlice::get`, `Package::clone`, the hoister, the
-/// printers) index with them unchecked. Out-of-range values from a corrupt or
-/// crafted lockfile must fail the parse so the installer can warn and
-/// re-resolve instead of panicking.
+/// `package::serializer::load` and `buffers::load` memcpy the package columns,
+/// the tree list and the id buffers verbatim from disk, and their consumers
+/// (`ExternalSlice::get`, `Package::clone`, the hoister, the printers) index
+/// with them unchecked. Validate every `ExternalSlice` window (`dependencies`,
+/// `resolutions`, `bin.map`, tree `dependencies`) and element id (tree
+/// `dependency_id` / `parent`, the `resolutions` and `hoisted_dependencies`
+/// buffers) so a corrupt or crafted lockfile fails the parse and the installer
+/// warns and re-resolves instead of panicking. String `(off, len)` pairs are
+/// not covered here: `SemverString::slice` already clamps them.
 fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
     let buffers = &lockfile.buffers;
     let dependencies_len = buffers.dependencies.len();
@@ -910,6 +913,9 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
         return Err(bun_core::err!("InvalidLockfile"));
     }
 
+    // A package's two windows must be the same range, not just two in-bounds
+    // ranges: consumers derive dependency ids from one and index the other
+    // with them.
     for (dependencies, resolutions) in lockfile
         .packages
         .items_dependencies()
@@ -917,10 +923,24 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
         .zip(lockfile.packages.items_resolutions())
     {
         if !slice_in_bounds(dependencies.off, dependencies.len, dependencies_len)
-            || !slice_in_bounds(resolutions.off, resolutions.len, resolutions_len)
-            || dependencies.len != resolutions.len
+            || resolutions.off != dependencies.off
+            || resolutions.len != dependencies.len
         {
             return Err(bun_core::err!("InvalidLockfile"));
+        }
+    }
+
+    // `bin` is a tagged union; the `Map` arm is an `(off, len)` window into
+    // `extern_strings` (the tag byte itself is validated by the package
+    // deserializer).
+    let extern_strings_len = buffers.extern_strings.len();
+    for package_bin in lockfile.packages.items_bin() {
+        if package_bin.tag == bin::Tag::Map {
+            // SAFETY: `tag == Map` discriminates the active union field.
+            let map = unsafe { package_bin.value.map };
+            if !slice_in_bounds(map.off, map.len, extern_strings_len) {
+                return Err(bun_core::err!("InvalidLockfile"));
+            }
         }
     }
 

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -910,7 +910,7 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
     // `dependencies` and `resolutions` are parallel buffers: the tree builder
     // iterates a package's `resolutions` range and indexes both with it.
     if resolutions_len != dependencies_len {
-        return Err(bun_core::err!("InvalidLockfile"));
+        return Err(crate::Error::InvalidLockfile);
     }
 
     // A package's two windows must be the same range, not just two in-bounds
@@ -926,7 +926,7 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
             || resolutions.off != dependencies.off
             || resolutions.len != dependencies.len
         {
-            return Err(bun_core::err!("InvalidLockfile"));
+            return Err(crate::Error::InvalidLockfile);
         }
     }
 
@@ -940,7 +940,7 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
             // SAFETY: `tag == Map` discriminates the active union field.
             let map = unsafe { package_bin.value.map };
             if !slice_in_bounds(map.off, map.len, extern_strings_len) || map.len % 2 != 0 {
-                return Err(bun_core::err!("InvalidLockfile"));
+                return Err(crate::Error::InvalidLockfile);
             }
         }
     }
@@ -948,13 +948,13 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
     let packages_len = lockfile.packages.len();
     for &package_id in buffers.resolutions.iter() {
         if package_id != invalid_package_id && package_id as usize >= packages_len {
-            return Err(bun_core::err!("InvalidLockfile"));
+            return Err(crate::Error::InvalidLockfile);
         }
     }
 
     for &dependency_id in buffers.hoisted_dependencies.iter() {
         if dependency_id != invalid_dependency_id && dependency_id as usize >= dependencies_len {
-            return Err(bun_core::err!("InvalidLockfile"));
+            return Err(crate::Error::InvalidLockfile);
         }
     }
 
@@ -968,13 +968,13 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
         // with its id.
         let dependency_id_valid = (tree.dependency_id as usize) < dependencies_len
             || (tree_index == 0
-                && (tree.dependency_id == Tree::ROOT_DEP_ID
+                && (tree.dependency_id == super::tree::ROOT_DEP_ID
                     || tree.dependency_id == invalid_dependency_id));
         if !dependency_id_valid
             || (tree.parent != Tree::INVALID_ID && tree.parent as usize >= trees_len)
             || !slice_in_bounds(tree.dependencies.off, tree.dependencies.len, hoisted_len)
         {
-            return Err(bun_core::err!("InvalidLockfile"));
+            return Err(crate::Error::InvalidLockfile);
         }
     }
 

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -11,7 +11,7 @@ use bun_io::Write as _;
 use super::PatchedDep;
 use super::override_map::ScopedOverride;
 use super::{
-    FormatVersion, Lockfile, Scratch, Stream, StringPool, buffers, package,
+    FormatVersion, Lockfile, Scratch, Stream, StringPool, Tree, buffers, package,
     package_index as PackageIndex,
 };
 use crate::ALIGNMENT_BYTES_TO_REPEAT_BUFFER;
@@ -22,6 +22,7 @@ use crate::package_manager_real::Options as PackageManagerOptions;
 use crate::resolution_real::Tag as ResolutionTag;
 use bun_ast::Log;
 use bun_core::strings;
+use crate::{invalid_dependency_id, invalid_package_id};
 use bun_install::{PackageID, PackageManager, PackageNameAndVersionHash, PackageNameHash};
 use bun_semver::{self as semver, String as SemverString};
 
@@ -454,6 +455,12 @@ pub(crate) fn load(
     res.migrated_from_lockb_v2 = migrate_from_v2;
 
     lockfile.buffers = buffers::load(stream, log, manager.as_deref_mut())?;
+
+    // Like `meta.id` above, every slice descriptor and element id in the
+    // package columns and tree list is memcpy'd verbatim from disk, and the
+    // consumers index with them unchecked. Reject out-of-range values here.
+    validate_buffer_ranges(lockfile)?;
+
     if stream.read_int_le::<u64>()? != 0 {
         return Err(crate::Error::LockfileIsMalformedExpected0AtTheEnd);
     }
@@ -877,4 +884,73 @@ pub(crate) fn load(
     debug_assert!(stream.pos as u64 == total_buffer_size);
 
     Ok(res)
+}
+
+/// `true` when the `(off, len)` window stays inside a buffer of `buffer_len`
+/// elements. Computed in `usize` so `off + len` cannot overflow `u32`.
+#[inline]
+fn slice_in_bounds(off: u32, len: u32, buffer_len: usize) -> bool {
+    off as usize + len as usize <= buffer_len
+}
+
+/// `package::serializer::load` and `buffers::load` memcpy slice descriptors
+/// (`(off, len)` pairs) and element ids verbatim from disk, and their
+/// consumers (`ExternalSlice::get`, `Package::clone`, the hoister, the
+/// printers) index with them unchecked. Out-of-range values from a corrupt or
+/// crafted lockfile must fail the parse so the installer can warn and
+/// re-resolve instead of panicking.
+fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
+    let buffers = &lockfile.buffers;
+    let dependencies_len = buffers.dependencies.len();
+    let resolutions_len = buffers.resolutions.len();
+
+    // `dependencies` and `resolutions` are parallel buffers: the tree builder
+    // iterates a package's `resolutions` range and indexes both with it.
+    if resolutions_len != dependencies_len {
+        return Err(bun_core::err!("InvalidLockfile"));
+    }
+
+    for (dependencies, resolutions) in lockfile
+        .packages
+        .items_dependencies()
+        .iter()
+        .zip(lockfile.packages.items_resolutions())
+    {
+        if !slice_in_bounds(dependencies.off, dependencies.len, dependencies_len)
+            || !slice_in_bounds(resolutions.off, resolutions.len, resolutions_len)
+            || dependencies.len != resolutions.len
+        {
+            return Err(bun_core::err!("InvalidLockfile"));
+        }
+    }
+
+    let packages_len = lockfile.packages.len();
+    for &package_id in buffers.resolutions.iter() {
+        if package_id != invalid_package_id && package_id as usize >= packages_len {
+            return Err(bun_core::err!("InvalidLockfile"));
+        }
+    }
+
+    for &dependency_id in buffers.hoisted_dependencies.iter() {
+        if dependency_id != invalid_dependency_id && dependency_id as usize >= dependencies_len {
+            return Err(bun_core::err!("InvalidLockfile"));
+        }
+    }
+
+    let trees_len = buffers.trees.len();
+    let hoisted_len = buffers.hoisted_dependencies.len();
+    for tree in buffers.trees.iter() {
+        // `dependency_id` is a real dependency id or a sentinel
+        // (`ROOT_DEP_ID` / `invalid_dependency_id`, both above any real id);
+        // `buffers::load` already remapped legacy package-id keyed trees.
+        if (tree.dependency_id < Tree::ROOT_DEP_ID
+            && tree.dependency_id as usize >= dependencies_len)
+            || (tree.parent != Tree::INVALID_ID && tree.parent as usize >= trees_len)
+            || !slice_in_bounds(tree.dependencies.off, tree.dependencies.len, hoisted_len)
+        {
+            return Err(bun_core::err!("InvalidLockfile"));
+        }
+    }
+
+    Ok(())
 }

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -456,9 +456,6 @@ pub(crate) fn load(
 
     lockfile.buffers = buffers::load(stream, log, manager.as_deref_mut())?;
 
-    // Like `meta.id` above, every slice descriptor and element id in the
-    // package columns and tree list is memcpy'd verbatim from disk, and the
-    // consumers index with them unchecked. Reject out-of-range values here.
     validate_buffer_ranges(lockfile)?;
 
     if stream.read_int_le::<u64>()? != 0 {
@@ -886,36 +883,28 @@ pub(crate) fn load(
     Ok(res)
 }
 
-/// `true` when the `(off, len)` window stays inside a buffer of `buffer_len`
-/// elements. Computed in `usize` so `off + len` cannot overflow `u32`.
+/// `off + len <= buffer_len`, computed in `usize` so the sum cannot wrap.
 #[inline]
 fn slice_in_bounds(off: u32, len: u32, buffer_len: usize) -> bool {
     off as usize + len as usize <= buffer_len
 }
 
-/// `package::serializer::load` and `buffers::load` memcpy the package columns,
-/// the tree list and the id buffers verbatim from disk, and their consumers
-/// (`ExternalSlice::get`, `Package::clone`, the hoister, the printers) index
-/// with them unchecked. Validate every `ExternalSlice` window (`dependencies`,
-/// `resolutions`, `bin.map`, tree `dependencies`) and element id (tree
-/// `dependency_id` / `parent`, the `resolutions` and `hoisted_dependencies`
-/// buffers) so a corrupt or crafted lockfile fails the parse and the installer
-/// warns and re-resolves instead of panicking. String `(off, len)` pairs are
-/// not covered here: `SemverString::slice` already clamps them.
+/// Rejects slice windows and element ids that the rest of the installer
+/// indexes with unchecked, so a corrupt or crafted lockfile fails the parse
+/// instead of panicking later. String `(off, len)` pairs are exempt:
+/// `SemverString::slice` clamps them.
 fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
     let buffers = &lockfile.buffers;
     let dependencies_len = buffers.dependencies.len();
     let resolutions_len = buffers.resolutions.len();
 
-    // `dependencies` and `resolutions` are parallel buffers: the tree builder
-    // iterates a package's `resolutions` range and indexes both with it.
+    // Parallel buffers: one dependency id indexes both.
     if resolutions_len != dependencies_len {
         return Err(crate::Error::InvalidLockfile);
     }
 
-    // A package's two windows must be the same range, not just two in-bounds
-    // ranges: consumers derive dependency ids from one and index the other
-    // with them.
+    // For the same reason a package's two windows must be one range, not just
+    // two in-bounds ranges.
     for (dependencies, resolutions) in lockfile
         .packages
         .items_dependencies()
@@ -930,10 +919,8 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
         }
     }
 
-    // `bin` is a tagged union; the `Map` arm is an `(off, len)` window into
-    // `extern_strings` (the tag byte itself is validated by the package
-    // deserializer). The window holds `[name, target]` pairs and every
-    // consumer walks it two at a time, so its length must also be even.
+    // A `Map` bin is a window of `[name, target]` pairs in `extern_strings`,
+    // walked two at a time, so it must also have even length.
     let extern_strings_len = buffers.extern_strings.len();
     for package_bin in lockfile.packages.items_bin() {
         if package_bin.tag == bin::Tag::Map {
@@ -958,20 +945,20 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
         }
     }
 
-    let trees_len = buffers.trees.len();
     let hoisted_len = buffers.hoisted_dependencies.len();
     for (tree_index, tree) in buffers.trees.iter().enumerate() {
-        // Only the root node carries a sentinel (`ROOT_DEP_ID`, or
-        // `invalid_dependency_id` from `Tree::default`). Every other node was
-        // created for a dependency, and the consumers (`Tree::folder_name`,
-        // `Lockfile::is_workspace_tree_id`) index `buffers.dependencies`
-        // with its id.
+        // Only the root may carry a sentinel dependency id; every other
+        // tree's id is used to index `buffers.dependencies`.
         let dependency_id_valid = (tree.dependency_id as usize) < dependencies_len
             || (tree_index == 0
                 && (tree.dependency_id == super::tree::ROOT_DEP_ID
                     || tree.dependency_id == invalid_dependency_id));
-        if !dependency_id_valid
-            || (tree.parent != Tree::INVALID_ID && tree.parent as usize >= trees_len)
+        // The builder appends each tree after its parent: ids are positions
+        // and a parent precedes its child, which also rules out parent cycles.
+        let parent_valid = tree.parent == Tree::INVALID_ID || (tree.parent as usize) < tree_index;
+        if tree.id as usize != tree_index
+            || !dependency_id_valid
+            || !parent_valid
             || !slice_in_bounds(tree.dependencies.off, tree.dependencies.len, hoisted_len)
         {
             return Err(crate::Error::InvalidLockfile);

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -932,6 +932,7 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
         }
     }
 
+    // An unresolved optional peer keeps `invalid_package_id` as its resolution.
     let packages_len = lockfile.packages.len();
     for &package_id in buffers.resolutions.iter() {
         if package_id != invalid_package_id && package_id as usize >= packages_len {
@@ -939,8 +940,9 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
         }
     }
 
+    // `Builder::clean` drops unresolved dependencies, so no sentinel here.
     for &dependency_id in buffers.hoisted_dependencies.iter() {
-        if dependency_id != invalid_dependency_id && dependency_id as usize >= dependencies_len {
+        if dependency_id as usize >= dependencies_len {
             return Err(crate::Error::InvalidLockfile);
         }
     }

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -959,12 +959,14 @@ fn validate_buffer_ranges(lockfile: &Lockfile) -> Result<(), Error> {
 
     let trees_len = buffers.trees.len();
     let hoisted_len = buffers.hoisted_dependencies.len();
-    for tree in buffers.trees.iter() {
-        // `dependency_id` is a real dependency id or a sentinel
-        // (`ROOT_DEP_ID` / `invalid_dependency_id`, both above any real id);
-        // `buffers::load` already remapped legacy package-id keyed trees.
-        if (tree.dependency_id < Tree::ROOT_DEP_ID
-            && tree.dependency_id as usize >= dependencies_len)
+    for (tree_index, tree) in buffers.trees.iter().enumerate() {
+        // `invalid_dependency_id` is the only sentinel the consumers handle
+        // (`Tree::folder_name`); `ROOT_DEP_ID` is only ever written on the
+        // root node, which nothing takes the folder name of.
+        let dependency_id_valid = (tree.dependency_id as usize) < dependencies_len
+            || tree.dependency_id == invalid_dependency_id
+            || (tree_index == 0 && tree.dependency_id == Tree::ROOT_DEP_ID);
+        if !dependency_id_valid
             || (tree.parent != Tree::INVALID_ID && tree.parent as usize >= trees_len)
             || !slice_in_bounds(tree.dependencies.off, tree.dependencies.len, hoisted_len)
         {

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -418,8 +418,14 @@ it("rejects a binary lockfile whose package scripts flag byte is out of range", 
 // unchecked by the yarn printer, `Package.clone` and the hoister, so an `off`
 // past the end of its buffer panicked:
 //   "range start index 4294967280 out of range for slice of length 3"
-for (const column of ["dependencies", "resolutions"] as const) {
-  it(`rejects a binary lockfile whose package ${column} offset is out of range`, async () => {
+// The two windows must also be the same range: consumers derive dependency
+// ids from one and index the other with them.
+for (const [what, column, poke] of [
+  ["dependencies offset is out of range", "dependencies", 0xfffffff0],
+  ["resolutions offset is out of range", "resolutions", 0xfffffff0],
+  ["resolutions window does not match dependencies", "resolutions", 0],
+] as const) {
+  it(`rejects a binary lockfile whose package ${what}`, async () => {
     const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
 
     // Migrating a package-lock.json with `--lockfile-only` writes bun.lockb
@@ -477,10 +483,13 @@ for (const column of ["dependencies", "resolutions"] as const) {
     const resolutionSize = fmt === 2 ? 64 : 72;
     const columnStart = begin + N * (8 + 8 + resolutionSize) + (column === "resolutions" ? N * 8 : 0);
     expect(N).toBe(3);
-    // Sanity: the root package's list is the first two of the three entries.
+    // Sanity: the root package's list is the first two of the three entries,
+    // and the last package's window starts right after them, so overwriting
+    // its `off` with 0 always de-pairs it from its `dependencies` window.
     expect(lockb.readUInt32LE(columnStart)).toBe(0);
     expect(lockb.readUInt32LE(columnStart + 4)).toBe(2);
-    lockb.writeUInt32LE(0xfffffff0, columnStart + 2 * 8);
+    expect(lockb.readUInt32LE(columnStart + 2 * 8)).toBe(2);
+    lockb.writeUInt32LE(poke, columnStart + 2 * 8);
     await write(lockbPath, lockb);
 
     // `bun bun.lockb` dereferences every package's dependency list to print

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -411,6 +411,112 @@ it("rejects a binary lockfile whose package scripts flag byte is out of range", 
   expect(code).toBe(0);
   expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(true);
 });
+
+// The package list is stored SoA; `dependencies` and `resolutions` are
+// per-package `(off: u32, len: u32)` windows into `buffers.dependencies` /
+// `buffers.resolutions`. Both are memcpy'd from disk and dereferenced
+// unchecked by the yarn printer, `Package.clone` and the hoister, so an `off`
+// past the end of its buffer panicked:
+//   "range start index 4294967280 out of range for slice of length 3"
+for (const column of ["dependencies", "resolutions"] as const) {
+  it(`rejects a binary lockfile whose package ${column} offset is out of range`, async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
+
+    // Migrating a package-lock.json with `--lockfile-only` writes bun.lockb
+    // without fetching anything: the resolved URLs (which must live under the
+    // configured registry) are transcribed into the lockfile, never contacted.
+    const resolved = (name: string) => `${registry.registryUrl()}${name}/-/${name}-1.0.0.tgz`;
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "corrupt-lockb-slices",
+          version: "1.0.0",
+          dependencies: { depa: "1.0.0", depb: "1.0.0" },
+        }),
+      ),
+      write(
+        join(packageDir, "package-lock.json"),
+        JSON.stringify({
+          name: "corrupt-lockb-slices",
+          version: "1.0.0",
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            "": { name: "corrupt-lockb-slices", version: "1.0.0", dependencies: { depa: "1.0.0", depb: "1.0.0" } },
+            "node_modules/depa": { version: "1.0.0", resolved: resolved("depa"), dependencies: { depb: "1.0.0" } },
+            "node_modules/depb": { version: "1.0.0", resolved: resolved("depb") },
+          },
+        }),
+      ),
+    ]);
+    {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--lockfile-only", "--no-progress"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(stderrForInstall(err)).toContain("Saved lockfile");
+      expect(out).toBeDefined();
+      expect(code).toBe(0);
+    }
+
+    const lockbPath = join(packageDir, "bun.lockb");
+    expect(await exists(lockbPath)).toBe(true);
+
+    // Locate the column (the SoA walk documented in the `meta` test above)
+    // and point the last package's `off` far past the end of its buffer. Only
+    // the start index matters; the end is already clamped.
+    const lockb = Buffer.from(await file(lockbPath).arrayBuffer());
+    const fmt = lockb.readUInt32LE(42);
+    const N = Number(lockb.readBigUInt64LE(86));
+    const begin = Number(lockb.readBigUInt64LE(110));
+    const resolutionSize = fmt === 2 ? 64 : 72;
+    const columnStart = begin + N * (8 + 8 + resolutionSize) + (column === "resolutions" ? N * 8 : 0);
+    expect(N).toBe(3);
+    // Sanity: the root package's list is the first two of the three entries.
+    expect(lockb.readUInt32LE(columnStart)).toBe(0);
+    expect(lockb.readUInt32LE(columnStart + 4)).toBe(2);
+    lockb.writeUInt32LE(0xfffffff0, columnStart + 2 * 8);
+    await write(lockbPath, lockb);
+
+    // `bun bun.lockb` dereferences every package's dependency list to print
+    // the yarn lockfile; it must report a parse error instead of crashing.
+    {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "bun.lockb"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toContain("error parsing lockfile: InvalidLockfile");
+      expect(out).toBe("");
+      expect(code).toBe(1);
+    }
+
+    // An install must ignore the invalid lockfile and fall back to a fresh
+    // resolve (which then fails: these packages only exist in the lockfile).
+    {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--no-progress"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, rawErr, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(stderrForInstall(rawErr)).toContain("Ignoring lockfile");
+      expect(out).toBeDefined();
+      expect(code).not.toBe(0);
+    }
+  });
+}
+
 it("rejects a binary lockfile whose git resolved tag contains path separators", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
 

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -492,39 +492,104 @@ for (const [what, column, poke] of [
     lockb.writeUInt32LE(poke, columnStart + 2 * 8);
     await write(lockbPath, lockb);
 
-    // `bun bun.lockb` dereferences every package's dependency list to print
-    // the yarn lockfile; it must report a parse error instead of crashing.
-    {
+    // Each command is a separate door into the corrupt lockfile, and a
+    // command that re-resolves rewrites the file, so restore the corrupt
+    // bytes before each run. Run all three before asserting: one door that
+    // crashes must not hide what the others do.
+    const corrupt = Buffer.from(lockb);
+    const run = async (args: string[]) => {
+      await write(lockbPath, corrupt);
       const { stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "bun.lockb"],
+        cmd: [bunExe(), ...args],
         cwd: packageDir,
         stdout: "pipe",
         stderr: "pipe",
         env,
       });
       const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
-      expect(err).toContain("error parsing lockfile: InvalidLockfile");
-      expect(out).toBe("");
-      expect(code).toBe(1);
-    }
+      return { out, err, code };
+    };
+    const print = await run(["bun.lockb"]);
+    const install = await run(["install", "--no-progress"]);
+    const frozen = await run(["install", "--no-progress", "--frozen-lockfile"]);
 
     // An install must ignore the invalid lockfile and fall back to a fresh
     // resolve (which then fails: these packages only exist in the lockfile).
-    {
-      const { stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install", "--no-progress"],
-        cwd: packageDir,
-        stdout: "pipe",
-        stderr: "pipe",
-        env,
-      });
-      const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    // `--frozen-lockfile` reads the lockfile through the same path. Both are
+    // asserted before the printer: they are the commands the crash reports
+    // name, and an unfixed binary panics in all three.
+    for (const { err, out, code } of [install, frozen]) {
       expect(err).toContain("Ignoring lockfile");
       expect(out).toBeDefined();
       expect(code).not.toBe(0);
     }
+
+    // `bun bun.lockb` dereferences every package's dependency list to print
+    // the yarn lockfile; it must report a parse error instead of crashing.
+    expect(print.err).toContain("error parsing lockfile: InvalidLockfile");
+    expect(print.out).toBe("");
+    expect(print.code).toBe(1);
   });
 }
+
+it("rejects a binary lockfile whose resolution names a package id past the package count", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "corrupt-lockb-resolution-id",
+      version: "1.0.0",
+      dependencies: {
+        "no-deps": "1.0.0",
+        "a-dep": "1.0.1",
+      },
+    }),
+  );
+
+  await runBunInstall(env, packageDir);
+  const lockbPath = join(packageDir, "bun.lockb");
+
+  // Each buffer is written as a 16-byte (start, end) header, a type-name
+  // prefix, then the aligned payload. `hoisted_dependencies` and
+  // `resolutions` are both `u32` arrays, written in that order, so the second
+  // occurrence of the `u32` prefix belongs to `resolutions`.
+  const lockb = Buffer.from(await file(lockbPath).arrayBuffer());
+  const N = Number(lockb.readBigUInt64LE(86));
+  const u32Prefix = "\n<u32> 4 sizeof, 4 alignof\n";
+  const hoisted = lockb.indexOf(u32Prefix);
+  const resolutionsPrefix = lockb.indexOf(u32Prefix, hoisted + 1);
+  expect(resolutionsPrefix).toBeGreaterThan(hoisted);
+  const resolutionsStart = Number(lockb.readBigUInt64LE(resolutionsPrefix - 16));
+  const resolutionsEnd = Number(lockb.readBigUInt64LE(resolutionsPrefix - 8));
+  expect(resolutionsEnd - resolutionsStart).toBeGreaterThanOrEqual(4);
+  expect(lockb.readUInt32LE(resolutionsStart)).toBeLessThan(N);
+  lockb.writeUInt32LE(N, resolutionsStart);
+  await write(lockbPath, lockb);
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+  // A resolution element indexes the package list. One id past the end is in
+  // range for every window check, so only the element check rejects it.
+  // Unvalidated, the id reached `Package::clone` and the install gave up with
+  // a bogus "failed to resolve" instead of re-resolving.
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--no-progress"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+  expect(err).toContain("Ignoring lockfile");
+  expect(err).not.toContain("failed to resolve");
+  expect(out).toContain("no-deps@1.0.0");
+  expect(out).toContain("a-dep@1.0.1");
+  expect(code).toBe(0);
+  expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(true);
+  expect(await exists(join(packageDir, "node_modules", "a-dep"))).toBe(true);
+});
 
 it("rejects a binary lockfile whose git resolved tag contains path separators", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -420,12 +420,52 @@ it("rejects a binary lockfile whose package scripts flag byte is out of range", 
 //   "range start index 4294967280 out of range for slice of length 3"
 // The two windows must also be the same range: consumers derive dependency
 // ids from one and index the other with them.
-for (const [what, column, poke] of [
-  ["dependencies offset is out of range", "dependencies", 0xfffffff0],
-  ["resolutions offset is out of range", "resolutions", 0xfffffff0],
-  ["resolutions window does not match dependencies", "resolutions", 0],
+function corruptPackageColumn(column: "dependencies" | "resolutions", poke: number) {
+  return (lockb: Buffer) => {
+    // Locate the column (the SoA walk documented in the `meta` test above)
+    // and overwrite the last package's `off`. Only the start index matters;
+    // the end is already clamped.
+    const fmt = lockb.readUInt32LE(42);
+    const N = Number(lockb.readBigUInt64LE(86));
+    const begin = Number(lockb.readBigUInt64LE(110));
+    const resolutionSize = fmt === 2 ? 64 : 72;
+    const columnStart = begin + N * (8 + 8 + resolutionSize) + (column === "resolutions" ? N * 8 : 0);
+    expect(N).toBe(3);
+    // Sanity: the root package's list is the first two of the three entries,
+    // and the last package's window starts right after them, so overwriting
+    // its `off` with 0 always de-pairs it from its `dependencies` window.
+    expect(lockb.readUInt32LE(columnStart)).toBe(0);
+    expect(lockb.readUInt32LE(columnStart + 4)).toBe(2);
+    expect(lockb.readUInt32LE(columnStart + 2 * 8)).toBe(2);
+    lockb.writeUInt32LE(poke, columnStart + 2 * 8);
+  };
+}
+
+// The hoisted tree list is written as 20-byte `[id|dependency_id|parent|off|len]`
+// records behind a 16-byte (start, end) header and a type-name prefix. Trees
+// are appended after their parent, so a parent id must precede the tree's own
+// position; a root that names itself as parent is the smallest parent cycle,
+// which the parent-chain walks over a loaded tree (`bun update`'s cleanup of
+// collapsed copies) would never leave.
+function corruptRootTreeParent(lockb: Buffer) {
+  const prefix = lockb.indexOf("\n<install.lockfile.Tree> 20 sizeof, 4 alignof\n");
+  expect(prefix).toBeGreaterThan(16);
+  const treesStart = Number(lockb.readBigUInt64LE(prefix - 16));
+  const treesEnd = Number(lockb.readBigUInt64LE(prefix - 8));
+  // Everything hoists, so there is exactly the root tree: id 0, no parent.
+  expect(treesEnd - treesStart).toBe(20);
+  expect(lockb.readUInt32LE(treesStart)).toBe(0);
+  expect(lockb.readUInt32LE(treesStart + 8)).toBe(0xffffffff);
+  lockb.writeUInt32LE(0, treesStart + 8);
+}
+
+for (const [what, corrupt] of [
+  ["package dependencies offset is out of range", corruptPackageColumn("dependencies", 0xfffffff0)],
+  ["package resolutions offset is out of range", corruptPackageColumn("resolutions", 0xfffffff0)],
+  ["package resolutions window does not match dependencies", corruptPackageColumn("resolutions", 0)],
+  ["root tree is its own parent", corruptRootTreeParent],
 ] as const) {
-  it(`rejects a binary lockfile whose package ${what}`, async () => {
+  it(`rejects a binary lockfile whose ${what}`, async () => {
     const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
 
     // Migrating a package-lock.json with `--lockfile-only` writes bun.lockb
@@ -473,32 +513,17 @@ for (const [what, column, poke] of [
     const lockbPath = join(packageDir, "bun.lockb");
     expect(await exists(lockbPath)).toBe(true);
 
-    // Locate the column (the SoA walk documented in the `meta` test above)
-    // and point the last package's `off` far past the end of its buffer. Only
-    // the start index matters; the end is already clamped.
     const lockb = Buffer.from(await file(lockbPath).arrayBuffer());
-    const fmt = lockb.readUInt32LE(42);
-    const N = Number(lockb.readBigUInt64LE(86));
-    const begin = Number(lockb.readBigUInt64LE(110));
-    const resolutionSize = fmt === 2 ? 64 : 72;
-    const columnStart = begin + N * (8 + 8 + resolutionSize) + (column === "resolutions" ? N * 8 : 0);
-    expect(N).toBe(3);
-    // Sanity: the root package's list is the first two of the three entries,
-    // and the last package's window starts right after them, so overwriting
-    // its `off` with 0 always de-pairs it from its `dependencies` window.
-    expect(lockb.readUInt32LE(columnStart)).toBe(0);
-    expect(lockb.readUInt32LE(columnStart + 4)).toBe(2);
-    expect(lockb.readUInt32LE(columnStart + 2 * 8)).toBe(2);
-    lockb.writeUInt32LE(poke, columnStart + 2 * 8);
+    corrupt(lockb);
     await write(lockbPath, lockb);
 
     // Each command is a separate door into the corrupt lockfile, and a
     // command that re-resolves rewrites the file, so restore the corrupt
     // bytes before each run. Run all three before asserting: one door that
     // crashes must not hide what the others do.
-    const corrupt = Buffer.from(lockb);
+    const corruptBytes = Buffer.from(lockb);
     const run = async (args: string[]) => {
-      await write(lockbPath, corrupt);
+      await write(lockbPath, corruptBytes);
       const { stdout, stderr, exited } = spawn({
         cmd: [bunExe(), ...args],
         cwd: packageDir,

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -459,11 +459,30 @@ function corruptRootTreeParent(lockb: Buffer) {
   lockb.writeUInt32LE(0, treesStart + 8);
 }
 
+// `hoisted_dependencies` (the `u32` array right behind the tree list) holds
+// the dependency ids each tree's window selects. The writer never stores the
+// unresolved sentinel there, and the readers that walk a loaded tree index
+// `dependencies` with every element, so the sentinel must be rejected too.
+function corruptHoistedDependency(lockb: Buffer) {
+  const trees = lockb.indexOf("\n<install.lockfile.Tree> 20 sizeof, 4 alignof\n");
+  expect(trees).toBeGreaterThan(16);
+  const prefix = lockb.indexOf("\n<u32> 4 sizeof, 4 alignof\n", trees + 1);
+  expect(prefix).toBeGreaterThan(trees);
+  const hoistedStart = Number(lockb.readBigUInt64LE(prefix - 16));
+  const hoistedEnd = Number(lockb.readBigUInt64LE(prefix - 8));
+  // The root tree holds both packages: two ids, each one of the three
+  // dependencies in the lockfile.
+  expect(hoistedEnd - hoistedStart).toBe(8);
+  expect(lockb.readUInt32LE(hoistedStart)).toBeLessThan(3);
+  lockb.writeUInt32LE(0xffffffff, hoistedStart);
+}
+
 for (const [what, corrupt] of [
   ["package dependencies offset is out of range", corruptPackageColumn("dependencies", 0xfffffff0)],
   ["package resolutions offset is out of range", corruptPackageColumn("resolutions", 0xfffffff0)],
   ["package resolutions window does not match dependencies", corruptPackageColumn("resolutions", 0)],
   ["root tree is its own parent", corruptRootTreeParent],
+  ["hoisted dependency id is the unresolved sentinel", corruptHoistedDependency],
 ] as const) {
   it(`rejects a binary lockfile whose ${what}`, async () => {
     const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -465,7 +465,7 @@ for (const [what, column, poke] of [
         env,
       });
       const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
-      expect(stderrForInstall(err)).toContain("Saved lockfile");
+      expect(err).toContain("Saved lockfile");
       expect(out).toBeDefined();
       expect(code).toBe(0);
     }
@@ -518,8 +518,8 @@ for (const [what, column, poke] of [
         stderr: "pipe",
         env,
       });
-      const [out, rawErr, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
-      expect(stderrForInstall(rawErr)).toContain("Ignoring lockfile");
+      const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toContain("Ignoring lockfile");
       expect(out).toBeDefined();
       expect(code).not.toBe(0);
     }


### PR DESCRIPTION
### Problem
- A corrupt or crafted `bun.lockb` crashes bun. With one package's `dependencies.off` pointing past its buffer, `bun install` and `bun bun.lockb` both die with `panic: range start index 4294967280 out of range for slice of length 3`.
- `Serializer::load` (`src/install/lockfile/bun.lockb.rs`) memcpys the package columns, the tree list and the id buffers from disk, and their consumers index with them unchecked. `ExternalSlice::get` clamps only the end of an `(off, len)` window, never its start. The one release-mode check today is `meta.id < packages.len()`.

### Fix
- `validate_buffer_ranges` runs right after the buffers load and rejects the lockfile as `InvalidLockfile` (install warns `Ignoring lockfile` and re-resolves, `bun bun.lockb` exits 1) when any package window, `bin.map` window, tree field, or id-buffer element is out of range or breaks a structural invariant the consumers rely on. The list is under Notes.
- The legacy tree remap in `buffers::load` runs before that, so it gets its own guard: the two id buffers must have equal length before one sizes a bitset the other indexes.
- Correct because every invariant is what bun's only writer produces. Checked byte-for-byte against all five real `bun.lockb` fixtures in the repo (old and new writer); all still load with identical output.
- Verified: `test/cli/install/bun-lockb.test.ts`, six corruption cases, each run through `bun install`, `bun install --frozen-lockfile` and `bun bun.lockb`. The unfixed build panics or accepts in all of them.

### Background
- `bun.lockb` stores the package list as columns (SoA). A package's `dependencies` and `resolutions` are `(off, len)` windows into two parallel buffers that one dependency id indexes together.
- The hoisted `node_modules` layout is a flat tree list. The builder appends each tree after its parent, so a tree's id is its position and its parent precedes it.
- `bun update`, `bun audit` and dedupe walk the loaded tree's parent chain (`prune::open_tree_folder`); the installer itself rebuilds the tree first.

<details><summary>Notes</summary>

What `validate_buffer_ranges` rejects:

- `buffers.resolutions.len() != buffers.dependencies.len()` (parallel buffers).
- A package whose `dependencies` window leaves its buffer, or whose `resolutions` window is not the same range (consumers derive dependency ids from one and index the other with them).
- A `bin` `Map` window that leaves `extern_strings` or has odd length (it holds `[name, target]` pairs walked two at a time; the tag byte itself is validated by the package deserializer).
- An element of `buffers.resolutions` that is neither `invalid_package_id` nor `< packages.len()`; an element of `buffers.hoisted_dependencies` that is not `< dependencies.len()` (`Builder::clean` drops unresolved dependencies, so no sentinel is legitimate there).
- A tree whose `id` is not its position, whose `parent` is not an earlier position (root: not `INVALID_ID`) (this rules out every parent cycle, which the loaded-tree walks above would never leave), whose `dependencies` window leaves `hoisted_dependencies`, or, for a non-root tree, whose `dependency_id` is out of range (only the root carries a sentinel: `ROOT_DEP_ID`, or `invalid_dependency_id` as `Tree::default` has it).

String `(off, len)` pairs are not covered: `SemverString::slice` already clamps them.

Test cases (`bun-lockb.test.ts`): a `bun.lockb` is generated offline by migrating a `package-lock.json` with `--lockfile-only`, then one field is corrupted: `dependencies.off` out of range, `resolutions.off` out of range, an in-bounds `resolutions` window that no longer matches `dependencies`, a root tree that names itself as parent, and a hoisted dependency id set to the unresolved sentinel. Each case runs all three commands against the same corrupt bytes and asserts the two install doors before the printer. A sixth case (registry-backed) writes a resolution element one past the package count, which every window check accepts and only the element check rejects; unfixed, the install ends with a bogus "failed to resolve" instead of re-resolving.

Real-lockfile regression check: `fixtures/bun.lockb.v2`, `fixtures/bun.lockb.v2-most-features` (4 trees), `fixtures/invalid-optional-peer.lockb` (69 packages, 3 trees), `test/integration/sharp/bun.lockb`, and `bun.lockb.bin-linking` (6 trees, nesting depth 4) all satisfy `id == position`, root `parent == INVALID_ID`, `parent < position`, and load unchanged; `migrate-bun-lockb-v2.test.ts` and the `invalid-optional-peer` conversion snapshot in `bun-lock.test.ts` are unchanged.

#32306 is related: it makes `relative_path_and_depth` reject a parent cycle when it meets one. With this change such a lockfile no longer loads at all, so that guard becomes a second line of defense rather than the first.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-lockb.test.ts

<!-- robobun:evidence:end -->
