### PR TITLE
shell: fix use-after-free when a pipe read fails inside the spawn call

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -581,12 +581,13 @@ impl Cmd {
         // with the correct `child` once `spawn_async` writes through
         // `out_subproc`. `interp` is left null until `spawn_async` and the
         // `did_exit_immediately` handling have returned: a synchronous
-        // `Cmd::on_exit` reached via the process exit handler would otherwise
-        // drive the trampoline (`Yield::run(&*interp)`) while this frame
-        // still holds `&Interpreter`, tearing the Cmd down (and freeing
+        // `Cmd::on_exit` (process exit handler) or `Cmd::buffered_output_close`
+        // (an eager `read_all` on a pipe erroring inside the spawn) would
+        // otherwise drive the trampoline (`Yield::run(&*interp)`) while this
+        // frame still holds `&Interpreter`, tearing the Cmd down (and freeing
         // `child`) underneath the live `subproc` borrow. With `interp` null,
-        // `on_exit` records `exit_code`/`state = Done` and returns; we resume
-        // via the Yield we hand back below.
+        // both record `exit_code`/`state = Done` and return; we resume via
+        // the Yield we hand back below.
         let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
         let buffered_closed = BufferedIoClosed::from_stdio(&spawn_args.stdio);
         interp.as_cmd_mut(this).exec = Exec::Subproc(Box::new(SubprocExec {
@@ -965,12 +966,20 @@ impl Cmd {
             // `*mut Interpreter` it already holds, landing in `Cmd::next` →
             // `CmdState::Done` → `interp.child_done(...)`.
             self.state = CmdState::Done;
-            let this_id = match &self.exec {
-                Exec::Subproc(sub) => sub.this_id,
+            let (interp, this_id) = match &self.exec {
+                Exec::Subproc(sub) => (sub.interp, sub.this_id),
                 // Only the subprocess path calls this; builtin output goes
                 // through `Builtin::done` → `on_exec_done`.
                 _ => return Yield::suspended(),
             };
+            // Same gate as `on_exit`: `exec.interp` is null until
+            // `transition_to_exec` returns from `spawn_async`. A runnable
+            // Yield here would reach `Cmd::deinit` and free the
+            // `ShellSubprocess` the spawn frame still dereferences;
+            // `transition_to_exec` resumes via its `CmdState::Done` check.
+            if interp.is_null() {
+                return Yield::suspended();
+            }
             // The `!spawn_arena_freed` arm
             // (`ShellAsyncSubprocessDone::enqueue`) is unreachable here in
             // practice — `initSubproc` sets `spawn_arena_freed = true` before

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -27,11 +27,6 @@ pub struct Cmd {
     pub redirection_fd: Option<*mut CowFd>,
     pub exec: Exec,
     pub exit_code: Option<ExitCode>,
-    /// There is no spawn arena to free (argv is heap-allocated as
-    /// `Vec<Vec<u8>>`), but the flag is kept to preserve
-    /// `bufferedOutputClose`'s control-flow split (post-spawn vs pre-spawn
-    /// completion).
-    pub spawn_arena_freed: bool,
 }
 
 #[derive(Default, strum::IntoStaticStr)]
@@ -221,7 +216,6 @@ impl Cmd {
             redirection_fd: None,
             exec: Exec::None,
             exit_code: None,
-            spawn_arena_freed: false,
         }))
     }
 
@@ -661,9 +655,7 @@ impl Cmd {
         // pointer into `*child_out` (== `sub.child`); valid until `Cmd::deinit`
         // reclaims the box. Single-threaded.
         let subproc = unsafe { &mut *child };
-        // Ordering: `subproc.ref()` precedes `spawn_arena_freed = true`.
         subproc.r#ref();
-        interp.as_cmd_mut(this).spawn_arena_freed = true;
         drop(arena);
 
         if did_exit_immediately {
@@ -913,8 +905,7 @@ impl Cmd {
             // subprocess box was returned. Nothing to tear down.
             Exec::Subproc(_) => {}
         }
-        // Argv/env are heap-owned `Vec`s; there is no spawn arena to free (see
-        // `spawn_arena_freed`).
+        // Argv/env are heap-owned `Vec`s; there is no spawn arena to free.
         // `base.shell` is borrowed (or, when parent is Pipeline, freed by
         // `Pipeline::child_done` before this runs) — never freed here.
         me.base.end_scope();
@@ -980,12 +971,6 @@ impl Cmd {
             if interp.is_null() {
                 return Yield::suspended();
             }
-            // The `!spawn_arena_freed` arm
-            // (`ShellAsyncSubprocessDone::enqueue`) is unreachable here in
-            // practice — `initSubproc` sets `spawn_arena_freed = true` before
-            // any pipe can close. Kept as the same `Yield::Next` since the
-            // task body (`runFromMainThread`) is identical.
-            let _ = self.spawn_arena_freed;
             return Yield::Next(this_id);
         }
         Yield::suspended()

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -963,11 +963,9 @@ impl Cmd {
                 // through `Builtin::done` → `on_exec_done`.
                 _ => return Yield::suspended(),
             };
-            // Same gate as `on_exit`: `exec.interp` is null until
-            // `transition_to_exec` returns from `spawn_async`. A runnable
-            // Yield here would reach `Cmd::deinit` and free the
-            // `ShellSubprocess` the spawn frame still dereferences;
-            // `transition_to_exec` resumes via its `CmdState::Done` check.
+            // Same gate as `on_exit`: `exec.interp` stays null until the spawn
+            // returns, so a Yield run here would reach `Cmd::deinit` and free the
+            // `ShellSubprocess` still on the spawn frame. `transition_to_exec` resumes.
             if interp.is_null() {
                 return Yield::suspended();
             }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1244,17 +1244,22 @@ impl Readable {
         event_loop: EventLoopHandle,
         eager: bool,
     ) -> bun_sys::Result<()> {
-        if let Readable::Pipe(pipe) = self {
-            let p = arc_as_mut_ptr(pipe);
-            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell, and
-            // during `spawn` the `Arc<PipeReader>` is uniquely held (the
-            // reader callback is registered by `start` itself), so no other
-            // `&PipeReader` can exist for this scope.
-            let p = unsafe { &mut *p };
-            p.start(process, event_loop)?;
-            if eager {
-                p.read_all();
-            }
+        // `start` (poll registration failing) and `read_all` (the eager read
+        // erroring) can both complete the reader synchronously, which runs
+        // `close_io` → `Readable::finalize` and drops this slot's `Arc`.
+        // Clone it so the `PipeReader` outlives both re-entrant calls.
+        let keepalive = match self {
+            Readable::Pipe(pipe) => Arc::clone(pipe),
+            _ => return Ok(()),
+        };
+        let p = arc_as_mut_ptr(&keepalive);
+        // SAFETY: see `arc_as_mut_ptr` — single-threaded shell; the
+        // re-entrant reader callbacks only hold raw `*mut PipeReader`, so no
+        // other `&PipeReader` can exist for this scope.
+        let p = unsafe { &mut *p };
+        p.start(process, event_loop)?;
+        if eager {
+            p.read_all();
         }
         Ok(())
     }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -2014,6 +2014,13 @@ impl PipeReader {
         match self.reader.start(self.stdio_result.unwrap(), true) {
             bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
             bun_sys::Result::Ok(()) => {
+                // `reader.start` reports a poll-registration failure through
+                // `on_reader_error` (not its return value), so the reader may
+                // already be errored/torn down here; same guard as
+                // `SubprocessPipeReader::start`.
+                if matches!(self.state, PipeReaderState::Err(_)) {
+                    return Ok(());
+                }
                 #[cfg(unix)]
                 {
                     // TODO: are these flags correct

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -105,24 +105,18 @@ async function runWithShim(script: string) {
   return { stdout, stderr, exitCode };
 }
 
-test.skipIf(!isLinux || !cc)(
-  "shell survives a synchronous stdout pipe read error during spawn",
-  async () => {
-    const { stdout, stderr, exitCode } = await runWithShim("stdout-only.js");
-    const line = stdout.trim().split("\n").pop() ?? "";
-    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
-    expect(JSON.parse(line)).toEqual({ exitCode: 12 }); // ENOMEM
-    expect(exitCode).toBe(0);
-  },
-);
+test.skipIf(!isLinux || !cc)("shell survives a synchronous stdout pipe read error during spawn", async () => {
+  const { stdout, stderr, exitCode } = await runWithShim("stdout-only.js");
+  const line = stdout.trim().split("\n").pop() ?? "";
+  expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+  expect(JSON.parse(line)).toEqual({ exitCode: 12 }); // ENOMEM
+  expect(exitCode).toBe(0);
+});
 
-test.skipIf(!isLinux || !cc)(
-  "shell survives synchronous stdout and stderr pipe read errors during spawn",
-  async () => {
-    const { stdout, stderr, exitCode } = await runWithShim("both-pipes.js");
-    const line = stdout.trim().split("\n").pop() ?? "";
-    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
-    expect(JSON.parse(line)).toEqual({ exitCode: 12 }); // ENOMEM
-    expect(exitCode).toBe(0);
-  },
-);
+test.skipIf(!isLinux || !cc)("shell survives synchronous stdout and stderr pipe read errors during spawn", async () => {
+  const { stdout, stderr, exitCode } = await runWithShim("both-pipes.js");
+  const line = stdout.trim().split("\n").pop() ?? "";
+  expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+  expect(JSON.parse(line)).toEqual({ exitCode: 12 }); // ENOMEM
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -1,14 +1,25 @@
-// An LD_PRELOAD shim makes recv() on the shell's stdout/stderr socketpair fail
-// with ENOMEM so the eager pipe read inside ShellSubprocess::spawn_async errors
-// synchronously. The resulting Cmd::buffered_output_close used to hand back a
-// runnable Yield that drove the trampoline into Cmd::deinit, freeing the
-// ShellSubprocess out from under the still-running spawn call:
+// An LD_PRELOAD shim injects ENOMEM into the shell's stdout/stderr pipe setup
+// so the error surfaces synchronously from inside ShellSubprocess::spawn_async.
+// Two faults are covered, both of which used to free live objects out from
+// under the still-running spawn call:
 //
-//   AddressSanitizer: heap-use-after-free (READ)
-//     Readable::start_pipe_reader            shell/subproc.rs:1247
-//     ShellSubprocess::spawn_maybe_sync_impl shell/subproc.rs:888
-//   freed by: Cmd::deinit <- Interpreter::deinit_node
-//             <- PipeReader::run_yield_with <- PipeReader::on_reader_error
+// 1. recv() fails: the eager read_all errors, Cmd::buffered_output_close
+//    handed back a runnable Yield, and the trampoline reached Cmd::deinit,
+//    freeing the ShellSubprocess the spawn frame still held:
+//      AddressSanitizer: heap-use-after-free (READ)
+//        Readable::start_pipe_reader            shell/subproc.rs:1247
+//        ShellSubprocess::spawn_maybe_sync_impl shell/subproc.rs:888
+//      freed by: Cmd::deinit <- Interpreter::deinit_node
+//                <- PipeReader::run_yield_with <- PipeReader::on_reader_error
+//
+// 2. epoll_ctl() fails: register_poll inside PipeReader::start fires
+//    on_reader_error, whose close_io drops the Readable::Pipe slot's Arc, and
+//    start() then kept dereferencing the freed PipeReader:
+//      AddressSanitizer: heap-use-after-free (READ)
+//        PollOrFd::get_poll                     io/pipes.rs:41
+//        PipeReader::start                      shell/subproc.rs:2015
+//        Readable::start_pipe_reader            shell/subproc.rs:1254
+//      freed by: Arc<PipeReader> drop (the on_reader_error guard)
 //
 // The command must instead finish cleanly with the syscall errno as its exit
 // code (ENOMEM = 12 on Linux).
@@ -18,42 +29,93 @@ import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
-// Interposes recv(2). When SHELL_FAIL_RECV=1, every recv fails with ENOMEM.
-// The only recv calls a `bun -e` shell script makes are the eager reads on the
-// subprocess's stdout/stderr socketpairs, so no counting is needed.
+// SHELL_FAIL_RECV=1 makes every recv fail with ENOMEM. SHELL_FAIL_EPOLL=1
+// makes every epoll_ctl ADD/MOD on a pipe-like fd fail with ENOMEM. Bun's
+// spawn "pipes" are AF_UNIX socketpairs on Linux and FilePoll registers them
+// through the raw syscall(SYS_epoll_ctl, ...) wrapper, not the libc epoll_ctl
+// symbol, so syscall(2) is what the epoll mode interposes.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
+#include <stdarg.h>
 #include <stdlib.h>
+#include <sys/epoll.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 static ssize_t (*real_recv)(int, void *, size_t, int);
-static int fail = -1;
+static long (*real_syscall)(long, long, long, long, long, long, long);
+static int fail_recv = -1;
+static int fail_epoll = -1;
+
+static void init_modes(void) {
+  if (fail_recv < 0) fail_recv = getenv("SHELL_FAIL_RECV") != NULL;
+  if (fail_epoll < 0) fail_epoll = getenv("SHELL_FAIL_EPOLL") != NULL;
+}
+
+static int is_pipe_like(int fd) {
+  struct stat st;
+  if (fstat(fd, &st) != 0) return 0;
+  if (S_ISFIFO(st.st_mode)) return 1;
+  if (S_ISSOCK(st.st_mode)) {
+    int domain = 0;
+    socklen_t len = sizeof(domain);
+    if (getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &domain, &len) == 0 && domain == AF_UNIX) return 1;
+  }
+  return 0;
+}
 
 ssize_t recv(int fd, void *buf, size_t len, int flags) {
-    if (!real_recv) {
-        real_recv = (ssize_t (*)(int, void *, size_t, int)) dlsym(RTLD_NEXT, "recv");
-        fail = getenv("SHELL_FAIL_RECV") != NULL;
+  if (!real_recv) {
+    real_recv = (ssize_t (*)(int, void *, size_t, int))dlsym(RTLD_NEXT, "recv");
+    init_modes();
+  }
+  if (fail_recv) {
+    errno = ENOMEM;
+    return -1;
+  }
+  return real_recv(fd, buf, len, flags);
+}
+
+long syscall(long number, ...) {
+  va_list ap;
+  long a, b, c, d, e, f;
+  va_start(ap, number);
+  a = va_arg(ap, long);
+  b = va_arg(ap, long);
+  c = va_arg(ap, long);
+  d = va_arg(ap, long);
+  e = va_arg(ap, long);
+  f = va_arg(ap, long);
+  va_end(ap);
+  if (!real_syscall) {
+    real_syscall = (long (*)(long, long, long, long, long, long, long))dlsym(RTLD_NEXT, "syscall");
+    init_modes();
+  }
+  if (number == SYS_epoll_ctl && fail_epoll) {
+    int op = (int)b;
+    if ((op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD) && is_pipe_like((int)c)) {
+      errno = ENOMEM;
+      return -1;
     }
-    if (fail) {
-        errno = ENOMEM;
-        return -1;
-    }
-    return real_recv(fd, buf, len, flags);
+  }
+  return real_syscall(number, a, b, c, d, e, f);
 }
 `;
 
-// stderr is redirected away from the capture pipe, so the faulted stdout read
-// is the last open stream: closing it finishes the Cmd from inside the spawn.
+// stderr is redirected away from the capture pipe, so the faulted stdout
+// stream is the last open one: closing it finishes the Cmd from inside spawn.
 const STDOUT_ONLY_FIXTURE = /* js */ `
 import { $ } from "bun";
 const r = await $\`head -c 64 /dev/zero 2> /dev/null\`.nothrow();
 console.log(JSON.stringify({ exitCode: r.exitCode }));
 `;
 
-// Both stdout and stderr are capture pipes; the stderr read (faulted from
+// Both stdout and stderr are capture pipes; the stderr fault (raised from
 // inside spawn_async's own stack frame) is the one that finishes the Cmd.
 const BOTH_PIPES_FIXTURE = /* js */ `
 import { $ } from "bun";
@@ -88,7 +150,7 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
-async function runWithShim(script: string) {
+async function runWithShim(script: string, mode: "SHELL_FAIL_RECV" | "SHELL_FAIL_EPOLL") {
   const existing = bunEnv.LD_PRELOAD;
   await using proc = Bun.spawn({
     cmd: [bunExe(), script],
@@ -96,7 +158,7 @@ async function runWithShim(script: string) {
     env: {
       ...bunEnv,
       LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
-      SHELL_FAIL_RECV: "1",
+      [mode]: "1",
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -105,18 +167,47 @@ async function runWithShim(script: string) {
   return { stdout, stderr, exitCode };
 }
 
-test.skipIf(!isLinux || !cc)("shell survives a synchronous stdout pipe read error during spawn", async () => {
-  const { stdout, stderr, exitCode } = await runWithShim("stdout-only.js");
-  const line = stdout.trim().split("\n").pop() ?? "";
-  expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
-  expect(JSON.parse(line)).toEqual({ exitCode: 12 }); // ENOMEM
-  expect(exitCode).toBe(0);
-});
+// The shell surfaces the failed syscall's errno as the command's exit code.
+const ENOMEM = 12;
 
-test.skipIf(!isLinux || !cc)("shell survives synchronous stdout and stderr pipe read errors during spawn", async () => {
-  const { stdout, stderr, exitCode } = await runWithShim("both-pipes.js");
+function lastJsonLine(stdout: string, stderr: string) {
   const line = stdout.trim().split("\n").pop() ?? "";
   expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
-  expect(JSON.parse(line)).toEqual({ exitCode: 12 }); // ENOMEM
-  expect(exitCode).toBe(0);
-});
+  return JSON.parse(line);
+}
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell survives a synchronous stdout pipe read error during spawn",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("stdout-only.js", "SHELL_FAIL_RECV");
+    expect(lastJsonLine(stdout, stderr)).toEqual({ exitCode: ENOMEM });
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell survives synchronous stdout and stderr pipe read errors during spawn",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("both-pipes.js", "SHELL_FAIL_RECV");
+    expect(lastJsonLine(stdout, stderr)).toEqual({ exitCode: ENOMEM });
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell survives a synchronous epoll_ctl failure registering the stdout pipe",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("stdout-only.js", "SHELL_FAIL_EPOLL");
+    expect(lastJsonLine(stdout, stderr)).toEqual({ exitCode: ENOMEM });
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell survives synchronous epoll_ctl failures registering both pipes",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("both-pipes.js", "SHELL_FAIL_EPOLL");
+    expect(lastJsonLine(stdout, stderr)).toEqual({ exitCode: ENOMEM });
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -1,39 +1,17 @@
-// An LD_PRELOAD shim injects ENOMEM into the shell's stdout/stderr pipe setup
-// so the error surfaces synchronously from inside ShellSubprocess::spawn_async.
-// Two faults are covered, both of which used to free live objects out from
-// under the still-running spawn call:
-//
-// 1. recv() fails: the eager read_all errors, Cmd::buffered_output_close
-//    handed back a runnable Yield, and the trampoline reached Cmd::deinit,
-//    freeing the ShellSubprocess the spawn frame still held:
-//      AddressSanitizer: heap-use-after-free (READ)
-//        Readable::start_pipe_reader            shell/subproc.rs:1247
-//        ShellSubprocess::spawn_maybe_sync_impl shell/subproc.rs:888
-//      freed by: Cmd::deinit <- Interpreter::deinit_node
-//                <- PipeReader::run_yield_with <- PipeReader::on_reader_error
-//
-// 2. epoll_ctl() fails: register_poll inside PipeReader::start fires
-//    on_reader_error, whose close_io drops the Readable::Pipe slot's Arc, and
-//    start() then kept dereferencing the freed PipeReader:
-//      AddressSanitizer: heap-use-after-free (READ)
-//        PollOrFd::get_poll                     io/pipes.rs:41
-//        PipeReader::start                      shell/subproc.rs:2015
-//        Readable::start_pipe_reader            shell/subproc.rs:1254
-//      freed by: Arc<PipeReader> drop (the on_reader_error guard)
-//
-// The command must instead finish cleanly with the syscall errno as its exit
-// code (ENOMEM = 12 on Linux).
+// An LD_PRELOAD shim injects ENOMEM into a shell command's pipe setup (recv()
+// on the eager read, or epoll_ctl() registering the pipe) so the reader error
+// surfaces synchronously from inside the spawn call. The command must finish
+// with the syscall errno as its exit code, not tear state down under the spawn.
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
-// SHELL_FAIL_RECV=1 makes every recv fail with ENOMEM. SHELL_FAIL_EPOLL=1
-// makes every epoll_ctl ADD/MOD on a pipe-like fd fail with ENOMEM. Bun's
-// spawn "pipes" are AF_UNIX socketpairs on Linux and FilePoll registers them
-// through the raw syscall(SYS_epoll_ctl, ...) wrapper, not the libc epoll_ctl
-// symbol, so syscall(2) is what the epoll mode interposes.
+// SHELL_FAIL_RECV=1 makes every recv fail with ENOMEM; SHELL_FAIL_EPOLL=1
+// makes every epoll_ctl ADD/MOD on a pipe-like fd fail with ENOMEM. FilePoll
+// registers the socketpair through the raw syscall(SYS_epoll_ctl, ...) wrapper,
+// not the libc epoll_ctl symbol, so the epoll mode interposes syscall(2).
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -150,7 +128,10 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
-async function runWithShim(script: string, mode: "SHELL_FAIL_RECV" | "SHELL_FAIL_EPOLL") {
+// The shell surfaces the failed syscall's errno as the command's exit code.
+const ENOMEM = 12;
+
+async function expectShellFault(script: string, mode: "SHELL_FAIL_RECV" | "SHELL_FAIL_EPOLL") {
   const existing = bunEnv.LD_PRELOAD;
   await using proc = Bun.spawn({
     cmd: [bunExe(), script],
@@ -158,56 +139,53 @@ async function runWithShim(script: string, mode: "SHELL_FAIL_RECV" | "SHELL_FAIL
     env: {
       ...bunEnv,
       LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+      SHELL_FAIL_RECV: undefined,
+      SHELL_FAIL_EPOLL: undefined,
       [mode]: "1",
     },
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
-}
-
-// The shell surfaces the failed syscall's errno as the command's exit code.
-const ENOMEM = 12;
-
-function lastJsonLine(stdout: string, stderr: string) {
   const line = stdout.trim().split("\n").pop() ?? "";
-  expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
-  return JSON.parse(line);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    parsed = line;
+  }
+  // One combined assertion so a crash surfaces stderr and the exit code in the diff.
+  expect({ parsed, stderr, exitCode }).toEqual({
+    parsed: { exitCode: ENOMEM },
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
 }
 
 test.concurrent.skipIf(!isLinux || !cc)(
   "shell survives a synchronous stdout pipe read error during spawn",
   async () => {
-    const { stdout, stderr, exitCode } = await runWithShim("stdout-only.js", "SHELL_FAIL_RECV");
-    expect(lastJsonLine(stdout, stderr)).toEqual({ exitCode: ENOMEM });
-    expect(exitCode).toBe(0);
+    await expectShellFault("stdout-only.js", "SHELL_FAIL_RECV");
   },
 );
 
 test.concurrent.skipIf(!isLinux || !cc)(
   "shell survives synchronous stdout and stderr pipe read errors during spawn",
   async () => {
-    const { stdout, stderr, exitCode } = await runWithShim("both-pipes.js", "SHELL_FAIL_RECV");
-    expect(lastJsonLine(stdout, stderr)).toEqual({ exitCode: ENOMEM });
-    expect(exitCode).toBe(0);
+    await expectShellFault("both-pipes.js", "SHELL_FAIL_RECV");
   },
 );
 
 test.concurrent.skipIf(!isLinux || !cc)(
   "shell survives a synchronous epoll_ctl failure registering the stdout pipe",
   async () => {
-    const { stdout, stderr, exitCode } = await runWithShim("stdout-only.js", "SHELL_FAIL_EPOLL");
-    expect(lastJsonLine(stdout, stderr)).toEqual({ exitCode: ENOMEM });
-    expect(exitCode).toBe(0);
+    await expectShellFault("stdout-only.js", "SHELL_FAIL_EPOLL");
   },
 );
 
 test.concurrent.skipIf(!isLinux || !cc)(
   "shell survives synchronous epoll_ctl failures registering both pipes",
   async () => {
-    const { stdout, stderr, exitCode } = await runWithShim("both-pipes.js", "SHELL_FAIL_EPOLL");
-    expect(lastJsonLine(stdout, stderr)).toEqual({ exitCode: ENOMEM });
-    expect(exitCode).toBe(0);
+    await expectShellFault("both-pipes.js", "SHELL_FAIL_EPOLL");
   },
 );

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -1,0 +1,128 @@
+// An LD_PRELOAD shim makes recv() on the shell's stdout/stderr socketpair fail
+// with ENOMEM so the eager pipe read inside ShellSubprocess::spawn_async errors
+// synchronously. The resulting Cmd::buffered_output_close used to hand back a
+// runnable Yield that drove the trampoline into Cmd::deinit, freeing the
+// ShellSubprocess out from under the still-running spawn call:
+//
+//   AddressSanitizer: heap-use-after-free (READ)
+//     Readable::start_pipe_reader            shell/subproc.rs:1247
+//     ShellSubprocess::spawn_maybe_sync_impl shell/subproc.rs:888
+//   freed by: Cmd::deinit <- Interpreter::deinit_node
+//             <- PipeReader::run_yield_with <- PipeReader::on_reader_error
+//
+// The command must instead finish cleanly with the syscall errno as its exit
+// code (ENOMEM = 12 on Linux).
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+// Interposes recv(2). When SHELL_FAIL_RECV=1, every recv fails with ENOMEM.
+// The only recv calls a `bun -e` shell script makes are the eager reads on the
+// subprocess's stdout/stderr socketpairs, so no counting is needed.
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+static ssize_t (*real_recv)(int, void *, size_t, int);
+static int fail = -1;
+
+ssize_t recv(int fd, void *buf, size_t len, int flags) {
+    if (!real_recv) {
+        real_recv = (ssize_t (*)(int, void *, size_t, int)) dlsym(RTLD_NEXT, "recv");
+        fail = getenv("SHELL_FAIL_RECV") != NULL;
+    }
+    if (fail) {
+        errno = ENOMEM;
+        return -1;
+    }
+    return real_recv(fd, buf, len, flags);
+}
+`;
+
+// stderr is redirected away from the capture pipe, so the faulted stdout read
+// is the last open stream: closing it finishes the Cmd from inside the spawn.
+const STDOUT_ONLY_FIXTURE = /* js */ `
+import { $ } from "bun";
+const r = await $\`head -c 64 /dev/zero 2> /dev/null\`.nothrow();
+console.log(JSON.stringify({ exitCode: r.exitCode }));
+`;
+
+// Both stdout and stderr are capture pipes; the stderr read (faulted from
+// inside spawn_async's own stack frame) is the one that finishes the Cmd.
+const BOTH_PIPES_FIXTURE = /* js */ `
+import { $ } from "bun";
+const r = await $\`head -c 64 /dev/zero\`.nothrow();
+console.log(JSON.stringify({ exitCode: r.exitCode }));
+`;
+
+let shimPath: string;
+let dir: ReturnType<typeof tempDir> | undefined;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  dir = tempDir("shell-pipe-read-fault", {
+    "shim.c": SHIM_C,
+    "stdout-only.js": STDOUT_ONLY_FIXTURE,
+    "both-pipes.js": BOTH_PIPES_FIXTURE,
+  });
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+async function runWithShim(script: string) {
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), script],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+      SHELL_FAIL_RECV: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.skipIf(!isLinux || !cc)(
+  "shell survives a synchronous stdout pipe read error during spawn",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("stdout-only.js");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+    expect(JSON.parse(line)).toEqual({ exitCode: 12 }); // ENOMEM
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.skipIf(!isLinux || !cc)(
+  "shell survives synchronous stdout and stderr pipe read errors during spawn",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("both-pipes.js");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+    expect(JSON.parse(line)).toEqual({ exitCode: 12 }); // ENOMEM
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## Problem

Two heap use-after-frees in the Bun Shell, both from the same root cause: a pipe error surfacing synchronously from inside the spawn call tears down state that the spawn frame is still using. Found by syscall-fault-injection fuzzing against `origin/main` (release-asan).

1. `recv()` failing on the eager pipe read frees the `ShellSubprocess`:

```
AddressSanitizer: heap-use-after-free (READ)
  use:   <Readable>::start_pipe_reader            shell/subproc.rs:1247
         <ShellSubprocess>::spawn_maybe_sync_impl shell/subproc.rs:888
         <ShellSubprocess>::spawn_async           shell/subproc.rs:568
         <Cmd>::transition_to_exec                shell/states/Cmd.rs:636
  freed: drop<Box<ShellSubprocess>>
         <Cmd>::deinit                            shell/states/Cmd.rs:907
         <Interpreter>::deinit_node               shell/interpreter.rs:1043
         ...
         <PipeReader>::run_yield_with             shell/subproc.rs:1920
         <PipeReader>::on_reader_error            shell/subproc.rs:2349
         <PipeReader>::read_all                   shell/subproc.rs:1991
```

2. `epoll_ctl()` failing during poll registration frees the `PipeReader`:

```
AddressSanitizer: heap-use-after-free (READ)
  use:   <bun_io::pipes::PollOrFd>::get_poll      io/pipes.rs:41
         <PipeReader>::start                      shell/subproc.rs:2015
         <Readable>::start_pipe_reader            shell/subproc.rs:1254
         <ShellSubprocess>::spawn_maybe_sync_impl shell/subproc.rs:878
  freed: Arc<PipeReader> drop
         <PipeReader>::on_reader_error            shell/subproc.rs:2351
```

## Cause

`Cmd::transition_to_exec` stages `SubprocExec.interp = null` before calling `spawn_async`, specifically so a synchronous `Cmd::on_exit` fired from inside the spawn cannot drive the trampoline into `Cmd::deinit` while the spawn frame still holds the `ShellSubprocess`. The backref is published, and any `Done` state picked up, only after the spawn returns.

The pipe callbacks bypass that gate in two ways:

- `PipeReader` carries its own `interp` backref, populated at `PipeReader::create` time. `spawn_maybe_sync_impl` does an eager `read_all()` on the freshly created stdout/stderr pipes, so if that `recv()` fails (`ENOMEM`/`EMFILE`/`ENFILE`), `on_reader_error` reaches `Cmd::buffered_output_close`, which records the errno as the exit code, closes the stream, and, once every piped stream is closed, returns `Yield::Next`. `PipeReader::finish_after_state_set` runs that with its own ungated `interp`, landing in `Cmd::deinit` and freeing the `Box<ShellSubprocess>` that `spawn_maybe_sync_impl` keeps dereferencing. On a release build the follow-on access is a deterministic `panic: expected Node::Cmd at Node#2, got Free`.

- The same `on_reader_error` can also fire from inside `PipeReader::start`: `PosixBufferedReader::register_poll` reports an `epoll_ctl` failure through the vtable and `PosixBufferedReader::start` then returns `Ok(())` regardless. `Cmd::buffered_output_close` calls `close_io`, and `Readable::finalize` drops the `Readable::Pipe` slot's `Arc<PipeReader>` from inside the callback, so the callback's own guard becomes the last reference and the `PipeReader` is freed when it returns. `PipeReader::start` then reads `self.reader.handle` and writes `self.reader.flags` on the freed object, and `Readable::start_pipe_reader` held no keepalive of its own.

## Fix

Two pieces, one per victim:

- `Cmd::buffered_output_close` now applies the same null-`interp` gate `Cmd::on_exit` already has: if `exec.interp` is still null, the command is marked `Done` but the Yield is suspended, and `transition_to_exec`'s existing `CmdState::Done` check resumes it once the spawn has unwound. This is the single choke point for every pipe-side completion path (`on_reader_error`, `on_reader_done`, `on_captured_writer_done`, `CapturedWriter::on_iowriter_chunk`).
- `Readable::start_pipe_reader` now holds an `Arc::clone` of the `PipeReader` across `start()` and `read_all()`, since both can complete the reader synchronously and drop the `Readable::Pipe` slot's ref. This is the same keepalive `PipeReader::guard_from_raw` already provides for the `on_reader_{done,error}` callbacks themselves.

Also deleted in this PR: `Cmd::spawn_arena_freed`. It was only ever written and then discarded with `let _ =`, and the comment that justified keeping it ("`initSubproc` sets `spawn_arena_freed = true` before any pipe can close") states exactly the premise this bug disproves. The `exec.interp` gate now encodes the pre/post-spawn split directly.

## Test

`test/js/bun/shell/shell-pipe-read-fault.test.ts` uses an `LD_PRELOAD` shim (same pattern as `serve-epoll-add-fail.test.ts`) with two env-selected fault modes: `SHELL_FAIL_RECV` makes `recv()` return `ENOMEM`, and `SHELL_FAIL_EPOLL` makes `epoll_ctl(ADD|MOD)` on pipe-like fds return `ENOMEM`. The epoll mode interposes `syscall(2)` because `FilePoll` registration goes through the raw `syscall(SYS_epoll_ctl, ...)` wrapper rather than the libc `epoll_ctl` symbol. Four tests cover recv and epoll each with stdout-only and stdout+stderr capture pipes. Linux-only, skipped when no C compiler is present.

Each half of the fix is independently load-bearing:

| Build | recv tests | epoll tests |
| --- | --- | --- |
| unfixed main | fail (ShellSubprocess UAF) | fail (PipeReader UAF) |
| gate only, no keepalive | pass | fail (PipeReader UAF) |
| gate + keepalive | pass | pass |

Existing shell suites (`bunshell.test.ts`, `bunshell-default.test.ts`, `shelloutput.test.ts`, `epipe.test.ts`, `exec.test.ts`, `file-io.test.ts`, `pipeline_stack.test.ts`, `yield.test.ts`, `shell-blocking-pipe.test.ts`, and others, 560 tests) still pass.
