### PR TITLE
Add missing exception check in JSC__JSValue__putToPropertyKey

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4047,6 +4047,7 @@ void JSC__JSValue__putToPropertyKey(JSC::EncodedJSValue JSValue0, JSC::JSGlobalO
     auto pkey = key.toPropertyKey(arg1);
     RETURN_IF_EXCEPTION(scope, );
     object->putDirectMayBeIndex(arg1, pkey, value);
+    RETURN_IF_EXCEPTION(scope, );
 }
 
 extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__putMayBeIndex(JSC::EncodedJSValue target, JSC::JSGlobalObject* globalObject, const BunString* key, JSC::EncodedJSValue value)

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -147,7 +147,12 @@ test("object argument with a sparse numeric key", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // Debug builds print "[macro] call take" to stdout before the script's own output.
-  expect(stdout).toEndWith("200000\n");
-  expect(exitCode).toBe(0);
+  // One combined assertion so stderr (where JSC prints the exception check failure) shows up in
+  // the diff if the child aborts. Debug builds print "[macro] call take" to stdout before the
+  // script's own output, so only the tail of stdout is matched.
+  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toMatchObject({
+    stdout: expect.stringMatching(/200000\n$/),
+    exitCode: 0,
+    signalCode: null,
+  });
 });

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,5 +1,6 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import defaultMacro, {
   addStrings,
   addStringsUTF16,
@@ -128,4 +129,25 @@ test("namespace import", () => {
 
 test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
+});
+
+// A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside
+// JSC__JSValue__putToPropertyKey take a path that can throw, so the binding must check for
+// an exception. BUN_JSC_validateExceptionChecks=1 aborts the child if the check is missing.
+test("object argument with a sparse numeric key", async () => {
+  using dir = tempDir("macro-sparse-key", {
+    "take.ts": `export function take(o: any) {\n  return Object.keys(o).join(",");\n}\n`,
+    "index.ts": `import { take } from "./take.ts" with { type: "macro" };\nconsole.log(take({ 200000: 1 }));\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Debug builds print "[macro] call take" to stdout before the script's own output.
+  expect(stdout).toEndWith("200000\n");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem

`JSC__JSValue__putToPropertyKey` (src/jsc/bindings/bindings.cpp) declares a `ThrowScope` and checks it after `toPropertyKey`, but not after `putDirectMayBeIndex`. When the key parses as a large array index, the put takes JSC's sparse / beyond-vector-length path, which can throw (out of memory, sparse map limits). The binding then destroys the scope with the exception unchecked, which JSC's exception check validation catches:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: putDirectIndexBeyondVectorLengthWithArrayStorage @ JSObject.cpp:3446
        (ExceptionScope::m_recursionDepth was 12)
    But the exception was unchecked as of this scope: JSC__JSValue__putToPropertyKey @ src/jsc/bindings/bindings.cpp:4042
        (ExceptionScope::m_recursionDepth was 11)
ASSERTION FAILED: exception check validation failed
    JSC::VM::verifyExceptionCheckNeedIsSatisfied   (VM.cpp:1561)
```

The binding is used by native code that builds objects with runtime-provided keys: the Redis client materializing RESP replies (where this was first seen, with field names coming from the server) and macro argument conversion (`object_to_js`). The macro path gives a deterministic repro:

```ts
// take.ts
export function take(o: any) {
  return Object.keys(o).join(",");
}
// index.ts
import { take } from "./take.ts" with { type: "macro" };
console.log(take({ 200000: 1 }));
```

```sh
BUN_JSC_validateExceptionChecks=1 bun run index.ts
```

On a debug (assertion-enabled) build this aborts with the output above before the fix.

### Fix

Add `RETURN_IF_EXCEPTION(scope, )` after the put, matching `JSC__JSValue__putMayBeIndex` directly below it. The Rust wrapper (`JSValue::put_to_property_key`, routed through `call_check_slow`) already turns the pending exception into an error for its callers, so nothing else changes.

I audited the neighboring put bindings: `putMayBeIndex` already checks, and `putIndex`, `push`, and the `putRecord` pair do not hold an unreleased C++ `ThrowScope` across the put (their exception check happens in the Rust-side caller scope), so `putToPropertyKey` was the only one affected.

### Verification

New test in `test/bundler/transpiler/macro-test.test.ts` spawns the repro with `BUN_JSC_validateExceptionChecks=1` and asserts the output and a zero exit code. On an unfixed debug build the child aborts (exit code 134); with the fix the whole macro test file passes under `bun bd test`.
