### PR TITLE
run: render a live pane per --parallel task on an interactive terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bun_ghostty_vt_sys"
+version = "0.0.0"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "bun_glob"
 version = "0.0.0"
 dependencies = [
@@ -1643,6 +1650,7 @@ dependencies = [
  "bun_dns",
  "bun_dotenv",
  "bun_event_loop",
+ "bun_ghostty_vt_sys",
  "bun_glob",
  "bun_hash",
  "bun_highway",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "src/dotenv",
   "src/event_loop",
   "src/exe_format",
+  "src/ghostty_vt_sys",
   "src/highway",
   "src/http_jsc",
   "src/http_types",
@@ -386,6 +387,7 @@ bun_dns = { path = "src/dns" }
 bun_dotenv = { path = "src/dotenv" }
 bun_event_loop = { path = "src/event_loop" }
 bun_exe_format = { path = "src/exe_format" }
+bun_ghostty_vt_sys = { path = "src/ghostty_vt_sys" }
 bun_highway = { path = "src/highway" }
 bun_http_jsc = { path = "src/http_jsc" }
 bun_http_types = { path = "src/http_types" }

--- a/docs/pm/filter.mdx
+++ b/docs/pm/filter.mdx
@@ -118,7 +118,7 @@ bun run --parallel --filter '*' build lint
 
 Each line of output is prefixed with the package and script name (`pkg-a:build | ...`). Without `--filter`/`--workspaces`, the prefix is just the script name (`build | ...`). When a package's `package.json` has no `name` field, Bun uses the relative path from the workspace root instead.
 
-When stdout is an interactive terminal, `--parallel` and `--sequential` render one live pane per script instead. Each script runs on its own pseudo-terminal sized to the pane and its output is replayed into a virtual terminal (powered by [libghostty-vt](https://github.com/ghostty-org/ghostty)), so progress bars, carriage-return spinners, cursor movement, and colors display the way a real terminal would show them. Rows that scroll out of a pane are summarized as `[N lines elided]`; `--elide-lines` sets the pane height. When stdout is not a terminal (pipes, redirects, CI), the prefixed line output above is used instead.
+On macOS and Linux, when stdout is an interactive terminal, `--parallel` and `--sequential` render one live pane per script instead. Each script runs on its own pseudo-terminal sized to the pane and its output is replayed into a virtual terminal (powered by [libghostty-vt](https://github.com/ghostty-org/ghostty)), so progress bars, carriage-return spinners, cursor movement, and colors display the way a real terminal would show them. Rows that scroll out of a pane are summarized as `[N lines elided]`; `--elide-lines` sets the pane height. When stdout is not a terminal (pipes, redirects, CI), the prefixed line output above is used instead.
 
 Use `--if-present` with `--workspaces` to skip packages that don't have the requested script instead of erroring.
 

--- a/docs/pm/filter.mdx
+++ b/docs/pm/filter.mdx
@@ -97,7 +97,7 @@ bun run --filter foo myscript
 
 ### Parallel and sequential mode
 
-Combine `--filter` or `--workspaces` with `--parallel` or `--sequential` to run scripts across workspace packages with Foreman-style prefixed output:
+Combine `--filter` or `--workspaces` with `--parallel` or `--sequential` to run scripts across workspace packages:
 
 ```bash terminal icon="terminal"
 # Run "build" in all matching packages concurrently
@@ -117,6 +117,8 @@ bun run --parallel --filter '*' build lint
 ```
 
 Each line of output is prefixed with the package and script name (`pkg-a:build | ...`). Without `--filter`/`--workspaces`, the prefix is just the script name (`build | ...`). When a package's `package.json` has no `name` field, Bun uses the relative path from the workspace root instead.
+
+When stdout is an interactive terminal, `--parallel` and `--sequential` render one live pane per script instead. Each script runs on its own pseudo-terminal sized to the pane and its output is replayed into a virtual terminal (powered by [libghostty-vt](https://github.com/ghostty-org/ghostty)), so progress bars, carriage-return spinners, cursor movement, and colors display the way a real terminal would show them. Rows that scroll out of a pane are summarized as `[N lines elided]`; `--elide-lines` sets the pane height. When stdout is not a terminal (pipes, redirects, CI), the prefixed line output above is used instead.
 
 Use `--if-present` with `--workspaces` to skip packages that don't have the requested script instead of erroring.
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -851,7 +851,7 @@ bun run --silent dev
 
 ### `run.elide-lines` - truncate filtered output
 
-The number of lines of script output shown per script when using `--filter`. Default `10`. Set to `0` to show all lines. Equivalent to the `--elide-lines` flag.
+The number of lines of script output shown per script when using `--filter`, and the pane height for `--parallel`/`--sequential` on an interactive terminal. Default `10`. With `--filter`, set to `0` to show all lines. Equivalent to the `--elide-lines` flag.
 
 ```toml title="bunfig.toml" icon="settings"
 [run]

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -851,7 +851,7 @@ bun run --silent dev
 
 ### `run.elide-lines` - truncate filtered output
 
-The number of lines of script output shown per script when using `--filter`, and the pane height for `--parallel`/`--sequential` on an interactive terminal. Default `10`. With `--filter`, set to `0` to show all lines. Equivalent to the `--elide-lines` flag.
+The number of lines of script output shown per script when using `--filter`, and the pane height for `--parallel`/`--sequential` on an interactive terminal (macOS and Linux). Default `10`. With `--filter`, set to `0` to show all lines. Equivalent to the `--elide-lines` flag.
 
 ```toml title="bunfig.toml" icon="settings"
 [run]

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -29,7 +29,7 @@ bun run <file or script>
 ### Workspace Management
 
 <ParamField path="--elide-lines" type="number" default="10">
-  Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines
+  Lines of script output shown per `--filter` or `--parallel`/`--sequential` pane. With `--filter`, 0 shows all lines
 </ParamField>
 
 <ParamField path="--filter" type="string">
@@ -41,11 +41,13 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--parallel" type="boolean">
-  Run multiple scripts or workspace scripts concurrently with prefixed output
+  Run multiple scripts or workspace scripts concurrently. On an interactive terminal each script renders into its own
+  pane; otherwise each line of output is prefixed with the script name
 </ParamField>
 
 <ParamField path="--sequential" type="boolean">
-  Run multiple scripts or workspace scripts one after another with prefixed output
+  Run multiple scripts or workspace scripts one after another. On an interactive terminal each script renders into its
+  own pane; otherwise each line of output is prefixed with the script name
 </ParamField>
 
 <ParamField path="--no-exit-on-error" type="boolean">

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -41,13 +41,13 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--parallel" type="boolean">
-  Run multiple scripts or workspace scripts concurrently. On an interactive terminal each script renders into its own
-  pane; otherwise each line of output is prefixed with the script name
+  Run multiple scripts or workspace scripts concurrently. On an interactive terminal (macOS and Linux) each script
+  renders into its own pane; otherwise each line of output is prefixed with the script name
 </ParamField>
 
 <ParamField path="--sequential" type="boolean">
-  Run multiple scripts or workspace scripts one after another. On an interactive terminal each script renders into its
-  own pane; otherwise each line of output is prefixed with the script name
+  Run multiple scripts or workspace scripts one after another. On an interactive terminal (macOS and Linux) each script
+  renders into its own pane; otherwise each line of output is prefixed with the script name
 </ParamField>
 
 <ParamField path="--no-exit-on-error" type="boolean">

--- a/patches/ghostty-vt/lib-vt-only.patch
+++ b/patches/ghostty-vt/lib-vt-only.patch
@@ -1,5 +1,3 @@
-diff --git a/build.zig b/build.zig
-index 8ef7701..7ebcc1e 100644
 --- a/build.zig
 +++ b/build.zig
 @@ -56,6 +56,29 @@ pub fn build(b: *std.Build) !void {

--- a/patches/ghostty-vt/lib-vt-only.patch
+++ b/patches/ghostty-vt/lib-vt-only.patch
@@ -30,3 +30,18 @@
      // All our steps which we'll hook up later. The steps are shown
      // up here just so that they are more self-documenting.
      const run_step = b.step("run", "Run the app");
+--- a/src/build/GhosttyLibVt.zig
++++ b/src/build/GhosttyLibVt.zig
+@@ -222,6 +222,12 @@
+         lib.bundle_compiler_rt = true;
+         lib.bundle_ubsan_rt = true;
+ 
++        // One section per function/data symbol so a consumer linking with
++        // --gc-sections / -dead_strip can drop the parts of the C API it
++        // does not call.
++        lib.link_function_sections = true;
++        lib.link_data_sections = true;
++
+         // Enable PIC so the static library can be linked into PIE
+         // executables, which is the default on most Linux distributions.
+         lib.root_module.pic = true;

--- a/patches/ghostty-vt/lib-vt-only.patch
+++ b/patches/ghostty-vt/lib-vt-only.patch
@@ -1,0 +1,34 @@
+diff --git a/build.zig b/build.zig
+index 8ef7701..7ebcc1e 100644
+--- a/build.zig
++++ b/build.zig
+@@ -56,6 +56,29 @@ pub fn build(b: *std.Build) !void {
+         &deps,
+     );
+ 
++    // When only the VT library is requested, build it and stop. This avoids
++    // walking the full Ghostty app dependency graph (GTK, fonts, renderers,
++    // ...), which would otherwise lazily fetch dozens of packages that
++    // libghostty-vt does not need.
++    if (config.emit_lib_vt) {
++        const vt_static = try buildpkg.GhosttyLibVt.initStatic(b, &mod);
++        const static_lib_name = if (config.target.result.os.tag == .windows)
++            "ghostty-vt-static.lib"
++        else
++            "libghostty-vt.a";
++        b.getInstallStep().dependOn(&b.addInstallLibFile(
++            vt_static.output,
++            static_lib_name,
++        ).step);
++        b.getInstallStep().dependOn(&b.addInstallDirectory(.{
++            .source_dir = b.path("include/ghostty"),
++            .install_dir = .header,
++            .install_subdir = "ghostty",
++            .include_extensions = &.{".h"},
++        }).step);
++        return;
++    }
++
+     // All our steps which we'll hook up later. The steps are shown
+     // up here just so that they are more self-documenting.
+     const run_step = b.step("run", "Run the app");

--- a/patches/ghostty-vt/lib-vt-only.patch
+++ b/patches/ghostty-vt/lib-vt-only.patch
@@ -32,16 +32,32 @@
      const run_step = b.step("run", "Run the app");
 --- a/src/build/GhosttyLibVt.zig
 +++ b/src/build/GhosttyLibVt.zig
-@@ -222,6 +222,12 @@
-         lib.bundle_compiler_rt = true;
-         lib.bundle_ubsan_rt = true;
+@@ -215,12 +215,22 @@
+     );
  
+     if (kind == .static) {
+-        // These must be bundled since we're compiling into a static lib.
+-        // Otherwise, you get undefined symbol errors. This could cause
+-        // problems if you're linking multiple static Zig libraries but
+-        // we'll cross that bridge when we get to it.
+-        lib.bundle_compiler_rt = true;
+-        lib.bundle_ubsan_rt = true;
++        // Do NOT bundle Zig's compiler_rt: it defines `memcpy`, `memset`,
++        // `memmove`, `memcmp`, and most of libm (`exp`, `log`, `fma`, ...)
++        // as weak globals. A consumer that links this archive before libc,
++        // which is every ordinary C link line, extracts those and silently
++        // replaces libc's optimized versions for its entire binary. The few
++        // `__`-prefixed builtins the Zig code needs (`__udivti3`, ...) come
++        // from the consumer's own compiler runtime instead, and ubsan_rt is
++        // never referenced because this library is built without sanitizers.
++        lib.bundle_compiler_rt = false;
++        lib.bundle_ubsan_rt = false;
++
 +        // One section per function/data symbol so a consumer linking with
 +        // --gc-sections / -dead_strip can drop the parts of the C API it
 +        // does not call.
 +        lib.link_function_sections = true;
 +        lib.link_data_sections = true;
-+
+ 
          // Enable PIC so the static library can be linked into PIE
          // executables, which is the default on most Linux distributions.
-         lib.root_module.pic = true;

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -28,7 +28,7 @@ This directory generates `build.ninja`. The scripts **describe** the build; ninj
 - `nested-zig` — invoke `zig build` through `zig-build-cli.ts`, which resolves a Zig toolchain (`$BUN_ZIG` → `$PATH` → a sha256-pinned download into the build cache) and pre-fetches the dep's Zig packages through our downloader so the nested build never touches the network itself (ghostty-vt).
 - `prebuilt` — skip build entirely, download compiled `.a`/`.lib` (WebKit, nodejs-headers).
 
-The `dep` pool (depth 4) throttles concurrent nested cmake/cargo sub-builds so they don't oversubscribe cores.
+The `dep` pool (depth 4) throttles concurrent nested cmake/cargo/zig sub-builds so they don't oversubscribe cores.
 
 **Self-obsoleting workarounds** — see "Adding a workaround" below.
 
@@ -205,6 +205,7 @@ Split CI modes: `rust-only` (lolhtml+codegen+cargo → libbun_rust.a), `cpp-only
 | `download.ts`                  | `downloadWithRetry()`, archive extraction                                                                               |
 | `winsysroot.ts`                | Windows MSVC CRT + SDK sysroot (xwin): validates, adds case aliases, CI fetch                                           |
 | `fetch-cli.ts`                 | Build-time CLI ninja invokes for downloads                                                                              |
+| `zig-build-cli.ts`             | Build-time CLI for nested-zig deps: resolve Zig, prefetch packages, run `zig build`                                     |
 | `ci.ts`                        | CI integration — annotations, artifacts, log groups                                                                     |
 | `clean.ts`                     | `bun run clean` preset-based cleanup                                                                                    |
 | `glob-sources.ts` (parent dir) | Source glob patterns + CLI to print them                                                                                |

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -25,6 +25,7 @@ This directory generates `build.ninja`. The scripts **describe** the build; ninj
 - `direct` — list the dep's sources explicitly; each becomes a first-class `cc`/`cxx` edge in our graph and the `.o`s go straight into bun's link. The default for the C/C++ deps (zlib, zstd, boringssl, libarchive, mimalloc, …). Skips a sub-process configure entirely and lets LTO see across the dep boundary.
 - `nested-cmake` — invoke the dep's own cmake configure + build as ninja edges. For deps whose build is too entangled to list by hand. Flags forwarded via `-DCMAKE_C_FLAGS`; cmake's own dependency tracking handles incrementality inside.
 - `cargo` — invoke cargo build (lolhtml). Cargo's incremental build is reliable; `restat = 1` keeps our downstream no-ops fast.
+- `nested-zig` — invoke `zig build` through `zig-build-cli.ts`, which resolves a Zig toolchain (`$BUN_ZIG` → `$PATH` → a sha256-pinned download into the build cache) and pre-fetches the dep's Zig packages through our downloader so the nested build never touches the network itself (ghostty-vt).
 - `prebuilt` — skip build entirely, download compiled `.a`/`.lib` (WebKit, nodejs-headers).
 
 The `dep` pool (depth 4) throttles concurrent nested cmake/cargo sub-builds so they don't oversubscribe cores.

--- a/scripts/build/deps/README.md
+++ b/scripts/build/deps/README.md
@@ -114,6 +114,11 @@ export const mydep: Dependency = {
 - **`nested-zig`**: Runs `zig build` via `../zig-build-cli.ts`, which finds
   (or downloads) a pinned Zig toolchain and pre-fetches the dep's Zig
   packages through our downloader. See `NestedZigBuild` in `../source.ts`.
+  Always set `exportPrefix` to the dep's C-API prefix: a Zig static library
+  that bundles compiler_rt exports `memcpy`, `memset`, and most of libm as
+  weak globals, and an executable linking that archive ahead of libc picks
+  them up and silently replaces the libc implementations for the whole
+  binary. The check turns any such symbol leak into a build error.
   Currently just ghostty-vt.
 - **`none`**: Header-only or prebuilt. No build step; `.ref` stamp is the output.
 

--- a/scripts/build/deps/README.md
+++ b/scripts/build/deps/README.md
@@ -111,6 +111,10 @@ export const mydep: Dependency = {
 - **`nested-cmake`**: Runs `cmake --fresh -B ...` then `cmake --build`.
   See `NestedCmakeBuild` in `../source.ts` for all fields.
 - **`cargo`**: Rust deps (currently just lolhtml). See `CargoBuild` in `../source.ts`.
+- **`nested-zig`**: Runs `zig build` via `../zig-build-cli.ts`, which finds
+  (or downloads) a pinned Zig toolchain and pre-fetches the dep's Zig
+  packages through our downloader. See `NestedZigBuild` in `../source.ts`.
+  Currently just ghostty-vt.
 - **`none`**: Header-only or prebuilt. No build step; `.ref` stamp is the output.
 
 ## Worked examples

--- a/scripts/build/deps/ghostty-vt.ts
+++ b/scripts/build/deps/ghostty-vt.ts
@@ -34,8 +34,11 @@ export const ghosttyVt: Dependency = {
   // app's build graph, which lazily fetches ~30 packages (GTK, fonts,
   // renderers) the VT library never uses. The patch returns right after
   // installing the VT static lib + headers (shrinking the dependency set to
-  // the two packages below) and splits the lib into one section per symbol
-  // so bun's --gc-sections link can drop the unused parts of the C API.
+  // the two packages below), splits the lib into one section per symbol so
+  // bun's --gc-sections link can drop the unused parts of the C API, and,
+  // critically, stops bundling Zig's compiler_rt, which exports `memcpy`,
+  // `memset`, and most of libm and would otherwise replace the libc
+  // versions in the whole bun binary (see `exportPrefix` below).
   patches: ["patches/ghostty-vt/lib-vt-only.patch"],
 
   build: () => ({
@@ -49,13 +52,19 @@ export const ghosttyVt: Dependency = {
       "-Dapp-runtime=none",
       "-Demit-xcframework=false",
       // A release mode always, even for debug bun builds: a Debug Zig
-      // library bundles Zig's UBSan runtime, which collides with the
-      // `__ubsan_*` symbols clang provides in bun's ASAN profiles.
+      // library emits UBSan checks, and the patch deliberately does not
+      // bundle Zig's ubsan runtime (nothing else defines those handlers).
       // ReleaseSmall over ReleaseFast: the pane renderer runs at human
       // output rates, and Small halves this library's contribution to
       // the linked bun binary (~0.6 MB vs ~1.2 MB after --gc-sections).
       "-Doptimize=ReleaseSmall",
     ],
+    // libghostty-vt must export nothing but its C API. Zig's bundled
+    // compiler_rt defines `memcpy`, `memset`, `memmove`, and most of libm
+    // as weak globals; linked into bun ahead of libc, those replaced the
+    // glibc implementations for the entire binary (a ~4x slower `memcpy`).
+    // The patch disables the bundling; this check keeps it that way.
+    exportPrefix: "ghostty_",
     packages: [
       {
         // jacobsandlund/uucode — Unicode tables (grapheme/width data).

--- a/scripts/build/deps/ghostty-vt.ts
+++ b/scripts/build/deps/ghostty-vt.ts
@@ -1,0 +1,102 @@
+/**
+ * libghostty-vt — Ghostty's terminal emulator library.
+ *
+ * Backs the pane renderer in `bun run --parallel` (`Panes` in
+ * `src/runtime/cli/multi_run.rs`): each task's pty output is replayed into
+ * a virtual terminal so progress bars, cursor movement, and colors resolve
+ * to what a real terminal would show. The Rust bindings live in
+ * `src/ghostty_vt_sys/`; no C/C++ in bun includes the headers.
+ *
+ * Ghostty only ships libghostty-vt from its main branch (no tagged release
+ * includes the C API yet), so this pins a main commit.
+ *
+ * ## Build
+ *
+ * This is the only `nested-zig` dep: libghostty-vt is pure Zig. The
+ * `dep_zig_build` ninja edge runs `scripts/build/zig-build-cli.ts`, which
+ * finds a Zig 0.15 toolchain ($BUN_ZIG → $PATH → a sha256-pinned download
+ * into the build cache) and runs `zig build`. That and the two `packages`
+ * below are the entire toolchain footprint — see `NestedZigBuild` in
+ * `../source.ts`.
+ *
+ * `-Dsimd=false` matters: without it Ghostty vendors its own highway and
+ * simdutf into the archive, both of which bun already links, and the
+ * duplicate C++ definitions would be an ODR violation. With it the library
+ * is pure Zig — the only bundled object is Zig's compiler_rt, whose
+ * symbols are all weak.
+ *
+ * `-Doptimize=ReleaseFast` is intentional even for debug bun builds: a
+ * Debug Zig library bundles Zig's UBSan runtime, which would collide with
+ * the `__ubsan_*` symbols clang's sanitizer runtime provides in bun's
+ * ASAN profiles. The VT library is a leaf with its own test suite
+ * upstream; bun gains nothing from a checked build of it.
+ *
+ * ## Bumping the commit
+ *
+ * 1. Update `GHOSTTY_COMMIT`.
+ * 2. Re-derive the two `packages` hashes from the new commit's
+ *    `build.zig.zon` (`uucode`) and `pkg/zlib/build.zig.zon` (`zlib`).
+ *    Ghostty mirrors both on `deps.files.ghostty.org`; the URLs here are
+ *    the upstreams they mirror, which hash to the same content
+ *    (zig package hashes are content-addressed, not URL-addressed).
+ *    A stale hash fails the build naming this file.
+ * 3. Re-check `patches/ghostty-vt/lib-vt-only.patch` still applies.
+ */
+
+import type { Dependency } from "../source.ts";
+
+const GHOSTTY_COMMIT = "f9194f93deeec82670771fc3909132b37356b155";
+
+export const ghosttyVt: Dependency = {
+  name: "ghostty-vt",
+
+  source: () => ({
+    kind: "github-archive",
+    repo: "ghostty-org/ghostty",
+    commit: GHOSTTY_COMMIT,
+  }),
+
+  // Upstream's `zig build -Demit-lib-vt` still constructs the whole Ghostty
+  // app's build graph, which lazily fetches ~30 packages (GTK, fonts,
+  // renderers) the VT library never uses. The patch returns right after
+  // installing the VT static lib + headers, shrinking the dependency set to
+  // the two packages below.
+  patches: ["patches/ghostty-vt/lib-vt-only.patch"],
+
+  build: () => ({
+    kind: "nested-zig",
+    args: [
+      "-Demit-lib-vt",
+      "-Dsimd=false",
+      "-Dapp-runtime=none",
+      "-Demit-xcframework=false",
+      "-Doptimize=ReleaseFast",
+    ],
+    packages: [
+      {
+        // jacobsandlund/uucode — Unicode tables (grapheme/width data).
+        // The one eager (non-lazy) package in ghostty's build.zig.zon.
+        url: "https://github.com/jacobsandlund/uucode/archive/refs/tags/v0.2.0.tar.gz",
+        hash: "uucode-0.2.0-ZZjBPqZVVABQepOqZHR7vV_NcaN-wats0IB6o-Exj6m9",
+      },
+      {
+        // madler/zlib — pulled in by ghostty's build tooling
+        // (`GhosttyFrameData`), not linked into libghostty-vt itself.
+        url: "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
+        hash: "N-V-__8AAB0eQwD-0MdOEBmz7intriBReIsIDNlukNVoNu6o",
+      },
+    ],
+  }),
+
+  provides: () => ({
+    libs: ["ghostty-vt"],
+    // bun's bindings are hand-written `extern "C"` declarations in
+    // `src/ghostty_vt_sys/ghostty_vt.rs`; nothing in bun's C/C++ includes
+    // the installed `include/ghostty/` headers.
+    includes: [],
+  }),
+
+  // The pane renderer is pty-based and lives behind `#[cfg(unix)]` in
+  // multi_run.rs; on Windows nothing references the library's symbols.
+  enabled: cfg => !cfg.windows,
+};

--- a/scripts/build/deps/ghostty-vt.ts
+++ b/scripts/build/deps/ghostty-vt.ts
@@ -65,13 +65,7 @@ export const ghosttyVt: Dependency = {
 
   build: () => ({
     kind: "nested-zig",
-    args: [
-      "-Demit-lib-vt",
-      "-Dsimd=false",
-      "-Dapp-runtime=none",
-      "-Demit-xcframework=false",
-      "-Doptimize=ReleaseFast",
-    ],
+    args: ["-Demit-lib-vt", "-Dsimd=false", "-Dapp-runtime=none", "-Demit-xcframework=false", "-Doptimize=ReleaseFast"],
     packages: [
       {
         // jacobsandlund/uucode — Unicode tables (grapheme/width data).

--- a/scripts/build/deps/ghostty-vt.ts
+++ b/scripts/build/deps/ghostty-vt.ts
@@ -8,39 +8,13 @@
  * `src/ghostty_vt_sys/`; no C/C++ in bun includes the headers.
  *
  * Ghostty only ships libghostty-vt from its main branch (no tagged release
- * includes the C API yet), so this pins a main commit.
- *
- * ## Build
- *
- * This is the only `nested-zig` dep: libghostty-vt is pure Zig. The
- * `dep_zig_build` ninja edge runs `scripts/build/zig-build-cli.ts`, which
- * finds a Zig 0.15 toolchain ($BUN_ZIG → $PATH → a sha256-pinned download
- * into the build cache) and runs `zig build`. That and the two `packages`
- * below are the entire toolchain footprint — see `NestedZigBuild` in
- * `../source.ts`.
- *
- * `-Dsimd=false` matters: without it Ghostty vendors its own highway and
- * simdutf into the archive, both of which bun already links, and the
- * duplicate C++ definitions would be an ODR violation. With it the library
- * is pure Zig — the only bundled object is Zig's compiler_rt, whose
- * symbols are all weak.
- *
- * `-Doptimize=ReleaseFast` is intentional even for debug bun builds: a
- * Debug Zig library bundles Zig's UBSan runtime, which would collide with
- * the `__ubsan_*` symbols clang's sanitizer runtime provides in bun's
- * ASAN profiles. The VT library is a leaf with its own test suite
- * upstream; bun gains nothing from a checked build of it.
- *
- * ## Bumping the commit
- *
- * 1. Update `GHOSTTY_COMMIT`.
- * 2. Re-derive the two `packages` hashes from the new commit's
- *    `build.zig.zon` (`uucode`) and `pkg/zlib/build.zig.zon` (`zlib`).
- *    Ghostty mirrors both on `deps.files.ghostty.org`; the URLs here are
- *    the upstreams they mirror, which hash to the same content
- *    (zig package hashes are content-addressed, not URL-addressed).
- *    A stale hash fails the build naming this file.
- * 3. Re-check `patches/ghostty-vt/lib-vt-only.patch` still applies.
+ * includes the C API yet), so this pins a main commit. Bumping it means
+ * re-deriving the two `packages` hashes below from the new commit's
+ * `build.zig.zon` (uucode) and `pkg/zlib/build.zig.zon` (zlib) — both are
+ * content-addressed, so the GitHub upstream URLs used here hash the same
+ * as the `deps.files.ghostty.org` mirrors they point at, and a stale hash
+ * fails the build naming this file — and re-checking that the patch still
+ * applies. The build mechanism is `NestedZigBuild` in `../source.ts`.
  */
 
 import type { Dependency } from "../source.ts";
@@ -65,7 +39,19 @@ export const ghosttyVt: Dependency = {
 
   build: () => ({
     kind: "nested-zig",
-    args: ["-Demit-lib-vt", "-Dsimd=false", "-Dapp-runtime=none", "-Demit-xcframework=false", "-Doptimize=ReleaseFast"],
+    args: [
+      "-Demit-lib-vt",
+      // Without this Ghostty vendors its own highway and simdutf into the
+      // archive; bun already links both, and the duplicate C++ definitions
+      // would be an ODR violation. With it the library is pure Zig.
+      "-Dsimd=false",
+      "-Dapp-runtime=none",
+      "-Demit-xcframework=false",
+      // Always, even for debug bun builds: a Debug Zig library bundles
+      // Zig's UBSan runtime, which collides with the `__ubsan_*` symbols
+      // clang's sanitizer runtime provides in bun's ASAN profiles.
+      "-Doptimize=ReleaseFast",
+    ],
     packages: [
       {
         // jacobsandlund/uucode — Unicode tables (grapheme/width data).

--- a/scripts/build/deps/ghostty-vt.ts
+++ b/scripts/build/deps/ghostty-vt.ts
@@ -33,8 +33,9 @@ export const ghosttyVt: Dependency = {
   // Upstream's `zig build -Demit-lib-vt` still constructs the whole Ghostty
   // app's build graph, which lazily fetches ~30 packages (GTK, fonts,
   // renderers) the VT library never uses. The patch returns right after
-  // installing the VT static lib + headers, shrinking the dependency set to
-  // the two packages below.
+  // installing the VT static lib + headers (shrinking the dependency set to
+  // the two packages below) and splits the lib into one section per symbol
+  // so bun's --gc-sections link can drop the unused parts of the C API.
   patches: ["patches/ghostty-vt/lib-vt-only.patch"],
 
   build: () => ({
@@ -47,10 +48,13 @@ export const ghosttyVt: Dependency = {
       "-Dsimd=false",
       "-Dapp-runtime=none",
       "-Demit-xcframework=false",
-      // Always, even for debug bun builds: a Debug Zig library bundles
-      // Zig's UBSan runtime, which collides with the `__ubsan_*` symbols
-      // clang's sanitizer runtime provides in bun's ASAN profiles.
-      "-Doptimize=ReleaseFast",
+      // A release mode always, even for debug bun builds: a Debug Zig
+      // library bundles Zig's UBSan runtime, which collides with the
+      // `__ubsan_*` symbols clang provides in bun's ASAN profiles.
+      // ReleaseSmall over ReleaseFast: the pane renderer runs at human
+      // output rates, and Small halves this library's contribution to
+      // the linked bun binary (~0.6 MB vs ~1.2 MB after --gc-sections).
+      "-Doptimize=ReleaseSmall",
     ],
     packages: [
       {

--- a/scripts/build/deps/index.ts
+++ b/scripts/build/deps/index.ts
@@ -14,6 +14,7 @@ import type { Dependency } from "../source.ts";
 import { boringssl } from "./boringssl.ts";
 import { brotli } from "./brotli.ts";
 import { cares } from "./cares.ts";
+import { ghosttyVt } from "./ghostty-vt.ts";
 import { hdrhistogram } from "./hdrhistogram.ts";
 import { highway } from "./highway.ts";
 import { libarchive } from "./libarchive.ts";
@@ -57,6 +58,7 @@ export const allDeps: readonly Dependency[] = [
   libspng,
   libwebp,
   cares,
+  ghosttyVt,
   hdrhistogram,
   highway,
   libuv,
@@ -81,6 +83,7 @@ export {
   boringssl,
   brotli,
   cares,
+  ghosttyVt,
   hdrhistogram,
   highway,
   libarchive,

--- a/scripts/build/fetch-cli.ts
+++ b/scripts/build/fetch-cli.ts
@@ -242,6 +242,15 @@ function normalizeLf(s: string): string {
  * so a CRLF-mangled checkout still applies cleanly. --no-index: dest/ is
  * not a git repo. --ignore-whitespace / --ignore-space-change: patches are
  * authored against upstream which may have different trailing whitespace.
+ *
+ * Patches MUST be in plain unified-diff format (`--- a/X` / `+++ b/X`),
+ * not `git format-patch`/`git diff` output with a `diff --git` header.
+ * `dest/` sits inside bun's own git worktree, and `git apply` treats
+ * git-header patch paths as repo-toplevel-relative: `build.zig` resolves
+ * to `<repo>/build.zig`, falls outside the cwd, and is SILENTLY skipped
+ * with exit 0. Traditional diffs get the cwd prefix prepended instead,
+ * which is the behavior we want. The skip check below catches a
+ * regression either way.
  */
 function applyPatch(dest: string, patchPath: string, patchBody: string): void {
   const result = spawnSync("git", ["apply", "--ignore-whitespace", "--ignore-space-change", "--no-index", "-"], {
@@ -262,6 +271,17 @@ function applyPatch(dest: string, patchPath: string, patchBody: string): void {
     throw new BuildError(`Patch failed: ${result.stderr}`, {
       file: patchPath,
       hint: "The patch may be out of date with the pinned commit",
+    });
+  }
+
+  // `git apply` reports a path it decided not to touch with exit 0; that
+  // would leave the source unpatched while `.ref` claims otherwise.
+  if (result.stderr.includes("Skipped patch")) {
+    throw new BuildError(`git apply silently skipped a path: ${result.stderr}`, {
+      file: patchPath,
+      hint:
+        "Patches must be plain unified diffs ('--- a/file'), not `git diff` output " +
+        "with a 'diff --git' header — see the comment on applyPatch in fetch-cli.ts",
     });
   }
 }

--- a/scripts/build/fetch-cli.ts
+++ b/scripts/build/fetch-cli.ts
@@ -248,16 +248,21 @@ function normalizeLf(s: string): string {
  * `dest/` sits inside bun's own git worktree, and `git apply` treats
  * git-header patch paths as repo-toplevel-relative: `build.zig` resolves
  * to `<repo>/build.zig`, falls outside the cwd, and is SILENTLY skipped
- * with exit 0. Traditional diffs get the cwd prefix prepended instead,
- * which is the behavior we want. The skip check below catches a
- * regression either way.
+ * with exit 0 and nothing changed on disk. Traditional diffs get the cwd
+ * prefix prepended instead, which is the behavior we want.
+ *
+ * The skip check below catches a regression. It depends on `-v`: git only
+ * says `Skipped patch '<path>'.` above normal verbosity (an unadorned
+ * `git apply` skips with exit 0 and EMPTY stderr), and the message goes
+ * through gettext, so `LC_ALL=C` pins it to the English spelling.
  */
 function applyPatch(dest: string, patchPath: string, patchBody: string): void {
-  const result = spawnSync("git", ["apply", "--ignore-whitespace", "--ignore-space-change", "--no-index", "-"], {
+  const result = spawnSync("git", ["apply", "-v", "--ignore-whitespace", "--ignore-space-change", "--no-index", "-"], {
     cwd: dest,
     input: normalizeLf(patchBody),
     stdio: ["pipe", "ignore", "pipe"],
     encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C" },
   });
 
   if (result.error) {

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -669,8 +669,11 @@ export function registerDepRules(n: Ninja, cfg: Config): void {
   // dep's Zig packages through our downloader, and runs `zig build` in the
   // source dir. restat: the nested zig build is itself incremental, so a
   // no-op install preserves output mtimes and prunes downstream.
+  //
+  // $env is stream.ts `--env=K=V` args (ninja has no native env support);
+  // same mechanism as dep_cargo.
   n.rule("dep_zig_build", {
-    command: `${stream} --cwd=$srcdir ${cfg.jsRuntime} ${q(zigBuildCliPath)} --prefix $prefix --cache $cache $packages -- $args`,
+    command: `${stream} --cwd=$srcdir $env ${cfg.jsRuntime} ${q(zigBuildCliPath)} --prefix $prefix --cache $cache $packages -- $args`,
     description: "zig $name",
     restat: true,
     pool: "dep",
@@ -1438,6 +1441,13 @@ function emitNestedZig(
   // override it and produce a host-arch artifact in a cross build.
   const args = [...spec.args, `-Dtarget=${zigTargetTriple(cfg)}`];
 
+  // Zig has no bundled bionic libc (ziglang/zig#23906), so an Android
+  // cross-compile needs the NDK sysroot. Bun's own Android build already
+  // resolved it; forward it through the env var Zig build scripts
+  // conventionally read (`findNDKPath` in ghostty's pkg/android-ndk).
+  const env: Record<string, string> = {};
+  if (cfg.androidNdk !== undefined) env.ANDROID_NDK_HOME = cfg.androidNdk;
+
   n.build({
     outputs: libs,
     rule: "dep_zig_build",
@@ -1450,6 +1460,9 @@ function emitNestedZig(
       cache: cfg.cacheDir,
       packages: spec.packages.map(p => `--package ${quote(p.url, hostWin)} ${p.hash}`).join(" "),
       args: quoteArgs(args, hostWin),
+      env: Object.entries(env)
+        .map(([k, v]) => `--env=${k}=${quote(v, hostWin)}`)
+        .join(" "),
     },
   });
   n.phony(name, libs);

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -30,6 +30,7 @@ import { writeIfChanged } from "./fs.ts";
 import type { Ninja } from "./ninja.ts";
 import { quote, quoteArgs, slash } from "./shell.ts";
 import { streamPath } from "./stream.ts";
+import { zigBuildCliPath } from "./zig-build-cli.ts";
 
 /**
  * If the source dir exists with a stale (or missing) identity stamp,
@@ -162,6 +163,7 @@ export type Source =
  */
 export type BuildSpec =
   | NestedCmakeBuild
+  | NestedZigBuild
   | CargoBuild
   | DirectBuild
   | {
@@ -334,6 +336,53 @@ export interface PreBuildSpec {
    * Also the ninja outputs — if missing, preBuild runs.
    */
   outputs: string[];
+}
+
+/**
+ * Build a dep with its own `build.zig` via `zig build`.
+ *
+ * One ninja edge runs `scripts/build/zig-build-cli.ts`, which resolves a
+ * Zig compiler (`$BUN_ZIG` → `$PATH` → auto-download into `cfg.cacheDir`),
+ * pre-fetches the dep's Zig package dependencies through our downloader,
+ * then runs `zig build <args> --prefix <buildDir>/deps/<name>`. Like
+ * nested-cmake, the nested build system owns incrementality; `restat = 1`
+ * prunes our downstream when the install is a no-op.
+ */
+export interface NestedZigBuild {
+  kind: "nested-zig";
+  /**
+   * `zig build` args (e.g. `-Demit-lib-vt`, `-Doptimize=ReleaseFast`).
+   * A `-Dtarget=<triple>` derived from `cfg` via `zigTargetTriple()` is
+   * always appended so the artifact matches bun's target, not the host.
+   * `--prefix` is always appended and must not appear here.
+   */
+  args: string[];
+  /**
+   * The dep's Zig package dependencies, resolved to exact URLs and the
+   * content hashes its `build.zig.zon` pins. Prefetched into the Zig
+   * global cache before `zig build` runs so the nested build never makes
+   * its own network requests (and so downloads go through our retrying,
+   * proxy-aware, prefetch-cached path like every other dep's).
+   *
+   * These must be kept in sync with the dep's `build.zig.zon` when its
+   * commit is bumped. A stale hash fails the build with a message that
+   * names this field.
+   */
+  packages: Array<{ url: string; hash: string }>;
+}
+
+/**
+ * Zig target triple for bun's build target, e.g. `x86_64-linux-gnu`.
+ * Passed as `-Dtarget=` so `zig build` cross-compiles deterministically
+ * instead of sniffing the host.
+ */
+export function zigTargetTriple(cfg: Config): string {
+  const arch = cfg.arm64 ? "aarch64" : "x86_64";
+  if (cfg.darwin) return `${arch}-macos`;
+  if (cfg.freebsd) return `${arch}-freebsd`;
+  if (cfg.windows) return `${arch}-windows`;
+  assert(cfg.linux, `zigTargetTriple: unsupported target os "${cfg.os}"`);
+  return `${arch}-linux-${cfg.abi ?? "gnu"}`;
 }
 
 export interface CargoBuild {
@@ -615,6 +664,18 @@ export function registerDepRules(n: Ninja, cfg: Config): void {
     });
   }
 
+  // Zig build: one edge that runs zig-build-cli.ts. That script resolves a
+  // Zig toolchain ($BUN_ZIG → $PATH → cached download), prefetches the
+  // dep's Zig packages through our downloader, and runs `zig build` in the
+  // source dir. restat: the nested zig build is itself incremental, so a
+  // no-op install preserves output mtimes and prunes downstream.
+  n.rule("dep_zig_build", {
+    command: `${stream} --cwd=$srcdir ${cfg.jsRuntime} ${q(zigBuildCliPath)} --prefix $prefix --cache $cache $packages -- $args`,
+    description: "zig $name",
+    restat: true,
+    pool: "dep",
+  });
+
   // preBuild: runs an arbitrary command before cmake configure. Used for
   // build steps that live outside cmake (ICU via msbuild on Windows).
   // restat: if outputs are unchanged (script is idempotent), prune
@@ -782,6 +843,9 @@ export function resolveDep(
     if (buildSpec.kind === "nested-cmake") {
       stampDir = buildSpec.sourceSubdir ? resolve(srcDir, buildSpec.sourceSubdir) : srcDir;
       stampFile = "CMakeLists.txt";
+    } else if (buildSpec.kind === "nested-zig") {
+      stampDir = srcDir;
+      stampFile = "build.zig";
     } else if (buildSpec.kind === "cargo") {
       stampDir = resolve(srcDir, buildSpec.manifestDir);
       stampFile = "Cargo.toml";
@@ -834,6 +898,15 @@ export function resolveDep(
       // source changes reliably (git checkout preserves mtimes of files
       // unchanged between commits). The inner ninja detects what's stale.
       alwaysBuild: source.kind === "local",
+    });
+    libs = result.libs;
+    outputs = result.libs;
+  } else if (buildSpec.kind === "nested-zig") {
+    const result = emitNestedZig(n, cfg, dep.name, buildSpec, {
+      srcDir,
+      sourceStamp,
+      provides,
+      fetchDepStamps,
     });
     libs = result.libs;
     outputs = result.libs;
@@ -922,6 +995,12 @@ export function computeDepLibs(cfg: Config, dep: Dependency): string[] {
       libs.push(...buildSpec.preBuild.outputs);
     }
     return libs;
+  }
+
+  // nested-zig: `zig build --prefix <buildDir>` installs libs under lib/.
+  if (buildSpec.kind === "nested-zig") {
+    const libDir = resolve(depBuildDir(cfg, dep.name), "lib");
+    return provides.libs.map(lib => resolve(libDir, `${cfg.libPrefix}${lib}${cfg.libSuffix}`));
   }
 
   // cargo: single lib in targetDir/<triple?>/<profile>/.
@@ -1317,6 +1396,65 @@ function emitNestedCmake(
   n.phony(name, allLibs);
 
   return { libs: allLibs };
+}
+
+interface EmitNestedZigInput {
+  /** Resolved source dir (vendor/<name>). */
+  srcDir: string;
+  /** The "source is ready" file (vendor/<name>/.ref or build.zig). */
+  sourceStamp: string;
+  provides: Provides;
+  /** Cross-dep build outputs; implicit inputs so they're built first. */
+  fetchDepStamps: string[];
+}
+
+/**
+ * Emit a ninja build rule for a `build.zig` project. Returns the static
+ * libs `zig build --prefix <buildDir>/deps/<name>` installs under `lib/`.
+ *
+ * One edge, no separate configure: `zig build` owns its own incremental
+ * graph (like cargo). The heavy lifting — finding or downloading Zig,
+ * prefetching the dep's Zig packages — happens inside zig-build-cli.ts at
+ * build time, so the configure step never touches the network or probes
+ * for a toolchain it may not need.
+ */
+function emitNestedZig(
+  n: Ninja,
+  cfg: Config,
+  name: string,
+  spec: NestedZigBuild,
+  input: EmitNestedZigInput,
+): { libs: string[] } {
+  const hostWin = cfg.host.os === "windows";
+  const { srcDir, sourceStamp, provides, fetchDepStamps } = input;
+  const buildDir = depBuildDir(cfg, name);
+
+  // `zig build --prefix` installs libraries under `<prefix>/lib/` and
+  // names them with the host platform's conventions.
+  const libs = provides.libs.map(lib => resolve(buildDir, "lib", `${cfg.libPrefix}${lib}${cfg.libSuffix}`));
+  assert(libs.length > 0, `nested-zig dep "${name}" must declare at least one provides.libs entry`);
+
+  // The target triple is appended LAST so a dep cannot accidentally
+  // override it and produce a host-arch artifact in a cross build.
+  const args = [...spec.args, `-Dtarget=${zigTargetTriple(cfg)}`];
+
+  n.build({
+    outputs: libs,
+    rule: "dep_zig_build",
+    inputs: [],
+    implicitInputs: [sourceStamp, zigBuildCliPath, ...fetchDepStamps],
+    vars: {
+      name,
+      srcdir: srcDir,
+      prefix: buildDir,
+      cache: cfg.cacheDir,
+      packages: spec.packages.map(p => `--package ${quote(p.url, hostWin)} ${p.hash}`).join(" "),
+      args: quoteArgs(args, hostWin),
+    },
+  });
+  n.phony(name, libs);
+
+  return { libs };
 }
 
 interface EmitCargoInput {

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -910,6 +910,8 @@ export function resolveDep(
       sourceStamp,
       provides,
       fetchDepStamps,
+      // Local-mode source edits aren't tracked by the `build.zig` stamp.
+      alwaysBuild: source.kind === "local",
     });
     libs = result.libs;
     outputs = result.libs;
@@ -1409,6 +1411,12 @@ interface EmitNestedZigInput {
   provides: Provides;
   /** Cross-dep build outputs; implicit inputs so they're built first. */
   fetchDepStamps: string[];
+  /**
+   * Always re-invoke `zig build`. For `local` mode deps, whose source
+   * edits we cannot track (the stamp is only `build.zig`). Zig's own
+   * incremental build makes the no-op fast; restat=1 prunes downstream.
+   */
+  alwaysBuild: boolean;
 }
 
 /**
@@ -1429,7 +1437,7 @@ function emitNestedZig(
   input: EmitNestedZigInput,
 ): { libs: string[] } {
   const hostWin = cfg.host.os === "windows";
-  const { srcDir, sourceStamp, provides, fetchDepStamps } = input;
+  const { srcDir, sourceStamp, provides, fetchDepStamps, alwaysBuild } = input;
   const buildDir = depBuildDir(cfg, name);
 
   // `zig build --prefix` installs libraries under `<prefix>/lib/` and
@@ -1448,11 +1456,14 @@ function emitNestedZig(
   const env: Record<string, string> = {};
   if (cfg.androidNdk !== undefined) env.ANDROID_NDK_HOME = cfg.androidNdk;
 
+  const implicitInputs = [sourceStamp, zigBuildCliPath, ...fetchDepStamps];
+  if (alwaysBuild) implicitInputs.push(n.always());
+
   n.build({
     outputs: libs,
     rule: "dep_zig_build",
     inputs: [],
-    implicitInputs: [sourceStamp, zigBuildCliPath, ...fetchDepStamps],
+    implicitInputs,
     vars: {
       name,
       srcdir: srcDir,

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -369,6 +369,16 @@ export interface NestedZigBuild {
    * names this field.
    */
   packages: Array<{ url: string; hash: string }>;
+  /**
+   * When set, the build fails if a produced archive exports any symbol
+   * that does not start with this prefix (checked with the toolchain's
+   * `nm`). A Zig static library that bundles compiler_rt exports `memcpy`,
+   * `memset`, and most of libm as weak globals, and an executable linking
+   * the archive ahead of libc extracts them and silently replaces the libc
+   * implementations for its whole binary. Declaring the dep's public C API
+   * prefix makes that class of symbol leak a build error instead.
+   */
+  exportPrefix?: string;
 }
 
 /**
@@ -673,7 +683,7 @@ export function registerDepRules(n: Ninja, cfg: Config): void {
   // $env is stream.ts `--env=K=V` args (ninja has no native env support);
   // same mechanism as dep_cargo.
   n.rule("dep_zig_build", {
-    command: `${stream} --cwd=$srcdir $env ${cfg.jsRuntime} ${q(zigBuildCliPath)} --prefix $prefix --cache $cache $packages -- $args`,
+    command: `${stream} --cwd=$srcdir $env ${cfg.jsRuntime} ${q(zigBuildCliPath)} --prefix $prefix --cache $cache $verify $packages -- $args`,
     description: "zig $name",
     restat: true,
     pool: "dep",
@@ -1456,6 +1466,19 @@ function emitNestedZig(
   const env: Record<string, string> = {};
   if (cfg.androidNdk !== undefined) env.ANDROID_NDK_HOME = cfg.androidNdk;
 
+  // The exported-symbol check runs with the `nm` that sits next to the
+  // configured `ar` (`llvm-nm` for an LLVM toolchain, binutils `nm`
+  // otherwise); both accept the same flags for this use.
+  let verify = "";
+  if (spec.exportPrefix !== undefined) {
+    const nm = cfg.ar.replace(/ar((?:-\d+)?(?:\.exe)?)$/, "nm$1");
+    assert(
+      nm !== cfg.ar && existsSync(nm),
+      `nested-zig dep "${name}" declares exportPrefix, but no \`nm\` was found next to \`ar\` (${cfg.ar})`,
+    );
+    verify = `--nm ${quote(nm, hostWin)} --expect-export-prefix ${quote(spec.exportPrefix, hostWin)}`;
+  }
+
   const implicitInputs = [sourceStamp, zigBuildCliPath, ...fetchDepStamps];
   if (alwaysBuild) implicitInputs.push(n.always());
 
@@ -1469,6 +1492,7 @@ function emitNestedZig(
       srcdir: srcDir,
       prefix: buildDir,
       cache: cfg.cacheDir,
+      verify,
       packages: spec.packages.map(p => `--package ${quote(p.url, hostWin)} ${p.hash}`).join(" "),
       args: quoteArgs(args, hostWin),
       env: Object.entries(env)

--- a/scripts/build/zig-build-cli.ts
+++ b/scripts/build/zig-build-cli.ts
@@ -1,0 +1,271 @@
+/**
+ * zig-build-cli — the build-time entry point for `nested-zig` deps.
+ *
+ * Invoked by the `dep_zig_build` ninja rule (see source.ts). It does three
+ * things, all at BUILD time (never at configure time):
+ *
+ *  1. Resolve a Zig compiler (see `resolveZig`).
+ *  2. Pre-fetch the dep's Zig package dependencies into the Zig global
+ *     cache so `zig build` never makes its own network requests. Zig's
+ *     package manager is content-addressed: a package that is already in
+ *     the cache under the hash declared in `build.zig.zon` is used as-is
+ *     and its URL is never consulted, so this also keeps all downloads on
+ *     our `downloadWithRetry` path (retries, prefetch cache, proxies).
+ *  3. Run `zig build <args> --prefix <prefix>` in the dep's source dir.
+ *
+ * ## Usage (ninja only — not meant to be run by hand)
+ *
+ *   zig-build-cli.ts --prefix <dir> --cache <dir>
+ *                    [--package <url> <zig-package-hash>]...
+ *                    -- <zig build args...>
+ *
+ * cwd must be the dep's source directory (the ninja rule sets it via
+ * stream.ts `--cwd=`).
+ */
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import { delimiter, join, resolve } from "node:path";
+import { downloadWithRetry } from "./download.ts";
+import { BuildError, assert } from "./error.ts";
+
+/** Absolute path to this file, for ninja rule command strings. */
+export const zigBuildCliPath: string = import.meta.filename;
+
+/**
+ * The pinned Zig release used to build `nested-zig` deps. Bumping it means
+ * updating every sha256 below from
+ * https://ziglang.org/download/index.json (the same data is mirrored at
+ * github.com/ziglang/www.ziglang.org in assets/download/index.json).
+ */
+export const ZIG_VERSION = "0.15.2";
+
+/**
+ * Official release tarball sha256s, keyed by `<arch>-<os>` in Zig's own
+ * naming. The downloaded tarball is rejected if its digest differs.
+ */
+const ZIG_TARBALL_SHA256: Record<string, string> = {
+  "x86_64-linux": "02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239",
+  "aarch64-linux": "958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f",
+  "x86_64-macos": "375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f",
+  "aarch64-macos": "3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b",
+  "x86_64-freebsd": "5509ff57cd3f219165caed0da10221739af82742b9edfcda3f7bfaf4da7212dd",
+  "aarch64-freebsd": "c62efd319f86663eb7747709dfca259205edba8eaee98efc96a51ce40a9437de",
+};
+
+/**
+ * Zig's `<arch>-<os>` key for the machine running this build. The Linux
+ * binaries are fully static (musl), so one tarball covers glibc and musl
+ * hosts.
+ */
+function hostZigPlatform(): string {
+  const archNames: Record<string, string> = { x64: "x86_64", arm64: "aarch64" };
+  const osNames: Record<string, string> = { linux: "linux", darwin: "macos", freebsd: "freebsd" };
+  const arch = archNames[process.arch];
+  const os = osNames[process.platform];
+  assert(
+    arch !== undefined && os !== undefined,
+    `No Zig ${ZIG_VERSION} download for host ${process.platform}-${process.arch}`,
+    {
+      hint: "Install Zig yourself and point BUN_ZIG at it, or add the platform to ZIG_TARBALL_SHA256 in zig-build-cli.ts",
+    },
+  );
+  return `${arch}-${os}`;
+}
+
+/**
+ * Find a usable `zig` executable, in order:
+ *
+ *  1. `$BUN_ZIG` — an explicit path, taken as-is (no version check: the
+ *     nested `zig build` enforces its own `minimum_zig_version`).
+ *  2. `zig` on `$PATH` whose `zig version` reports `major.minor` matching
+ *     `ZIG_VERSION`. A mismatched system Zig is skipped, not fatal.
+ *  3. Download the official `ZIG_VERSION` release into
+ *     `<cacheDir>/zig/<version>/`, verifying its sha256 against the pinned
+ *     table above. Cached per machine like the other toolchain downloads.
+ */
+async function resolveZig(cacheDir: string): Promise<string> {
+  const fromEnv = process.env.BUN_ZIG;
+  if (fromEnv) {
+    assert(existsSync(fromEnv), `BUN_ZIG points at a path that does not exist: ${fromEnv}`);
+    return fromEnv;
+  }
+
+  const wantMinor = ZIG_VERSION.split(".").slice(0, 2).join(".");
+  const exe = process.platform === "win32" ? "zig.exe" : "zig";
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (dir.length === 0) continue;
+    const candidate = join(dir, exe);
+    if (!existsSync(candidate)) continue;
+    const probe = spawnSync(candidate, ["version"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    const version = probe.status === 0 ? (probe.stdout ?? "").trim() : "";
+    if (version.split(".").slice(0, 2).join(".") === wantMinor) {
+      return candidate;
+    }
+  }
+
+  // ─── Download ───
+  const platform = hostZigPlatform();
+  const sha = ZIG_TARBALL_SHA256[platform];
+  assert(sha !== undefined, `No pinned Zig ${ZIG_VERSION} sha256 for ${platform}`, {
+    hint: "Add it to ZIG_TARBALL_SHA256 in zig-build-cli.ts (from ziglang.org/download/index.json), or set BUN_ZIG",
+  });
+
+  const installDir = resolve(cacheDir, "zig", ZIG_VERSION);
+  const zigExe = join(installDir, "zig");
+  if (existsSync(zigExe)) return zigExe;
+
+  const name = `zig-${platform}-${ZIG_VERSION}`;
+  const url = `https://ziglang.org/download/${ZIG_VERSION}/${name}.tar.xz`;
+  console.log(`downloading ${url}`);
+  const tarball = `${installDir}.${process.pid}.tar.xz`;
+  const staging = `${installDir}.${process.pid}.staging`;
+  await mkdir(resolve(installDir, ".."), { recursive: true });
+  try {
+    await downloadWithRetry(url, tarball, name);
+
+    const digest = createHash("sha256").update(readFileSync(tarball)).digest("hex");
+    assert(digest === sha, `Zig tarball sha256 mismatch for ${name}`, {
+      hint: `expected ${sha}\n     got ${digest}\nfrom ${url}`,
+    });
+
+    // -J: the official Zig release archives are .tar.xz on every platform
+    // this dep supports. -m normalizes mtimes (same as extractTarGz).
+    await mkdir(staging, { recursive: true });
+    const tar = spawnSync("tar", ["-xJmf", tarball, "-C", staging, "--strip-components=1"], {
+      stdio: ["ignore", "ignore", "pipe"],
+      encoding: "utf8",
+    });
+    assert(tar.status === 0, `Failed to extract ${name}.tar.xz: ${tar.stderr ?? tar.error?.message}`, {
+      hint: "Extracting .tar.xz requires xz (apt install xz-utils / brew install xz)",
+    });
+
+    // Publish atomically: the rename is the single step that makes a
+    // complete toolchain visible at installDir. A concurrent build that
+    // won the race already produced the same content.
+    await rm(installDir, { recursive: true, force: true });
+    await rm(tarball, { force: true });
+    const fs = await import("node:fs/promises");
+    try {
+      await fs.rename(staging, installDir);
+    } catch (err) {
+      if (!existsSync(zigExe)) throw err;
+    }
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+    await rm(tarball, { force: true });
+  }
+
+  assert(existsSync(zigExe), `Zig extraction produced no ${zigExe}`);
+  return zigExe;
+}
+
+/**
+ * Ensure a Zig package is present in the global cache at `expectedHash`.
+ *
+ * Downloads `url` through our downloader, then hands the local tarball to
+ * `zig fetch`, which unpacks it into `<globalCache>/p/<hash>/` keyed by
+ * the content hash it computes. A mismatch between that hash and the one
+ * `build.zig.zon` expects means the URL no longer serves the pinned
+ * content — fail loudly rather than letting `zig build` fall back to the
+ * network.
+ */
+async function prefetchZigPackage(
+  zig: string,
+  globalCache: string,
+  url: string,
+  expectedHash: string,
+): Promise<void> {
+  if (existsSync(join(globalCache, "p", expectedHash))) return;
+
+  console.log(`fetching zig package ${expectedHash}`);
+  const tarball = join(globalCache, `prefetch.${process.pid}.${createHash("sha256").update(url).digest("hex").slice(0, 8)}.tar.gz`);
+  try {
+    await downloadWithRetry(url, tarball, expectedHash);
+    const fetched = spawnSync(zig, ["fetch", tarball], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, ZIG_GLOBAL_CACHE_DIR: globalCache },
+    });
+    assert(fetched.status === 0, `zig fetch failed for ${url}: ${fetched.stderr ?? fetched.error?.message}`);
+    const got = (fetched.stdout ?? "").trim();
+    assert(got === expectedHash, `Zig package hash mismatch for ${url}`, {
+      hint:
+        `expected ${expectedHash}\n     got ${got}\n` +
+        `The URL no longer serves the content build.zig.zon pins. ` +
+        `Update the --package hash in deps/ghostty-vt.ts to match the new build.zig.zon.`,
+    });
+  } finally {
+    await rm(tarball, { force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  let prefix = "";
+  let cacheDir = "";
+  const packages: Array<{ url: string; hash: string }> = [];
+  const zigArgs: string[] = [];
+
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--prefix") {
+      prefix = argv[++i] ?? "";
+    } else if (a === "--cache") {
+      cacheDir = argv[++i] ?? "";
+    } else if (a === "--package") {
+      const url = argv[++i];
+      const hash = argv[++i];
+      assert(url !== undefined && hash !== undefined, "--package requires <url> <hash>");
+      packages.push({ url, hash });
+    } else if (a === "--") {
+      zigArgs.push(...argv.slice(i + 1));
+      break;
+    } else {
+      throw new BuildError(`Unknown zig-build-cli argument: ${a}`);
+    }
+  }
+  assert(prefix.length > 0 && cacheDir.length > 0, "zig-build-cli: --prefix and --cache are required");
+
+  const zig = await resolveZig(cacheDir);
+
+  // Shared across profiles and checkouts (package store + compiled Zig
+  // stdlib), like the tarball cache. The local cache is per dep build dir
+  // so debug and release builds never invalidate each other.
+  const globalCache = resolve(cacheDir, "zig-global-cache");
+  const localCache = resolve(prefix, ".zig-cache");
+  await mkdir(globalCache, { recursive: true });
+
+  for (const pkg of packages) {
+    await prefetchZigPackage(zig, globalCache, pkg.url, pkg.hash);
+  }
+
+  const result = spawnSync(zig, ["build", ...zigArgs, "--prefix", prefix], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      ZIG_GLOBAL_CACHE_DIR: globalCache,
+      ZIG_LOCAL_CACHE_DIR: localCache,
+    },
+  });
+  if (result.error) {
+    throw new BuildError(`Failed to spawn ${zig}`, { cause: result.error });
+  }
+  if (result.status !== 0) {
+    throw new BuildError(`zig build exited with ${result.status}`, {
+      hint: `command: ${zig} build ${zigArgs.join(" ")} --prefix ${prefix}`,
+    });
+  }
+}
+
+if (process.argv[1] === import.meta.filename) {
+  main().catch(err => {
+    if (err instanceof BuildError) {
+      process.stderr.write(err.format());
+      process.exit(1);
+    }
+    throw err;
+  });
+}

--- a/scripts/build/zig-build-cli.ts
+++ b/scripts/build/zig-build-cli.ts
@@ -25,7 +25,7 @@
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { mkdir, rename, rm } from "node:fs/promises";
 import { delimiter, join, resolve } from "node:path";
 import { downloadWithRetry } from "./download.ts";
@@ -203,9 +203,62 @@ async function prefetchZigPackage(zig: string, globalCache: string, url: string,
   }
 }
 
+/**
+ * Fail the build if any archive `zig build` installed exports a symbol that
+ * does not start with `exportPrefix`.
+ *
+ * A Zig static library that bundles compiler_rt defines `memcpy`, `memset`,
+ * `memmove`, `memcmp`, and most of libm as weak globals. An executable that
+ * links the archive ahead of libc (every ordinary link line) extracts those
+ * members and silently replaces the libc implementations for the whole
+ * binary; with `-Doptimize=ReleaseSmall` that made every `memcpy` in bun
+ * about 4x slower. The dep's patch disables the bundling; this check makes
+ * the property "this archive only exports its C API" hold from then on.
+ */
+function verifyArchiveExports(nm: string, prefix: string, exportPrefix: string): void {
+  const libDir = resolve(prefix, "lib");
+  const archives = readdirSync(libDir).filter(f => f.endsWith(".a") || f.endsWith(".lib"));
+  assert(archives.length > 0, `zig-build-cli: no archives found under ${libDir} to verify`);
+  for (const archive of archives) {
+    const path = resolve(libDir, archive);
+    const out = spawnSync(nm, ["--defined-only", "--extern-only", path], { encoding: "utf8" });
+    if (out.error || out.status !== 0) {
+      throw new BuildError(`Failed to run ${nm} on ${path}`, {
+        cause: out.error,
+        hint: out.stderr?.toString(),
+      });
+    }
+    const offenders = new Set<string>();
+    for (const line of out.stdout.split("\n")) {
+      // llvm-nm archive output: `member.o:` headers, blank lines, and
+      // `<addr> <type> <name>` symbol lines. Keep the defined names.
+      const trimmed = line.trim();
+      if (trimmed.length === 0 || trimmed.endsWith(":")) continue;
+      const name = trimmed.split(/\s+/).pop()!.replace(/@.*$/, "");
+      if (!name.startsWith(exportPrefix)) offenders.add(name);
+    }
+    if (offenders.size > 0) {
+      const list = [...offenders].sort();
+      const shown = list.slice(0, 12).join(", ");
+      throw new BuildError(
+        `${archive} exports ${list.length} symbol(s) outside its public API (${exportPrefix}*): ${shown}${list.length > 12 ? ", ..." : ""}`,
+        {
+          hint:
+            `A Zig static library must not export anything but its C API. In particular, Zig's bundled\n` +
+            `compiler_rt defines libc/libm symbols (memcpy, memset, exp, ...) that would silently replace\n` +
+            `the libc implementations for every consumer of the archive. Keep bundle_compiler_rt and\n` +
+            `bundle_ubsan_rt disabled in the dep's patch (see patches/ghostty-vt/lib-vt-only.patch).`,
+        },
+      );
+    }
+  }
+}
+
 async function main(): Promise<void> {
   let prefix = "";
   let cacheDir = "";
+  let nm = "";
+  let exportPrefix = "";
   const packages: Array<{ url: string; hash: string }> = [];
   const zigArgs: string[] = [];
 
@@ -216,6 +269,10 @@ async function main(): Promise<void> {
       prefix = argv[++i] ?? "";
     } else if (a === "--cache") {
       cacheDir = argv[++i] ?? "";
+    } else if (a === "--nm") {
+      nm = argv[++i] ?? "";
+    } else if (a === "--expect-export-prefix") {
+      exportPrefix = argv[++i] ?? "";
     } else if (a === "--package") {
       const url = argv[++i];
       const hash = argv[++i];
@@ -229,6 +286,10 @@ async function main(): Promise<void> {
     }
   }
   assert(prefix.length > 0 && cacheDir.length > 0, "zig-build-cli: --prefix and --cache are required");
+  assert(
+    (exportPrefix.length === 0) === (nm.length === 0),
+    "zig-build-cli: --expect-export-prefix and --nm must be passed together",
+  );
 
   const zig = await resolveZig(cacheDir);
 
@@ -258,6 +319,10 @@ async function main(): Promise<void> {
     throw new BuildError(`zig build exited with ${result.status}`, {
       hint: `command: ${zig} build ${zigArgs.join(" ")} --prefix ${prefix}`,
     });
+  }
+
+  if (exportPrefix.length > 0) {
+    verifyArchiveExports(nm, prefix, exportPrefix);
   }
 }
 

--- a/scripts/build/zig-build-cli.ts
+++ b/scripts/build/zig-build-cli.ts
@@ -29,7 +29,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { mkdir, rename, rm } from "node:fs/promises";
 import { delimiter, join, resolve } from "node:path";
 import { downloadWithRetry } from "./download.ts";
-import { BuildError, assert } from "./error.ts";
+import { assert, BuildError } from "./error.ts";
 
 /** Absolute path to this file, for ninja rule command strings. */
 export const zigBuildCliPath: string = import.meta.filename;

--- a/scripts/build/zig-build-cli.ts
+++ b/scripts/build/zig-build-cli.ts
@@ -26,7 +26,7 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rename, rm } from "node:fs/promises";
 import { delimiter, join, resolve } from "node:path";
 import { downloadWithRetry } from "./download.ts";
 import { BuildError, assert } from "./error.ts";
@@ -83,8 +83,8 @@ function hostZigPlatform(): string {
  *  2. `zig` on `$PATH` whose `zig version` reports `major.minor` matching
  *     `ZIG_VERSION`. A mismatched system Zig is skipped, not fatal.
  *  3. Download the official `ZIG_VERSION` release into
- *     `<cacheDir>/zig/<version>/`, verifying its sha256 against the pinned
- *     table above. Cached per machine like the other toolchain downloads.
+ *     `<cacheDir>/zig/<version>/<arch-os>/`, verifying its sha256 against
+ *     the pinned table above. Cached like the other toolchain downloads.
  */
 async function resolveZig(cacheDir: string): Promise<string> {
   const fromEnv = process.env.BUN_ZIG;
@@ -113,7 +113,7 @@ async function resolveZig(cacheDir: string): Promise<string> {
     hint: "Add it to ZIG_TARBALL_SHA256 in zig-build-cli.ts (from ziglang.org/download/index.json), or set BUN_ZIG",
   });
 
-  const installDir = resolve(cacheDir, "zig", ZIG_VERSION);
+  const installDir = resolve(cacheDir, "zig", ZIG_VERSION, platform);
   const zigExe = join(installDir, "zig");
   if (existsSync(zigExe)) return zigExe;
 
@@ -143,13 +143,16 @@ async function resolveZig(cacheDir: string): Promise<string> {
     });
 
     // Publish atomically: the rename is the single step that makes a
-    // complete toolchain visible at installDir. A concurrent build that
-    // won the race already produced the same content.
+    // complete toolchain visible at installDir. A concurrent build may
+    // have published a complete install while this one was downloading;
+    // use it instead of replacing it. The rm below only clears a crashed,
+    // incomplete extract (a directory rename cannot overwrite a non-empty
+    // target on any platform).
+    if (existsSync(zigExe)) return zigExe;
     await rm(installDir, { recursive: true, force: true });
     await rm(tarball, { force: true });
-    const fs = await import("node:fs/promises");
     try {
-      await fs.rename(staging, installDir);
+      await rename(staging, installDir);
     } catch (err) {
       if (!existsSync(zigExe)) throw err;
     }

--- a/scripts/build/zig-build-cli.ts
+++ b/scripts/build/zig-build-cli.ts
@@ -235,7 +235,14 @@ function verifyArchiveExports(nm: string, prefix: string, exportPrefix: string):
       const trimmed = line.trim();
       if (trimmed.length === 0 || trimmed.endsWith(":")) continue;
       const name = trimmed.split(/\s+/).pop()!.replace(/@.*$/, "");
-      if (!name.startsWith(exportPrefix)) offenders.add(name);
+      // Mach-O prefixes every C symbol with `_` (so the API is
+      // `_ghostty_*` there) and defines reserved `__mh_*` header
+      // symbols; ELF uses the bare name. A leaked libc symbol is caught
+      // either way: neither `memcpy` nor `_memcpy` matches any of these.
+      if (name.startsWith(exportPrefix)) continue;
+      if (name.startsWith(`_${exportPrefix}`)) continue;
+      if (name.startsWith("__mh_")) continue;
+      offenders.add(name);
     }
     if (offenders.size > 0) {
       const list = [...offenders].sort();

--- a/scripts/build/zig-build-cli.ts
+++ b/scripts/build/zig-build-cli.ts
@@ -172,16 +172,14 @@ async function resolveZig(cacheDir: string): Promise<string> {
  * content — fail loudly rather than letting `zig build` fall back to the
  * network.
  */
-async function prefetchZigPackage(
-  zig: string,
-  globalCache: string,
-  url: string,
-  expectedHash: string,
-): Promise<void> {
+async function prefetchZigPackage(zig: string, globalCache: string, url: string, expectedHash: string): Promise<void> {
   if (existsSync(join(globalCache, "p", expectedHash))) return;
 
   console.log(`fetching zig package ${expectedHash}`);
-  const tarball = join(globalCache, `prefetch.${process.pid}.${createHash("sha256").update(url).digest("hex").slice(0, 8)}.tar.gz`);
+  const tarball = join(
+    globalCache,
+    `prefetch.${process.pid}.${createHash("sha256").update(url).digest("hex").slice(0, 8)}.tar.gz`,
+  );
   try {
     await downloadWithRetry(url, tarball, expectedHash);
     const fetched = spawnSync(zig, ["fetch", tarball], {

--- a/src/ghostty_vt_sys/Cargo.toml
+++ b/src/ghostty_vt_sys/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bun_ghostty_vt_sys"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+path = "lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+scopeguard.workspace = true

--- a/src/ghostty_vt_sys/ghostty_vt.rs
+++ b/src/ghostty_vt_sys/ghostty_vt.rs
@@ -29,6 +29,7 @@ pub const GHOSTTY_FORMATTER_FORMAT_VT: FormatterFormat = 1;
 
 /// `GhosttyTerminalData` (the subset Bun reads).
 pub type TerminalData = c_int;
+pub const GHOSTTY_TERMINAL_DATA_CURSOR_X: TerminalData = 3;
 pub const GHOSTTY_TERMINAL_DATA_CURSOR_Y: TerminalData = 4;
 pub const GHOSTTY_TERMINAL_DATA_SCROLLBACK_ROWS: TerminalData = 15;
 
@@ -306,8 +307,22 @@ impl VirtualTerminal {
         }
     }
 
+    /// 0-indexed column of the cursor.
+    fn cursor_col(&self) -> u16 {
+        let mut out: u16 = 0;
+        // SAFETY: `term` is live; CURSOR_X writes a `uint16_t`.
+        let rc = unsafe {
+            ghostty_terminal_get(
+                self.term.as_ptr(),
+                GHOSTTY_TERMINAL_DATA_CURSOR_X,
+                (&raw mut out).cast::<c_void>(),
+            )
+        };
+        if rc == GHOSTTY_SUCCESS { out } else { 0 }
+    }
+
     /// 0-indexed row of the cursor within the active area.
-    pub fn cursor_row(&self) -> u16 {
+    fn cursor_row(&self) -> u16 {
         let mut out: u16 = 0;
         // SAFETY: `term` is live; CURSOR_Y writes a `uint16_t`.
         let rc = unsafe {
@@ -335,14 +350,13 @@ impl VirtualTerminal {
         if rc == GHOSTTY_SUCCESS { out } else { 0 }
     }
 
-    /// Rows of the active area that carry content: everything up to and
-    /// including the cursor row, or the full height once output has
-    /// scrolled. Keeps short-lived tasks from rendering a block of blanks.
+    /// Rows of the active area that carry content: everything through the
+    /// cursor's row, EXCLUDING that row when the cursor is resting at
+    /// column 0 on it (the position after a trailing newline). A task
+    /// that has printed N complete lines renders N rows, not N plus a
+    /// blank; a task that has printed nothing renders zero.
     pub fn used_rows(&self) -> u16 {
-        if self.scrollback_rows() > 0 {
-            return self.rows;
-        }
-        (self.cursor_row() + 1).min(self.rows)
+        (self.cursor_row() + u16::from(self.cursor_col() > 0)).min(self.rows)
     }
 
     /// Serialize one row of the active area as VT text — SGR colors and

--- a/src/ghostty_vt_sys/ghostty_vt.rs
+++ b/src/ghostty_vt_sys/ghostty_vt.rs
@@ -1,0 +1,462 @@
+//! Raw FFI declarations for libghostty-vt plus `VirtualTerminal`, a safe
+//! owning wrapper over the handful of entry points Bun needs.
+//!
+//! The declarations mirror `vendor/ghostty-vt/include/ghostty/vt/*.h`.
+//! Every enum in that API is explicitly backed by C `int`
+//! (`GHOSTTY_ENUM_TYPED`), so they are declared here as `c_int` constants
+//! rather than Rust enums: the library may add variants and we must not
+//! UB on an unknown discriminant.
+
+use core::ffi::{c_int, c_void};
+use core::ptr::NonNull;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Types (ghostty/vt/types.h)
+// ───────────────────────────────────────────────────────────────────────────
+
+/// `GhosttyResult`
+pub type Result_ = c_int;
+pub const GHOSTTY_SUCCESS: Result_ = 0;
+pub const GHOSTTY_OUT_OF_MEMORY: Result_ = -1;
+pub const GHOSTTY_INVALID_VALUE: Result_ = -2;
+pub const GHOSTTY_OUT_OF_SPACE: Result_ = -3;
+pub const GHOSTTY_NO_VALUE: Result_ = -4;
+
+/// `GhosttyFormatterFormat`
+pub type FormatterFormat = c_int;
+pub const GHOSTTY_FORMATTER_FORMAT_PLAIN: FormatterFormat = 0;
+pub const GHOSTTY_FORMATTER_FORMAT_VT: FormatterFormat = 1;
+
+/// `GhosttyTerminalData` (the subset Bun reads).
+pub type TerminalData = c_int;
+pub const GHOSTTY_TERMINAL_DATA_CURSOR_Y: TerminalData = 4;
+pub const GHOSTTY_TERMINAL_DATA_SCROLLBACK_ROWS: TerminalData = 15;
+
+/// `GhosttyPointTag`
+pub type PointTag = c_int;
+pub const GHOSTTY_POINT_TAG_ACTIVE: PointTag = 0;
+
+// Opaque handles. The C side declares `typedef struct FooImpl* Foo;` — we
+// model them as `NonNull<Opaque>` where non-null is guaranteed.
+#[repr(C)]
+pub struct TerminalImpl {
+    _opaque: [u8; 0],
+}
+#[repr(C)]
+pub struct FormatterImpl {
+    _opaque: [u8; 0],
+}
+
+/// `GhosttyTerminalOptions`
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct TerminalOptions {
+    pub cols: u16,
+    pub rows: u16,
+    /// Scrollback retention limit in bytes (ghostty pages the history and
+    /// trims the oldest page once the total exceeds this).
+    pub max_scrollback: usize,
+}
+
+/// `GhosttyPointCoordinate`
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct PointCoordinate {
+    pub x: u16,
+    pub y: u32,
+}
+
+/// `GhosttyPointValue` (union padded to 16 bytes for ABI stability)
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union PointValue {
+    pub coordinate: PointCoordinate,
+    pub _padding: [u64; 2],
+}
+
+/// `GhosttyPoint`
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Point {
+    pub tag: PointTag,
+    pub value: PointValue,
+}
+
+impl Point {
+    pub fn active(x: u16, y: u32) -> Self {
+        Self {
+            tag: GHOSTTY_POINT_TAG_ACTIVE,
+            value: PointValue {
+                coordinate: PointCoordinate { x, y },
+            },
+        }
+    }
+}
+
+/// `GhosttyGridRef` — an untracked reference into the terminal grid. Only
+/// valid until the next mutating terminal call (`vt_write`, `resize`, ...).
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GridRef {
+    pub size: usize,
+    pub node: *mut c_void,
+    pub x: u16,
+    pub y: u16,
+}
+
+impl GridRef {
+    pub fn zeroed() -> Self {
+        Self {
+            size: core::mem::size_of::<Self>(),
+            node: core::ptr::null_mut(),
+            x: 0,
+            y: 0,
+        }
+    }
+}
+
+/// `GhosttySelection`
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Selection {
+    pub size: usize,
+    pub start: GridRef,
+    pub end: GridRef,
+    pub rectangle: bool,
+}
+
+/// `GhosttyFormatterScreenExtra`
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FormatterScreenExtra {
+    pub size: usize,
+    pub cursor: bool,
+    pub style: bool,
+    pub hyperlink: bool,
+    pub protection: bool,
+    pub kitty_keyboard: bool,
+    pub charsets: bool,
+}
+
+/// `GhosttyFormatterTerminalExtra`
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FormatterTerminalExtra {
+    pub size: usize,
+    pub palette: bool,
+    pub modes: bool,
+    pub scrolling_region: bool,
+    pub tabstops: bool,
+    pub pwd: bool,
+    pub keyboard: bool,
+    pub screen: FormatterScreenExtra,
+}
+
+/// `GhosttyFormatterTerminalOptions`
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FormatterTerminalOptions {
+    pub size: usize,
+    pub emit: FormatterFormat,
+    pub unwrap: bool,
+    pub trim: bool,
+    pub extra: FormatterTerminalExtra,
+    pub selection: *const Selection,
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Functions
+// ───────────────────────────────────────────────────────────────────────────
+
+unsafe extern "C" {
+    // Allocator: `None` ⇔ the C `NULL` "use the default allocator" contract.
+    // `GhosttyAllocator` is never constructed on the Rust side, so its shape
+    // is irrelevant here; declare the parameter as an opaque pointer.
+    pub(crate) fn ghostty_terminal_new(
+        allocator: *const c_void,
+        terminal: *mut *mut TerminalImpl,
+        options: TerminalOptions,
+    ) -> Result_;
+    pub(crate) fn ghostty_terminal_free(terminal: *mut TerminalImpl);
+    pub(crate) fn ghostty_terminal_resize(
+        terminal: *mut TerminalImpl,
+        cols: u16,
+        rows: u16,
+        cell_width_px: u32,
+        cell_height_px: u32,
+    ) -> Result_;
+    pub(crate) fn ghostty_terminal_vt_write(
+        terminal: *mut TerminalImpl,
+        data: *const u8,
+        len: usize,
+    );
+    pub(crate) fn ghostty_terminal_get(
+        terminal: *mut TerminalImpl,
+        data: TerminalData,
+        out: *mut c_void,
+    ) -> Result_;
+    pub(crate) fn ghostty_terminal_grid_ref(
+        terminal: *mut TerminalImpl,
+        point: Point,
+        out_ref: *mut GridRef,
+    ) -> Result_;
+
+    pub(crate) fn ghostty_formatter_terminal_new(
+        allocator: *const c_void,
+        formatter: *mut *mut FormatterImpl,
+        terminal: *mut TerminalImpl,
+        options: FormatterTerminalOptions,
+    ) -> Result_;
+    pub(crate) fn ghostty_formatter_format_buf(
+        formatter: *mut FormatterImpl,
+        buf: *mut u8,
+        buf_len: usize,
+        out_written: *mut usize,
+    ) -> Result_;
+    pub(crate) fn ghostty_formatter_free(formatter: *mut FormatterImpl);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Safe wrapper
+// ───────────────────────────────────────────────────────────────────────────
+
+/// An owning handle to a libghostty-vt terminal emulator.
+///
+/// Feed raw child output through [`write`](Self::write) and read back a
+/// styled snapshot one row at a time with
+/// [`format_active_row`](Self::format_active_row). The terminal owns a cell
+/// grid plus bounded scrollback, so carriage-return progress bars, cursor
+/// movement, and screen clears all resolve to the text a real terminal
+/// would be showing rather than leaking control bytes into the UI.
+///
+/// Not `Send`/`Sync`: libghostty-vt terminals have no internal locking.
+pub struct VirtualTerminal {
+    term: NonNull<TerminalImpl>,
+    cols: u16,
+    rows: u16,
+    /// Reused across `format` calls; grown on `GHOSTTY_OUT_OF_SPACE`.
+    fmt_buf: Vec<u8>,
+    /// `!Send + !Sync`
+    _not_send: core::marker::PhantomData<*mut TerminalImpl>,
+}
+
+impl VirtualTerminal {
+    /// `max_scrollback` is the history retention limit in bytes; 0 keeps no
+    /// history beyond the visible `rows`. Returns `None` on allocation
+    /// failure or if `cols`/`rows` is 0.
+    pub fn new(cols: u16, rows: u16, max_scrollback: usize) -> Option<Self> {
+        if cols == 0 || rows == 0 {
+            return None;
+        }
+        let mut raw: *mut TerminalImpl = core::ptr::null_mut();
+        // SAFETY: `raw` is a valid out-pointer; a NULL allocator selects the
+        // library's default allocator.
+        let rc = unsafe {
+            ghostty_terminal_new(
+                core::ptr::null(),
+                &raw mut raw,
+                TerminalOptions {
+                    cols,
+                    rows,
+                    max_scrollback,
+                },
+            )
+        };
+        if rc != GHOSTTY_SUCCESS {
+            return None;
+        }
+        Some(Self {
+            term: NonNull::new(raw)?,
+            cols,
+            rows,
+            fmt_buf: Vec::new(),
+            _not_send: core::marker::PhantomData,
+        })
+    }
+
+    pub fn cols(&self) -> u16 {
+        self.cols
+    }
+
+    pub fn rows(&self) -> u16 {
+        self.rows
+    }
+
+    /// Feed raw bytes from the child's pty into the emulator.
+    pub fn write(&mut self, data: &[u8]) {
+        if data.is_empty() {
+            return;
+        }
+        // SAFETY: `term` is live; `data` is a valid slice for this call.
+        unsafe { ghostty_terminal_vt_write(self.term.as_ptr(), data.as_ptr(), data.len()) };
+    }
+
+    /// Resize the grid. Existing content reflows.
+    pub fn resize(&mut self, cols: u16, rows: u16) {
+        if cols == 0 || rows == 0 || (cols == self.cols && rows == self.rows) {
+            return;
+        }
+        // SAFETY: `term` is live. Pixel sizes are unused by Bun (no image
+        // protocol rendering) so 0/0 is fine.
+        if unsafe { ghostty_terminal_resize(self.term.as_ptr(), cols, rows, 0, 0) }
+            == GHOSTTY_SUCCESS
+        {
+            self.cols = cols;
+            self.rows = rows;
+        }
+    }
+
+    /// 0-indexed row of the cursor within the active area.
+    pub fn cursor_row(&self) -> u16 {
+        let mut out: u16 = 0;
+        // SAFETY: `term` is live; CURSOR_Y writes a `uint16_t`.
+        let rc = unsafe {
+            ghostty_terminal_get(
+                self.term.as_ptr(),
+                GHOSTTY_TERMINAL_DATA_CURSOR_Y,
+                (&raw mut out).cast::<c_void>(),
+            )
+        };
+        if rc == GHOSTTY_SUCCESS { out } else { 0 }
+    }
+
+    /// Number of rows that have scrolled off the top of the active area
+    /// into history.
+    pub fn scrollback_rows(&self) -> usize {
+        let mut out: usize = 0;
+        // SAFETY: `term` is live; SCROLLBACK_ROWS writes a `size_t`.
+        let rc = unsafe {
+            ghostty_terminal_get(
+                self.term.as_ptr(),
+                GHOSTTY_TERMINAL_DATA_SCROLLBACK_ROWS,
+                (&raw mut out).cast::<c_void>(),
+            )
+        };
+        if rc == GHOSTTY_SUCCESS { out } else { 0 }
+    }
+
+    /// Rows of the active area that carry content: everything up to and
+    /// including the cursor row, or the full height once output has
+    /// scrolled. Keeps short-lived tasks from rendering a block of blanks.
+    pub fn used_rows(&self) -> u16 {
+        if self.scrollback_rows() > 0 {
+            return self.rows;
+        }
+        (self.cursor_row() + 1).min(self.rows)
+    }
+
+    /// Serialize one row of the active area as VT text — SGR colors and
+    /// styles preserved, trailing whitespace trimmed, no trailing newline —
+    /// into `out`, which is cleared first.
+    ///
+    /// Returns `false` (leaving `out` empty) if `y` is out of range or the
+    /// formatter fails.
+    pub fn format_active_row(&mut self, y: u16, out: &mut Vec<u8>) -> bool {
+        out.clear();
+        if y >= self.rows {
+            return false;
+        }
+
+        // Untracked grid refs go stale on the next mutating terminal call,
+        // and the formatter captures them at creation, so both the selection
+        // and the formatter must be rebuilt for every snapshot.
+        let mut selection = Selection {
+            size: core::mem::size_of::<Selection>(),
+            start: GridRef::zeroed(),
+            end: GridRef::zeroed(),
+            rectangle: false,
+        };
+        let start = Point::active(0, u32::from(y));
+        let end = Point::active(self.cols - 1, u32::from(y));
+        // SAFETY: `term` is live; both points are within the active area.
+        let ok = unsafe {
+            ghostty_terminal_grid_ref(self.term.as_ptr(), start, &raw mut selection.start)
+                == GHOSTTY_SUCCESS
+                && ghostty_terminal_grid_ref(self.term.as_ptr(), end, &raw mut selection.end)
+                    == GHOSTTY_SUCCESS
+        };
+        if !ok {
+            return false;
+        }
+
+        let options = FormatterTerminalOptions {
+            size: core::mem::size_of::<FormatterTerminalOptions>(),
+            emit: GHOSTTY_FORMATTER_FORMAT_VT,
+            unwrap: false,
+            trim: true,
+            extra: FormatterTerminalExtra {
+                size: core::mem::size_of::<FormatterTerminalExtra>(),
+                screen: FormatterScreenExtra {
+                    size: core::mem::size_of::<FormatterScreenExtra>(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            selection: &raw const selection,
+        };
+
+        let mut formatter: *mut FormatterImpl = core::ptr::null_mut();
+        // SAFETY: `term` is live, `formatter` is a valid out-pointer, and
+        // `selection` (when set) outlives this call.
+        let rc = unsafe {
+            ghostty_formatter_terminal_new(
+                core::ptr::null(),
+                &raw mut formatter,
+                self.term.as_ptr(),
+                options,
+            )
+        };
+        if rc != GHOSTTY_SUCCESS || formatter.is_null() {
+            return false;
+        }
+        // SAFETY: `formatter` was created above and is freed exactly once here.
+        let _free = scopeguard::guard(formatter, |f| unsafe { ghostty_formatter_free(f) });
+
+        // First attempt reuses whatever capacity a previous format left;
+        // GHOSTTY_OUT_OF_SPACE hands back the exact size for the retry.
+        if self.fmt_buf.capacity() == 0 {
+            self.fmt_buf
+                .reserve((usize::from(self.cols) + 1) * usize::from(self.rows) * 4);
+        }
+        loop {
+            let cap = self.fmt_buf.capacity();
+            let mut written: usize = 0;
+            // SAFETY: `formatter` is live; `fmt_buf` has `cap` writable bytes.
+            let rc = unsafe {
+                ghostty_formatter_format_buf(
+                    formatter,
+                    self.fmt_buf.as_mut_ptr(),
+                    cap,
+                    &raw mut written,
+                )
+            };
+            match rc {
+                GHOSTTY_SUCCESS => {
+                    // SAFETY: the formatter reported `written <= cap`
+                    // initialized bytes.
+                    unsafe { self.fmt_buf.set_len(written.min(cap)) };
+                    break;
+                }
+                GHOSTTY_OUT_OF_SPACE => {
+                    if written <= cap {
+                        // Cannot make progress; treat as a failed format.
+                        return false;
+                    }
+                    self.fmt_buf.reserve(written - self.fmt_buf.len());
+                }
+                _ => return false,
+            }
+        }
+
+        out.extend_from_slice(&self.fmt_buf);
+        true
+    }
+}
+
+impl Drop for VirtualTerminal {
+    fn drop(&mut self) {
+        // SAFETY: `term` was created by `ghostty_terminal_new` and is freed
+        // exactly once here.
+        unsafe { ghostty_terminal_free(self.term.as_ptr()) };
+    }
+}

--- a/src/ghostty_vt_sys/ghostty_vt.rs
+++ b/src/ghostty_vt_sys/ghostty_vt.rs
@@ -426,11 +426,12 @@ impl VirtualTerminal {
         // SAFETY: `formatter` was created above and is freed exactly once here.
         let _free = scopeguard::guard(formatter, |f| unsafe { ghostty_formatter_free(f) });
 
-        // First attempt reuses whatever capacity a previous format left;
-        // GHOSTTY_OUT_OF_SPACE hands back the exact size for the retry.
+        // First attempt reuses whatever capacity a previous format left; a
+        // new buffer starts at a one-row estimate (up to 4 UTF-8 bytes per
+        // cell plus SGR escapes), and GHOSTTY_OUT_OF_SPACE hands back the
+        // exact required size for the retry.
         if self.fmt_buf.capacity() == 0 {
-            self.fmt_buf
-                .reserve((usize::from(self.cols) + 1) * usize::from(self.rows) * 4);
+            self.fmt_buf.reserve((usize::from(self.cols) + 1) * 8);
         }
         loop {
             let cap = self.fmt_buf.capacity();

--- a/src/ghostty_vt_sys/lib.rs
+++ b/src/ghostty_vt_sys/lib.rs
@@ -1,0 +1,11 @@
+//! Bindings for libghostty-vt, Ghostty's terminal emulator library.
+//!
+//! `ghostty_vt` holds the raw `extern "C"` declarations against
+//! `include/ghostty/vt.h` plus `VirtualTerminal`, a safe owning wrapper.
+//! The library is vendored and built by `scripts/build/deps/ghostty-vt.ts`;
+//! symbols resolve at the final link like every other vendored C dep.
+#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#![warn(unused_must_use)]
+pub mod ghostty_vt;
+
+pub use ghostty_vt::VirtualTerminal;

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -46,6 +46,7 @@ bun_css.workspace = true
 bun_dns.workspace = true
 bun_dotenv.workspace = true
 bun_event_loop.workspace = true
+bun_ghostty_vt_sys.workspace = true
 bun_glob.workspace = true
 bun_highway.workspace = true
 bun_http.workspace = true

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -152,6 +152,9 @@ pub mod bun {
             CreatePtyError, OpenPtyFn, OpenPtyTermios, PtyResult, Winsize,
         };
         // `bun run --parallel` gives each task a pty for its pane renderer.
+        // That renderer is unix-only (see `Panes` in multi_run.rs), so the
+        // re-export is too; otherwise it is an unused import on Windows.
+        #[cfg(unix)]
         pub(crate) use crate::api::bun_terminal_body::create_pty;
     }
     pub use terminal::Terminal;

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -151,6 +151,8 @@ pub mod bun {
         pub use crate::api::bun_terminal_body::{
             CreatePtyError, OpenPtyFn, OpenPtyTermios, PtyResult, Winsize,
         };
+        // `bun run --parallel` gives each task a pty for its pane renderer.
+        pub(crate) use crate::api::bun_terminal_body::create_pty;
     }
     pub use terminal::Terminal;
 

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -748,7 +748,7 @@ impl From<CreatePtyError> for bun_core::Error {
     }
 }
 
-fn create_pty(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
+pub(crate) fn create_pty(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
     #[cfg(unix)]
     {
         return create_pty_posix(cols, rows);

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -337,10 +337,10 @@ pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
         "--workspaces                      Run a script in all workspace packages (from the \"workspaces\" field in package.json)"
     ),
     parse_param!(
-        "--parallel                        Run multiple scripts concurrently: a pane per script on a terminal, `label | line` prefixes otherwise"
+        "--parallel                        Run multiple scripts concurrently: a pane per script on an interactive terminal (macOS and Linux), `label | line` prefixes otherwise"
     ),
     parse_param!(
-        "--sequential                      Run multiple scripts sequentially: a pane per script on a terminal, `label | line` prefixes otherwise"
+        "--sequential                      Run multiple scripts sequentially: a pane per script on an interactive terminal (macOS and Linux), `label | line` prefixes otherwise"
     ),
     parse_param!(
         "--no-exit-on-error                Continue running other scripts when one fails (with --parallel/--sequential)"

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -337,10 +337,10 @@ pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
         "--workspaces                      Run a script in all workspace packages (from the \"workspaces\" field in package.json)"
     ),
     parse_param!(
-        "--parallel                        Run multiple scripts concurrently with Foreman-style output"
+        "--parallel                        Run multiple scripts concurrently: a pane per script on a terminal, `label | line` prefixes otherwise"
     ),
     parse_param!(
-        "--sequential                      Run multiple scripts sequentially with Foreman-style output"
+        "--sequential                      Run multiple scripts sequentially: a pane per script on a terminal, `label | line` prefixes otherwise"
     ),
     parse_param!(
         "--no-exit-on-error                Continue running other scripts when one fails (with --parallel/--sequential)"
@@ -352,7 +352,7 @@ pub(crate) const AUTO_ONLY_PARAMS: &[ParamType] = concat_params!(
         // parse_param!("--all"),
         parse_param!("--silent                          Don't print the script command"),
         parse_param!(
-            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines."
+            "--elide-lines <NUMBER>            Lines of script output shown per --filter or --parallel/--sequential pane (default: 10). With --filter, 0 shows all lines."
         ),
         parse_param!("-v, --version                     Print version and exit"),
         parse_param!("--revision                        Print version with revision and exit"),
@@ -370,7 +370,7 @@ pub(crate) const RUN_ONLY_PARAMS: &[ParamType] = concat_params!(
     &[
         parse_param!("--silent                          Don't print the script command"),
         parse_param!(
-            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines."
+            "--elide-lines <NUMBER>            Lines of script output shown per --filter or --parallel/--sequential pane (default: 10). With --filter, 0 shows all lines."
         ),
     ],
     AUTO_OR_RUN_PARAMS,

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1,5 +1,7 @@
 use core::ffi::{c_char, c_void};
 use core::ptr;
+#[cfg(unix)]
+use std::io::Write as _;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
@@ -24,6 +26,14 @@ use crate::api::bun::process::{
     self as spawn, Process, Rusage, SpawnOptions, SpawnProcessResult, Status,
     event_loop_handle_to_ctx,
 };
+// Pty creation (openpty) and the per-task virtual terminal for the pane
+// renderer; see `Panes`.
+#[cfg(unix)]
+use crate::api::bun::terminal::create_pty;
+#[cfg(unix)]
+use bun_ghostty_vt_sys::VirtualTerminal;
+#[cfg(unix)]
+use bun_sys::FdExt as _;
 use bun_dotenv::Loader as DotEnvLoader;
 type OutputWriter = bun_core::io::Writer;
 
@@ -116,6 +126,11 @@ pub(crate) struct ProcessHandle<'a> {
     /// Dependents across sequential groups (group N -> group N+1).
     /// These ARE started even if this handle fails when --no-exit-on-error is set.
     next_dependents: Vec<*mut ProcessHandle<'a>>,
+
+    /// Pane mode only (`State::panes` is `Some`): the virtual terminal this
+    /// task's pty output is replayed into. `None` until `start()`.
+    #[cfg(unix)]
+    vt: Option<VirtualTerminal>,
 }
 
 impl<'a> ProcessHandle<'a> {
@@ -123,6 +138,35 @@ impl<'a> ProcessHandle<'a> {
         // SAFETY: state is a backref into the `State` on `run`'s stack; lives for the whole loop.
         let state = unsafe { &mut *self.state.cast_mut() };
         state.remaining_scripts += 1;
+
+        // Pane mode: give the task a pty sized to its pane so it behaves
+        // like it's on a real terminal (colors, correct width, `\r`
+        // progress bars), and a virtual terminal to replay that output
+        // into. stdin stays `/dev/null` exactly like the pipe path —
+        // --parallel never feeds children input — so a child that reads
+        // stdin sees EOF in both modes.
+        #[cfg(unix)]
+        let pty_fds: Option<(bun_sys::Fd, bun_sys::Fd)> = if let Some(panes) = &state.panes {
+            let pty = create_pty(panes.cols, panes.rows)?;
+            // The reader polls `read_fd` (the nonblocking, close-on-exec dup
+            // of the master); the other master-side dups are not needed and
+            // must not keep the pty alive past the reader.
+            pty.master.close();
+            pty.write_fd.close();
+            // The same slave fd is dup2'd onto the child's 1 and 2; the
+            // parent's copy is closed right after the spawn below.
+            self.options.stdout = spawn::Stdio::Pipe(pty.slave);
+            self.options.stderr = spawn::Stdio::Pipe(pty.slave);
+            self.vt = VirtualTerminal::new(panes.cols, panes.rows, Panes::SCROLLBACK_BYTES);
+            if self.vt.is_none() {
+                pty.read_fd.close();
+                pty.slave.close();
+                return Err(err!("VirtualTerminalInitFailed"));
+            }
+            Some((pty.read_fd, pty.slave))
+        } else {
+            None
+        };
 
         // Null-terminated argv array, as required by spawnProcess.
         let argv: [*const c_char; 4] = [
@@ -203,7 +247,21 @@ impl<'a> ProcessHandle<'a> {
         }
 
         #[cfg(unix)]
-        {
+        if let Some((read_fd, slave)) = pty_fds {
+            // Close the parent's only copy of the pty slave so the master
+            // reports hangup once the child — now its sole holder — exits.
+            // `options.stdout`/`stderr` held the same fd; reset them so
+            // nothing can reuse it after the close.
+            slave.close();
+            self.options.stdout = spawn::Stdio::Ignore;
+            self.options.stderr = spawn::Stdio::Ignore;
+            // stdout and stderr are merged by the pty, so only one reader
+            // runs; `stderr_reader` stays idle.
+            self.stdout_reader
+                .reader
+                .start(read_fd, true)
+                .map_err(Error::from)?;
+        } else {
             if let Some(stdout_fd) = stdout_fd {
                 let _ = bun_sys::set_nonblocking(stdout_fd);
                 self.stdout_reader
@@ -284,6 +342,81 @@ const COLORS: [&[u8]; 6] = [
 ];
 const RESET: &[u8] = ansi::RESET.as_bytes();
 
+/// Compile-time ANSI-tag expansion (colors are always on in pane mode —
+/// `Panes::init` already required an ANSI-capable stdout).
+#[cfg(unix)]
+macro_rules! fmt {
+    ($s:literal) => {
+        bun_core::Output::pretty_fmt!($s, true)
+    };
+}
+
+/// The pane renderer used when stdout is an interactive terminal.
+///
+/// Each task is spawned onto a pty sized `cols`×`rows` and its output is
+/// replayed into a libghostty-vt [`VirtualTerminal`] (`ProcessHandle::vt`).
+/// `redraw` then repaints one pane per task from that terminal's cell
+/// grid, so carriage-return progress bars, cursor movement, clears, and
+/// colors all resolve to what a real terminal would be showing instead
+/// of leaking control bytes into the interleaved output.
+///
+/// When stdout is not an interactive terminal (pipes, redirects, CI) this
+/// is `None` and every task keeps the `label | line` prefix renderer.
+#[cfg(unix)]
+struct Panes {
+    /// Pane interior width in cells: the terminal's width minus the `│ `
+    /// gutter. Also the width each task's pty reports.
+    cols: u16,
+    /// Pane height in rows (`--elide-lines`, default 10). Also the height
+    /// each task's pty reports.
+    rows: u16,
+    /// Accumulates a whole frame, then is written to stdout in one shot
+    /// inside a synchronized-update bracket so the repaint never tears.
+    draw_buf: Vec<u8>,
+    /// Scratch for one formatted terminal row.
+    row_buf: Vec<u8>,
+    /// `\n` count of the previous frame: how many lines to cursor-up over
+    /// before painting the next one.
+    last_lines_written: usize,
+    /// Set on every read and every exit; drained once per event-loop tick
+    /// by `flush_redraw` so a chatty task can't force a repaint per chunk.
+    needs_redraw: bool,
+}
+
+#[cfg(unix)]
+impl Panes {
+    /// Pane height when `--elide-lines` is absent; matches `bun run --filter`.
+    const DEFAULT_ROWS: usize = 10;
+    /// Cell width of the `│ ` gutter prefixed to every pane row.
+    const GUTTER_COLS: u16 = 2;
+    /// Per-task scrollback retention, in bytes. Rows that scroll off the
+    /// top of a pane land here and surface as the `[N lines elided]` count.
+    const SCROLLBACK_BYTES: usize = 2 * 1024 * 1024;
+
+    /// `Some` only when stdout is an ANSI-capable interactive terminal
+    /// whose width is readable. Anything else keeps the prefix renderer,
+    /// so piped/CI output is byte-for-byte what it was before panes existed.
+    fn init(elide_lines: Option<usize>) -> Option<Self> {
+        if !Output::enable_ansi_colors_stdout() || !Output::is_stdout_tty() {
+            return None;
+        }
+        let width = Output::File::from(bun_core::Fd::stdout()).winsize()?.col;
+        let cols = width.checked_sub(Self::GUTTER_COLS).filter(|c| *c > 0)?;
+        let rows = elide_lines
+            .filter(|n| *n > 0)
+            .unwrap_or(Self::DEFAULT_ROWS)
+            .min(usize::from(u16::MAX)) as u16;
+        Some(Self {
+            cols,
+            rows,
+            draw_buf: Vec::new(),
+            row_buf: Vec::new(),
+            last_lines_written: 0,
+            needs_redraw: false,
+        })
+    }
+}
+
 struct State<'a> {
     handles: Box<[ProcessHandle<'a>]>,
     event_loop: *mut MiniEventLoop<'static>,
@@ -298,6 +431,8 @@ struct State<'a> {
     no_exit_on_error: bool,
     env: *mut DotEnvLoader<'static>,
     use_colors: bool,
+    #[cfg(unix)]
+    panes: Option<Panes>,
 }
 
 impl<'a> State<'a> {
@@ -306,6 +441,19 @@ impl<'a> State<'a> {
     }
 
     fn read_chunk(&mut self, pipe: &mut PipeReader<'a>, chunk: &[u8]) -> Result<(), Error> {
+        #[cfg(unix)]
+        if let Some(panes) = &mut self.panes {
+            // SAFETY: `pipe.handle` is the backref set in `ProcessHandle::
+            // start()`; `vt` is disjoint from `pipe`'s fields. Same pattern
+            // as the prefix path's `&*pipe.handle` below.
+            if let Some(vt) = unsafe { &mut (*pipe.handle.cast_mut()).vt } {
+                vt.write(chunk);
+            }
+            // Coalesced: `flush_redraw` repaints at most once per tick.
+            panes.needs_redraw = true;
+            return Ok(());
+        }
+
         pipe.line_buffer.extend_from_slice(chunk);
 
         // Route to correct parent stream: child stdout -> parent stdout, child stderr -> parent stderr
@@ -379,9 +527,9 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    fn process_exit(&mut self, handle: &mut ProcessHandle<'a>) -> Result<(), Error> {
-        self.remaining_scripts -= 1;
-
+    /// Prefix-mode exit reporting: flush each pipe's partial last line,
+    /// then write the exit status to stderr behind the task's `label | `.
+    fn process_exit_prefix(&mut self, handle: &mut ProcessHandle<'a>) -> Result<(), Error> {
         // Flush remaining buffers (stdout first, then stderr)
         // Reshaped for borrowck — `flush_pipe_buffer` would need both
         // `&ProcessHandle` and `&mut handle.stdout_reader` which overlap. Route
@@ -425,6 +573,23 @@ impl<'a> State<'a> {
                 writer.write_all(b"Error\n")?;
             }
         }
+        Ok(())
+    }
+
+    fn process_exit(&mut self, handle: &mut ProcessHandle<'a>) -> Result<(), Error> {
+        self.remaining_scripts -= 1;
+
+        // Pane mode writes nothing here: the pane footer carries the exit
+        // status and `flush_redraw` repaints after this tick (and once more
+        // after the event loop exits, so the final exit is never missed).
+        #[cfg(unix)]
+        if let Some(panes) = &mut self.panes {
+            panes.needs_redraw = true;
+        } else {
+            self.process_exit_prefix(handle)?;
+        }
+        #[cfg(not(unix))]
+        self.process_exit_prefix(handle)?;
 
         // Check if we should abort on error
         let failed = match &handle.process.as_ref().unwrap().status {
@@ -525,6 +690,154 @@ impl<'a> State<'a> {
             }
         }
         0
+    }
+}
+
+#[cfg(unix)]
+impl<'a> State<'a> {
+    /// Repaint the pane UI if anything changed since the last frame.
+    /// Called once per event-loop tick and once after the loop exits.
+    fn flush_redraw(&mut self) -> Result<(), Error> {
+        if self.panes.as_ref().is_some_and(|p| p.needs_redraw) {
+            self.redraw()?;
+        }
+        Ok(())
+    }
+
+    /// Erase the previous frame and paint one pane per task into a single
+    /// stdout write, bracketed by a synchronized update so the terminal
+    /// swaps frames atomically.
+    ///
+    /// Autowrap is disabled for the frame so an over-long header truncates
+    /// instead of soft-wrapping; the frame's `\n` count is then exactly the
+    /// number of terminal lines it occupies, which is what the next frame's
+    /// cursor-up erase relies on. Pane rows can never exceed the terminal
+    /// width by construction (`Panes::cols` plus the 2-cell gutter).
+    fn redraw(&mut self) -> Result<(), Error> {
+        // `draw_buf`/`row_buf` (inside `panes`) and each handle's `vt` are
+        // mutated in the same loop; destructuring keeps the two `&mut`
+        // borrows of `self` provably disjoint.
+        let State { handles, panes, .. } = self;
+        let Some(panes) = panes.as_mut() else {
+            return Ok(());
+        };
+        panes.needs_redraw = false;
+        panes.draw_buf.clear();
+        panes
+            .draw_buf
+            .extend_from_slice(Output::SYNCHRONIZED_START.as_bytes());
+        // DECAWM off: long lines truncate instead of soft-wrapping.
+        panes.draw_buf.extend_from_slice(b"\x1b[?7l");
+        if panes.last_lines_written > 0 {
+            // Move to column 0 and clear, then cursor-up-and-clear once per
+            // line of the previous frame.
+            panes.draw_buf.extend_from_slice(b"\x1b[0G\x1b[K");
+            for _ in 0..panes.last_lines_written {
+                panes.draw_buf.extend_from_slice(b"\x1b[1A\x1b[K");
+            }
+        }
+        for handle in handles.iter_mut() {
+            // `command` is NUL-terminated for argv; drop the NUL for display.
+            let command = handle
+                .config
+                .command
+                .strip_suffix(&[0])
+                .unwrap_or(&handle.config.command);
+            write!(
+                &mut panes.draw_buf,
+                fmt!("<b>{s}<r> <d>$ {s}<r>\n"),
+                bstr::BStr::new(&handle.config.label),
+                bstr::BStr::new(command),
+            )?;
+            if let Some(vt) = &mut handle.vt {
+                let elided = vt.scrollback_rows();
+                if elided > 0 {
+                    write!(
+                        &mut panes.draw_buf,
+                        fmt!("<cyan>│<r> <d>[{d} lines elided]<r>\n"),
+                        elided,
+                    )?;
+                }
+                for y in 0..vt.used_rows() {
+                    panes
+                        .draw_buf
+                        .extend_from_slice(fmt!("<cyan>│<r> ").as_bytes());
+                    if vt.format_active_row(y, &mut panes.row_buf) {
+                        panes.draw_buf.extend_from_slice(&panes.row_buf);
+                    }
+                    // Keep a row's styles from bleeding into the next gutter.
+                    panes.draw_buf.extend_from_slice(RESET);
+                    panes.draw_buf.push(b'\n');
+                }
+            }
+            panes
+                .draw_buf
+                .extend_from_slice(fmt!("<cyan>└─<r> ").as_bytes());
+            match handle.process.as_ref().map(|p| &p.status) {
+                Some(Status::Running) => {
+                    panes
+                        .draw_buf
+                        .extend_from_slice(fmt!("<cyan>Running...<r>\n").as_bytes());
+                }
+                Some(Status::Exited(exited)) => {
+                    if exited.code != 0 {
+                        write!(
+                            &mut panes.draw_buf,
+                            fmt!("<red>Exited with code {d}<r>\n"),
+                            exited.code,
+                        )?;
+                    } else if let (Some(start), Some(end)) = (handle.start_time, handle.end_time) {
+                        let ms = end.duration_since(start).as_nanos() as f64 / 1_000_000.0;
+                        if ms > 1000.0 {
+                            write!(
+                                &mut panes.draw_buf,
+                                fmt!("<cyan>Done in {:.2}s<r>\n"),
+                                ms / 1000.0,
+                            )?;
+                        } else {
+                            write!(&mut panes.draw_buf, fmt!("<cyan>Done in {:.0}ms<r>\n"), ms)?;
+                        }
+                    } else {
+                        panes
+                            .draw_buf
+                            .extend_from_slice(fmt!("<cyan>Done<r>\n").as_bytes());
+                    }
+                }
+                Some(Status::Signaled(signal)) => {
+                    if *signal == bun_sys::SignalCode::SIGINT.0 {
+                        panes
+                            .draw_buf
+                            .extend_from_slice(fmt!("<red>Interrupted<r>\n").as_bytes());
+                    } else {
+                        write!(
+                            &mut panes.draw_buf,
+                            fmt!("<red>Signaled: {s}<r>\n"),
+                            bun_sys::SignalCode(*signal).name().unwrap_or("unknown"),
+                        )?;
+                    }
+                }
+                Some(_) => {
+                    panes
+                        .draw_buf
+                        .extend_from_slice(fmt!("<red>Error<r>\n").as_bytes());
+                }
+                None => {
+                    write!(
+                        &mut panes.draw_buf,
+                        fmt!("<cyan><d>Waiting for {d} other script(s)<r>\n"),
+                        handle.remaining_dependencies,
+                    )?;
+                }
+            }
+        }
+        // Restore autowrap before handing the terminal back.
+        panes.draw_buf.extend_from_slice(b"\x1b[?7h");
+        panes
+            .draw_buf
+            .extend_from_slice(Output::SYNCHRONIZED_END.as_bytes());
+        panes.last_lines_written = panes.draw_buf.iter().filter(|&&c| c == b'\n').count();
+        let _ = bun_sys::File::stdout().write_all(&panes.draw_buf);
+        Ok(())
     }
 }
 
@@ -1111,6 +1424,8 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         no_exit_on_error: ctx.no_exit_on_error,
         env: env_ptr,
         use_colors,
+        #[cfg(unix)]
+        panes: Panes::init(ctx.bundler_options.elide_lines),
     };
 
     // Initialize handles
@@ -1137,6 +1452,8 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             remaining_dependencies: 0,
             group_dependents: Vec::new(),
             next_dependents: Vec::new(),
+            #[cfg(unix)]
+            vt: None,
             options: SpawnOptions {
                 stdin: spawn::Stdio::Ignore,
                 #[cfg(unix)]
@@ -1209,6 +1526,11 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
 
     AbortHandler::install();
 
+    // Paint the initial frame (all panes "Running..." / "Waiting") so the
+    // UI is visible before the first byte of output arrives.
+    #[cfg(unix)]
+    state.redraw()?;
+
     while !state.is_done() {
         if SHOULD_ABORT.load(Ordering::SeqCst) && !state.aborted {
             AbortHandler::uninstall();
@@ -1216,7 +1538,14 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         }
         // SAFETY: event_loop points at the thread-lifetime MiniEventLoop singleton.
         unsafe { (*event_loop).tick_once((&raw const state).cast_mut().cast::<c_void>()) };
+        // Pane mode: at most one repaint per tick, however many reads landed.
+        #[cfg(unix)]
+        state.flush_redraw()?;
     }
+    // The final `process_exit` sets `is_done` and exits the loop before
+    // `flush_redraw` runs, so paint the last frame here.
+    #[cfg(unix)]
+    state.flush_redraw()?;
 
     let status = state.finalize();
     Global::exit(status as u32);

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -167,6 +167,17 @@ impl<'a> ProcessHandle<'a> {
         } else {
             None
         };
+        // Close both fds if anything between here and the hand-off below
+        // fails, so they never outlive an error. (Every `Err` from `start`
+        // is fatal to the whole run today, but the cleanup contract should
+        // not depend on that.)
+        #[cfg(unix)]
+        let pty_guard = scopeguard::guard(pty_fds, |fds| {
+            if let Some((read_fd, slave)) = fds {
+                read_fd.close();
+                slave.close();
+            }
+        });
 
         // Null-terminated argv array, as required by spawnProcess.
         let argv: [*const c_char; 4] = [
@@ -246,6 +257,12 @@ impl<'a> ProcessHandle<'a> {
             }
         }
 
+        // The spawn succeeded, so the hand-off is now explicit: `slave` is
+        // closed unconditionally below and `read_fd` is owned by the reader
+        // (or closed on the reader's own error path). Disarm the guard so
+        // neither fd can be closed twice.
+        #[cfg(unix)]
+        let pty_fds = scopeguard::ScopeGuard::into_inner(pty_guard);
         #[cfg(unix)]
         if let Some((read_fd, slave)) = pty_fds {
             // Close the parent's only copy of the pty slave so the master
@@ -257,10 +274,10 @@ impl<'a> ProcessHandle<'a> {
             self.options.stderr = spawn::Stdio::Ignore;
             // stdout and stderr are merged by the pty, so only one reader
             // runs; `stderr_reader` stays idle.
-            self.stdout_reader
-                .reader
-                .start(read_fd, true)
-                .map_err(Error::from)?;
+            if let Err(err) = self.stdout_reader.reader.start(read_fd, true) {
+                read_fd.close();
+                return Err(Error::from(err));
+            }
         } else {
             if let Some(stdout_fd) = stdout_fd {
                 let _ = bun_sys::set_nonblocking(stdout_fd);
@@ -367,16 +384,20 @@ struct Panes {
     /// Pane interior width in cells: the terminal's width minus the `│ `
     /// gutter. Also the width each task's pty reports.
     cols: u16,
-    /// Pane height in rows (`--elide-lines`, default 10). Also the height
-    /// each task's pty reports.
+    /// Pane height in rows (`--elide-lines`, default 10, shrunk so the
+    /// whole frame fits the terminal). Also the height each task's pty
+    /// reports.
     rows: u16,
+    /// Terminal height in rows at startup. Bounds how many lines of the
+    /// previous frame the cursor-up erase can still reach.
+    term_rows: u16,
     /// Accumulates a whole frame, then is written to stdout in one shot
     /// inside a synchronized-update bracket so the repaint never tears.
     draw_buf: Vec<u8>,
     /// Scratch for one formatted terminal row.
     row_buf: Vec<u8>,
-    /// `\n` count of the previous frame: how many lines to cursor-up over
-    /// before painting the next one.
+    /// Lines of the previous frame to cursor-up over before painting the
+    /// next one: its `\n` count, capped to what is still on screen.
     last_lines_written: usize,
     /// Set on every read and every exit; drained once per event-loop tick
     /// by `flush_redraw` so a chatty task can't force a repaint per chunk.
@@ -389,23 +410,40 @@ impl Panes {
     const DEFAULT_ROWS: usize = 10;
     /// Cell width of the `│ ` gutter prefixed to every pane row.
     const GUTTER_COLS: u16 = 2;
+    /// Lines a pane occupies beyond its content rows: the header, the
+    /// `[N lines elided]` line, and the `└─` footer.
+    const CHROME_ROWS: usize = 3;
     /// Per-task scrollback retention, in bytes. Rows that scroll off the
     /// top of a pane land here and surface as the `[N lines elided]` count.
     const SCROLLBACK_BYTES: usize = 2 * 1024 * 1024;
 
     /// `Some` only when stdout is an ANSI-capable interactive terminal
-    /// whose width is readable, on a platform where ptys can be created.
+    /// whose size is readable, on a platform where ptys can be created.
     /// Anything else keeps the prefix renderer, so piped/CI output is
     /// byte-for-byte what it was before panes existed.
-    fn init(elide_lines: Option<usize>) -> Option<Self> {
+    fn init(elide_lines: Option<usize>, task_count: usize) -> Option<Self> {
         if !Output::enable_ansi_colors_stdout() || !Output::is_stdout_tty() {
             return None;
         }
-        let width = Output::File::from(bun_core::Fd::stdout()).winsize()?.col;
-        let cols = width.checked_sub(Self::GUTTER_COLS).filter(|c| *c > 0)?;
+        let winsize = Output::File::from(bun_core::Fd::stdout()).winsize()?;
+        let cols = winsize
+            .col
+            .checked_sub(Self::GUTTER_COLS)
+            .filter(|c| *c > 0)?;
+        // Shrink the pane height so the whole frame fits the terminal
+        // whenever that is possible. A frame taller than the terminal
+        // scrolls its top into scrollback, which the next frame's
+        // cursor-up erase (clamped at row 1) can never reach. With enough
+        // tasks even 1-row panes cannot fit; `last_lines_written` is then
+        // capped to the reachable height in `redraw`.
+        let fits = usize::from(winsize.row)
+            .saturating_sub(task_count.saturating_mul(Self::CHROME_ROWS))
+            .checked_div(task_count)
+            .unwrap_or(usize::MAX);
         let rows = elide_lines
             .filter(|n| *n > 0)
             .unwrap_or(Self::DEFAULT_ROWS)
+            .min(fits.max(1))
             .min(usize::from(u16::MAX)) as u16;
         // Every task is about to be given a pty; prove one can be created
         // before committing to the pane renderer, so an environment with
@@ -419,6 +457,7 @@ impl Panes {
         Some(Self {
             cols,
             rows,
+            term_rows: winsize.row,
             draw_buf: Vec::new(),
             row_buf: Vec::new(),
             last_lines_written: 0,
@@ -722,7 +761,9 @@ impl<'a> State<'a> {
     /// instead of soft-wrapping; the frame's `\n` count is then exactly the
     /// number of terminal lines it occupies, which is what the next frame's
     /// cursor-up erase relies on. Pane rows can never exceed the terminal
-    /// width by construction (`Panes::cols` plus the 2-cell gutter).
+    /// width by construction (`Panes::cols` plus the 2-cell gutter), and
+    /// the erase count is capped to the terminal height, past which a
+    /// scrolled-off line is out of the cursor's reach anyway.
     fn redraw(&mut self) -> Result<(), Error> {
         // `draw_buf`/`row_buf` (inside `panes`) and each handle's `vt` are
         // mutated in the same loop; destructuring keeps the two `&mut`
@@ -862,7 +903,15 @@ impl<'a> State<'a> {
         panes
             .draw_buf
             .extend_from_slice(Output::SYNCHRONIZED_END.as_bytes());
-        panes.last_lines_written = panes.draw_buf.iter().filter(|&&c| c == b'\n').count();
+        // A frame taller than the terminal scrolled its top out of the
+        // cursor's reach; only the visible lines can (and need to) be
+        // erased, so don't emit more cursor-ups than the screen has rows.
+        panes.last_lines_written = panes
+            .draw_buf
+            .iter()
+            .filter(|&&c| c == b'\n')
+            .count()
+            .min(usize::from(panes.term_rows).saturating_sub(1));
         let _ = bun_sys::File::stdout().write_all(&panes.draw_buf);
         Ok(())
     }
@@ -1452,7 +1501,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         env: env_ptr,
         use_colors,
         #[cfg(unix)]
-        panes: Panes::init(ctx.bundler_options.elide_lines),
+        panes: Panes::init(ctx.bundler_options.elide_lines, configs.len()),
     };
 
     // Initialize handles

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -445,6 +445,9 @@ impl Panes {
         // tasks even 1-row panes cannot fit; `last_lines_written` is then
         // capped to the reachable height in `redraw`.
         let fits = usize::from(winsize.row)
+            // A frame of exactly `term_rows` newline-terminated lines still
+            // scrolls once: the last `\n` needs a resting row below it.
+            .saturating_sub(1)
             .saturating_sub(task_count.saturating_mul(Self::CHROME_ROWS))
             .checked_div(task_count)
             .unwrap_or(usize::MAX);
@@ -753,7 +756,7 @@ impl<'a> State<'a> {
 #[cfg(unix)]
 impl<'a> State<'a> {
     /// Repaint the pane UI if anything changed since the last frame.
-    /// Called once per event-loop tick and once after the loop exits.
+    /// Called once per event-loop tick.
     fn flush_redraw(&mut self) -> Result<(), Error> {
         if self.panes.as_ref().is_some_and(|p| p.needs_redraw) {
             self.redraw()?;

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -58,7 +58,7 @@ struct ScriptConfig {
 /// so output can be routed to the correct parent stream.
 pub struct PipeReader<'a> {
     reader: BufferedReader,
-    handle: *const ProcessHandle<'a>, // set in ProcessHandle::start()
+    handle: *mut ProcessHandle<'a>, // set in ProcessHandle::start()
     is_stderr: bool,
     line_buffer: Vec<u8>,
 }
@@ -68,7 +68,7 @@ impl<'a> PipeReader<'a> {
         Self {
             // BufferedReader::init(This) — the parent type fills the vtable.
             reader: BufferedReader::init::<Self>(),
-            handle: ptr::null(),
+            handle: ptr::null_mut(),
             is_stderr,
             line_buffer: Vec::new(),
         }
@@ -230,8 +230,10 @@ impl<'a> ProcessHandle<'a> {
         let stderr_fd = spawned.stderr;
         let process = spawned.to_process(EventLoopHandle::init_mini(state.event_loop), false);
 
-        self.stdout_reader.handle = std::ptr::from_ref(self);
-        self.stderr_reader.handle = std::ptr::from_ref(self);
+        // The pane reader writes `self.vt` through this backref, so it needs
+        // write provenance: `&raw mut`, never a shared reborrow of `&mut self`.
+        self.stdout_reader.handle = &raw mut *self;
+        self.stderr_reader.handle = &raw mut *self;
         // Compute parent ptrs before calling `set_parent` to avoid
         // borrowck seeing two simultaneous &mut borrows of the same field.
         let stdout_parent = (&raw mut self.stdout_reader).cast::<c_void>();
@@ -492,10 +494,10 @@ impl<'a> State<'a> {
     fn read_chunk(&mut self, pipe: &mut PipeReader<'a>, chunk: &[u8]) -> Result<(), Error> {
         #[cfg(unix)]
         if let Some(panes) = &mut self.panes {
-            // SAFETY: `pipe.handle` is the backref set in `ProcessHandle::
-            // start()`; `vt` is disjoint from `pipe`'s fields. Same pattern
-            // as the prefix path's `&*pipe.handle` below.
-            if let Some(vt) = unsafe { &mut (*pipe.handle.cast_mut()).vt } {
+            // SAFETY: `pipe.handle` is the `&raw mut` backref set in
+            // `ProcessHandle::start()`, so it carries write provenance;
+            // the handle outlives `pipe`, and `vt` is disjoint from `pipe`.
+            if let Some(vt) = unsafe { &mut (*pipe.handle).vt } {
                 vt.write(chunk);
             }
             // Coalesced: `flush_redraw` repaints at most once per tick.

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -637,8 +637,8 @@ impl<'a> State<'a> {
         self.remaining_scripts -= 1;
 
         // Pane mode writes nothing here: the pane footer carries the exit
-        // status and `flush_redraw` repaints after this tick (and once more
-        // after the event loop exits, so the final exit is never missed).
+        // status, and the main loop's `flush_redraw` repaints once this
+        // tick returns.
         #[cfg(unix)]
         if let Some(panes) = &mut self.panes {
             panes.needs_redraw = true;
@@ -1623,13 +1623,12 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         // SAFETY: event_loop points at the thread-lifetime MiniEventLoop singleton.
         unsafe { (*event_loop).tick_once((&raw const state).cast_mut().cast::<c_void>()) };
         // Pane mode: at most one repaint per tick, however many reads landed.
+        // This is the final frame too: the last `process_exit` fires inside
+        // `tick_once`, so its repaint lands here before the loop condition
+        // sees `is_done`.
         #[cfg(unix)]
         state.flush_redraw()?;
     }
-    // The final `process_exit` sets `is_done` and exits the loop before
-    // `flush_redraw` runs, so paint the last frame here.
-    #[cfg(unix)]
-    state.flush_redraw()?;
 
     let status = state.finalize();
     Global::exit(status as u32);

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -30,11 +30,11 @@ use crate::api::bun::process::{
 // renderer; see `Panes`.
 #[cfg(unix)]
 use crate::api::bun::terminal::create_pty;
+use bun_dotenv::Loader as DotEnvLoader;
 #[cfg(unix)]
 use bun_ghostty_vt_sys::VirtualTerminal;
 #[cfg(unix)]
 use bun_sys::FdExt as _;
-use bun_dotenv::Loader as DotEnvLoader;
 type OutputWriter = bun_core::io::Writer;
 
 /// Value type for package.json `scripts` map. Mirrors
@@ -394,8 +394,9 @@ impl Panes {
     const SCROLLBACK_BYTES: usize = 2 * 1024 * 1024;
 
     /// `Some` only when stdout is an ANSI-capable interactive terminal
-    /// whose width is readable. Anything else keeps the prefix renderer,
-    /// so piped/CI output is byte-for-byte what it was before panes existed.
+    /// whose width is readable, on a platform where ptys can be created.
+    /// Anything else keeps the prefix renderer, so piped/CI output is
+    /// byte-for-byte what it was before panes existed.
     fn init(elide_lines: Option<usize>) -> Option<Self> {
         if !Output::enable_ansi_colors_stdout() || !Output::is_stdout_tty() {
             return None;
@@ -406,6 +407,15 @@ impl Panes {
             .filter(|n| *n > 0)
             .unwrap_or(Self::DEFAULT_ROWS)
             .min(usize::from(u16::MAX)) as u16;
+        // Every task is about to be given a pty; prove one can be created
+        // before committing to the pane renderer, so an environment with
+        // no openpty (or no /dev/ptmx) degrades to the prefix renderer
+        // instead of failing the whole run on the first task.
+        let probe = create_pty(cols, rows).ok()?;
+        probe.master.close();
+        probe.read_fd.close();
+        probe.write_fd.close();
+        probe.slave.close();
         Some(Self {
             cols,
             rows,

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -727,7 +727,13 @@ impl<'a> State<'a> {
         // `draw_buf`/`row_buf` (inside `panes`) and each handle's `vt` are
         // mutated in the same loop; destructuring keeps the two `&mut`
         // borrows of `self` provably disjoint.
-        let State { handles, panes, .. } = self;
+        let State {
+            handles,
+            panes,
+            aborted,
+            ..
+        } = self;
+        let aborted = *aborted;
         let Some(panes) = panes.as_mut() else {
             return Ok(());
         };
@@ -830,6 +836,17 @@ impl<'a> State<'a> {
                     panes
                         .draw_buf
                         .extend_from_slice(fmt!("<red>Error<r>\n").as_bytes());
+                }
+                // Never started. A task can be in this state because it is
+                // genuinely waiting on dependencies, or because it will
+                // never run: `skip_dependents` drained its dependency count
+                // without starting it (a pre/main script in its group
+                // failed), or the run was aborted. Rendering "Waiting"
+                // into the final frame for the latter would be a lie.
+                None if aborted || handle.remaining_dependencies == 0 => {
+                    panes
+                        .draw_buf
+                        .extend_from_slice(fmt!("<d>Skipped<r>\n").as_bytes());
                 }
                 None => {
                     write!(

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1626,12 +1626,16 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         // SAFETY: event_loop points at the thread-lifetime MiniEventLoop singleton.
         unsafe { (*event_loop).tick_once((&raw const state).cast_mut().cast::<c_void>()) };
         // Pane mode: at most one repaint per tick, however many reads landed.
-        // This is the final frame too: the last `process_exit` fires inside
-        // `tick_once`, so its repaint lands here before the loop condition
-        // sees `is_done`.
         #[cfg(unix)]
         state.flush_redraw()?;
     }
+    // Paint the final frame unconditionally: under load the loop has been
+    // observed to exit with the last in-loop repaint still showing a task
+    // as Running (the mechanism is not yet understood; see PR #32761), and
+    // a user's terminal must never be left at that stale state. Not a
+    // `flush_redraw`, which gates on `needs_redraw`.
+    #[cfg(unix)]
+    state.redraw()?;
 
     let status = state.finalize();
     Global::exit(status as u32);

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -428,6 +428,12 @@ impl Panes {
             return None;
         }
         let winsize = Output::File::from(bun_core::Fd::stdout()).winsize()?;
+        // With 0 rows, `redraw`'s cursor-up erase (clamped to `term_rows - 1`)
+        // never fires and every repaint appends below the last. Treat it like
+        // an unreadable size, the same as the too-narrow `col` check below.
+        if winsize.row == 0 {
+            return None;
+        }
         let cols = winsize
             .col
             .checked_sub(Self::GUTTER_COLS)

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2071,6 +2071,16 @@ describe.skipIf(isWindows)("parallel: pane renderer", () => {
         raw += decoder.decode(chunk, { stream: true });
         if (until(raw)) done.resolve();
       },
+      // The pty's read side ends once the child has exited and closed the
+      // slave, so no more bytes can arrive. If `until` never held by then,
+      // fail with what did arrive instead of hanging until the test
+      // timeout. (This also fires when `await using` disposes the
+      // terminal after a successful run; `done` is settled by then.)
+      exit() {
+        if (!until(raw)) {
+          done.reject(new Error(`pty stream ended before the expected output arrived; got:\n${raw}`));
+        }
+      },
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), ...args],
@@ -2198,6 +2208,58 @@ describe.skipIf(isWindows)("parallel: pane renderer", () => {
     // resting cursor, so 2 lines are visible and 12 are in scrollback.
     expect(frame).toContain("│ [12 lines elided]");
     expect(frame.match(/^│ row-\d+$/gm)).toEqual(["│ row-12", "│ row-13"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("the pane height shrinks so the whole frame fits a short terminal", async () => {
+    using dir = tempDir("mr-pane-short-term", {
+      "package.json": JSON.stringify({
+        scripts: {
+          many: `${bunExe()} -e "for (let i = 0; i < 20; i++) console.log('row-' + i)"`,
+        },
+      }),
+    });
+    // A frame taller than the terminal would scroll its top out of the
+    // cursor-up erase's reach on every repaint. On a 12-row terminal the
+    // one pane's header, elided line, and footer take 3 rows, so its
+    // height shrinks from the default 10 to 9.
+    const { raw, exitCode } = await runOnPty(["run", "--parallel", "many"], String(dir), allDone(1), {
+      cols: 100,
+      rows: 12,
+    });
+    const frame = lastFrame(raw);
+    // 20 lines into a 9-row pty: the bottom row holds the resting
+    // cursor, so 8 lines are visible and 12 are in scrollback.
+    expect(frame).toContain("│ [12 lines elided]");
+    expect(frame.match(/^│ row-\d+$/gm)).toEqual(Array.from({ length: 8 }, (_, i) => `│ row-${i + 12}`));
+    expect(exitCode).toBe(0);
+  });
+
+  test("the erase never cursor-ups past the top of the terminal", async () => {
+    using dir = tempDir("mr-pane-tall-frame", {
+      "package.json": JSON.stringify({
+        scripts: {
+          t1: "echo one",
+          t2: "echo two",
+          t3: "echo three",
+        },
+      }),
+    });
+    // Three panes cannot fit an 8-row terminal even at a 1-row height,
+    // so every frame scrolls. Lines that scrolled into scrollback are
+    // out of the cursor's reach, so the next frame's erase must never
+    // emit more cursor-ups than the terminal has rows.
+    const rows = 8;
+    const { raw, exitCode } = await runOnPty(["run", "--parallel", "t1", "t2", "t3"], String(dir), allDone(3), {
+      cols: 100,
+      rows,
+    });
+    const frames = completeFrames(raw);
+    // The initial all-Running frame plus at least one repaint.
+    expect(frames.length).toBeGreaterThan(1);
+    for (const frame of frames) {
+      expect((frame.match(/\x1b\[1A/g) ?? []).length).toBeLessThan(rows);
+    }
     expect(exitCode).toBe(0);
   });
 

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2048,7 +2048,7 @@ describe("workspace integration", () => {
 // this file exercises through a pipe.
 //
 // These tests give `bun run --parallel` a real pty via `Bun.Terminal`.
-describe.skipIf(isWindows)("parallel: pane renderer", () => {
+describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
   /**
    * Run `bun <args>` with its stdio on a fresh pty. `until(raw)` decides
    * when every byte we intend to assert on has arrived — the pty read side

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2048,7 +2048,12 @@ describe("workspace integration", () => {
 // this file exercises through a pipe.
 //
 // These tests give `bun run --parallel` a real pty via `Bun.Terminal`.
-describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
+//
+// Deliberately NOT `describe.concurrent`: each test is a pty plus a process
+// tree (an outer `bun run` and its task children), so running all twelve at
+// once puts ~40 simultaneous processes on the runner's machine. On CI that
+// load was measurable in the files that happen to run right after this one.
+describe.skipIf(isWindows)("parallel: pane renderer", () => {
   /**
    * Run `bun <args>` with its stdio on a fresh pty, wait for it to exit,
    * and return everything it wrote. `until(raw)` asserts that the bytes

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2216,6 +2216,51 @@ describe.skipIf(isWindows)("parallel: pane renderer", () => {
     expect(exitCode).toBe(3);
   });
 
+  // A task that never starts is in the same "no process" state as one that
+  // is genuinely waiting on its dependencies, so the final frame must
+  // distinguish them: a pane left saying "Waiting for N other script(s)"
+  // after the run has exited would be a lie. Both ways a task can end up
+  // never started get their own test, one per clause of the check.
+
+  test("a pre-script failure marks its skipped dependents as Skipped", async () => {
+    using dir = tempDir("mr-pane-skip", {
+      "package.json": JSON.stringify({
+        // `prebad` fails, so `bad` never starts. With --no-exit-on-error
+        // its dependency count is drained (skip_dependents) but no process
+        // is ever attached to it.
+        scripts: { prebad: "exit 7", bad: "echo never-ran" },
+      }),
+    });
+    const { raw, exitCode } = await runOnPty(
+      ["run", "--parallel", "--no-exit-on-error", "bad"],
+      String(dir),
+      allDone(1),
+    );
+    const frame = lastFrame(raw);
+    expect(frame).toContain("└─ Exited with code 7");
+    expect(frame).toContain("└─ Skipped");
+    expect(frame).not.toContain("Waiting");
+    expect(frame).not.toContain("│ never-ran");
+    expect(exitCode).toBe(7);
+  });
+
+  test("aborting the run marks never-started tasks as Skipped", async () => {
+    using dir = tempDir("mr-pane-abort-skip", {
+      "package.json": JSON.stringify({
+        // Without --no-exit-on-error, `prebad` failing aborts the run;
+        // `bad` never starts and still holds its dependency count.
+        scripts: { prebad: "exit 7", bad: "echo never-ran" },
+      }),
+    });
+    const { raw, exitCode } = await runOnPty(["run", "--parallel", "bad"], String(dir), allDone(1));
+    const frame = lastFrame(raw);
+    expect(frame).toContain("└─ Exited with code 7");
+    expect(frame).toContain("└─ Skipped");
+    expect(frame).not.toContain("Waiting");
+    expect(frame).not.toContain("│ never-ran");
+    expect(exitCode).toBe(7);
+  });
+
   test("piped output never renders panes, even with colors forced on", async () => {
     using dir = tempDir("mr-pane-piped", {
       "package.json": JSON.stringify({

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2054,12 +2054,17 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
    * when every byte we intend to assert on has arrived — the pty read side
    * races the child's exit, so waiting on the condition (never on time) is
    * what makes this deterministic.
+   *
+   * `prelude` is a shell command to run *inside* the pty before exec'ing
+   * bun (e.g. `stty rows 0` to give the pty a size `Bun.Terminal` refuses
+   * to create). It goes through `sh -c '... && exec "$0" "$@"'` so bun's
+   * path and args need no quoting.
    */
   async function runOnPty(
     args: string[],
     dir: string,
     until: (raw: string) => boolean,
-    { cols = 100, rows = 40 } = {},
+    { cols = 100, rows = 40, prelude = "" } = {},
   ): Promise<{ raw: string; exitCode: number }> {
     let raw = "";
     const decoder = new TextDecoder();
@@ -2085,7 +2090,7 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
       },
     });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), ...args],
+      cmd: prelude ? ["sh", "-c", `${prelude} && exec "$0" "$@"`, bunExe(), ...args] : [bunExe(), ...args],
       // The pane renderer is gated on an ANSI-capable terminal, so the
       // NO_COLOR/CI that bunEnv sets for every other test must come off.
       env: { ...bunEnv, NO_COLOR: undefined, CI: undefined },
@@ -2345,5 +2350,28 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
     expect(stdout).not.toContain("│");
     expect(stdout).not.toContain("└─");
     expect(r.exitCode).toBe(0);
+  });
+
+  test("a terminal reporting 0 rows keeps the prefix renderer", async () => {
+    using dir = tempDir("mr-pane-zero-rows", {
+      "package.json": JSON.stringify({
+        scripts: {
+          a: `${bunExe()} -e "console.log('plain-a')"`,
+        },
+      }),
+    });
+    // A 0-row terminal can never be repainted (the cursor-up erase has no
+    // rows to reach), so the pane renderer treats it like an unreadable
+    // size and falls back to the prefix renderer. `Bun.Terminal` replaces
+    // `rows: 0` with a default, so `stty` resizes the pty from inside it;
+    // `<&1` points stty at the pty (stdout), which it definitely is.
+    const { raw, exitCode } = await runOnPty(["run", "--parallel", "a"], String(dir), r => r.includes("plain-a"), {
+      prelude: "stty rows 0 <&1",
+    });
+    const out = Bun.stripANSI(raw).replaceAll("\r\n", "\n");
+    expectPrefixed(out, "a", "plain-a");
+    expect(out).not.toContain("│");
+    expect(out).not.toContain("└─");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2230,17 +2230,18 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
     });
     // A frame taller than the terminal would scroll its top out of the
     // cursor-up erase's reach on every repaint. On a 12-row terminal the
-    // one pane's header, elided line, and footer take 3 rows, so its
-    // height shrinks from the default 10 to 9.
+    // one pane's header, elided line, and footer take 3 rows, and the
+    // frame's trailing newline needs a resting row, so its height
+    // shrinks from the default 10 to 8 (12 - 1 - 3).
     const { raw, exitCode } = await runOnPty(["run", "--parallel", "many"], String(dir), allDone(1), {
       cols: 100,
       rows: 12,
     });
     const frame = lastFrame(raw);
-    // 20 lines into a 9-row pty: the bottom row holds the resting
-    // cursor, so 8 lines are visible and 12 are in scrollback.
-    expect(frame).toContain("│ [12 lines elided]");
-    expect(frame.match(/^│ row-\d+$/gm)).toEqual(Array.from({ length: 8 }, (_, i) => `│ row-${i + 12}`));
+    // 20 lines into an 8-row pty: the bottom row holds the resting
+    // cursor, so 7 lines are visible and 13 are in scrollback.
+    expect(frame).toContain("│ [13 lines elided]");
+    expect(frame.match(/^│ row-\d+$/gm)).toEqual(Array.from({ length: 7 }, (_, i) => `│ row-${i + 13}`));
     expect(exitCode).toBe(0);
   });
 

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { realpathSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMusl, isWindows, tempDir } from "harness";
 import path from "path";
 
 // Helper: spawn bun with multi-run flags, returns { stdout, stderr, exitCode }
@@ -2050,10 +2050,10 @@ describe("workspace integration", () => {
 // These tests give `bun run --parallel` a real pty via `Bun.Terminal`.
 describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
   /**
-   * Run `bun <args>` with its stdio on a fresh pty. `until(raw)` decides
-   * when every byte we intend to assert on has arrived — the pty read side
-   * races the child's exit, so waiting on the condition (never on time) is
-   * what makes this deterministic.
+   * Run `bun <args>` with its stdio on a fresh pty, wait for it to exit,
+   * and return everything it wrote. `until(raw)` asserts that the bytes
+   * a test means to inspect actually arrived; if it does not hold once
+   * the output is complete, the helper throws with what did arrive.
    *
    * `prelude` is a shell command to run *inside* the pty before exec'ing
    * bun (e.g. `stty rows 0` to give the pty a size `Bun.Terminal` refuses
@@ -2068,39 +2068,36 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
   ): Promise<{ raw: string; exitCode: number }> {
     let raw = "";
     const decoder = new TextDecoder();
-    const done = Promise.withResolvers<void>();
-    await using terminal = new Bun.Terminal({
-      cols,
-      rows,
-      data(_term: Bun.Terminal, chunk: Uint8Array) {
-        raw += decoder.decode(chunk, { stream: true });
-        if (until(raw)) done.resolve();
-      },
-      // The pty's read side ends once the child has exited and closed the
-      // slave, so no more bytes can arrive. If `until` never held by then,
-      // fail with what did arrive instead of hanging until the test
-      // timeout. (This also fires when `await using` disposes the
-      // terminal after a successful run; `done` is settled by then.)
-      exit() {
-        // Flush a trailing partial UTF-8 sequence the streaming decoder buffered.
-        raw += decoder.decode();
-        if (!until(raw)) {
-          done.reject(new Error(`pty stream ended before the expected output arrived; got:\n${raw}`));
-        }
-      },
-    });
-    await using proc = Bun.spawn({
-      cmd: prelude ? ["sh", "-c", `${prelude} && exec "$0" "$@"`, bunExe(), ...args] : [bunExe(), ...args],
-      // The pane renderer is gated on an ANSI-capable terminal, so the
-      // NO_COLOR/CI that bunEnv sets for every other test must come off.
-      env: { ...bunEnv, NO_COLOR: undefined, CI: undefined },
-      cwd: dir,
-      terminal,
-    });
-    // Awaited together: `exit()` rejects `done` from the event loop, and a
-    // sequential `await proc.exited` first would leave that rejection with
-    // no handler attached for a tick.
-    const [exitCode] = await Promise.all([proc.exited, done.promise]);
+    let exitCode: number;
+    {
+      await using terminal = new Bun.Terminal({
+        cols,
+        rows,
+        data(_term: Bun.Terminal, chunk: Uint8Array) {
+          raw += decoder.decode(chunk, { stream: true });
+        },
+      });
+      await using proc = Bun.spawn({
+        cmd: prelude ? ["sh", "-c", `${prelude} && exec "$0" "$@"`, bunExe(), ...args] : [bunExe(), ...args],
+        // The pane renderer is gated on an ANSI-capable terminal, so the
+        // NO_COLOR/CI that bunEnv sets for every other test must come off.
+        env: { ...bunEnv, NO_COLOR: undefined, CI: undefined },
+        cwd: dir,
+        terminal,
+      });
+      exitCode = await proc.exited;
+      // Leaving this block disposes the pty, which drains every byte still
+      // buffered on the master side into `data()` before it completes, so
+      // `raw` is final (and complete) once the block exits. Nothing here
+      // may wait on the Terminal's `exit` callback: `Bun.Terminal` keeps
+      // its own slave fd, so the master never sees EOF and `exit` never
+      // fires, not even at disposal.
+    }
+    // Flush a trailing partial UTF-8 sequence the streaming decoder buffered.
+    raw += decoder.decode();
+    if (!until(raw)) {
+      throw new Error(`pty stream ended before the expected output arrived; got:\n${raw}`);
+    }
     return { raw, exitCode };
   }
 
@@ -2355,7 +2352,11 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
     expect(r.exitCode).toBe(0);
   });
 
-  test("a terminal reporting 0 rows keeps the prefix renderer", async () => {
+  // musl (Alpine) ships busybox, whose `stty` rejects `rows 0` outright
+  // ("stty: number 0 is not in 1..2147483647 range"); GNU and BSD stty
+  // accept it, and there is no other portable way to give a pty a 0-row
+  // winsize (`Bun.Terminal` refuses to create or resize one).
+  test.skipIf(isMusl)("a terminal reporting 0 rows keeps the prefix renderer", async () => {
     using dir = tempDir("mr-pane-zero-rows", {
       "package.json": JSON.stringify({
         scripts: {
@@ -2376,5 +2377,19 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
     expect(out).not.toContain("│");
     expect(out).not.toContain("└─");
     expect(exitCode).toBe(0);
+  });
+
+  test("runOnPty rejects with the captured output when `until` never holds", async () => {
+    using dir = tempDir("mr-pane-reject", {
+      "package.json": JSON.stringify({ scripts: { a: "echo hi" } }),
+    });
+    // An earlier shape of the helper waited on a promise that only the
+    // Terminal's never-firing `exit` callback could settle, so an `until`
+    // that never held burned the whole 90s test timeout (and hid a
+    // genuine failure behind it on Alpine). It must reject promptly,
+    // carrying the complete output that did arrive.
+    await expect(runOnPty(["run", "--parallel", "a"], String(dir), () => false)).rejects.toThrow(
+      /ended before the expected output arrived[\s\S]*hi/,
+    );
   });
 });

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2097,8 +2097,10 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
       cwd: dir,
       terminal,
     });
-    const exitCode = await proc.exited;
-    await done.promise;
+    // Awaited together: `exit()` rejects `done` from the event loop, and a
+    // sequential `await proc.exited` first would leave that rejection with
+    // no handler attached for a tick.
+    const [exitCode] = await Promise.all([proc.exited, done.promise]);
     return { raw, exitCode };
   }
 

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -7,7 +7,7 @@ import path from "path";
 async function runMulti(
   args: string[],
   dir: string,
-  extraEnv?: Record<string, string>,
+  extraEnv?: Record<string, string | undefined>,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
@@ -1565,6 +1565,12 @@ describe.concurrent("concurrent stdout + stderr from same script", () => {
 
 describe.concurrent("dependency chains", () => {
   test("sequential with pre/post creates deep chain that works", async () => {
+    // The property under test is the ORDERING of a 9-deep pre->main->post
+    // chain, which only needs 9 trivial children. `echo` is a builtin of
+    // both `sh -c` (posix) and `bun exec` (windows). The bun children it
+    // used before cost ~700ms each to START under a debug+ASAN build, and
+    // --sequential runs them one after another, which blew the 5s test
+    // budget on a slow machine.
     using dir = tempDir("mr-deep-chain", {
       "package.json": JSON.stringify({
         scripts: {
@@ -2029,6 +2035,206 @@ describe("workspace integration", () => {
     const r = await runMulti(["run", "--parallel", "--filter", "./packages/my-pkg", "build"], String(dir));
     // Label should use relative path "packages/my-pkg" instead of empty string
     expectPrefixed(r.stdout, "packages/my-pkg:build", "no-name-ok");
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+// ─── PARALLEL: PANE RENDERER (TTY) ────────────────────────────────────────────
+//
+// When stdout is an interactive, ANSI-capable terminal, `--parallel` spawns
+// each task onto a pty sized to its pane and replays the output into a
+// libghostty-vt virtual terminal, then repaints one pane per task. Non-tty
+// output keeps the `label | line` prefix renderer, which every other test in
+// this file exercises through a pipe.
+//
+// These tests give `bun run --parallel` a real pty via `Bun.Terminal`.
+describe.skipIf(isWindows)("parallel: pane renderer", () => {
+  /**
+   * Run `bun <args>` with its stdio on a fresh pty. `until(raw)` decides
+   * when every byte we intend to assert on has arrived — the pty read side
+   * races the child's exit, so waiting on the condition (never on time) is
+   * what makes this deterministic.
+   */
+  async function runOnPty(
+    args: string[],
+    dir: string,
+    until: (raw: string) => boolean,
+    { cols = 100, rows = 40 } = {},
+  ): Promise<{ raw: string; exitCode: number }> {
+    let raw = "";
+    const decoder = new TextDecoder();
+    const done = Promise.withResolvers<void>();
+    await using terminal = new Bun.Terminal({
+      cols,
+      rows,
+      data(_term: Bun.Terminal, chunk: Uint8Array) {
+        raw += decoder.decode(chunk, { stream: true });
+        if (until(raw)) done.resolve();
+      },
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      // The pane renderer is gated on an ANSI-capable terminal, so the
+      // NO_COLOR/CI that bunEnv sets for every other test must come off.
+      env: { ...bunEnv, NO_COLOR: undefined, CI: undefined },
+      cwd: dir,
+      terminal,
+    });
+    const exitCode = await proc.exited;
+    await done.promise;
+    return { raw, exitCode };
+  }
+
+  /** Fully painted frames, oldest to newest. Each is bracketed by a
+   * synchronized update (`CSI ? 2026 h` ... `l`); an in-flight partial
+   * frame at the tail of `raw` is dropped. */
+  function completeFrames(raw: string): string[] {
+    return raw.split("\x1b[?2026h").filter(f => f.includes("\x1b[?2026l"));
+  }
+
+  /**
+   * `until` predicate: some single complete frame shows a terminal status
+   * for every one of `n` tasks. Statuses never go backwards (a Done task
+   * stays Done), so every LATER complete frame also satisfies it —
+   * including `lastFrame()`, which is what the tests assert on.
+   */
+  function allDone(n: number) {
+    return (raw: string) =>
+      completeFrames(raw).some(
+        f => (f.match(/(Done in |Exited with code |Signaled: |Interrupted)/g) ?? []).length >= n,
+      );
+  }
+
+  /** The last fully painted frame, as the plain text a terminal would show. */
+  function lastFrame(raw: string): string {
+    const frames = completeFrames(raw);
+    expect(frames.length).toBeGreaterThan(0);
+    return (
+      frames[frames.length - 1]!// The erase-previous-frame prefix and every other escape sequence.
+      .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "")
+        // The pty's ONLCR maps the renderer's `\n` to `\r\n`.
+        .replaceAll("\r\n", "\n")
+    );
+  }
+
+  test("each task gets a pty sized to its pane and renders into a gutter", async () => {
+    using dir = tempDir("mr-pane-basic", {
+      "package.json": JSON.stringify({
+        scripts: {
+          size: `${bunExe()} -e "console.log('cols='+process.stdout.columns+' tty='+process.stdout.isTTY)"`,
+          lines: `${bunExe()} -e "for (let i = 0; i < 3; i++) console.log('line-' + i)"`,
+        },
+      }),
+    });
+    const { raw, exitCode } = await runOnPty(["run", "--parallel", "size", "lines"], String(dir), allDone(2), {
+      cols: 100,
+    });
+    const frame = lastFrame(raw);
+    // Header (`label $ command`), one `│ ` gutter row per output line, and
+    // a `└─ <status>` footer per task, in declaration order.
+    expect(frame).toContain("size $");
+    expect(frame).toContain("lines $");
+    // The task saw a real tty whose width is the pane interior: the
+    // terminal's 100 columns minus the 2-cell `│ ` gutter.
+    expect(frame).toContain("│ cols=98 tty=true");
+    expect(frame).toContain("│ line-0");
+    expect(frame).toContain("│ line-1");
+    expect(frame).toContain("│ line-2");
+    expect(frame.match(/└─ Done in \d/g)).toHaveLength(2);
+    expect(exitCode).toBe(0);
+  });
+
+  test("carriage-return overwrites resolve like a real terminal", async () => {
+    using dir = tempDir("mr-pane-cr", {
+      "package.json": JSON.stringify({
+        scripts: {
+          spin: `${bunExe()} -e "for (const s of ['25%','50%','75%']) process.stdout.write('\\rstep ' + s); console.log('\\rall done')"`,
+        },
+      }),
+    });
+    const { raw, exitCode } = await runOnPty(["run", "--parallel", "spin"], String(dir), allDone(1));
+    const frame = lastFrame(raw);
+    // Four `\r`-prefixed writes land on ONE terminal row; the pane shows
+    // only the final overwrite, never the intermediate fragments.
+    expect(frame.match(/^│ .*$/gm)).toEqual(["│ all done"]);
+    expect(frame).not.toContain("step 25%");
+    expect(exitCode).toBe(0);
+  });
+
+  test("rows that scroll out of the pane are counted as elided", async () => {
+    using dir = tempDir("mr-pane-elide", {
+      "package.json": JSON.stringify({
+        scripts: {
+          many: `${bunExe()} -e "for (let i = 0; i < 14; i++) console.log('row-' + i)"`,
+        },
+      }),
+    });
+    // The pane is a real 10-row terminal. 14 newline-terminated lines
+    // leave the cursor resting on a blank bottom row, so the visible
+    // content is the last 9 lines and the other 5 are in scrollback —
+    // exactly what `seq 14` in a 10-row terminal window shows.
+    const { raw, exitCode } = await runOnPty(["run", "--parallel", "many"], String(dir), allDone(1));
+    const frame = lastFrame(raw);
+    expect(frame).toContain("│ [5 lines elided]");
+    expect(frame.match(/^│ row-\d+$/gm)).toEqual(Array.from({ length: 9 }, (_, i) => `│ row-${i + 5}`));
+    expect(exitCode).toBe(0);
+  });
+
+  test("--elide-lines sets the pane height", async () => {
+    using dir = tempDir("mr-pane-elide-flag", {
+      "package.json": JSON.stringify({
+        scripts: {
+          many: `${bunExe()} -e "for (let i = 0; i < 14; i++) console.log('row-' + i)"`,
+        },
+      }),
+    });
+    const { raw, exitCode } = await runOnPty(
+      ["run", "--parallel", "--elide-lines", "3", "many"],
+      String(dir),
+      allDone(1),
+    );
+    const frame = lastFrame(raw);
+    // The task's terminal is 3 rows tall; the bottom row holds the
+    // resting cursor, so 2 lines are visible and 12 are in scrollback.
+    expect(frame).toContain("│ [12 lines elided]");
+    expect(frame.match(/^│ row-\d+$/gm)).toEqual(["│ row-12", "│ row-13"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a failing task's exit code lands in its footer and the exit code", async () => {
+    using dir = tempDir("mr-pane-fail", {
+      "package.json": JSON.stringify({
+        scripts: {
+          bad: `${bunExe()} -e "console.log('about to fail'); process.exit(3)"`,
+        },
+      }),
+    });
+    const { raw, exitCode } = await runOnPty(["run", "--parallel", "bad"], String(dir), allDone(1));
+    const frame = lastFrame(raw);
+    expect(frame).toContain("│ about to fail");
+    expect(frame).toContain("└─ Exited with code 3");
+    expect(exitCode).toBe(3);
+  });
+
+  test("piped output never renders panes, even with colors forced on", async () => {
+    using dir = tempDir("mr-pane-piped", {
+      "package.json": JSON.stringify({
+        scripts: {
+          a: `${bunExe()} -e "console.log('plain-a')"`,
+        },
+      }),
+    });
+    // FORCE_COLOR turns ANSI on for a pipe, but the pane renderer also
+    // requires stdout to BE a terminal; a pipe must stay on the
+    // `label | line` prefix renderer.
+    const r = await runMulti(["run", "--parallel", "a"], String(dir), {
+      FORCE_COLOR: "1",
+      NO_COLOR: undefined,
+    });
+    const stdout = Bun.stripANSI(r.stdout);
+    expectPrefixed(stdout, "a", "plain-a");
+    expect(stdout).not.toContain("│");
+    expect(stdout).not.toContain("└─");
     expect(r.exitCode).toBe(0);
   });
 });

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2077,6 +2077,8 @@ describe.concurrent.skipIf(isWindows)("parallel: pane renderer", () => {
       // timeout. (This also fires when `await using` disposes the
       // terminal after a successful run; `done` is settled by then.)
       exit() {
+        // Flush a trailing partial UTF-8 sequence the streaming decoder buffered.
+        raw += decoder.decode();
         if (!until(raw)) {
           done.reject(new Error(`pty stream ended before the expected output arrived; got:\n${raw}`));
         }

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2110,8 +2110,8 @@ describe.skipIf(isWindows)("parallel: pane renderer", () => {
     const frames = completeFrames(raw);
     expect(frames.length).toBeGreaterThan(0);
     return (
-      frames[frames.length - 1]!// The erase-previous-frame prefix and every other escape sequence.
-      .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "")
+      frames[frames.length - 1]! // The erase-previous-frame prefix and every other escape sequence.
+        .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "")
         // The pty's ONLCR maps the renderer's `\n` to `\r\n`.
         .replaceAll("\r\n", "\n")
     );


### PR DESCRIPTION
`bun run --parallel` (and `--sequential`) now renders a live pane per task when stdout is an interactive terminal, backed by Ghostty's terminal emulator library ([libghostty-vt](https://github.com/ghostty-org/ghostty)). Non-interactive output (pipes, redirects, CI) keeps the existing `label | line` prefix renderer byte for byte.

This is the same move turborepo made in [vercel/turborepo#13135](https://github.com/vercel/turborepo/pull/13135), requested for Bun by a maintainer.

### What it looks like

Each task is spawned onto a pty sized to its pane, so it sees a real terminal and behaves like one (colors on, correct width, `process.stdout.isTTY === true`). Its output is replayed into a libghostty-vt virtual terminal, and the UI repaints one pane per task from that terminal's cell grid.

```
alpha $ bun -e "...14 colored lines..."
│ [5 lines elided]
│ alpha line 5 blue
│ alpha line 6 red
  ...
│ alpha line 13 green
└─ Done in 300ms
beta $ bun -e "...carriage-return progress bar..."
│ progress done
└─ Done in 404ms
gamma $ bun -e "console.log('cols='+process.stdout.columns+' tty='+process.stdout.isTTY)"
│ cols=98 tty=true
└─ Done in 429ms
```

Because the bytes go through a real terminal emulator instead of being split on `\n`:

- `\r`-based progress bars and spinners resolve to their final text instead of spraying fragments
- cursor movement and screen clears resolve instead of corrupting the layout
- colors survive, and tools that gate color on `isatty()` turn it on
- `[N lines elided]` is the terminal's actual scrollback row count
- the repaint counts real terminal rows (autowrap is disabled for the frame), so the cursor-up erase can't drift the way `--filter`'s byte-counting repaint can today

Repaints are coalesced to at most one per event loop tick, so a task that writes a lot can't force a repaint per read.

### The important part for reviewers: this adds Zig to the build

libghostty-vt is pure Zig and ships no prebuilt static libraries for Linux or Windows, so building it means building it with `zig`. Either approach (build-time Zig, or a fork repo publishing prebuilt static libs per target) was okayed; I went with the build pipeline because it needs no new infrastructure, and swapping to a prebuilt later only touches `scripts/build/deps/ghostty-vt.ts`.

The integration is one new dependency kind, `nested-zig`, that mirrors the existing `cargo` kind: a single ninja edge runs `scripts/build/zig-build-cli.ts`, which

1. resolves a Zig compiler: `$BUN_ZIG`, then a matching `zig` on `$PATH`, then a sha256-pinned download of the official 0.15.2 release into the build cache (the same place WebKit prebuilts and tarballs live). Nothing needs to change in CI images or contributor setups.
2. pre-fetches the dep's two Zig package dependencies (uucode and zlib, both from GitHub) through Bun's own retrying, proxy-aware downloader, so the nested `zig build` never makes a network request itself. Zig's package store is content-addressed, so the hashes pinned in `deps/ghostty-vt.ts` are verified against the ones ghostty's `build.zig.zon` declares.
3. runs `zig build -Demit-lib-vt -Dsimd=false ... -Dtarget=<bun's target>` with `--prefix` pointed at the dep build dir.

Two flags matter:

- `-Dsimd=false`: without it ghostty vendors its own `highway` and `simdutf` into the archive. Bun already links both, and the duplicate C++ definitions would be an ODR violation. With it the library is pure Zig; `nm` confirms zero `hwy::`/`simdutf::` symbols.
- A release optimize mode always, even for debug Bun builds: a Debug Zig library emits UBSan checks, and the patch deliberately does not bundle Zig's UBSan runtime, so nothing would define their handlers. libghostty-vt is a leaf with its own upstream test suite.

`patches/ghostty-vt/lib-vt-only.patch` does three things, and the middle one is the most important line in this PR's build integration:

1. Adds an early return after installing the VT static lib. Upstream's `zig build -Demit-lib-vt` still constructs the whole Ghostty app's build graph, which lazily fetches about 30 packages (GTK, fonts, renderers) the VT library never touches; the early return shrinks the dependency set to the two packages above and the build to about 45 seconds.
2. Sets `bundle_compiler_rt = false` and `bundle_ubsan_rt = false`. Zig's bundled compiler_rt defines `memcpy`, `memset`, `memmove`, `memcmp`, and most of libm (`exp`, `log`, `fma`, `round`, ...) as weak globals. A consumer that links the archive ahead of libc, which is every ordinary link line, extracts those and silently replaces the libc implementations for its entire binary: a probe measured bun's `memcpy` at 11.3 GB/s with the bundled compiler_rt vs 42.9 GB/s without it. With the bundling disabled, the archive is a single object whose only exported symbols are the 156 `ghostty_*` API functions; the six standard `__`-prefixed builtins ghostty's code needs come from clang's own runtime at bun's link. A build-time guard (`exportPrefix` on the `nested-zig` dep spec) fails the build if the archive ever exports anything outside `ghostty_*` again, so a future ghostty bump cannot silently reintroduce the class.
3. Sets `link_function_sections`/`link_data_sections` on the static lib so `--gc-sections` can drop the unused parts of the C API (see Binary size below).

The patch is worth upstreaming to ghostty separately, in particular item 2, which affects anyone embedding libghostty into a C or C++ program.

### Binary size

The binary-size check flagged this PR at about +1 MB per unix target, which is the real cost of shipping a terminal emulator, so it deserves its own number. Bun only calls 9 of libghostty-vt's entry points, but Zig emits the whole library as a single object file, so Bun's existing `--gc-sections` link could not strip the rest. Two changes halve it:

- the patch sets `link_function_sections`/`link_data_sections` on the lib (one section per symbol), so `--gc-sections`/`-dead_strip` can drop the unused parts of the C API
- `-Doptimize=ReleaseSmall` instead of `ReleaseFast`. The pane renderer feeds pty output at human rates, so Fast buys nothing here.

Measured with a `--gc-sections` test link referencing exactly the symbols Bun uses (linux-x64, `size` text+data+bss):

| configuration | contribution |
| --- | ---: |
| ReleaseFast, monolithic object (before) | 1,340,767 B |
| + function/data sections | 1,132,903 B |
| + ReleaseSmall (this PR) | 633,741 B |

The remaining ~0.62 MB is the emulator itself: VT stream parser, cell grid, Unicode width tables, formatter. It is a new dependency backing a new feature rather than a regression, so the commit carries `[skip size check]`. If that cost is not acceptable I am happy to revisit (a prebuilt-per-target fork, or dropping the feature), but there is no further low-hanging strip: `kitty_graphics`, the one obviously unused subsystem left, is only ~20 KB of it.

### Drive-by fix: `git apply` silently skipping dep patches

While wiring the patch up I found that `git apply` treats a patch with a `diff --git` header as repo-toplevel-relative. Because `vendor/<dep>/` sits inside Bun's own git worktree, such a patch's `build.zig` resolved against the repo root, fell outside the cwd, and was silently skipped with exit 0, leaving the source unpatched while `.ref` claimed otherwise. Every existing patch in `patches/` happens to be a plain unified diff (which gets the cwd prefix prepended and works), so nothing was broken, but only by luck. `applyPatch` in `fetch-cli.ts` now documents the requirement and turns a `Skipped patch` in git's stderr into a hard error.

### Scope and deliberate exclusions

- **Windows keeps the prefix renderer.** All the pane code is behind `#[cfg(unix)]` and the dep is `enabled: cfg => !cfg.windows`. The ConPTY half already exists in `Terminal.rs`; wiring it up is a follow-up. Cross-checked that `x86_64-pc-windows-msvc`, `aarch64-apple-darwin`, `x86_64-unknown-freebsd`, and `aarch64-linux-android` all still compile.
- On a unix platform where `openpty` is unavailable (FreeBSD today, per `Terminal.rs`, or a container without `/dev/ptmx`), `Panes::init` probes one pty up front and falls back to the prefix renderer rather than failing the run.
- `bun run --filter` (without `--parallel`/`--sequential`) keeps its existing repaint UI. Backing it with the same virtual terminal would fix its soft-wrap cursor math and is a natural follow-up, but it is a separate code path (`filter_run.rs`). Two smaller items belong to that same follow-up because both renderers share them: sanitizing embedded `\n`/`\r` out of the displayed label/command in the repaint header (today a package.json script written with a literal newline renders a two-line header in both renderers), and any other header-formatting parity.
- One known low-rate issue these tests catch flaking (and passing on retry), now seen on four lanes: the run can exit with the last painted frame still showing `Running...` for one task. 95dbea87 added an unconditional repaint after the loop exits, but the flake recurred on build 70696 with only three frames captured, meaning that repaint apparently never executed; the process exits before reaching it via a path I could not locate by reading (`process_exit` is the only `remaining_scripts` decrementer, is only called from `on_process_exit` which sets the status first, and every `?` in the loop body is on an infallible `Vec` write). 300 local iterations under CPU and fork load on a debug build do not reproduce it. Properly instrumenting this needs a release build on the aarch64 CI runners themselves. The defect is cosmetic (the final frame says `Running...` instead of `Done in Nms`; the run and its exit code are correct) and the test's failure carries the full captured output, so the next occurrence will have the same diagnostic data.
- No terminal resize (SIGWINCH) handling yet; the pane width is read once at startup.

### Other changes

- `create_pty` in `Terminal.rs` becomes `pub(crate)` (it was already a standalone function; `bun run` just couldn't reach it).
- `src/ghostty_vt_sys/` holds the hand-written `extern "C"` declarations plus a safe `VirtualTerminal` wrapper, following the `libdeflate_sys` pattern (no build.rs; symbols resolve at the final link).

### Verification

- 130/130 tests in `test/cli/run/multi-run.test.ts` pass with this change.
- The new `parallel: pane renderer` describe block is 12 tests. Nine give `bun run --parallel` a pty via `Bun.Terminal` and assert the rendered frames: gutter rows, the child-visible pty size, `\r` resolution, the elided count, `--elide-lines`, the pane-height shrink on a short terminal, the erase clamp, the `Skipped` footer for never-started dependents (on a pre-script failure and on abort), and a failing task's footer and exit code. All fail against the released Bun.
- Two pin the fallbacks to the prefix renderer: `FORCE_COLOR=1` on a pipe (stdout is not a terminal), and a pty that `stty` has resized to 0 rows (a size no repaint can use). Both assert the `label | line` prefix output with no pane glyphs. The 0-row one is `skipIf(isMusl)`: busybox `stty` (Alpine) rejects `rows 0` outright, and there is no other portable way to give a pty a 0-row winsize. Every other `--parallel`/`--sequential` test in the file exercises the piped path and is unchanged.
- The twelfth pins the `runOnPty` helper's failure path: an `until` predicate that never holds must reject promptly with the output that did arrive. The original helper waited on a promise that only `Bun.Terminal`'s `exit` callback could settle, and that callback never fires (the Terminal holds its own slave fd, so the pty master never reaches EOF, not even at disposal), so such a case burned the whole 90s test timeout. The helper now waits for the process, lets the Terminal's disposal drain the remaining master-side bytes into `data()`, and only then evaluates `until` on the complete output.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/multi-run.test.ts

<!-- robobun:evidence:end -->

