### PR TITLE
bun:ffi: don't re-enter JS from a JSCallback while an exception is pending

### DIFF
--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -191,6 +191,13 @@ static JSC::EncodedJSValue invokeFFICallback(Zig::GlobalObject* globalObject, JS
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // An earlier invocation during the same native call already threw. The native caller cannot
+    // unwind, so do not re-enter JS while that exception is pending (JSC asserts on entry); it
+    // surfaces once the enclosing FFI call returns to JS.
+    if (scope.exception()) [[unlikely]]
+        return JSC::JSValue::encode(JSC::jsNull());
+
     auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments);
     RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsNull()));
     return JSC::JSValue::encode(result);

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1085,3 +1085,66 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
     });
   }
 });
+
+// A system C library exporting qsort(), so that native code invokes a JSCallback
+// more than once inside a single FFI call. null skips the test: no reachable C
+// library, or bun:ffi itself is unavailable on this platform (Windows ARM64).
+const qsortLibPath = (() => {
+  const symbols = { qsort: { args: ["ptr", "u64", "u64", "function"], returns: "void" } };
+  for (const name of [
+    "/usr/lib/libSystem.B.dylib", // macOS
+    "msvcrt.dll", // Windows
+    "libc.so.6", // glibc
+    `libc.musl-${process.arch === "arm64" ? "aarch64" : "x86_64"}.so.1`, // musl
+  ]) {
+    try {
+      _dlopen(name, symbols).close();
+      return name;
+    } catch {}
+  }
+  return null;
+})();
+
+// After a JSCallback throws, its exception stays pending in the VM until the
+// enclosing FFI call returns to JS. Native code cannot see it and keeps calling
+// the callback; re-entering JS then would trip JSC's assertNoException.
+it.if(!!qsortLibPath)("JSCallback that throws is not re-entered for the rest of the native call", async () => {
+  const code = `
+    import { dlopen, ptr, JSCallback } from "bun:ffi";
+    const lib = dlopen(${JSON.stringify(qsortLibPath)}, {
+      qsort: { args: ["ptr", "u64", "u64", "function"], returns: "void" },
+    });
+    let calls = 0;
+    const cb = new JSCallback(
+      () => {
+        calls++;
+        throw new Error("cb-throw");
+      },
+      { args: ["ptr", "ptr"], returns: "i32" },
+    );
+    const values = new Int32Array([5, 3, 8, 1, 9, 2, 7, 4]);
+    try {
+      lib.symbols.qsort(ptr(values), values.length, 4, cb.ptr);
+      console.log("did-not-throw");
+    } catch (e) {
+      console.log("caught:", e.message);
+    }
+    console.log("calls:", calls);
+    cb.close();
+    lib.close();
+    console.log("done");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // stderr is in the received object so failures show it (the JSC assertion
+  // text lands there), but it is not asserted empty: ASAN/debug builds warn.
+  // Only the first qsort comparison may reach JS, so calls stays 1.
+  expect({ stdout, stderr, exitCode }).toMatchObject({
+    stdout: "caught: cb-throw\ncalls: 1\ndone\n",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
### What

A `JSCallback` whose JS body throws leaves the exception installed in the VM while control returns to the foreign caller, which cannot unwind it. When that caller invokes the callback again before returning (for example `qsort` calling its comparator a second time), Bun re-enters JSC with the exception still pending and assertion-enabled builds abort:

```
ASSERTION FAILED: Unexpected exception observed on thread Thread:0x... at:
The exception was thrown from thread Thread:0x... at:
Error Exception: cb-throw

!exception()
JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

Repro (debug / ASAN builds):

```js
import { dlopen, ptr, JSCallback } from "bun:ffi";
const libc = dlopen("libc.so.6", { qsort: { args: ["ptr", "u64", "u64", "function"], returns: "void" } });
const cb = new JSCallback(() => { throw new Error("cb-throw"); }, { args: ["ptr", "ptr"], returns: "i32" });
const arr = new Int32Array([3, 1, 2]);
try { libc.symbols.qsort(ptr(arr), arr.length, 4, cb.ptr); } catch (e) { console.log("caught", String(e)); }
console.log("survived");
```

### Cause

The FFI callback glue leaves the exception pending so it surfaces once the enclosing FFI call returns to JS, which is the normal JSC host-function contract. What was missing is the other half of that contract: while an exception is pending, nothing may start a new JS execution. The native caller has no way to know a throw happened and keeps invoking the callback; `Interpreter::executeCallImpl` begins with `scope.assertNoException()`, which is what aborts. Release builds happen to survive because `VMTraps::NeedExceptionHandling` short-circuits the callee before its body runs, but that is exactly the state JSC's assertion forbids.

### Fix

`invokeFFICallback`, the shared tail of every `FFI_Callback_*` entry point, now returns immediately, without entering JS, when the VM already has a pending exception. Everything else is unchanged: the exception still stays pending and is raised at the enclosing FFI call site.

### Verification

New test in `test/js/bun/ffi/ffi.test.js` spawns a child that `qsort`s 8 elements with a comparator that throws, and asserts the error is caught at the `qsort()` call site, the callback body ran exactly once, and the process exited 0.

- unfixed `bun-debug` (current `main`): the child aborts with the assertion above and the test fails
- fixed `bun-debug`: the whole `test/js/bun/ffi/` directory passes, including the two tests added by #32792; also clean under `BUN_JSC_validateExceptionChecks=1`
- the assertion only exists in ASSERT_ENABLED JSC builds, so the release binary passes the test before and after; debug and ASAN lanes are where it distinguishes

### Rebase note

#32792 landed on `main` while this was open and performed the same `invokeFFICallback` deduplication of the `FFI_Callback_*` entry points, for an independent bug (re-throwing JSC's TerminationException). This PR is rebased on top of it, so the remaining `src/` change is just the pending-exception guard inside that helper. #32778 fixes a third independent `JSCallback` bug in the same functions.