### PR TITLE
worker: detect the host time zone once per process, not once per Worker

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -449,6 +449,19 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     vm.heap.acquireAccess();
     JSC::JSLockHolder locker(vm);
 
+    // JSC re-runs ICU host time-zone detection in every large-heap VM constructor with
+    // nothing caching it across VMs, so each `new Worker` rescans /usr/share/zoneinfo when
+    // /etc/localtime is a regular file. Pin the first VM's result as the WTF override.
+    if (!miniMode) {
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [&vm] {
+            WTF::Vector<char16_t, 32> timeZoneID;
+            WTF::getTimeZoneOverride(timeZoneID);
+            if (timeZoneID.isEmpty())
+                WTF::setTimeZoneOverride(vm.dateCache.defaultTimeZone().toString());
+        });
+    }
+
     {
         const char* disable_stop_if_necessary_timer = getenv("BUN_DISABLE_STOP_IF_NECESSARY_TIMER");
         // Keep stopIfNecessaryTimer enabled by default when either:

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isLinux, libcPathForDlopen, tempDir } from "harness";
 import path from "path";
 import wt from "worker_threads";
 
@@ -201,60 +201,28 @@ describe("web worker", () => {
     });
   });
 
-  test("worker with event listeners doesn't close event loop", done => {
-    const x = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), "worker-fixture-many-messages.js"],
+  // The child creates a Worker, ping-pongs ~50 messages with it, prints "done", and must
+  // then exit on its own. Exiting early drops "done"; never exiting trips the test timeout.
+  async function expectWorkerKeepsEventLoopAlive(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), fixture],
       env: bunEnv,
-      stdio: ["inherit", "pipe", "inherit"],
+      stderr: "pipe",
     });
-
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
-    x.exited.then(async code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        done(new Error("exited with non-zero code"));
-      } else {
-        const text = await new Response(x.stdout).text();
-        if (!text.includes("done")) {
-          console.log({ text });
-          done(new Error("event loop killed early"));
-        } else {
-          done();
-        }
-      }
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), signalCode: proc.signalCode, exitCode }).toEqual({
+      stdout: "done",
+      signalCode: null,
+      exitCode: 0,
     });
+  }
+
+  test("worker with event listeners doesn't close event loop", async () => {
+    await expectWorkerKeepsEventLoopAlive("worker-fixture-many-messages.js");
   });
 
-  test("worker with event listeners doesn't close event loop 2", done => {
-    const x = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), "worker-fixture-many-messages2.js"],
-      env: bunEnv,
-      stdio: ["inherit", "pipe", "inherit"],
-    });
-
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
-    x.exited.then(async code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        done(new Error("exited with non-zero code"));
-      } else {
-        const text = await new Response(x.stdout).text();
-        if (!text.includes("done")) {
-          console.log({ text });
-          done(new Error("event loop killed early"));
-        } else {
-          done();
-        }
-      }
-    });
+  test("worker with event listeners doesn't close event loop 2", async () => {
+    await expectWorkerKeepsEventLoopAlive("worker-fixture-many-messages2.js");
   });
 
   test("worker with process.exit", done => {
@@ -295,6 +263,66 @@ describe("web worker", () => {
       expect(err.message).toBe("5");
       expect(err.error).toBe(null);
     });
+  });
+
+  // Every Worker constructs a JSC VM, and JSC re-runs ICU host time-zone detection for
+  // each one: a content scan of /usr/share/zoneinfo when /etc/localtime is a regular
+  // file. The host zone must be detected once per process and reused by Workers.
+  // Linux-only: ICU's Windows host detection doesn't read the TZ variable this mutates.
+  test.skipIf(!isLinux)("Worker reuses the host time zone detected at startup", async () => {
+    using dir = tempDir("worker-host-tz", {
+      "main.js": `
+        import { dlopen } from "bun:ffi";
+
+        // The main thread's VM detected the host time zone at startup (TZ is unset).
+        const mainTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        // Inject a zone the host is not in, so a Worker that re-detects is distinguishable.
+        const injectedTz = mainTz === "Pacific/Kiritimati" ? "America/New_York" : "Pacific/Kiritimati";
+
+        // Change the C-level TZ environment variable, which ICU's host time-zone
+        // detection reads. Bun's process.env assignments never call setenv(), so
+        // this is only observable if a later VM re-runs the host detection.
+        const { symbols } = dlopen(${JSON.stringify(libcPathForDlopen())}, {
+          setenv: { args: ["ptr", "ptr", "i32"], returns: "i32" },
+        });
+        const cstr = s => {
+          const buf = Buffer.alloc(Buffer.byteLength(s) + 1);
+          buf.write(s);
+          return buf;
+        };
+        if (symbols.setenv(cstr("TZ"), cstr(injectedTz), 1) !== 0) {
+          throw new Error("setenv failed");
+        }
+
+        const worker = new Worker(new URL("./worker.js", import.meta.url).href);
+        const workerTz = await new Promise((resolve, reject) => {
+          worker.onmessage = e => resolve(e.data);
+          worker.onerror = e => reject(new Error(e.message));
+        });
+        worker.terminate();
+        console.log(JSON.stringify({ injectedTz, mainTz, workerTz }));
+      `,
+      "worker.js": `postMessage(Intl.DateTimeFormat().resolvedOptions().timeZone);`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      // TZ must be absent so the main thread detects the host time zone.
+      env: { ...bunEnv, TZ: undefined },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Surface the child's stderr if it crashed, instead of an opaque JSON parse error.
+    expect(exitCode, stderr).toBe(0);
+    const { injectedTz, mainTz, workerTz } = JSON.parse(stdout) as {
+      injectedTz: string;
+      mainTz: string;
+      workerTz: string;
+    };
+    expect(mainTz).not.toBe(injectedTz);
+    expect(workerTz).toBe(mainTz);
   });
 });
 


### PR DESCRIPTION
`new Worker` is significantly slower on hosts where `/etc/localtime` is a regular file (not a symlink) and `TZ` is unset, which is the default on Amazon Linux, distroless, and many minimal container images.

### Repro

```js
const src = URL.createObjectURL(new Blob(["postMessage(1)"], { type: "application/javascript" }));
for (let i = 0; i < 8; i++) {
  const w = new Worker(src);
  await new Promise(r => (w.onmessage = r));
  w.terminate();
}
```

Each Worker performs a few hundred `openat`/`read`/`fstat` over `/usr/share/zoneinfo/**` before running any user code, serialized on a process-global lock. Measured with the kernel's `syscr` counter from `/proc/self/io`, 8 Workers, `TZ` unset:

| | regular-file `/etc/localtime` | symlink `/etc/localtime` |
|---|---|---|
| before | 1971 read syscalls | 44 |
| after | 112 | unchanged |

With the regular file and `TZ=Etc/UTC`, the before count is also 44, confirming the scan is the whole difference. In the same binary after the fix, the regular-file and symlink counts match.

### Cause

Every `new Worker` constructs a new `JSC::VM`. For large-heap VMs, `VM::VM` eagerly resolves the time zone (`dateCache.timeZoneDisplayName(false)` in `VM.cpp`), which reaches `retrieveTimeZoneInformation()` in `JSDateMath.cpp`. That function has a cross-VM cache, but its staleness check is `#if PLATFORM(COCOA)`, and Bun builds JSC as the JSCOnly port, which never defines `PLATFORM(COCOA)` on any OS (`PlatformLegacy.h`: `JSCOnly does not provide PLATFORM() macro`). So for Bun it unconditionally re-detects in every VM, calling `ucal_getHostTimeZone()`.

ICU's host detection with `TZ` unset reads `/etc/localtime`. If it is a symlink, the zone name comes from `readlink`. If it is a regular file, ICU names it by content-comparing it against every file under `/usr/share/zoneinfo` (`searchForTZFile` in ICU's `putil.cpp`), and `TimeZone::detectHostTimeZone()` explicitly clears ICU's own cache first, so the scan repeats for every VM.

Before calling `ucal_getHostTimeZone()`, `retrieveTimeZoneInformation()` checks WTF's process-global time-zone override (`getTimeZoneOverride`) and skips the detection entirely when it is non-empty. Bun already uses that override for `$TZ`, `process.env.TZ` assignment, and `bun:jsc`'s `setTimeZone()`, but never populates it when `TZ` is unset.

### Fix

In `Zig__GlobalObject__create`, right after the first large-heap VM is constructed, read back the zone its constructor just resolved (`vm.dateCache.defaultTimeZone()`) and install it as WTF's process-wide override via `WTF::setTimeZoneOverride`, under a `std::once_flag`. Every subsequent VM, including every Worker's, then takes the override fast path. Node resolves the host time zone once per process for the same reason.

- `$TZ`, `process.env.TZ` assignment, and `bun:jsc` `setTimeZone()` replace the override, so they still take precedence. With `$TZ` set, ICU resolves it from the environment without touching `/etc/localtime`, so nothing changes.
- `Intl.DateTimeFormat().resolvedOptions().timeZone`, `Date#getTimezoneOffset`, `Date#toString`, and `process.env.TZ` are byte-identical to the released build across unset, Olson, POSIX (`EST5EDT`), path-style, bogus, and empty `TZ`.
- The one intentional behavior change is the point of the fix: the host zone is resolved once at startup instead of once per Worker, so a Worker created after the host state changes mid-process (which the test constructs with a C-level `setenv()`) now agrees with the main thread instead of diverging.
- Gated on `!miniMode` so `--smol` keeps its existing lazy, on-first-`Date` detection (`VM::VM` only pre-resolves the zone for `HeapType::Large`).
- No new includes and no platform conditionals: the result is read from `JSC::DateCache`, which this file already uses, rather than by calling ICU directly. (An earlier revision called `ucal_getHostTimeZone()` from Bun, but `<unicode/ucal.h>` is not in the macOS JSC prebuilt's header set.)
- `BakeCreateProdGlobal` is the one other `VM::tryCreate(HeapType::Large)` site and is intentionally left alone: the main VM always exists first on that path, so the once-init has already run.

### Test

The syscall count is not observable from a test, so the test asserts the behavioral consequence of detecting once: a Worker created after the C-level `TZ` environment variable changes (via an FFI `setenv()`, which `process.env` assignment never reaches) must still agree with the main thread about the default time zone. On the released build it fails with

```
  {
    "exitCode": 0,
-   "workerTz": "UTC",
+   "workerTz": "Pacific/Kiritimati",
  }
```

because the Worker's VM re-ran the host detection and picked up the mutated `TZ`. The injected zone is chosen so it never equals the host's, and the child's exit code is asserted (with its stderr as the failure message) before its stdout is parsed.

Two pre-existing tests in the same file, "worker with event listeners doesn't close event loop" and "... 2", race the child against a hard-coded 1000ms kill timer; a debug+ASAN child needs ~1020ms, so they fail under `bun bd test` with or without this change. They are rewritten to await the child's exit while asserting the same properties: stdout is `done`, exit code 0, and `signalCode === null` (exited on its own, not killed).

`bun bd test test/js/web/workers/worker.test.ts`: 24 pass, 0 fail.