### PR TITLE
node:path: fix normalize of a first segment ending in ".."

### DIFF
--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -1718,8 +1718,9 @@ fn normalize_string_t<T: PathCharCwd, const PLATFORM: Platform>(
 
                 // Translated from the following JS code:
                 //   lastSegmentLength = i - lastSlash - 1;
-                let subtract = last_slash.map_or(2, |ls| ls + 1);
-                last_segment_length = i.saturating_sub(subtract);
+                // `lastSlash` starts at -1 in Node, so the first segment's
+                // length is `i - 0`, i.e. exactly the slice just appended.
+                last_segment_length = slice.len();
             }
             last_slash = Some(i);
             dots = Some(0);

--- a/test/js/node/path/normalize.test.js
+++ b/test/js/node/path/normalize.test.js
@@ -52,6 +52,28 @@ describe("path.normalize", () => {
     assert.strictEqual(path.posix.normalize("foo/bar\\baz"), "foo/bar\\baz");
   });
 
+  test("first segment of exactly 4 chars ending in '..' followed by '..'", () => {
+    // normalizeString's lastSegmentLength for the FIRST segment must be `i`
+    // (Node's lastSlash starts at -1), not `i - 2`: a 4-char first segment
+    // ending in ".." was misrecorded as a literal ".." and never popped.
+    assert.strictEqual(path.posix.normalize("bb../../x"), "x");
+    assert.strictEqual(path.win32.normalize("bb..\\..\\x"), "x");
+    assert.strictEqual(path.win32.normalize("bb../../x"), "x");
+    assert.strictEqual(path.posix.normalize("..../../x"), "x");
+    assert.strictEqual(path.posix.normalize("bb../.."), ".");
+    assert.strictEqual(path.posix.normalize("bb../../"), "./");
+    assert.strictEqual(path.posix.join("bb..", "..", "x"), "x");
+    assert.strictEqual(path.win32.join("bb..", "..", "x"), "x");
+    // Other first-segment shapes are unaffected.
+    assert.strictEqual(path.posix.normalize("b../../x"), "x");
+    assert.strictEqual(path.posix.normalize("abc../../x"), "x");
+    assert.strictEqual(path.posix.normalize("abcd/../x"), "x");
+    // A real ".." first segment still can't be popped, and absolute paths
+    // never start a segment at lastSlash === -1.
+    assert.strictEqual(path.posix.normalize("../../x"), "../../x");
+    assert.strictEqual(path.posix.normalize("/bb../../x"), "/x");
+  });
+
   test("very long paths", () => {
     // Regression test: buffer overflow with paths longer than PATH_SIZE
     // This used to panic with "index out of bounds" because the buffer


### PR DESCRIPTION
```js
path.posix.normalize("bb../../x")
// bun:  "bb../../x"
// node: "x"
```

### Cause

`normalize_string_t` in `src/runtime/node/path.rs` translates Node's

```js
lastSegmentLength = i - lastSlash - 1;
```

where `lastSlash` starts at `-1`, so the FIRST segment's length is `i`. The port used `last_slash.map_or(2, |ls| ls + 1)` as the subtrahend, i.e. `i - 2` instead of `i - 0`.

The only consumer of `lastSegmentLength` is the `..`-popping check, which uses `lastSegmentLength == 2` together with the buffer ending in `..` to recognize a literal `..` segment (which cannot be popped) as opposed to a longer segment that merely ends in two dots. A 4-char first segment ending in `..` (`"bb.."`, `"...."`) was therefore misrecorded as length 2 and treated as an un-poppable `..`, so the `..` that follows was appended instead of popping the segment.

This affects `normalize` and `join` on both posix and win32 (they share `normalize_string_t`). Absolute paths are unaffected because the leading separator sets `lastSlash`. Node's own `test-path-normalize.js` happens not to cover this shape (its `..`-suffixed segments are never the first component), which is how it survived.

### Fix

`last_segment_length = slice.len()`, where `slice` is the segment just appended (`path[lastSlash + 1 .. i]`, computed two lines above). That is exactly `i - lastSlash - 1`.

### Verification

Every expected value in the added test was verified against `node v26.3.0`. On the released Bun the new test block fails. With this change:

- `bun bd test test/js/node/path/normalize.test.js test/js/node/path/resolve.test.js`: 8 pass, 0 fail
- `bun bd test test/js/node/path/`: 124 pass, 0 fail
- Node's upstream `test-path-normalize.js`, `test-path-join.js`, `test-path.js`, `test-path-resolve.js`, and `test-path-relative.js` all still pass
- `cargo check -p bun_runtime` is clean for both `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`

### Note

An earlier revision of this PR also fixed the `path.win32.resolve` drive-relative buffer-aliasing bug (#31182). That fix is dropped from this PR because #31735 already has the identical change; this PR now carries only the unrelated `normalizeString` fix.
