### PR TITLE
Harden bun.exe against DLL search-order hijacking on Windows

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -983,8 +983,9 @@ export const linkerFlags: Flag[] = [
   },
   {
     // Writes DependentLoadFlags into the PE load-config directory so the OS
-    // loader resolves bun.exe's static imports from System32 only. Delay-loads
-    // and runtime LoadLibrary are covered by SetDefaultDllDirectories in main().
+    // loader resolves bun.exe's static imports from System32 only. The
+    // /delayload set below is covered by the __pfnDliNotifyHook2 delay-load
+    // hook in src/jsc/bindings/WindowsDelayLoadHook.cpp.
     flag: "/DEPENDENTLOADFLAG:0x800",
     when: c => c.windows,
     desc: "Static DLL imports resolve from System32 only (LOAD_LIBRARY_SEARCH_SYSTEM32)",

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -982,6 +982,14 @@ export const linkerFlags: Flag[] = [
     desc: "18MB stack reserve (JSC uses deep recursion), no error limit",
   },
   {
+    // Writes DependentLoadFlags into the PE load-config directory so the OS
+    // loader resolves bun.exe's static imports from System32 only. Delay-loads
+    // and runtime LoadLibrary are covered by SetDefaultDllDirectories in main().
+    flag: "/DEPENDENTLOADFLAG:0x800",
+    when: c => c.windows,
+    desc: "Static DLL imports resolve from System32 only (LOAD_LIBRARY_SEARCH_SYSTEM32)",
+  },
+  {
     flag: "/DEBUG:FULL",
     when: c => c.windows && c.debug,
     desc: "Emit PDB so the crash handler can symbolize stack traces",

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -154,10 +154,17 @@ pub unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) -> c_int 
     // Restrict the default DLL search path to System32 before anything can
     // LoadLibrary (delay-load resolution, dbghelp, WIC, bcryptprimitives).
     // Explicit-path loads (`process.dlopen` of `.node` addons) are unaffected.
+    // The call cannot fail on supported Windows; the debug assert surfaces a
+    // regression on CI, and release degrades to the default (pre-hardening)
+    // search order rather than refusing to start over a defense-in-depth knob.
     #[cfg(windows)]
     {
-        let _ = bun_sys::windows::kernel32::SetDefaultDllDirectories(
+        let _hardened = bun_sys::windows::kernel32::SetDefaultDllDirectories(
             bun_sys::windows::kernel32::LOAD_LIBRARY_SEARCH_SYSTEM32,
+        ) != 0;
+        debug_assert!(
+            _hardened,
+            "SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32) failed"
         );
     }
 

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -151,23 +151,6 @@ pub extern "C" fn __lsan_default_suppressions() -> *const core::ffi::c_char {
 /// the entire process — guaranteed by the C runtime that calls this symbol.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) -> c_int {
-    // Restrict the default DLL search path to System32 before anything can
-    // LoadLibrary (delay-load resolution, dbghelp, WIC, bcryptprimitives).
-    // Explicit-path loads (`process.dlopen` of `.node` addons) are unaffected.
-    // The call cannot fail on supported Windows; the debug assert surfaces a
-    // regression on CI, and release degrades to the default (pre-hardening)
-    // search order rather than refusing to start over a defense-in-depth knob.
-    #[cfg(windows)]
-    {
-        let _hardened = bun_sys::windows::kernel32::SetDefaultDllDirectories(
-            bun_sys::windows::kernel32::LOAD_LIBRARY_SEARCH_SYSTEM32,
-        ) != 0;
-        debug_assert!(
-            _hardened,
-            "SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32) failed"
-        );
-    }
-
     // 0. Capture argv FIRST — before the crash handler, whose panic path
     //    dumps the command line via `bun_core::argv()`.
     //    SAFETY: `argc`/`argv` come from the C runtime; the argv block lives

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -151,6 +151,16 @@ pub extern "C" fn __lsan_default_suppressions() -> *const core::ffi::c_char {
 /// the entire process — guaranteed by the C runtime that calls this symbol.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) -> c_int {
+    // Restrict the default DLL search path to System32 before anything can
+    // LoadLibrary (delay-load resolution, dbghelp, WIC, bcryptprimitives).
+    // Explicit-path loads (`process.dlopen` of `.node` addons) are unaffected.
+    #[cfg(windows)]
+    {
+        let _ = bun_sys::windows::kernel32::SetDefaultDllDirectories(
+            bun_sys::windows::kernel32::LOAD_LIBRARY_SEARCH_SYSTEM32,
+        );
+    }
+
     // 0. Capture argv FIRST — before the crash handler, whose panic path
     //    dumps the command line via `bun_core::argv()`.
     //    SAFETY: `argc`/`argv` come from the C runtime; the argv block lives

--- a/src/jsc/bindings/SecretsWindows.cpp
+++ b/src/jsc/bindings/SecretsWindows.cpp
@@ -34,8 +34,9 @@ public:
     {
         if (loaded) return true;
 
-        // Load advapi32.dll which contains the Credential Manager API
-        handle = LoadLibraryW(L"advapi32.dll");
+        // Load advapi32.dll (Credential Manager API) from System32 only, so a
+        // same-named DLL planted in the application directory / CWD is ignored.
+        handle = LoadLibraryExW(L"advapi32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
         if (!handle) {
             return false;
         }

--- a/src/jsc/bindings/WindowsDelayLoadHook.cpp
+++ b/src/jsc/bindings/WindowsDelayLoadHook.cpp
@@ -1,0 +1,43 @@
+#include "root.h"
+
+#if OS(WINDOWS)
+
+#include <windows.h>
+#include <delayimp.h>
+
+// bun.exe delay-loads a set of Windows system DLLs (the /delayload list in
+// scripts/build/flags.ts). The default delay-load helper in delayimp.lib
+// resolves each one at first use with LoadLibraryExA(name, NULL, 0), which
+// searches the application directory (and, for names outside KnownDlls, the
+// CWD and PATH) before System32. Every name on that list is a Windows system
+// DLL that only legitimately lives in System32, so a same-named DLL planted
+// next to bun.exe would be loaded in its place.
+//
+// dliNotePreLoadLibrary lets this hook perform the load itself; the helper
+// uses the returned module instead of searching. Restricting that one load to
+// System32 closes the gap without touching the process-wide DLL search path,
+// so process.dlopen() of .node addons (and their sibling-directory
+// dependencies), bun:ffi dlopen(), bun:sqlite loadExtension(), and every
+// other LoadLibrary in the process resolve exactly as they do under node.exe.
+//
+// The delay-loaded names are guaranteed to exist in System32, so the
+// restricted load cannot fail on a functioning Windows install. If it ever
+// does, returning NULL lets the helper run its stock LoadLibraryExA, whose
+// own failure raises the usual delay-load exception.
+//
+// The matching restriction for bun.exe's static import table is
+// /DEPENDENTLOADFLAG:0x800 in scripts/build/flags.ts.
+static FARPROC WINAPI bunDelayLoadNotifyHook(unsigned dliNotify, PDelayLoadInfo pdli)
+{
+    if (dliNotify == dliNotePreLoadLibrary)
+        return reinterpret_cast<FARPROC>(::LoadLibraryExA(pdli->szDll, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
+    return nullptr;
+}
+
+// delayimp.lib declares this `extern "C" const` pointer and holds a default
+// NULL definition in a lazily pulled archive member. Defining it here, in an
+// object that is always part of the link, satisfies the reference first, so
+// __delayLoadHelper2 calls the hook above for every delay-loaded import.
+extern "C" const PfnDliHook __pfnDliNotifyHook2 = bunDelayLoadNotifyHook;
+
+#endif // OS(WINDOWS)

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -899,8 +899,8 @@ fn factory() -> Result<ComPtr<IWICImagingFactory>, BackendError> {
 fn load_factory() {
     // Resolve the one flat C export first; if windowscodecs.dll isn't present
     // we never attempt CoCreateInstance and the whole backend stays disabled.
-    // LOAD_LIBRARY_SEARCH_SYSTEM32 pins the load to %windir%\System32 even if
-    // this ever runs before main() sets the process-wide default.
+    // LOAD_LIBRARY_SEARCH_SYSTEM32 pins the load to %windir%\System32, so a
+    // same-named DLL planted in the application directory / CWD is ignored.
     // SAFETY: literal C string, null reserved handle; safe from any thread.
     let dll = unsafe {
         windows::LoadLibraryExA(

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -853,7 +853,7 @@ unsafe extern "system" {
 }
 
 /// `WICConvertBitmapSource` is the one flat export from windowscodecs.dll we
-/// need. Loaded lazily (LoadLibraryExA inside `loadFactory`) so the binary
+/// need. Loaded lazily (LoadLibraryExA inside `load_factory`) so the binary
 /// carries no import-table dependency on windowscodecs — nano-server / stripped
 /// containers without the WIC feature still launch and just fall back.
 type WICConvertBitmapSourceFn = unsafe extern "system" fn(

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -853,7 +853,7 @@ unsafe extern "system" {
 }
 
 /// `WICConvertBitmapSource` is the one flat export from windowscodecs.dll we
-/// need. Loaded lazily (LoadLibraryA inside `loadFactory`) so the binary
+/// need. Loaded lazily (LoadLibraryExA inside `loadFactory`) so the binary
 /// carries no import-table dependency on windowscodecs — nano-server / stripped
 /// containers without the WIC feature still launch and just fall back.
 type WICConvertBitmapSourceFn = unsafe extern "system" fn(
@@ -899,8 +899,16 @@ fn factory() -> Result<ComPtr<IWICImagingFactory>, BackendError> {
 fn load_factory() {
     // Resolve the one flat C export first; if windowscodecs.dll isn't present
     // we never attempt CoCreateInstance and the whole backend stays disabled.
-    // SAFETY: literal C string; LoadLibraryA is safe to call from any thread.
-    let dll = unsafe { windows::LoadLibraryA(c"windowscodecs.dll".as_ptr()) };
+    // LOAD_LIBRARY_SEARCH_SYSTEM32 pins the load to %windir%\System32 even if
+    // this ever runs before main() sets the process-wide default.
+    // SAFETY: literal C string, null reserved handle; safe from any thread.
+    let dll = unsafe {
+        windows::LoadLibraryExA(
+            c"windowscodecs.dll".as_ptr(),
+            ptr::null_mut(),
+            windows::kernel32::LOAD_LIBRARY_SEARCH_SYSTEM32,
+        )
+    };
     if dll.is_null() {
         return;
     }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3261,7 +3261,7 @@ pub fn GetProcAddressA(ptr: Option<*mut c_void>, utf8: &bun_core::ZStr) -> Optio
     if sym.is_null() { None } else { Some(sym) }
 }
 
-pub use bun_windows_sys::externs::LoadLibraryA;
+pub use bun_windows_sys::externs::{LoadLibraryA, LoadLibraryExA};
 
 unsafe extern "system" {
     #[link_name = "CreateHardLinkW"]

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -594,6 +594,11 @@ pub mod kernel32 {
     }
     pub const MEM_FREE: u32 = 0x10000;
 
+    /// `LOAD_LIBRARY_SEARCH_SYSTEM32` (`libloaderapi.h`): restrict the DLL
+    /// search path to `%windir%\System32`. Passed to `SetDefaultDllDirectories`
+    /// (process-wide default) and to `LoadLibraryEx*` (per-call).
+    pub const LOAD_LIBRARY_SEARCH_SYSTEM32: DWORD = 0x0000_0800;
+
     #[link(name = "kernel32")]
     unsafe extern "system" {
         /// No preconditions; reads thread-local Win32 error slot.
@@ -639,6 +644,11 @@ pub mod kernel32 {
             lpOverlapped: *mut c_void,
         ) -> BOOL;
         pub fn LoadLibraryExW(lpLibFileName: LPCWSTR, hFile: HANDLE, dwFlags: DWORD) -> HMODULE;
+        /// `SetDefaultDllDirectories` (`libloaderapi.h`): sets the process-wide
+        /// default DLL search path used by every `LoadLibrary[Ex]` call that does
+        /// not pass explicit `LOAD_LIBRARY_SEARCH_*` flags. No pointer
+        /// preconditions: `DirectoryFlags` is a by-value bitmask.
+        pub safe fn SetDefaultDllDirectories(DirectoryFlags: DWORD) -> BOOL;
         pub fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *mut DWORD) -> BOOL;
         /// `FlushFileBuffers` — fsync(2)-equivalent for HANDLE-backed files.
         pub fn FlushFileBuffers(hFile: HANDLE) -> BOOL;
@@ -1329,6 +1339,11 @@ unsafe extern "system" {
     pub fn GetProcAddress(ptr: *mut c_void, name: *const c_char) -> *mut c_void;
 
     pub fn LoadLibraryA(name: *const c_char) -> *mut c_void;
+
+    /// `LoadLibraryExA` (`libloaderapi.h`). `hFile` is reserved and must be
+    /// null; `dwFlags` takes the `LOAD_LIBRARY_SEARCH_*` /
+    /// `LOAD_WITH_ALTERED_SEARCH_PATH` bits.
+    pub fn LoadLibraryExA(name: *const c_char, hFile: *mut c_void, dwFlags: DWORD) -> *mut c_void;
 }
 
 // Declared as `extern "system"` so the callconv is correct on all targets

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -595,8 +595,9 @@ pub mod kernel32 {
     pub const MEM_FREE: u32 = 0x10000;
 
     /// `LOAD_LIBRARY_SEARCH_SYSTEM32` (`libloaderapi.h`): restrict the DLL
-    /// search path to `%windir%\System32`. Passed to `SetDefaultDllDirectories`
-    /// (process-wide default) and to `LoadLibraryEx*` (per-call).
+    /// search to `%windir%\System32`. Passed as `dwFlags` to `LoadLibraryEx*`
+    /// for loads of system DLLs that must not be satisfied from the
+    /// application directory, CWD, or `PATH`.
     pub const LOAD_LIBRARY_SEARCH_SYSTEM32: DWORD = 0x0000_0800;
 
     #[link(name = "kernel32")]
@@ -644,11 +645,6 @@ pub mod kernel32 {
             lpOverlapped: *mut c_void,
         ) -> BOOL;
         pub fn LoadLibraryExW(lpLibFileName: LPCWSTR, hFile: HANDLE, dwFlags: DWORD) -> HMODULE;
-        /// `SetDefaultDllDirectories` (`libloaderapi.h`): sets the process-wide
-        /// default DLL search path used by every `LoadLibrary[Ex]` call that does
-        /// not pass explicit `LOAD_LIBRARY_SEARCH_*` flags. No pointer
-        /// preconditions: `DirectoryFlags` is a by-value bitmask.
-        pub safe fn SetDefaultDllDirectories(DirectoryFlags: DWORD) -> BOOL;
         pub fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *mut DWORD) -> BOOL;
         /// `FlushFileBuffers` — fsync(2)-equivalent for HANDLE-backed files.
         pub fn FlushFileBuffers(hFile: HANDLE) -> BOOL;

--- a/test/js/bun/symbols.test.ts
+++ b/test/js/bun/symbols.test.ts
@@ -174,4 +174,36 @@ if (process.platform === "win32") {
     // Sanity check: we actually parsed something meaningful.
     expect(imports.some(i => i.dll.toLowerCase() === "kernel32.dll")).toBe(true);
   });
+
+  // 0x800 = LOAD_LIBRARY_SEARCH_SYSTEM32, written into the PE load-config
+  // directory by /DEPENDENTLOADFLAG:0x800 (scripts/build/flags.ts). Without it
+  // the loader resolves static imports via the default search order (the
+  // application directory is checked BEFORE System32), so a same-named DLL
+  // planted next to bun.exe is loaded instead of the real system DLL.
+  // Delay-loads and runtime LoadLibrary are covered separately by
+  // SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32) in src/bun_bin/lib.rs.
+  test("PE load-config restricts static DLL imports to System32", async () => {
+    const readobj = Bun.which("llvm-readobj");
+    if (!readobj) {
+      throw new Error("llvm-readobj not found. It ships with LLVM (required to build bun).");
+    }
+
+    // --coff-load-config dumps IMAGE_LOAD_CONFIG_DIRECTORY64. The field prints
+    // as `  DependentLoadFlags: 0x800`.
+    const output = await $`${readobj} --coff-load-config ${BUN_EXE}`.text();
+
+    const match = output.match(/^\s*DependentLoadFlags:\s*(0x[0-9a-fA-F]+)\s*$/m);
+    if (!match) {
+      // A missing line means the PE has no load-config directory at all (the
+      // MSVC CRT's `_load_config_used` symbol did not make it into the link),
+      // not just an unset flag. Fail loudly rather than silently passing.
+      throw new Error(
+        `llvm-readobj --coff-load-config did not report DependentLoadFlags for ${BUN_EXE}.\n` +
+          `Either bun.exe lost its PE load-config directory or the llvm-readobj output format changed.\n\n` +
+          output.slice(0, 1000),
+      );
+    }
+
+    expect(Number(match[1])).toBe(0x800);
+  });
 }

--- a/test/js/bun/symbols.test.ts
+++ b/test/js/bun/symbols.test.ts
@@ -247,14 +247,19 @@ if (process.platform === "win32") {
       // parent's ("Path"); mergeWindowEnvs collapses the casings so exactly
       // one PATH reaches the child instead of a conflicting Path + PATH pair.
       env: mergeWindowEnvs([bunEnv, { PATH: `${String(plantDir)};${process.env.PATH || process.env.Path || ""}` }]),
+      stderr: "pipe",
     });
 
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // An unhardened bun resolves the bare name through the PATH leg of the
     // default search, so the load succeeds and the message is the later
-    // "Symbol ... not found" instead, which fails this assertion.
-    expect(stdout).toContain(`Failed to open library "${PROBE}"`);
-    expect(exitCode).toBe(0);
+    // "Symbol ... not found" instead, which fails this assertion. stderr is
+    // in the received object so a failure diff shows it, but it is never
+    // asserted empty (debug/ASAN builds emit benign warnings there).
+    expect({ exitCode, stderr, stdout }).toMatchObject({
+      exitCode: 0,
+      stdout: expect.stringContaining(`Failed to open library "${PROBE}"`),
+    });
   });
 }

--- a/test/js/bun/symbols.test.ts
+++ b/test/js/bun/symbols.test.ts
@@ -1,8 +1,8 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isArm64, mergeWindowEnvs, tempDir } from "harness";
 import { copyFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, isArm64, mergeWindowEnvs, tempDir } from "harness";
 
 const BUN_EXE = bunExe();
 

--- a/test/js/bun/symbols.test.ts
+++ b/test/js/bun/symbols.test.ts
@@ -1,6 +1,8 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
-import { bunExe } from "harness";
+import { copyFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, isArm64, mergeWindowEnvs, tempDir } from "harness";
 
 const BUN_EXE = bunExe();
 
@@ -205,5 +207,54 @@ if (process.platform === "win32") {
     }
 
     expect(Number(match[1])).toBe(0x800);
+  });
+
+  // Runtime counterpart to the load-config assertion above: proves that
+  // SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32) in main()
+  // (src/bun_bin/lib.rs) actually took effect for the whole process.
+  //
+  // A real System32 DLL is copied under a synthetic name into a directory that
+  // is then prepended to a child bun's PATH. `bun:ffi`'s dlopen() first does a
+  // plain default-search-order LoadLibrary on the bare name. Without the
+  // hardening, the PATH leg of the default search finds the copy, the library
+  // loads, and dlopen() gets as far as the bogus symbol lookup ("Symbol ... not
+  // found"). With it, only System32 is searched, the synthetic name is not
+  // there, dlopen()'s cwd-relative fallback also misses (the child's cwd is a
+  // separate empty directory), and it throws "Failed to open library".
+  //
+  // bun:ffi is not built on windows-arm64 (tinycc has no arm64-coff backend).
+  test.skipIf(isArm64)("SetDefaultDllDirectories removes PATH from the default DLL search order", async () => {
+    // version.dll: tiny, dependency-free beyond KnownDlls, no DllMain side
+    // effects, so a byte-for-byte copy under another name loads cleanly.
+    const source = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "version.dll");
+    expect(existsSync(source)).toBe(true);
+
+    const PROBE = "bun-dll-search-probe.dll";
+    using plantDir = tempDir("dll-search-plant", {});
+    using cwdDir = tempDir("dll-search-cwd", {});
+    copyFileSync(source, join(String(plantDir), PROBE));
+
+    const script =
+      `try {` +
+      `  require("bun:ffi").dlopen(${JSON.stringify(PROBE)}, { bun_dll_search_probe_symbol: { args: [], returns: "int" } });` +
+      `  console.log("LOADED");` +
+      `} catch (e) { console.log(String(e && e.message)); }`;
+
+    await using proc = Bun.spawn({
+      cmd: [BUN_EXE, "-e", script],
+      cwd: String(cwdDir),
+      // Windows env var names are case-insensitive and bunEnv inherits the
+      // parent's ("Path"); mergeWindowEnvs collapses the casings so exactly
+      // one PATH reaches the child instead of a conflicting Path + PATH pair.
+      env: mergeWindowEnvs([bunEnv, { PATH: `${String(plantDir)};${process.env.PATH || process.env.Path || ""}` }]),
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    // An unhardened bun resolves the bare name through the PATH leg of the
+    // default search, so the load succeeds and the message is the later
+    // "Symbol ... not found" instead, which fails this assertion.
+    expect(stdout).toContain(`Failed to open library "${PROBE}"`);
+    expect(exitCode).toBe(0);
   });
 }

--- a/test/js/bun/symbols.test.ts
+++ b/test/js/bun/symbols.test.ts
@@ -1,8 +1,6 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isArm64, mergeWindowEnvs, tempDir } from "harness";
-import { copyFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { bunExe } from "harness";
 
 const BUN_EXE = bunExe();
 
@@ -181,9 +179,9 @@ if (process.platform === "win32") {
   // directory by /DEPENDENTLOADFLAG:0x800 (scripts/build/flags.ts). Without it
   // the loader resolves static imports via the default search order (the
   // application directory is checked BEFORE System32), so a same-named DLL
-  // planted next to bun.exe is loaded instead of the real system DLL.
-  // Delay-loads and runtime LoadLibrary are covered separately by
-  // SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32) in src/bun_bin/lib.rs.
+  // planted next to bun.exe is loaded instead of the real system DLL. The
+  // /delayload set is covered separately by the __pfnDliNotifyHook2 hook in
+  // src/jsc/bindings/WindowsDelayLoadHook.cpp.
   test("PE load-config restricts static DLL imports to System32", async () => {
     const readobj = Bun.which("llvm-readobj");
     if (!readobj) {
@@ -207,59 +205,5 @@ if (process.platform === "win32") {
     }
 
     expect(Number(match[1])).toBe(0x800);
-  });
-
-  // Runtime counterpart to the load-config assertion above: proves that
-  // SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32) in main()
-  // (src/bun_bin/lib.rs) actually took effect for the whole process.
-  //
-  // A real System32 DLL is copied under a synthetic name into a directory that
-  // is then prepended to a child bun's PATH. `bun:ffi`'s dlopen() first does a
-  // plain default-search-order LoadLibrary on the bare name. Without the
-  // hardening, the PATH leg of the default search finds the copy, the library
-  // loads, and dlopen() gets as far as the bogus symbol lookup ("Symbol ... not
-  // found"). With it, only System32 is searched, the synthetic name is not
-  // there, dlopen()'s cwd-relative fallback also misses (the child's cwd is a
-  // separate empty directory), and it throws "Failed to open library".
-  //
-  // bun:ffi is not built on windows-arm64 (tinycc has no arm64-coff backend).
-  test.skipIf(isArm64)("SetDefaultDllDirectories removes PATH from the default DLL search order", async () => {
-    // version.dll: tiny, dependency-free beyond KnownDlls, no DllMain side
-    // effects, so a byte-for-byte copy under another name loads cleanly.
-    const source = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "version.dll");
-    expect(existsSync(source)).toBe(true);
-
-    const PROBE = "bun-dll-search-probe.dll";
-    using plantDir = tempDir("dll-search-plant", {});
-    using cwdDir = tempDir("dll-search-cwd", {});
-    copyFileSync(source, join(String(plantDir), PROBE));
-
-    const script =
-      `try {` +
-      `  require("bun:ffi").dlopen(${JSON.stringify(PROBE)}, { bun_dll_search_probe_symbol: { args: [], returns: "int" } });` +
-      `  console.log("LOADED");` +
-      `} catch (e) { console.log(String(e && e.message)); }`;
-
-    await using proc = Bun.spawn({
-      cmd: [BUN_EXE, "-e", script],
-      cwd: String(cwdDir),
-      // Windows env var names are case-insensitive and bunEnv inherits the
-      // parent's ("Path"); mergeWindowEnvs collapses the casings so exactly
-      // one PATH reaches the child instead of a conflicting Path + PATH pair.
-      env: mergeWindowEnvs([bunEnv, { PATH: `${String(plantDir)};${process.env.PATH || process.env.Path || ""}` }]),
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    // An unhardened bun resolves the bare name through the PATH leg of the
-    // default search, so the load succeeds and the message is the later
-    // "Symbol ... not found" instead, which fails this assertion. stderr is
-    // in the received object so a failure diff shows it, but it is never
-    // asserted empty (debug/ASAN builds emit benign warnings there).
-    expect({ exitCode, stderr, stdout }).toMatchObject({
-      exitCode: 0,
-      stdout: expect.stringContaining(`Failed to open library "${PROBE}"`),
-    });
   });
 }


### PR DESCRIPTION
### What

`bun.exe` has no DLL search-path hardening: no `/DEPENDENTLOADFLAG` in the link, and its DLL loads use the default Windows search order. The default order checks the application directory before `System32`, and for names not in the KnownDlls list it also checks the CWD and `PATH`. So a DLL named after one of bun's system dependencies, dropped next to `bun.exe` (or, for non-KnownDlls, in the working directory), is loaded in place of the real one. The reachable names:

- the eight `/delayload` DLLs in the release link (`ole32`, `WINMM`, `dbghelp`, `WS2_32`, `WSOCK32`, `ADVAPI32`, `IPHLPAPI`, `CRYPT32`), resolved by the default delay-load helper in `delayimp.lib` via `LoadLibraryExA(name, NULL, 0)`
- `windowscodecs.dll` (`Bun.Image`'s WIC backend) and `advapi32.dll` (`Bun.secrets`), loaded lazily by bare name
- the static import table itself

`dbghelp.dll` and `windowscodecs.dll` are not KnownDlls, so they are hijackable from both the application directory and the CWD. This is same-user (whoever can write to `%USERPROFILE%\.bun\bin` could also replace `bun.exe`), so it is defense in depth rather than a privilege boundary. It matters for code-signing integrity and for `bun.exe` launched from a directory less trusted than the binary.

### Fix

Every DLL `bun.exe` itself loads by bare name is a Windows system DLL that lives only in `System32`, so restrict each of bun's own load mechanisms to `System32`. Three scoped changes, none of which touches the process-wide DLL search path:

1. **`/DEPENDENTLOADFLAG:0x800`** (`scripts/build/flags.ts`). Written into the PE load-config directory; the OS loader then resolves the static import table from `System32` only. `0x800` is `LOAD_LIBRARY_SEARCH_SYSTEM32`. This flag does not affect delay-loads (the standard delay-load helper ignores `DependentLoadFlags`), hence:
2. **A delay-load notification hook** (`src/jsc/bindings/WindowsDelayLoadHook.cpp`). `delayimp.lib`, which bun already links for `/delayload`, resolves each delay-loaded import on first use with `LoadLibraryExA(name, NULL, 0)`, meaning the default search order. `__pfnDliNotifyHook2` lets a program perform that load itself, so the hook does it with `LoadLibraryExA(name, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)`. This covers exactly the eight delay-loaded DLLs and nothing else.
3. The two explicit bare-name system-DLL loads switch to `LoadLibraryEx(..., LOAD_LIBRARY_SEARCH_SYSTEM32)`: `windowscodecs.dll` in `src/runtime/image/backend_wic.rs` and `advapi32.dll` in `src/jsc/bindings/SecretsWindows.cpp`.

### Why not a process-wide `SetDefaultDllDirectories`

An earlier revision of this PR called `SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32)` at the top of `main()` instead of #2, on the claim that `.node` addons were unaffected because `LOAD_WITH_ALTERED_SEARCH_PATH` with an absolute path is documented as exempt. Review showed that claim does not hold up: MSDN scopes the process default it installs to calls made with no `LOAD_LIBRARY_SEARCH_*` flags, and `LOAD_WITH_ALTERED_SEARCH_PATH` (`0x8`) is not one of those flags. Under that reading, the sibling-directory dependent DLLs of every `.node` addon (sharp's `libvips-42.dll`, canvas) would resolve from `System32` only and `require()` would fail with `ERROR_MOD_NOT_FOUND`. It would also have regressed bare or CWD-relative names in `bun:sqlite`'s `loadExtension()`, a `bun:ffi` `dlopen()` target's own sibling dependencies, and the `tracy.dll` probe.

Risking the Windows native-addon ecosystem is not an acceptable trade for a defense-in-depth change, and the question is not empirically resolvable without a Windows machine to test `require("sharp")` on. The delay-load hook covers the same gap (the application-directory plant of a delay-loaded system DLL is the scenario this PR exists for) with no ambiguity and no blast radius: it is scoped to bun's own eight delay imports, and `process.dlopen`, `bun:ffi`, `bun:sqlite`, `AddDllDirectory`, `PATH`, and every third-party addon behave exactly as they do under `node.exe`, which does not change the process default either.

### Compatibility

Nothing in this PR changes the process-wide DLL search path. The three mechanisms affect only DLLs that `bun.exe` loads itself, all of which are Windows system DLLs that exist only in `System32`. Native addons, `bun:ffi`, `bun:sqlite`, and `Database.setCustomSQLite()` are untouched.

### Verification

- `test/js/bun/symbols.test.ts` gains a test that runs `llvm-readobj --coff-load-config bun.exe` and asserts `DependentLoadFlags` is exactly `0x800`, failing loudly rather than vacuously if the PE ever loses its load-config directory. The flag and the parser were validated against real PEs built locally: `lld-link /dependentloadflag:0x800` yields `DependentLoadFlags: 0x800`; without the flag the field reads `0x0`, so the assertion fails on an unhardened binary.
- The delay-load hook is only exercised by a release link (`/delayload` is release-only), so it is not reachable from the CI test lanes, which run the debug binary. That is the same testability class as `/delayload` itself. Manual check on a Windows release build: drop a stub `dbghelp.dll` next to `bun.exe` and run `bun --version`; with the hook the stub is ignored.
- `cargo check -p bun_bin` is green for `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`, and the Linux host.
- The Windows CI build lanes (`build-cpp`, `build-rust`, `build-bun`, `verify-baseline`) pass for `windows-x64`, `windows-x64-baseline`, and `windows-aarch64` on the final revision. That covers the one piece that could not be verified locally: `WindowsDelayLoadHook.cpp` compiles against the real MSVC headers (`delayimp.h`), and the link with `/DEPENDENTLOADFLAG:0x800` plus the `__pfnDliNotifyHook2` definition against `delayimp.lib` succeeds with no duplicate-symbol conflict.

