### PR TITLE
Bun.{JSON5,JSONC,TOML,YAML}.parse: reject inputs of 2^31 bytes or more instead of panicking

### DIFF
--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -259,6 +259,21 @@ pub(crate) fn with_text_format_source<R>(
         _str_hold.slice()
     };
 
+    // Every parser reached from here records source positions as an `i32`
+    // (`ast::Loc` via `usize2loc` for JSONC/TOML, JSON5's token locs, YAML's
+    // `Pos`), so an input those offsets cannot represent panics inside the
+    // lexer instead of reporting an error. Reject it before parsing.
+    if bytes.len() > i32::MAX as usize {
+        return Err(global.throw_range_error(
+            bytes.len() as i64,
+            bun_jsc::RangeErrorOptions {
+                field_name: b"input.byteLength",
+                max: i64::from(i32::MAX),
+                ..Default::default()
+            },
+        ));
+    }
+
     let mut log = bun_ast::Log::init();
     let source = bun_ast::Source::init_path_string(path, bytes);
 

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -1707,10 +1707,17 @@ describe("stringify memory", () => {
 // never read. The runtime accepts a TypedArray here (the binding takes a
 // Blob, Buffer or string); the declared `string` type is narrower.
 test("parse rejects an input of 2**31 bytes or more instead of panicking", () => {
-  const input = new Uint8Array(2 ** 31 + 2) as unknown as string;
+  let input: Uint8Array;
+  try {
+    input = new Uint8Array(2 ** 31 + 2);
+  } catch {
+    // The 2 GiB reservation itself can fail on a memory-pressured runner;
+    // there is nothing to test then.
+    return;
+  }
   let err: any;
   try {
-    JSON5.parse(input);
+    JSON5.parse(input as unknown as string);
   } catch (e) {
     err = e;
   }

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -1699,3 +1699,24 @@ describe("stringify memory", () => {
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
   });
 });
+
+// The JSON5 lexer records every source position as an i32, so an input of
+// 2**31 bytes or more used to abort the process with
+// `panic: int cast: TryFromIntError(PosOverflow)` instead of throwing. It is
+// rejected before parsing, so the Uint8Array below is virtual pages that are
+// never read. The runtime accepts a TypedArray here (the binding takes a
+// Blob, Buffer or string); the declared `string` type is narrower.
+test("parse rejects an input of 2**31 bytes or more instead of panicking", () => {
+  const input = new Uint8Array(2 ** 31 + 2) as unknown as string;
+  let err: any;
+  try {
+    JSON5.parse(input);
+  } catch (e) {
+    err = e;
+  }
+  expect(err?.constructor?.name).toBe("RangeError");
+  expect(err?.code).toBe("ERR_OUT_OF_RANGE");
+  expect(err?.message).toBe(
+    'The value of "input.byteLength" is out of range. It must be <= 2147483647. Received 2147483650',
+  );
+});

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -4743,3 +4743,24 @@ describe("plain scalar whitespace handling", () => {
     expect(() => YAML.parse("g: -")).toThrow(SyntaxError);
   });
 });
+
+// The YAML scanner records every source position as an i32, so an input of
+// 2**31 bytes or more used to abort the process with
+// `panic: int cast: TryFromIntError(PosOverflow)` instead of throwing. It is
+// rejected before parsing, so the Uint8Array below is virtual pages that are
+// never read. The runtime accepts a TypedArray here (the binding takes a
+// Blob, Buffer or string); the declared `string` type is narrower.
+test("parse rejects an input of 2**31 bytes or more instead of panicking", () => {
+  const input = new Uint8Array(2 ** 31 + 2) as unknown as string;
+  let err: any;
+  try {
+    YAML.parse(input);
+  } catch (e) {
+    err = e;
+  }
+  expect(err?.constructor?.name).toBe("RangeError");
+  expect(err?.code).toBe("ERR_OUT_OF_RANGE");
+  expect(err?.message).toBe(
+    'The value of "input.byteLength" is out of range. It must be <= 2147483647. Received 2147483650',
+  );
+});

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -4751,10 +4751,17 @@ describe("plain scalar whitespace handling", () => {
 // never read. The runtime accepts a TypedArray here (the binding takes a
 // Blob, Buffer or string); the declared `string` type is narrower.
 test("parse rejects an input of 2**31 bytes or more instead of panicking", () => {
-  const input = new Uint8Array(2 ** 31 + 2) as unknown as string;
+  let input: Uint8Array;
+  try {
+    input = new Uint8Array(2 ** 31 + 2);
+  } catch {
+    // The 2 GiB reservation itself can fail on a memory-pressured runner;
+    // there is nothing to test then.
+    return;
+  }
   let err: any;
   try {
-    YAML.parse(input);
+    YAML.parse(input as unknown as string);
   } catch (e) {
     err = e;
   }


### PR DESCRIPTION
### Repro

All four abort the process on the release binary with `panic: int cast: TryFromIntError(PosOverflow)`:

```js
Bun.JSON5.parse(new Uint8Array(2 ** 31 + 2).fill(32));

const n = 2 ** 31 + 8, b = new Uint8Array(n).fill(10);
b.set([97, 58, 32, 49, 10], n - 5);
Bun.YAML.parse(b);

Bun.TOML.parse("#" + "\u00e9".repeat(2 ** 30 + 4) + "\na=1");
Bun.JSONC.parse("//" + "\u00e9".repeat(2 ** 30 + 4) + "\n1");
```

Same bug class as #32752 (`Bun.markdown`).

### Why

Every parser behind `Bun.{JSON5,JSONC,TOML,YAML}.parse` records source positions as an `i32`:

- JSONC and TOML go through `ast::usize2loc`, `start: i32::try_from(loc).expect("int cast")` (`src/ast/lib.rs`)
- JSON5 builds every token with `start: i32::try_from(self.pos).expect("int cast")` (`src/parsers/json5.rs`)
- YAML's `Pos::loc()` does `i32::try_from(self.0).expect("int cast")` (`src/parsers/yaml.rs`)

JSON5 and YAML accept a `Blob` / `Buffer` directly, so a 2^32-byte `Uint8Array` gets there in one call. All four accept a string, and JSC strings are Latin-1 or UTF-16 internally, so a string well under 2 GiB can still produce more than 2^31 UTF-8 bytes (the `\u00e9` repros above). No entry point checked the length.

### Fix

All four host fns already share one entry point, `with_text_format_source` (`src/runtime/api.rs`), which resolves the argument to the `&[u8]` the parser will see. It now rejects anything the parsers' offsets cannot represent, before `Source::init_path_string`:

```
RangeError [ERR_OUT_OF_RANGE]: The value of "input.byteLength" is out of range. It must be <= 2147483647. Received 2147483650
```

Same code and wording as #32752.

Not covered here, same `i32`-offset constraint but different entry points: `Bun.Transpiler.transformSync` and anything that loads a file into the JS parser or bundler. Those go through the shared `ast::Source` / logger machinery used by the whole build pipeline, which is a much larger change than the four `Bun.*` parse APIs.

### Test

One test each in `test/js/bun/json5/json5.test.ts` and `test/js/bun/yaml/yaml.test.ts`, asserting the exact error class, code and message. The check happens before any byte of the input is read, so the 2^31+2-byte `Uint8Array` is virtual pages that are never materialized; each test runs in ~6ms.

JSONC and TOML only accept a string (`accept_blob_or_buffer` is false for them), and the cheapest string whose UTF-8 form exceeds 2^31 bytes commits ~3 GB both before and after the fix, so they have no automated test. They call the identical guard five lines away from the two that do.

```
bun bd test test/js/bun/json5/json5.test.ts   # 321 pass
bun bd test test/js/bun/yaml/yaml.test.ts     # 609 pass
bun bd test test/js/bun/jsonc/                # 14 pass
bun bd test test/js/bun/resolve/toml/         # 17 pass

USE_SYSTEM_BUN=1 bun test <json5,yaml files> -t "2**31"   # 2 fail
# json5: gets SyntaxError instead of RangeError
# yaml:  returns null instead of throwing
```
