### PR TITLE
ffi: reject non-void return types on threadsafe JSCallbacks

### DIFF
--- a/docs/runtime/ffi.mdx
+++ b/docs/runtime/ffi.mdx
@@ -315,12 +315,18 @@ When you're done with a JSCallback, you should call `close()` to free the memory
 
 Currently, thread-safe callbacks work best when run from another thread that is running JavaScript code, i.e. a [`Worker`](/runtime/workers). A future version of Bun will enable them to be called from any thread (such as new threads spawned by your native library that Bun is not aware of).
 
+A thread-safe callback is dispatched to the JavaScript thread asynchronously, so it has no way to hand a result back to the native caller. `returns` must be `"void"` (the default); any other return type throws at construction.
+
 ```ts
-const searchIterator = new JSCallback((ptr, length) => /hello/.test(new CString(ptr, length)), {
-  returns: "bool",
-  args: ["ptr", "usize"],
-  threadsafe: true, // Optional. Defaults to `false`
-});
+const onMatch = new JSCallback(
+  (ptr, length) => {
+    console.log(new CString(ptr, length));
+  },
+  {
+    args: ["ptr", "usize"],
+    threadsafe: true, // Optional. Defaults to `false`
+  },
+);
 ```
 
 <Note>

--- a/docs/runtime/ffi.mdx
+++ b/docs/runtime/ffi.mdx
@@ -290,7 +290,7 @@ const {
   },
 });
 
-const searchIterator = new JSCallback((ptr, length) => /hello/.test(new CString(ptr, length)), {
+const searchIterator = new JSCallback((ptr, length) => /hello/.test(new CString(ptr, 0, length)), {
   returns: "bool",
   args: ["ptr", "usize"],
 });
@@ -320,7 +320,7 @@ A thread-safe callback is dispatched to the JavaScript thread asynchronously, so
 ```ts
 const onMatch = new JSCallback(
   (ptr, length) => {
-    console.log(new CString(ptr, length));
+    console.log(new CString(ptr, 0, length));
   },
   {
     args: ["ptr", "usize"],

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -515,6 +515,10 @@ declare module "bun:ffi" {
      * performance penalty needs to be less than the performance gain from
      * running the function in a separate thread.
      *
+     * A thread-safe callback is dispatched to the JavaScript thread
+     * asynchronously, so it cannot return a value to the native caller.
+     * `returns` must be `"void"` (the default).
+     *
      * @default false
      */
     readonly threadsafe?: boolean;
@@ -1106,6 +1110,11 @@ declare module "bun:ffi" {
      * If called multiple times, does nothing after the first call.
      */
     close(): void;
+
+    /**
+     * Calls {@link JSCallback.prototype.close}, so `using` releases the callback.
+     */
+    [Symbol.dispose](): void;
   }
 
   /**

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -81,9 +81,10 @@ delete ffi.closeCallback;
 
 class JSCallback {
   constructor(cb, options) {
-    const { ctx, ptr } = nativeCallback(options, cb);
-    this.#ctx = ctx;
-    this.ptr = ptr;
+    const result = nativeCallback(options, cb);
+    if (Error.isError(result)) throw result;
+    this.#ctx = result.ctx;
+    this.ptr = result.ptr;
     this.#threadsafe = !!options?.threadsafe;
   }
 

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -393,7 +393,9 @@ static const WTF::String toStringStatic(ZigString str)
 
 static JSC::JSValue getErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    WTF::String message = toString(*str);
+    // Must copy (like the sibling get*ErrorInstance helpers): `toString` uses
+    // StringImpl::createWithoutCopying, but the Error outlives the caller's bytes.
+    WTF::String message = toStringCopy(*str);
     if (message.isNull() && str->len > 0) [[unlikely]] {
         // pending exception while creating an error.
         return {};

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2095,7 +2095,15 @@ impl Function {
         let mut source_code: Vec<u8> = Vec::new();
         // SAFETY: js_context/js_function are live for the call
         let ffi_wrapper = unsafe { Bun__createFFICallbackFunction(js_context, js_function) };
-        self.print_callback_source_code(Some(js_context), Some(ffi_wrapper), &mut source_code)?;
+        // Heap-allocated wrapper with two JSC::Strong roots. Ownership
+        // transfers to Step::Compiled on success; on every earlier exit
+        // (TCCMissing, Step::Failed) this guard derefs it instead of leaking.
+        let ffi_wrapper = scopeguard::guard(ffi_wrapper, |p| {
+            // SAFETY: p came from Bun__createFFICallbackFunction and was not
+            // stored in Step::Compiled, so we still hold the +1.
+            unsafe { FFICallbackFunctionWrapper_destroy(p) };
+        });
+        self.print_callback_source_code(Some(js_context), Some(*ffi_wrapper), &mut source_code)?;
 
         #[cfg(all(debug_assertions, unix))]
         'debug_write: {
@@ -2222,7 +2230,9 @@ impl Function {
             // dereferenced or written through on the Rust side; stored as
             // NonNull to avoid laundering &T → *mut T provenance.
             js_context: Some(NonNull::from(js_context)),
-            ffi_callback_function_wrapper: NonNull::new(ffi_wrapper),
+            ffi_callback_function_wrapper: NonNull::new(scopeguard::ScopeGuard::into_inner(
+                ffi_wrapper,
+            )),
         });
         Ok(())
     }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1816,12 +1816,6 @@ pub(super) fn generate_symbol_for_function(
         ));
     }
 
-    if function.threadsafe && return_type != ABIType::Void {
-        return Ok(Some(
-            ZigString::static_(b"Threadsafe functions must return void").to_error_instance(global),
-        ));
-    }
-
     *function = Function::default();
     function.base_name = None;
     function.arg_types = abi_types;
@@ -2091,6 +2085,13 @@ impl Function {
         is_threadsafe: bool,
     ) -> Result<(), bun_core::Error> {
         jsc::mark_binding();
+        // FFI_Callback_threadsafe_call is void: it posts a task and returns
+        // before the JS function runs, so there is no return-value channel. A
+        // non-void trampoline would read an uninitialized EncodedJSValue.
+        if is_threadsafe && self.return_type != ABIType::Void {
+            self.fail(b"Threadsafe functions must return void");
+            return Ok(());
+        }
         let mut source_code: Vec<u8> = Vec::new();
         // SAFETY: js_context/js_function are live for the call
         let ffi_wrapper = unsafe { Bun__createFFICallbackFunction(js_context, js_function) };

--- a/src/runtime/ffi/host_fns.rs
+++ b/src/runtime/ffi/host_fns.rs
@@ -123,12 +123,6 @@ pub fn generate_symbol_for_function(
         ))));
     }
 
-    if function.threadsafe && return_type != ABIType::Void {
-        return Ok(Some(global.create_error_instance(format_args!(
-            "Threadsafe functions must return void"
-        ))));
-    }
-
     // `Function` has a `Drop` impl, so functional-record-update
     // (`..Default::default()`) is rejected (E0509). Reset to default and assign
     // the parsed fields individually instead.

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -1,4 +1,4 @@
-import { dlopen, linkSymbols } from "bun:ffi";
+import { dlopen, JSCallback, linkSymbols } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import { isArm64, isMusl, isWindows } from "harness";
 
@@ -85,5 +85,46 @@ describe.skipIf(isFFIUnavailable)("FFI error messages", () => {
         },
       });
     }).toThrow('you must provide a "ptr" field with the memory address of the native function.');
+  });
+
+  describe("JSCallback", () => {
+    // A threadsafe callback is dispatched to the JS thread asynchronously, so
+    // it has no return-value channel: the trampoline would otherwise hand the
+    // native caller an uninitialized EncodedJSValue.
+    test.each(["u64", "int", "i64", "bool", "f64", "ptr", "cstring"] as const)(
+      "threadsafe: true with returns: %s throws at construction",
+      returns => {
+        expect(() => {
+          new JSCallback(() => 0, { args: ["i64"], returns, threadsafe: true });
+        }).toThrow("Threadsafe functions must return void");
+      },
+    );
+
+    test("threadsafe: true with an omitted return type still constructs", () => {
+      using cb = new JSCallback(() => {}, { args: ["i64"], threadsafe: true });
+      expect(cb.ptr).toBeGreaterThan(0);
+    });
+
+    test("threadsafe: true with returns: 'void' still constructs", () => {
+      using cb = new JSCallback(() => {}, { args: ["i64"], returns: "void", threadsafe: true });
+      expect(cb.ptr).toBeGreaterThan(0);
+    });
+
+    test("non-threadsafe callbacks may still return non-void", () => {
+      using cb = new JSCallback(x => x, { args: ["u64"], returns: "u64" });
+      expect(cb.ptr).toBeGreaterThan(0);
+    });
+
+    // JSCallback must throw native validation errors, like dlopen/cc/linkSymbols.
+    test.each([
+      ["returns: buffer", { returns: "buffer" }, "Cannot return a buffer to JavaScript"],
+      ["returns: napi_env", { returns: "napi_env" }, "Cannot return napi_env to JavaScript"],
+      ["unknown arg type", { args: ["not_a_real_type"] }, "Unknown type not_a_real_type"],
+      ["unknown return type", { returns: "not_a_real_type" }, "Unknown return type not_a_real_type"],
+    ])("%s throws at construction", (_name, options, message) => {
+      expect(() => {
+        new JSCallback(() => {}, options as any);
+      }).toThrow(message);
+    });
   });
 });


### PR DESCRIPTION
## Reproduction

```js
import { CFunction, JSCallback } from "bun:ffi";
for (let i = 0; i < 200; i++) {
  const cb = new JSCallback((a, b) => Number(a) + Number(b ?? 0), { args: ["i64"], returns: "u64", threadsafe: true });
  const f = new CFunction({ ptr: cb.ptr, args: ["int"], returns: "int" });
  try { f(i); } catch {}
  cb.close();
}
```

On `main` this SEGVs (`panic(main thread): Segmentation fault at address 0x4F048506`), with the top frame in `JSC__JSValue__toUInt64NoTruncate` decoding garbage bits as a `JSCell*`. With an integer return type instead (`returns: "int"`), there is no crash, only a silently wrong result: a callback that returns `7` hands the native caller a stale value like `1325696257`.

## Cause

A threadsafe `JSCallback` binds `FFI_Callback_threadsafe_call` as the TCC trampoline's `FFI_Callback_call` symbol. That function is `void` in C++: it posts a task to the JS thread and returns before the JS function runs, so there is no return-value channel. But the generated C stub declares `FFI_Callback_call` as returning an `EncodedJSValue`, so for any non-void return type it reads an uninitialized return register.

Bun already has a guard for exactly this, with the message `Threadsafe functions must return void`, but it never fires. In `generate_symbol_for_function` it tests `function.threadsafe` (the out-param, still at its `Default` of `false`) instead of the local `threadsafe` parsed a few lines earlier; the field is only assigned below the check.

Even with a working guard, `JSCallback`'s constructor swallows the error. Native validation errors are returned (not thrown), and the constructor destructures `{ ctx, ptr }` straight out of `nativeCallback`'s result, so an `Error` return becomes `ptr: undefined`. `dlopen`, `cc`, and `linkSymbols` all do `if (Error.isError(result)) throw result`; `JSCallback` is the only entry point that does not.

## Fix

1. **Reject the configuration in `Function::compile_callback`** (`src/runtime/ffi/ffi_body.rs`), the layer that owns the trampoline, via the existing `self.fail()` / `Step::Failed` path, before any allocation. The dead checks in both copies of `generate_symbol_for_function` (`ffi_body.rs`, `host_fns.rs`) are deleted rather than fixed in place: that parser also serves `dlopen`, `cc`, `CFunction`, and `linkSymbols`, where `threadsafe` is documented as JSCallback-only and is a parsed-but-unread no-op (`self.threadsafe` has exactly one reader: `callback()` passing it to `compile_callback`). Firing the check there would newly reject valid native-function specs.
2. **Throw native validation errors from the `JSCallback` constructor** (`src/js/bun/ffi.ts`), matching `dlopen` / `cc` / `linkSymbols`. This also unswallows the other construction errors (`returns: "buffer"`, `returns: "napi_env"`, unknown types), which previously succeeded with `ptr: undefined`.
3. **Copy the error message in `Zig::getErrorInstance`** (`src/jsc/bindings/helpers.h`). Running the new test under `bun bd` (ASAN) tripped a pre-existing heap-use-after-free:

   ```
   ==18225==ERROR: AddressSanitizer: heap-use-after-free ... READ of size 1
     #0 simdutf::icelake::validate_ascii
     ...
     #9 bun_runtime::test_runner::expect::to_throw::to_throw   toThrow.rs:236
   freed by thread T0 here:
     #7 <alloc::boxed::Box<[u8]> as core::ops::drop::Drop>::drop
     #9 core::ptr::drop_in_place::<bun_runtime::ffi::ffi_body::Step>
     #10 core::ptr::drop_in_place::<bun_runtime::ffi::ffi_body::Function>
     #11 <bun_runtime::ffi::ffi_body::FFI>::callback   ffi_body.rs:1320
   previously allocated by thread T0 here:
     #11 <bun_runtime::ffi::ffi_body::Function>::fail
   ```

   `getErrorInstance` builds the `Error`'s message with `toString(*str)`, which uses `WTF::StringImpl::createWithoutCopying`: the JS string borrows the caller's bytes for the lifetime of the `Error`. Its three siblings (`getTypeErrorInstance`, `getSyntaxErrorInstance`, `getRangeErrorInstance`) all use `toStringCopy(*str)`. The new guard's message is a `Box<[u8]>` inside `Step::Failed`, owned by a local `Function` that drops when `callback()` returns, so reading `.message` on the thrown error reads freed memory.

   Switching `getErrorInstance` to `toStringCopy` matches its siblings. I audited every `ZigString::to_error_instance` caller in the tree: none relies on the non-copying or external-adoption behavior (so nothing leaks), and six more latent UAFs are closed by the same line: `JSGlobalObject::create_error`'s interpolated slow path (every `create_error_instance(format_args!("...{}..."))` in the codebase formats into a local `Vec<u8>`; the `// it alwayas clones` comment there was the author's assumption, and this change makes it true), two sites in `AsyncModule.rs`, and the other three FFI `Step::Failed` arms. None of those had fired because the freed bytes usually survive intact under mimalloc, and the FFI ones additionally had the error swallowed by (2).

Also fixed the `docs/runtime/ffi.mdx` example, which paired `threadsafe: true` with `returns: "bool"` (a configuration that has never worked), documented the constraint on `FFIFunction.threadsafe` in `bun-types`, and declared `[Symbol.dispose]()` on the `JSCallback` type (the runtime already implements it).

## Verification

`test/js/bun/ffi/ffi-error-messages.test.ts`:

| | result |
|---|---|
| `USE_SYSTEM_BUN=1 bun test` (unfixed) | 8 pass, 11 fail (none of the new `toThrow` assertions throw) |
| `bun bd test` (fixed, ASAN) | 19 pass, 0 fail |

With only the Rust + JS fixes and (3) reverted, `bun bd test` aborts with the ASAN report above.

The existing `JSCallback` round-trip (48) and `threadsafe callback` (24) matrices in `ffi.test.js`, the rest of `test/js/bun/ffi/`, `test/js/web/html/FormData.test.ts` (129), and `test/integration/bun-types/bun-types.test.ts` all pass unchanged.

## Related

- #31779 (EffortlessSteven, June 3) independently found and fixed the dead `function.threadsafe` read and the constructor error swallow three weeks before this PR was opened; my duplicate search only covered robobun-authored PRs and missed it. The two differ in where the guard lives (this PR scopes it to `compile_callback`, so `dlopen`/`cc`/`CFunction` specs carrying the JSCallback-only `threadsafe` flag keep working), in whether the `Step::Failed` error path is also surfaced, and in test placement (#31779's tests sit inside the `ffi.test.js` block gated on a fixture CI never builds). The full comparison is in [this comment](https://github.com/oven-sh/bun/pull/32782#issuecomment-4812883510). If this PR is the one that lands, the guard fix should carry a `Co-authored-by` for #31779's author.
- #30165 fixes a different threadsafe-`JSCallback` bug (`JSBigInt` allocated off the JS thread for 64-bit integer arguments) and, as a secondary change, the same dead guard; it predates the Rust rewrite and is currently conflicting. Landing the guard here lets that PR drop the overlapping commit on rebase.
- #31892 edits an adjacent line in the same `helpers.h` `get*ErrorInstance` helpers (`createError` -> `createErrorAllowEmptyMessage`); orthogonal, small textual conflict for whichever lands second.



