### PR TITLE
node:http2: cover RFC 9113 4.2 max-frame-size enforcement in the inbound engine

### DIFF
--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -43,12 +43,17 @@ const ErrorCode = {
 type Frame = { length: number; type: number; flags: number; streamId: number; payload: Buffer };
 
 function encodeFrame(type: number, flags: number, streamId: number, payload: Buffer = Buffer.alloc(0)): Buffer {
+  return Buffer.concat([frameHeader(type, flags, streamId, payload.length), payload]);
+}
+
+/** A bare 9-byte frame header: `length` is what the header declares, not what follows it. */
+function frameHeader(type: number, flags: number, streamId: number, length: number): Buffer {
   const header = Buffer.alloc(9);
-  header.writeUIntBE(payload.length, 0, 3); // 24-bit length
+  header.writeUIntBE(length, 0, 3); // 24-bit length
   header.writeUInt8(type, 3);
   header.writeUInt8(flags, 4);
   header.writeUInt32BE(streamId & 0x7fffffff, 5); // reserved bit clear
-  return Buffer.concat([header, payload]);
+  return header;
 }
 
 /** A minimal raw HTTP/2 client: send arbitrary frames, collect parsed inbound frames. */
@@ -422,15 +427,6 @@ describe("frame size limit (checklist §4.2)", () => {
   // (`Connection::receive`) from the 9-byte header alone, before any payload
   // is buffered: a header declaring a ~16 MiB payload is answered with
   // GOAWAY(FRAME_SIZE_ERROR) without waiting for the bytes it promises.
-  function frameHeader(type: number, streamId: number, length: number): Buffer {
-    const b = Buffer.alloc(9);
-    b.writeUIntBE(length, 0, 3);
-    b.writeUInt8(type, 3);
-    b.writeUInt8(0, 4);
-    b.writeUInt32BE(streamId & 0x7fffffff, 5);
-    return b;
-  }
-
   test.each([
     // Use a multiple of 6 for SETTINGS so the §6.5 length rule cannot mask the §4.2 check.
     ["SETTINGS", FrameType.SETTINGS, 0, 0xfffffc],
@@ -446,7 +442,7 @@ describe("frame size limit (checklist §4.2)", () => {
       c.sendPreface();
       c.sendEmptySettings();
       // Header declaring a multi-MiB payload, followed by only a handful of payload bytes.
-      c.send(frameHeader(type, streamId, length));
+      c.send(frameHeader(type, 0, streamId, length));
       c.send(Buffer.alloc(16, 0));
       // The GOAWAY must arrive even though the declared payload was never sent.
       const goaway = await c.waitForGoaway();
@@ -516,10 +512,7 @@ describe("frame size limit with a non-default SETTINGS_MAX_FRAME_SIZE (checklist
     c.sendEmptySettings();
     // Only the header and a sliver of payload: the rejection must come from
     // the declared length (32769), not from buffering the payload.
-    const header = Buffer.alloc(9);
-    header.writeUIntBE(MAX_FRAME_SIZE + 1, 0, 3);
-    header.writeUInt8(0xff, 3);
-    c.send(header);
+    c.send(frameHeader(0xff, 0, 0, MAX_FRAME_SIZE + 1));
     c.send(Buffer.alloc(16, 0));
     const goaway = await c.waitForGoaway();
     expect(goawayErrorCode(goaway)).toBe(ErrorCode.FRAME_SIZE_ERROR);

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -417,6 +417,114 @@ describe("frame size limit (checklist §4.2)", () => {
     expect(goawayErrorCode(goaway)).toBe(ErrorCode.FRAME_SIZE_ERROR);
     c.destroy();
   });
+
+  // §4.2 applies to every frame type and is enforced by the inbound engine
+  // (`Connection::receive`) from the 9-byte header alone, before any payload
+  // is buffered: a header declaring a ~16 MiB payload is answered with
+  // GOAWAY(FRAME_SIZE_ERROR) without waiting for the bytes it promises.
+  function frameHeader(type: number, streamId: number, length: number): Buffer {
+    const b = Buffer.alloc(9);
+    b.writeUIntBE(length, 0, 3);
+    b.writeUInt8(type, 3);
+    b.writeUInt8(0, 4);
+    b.writeUInt32BE(streamId & 0x7fffffff, 5);
+    return b;
+  }
+
+  test.each([
+    // Use a multiple of 6 for SETTINGS so the §6.5 length rule cannot mask the §4.2 check.
+    ["SETTINGS", FrameType.SETTINGS, 0, 0xfffffc],
+    ["GOAWAY", FrameType.GOAWAY, 0, 0xffffff],
+    ["PUSH_PROMISE", FrameType.PUSH_PROMISE, 1, 0xffffff],
+    ["ALTSVC", 0x0a, 0, 0xffffff],
+    ["ORIGIN", 0x0c, 0, 0xffffff],
+    ["unknown (0xff)", 0xff, 0, 0xffffff],
+  ])(
+    "an oversized %s frame is rejected from the header alone (no buffering)",
+    async (_name, type, streamId, length) => {
+      const c = await RawH2.connect(port);
+      c.sendPreface();
+      c.sendEmptySettings();
+      // Header declaring a multi-MiB payload, followed by only a handful of payload bytes.
+      c.send(frameHeader(type, streamId, length));
+      c.send(Buffer.alloc(16, 0));
+      // The GOAWAY must arrive even though the declared payload was never sent.
+      const goaway = await c.waitForGoaway();
+      expect(goawayErrorCode(goaway)).toBe(ErrorCode.FRAME_SIZE_ERROR);
+      c.destroy();
+    },
+  );
+});
+
+describe("frame size limit with a non-default SETTINGS_MAX_FRAME_SIZE (checklist §4.2)", () => {
+  // §4.2/§6.5.2: the limit is the endpoint's own *advertised*
+  // SETTINGS_MAX_FRAME_SIZE, not the protocol default of 16384.
+  const MAX_FRAME_SIZE = 32768;
+  let bigServer: http2.Http2Server;
+  let bigPort: number;
+
+  beforeAll(async () => {
+    bigServer = http2.createServer({ settings: { maxFrameSize: MAX_FRAME_SIZE } });
+    bigServer.on("stream", (stream: any) => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    bigServer.listen(0);
+    await once(bigServer, "listening");
+    bigPort = (bigServer.address() as net.AddressInfo).port;
+  });
+
+  afterAll(() => {
+    bigServer?.close();
+  });
+
+  /** Decode the first occurrence of `id` in a SETTINGS payload. */
+  function settingValue(f: Frame, id: number): number | undefined {
+    for (let off = 0; off + 6 <= f.payload.length; off += 6) {
+      if (f.payload.readUInt16BE(off) === id) return f.payload.readUInt32BE(off + 2);
+    }
+    return undefined;
+  }
+
+  test("the server advertises the configured SETTINGS_MAX_FRAME_SIZE", async () => {
+    const c = await RawH2.connect(bigPort);
+    c.sendPreface();
+    c.sendEmptySettings();
+    const settings = await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+    expect(settingValue(settings, 0x5)).toBe(MAX_FRAME_SIZE);
+    c.destroy();
+  });
+
+  test("a frame over the default but within the advertised limit is accepted", async () => {
+    const c = await RawH2.connect(bigPort);
+    c.sendPreface();
+    c.sendEmptySettings();
+    // 20000 > 16384 (the default) but <= 32768 (advertised): the connection
+    // must stay usable. Unknown frame types are ignored (§4.1, §5.5).
+    c.sendFrame(0xff, 0, 0, Buffer.alloc(20000, 0));
+    const ping = Buffer.from("pingpong", "latin1");
+    c.sendFrame(FrameType.PING, 0, 0, ping);
+    const ack = await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) === 1);
+    expect(ack.payload).toEqual(ping);
+    expect(c.frames.filter(f => f.type === FrameType.GOAWAY)).toEqual([]);
+    c.destroy();
+  });
+
+  test("a frame one byte over the advertised limit is a FRAME_SIZE_ERROR", async () => {
+    const c = await RawH2.connect(bigPort);
+    c.sendPreface();
+    c.sendEmptySettings();
+    // Only the header and a sliver of payload: the rejection must come from
+    // the declared length (32769), not from buffering the payload.
+    const header = Buffer.alloc(9);
+    header.writeUIntBE(MAX_FRAME_SIZE + 1, 0, 3);
+    header.writeUInt8(0xff, 3);
+    c.send(header);
+    c.send(Buffer.alloc(16, 0));
+    const goaway = await c.waitForGoaway();
+    expect(goawayErrorCode(goaway)).toBe(ErrorCode.FRAME_SIZE_ERROR);
+    c.destroy();
+  });
 });
 
 // ── Client-side conformance: a raw byte-level HTTP/2 *server* drives a Bun `node:http2`


### PR DESCRIPTION
Test-only. Salvaged from #32673, which was closed because its `src/` half guarded the legacy `h2_frame_parser.rs` dispatcher (dead code since #31584); these conformance tests were the useful part, and they exercise the live inbound engine.

### What

RFC 9113 4.2 requires an endpoint to reject any frame whose declared length exceeds its own advertised `SETTINGS_MAX_FRAME_SIZE` with `FRAME_SIZE_ERROR`. The engine enforces this in `Connection::receive` (`src/runtime/api/bun/h2/connection.rs`) from the 9-byte header alone, before buffering the payload, so a peer cannot pin ~16 MiB per connection with a 9-byte header.

The one existing 4.2 test sends a complete 16385-byte HEADERS frame, which does not pin down either property (a check that buffered the frame first, or one that only covered HEADERS, would also pass it). Added:

- `test.each` over SETTINGS / GOAWAY / PUSH_PROMISE / ALTSVC / ORIGIN / unknown (0xff): a header declaring a ~16 MiB payload followed by only 16 bytes must be answered with `GOAWAY(FRAME_SIZE_ERROR)`. Proves every frame type is covered and the check reads only the header.
- A server advertising `maxFrameSize: 32768`: the advertisement is asserted on the wire, a 20000-byte frame (over the 16384 default, within the advertised limit) is accepted with the connection still usable (PING ack, no GOAWAY), and a frame declaring 32769 is rejected from the header alone. Proves the limit compared is the locally advertised setting, not the protocol default.

### Verification

All 32 tests in the file pass against both the debug build and the released binary (the engine already conforms; this is coverage, not a behavior change).

Reverting the engine check (deleting the `hdr.length > self.local_settings.max_frame_size` block in `Connection::receive`) and rebuilding makes exactly the new header-only cases fail by timing out waiting for the GOAWAY, which is what they exist to catch:

```
(pass) a frame exceeding SETTINGS_MAX_FRAME_SIZE is a FRAME_SIZE_ERROR   <- existing test still passes
(fail) an oversized SETTINGS frame is rejected from the header alone (no buffering)
(fail) an oversized GOAWAY frame is rejected from the header alone (no buffering)
(fail) an oversized PUSH_PROMISE frame is rejected from the header alone (no buffering)
(fail) an oversized ALTSVC frame is rejected from the header alone (no buffering)
(fail) an oversized ORIGIN frame is rejected from the header alone (no buffering)
(fail) an oversized unknown (0xff) frame is rejected from the header alone (no buffering)
(pass) the server advertises the configured SETTINGS_MAX_FRAME_SIZE
(pass) a frame over the default but within the advertised limit is accepted
(fail) a frame one byte over the advertised limit is a FRAME_SIZE_ERROR
```

The existing full-frame test keeps passing without the engine check (the buffered HEADERS path still errors out later), so it alone was not protecting this code.

```
bun bd test test/js/node/http2/h2-conformance.test.ts   # 32 pass
```
