### PR TITLE
feat(run): add --prefix alias for --cwd

### DIFF
--- a/src/clap/comptime.rs
+++ b/src/clap/comptime.rs
@@ -551,15 +551,7 @@ impl<Id> ComptimeClap<Id> {
             if param.names.long.is_none() && param.names.short.is_none() {
                 pos.push(arg.value.unwrap());
                 if opt.stop_after_positional_at > 0 && pos.len() >= opt.stop_after_positional_at {
-                    let mut remaining_ = stream.iter.remain();
-                    let first: &[u8] = if !remaining_.is_empty() {
-                        remaining_[0]
-                    } else {
-                        b""
-                    };
-                    if !first.is_empty() && first == b"--" {
-                        remaining_ = &remaining_[1..];
-                    }
+                    let remaining_ = stream.iter.remain();
 
                     passthrough_positionals.reserve_exact(remaining_.len());
                     for arg_ in remaining_ {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -85,6 +85,9 @@ const BASE_PARAMS_: &[ParamType] = concat_params!(
             "--cwd <STR>                       Absolute path to resolve files & entry points from. This just changes the process' cwd."
         ),
         parse_param!(
+            "--prefix <STR>                    Run from the specified directory (alias for --cwd)"
+        ),
+        parse_param!(
             "-c, --config <PATH>?              Specify path to Bun config file. Default <d>$cwd<r>/bunfig.toml"
         ),
         parse_param!("-h, --help                        Display this menu and exit"),
@@ -754,6 +757,91 @@ pub use bun_bunfig::arguments::{load_config_path, load_config_with_cmd_args};
 /// the attached value `e`. Bun's `-p` takes the code, so `-pe X` is `-p X`.
 pub const NODE_SHORT_ALIASES: &[(&[u8], &[u8])] = &[(b"-pe", b"-p")];
 
+fn missing_option_value(flag: &[u8]) -> ! {
+    bun_core::pretty_errorln!(
+        "<red>error<r><d>:<r> The argument '{}' requires a value but none was supplied.",
+        BStr::new(flag),
+    );
+    Output::flush();
+    Global::exit(1);
+}
+
+fn cwd_prefix_scan_limit(remaining: &[&[u8]], positionals: &[&[u8]]) -> usize {
+    if positionals.iter().any(|p| *p == b"--") {
+        return 0;
+    }
+    remaining
+        .iter()
+        .position(|a| *a == b"--")
+        .unwrap_or(remaining.len())
+}
+
+fn passthrough_start(remaining: &[&[u8]], positionals: &[&[u8]]) -> usize {
+    if positionals.iter().any(|p| *p == b"--") {
+        return 0;
+    }
+    remaining
+        .iter()
+        .position(|a| *a == b"--")
+        .map(|i| i + 1)
+        .unwrap_or(0)
+}
+
+/// `--cwd` / `--prefix` can appear after the script name for `bun run` (npm-style).
+/// `stop_after_positional_at` leaves them in `remaining()` instead of `option()`.
+fn cwd_prefix_in_remaining<'a>(
+    remaining: &'a [&'static [u8]],
+    scan_limit: usize,
+) -> (Option<&'a [u8]>, Option<&'a [u8]>, Vec<usize>) {
+    let mut cwd = None;
+    let mut prefix = None;
+    let mut skip = Vec::new();
+    let mut i = 0;
+    while i < scan_limit {
+        let arg = remaining[i];
+        let slot: &mut Option<&[u8]> = if arg == b"--cwd" {
+            &mut cwd
+        } else if arg == b"--prefix" {
+            &mut prefix
+        } else if arg.len() > b"--cwd".len() + 1
+            && strings::has_prefix_comptime(arg, b"--cwd")
+            && arg[b"--cwd".len()] == b'='
+        {
+            if cwd.is_none() {
+                cwd = Some(&arg[b"--cwd".len() + 1..]);
+            }
+            skip.push(i);
+            i += 1;
+            continue;
+        } else if arg.len() > b"--prefix".len() + 1
+            && strings::has_prefix_comptime(arg, b"--prefix")
+            && arg[b"--prefix".len()] == b'='
+        {
+            if prefix.is_none() {
+                prefix = Some(&arg[b"--prefix".len() + 1..]);
+            }
+            skip.push(i);
+            i += 1;
+            continue;
+        } else {
+            i += 1;
+            continue;
+        };
+
+        if i + 1 < remaining.len() && !remaining[i + 1].starts_with(b"-") {
+            if slot.is_none() {
+                *slot = Some(remaining[i + 1]);
+            }
+            skip.push(i);
+            skip.push(i + 1);
+            i += 2;
+        } else {
+            missing_option_value(arg);
+        }
+    }
+    (cwd, prefix, skip)
+}
+
 /// Parse `argv` into `api::TransformOptions` for the given subcommand.
 ///
 /// `command::tag_params(cmd)` does a runtime lookup of the per-subcommand
@@ -803,10 +891,28 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         }
     }
 
-    // ── --cwd ────────────────────────────────────────────────────────────────
+    // ── --cwd / --prefix ─────────────────────────────────────────────────────
     // `api::TransformOptions.absolute_working_dir` is `Option<Box<[u8]>>`,
     // so we dupe into a plain `Box<[u8]>`.
-    let cwd: Box<[u8]> = if let Some(cwd_arg) = args.option(b"--cwd") {
+    let remaining = args.remaining();
+    let positionals = args.positionals();
+    let scan_limit = cwd_prefix_scan_limit(remaining, positionals);
+    let passthrough_start = passthrough_start(remaining, positionals);
+    let (remaining_cwd, remaining_prefix, passthrough_skip) =
+        if matches!(
+            cmd,
+            CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::RunAsNodeCommand
+        ) {
+            cwd_prefix_in_remaining(remaining, scan_limit)
+        } else {
+            (None, None, Vec::new())
+        };
+    let cwd_arg = args
+        .option(b"--cwd")
+        .or(remaining_cwd)
+        .or(args.option(b"--prefix"))
+        .or(remaining_prefix);
+    let cwd: Box<[u8]> = if let Some(cwd_arg) = cwd_arg {
         let mut outbuf = PathBuffer::uninit();
         // An absolute --cwd needs no base; a relative one still requires a
         // live cwd (an exe-dir base would silently chdir somewhere else).
@@ -969,7 +1075,13 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         ctx.runtime_options.preserve_symlinks_main = true;
     }
 
-    ctx.passthrough = slice_to_owned(args.remaining());
+    ctx.passthrough = remaining
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i >= passthrough_start)
+        .filter(|(i, _)| !passthrough_skip.contains(i))
+        .map(|(_, s)| Box::<[u8]>::from(*s))
+        .collect();
 
     if matches!(
         cmd,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -824,7 +824,7 @@ fn cwd_prefix_in_remaining<'a>(
             continue;
         };
 
-        if i + 1 < remaining.len() {
+        if i + 1 < scan_limit {
             *slot = Some(remaining[i + 1]);
             skip.push(i);
             skip.push(i + 1);
@@ -901,11 +901,12 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         } else {
             (None, None, Vec::new())
         };
-    let cwd_arg = args
-        .option(b"--cwd")
-        .or(remaining_cwd)
-        .or(args.option(b"--prefix"))
-        .or(remaining_prefix);
+    // Last same-type flag wins, including after the script name. All --cwd
+    // values still beat --prefix.
+    let cwd_arg = remaining_cwd
+        .or(args.option(b"--cwd"))
+        .or(remaining_prefix)
+        .or(args.option(b"--prefix"));
     let cwd: Box<[u8]> = if let Some(cwd_arg) = cwd_arg {
         let mut outbuf = PathBuffer::uninit();
         // An absolute --cwd needs no base; a relative one still requires a

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -807,9 +807,7 @@ fn cwd_prefix_in_remaining<'a>(
             && strings::has_prefix_comptime(arg, b"--cwd")
             && arg[b"--cwd".len()] == b'='
         {
-            if cwd.is_none() {
-                cwd = Some(&arg[b"--cwd".len() + 1..]);
-            }
+            cwd = Some(&arg[b"--cwd".len() + 1..]);
             skip.push(i);
             i += 1;
             continue;
@@ -817,9 +815,7 @@ fn cwd_prefix_in_remaining<'a>(
             && strings::has_prefix_comptime(arg, b"--prefix")
             && arg[b"--prefix".len()] == b'='
         {
-            if prefix.is_none() {
-                prefix = Some(&arg[b"--prefix".len() + 1..]);
-            }
+            prefix = Some(&arg[b"--prefix".len() + 1..]);
             skip.push(i);
             i += 1;
             continue;
@@ -828,10 +824,8 @@ fn cwd_prefix_in_remaining<'a>(
             continue;
         };
 
-        if i + 1 < remaining.len() && !remaining[i + 1].starts_with(b"-") {
-            if slot.is_none() {
-                *slot = Some(remaining[i + 1]);
-            }
+        if i + 1 < remaining.len() {
+            *slot = Some(remaining[i + 1]);
             skip.push(i);
             skip.push(i + 1);
             i += 2;

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -305,13 +305,13 @@ describe.concurrent("bun run", () => {
     });
   }
 
-  it("should show the correct working directory when run with --cwd", async () => {
-    using dir = tempDir("bun-run-cwd", {
+  it.each(["--cwd", "--prefix"])("should show the correct working directory when run with %s", async flag => {
+    using dir = tempDir(`bun-run-${flag.replace("--", "")}`, {
       "subdir/test.js": `console.log(process.cwd());`,
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "--cwd", "subdir", "test.js"],
+      cmd: [bunExe(), "run", flag, "subdir", "test.js"],
       cwd: String(dir),
       stdin: "ignore",
       stdout: "pipe",
@@ -322,10 +322,136 @@ describe.concurrent("bun run", () => {
       },
     });
 
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toMatch(/subdir/);
     // The exit code will not be 1 if it panics.
+    expect(exitCode).toBe(0);
+  });
+
+  it.each(["--cwd", "--prefix"])(
+    "should show the correct working directory when run with %s after the script name",
+    async flag => {
+      using dir = tempDir(`bun-run-${flag.replace("--", "")}-after-script`, {
+        "subdir/test.js": `console.log(process.cwd());`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "test.js", flag, "subdir"],
+        cwd: String(dir),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...bunEnv,
+          BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+        },
+      });
+
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toMatch(/subdir/);
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  it("should run package.json scripts with --prefix after the script name", async () => {
+    using dir = tempDir("bun-run-dev-prefix-after-script", {
+      "subdir/test.js": `console.log(process.cwd());`,
+      "subdir/package.json": JSON.stringify({
+        name: "test",
+        scripts: { dev: "bun ./test.js" },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "dev", "--prefix", "subdir/"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toMatch(/subdir/);
+    expect(exitCode).toBe(0);
+  });
+
+  it("should prefer --cwd over --prefix when both are set", async () => {
+    using dir = tempDir("bun-run-cwd-over-prefix", {
+      "good/test.js": `console.log(process.cwd());`,
+      "bad/test.js": `console.log("wrong");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--cwd", "good", "--prefix", "bad", "test.js"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toMatch(/good/);
+    expect(stdout).not.toMatch(/wrong/);
+    expect(exitCode).toBe(0);
+  });
+
+  it("should prefer --cwd over --prefix when both appear after the script name", async () => {
+    using dir = tempDir("bun-run-cwd-over-prefix-after-script", {
+      "good/test.js": `console.log(process.cwd());`,
+      "bad/test.js": `console.log("wrong");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "test.js", "--cwd", "good", "--prefix", "bad"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toMatch(/good/);
+    expect(stdout).not.toMatch(/wrong/);
+    expect(exitCode).toBe(0);
+  });
+
+  it("should not treat --cwd or --prefix after -- as bun flags", async () => {
+    using dir = tempDir("bun-run-double-dash-cwd", {
+      "test.js": `console.log(JSON.stringify(process.argv.slice(2)));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "test.js", "--", "--cwd", "ignored"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.replaceAll("\r\n", "\n")).toBe('["--cwd","ignored"]\n');
     expect(exitCode).toBe(0);
   });
 

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -503,6 +503,55 @@ describe.concurrent("bun run", () => {
     expect(exitCode).toBe(0);
   });
 
+  it.each(["--cwd", "--prefix"])("should error when %s is immediately followed by --", async flag => {
+    using dir = tempDir(`bun-run-${flag.replace("--", "")}-value-is-delimiter`, {
+      "test.js": `console.log("ran");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "test.js", flag, "--", "arg"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain(`The argument '${flag}' requires a value but none was supplied.`);
+    expect(stdout).not.toContain("ran");
+    expect(exitCode).toBe(1);
+  });
+
+  it.each(["--cwd", "--prefix"])("should use the last %s when it appears both before and after the script name", async flag => {
+    using dir = tempDir(`bun-run-${flag.replace("--", "")}-last-across-boundary`, {
+      "first/test.js": `console.log("first");`,
+      "second/test.js": `console.log(process.cwd());`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", flag, "first", "test.js", flag, "second"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toMatch(/second/);
+    expect(stdout).not.toMatch(/first/);
+    expect(exitCode).toBe(0);
+  });
+
   describe("--cwd longer than the OS path limit", () => {
     // Longer than PATH_MAX on every platform (4096 on Linux, 1024 on macOS).
     const tooLong = Buffer.alloc(5000, "a").toString();

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -455,6 +455,54 @@ describe.concurrent("bun run", () => {
     expect(exitCode).toBe(0);
   });
 
+  it.each(["--cwd", "--prefix"])("should use the last %s after the script name", async flag => {
+    using dir = tempDir(`bun-run-${flag.replace("--", "")}-last-wins`, {
+      "first/test.js": `console.log("first");`,
+      "second/test.js": `console.log(process.cwd());`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "test.js", flag, "first", flag, "second"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toMatch(/second/);
+    expect(stdout).not.toMatch(/first/);
+    expect(exitCode).toBe(0);
+  });
+
+  it.each(["--cwd", "--prefix"])("should accept a dash-prefixed directory for %s after the script name", async flag => {
+    using dir = tempDir(`bun-run-${flag.replace("--", "")}-dash-dir`, {
+      "-workspace/test.js": `console.log(process.cwd());`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "test.js", flag, "-workspace"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toMatch(/-workspace/);
+    expect(exitCode).toBe(0);
+  });
+
   describe("--cwd longer than the OS path limit", () => {
     // Longer than PATH_MAX on every platform (4096 on Linux, 1024 on macOS).
     const tooLong = Buffer.alloc(5000, "a").toString();


### PR DESCRIPTION
## Context

On npm/Node, workspaces are using `--prefix` while bun only supported `--cwd`. It allows to use bun on those projects

## Summary

- Add `--prefix <STR>` to global CLI params as an npm-compatible alias for `--cwd`
- Parse `--prefix` identically to `--cwd` in `Arguments::parse` (`--cwd` wins if both are set)
- Parameterize the existing `bun run` cwd test to cover both flags

Ports the change from #24673 (closed without merge during the Zig → Rust migration) to the Rust CLI in `src/runtime/cli/Arguments.rs`.

Fixes #15135

## Test plan

- [x] `bun bd test test/cli/install/bun-run.test.ts -t "should show the correct working directory"` — both `--cwd` and `--prefix` pass
- [x] `USE_SYSTEM_BUN=1 bun test test/cli/install/bun-run.test.ts -t "should show the correct working directory"` — `--prefix` fails, `--cwd` passes (confirms the test exercises the new code path)