### PR TITLE
sql(postgres): stop sending a redundant Sync after a simple Query

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -423,9 +423,11 @@ pub(crate) fn execute_query<Context: WriterContext>(
     query: &[u8],
     mut writer: protocol::NewWriter<Context>,
 ) -> Result<(), AnyPostgresError> {
+    // A simple Query ('Q') is its own sync point: the backend always answers it
+    // with exactly one ReadyForQuery. Appending a Sync made it send a second,
+    // unaccounted ReadyForQuery that re-armed advance() mid-prepare.
     protocol::write_query(query, &mut writer)?;
     writer.write(&protocol::FLUSH)?;
-    writer.write(&protocol::SYNC)?;
     Ok(())
 }
 

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -424,8 +424,8 @@ pub(crate) fn execute_query<Context: WriterContext>(
     mut writer: protocol::NewWriter<Context>,
 ) -> Result<(), AnyPostgresError> {
     // A simple Query ('Q') is its own sync point: the backend always answers it
-    // with exactly one ReadyForQuery. Appending a Sync made it send a second,
-    // unaccounted ReadyForQuery that re-armed advance() mid-prepare.
+    // with exactly one ReadyForQuery. Do not append a Sync here: it would elicit
+    // a second, unaccounted ReadyForQuery that re-arms advance() mid-prepare.
     protocol::write_query(query, &mut writer)?;
     writer.write(&protocol::FLUSH)?;
     Ok(())

--- a/test/js/sql/postgres-simple-query-pipeline.test.ts
+++ b/test/js/sql/postgres-simple-query-pipeline.test.ts
@@ -5,6 +5,10 @@
 // connection's "ready" state while the next query's Parse+Describe round trip
 // was still in flight, and advance() then pipelined a third query into that
 // window, so its replies were delivered to the wrong query.
+//
+// The simple protocol is used for query.simple(), for sql.unsafe(text) with
+// no parameters, and for the BEGIN/COMMIT/ROLLBACK of sql.begin(), so every
+// one of those emitted the spurious ReadyForQuery.
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
@@ -24,6 +28,26 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       sql`SELECT 'AAAA'::text AS v`.simple(),
       sql`SELECT ${"BBBB"}::text AS v`,
       sql`SELECT 'CCCC'::text AS v`.simple(),
+    ]);
+
+    expect({ a, b, c }).toEqual({
+      a: [{ v: "AAAA" }],
+      b: [{ v: "BBBB" }],
+      c: [{ v: "CCCC" }],
+    });
+  });
+
+  // sql.unsafe(text) with no parameters routes through the same simple ('Q')
+  // protocol, so the same misattribution happens without the caller ever
+  // opting into simple mode.
+  test("unsafe() with no parameters does not steal the rows of an in-flight prepare", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5, connectionTimeout: 5 });
+
+    const [a, b, c] = await Promise.all([
+      sql.unsafe(`SELECT 'AAAA'::text AS v`),
+      sql.unsafe(`SELECT $1::text AS v`, ["BBBB"]),
+      sql.unsafe(`SELECT 'CCCC'::text AS v`),
     ]);
 
     expect({ a, b, c }).toEqual({

--- a/test/js/sql/postgres-simple-query-pipeline.test.ts
+++ b/test/js/sql/postgres-simple-query-pipeline.test.ts
@@ -1,0 +1,56 @@
+// A simple-protocol Query ('Q') is its own sync point: the backend answers it
+// with exactly one ReadyForQuery. Bun also appended an extended-protocol Sync
+// after every 'Q', so the server replied with a second, unaccounted
+// ReadyForQuery per simple query. That spurious ReadyForQuery re-armed the
+// connection's "ready" state while the next query's Parse+Describe round trip
+// was still in flight, and advance() then pipelined a third query into that
+// window, so its replies were delivered to the wrong query.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+
+  // Before the fix: the second ReadyForQuery from A's redundant Sync lets C's
+  // 'Q' go out inside B's Parse+Describe window. C's result set then arrives
+  // while B is still the current query, so B resolves with C's row and C
+  // resolves with B's (field-less) Bind+Execute row: b = [{v:"CCCC"}], c = [{}].
+  test("a simple query does not steal the rows of an in-flight prepare", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5, connectionTimeout: 5 });
+
+    const [a, b, c] = await Promise.all([
+      sql`SELECT 'AAAA'::text AS v`.simple(),
+      sql`SELECT ${"BBBB"}::text AS v`,
+      sql`SELECT 'CCCC'::text AS v`.simple(),
+    ]);
+
+    expect({ a, b, c }).toEqual({
+      a: [{ v: "AAAA" }],
+      b: [{ v: "BBBB" }],
+      c: [{ v: "CCCC" }],
+    });
+  });
+
+  // Same root, different symptom: when the third query needs its own Parse, the
+  // spurious ReadyForQuery also clears the waiting-to-prepare state, so C's
+  // Parse+Describe is pipelined inside B's. C's describe reply is then consumed
+  // under B, C's statement never leaves the Parsing state, and C never settles.
+  test("a second prepare queued behind an in-flight prepare still settles", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5, connectionTimeout: 5 });
+
+    const [a, b, c] = await Promise.all([
+      sql`SELECT 'AAAA'::text AS v`.simple(),
+      sql`SELECT ${"BBBB"}::text AS v`,
+      sql`SELECT ${"CCCC"}::text AS x`,
+    ]);
+
+    expect({ a, b, c }).toEqual({
+      a: [{ v: "AAAA" }],
+      b: [{ v: "BBBB" }],
+      c: [{ x: "CCCC" }],
+    });
+  });
+});


### PR DESCRIPTION
### What

`Bun.SQL` (Postgres) silently delivers another query's rows to the wrong query, with no error, when a simple-protocol query runs concurrently with a not-yet-prepared parameterized query on the same connection. A second variant of the same bug makes the third query hang forever.

The simple query protocol ('Q') is used by `query.simple()`, by `sql.unsafe(text)` with no parameters (`src/js/bun/sql.ts:134`), and by the `BEGIN`/`COMMIT`/`ROLLBACK` that `sql.begin()` issues, so this is reachable without the caller ever opting into simple mode.

### Repro

Reproduces on Bun 1.3.14, 1.4.0, and main, against a real Postgres, every run:

```js
const sql = new Bun.SQL({ ...conn, max: 1 });

const [a, b, c] = await Promise.all([
  sql.unsafe(`SELECT 'AAAA'::text AS v`),       // no params -> simple 'Q'
  sql.unsafe(`SELECT $1::text AS v`, ["BBBB"]), // first use -> Parse/Describe round trip
  sql.unsafe(`SELECT 'CCCC'::text AS v`),       // no params -> simple 'Q'
]);
// a -> [{ v: "AAAA" }]   ok
// b -> [{ v: "CCCC" }]   b got C's row
// c -> [{}]              c got B's field-less Bind/Execute row
```

The same happens with `.simple()` in place of the no-parameter `unsafe()` calls. If the third query is parameterized instead, it never resolves.

### Cause

`PostgresRequest::execute_query` wrote `Query ('Q') + Flush + Sync` for the simple query protocol. A simple `Q` is its own sync point: the backend always answers it with exactly one `ReadyForQuery`. The trailing `Sync` made the server send a second, unaccounted `ReadyForQuery` per simple query.

The only place `IS_READY_FOR_QUERY` is set (and `WAITING_TO_PREPARE` cleared) is the `ReadyForQuery` handler, and the two flags are otherwise mutually exclusive with the prepare path. So the state machine is correct as long as every `ReadyForQuery` corresponds to an operation Bun wrote. The extra one breaks that: it arrives right after `advance()` has written the next query's `Parse+Describe+Sync`, re-arms `IS_READY_FOR_QUERY`, clears `WAITING_TO_PREPARE`, and triggers another `advance()`. That pass skips the head query (its statement is `Parsing`) and admits the third query into the prepare's Describe window. From there the FIFO reply dispatch hands each arriving result set to the wrong head-of-queue request.

Wire traces captured through a logging proxy against a real Postgres 17:

<details>
<summary>before (broken) and after (fixed)</summary>

Before: A's extra `Sync` yields two `Z`. The second one lets C's `Q` out between B's `Parse/Describe/Sync` and B's `Bind/Execute`, so C's result set (`T D C Z`) arrives while B is still the current query.

```
-> Q "SELECT 'AAAA' AS v"
-> H  (Flush)
-> S  (Sync)           <- redundant
<- T D C
<- Z                   <- A's ReadyForQuery
<- Z                   <- extra ReadyForQuery from A's Sync
-> P "SELECT $1 AS v"  <- B: Parse
-> D                   <- B: Describe
-> S                   <- B: Sync
-> Q "SELECT 'CCCC' AS v"   <- C, admitted by the extra Z's advance()
-> H
-> S
<- 1 t T Z             <- B's describe reply
<- T D C Z Z           <- C's result set, delivered to B
-> B E H S             <- B: Bind/Execute
<- 2 D C Z             <- B's result set, delivered to C
```

After: one `Z` per simple query, and each query's full exchange completes before the next one is written.

```
-> Q "SELECT 'AAAA' AS v"
-> H
<- T D C Z
-> P "SELECT $1 AS v"
-> D
-> S
<- 1 t T Z
-> B E H S
<- 2 D C Z
-> Q "SELECT 'CCCC' AS v"
-> H
<- T D C Z
```

`sql.begin()` after the fix, for reference (the transaction-status byte in `Z` tracks `I -> T -> T -> T -> I` correctly):

```
-> Q "BEGIN"                       -> H
<- Z status=T
-> P/D "UPDATE ... WHERE id = $1"  -> S
<- 1 t T, Z status=T
-> B E                             -> H -> S
<- 2 D C, Z status=T
-> Q "COMMIT"                      -> H
<- Z status=I
```

</details>

The `Flush + Sync` after `Q` dates to the original Zig implementation of `executeQuery` and was carried through the Rust port unchanged. `Flush` after a `Q` elicits no response, so it is left alone.

### Fix

Stop writing `Sync` after a simple `Q` in `execute_query`. One `ReadyForQuery` per operation is the invariant the rest of the connection state machine already assumes.

### Test

`test/js/sql/postgres-simple-query-pipeline.test.ts`, against a real Postgres via `describeWithContainer`. All three cases fail on the unfixed build:

```
(fail) postgres > a simple query does not steal the rows of an in-flight prepare
  expected b: [{v:"BBBB"}] c: [{v:"CCCC"}], received b: [{v:"CCCC"}] c: [{}]
(fail) postgres > unsafe() with no parameters does not steal the rows of an in-flight prepare
  same misattribution through the sql.unsafe() entry point
(fail) postgres > a second prepare queued behind an in-flight prepare still settles
  ^ this test timed out after 5000ms.
```

and pass with the fix. The existing `test/js/sql/` Postgres suites (`postgres-multi-statement-fields`, `sql-prepare-false`, `wire-frames`, the binary/onconnect/close ones) still pass.
