### PR TITLE
bun:ffi: don't free a JSCallback's trampoline while a native caller is inside it

### DIFF
--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -1104,6 +1104,14 @@ declare module "bun:ffi" {
      * Free the memory allocated for the callback
      *
      * If called multiple times, does nothing after the first call.
+     *
+     * For non-threadsafe callbacks, it is safe to call this from inside the
+     * callback itself: the memory is not released until the native call stack
+     * that invoked the callback has fully unwound.
+     *
+     * For `threadsafe: true` callbacks, Bun cannot know when a foreign thread
+     * stops using the pointer; the caller must ensure no other thread is still
+     * calling it before closing.
      */
     close(): void;
   }

--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -49,6 +49,13 @@ public:
     // Cached on the JS thread at construction time so the foreign-thread
     // trampoline never has to dereference a Strong to find the context.
     WebCore::ScriptExecutionContextIdentifier m_contextId;
+    // Depth of FFI_Callback_call_* frames currently on the JS thread's stack.
+    // Only touched on the JS thread; the threadsafe entry point never bumps it.
+    unsigned m_activeCallCount { 0 };
+    // The Rust `*mut Function` whose drop JSCallback.close() deferred because a
+    // trampoline frame for this callback was on the stack. Consumed by the
+    // outermost FFICallbackCallScope destructor; opaque, never dereferenced here.
+    void* m_pendingCloseFunction { nullptr };
     ~FFICallbackFunctionWrapper() = default;
 
     FFICallbackFunctionWrapper(JSC::JSFunction* function, Zig::GlobalObject* globalObject)
@@ -58,6 +65,49 @@ public:
     {
     }
 };
+
+// Implemented in Rust (runtime/ffi/ffi_body.rs): enqueues an event-loop task
+// that drops `function` (a `*mut Function`) once no FFI_Callback_call_* frame
+// for it is left on the native stack.
+extern "C" void Bun__FFIFunction__scheduleDeferredDrop(void* function);
+
+// Tracks that a TinyCC-compiled trampoline for this callback is on the native
+// stack, so JSCallback.close() called from inside the callback defers freeing
+// the trampoline's executable memory instead of unmapping it under the caller.
+class FFICallbackCallScope {
+public:
+    explicit FFICallbackCallScope(FFICallbackFunctionWrapper& wrapper)
+        : m_wrapper(wrapper)
+    {
+        m_wrapper.m_activeCallCount++;
+    }
+    ~FFICallbackCallScope()
+    {
+        // Only the outermost frame schedules the drop. No JS can run between
+        // here and the event loop draining its task queue, so a tick started
+        // from inside the callback can never free the trampoline while a frame
+        // below still has to return into it.
+        if (--m_wrapper.m_activeCallCount == 0 && m_wrapper.m_pendingCloseFunction) {
+            void* function = m_wrapper.m_pendingCloseFunction;
+            m_wrapper.m_pendingCloseFunction = nullptr;
+            Bun__FFIFunction__scheduleDeferredDrop(function);
+        }
+    }
+
+private:
+    FFICallbackFunctionWrapper& m_wrapper;
+};
+
+extern "C" bool FFICallbackFunctionWrapper_hasActiveCalls(FFICallbackFunctionWrapper* wrapper)
+{
+    return wrapper->m_activeCallCount > 0;
+}
+
+extern "C" void FFICallbackFunctionWrapper_setPendingClose(FFICallbackFunctionWrapper* wrapper, void* function)
+{
+    wrapper->m_pendingCloseFunction = function;
+}
+
 extern "C" void FFICallbackFunctionWrapper_destroy(FFICallbackFunctionWrapper* wrapper)
 {
     // deref, not delete: pending event-loop tasks may still hold refs.
@@ -199,6 +249,7 @@ static JSC::EncodedJSValue invokeFFICallback(Zig::GlobalObject* globalObject, JS
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     for (size_t i = 0; i < argCount; ++i)
         arguments.appendWithCrashOnOverflow(JSC::JSValue::decode(args[i]));
@@ -225,6 +276,7 @@ FFI_Callback_threadsafe_call(FFICallbackFunctionWrapper& wrapper, size_t argCoun
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_0(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
@@ -232,6 +284,7 @@ FFI_Callback_call_0(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::E
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_1(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
@@ -240,6 +293,7 @@ FFI_Callback_call_1(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::E
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_2(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
@@ -248,6 +302,7 @@ FFI_Callback_call_2(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::E
 
 extern "C" JSC::EncodedJSValue FFI_Callback_call_3(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
@@ -257,6 +312,7 @@ extern "C" JSC::EncodedJSValue FFI_Callback_call_3(FFICallbackFunctionWrapper& w
 
 extern "C" JSC::EncodedJSValue FFI_Callback_call_4(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
@@ -267,6 +323,7 @@ extern "C" JSC::EncodedJSValue FFI_Callback_call_4(FFICallbackFunctionWrapper& w
 
 extern "C" JSC::EncodedJSValue FFI_Callback_call_5(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
@@ -279,6 +336,7 @@ extern "C" JSC::EncodedJSValue FFI_Callback_call_5(FFICallbackFunctionWrapper& w
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_6(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
@@ -292,6 +350,7 @@ FFI_Callback_call_6(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::E
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_7(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
+    FFICallbackCallScope callScope { wrapper };
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1251,7 +1251,7 @@ impl FFI {
 
     pub fn close_callback(_global_this: &JSGlobalObject, ctx: JSValue) -> JSValue {
         // SAFETY: ctx encodes a heap::alloc(*mut Function) created by `callback`
-        drop(unsafe { bun_core::heap::take(ctx.as_ptr_address() as *mut Function) });
+        release_callback_function(ctx.as_ptr_address() as *mut Function);
         JSValue::UNDEFINED
     }
 
@@ -1917,6 +1917,52 @@ impl Default for Function {
 
 unsafe extern "C" {
     fn FFICallbackFunctionWrapper_destroy(_: *mut c_void);
+    fn FFICallbackFunctionWrapper_hasActiveCalls(_: *mut c_void) -> bool;
+    fn FFICallbackFunctionWrapper_setPendingClose(_: *mut c_void, _: *mut c_void);
+}
+
+/// Drops the `heap::alloc`'d `Function` behind a `JSCallback` if no TinyCC
+/// trampoline frame for it is on the native stack; dropping sooner would unmap
+/// the executable page the native caller still has to return into. Otherwise
+/// arms the wrapper so the outermost `FFICallbackCallScope` destructor
+/// (JSFFIFunction.cpp) schedules the drop once that stack has fully unwound.
+fn release_callback_function(function: *mut Function) {
+    // SAFETY: `function` is a live `heap::alloc`'d pointer; the wrapper it
+    // owns is only released by `Function::drop`, which has not run yet.
+    if let Some(wrapper) = unsafe { (*function).callback_wrapper() } {
+        // SAFETY: `wrapper` is the live C++ wrapper the `Function` owns.
+        if unsafe { FFICallbackFunctionWrapper_hasActiveCalls(wrapper.as_ptr()) } {
+            // SAFETY: `function` is stored opaquely; C++ never dereferences it.
+            unsafe {
+                FFICallbackFunctionWrapper_setPendingClose(wrapper.as_ptr(), function.cast())
+            };
+            return;
+        }
+    }
+    // SAFETY: no trampoline frame is live; the `heap::alloc`'d box is ours.
+    drop(unsafe { bun_core::heap::take(function) });
+}
+
+/// Enqueues an event-loop task that re-runs [`release_callback_function`] for
+/// `function` (the `heap::alloc`'d `*mut Function`). Called by the outermost
+/// `FFICallbackCallScope` destructor in JSFFIFunction.cpp when a pending close
+/// is armed. The task routes back through `release_callback_function` instead
+/// of dropping unconditionally: a nested event-loop tick can run it while a
+/// later native invocation of the same callback is on the stack, in which case
+/// it must re-arm the wrapper rather than free the trampoline.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn Bun__FFIFunction__scheduleDeferredDrop(function: *mut c_void) {
+    fn run(function: *mut Function) -> bun_event_loop::JsResult<()> {
+        release_callback_function(function);
+        Ok(())
+    }
+    // `ManagedTask::new` (no `cleanup` hook) is deliberate: if the VM tears
+    // down first, leaking the `Function` is safer than running `Function::drop`
+    // (which releases `JSC::Strong`s) from `EventLoop::deinit`.
+    let task = jsc::ManagedTask::ManagedTask::new(function.cast::<Function>(), run);
+    jsc::VirtualMachineRef::get()
+        .event_loop_mut()
+        .enqueue_task(task);
 }
 
 impl Drop for Function {
@@ -1943,6 +1989,15 @@ impl Function {
             }
         }
         self.return_type == ABIType::NapiValue
+    }
+
+    /// The `FFICallbackFunctionWrapper` this callback owns, or `None` for
+    /// non-callback (dlopen / cc) functions.
+    fn callback_wrapper(&self) -> Option<NonNull<c_void>> {
+        match &self.step {
+            Step::Compiled(compiled) => compiled.ffi_callback_function_wrapper,
+            _ => None,
+        }
     }
 
     fn fail(&mut self, msg: &'static [u8]) {

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe, isArm64, isGlibcVersionAtLeast, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isArm64, isGlibcVersionAtLeast, isMusl, isWindows, tempDir } from "harness";
 import { platform } from "os";
 
 import {
@@ -789,6 +789,120 @@ it.skipIf(isFFIUnavailable)("JSCallback tolerates worker.terminate() arriving in
     stderr: "",
     exitCode: 0,
     signalCode: null,
+  });
+});
+
+// bun:ffi (TinyCC) is unavailable on Windows ARM64.
+// Each case runs in a subprocess: the bug is a wild jump into freed TinyCC
+// executable memory, which takes the whole process down.
+describe.skipIf(isWindows && isArm64)("JSCallback.close() from inside the callback", () => {
+  it.concurrent("does not free the trampoline under the native caller", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { CFunction, JSCallback } from "bun:ffi";
+         let cb;
+         cb = new JSCallback(() => { cb.close(); return 7; }, { args: [], returns: "i32" });
+         const call = new CFunction({ ptr: cb.ptr, args: [], returns: "i32" });
+         console.log("result", call());
+         console.log("closed", cb.ptr);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr is drained but not asserted: ASAN/debug builds emit benign warnings.
+    expect({ stdout, exitCode }).toEqual({ stdout: "result 7\nclosed null\n", exitCode: 0 });
+  });
+
+  // qsort keeps invoking the comparator after the callback closes itself, so
+  // this also covers re-entry into the trampoline after close(). musl has no
+  // libc.so.6 soname and Windows has no qsort in a predictable DLL, so skip.
+  it.concurrent.skipIf(isWindows || isMusl)(
+    "keeps working for the rest of the native call that triggered it",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { dlopen, ptr, read, JSCallback } from "bun:ffi";
+           const name = process.platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6";
+           const libc = dlopen(name, { qsort: { args: ["ptr", "u64", "u64", "function"], returns: "void" } });
+           let n = 0;
+           let cb;
+           cb = new JSCallback(
+             (a, b) => {
+               if (++n === 1) cb.close();
+               return read.i32(a, 0) - read.i32(b, 0);
+             },
+             { args: ["ptr", "ptr"], returns: "i32" },
+           );
+           const arr = new Int32Array([5, 3, 9, 1, 7, 2, 8, 4, 6, 0]);
+           libc.symbols.qsort(ptr(arr), arr.length, 4, cb.ptr);
+           console.log(Array.from(arr).join(","), n > 1);`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, exitCode }).toEqual({ stdout: "0,1,2,3,4,5,6,7,8,9 true\n", exitCode: 0 });
+    },
+  );
+
+  // drainMicrotasks() runs a full event-loop tick, so the deferred drop must
+  // not be in the task queue while the trampoline is still on the stack.
+  it.concurrent("survives a nested event-loop tick from inside the callback", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { drainMicrotasks } from "bun:jsc";
+         import { CFunction, JSCallback } from "bun:ffi";
+         let cb;
+         cb = new JSCallback(() => { cb.close(); drainMicrotasks(); return 7; }, { args: [], returns: "i32" });
+         const call = new CFunction({ ptr: cb.ptr, args: [], returns: "i32" });
+         console.log("result", call());
+         console.log("closed", cb.ptr);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "result 7\nclosed null\n", exitCode: 0 });
+  });
+
+  // Once the drop has been scheduled (after the first invocation unwound), a
+  // nested tick from a LATER invocation of the same callback must not run it.
+  it.concurrent.skipIf(isWindows || isMusl)("survives a nested event-loop tick from a later invocation", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { drainMicrotasks } from "bun:jsc";
+           import { dlopen, ptr, read, JSCallback } from "bun:ffi";
+           const name = process.platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6";
+           const libc = dlopen(name, { qsort: { args: ["ptr", "u64", "u64", "function"], returns: "void" } });
+           let n = 0;
+           let cb;
+           cb = new JSCallback(
+             (a, b) => {
+               n++;
+               if (n === 1) cb.close();
+               else drainMicrotasks();
+               return read.i32(a, 0) - read.i32(b, 0);
+             },
+             { args: ["ptr", "ptr"], returns: "i32" },
+           );
+           const arr = new Int32Array([5, 3, 9, 1, 7, 2, 8, 4, 6, 0]);
+           libc.symbols.qsort(ptr(arr), arr.length, 4, cb.ptr);
+           console.log(Array.from(arr).join(","), n > 1);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "0,1,2,3,4,5,6,7,8,9 true\n", exitCode: 0 });
   });
 });
 


### PR DESCRIPTION
Closing a `JSCallback` from inside the callback itself frees the TinyCC state that owns the trampoline's executable memory while the native caller is still on the stack. The in-flight invocation returns into the unmapped page, and the caller keeps jumping to the freed function pointer for the rest of the native call.

### Reproduction

```js
import { dlopen, ptr, JSCallback } from "bun:ffi";
const libc = dlopen("libc.so.6", { qsort: { args: ["ptr", "u64", "u64", "function"], returns: "void" } });
let n = 0, cb;
cb = new JSCallback((a, b) => { if (++n === 1) cb.close(); return 0; }, { args: ["ptr", "ptr"], returns: "i32" });
const arr = new Int32Array([5, 3, 9, 1, 7, 2, 8, 4, 6, 0]);
libc.symbols.qsort(ptr(arr), arr.length, 4, cb.ptr); // qsort calls the callback; the callback closes itself
console.log("survived", n);
```

```
panic(main thread): Segmentation fault at address 0x34E6D8893B6
```

Under ASan it reports `SEGV ... PC is at a non-executable region. Maybe a wild jump?`. Reproduces on every run. A self-contained variant with no library dependency crashes the same way (`CFunction` invoking a `JSCallback` that closes itself).

### Cause

`JSCallback.close()` -> `closeCallback(ctx)` drops the `Function` synchronously, and `Function::drop` calls `TCC::State::destroy`, which unmaps the page holding the compiled trampoline (`my_callback_function`). When `close()` runs from inside the callback the native stack is

```
qsort
  my_callback_function        <- TinyCC executable memory
    FFI_Callback_call_2       <- bun's .text, calls into JS
      JS callback -> cb.close()
```

There is no safe point anywhere on that stack. Even after `FFI_Callback_call_2` returns, the trampoline still has to execute its own return-value conversion and `ret` out of the page that was just unmapped, and `qsort` calls it again for every remaining comparison.

### Fix

- `FFICallbackFunctionWrapper` (`JSFFIFunction.cpp`) counts how many `FFI_Callback_call_*` frames are on the JS thread's stack, via an RAII scope in each of the nine non-threadsafe entry points. The threadsafe entry point runs on a foreign thread and only posts a task, so it is not touched.
- `close()` from inside the callback no longer drops the `Function`. It arms a pending-close flag on the wrapper. Closing with no call in flight (the normal case) still drops immediately, so a tight create/close loop does not accumulate TinyCC states.
- The outermost `FFICallbackCallScope` destructor (call depth reaches 0) is the only place that enqueues the deferred drop as an event-loop task. No JS can execute between that point and the event loop draining its queue, so nothing can free the trampoline while a frame still has to return into it. In particular, a full `EventLoop::tick()` triggered from inside the callback (`require("bun:jsc").drainMicrotasks()`, `bun:test`'s `resolves`/`rejects` via `wait_for_promise`) finds nothing in the queue because the drop has not been scheduled yet. Enqueuing directly from `close()` would leave exactly that hole.
- The enqueued task routes back through the same check rather than dropping unconditionally: a nested tick from a later native invocation of the same callback (e.g. qsort's next comparison) can still run it while a trampoline frame is live, in which case it re-arms the wrapper and the new outermost scope reschedules it. (A task that re-enqueues itself instead would hang: `EventLoop::tick()` drains the queue until it is empty.)

Deferring the drop also keeps the `JSC::Strong` on the JS function alive for the remaining invocations the native caller makes before it returns, so a callback that closes itself keeps working until the caller is done. The repro above now prints `survived 15`: the close on comparison 1 did not stop `qsort` from finishing.

### Verification

Four subprocess tests in `test/js/bun/ffi/ffi.test.js`:

- a self-contained `CFunction` case, covering the return-into-freed-page shape on every platform bun:ffi supports
- the `qsort` case (glibc Linux + macOS), which additionally asserts the array still sorts, proving the callback stays callable for the rest of the native call
- both again with `require("bun:jsc").drainMicrotasks()` inside the callback, proving a nested event-loop tick (from the closing invocation, and from a later invocation) cannot run the deferred drop early

All four crash the child before the fix and pass after, on both the released binary and `bun bd`.


### Rebase note

Rebased onto main after #32792 landed and conflicted in `JSFFIFunction.cpp` and `ffi.test.js`. #32792 consolidated the ten `FFI_Callback_*` entry points onto a shared `invokeFFICallback()` helper; the `FFICallbackCallScope` RAII guard now sits at the top of each of the nine non-threadsafe entry points' one-line bodies instead of being woven into their old preludes. No semantic change. #32792's two new `JSCallback` tests and this PR's four coexist in `ffi.test.js`, and all six pass together.
