### PR TITLE
node:zlib: don't abort when the native handle is driven outside the zlib.ts lifecycle

### DIFF
--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -279,6 +279,21 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
 }
 
 impl<T: CompressionStreamImpl> CompressionStream<T> {
+    /// Rejects a call on a handle whose `Context` was already torn down by
+    /// `close()`. A closed `Context` is in `NodeMode::NONE` with its native
+    /// state freed, which none of its `mode` matches handle.
+    pub(crate) fn throw_if_closed(this: &T, global_this: &JSGlobalObject) -> JsResult<()> {
+        if this.closed().get() {
+            return Err(global_this
+                .err(
+                    ErrorCode::INVALID_STATE,
+                    format_args!("zlib binding closed"),
+                )
+                .throw());
+        }
+        Ok(())
+    }
+
     pub(crate) fn write(
         this: &T,
         global_this: &JSGlobalObject,
@@ -388,6 +403,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                 .err(ErrorCode::INVALID_STATE, format_args!("Pending close"))
                 .throw());
         }
+        Self::throw_if_closed(this, global_this)?;
         // Pin both buffers before mutating any state: materializing a
         // FastTypedArray's backing store can fail on OOM, and failing here
         // leaves nothing to unwind.
@@ -540,10 +556,12 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         this.flush_write_result(global, this_value);
         this_value.ensure_still_alive();
 
-        let write_callback: JSValue = T::write_callback_get_cached(this_value).unwrap();
-
-        vm.event_loop_ref()
-            .run_callback(write_callback, global, this_value, &[]);
+        // `init()` caches the JS write callback; a handle whose `init()` was
+        // never called has none, so there is nothing to notify.
+        if let Some(write_callback) = T::write_callback_get_cached(this_value) {
+            vm.event_loop_ref()
+                .run_callback(write_callback, global, this_value, &[]);
+        }
 
         if this.pending_reset().get() {
             Self::reset_internal(&this, global, this_value);
@@ -677,6 +695,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                 .err(ErrorCode::INVALID_STATE, format_args!("Pending close"))
                 .throw());
         }
+        Self::throw_if_closed(this, global_this)?;
         this.write_in_progress().set(true);
         this.ref_();
 
@@ -827,20 +846,19 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             Err(_) => return,
         };
 
-        let callback: JSValue = T::error_callback_get_cached(this_value).unwrap_or_else(|| {
-            bun_core::Output::panic(format_args!(
-                "Assertion failure: cachedErrorCallback is null in node:zlib binding",
-            ))
-        });
-
-        // SAFETY: `bun_vm()` and `event_loop()` are non-null for a Bun-owned global.
-        let vm = global_this.bun_vm();
-        vm.event_loop_ref().run_callback(
-            callback,
-            global_this,
-            this_value,
-            &[msg_value, err_value, code_value],
-        );
+        // The `zlib.ts` wrapper installs `onerror` right after construction,
+        // but a handle driven directly has none; there is nobody to notify.
+        // The pending reset/close handling below still runs either way.
+        if let Some(callback) = T::error_callback_get_cached(this_value) {
+            // SAFETY: `bun_vm()` and `event_loop()` are non-null for a Bun-owned global.
+            let vm = global_this.bun_vm();
+            vm.event_loop_ref().run_callback(
+                callback,
+                global_this,
+                this_value,
+                &[msg_value, err_value, code_value],
+            );
+        }
 
         if this.pending_reset().get() {
             Self::reset_internal(this, global_this, this_value);

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -279,10 +279,23 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
 }
 
 impl<T: CompressionStreamImpl> CompressionStream<T> {
-    /// Rejects a call on a handle whose `Context` was already torn down by
-    /// `close()`: its native state is freed and its `mode` is `NodeMode::NONE`,
-    /// which `Context::do_work` and `Context::init` have no arm for.
-    pub(crate) fn throw_if_closed(this: &T, global_this: &JSGlobalObject) -> JsResult<()> {
+    /// Rejects a call on a handle that cannot accept a new operation: an async
+    /// write still holds `&mut Context` on a worker thread, a pending close is
+    /// about to tear it down, or a closed one already did (`mode` is `NONE`).
+    pub(crate) fn throw_unless_idle(this: &T, global_this: &JSGlobalObject) -> JsResult<()> {
+        if this.write_in_progress().get() {
+            return Err(global_this
+                .err(
+                    ErrorCode::INVALID_STATE,
+                    format_args!("Write already in progress"),
+                )
+                .throw());
+        }
+        if this.pending_close().get() {
+            return Err(global_this
+                .err(ErrorCode::INVALID_STATE, format_args!("Pending close"))
+                .throw());
+        }
         if this.closed().get() {
             return Err(global_this
                 .err(
@@ -390,20 +403,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         }
         let _ = (in_off, in_len, out_off, out_len);
 
-        if this.write_in_progress().get() {
-            return Err(global_this
-                .err(
-                    ErrorCode::INVALID_STATE,
-                    format_args!("Write already in progress"),
-                )
-                .throw());
-        }
-        if this.pending_close().get() {
-            return Err(global_this
-                .err(ErrorCode::INVALID_STATE, format_args!("Pending close"))
-                .throw());
-        }
-        Self::throw_if_closed(this, global_this)?;
+        Self::throw_unless_idle(this, global_this)?;
         // Pin both buffers before mutating any state: materializing a
         // FastTypedArray's backing store can fail on OOM, and failing here
         // leaves nothing to unwind.
@@ -682,20 +682,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         );
         let _ = (in_off, in_len, out_off, out_len);
 
-        if this.write_in_progress().get() {
-            return Err(global_this
-                .err(
-                    ErrorCode::INVALID_STATE,
-                    format_args!("Write already in progress"),
-                )
-                .throw());
-        }
-        if this.pending_close().get() {
-            return Err(global_this
-                .err(ErrorCode::INVALID_STATE, format_args!("Pending close"))
-                .throw());
-        }
-        Self::throw_if_closed(this, global_this)?;
+        Self::throw_unless_idle(this, global_this)?;
         this.write_in_progress().set(true);
         this.ref_();
 

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -280,8 +280,8 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
 
 impl<T: CompressionStreamImpl> CompressionStream<T> {
     /// Rejects a call on a handle whose `Context` was already torn down by
-    /// `close()`. A closed `Context` is in `NodeMode::NONE` with its native
-    /// state freed, which none of its `mode` matches handle.
+    /// `close()`: its native state is freed and its `mode` is `NodeMode::NONE`,
+    /// which `Context::do_work` and `Context::init` have no arm for.
     pub(crate) fn throw_if_closed(this: &T, global_this: &JSGlobalObject) -> JsResult<()> {
         if this.closed().get() {
             return Err(global_this

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -189,9 +189,9 @@ mod _impl {
                     )
                     .throw());
             }
-            // A closed `Context` is in `NodeMode::NONE`, which `Context::init`
-            // cannot re-initialize.
-            CompressionStream::<Self>::throw_if_closed(self, global_this)?;
+            // Racing an in-flight async write would alias `&mut Context`
+            // across threads; a closed `Context` cannot be re-initialized.
+            CompressionStream::<Self>::throw_unless_idle(self, global_this)?;
 
             // `flush_write_result` writes two u32s into this array, so the
             // caller-supplied array must hold at least 2 elements.
@@ -268,6 +268,9 @@ mod _impl {
                 if err.is_error() {
                     // impl.emitError(this, globalThis, this_value, err); //XXX: onerror isn't set yet
                     self.stream.with_mut(|s| s.close());
+                    // The Context is torn down (`mode` is `NONE`); reject any
+                    // further operation the way `close()` does.
+                    self.closed.set(true);
                     return Ok(JSValue::FALSE);
                 }
             }
@@ -529,7 +532,11 @@ mod _impl {
         }
 
         pub fn close(&mut self) {
-            self.deinit_state();
+            // Idempotent: a handle that was never (successfully) initialized,
+            // or that was already closed, has no encoder/decoder to free.
+            if self.state.is_some() {
+                self.deinit_state();
+            }
             self.mode = bun_zlib::NodeMode::NONE;
         }
 

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -189,6 +189,9 @@ mod _impl {
                     )
                     .throw());
             }
+            // A closed `Context` is in `NodeMode::NONE`, which `Context::init`
+            // cannot re-initialize.
+            CompressionStream::<Self>::throw_if_closed(self, global_this)?;
 
             // `flush_write_result` writes two u32s into this array, so the
             // caller-supplied array must hold at least 2 elements.
@@ -429,6 +432,11 @@ mod _impl {
         }
 
         pub fn do_work(&mut self) {
+            // A handle driven before `init()` has no encoder/decoder state;
+            // brotli dereferences the state pointer unconditionally.
+            if self.state.is_none() {
+                return;
+            }
             match self.mode {
                 bun_zlib::NodeMode::BROTLI_ENCODE => {
                     let mut next_in = self.next_in;

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -130,6 +130,9 @@ mod _impl {
                 )
                 .throw());
             }
+            // A closed `Context` is in `NodeMode::NONE`, which `Context::init`
+            // cannot re-initialize.
+            CompressionStream::<Self>::throw_if_closed(self, global)?;
 
             let window_bits =
                 validators::validate_int32(global, arguments.ptr[0], "windowBits", None, None)?;
@@ -183,6 +186,18 @@ mod _impl {
                         ));
                     }
                 };
+                // `deflateSetDictionary`/`inflateSetDictionary` take a `uInt`
+                // length; reject anything larger before `Context::init` copies it.
+                if dictionary_buf.byte_len > u32::MAX as usize {
+                    return Err(global.throw_range_error(
+                        dictionary_buf.byte_len as i64,
+                        bun_jsc::RangeErrorOptions {
+                            field_name: b"dictionary.byteLength",
+                            max: i64::from(u32::MAX),
+                            ..Default::default()
+                        },
+                    ));
+                }
                 Some(dictionary_buf.byte_slice())
             };
 

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -210,6 +210,12 @@ mod _impl {
 
             self.stream
                 .with_mut(|s| s.init(level, window_bits, mem_level, strategy, dictionary));
+            // `Context::init` leaves `mode` at `NONE` when `deflateInit2_` /
+            // `inflateInit2_` rejects its arguments; mark the wrapper closed so
+            // the next operation is rejected instead of re-entering `NONE`.
+            if self.stream.with_mut(|s| s.mode == c::NodeMode::NONE) {
+                self.closed.set(true);
+            }
 
             Ok(JSValue::UNDEFINED)
         }

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -130,9 +130,9 @@ mod _impl {
                 )
                 .throw());
             }
-            // A closed `Context` is in `NodeMode::NONE`, which `Context::init`
-            // cannot re-initialize.
-            CompressionStream::<Self>::throw_if_closed(self, global)?;
+            // Racing an in-flight async write would alias `&mut Context`
+            // across threads; a closed `Context` cannot be re-initialized.
+            CompressionStream::<Self>::throw_unless_idle(self, global)?;
 
             let window_bits =
                 validators::validate_int32(global, arguments.ptr[0], "windowBits", None, None)?;
@@ -226,6 +226,9 @@ mod _impl {
                     )
                     .throw());
             }
+            // `set_params` calls `deflateParams` on the same `z_stream` an
+            // in-flight async write's `deflate()` is using.
+            CompressionStream::<Self>::throw_unless_idle(self, global)?;
 
             let level = validators::validate_int32(global, arguments.ptr[0], "level", None, None)?;
             let strategy =
@@ -624,7 +627,14 @@ impl Context {
             BROTLI_ENCODE | BROTLI_DECODE => {}
             ZSTD_COMPRESS | ZSTD_DECOMPRESS => {}
         }
-        debug_assert!(status == c::ReturnCode::Ok || status == c::ReturnCode::DataError);
+        // Ok: normal. DataError: pending output discarded by inflateEnd.
+        // StreamError: a handle whose init() threw before deflateInit2_/
+        // inflateInit2_ ran, so the zeroed z_stream has nothing to free.
+        debug_assert!(
+            status == c::ReturnCode::Ok
+                || status == c::ReturnCode::DataError
+                || status == c::ReturnCode::StreamError
+        );
         self.mode = NONE;
     }
 }

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -152,6 +152,9 @@ mod _impl {
                     )
                     .throw());
             }
+            // A closed `Context` is in `NodeMode::NONE`, which `Context::init`
+            // cannot re-initialize.
+            CompressionStream::<Self>::throw_if_closed(self, global)?;
 
             let init_params_array_value = arguments[0];
             let pledged_src_size_value = arguments[1];
@@ -420,6 +423,11 @@ mod _impl {
         }
 
         pub fn do_work(&mut self) {
+            // A handle driven before `init()` has no CCtx/DCtx; zstd
+            // dereferences the context pointer unconditionally.
+            if self.state.is_none() {
+                return;
+            }
             self.remaining = match self.mode {
                 // SAFETY: state is a valid CCtx; input/output point to caller-kept-alive buffers (set_buffers).
                 NodeMode::ZSTD_COMPRESS => unsafe {

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -152,9 +152,9 @@ mod _impl {
                     )
                     .throw());
             }
-            // A closed `Context` is in `NodeMode::NONE`, which `Context::init`
-            // cannot re-initialize.
-            CompressionStream::<Self>::throw_if_closed(self, global)?;
+            // Racing an in-flight async write would alias `&mut Context`
+            // across threads; a closed `Context` cannot be re-initialized.
+            CompressionStream::<Self>::throw_unless_idle(self, global)?;
 
             let init_params_array_value = arguments[0];
             let pledged_src_size_value = arguments[1];
@@ -236,6 +236,9 @@ mod _impl {
                     .with_mut(|s| s.set_params(c_uint::try_from(i).expect("int cast"), x));
                 if err_.is_error() {
                     self.stream.with_mut(|s| s.close());
+                    // The Context is torn down (`mode` is `NONE`); reject any
+                    // further operation the way `close()` does.
+                    self.closed.set(true);
                     // SAFETY: is_error() ⇔ msg is non-null; it points at a NUL-terminated C string.
                     let msg = unsafe { bun_core::ffi::cstr(err_.msg) }.to_bytes();
                     return Err(global
@@ -522,6 +525,12 @@ mod _impl {
         }
 
         pub fn close(&mut self) {
+            // Idempotent: a handle that was never (successfully) initialized,
+            // or that was already closed, has no CCtx/DCtx to reset or free.
+            if self.state.is_none() {
+                self.mode = NodeMode::NONE;
+                return;
+            }
             let _ = match self.mode {
                 // SAFETY: state is a valid CCtx/DCtx for this mode.
                 NodeMode::ZSTD_COMPRESS => unsafe {

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -321,8 +321,18 @@ describe.concurrent("zlib native handle driven outside the zlib.ts lifecycle", (
        catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
       "threw ERR_INVALID_STATE: Write already in progress",
     ],
-    // init() that creates the native state but then fails on a bad parameter
-    // key tears the Context down; the handle has to reject further use.
+    // init() that fails partway (zlib: deflateInit2_ rejects the arguments;
+    // brotli/zstd: a bad parameter key after the state was created) tears the
+    // Context down; the handle has to reject further use.
+    [
+      "zlib: a handle whose init() arguments were rejected is closed",
+      `const C = zlib.createDeflate()._handle.constructor;
+       const h = new C(1);
+       h.init(100, 6, 8, 0, new Uint32Array(2), () => {}, undefined);
+       try { h.init(15, 6, 8, 0, new Uint32Array(2), () => {}, undefined); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      CLOSED,
+    ],
     [
       "brotli: a handle whose init() parameters were rejected is closed",
       `const C = zlib.createBrotliCompress()._handle.constructor;

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -163,7 +163,9 @@ describe.concurrent("zlib native handle driven outside the zlib.ts lifecycle", (
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    // stderr is drained so a large diagnostic can't fill the pipe and block
+    // the child, but it isn't asserted on (debug/ASAN builds write to it).
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stdout: stdout.trim(), exitCode };
   }
 

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -146,3 +146,134 @@ describe("zlib native handle writeState", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// The zlib.ts wrapper always drives the native handle as
+// constructor -> init() -> write*() -> close(), caches onerror/writeCallback
+// in init(), and nulls `_handle` on close. The native binding assumed that
+// protocol: driving a handle outside it (reachable through `_handle` and
+// `_handle.constructor`) used to abort the whole process with a Rust
+// `unreachable!()` / `unwrap()` on `None`, or hand a null state pointer
+// straight into brotli/zstd. Each case runs in a subprocess so a regression
+// fails one test instead of taking down the runner. `handled` means the child
+// reached the statement after the call; `threw ...` echoes the JS error.
+describe.concurrent("zlib native handle driven outside the zlib.ts lifecycle", () => {
+  async function run(body: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const zlib = require("node:zlib");\n${body}`],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    return { stdout: stdout.trim(), exitCode };
+  }
+
+  const CLOSED = "threw ERR_INVALID_STATE: zlib binding closed";
+  const cases: [name: string, body: string, expected: string][] = [
+    // init() after close(): the Context is in NodeMode::NONE, which
+    // Context::init treats as unreachable.
+    [
+      "zlib: init() after close() throws",
+      `const h = zlib.createDeflate()._handle;
+       h.close();
+       try { h.init(15, 6, 8, 0, new Uint32Array(2), () => {}, undefined); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      CLOSED,
+    ],
+    [
+      "brotli: init() after close() throws",
+      `const h = zlib.createBrotliCompress()._handle;
+       h.close();
+       try { h.init(new Uint32Array(0), new Uint32Array(2), () => {}); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      CLOSED,
+    ],
+    [
+      "zstd: init() after close() throws",
+      `const h = zlib.createZstdCompress()._handle;
+       h.close();
+       try { h.init(new Uint32Array(0), undefined, new Uint32Array(2), () => {}); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      CLOSED,
+    ],
+    // write/writeSync after close(): brotli/zstd do_work() treated
+    // NodeMode::NONE as unreachable; zlib silently no-op'd on an ended stream.
+    [
+      "zlib: writeSync() after close() throws",
+      `const h = zlib.createDeflate()._handle;
+       h.close();
+       try { h.writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      CLOSED,
+    ],
+    [
+      "brotli: writeSync() after close() throws",
+      `const h = zlib.createBrotliCompress()._handle;
+       h.close();
+       try { h.writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      CLOSED,
+    ],
+    [
+      "zstd: writeSync() after close() throws",
+      `const h = zlib.createZstdCompress()._handle;
+       h.close();
+       try { h.writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      CLOSED,
+    ],
+    // writeSync() before init(): brotli/zstd were handed a null state
+    // pointer, which their C APIs dereference unconditionally.
+    [
+      "brotli: writeSync() before init() does not dereference a null encoder",
+      `const C = zlib.createBrotliCompress()._handle.constructor;
+       new C(8).writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64); console.log("handled");`,
+      "handled",
+    ],
+    [
+      "zstd: writeSync() before init() does not dereference a null CCtx",
+      `const C = zlib.createZstdCompress()._handle.constructor;
+       new C(10).writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64); console.log("handled");`,
+      "handled",
+    ],
+    // With no onerror / writeCallback cached (init() never ran), an error or
+    // an async write completion had no callback to unwrap.
+    [
+      "zlib: an error with no onerror cached is dropped, not fatal",
+      `const C = zlib.createDeflate()._handle.constructor;
+       new C(1).reset(); console.log("handled");`,
+      "handled",
+    ],
+    [
+      "brotli: async write() with no writeCallback cached completes",
+      `const C = zlib.createBrotliDecompress()._handle.constructor;
+       const h = new C(9);
+       h.reset();
+       h.write(0, null, 0, 0, new Uint8Array(64), 0, 64);
+       console.log("handled");`,
+      "handled",
+    ],
+  ];
+
+  for (const [name, body, expected] of cases) {
+    test.concurrent(name, async () => {
+      expect(await run(body)).toEqual({ stdout: expected, exitCode: 0 });
+    });
+  }
+
+  // deflateSetDictionary / inflateSetDictionary take a `uInt` length; a 2**32
+  // byte dictionary overflowed the cast after the native handle had already
+  // copied it. The length is now rejected before the copy, so the Uint8Array
+  // below is never read and stays virtual (cheap).
+  test.concurrent("zlib: a 2**32-byte dictionary throws instead of overflowing a u32", async () => {
+    expect(
+      await run(
+        `try { zlib.deflateSync(Buffer.from("hello"), { dictionary: new Uint8Array(2 ** 32) }); console.log("handled"); }
+         catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      ),
+    ).toEqual({
+      stdout:
+        'threw ERR_OUT_OF_RANGE: The value of "dictionary.byteLength" is out of range. It must be <= 4294967295. Received 4294967296',
+      exitCode: 0,
+    });
+  });
+});

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -160,7 +160,11 @@ describe.concurrent("zlib native handle driven outside the zlib.ts lifecycle", (
   async function run(body: string) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `const zlib = require("node:zlib");\n${body}`],
-      env: bunEnv,
+      // BUN_DESTRUCT_VM_ON_EXIT makes exit run `lastChanceToFinalize`, so the
+      // finalizer of every handle the case leaves behind runs deterministically
+      // (the ASAN CI lanes do this on every exit; without it the child "passes"
+      // and then aborts only on those lanes).
+      env: { ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1" },
       stderr: "pipe",
     });
     // stderr is drained so a large diagnostic can't fill the pipe and block
@@ -253,6 +257,91 @@ describe.concurrent("zlib native handle driven outside the zlib.ts lifecycle", (
        h.write(0, null, 0, 0, new Uint8Array(64), 0, 64);
        console.log("handled");`,
       "handled",
+    ],
+    // A constructed-but-never-initialized handle reaching the GC finalizer:
+    // brotli/zstd Context::close() tried to free/reset a state that was never
+    // created, and zlib's asserted that deflateEnd accepted the zeroed stream.
+    [
+      "zlib: a never-initialized handle finalizes cleanly",
+      `const C = zlib.createDeflate()._handle.constructor;
+       new C(1); console.log("handled");`,
+      "handled",
+    ],
+    [
+      "brotli: a never-initialized handle finalizes cleanly",
+      `const C = zlib.createBrotliCompress()._handle.constructor;
+       new C(8); console.log("handled");`,
+      "handled",
+    ],
+    [
+      "zstd: a never-initialized handle finalizes cleanly",
+      `const C = zlib.createZstdCompress()._handle.constructor;
+       new C(10); console.log("handled");`,
+      "handled",
+    ],
+    // init()/params() while an async write() is still running on the thread
+    // pool: both sides would mutate the same native stream concurrently.
+    [
+      "zlib: init() while an async write is in flight throws",
+      `const C = zlib.createDeflate()._handle.constructor;
+       const h = new C(1);
+       h.init(15, 6, 8, 0, new Uint32Array(2), () => {}, undefined);
+       h.write(0, null, 0, 0, new Uint8Array(64), 0, 64);
+       try { h.init(15, 6, 8, 0, new Uint32Array(2), () => {}, undefined); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      "threw ERR_INVALID_STATE: Write already in progress",
+    ],
+    [
+      "zlib: params() while an async write is in flight throws",
+      `const C = zlib.createDeflate()._handle.constructor;
+       const h = new C(1);
+       h.init(15, 6, 8, 0, new Uint32Array(2), () => {}, undefined);
+       h.write(0, null, 0, 0, new Uint8Array(64), 0, 64);
+       try { h.params(1, 0); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      "threw ERR_INVALID_STATE: Write already in progress",
+    ],
+    [
+      "brotli: init() while an async write is in flight throws",
+      `const C = zlib.createBrotliCompress()._handle.constructor;
+       const h = new C(8);
+       h.init(new Uint32Array(0), new Uint32Array(2), () => {});
+       h.write(0, null, 0, 0, new Uint8Array(64), 0, 64);
+       try { h.init(new Uint32Array(0), new Uint32Array(2), () => {}); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      "threw ERR_INVALID_STATE: Write already in progress",
+    ],
+    [
+      "zstd: init() while an async write is in flight throws",
+      `const C = zlib.createZstdCompress()._handle.constructor;
+       const h = new C(10);
+       h.init(new Uint32Array(0), undefined, new Uint32Array(2), () => {});
+       h.write(0, null, 0, 0, new Uint8Array(64), 0, 64);
+       try { h.init(new Uint32Array(0), undefined, new Uint32Array(2), () => {}); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      "threw ERR_INVALID_STATE: Write already in progress",
+    ],
+    // init() that creates the native state but then fails on a bad parameter
+    // key tears the Context down; the handle has to reject further use.
+    [
+      "brotli: a handle whose init() parameters were rejected is closed",
+      `const C = zlib.createBrotliCompress()._handle.constructor;
+       const h = new C(8);
+       const p = new Uint32Array(50).fill(0xffffffff); p[49] = 0;
+       const r = h.init(p, new Uint32Array(2), () => {});
+       try { h.writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64); console.log("handled " + r); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message + " " + r); }`,
+      "threw ERR_INVALID_STATE: zlib binding closed false",
+    ],
+    [
+      "zstd: a handle whose init() parameters were rejected is closed",
+      `const C = zlib.createZstdCompress()._handle.constructor;
+       const h = new C(10);
+       const p = new Uint32Array(50).fill(0xffffffff); p[49] = 0;
+       try { h.init(p, undefined, new Uint32Array(2), () => {}); } catch {}
+       try { h.writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      "threw ERR_INVALID_STATE: zlib binding closed",
     ],
   ];
 


### PR DESCRIPTION
### What

The `zlib.ts` wrapper drives the `NativeZlib` / `NativeBrotli` / `NativeZstd` handles as constructor -> `init()` -> `write*()` -> `close()`, caches `onerror` and the write callback in `init()`, and nulls `_handle` on close. The native binding assumed that protocol. Driving a handle outside it, which only takes reaching `_handle` (and its `constructor`), aborts the whole process. Eleven distinct ways, all reproduced on the release binary; two are null-pointer segfaults and one needs nothing but `new`:

```js
const zlib = require("node:zlib");

// 1) 2^32-byte dictionary via the PUBLIC API (no _handle needed):
zlib.deflateSync(Buffer.from("hi"), { dictionary: new Uint8Array(2 ** 32) });
// panic: int cast: TryFromIntError(PosOverflow)

// 2) constructing a handle and never initializing it; the GC finalizer
//    frees/resets native state that was never created:
new (zlib.createBrotliCompress()._handle.constructor)(8); Bun.gc(true);
// panic: called `Option::unwrap()` on a `None` value
new (zlib.createZstdCompress()._handle.constructor)(10); Bun.gc(true);
// panic(main thread): Segmentation fault at address 0xE38

// 3) writeSync() before init() (brotli/zstd): NULL state pointer into the C library
new (zlib.createZstdCompress()._handle.constructor)(10).writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64);
// panic(main thread): Segmentation fault at address 0xE38

// 4) writeSync() after close() (brotli/zstd):
const h = zlib.createBrotliCompress()._handle;
h.close(); h.writeSync(0, null, 0, 0, new Uint8Array(64), 0, 64);
// panic: internal error: entered unreachable code

// 5) init() after close() (all three):
const h2 = zlib.createDeflate()._handle;
h2.close(); h2.init(15, 6, 8, 0, new Uint32Array(2), () => {}, undefined);
// panic: internal error: entered unreachable code

// 6) init() whose deflateInit2_ rejects the arguments, then init() again:
const h3 = new (zlib.createDeflate()._handle.constructor)(1);
h3.init(100, 6, 8, 0, new Uint32Array(2), () => {}, undefined);
h3.init(15, 6, 8, 0, new Uint32Array(2), () => {}, undefined);
// panic: internal error: entered unreachable code

// 7) any stream error with no cached onerror:
new (zlib.createDeflate()._handle.constructor)(1).reset();
// panic: Assertion failure: cachedErrorCallback is null in node:zlib binding

// 8) an async write completing with no cached writeCallback:
const h4 = new (zlib.createBrotliDecompress()._handle.constructor)(9);
h4.reset(); h4.write(0, null, 0, 0, new Uint8Array(64), 0, 64);
// panic: called `Option::unwrap()` on a `None` value
```

Plus two that are not aborts but are worse: `init()` or `params()` called while an async `write()` is still running on the thread pool mutates the same native `z_stream` / encoder from two threads (the worker holds `&mut Context` inside `deflate()` while the JS thread runs `deflateInit2_` on it), and a brotli/zstd `init()` whose parameter setup fails tears the `Context` down without marking the handle closed, so the next call aborts anyway.

### Why

- After `close()`, or after a failed `init()`, the `Context` is in `NodeMode::NONE` with its native state freed; `Context::{do_work,init}` and brotli's `get_error_info` have no arm for `NONE` and hit `unreachable!()`. `reset()` already guarded on `closed`; `write`, `writeSync` and `init` did not, and nothing guarded against an in-flight write.
- `init()` can fail three different ways without anything recording it: zlib's `deflateInit2_`/`inflateInit2_` rejecting the arguments, and brotli/zstd's per-parameter setup failing after the state was created. All three leave `{ closed: false, mode: NONE }`.
- Before `init()`, brotli/zstd have no encoder/decoder state at all. `do_work()` passes the null pointer into `BrotliEncoderCompressStream` / `ZSTD_compressStream2`, and the GC finalizer does the same through `Context::close()` (`deinit_state` unwraps the `None`; zstd hands the null `CCtx` to `ZSTD_CCtx_reset`). So a handle that is merely constructed and collected already aborts.
- `NativeZlib::Context::close()` asserted that `deflateEnd`/`inflateEnd` returned `Z_OK`/`Z_DATA_ERROR`; on a `z_stream` whose init never ran they return `Z_STREAM_ERROR` (with nothing to free), which fired the assertion in debug/ASAN builds.
- `emit_error()` and the async write-completion path `unwrap()` JS callbacks that only `init()` caches.
- `NativeZlib::init()` copied the dictionary into a `Vec` and only then did `u32::try_from(dict.len()).expect("int cast")`; JSC allows a 2^32-byte `Uint8Array` and `deflateSetDictionary` takes a `uInt` length.

### Fix

- `throw_if_closed` is generalized into `CompressionStream::throw_unless_idle` (`write_in_progress` / `pending_close` / `closed`, in the shared mixin so all three stream types at once). `write()`, `writeSync()`, each class's `init()`, and `NativeZlib::params()` call it; `write()`/`writeSync()` previously carried their own copies of the first two checks.
- Every `init()` failure path now marks the handle `closed`: `NativeZlib::init()` checks whether `Context::init` ended in `NodeMode::NONE`, and the brotli/zstd parameter-failure branches set it after tearing the `Context` down.
- Brotli and zstd `Context::close()` early-return when the native state was never created. This also makes `close()` idempotent, which overlaps the user-called double-`close()` case that #32382 fixes in the same function; it became required here because the GC finalizer goes through the same `close()`.
- `NativeZlib::Context::close()`'s debug assertion also accepts `Z_STREAM_ERROR`.
- Brotli/Zstd `Context::do_work()` return early when the state was never created. `NativeZlib` already tolerates this (zlib's own `deflateStateCheck` null-checks the stream).
- `emit_error()` and the write-completion path skip the JS callback when none is cached instead of panicking; the pending reset/close handling still runs. Node behaves the same way.
- `NativeZlib::init()` rejects a dictionary longer than `u32::MAX` before copying it: `RangeError [ERR_OUT_OF_RANGE]: The value of "dictionary.byteLength" is out of range. It must be <= 4294967295. Received 4294967296`. With the check before the copy, a 2^32-byte `Uint8Array` argument is never read, so the test stays cheap.

Intentionally not touched here:
- brotli `set_flush` receiving zlib flush constants `4..=6` is #32358 (whose fix, mapping them like Node does, is the right one).
- a second `init()` on an already-initialized, idle handle leaks the first encoder/`internal_state`. That is a bounded leak rather than an abort, Node has the same gap, and it needs its own leak-regression test; left as a follow-up.
- `NativeZlib::params()` after `close()` is already safe (`Context::set_params` has a `_ => {}` arm).

### Test

`test/js/node/zlib/zlib-handle-bounds-check.test.ts` gains one subprocess test per case (21 new). The children run with `BUN_DESTRUCT_VM_ON_EXIT=1` so the GC finalizers run deterministically on every lane, not only the ASAN lanes that destroy the VM at exit (which is how CI caught the finalizer class in the first place).

```
bun bd test test/js/node/zlib/zlib-handle-bounds-check.test.ts   # 30 pass
bun bd test test/js/node/zlib/zlib.test.js                       # 376 pass (2 pre-existing debug-only timeouts)
USE_SYSTEM_BUN=1 bun test <same file>                            # the new cases fail (aborts / wrong result)
```

The 14 `test-zlib-{write-after-close,close-after-*,flush*,brotli*,params,dictionary*,reset-before-write,...}` node-upstream tests still pass. The two `streaming encode doesn't wait for entire input` failures in `zlib.test.js` are pre-existing on debug+ASAN runners: the test's own byte-fill setup loop takes 42s against a 15s limit before any compression happens.
