### PR TITLE
node:vm: replace the JSC Watchdog with a cancellable deadline for the timeout option

### DIFF
--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -58,8 +58,6 @@ impl VM {
         JSC__VM__setControlFlowProfiler(self, enabled)
     }
 
-    /// Whether a `node:vm` evaluation with the `timeout` option is currently
-    /// running on this VM.
     pub fn has_execution_time_limit(&self) -> bool {
         JSC__VM__hasExecutionTimeLimit(self)
     }

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -58,6 +58,8 @@ impl VM {
         JSC__VM__setControlFlowProfiler(self, enabled)
     }
 
+    /// Whether a `node:vm` evaluation with the `timeout` option is currently
+    /// running on this VM.
     pub fn has_execution_time_limit(&self) -> bool {
         JSC__VM__hasExecutionTimeLimit(self)
     }
@@ -114,7 +116,7 @@ impl VM {
         JSC__VM__executionForbidden(self)
     }
 
-    // These four functions fire VM traps. To understand what that means, see VMTraps.h for a giant explainer.
+    // These functions fire VM traps. To understand what that means, see VMTraps.h for a giant explainer.
     // These may be called concurrently from another thread.
 
     /// Fires NeedTermination Trap. Thread safe. See jsc's "VMTraps.h" for explaination on traps.

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -127,6 +127,10 @@ public:
     void* bunVM;
     Bun::JSCTaskScheduler deferredWorkTimer;
 
+    // Number of live `node:vm` evaluation deadlines (Bun::NodeVMEvalTimeout)
+    // on this VM. Read by JSC__VM__hasExecutionTimeLimit.
+    unsigned nodeVMEvalTimeoutDepth { 0 };
+
     // Backing storage for Bun::IsolatedModuleCache (see IsolatedModuleCache.h).
     // All access should go through that class. Stored as the JSC base type to
     // avoid pulling ZigSourceProvider.h into this header; the cache class

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -30,6 +30,10 @@ namespace Zig {
 class GlobalObject;
 }
 
+namespace Bun {
+class NodeVMEvalTimeout;
+}
+
 namespace WebCore {
 using namespace JSC;
 using namespace Zig;
@@ -127,9 +131,10 @@ public:
     void* bunVM;
     Bun::JSCTaskScheduler deferredWorkTimer;
 
-    // Number of live `node:vm` evaluation deadlines (Bun::NodeVMEvalTimeout)
-    // on this VM. Read by JSC__VM__hasExecutionTimeLimit.
-    unsigned nodeVMEvalTimeoutDepth { 0 };
+    // Innermost armed `node:vm` evaluation deadline on this VM, forming an
+    // intrusive stack through NodeVMEvalTimeout::m_enclosing (evaluations
+    // nest strictly). Read by JSC__VM__hasExecutionTimeLimit.
+    Bun::NodeVMEvalTimeout* nodeVMEvalTimeouts { nullptr };
 
     // Backing storage for Bun::IsolatedModuleCache (see IsolatedModuleCache.h).
     // All access should go through that class. Stored as the JSC base type to

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -673,6 +673,10 @@ bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JS
     } else {
         throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, deadline->milliseconds(), "ms"_s));
     }
+    // Now that this evaluation's own error has been thrown, hand the shared
+    // termination signal back to any enclosing deadline that also expired.
+    if (deadline)
+        deadline->raiseExpiredEnclosingDeadline();
     return true;
 }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -674,9 +674,10 @@ bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JS
         throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, deadline->milliseconds(), "ms"_s));
     }
     // Now that this evaluation's own error has been thrown, hand the shared
-    // termination signal back to any enclosing deadline that also expired.
-    if (deadline)
-        deadline->raiseExpiredEnclosingDeadline();
+    // termination signal back to any enclosing deadline that already expired.
+    // This is not gated on `deadline`: a breakOnSigint evaluation with no (or
+    // an unexpired) deadline consumes the same coalesced signal.
+    NodeVMEvalTimeout::raiseExpiredDeadline(vm);
     return true;
 }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -647,12 +647,9 @@ bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JS
     bool sigintReceived = receiver->getSigintReceived();
 
     if (vm.hasTerminationRequest()) {
-        // The termination was requested by something other than this
-        // evaluation's deadline or SIGINT watcher (e.g. Worker.terminate()).
-        // Leave it in place so it keeps propagating.
+        // A foreign termination (e.g. Worker.terminate()) keeps propagating.
         if (!sigintReceived && !timedOut)
             return false;
-        // Discard microtasks the terminated evaluation already scheduled;
         // clearForGlobalObject(nullptr) is a no-op.
         vm.drainMicrotasksForGlobalObject(evaluationGlobalObject);
         // The termination may have fired inside an afterEvaluate microtask
@@ -664,8 +661,6 @@ bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JS
     } else if (!timedOut) {
         return false;
     }
-    // Reaching here with no termination request means the deadline expired
-    // after the evaluation's last trap check; Node reports a timeout anyway.
 
     if (sigintReceived) {
         receiver->setSigintReceived(false);
@@ -673,10 +668,6 @@ bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JS
     } else {
         throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, deadline->milliseconds(), "ms"_s));
     }
-    // Now that this evaluation's own error has been thrown, hand the shared
-    // termination signal back to any enclosing deadline that already expired.
-    // This is not gated on `deadline`: a breakOnSigint evaluation with no (or
-    // an unexpired) deadline consumes the same coalesced signal.
     NodeVMEvalTimeout::raiseExpiredDeadline(vm);
     return true;
 }

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -61,6 +61,7 @@
 #include "NodeVMScriptFetcher.h"
 #include "wtf/FileHandle.h"
 
+#include "../vm/NodeVMEvalTimeout.h"
 #include "../vm/SigintWatcher.h"
 
 #include "JavaScriptCore/GetterSetter.h"
@@ -638,6 +639,41 @@ void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* err
     }
 
     writeArrowHeaderStack(vm, errorInstance, url, reportedLine, sourceLineText, caretColumn, stack);
+}
+
+bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSGlobalObject* evaluationGlobalObject, JSC::ThrowScope& scope, SigintReceiver* receiver, NodeVMEvalTimeout* deadline)
+{
+    bool timedOut = deadline && deadline->expired();
+    bool sigintReceived = receiver->getSigintReceived();
+
+    if (vm.hasTerminationRequest()) {
+        // The termination was requested by something other than this
+        // evaluation's deadline or SIGINT watcher (e.g. Worker.terminate()).
+        // Leave it in place so it keeps propagating.
+        if (!sigintReceived && !timedOut)
+            return false;
+        // Discard microtasks the terminated evaluation already scheduled;
+        // clearForGlobalObject(nullptr) is a no-op.
+        vm.drainMicrotasksForGlobalObject(evaluationGlobalObject);
+        // The termination may have fired inside an afterEvaluate microtask
+        // checkpoint, leaving the termination exception pending; clear it so
+        // the ERR_SCRIPT_EXECUTION_* error below replaces it.
+        if (vm.hasPendingTerminationException())
+            DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+        vm.clearHasTerminationRequest();
+    } else if (!timedOut) {
+        return false;
+    }
+    // Reaching here with no termination request means the deadline expired
+    // after the evaluation's last trap check; Node reports a timeout anyway.
+
+    if (sigintReceived) {
+        receiver->setSigintReceived(false);
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
+    } else {
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, deadline->milliseconds(), "ms"_s));
+    }
+    return true;
 }
 
 // Returns an encoded exception if the options are invalid.

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -21,6 +21,8 @@ namespace Bun {
 class NodeVMGlobalObject;
 class NodeVMContextOptions;
 class CompileFunctionOptions;
+class NodeVMEvalTimeout;
+class SigintReceiver;
 
 namespace NodeVM {
 
@@ -42,6 +44,17 @@ JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue,
 bool isContext(JSC::JSGlobalObject* globalObject, JSValue);
 bool getContextArg(JSC::JSGlobalObject* globalObject, JSValue& contextArg);
 bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JSValue value);
+// Post-evaluation check shared by every `node:vm` evaluation entry point.
+// Converts a termination raised by this evaluation's own `timeout` deadline or
+// SIGINT watcher into the matching ERR_SCRIPT_EXECUTION_* error (created in
+// `globalObject`'s realm) and returns true. A termination requested by
+// anything else (e.g. Worker.terminate()) is left in place so it keeps
+// propagating, and false is returned.
+// `evaluationGlobalObject` is the global whose still-queued microtasks are
+// discarded on termination. Pass null for a module evaluated without its own
+// context so the caller's unrelated microtasks are not dropped.
+// `deadline` must already be disarmed.
+bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSGlobalObject* evaluationGlobalObject, JSC::ThrowScope& scope, SigintReceiver* receiver, NodeVMEvalTimeout* deadline);
 
 } // namespace NodeVM
 

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -50,9 +50,10 @@ bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JS
 // `globalObject`'s realm) and returns true. A termination requested by
 // anything else (e.g. Worker.terminate()) is left in place so it keeps
 // propagating, and false is returned.
-// `evaluationGlobalObject` is the global whose still-queued microtasks are
-// discarded on termination. Pass null for a module evaluated without its own
-// context so the caller's unrelated microtasks are not dropped.
+// `evaluationGlobalObject` is the vm context global whose still-queued
+// microtasks are discarded on termination. Pass null when the evaluation ran
+// in the caller's own global (runInThisContext, or a module without its own
+// context) so the caller's unrelated microtasks are not dropped.
 // `deadline` must already be disarmed.
 bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSGlobalObject* evaluationGlobalObject, JSC::ThrowScope& scope, SigintReceiver* receiver, NodeVMEvalTimeout* deadline);
 

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -8,8 +8,8 @@
 #include "JavaScriptCore/Exception.h"
 #include "JavaScriptCore/JSModuleRecord.h"
 #include "JavaScriptCore/JSPromise.h"
-#include "JavaScriptCore/Watchdog.h"
 
+#include "../vm/NodeVMEvalTimeout.h"
 #include "../vm/SigintWatcher.h"
 
 namespace Bun {
@@ -49,8 +49,6 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
 
     return array;
 }
-
-void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout);
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
@@ -93,29 +91,21 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         NodeVMGlobalObject* nodeVmGlobalObject = NodeVM::getGlobalObjectFromContext(globalObject, m_context.get(), false);
         RETURN_IF_EXCEPTION(scope, {});
         if (nodeVmGlobalObject && nodeVmGlobalObject->hasOwnMicrotaskQueue()) {
-            std::optional<double> oldLimit;
+            std::optional<NodeVMEvalTimeout> deadline;
             if (timeout != 0)
-                setupWatchdog(vm, timeout, &oldLimit.emplace(), nullptr);
+                deadline.emplace(vm, timeout);
             nodeVmGlobalObject->drainOwnMicrotasks();
-            if (timeout != 0)
-                vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
+            if (deadline)
+                deadline->disarm();
             // The drain may legitimately leave the termination exception
-            // pending (watchdog fired mid-checkpoint); observe it so the
+            // pending (the deadline fired mid-checkpoint); observe it so the
             // exception-check validator is satisfied before the TOP scope
-            // below, then convert it to ERR_SCRIPT_EXECUTION_*.
+            // inside checkForTermination, which converts it to
+            // ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
-            if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-                vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-                DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-                vm.clearHasTerminationRequest();
-                if (getSigintReceived()) {
-                    setSigintReceived(false);
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-                } else {
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-                }
+            if (NodeVM::checkForTermination(vm, globalObject, nodeVmGlobalObject, scope, this, deadline ? &*deadline : nullptr))
                 return {};
-            }
+            RETURN_IF_EXCEPTION(scope, {});
         }
         return m_evaluationResult.get();
     }
@@ -188,7 +178,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // (awaiting it from the outer context would enqueue the thenable job on
     // the inner queue, which is not drained automatically). Wrap the result
     // in an outer-context promise and checkpoint the inner queue — still
-    // inside the watchdog scope so `timeout` bounds the microtask drain too.
+    // inside the deadline scope so `timeout` bounds the microtask drain too.
     auto drainAfterEvaluate = [&] {
         if (scope.exception() || vm.hasTerminationRequest())
             return;
@@ -220,10 +210,9 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
 
     setSigintReceived(false);
 
-    std::optional<double> oldLimit, newLimit;
-
+    std::optional<NodeVMEvalTimeout> deadline;
     if (timeout != 0) {
-        setupWatchdog(vm, timeout, &oldLimit.emplace(), &newLimit.emplace());
+        deadline.emplace(vm, timeout);
     }
 
     if (breakOnSigint) {
@@ -235,28 +224,18 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         drainAfterEvaluate();
     }
 
-    if (timeout != 0) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
+    if (deadline) {
+        deadline->disarm();
     }
 
-    // Evaluation (or the afterEvaluate drain) may leave an exception pending
-    // — a regular one is rethrown by VM_RETURN_IF_EXCEPTION below, a
-    // termination one is converted to ERR_SCRIPT_EXECUTION_* here. Observe it
-    // so the exception-check validator is satisfied before the TOP scope.
+    // Evaluation (or the afterEvaluate drain) may leave an exception pending.
+    // A regular one is rethrown by VM_RETURN_IF_EXCEPTION below; a
+    // termination raised by this evaluation's own deadline or SIGINT watcher
+    // is converted to ERR_SCRIPT_EXECUTION_* here, and any other termination
+    // keeps propagating. Observe it so the exception-check validator is
+    // satisfied before the TOP scope.
     std::ignore = scope.exception();
-    if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-        vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (getSigintReceived()) {
-            setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout != 0) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
-        }
-    } else {
+    if (!NodeVM::checkForTermination(vm, globalObject, nodeVmGlobalObject, scope, this, deadline ? &*deadline : nullptr)) {
         setSigintReceived(false);
     }
 

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -98,10 +98,8 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             if (deadline)
                 deadline->disarm();
             // The drain may legitimately leave the termination exception
-            // pending (the deadline fired mid-checkpoint); observe it so the
-            // exception-check validator is satisfied before the TOP scope
-            // inside checkForTermination, which converts it to
-            // ERR_SCRIPT_EXECUTION_*.
+            // pending; observe it so the exception-check validator is
+            // satisfied before the TOP scope inside checkForTermination.
             std::ignore = scope.exception();
             if (NodeVM::checkForTermination(vm, globalObject, nodeVmGlobalObject, scope, this, deadline ? &*deadline : nullptr))
                 return {};
@@ -228,12 +226,9 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         deadline->disarm();
     }
 
-    // Evaluation (or the afterEvaluate drain) may leave an exception pending.
-    // A regular one is rethrown by VM_RETURN_IF_EXCEPTION below; a
-    // termination raised by this evaluation's own deadline or SIGINT watcher
-    // is converted to ERR_SCRIPT_EXECUTION_* here, and any other termination
-    // keeps propagating. Observe it so the exception-check validator is
-    // satisfied before the TOP scope.
+    // Evaluation (or the afterEvaluate drain) may leave an exception pending;
+    // observe it so the exception-check validator is satisfied before the TOP
+    // scope inside checkForTermination.
     std::ignore = scope.exception();
     if (!NodeVM::checkForTermination(vm, globalObject, nodeVmGlobalObject, scope, this, deadline ? &*deadline : nullptr)) {
         setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -427,7 +427,10 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         deadline->disarm();
     }
 
-    if (checkForTermination(vm, globalObject, globalObject, scope, script, deadline ? &*deadline : nullptr)) {
+    // runInThisContext evaluates in the caller's own global: there is no
+    // separate context whose microtasks could be discarded without also
+    // dropping the caller's, so pass null for evaluationGlobalObject.
+    if (checkForTermination(vm, globalObject, nullptr, scope, script, deadline ? &*deadline : nullptr)) {
         return {};
     }
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -427,9 +427,6 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         deadline->disarm();
     }
 
-    // runInThisContext evaluates in the caller's own global: there is no
-    // separate context whose microtasks could be discarded without also
-    // dropping the caller's, so pass null for evaluationGlobalObject.
     if (checkForTermination(vm, globalObject, nullptr, scope, script, deadline ? &*deadline : nullptr)) {
         return {};
     }

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -11,6 +11,7 @@
 #include "JavaScriptCore/SourceCodeKey.h"
 
 #include "NodeVMScriptFetcher.h"
+#include "../vm/NodeVMEvalTimeout.h"
 #include "../vm/SigintWatcher.h"
 
 #include <bit>
@@ -306,53 +307,6 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
-static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
-{
-    if (vm.hasTerminationRequest()) {
-        vm.drainMicrotasksForGlobalObject(globalObject);
-        // The termination may have fired inside an afterEvaluate microtask
-        // checkpoint, leaving the termination exception pending; clear it so
-        // the ERR_SCRIPT_EXECUTION_* error below replaces it.
-        if (vm.hasPendingTerminationException())
-            DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (script->getSigintReceived()) {
-            script->setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
-        }
-        return true;
-    }
-
-    return false;
-}
-
-void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout)
-{
-    JSC::JSLockHolder locker(vm);
-    JSC::Watchdog& dog = vm.ensureWatchdog();
-    dog.enteredVM();
-
-    Seconds oldLimit = dog.getTimeLimit();
-
-    if (oldTimeout) {
-        *oldTimeout = oldLimit.milliseconds();
-    }
-
-    if (oldLimit.isInfinity() || timeout < oldLimit.milliseconds()) {
-        dog.setTimeLimit(WTF::Seconds::fromMilliseconds(timeout));
-    } else {
-        timeout = oldLimit.milliseconds();
-    }
-
-    if (newTimeout) {
-        *newTimeout = timeout;
-    }
-}
-
 static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVMScript* script, JSObject* contextifiedObject, JSValue optionsArg, bool allowStringInPlaceOfOptions = false)
 {
     VM& vm = JSC::getVM(globalObject);
@@ -379,16 +333,15 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         result = JSC::evaluate(globalObject, script->source(), globalObject, exception);
     };
 
-    std::optional<double> oldLimit, newLimit;
-
+    std::optional<NodeVMEvalTimeout> deadline;
     if (options.timeout) {
-        setupWatchdog(vm, *options.timeout, &oldLimit.emplace(), &newLimit.emplace());
+        deadline.emplace(vm, *options.timeout);
     }
 
     script->setSigintReceived(false);
 
     // Node performs the afterEvaluate microtask checkpoint inside the
-    // watchdog/SIGINT scope, so a `timeout` also bounds microtasks the script
+    // deadline/SIGINT scope, so a `timeout` also bounds microtasks the script
     // scheduled on the context's own queue (e.g. promise jobs).
     auto drainAfterEvaluate = [&] {
         if (!exception && !vm.hasTerminationRequest() && globalObject->hasOwnMicrotaskQueue())
@@ -404,11 +357,11 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         drainAfterEvaluate();
     }
 
-    if (options.timeout) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
+    if (deadline) {
+        deadline->disarm();
     }
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, globalObject, scope, script, deadline ? &*deadline : nullptr)) {
         return {};
     }
 
@@ -455,10 +408,9 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         result = JSC::evaluate(globalObject, script->source(), globalObject, exception);
     };
 
-    std::optional<double> oldLimit, newLimit;
-
+    std::optional<NodeVMEvalTimeout> deadline;
     if (options.timeout) {
-        setupWatchdog(vm, *options.timeout, &oldLimit.emplace(), &newLimit.emplace());
+        deadline.emplace(vm, *options.timeout);
     }
 
     script->setSigintReceived(false);
@@ -471,11 +423,11 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         run();
     }
 
-    if (options.timeout) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
+    if (deadline) {
+        deadline->disarm();
     }
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, globalObject, scope, script, deadline ? &*deadline : nullptr)) {
         return {};
     }
 

--- a/src/jsc/bindings/NodeVMSyntheticModule.cpp
+++ b/src/jsc/bindings/NodeVMSyntheticModule.cpp
@@ -16,7 +16,6 @@
 #include "JavaScriptCore/ModuleProgramCodeBlock.h"
 #include "JavaScriptCore/Parser.h"
 #include "JavaScriptCore/SourceCodeKey.h"
-#include "JavaScriptCore/Watchdog.h"
 
 #include "../vm/SigintWatcher.h"
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -79,7 +79,6 @@
 #include "JavaScriptCore/StackVisitor.h"
 #include "JavaScriptCore/VM.h"
 #include "JavaScriptCore/WasmFaultSignalHandler.h"
-#include "JavaScriptCore/Watchdog.h"
 #include "ZigGlobalObject.h"
 #include "helpers.h"
 #include "JavaScriptCore/JSObjectInlines.h"
@@ -2822,12 +2821,9 @@ void JSC__VM__collectAsync(JSC::VM* vm)
 
 extern "C" bool JSC__VM__hasExecutionTimeLimit(JSC::VM* vm)
 {
-    JSC::JSLockHolder locker(vm);
-    if (vm->watchdog()) {
-        return vm->watchdog()->hasTimeLimit();
-    }
-
-    return false;
+    // True while a `node:vm` evaluation with the `timeout` option is running
+    // (see Bun::NodeVMEvalTimeout). Only read from the VM's own thread.
+    return WebCore::clientData(*vm)->nodeVMEvalTimeoutDepth > 0;
 }
 
 size_t JSC__VM__heapSize(JSC::VM* arg0)
@@ -4813,19 +4809,6 @@ size_t JSC__VM__runGC(JSC::VM* vm, bool sync)
     return JSC::Options::useJIT();
 }
 
-void JSC__VM__clearExecutionTimeLimit(JSC::VM* vm)
-{
-    JSC::JSLockHolder locker(vm);
-    if (vm->watchdog())
-        vm->watchdog()->setTimeLimit(JSC::Watchdog::noTimeLimit);
-}
-void JSC__VM__setExecutionTimeLimit(JSC::VM* vm, double limit)
-{
-    JSC::JSLockHolder locker(vm);
-    JSC::Watchdog& watchdog = vm->ensureWatchdog();
-    watchdog.setTimeLimit(WTF::Seconds { limit });
-}
-
 bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0)
 {
     JSC::Exception* exception = dynamicDowncast<JSC::Exception>(JSC::JSValue::decode(JSValue0));
@@ -4947,10 +4930,6 @@ void JSC__VM__notifyNeedDebuggerBreak(JSC::VM* arg0)
 void JSC__VM__notifyNeedShellTimeoutCheck(JSC::VM* arg0)
 {
     (*arg0).notifyNeedShellTimeoutCheck();
-}
-void JSC__VM__notifyNeedWatchdogCheck(JSC::VM* arg0)
-{
-    (*arg0).notifyNeedWatchdogCheck();
 }
 
 void JSC__VM__throwError(JSC::VM* vm_, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue encodedValue)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2823,7 +2823,7 @@ extern "C" bool JSC__VM__hasExecutionTimeLimit(JSC::VM* vm)
 {
     // True while a `node:vm` evaluation with the `timeout` option is running
     // (see Bun::NodeVMEvalTimeout). Only read from the VM's own thread.
-    return WebCore::clientData(*vm)->nodeVMEvalTimeoutDepth > 0;
+    return WebCore::clientData(*vm)->nodeVMEvalTimeouts != nullptr;
 }
 
 size_t JSC__VM__heapSize(JSC::VM* arg0)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2821,8 +2821,6 @@ void JSC__VM__collectAsync(JSC::VM* vm)
 
 extern "C" bool JSC__VM__hasExecutionTimeLimit(JSC::VM* vm)
 {
-    // True while a `node:vm` evaluation with the `timeout` option is running
-    // (see Bun::NodeVMEvalTimeout). Only read from the VM's own thread.
     return WebCore::clientData(*vm)->nodeVMEvalTimeouts != nullptr;
 }
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -300,7 +300,6 @@ CPP_DECL void JSC__JSValue__toZigString(JSC::EncodedJSValue JSValue0, ZigString*
 #pragma mark - JSC::VM
 
 CPP_DECL size_t JSC__VM__blockBytesAllocated(JSC::VM* arg0);
-CPP_DECL void JSC__VM__clearExecutionTimeLimit(JSC::VM* arg0);
 CPP_DECL void JSC__VM__collectAsync(JSC::VM* arg0);
 CPP_DECL JSC::VM* JSC__VM__create(unsigned char HeapType0);
 CPP_DECL void JSC__VM__deinit(JSC::VM* arg0, JSC::JSGlobalObject* arg1);
@@ -315,12 +314,10 @@ CPP_DECL bool JSC__VM__isJITEnabled();
 CPP_DECL void JSC__VM__notifyNeedDebuggerBreak(JSC::VM* arg0);
 CPP_DECL void JSC__VM__notifyNeedShellTimeoutCheck(JSC::VM* arg0);
 CPP_DECL void JSC__VM__notifyNeedTermination(JSC::VM* arg0);
-CPP_DECL void JSC__VM__notifyNeedWatchdogCheck(JSC::VM* arg0);
 CPP_DECL void JSC__VM__releaseWeakRefs(JSC::VM* arg0);
 CPP_DECL size_t JSC__VM__runGC(JSC::VM* arg0, bool arg1);
 CPP_DECL void JSC__VM__setControlFlowProfiler(JSC::VM* arg0, bool arg1);
 CPP_DECL void JSC__VM__setExecutionForbidden(JSC::VM* arg0, bool arg1);
-CPP_DECL void JSC__VM__setExecutionTimeLimit(JSC::VM* arg0, double arg1);
 CPP_DECL void JSC__VM__shrinkFootprint(JSC::VM* arg0);
 CPP_DECL void JSC__VM__throwError(JSC::VM* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__VM__throwError(JSC::VM* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);

--- a/src/jsc/bindings/vm/NodeVMEvalTimeout.cpp
+++ b/src/jsc/bindings/vm/NodeVMEvalTimeout.cpp
@@ -68,17 +68,15 @@ void NodeVMEvalTimeout::disarm()
     m_vm.traps().clearTrap(VMTraps::NeedTermination);
 }
 
-void NodeVMEvalTimeout::raiseExpiredEnclosingDeadline()
+void NodeVMEvalTimeout::raiseExpiredDeadline(VM& vm)
 {
-    ASSERT(!m_armed);
-    if (!m_expired)
-        return;
-    // An enclosing deadline that expires after this check raises the
-    // request from its own timer, so nothing is lost by only checking
-    // deadlines that have already expired.
-    for (NodeVMEvalTimeout* enclosing = m_enclosing; enclosing; enclosing = enclosing->m_enclosing) {
-        if (enclosing->hasExpired()) {
-            m_vm.notifyNeedTermination();
+    // The evaluation that just finished has already been popped (disarm()),
+    // so this walks only the still-armed enclosing deadlines. One that
+    // expires after this check raises the request from its own timer, so
+    // nothing is lost by only checking deadlines that have already expired.
+    for (NodeVMEvalTimeout* armed = WebCore::clientData(vm)->nodeVMEvalTimeouts; armed; armed = armed->m_enclosing) {
+        if (armed->hasExpired()) {
+            vm.notifyNeedTermination();
             return;
         }
     }

--- a/src/jsc/bindings/vm/NodeVMEvalTimeout.cpp
+++ b/src/jsc/bindings/vm/NodeVMEvalTimeout.cpp
@@ -18,7 +18,9 @@ NodeVMEvalTimeout::NodeVMEvalTimeout(VM& vm, int64_t milliseconds)
     // TerminationException to exist, and it can only be created on this
     // thread.
     vm.ensureTerminationException();
-    WebCore::clientData(vm)->nodeVMEvalTimeoutDepth++;
+    auto* clientData = WebCore::clientData(vm);
+    m_enclosing = clientData->nodeVMEvalTimeouts;
+    clientData->nodeVMEvalTimeouts = this;
     {
         WTF::Locker locker { m_state->lock };
         m_state->vm = &vm;
@@ -37,23 +39,49 @@ NodeVMEvalTimeout::~NodeVMEvalTimeout()
     disarm();
 }
 
+bool NodeVMEvalTimeout::hasExpired() const
+{
+    WTF::Locker locker { m_state->lock };
+    return m_state->expired;
+}
+
 void NodeVMEvalTimeout::disarm()
 {
     if (!m_armed)
         return;
     m_armed = false;
-    WebCore::clientData(m_vm)->nodeVMEvalTimeoutDepth--;
+    // Evaluations nest strictly, so this is the innermost armed deadline.
+    auto* clientData = WebCore::clientData(m_vm);
+    ASSERT(clientData->nodeVMEvalTimeouts == this);
+    clientData->nodeVMEvalTimeouts = m_enclosing;
     {
         WTF::Locker locker { m_state->lock };
         m_state->vm = nullptr;
         m_expired = m_state->expired;
     }
+    if (!m_expired)
+        return;
     // If the deadline passed after the evaluation's last trap check, the
     // NeedTermination trap is still pending and would terminate whatever JS
     // runs next. It was raised on behalf of this evaluation, so consume it;
     // the caller reports ERR_SCRIPT_EXECUTION_TIMEOUT either way.
-    if (m_expired)
-        m_vm.traps().clearTrap(VMTraps::NeedTermination);
+    m_vm.traps().clearTrap(VMTraps::NeedTermination);
+}
+
+void NodeVMEvalTimeout::raiseExpiredEnclosingDeadline()
+{
+    ASSERT(!m_armed);
+    if (!m_expired)
+        return;
+    // An enclosing deadline that expires after this check raises the
+    // request from its own timer, so nothing is lost by only checking
+    // deadlines that have already expired.
+    for (NodeVMEvalTimeout* enclosing = m_enclosing; enclosing; enclosing = enclosing->m_enclosing) {
+        if (enclosing->hasExpired()) {
+            m_vm.notifyNeedTermination();
+            return;
+        }
+    }
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/vm/NodeVMEvalTimeout.cpp
+++ b/src/jsc/bindings/vm/NodeVMEvalTimeout.cpp
@@ -1,0 +1,59 @@
+#include "NodeVMEvalTimeout.h"
+
+#include "BunClientData.h"
+
+#include <JavaScriptCore/VMTraps.h>
+#include <wtf/WorkQueue.h>
+
+namespace Bun {
+
+using namespace JSC;
+
+NodeVMEvalTimeout::NodeVMEvalTimeout(VM& vm, int64_t milliseconds)
+    : m_state(adoptRef(*new State))
+    , m_vm(vm)
+    , m_milliseconds(milliseconds)
+{
+    // The timer's notifyNeedTermination() needs the singleton
+    // TerminationException to exist, and it can only be created on this
+    // thread.
+    vm.ensureTerminationException();
+    WebCore::clientData(vm)->nodeVMEvalTimeoutDepth++;
+    {
+        WTF::Locker locker { m_state->lock };
+        m_state->vm = &vm;
+    }
+    VMTraps::queue().dispatchAfter(Seconds::fromMilliseconds(milliseconds), [state = m_state.copyRef()] {
+        WTF::Locker locker { state->lock };
+        if (!state->vm)
+            return;
+        state->expired = true;
+        state->vm->notifyNeedTermination();
+    });
+}
+
+NodeVMEvalTimeout::~NodeVMEvalTimeout()
+{
+    disarm();
+}
+
+void NodeVMEvalTimeout::disarm()
+{
+    if (!m_armed)
+        return;
+    m_armed = false;
+    WebCore::clientData(m_vm)->nodeVMEvalTimeoutDepth--;
+    {
+        WTF::Locker locker { m_state->lock };
+        m_state->vm = nullptr;
+        m_expired = m_state->expired;
+    }
+    // If the deadline passed after the evaluation's last trap check, the
+    // NeedTermination trap is still pending and would terminate whatever JS
+    // runs next. It was raised on behalf of this evaluation, so consume it;
+    // the caller reports ERR_SCRIPT_EXECUTION_TIMEOUT either way.
+    if (m_expired)
+        m_vm.traps().clearTrap(VMTraps::NeedTermination);
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/vm/NodeVMEvalTimeout.h
+++ b/src/jsc/bindings/vm/NodeVMEvalTimeout.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "root.h"
+
+#include <wtf/Lock.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace Bun {
+
+// Wall-clock deadline for a `node:vm` evaluation that was given the `timeout`
+// option. Arms a one-shot timer on a background queue; if it fires while the
+// evaluation is still running it requests termination of the in-flight JS
+// (VM::notifyNeedTermination), like Node's per-evaluation watchdog thread.
+// `disarm()` must be called on the JS thread once the evaluation has returned;
+// after that `expired()` reports whether the deadline was hit.
+//
+// The JSC Watchdog is deliberately not used here. It measures CPU time while
+// Node's `timeout` is wall-clock, and it cannot be disarmed: its wall timer
+// stays in flight after `setTimeLimit(noTimeLimit)`, and servicing the
+// resulting NeedWatchdogCheck trap later restarts the timer with no limit set
+// (`ASSERT(hasTimeLimit())` in Watchdog::startTimer) or terminates whatever
+// unrelated JS happens to be on the stack.
+class NodeVMEvalTimeout {
+    WTF_MAKE_NONCOPYABLE(NodeVMEvalTimeout);
+
+public:
+    NodeVMEvalTimeout(JSC::VM&, int64_t milliseconds);
+    ~NodeVMEvalTimeout();
+
+    // Idempotent. Stops the timer and, if it already fired, consumes the
+    // NeedTermination trap it raised so it cannot leak into unrelated JS.
+    void disarm();
+
+    // Only meaningful after disarm().
+    bool expired() const { return m_expired; }
+    int64_t milliseconds() const { return m_milliseconds; }
+
+private:
+    // Shared with the timer lambda, which can outlive this stack object.
+    struct State : public ThreadSafeRefCounted<State> {
+        WTF::Lock lock;
+        // Non-null only while armed; disarm() clears it so a late firing
+        // never touches a VM that may since have been torn down.
+        JSC::VM* vm WTF_GUARDED_BY_LOCK(lock) { nullptr };
+        bool expired WTF_GUARDED_BY_LOCK(lock) { false };
+    };
+
+    Ref<State> m_state;
+    JSC::VM& m_vm;
+    int64_t m_milliseconds;
+    bool m_armed { true };
+    bool m_expired { false };
+};
+
+} // namespace Bun

--- a/src/jsc/bindings/vm/NodeVMEvalTimeout.h
+++ b/src/jsc/bindings/vm/NodeVMEvalTimeout.h
@@ -14,6 +14,13 @@ namespace Bun {
 // `disarm()` must be called on the JS thread once the evaluation has returned;
 // after that `expired()` reports whether the deadline was hit.
 //
+// Armed deadlines form an intrusive per-VM stack (evaluations nest strictly).
+// The NeedTermination trap they fire is a single coalescing per-VM signal, so
+// when an evaluation consumes it for its own expired deadline, disarm()
+// re-raises it if an enclosing armed deadline has also expired; otherwise that
+// enclosing evaluation would never be interrupted again (its timer is
+// one-shot).
+//
 // The JSC Watchdog is deliberately not used here. It measures CPU time while
 // Node's `timeout` is wall-clock, and it cannot be disarmed: its wall timer
 // stays in flight after `setTimeLimit(noTimeLimit)`, and servicing the
@@ -31,6 +38,15 @@ public:
     // NeedTermination trap it raised so it cannot leak into unrelated JS.
     void disarm();
 
+    // Must run after disarm(), once this evaluation's own timeout error has
+    // been thrown. If an enclosing armed deadline has also expired, disarm()
+    // consumed the (coalesced) termination request its one-shot timer had
+    // raised, so raise it again on its behalf. Deferring this until after
+    // the ERR_SCRIPT_EXECUTION_TIMEOUT has been created keeps the new
+    // termination request from being serviced in the middle of constructing
+    // that error.
+    void raiseExpiredEnclosingDeadline();
+
     // Only meaningful after disarm().
     bool expired() const { return m_expired; }
     int64_t milliseconds() const { return m_milliseconds; }
@@ -45,8 +61,12 @@ private:
         bool expired WTF_GUARDED_BY_LOCK(lock) { false };
     };
 
+    bool hasExpired() const;
+
     Ref<State> m_state;
     JSC::VM& m_vm;
+    // Next-innermost armed deadline on this VM when this one was armed.
+    NodeVMEvalTimeout* m_enclosing { nullptr };
     int64_t m_milliseconds;
     bool m_armed { true };
     bool m_expired { false };

--- a/src/jsc/bindings/vm/NodeVMEvalTimeout.h
+++ b/src/jsc/bindings/vm/NodeVMEvalTimeout.h
@@ -16,10 +16,10 @@ namespace Bun {
 //
 // Armed deadlines form an intrusive per-VM stack (evaluations nest strictly).
 // The NeedTermination trap they fire is a single coalescing per-VM signal, so
-// when an evaluation consumes it for its own expired deadline, disarm()
-// re-raises it if an enclosing armed deadline has also expired; otherwise that
-// enclosing evaluation would never be interrupted again (its timer is
-// one-shot).
+// after an evaluation consumes it for its own expired deadline (or its own
+// SIGINT), raiseExpiredDeadline() raises it again on behalf of any enclosing
+// armed deadline that has also expired; otherwise that enclosing evaluation
+// would never be interrupted again (its timer is one-shot).
 //
 // The JSC Watchdog is deliberately not used here. It measures CPU time while
 // Node's `timeout` is wall-clock, and it cannot be disarmed: its wall timer
@@ -38,14 +38,14 @@ public:
     // NeedTermination trap it raised so it cannot leak into unrelated JS.
     void disarm();
 
-    // Must run after disarm(), once this evaluation's own timeout error has
-    // been thrown. If an enclosing armed deadline has also expired, disarm()
-    // consumed the (coalesced) termination request its one-shot timer had
-    // raised, so raise it again on its behalf. Deferring this until after
-    // the ERR_SCRIPT_EXECUTION_TIMEOUT has been created keeps the new
-    // termination request from being serviced in the middle of constructing
-    // that error.
-    void raiseExpiredEnclosingDeadline();
+    // Raises the termination request again if any still-armed deadline on
+    // this VM has already expired: such a deadline's one-shot timer has
+    // fired, so the request the evaluation that just finished consumed (for
+    // its own timeout or SIGINT) was the only signal left. Must run after
+    // that evaluation's own ERR_SCRIPT_EXECUTION_* error has been created,
+    // so the new termination request cannot be serviced in the middle of
+    // constructing it.
+    static void raiseExpiredDeadline(JSC::VM&);
 
     // Only meaningful after disarm().
     bool expired() const { return m_expired; }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1416,18 +1416,19 @@ describe("node:vm timeout option", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("OK\n");
-    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 
   test("terminates a runaway script", () => {
-    expect(() => runInThisContext("while (true) {}", { timeout: 100 })).toThrow({
-      name: "Error",
-      message: "Script execution timed out after 100ms",
-    });
+    expect(() => runInThisContext("while (true) {}", { timeout: 100 })).toThrow(
+      expect.objectContaining({
+        code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
+        message: "Script execution timed out after 100ms",
+      }),
+    );
   });
 
   // runInThisContext evaluates in the caller's own global, so timing out must
@@ -1438,7 +1439,10 @@ describe("node:vm timeout option", () => {
       survived = true;
     });
     expect(() => runInThisContext("while (true) {}", { timeout: 100 })).toThrow(
-      "Script execution timed out after 100ms",
+      expect.objectContaining({
+        code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
+        message: "Script execution timed out after 100ms",
+      }),
     );
     await Promise.resolve();
     expect(survived).toBe(true);
@@ -1449,7 +1453,10 @@ describe("node:vm timeout option", () => {
       runInVM: (timeout: number) => runInNewContext("while (true) {}", context, { timeout }),
     });
     expect(() => runInNewContext("runInVM(50)", context, { timeout: 100_000 })).toThrow(
-      "Script execution timed out after 50ms",
+      expect.objectContaining({
+        code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
+        message: "Script execution timed out after 50ms",
+      }),
     );
   });
 
@@ -1460,7 +1467,10 @@ describe("node:vm timeout option", () => {
       runInVM: (timeout: number) => runInNewContext("while (true) {}", context, { timeout }),
     });
     expect(() => runInNewContext("runInVM(100000)", context, { timeout: 100 })).toThrow(
-      "Script execution timed out after 100ms",
+      expect.objectContaining({
+        code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
+        message: "Script execution timed out after 100ms",
+      }),
     );
   });
 
@@ -1484,10 +1494,9 @@ describe("node:vm timeout option", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("ERR_SCRIPT_EXECUTION_TIMEOUT\n");
-    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 
@@ -1517,10 +1526,9 @@ describe("node:vm timeout option", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("ERR_SCRIPT_EXECUTION_TIMEOUT\nmicrotask survived: true\n");
-    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1422,6 +1422,40 @@ describe("node:vm timeout option", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A default-mode context shares the host's microtask queue, so a guest
+  // `Promise.resolve().then(loop)` chain drains on the host queue after
+  // runInContext returns. With the stale JSC Watchdog the 80ms deadline fired
+  // during that chain and left the VM terminated: every later host callback
+  // (timers, the process exit handler) was silently skipped and the process
+  // exited 0.
+  test("a guest microtask loop that outlives the evaluation's deadline does not poison host callbacks", async () => {
+    const fixture = `
+      import vm from "node:vm";
+      const c = vm.createContext({ N: { n: 0 } });
+      setTimeout(() => {
+        Promise.resolve().then(() => console.log("host microtask ran"));
+        console.log("host timer ran, later vm eval: " + vm.runInNewContext("6*7", {}));
+      }, 400);
+      vm.runInContext(
+        "const t = Date.now(); (function loop(){ N.n++; if (Date.now() - t < 200) Promise.resolve().then(loop); })(); 1",
+        c, { timeout: 80 },
+      );
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("host timer ran, later vm eval: 42\nhost microtask ran\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("terminates a runaway script", () => {
     expect(() => runInThisContext("while (true) {}", { timeout: 100 })).toThrow(
       expect.objectContaining({

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1430,6 +1430,20 @@ describe("node:vm timeout option", () => {
     });
   });
 
+  // runInThisContext evaluates in the caller's own global, so timing out must
+  // not discard microtasks the caller queued before the call.
+  test("a timed-out runInThisContext does not cancel the caller's microtasks", async () => {
+    let survived = false;
+    Promise.resolve().then(() => {
+      survived = true;
+    });
+    expect(() => runInThisContext("while (true) {}", { timeout: 100 })).toThrow(
+      "Script execution timed out after 100ms",
+    );
+    await Promise.resolve();
+    expect(survived).toBe(true);
+  });
+
   test("nested: the inner deadline fires first and propagates out", () => {
     const context = createContext({
       runInVM: (timeout: number) => runInNewContext("while (true) {}", context, { timeout }),

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1383,3 +1383,130 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("node:vm timeout option", () => {
+  // A timed evaluation must fully disarm its deadline once it returns. The
+  // JSC-Watchdog-based implementation restored the time limit but left the
+  // armed wall-clock deadline (and its in-flight timer) behind, so the first
+  // trap check after the stale deadline elapsed either re-armed a watchdog
+  // with no time limit (ASSERTION FAILED: hasTimeLimit() in
+  // Watchdog::startTimer on debug builds) or terminated whatever unrelated
+  // JS happened to be running (release builds).
+  test("a completed timed evaluation does not affect later code", async () => {
+    const fixture = `
+      import vm from "node:vm";
+      // Warm up so the timed evaluation below stays well under its deadline.
+      vm.runInNewContext("1", {});
+      vm.runInNewContext("1", {}, { timeout: 250 });
+      // Let the stale 250ms deadline elapse while no JS is running.
+      Bun.sleepSync(400);
+      // Debug builds used to abort here (Watchdog::startTimer with no limit).
+      vm.runInNewContext("1", {});
+      // Release builds used to terminate the main script here once the stale
+      // CPU budget ran out.
+      const start = Date.now();
+      while (Date.now() - start < 400) {}
+      console.log("OK");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("OK\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("terminates a runaway script", () => {
+    expect(() => runInThisContext("while (true) {}", { timeout: 100 })).toThrow({
+      name: "Error",
+      message: "Script execution timed out after 100ms",
+    });
+  });
+
+  test("nested: the inner deadline fires first and propagates out", () => {
+    const context = createContext({
+      runInVM: (timeout: number) => runInNewContext("while (true) {}", context, { timeout }),
+    });
+    expect(() => runInNewContext("runInVM(50)", context, { timeout: 100_000 })).toThrow(
+      "Script execution timed out after 50ms",
+    );
+  });
+
+  // The outer deadline fires while the inner (longer) evaluation is running.
+  // The inner call must not claim that termination as its own timeout.
+  test("nested: the outer deadline fires first and is reported by the outer call", () => {
+    const context = createContext({
+      runInVM: (timeout: number) => runInNewContext("while (true) {}", context, { timeout }),
+    });
+    expect(() => runInNewContext("runInVM(100000)", context, { timeout: 100 })).toThrow(
+      "Script execution timed out after 100ms",
+    );
+  });
+
+  test("SourceTextModule.evaluate honors the timeout option", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const mod = new vm.SourceTextModule("while (true) {}");
+      await mod.link(() => {});
+      try {
+        await mod.evaluate({ timeout: 100 });
+        console.log("UNEXPECTED_OK");
+      } catch (err) {
+        console.log(err.code);
+      }
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("ERR_SCRIPT_EXECUTION_TIMEOUT\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  // A module with no `context` option evaluates in the caller's own global.
+  // Timing out must not discard the caller's already-queued microtasks
+  // (test-vm-module-basic.js hangs if they are dropped).
+  test("a timed-out context-less module does not cancel the caller's microtasks", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const mod = new vm.SourceTextModule("while (true) {}");
+      await mod.link(() => {});
+      let survived = false;
+      Promise.resolve().then(() => { survived = true; });
+      try {
+        await mod.evaluate({ timeout: 100 });
+        console.log("UNEXPECTED_OK");
+      } catch (err) {
+        console.log(err.code);
+      }
+      console.log("microtask survived: " + survived);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("ERR_SCRIPT_EXECUTION_TIMEOUT\nmicrotask survived: true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1474,6 +1474,41 @@ describe("node:vm timeout option", () => {
     );
   });
 
+  // Every deadline's one-shot timer feeds the same per-VM NeedTermination
+  // signal. When an inner evaluation times out and consumes it, an enclosing
+  // deadline that also already expired must be raised again on its behalf,
+  // or the enclosing script (whose own timer will never fire again) runs
+  // forever once it catches the inner error. The inner evaluation blocks in
+  // a host call past both deadlines so both timers have fired by the time it
+  // returns.
+  test("nested: an inner timeout does not swallow an expired outer deadline", async () => {
+    const fixture = `
+      import vm from "node:vm";
+      const context = vm.createContext({
+        sleepSync: Bun.sleepSync,
+        runInner: () => vm.runInNewContext("sleepSync(600)", context, { timeout: 150 }),
+      });
+      try {
+        vm.runInNewContext("try { runInner() } catch (err) {} while (true) {}", context, { timeout: 250 });
+        console.log("UNEXPECTED_OK");
+      } catch (err) {
+        console.log(err.message);
+      }
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("Script execution timed out after 250ms\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("SourceTextModule.evaluate honors the timeout option", async () => {
     const fixture = `
       const vm = require("node:vm");


### PR DESCRIPTION
### Repro

```js
import vm from "node:vm";
vm.runInNewContext("1", {}, { timeout: 25 }); // arms the per-VM JSC Watchdog
Bun.sleepSync(60);                            // the 25ms wall deadline elapses in host code
vm.runInNewContext("1", {});                  // next eval services the stale trap
```

On an assertions build:

```
ASSERTION FAILED: hasTimeLimit()
vendor/WebKit/Source/JavaScriptCore/runtime/Watchdog.cpp(133) : void JSC::Watchdog::startTimer(Seconds)
```

On release the same state is reached silently and the damage lands on whatever JS runs next. This hangs forever on 1.4.0:

```js
const vm = require("node:vm");
vm.runInNewContext("1", {}, { timeout: 25 });
const t = Date.now();
while (Date.now() - t < 300) {} // the main script is terminated by the stale deadline
console.log("never reached");
```

### Cause

`setupWatchdog` armed the shared `JSC::Watchdog` and restored `setTimeLimit(noTimeLimit)` after the evaluation. That clears the limit but not the armed wall deadline (`m_deadline`) or the timer already dispatched on the VMTraps queue, and the watchdog stays `isActive()` because `node:vm` evaluations run inside the caller's `VMEntryScope`. When the stale timer fires, the next trap check calls `Watchdog::shouldTerminate()`:

- the wall deadline has expired but the CPU deadline has not (the process was idle), so it calls `startTimer(remainingCPUTime)` with no time limit set, which is the assertion;
- on release it re-arms, and once the leftover CPU budget is consumed it terminates the JS that happens to be running. Outside a `node:vm` eval nothing converts that into an error, so the main script dies; inside an untimed eval it hit `RELEASE_ASSERT_NOT_REACHED`.

There is no call sequence that returns the Watchdog to a safe state from outside: it has no cancel API, `exitedVM()` belongs to the `VMEntryScope`, and `stopTimer()` sets the CPU deadline to infinity which makes the dangerous branch unconditionally true. It also measures CPU time, while Node's `timeout` is wall-clock.

### Fix

Stop using the JSC Watchdog for `node:vm` timeouts. `NodeVMEvalTimeout` arms a one-shot wall-clock deadline on the VMTraps queue that calls `VM::notifyNeedTermination()` if it fires while the evaluation is still running (the design of Node's per-evaluation watchdog thread, and the mechanism `breakOnSigint` already uses). `disarm()` runs when the evaluation returns: it neutralizes the timer and, if the deadline fired after the evaluation's last trap check, consumes the pending `NeedTermination` trap so it cannot leak into later JS.

`checkForTermination` is now shared by all four evaluation entry points and only reports `ERR_SCRIPT_EXECUTION_TIMEOUT` / `ERR_SCRIPT_EXECUTION_INTERRUPTED` when this evaluation's own deadline or SIGINT watcher raised the termination. Anything else (for example `Worker.terminate()` during an eval) keeps propagating instead of being mislabelled or asserting. Nested timeouts attribute the error to whichever deadline actually fired, which is what Node does (`test-vm-timeout.js` covers both directions).

Armed deadlines form an intrusive per-VM stack. `NeedTermination` is a single coalescing per-VM signal, so when a nested evaluation consumes it for its own expired deadline, it raises the request again on behalf of any enclosing deadline that has also expired, since that deadline's one-shot timer will never fire again. Without this, an outer script that catches the inner timeout error can run past its own deadline forever. The request is raised only after the inner evaluation's own error has been created: error construction can service pending traps, and `ErrorCodeCache::createError` does not expect the termination exception (whose value is not an object) to be the exception thrown during `ErrorInstance::create`. That latent issue is pre-existing, reachable by any cross-thread termination that lands during error creation, and left for a separate change (there is an existing TODO on that line in `ErrorCode.cpp`).

`JSC__VM__hasExecutionTimeLimit` (the spawnSync fast-path gate) now reports whether a `node:vm` deadline is armed. `JSC__VM__setExecutionTimeLimit`, `JSC__VM__clearExecutionTimeLimit` and `JSC__VM__notifyNeedWatchdogCheck` had no callers and are deleted along with the mechanism they exposed.

### Verification

- New tests in `test/js/node/vm/vm.test.ts`: the repro above (fails on an unfixed debug build with the `hasTimeLimit()` assertion and on unfixed release by hanging), runaway-script timeout, both nested orderings, an expired outer deadline surviving a nested timeout, `SourceTextModule.evaluate({ timeout })`, and a regression test that a timed-out context-less module does not discard the caller's queued microtasks.
- All 95 `test/js/node/test/parallel/test-vm-*.js` pass on the debug build (same as before the change), including `test-vm-timeout.js`, the `test-vm-timeout-escape-promise*` set, and `test-vm-sigint*`.
- `test/js/node/vm/` is green: 223 pass, 0 fail.

Note: #30598 (open) proposes arming this same JSC Watchdog around `bun test --timeout` callbacks and touches the same files. That approach inherits the stale-deadline problem described here for any callback that finishes before its deadline.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 12 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/162] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[28/162] cxx obj/unified/UnifiedSource-src_jsc_bindings_vm-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings_vm-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -g3 -gz=zstd -glldb -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -Wno-c23-extensions -ffunction-sections -fdata-sections -faddrsig -fno-semantic-interposition -fno-delete-null-pointer-checks -fdiagnostics-color=always -ferror-limit=100 -std=gn
... (truncated)

release without fix: 10 failed, 62 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.56ms]
(pass) vm > runInContext() > can return a value [0.36ms]
(pass) vm > runInContext() > can return a complex value [0.36ms]
(pass) vm > runInContext() > can return the last value [0.30ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.38ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.26ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.31ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.34ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.29ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.27ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.27ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.26ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.25ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.26ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (24da7d201)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [38.36ms]
(pass) vm > runInContext() > can return a value [27.93ms]
(pass) vm > runInContext() > can return a complex value [25.14ms]
(pass) vm > runInContext() > can return the last value [16.99ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [19.30ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [16.78ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [17.63ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [18.92ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.81ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [22.28ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [21.54ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [24.32ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     24da7d201e
  features     baseline

22 deps, 108 codegen, 1171 objects in 1130ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [45.00ms]
[2/1234] gen ErrorCode+*.h
[3/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1234] gen .bind.ts → GeneratedBindings.cpp
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1234] gen bindgenv2
[8/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1234] fetch tinycc
[tinycc] up to date
[10/1234] install /workspace/bun/src/node-fallback
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VM.rs                              |   2 +-
 src/jsc/bindings/BunClientData.h           |   9 ++
 src/jsc/bindings/NodeVM.cpp                |  32 +++++
 src/jsc/bindings/NodeVM.h                  |  14 ++
 src/jsc/bindings/NodeVMModule.cpp          |  62 +++-----
 src/jsc/bindings/NodeVMScript.cpp          |  72 ++--------
 src/jsc/bindings/NodeVMSyntheticModule.cpp |   1 -
 src/jsc/bindings/bindings.cpp              |  25 +---
 src/jsc/bindings/headers.h                 |   3 -
 src/jsc/bindings/vm/NodeVMEvalTimeout.cpp  |  85 +++++++++++
 src/jsc/bindings/vm/NodeVMEvalTimeout.h    |  75 ++++++++++
 test/js/node/vm/vm.test.ts                 | 218 +++++++++++++++++++++++++++++
 12 files changed, 465 insertions(+), 133 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/VM.rs                                   3      5     27
src/jsc/bindings/BunClientData.h                4      3     27
src/jsc/bindings/NodeVM.cpp                     6      8     27
src/jsc/bindings/NodeVM.h                       4      6     27
src/jsc/bindings/NodeVMModule.cpp               7     12     27
src/jsc/bindings/NodeVMScript.cpp               5      8     27
src/jsc/bindings/NodeVMSyntheticModule.cpp      0      0     27
src/jsc/bindings/bindings.cpp                   4      6     27
src/jsc/bindings/headers.h                      1      3     27
src/jsc/bindings/vm/NodeVMEvalTimeout.cpp       2      5     27
src/jsc/bindings/vm/NodeVMEvalTimeout.h         2      4     27
test/js/node/vm/vm.test.ts                      8     12     27
```

</details>

<!-- robobun:evidence:end -->