### PR TITLE
node:crypto: fix segfault when setAAD is called on a non-AEAD cipher

### DIFF
--- a/src/jsc/bindings/node/crypto/JSCipherPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipherPrototype.cpp
@@ -351,6 +351,12 @@ JSC_DEFINE_HOST_FUNCTION(jsCipherSetAAD, (JSC::JSGlobalObject * globalObject, JS
         return ERR::OUT_OF_RANGE(scope, globalObject, "buffer is too big"_s, 0, INT_MAX, jsNumber(aadbuf->byteLength()));
     }
 
+    // Passing a NULL output buffer to EVP_CipherUpdate is only valid for AEAD
+    // modes; for any other mode it writes the ciphertext through the NULL pointer.
+    if (!cipher->m_ctx || !cipher->isAuthenticatedMode()) {
+        return ERR::CRYPTO_INVALID_STATE(scope, globalObject, "setAAD"_s);
+    }
+
     MarkPopErrorOnReturn popError;
 
     int32_t outlen;

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -849,16 +849,18 @@ it("cipher.setAAD should not throw if encoding or plaintextLength is undefined #
 // buffer, which only AEAD modes treat as "discard the output". Runs in a subprocess so
 // the segfault on an unfixed build doesn't take out the test runner.
 it("cipher.setAAD on a non-authenticated cipher throws ERR_CRYPTO_INVALID_STATE", async () => {
+  const cases = [
+    ["createCipheriv", "aes-128-cbc", 16, 16],
+    ["createDecipheriv", "aes-128-cbc", 16, 16],
+    ["createCipheriv", "aes-256-ctr", 32, 16],
+    ["createDecipheriv", "aes-256-ctr", 32, 16],
+    ["createCipheriv", "aes-128-ecb", 16, 0],
+    ["createDecipheriv", "aes-128-ecb", 16, 0],
+  ];
   const script = `
     const crypto = require("node:crypto");
     const aad = Buffer.alloc(64);
-    const cases = [
-      ["createCipheriv", "aes-128-cbc", 16, 16],
-      ["createDecipheriv", "aes-128-cbc", 16, 16],
-      ["createCipheriv", "aes-256-ctr", 32, 16],
-      ["createCipheriv", "aes-128-ecb", 16, 0],
-    ];
-    for (const [fn, algorithm, keyLen, ivLen] of cases) {
+    for (const [fn, algorithm, keyLen, ivLen] of ${JSON.stringify(cases)}) {
       const cipher = crypto[fn](algorithm, Buffer.alloc(keyLen), ivLen ? Buffer.alloc(ivLen) : null);
       try {
         cipher.setAAD(aad);
@@ -870,13 +872,11 @@ it("cipher.setAAD on a non-authenticated cipher throws ERR_CRYPTO_INVALID_STATE"
   `;
   await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe(
-    "createCipheriv aes-128-cbc: ERR_CRYPTO_INVALID_STATE\n" +
-      "createDecipheriv aes-128-cbc: ERR_CRYPTO_INVALID_STATE\n" +
-      "createCipheriv aes-256-ctr: ERR_CRYPTO_INVALID_STATE\n" +
-      "createCipheriv aes-128-ecb: ERR_CRYPTO_INVALID_STATE\n",
-  );
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: cases.map(([fn, algorithm]) => `${fn} ${algorithm}: ERR_CRYPTO_INVALID_STATE\n`).join(""),
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 it("generatePrime(Sync) should return an ArrayBuffer", async () => {

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 import crypto from "node:crypto";
 import { PassThrough, Readable } from "node:stream";
@@ -842,6 +843,40 @@ it("cipher.setAAD should not throw if encoding or plaintextLength is undefined #
       plaintextLength: undefined,
     });
   }).not.toThrow();
+});
+
+// Non-AEAD modes must reject setAAD: the AAD pass hands EVP_CipherUpdate a NULL output
+// buffer, which only AEAD modes treat as "discard the output". Runs in a subprocess so
+// the segfault on an unfixed build doesn't take out the test runner.
+it("cipher.setAAD on a non-authenticated cipher throws ERR_CRYPTO_INVALID_STATE", async () => {
+  const script = `
+    const crypto = require("node:crypto");
+    const aad = Buffer.alloc(64);
+    const cases = [
+      ["createCipheriv", "aes-128-cbc", 16, 16],
+      ["createDecipheriv", "aes-128-cbc", 16, 16],
+      ["createCipheriv", "aes-256-ctr", 32, 16],
+      ["createCipheriv", "aes-128-ecb", 16, 0],
+    ];
+    for (const [fn, algorithm, keyLen, ivLen] of cases) {
+      const cipher = crypto[fn](algorithm, Buffer.alloc(keyLen), ivLen ? Buffer.alloc(ivLen) : null);
+      try {
+        cipher.setAAD(aad);
+        console.log(fn + " " + algorithm + ": returned");
+      } catch (e) {
+        console.log(fn + " " + algorithm + ": " + e.code);
+      }
+    }
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe(
+    "createCipheriv aes-128-cbc: ERR_CRYPTO_INVALID_STATE\n" +
+      "createDecipheriv aes-128-cbc: ERR_CRYPTO_INVALID_STATE\n" +
+      "createCipheriv aes-256-ctr: ERR_CRYPTO_INVALID_STATE\n" +
+      "createCipheriv aes-128-ecb: ERR_CRYPTO_INVALID_STATE\n",
+  );
+  expect(exitCode).toBe(0);
 });
 
 it("generatePrime(Sync) should return an ArrayBuffer", async () => {


### PR DESCRIPTION
### What does this PR do?

`cipher.setAAD()` on a non-authenticated cipher segfaults instead of throwing. Two lines of public API crash the process:

```js
import { createCipheriv } from "node:crypto";
createCipheriv("aes-128-cbc", Buffer.alloc(16), Buffer.alloc(16)).setAAD(Buffer.alloc(16));
```

```
panic(main thread): Segmentation fault at address 0x0
```

Under ASAN: `SEGV on unknown address 0x000000000000 ... caused by a WRITE memory access`, in `aes_hw_cbc_encrypt`.

`createDecipheriv` is equally affected, as is any non-AEAD algorithm (`aes-256-ctr`, `aes-128-ecb`, ...). Node throws `ERR_CRYPTO_INVALID_STATE` for the same input.

### Cause

`jsCipherSetAAD` in `src/jsc/bindings/node/crypto/JSCipherPrototype.cpp` passes the AAD to `EVP_CipherUpdate` with `out == nullptr` unconditionally. A NULL output buffer only means "absorb as AAD" for AEAD modes (GCM/CCM/OCB/chacha20-poly1305). For every other mode OpenSSL encrypts the input into the NULL output pointer, a NULL write. It only fires once a full block of AAD accumulates, which is why fewer than 16 bytes happens to survive on CBC.

Node's `CipherBase::SetAAD` starts with `if (!ctx_ || !IsAuthenticatedMode()) return false;`, and its `setAuthTag` sibling in this same file already has the equivalent guard. `setAAD` was the only method missing it.

### Fix

Add the same `!m_ctx || !isAuthenticatedMode()` guard and throw `ERR_CRYPTO_INVALID_STATE("setAAD")`, matching Node. Audited the other prototype methods (`update`, `final`, `setAutoPadding`, `getAuthTag`, `setAuthTag`): all already check `m_ctx` before reaching the cipher, either directly or via the null-safe `CipherCtxPointer` helpers.

### Verification

New test in `test/js/node/crypto/node-crypto.test.js` spawns a subprocess and sweeps `createCipheriv`/`createDecipheriv` across `aes-128-cbc`, `aes-256-ctr`, and `aes-128-ecb`, asserting `ERR_CRYPTO_INVALID_STATE` and exit code 0. On an unfixed build the child segfaults and produces no output.

`test-crypto-authenticated.js`, `test-crypto-authenticated-stream.js`, and `test-crypto-cipheriv-decipheriv.js` from the Node suite still pass, and the GCM `setAAD` happy path is unaffected.
