### PR TITLE
webcore: propagate exceptions from readableStreamTee instead of reporting them as uncaught

### DIFF
--- a/src/jsc/bindings/webcore/ReadableStream.cpp
+++ b/src/jsc/bindings/webcore/ReadableStream.cpp
@@ -319,12 +319,9 @@ extern "C" bool ReadableStream__tee(JSC::EncodedJSValue possibleReadableStream, 
 
         auto callData = JSC::getCallData(function);
         auto result = JSC::call(lexicalGlobalObject, function, callData, thisValue, arguments);
-#if ASSERT_ENABLED
-        if (scope.exception()) [[unlikely]] {
-            Bun__reportError(lexicalGlobalObject, JSC::JSValue::encode(scope.exception()));
-        }
-#endif
-        EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+        // readableStreamTee throws a catchable TypeError when the stream is already
+        // locked (reachable from Request/Response.clone()). Propagate it; reporting
+        // it as uncaught here would clear it and set a nonzero exit code.
         RETURN_IF_EXCEPTION(scope, {});
         return result;
     };

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -520,6 +520,54 @@ test("ReadableStream with mixed content (starting with ArrayBuffer) can be conve
   expect(text).toContain("Здравствуй, мир!");
 });
 
+// clone() on a body whose stream is locked must throw a single, catchable
+// TypeError. It must not also report the same error as an uncaught exception:
+// that sets the process exit code to 1 even though the user handled the throw,
+// and the swallowed exception made clone() surface a bogus "Value is not a
+// sequence" instead.
+test.each(["Request", "Response"])(
+  "%s.clone() on a locked stream body throws a catchable TypeError and does not fail the process",
+  async kind => {
+    const construct =
+      kind === "Request"
+        ? `new Request("http://example.com/", { method: "POST", body: stream, duplex: "half" })`
+        : `new Response(stream)`;
+    const script = `
+      const stream = new ReadableStream({ start() {} });
+      const target = ${construct};
+      target.body.getReader(); // lock the body stream
+      try {
+        target.clone();
+        console.log("no throw");
+      } catch (e) {
+        console.log("caught " + e.constructor.name + ": " + e.message);
+      }
+      // Give the event loop a turn so a deferred error report would surface.
+      await new Promise(resolve => setImmediate(resolve));
+      console.log("done");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+      stdout: ["caught TypeError: ReadableStream is locked", "done"],
+      exitCode: 0,
+    });
+    expect(stderr).not.toContain("ReadableStream is locked");
+  },
+);
+
 test("Blob type from a consumed Response keeps the original content-type after clones with different content-types are consumed", async () => {
   // The Response and its clones share one underlying body store. Consuming a clone
   // with a different Content-Type must not change (or invalidate) the type of a Blob

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -520,11 +520,9 @@ test("ReadableStream with mixed content (starting with ArrayBuffer) can be conve
   expect(text).toContain("Здравствуй, мир!");
 });
 
-// clone() on a body whose stream is locked must throw a single, catchable
-// TypeError. It must not also report the same error as an uncaught exception:
-// that sets the process exit code to 1 even though the user handled the throw,
-// and the swallowed exception made clone() surface a bogus "Value is not a
-// sequence" instead.
+// clone() on a locked-stream body must throw a single catchable TypeError.
+// It must not also report the error as uncaught: that sets exit code 1 and
+// clears the pending exception even though the user handled the throw.
 test.each(["Request", "Response"])(
   "%s.clone() on a locked stream body throws a catchable TypeError and does not fail the process",
   async kind => {

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -554,11 +554,7 @@ test.each(["Request", "Response"])(
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
       stdout: ["caught TypeError: ReadableStream is locked", "done"],


### PR DESCRIPTION
### Problem

Calling `.clone()` on a `Request` or `Response` whose body stream is locked is supposed to throw a single, catchable `TypeError`. In `ASSERT_ENABLED` builds (debug, and the asan release lane) it instead did three wrong things at once:

```ts
const q = new Request("http://example.com/", {
  method: "POST",
  body: new ReadableStream({ start() {} }),
  duplex: "half",
});
q.body.getReader(); // lock the body stream
try {
  q.clone();
} catch (e) {
  console.log("caught:", e.message);
}
```

```
TypeError: ReadableStream is locked   <- reported as UNCAUGHT even though it was caught
      at repro.ts:8:5
caught: Value is not a sequence       <- the catch block gets the wrong error
(exit code 1)                         <- process fails despite the try/catch
```

Release builds behaved correctly (`caught: ReadableStream is locked`, exit 0). `Response.clone()` hits the same path.

### Cause

`ReadableStream__tee` invokes the `readableStreamTee` builtin through a local helper in `src/jsc/bindings/webcore/ReadableStream.cpp`. That builtin throws a `TypeError("ReadableStream is locked")` synchronously when the stream is already locked, which is exactly what `Request.clone()` relies on.

The helper contained this after the call:

```cpp
#if ASSERT_ENABLED
        if (scope.exception()) [[unlikely]] {
            Bun__reportError(lexicalGlobalObject, JSC::JSValue::encode(scope.exception()));
        }
#endif
        EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
        RETURN_IF_EXCEPTION(scope, {});
```

`Bun__reportError` routes through `VirtualMachine::uncaught_exception`, which prints the error, sets the process exit code to 1, and clears the pending exception. With the exception gone, `RETURN_IF_EXCEPTION` no longer fired, so control reached `convert<IDLSequence<...>>` on the empty `JSValue` returned by the failed `JSC::call`, which is where the bogus `"Value is not a sequence"` came from.

The `EXCEPTION_ASSERT` on the next line encodes the same false invariant (that `readableStreamTee` can never throw a non-termination exception); without the `Bun__reportError` clearing the exception it would have aborted instead.

### Fix

Drop both lines and let `RETURN_IF_EXCEPTION` propagate the exception. `ReadableStream__tee` already returns `false` with the exception pending, and the Rust caller (`from_js_host_call_generic` in `ReadableStream::tee`) already converts that into an `Err` that reaches the user's `catch`. This makes debug and asan builds match what release builds already did.

`ReadableStream.prototype.tee()` was never affected: it goes through the JS builtin directly and does not use this C++ wrapper.

### Verification

New `test.each(["Request", "Response"])` cases in `test/js/web/fetch/body-clone.test.ts` spawn a child, lock the body, `clone()`, and assert the exact caught message and exit code 0.

Before (debug build):

```
  {
-   "exitCode": 0,
+   "exitCode": 1,
    "stdout": [
-     "caught TypeError: ReadableStream is locked",
+     "caught TypeError: Value is not a sequence",
      "done",
    ],
  }
```

After: both pass, and the existing `body-clone.test.ts` (27), `body.test.ts` / `body-stream.test.ts` / `body-mixin-errors.test.ts` (9434), and `streams.test.js` suites still pass.
