### PR TITLE
node:buffer: fix six Node compatibility divergences

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1844,10 +1844,12 @@ pub(crate) mod strings_impl {
     }
 
     /// Port of `elementLengthUTF16IntoUTF8` — exact UTF-8 byte length of a UTF-16
-    /// (LE) input. simdutf-backed; falls back to scalar would be in unicode_draft.
+    /// (LE) input, charging 3 bytes (U+FFFD) per unpaired surrogate. This is
+    /// exactly what `copy_utf16_into_utf8` / `to_utf8_alloc` write, so it is a
+    /// valid exact allocation size even for ill-formed UTF-16.
     #[inline]
     pub fn element_length_utf16_into_utf8(utf16: &[u16]) -> usize {
-        simdutf::length::utf8::from::utf16::le(utf16)
+        simdutf::length::utf8::from::utf16::le_with_replacement(utf16)
     }
 
     /// Port of `elementLengthLatin1IntoUTF8`.
@@ -1869,7 +1871,7 @@ pub(crate) mod strings_impl {
         let utf8_len = if worst_case <= buf.len() {
             worst_case
         } else {
-            simdutf::length::utf8::from::utf16::le(utf16)
+            element_length_utf16_into_utf8(utf16)
         };
         copy_utf16_into_utf8_with_utf8_len(buf, utf16, utf8_len)
     }

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1843,10 +1843,9 @@ pub(crate) mod strings_impl {
         pub written: u32,
     }
 
-    /// Port of `elementLengthUTF16IntoUTF8` — exact UTF-8 byte length of a UTF-16
-    /// (LE) input, charging 3 bytes (U+FFFD) per unpaired surrogate. This is
-    /// exactly what `copy_utf16_into_utf8` / `to_utf8_alloc` write, so it is a
-    /// valid exact allocation size even for ill-formed UTF-16.
+    /// Port of `elementLengthUTF16IntoUTF8`: the exact UTF-8 byte length of a
+    /// UTF-16 (LE) input, charging 3 bytes (U+FFFD) per unpaired surrogate,
+    /// which is exactly what `copy_utf16_into_utf8` / `to_utf8_alloc` write.
     #[inline]
     pub fn element_length_utf16_into_utf8(utf16: &[u16]) -> usize {
         simdutf::length::utf8::from::utf16::le_with_replacement(utf16)

--- a/src/bun_core/string/StringBuilder.rs
+++ b/src/bun_core/string/StringBuilder.rs
@@ -44,14 +44,14 @@ impl StringBuilder {
     }
 
     pub fn count16(&mut self, slice: &[u16]) {
-        self.cap += simdutf::length::utf8::from::utf16::le(slice);
+        self.cap += crate::string::strings::element_length_utf16_into_utf8(slice);
     }
 
     pub fn count16_z(&mut self, slice: &[u16]) {
         // Callers pass &[u16] (WStr has no len method on its DST slice yet).
-        // For WTF-16 with lone surrogates the simdutf length estimate
-        // overestimates by 0-1 bytes, which is fine for a capacity reservation.
-        self.cap += simdutf::length::utf8::from::utf16::le(slice) + 1;
+        // element_length_utf16_into_utf8 charges 3 bytes (U+FFFD) per unpaired
+        // surrogate, which is exactly what append16's fallback writes.
+        self.cap += crate::string::strings::element_length_utf16_into_utf8(slice) + 1;
     }
 
     pub fn append16(&mut self, slice: &[u16]) -> Option<&mut ZStr> {
@@ -76,10 +76,10 @@ impl StringBuilder {
             Some(unsafe { ZStr::from_raw_mut(buf_ptr, count) })
         } else {
             // Fallback: WTF-16 → WTF-8 via the slow path that handles lone surrogates.
-            // The signature returns a borrow into `self`, so we copy
-            // the WTF-8 bytes into the builder's reserved buffer (count16_z reserved
-            // enough — simdutf's length estimate is an upper bound for WTF-16) and
-            // drop the temporary Vec normally. No `mem::forget`.
+            // The signature returns a borrow into `self`, so we copy the WTF-8
+            // bytes into the builder's reserved buffer (count16_z uses the same
+            // replacement-aware length, so the reservation is exact) and drop
+            // the temporary Vec normally. No `mem::forget`.
             let out = crate::string::strings::to_utf8_alloc(slice);
             let len = out.len();
             let avail = self.cap - self.len;

--- a/src/jsc/ErrorCode.rs
+++ b/src/jsc/ErrorCode.rs
@@ -711,9 +711,11 @@ impl ErrorCode {
     pub const FS_CP_SYMLINK_TO_SUBDIRECTORY: ErrorCode = ErrorCode(326);
     /// `ERR_DIR_CONCURRENT_OPERATION` (instanceof Error)
     pub const DIR_CONCURRENT_OPERATION: ErrorCode = ErrorCode(327);
+    /// `ERR_INVALID_BUFFER_SIZE` (instanceof RangeError)
+    pub const INVALID_BUFFER_SIZE: ErrorCode = ErrorCode(328);
 
     /// == C++ `NODE_ERROR_COUNT`.
-    pub const COUNT: u16 = 328;
+    pub const COUNT: u16 = 329;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -861,6 +863,7 @@ impl ErrorCode {
     pub const ERR_INVALID_ARG_TYPE: ErrorCode = ErrorCode::INVALID_ARG_TYPE;
     pub const ERR_INVALID_ARG_VALUE: ErrorCode = ErrorCode::INVALID_ARG_VALUE;
     pub const ERR_INVALID_ASYNC_ID: ErrorCode = ErrorCode::INVALID_ASYNC_ID;
+    pub const ERR_INVALID_BUFFER_SIZE: ErrorCode = ErrorCode::INVALID_BUFFER_SIZE;
     pub const ERR_INVALID_CHAR: ErrorCode = ErrorCode::INVALID_CHAR;
     pub const ERR_INVALID_CURSOR_POS: ErrorCode = ErrorCode::INVALID_CURSOR_POS;
     pub const ERR_INVALID_FD_TYPE: ErrorCode = ErrorCode::INVALID_FD_TYPE;
@@ -1429,6 +1432,7 @@ static CODE_STR: [&str; ErrorCode::COUNT as usize] = [
     "ERR_FS_CP_EEXIST",
     "ERR_FS_CP_SYMLINK_TO_SUBDIRECTORY",
     "ERR_DIR_CONCURRENT_OPERATION",
+    "ERR_INVALID_BUFFER_SIZE",
 ];
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -134,6 +134,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_INVALID_ARG_TYPE", TypeError],
   ["ERR_INVALID_ARG_VALUE", TypeError, undefined, RangeError],
   ["ERR_INVALID_ASYNC_ID", RangeError],
+  ["ERR_INVALID_BUFFER_SIZE", RangeError],
   ["ERR_INVALID_CHAR", TypeError],
   ["ERR_INVALID_CURSOR_POS", TypeError],
   ["ERR_INVALID_FD_TYPE", TypeError],

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -134,7 +134,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INVALID_ARG_TYPE", TypeError],
   ["ERR_INVALID_ARG_VALUE", TypeError, undefined, RangeError],
   ["ERR_INVALID_ASYNC_ID", RangeError],
-  ["ERR_INVALID_BUFFER_SIZE", RangeError],
   ["ERR_INVALID_CHAR", TypeError],
   ["ERR_INVALID_CURSOR_POS", TypeError],
   ["ERR_INVALID_FD_TYPE", TypeError],
@@ -340,5 +339,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_FS_CP_EEXIST", Error],
   ["ERR_FS_CP_SYMLINK_TO_SUBDIRECTORY", Error],
   ["ERR_DIR_CONCURRENT_OPERATION", Error],
+  ["ERR_INVALID_BUFFER_SIZE", RangeError],
 ];
 export default errors;

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1319,7 +1319,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
 
     auto value = callFrame->uncheckedArgument(0);
     // Capture byteLength up front for two orthogonal purposes:
-    //  1. The upper-bound argument to validateNumber(end) so `end >
+    //  1. The upper-bound argument to validateInteger(end) so `end >
     //     buf.length` throws ERR_OUT_OF_RANGE with Node's wording and
     //     against the length the caller saw (matches Node: parseEncoding
     //     may run a user toString before this check, but the Node-
@@ -1362,7 +1362,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     }
 
     // ── 1. Encoding parse (FIRST validation) ────────────────────────────
-    // Node validates encoding before either `validateNumber` call, so
+    // Node validates encoding before either `validateInteger` call, so
     // `fill("a", 0, buf.length + 1, "bogus")` and `fill("a", -1, 0,
     // "bogus")` throw ERR_UNKNOWN_ENCODING (not ERR_OUT_OF_RANGE) — the
     // encoding error wins. parseEncoding is also the first
@@ -2685,25 +2685,22 @@ static size_t validateOffsetBigInt64(JSC::JSGlobalObject* lexicalGlobalObject, J
     }
 
     auto offsetD = offsetVal.asNumber();
-    // Node checks integer-ness before the sign, so -1.5 reports "an integer".
-    if (std::fmod(offsetD, 1.0) != 0) [[unlikely]] {
+    // Node's boundsError tests `Math.floor(value) !== value` before the range,
+    // so -1.5 and NaN report "an integer" while +-Infinity (for which floor is
+    // an identity) fall through to the range message.
+    if (std::floor(offsetD) != offsetD) [[unlikely]] {
         Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);
         return 0;
     }
 
-    if (offsetD < 0) [[unlikely]] {
+    // Range-check the double before truncating so +-Infinity never reaches
+    // truncateDoubleToUint64.
+    if (offsetD < 0 || offsetD > static_cast<double>(maxOffset)) [[unlikely]] {
         Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, maxOffset, offsetVal);
         return 0;
     }
 
-    offset = truncateDoubleToUint64(offsetD);
-
-    if (offset > maxOffset) [[unlikely]] {
-        Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, maxOffset, offsetVal);
-        return 0;
-    }
-
-    return offset;
+    return truncateDoubleToUint64(offsetD);
 }
 
 JSC_DEFINE_JIT_OPERATION(jsBufferConstructorAllocWithoutTypeChecks, JSUint8Array*, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int byteLength))

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1375,23 +1375,21 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     }
 
     // ── 2. Pure offset / end coercion (no user JS) ──────────────────────
-    // validateNumber rejects non-numbers without coercion, and toLength
-    // on a number is a C++ conversion. parseEncoding above may have
+    // Node routes both through validateOffset (= validateInteger), so a
+    // fractional or NaN offset/end throws ERR_OUT_OF_RANGE "an integer"
+    // instead of being truncated. parseEncoding above may have
     // detached/resized the buffer, but the `limit` captured pre-coercion
     // is still the correct Node-compat upper bound for ERR_OUT_OF_RANGE;
     // the final write range is clamped against a separate post-coercion
     // byteLength read further down.
     //     https://github.com/nodejs/node/blob/v22.9.0/lib/buffer.js#L1066-L1079
-    //     https://github.com/nodejs/node/blob/v22.9.0/lib/buffer.js#L122
     if (!offsetValue.isUndefined()) {
-        Bun::V::validateNumber(scope, lexicalGlobalObject, offsetValue, "offset"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength));
+        Bun::V::validateInteger(scope, lexicalGlobalObject, offsetValue, "offset"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &offset);
         RETURN_IF_EXCEPTION(scope, {});
-        offset = offsetValue.toLength(lexicalGlobalObject);
     }
     if (!endValue.isUndefined()) {
-        Bun::V::validateNumber(scope, lexicalGlobalObject, endValue, "end"_s, jsNumber(0), jsNumber(limit));
+        Bun::V::validateInteger(scope, lexicalGlobalObject, endValue, "end"_s, jsNumber(0), jsNumber(limit), &end);
         RETURN_IF_EXCEPTION(scope, {});
-        end = endValue.toLength(lexicalGlobalObject);
     }
 
     // Node short-circuits empty/inverted ranges before coercing `value`,
@@ -1557,6 +1555,22 @@ static int64_t indexOf16(const uint8_t* thisPtr, int64_t thisLength, const uint8
     return idx * 2;
 }
 
+// UCS2 searches operate on whole uint16_t units (Node's SearchString<uint16_t>),
+// so a match can only start on an even byte offset.
+static int64_t lastIndexOf16(const uint8_t* thisPtr, int64_t thisLength, const uint8_t* valuePtr, int64_t valueLength, int64_t byteOffset)
+{
+    if (thisLength == 1) return -1;
+    if (valueLength == 1) return -1;
+    thisLength /= 2;
+    valueLength /= 2;
+    byteOffset /= 2;
+    auto haystack = std::span<const uint16_t>((const uint16_t*)(thisPtr), std::min(thisLength, byteOffset + valueLength));
+    auto needle = std::span<const uint16_t>((const uint16_t*)(valuePtr), valueLength);
+    auto it = std::find_end(haystack.begin(), haystack.end(), needle.begin(), needle.end());
+    if (it == haystack.end()) return -1;
+    return std::distance(haystack.begin(), it) * 2;
+}
+
 static int64_t lastIndexOf(const uint8_t* thisPtr, int64_t thisLength, const uint8_t* valuePtr, int64_t valueLength, int64_t byteOffset)
 {
     auto start = thisPtr;
@@ -1651,14 +1665,12 @@ static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last
     if (encoding == BufferEncodingType::ucs2) searchEnd &= ~static_cast<size_t>(1);
 
     const uint8_t* typedVectorValue = arrayValue->typedVector();
-    if (last) {
-        return lastIndexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
-    }
     if (encoding == BufferEncodingType::ucs2) {
-        return indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
+        return last ? lastIndexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset)
+                    : indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }
-
-    return indexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
+    return last ? lastIndexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset)
+                : indexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
 }
 
 static int64_t indexOfBuffer(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, double endD, JSC::JSGenericTypedArrayView<JSC::Uint8Adaptor>* array, BufferEncodingType encoding)
@@ -1674,13 +1686,12 @@ static int64_t indexOfBuffer(JSC::JSGlobalObject* lexicalGlobalObject, bool last
     if (encoding == BufferEncodingType::ucs2) searchEnd &= ~static_cast<size_t>(1);
 
     const uint8_t* typedVectorValue = array->typedVector();
-    if (last) {
-        return lastIndexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
-    }
     if (encoding == BufferEncodingType::ucs2) {
-        return indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
+        return last ? lastIndexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset)
+                    : indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }
-    return indexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
+    return last ? lastIndexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset)
+                : indexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
 }
 
 static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, JSC::CallFrame* callFrame, typename IDLOperation<JSArrayBufferView>::ClassParameter buffer, bool last)
@@ -1690,7 +1701,10 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
     std::optional<BufferEncodingType> encoding = std::nullopt;
     double byteOffsetD = 0;
 
-    if (byteLength == 0) return -1;
+    // An empty haystack is NOT an immediate -1: Node still finds an empty
+    // needle in it (Buffer.alloc(0).indexOf(Buffer.alloc(0)) === 0), and it
+    // still runs the byteOffset coercion (which can invoke user valueOf).
+    // computeIndexOfRange handles both the empty haystack and empty needle.
 
     auto valueValue = callFrame->argument(0);
     auto byteOffsetValue = callFrame->argument(1);
@@ -1752,7 +1766,6 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
         RETURN_IF_EXCEPTION(scope, -1);
         const uint8_t* typedVector;
         if (!refetchBufferState(typedVector, byteLength)) return -1;
-        if (byteLength == 0) return -1;
         return indexOfNumber(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, endD, byteValue);
     }
 
@@ -1773,7 +1786,6 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
         RETURN_IF_EXCEPTION(scope, -1);
         const uint8_t* typedVector;
         if (!refetchBufferState(typedVector, byteLength)) return -1;
-        if (byteLength == 0) return -1;
         return indexOfString(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, endD, str, encoding.value());
     }
 
@@ -1781,7 +1793,6 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
         if (!encoding.has_value()) encoding = BufferEncodingType::utf8;
         const uint8_t* typedVector;
         if (!refetchBufferState(typedVector, byteLength)) return -1;
-        if (byteLength == 0) return -1;
         // A needle whose backing buffer was detached by a valueOf/toPrimitive
         // callback above reports byteLength()==0; computeIndexOfRange's
         // empty-needle path handles that (clamped to `end`) without touching
@@ -1907,8 +1918,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_swap16Body(JSC::JSGlobalObj
     constexpr size_t elemSize = 2;
     size_t length = castedThis->byteLength();
     if (length % elemSize != 0) {
-        throwNodeRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 16-bits"_s);
-        return {};
+        return Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_INVALID_BUFFER_SIZE, "Buffer size must be a multiple of 16-bits"_s);
     }
 
     if (castedThis->isDetached()) [[unlikely]] {
@@ -1937,8 +1947,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_swap32Body(JSC::JSGlobalObj
     constexpr int elemSize = 4;
     int64_t length = static_cast<int64_t>(castedThis->byteLength());
     if (length % elemSize != 0) {
-        throwNodeRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 32-bits"_s);
-        return {};
+        return Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_INVALID_BUFFER_SIZE, "Buffer size must be a multiple of 32-bits"_s);
     }
 
     if (castedThis->isDetached()) [[unlikely]] {
@@ -1972,8 +1981,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_swap64Body(JSC::JSGlobalObj
     constexpr size_t elemSize = 8;
     size_t length = castedThis->byteLength();
     if (length % elemSize != 0) {
-        throwNodeRangeError(lexicalGlobalObject, scope, "Buffer size must be a multiple of 64-bits"_s);
-        return {};
+        return Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_INVALID_BUFFER_SIZE, "Buffer size must be a multiple of 64-bits"_s);
     }
 
     if (castedThis->isDetached()) [[unlikely]] {
@@ -2654,8 +2662,10 @@ static size_t validateOffsetBigInt64(JSC::JSGlobalObject* lexicalGlobalObject, J
 
     if (offsetVal.isInt32()) {
         int32_t offsetI = offsetVal.asInt32();
+        // Node's boundsError reports a negative offset as ERR_OUT_OF_RANGE
+        // (">= 0 and <= max"), not ERR_BUFFER_OUT_OF_BOUNDS.
         if (offsetI < 0) [[unlikely]] {
-            Bun::ERR::BUFFER_OUT_OF_BOUNDS(scope, lexicalGlobalObject, "offset"_s);
+            Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, maxOffset, offsetVal);
             return 0;
         }
 
@@ -2675,13 +2685,14 @@ static size_t validateOffsetBigInt64(JSC::JSGlobalObject* lexicalGlobalObject, J
     }
 
     auto offsetD = offsetVal.asNumber();
-    if (offsetD < 0) [[unlikely]] {
-        Bun::ERR::BUFFER_OUT_OF_BOUNDS(scope, lexicalGlobalObject, "offset"_s);
+    // Node checks integer-ness before the sign, so -1.5 reports "an integer".
+    if (std::fmod(offsetD, 1.0) != 0) [[unlikely]] {
+        Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);
         return 0;
     }
 
-    if (std::fmod(offsetD, 1.0) != 0) [[unlikely]] {
-        Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);
+    if (offsetD < 0) [[unlikely]] {
+        Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, maxOffset, offsetVal);
         return 0;
     }
 

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1747,7 +1747,8 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
     // after all JS calls in each code path are complete.
 
     // Helper: re-fetch buffer state after JS calls. Returns false if the buffer
-    // was detached; caller treats this as an empty buffer (matches Node.js: -1).
+    // was detached; the caller returns -1 (matches Node.js for a detached
+    // haystack). A merely EMPTY haystack is not -1; see computeIndexOfRange.
     auto refetchBufferState = [&](const uint8_t*& typedVector, size_t& len) -> bool {
         if (buffer->isDetached()) [[unlikely]] {
             typedVector = nullptr;

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1702,8 +1702,7 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
     double byteOffsetD = 0;
 
     // An empty haystack is NOT an immediate -1: Node still finds an empty
-    // needle in it (Buffer.alloc(0).indexOf(Buffer.alloc(0)) === 0), and it
-    // still runs the byteOffset coercion (which can invoke user valueOf).
+    // needle in it (Buffer.alloc(0).indexOf(Buffer.alloc(0)) === 0).
     // computeIndexOfRange handles both the empty haystack and empty needle.
 
     auto valueValue = callFrame->argument(0);

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -2647,52 +2647,34 @@ extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(jsBufferConstructorAll
 
 static size_t validateOffsetBigInt64(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, JSC::JSValue offsetVal, size_t byteLength)
 {
+    // Node's checkBounds/boundsError validates the offset's type and
+    // integer-ness before reporting a too-short buffer, and reports a
+    // too-short buffer (its `length < 0` test) before the offset's range.
+    double offsetD = 0;
+    if (!offsetVal.isUndefined()) {
+        if (offsetVal.isInt32()) {
+            offsetD = offsetVal.asInt32();
+        } else if (!offsetVal.isNumber()) [[unlikely]] {
+            Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "offset"_s, "number"_s, offsetVal);
+            return 0;
+        } else {
+            offsetD = offsetVal.asNumber();
+            // Node tests `Math.floor(value) !== value`: true for NaN and
+            // fractions, false for +-Infinity (which get a later error).
+            if (std::floor(offsetD) != offsetD) [[unlikely]] {
+                Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);
+                return 0;
+            }
+        }
+    }
+
     if (byteLength < 8) [[unlikely]] {
         auto* error = Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_BUFFER_OUT_OF_BOUNDS, "Attempt to access memory outside buffer bounds"_s);
         scope.throwException(lexicalGlobalObject, error);
         return 0;
     }
 
-    if (offsetVal.isUndefined()) {
-        return 0;
-    }
-
-    size_t offset;
     size_t maxOffset = byteLength - 8;
-
-    if (offsetVal.isInt32()) {
-        int32_t offsetI = offsetVal.asInt32();
-        // Node's boundsError reports a negative offset as ERR_OUT_OF_RANGE
-        // (">= 0 and <= max"), not ERR_BUFFER_OUT_OF_BOUNDS.
-        if (offsetI < 0) [[unlikely]] {
-            Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, maxOffset, offsetVal);
-            return 0;
-        }
-
-        offset = static_cast<size_t>(offsetI);
-
-        if (offset > maxOffset) [[unlikely]] {
-            Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, maxOffset, offsetVal);
-            return 0;
-        }
-
-        return offset;
-    }
-
-    if (!offsetVal.isNumber()) [[unlikely]] {
-        Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "offset"_s, "number"_s, offsetVal);
-        return 0;
-    }
-
-    auto offsetD = offsetVal.asNumber();
-    // Node's boundsError tests `Math.floor(value) !== value` before the range,
-    // so -1.5 and NaN report "an integer" while +-Infinity (for which floor is
-    // an identity) fall through to the range message.
-    if (std::floor(offsetD) != offsetD) [[unlikely]] {
-        Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);
-        return 0;
-    }
-
     // Range-check the double before truncating so +-Infinity never reaches
     // truncateDoubleToUint64.
     if (offsetD < 0 || offsetD > static_cast<double>(maxOffset)) [[unlikely]] {

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -144,7 +144,6 @@ pub(crate) unsafe extern "C" fn Bun__encoding__writeUTF16(
     r.unwrap_or(0)
 }
 
-// TODO(@190n) handle unpaired surrogates
 /// # Safety
 /// Caller (C++) must guarantee `input[..len]` is valid for reading.
 #[unsafe(no_mangle)]

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -156,7 +156,6 @@ pub(crate) unsafe extern "C" fn Bun__encoding__byteLengthLatin1AsUTF8(
     unsafe { byte_length_u8::<{ enc::UTF8 }>(input, len) }
 }
 
-// TODO(@190n) handle unpaired surrogates
 /// # Safety
 /// Caller (C++) must guarantee `input[..len]` is valid for reading.
 #[unsafe(no_mangle)]

--- a/src/simdutf_sys/bun-simdutf.cpp
+++ b/src/simdutf_sys/bun-simdutf.cpp
@@ -294,6 +294,15 @@ size_t simdutf__utf8_length_from_utf16le(const char16_t* input, size_t length)
     return simdutf::utf8_length_from_utf16le(input, length);
 }
 
+// Unlike the non-validating variant above (which charges every surrogate code
+// unit 2 bytes), this charges 3 bytes (U+FFFD) for each unpaired surrogate,
+// matching what the replacement encoder produces. `.count` is documented to be
+// correct even when `.error` is SURROGATE.
+size_t simdutf__utf8_length_from_utf16le_with_replacement(const char16_t* input, size_t length)
+{
+    return simdutf::utf8_length_from_utf16le_with_replacement(input, length).count;
+}
+
 size_t simdutf__utf8_length_from_utf16be(const char16_t* input, size_t length)
 {
     return simdutf::utf8_length_from_utf16be(input, length);

--- a/src/simdutf_sys/bun-simdutf.cpp
+++ b/src/simdutf_sys/bun-simdutf.cpp
@@ -294,10 +294,9 @@ size_t simdutf__utf8_length_from_utf16le(const char16_t* input, size_t length)
     return simdutf::utf8_length_from_utf16le(input, length);
 }
 
-// Unlike the non-validating variant above (which charges every surrogate code
-// unit 2 bytes), this charges 3 bytes (U+FFFD) for each unpaired surrogate,
-// matching what the replacement encoder produces. `.count` is documented to be
-// correct even when `.error` is SURROGATE.
+// Unlike the non-validating variant above, this charges 3 bytes (U+FFFD) per
+// unpaired surrogate, matching the replacement encoder's output. `.count` is
+// documented to be correct even when `.error` is SURROGATE.
 size_t simdutf__utf8_length_from_utf16le_with_replacement(const char16_t* input, size_t length)
 {
     return simdutf::utf8_length_from_utf16le_with_replacement(input, length).count;

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -212,6 +212,10 @@ unsafe extern "C" {
     pub fn simdutf__count_utf16be(buf: *const u16, length: usize) -> usize;
     pub fn simdutf__count_utf8(buf: *const u8, length: usize) -> usize;
     pub(crate) fn simdutf__utf8_length_from_utf16le(input: *const u16, length: usize) -> usize;
+    pub(crate) fn simdutf__utf8_length_from_utf16le_with_replacement(
+        input: *const u16,
+        length: usize,
+    ) -> usize;
     pub fn simdutf__utf8_length_from_utf16be(input: *const u16, length: usize) -> usize;
     pub(crate) fn simdutf__utf32_length_from_utf16le(input: *const u16, length: usize) -> usize;
     pub fn simdutf__utf32_length_from_utf16be(input: *const u16, length: usize) -> usize;
@@ -604,6 +608,18 @@ pub mod length {
                 pub fn le(input: &[u16]) -> usize {
                     // SAFETY: input is a valid slice; FFI reads exactly len u16s.
                     unsafe { simdutf__utf8_length_from_utf16le(input.as_ptr(), input.len()) }
+                }
+                /// Like [`le`], but charges 3 bytes (U+FFFD) per unpaired
+                /// surrogate instead of assuming valid UTF-16. This is the
+                /// exact byte count produced by the replacement encoder.
+                pub fn le_with_replacement(input: &[u16]) -> usize {
+                    // SAFETY: input is a valid slice; FFI reads exactly len u16s.
+                    unsafe {
+                        simdutf__utf8_length_from_utf16le_with_replacement(
+                            input.as_ptr(),
+                            input.len(),
+                        )
+                    }
                 }
                 pub fn be(input: &[u16]) -> usize {
                     // SAFETY: input is a valid slice; FFI reads exactly len u16s.

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -360,6 +360,39 @@ for (let withOverridenBufferWrite of [false, true]) {
         }
       });
 
+      it("write BigInt64 with a negative offset throws ERR_OUT_OF_RANGE", () => {
+        // Node's boundsError reports a negative offset as ERR_OUT_OF_RANGE
+        // (">= 0 and <= max"), not ERR_BUFFER_OUT_OF_BOUNDS.
+        const buf = Buffer.alloc(16);
+        for (const fn of ["writeBigInt64LE", "writeBigInt64BE", "writeBigUInt64LE", "writeBigUInt64BE"]) {
+          expect(() => buf[fn](1n, -1)).toThrow(
+            expect.objectContaining({
+              code: "ERR_OUT_OF_RANGE",
+              message: 'The value of "offset" is out of range. It must be >= 0 and <= 8. Received -1',
+            }),
+          );
+          // A fractional offset reports "an integer", even when negative.
+          expect(() => buf[fn](1n, -1.5)).toThrow(
+            expect.objectContaining({
+              code: "ERR_OUT_OF_RANGE",
+              message: 'The value of "offset" is out of range. It must be an integer. Received -1.5',
+            }),
+          );
+          // The too-large path is unchanged.
+          expect(() => buf[fn](1n, 9)).toThrow(
+            expect.objectContaining({
+              code: "ERR_OUT_OF_RANGE",
+              message: 'The value of "offset" is out of range. It must be >= 0 and <= 8. Received 9',
+            }),
+          );
+          // A too-short buffer is still ERR_BUFFER_OUT_OF_BOUNDS (matches Node's
+          // boundsError when `length < 0`).
+          expect(() => Buffer.alloc(7)[fn](1n, 0)).toThrow(
+            expect.objectContaining({ code: "ERR_BUFFER_OUT_OF_BOUNDS" }),
+          );
+        }
+      });
+
       it("copy() beyond end of buffer", () => {
         const b = Buffer.allocUnsafe(64);
         // Try to copy 0 bytes worth of data into an empty buffer
@@ -1652,6 +1685,27 @@ for (let withOverridenBufferWrite of [false, true]) {
         );
       });
 
+      it("Buffer.byteLength matches the encoder for unpaired surrogates", () => {
+        // byteLength used simdutf's non-validating UTF-16 length, which charges
+        // an unpaired surrogate 2 bytes; the encoder writes U+FFFD (3 bytes).
+        // byteLength(s) === Buffer.from(s).length must hold by definition.
+        const cases = [
+          "\ud800",
+          "\udfff",
+          "\ud800a",
+          "a\ud800",
+          "\ud800a".repeat(17),
+          "\ud800\udc00",
+          "a\udc00\ud800b",
+        ];
+        expect(cases.map(s => ({ input: JSON.stringify(s), byteLength: Buffer.byteLength(s, "utf8") }))).toEqual(
+          cases.map(s => ({ input: JSON.stringify(s), byteLength: Buffer.from(s, "utf8").length })),
+        );
+        expect(Buffer.byteLength("\ud800a".repeat(17), "utf8")).toBe(68);
+        // TextEncoder shares the same length helper and must agree.
+        expect(new TextEncoder().encode("\ud800a".repeat(17)).byteLength).toBe(68);
+      });
+
       it("Buffer.isBuffer", () => {
         expect(Buffer.isBuffer(new Buffer(1))).toBe(true);
         gc();
@@ -2180,6 +2234,31 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(buf.includes("this", 4)).toBe(false);
       });
 
+      it("indexOf/lastIndexOf/includes on an empty buffer", () => {
+        // An empty haystack is not an automatic -1: Node still finds an
+        // empty needle in it at offset 0.
+        const empty = Buffer.alloc(0);
+        expect(empty.indexOf(Buffer.alloc(0))).toBe(0);
+        expect(empty.lastIndexOf(Buffer.alloc(0))).toBe(0);
+        expect(empty.includes(Buffer.alloc(0))).toBe(true);
+        expect(empty.indexOf("")).toBe(0);
+        expect(empty.lastIndexOf("")).toBe(0);
+        expect(empty.includes("")).toBe(true);
+        // byteOffset is clamped to [0, length] for an empty needle.
+        expect(empty.indexOf("", 5)).toBe(0);
+        expect(empty.indexOf("", -5)).toBe(0);
+        // A non-empty needle in an empty haystack is still -1.
+        expect(empty.indexOf("a")).toBe(-1);
+        expect(empty.indexOf(Buffer.from("a"))).toBe(-1);
+        expect(empty.indexOf(97)).toBe(-1);
+        expect(empty.lastIndexOf(97)).toBe(-1);
+        expect(empty.includes(97)).toBe(false);
+        // A non-empty haystack with an empty needle was already correct.
+        expect(Buffer.from("ab").indexOf(Buffer.alloc(0))).toBe(0);
+        expect(Buffer.from("ab").indexOf(Buffer.alloc(0), 5)).toBe(2);
+        expect(Buffer.from("ab").lastIndexOf("")).toBe(2);
+      });
+
       it("indexOf", () => {
         const buf = Buffer.from("this is a buffer");
 
@@ -2360,6 +2439,26 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(b16.lastIndexOf("hello", 22, "ucs2")).toBe(0);
       });
 
+      it("lastIndexOf with utf16le only matches on a code-unit boundary", () => {
+        // UCS2 searches operate on whole uint16_t units (Node's
+        // SearchString<uint16_t>), so a raw byte match at an ODD offset is
+        // not a real match. The backward search used a byte-level std::find_end.
+        // The needle "a" is bytes [0x61, 0x00]; they occur only at byte 1 here.
+        const h = Buffer.from([0x00, 0x61, 0x00, 0x00]);
+        expect(h.lastIndexOf(Buffer.from("a", "utf16le"), undefined, "utf16le")).toBe(-1);
+        expect(h.lastIndexOf("a", undefined, "utf16le")).toBe(-1);
+        // The forward search was already uint16-aligned.
+        expect(h.indexOf("a", 0, "utf16le")).toBe(-1);
+        // An even-offset match is still found.
+        const h2 = Buffer.from("ba", "utf16le");
+        expect(h2.lastIndexOf("a", undefined, "utf16le")).toBe(2);
+        expect(h2.lastIndexOf(Buffer.from("a", "utf16le"), undefined, "utf16le")).toBe(2);
+        // byteOffset is floored to a code-unit boundary.
+        const h3 = Buffer.from("aaaa", "utf16le");
+        expect(h3.lastIndexOf("a", 5, "utf16le")).toBe(4);
+        expect(h3.lastIndexOf("a", 3, "utf16le")).toBe(2);
+      });
+
       for (let fn of [Buffer.prototype.slice, Buffer.prototype.subarray]) {
         it(`Buffer.${fn.name}`, () => {
           const buf = new Buffer("buffer");
@@ -2405,6 +2504,8 @@ for (let withOverridenBufferWrite of [false, true]) {
           expect.unreachable();
         } catch (exception) {
           expect(exception.message).toBe("Buffer size must be a multiple of 16-bits");
+          expect(exception.code).toBe("ERR_INVALID_BUFFER_SIZE");
+          expect(exception).toBeInstanceOf(RangeError);
         }
       });
 
@@ -2431,6 +2532,8 @@ for (let withOverridenBufferWrite of [false, true]) {
           expect.unreachable();
         } catch (exception) {
           expect(exception.message).toBe("Buffer size must be a multiple of 32-bits");
+          expect(exception.code).toBe("ERR_INVALID_BUFFER_SIZE");
+          expect(exception).toBeInstanceOf(RangeError);
         }
       });
 
@@ -2457,6 +2560,8 @@ for (let withOverridenBufferWrite of [false, true]) {
           expect.unreachable();
         } catch (exception) {
           expect(exception.message).toBe("Buffer size must be a multiple of 64-bits");
+          expect(exception.code).toBe("ERR_INVALID_BUFFER_SIZE");
+          expect(exception).toBeInstanceOf(RangeError);
         }
       });
 
@@ -2956,6 +3061,33 @@ for (let withOverridenBufferWrite of [false, true]) {
         // Make sure these throw.
         expect(() => Buffer.allocUnsafe(8).fill("a", -1)).toThrow();
         expect(() => Buffer.allocUnsafe(8).fill("a", 0, 9)).toThrow();
+      });
+
+      it("fill() with a fractional offset or end throws ERR_OUT_OF_RANGE", () => {
+        // Node routes offset/end through validateOffset (= validateInteger),
+        // so a non-integer throws instead of being silently truncated.
+        expect(() => Buffer.alloc(4, "x").fill("a", 1.5)).toThrow(
+          expect.objectContaining({
+            code: "ERR_OUT_OF_RANGE",
+            message: 'The value of "offset" is out of range. It must be an integer. Received 1.5',
+          }),
+        );
+        expect(() => Buffer.alloc(4, "x").fill("a", 0, 1.5)).toThrow(
+          expect.objectContaining({
+            code: "ERR_OUT_OF_RANGE",
+            message: 'The value of "end" is out of range. It must be an integer. Received 1.5',
+          }),
+        );
+        expect(() => Buffer.alloc(4, "x").fill("a", NaN)).toThrow(
+          expect.objectContaining({
+            code: "ERR_OUT_OF_RANGE",
+            message: 'The value of "offset" is out of range. It must be an integer. Received NaN',
+          }),
+        );
+        // Integer offsets still work and still range-check.
+        expect(Buffer.alloc(4, "x").fill("a", 3).toString()).toBe("xxxa");
+        expect(() => Buffer.alloc(4).fill("a", -1)).toThrow(expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }));
+        expect(() => Buffer.alloc(4).fill("a", 0, 5)).toThrow(expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }));
       });
 
       it("fill() should not hang indefinitely", () => {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -360,7 +360,7 @@ for (let withOverridenBufferWrite of [false, true]) {
         }
       });
 
-      it("write BigInt64 with a negative offset throws ERR_OUT_OF_RANGE", () => {
+      it("write BigInt64 with an out-of-range or non-integer offset throws ERR_OUT_OF_RANGE", () => {
         // Node's boundsError reports a negative offset as ERR_OUT_OF_RANGE
         // (">= 0 and <= max"), not ERR_BUFFER_OUT_OF_BOUNDS.
         const buf = Buffer.alloc(16);
@@ -371,11 +371,32 @@ for (let withOverridenBufferWrite of [false, true]) {
               message: 'The value of "offset" is out of range. It must be >= 0 and <= 8. Received -1',
             }),
           );
-          // A fractional offset reports "an integer", even when negative.
+          // A fractional or NaN offset reports "an integer", even when negative.
           expect(() => buf[fn](1n, -1.5)).toThrow(
             expect.objectContaining({
               code: "ERR_OUT_OF_RANGE",
               message: 'The value of "offset" is out of range. It must be an integer. Received -1.5',
+            }),
+          );
+          expect(() => buf[fn](1n, NaN)).toThrow(
+            expect.objectContaining({
+              code: "ERR_OUT_OF_RANGE",
+              message: 'The value of "offset" is out of range. It must be an integer. Received NaN',
+            }),
+          );
+          // +-Infinity are NOT "an integer" to Node's boundsError (its
+          // Math.floor(value) !== value test is false for them), so they
+          // get the range message instead.
+          expect(() => buf[fn](1n, Infinity)).toThrow(
+            expect.objectContaining({
+              code: "ERR_OUT_OF_RANGE",
+              message: 'The value of "offset" is out of range. It must be >= 0 and <= 8. Received Infinity',
+            }),
+          );
+          expect(() => buf[fn](1n, -Infinity)).toThrow(
+            expect.objectContaining({
+              code: "ERR_OUT_OF_RANGE",
+              message: 'The value of "offset" is out of range. It must be >= 0 and <= 8. Received -Infinity',
             }),
           );
           // The too-large path is unchanged.

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -411,6 +411,35 @@ for (let withOverridenBufferWrite of [false, true]) {
           expect(() => Buffer.alloc(7)[fn](1n, 0)).toThrow(
             expect.objectContaining({ code: "ERR_BUFFER_OUT_OF_BOUNDS" }),
           );
+          // On a too-short buffer Node still reports the offset's type and
+          // integer-ness FIRST, and only then the buffer length.
+          expect(() => Buffer.alloc(7)[fn](1n, "x")).toThrow(
+            expect.objectContaining({
+              name: "TypeError",
+              code: "ERR_INVALID_ARG_TYPE",
+              message: `The "offset" argument must be of type number. Received type string ('x')`,
+            }),
+          );
+          expect(() => Buffer.alloc(7)[fn](1n, 1.5)).toThrow(
+            expect.objectContaining({
+              code: "ERR_OUT_OF_RANGE",
+              message: 'The value of "offset" is out of range. It must be an integer. Received 1.5',
+            }),
+          );
+          expect(() => Buffer.alloc(7)[fn](1n, NaN)).toThrow(
+            expect.objectContaining({
+              code: "ERR_OUT_OF_RANGE",
+              message: 'The value of "offset" is out of range. It must be an integer. Received NaN',
+            }),
+          );
+          // An integer (or +-Infinity) offset on a too-short buffer is still
+          // the buffer error: Node's `length < 0` test beats the range message.
+          expect(() => Buffer.alloc(7)[fn](1n, -1)).toThrow(
+            expect.objectContaining({ code: "ERR_BUFFER_OUT_OF_BOUNDS" }),
+          );
+          expect(() => Buffer.alloc(7)[fn](1n, Infinity)).toThrow(
+            expect.objectContaining({ code: "ERR_BUFFER_OUT_OF_BOUNDS" }),
+          );
         }
       });
 

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2461,10 +2461,9 @@ for (let withOverridenBufferWrite of [false, true]) {
       });
 
       it("lastIndexOf with utf16le only matches on a code-unit boundary", () => {
-        // UCS2 searches operate on whole uint16_t units (Node's
-        // SearchString<uint16_t>), so a raw byte match at an ODD offset is
-        // not a real match. The backward search used a byte-level std::find_end.
-        // The needle "a" is bytes [0x61, 0x00]; they occur only at byte 1 here.
+        // UCS2 searches operate on whole uint16_t units (Node's SearchString<uint16_t>),
+        // so a raw byte match at an ODD offset is not a real match. The needle
+        // "a" is bytes [0x61, 0x00]; they occur here only at byte offset 1.
         const h = Buffer.from([0x00, 0x61, 0x00, 0x00]);
         expect(h.lastIndexOf(Buffer.from("a", "utf16le"), undefined, "utf16le")).toBe(-1);
         expect(h.lastIndexOf("a", undefined, "utf16le")).toBe(-1);


### PR DESCRIPTION
Six `node:buffer` behaviors that disagree with Node, found by comparing Bun and Node output over the same inputs. All are exercised by new or strengthened tests in `test/js/node/buffer.test.js`; every expected value was verified against `node v26.3.0`.

### `Buffer.byteLength` under-counts unpaired surrogates

```js
const s = "\ud800a".repeat(17);
Buffer.byteLength(s, "utf8");    // bun: 51   node: 68
Buffer.from(s, "utf8").length;   // bun: 68   node: 68
```

`Bun__encoding__byteLengthUTF16AsUTF8` (which carried a `// TODO(@190n) handle unpaired surrogates`) went through `element_length_utf16_into_utf8`, which called simdutf's non-validating `utf8_length_from_utf16le`. That function charges every code unit in `0xD800..0xDFFF` two bytes, half of an assumed 4-byte pair. The encoder replaces each unpaired surrogate with U+FFFD (three bytes), so `byteLength` disagreed with `Buffer.from(s).length`. That is an under-allocation footgun for the common `Buffer.allocUnsafe(Buffer.byteLength(s))` + `buf.write(s)` pattern (the write is bounds-checked, so the result is truncation, not a memory error).

simdutf already ships the correct function, `utf8_length_from_utf16le_with_replacement` (SIMD-accelerated; `.count` is documented to be valid even when the error field is `SURROGATE`). It just was not exposed through the FFI shim. This adds the binding and points `element_length_utf16_into_utf8` at it. The new value is always greater than or equal to the old one and exactly matches the encoder's output, so every existing caller that used it as an allocation size or an expected-written length is either unchanged (valid UTF-16) or corrected (lone surrogates). As a side effect, `TextEncoder.encode` no longer falls back to a second allocation for lone-surrogate input.

### `lastIndexOf` with `utf16le` does a raw byte search

```js
// "a" in utf16le is the byte pair [0x61, 0x00]; it occurs here only at byte offset 1
Buffer.from([0x00, 0x61, 0x00, 0x00]).lastIndexOf("a", undefined, "utf16le");
// bun: 1   node: -1
```

Node searches in `uint16_t` units, so a UCS2 match can only start on an even byte offset. Bun's forward `indexOf`/`includes` already do this via `indexOf16`, but in `indexOfString`/`indexOfBuffer` the `last` branch was taken before the `ucs2` branch, so backward searches always fell through to the byte-level `std::find_end`. This adds a `lastIndexOf16` mirroring `indexOf16` and moves the `ucs2` branch outward.

### Empty haystack short-circuits before the empty-needle logic

```js
Buffer.alloc(0).indexOf(Buffer.alloc(0)); // bun: -1   node: 0
```

`computeIndexOfRange` already implements Node's semantics here (an empty needle is found at the clamped byteOffset; a non-empty needle in an empty haystack is -1), but `if (byteLength == 0) return -1;` in the dispatcher and three per-type re-checks ran first. They are removed, so the shared helper is the single source of truth. The byteOffset coercion (which can run user `valueOf`) is also no longer skipped for an empty buffer, matching Node.

### `fill()` silently truncates a fractional offset

```js
Buffer.alloc(4, "x").fill("a", 1.5);
// bun:  <Buffer 78 61 61 61>
// node: throws ERR_OUT_OF_RANGE 'The value of "offset" is out of range. It must be an integer. Received 1.5'
```

`offset` and `end` went through `validateNumber` (which has no integer check) and were then truncated with `toLength`. Node routes both through `validateOffset`, which is `validateInteger`. `Bun::V::validateInteger` already exists and is used the same way by `compare()` in the same file.

### `swap16`/`swap32`/`swap64` throw the wrong `code`

```js
try { Buffer.alloc(3).swap16(); } catch (e) { e.code }
// bun: "ERR_OUT_OF_RANGE"   node: "ERR_INVALID_BUFFER_SIZE"
```

The message was already correct, but `throwNodeRangeError` hardcodes `ERR_OUT_OF_RANGE`. Node uses `ERR_INVALID_BUFFER_SIZE` (a `RangeError`), which did not exist in `ErrorCode.ts`; it is added there.

### `writeBig[U]Int64LE/BE` with a negative offset throws the wrong code

```js
Buffer.alloc(16).writeBigInt64LE(1n, -1);
// bun:  ERR_BUFFER_OUT_OF_BOUNDS: "offset" is outside of buffer bounds
// node: ERR_OUT_OF_RANGE: The value of "offset" is out of range. It must be >= 0 and <= 8. Received -1
```

Node's `boundsError` puts a negative offset in the same `>= 0 and <= max` bucket as a too-large one; `ERR_BUFFER_OUT_OF_BOUNDS` is reserved for a buffer that is too short to hold 8 bytes at all. `validateOffsetBigInt64`'s two negative branches now issue the same `OUT_OF_RANGE` the too-large path already used, and the integer-ness check moves ahead of the sign check so that `-1.5` reports `an integer`, also matching Node.

During review this grew into a full reordering of `validateOffsetBigInt64` to match Node's `validateNumber` then `boundsError` sequence exactly: the offset's type is checked first, then its integer-ness (using `Math.floor(value) !== value` semantics, so `NaN` and fractions report `an integer` while `+-Infinity` do not), then the too-short buffer, then the range. This makes `Buffer.alloc(7).writeBigInt64LE(1n, "x")` a `TypeError` `ERR_INVALID_ARG_TYPE` and `Buffer.alloc(7).writeBigInt64LE(1n, 1.5)` an `ERR_OUT_OF_RANGE`, as in Node, instead of `ERR_BUFFER_OUT_OF_BOUNDS` for both. Every combination is in the test block and verified against Node v26.3.0.

### Verification

On the released Bun the 8 new or strengthened test blocks all fail (16 failures across `buffer.test.js`'s two parameterized suites; the other 501 tests are unchanged). With this change:

- `bun bd test test/js/node/buffer.test.js`: 516 pass, 0 fail
- Node's upstream `test-buffer-{indexof,fill,swap,bytelength,bigint64}.js` all still pass
- `bun bd test test/js/web/encoding/`: 2433 pass, 0 fail (`element_length_utf16_into_utf8` also feeds `TextEncoder`)
- `bun bd test test/js/node/buffer-utf16.test.ts test/js/node/buffer-indexOf-detach.test.ts test/js/node/buffer-copy-fill-detach.test.ts test/js/node/buffer-compare-bounds.test.ts test/js/node/buffer-concat.test.ts`: 64 pass, 0 fail



### Related

#32383 works around the same `element_length_utf16_into_utf8` under-count at `TextEncoder`'s call site (it caused a double `Uint8Array` allocation per `encode()` for large lone-surrogate input). The root-cause fix here resolves that too: verified with 20 `encode()` calls on a 100,000-unit string containing a lone surrogate going from 40 live `Uint8Array`s to 20, with no change to `TextEncoder.rs`.

