### PR TITLE
Keep an aborted AbortSignal's wrapper alive while its controller is still reachable

### DIFF
--- a/src/jsc/bindings/webcore/JSAbortSignalCustom.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignalCustom.cpp
@@ -39,37 +39,39 @@ bool JSAbortSignalOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> ha
         return true;
     }
 
-    if (abortSignal.aborted())
-        return false;
-
-    if (abortSignal.isFollowingSignal()) {
-        if (reason) [[unlikely]]
-            *reason = "Is Following Signal"_s;
-        return true;
-    }
-
-    if (abortSignal.hasAbortEventListener()) {
-        if (abortSignal.hasActiveTimeoutTimer()) {
+    if (!abortSignal.aborted()) {
+        if (abortSignal.isFollowingSignal()) {
             if (reason) [[unlikely]]
-                *reason = "Has Timeout And Abort Event Listener"_s;
+                *reason = "Is Following Signal"_s;
             return true;
         }
-        if (abortSignal.isDependent()) {
-            if (!abortSignal.sourceSignals().isEmptyIgnoringNullReferences()) {
+
+        if (abortSignal.hasAbortEventListener()) {
+            if (abortSignal.hasActiveTimeoutTimer()) {
                 if (reason) [[unlikely]]
-                    *reason = "Has Source Signals And Abort Event Listener"_s;
+                    *reason = "Has Timeout And Abort Event Listener"_s;
+                return true;
+            }
+            if (abortSignal.isDependent()) {
+                if (!abortSignal.sourceSignals().isEmptyIgnoringNullReferences()) {
+                    if (reason) [[unlikely]]
+                        *reason = "Has Source Signals And Abort Event Listener"_s;
+                    return true;
+                }
+            }
+
+            // https://github.com/oven-sh/bun/issues/4517
+            if (abortSignal.hasPendingActivity()) {
+                if (reason) [[unlikely]]
+                    *reason = "Has Pending Activity"_s;
                 return true;
             }
         }
-
-        // https://github.com/oven-sh/bun/issues/4517
-        if (abortSignal.hasPendingActivity()) {
-            if (reason) [[unlikely]]
-                *reason = "Has Pending Activity"_s;
-            return true;
-        }
     }
 
+    // Even when aborted, the wrapper must stay alive while an opaque root (e.g. the wrapper of
+    // the AbortController that owns the signal) keeps it reachable: the JS listener functions
+    // registered on the native signal are only kept alive through it (JSEventListener::m_wrapper).
     return visitor.containsOpaqueRoot(&abortSignal);
 }
 

--- a/test/js/web/abort/abort-controller-gc-reason.test.ts
+++ b/test/js/web/abort/abort-controller-gc-reason.test.ts
@@ -82,4 +82,57 @@ describe("AbortController GC", () => {
     expect(stdout.trim()).toBe("PASS");
     expect(exitCode).toBe(0);
   });
+
+  // The signal's wrapper owns the JS functions of its event listeners
+  // (JSEventListener::m_wrapper). It must not be collected once aborted while the
+  // retained controller still exposes the signal, or those listeners are lost.
+  test("abort event listeners survive GC when only controller is retained", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          let fired = 0;
+          const controllers = [];
+          for (let i = 0; i < 200; i++) {
+            const ac = new AbortController();
+            ac.signal.addEventListener("abort", () => {
+              fired++;
+            });
+            ac.signal.tag = i;
+            ac.abort();
+            controllers.push(ac);
+          }
+          if (fired !== 200) {
+            console.error("FAIL: expected 200 abort events before GC, got", fired);
+            process.exit(1);
+          }
+
+          for (let i = 0; i < 10; i++) {
+            Bun.gc(true);
+          }
+
+          let lostTags = 0;
+          for (let i = 0; i < controllers.length; i++) {
+            if (controllers[i].signal.tag !== i) lostTags++;
+          }
+          for (const ac of controllers) {
+            ac.signal.dispatchEvent(new Event("abort"));
+          }
+          if (lostTags !== 0 || fired !== 400) {
+            console.error("FAIL: lostTags =", lostTags, "fired =", fired);
+            process.exit(1);
+          }
+          console.log("PASS");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toEqual({ stdout: "PASS", exitCode: 0, stderr });
+  });
 });


### PR DESCRIPTION
### Problem

If an `AbortController` stays reachable after `abort()`, a GC can collect its signal's JS wrapper even though JS event listeners are still registered on the live native signal. `JSEventListener` only keeps the listener function alive through that wrapper (`m_wrapper` and `m_jsFunction` are weak), so those listeners lose their functions:

- release builds: later dispatches on `controller.signal` silently invoke nothing, and expando properties on `controller.signal` disappear
- debug builds: `ASSERTION FAILED: m_wrapper` in `WebCore::JSEventListener::ensureJSFunction` (`src/jsc/bindings/webcore/JSEventListener.h:157`), SIGABRT

```js
const acs = [];
for (let i = 0; i < 500; i++) {
  const ac = new AbortController();
  ac.signal.addEventListener("abort", () => {});
  ac.abort();
  acs.push(ac);
}
Bun.gc(true);
for (const ac of acs) ac.signal.dispatchEvent(new Event("abort"));
```

On bun 1.4.0 the 500 post-GC dispatches call no listeners; a debug build aborts with the assertion above.

### Cause

`JSAbortSignalOwner::isReachableFromOpaqueRoots` returned `false` as soon as `abortSignal.aborted()`, before the final `visitor.containsOpaqueRoot(&abortSignal)` check. `JSAbortController::visitChildrenImpl` does add the signal as an opaque root, but once the signal had fired that root was never consulted, so the wrapper (and with it every registered listener's function) was collected out from under the still reachable native signal.

### Fix

In `JSAbortSignalCustom.cpp`, `aborted()` now only skips the "can this still abort" keep-alive conditions; every state falls through to the opaque-root check, so the wrapper lives exactly as long as something (its `AbortController`'s wrapper) keeps the native signal reachable from JS. Signals whose controller is also unreachable are still collected as before.

### Verification

New case in `test/js/web/abort/abort-controller-gc-reason.test.ts`: register listeners, abort, GC, re-dispatch while only the controllers are retained.

- before: `ASSERTION FAILED: m_wrapper`, child exits with 134 (debug); listeners never fire again on release (1.4.0)
- after: `bun bd test test/js/web/abort/` passes, and `test/js/web/streams/pipeTo-signal-leak.test.ts` still passes (covers the opposite direction: dropping the controller must keep aborted signals collectable)
