### PR TITLE
node:cluster: don't unwrap a non-Subprocess handle in the primary IPC bindings

### DIFF
--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -169,7 +169,12 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
     let arguments = frame.arguments_old::<4>().ptr;
     // `as_class_ref` is the safe shared-borrow downcast (centralised deref
     // proof in `JSValue`); `Subprocess::ipc(&self)` projects the `JsCell`.
-    let subprocess = arguments[0].as_class_ref::<Subprocess<'_>>().unwrap();
+    // `cluster.Worker({ process })` accepts any object, so `process[kHandle]`
+    // is `undefined` unless `cluster.fork()` created the process; Node's
+    // `sendHelper` returns false for a worker with no IPC channel.
+    let Some(subprocess) = arguments[0].as_class_ref::<Subprocess<'_>>() else {
+        return Ok(JSValue::FALSE);
+    };
     let message = arguments[1];
     let handle = arguments[2];
     let callback = arguments[3];
@@ -227,7 +232,11 @@ pub(crate) fn on_internal_message_primary(
 ) -> JsResult<JSValue> {
     let arguments = frame.arguments_old::<3>().ptr;
     // `as_class_ref` is the safe shared-borrow downcast; `ipc()` takes `&self`.
-    let subprocess = arguments[0].as_class_ref::<Subprocess<'_>>().unwrap();
+    // Same guard as `send_helper_primary`: nothing to subscribe to when the
+    // worker's process has no native child handle.
+    let Some(subprocess) = arguments[0].as_class_ref::<Subprocess<'_>>() else {
+        return Ok(JSValue::UNDEFINED);
+    };
     let Some(ipc_data) = subprocess.ipc() else {
         return Ok(JSValue::UNDEFINED);
     };

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -162,12 +162,9 @@ process.send("regular message");
 });
 
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {
-  // `new cluster.Worker({ process })` accepts any object (Node's tests mock
-  // workers this way). `Worker.prototype.disconnect` in the primary routes
-  // through `sendHelper(worker.process[kHandle], ...)`, and `kHandle` is a
-  // private symbol that only `cluster.fork()` sets, so the native binding is
-  // handed `undefined`. It used to unwrap that into a process abort; Node's
-  // sendHelper just returns false and disconnect() returns the worker.
+  // `kHandle` is a private symbol that only `cluster.fork()` sets, so a
+  // `cluster.Worker({ process })` built around a plain object (how Node's own
+  // tests mock workers) hands `undefined` to the native `sendHelper` binding.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -181,7 +181,9 @@ test("disconnect() on a cluster.Worker built around a plain object does not abor
       `,
     ],
     env: bunEnv,
-    stderr: "pipe",
+    // Inherited so that on regression the child's abort output reaches the
+    // runner log instead of filling an unread pipe.
+    stderr: "inherit",
   });
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "returned self: true", exitCode: 0 });

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunRun, joinP, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, joinP, tempDirWithFiles } from "harness";
 
 test("cloneable and transferable equals", () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -159,4 +159,30 @@ process.send("regular message");
   });
   const { stdout } = bunRun(joinP(dir, "parent.ts"), bunEnv);
   expect(stdout).toContain("P received regular message");
+});
+
+test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {
+  // `new cluster.Worker({ process })` accepts any object (Node's tests mock
+  // workers this way). `Worker.prototype.disconnect` in the primary routes
+  // through `sendHelper(worker.process[kHandle], ...)`, and `kHandle` is a
+  // private symbol that only `cluster.fork()` sets, so the native binding is
+  // handed `undefined`. It used to unwrap that into a process abort; Node's
+  // sendHelper just returns false and disconnect() returns the worker.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const cluster = require("node:cluster");
+        const fake = { on() {}, disconnect() {}, kill() {}, send() { return false; } };
+        const worker = new cluster.Worker({ process: fake });
+        const returned = worker.disconnect();
+        console.log("returned self:", returned === worker);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "returned self: true", exitCode: 0 });
 });


### PR DESCRIPTION
### Repro

```js
const cluster = require("node:cluster");
const fake = { on() {}, disconnect() {}, kill() {}, send() { return false; } };
new cluster.Worker({ process: fake }).disconnect();
```

```
panic: called `Option::unwrap()` on a `None` value
```

The same code in Node returns the worker; `new cluster.Worker({ process })` with a plain object is how Node's own cluster tests mock workers.

### Cause

`Worker.prototype.disconnect` in the primary routes through `send(worker, ...)` -> `sendHelper(worker.process[kHandle], message, handle, cb)`. `kHandle` is a private symbol that only `cluster.fork()` sets on the child process it creates, so a user-supplied `process` object hands `undefined` to the native binding, and `send_helper_primary` (`src/runtime/node/node_cluster_binding.rs`) did:

```rust
let subprocess = arguments[0].as_class_ref::<Subprocess<'_>>().unwrap();
```

`panic = "abort"`, so the whole process dies.

### Fix

Downcast with `let Some(..) = .. else` and fall through to the same "no IPC channel" result the function already returns two lines later when `subprocess.ipc()` is unset: `false`, which matches Node's `sendHelper` (it bails on `!proc.connected`). `on_internal_message_primary` has the identical `.unwrap()` on the identical argument and gets the identical guard (it is only reached from `cluster.fork()` today, but it is the same pattern in the same file).

### Test

Added to `test/js/node/cluster.test.ts`; the child must print `returned self: true` and exit 0.

```
bun bd test test/js/node/cluster.test.ts                          # 5 pass
USE_SYSTEM_BUN=1 bun test test/js/node/cluster.test.ts -t disconnect   # 1 fail (abort)
```

The 14 `test-cluster-{worker-constructor,disconnect*,send*,worker-{destroy,kill}}` node-upstream tests still pass.
