### PR TITLE
Fix cross-thread WeakPtr destruction in AbortSignal.any()'s GC reachability callback

### DIFF
--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -123,6 +123,11 @@ public:
     const AbortSignalSet& sourceSignals() const { return m_sourceSignals; }
     AbortSignalSet& sourceSignals() { return m_sourceSignals; }
 
+    // Read-only emptiness probe for GC marker threads (JSAbortSignalOwner::isReachableFromOpaqueRoots).
+    // WeakListHashSet::isEmptyIgnoringNullReferences() prunes dead entries, destroying WeakPtrs whose
+    // single-threaded impls (and the nodes holding them) may only be released on the owning thread.
+    bool hasAliveSourceSignals() const { return m_sourceSignals.begin() != m_sourceSignals.end(); }
+
     // https://github.com/oven-sh/bun/issues/4517
     void incrementPendingActivityCount() { ++pendingActivityCount; }
     void decrementPendingActivityCount() { --pendingActivityCount; }

--- a/src/jsc/bindings/webcore/JSAbortSignalCustom.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignalCustom.cpp
@@ -55,7 +55,9 @@ bool JSAbortSignalOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> ha
             return true;
         }
         if (abortSignal.isDependent()) {
-            if (!abortSignal.sourceSignals().isEmptyIgnoringNullReferences()) {
+            // This runs on GC marker threads, so it must not mutate the signal:
+            // sourceSignals().isEmptyIgnoringNullReferences() prunes dead entries.
+            if (abortSignal.hasAliveSourceSignals()) {
                 if (reason) [[unlikely]]
                     *reason = "Has Source Signals And Abort Event Listener"_s;
                 return true;

--- a/test/js/web/abort/abort-controller-gc-reason.test.ts
+++ b/test/js/web/abort/abort-controller-gc-reason.test.ts
@@ -99,11 +99,9 @@ describe("AbortController GC", () => {
     expect(exitCode).toBe(0);
   });
 
-  // AbortSignal.any(): JSAbortSignalOwner::isReachableFromOpaqueRoots probed the dependent
-  // signal's source set with WeakListHashSet::isEmptyIgnoringNullReferences(), which prunes
-  // dead entries. It runs on JSC's parallel marker threads, so once every source controller
-  // had been collected, a HeapHelper thread destroyed WeakPtrImpls owned by the JS thread
-  // ("ASSERTION FAILED: m_creationThread == currentThreadID()"; a data race in release).
+  // JSAbortSignalOwner::isReachableFromOpaqueRoots runs on JSC's parallel marker threads and
+  // must not prune the dependent signal's source set there: doing so destroys WeakPtrImpls
+  // owned by the JS thread once every source controller has been collected.
   test("AbortSignal.any() dependent signals survive parallel GC after their sources are collected", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/web/abort/abort-controller-gc-reason.test.ts
+++ b/test/js/web/abort/abort-controller-gc-reason.test.ts
@@ -99,6 +99,61 @@ describe("AbortController GC", () => {
     expect(exitCode).toBe(0);
   });
 
+  // AbortSignal.any(): JSAbortSignalOwner::isReachableFromOpaqueRoots probed the dependent
+  // signal's source set with WeakListHashSet::isEmptyIgnoringNullReferences(), which prunes
+  // dead entries. It runs on JSC's parallel marker threads, so once every source controller
+  // had been collected, a HeapHelper thread destroyed WeakPtrImpls owned by the JS thread
+  // ("ASSERTION FAILED: m_creationThread == currentThreadID()"; a data race in release).
+  test("AbortSignal.any() dependent signals survive parallel GC after their sources are collected", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const noop = () => {};
+          function makeBatch(n) {
+            const out = [];
+            for (let i = 0; i < n; i++) {
+              // The controllers (and their signals) are dropped, so every source of the
+              // dependent signal is collected, leaving only dead weak references behind.
+              const a = new AbortController();
+              const b = new AbortController();
+              const c = new AbortController();
+              const dep = AbortSignal.any([a.signal, b.signal, c.signal]);
+              dep.addEventListener("abort", noop);
+              out.push(dep);
+            }
+            return out;
+          }
+          const keep = [];
+          for (let round = 0; round < 24; round++) {
+            keep.push(makeBatch(100));
+            if (keep.length > 6) keep.shift();
+            Bun.gc(true);
+          }
+          console.log("PASS");
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        // `bun -e` defaults to a single GC marker; the weak-handle visit has to happen on
+        // the parallel marker threads to reach the cross-thread mutation.
+        BUN_JSC_numberOfGCMarkers: "8",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is only reported for diagnostics; debug/ASAN builds may emit benign warnings.
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toEqual({
+      stdout: "PASS",
+      exitCode: 0,
+      stderr: expect.any(String),
+    });
+  });
+
   test("signal.reason survives GC with many controllers", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
### Symptom

`AbortSignal.any()` under GC pressure aborts debug/ASAN builds on a JSC parallel marker thread ("HeapHelper"), several threads at once:

```
ASSERTION FAILED: m_creationThread == currentThreadID()
wtf/SingleThreadIntegralWrapper.h(57): WTF::SingleThreadIntegralWrapper<unsigned int>::assertThread()
```

ASAN-symbolized stack of the aborting helper thread:

```
WTF::WeakPtrImplBaseSingleThread<WebCore::WeakPtrImplWithEventTargetData>::deref()
~WeakPtr -> ~ListHashSetNode -> WTF::HashTable::clear
WTF::WeakListHashSet<WebCore::AbortSignal, WebCore::WeakPtrImplWithEventTargetData>::isEmptyIgnoringNullReferences()
WebCore::JSAbortSignalOwner::isReachableFromOpaqueRoots   src/jsc/bindings/webcore/JSAbortSignalCustom.cpp:58
JSC::WeakBlock::specializedVisit
JSC::MarkedSpace::forEachWeakInParallel   ("Ws" marking constraint)
JSC::SlotVisitor::drainFromShared         (ParallelHelperPool "HeapHelper" thread)
```

Repro (crashes in about a second on a debug or ASAN build of main; release builds hit the same code path but have no assertion, so the race is silent there):

```js
const noop = () => {};
function makeBatch(n) {
  const out = [];
  for (let i = 0; i < n; i++) {
    const a = new AbortController(), b = new AbortController(), c = new AbortController(); // dropped -> collected
    const dep = AbortSignal.any([a.signal, b.signal, c.signal]);
    dep.addEventListener("abort", noop);
    out.push(dep);
  }
  return out;
}
const keep = [];
for (let round = 0; round < 400; round++) {
  keep.push(makeBatch(400));
  if (keep.length > 12) keep.shift();
  Bun.gc(true);
  if ((round & 15) === 0) await new Promise(r => setTimeout(r, 1));
}
```

### Cause

`JSAbortSignalOwner::isReachableFromOpaqueRoots()` runs on JSC's parallel marker threads. For a dependent signal with an abort listener it called `sourceSignals().isEmptyIgnoringNullReferences()`. The source set is a `WTF::WeakListHashSet`, and that method is not read-only: when every entry is dead it `const_cast`s and `clear()`s the set.

Running that on a marker thread destroys `WeakPtr`s off their owning thread. `WeakPtrImplWithEventTargetData` uses a non-atomic, thread-asserted refcount (`SingleThreadIntegralWrapper`), so assert-enabled builds crash, and release builds get an unsynchronized cross-thread deref that can `delete` impl objects (which also host the signal's `EventTargetData`) and free hash-table nodes while the JS thread is still using them.

(`WeakHashSet::isEmptyIgnoringNullReferences()` is read-only; the `WeakListHashSet` flavor used here is the one that prunes, which is easy to miss at the call site.)

### Fix

- `AbortSignal::hasAliveSourceSignals()`: const, read-only emptiness probe (`begin() != end()` skips dead entries without destroying them).
- `isReachableFromOpaqueRoots()` uses it instead of `isEmptyIgnoringNullReferences()`.

The liveness rule is unchanged: a dependent signal with an abort listener stays alive while any source signal is alive. Dead entries are still pruned on the JS thread by the container's amortized cleanup on add/remove and by `markAborted()`'s `clear()`. No other GC visitor in `src/jsc/bindings` touches a weak container (grepped `isReachableFromOpaqueRoots` / `visitAdditionalChildren` implementations).

### Verification

New test in `test/js/web/abort/abort-controller-gc-reason.test.ts` spawns the repro with `BUN_JSC_numberOfGCMarkers=8` (one-shot `bun -e` defaults to a single marker, which hides the bug by running the weak-handle visit on the JS thread).

Without the fix (`bun bd test`, debug+ASAN):

```
(fail) AbortController GC > AbortSignal.any() dependent signals survive parallel GC after their sources are collected
  exitCode: 134
  stderr: ASSERTION FAILED: m_creationThread == currentThreadID()
          wtf/SingleThreadIntegralWrapper.h(57) ... assertThread() ...
```

With the fix, all 4 tests in the file pass (new test 3/3 runs), and the larger repro above runs to completion.

Note: #32777 (a different AbortSignal GC bug, wrapper liveness once aborted) edits the same function, so whichever lands second needs a trivial rebase.
