### PR TITLE
install: let `bun add <url>` replace a package installed from a different URL

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -846,12 +846,33 @@ pub(crate) fn edit(
                     }
                 }
 
+                // A URL entry is keyed by its URL; once resolved, its name may
+                // already have an entry (installed from a different URL). Merge
+                // into this slot instead of emitting a duplicate key.
+                let resolved_name = request.get_resolved_name(&manager.lockfile);
+                if request.package_id != INVALID_PACKAGE_ID
+                    && !resolved_name.is_empty()
+                    && resolved_name != request.get_name()
+                {
+                    if let Some(existing) = new_dependencies.iter().position(|p| {
+                        p.key.as_ref().is_some_and(|key| {
+                            key.data
+                                .e_string()
+                                .is_some_and(|s| s.eql_bytes(resolved_name))
+                        })
+                    }) {
+                        if existing != k {
+                            new_dependencies.remove(existing);
+                            if existing < k {
+                                k -= 1;
+                            }
+                        }
+                    }
+                }
+
                 new_dependencies[k].key = Some(Expr::allocate(
                     arena,
-                    E::EString::init(arena_dup(
-                        arena,
-                        request.get_resolved_name(&manager.lockfile),
-                    )),
+                    E::EString::init(arena_dup(arena, resolved_name)),
                     bun_ast::Loc::EMPTY,
                 ));
 

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -846,9 +846,8 @@ pub(crate) fn edit(
                     }
                 }
 
-                // A URL entry is keyed by its URL; once resolved, its name may
-                // already have an entry (installed from a different URL). Merge
-                // into this slot instead of emitting a duplicate key.
+                // The resolved name may already have its own entry (installed from a
+                // different URL); remove it instead of emitting a duplicate key.
                 let resolved_name = request.get_resolved_name(&manager.lockfile);
                 if request.package_id != INVALID_PACKAGE_ID
                     && !resolved_name.is_empty()

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -847,24 +847,27 @@ pub(crate) fn edit(
                 }
 
                 // The resolved name may already have its own entry (installed from a
-                // different URL); remove it instead of emitting a duplicate key.
+                // different URL); remove every such entry instead of emitting a duplicate key.
                 let resolved_name = request.get_resolved_name(&manager.lockfile);
                 if request.package_id != INVALID_PACKAGE_ID
                     && !resolved_name.is_empty()
                     && resolved_name != request.get_name()
                 {
-                    if let Some(existing) = new_dependencies.iter().position(|p| {
-                        p.key.as_ref().is_some_and(|key| {
-                            key.data
-                                .e_string()
-                                .is_some_and(|s| s.eql_bytes(resolved_name))
-                        })
-                    }) {
-                        if existing != k {
-                            new_dependencies.remove(existing);
-                            if existing < k {
+                    let mut i = 0;
+                    while i < new_dependencies.len() {
+                        if i != k
+                            && new_dependencies[i].key.as_ref().is_some_and(|key| {
+                                key.data
+                                    .e_string()
+                                    .is_some_and(|s| s.eql_bytes(resolved_name))
+                            })
+                        {
+                            new_dependencies.remove(i);
+                            if i < k {
                                 k -= 1;
                             }
+                        } else {
+                            i += 1;
                         }
                     }
                 }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -854,6 +854,128 @@ impl Lockfile {
         Ok(())
     }
 
+    /// `bun add <url>` starts URL-keyed, then `assign_root_resolution` renames it.
+    /// If another URL already installed the same name, hoisting sees a loop.
+    /// The new request supersedes the stale root, so drop it before rebuilding.
+    fn remove_superseded_root_dependencies(
+        old: &mut Lockfile,
+        manager: &mut PackageManager,
+        updates: &[UpdateRequest],
+    ) {
+        if updates.is_empty() {
+            return;
+        }
+
+        let workspace_package_id = manager
+            .root_package_id
+            .get(old, manager.workspace_name_hash) as usize;
+        if workspace_package_id >= old.packages.len() {
+            return;
+        }
+
+        let dep_slice: DependencySlice = old.packages.items_dependencies()[workspace_package_id];
+        let res_slice: PackageIDSlice = old.packages.items_resolutions()[workspace_package_id];
+        let n = dep_slice.len as usize;
+        if n < 2
+            || res_slice.len as usize != n
+            || dep_slice.off as usize + n > old.buffers.dependencies.len()
+            || res_slice.off as usize + n > old.buffers.resolutions.len()
+        {
+            return;
+        }
+
+        let keep: Vec<bool> = {
+            let string_buf = old.buffers.string_bytes.as_slice();
+            let deps: &[Dependency] = dep_slice.get(old.buffers.dependencies.as_slice());
+            let resolutions: &[PackageID] = res_slice.get(old.buffers.resolutions.as_slice());
+
+            // A root dependency is "requested" when it matches one of the
+            // update requests the user typed. Only non-aliased URL adds get
+            // renamed to the resolved name, so only those can collide.
+            let mut matched = vec![false; n];
+            let mut superseding: Vec<(PackageNameHash, dependency::Behavior, PackageID)> =
+                Vec::new();
+            for (i, dep) in deps.iter().enumerate() {
+                for update in updates.iter() {
+                    if update.matches(dep, string_buf) {
+                        matched[i] = true;
+                        if !update.is_aliased
+                            && !dep.behavior.is_peer()
+                            && matches!(
+                                dep.version.tag,
+                                dependency::Tag::Tarball
+                                    | dependency::Tag::Git
+                                    | dependency::Tag::Github
+                            )
+                        {
+                            superseding.push((dep.name_hash, dep.behavior, resolutions[i]));
+                        }
+                        break;
+                    }
+                }
+            }
+
+            // Prune only within the same dependency group (identical behavior) and
+            // when the resolution differs, matching the package.json editor's
+            // single-group rewrite; a cross-group collision stays a loud loop.
+            let mut keep = vec![true; n];
+            for (i, dep) in deps.iter().enumerate() {
+                if matched[i] || dep.behavior.is_peer() {
+                    continue;
+                }
+                for &(name_hash, behavior, winner_resolution) in &superseding {
+                    if dep.name_hash == name_hash
+                        && dep.behavior == behavior
+                        && resolutions[i] != winner_resolution
+                    {
+                        keep[i] = false;
+                        break;
+                    }
+                }
+            }
+            keep
+        };
+
+        let removed = keep.iter().filter(|k| !**k).count();
+        if removed == 0 {
+            return;
+        }
+
+        // Compact both parallel arrays in place (order-preserving retain). The
+        // trailing `removed` slots fall outside the shrunk slice and are never
+        // read again; the cloner rebuilds `buffers` compactly from the slice.
+        {
+            let deps = dep_slice.mut_(old.buffers.dependencies.as_mut_slice());
+            let mut w = 0;
+            for r in 0..n {
+                if keep[r] {
+                    if w != r {
+                        deps.swap(w, r);
+                    }
+                    w += 1;
+                }
+            }
+        }
+        {
+            let resolutions = res_slice.mut_(old.buffers.resolutions.as_mut_slice());
+            let mut w = 0;
+            for r in 0..n {
+                if keep[r] {
+                    if w != r {
+                        resolutions.swap(w, r);
+                    }
+                    w += 1;
+                }
+            }
+        }
+
+        let new_len = (n - removed) as u32;
+        old.packages.items_mut::<"dependencies", DependencySlice>()[workspace_package_id].len =
+            new_len;
+        old.packages.items_mut::<"resolutions", PackageIDSlice>()[workspace_package_id].len =
+            new_len;
+    }
+
     pub fn resolve_catalog_dependency(&self, dep: &Dependency) -> Option<DependencyVersion> {
         if dep.version.tag != dependency::Tag::Catalog {
             return Some(dep.version.clone());
@@ -1223,7 +1345,9 @@ fn clean_preprocess_update_requests_cold(
     updates: &mut [UpdateRequest],
     exact_versions: bool,
 ) -> Result<(), BunError> {
-    Lockfile::preprocess_update_requests(old, manager, updates, exact_versions)
+    Lockfile::preprocess_update_requests(old, manager, updates, exact_versions)?;
+    Lockfile::remove_superseded_root_dependencies(old, manager, updates);
+    Ok(())
 }
 
 #[cold]

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -854,9 +854,9 @@ impl Lockfile {
         Ok(())
     }
 
-    /// `bun add <url>` starts URL-keyed, then `assign_root_resolution` renames it.
-    /// If another URL already installed the same name, hoisting sees a loop.
-    /// The new request supersedes the stale root, so drop it before rebuilding.
+    /// Drops root entries that a `bun add <url>` request replaced: once resolution
+    /// renames the request to its package name, a stale entry for that name from a
+    /// different URL would make hoisting report a dependency loop.
     fn remove_superseded_root_dependencies(
         old: &mut Lockfile,
         manager: &mut PackageManager,
@@ -889,9 +889,7 @@ impl Lockfile {
             let deps: &[Dependency] = dep_slice.get(old.buffers.dependencies.as_slice());
             let resolutions: &[PackageID] = res_slice.get(old.buffers.resolutions.as_slice());
 
-            // A root dependency is "requested" when it matches one of the
-            // update requests the user typed. Only non-aliased URL adds get
-            // renamed to the resolved name, so only those can collide.
+            // Only non-aliased URL adds get renamed to the resolved name, so only those can collide.
             let mut matched = vec![false; n];
             let mut superseding: Vec<(PackageNameHash, dependency::Behavior, PackageID)> =
                 Vec::new();
@@ -915,9 +913,8 @@ impl Lockfile {
                 }
             }
 
-            // Prune only within the same dependency group (identical behavior) and
-            // when the resolution differs, matching the package.json editor's
-            // single-group rewrite; a cross-group collision stays a loud loop.
+            // Prune within the same behavior group only, matching the package.json
+            // rewrite; a cross-group collision stays a loud DependencyLoop.
             let mut keep = vec![true; n];
             for (i, dep) in deps.iter().enumerate() {
                 if matched[i] || dep.behavior.is_peer() {
@@ -941,9 +938,8 @@ impl Lockfile {
             return;
         }
 
-        // Compact both parallel arrays in place (order-preserving retain). The
-        // trailing `removed` slots fall outside the shrunk slice and are never
-        // read again; the cloner rebuilds `buffers` compactly from the slice.
+        // Order-preserving retain; the trailing slots fall outside the shrunk
+        // slice and the cloner never reads them.
         {
             let deps = dep_slice.mut_(old.buffers.dependencies.as_mut_slice());
             let mut w = 0;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -904,6 +904,7 @@ impl Lockfile {
                                 dependency::Tag::Tarball
                                     | dependency::Tag::Git
                                     | dependency::Tag::Github
+                                    | dependency::Tag::Folder
                             )
                         {
                             superseding.push((dep.name_hash, dep.behavior, resolutions[i]));

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -905,6 +905,7 @@ impl Lockfile {
                                     | dependency::Tag::Git
                                     | dependency::Tag::Github
                                     | dependency::Tag::Folder
+                                    | dependency::Tag::Symlink
                             )
                         {
                             superseding.push((dep.name_hash, dep.behavior, resolutions[i]));

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2730,6 +2730,82 @@ it("should update a folder dependency when adding the same package from a differ
   });
 });
 
+it("should replace an existing registry dependency when adding the same package as a URL", async () => {
+  using tmpRoot = tempDir("bun-add-npm-to-url", {});
+  const tmpDir = String(tmpRoot);
+  const pkgDir = join(tmpDir, "package");
+  await mkdir(pkgDir, { recursive: true });
+  await writeFile(join(pkgDir, "package.json"), JSON.stringify({ name: "baz", version: "9.9.9" }));
+  {
+    const { exited } = spawn({
+      cmd: ["tar", "-czf", join(tmpDir, "baz-url.tgz"), "-C", tmpDir, "package"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await exited).toBe(0);
+  }
+  using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response(Bun.file(join(tmpDir, "baz-url.tgz"))),
+  });
+  const baz_url = `${server.url.href.replace(/\/+$/, "")}/baz-url.tgz`;
+
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": { bin: { "baz-run": "index.js" } } }));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+
+  // Install baz from the registry first.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", "baz"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed baz@0.0.3");
+    expect(exitCode).toBe(0);
+  }
+  expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: { baz: "^0.0.3" },
+  });
+
+  // Adding a tarball URL for the same package replaces the registry entry
+  // rather than reporting a dependency loop.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", baz_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("dependency loop");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed baz@");
+    expect(exitCode).toBe(0);
+  }
+
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"baz"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw)).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: { baz: baz_url },
+  });
+  expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
+    name: "baz",
+    version: "9.9.9",
+  });
+});
+
 it("should add multiple dependencies specified on command line", async () => {
   expect(check_npm_auth_type.check).toBe(true);
   using server = Bun.serve({

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2666,6 +2666,70 @@ it("should update a GitHub dependency when adding the same repo at a different r
   });
 });
 
+it("should update a folder dependency when adding the same package from a different folder", async () => {
+  // Two local folders containing the same package name at different versions.
+  using tmpRoot = tempDir("bun-add-folder-replace", {
+    "pkg-v1/package.json": JSON.stringify({ name: "mypkg", version: "1.0.0" }),
+    "pkg-v2/package.json": JSON.stringify({ name: "mypkg", version: "2.0.0" }),
+  });
+  const tmpDir = String(tmpRoot);
+
+  setHandler(dummyRegistry([]));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+
+  // First add installs mypkg@1.0.0 from the first folder.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", join(tmpDir, "pkg-v1")],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(out).toContain("installed mypkg@");
+    expect(exitCode).toBe(0);
+  }
+  expect(await file(join(package_dir, "node_modules", "mypkg", "package.json")).json()).toMatchObject({
+    name: "mypkg",
+    version: "1.0.0",
+  });
+
+  // Second add of a different folder for the same package must replace the
+  // entry and install the new folder's contents, not keep the stale one.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", join(tmpDir, "pkg-v2")],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("dependency loop");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed mypkg@");
+    expect(exitCode).toBe(0);
+  }
+
+  // package.json points at the new folder with no duplicate entry.
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"mypkg"\s*:/g) ?? []).toHaveLength(1);
+  const pkg = JSON.parse(raw);
+  expect(Object.keys(pkg.dependencies)).toEqual(["mypkg"]);
+  expect(pkg.dependencies.mypkg).toContain("pkg-v2");
+
+  // The installed package is the v2 contents.
+  expect(await file(join(package_dir, "node_modules", "mypkg", "package.json")).json()).toMatchObject({
+    name: "mypkg",
+    version: "2.0.0",
+  });
+});
+
 it("should add multiple dependencies specified on command line", async () => {
   expect(check_npm_auth_type.check).toBe(true);
   using server = Bun.serve({

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,7 +1,16 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import {
+  bunExe,
+  bunEnv as env,
+  readdirSorted,
+  tempDir,
+  tmpdirSync,
+  toBeValidBin,
+  toBeWorkspaceLink,
+  toHaveBins,
+} from "harness";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
@@ -2468,6 +2477,192 @@ it("should not add duplicate package.json entries when installing the same tarba
     dependencies: {
       baz: tarball_url,
     },
+  });
+});
+
+it("should update a package installed from one tarball URL to a different tarball URL (#32757)", async () => {
+  // Build two tarballs for the same package name at two different versions.
+  using tmpRoot = tempDir("bun-add-url-replace", {});
+  const tmpDir = String(tmpRoot);
+  for (const version of ["1.0.0", "2.0.0"]) {
+    const dir = join(tmpDir, version, "package");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "mypkg", version }));
+    const { exited } = spawn({
+      cmd: ["tar", "-czf", join(tmpDir, `v${version}.tgz`), "-C", join(tmpDir, version), "package"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await exited).toBe(0);
+  }
+
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const file = new URL(req.url).pathname.includes("v2") ? "v2.0.0.tgz" : "v1.0.0.tgz";
+      return new Response(Bun.file(join(tmpDir, file)));
+    },
+  });
+  const server_url = server.url.href.replace(/\/+$/, "");
+  // Two distinct URLs for the same package. Differ by path rather than a query
+  // string: a "?" in a tarball URL lands in the extraction temp-dir name, which
+  // is rejected on Windows (a separate, pre-existing issue from this fix).
+  const v1_url = `${server_url}/v1.tgz`;
+  const v2_url = `${server_url}/v2.tgz`;
+
+  setHandler(dummyRegistry([]));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+
+  // First add installs mypkg@1.0.0 from the v1 URL.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", v1_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).toContain("Saved lockfile");
+    expect(out).toContain("installed mypkg@");
+    expect(exitCode).toBe(0);
+  }
+  expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: { mypkg: v1_url },
+  });
+
+  // Second add of a different URL for the same package must replace the entry
+  // rather than fail with a dependency loop.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", v2_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("dependency loop");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed mypkg@");
+    expect(exitCode).toBe(0);
+  }
+
+  // package.json points at the new URL with no duplicate entry.
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"mypkg"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw)).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: { mypkg: v2_url },
+  });
+
+  // The installed package is the v2 build.
+  expect(await file(join(package_dir, "node_modules", "mypkg", "package.json")).json()).toMatchObject({
+    name: "mypkg",
+    version: "2.0.0",
+  });
+});
+
+it("should update a GitHub dependency when adding the same repo at a different ref (#8031)", async () => {
+  // GitHub tarballs wrap files under `<owner>-<repo>-<sha>/`; bun stores that
+  // directory name as the resolved ref, so the two tags need distinct roots.
+  using tmpRoot = tempDir("bun-add-github-replace", {});
+  const tmpDir = String(tmpRoot);
+  const refs = [
+    { tag: "v1.0.0", root: "owner-repo-aaaa111", version: "1.0.0" },
+    { tag: "v2.0.0", root: "owner-repo-bbbb222", version: "2.0.0" },
+  ] as const;
+  for (const { root, version } of refs) {
+    const dir = join(tmpDir, root);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "mypkg", version }));
+    const { exited } = spawn({
+      cmd: ["tar", "-czf", join(tmpDir, `${root}.tgz`), "-C", tmpDir, root],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await exited).toBe(0);
+  }
+
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const path = new URL(req.url).pathname;
+      const ref = refs.find(r => path.endsWith(`/tarball/${r.tag}`));
+      if (ref) {
+        return new Response(Bun.file(join(tmpDir, `${ref.root}.tgz`)), {
+          headers: { "Content-Type": "application/gzip" },
+        });
+      }
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+
+  setHandler(dummyRegistry([]));
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+
+  const githubEnv = {
+    ...env,
+    GITHUB_API_URL: server.url.href.replace(/\/+$/, ""),
+    BUN_INSTALL_CACHE_DIR: join(package_dir, ".add-cache"),
+  };
+
+  // First add installs mypkg@1.0.0 from the v1 tag.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", "owner/repo#v1.0.0"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env: githubEnv,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(out).toContain("installed mypkg@");
+    expect(exitCode).toBe(0);
+  }
+  expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: { mypkg: "owner/repo#v1.0.0" },
+  });
+
+  // Second add of a different tag for the same repo must replace the entry
+  // rather than fail with a dependency loop.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", "owner/repo#v2.0.0"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env: githubEnv,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("dependency loop");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed mypkg@");
+    expect(exitCode).toBe(0);
+  }
+
+  // package.json points at the new tag with no duplicate entry.
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"mypkg"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw)).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: { mypkg: "owner/repo#v2.0.0" },
+  });
+  expect(await file(join(package_dir, "node_modules", "mypkg", "package.json")).json()).toMatchObject({
+    name: "mypkg",
+    version: "2.0.0",
   });
 });
 


### PR DESCRIPTION
Fixes #32757. Fixes #8031.

## Repro

With a package already installed from one spec, adding the same package from a different spec fails instead of updating it:

```sh
bun add mishoo/UglifyJS#v3.14.1
bun add mishoo/UglifyJS#v3.14.2
```

```
error: Package "uglify-js@github:mishoo/UglifyJS#e219a9a" has a dependency loop
  Resolution: "uglify-js@github:mishoo/UglifyJS#8578688"
  Dependency: "uglify-js@mishoo/UglifyJS#v3.14.1"
error: An internal error occurred (DependencyLoop)
```

The same happens for remote tarball URLs (#32757), and for adding a URL when the package is already installed from the registry. For two local folders with the same package name, the install silently kept the old contents while `package.json` pointed at the new folder.

## Cause

A github/git/tarball/folder dependency is keyed by its spec string until it is resolved, because the real package name is not known in advance. The package.json editor therefore appends a second root dependency for the new spec even when the package is already present under a different spec. After resolution, `assign_root_resolution` renames the spec-keyed dependency to the resolved package name, leaving two root dependencies that share one name but resolve to different packages. The tree hoister (`src/install/lockfile/Tree.rs`) rejects that as `error.DependencyLoop`.

`bun add foo@2` avoids this because the name is known up front, so the editor matches and replaces the existing `foo` entry in place. URL/path adds cannot match by name before resolution, so the duplicate is only detectable afterward.

## Fix

Treat the newly requested spec as superseding the existing entry:

- `Lockfile::remove_superseded_root_dependencies` runs before the lockfile is rebuilt (after resolution, so the new dependency is already renamed). It drops a pre-existing root dependency whose name now matches a just-added, non-aliased github/git/tarball/folder/symlink dependency of the same group. The cloner then rebuilds a single entry and the hoister no longer loops.
- The package.json editor, when it rekeys a URL entry to its resolved name, removes every existing entry of that name instead of emitting a duplicate key.

Both are scoped to the collision case, so npm/aliased adds and same-spec re-adds (#30499, #30933) are unaffected. An existing registry dependency is intentionally superseded when the user explicitly `bun add`s a URL for the same package; this matches npm and is what the `bun remove && bun add` workaround reported in #8031 was approximating.

## Verification

New regression tests in `test/cli/install/bun-add.test.ts`:

- `#32757`: two different remote tarball URLs for the same package name.
- `#8031`: `owner/repo#v1` then `owner/repo#v2` against a local mock of the GitHub tarball API (no network access).
- folder: two local folders with the same package name.
- npm to URL: start from a registry semver dep, then add a tarball URL for the same package.

All four fail on the current release and pass with this change. Existing tarball/folder dedup tests (#30499, #30933), the npm re-add path, and `should add dependency (GitHub)` still pass.

## Related reports

The pruning covers `Tag::Git` as well, so the same dependency-loop reported for git URLs and query-string tarballs (#20647, #21405) shares this root cause and is resolved on POSIX. The separate Windows issue where a `?` in a tarball URL lands in the temp-directory name is unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->