### PR TITLE
node:http2: apply SETTINGS_HEADER_TABLE_SIZE to the HPACK decoder and encoder

### DIFF
--- a/src/http/lshpack.rs
+++ b/src/http/lshpack.rs
@@ -130,6 +130,14 @@ impl HPACK {
         lshpack_wrapper_enc_set_max_capacity(self, max_capacity as c_uint);
     }
 
+    /// Adjust the decoder's maximum dynamic-table capacity after init: the
+    /// SETTINGS_HEADER_TABLE_SIZE we advertised, once the peer has ACKed it.
+    /// Bounds the value a peer's RFC 7541 §6.3 Dynamic Table Size Update may
+    /// carry; a shrink evicts entries in lockstep with the peer's encoder.
+    pub fn set_decoder_max_capacity(&mut self, max_capacity: u32) {
+        lshpack_wrapper_dec_set_max_capacity(self, max_capacity as c_uint);
+    }
+
     // Raw `*mut HPACK` teardown is subsumed by the
     // safe [`HpackHandle`] RAII wrapper below — every owner holds an
     // `HpackHandle`, so the raw destructor is private to `HpackHandle::drop`.
@@ -212,6 +220,7 @@ unsafe extern "C" {
     // Only precondition is a valid non-null `*HPACK`; `&mut HPACK` (ABI-identical
     // thin pointer) discharges it at the type level, so this is `safe fn`.
     safe fn lshpack_wrapper_enc_set_max_capacity(self_: &mut HPACK, max_capacity: c_uint);
+    safe fn lshpack_wrapper_dec_set_max_capacity(self_: &mut HPACK, max_capacity: c_uint);
     // Frees `self_` (lshpack_{enc,dec}_cleanup + mi_free) — ownership transfer,
     // so this keeps its raw-pointer signature and caller-side safety obligation.
     fn lshpack_wrapper_deinit(self_: *mut HPACK);

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -441,6 +441,11 @@ void lshpack_wrapper_enc_set_max_capacity(lshpack_wrapper* self, unsigned max_ca
     lshpack_enc_set_max_capacity(&self->enc, max_capacity);
 }
 
+void lshpack_wrapper_dec_set_max_capacity(lshpack_wrapper* self, unsigned max_capacity)
+{
+    lshpack_dec_set_max_capacity(&self->dec, max_capacity);
+}
+
 void lshpack_wrapper_deinit(lshpack_wrapper* self)
 {
     lshpack_dec_cleanup(&self->dec);

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -162,10 +162,10 @@ pub struct Connection {
     /// The initial window size the peer has ACKed (RFC 9113 6.5.3): until our SETTINGS is ACKed,
     /// the peer may legitimately send according to the previous value - enforce the larger.
     acked_local_initial_window: u32,
-    /// INITIAL_WINDOW_SIZE values of sent-but-unACKed SETTINGS frames, in send order. §6.5.3:
-    /// ACKs apply to outstanding SETTINGS in order, so each inbound ACK pops the front - the
-    /// value the peer actually acknowledged - rather than assuming the latest submission.
-    pub pending_local_window_acks: std::collections::VecDeque<u32>,
+    /// Snapshots of sent-but-unACKed SETTINGS frames, in send order. §6.5.3: ACKs apply to
+    /// outstanding SETTINGS in order, so each inbound ACK pops the front - the values the peer
+    /// actually acknowledged - rather than assuming the latest submission.
+    pub pending_local_settings_acks: std::collections::VecDeque<Settings>,
     invalid_frame_count: u32,
     /// Maximum number of entries accepted in a single inbound SETTINGS frame (node's maxSettings
     /// session option, nghttp2's max_settings; not a SETTINGS parameter). Frames carrying more
@@ -224,7 +224,7 @@ impl Connection {
             max_header_list_pairs: 128,
             max_invalid_frames: 1000,
             acked_local_initial_window: 65_535,
-            pending_local_window_acks: std::collections::VecDeque::new(),
+            pending_local_settings_acks: std::collections::VecDeque::new(),
             invalid_frame_count: 0,
             max_settings: 32,
             send_window: SendWindow::new(wire::DEFAULT_WINDOW_SIZE),
@@ -281,8 +281,8 @@ impl Connection {
     pub fn send_settings(&mut self, sink: &impl Sink) {
         let mut buf = [0u8; Settings::STANDARD_COUNT * 6];
         let n = self.local_settings.pack_standard(&mut buf);
-        self.pending_local_window_acks
-            .push_back(self.local_settings.initial_window_size);
+        self.pending_local_settings_acks
+            .push_back(self.local_settings);
         self.write_frame(sink, FrameType::Settings, 0, 0, &buf[..n]);
     }
 
@@ -563,12 +563,17 @@ impl Connection {
                 return true;
             }
             self.local_settings_acked = true;
-            // §6.5.3: this ACK acknowledges the oldest outstanding SETTINGS, whose window size
-            // may differ from the latest submission when several SETTINGS are in flight.
-            self.acked_local_initial_window = self
-                .pending_local_window_acks
+            // §6.5.3: this ACK acknowledges the oldest outstanding SETTINGS, whose values may
+            // differ from the latest submission when several SETTINGS are in flight.
+            let acked = self
+                .pending_local_settings_acks
                 .pop_front()
-                .unwrap_or(self.local_settings.initial_window_size);
+                .unwrap_or(self.local_settings);
+            self.acked_local_initial_window = acked.initial_window_size;
+            // RFC 7541 §6.3: the limit on the peer's Dynamic Table Size Update is the
+            // SETTINGS_HEADER_TABLE_SIZE the peer has ACKed. Resize OUR decoder to match
+            // (the non-ACK branch below handles the encoder side of the peer's settings).
+            self.hpack.set_decoder_capacity(acked.header_table_size);
             let snapshot = self.local_settings;
             sink.on_local_settings(&snapshot);
             return false;

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -571,11 +571,13 @@ impl Connection {
                 .unwrap_or(self.local_settings);
             self.acked_local_initial_window = acked.initial_window_size;
             // RFC 7541 §6.3: the limit on the peer's Dynamic Table Size Update is the
-            // SETTINGS_HEADER_TABLE_SIZE the peer has ACKed. Resize OUR decoder to match
-            // (the non-ACK branch below handles the encoder side of the peer's settings).
+            // SETTINGS_HEADER_TABLE_SIZE the peer has ACKed. Resize OUR decoder to match. (The
+            // outbound encoder is the mirror: the embedder applies the PEER's header table size
+            // to it from Sink::on_remote_settings.)
             self.hpack.set_decoder_capacity(acked.header_table_size);
-            let snapshot = self.local_settings;
-            sink.on_local_settings(&snapshot);
+            // The `localSettings` event / `session.localSettings` must report the values the peer
+            // just acknowledged (what nghttp2's local_settings holds), not the latest submission.
+            sink.on_local_settings(&acked);
             return false;
         }
         // node's maxSettings (nghttp2 max_settings): refuse SETTINGS frames carrying more entries

--- a/src/runtime/api/bun/h2/hpack.rs
+++ b/src/runtime/api/bun/h2/hpack.rs
@@ -16,6 +16,9 @@ pub const MAX_SIZE_UPDATE_BYTES: usize = 6;
 pub struct Coder {
     hpack: HpackHandle,
     enc_capacity: u32,
+    /// The maximum the decoder accepts in a §6.3 Dynamic Table Size Update: the
+    /// SETTINGS_HEADER_TABLE_SIZE we last advertised and the peer has ACKed (§6.5.3).
+    dec_capacity: u32,
     /// A capacity change requested by the peer's SETTINGS_HEADER_TABLE_SIZE, applied + announced at
     /// the start of the next encoded header block. `None` = nothing pending.
     pending_enc_capacity: Option<u32>,
@@ -26,6 +29,7 @@ impl Coder {
         Coder {
             hpack: HpackHandle::new(max_capacity),
             enc_capacity: max_capacity,
+            dec_capacity: max_capacity,
             pending_enc_capacity: None,
         }
     }
@@ -37,6 +41,19 @@ impl Coder {
             return;
         }
         self.pending_enc_capacity = Some(capacity);
+    }
+
+    /// Apply OUR SETTINGS_HEADER_TABLE_SIZE to the decoder once the peer has ACKed it. The value
+    /// we advertise bounds the peer encoder's §6.3 Dynamic Table Size Update (RFC 7541 §6.3), so a
+    /// decoder left at its construction-time capacity rejects a conforming peer that grows up to
+    /// the new max. No-op when unchanged: re-applying would reset the table size the peer's
+    /// encoder last chose via a size update.
+    pub fn set_decoder_capacity(&mut self, capacity: u32) {
+        if capacity == self.dec_capacity {
+            return;
+        }
+        self.hpack.set_decoder_max_capacity(capacity);
+        self.dec_capacity = capacity;
     }
 
     /// If a capacity change is pending, apply it and write the §6.3 size-update opcode into `dst` at

--- a/src/runtime/api/bun/h2/hpack.rs
+++ b/src/runtime/api/bun/h2/hpack.rs
@@ -10,8 +10,10 @@
 
 use bun_http::lshpack::{DecodeResult, HpackError, HpackHandle};
 
-/// RFC 7541 §6.3: a Dynamic Table Size Update integer never needs more than 6 bytes for a u32.
-pub const MAX_SIZE_UPDATE_BYTES: usize = 6;
+/// RFC 7541 §4.2: a header block opens with at most two §6.3 Dynamic Table Size Updates (the
+/// interval minimum, then the final value). A §5.1 5-bit-prefix integer for a u32 never needs more
+/// than 6 bytes, so this bounds what [`Coder::take_pending_size_update`] can write.
+pub const MAX_SIZE_UPDATE_BYTES: usize = 12;
 
 pub struct Coder {
     hpack: HpackHandle,
@@ -22,6 +24,11 @@ pub struct Coder {
     /// A capacity change requested by the peer's SETTINGS_HEADER_TABLE_SIZE, applied + announced at
     /// the start of the next encoded header block. `None` = nothing pending.
     pending_enc_capacity: Option<u32>,
+    /// RFC 7541 §4.2: the SMALLEST capacity the peer requested since the last header block. The
+    /// peer's decoder evicts eagerly on each of its SETTINGS, so a transient minimum below the
+    /// final value must still be applied and signaled (as the first of two size updates) or the
+    /// two tables diverge. Only meaningful while `pending_enc_capacity` is `Some`.
+    pending_enc_min: u32,
 }
 
 impl Coder {
@@ -31,6 +38,7 @@ impl Coder {
             enc_capacity: max_capacity,
             dec_capacity: max_capacity,
             pending_enc_capacity: None,
+            pending_enc_min: max_capacity,
         }
     }
 
@@ -40,6 +48,10 @@ impl Coder {
         if capacity == self.enc_capacity && self.pending_enc_capacity.is_none() {
             return;
         }
+        self.pending_enc_min = match self.pending_enc_capacity {
+            Some(_) => self.pending_enc_min.min(capacity),
+            None => capacity,
+        };
         self.pending_enc_capacity = Some(capacity);
     }
 
@@ -56,15 +68,25 @@ impl Coder {
         self.dec_capacity = capacity;
     }
 
-    /// If a capacity change is pending, apply it and write the §6.3 size-update opcode into `dst` at
-    /// `offset`. Returns bytes written (0 if none). `dst[offset..]` needs >= MAX_SIZE_UPDATE_BYTES.
+    /// If a capacity change is pending, apply it and write the §6.3 size-update opcode(s) into
+    /// `dst` at `offset`. Returns bytes written (0 if none). `dst[offset..]` needs >=
+    /// MAX_SIZE_UPDATE_BYTES.
     pub fn take_pending_size_update(&mut self, dst: &mut [u8], offset: usize) -> usize {
         let Some(cap) = self.pending_enc_capacity.take() else {
             return 0;
         };
+        let mut n = 0;
+        // §4.2: when the interval's minimum is below its final value, the minimum MUST be signaled
+        // first (at most two size updates per block). Applying it evicts our table exactly as the
+        // peer's decoder already did at that SETTINGS, keeping the two tables in lockstep.
+        let min = self.pending_enc_min;
+        if min < cap {
+            self.hpack.set_encoder_max_capacity(min);
+            n += write_table_size_update(dst, offset, min);
+        }
         self.hpack.set_encoder_max_capacity(cap);
         self.enc_capacity = cap;
-        write_table_size_update(dst, offset, cap)
+        n + write_table_size_update(dst, offset + n, cap)
     }
 
     #[inline]

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1357,7 +1357,9 @@ pub struct H2FrameParser {
 
     streams: JsCell<BunHashMap<u32, *mut Stream>>,
 
-    hpack: JsCell<Option<lshpack::HpackHandle>>,
+    /// Outbound HPACK encoder (the engine in `engine` owns the inbound decoder). `Coder` carries
+    /// the pending RFC 7541 §6.3 size update queued by a peer SETTINGS_HEADER_TABLE_SIZE change.
+    hpack: JsCell<Option<crate::api::h2::hpack::Coder>>,
 
     has_nonnative_backpressure: Cell<bool>,
     ref_count: bun_ptr::RefCount<Self>, // intrusive — bun.ptr.RefCount(@This(), "ref_count", deinit, .{})
@@ -2227,6 +2229,18 @@ impl H2FrameParser {
         value: &[u8],
         never_index: bool,
     ) -> Result<usize, bun_core::Error> {
+        // Every outbound header block (request/respond, trailers, push promise) funnels its fields
+        // through here into a fresh, initially empty buffer, so the first field of a block is
+        // where RFC 7541 §6.3 requires a pending Dynamic Table Size Update to be announced.
+        if encoded_headers.is_empty() {
+            let mut opcode = [0u8; crate::api::h2::hpack::MAX_SIZE_UPDATE_BYTES];
+            let n = self.hpack.with_mut(|hpack| {
+                hpack
+                    .as_mut()
+                    .map_or(0, |hpack| hpack.take_pending_size_update(&mut opcode, 0))
+            });
+            encoded_headers.extend_from_slice(&opcode[..n]);
+        }
         let old_len = encoded_headers.len();
         let required = old_len + name.len() + value.len() + HPACK_ENTRY_OVERHEAD;
         // Note: materializing `&mut [u8]` over uninitialized capacity is UB and
@@ -5601,6 +5615,15 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
             ..Default::default()
         };
         self.remote_settings.set(Some(fp));
+        // RFC 7541 §4.2: the peer's HEADER_TABLE_SIZE bounds OUR encoder's dynamic table. Queue a
+        // §6.3 size update for the start of the next outbound header block; a peer that lowered
+        // the limit (nginx advertises 0 to every upstream) rejects blocks that keep referencing
+        // the old table. queue_encoder_capacity is a no-op when the value is unchanged.
+        self.hpack.with_mut(|hpack| {
+            if let Some(hpack) = hpack.as_mut() {
+                hpack.queue_encoder_capacity(settings.header_table_size);
+            }
+        });
         // §6.9.2 (mirrors the legacy inbound): when the peer's INITIAL_WINDOW_SIZE grows, raise the
         // send window of streams opened before its SETTINGS arrived (a client's first request is
         // typically sent before the server's SETTINGS lands), then resume queued sends.
@@ -9387,12 +9410,12 @@ impl H2FrameParser {
             .strong_this
             .with_mut(|s| s.set_strong(this_value, global_object));
 
-        // Note: `HPACK::init` returns a C-allocated wrapper that must be
-        // torn down via `lshpack_wrapper_deinit` (runs `lshpack_{enc,dec}_cleanup`
-        // before freeing). Wrapping it in `heap::take` and letting `Box` drop
-        // would `mi_free` the struct but leak the encoder/decoder internals.
-        this_ref.hpack.set(Some(lshpack::HpackHandle::new(
-            this_ref.local_settings.get().header_table_size,
+        // RFC 7541 §4.2: the outbound encoder is bounded by the PEER's SETTINGS_HEADER_TABLE_SIZE,
+        // which starts at the 4096 default until its SETTINGS arrives (our own headerTableSize
+        // governs the inbound decoder, owned by the engine). `Coder` owns an `HpackHandle` whose
+        // teardown runs `lshpack_wrapper_deinit` (cleanup + free), not a bare `mi_free`.
+        this_ref.hpack.set(Some(crate::api::h2::hpack::Coder::new(
+            crate::api::h2::wire::DEFAULT_HEADER_TABLE_SIZE,
         )));
         if is_server {
             let _ = this_ref.set_settings(this_ref.local_settings.get());

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1319,9 +1319,9 @@ pub struct H2FrameParser {
     /// Same bridge per stream: (stream id, bytes) pairs drained into the engine's per-stream send
     /// windows in rewrite_read.
     pending_stream_send_consumed: JsCell<Vec<(u32, u64)>>,
-    /// INITIAL_WINDOW_SIZE of each SETTINGS frame the legacy encoder sent, in send order, drained
-    /// into the engine's per-SETTINGS ack queue in rewrite_read (§6.5.3: ACKs apply in order).
-    pending_settings_window_submissions: JsCell<Vec<u32>>,
+    /// Snapshot of each SETTINGS frame the legacy encoder sent, in send order, drained into the
+    /// engine's per-SETTINGS ack queue in rewrite_read (§6.5.3: ACKs apply in order).
+    pending_settings_submissions: JsCell<Vec<crate::api::h2::settings::Settings>>,
     /// Stream ids whose legacy-side lifecycle finished while a dispatch held the engine
     /// borrow (the normal request path: receive() -> JS handler -> respond -> END_STREAM).
     /// Drained into Connection::close_stream on the next rewrite_read batch.
@@ -2399,10 +2399,10 @@ impl H2FrameParser {
             .set(self.outstanding_settings.get() + 1);
 
         self.local_settings.set(settings);
-        // Remember which INITIAL_WINDOW_SIZE this submission carries so the engine can attribute
-        // the peer's ACK to it (§6.5.3 - ACKs apply to outstanding SETTINGS in order).
-        self.pending_settings_window_submissions
-            .with_mut(|v| v.push(settings.initial_window_size));
+        // Remember the values this submission carries so the engine can attribute the peer's ACK
+        // to it (§6.5.3 - ACKs apply to outstanding SETTINGS in order).
+        self.pending_settings_submissions
+            .with_mut(|v| v.push(self.rewrite_local_settings()));
         let _ = self.local_settings.get().write(&mut stream);
         let _ = self.write(&buffer);
         true
@@ -2633,8 +2633,8 @@ impl H2FrameParser {
         };
         self.outstanding_settings
             .set(self.outstanding_settings.get() + 1);
-        self.pending_settings_window_submissions
-            .with_mut(|v| v.push(self.local_settings.get().initial_window_size));
+        self.pending_settings_submissions
+            .with_mut(|v| v.push(self.rewrite_local_settings()));
         let _ = settings_header.write(&mut preface_stream);
         let _ = self.local_settings.get().write(&mut preface_stream);
         let _ = self.write(&preface_buffer);
@@ -5433,10 +5433,10 @@ impl H2FrameParser {
                 });
             });
             // Register SETTINGS submissions the legacy encoder sent since the last batch, so the
-            // engine attributes each inbound ACK to the right INITIAL_WINDOW_SIZE (§6.5.3).
-            self.pending_settings_window_submissions.with_mut(|v| {
-                for w in v.drain(..) {
-                    engine.pending_local_window_acks.push_back(w);
+            // engine attributes each inbound ACK to the right submission's values (§6.5.3).
+            self.pending_settings_submissions.with_mut(|v| {
+                for s in v.drain(..) {
+                    engine.pending_local_settings_acks.push_back(s);
                 }
             });
             // Streams whose legacy lifecycle finished since the last batch: evict the engine
@@ -9219,7 +9219,7 @@ impl H2FrameParser {
             pending_stream_send_consumed: JsCell::new(Vec::new()),
             pending_engine_stream_closes: JsCell::new(Vec::new()),
             dispatch_depth: Cell::new(0),
-            pending_settings_window_submissions: JsCell::new(Vec::new()),
+            pending_settings_submissions: JsCell::new(Vec::new()),
             max_rejected_streams: Cell::new(100),
             max_session_invalid_frames: Cell::new(1000),
             max_outstanding_settings: Cell::new(10),

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -506,10 +506,24 @@ class RawH2Server {
   }
 }
 
-/** HPACK string literal: 7-bit length prefix, no Huffman coding. */
+/** RFC 7541 §5.1 prefixed integer: `pattern` carries the opcode bits above the N-bit prefix. */
+function hpackInt(value: number, prefixBits: number, pattern: number): Buffer {
+  const max = (1 << prefixBits) - 1;
+  if (value < max) return Buffer.from([pattern | value]);
+  const out = [pattern | max];
+  let rest = value - max;
+  while (rest >= 128) {
+    out.push((rest & 0x7f) | 0x80);
+    rest >>= 7;
+  }
+  out.push(rest);
+  return Buffer.from(out);
+}
+
+/** HPACK string literal: 7-bit prefixed length, no Huffman coding. */
 function hpackLiteral(str: string): Buffer {
   const bytes = Buffer.from(str, "latin1");
-  return Buffer.concat([Buffer.from([bytes.length]), bytes]);
+  return Buffer.concat([hpackInt(bytes.length, 7, 0x00), bytes]);
 }
 
 describe("push stream states (checklist §5.1, RFC 9113 §6.4/§8.4)", () => {
@@ -1065,6 +1079,122 @@ describe("inbound stream lifecycle", () => {
     } finally {
       c.destroy();
       server.close();
+    }
+  });
+});
+
+// ── Local SETTINGS_HEADER_TABLE_SIZE must resize the server's HPACK decoder (RFC 7541 §4.2/§6.3).
+//
+// The value a server advertises bounds the peer encoder's §6.3 Dynamic Table Size Update. Applying
+// it only at parser construction means a `session.settings({ headerTableSize })` issued after the
+// connection is up advertises the new maximum without ever applying it to the decoder, so a
+// conforming peer that ACKs the SETTINGS and opens its next header block with a size update up to
+// that maximum is torn down with GOAWAY(COMPRESSION_ERROR) and an uncaught ERR_HTTP2_SESSION_ERROR.
+
+describe("local SETTINGS_HEADER_TABLE_SIZE resizes the HPACK decoder (RFC 7541 §6.3)", () => {
+  const HEADER_TABLE_SIZE = 0x1;
+  /** RFC 7541 §6.3 Dynamic Table Size Update opcode (001 pattern, 5-bit prefix). */
+  const dynamicTableSizeUpdate = (size: number) => hpackInt(size, 5, 0x20);
+  /** Minimal GET /: :method GET (2), :scheme http (6), :path / (4), :authority literal. */
+  const getRoot = () => Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
+  const readSetting = (f: Frame, id: number): number | undefined => {
+    for (let i = 0; i + 6 <= f.payload.length; i += 6) {
+      if (f.payload.readUInt16BE(i) === id) return f.payload.readUInt32BE(i + 2);
+    }
+  };
+
+  /** A server that answers every request with a 200 and runs `body` on the first stream's session. */
+  async function serverThatThenCalls(body: (s: http2.Http2Session) => void) {
+    const h2server = http2.createServer();
+    const sessionErrors: string[] = [];
+    h2server.on("session", s => s.on("error", e => sessionErrors.push((e as any).code ?? e.message)));
+    let first = true;
+    h2server.on("stream", stream => {
+      stream.on("error", () => {});
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+      if (first) {
+        first = false;
+        body(stream.session!);
+      }
+    });
+    h2server.listen(0);
+    await once(h2server, "listening");
+    return { h2server, h2port: (h2server.address() as net.AddressInfo).port, sessionErrors };
+  }
+
+  test("a §6.3 size update up to the grown, ACKed table size is accepted and the table really grows", async () => {
+    const NEW_TABLE = 8192;
+    const { h2server, h2port, sessionErrors } = await serverThatThenCalls(s =>
+      s.settings({ headerTableSize: NEW_TABLE }),
+    );
+    const c = await RawH2.connect(h2port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      c.sendSettingsAck();
+      // Request 1 triggers the server's settings({ headerTableSize }).
+      c.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM|END_HEADERS */, 1, getRoot());
+      await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      await c.waitFor(
+        f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0 && readSetting(f, HEADER_TABLE_SIZE) === NEW_TABLE,
+      );
+      // ACKing the grown SETTINGS is what permits a size update up to NEW_TABLE (§6.3).
+      c.sendSettingsAck();
+      // Request 3: size update to the new maximum, then a literal-with-incremental-indexing
+      // header that only fits in the grown table (5 + 6000 + 32 = 6037 bytes > the 4096 default).
+      const big = Buffer.concat([
+        Buffer.from([0x40]),
+        hpackLiteral("x-big"),
+        hpackLiteral(Buffer.alloc(6000, 0x61).toString("latin1")),
+      ]);
+      c.sendFrame(FrameType.HEADERS, 0x5, 3, Buffer.concat([dynamicTableSizeUpdate(NEW_TABLE), getRoot(), big]));
+      await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 3);
+      // Request 5 references the inserted entry by dynamic index 62 (61 static entries + 1),
+      // proving the decoder grew its table rather than merely tolerating the size update.
+      c.sendFrame(FrameType.HEADERS, 0x5, 5, Buffer.concat([getRoot(), Buffer.from([0x80 | 62])]));
+      await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 5);
+      expect(c.frames.filter(f => f.type === FrameType.GOAWAY)).toEqual([]);
+      expect(sessionErrors).toEqual([]);
+    } finally {
+      c.destroy();
+      h2server.close();
+    }
+  });
+
+  test("an ACK applies the oldest outstanding SETTINGS' header table size, not the latest (§6.5.3)", async () => {
+    const GROWN = 8192;
+    // #1 grows the table to 8192; #2 shrinks it to 512 before #1 is ACKed. After ACKing only
+    // #1, the client is bound by 8192, so a size update to 8192 must be accepted.
+    const { h2server, h2port, sessionErrors } = await serverThatThenCalls(s => {
+      s.settings({ headerTableSize: GROWN });
+      s.settings({ headerTableSize: 512 });
+    });
+    const c = await RawH2.connect(h2port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      c.sendSettingsAck();
+      c.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM|END_HEADERS */, 1, getRoot());
+      await c.waitFor(
+        f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0 && readSetting(f, HEADER_TABLE_SIZE) === 512,
+      );
+      // Both post-connect SETTINGS reached us, in submission order, before the first was ACKed.
+      const tableSizes = c.frames
+        .filter(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0)
+        .map(f => readSetting(f, HEADER_TABLE_SIZE));
+      expect(tableSizes.slice(-2)).toEqual([GROWN, 512]);
+      c.sendSettingsAck(); // ACKs #1 (8192) only; #2 (512) is still outstanding.
+      c.sendFrame(FrameType.HEADERS, 0x5, 3, Buffer.concat([dynamicTableSizeUpdate(GROWN), getRoot()]));
+      await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 3);
+      expect(c.frames.filter(f => f.type === FrameType.GOAWAY)).toEqual([]);
+      expect(sessionErrors).toEqual([]);
+      c.sendSettingsAck(); // ACK #2 (512).
+    } finally {
+      c.destroy();
+      h2server.close();
     }
   });
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -520,6 +520,56 @@ function hpackInt(value: number, prefixBits: number, pattern: number): Buffer {
   return Buffer.from(out);
 }
 
+/** RFC 7541 §5.1: read a prefixed integer at `pos`; returns the value and the next offset. */
+function readHpackInt(block: Buffer, pos: number, prefixBits: number): { value: number; next: number } {
+  const max = (1 << prefixBits) - 1;
+  let value = block[pos++] & max;
+  if (value < max) return { value, next: pos };
+  for (let m = 0; ; m += 7) {
+    const b = block[pos++];
+    value += (b & 0x7f) * 2 ** m;
+    if (!(b & 0x80)) return { value, next: pos };
+  }
+}
+
+/** Walk a header block and collect every table index it resolves against the dynamic table (> 61). */
+function dynamicTableIndexes(block: Buffer): number[] {
+  const out: number[] = [];
+  let i = 0;
+  const readInt = (prefixBits: number) => {
+    const r = readHpackInt(block, i, prefixBits);
+    i = r.next;
+    return r.value;
+  };
+  // The Huffman flag lives above the 7-bit length prefix, so readInt(7) masks it off. readInt
+  // already advanced past the length byte(s); add the body length in a SECOND statement (an
+  // `i += readInt(7)` captures `i` for the addition before the call mutates it).
+  const skipString = () => {
+    const length = readInt(7);
+    i += length;
+  };
+  const name = (index: number) => {
+    if (index > 61) out.push(index);
+    if (index === 0) skipString();
+  };
+  while (i < block.length) {
+    const b = block[i];
+    if (b & 0x80) {
+      const index = readInt(7); // §6.1 indexed header field
+      if (index > 61) out.push(index);
+    } else if (b & 0x40) {
+      name(readInt(6)); // §6.2.1 literal with incremental indexing
+      skipString();
+    } else if ((b & 0xe0) === 0x20) {
+      readInt(5); // §6.3 dynamic table size update
+    } else {
+      name(readInt(4)); // §6.2.2 / §6.2.3 literal without / never indexed
+      skipString();
+    }
+  }
+  return out;
+}
+
 /** HPACK string literal: 7-bit prefixed length, no Huffman coding. */
 function hpackLiteral(str: string): Buffer {
   const bytes = Buffer.from(str, "latin1");
@@ -1083,26 +1133,28 @@ describe("inbound stream lifecycle", () => {
   });
 });
 
-// ── Local SETTINGS_HEADER_TABLE_SIZE must resize the server's HPACK decoder (RFC 7541 §4.2/§6.3).
+// ── SETTINGS_HEADER_TABLE_SIZE must be applied to both HPACK coders after construction (RFC 7541).
 //
-// The value a server advertises bounds the peer encoder's §6.3 Dynamic Table Size Update. Applying
-// it only at parser construction means a `session.settings({ headerTableSize })` issued after the
-// connection is up advertises the new maximum without ever applying it to the decoder, so a
-// conforming peer that ACKs the SETTINGS and opens its next header block with a size update up to
-// that maximum is torn down with GOAWAY(COMPRESSION_ERROR) and an uncaught ERR_HTTP2_SESSION_ERROR.
+// Two directions, each covered by a describe below:
+//   - The value WE advertise bounds the peer encoder's §6.3 Dynamic Table Size Update; OUR decoder
+//     must grow to it once the peer ACKs, or a conforming peer is torn down with
+//     GOAWAY(COMPRESSION_ERROR) and an uncaught ERR_HTTP2_SESSION_ERROR.
+//   - The value the PEER advertises bounds OUR encoder, which must apply it and open its next
+//     header block with a §6.3 size update. nginx advertises 0 to every h2 upstream and rejects a
+//     server that keeps referencing the dynamic table ("upstream sent invalid http2 table index").
+
+const HEADER_TABLE_SIZE = 0x1;
+/** RFC 7541 §6.3 Dynamic Table Size Update opcode (001 pattern, 5-bit prefix). */
+const dynamicTableSizeUpdate = (size: number) => hpackInt(size, 5, 0x20);
+/** Minimal GET /: :method GET (2), :scheme http (6), :path / (4), :authority literal. */
+const getRoot = () => Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
+const readSetting = (f: Frame, id: number): number | undefined => {
+  for (let i = 0; i + 6 <= f.payload.length; i += 6) {
+    if (f.payload.readUInt16BE(i) === id) return f.payload.readUInt32BE(i + 2);
+  }
+};
 
 describe("local SETTINGS_HEADER_TABLE_SIZE resizes the HPACK decoder (RFC 7541 §6.3)", () => {
-  const HEADER_TABLE_SIZE = 0x1;
-  /** RFC 7541 §6.3 Dynamic Table Size Update opcode (001 pattern, 5-bit prefix). */
-  const dynamicTableSizeUpdate = (size: number) => hpackInt(size, 5, 0x20);
-  /** Minimal GET /: :method GET (2), :scheme http (6), :path / (4), :authority literal. */
-  const getRoot = () => Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
-  const readSetting = (f: Frame, id: number): number | undefined => {
-    for (let i = 0; i + 6 <= f.payload.length; i += 6) {
-      if (f.payload.readUInt16BE(i) === id) return f.payload.readUInt32BE(i + 2);
-    }
-  };
-
   /** A server that answers every request with a 200 and runs `body` on the first stream's session. */
   async function serverThatThenCalls(body: (s: http2.Http2Session) => void) {
     const h2server = http2.createServer();
@@ -1167,7 +1219,9 @@ describe("local SETTINGS_HEADER_TABLE_SIZE resizes the HPACK decoder (RFC 7541 �
     const GROWN = 8192;
     // #1 grows the table to 8192; #2 shrinks it to 512 before #1 is ACKed. After ACKing only
     // #1, the client is bound by 8192, so a size update to 8192 must be accepted.
+    let session: http2.Http2Session | undefined;
     const { h2server, h2port, sessionErrors } = await serverThatThenCalls(s => {
+      session = s;
       s.settings({ headerTableSize: GROWN });
       s.settings({ headerTableSize: 512 });
     });
@@ -1189,9 +1243,62 @@ describe("local SETTINGS_HEADER_TABLE_SIZE resizes the HPACK decoder (RFC 7541 �
       c.sendSettingsAck(); // ACKs #1 (8192) only; #2 (512) is still outstanding.
       c.sendFrame(FrameType.HEADERS, 0x5, 3, Buffer.concat([dynamicTableSizeUpdate(GROWN), getRoot()]));
       await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 3);
+      // `session.localSettings` reports the submission that ACK acknowledged, not the latest
+      // one still in flight (node: nghttp2_session_update_local_settings applies the oldest).
+      expect(session!.localSettings.headerTableSize).toBe(GROWN);
       expect(c.frames.filter(f => f.type === FrameType.GOAWAY)).toEqual([]);
       expect(sessionErrors).toEqual([]);
       c.sendSettingsAck(); // ACK #2 (512).
+    } finally {
+      c.destroy();
+      h2server.close();
+    }
+  });
+});
+
+describe("remote SETTINGS_HEADER_TABLE_SIZE resizes the HPACK encoder (RFC 7541 §6.3)", () => {
+  // https://github.com/oven-sh/bun/issues/19152
+  test("after the client advertises HEADER_TABLE_SIZE=0, responses stop using the dynamic table", async () => {
+    const h2server = http2.createServer();
+    const sessionErrors: string[] = [];
+    h2server.on("session", s => s.on("error", e => sessionErrors.push((e as any).code ?? e.message)));
+    // The same response header every time: against a live dynamic table the second response would
+    // reference the entry the first one inserted instead of re-sending it literally.
+    const shared = Buffer.alloc(40, 0x61).toString("latin1");
+    h2server.on("stream", stream => {
+      stream.on("error", () => {});
+      stream.respond({ ":status": 200, "x-shared": shared });
+      stream.end("ok");
+    });
+    h2server.listen(0);
+    await once(h2server, "listening");
+    const c = await RawH2.connect((h2server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      const disable = Buffer.alloc(6);
+      disable.writeUInt16BE(HEADER_TABLE_SIZE, 0); // value 0: the peer may not use the dynamic table
+      c.sendFrame(FrameType.SETTINGS, 0, 0, disable);
+      await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      c.sendSettingsAck();
+      // The server's ACK of OUR settings is the point from which its encoder is bound by 0.
+      await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 1);
+
+      c.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM|END_HEADERS */, 1, getRoot());
+      const r1 = await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      c.sendFrame(FrameType.HEADERS, 0x5, 3, getRoot());
+      const r3 = await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 3);
+
+      // Neither response is padded or carries priority, so its payload is the raw header block.
+      expect([r1.flags & 0x28, r3.flags & 0x28]).toEqual([0, 0]);
+      // §6.3: the first block after the shrink must open with a size update to the new maximum.
+      expect(r1.payload[0] & 0xe0).toBe(0x20);
+      expect(readHpackInt(r1.payload, 0, 5).value).toBe(0);
+      // Neither block references the dynamic table (the reference nginx rejects in #19152).
+      expect({ first: dynamicTableIndexes(r1.payload), second: dynamicTableIndexes(r3.payload) }).toEqual({
+        first: [],
+        second: [],
+      });
+      expect(sessionErrors).toEqual([]);
     } finally {
       c.destroy();
       h2server.close();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1170,7 +1170,7 @@ describe("local SETTINGS_HEADER_TABLE_SIZE resizes the HPACK decoder (RFC 7541 Â
         body(stream.session!);
       }
     });
-    h2server.listen(0);
+    h2server.listen(0, "127.0.0.1");
     await once(h2server, "listening");
     return { h2server, h2port: (h2server.address() as net.AddressInfo).port, sessionErrors };
   }
@@ -1277,7 +1277,7 @@ describe("remote SETTINGS_HEADER_TABLE_SIZE resizes the HPACK encoder (RFC 7541 
       stream.respond({ ":status": 200, "x-shared": shared });
       stream.end("ok");
     });
-    h2server.listen(0);
+    h2server.listen(0, "127.0.0.1");
     await once(h2server, "listening");
     return { h2server, h2port: (h2server.address() as net.AddressInfo).port, sessionErrors };
   }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1258,12 +1258,19 @@ describe("local SETTINGS_HEADER_TABLE_SIZE resizes the HPACK decoder (RFC 7541 �
 
 describe("remote SETTINGS_HEADER_TABLE_SIZE resizes the HPACK encoder (RFC 7541 §6.3)", () => {
   // https://github.com/oven-sh/bun/issues/19152
-  test("after the client advertises HEADER_TABLE_SIZE=0, responses stop using the dynamic table", async () => {
+  /** A SETTINGS payload carrying one HEADER_TABLE_SIZE entry. */
+  const headerTableSizeSetting = (value: number) => {
+    const b = Buffer.alloc(6);
+    b.writeUInt16BE(HEADER_TABLE_SIZE, 0);
+    b.writeUInt32BE(value, 2);
+    return b;
+  };
+
+  /** A server whose responses all carry the same custom header (so a live dynamic table would get used). */
+  async function responseServer() {
     const h2server = http2.createServer();
     const sessionErrors: string[] = [];
     h2server.on("session", s => s.on("error", e => sessionErrors.push((e as any).code ?? e.message)));
-    // The same response header every time: against a live dynamic table the second response would
-    // reference the entry the first one inserted instead of re-sending it literally.
     const shared = Buffer.alloc(40, 0x61).toString("latin1");
     h2server.on("stream", stream => {
       stream.on("error", () => {});
@@ -1272,16 +1279,22 @@ describe("remote SETTINGS_HEADER_TABLE_SIZE resizes the HPACK encoder (RFC 7541 
     });
     h2server.listen(0);
     await once(h2server, "listening");
-    const c = await RawH2.connect((h2server.address() as net.AddressInfo).port);
+    return { h2server, h2port: (h2server.address() as net.AddressInfo).port, sessionErrors };
+  }
+
+  const isServerSettingsAck = (f: Frame) => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 1;
+
+  test("after the client advertises HEADER_TABLE_SIZE=0, responses stop using the dynamic table", async () => {
+    const { h2server, h2port, sessionErrors } = await responseServer();
+    const c = await RawH2.connect(h2port);
     try {
       c.sendPreface();
-      const disable = Buffer.alloc(6);
-      disable.writeUInt16BE(HEADER_TABLE_SIZE, 0); // value 0: the peer may not use the dynamic table
-      c.sendFrame(FrameType.SETTINGS, 0, 0, disable);
+      // Value 0: the peer (us) never accepts a dynamic-table reference.
+      c.sendFrame(FrameType.SETTINGS, 0, 0, headerTableSizeSetting(0));
       await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
       c.sendSettingsAck();
       // The server's ACK of OUR settings is the point from which its encoder is bound by 0.
-      await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 1);
+      await c.waitFor(isServerSettingsAck);
 
       c.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM|END_HEADERS */, 1, getRoot());
       const r1 = await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
@@ -1298,6 +1311,41 @@ describe("remote SETTINGS_HEADER_TABLE_SIZE resizes the HPACK encoder (RFC 7541 
         first: [],
         second: [],
       });
+      expect(sessionErrors).toEqual([]);
+    } finally {
+      c.destroy();
+      h2server.close();
+    }
+  });
+
+  // RFC 7541 §4.2: when the peer changes HEADER_TABLE_SIZE more than once between two of our
+  // header blocks, the interval MINIMUM must be signaled first (at most two size updates per
+  // block). The peer's decoder evicts eagerly at each of its SETTINGS, so signaling only the
+  // final value leaves it with a smaller table than ours; nghttp2's inflater also hard-rejects
+  // a first size update above the interval minimum.
+  test("two table-size changes between blocks emit the interval minimum then the final value", async () => {
+    const { h2server, h2port, sessionErrors } = await responseServer();
+    const c = await RawH2.connect(h2port);
+    try {
+      c.sendPreface();
+      // Shrink to 0, then restore to 4096, before the server sends any header block.
+      c.sendFrame(FrameType.SETTINGS, 0, 0, headerTableSizeSetting(0));
+      c.sendFrame(FrameType.SETTINGS, 0, 0, headerTableSizeSetting(4096));
+      await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      c.sendSettingsAck();
+      // Both table-size changes have reached the encoder once both of our SETTINGS are ACKed.
+      await c.waitFor(f => isServerSettingsAck(f) && c.frames.filter(isServerSettingsAck).length >= 2);
+
+      c.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM|END_HEADERS */, 1, getRoot());
+      const r1 = await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      expect(r1.flags & 0x28).toBe(0);
+
+      // The block opens with size-update(0) then size-update(4096), in that order.
+      const first = readHpackInt(r1.payload, 0, 5);
+      const second = readHpackInt(r1.payload, first.next, 5);
+      expect([r1.payload[0] & 0xe0, r1.payload[first.next] & 0xe0]).toEqual([0x20, 0x20]);
+      expect([first.value, second.value]).toEqual([0, 4096]);
+      expect(dynamicTableIndexes(r1.payload)).toEqual([]);
       expect(sessionErrors).toEqual([]);
     } finally {
       c.destroy();


### PR DESCRIPTION
Fixes #19152

HTTP/2's `SETTINGS_HEADER_TABLE_SIZE` has two independent effects, and `node:http2` applied neither after the connection was up:

- the value **we** advertise bounds the peer encoder's RFC 7541 6.3 Dynamic Table Size Update and must grow **our decoder** once the peer ACKs it,
- the value **the peer** advertises bounds **our encoder**, which must shrink/grow its table and announce the change with a 6.3 size update at the start of its next header block.

Both HPACK coder capacities were only ever set at parser construction. Neither `fetch()`'s HTTP/2 client nor anything else is affected (it never changes its advertised table size after the preface).

### 1. Local SETTINGS (decoder side)

A server (or client) that calls `session.settings({ headerTableSize })` after the connection is established advertises the new maximum but never applies it to its decoder. A conforming peer that ACKs the SETTINGS and opens its next header block with a size update up to that maximum then kills the session:

```
GOAWAY errorCode=9 (COMPRESSION_ERROR) debug="HPACK decode error"
error: Stream closed with error code NGHTTP2_COMPRESSION_ERROR
 code: "ERR_HTTP2_STREAM_ERROR"
```

Node v26.3.0 accepts the same byte sequence. So a client that honours the SETTINGS the Bun server itself sent (nghttp2-based clients, gRPC, browsers behind a proxy, Bun's own `fetch` h2 client) takes down the session, and the resulting session error is uncaught unless the app installed a handler. Passing `headerTableSize` in the constructor options already worked, because the engine is created with that value; only post-construction `settings()` was broken.

Cause: `lshpack_dec_set_max_capacity` is only called from `lshpack_wrapper_init` (`src/jsc/bindings/c-bindings.cpp`). The ACK branch of `handle_settings` in `src/runtime/api/bun/h2/connection.rs` never touches the decoder, so lshpack rejects the peer's size update (`new_capacity > dec->hpd_max_capacity` in `vendor/lshpack/lshpack.c`) and `finish_header_block` maps that to `send_go_away(CompressionError, "HPACK decode error")`.

### 2. Remote SETTINGS (encoder side, #19152)

A client that advertises `SETTINGS_HEADER_TABLE_SIZE=0` (nginx sends this to every h2 upstream) must never be sent a dynamic-table reference, and the first header block after the change must open with a 6.3 size update. Bun does neither: its second response already references dynamic indexes, which nginx rejects:

```
upstream sent invalid http2 table index: 67 while reading response header from upstream
```

Node v26.3.0 emits the size update and zero dynamic indexes against the same client. A strict nghttp2 decoder (a node client doing `client.settings({ headerTableSize: <smaller> })`) rejects the whole block because the mandatory size update is missing.

Cause: the live outbound encoder is the `H2FrameParser`'s own `HpackHandle`; the engine's encoder-side handling (`Connection::begin_header_block` / `take_pending_size_update`) is only reached from its unit tests, and `set_encoder_max_capacity` had no callers on the live handle. `Sink::on_remote_settings` bridged the peer's settings into a `Cell` but never resized the encoder. The encoder was also initialized from OUR advertised `headerTableSize` instead of the 4096 default the peer is actually bound by until it receives our SETTINGS, a latent desync with any non-default setting.

### Fix

- `src/jsc/bindings/c-bindings.cpp` / `src/http/lshpack.rs`: add `lshpack_wrapper_dec_set_max_capacity`, the decoder counterpart of the existing encoder wrapper.
- `src/runtime/api/bun/h2/hpack.rs`: `Coder::set_decoder_capacity`, a no-op when unchanged so re-submitting the same size (Bun packs all 7 standard parameters into every SETTINGS frame) cannot clobber the table size the peer's encoder last chose via a size update.
- `src/runtime/api/bun/h2/hpack.rs`: `Coder` also now tracks the MINIMUM capacity the peer requested since the last header block. RFC 7541 4.2 requires the interval minimum to be signaled before the final value (at most two size updates per block), because the peer's decoder evicts eagerly at each of its SETTINGS; signaling only the latest value left its table smaller than ours, and a strict nghttp2 inflater rejects a first size update above the interval minimum outright.
- `src/runtime/api/bun/h2/connection.rs`: resize the decoder from the SETTINGS ACK branch of `handle_settings`. Applying on ACK rather than on send matches nghttp2 (`nghttp2_session_update_local_settings`): the peer applies our SETTINGS before emitting the ACK, so every header block after the ACK on the wire is encoded under the new limit and none before it is. The per-6.5.3 ack queue previously carried only `initial_window_size`; it now carries the full `Settings` snapshot so `header_table_size` is attributed to the correct submission when several SETTINGS are in flight, the same way the window already was.
- `src/runtime/api/bun/h2_frame_parser.rs`: replace the raw `HpackHandle` with the engine's `hpack::Coder`, which already carries the queued-capacity state and the 6.3 opcode writer. `on_remote_settings` queues the peer's value, and `encode_header_into_list` (the single funnel every outbound header block's fields go through) drains it at the start of the block. The encoder now initializes to the 4096 RFC default.
- While in the same branch: `on_local_settings` now receives the ACKed snapshot rather than the latest submission, so `session.localSettings` and the `localSettings` event report the values the peer actually acknowledged (what Node reports) when several SETTINGS are in flight.

### Verification

Four tests in `test/js/node/http2/h2-conformance.test.ts`, each driving a raw byte-level h2c client against a Bun `node:http2` server:

1. **Decoder, grow.** After the server grows `headerTableSize` to 8192 mid-session and the client ACKs, a 6.3 size update to 8192 followed by a 6037-byte incremental-indexing insertion is accepted, and a later request that references that entry from the dynamic table (index 62) gets a response. Proves the table actually grew, not that the size update was merely tolerated.
2. **Decoder, 6.5.3 ordering.** Two `settings()` in flight (8192 then 512); the client ACKs only the first and size-updates to 8192, which must be accepted because 8192 is the value that ACK bound. Also asserts `session.localSettings.headerTableSize` reports 8192, not 512.
3. **Encoder, #19152.** The client advertises `HEADER_TABLE_SIZE=0` in its preface. The first response block must open with a 6.3 size update to 0, and neither response block may reference a dynamic-table index, checked by a small HPACK opcode walker over the raw frame payloads.
4. **Encoder, 4.2 interval minimum.** The client sends `HEADER_TABLE_SIZE=0` then `HEADER_TABLE_SIZE=4096` before the server emits any header block. The first response block must open with size-update(0) then size-update(4096), in that order.

```
# src/ restored to unmodified origin/main, debug build:
 23 pass, 4 fail    # all four new tests
# with the fix:
 27 pass, 0 fail
```

Both standalone repros pass under the fix and pass under Node v26.3.0 unchanged. `test/js/node/http2/node-http2.test.js` (287) and the other http2 suites still pass.

<details>
<summary>Standalone repro for #19152 (raw h2c client against a Bun node:http2 server)</summary>

```js
// bun  repro.mjs  -> FAIL (dynamic indexes in response 3, no size update)
// node repro.mjs  -> PASS
import http2 from "node:http2";
import net from "node:net";
import { once } from "node:events";
const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
function encodeFrame(t, f, s, p = Buffer.alloc(0)) {
  const h = Buffer.alloc(9);
  h.writeUIntBE(p.length, 0, 3); h.writeUInt8(t, 3); h.writeUInt8(f, 4); h.writeUInt32BE(s & 0x7fffffff, 5);
  return Buffer.concat([h, p]);
}
function hpInt(v, pb, fb) {
  const m = (1 << pb) - 1;
  if (v < m) return Buffer.from([fb | v]);
  const o = [fb | m]; let r = v - m;
  while (r >= 128) { o.push((r & 0x7f) | 0x80); r >>= 7; }
  o.push(r); return Buffer.from(o);
}
const hpStr = s => { const b = Buffer.from(s, "latin1"); return Buffer.concat([hpInt(b.length, 7, 0), b]); };
const baseReq = () => Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpStr("localhost")]);
function dynamicIndexes(block) {
  let i = 0; const out = [];
  const readInt = pb => { const m = (1 << pb) - 1; let v = block[i++] & m; if (v < m) return v;
    for (let e = 0; ; e += 7) { const b = block[i++]; v += (b & 0x7f) * 2 ** e; if (!(b & 0x80)) return v; } };
  const skipStr = () => { const n = readInt(7); i += n; };
  while (i < block.length) {
    const b = block[i];
    if (b & 0x80) { const x = readInt(7); if (x > 61) out.push(x); }
    else if (b & 0x40) { const x = readInt(6); if (x > 61) out.push(x); if (x === 0) skipStr(); skipStr(); }
    else if ((b & 0xe0) === 0x20) readInt(5);
    else { const x = readInt(4); if (x > 61) out.push(x); if (x === 0) skipStr(); skipStr(); }
  }
  return out;
}
const SHARED = Buffer.alloc(40, 0x61).toString("latin1");
const server = http2.createServer();
server.on("stream", st => { st.on("error", () => {}); st.respond({ ":status": 200, "x-shared": SHARED }); st.end("ok"); });
server.listen(0); await once(server, "listening");
const sock = net.connect(server.address().port, "127.0.0.1");
sock.on("error", () => {}); await once(sock, "connect");
let buf = Buffer.alloc(0); const frames = []; const waiters = [];
sock.on("data", d => { buf = Buffer.concat([buf, d]);
  while (buf.length >= 9) { const l = buf.readUIntBE(0, 3); if (buf.length < 9 + l) break;
    const f = { type: buf.readUInt8(3), flags: buf.readUInt8(4), streamId: buf.readUInt32BE(5) & 0x7fffffff, payload: buf.subarray(9, 9 + l) };
    buf = buf.subarray(9 + l); frames.push(f);
    const j = waiters.findIndex(w => w.pred(f)); if (j !== -1) waiters.splice(j, 1)[0].resolve(f); } });
const waitFor = (pred, ms = 3000) => { const e = frames.find(pred); if (e) return Promise.resolve(e);
  return new Promise((res, rej) => { const w = { pred, resolve: res }; waiters.push(w);
    const t = setTimeout(() => rej(new Error("timeout")), ms); const o = w.resolve; w.resolve = f => { clearTimeout(t); o(f); }; }); };
const s = Buffer.alloc(6); s.writeUInt16BE(0x1, 0); s.writeUInt32BE(0, 2);
sock.write(PREFACE); sock.write(encodeFrame(4, 0, 0, s));
await waitFor(f => f.type === 4 && (f.flags & 1) === 0); sock.write(encodeFrame(4, 1, 0));
await waitFor(f => f.type === 4 && (f.flags & 1) === 1);
sock.write(encodeFrame(1, 0x5, 1, baseReq())); const r1 = await waitFor(f => f.type === 1 && f.streamId === 1);
sock.write(encodeFrame(1, 0x5, 3, baseReq())); const r3 = await waitFor(f => f.type === 1 && f.streamId === 3);
const sizeUpdate = (r1.payload[0] & 0xe0) === 0x20;
const d1 = dynamicIndexes(r1.payload), d3 = dynamicIndexes(r3.payload);
console.log("response 1 starts with a 6.3 size update:", sizeUpdate);
console.log("response 1 dynamic indexes:", d1, " response 3 dynamic indexes:", d3);
const ok = sizeUpdate && d1.length === 0 && d3.length === 0;
console.log(ok ? "PASS" : "FAIL"); sock.destroy(); server.close(); process.exit(ok ? 0 : 1);
```

</details>

<details>
<summary>Standalone repro for the decoder side</summary>

```js
// bun  repro.mjs  -> FAIL (GOAWAY errorCode=9 "HPACK decode error")
// node repro.mjs  -> PASS
import http2 from "node:http2";
import net from "node:net";
import { once } from "node:events";
const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
const NEW_TABLE = 8192;
function encodeFrame(t, f, s, p = Buffer.alloc(0)) {
  const h = Buffer.alloc(9);
  h.writeUIntBE(p.length, 0, 3); h.writeUInt8(t, 3); h.writeUInt8(f, 4); h.writeUInt32BE(s & 0x7fffffff, 5);
  return Buffer.concat([h, p]);
}
function hpInt(v, pb, fb) {
  const m = (1 << pb) - 1;
  if (v < m) return Buffer.from([fb | v]);
  const o = [fb | m]; let r = v - m;
  while (r >= 128) { o.push((r & 0x7f) | 0x80); r >>= 7; }
  o.push(r); return Buffer.from(o);
}
const hpStr = s => { const b = Buffer.from(s, "latin1"); return Buffer.concat([hpInt(b.length, 7, 0), b]); };
const dtsu = v => hpInt(v, 5, 0x20);
const baseReq = () => Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpStr("localhost")]);
const server = http2.createServer();
let bumped = false;
server.on("session", s => s.on("error", e => console.log("SESSION ERROR:", e.code ?? e.message)));
server.on("stream", st => {
  st.on("error", () => {}); st.respond({ ":status": 200 }); st.end("ok");
  if (!bumped) { bumped = true; st.session.settings({ headerTableSize: NEW_TABLE }); }
});
server.listen(0); await once(server, "listening");
const sock = net.connect(server.address().port, "127.0.0.1");
sock.on("error", () => {}); await once(sock, "connect");
let buf = Buffer.alloc(0); const frames = []; const waiters = [];
sock.on("data", d => { buf = Buffer.concat([buf, d]);
  while (buf.length >= 9) { const l = buf.readUIntBE(0, 3); if (buf.length < 9 + l) break;
    const f = { type: buf.readUInt8(3), flags: buf.readUInt8(4), streamId: buf.readUInt32BE(5) & 0x7fffffff, payload: buf.subarray(9, 9 + l) };
    buf = buf.subarray(9 + l); frames.push(f);
    const j = waiters.findIndex(w => w.pred(f)); if (j !== -1) waiters.splice(j, 1)[0].resolve(f); } });
const waitFor = (pred, ms = 3000) => { const e = frames.find(pred); if (e) return Promise.resolve(e);
  return new Promise((res, rej) => { const w = { pred, resolve: res }; waiters.push(w);
    const t = setTimeout(() => rej(new Error("timeout")), ms); const o = w.resolve; w.resolve = f => { clearTimeout(t); o(f); }; }); };
const readSetting = (f, id) => { for (let i = 0; i + 6 <= f.payload.length; i += 6) if (f.payload.readUInt16BE(i) === id) return f.payload.readUInt32BE(i + 2); };
sock.write(PREFACE); sock.write(encodeFrame(4, 0, 0));
await waitFor(f => f.type === 4 && (f.flags & 1) === 0); sock.write(encodeFrame(4, 1, 0));
sock.write(encodeFrame(1, 0x5, 1, baseReq())); await waitFor(f => f.type === 1 && f.streamId === 1);
await waitFor(f => f.type === 4 && (f.flags & 1) === 0 && readSetting(f, 0x1) === NEW_TABLE);
sock.write(encodeFrame(4, 1, 0)); // ACK the grown SETTINGS: we may now size-update to 8192
const big = Buffer.concat([Buffer.from([0x40]), hpStr("x-big"), hpStr(Buffer.alloc(6000, 0x61).toString("latin1"))]);
sock.write(encodeFrame(1, 0x5, 3, Buffer.concat([dtsu(NEW_TABLE), baseReq(), big])));
try {
  await waitFor(f => f.type === 1 && f.streamId === 3);
  sock.write(encodeFrame(1, 0x5, 5, Buffer.concat([baseReq(), Buffer.from([0x80 | 62])])));
  await waitFor(f => f.type === 1 && f.streamId === 5);
  console.log("PASS"); process.exit(0);
} catch {
  const g = frames.find(f => f.type === 7);
  console.log(g ? `FAIL: GOAWAY errorCode=${g.payload.readUInt32BE(4)} debug=${JSON.stringify(g.payload.subarray(8).toString())}` : "FAIL: timeout");
  process.exit(1);
}
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (223e4927c)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [431.58ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [125.74ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [78.39ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [67.39ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (87cb0aae5)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [7.39ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [1.83ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [1.29ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [0.82ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.75ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.68ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [0.66ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.63ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [2.19ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (223e4927c)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [423.01ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [126.58ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [88.80ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [61.48ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 733ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 254 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (6256ms)
Bundle modules (45ms)
Postprocesss modules (20ms)
Bundle Functions (574ms)
Generate Code (78ms)

[6.99s] Bundled "src/js" for production
  1888 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/lshpack.rs                       |   9 +
 src/jsc/bindings/c-bindings.cpp           |   5 +
 src/runtime/api/bun/h2/connection.rs      |  35 ++--
 src/runtime/api/bun/h2/hpack.rs           |  49 ++++-
 src/runtime/api/bun/h2_frame_parser.rs    |  65 ++++---
 test/js/node/http2/h2-conformance.test.ts | 289 +++++++++++++++++++++++++++++-
 6 files changed, 410 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/lshpack.rs                            1      2     30
src/jsc/bindings/c-bindings.cpp                1      1     30
src/runtime/api/bun/h2/connection.rs           4      6     31
src/runtime/api/bun/h2/hpack.rs                2      3     30
src/runtime/api/bun/h2_frame_parser.rs        11     10     30
test/js/node/http2/h2-conformance.test.ts      7     19     30
```

</details>

<!-- robobun:evidence:end -->