### PR TITLE
Don't panic generating a sourcemap for a source ending in a truncated UTF-8 sequence

### DIFF
--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -192,17 +192,19 @@ impl LineOffsetTable {
             let len_ = strings::wtf8_byte_sequence_length_with_invalid(b0);
             // After the SIMD skip below lands, the loop head
             // is overwhelmingly an ASCII '\r'/'\n' or a non-ASCII lead byte, so keep the
-            // 1-byte path branch-only and confine the zero+min+copy pad to the cold
+            // 1-byte path branch-only and confine the zero+copy pad to the cold
             // multibyte arm.
+            // `len_` is the lead byte's *declared* width; a source whose final bytes are
+            // a truncated multibyte sequence declares more bytes than remain, so every
+            // slice below (decode, SIMD-skip offset, advance) must use the clamped width.
+            let cp_len = (len_ as usize).min(remaining.len());
             let c: i32 = if len_ == 1 {
                 b0 as i32
             } else {
                 let mut cp_bytes = [0u8; 4];
-                let take = (len_ as usize).min(remaining.len());
-                cp_bytes[..take].copy_from_slice(&remaining[..take]);
+                cp_bytes[..cp_len].copy_from_slice(&remaining[..cp_len]);
                 strings::decode_wtf8_rune_t::<i32>(cp_bytes, len_, 0)
             };
-            let cp_len = len_ as usize;
 
             let offset = (remaining.as_ptr() as usize - base) as u32;
 
@@ -233,7 +235,7 @@ impl LineOffsetTable {
                         // skip ahead to the next newline or non-ascii character
                         if let Some(j) = strings::index_of_newline_or_non_ascii_check_start::<false>(
                             remaining,
-                            len_ as u32,
+                            cp_len as u32,
                         ) {
                             column += i32::try_from(j).expect("int cast");
                             remaining = &remaining[j as usize..];

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -408,3 +408,41 @@ console.log(go());
     }
   });
 });
+
+// LineOffsetTable::generate builds the per-line column table directly from the
+// raw source bytes, so it must tolerate a truncated trailing multi-byte UTF-8
+// sequence: a lead byte that declares more bytes than the file has left.
+describe.concurrent("sourcemap of a source with a truncated trailing UTF-8 sequence", () => {
+  test.each([
+    ["lone 4-byte lead 0xF0", [0xf0]],
+    ["lone 3-byte lead 0xE2", [0xe2]],
+    ["lone 2-byte lead 0xC3", [0xc3]],
+    ["overlong 2-byte lead 0xC1", [0xc1]],
+    ["2 of 3 bytes 0xE0 0x81", [0xe0, 0x81]],
+    ["3 of 4 bytes 0xF0 0x9F 0x92", [0xf0, 0x9f, 0x92]],
+  ] as [string, number[]][])("%s", async (_name, tail) => {
+    using dir = tempDir("sourcemap-truncated-utf8", {
+      "in.js": Buffer.concat([Buffer.from("console.log(1);//"), Buffer.from(tail)]),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--sourcemap=external", "--outdir=out", "in.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ exitCode, stdout, stderr }).toEqual({
+      exitCode: 0,
+      stdout: expect.any(String),
+      stderr: expect.any(String),
+    });
+    // `console.log(1);` is identical in every variant and the truncated bytes
+    // live in a stripped comment, so the encoded mappings must be identical too.
+    const map = await Bun.file(path.join(String(dir), "out", "in.js.map")).json();
+    expect(map).toMatchObject({
+      sources: ["../in.js"],
+      mappings: ";AAAA,QAAQ,IAAI,CAAC;",
+    });
+  });
+});


### PR DESCRIPTION
### Repro

A source file whose last bytes are a truncated multi-byte UTF-8 sequence (a lead byte that declares more bytes than the file has left) panics every sourcemap-printing path: `bun build --sourcemap=inline|external`, plain `bun <file>` (the runtime transpiler builds the same line table for stack-trace remapping), and `--hot` rebuilds.

```sh
printf 'console.log(1);//\xf0' > t.js
bun build --sourcemap=external --outdir=out t.js
```

```
panic: range start index 4 out of range for slice of length 1
```

at `LineOffsetTable::generate`, via `Chunk::add_source_mapping` / `js_printer::print_stmt`.

`bun build` without `--sourcemap` handles the same file fine, since the lexer already treats a truncated trailing sequence as EOF. Only the sourcemap line table is unguarded. Files ending mid-sequence show up in practice: truncated copies or downloads, an editor or CI job dying mid-write, or a file being rewritten while a build is in flight.

Other truncated tails hit the same bug: `\xe2`, `\xc3`, `\xc1`, `\xe0\x81`, `\xf0\x9f\x92`.

### Cause

`LineOffsetTable::generate_in` (`src/sourcemap/LineOffsetTable.rs`) walks the source one codepoint at a time. For each lead byte it gets the *declared* sequence width from `wtf8_byte_sequence_length_with_invalid`. The codepoint **decode** already clamps that width to the bytes remaining (`.min(remaining.len())`), but two other uses of it do not:

- the **advance**, `remaining = &remaining[cp_len..]`, so a lone `0xF0` at EOF indexes `[4..]` of a 1-byte slice (this is the reported panic)
- the **offset** passed to `index_of_newline_or_non_ascii_check_start`, which does `&slice[offset..]` internally; this is the panic site for overlong truncated leads such as `0xC1` and `0xE0 0x81`, whose zero-padded decode lands in the ASCII fast path

Every other caller of `wtf8_byte_sequence_length_with_invalid` in the tree already clamps both the decode and the advance: the lexer steppers and URL percent-encoder in `bun_core::strings`, the string escapers in `js_printer`, and the markdown ANSI renderer. (`Chunk::update_generated_line_and_column_slow` has a superficially similar unclamped advance, but it walks the printer *output*, which only grows by whole codepoints; the lexer strips a truncated trailing sequence from the source before anything reaches the printer, so it is not reachable and is left unchanged.)

### Fix

Compute the clamped width once, `cp_len = (len_ as usize).min(remaining.len())`, and use it for all three: the decode slice, the skip offset, and the advance. This is the same `clamped_width` idiom the string escapers in `js_printer` and `bun_core::string` already use.

For any non-truncated input `cp_len == len_`, so behavior is unchanged; the two can only differ within `len_ - 1` bytes of the end of the source.

### Verification

`test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts` gains a `test.each` over six truncated tails (`0xF0`, `0xE2`, `0xC3`, `0xC1`, `0xE0 0x81`, `0xF0 0x9F 0x92`), chosen so the set covers both panic sites. Each spawns `bun build --sourcemap=external` on the malformed source and asserts exit code 0 plus the exact emitted `sources` and `mappings`. The mappings are identical across every variant because the `console.log(1);` payload is byte-identical and the truncated bytes live in a stripped comment.

All six fail on an unpatched build with the panic above; all pass with the fix, and the rest of the file still passes.
