### PR TITLE
shell: fix use-after-free of the PipeReader when epoll registration fails

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -581,12 +581,13 @@ impl Cmd {
         // with the correct `child` once `spawn_async` writes through
         // `out_subproc`. `interp` is left null until `spawn_async` and the
         // `did_exit_immediately` handling have returned: a synchronous
-        // `Cmd::on_exit` reached via the process exit handler would otherwise
-        // drive the trampoline (`Yield::run(&*interp)`) while this frame
-        // still holds `&Interpreter`, tearing the Cmd down (and freeing
+        // `Cmd::on_exit` (process exit handler) or `Cmd::buffered_output_close`
+        // (an eager `read_all` on a pipe erroring inside the spawn) would
+        // otherwise drive the trampoline (`Yield::run(&*interp)`) while this
+        // frame still holds `&Interpreter`, tearing the Cmd down (and freeing
         // `child`) underneath the live `subproc` borrow. With `interp` null,
-        // `on_exit` records `exit_code`/`state = Done` and returns; we resume
-        // via the Yield we hand back below.
+        // both record `exit_code`/`state = Done` and return; we resume via
+        // the Yield we hand back below.
         let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
         let buffered_closed = BufferedIoClosed::from_stdio(&spawn_args.stdio);
         interp.as_cmd_mut(this).exec = Exec::Subproc(Box::new(SubprocExec {
@@ -965,12 +966,20 @@ impl Cmd {
             // `*mut Interpreter` it already holds, landing in `Cmd::next` →
             // `CmdState::Done` → `interp.child_done(...)`.
             self.state = CmdState::Done;
-            let this_id = match &self.exec {
-                Exec::Subproc(sub) => sub.this_id,
+            let (interp, this_id) = match &self.exec {
+                Exec::Subproc(sub) => (sub.interp, sub.this_id),
                 // Only the subprocess path calls this; builtin output goes
                 // through `Builtin::done` → `on_exec_done`.
                 _ => return Yield::suspended(),
             };
+            // Same gate as `on_exit`: `exec.interp` is null until
+            // `transition_to_exec` returns from `spawn_async`. A runnable
+            // Yield here would reach `Cmd::deinit` and free the
+            // `ShellSubprocess` the spawn frame still dereferences;
+            // `transition_to_exec` resumes via its `CmdState::Done` check.
+            if interp.is_null() {
+                return Yield::suspended();
+            }
             // The `!spawn_arena_freed` arm
             // (`ShellAsyncSubprocessDone::enqueue`) is unreachable here in
             // practice — `initSubproc` sets `spawn_arena_freed = true` before

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1245,14 +1245,19 @@ impl Readable {
         eager: bool,
     ) -> bun_sys::Result<()> {
         if let Readable::Pipe(pipe) = self {
-            let p = arc_as_mut_ptr(pipe);
-            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell, and
-            // during `spawn` the `Arc<PipeReader>` is uniquely held (the
-            // reader callback is registered by `start` itself), so no other
-            // `&PipeReader` can exist for this scope.
+            // `start()` can fire `on_reader_error` synchronously (poll
+            // registration failure), which drops this slot's strong ref via
+            // `ShellSubprocess::on_close_io`; this clone pins the allocation
+            // for the whole scope. Neither `pipe` nor `self` is read again.
+            let keepalive = Arc::clone(pipe);
+            let p = arc_as_mut_ptr(&keepalive);
+            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell; `keepalive`
+            // keeps `*p` alive across the re-entrant error path inside `start`
+            // (mirrors the `ScopedRef` guard in `SubprocessPipeReader::start`).
             let p = unsafe { &mut *p };
             p.start(process, event_loop)?;
             if eager {
+                // After an in-`start` error the state is `Err`: no-op.
                 p.read_all();
             }
         }
@@ -2009,6 +2014,12 @@ impl PipeReader {
         match self.reader.start(self.stdio_result.unwrap(), true) {
             bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
             bun_sys::Result::Ok(()) => {
+                // `reader.start()` reports a poll-registration failure via
+                // `on_reader_error` (not its return value); by the time it
+                // returns `Ok` the reader is already torn down.
+                if matches!(self.state, PipeReaderState::Err(_)) {
+                    return bun_sys::Result::Ok(());
+                }
                 #[cfg(unix)]
                 {
                     // TODO: are these flags correct

--- a/test/js/bun/shell/shell-epoll-add-fail.test.ts
+++ b/test/js/bun/shell/shell-epoll-add-fail.test.ts
@@ -1,0 +1,169 @@
+// An LD_PRELOAD shim makes epoll_ctl(EPOLL_CTL_ADD) fail with ENOSPC (what the
+// kernel returns when fs.epoll.max_user_watches is exhausted) for the AF_UNIX
+// SOCK_STREAM socketpair read ends Bun Shell registers for a spawned command's
+// captured stdout/stderr.
+//
+// Before the fix this is a heap-use-after-free: PosixBufferedReader::start()
+// reports the registration failure by synchronously firing on_reader_error,
+// which drops the last Arc<PipeReader> strong ref (via on_close_io) while the
+// PipeReader::start / Readable::start_pipe_reader call that owns it is still
+// executing. Same LD_PRELOAD pattern as serve-epoll-add-fail.test.ts, except
+// Bun issues epoll_ctl as a raw syscall(SYS_epoll_ctl, ...), so the shim has
+// to interpose syscall() rather than epoll_ctl().
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+// Only non-listening AF_UNIX SOCK_STREAM fds above the standard streams are
+// failed, so Bun's own startup registrations (eventfd/timerfd/pidfd) are
+// unaffected; the only matching fds in these fixtures are the socketpair read
+// ends Bun Shell holds for the spawned command's stdout/stderr.
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long (*real_syscall)(long, long, long, long, long, long, long);
+static int (*real_epoll_ctl)(int, int, int, struct epoll_event *);
+static int enabled = -1;
+
+static void shim_init(void) {
+    real_syscall = (long (*)(long, long, long, long, long, long, long)) dlsym(RTLD_NEXT, "syscall");
+    real_epoll_ctl = (int (*)(int, int, int, struct epoll_event *)) dlsym(RTLD_NEXT, "epoll_ctl");
+    enabled = getenv("FAIL_SHELL_EPOLL_ADD") != NULL;
+}
+
+static int should_fail(int fd) {
+    struct stat st;
+    int domain = 0, type = 0, acceptconn = 0;
+    socklen_t len = sizeof(int);
+    if (!enabled || fd <= 2) return 0;
+    if (fstat(fd, &st) != 0 || !S_ISSOCK(st.st_mode)) return 0;
+    if (getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &domain, &len) != 0) return 0;
+    len = sizeof(int);
+    if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &type, &len) != 0) return 0;
+    len = sizeof(int);
+    getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &acceptconn, &len);
+    return domain == AF_UNIX && type == SOCK_STREAM && !acceptconn;
+}
+
+long syscall(long number, ...) {
+    if (!real_syscall) shim_init();
+    va_list ap;
+    va_start(ap, number);
+    long a = va_arg(ap, long), b = va_arg(ap, long), c = va_arg(ap, long);
+    long d = va_arg(ap, long), e = va_arg(ap, long), f = va_arg(ap, long);
+    va_end(ap);
+    if (number == SYS_epoll_ctl && (int) b == EPOLL_CTL_ADD && should_fail((int) c)) {
+        errno = ENOSPC;
+        return -1;
+    }
+    return real_syscall(number, a, b, c, d, e, f);
+}
+
+int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event) {
+    if (!real_epoll_ctl) shim_init();
+    if (op == EPOLL_CTL_ADD && should_fail(fd)) {
+        errno = ENOSPC;
+        return -1;
+    }
+    return real_epoll_ctl(epfd, op, fd, event);
+}
+`;
+
+// A single external (non-builtin) command with captured stdout/stderr is
+// enough: starting either PipeReader performs the EPOLL_CTL_ADD that fails.
+const SINGLE_FIXTURE = /* js */ `
+import { $ } from "bun";
+const r = await $\`head -c 16 \${process.argv[2]}\`.quiet().nothrow();
+console.log(JSON.stringify({ done: true, exitCode: r.exitCode }));
+`;
+
+// The fuzzer reproduction shape: an external-command pipeline, repeated, so
+// both sides of the pipe go through start_pipe_reader on every iteration.
+const PIPELINE_FIXTURE = /* js */ `
+import { $ } from "bun";
+const file = process.argv[2];
+for (let i = 0; i < 8; i++) {
+  await $\`head -c 256 \${file} | head -c 16\`.quiet().nothrow();
+}
+console.log(JSON.stringify({ done: true }));
+`;
+
+let shimPath: string;
+let dir: ReturnType<typeof tempDir> | undefined;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  dir = tempDir("shell-epoll-add-fail", {
+    "shim.c": SHIM_C,
+    "single.js": SINGLE_FIXTURE,
+    "pipeline.js": PIPELINE_FIXTURE,
+    "input.txt": Buffer.alloc(2048, "y").toString(),
+  });
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+async function runWithShim(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), script, join(String(dir), "input.txt")],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
+      FAIL_SHELL_EPOLL_ADD: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+test.skipIf(!isLinux || !cc)(
+  "Bun Shell survives epoll_ctl(EPOLL_CTL_ADD) failing for a spawned command's output pipe",
+  async () => {
+    const { stdout, stderr, exitCode, signalCode } = await runWithShim("single.js");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    // stderr is included so an ASAN report / panic shows up in the failure message.
+    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+    expect(JSON.parse(line)).toEqual({ done: true, exitCode: expect.any(Number) });
+    expect(signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.skipIf(!isLinux || !cc)(
+  "Bun Shell survives epoll_ctl(EPOLL_CTL_ADD) failing inside a repeated external-command pipeline",
+  async () => {
+    const { stdout, stderr, exitCode, signalCode } = await runWithShim("pipeline.js");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+    expect(JSON.parse(line)).toEqual({ done: true });
+    expect(signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## Problem

Heap use-after-free in the Bun Shell when `epoll_ctl(EPOLL_CTL_ADD)` fails while registering a spawned command's output pipe. Found by syscall-fault-injection fuzzing against `origin/main` (release-asan). Deterministic on the first `$` invocation once the fault is injected.

```
AddressSanitizer: heap-use-after-free (READ)
  use:   <PollOrFd>::get_poll                     io/pipes.rs:41
         <PipeReader>::start                      shell/subproc.rs:2015
         <Readable>::start_pipe_reader            shell/subproc.rs:1254
         <ShellSubprocess>::spawn_maybe_sync_impl shell/subproc.rs:878
  freed: <Arc<shell::subproc::PipeReader>>::drop_slow
         <PipeReader>::on_reader_error            shell/subproc.rs:2351
         <PosixBufferedReader>::register_poll     io/PipeReader.rs:429
         <PosixBufferedReader>::start             io/PipeReader.rs:447
         <PipeReader>::start                      shell/subproc.rs:2009
```

`epoll_ctl(EPOLL_CTL_ADD)` really can fail on production machines (`ENOSPC` when `fs.epoll.max_user_watches` is exhausted, `ENOMEM` under memory pressure).

This is a different freed object from #32754 (`Box<ShellSubprocess>`, freed by a re-entrant `Cmd::deinit`). See "Relationship to #32754" below.

## Cause

`PosixBufferedReader::start()` always returns `Ok` for a pollable fd. When `register_poll`'s `epoll_ctl(EPOLL_CTL_ADD)` fails, it reports the error by synchronously firing `on_reader_error` instead (`io/PipeReader.rs:429`). That callback, still inside the `start()` call:

1. reaches `ShellSubprocess::on_close_io`, which replaces the owning `Readable::Pipe(Arc<PipeReader>)` slot with `Readable::Ignore`, dropping its strong ref, and
2. drops its own transient `Arc` guard on return, which was then the last strong ref.

The `PipeReader` allocation is freed while `Readable::start_pipe_reader` still holds a raw `&mut PipeReader` into it. `start()` then returns `Ok`, and `PipeReader::start` reads `self.reader.handle.get_poll()` from the freed allocation.

`Readable::start_pipe_reader`'s safety comment assumed "during spawn the `Arc<PipeReader>` is uniquely held". That invariant does not hold once the error callback can fire from inside `start()`. The equivalent `Bun.spawn` path, `SubprocessPipeReader::start`, already guards against this exact re-entrancy with a `ScopedRef` keepalive plus a post-`start()` state check; the shell's `PipeReader::start` was missing the same protection.

## Fix

Mirror the existing `SubprocessPipeReader::start` guard on the shell side (`src/runtime/shell/subproc.rs`):

- `Readable::start_pipe_reader` takes its own `Arc::clone` keepalive before calling `start()`, so the `Readable::Pipe` slot being replaced out from under it is no longer the last strong reference. The slot binding is not read again after `start()`.
- `PipeReader::start` skips the post-`start()` `get_poll()`/flag writes when `on_reader_error` already ran (`state` is `Err`), so the torn-down reader is not touched.

### Relationship to #32754

#32754 fixes a different free on the same trigger path: `on_reader_error` reaching `Cmd::buffered_output_close` from inside the spawn and running `Cmd::deinit` re-entrantly, which frees the `Box<ShellSubprocess>` and the interpreter node slot (`panic: expected Node::Cmd at Node#2, got Free`). Its fix is a one-hunk `interp.is_null()` gate in `Cmd::buffered_output_close`.

The `epoll_ctl` reproduction here reaches both bugs in sequence: with only the `PipeReader` keepalive applied, the same run then hits the `Node#2, got Free` panic. So this PR includes the same `src/runtime/shell/states/Cmd.rs` hunk, verbatim, that #32754 carries. The two PRs can land in either order; the second rebases to a no-op on that hunk. The `recv()`-fault regression test for the `Cmd` half lives in #32754.

## Test

`test/js/bun/shell/shell-epoll-add-fail.test.ts` (same `LD_PRELOAD` pattern as `serve-epoll-add-fail.test.ts`). Bun issues `epoll_ctl` as a raw `syscall(SYS_epoll_ctl, ...)` (`src/sys/linux_syscall.rs`), so the shim interposes `syscall()` itself, returning `ENOSPC` for `EPOLL_CTL_ADD` on non-listening `AF_UNIX` `SOCK_STREAM` fds. In the fixtures those are exactly the socketpair read ends Bun Shell holds for a spawned command's captured stdout/stderr. Two variants: a single external command, and a repeated external-command pipeline (the fuzzer's shape). Linux-only, skipped when no C compiler is present.

<details>
<summary>Verification (Linux x64, ASAN debug build)</summary>

Unfixed (`git stash push -- src/`): both tests fail; the single-command one aborts under ASan with the trace above.

```
(fail) Bun Shell survives epoll_ctl(EPOLL_CTL_ADD) failing for a spawned command's output pipe
  ==ERROR: AddressSanitizer: heap-use-after-free ... in <bun_io::pipes::PollOrFd>::get_poll
(fail) Bun Shell survives epoll_ctl(EPOLL_CTL_ADD) failing inside a repeated external-command pipeline
```

With only the `subproc.rs` change (no `Cmd.rs` hunk), the ASan UAF is gone but the run hits #32754's bug next:

```
panic: expected Node::Cmd at Node#2, got Free
```

With both changes, both tests pass. Also passing on the same build: `bunshell.test.ts` (376), `bunshell-default.test.ts`, `shelloutput.test.ts`, `epipe.test.ts`, `pipeline_stack.test.ts`, `yield.test.ts`, `lazy.test.ts`, `exec.test.ts`, `shell-blocking-pipe.test.ts`, `file-io.test.ts`, and #32754's `shell-pipe-read-fault.test.ts`. The failures in `shell-hang.test.ts` (700 ms per-test budget vs. a ~650 ms ASAN debug startup) and `leak.test.ts` reproduce identically on unmodified `origin/main` in the same environment.
</details>
