### PR TITLE
redis: clear the cached connectionPromise when connect() fails synchronously

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -979,8 +979,7 @@ impl JSValkeyClient {
             return Ok(promise);
         }
 
-        let promise_ptr = JSPromise::create(global_object);
-        let promise = promise_ptr.to_js();
+        let promise = JSPromise::create(global_object).to_js();
         Js::connection_promise_set_cached(this_value, global_object, promise);
 
         // If was manually closed, reset that flag
@@ -998,7 +997,7 @@ impl JSValkeyClient {
 
             if let Err(err) = self.connect() {
                 self.poll_ref.with_mut(|r| r.unref(vm_event_loop_ctx()));
-                self.reject_connection_promise(global_object, this_value, &mut *promise_ptr, err)?;
+                self.reject_connection_promise(global_object, this_value, err)?;
                 return Ok(promise);
             }
 
@@ -1014,7 +1013,7 @@ impl JSValkeyClient {
                     // reconnect() reported the failure through the onclose callback but
                     // never started a socket, so no event would ever settle the promise.
                     self.client_mut().flags.is_reconnecting = false;
-                    self.reject_connection_promise(global_object, this_value, promise_ptr, err)?;
+                    self.reject_connection_promise(global_object, this_value, err)?;
                 }
             }
             _ => {}
@@ -1023,17 +1022,20 @@ impl JSValkeyClient {
         Ok(promise)
     }
 
-    /// A synchronous connect() failure inside do_connect means no socket event
-    /// will ever settle the promise it just cached; clear the slot and reject
-    /// here, the same way on_valkey_connect and on_valkey_close settle it.
+    /// A synchronous connect() failure means no socket event will ever settle
+    /// the cached connectionPromise; take it out of the slot and reject it, the
+    /// same way on_valkey_connect and on_valkey_close settle it. No-op when the
+    /// slot is empty (the reconnect timer firing with no connect() pending).
     fn reject_connection_promise(
         &self,
         global_object: &JSGlobalObject,
         this_value: JSValue,
-        promise_ptr: &mut JSPromise,
         err: bun_core::Error,
     ) -> JsResult<()> {
         self.client_mut().flags.needs_to_open_socket = true;
+        let Some(cached) = Js::connection_promise_get_cached(this_value) else {
+            return Ok(());
+        };
         Js::connection_promise_set_cached(this_value, global_object, JSValue::ZERO);
         let err_value = global_object
             .err(
@@ -1042,7 +1044,9 @@ impl JSValkeyClient {
             )
             .to_js();
         let _exit = self.vm().enter_event_loop_scope();
-        promise_ptr.reject(global_object, Ok(err_value))?;
+        // `JSPromise` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
+        // The cached slot only ever holds a JSPromise.
+        JSPromise::opaque_mut(cached.as_promise().unwrap()).reject(global_object, Ok(err_value))?;
         Ok(())
     }
 
@@ -1226,13 +1230,19 @@ impl JSValkeyClient {
         // remains live past this call.
         unsafe { JSValkeyClient::deref(std::ptr::from_ref(self).cast_mut()) };
 
-        // Execute reconnection logic. The onclose callback already fired inside
-        // reconnect(); there is no promise to settle on the timer path.
-        let _ = self.reconnect();
+        // A .connect() promise can still be cached here: on_close()'s
+        // auto-reconnect branch schedules this timer without ever reaching
+        // on_valkey_close(), which is what normally clears and settles it.
+        if let Err(err) = self.reconnect() {
+            if let Some(this_value) = self.this_value.get().try_get() {
+                let _ = self.reject_connection_promise(&self.global_object, this_value, err);
+            }
+        }
     }
 
-    /// Returns the error when `connect()` fails synchronously, so `do_connect`
-    /// can settle the connection promise it cached (nothing else will).
+    /// Returns the error when `connect()` fails synchronously: nothing else
+    /// will settle a connectionPromise cached before the attempt, so the
+    /// caller must (see `reject_connection_promise`).
     pub fn reconnect(&self) -> Result<(), bun_core::Error> {
         if !self.client.get().flags.is_reconnecting {
             return Ok(());

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1234,9 +1234,14 @@ impl JSValkeyClient {
         // auto-reconnect branch schedules this timer without ever reaching
         // on_valkey_close(), which is what normally clears and settles it.
         if let Err(err) = self.reconnect() {
+            // No socket was created, so no close event will arrive to schedule
+            // another attempt; a stale is_reconnecting would keep update_poll_ref
+            // holding a strong this_value root forever and leak the JS wrapper.
+            self.client_mut().flags.is_reconnecting = false;
             if let Some(this_value) = self.this_value.get().try_get() {
                 let _ = self.reject_connection_promise(&self.global_object, this_value, err);
             }
+            self.update_poll_ref();
         }
     }
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -998,19 +998,7 @@ impl JSValkeyClient {
 
             if let Err(err) = self.connect() {
                 self.poll_ref.with_mut(|r| r.unref(vm_event_loop_ctx()));
-                self.client_mut().flags.needs_to_open_socket = true;
-                // Clear the cached slot before settling, like on_valkey_connect and
-                // on_valkey_close do. A stale settled promise here gets settled again
-                // by those paths, and a later connect() returns it instead of retrying.
-                Js::connection_promise_set_cached(this_value, global_object, JSValue::ZERO);
-                let err_value = global_object
-                    .err(
-                        jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,
-                        format_args!(" {} connecting to Valkey", err.name()),
-                    )
-                    .to_js();
-                let _exit = self.vm().enter_event_loop_scope();
-                promise_ptr.reject(global_object, Ok(err_value))?;
+                self.reject_connection_promise(global_object, this_value, &mut *promise_ptr, err)?;
                 return Ok(promise);
             }
 
@@ -1022,12 +1010,40 @@ impl JSValkeyClient {
             valkey::Status::Disconnected => {
                 self.client_mut().flags.is_reconnecting = true;
                 self.client_mut().retry_attempts = 0;
-                self.reconnect();
+                if let Err(err) = self.reconnect() {
+                    // reconnect() reported the failure through the onclose callback but
+                    // never started a socket, so no event would ever settle the promise.
+                    self.client_mut().flags.is_reconnecting = false;
+                    self.reject_connection_promise(global_object, this_value, promise_ptr, err)?;
+                }
             }
             _ => {}
         }
 
         Ok(promise)
+    }
+
+    /// A synchronous connect() failure inside do_connect means no socket event
+    /// will ever settle the promise it just cached; clear the slot and reject
+    /// here, the same way on_valkey_connect and on_valkey_close settle it.
+    fn reject_connection_promise(
+        &self,
+        global_object: &JSGlobalObject,
+        this_value: JSValue,
+        promise_ptr: &mut JSPromise,
+        err: bun_core::Error,
+    ) -> JsResult<()> {
+        self.client_mut().flags.needs_to_open_socket = true;
+        Js::connection_promise_set_cached(this_value, global_object, JSValue::ZERO);
+        let err_value = global_object
+            .err(
+                jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,
+                format_args!(" {} connecting to Valkey", err.name()),
+            )
+            .to_js();
+        let _exit = self.vm().enter_event_loop_scope();
+        promise_ptr.reject(global_object, Ok(err_value))?;
+        Ok(())
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1210,18 +1226,21 @@ impl JSValkeyClient {
         // remains live past this call.
         unsafe { JSValkeyClient::deref(std::ptr::from_ref(self).cast_mut()) };
 
-        // Execute reconnection logic
-        self.reconnect();
+        // Execute reconnection logic. The onclose callback already fired inside
+        // reconnect(); there is no promise to settle on the timer path.
+        let _ = self.reconnect();
     }
 
-    pub fn reconnect(&self) {
+    /// Returns the error when `connect()` fails synchronously, so `do_connect`
+    /// can settle the connection promise it cached (nothing else will).
+    pub fn reconnect(&self) -> Result<(), bun_core::Error> {
         if !self.client.get().flags.is_reconnecting {
-            return;
+            return Ok(());
         }
 
         if self.vm().is_shutting_down() {
             bun_core::hint::cold();
-            return;
+            return Ok(());
         }
 
         // Ref to keep this alive during the reconnection
@@ -1245,11 +1264,12 @@ impl JSValkeyClient {
                     .to_js(),
             );
             self.poll_ref.with_mut(|r| r.disable());
-            return;
+            return Err(err);
         }
 
         // Reset the socket timeout
         self.reset_connection_timeout();
+        Ok(())
     }
 
     // Callback for when Valkey client connects

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -999,6 +999,10 @@ impl JSValkeyClient {
             if let Err(err) = self.connect() {
                 self.poll_ref.with_mut(|r| r.unref(vm_event_loop_ctx()));
                 self.client_mut().flags.needs_to_open_socket = true;
+                // Clear the cached slot before settling, like on_valkey_connect and
+                // on_valkey_close do. A stale settled promise here gets settled again
+                // by those paths, and a later connect() returns it instead of retrying.
+                Js::connection_promise_set_cached(this_value, global_object, JSValue::ZERO);
                 let err_value = global_object
                     .err(
                         jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,

--- a/test/js/valkey/valkey-connect-retry.test.ts
+++ b/test/js/valkey/valkey-connect-retry.test.ts
@@ -173,36 +173,55 @@ test.skipIf(isWindows).concurrent("connect() rejects when a synchronous reconnec
 // The third connect path: on_close()'s auto-reconnect branch schedules
 // on_reconnect_timer without ever reaching on_valkey_close(), so the .connect()
 // promise is still cached when the timer fires. If reconnect()'s connect(2)
-// then fails synchronously, that promise must still settle.
+// then fails synchronously, that promise must still settle, and the failure
+// must also release the strong this_value root that on_close's auto-reconnect
+// bookkeeping took, or every such client leaks for the life of the process.
+const TIMER_ROUNDS = 8;
 test
   .skipIf(isWindows)
   .concurrent("connect() rejects when the auto-reconnect timer's attempt fails synchronously", async () => {
     const { stdout, stderr, exitCode, signalCode } = await run(
       "vk-reconnect-timer",
       /* ts */ `
+        import { heapStats } from "bun:jsc";
         import { rmSync } from "node:fs";
         import { RedisClient } from "bun";
         import { join } from "node:path";
         import { listenRespOk } from "./server.ts";
         const sock = join(import.meta.dir, "s");
-        const server = listenRespOk(sock);
-        // connectionTimeout: 0 disables the connection-timeout timer so the
-        // process can exit naturally once the promise settles.
-        const client = new RedisClient(\`redis+unix://\${sock}\`, { connectionTimeout: 0 });
-        const pending = client.connect().then(() => "resolved", (e) => e?.code);
-        // Kill the target in the same tick, before the handshake can complete.
-        // The socket close takes the auto-reconnect branch; the reconnect timer
-        // then retries connect(2) against a path that no longer exists.
-        server.stop(true);
-        rmSync(sock, { force: true });
-        console.log(JSON.stringify({ first: await pending }));
+        // Scoped to a function so the only thing that can keep a client alive
+        // after it returns is a leaked native strong this_value root.
+        async function connectThenLoseTheTarget() {
+          const server = listenRespOk(sock);
+          // connectionTimeout: 0 disables the connection-timeout timer so the
+          // process can exit naturally once the promise settles.
+          const client = new RedisClient(\`redis+unix://\${sock}\`, { connectionTimeout: 0 });
+          const pending = client.connect().then(() => "resolved", (e) => e?.code);
+          // Kill the target in the same tick, before the handshake can complete.
+          // The socket close takes the auto-reconnect branch; the reconnect timer
+          // then retries connect(2) against a path that no longer exists.
+          server.stop(true);
+          rmSync(sock, { force: true });
+          return await pending;
+        }
+        const results = new Set();
+        for (let i = 0; i < ${TIMER_ROUNDS}; i++) results.add(await connectThenLoseTheTarget());
+        Bun.gc(true);
+        await 1;
+        Bun.gc(true);
+        const alive = heapStats().objectTypeCounts.RedisClient ?? 0;
+        console.log(JSON.stringify({ results: [...results], alive }));
       `,
     );
-    expect({ stdout, exitCode, signalCode }, stderr).toEqual({
-      stdout: JSON.stringify({ first: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION" }),
+    const out = stdout ? JSON.parse(stdout) : {};
+    expect({ results: out.results, exitCode, signalCode }, stderr).toEqual({
+      results: ["ERR_SOCKET_CLOSED_BEFORE_CONNECTION"],
       exitCode: 0,
       signalCode: null,
     });
+    // Every round leaked one client before the fix. The half-of-rounds bound
+    // leaves headroom for instances conservatively rooted by the stack.
+    expect(out.alive, stderr).toBeLessThan(TIMER_ROUNDS / 2);
   });
 
 // on_valkey_close also re-reads the cached connectionPromise. close() while a

--- a/test/js/valkey/valkey-connect-retry.test.ts
+++ b/test/js/valkey/valkey-connect-retry.test.ts
@@ -3,14 +3,15 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // A `redis+unix://` path with no listener makes `connect()` fail synchronously
 // (inside the `.connect()` call itself) instead of via a deferred socket error.
-// That branch of `do_connect` used to leave the already-rejected
-// `connectionPromise` in its cached slot, so:
+// A synchronous `connect()` failure used to leave the cached `connectionPromise`
+// in a state nothing would ever repair:
 //   1. a later `.connect()` returned the stale rejected promise and never retried
 //   2. once a later connection attempt (started by any command) progressed,
 //      `on_valkey_connect` / `on_valkey_close` settled that same promise again:
 //        ASSERTION FAILED: arg0->status() == JSC::JSPromise::Status::Pending
 //        void JSC__JSPromise__reject(JSC::JSPromise*, JSGlobalObject*, EncodedJSValue)
 //        src/jsc/bindings/bindings.cpp:3733
+//   3. on the reconnect paths the promise simply never settled
 // Each case runs in its own process because the second settle aborts the whole
 // process under ASSERT-enabled builds.
 
@@ -65,12 +66,14 @@ async function run(name: string, reproTs: string) {
     stdout: "pipe",
     stderr: "pipe",
   });
+  // `stderr` is not asserted (ASAN/debug builds emit benign noise); it is
+  // passed as expect()'s failure message so the aborting assertion is visible.
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
 }
 
 test.skipIf(isWindows).concurrent("RedisClient.connect() retries after a synchronous connect failure", async () => {
-  const { stdout, exitCode, signalCode } = await run(
+  const { stdout, stderr, exitCode, signalCode } = await run(
     "vk-retry",
     /* ts */ `
         import { RedisClient } from "bun";
@@ -90,7 +93,7 @@ test.skipIf(isWindows).concurrent("RedisClient.connect() retries after a synchro
         server.stop(true);
       `,
   );
-  expect({ stdout, exitCode, signalCode }).toEqual({
+  expect({ stdout, exitCode, signalCode }, stderr).toEqual({
     stdout: JSON.stringify({
       first: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION",
       wasConnected: false,
@@ -108,7 +111,7 @@ test.skipIf(isWindows).concurrent("RedisClient.connect() retries after a synchro
 test
   .skipIf(isWindows)
   .concurrent("a later successful connection does not settle the stale connectionPromise", async () => {
-    const { stdout, exitCode, signalCode } = await run(
+    const { stdout, stderr, exitCode, signalCode } = await run(
       "vk-resolve",
       /* ts */ `
         import { RedisClient } from "bun";
@@ -126,20 +129,20 @@ test
         server.stop(true);
       `,
     );
-    expect({ stdout, exitCode, signalCode }).toEqual({
+    expect({ stdout, exitCode, signalCode }, stderr).toEqual({
       stdout: JSON.stringify({ first: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION", got: "OK" }),
       exitCode: 0,
       signalCode: null,
     });
   });
 
-// do_connect's other connect path: once a client has connected (so
+// do_connect's second connect path: once a client has connected (so
 // needs_to_open_socket is false), a later .connect() routes through
 // reconnect(). Its synchronous connect() failure used to be swallowed into the
 // onclose callback, leaving the cached connectionPromise pending forever, so
 // .connect() hung and every later .connect() returned the same stale promise.
 test.skipIf(isWindows).concurrent("connect() rejects when a synchronous reconnect attempt fails", async () => {
-  const { stdout, exitCode, signalCode } = await run(
+  const { stdout, stderr, exitCode, signalCode } = await run(
     "vk-reconnect",
     /* ts */ `
         import { RedisClient } from "bun";
@@ -160,12 +163,47 @@ test.skipIf(isWindows).concurrent("connect() rejects when a synchronous reconnec
         console.log(JSON.stringify({ first, second }));
       `,
   );
-  expect({ stdout, exitCode, signalCode }).toEqual({
+  expect({ stdout, exitCode, signalCode }, stderr).toEqual({
     stdout: JSON.stringify({ first: "OK", second: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION" }),
     exitCode: 0,
     signalCode: null,
   });
 });
+
+// The third connect path: on_close()'s auto-reconnect branch schedules
+// on_reconnect_timer without ever reaching on_valkey_close(), so the .connect()
+// promise is still cached when the timer fires. If reconnect()'s connect(2)
+// then fails synchronously, that promise must still settle.
+test
+  .skipIf(isWindows)
+  .concurrent("connect() rejects when the auto-reconnect timer's attempt fails synchronously", async () => {
+    const { stdout, stderr, exitCode, signalCode } = await run(
+      "vk-reconnect-timer",
+      /* ts */ `
+        import { rmSync } from "node:fs";
+        import { RedisClient } from "bun";
+        import { join } from "node:path";
+        import { listenRespOk } from "./server.ts";
+        const sock = join(import.meta.dir, "s");
+        const server = listenRespOk(sock);
+        // connectionTimeout: 0 disables the connection-timeout timer so the
+        // process can exit naturally once the promise settles.
+        const client = new RedisClient(\`redis+unix://\${sock}\`, { connectionTimeout: 0 });
+        const pending = client.connect().then(() => "resolved", (e) => e?.code);
+        // Kill the target in the same tick, before the handshake can complete.
+        // The socket close takes the auto-reconnect branch; the reconnect timer
+        // then retries connect(2) against a path that no longer exists.
+        server.stop(true);
+        rmSync(sock, { force: true });
+        console.log(JSON.stringify({ first: await pending }));
+      `,
+    );
+    expect({ stdout, exitCode, signalCode }, stderr).toEqual({
+      stdout: JSON.stringify({ first: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION" }),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
 
 // on_valkey_close also re-reads the cached connectionPromise. close() while a
 // later attempt is still mid-connect rejects the stale promise a second time
@@ -173,7 +211,7 @@ test.skipIf(isWindows).concurrent("connect() rejects when a synchronous reconnec
 test
   .skipIf(isWindows)
   .concurrent("close() during a later connection attempt does not reject the stale connectionPromise", async () => {
-    const { stdout, exitCode, signalCode } = await run(
+    const { stdout, stderr, exitCode, signalCode } = await run(
       "vk-reject",
       /* ts */ `
         import { RedisClient } from "bun";
@@ -191,7 +229,7 @@ test
         server.stop(true);
       `,
     );
-    expect({ stdout, exitCode, signalCode }).toEqual({
+    expect({ stdout, exitCode, signalCode }, stderr).toEqual({
       stdout: JSON.stringify({ first: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION", got: "ERR_REDIS_CONNECTION_CLOSED" }),
       exitCode: 0,
       signalCode: null,

--- a/test/js/valkey/valkey-connect-retry.test.ts
+++ b/test/js/valkey/valkey-connect-retry.test.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// A `redis+unix://` path with no listener makes `connect()` fail synchronously
+// (inside the `.connect()` call itself) instead of via a deferred socket error.
+// That branch of `do_connect` used to leave the already-rejected
+// `connectionPromise` in its cached slot, so:
+//   1. a later `.connect()` returned the stale rejected promise and never retried
+//   2. once a later connection attempt (started by any command) progressed,
+//      `on_valkey_connect` / `on_valkey_close` settled that same promise again:
+//        ASSERTION FAILED: arg0->status() == JSC::JSPromise::Status::Pending
+//        void JSC__JSPromise__reject(JSC::JSPromise*, JSGlobalObject*, EncodedJSValue)
+//        src/jsc/bindings/bindings.cpp:3733
+// Each case runs in its own process because the second settle aborts the whole
+// process under ASSERT-enabled builds.
+
+// Minimal Redis-ish unix-socket server: frames complete RESP arrays
+// (*N\r\n followed by N bulk strings) and replies +OK to each. +OK is a valid
+// HELLO reply, so the client reaches the connected state without a real Redis.
+const SERVER_TS = /* ts */ `
+  function consumeRespArray(buf) {
+    if (buf.length < 4 || buf[0] !== 0x2a /* '*' */) return 0;
+    let eol = buf.indexOf("\\r\\n");
+    if (eol < 0) return 0;
+    const count = parseInt(buf.subarray(1, eol).toString("latin1"), 10);
+    let off = eol + 2;
+    for (let i = 0; i < count; i++) {
+      if (off >= buf.length || buf[off] !== 0x24 /* '$' */) return 0;
+      eol = buf.indexOf("\\r\\n", off);
+      if (eol < 0) return 0;
+      const len = parseInt(buf.subarray(off + 1, eol).toString("latin1"), 10);
+      off = eol + 2 + len + 2;
+      if (off > buf.length) return 0;
+    }
+    return off;
+  }
+
+  export function listenRespOk(unix) {
+    return Bun.listen({
+      unix,
+      socket: {
+        open(socket) {
+          socket.data = { buf: Buffer.alloc(0) };
+        },
+        data(socket, chunk) {
+          socket.data.buf = Buffer.concat([socket.data.buf, chunk]);
+          let consumed;
+          while ((consumed = consumeRespArray(socket.data.buf)) > 0) {
+            socket.data.buf = socket.data.buf.subarray(consumed);
+            socket.write("+OK\\r\\n");
+          }
+        },
+        error() {},
+      },
+    });
+  }
+`;
+
+async function run(name: string, reproTs: string) {
+  using dir = tempDir(name, { "server.ts": SERVER_TS, "repro.ts": reproTs });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "repro.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+}
+
+test.skipIf(isWindows).concurrent("RedisClient.connect() retries after a synchronous connect failure", async () => {
+  const { stdout, exitCode, signalCode } = await run(
+    "vk-retry",
+    /* ts */ `
+        import { RedisClient } from "bun";
+        import { join } from "node:path";
+        import { listenRespOk } from "./server.ts";
+        const sock = join(import.meta.dir, "s");
+        const client = new RedisClient(\`redis+unix://\${sock}\`);
+        // No listener at \`sock\` yet: connect(2) on the unix path fails synchronously.
+        const first = await client.connect().then(() => "resolved", (e) => e?.code);
+        const wasConnected = client.connected;
+        // The target exists now. connect() must start a new attempt rather than
+        // hand back the promise it already rejected above.
+        const server = listenRespOk(sock);
+        const second = await client.connect().then((v) => v, (e) => e?.code);
+        console.log(JSON.stringify({ first, wasConnected, second, connected: client.connected }));
+        client.close();
+        server.stop(true);
+      `,
+  );
+  expect({ stdout, exitCode, signalCode }).toEqual({
+    stdout: JSON.stringify({
+      first: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION",
+      wasConnected: false,
+      second: "OK",
+      connected: true,
+    }),
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+// on_valkey_connect re-reads the cached connectionPromise once the handshake
+// finishes. If the failed connect() left its rejected promise in the slot, this
+// resolves it a second time.
+test
+  .skipIf(isWindows)
+  .concurrent("a later successful connection does not settle the stale connectionPromise", async () => {
+    const { stdout, exitCode, signalCode } = await run(
+      "vk-resolve",
+      /* ts */ `
+        import { RedisClient } from "bun";
+        import { join } from "node:path";
+        import { listenRespOk } from "./server.ts";
+        const sock = join(import.meta.dir, "s");
+        const client = new RedisClient(\`redis+unix://\${sock}\`);
+        const first = await client.connect().then(() => "resolved", (e) => e?.code);
+        const server = listenRespOk(sock);
+        // .get() reconnects via a path that does not consult the cached slot, so
+        // the connection proceeds and on_valkey_connect settles the slot.
+        const got = await client.get("k");
+        console.log(JSON.stringify({ first, got }));
+        client.close();
+        server.stop(true);
+      `,
+    );
+    expect({ stdout, exitCode, signalCode }).toEqual({
+      stdout: JSON.stringify({ first: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION", got: "OK" }),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+// on_valkey_close also re-reads the cached connectionPromise. close() while a
+// later attempt is still mid-connect rejects the stale promise a second time
+// (the JSC__JSPromise__reject half of the assertion).
+test
+  .skipIf(isWindows)
+  .concurrent("close() during a later connection attempt does not reject the stale connectionPromise", async () => {
+    const { stdout, exitCode, signalCode } = await run(
+      "vk-reject",
+      /* ts */ `
+        import { RedisClient } from "bun";
+        import { join } from "node:path";
+        import { listenRespOk } from "./server.ts";
+        const sock = join(import.meta.dir, "s");
+        const client = new RedisClient(\`redis+unix://\${sock}\`);
+        const first = await client.connect().then(() => "resolved", (e) => e?.code);
+        const server = listenRespOk(sock);
+        // Start a fresh connection via .get(), then close before it completes.
+        const pending = client.get("k").then(() => "resolved", (e) => e?.code);
+        client.close();
+        const got = await pending;
+        console.log(JSON.stringify({ first, got }));
+        server.stop(true);
+      `,
+    );
+    expect({ stdout, exitCode, signalCode }).toEqual({
+      stdout: JSON.stringify({ first: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION", got: "ERR_REDIS_CONNECTION_CLOSED" }),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });

--- a/test/js/valkey/valkey-connect-retry.test.ts
+++ b/test/js/valkey/valkey-connect-retry.test.ts
@@ -133,6 +133,40 @@ test
     });
   });
 
+// do_connect's other connect path: once a client has connected (so
+// needs_to_open_socket is false), a later .connect() routes through
+// reconnect(). Its synchronous connect() failure used to be swallowed into the
+// onclose callback, leaving the cached connectionPromise pending forever, so
+// .connect() hung and every later .connect() returned the same stale promise.
+test.skipIf(isWindows).concurrent("connect() rejects when a synchronous reconnect attempt fails", async () => {
+  const { stdout, exitCode, signalCode } = await run(
+    "vk-reconnect",
+    /* ts */ `
+        import { RedisClient } from "bun";
+        import { join } from "node:path";
+        import { listenRespOk } from "./server.ts";
+        const sock = join(import.meta.dir, "s");
+        // Connect successfully first so the next connect() takes the
+        // reconnect() path rather than the needs_to_open_socket one.
+        const server = listenRespOk(sock);
+        const client = new RedisClient(\`redis+unix://\${sock}\`, { autoReconnect: false });
+        const first = await client.connect().then((v) => v, (e) => e?.code);
+        // Drop the server and wait for the client to observe the close.
+        server.stop(true);
+        while (client.connected) await new Promise((r) => setImmediate(r));
+        // Nothing listens at \`sock\` anymore: connect(2) fails synchronously
+        // inside reconnect(), and the promise must still settle.
+        const second = await client.connect().then(() => "resolved", (e) => e?.code);
+        console.log(JSON.stringify({ first, second }));
+      `,
+  );
+  expect({ stdout, exitCode, signalCode }).toEqual({
+    stdout: JSON.stringify({ first: "OK", second: "ERR_SOCKET_CLOSED_BEFORE_CONNECTION" }),
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
 // on_valkey_close also re-reads the cached connectionPromise. close() while a
 // later attempt is still mid-connect rejects the stale promise a second time
 // (the JSC__JSPromise__reject half of the assertion).


### PR DESCRIPTION
### What does this PR do?

Fixes a promise double-settle in `Bun.RedisClient` found by fuzzing.

`RedisClient.prototype.connect()` caches the pending promise it returns in the `connectionPromise` cached-property slot so concurrent `connect()` calls coalesce. When the socket cannot be created inside `connect()` itself (a `redis+unix://` path whose target does not exist, `socket(2)` failure, a `connect(2)` errno other than `EINPROGRESS`), `do_connect` rejected that promise but never cleared the slot.

`on_valkey_connect` (resolve) and `on_valkey_close` (reject) both read the slot and settle whatever is in it. With the already-rejected promise still cached, the next connection attempt to make progress settles it a second time:

```
ASSERTION FAILED: arg0->status() == JSC::JSPromise::Status::Pending
  void JSC__JSPromise__reject(JSC::JSPromise*, JSGlobalObject*, EncodedJSValue)
  src/jsc/bindings/bindings.cpp:3733
```

(and the `JSC__JSPromise__resolve` twin at bindings.cpp:3764 when the later attempt succeeds instead of closing). On debug/ASAN builds this aborts the process; release builds silently operate on a non-pending promise.

The stale slot also has a behavior bug visible on release builds: a later `connect()` returned the same rejected promise instead of starting a new attempt.

Reproduction (no fault injection, the unix path just doesn't exist yet):

```js
const sock = "/tmp/not-there-yet.sock";
const c = new Bun.RedisClient(`redis+unix://${sock}`);
await c.connect().catch(() => {}); // fails synchronously, rejected promise stays cached
Bun.listen({ unix: sock, socket: { data(s) { s.write("+OK\r\n"); } } });
const p = c.get("k"); // reconnects via send(), which does not consult the slot
c.close();            // on_valkey_close rejects the stale promise again -> abort
await p.catch(() => {});
```

The original fuzz case reached the same branch with an injected `EAGAIN` on the first `connect(2)`, which is the only way a numeric-IP target produces a synchronous (rather than deferred) connect failure.

The fix is to clear the cached slot before rejecting, the same thing `on_valkey_connect` and `on_valkey_close` already do before settling it.

### The other two paths to the same stale slot

Code review found the rest of the class. A synchronous `connect()` failure can strand the cached `connectionPromise` from three entry points, and only the first was covered above:

1. `do_connect`'s `needs_to_open_socket` branch (the original fix): rejected the promise but left it cached.
2. `do_connect`'s `Status::Disconnected` arm calls `reconnect()`, whose synchronous failure was swallowed into the `onclose` callback. The freshly-cached promise stayed pending forever, so that `.connect()` hung and every later `.connect()` returned the same stale promise.
3. `on_reconnect_timer` calls `reconnect()` too, and the cached promise can still be alive there: after an asynchronous socket failure, `on_close()`'s auto-reconnect branch schedules the timer without ever reaching `on_valkey_close()` (which is what normally clears and settles the slot). The timer path discarded the error, so the `.connect()` promise hung.

All three now go through one helper, `reject_connection_promise`, which takes whatever is in the cached slot, clears it, and rejects it, the same read-clear-settle shape `on_valkey_connect` and `on_valkey_close` already use. `reconnect()` returns the synchronous `connect()` error so its two callers can do that.

### A GC leak on the timer path

Code review also caught that settling the promise on path 3 is not enough to make the client collectible. `on_close()`'s auto-reconnect branch sets `is_reconnecting`, so `update_poll_ref` upgrades `this_value` to a strong GC root. Once the timer's synchronous `connect()` failure ends the retry loop, nothing cleared the flag or re-evaluated the root, so every such client stayed reachable for the life of the process. The timer's `Err` branch now clears `is_reconnecting` and runs `update_poll_ref()` (the same teardown `do_connect`'s `reconnect()` error branch does), which downgrades `this_value` and releases the root.

Intentionally left out of this PR: when a timer-driven reconnect fails synchronously, pending *commands* in the offline and in-flight queues also never settle, because `reconnect()` routes the error through the `onclose` callback rather than `ValkeyClient::fail`. Fixing that requires calling `on_valkey_close()` from a context that did not take the socket keep-alive ref its trailing deref assumes, which is a refcount change unrelated to the promise slot this PR is about.

### How did you verify your code works?

`test/js/valkey/valkey-connect-retry.test.ts` covers the symptoms against an in-process RESP server (no Redis needed), each in its own subprocess because the double settle aborts the whole process under assert-enabled builds:

- `connect()` after a synchronous failure retries instead of returning the stale rejected promise
- a later successful connection (the `on_valkey_connect` resolve path)
- `close()` during a later attempt (the `on_valkey_close` reject path, the frame above)
- `connect()` whose synchronous failure goes through `do_connect`'s `reconnect()` call still settles
- `connect()` whose socket dies and whose reconnect timer then fails synchronously still settles, and the client is collectible afterwards (8 rounds, then `Bun.gc(true)` and `heapStats().objectTypeCounts.RedisClient < 4`)

On a build with none of the fixes all five fail: two die with SIGABRT on the assertion and the reconnect ones hang until the test timeout. With only the first three fixes, the last test fails with 9 `RedisClient` instances still alive. With the full change all five pass. A 50-iteration run of the fuzzer's original shape (injected `connect` EAGAIN + torn `send` via `bun:internal-for-testing`'s `socketFaultInjection`) also no longer crashes.



