### PR TITLE
redis: fix abort and hangs after a synchronously failing reconnect

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1231,16 +1231,13 @@ impl JSValkeyClient {
             r.ref_(vm_event_loop_ctx());
         });
 
-        if let Err(err) = self.connect() {
-            self.fail_with_js_value(
-                self.global_object
-                    .err(
-                        jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,
-                        format_args!("{} reconnecting", err.name()),
-                    )
-                    .to_js(),
-            );
-            self.poll_ref.with_mut(|r| r.disable());
+        if self.connect().is_err() {
+            // Same state machine as an async connect failure (`on_connect_error`):
+            // retry with backoff, or fail and settle the connection promise.
+            // `connect()` released its own ref; `on_close()` releases one, so balance.
+            self.ref_();
+            let _ = self.client_mut().on_close();
+            self.update_poll_ref();
             return;
         }
 
@@ -1463,19 +1460,6 @@ impl JSValkeyClient {
 
     pub fn client_fail(&self, message: &[u8], err: protocol::RedisError) -> JsTerminatedResult<()> {
         narrow_terminated(self.client_mut().fail(message, err))
-    }
-
-    pub fn fail_with_js_value(&self, value: JSValue) {
-        let Some(this_value) = self.this_value.get().try_get() else {
-            return;
-        };
-        let global_object = self.global_object;
-        if let Some(on_close) = Js::onclose_get_cached(this_value) {
-            let _exit = self.vm().enter_event_loop_scope();
-            if let Err(e) = on_close.call(&global_object, this_value, &[value]) {
-                global_object.report_active_exception_as_unhandled(e);
-            }
-        }
     }
 
     fn close_socket_next_tick(&self) {

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1192,10 +1192,10 @@ impl JSValkeyClient {
                 let _ = self.client_fail(msg, protocol::RedisError::ConnectionTimeout);
                 // TODO: properly propagate exception upwards
                 if already_detached {
-                    // `on_valkey_close()` releases one ref in its defer.
+                    // `on_valkey_close()`'s defer runs `update_poll_ref()` and
+                    // releases one ref; balance that release here.
                     self.ref_();
                     let _ = self.on_valkey_close();
-                    self.update_poll_ref();
                 }
             }
         }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1185,8 +1185,18 @@ impl JSValkeyClient {
                 .expect("unreachable");
                 let len = start - cur.len();
                 let msg = &buf[..len];
+                // Between reconnect attempts the socket is already detached, so
+                // `fail()`'s `close()` is a no-op and no close callback will ever
+                // settle the connection promise or release the poll ref.
+                let already_detached = self.client.get().socket.is_closed();
                 let _ = self.client_fail(msg, protocol::RedisError::ConnectionTimeout);
                 // TODO: properly propagate exception upwards
+                if already_detached {
+                    // `on_valkey_close()` releases one ref in its defer.
+                    self.ref_();
+                    let _ = self.on_valkey_close();
+                    self.update_poll_ref();
+                }
             }
         }
     }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -593,6 +593,10 @@ impl ValkeyClient {
             return Ok(());
         }
         self.flags.failed = true;
+        // A failed client is terminal until the next explicit `connect()`.
+        // A stale `is_reconnecting` would keep the event loop referenced via
+        // `update_poll_ref` and let a pending reconnect timer resurrect it.
+        self.flags.is_reconnecting = false;
         let val = Self::reject_all_pending_commands(
             &mut self.in_flight,
             &mut self.queue,
@@ -639,6 +643,12 @@ impl ValkeyClient {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();
 
+        // The socket is gone, so the session can no longer be authenticated.
+        // Every branch below must observe `connection_ready() == false`, or a
+        // later `connect()` + `enqueue()` sees a Disconnected-but-"ready" client.
+        self.flags.is_authenticated = false;
+        self.flags.is_selecting_db_internal = false;
+
         // If manually closing, don't attempt to reconnect
         if self.flags.is_manually_closed {
             debug!("skip reconnecting since the connection is manually closed");
@@ -675,8 +685,6 @@ impl ValkeyClient {
         );
 
         self.flags.is_reconnecting = true;
-        self.flags.is_authenticated = false;
-        self.flags.is_selecting_db_internal = false;
 
         // Signal reconnect timer should be started
         self.on_valkey_reconnect();
@@ -1344,8 +1352,12 @@ impl ValkeyClient {
             && self.queue.readable_length() > 0;
 
         if
-        // If there are any pending commands, queue this one
-        self.queue.readable_length() > 0
+        // Only an established, authenticated connection may take the
+        // direct-write path below. `connection_ready()` alone is not enough:
+        // a disconnected or still-connecting socket must go to the queue.
+        self.status != Status::Connected
+            // If there are any pending commands, queue this one
+            || self.queue.readable_length() > 0
             // With auto pipelining, we can accept commands regardless of in_flight commands
             || (!can_pipeline && self.in_flight.readable_length() > 0)
             // We need authentication before processing commands
@@ -1367,15 +1379,10 @@ impl ValkeyClient {
             return Ok(());
         }
 
-        match self.status {
-            Status::Connecting | Status::Connected => {
-                if command.write(self.writer()).is_err() {
-                    let global = self.global_object();
-                    let _ = promise.reject(&global, Ok(global.create_out_of_memory_error()));
-                    return Ok(());
-                }
-            }
-            _ => unreachable!(),
+        if command.write(self.writer()).is_err() {
+            let global = self.global_object();
+            let _ = promise.reject(&global, Ok(global.create_out_of_memory_error()));
+            return Ok(());
         }
 
         let cmd_pair = command::PromisePair {

--- a/test/js/valkey/valkey-reconnect-failure.test.ts
+++ b/test/js/valkey/valkey-reconnect-failure.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+
+// A previously-authenticated client that was closed used to keep
+// `is_authenticated` set. If a later connect() then failed synchronously (the
+// unix socket is gone, or socket() hits EMFILE), the client ended up
+// Disconnected with `failed` cleared but `connection_ready()` still true, and
+// the next non-pipelined command fell into `enqueue()`'s `_ => unreachable!()`
+// arm and aborted the process.
+//
+// The fixture uses a unix socket so the reconnect's connect(2) fails
+// synchronously (ENOENT) once the socket file is removed.
+const FIXTURE = /* ts */ `
+  import { join } from "node:path";
+
+  const mode = process.argv[2];
+  const sock = join(import.meta.dir, "valkey.sock");
+
+  // Minimal RESP mock: +OK to every inbound frame (HELLO handshake + commands).
+  function listen() {
+    return Bun.listen({
+      unix: sock,
+      socket: {
+        open() {},
+        data(s) {
+          s.write("+OK\\r\\n");
+        },
+        error() {},
+        close() {},
+        drain() {},
+      },
+    });
+  }
+
+  let srv = listen();
+
+  const options =
+    mode === "send"
+      ? { autoReconnect: false }
+      : mode === "no-pipelining"
+        ? { autoReconnect: false, enableAutoPipelining: false }
+        : {};
+
+  const client = new Bun.RedisClient("redis+unix://" + sock, options);
+  await client.connect();
+  await client.set("k", "v");
+  console.log("connected", client.connected);
+
+  client.close();
+  console.log("closed", client.connected);
+
+  // Unlinks the unix socket, so the next connect(2) fails with ENOENT.
+  srv.stop(true);
+
+  const connectPromise = client.connect();
+
+  if (mode === "recover") {
+    // autoReconnect (default) retries with backoff; bring the server back so
+    // the retry succeeds and the offline queue drains.
+    srv = listen();
+    const reply = client.send("INFO", []);
+    console.log("reply", await reply);
+    await connectPromise;
+    console.log("reconnected", client.connected);
+    srv.stop(true);
+  } else {
+    const command = mode === "no-pipelining" ? client.incr("n") : client.send("INFO", []);
+    const [connectResult, commandResult] = await Promise.allSettled([connectPromise, command]);
+    console.log("connect", connectResult.status, connectResult.reason?.code);
+    console.log("command", commandResult.status, commandResult.reason?.code, commandResult.reason?.message);
+  }
+`;
+
+async function runFixture(mode: string) {
+  using dir = tempDir("valkey-reconn", { "reconnect-fixture.ts": FIXTURE });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "reconnect-fixture.ts", mode],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: normalizeBunSnapshot(stdout, String(dir)), stderr, exitCode };
+}
+
+describe.skipIf(isWindows)("RedisClient after a synchronously failing reconnect", () => {
+  const rejected = [
+    "connected true",
+    "closed false",
+    "connect rejected ERR_REDIS_CONNECTION_CLOSED",
+    "command rejected ERR_REDIS_CONNECTION_CLOSED Connection has failed",
+  ].join("\n");
+
+  test.concurrent("non-pipelined command rejects instead of aborting the process", async () => {
+    const { stdout, stderr, exitCode } = await runFixture("send");
+    expect({ stdout, exitCode }, stderr).toEqual({ stdout: rejected, exitCode: 0 });
+  });
+
+  test.concurrent("enableAutoPipelining: false rejects instead of aborting the process", async () => {
+    const { stdout, stderr, exitCode } = await runFixture("no-pipelining");
+    expect({ stdout, exitCode }, stderr).toEqual({ stdout: rejected, exitCode: 0 });
+  });
+
+  test.concurrent("autoReconnect retries with backoff and drains the offline queue", async () => {
+    const { stdout, stderr, exitCode } = await runFixture("recover");
+    expect({ stdout, exitCode }, stderr).toEqual({
+      stdout: ["connected true", "closed false", "reply OK", "reconnected true"].join("\n"),
+      exitCode: 0,
+    });
+  });
+});
+
+// After auto-reconnect exhausts maxRetries and the client fails, the stale
+// `is_reconnecting` flag used to keep the event loop referenced forever, so
+// the process never exited.
+test.concurrent("process exits after auto-reconnect exhausts maxRetries", async () => {
+  const fixture = /* ts */ `
+    const srv = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open() {},
+        data(s) {
+          s.write("+OK\\r\\n");
+        },
+        error() {},
+        close() {},
+        drain() {},
+      },
+    });
+    const client = new Bun.RedisClient("redis://127.0.0.1:" + srv.port, { maxRetries: 1 });
+    await client.set("k", "v");
+    console.log("connected", client.connected);
+    const pending = client.get("k");
+    srv.stop(true);
+    const results = await Promise.allSettled([pending, client.get("k")]);
+    console.log(results.map(r => r.status + " " + r.reason?.code).join("|"));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: normalizeBunSnapshot(stdout), exitCode, signalCode: proc.signalCode }, stderr).toEqual({
+    stdout: ["connected true", "rejected ERR_REDIS_CONNECTION_CLOSED|rejected ERR_REDIS_CONNECTION_CLOSED"].join("\n"),
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/valkey/valkey-reconnect-failure.test.ts
+++ b/test/js/valkey/valkey-reconnect-failure.test.ts
@@ -111,11 +111,22 @@ describe.skipIf(isWindows)("RedisClient after a synchronously failing reconnect"
   });
 });
 
+async function runInline(fixture: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: normalizeBunSnapshot(stdout), stderr, exitCode, signalCode: proc.signalCode };
+}
+
 // After auto-reconnect exhausts maxRetries and the client fails, the stale
 // `is_reconnecting` flag used to keep the event loop referenced forever, so
 // the process never exited.
 test.concurrent("process exits after auto-reconnect exhausts maxRetries", async () => {
-  const fixture = /* ts */ `
+  const { stdout, stderr, exitCode, signalCode } = await runInline(/* ts */ `
     const srv = Bun.listen({
       hostname: "127.0.0.1",
       port: 0,
@@ -136,16 +147,33 @@ test.concurrent("process exits after auto-reconnect exhausts maxRetries", async 
     srv.stop(true);
     const results = await Promise.allSettled([pending, client.get("k")]);
     console.log(results.map(r => r.status + " " + r.reason?.code).join("|"));
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: normalizeBunSnapshot(stdout), exitCode, signalCode: proc.signalCode }, stderr).toEqual({
+  `);
+  expect({ stdout, exitCode, signalCode }, stderr).toEqual({
     stdout: ["connected true", "rejected ERR_REDIS_CONNECTION_CLOSED|rejected ERR_REDIS_CONNECTION_CLOSED"].join("\n"),
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/18895
+// When connectionTimeout fired between reconnect attempts the socket was
+// already detached, so fail()'s close() was a no-op and no close callback ever
+// settled the connect() promise or released the event loop.
+test.concurrent("connectionTimeout during a reconnect backoff settles connect() and exits", async () => {
+  const { stdout, stderr, exitCode, signalCode } = await runInline(/* ts */ `
+    // Bind and release a port so nothing is listening on it.
+    const probe = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+    const port = probe.port;
+    probe.stop(true);
+    const client = new Bun.RedisClient("redis://127.0.0.1:" + port, { connectionTimeout: 500 });
+    const results = await Promise.allSettled([client.connect(), client.get("k")]);
+    console.log(results.map(r => r.status + " " + r.reason?.code + " " + r.reason?.message).join("|"));
+  `);
+  expect({ stdout, exitCode, signalCode }, stderr).toEqual({
+    stdout: [
+      "rejected ERR_REDIS_CONNECTION_CLOSED Connection closed",
+      "rejected ERR_REDIS_CONNECTION_TIMEOUT Connection timeout reached after 500ms",
+    ].join("|"),
     exitCode: 0,
     signalCode: null,
   });


### PR DESCRIPTION
### What does this PR do?

Fixes a process abort (and the hangs behind it) in `Bun.RedisClient` reachable through the public API with no fault injection.

```
panic: internal error: entered unreachable code
  ValkeyClient::enqueue   src/runtime/valkey_jsc/valkey.rs   (`_ => unreachable!()`)
  ValkeyClient::send      (offline-queue arm)
```

Reproduction (against a minimal in-process RESP server that answers `+OK`; the unix socket only makes the reconnect's `connect(2)` fail synchronously with `ENOENT`, `socket(2)` returning `EMFILE` under fd pressure reaches the same branch for TCP):

```ts
const sock = "/tmp/vk.sock";
let srv = Bun.listen({ unix: sock, socket: { data(s) { s.write("+OK\r\n"); } } });

const c = new Bun.RedisClient(`redis+unix://${sock}`);
await c.connect();
await c.set("k", "v");   // authenticated
c.close();
srv.stop(true);          // unlinks the socket

c.connect().catch(() => {});  // reconnect's connect(2) fails synchronously
await c.send("INFO", []);     // aborts the whole process
```

Fixes #18895

### Cause

Three holes in the connection state machine stack up:

1. `ValkeyClient::on_close()` only cleared `flags.is_authenticated` on its auto-reconnect branch. After a manual `close()` (or a server-side close with `autoReconnect: false`), a disconnected client still reported `connection_ready() == true`.
2. `do_connect()` clears the sticky `failed` flag so an explicit `connect()` can recover (#29925). If that reconnect's `connect()` then fails synchronously, `reconnect()`'s error branch only fired the JS `onclose` callback: it never marked the client failed, never settled the cached connection promise, and ignored `autoReconnect` / `maxRetries`.
3. `enqueue()` assumed `connection_ready()` implies `Connecting | Connected` and put `_ => unreachable!()` in the status match. With (1) and (2), the client reaches `Status::Disconnected` with `connection_ready()` true and `failed` false, and the next command that cannot be auto-pipelined (`send("INFO")`, or any command with `enableAutoPipelining: false`) lands on the `unreachable!()`.

Writing the fix exposed two more in the same class (a terminal failure must settle the connection promise and release the event loop reference):

4. After `fail()` the stale `is_reconnecting` flag kept `update_poll_ref()` holding the event loop open forever, so a process whose client exhausted `maxRetries` never exited.
5. When `connectionTimeout` fires between reconnect attempts, the socket is already detached, so `fail()`'s `close()` is a no-op and no close callback ever reaches `on_valkey_close()`. The `connect()` promise stays pending and the event loop stays referenced. This is #18895: on current main, `new Bun.RedisClient("redis://localhost:<closed port>", { connectionTimeout: 30 }).connect()` rejects and then hangs the process forever, and an unresolvable host leaves the connect promise unsettled.

### Fix

- `on_close()` clears `is_authenticated` and `is_selecting_db_internal` unconditionally. A closed socket is never an authenticated session.
- `reconnect()` routes a synchronous `connect()` failure through `ValkeyClient::on_close()`, the same state machine the asynchronous `on_connect_error` path already uses. That settles the pending connection promise (via `on_valkey_close`), rejects queued commands, and honors `autoReconnect` / `maxRetries` with backoff. `connect()` releases its own keep-alive ref on the failure path, and `on_close()` releases one, so the branch takes one ref to balance. `JSValkeyClient::fail_with_js_value` loses its only caller and is deleted.
- `enqueue()` gates the direct-write fast path on `status == Connected` and drops the `_ => unreachable!()` arm entirely. A wire client must not be able to abort the process from state reachable through its public API. (Note: (1) alone already makes the panic unreachable; this removes the panic as a mechanism and also closes the pre-existing `Status::Connecting` arm, which would have written command bytes before the `HELLO` handshake if reached with a stale `is_authenticated`.)
- `ValkeyClient::fail_with_js_value()` clears `is_reconnecting` when the client enters the terminal failed state.
- `on_connection_timeout()` runs `on_valkey_close()` itself when the socket is already detached, so the connection promise settles and the poll ref is re-evaluated even though no socket close callback will arrive.

With these, every scenario in #18895 now settles the `connect()` promise and lets the process exit (details in the comment below). The total time to rejection with default options is still governed by `autoReconnect` / `maxRetries`, and `connectionTimeout` is still re-armed on every reconnect attempt (a per-attempt bound, not a total one); that is pre-existing and unchanged here.

### Overlap with #32768

#32768 (a different fuzz finding: `connectionPromise` double-settle and a GC leak) also edits `reconnect()`'s synchronous-failure branch, so the two will conflict textually. They fix different bugs: #32768 does not touch `on_close()` or `enqueue()`, and this PR does not touch the stale promise slot in `do_connect()`'s `needs_to_open_socket` branch (#32768's item 1). This PR's `reconnect()` change is the `on_close()` routing that #32768's description explicitly deferred ("Fixing that requires calling on_valkey_close() from a context that did not take the socket keep-alive ref"); the balancing `ref_()` here is that refcount change. I left a comment on #32768 with the details so whichever lands second can rebase.

### Verification

`test/js/valkey/valkey-reconnect-failure.test.ts` (in-process mock RESP server, no real Redis needed; each case in its own subprocess because the bug aborts the whole process):

- a non-pipelined command after the failed reconnect rejects with `ERR_REDIS_CONNECTION_CLOSED` instead of aborting (`autoReconnect: false`)
- same with `enableAutoPipelining: false`
- with `autoReconnect` on, the failed reconnect retries with backoff and the offline queue drains once it succeeds
- the process exits after auto-reconnect exhausts `maxRetries` (previously hung forever)
- `connectionTimeout` firing between reconnect attempts rejects the `connect()` promise and the process exits (previously the promise stayed pending and the process hung)

On `bun-v1.4.0-canary (942c22237)` all five fail: the first three abort with the panic above, the last two hang. With the fix all five pass under the ASAN debug build. The existing mock-server valkey suites (`valkey-gc`, `valkey-incremental-scan`, `valkey-tls-verify`, `reliability/resp-nesting-depth`) still pass, and both scenarios from `reliability/recovery.test.ts` (#29925) were re-verified against a local `redis-server`.

Reported by bun-sys-fuzz.
