### PR TITLE
sql: reject a Postgres message length below 4 as a protocol error

### DIFF
--- a/src/sql/postgres/protocol/CommandComplete.rs
+++ b/src/sql/postgres/protocol/CommandComplete.rs
@@ -18,8 +18,7 @@ impl CommandComplete {
         &mut self,
         mut reader: NewReader<Container>,
     ) -> Result<(), bun_core::Error> {
-        let length = reader.length()?;
-        debug_assert!(length >= 4);
+        reader.length()?;
 
         let tag = reader.read_z()?;
         *self = Self { command_tag: tag };

--- a/src/sql/postgres/protocol/ErrorResponse.rs
+++ b/src/sql/postgres/protocol/ErrorResponse.rs
@@ -24,7 +24,7 @@ impl ErrorResponse {
     ) -> Result<Self, AnyPostgresError> {
         // A length of exactly 4 is an empty message (no fields); `length()`
         // already rejected anything smaller.
-        let remaining_bytes = reader.length()?.saturating_sub(4);
+        let remaining_bytes = reader.length()? - 4;
         if remaining_bytes > 0 {
             return Ok(Self {
                 messages: FieldMessage::decode_list::<Container>(reader)?,

--- a/src/sql/postgres/protocol/ErrorResponse.rs
+++ b/src/sql/postgres/protocol/ErrorResponse.rs
@@ -22,12 +22,9 @@ impl ErrorResponse {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let mut remaining_bytes = reader.length()?;
-        if remaining_bytes < 4 {
-            return Err(AnyPostgresError::InvalidMessageLength);
-        }
-        remaining_bytes = remaining_bytes.saturating_sub(4);
-
+        // A length of exactly 4 is an empty message (no fields); `length()`
+        // already rejected anything smaller.
+        let remaining_bytes = reader.length()?.saturating_sub(4);
         if remaining_bytes > 0 {
             return Ok(Self {
                 messages: FieldMessage::decode_list::<Container>(reader)?,
@@ -40,20 +37,6 @@ impl ErrorResponse {
         context: Container,
     ) -> Result<Self, AnyPostgresError> {
         Self::decode_internal(NewReader { wrapped: context })
-    }
-
-    /// `NoticeResponse` decode: a declared length below 4 decodes as an empty
-    /// notice instead of failing, unlike `ErrorResponse`.
-    pub fn decode_notice_internal<Container: super::new_reader::ReaderContext>(
-        mut reader: NewReader<Container>,
-    ) -> Result<Self, AnyPostgresError> {
-        let remaining_bytes = reader.length()?.saturating_sub(4);
-        if remaining_bytes > 0 {
-            return Ok(Self {
-                messages: FieldMessage::decode_list::<Container>(reader)?,
-            });
-        }
-        Ok(Self::default())
     }
 }
 

--- a/src/sql/postgres/protocol/NegotiateProtocolVersion.rs
+++ b/src/sql/postgres/protocol/NegotiateProtocolVersion.rs
@@ -14,8 +14,7 @@ impl NegotiateProtocolVersion {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let length = reader.length()?;
-        debug_assert!(length >= 4);
+        reader.length()?;
 
         let version = reader.int4()?;
         let mut this = Self {

--- a/src/sql/postgres/protocol/NewReader.rs
+++ b/src/sql/postgres/protocol/NewReader.rs
@@ -156,10 +156,10 @@ impl<Context: ReaderContext> NewReaderWrap<Context> {
 
     pub fn length(&mut self) -> Result<PostgresInt32, AnyPostgresError> {
         let expected = self.int::<PostgresInt32>()?;
-        // The length of every Postgres v3 message includes the 4 bytes of the
-        // length field itself, so anything smaller is malformed wire data that
-        // also makes the stream unframeable. `expected` is server-controlled.
-        if expected < 4 {
+        // The length of every Postgres v3 message is a signed Int32 that
+        // includes its own 4 bytes, so a value below 4 (or negative, i.e. the
+        // sign bit set on the wire) is malformed. `expected` is server-controlled.
+        if expected < 4 || expected > i32::MAX as u32 {
             return Err(AnyPostgresError::InvalidMessageLength);
         }
         self.ensure_capacity((expected - 4) as usize)?;

--- a/src/sql/postgres/protocol/NewReader.rs
+++ b/src/sql/postgres/protocol/NewReader.rs
@@ -156,9 +156,13 @@ impl<Context: ReaderContext> NewReaderWrap<Context> {
 
     pub fn length(&mut self) -> Result<PostgresInt32, AnyPostgresError> {
         let expected = self.int::<PostgresInt32>()?;
-        // `int4` is u32 so always nonnegative; the saturating sub guards
-        // underflow when len < 4.
-        self.ensure_capacity(expected.saturating_sub(4) as usize)?;
+        // The length of every Postgres v3 message includes the 4 bytes of the
+        // length field itself, so anything smaller is malformed wire data that
+        // also makes the stream unframeable. `expected` is server-controlled.
+        if expected < 4 {
+            return Err(AnyPostgresError::InvalidMessageLength);
+        }
+        self.ensure_capacity((expected - 4) as usize)?;
 
         Ok(expected)
     }

--- a/src/sql/postgres/protocol/NoticeResponse.rs
+++ b/src/sql/postgres/protocol/NoticeResponse.rs
@@ -1,5 +1,3 @@
 /// NoticeResponse has the same wire format as ErrorResponse — a length-prefixed
-/// list of field messages — so it reuses the same type. Notices decode via
-/// `decode_notice_internal`, which tolerates a declared length below 4
-/// (decoding as empty) where `ErrorResponse` fails.
+/// list of field messages — so it reuses the same type and decoder.
 pub type NoticeResponse = crate::postgres::protocol::error_response::ErrorResponse;

--- a/src/sql/postgres/protocol/NotificationResponse.rs
+++ b/src/sql/postgres/protocol/NotificationResponse.rs
@@ -16,8 +16,7 @@ impl NotificationResponse {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let length = reader.length()?;
-        debug_assert!(length >= 4);
+        reader.length()?;
 
         Ok(Self {
             pid: reader.int4()?,

--- a/src/sql/postgres/protocol/ParameterStatus.rs
+++ b/src/sql/postgres/protocol/ParameterStatus.rs
@@ -14,8 +14,7 @@ impl ParameterStatus {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let length = reader.length()?;
-        debug_assert!(length >= 4);
+        reader.length()?;
 
         Ok(Self {
             name: reader.read_z()?,

--- a/src/sql/postgres/protocol/ReadyForQuery.rs
+++ b/src/sql/postgres/protocol/ReadyForQuery.rs
@@ -18,8 +18,7 @@ impl ReadyForQuery {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let length = reader.length()?;
-        debug_assert!(length >= 4);
+        reader.length()?;
 
         let status = reader.int::<u8>()?;
         // TransactionStatusIndicator is a `#[repr(transparent)] struct(u8)` newtype —

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -498,9 +498,6 @@ pub(crate) fn on_data<Context: ReaderContext>(
             _ => {
                 bun_core::scoped_log!(Postgres, "Unknown message: {}", c as char);
                 let length = reader.length()?;
-                if length < 4 {
-                    return Err(AnyPostgresError::InvalidMessageLength);
-                }
                 let to_skip = length.saturating_sub(4);
                 bun_core::scoped_log!(Postgres, "to_skip: {}", to_skip);
                 reader.skip(usize::try_from(to_skip).expect("int cast"))?;

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -498,7 +498,7 @@ pub(crate) fn on_data<Context: ReaderContext>(
             _ => {
                 bun_core::scoped_log!(Postgres, "Unknown message: {}", c as char);
                 let length = reader.length()?;
-                let to_skip = length.saturating_sub(4);
+                let to_skip = length - 4;
                 bun_core::scoped_log!(Postgres, "to_skip: {}", to_skip);
                 reader.skip(usize::try_from(to_skip).expect("int cast"))?;
             }

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2973,7 +2973,7 @@ impl PostgresSQLConnection {
             }
             MessageType::NoticeResponse => {
                 debug!("UNSUPPORTED NoticeResponse");
-                let _resp = protocol::NoticeResponse::decode_notice_internal(reader.reborrow())?;
+                let _resp = protocol::NoticeResponse::decode_internal(reader.reborrow())?;
                 // _resp dropped at scope end
             }
             MessageType::NotificationResponse => {

--- a/test/js/sql/postgres-invalid-message-length.test.ts
+++ b/test/js/sql/postgres-invalid-message-length.test.ts
@@ -1,0 +1,124 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// Every PostgreSQL v3 backend message carries an Int32 length that includes its
+// own 4 bytes (https://www.postgresql.org/docs/current/protocol-message-formats.html),
+// so a declared length below 4 is malformed and makes the stream unframeable
+// (libpq treats it as a sync loss). The length is server-controlled input:
+// shared servers, poolers (pgbouncer/pgcat), tunnels and sidecars all sit on
+// the connection path. It must surface as ERR_POSTGRES_INVALID_MESSAGE_LENGTH
+// on that connection rather than being trusted.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { listeningServer, pgAuthenticationOk, pgCString, pgRaw, pgReadyForQuery } from "./wire-frames";
+
+// connectionTimeout (seconds) bounds the connect-retry budget; keep it short
+// in tests that expect the failure to surface.
+
+/**
+ * Reply to the startup packet with AuthenticationOk followed by `frames`, so
+ * `frames` arrive before ReadyForQuery and connect() observes them. Returns
+ * connect()'s rejection.
+ */
+async function connectError(frames: Buffer[]): Promise<any> {
+  const { port, server } = await listeningServer(socket => {
+    socket.once("data", () => socket.write(Buffer.concat([pgAuthenticationOk(), ...frames])));
+    socket.on("error", () => {});
+  });
+  const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1, connectionTimeout: 1 });
+  try {
+    await db.connect();
+    throw new Error("expected connect() to reject");
+  } catch (err) {
+    return err;
+  } finally {
+    await db.close({ timeout: 0 });
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+/**
+ * Complete the handshake normally, then answer the first simple query with
+ * `frames`, so they arrive while a request is in flight. Returns the query's
+ * rejection.
+ */
+async function queryError(frames: Buffer[]): Promise<any> {
+  const { port, server } = await listeningServer(socket => {
+    let startup = true;
+    socket.on("data", data => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      if (data[0] !== 0x51 /* 'Q' */) return;
+      socket.write(Buffer.concat(frames));
+    });
+    socket.on("error", () => {});
+  });
+  const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1, connectionTimeout: 1 });
+  try {
+    await db`select x`.simple();
+    throw new Error("expected the query to reject");
+  } catch (err) {
+    return err;
+  } finally {
+    await db.close({ timeout: 0 });
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+// Each entry drives a different backend-message decoder with a length field
+// smaller than the 4 bytes the field itself occupies. All of them must fail
+// the connection with the same protocol error.
+const malformed: { name: string; frame: Buffer }[] = [
+  // ReadyForQuery is Byte1('Z') Int32(5) Byte1(status); only the length lies.
+  { name: "ReadyForQuery declaring length 3", frame: pgRaw("Z", Buffer.from("I"), 3) },
+  { name: "ReadyForQuery declaring length 0", frame: pgRaw("Z", Buffer.from("I"), 0) },
+  { name: "ParameterStatus declaring length 3", frame: pgRaw("S", Buffer.alloc(0), 3) },
+  { name: "NotificationResponse declaring length 3", frame: pgRaw("A", Buffer.alloc(0), 3) },
+  // NoticeResponse is not exempt: an unframeable length is fatal even for a notice.
+  { name: "NoticeResponse declaring length 3", frame: pgRaw("N", Buffer.alloc(0), 3) },
+  { name: "ErrorResponse declaring length 3", frame: pgRaw("E", Buffer.alloc(0), 3) },
+  // An unrecognized message type takes the skip-by-declared-length path.
+  { name: "unknown message type declaring length 3", frame: pgRaw("X", Buffer.alloc(0), 3) },
+];
+
+test.each(malformed)("postgres: $name is a protocol error", async ({ frame }) => {
+  const err = await connectError([frame]);
+  expect({ code: err.code, name: err.name }).toEqual({
+    code: "ERR_POSTGRES_INVALID_MESSAGE_LENGTH",
+    name: "PostgresError",
+  });
+});
+
+// CommandComplete is only decoded while a request is in flight, so it has to be
+// injected as the answer to a query rather than during the startup phase.
+test("postgres: CommandComplete declaring length 3 fails the in-flight query", async () => {
+  const err = await queryError([pgRaw("C", pgCString("SELECT 1"), 3)]);
+  expect({ code: err.code, name: err.name }).toEqual({
+    code: "ERR_POSTGRES_INVALID_MESSAGE_LENGTH",
+    name: "PostgresError",
+  });
+});
+
+// Boundary: a length of exactly 4 (an empty NoticeResponse) is the smallest
+// valid value and must still be accepted.
+test("postgres: an empty NoticeResponse (length exactly 4) is accepted", async () => {
+  const { port, server } = await listeningServer(socket => {
+    socket.once("data", () =>
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgRaw("N", Buffer.alloc(0)), pgReadyForQuery()])),
+    );
+    socket.on("error", () => {});
+  });
+  const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1 });
+  try {
+    await expect(db.connect()).resolves.toBeDefined();
+  } finally {
+    await db.close({ timeout: 0 });
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});

--- a/test/js/sql/postgres-invalid-message-length.test.ts
+++ b/test/js/sql/postgres-invalid-message-length.test.ts
@@ -71,13 +71,16 @@ async function queryError(frames: Buffer[]): Promise<any> {
   }
 }
 
-// Each entry drives a different backend-message decoder with a length field
-// smaller than the 4 bytes the field itself occupies. All of them must fail
-// the connection with the same protocol error.
+// Each entry drives a backend-message decoder with a length field that cannot
+// be valid: below the 4 bytes the field itself occupies, or negative (the
+// field is a signed Int32). All of them must fail the connection with the
+// same protocol error.
 const malformed: { name: string; frame: Buffer }[] = [
   // ReadyForQuery is Byte1('Z') Int32(5) Byte1(status); only the length lies.
   { name: "ReadyForQuery declaring length 3", frame: pgRaw("Z", Buffer.from("I"), 3) },
   { name: "ReadyForQuery declaring length 0", frame: pgRaw("Z", Buffer.from("I"), 0) },
+  // writeInt32BE(-1) puts 0xFFFFFFFF on the wire, the signed high half.
+  { name: "ReadyForQuery declaring length -1", frame: pgRaw("Z", Buffer.from("I"), -1) },
   { name: "ParameterStatus declaring length 3", frame: pgRaw("S", Buffer.alloc(0), 3) },
   { name: "NotificationResponse declaring length 3", frame: pgRaw("A", Buffer.alloc(0), 3) },
   // NoticeResponse is not exempt: an unframeable length is fatal even for a notice.

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -118,11 +118,12 @@ export function pgErrorResponse(fields: { S: string; C: string; M: string; [k: s
 }
 
 // PostgreSQL FE/BE protocol §55.7 generic backend message: Byte1(type) Int32(len = 4 + body.length) body
-// Low-level escape hatch for fault-injection tests that need a deliberately malformed body.
-export function pgRaw(type: string, body: Buffer): Buffer {
+// Low-level escape hatch for fault-injection tests that need a deliberately malformed body,
+// or (via `declaredLength`) a length field that lies about the body it precedes.
+export function pgRaw(type: string, body: Buffer, declaredLength: number = body.length + 4): Buffer {
   const buf = Buffer.alloc(5 + body.length);
   buf.write(type, 0);
-  buf.writeInt32BE(body.length + 4, 1);
+  buf.writeInt32BE(declaredLength, 1);
   body.copy(buf, 5);
   return buf;
 }


### PR DESCRIPTION
A Postgres backend (or a proxy / pooler in between) that sends a message whose 4 byte length field declares a value below 4 makes Bun's SQL client abort the whole process in any build with debug assertions enabled (debug, `release-asan`, `release-assertions`):

```
panic: assertion failed: length >= 4
src/sql/postgres/protocol/ReadyForQuery.rs:22
```

In release builds (debug assertions off) the `debug_assert!` compiles out and the malformed length is silently accepted instead.

### Reproduction

A mock server that completes the handshake and then sends a `ReadyForQuery` (`Z`) whose length field says 3:

```js
const srv = Bun.listen({
  hostname: "127.0.0.1", port: 0,
  socket: {
    open(s) { s.data = { n: 0 }; },
    data(s) {
      if (++s.data.n !== 1) return;
      const authOk = Buffer.from([0x52, 0,0,0,8, 0,0,0,0]); // 'R' AuthenticationOk
      const zBad   = Buffer.from([0x5a, 0,0,0,3, 0x49]);    // 'Z' ReadyForQuery, length = 3 (< 4)
      s.write(Buffer.concat([authOk, zBad]));
    },
    error() {}, close() {}, drain() {},
  },
});
const sql = new Bun.SQL({ hostname: "127.0.0.1", port: srv.port, database: "d", username: "u", password: "p", tls: false, max: 1 });
await sql`select 1`;
```

### Cause

Every PostgreSQL v3 message carries a signed `Int32` length that includes its own 4 bytes, so a value below 4 (or a negative one, i.e. the sign bit set on the wire) is malformed and makes the stream unframeable: there is no way to skip to the next message. libpq treats `msgLength < 4` as a sync loss for every message type, and because its comparison is on the signed type it rejects both halves.

The value is server controlled, but five decoders validated it with `debug_assert!`: `ReadyForQuery`, `ParameterStatus`, `CommandComplete`, `NotificationResponse`, and `NegotiateProtocolVersion`. Three other sites already returned `AnyPostgresError::InvalidMessageLength` for the same condition (`ErrorResponse::decode_internal`, `Authentication`, and the unknown-message arm in `PostgresRequest::on_data`).

### Fix

Move the check into `NewReaderWrap::length()`, the one helper every decoder reads the length through. A value below 4, or one with the sign bit set (`PostgresInt32` is `u32`, so the negative half of the protocol's signed `Int32` shows up as values above `i32::MAX`), now returns `AnyPostgresError::InvalidMessageLength`, which surfaces to JS as `ERR_POSTGRES_INVALID_MESSAGE_LENGTH` on the failed connection. Fallout, all in this PR:

- The five `debug_assert!(length >= 4)` became tautologies and are removed.
- The two pre-existing copies of the same check (`ErrorResponse::decode_internal` and the unknown-message arm) became dead and are removed.
- With its check gone, `ErrorResponse::decode_internal` became identical to `decode_notice_internal`, so the latter is deleted and `NoticeResponse` uses the shared decoder.

One deliberate behavior change: a `NoticeResponse` declaring a length below 4 previously decoded as an empty notice; it is now rejected like every other message, matching libpq. A `NoticeResponse` with an empty body (length exactly 4) is still accepted. The decoders that had no check at all (`DataRow`, `RowDescription`, `CopyData`, `ParameterDescription`) are covered by the shared check now too.

`NegotiateProtocolVersion` currently has no dispatch arm (a `v` byte falls through to the unknown-message path), so its assert was unreachable; it is removed for consistency but cannot be exercised by a test.

Out of scope: a server that declares an in-range length and never sends the bytes still parks the connection in the wait-for-more-data path until a timeout. That needs a max-message-size cap and is independent of length-field validity.

Net -23 lines in `src/`.

### Verification

`test/js/sql/postgres-invalid-message-length.test.ts` drives each reachable decoder with a frame whose length field lies (3, 0, and -1), plus the length-exactly-4 boundary as the positive control.

- Unfixed debug build: the file aborts with the panic above before reporting a single result.
- Unfixed release build (`USE_SYSTEM_BUN=1`): 7 of 10 cases fail because the malformed length is silently accepted and the connection times out.
- With the fix (`bun bd test`): all 10 pass, along with the 37 tests in the neighboring postgres wire suites (`wire-frames`, `postgres-binary-array-bounds`, `sql-connect-error-reporting`, `sql-close-pending-connection`, `sql-onconnect-onclose-throw`).
