### PR TITLE
ffi, napi: purify NaNs before NaN-boxing doubles from native code

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -504,6 +504,20 @@ impl JSValue {
     pub fn js_number(n: f64) -> JSValue {
         JSC__JSValue__jsNumberFromDouble(n)
     }
+    /// `JSC::purifyNaN` (PureNaN.h) — canonicalizes every NaN to the one
+    /// payload that is safe to NaN-box. Required before boxing any `f64`
+    /// whose bit pattern comes from outside the engine (FFI memory, native
+    /// addons, wire formats): other NaN payloads collide with the JSValue
+    /// tag space and decode as forged cells or immediates.
+    #[inline]
+    pub fn purify_nan(n: f64) -> f64 {
+        if n != n {
+            // `PNaNAsBits` in PureNaN.h; not `f64::NAN`, whose bit pattern
+            // is not guaranteed.
+            return f64::from_bits(0x7ff8_0000_0000_0000);
+        }
+        n
+    }
     /// `JSValue::jsDoubleNumber` (JSCJSValueInlines.h) — boxes an `f64`
     /// *always* as a double-encoded immediate (no int32 fast path). Required
     /// when the consumer round-trips through `f64::to_bits` / `as_number` and

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -511,7 +511,7 @@ impl JSValue {
     /// tag space and decode as forged cells or immediates.
     #[inline]
     pub fn purify_nan(n: f64) -> f64 {
-        if n != n {
+        if n.is_nan() {
             // `PNaNAsBits` in PureNaN.h; not `f64::NAN`, whose bit pattern
             // is not guaranteed.
             return f64::from_bits(0x7ff8_0000_0000_0000);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2154,7 +2154,9 @@ extern "C" napi_status napi_create_double(napi_env env, double value,
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
-    *result = toNapi(jsNumber(value), toJS(env));
+    // The addon controls every bit of `value`; an impure NaN must not be
+    // NaN-boxed as-is or it decodes as a forged JSValue (see PureNaN.h).
+    *result = toNapi(jsNumber(purifyNaN(value)), toJS(env));
     NAPI_RETURN_SUCCESS(env);
 }
 

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -96,6 +96,11 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 // if any but not all are set this value is a double precision number.
 #define NumberTag 0xfffe000000000000ll
 
+// The canonical quiet NaN (PureNaN.h). This is the only NaN that is safe to
+// NaN-box: any other payload can collide with the tag ranges above and decode
+// as a cell pointer, an immediate, or an Int32 instead of a double.
+#define PureNaN   0x7ff8000000000000ll
+
 typedef  void* JSCell;
 
 typedef union EncodedJSValue {
@@ -252,6 +257,11 @@ static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {
 static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
    EncodedJSValue res;
    res.asDouble = val;
+   // Mirrors JSC's purifyNaN(): a NaN payload taken from native memory would
+   // otherwise be NaN-boxed as-is and decode as a forged JSValue.
+   if (val != val) {
+     res.asInt64 = PureNaN;
+   }
    res.asInt64 += DoubleEncodeOffset;
    return res;
 }
@@ -291,6 +301,13 @@ static EncodedJSValue BOOLEAN_TO_JSVALUE(bool val) {
 
 
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) {
+  // Numbers that fit in an int32 are int32-tagged, not double-encoded
+  // (see JSVALUE_TO_INT64). Subtracting DoubleEncodeOffset from an
+  // int32-tagged value yields an impure NaN, not the number.
+  if (JSVALUE_IS_INT32(val)) {
+    return (double)JSVALUE_TO_INT32(val);
+  }
+
   val.asInt64 -= DoubleEncodeOffset;
   return val.asDouble;
 }

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -373,7 +373,9 @@ pub mod reader {
         let addr = addr_from_args(global_object, arguments)?;
         // SAFETY: see `read_unaligned_at`.
         let value = unsafe { read_unaligned_at::<f32>(addr) };
-        Ok(JSValue::js_number(value as f64))
+        // The bytes at `addr` are arbitrary; a crafted NaN payload must not
+        // reach the NaN-boxed encoding (see `JSValue::purify_nan`).
+        Ok(JSValue::js_number(JSValue::purify_nan(value as f64)))
     }
     pub(crate) fn f64(
         global_object: &JSGlobalObject,
@@ -383,7 +385,9 @@ pub mod reader {
         let addr = addr_from_args(global_object, arguments)?;
         // SAFETY: see `read_unaligned_at`.
         let value = unsafe { read_unaligned_at::<f64>(addr) };
-        Ok(JSValue::js_number(value))
+        // The bytes at `addr` are arbitrary; a crafted NaN payload must not
+        // reach the NaN-boxed encoding (see `JSValue::purify_nan`).
+        Ok(JSValue::js_number(JSValue::purify_nan(value)))
     }
     pub(crate) fn i64(
         global_object: &JSGlobalObject,

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1657,7 +1657,9 @@ pub(super) extern "C" fn napi_create_date(
     bun_output::scoped_log!(napi, "napi_create_date");
     let env = get_env!(env_);
     let result = get_out!(env, result_);
-    let mut args = [JSValue::js_number(time).as_object_ref()];
+    // The addon controls every bit of `time`. Purify before boxing: the Date
+    // constructor receives this JSValue before any timeClip runs.
+    let mut args = [JSValue::js_number(JSValue::purify_nan(time)).as_object_ref()];
     result.set(
         env,
         // SAFETY: `args` is a stack array of one valid JSValueRef; FFI constructs a Date.

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -456,3 +456,246 @@ describe.skipIf(isASAN || isFFIUnavailable)("GC liveness of compiled symbols and
     });
   });
 });
+
+describe.skipIf(isFFIUnavailable)("double <-> JSValue conversions", () => {
+  // JSC NaN-boxes doubles, so a NaN whose payload collides with the tag space
+  // ("impure NaN", see JSC's PureNaN.h) must never be encoded as-is: it would
+  // decode as a native-chosen JSValue (true, undefined, an Int32, or a cell
+  // pointer). Every native -> JS double boundary has to purify first.
+  // All scenarios run in one spawned fixture: a forged cell-pointer JSValue
+  // can crash the process, which must not take the test runner with it.
+  it("impure NaNs are purified: f64/f32 returns, JSCallback arguments, read.f64/f32", async () => {
+    using dir = tempDir("bun-ffi-impure-nan", {
+      "impure.c": /* c */ `
+        typedef unsigned long long bits64;
+        union caster { bits64 u; double d; float f; };
+
+        /* 0xfffe000000000007 + DoubleEncodeOffset(2^49) == 0x7 == JSValue(true) */
+        double forge_true(void) { union caster c; c.u = 0xfffe000000000007ULL; return c.d; }
+        /* 0xfffe00000000000a encodes to 0xa == JSValue(undefined) */
+        double forge_undefined(void) { union caster c; c.u = 0xfffe00000000000aULL; return c.d; }
+        /* 0xfffc...: encoded value lands in the Int32 tag range, reads back as 0x12345678 */
+        double forge_int32(void) { union caster c; c.u = 0xfffc000012345678ULL; return c.d; }
+        /* 0xfffe000012345678: encodes to a cell pointer 0x12345678 */
+        double forge_cell(void) { union caster c; c.u = 0xfffe000012345678ULL; return c.d; }
+        /* float NaN with a full payload widens to an impure double NaN */
+        float forge_f32(void) { union caster c; c.u = 0xffffffffULL; return c.f; }
+        /* the canonical quiet NaN and ordinary values must be unaffected */
+        double pure_nan(void) { union caster c; c.u = 0x7ff8000000000000ULL; return c.d; }
+        double normal_double(void) { return 1.5; }
+        double echo_f64(double x) { return x; }
+
+        typedef double (*js_cb)(double);
+        /* the JSCallback argument direction uses the same NaN-boxing */
+        double invoke_with_impure(js_cb cb) {
+          union caster c; c.u = 0xfffe000000000007ULL;
+          return cb(c.d);
+        }
+      `,
+      "fixture.js": /* js */ `
+        import { cc, ptr, read, JSCallback } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "impure.c"),
+          symbols: {
+            forge_true: { args: [], returns: "f64" },
+            forge_undefined: { args: [], returns: "f64" },
+            forge_int32: { args: [], returns: "f64" },
+            forge_cell: { args: [], returns: "f64" },
+            forge_f32: { args: [], returns: "f32" },
+            pure_nan: { args: [], returns: "f64" },
+            normal_double: { args: [], returns: "f64" },
+            echo_f64: { args: ["f64"], returns: "f64" },
+            invoke_with_impure: { args: ["ptr"], returns: "f64" },
+          },
+        });
+
+        const show = value => [typeof value, String(value)];
+        const results = {};
+        for (const name of [
+          "forge_true",
+          "forge_undefined",
+          "forge_int32",
+          "forge_cell",
+          "forge_f32",
+          "pure_nan",
+          "normal_double",
+        ]) {
+          results[name] = show(symbols[name]());
+        }
+        results.echo_f64 = show(symbols.echo_f64(2.5));
+
+        let callbackArg = null;
+        const callback = new JSCallback(
+          x => {
+            callbackArg = show(x);
+            return 0;
+          },
+          { args: ["f64"], returns: "f64" },
+        );
+        results.callback_return = show(symbols.invoke_with_impure(callback.ptr));
+        results.callback_arg = callbackArg;
+        callback.close();
+
+        results.read_f64 = show(read.f64(ptr(new BigUint64Array([0xfffe000000000007n])), 0));
+        results.read_f32 = show(read.f32(ptr(new Uint32Array([0xffffffff])), 0));
+
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is included in the received object so failures show it, but is not
+    // asserted empty: debug builds emit benign startup warnings.
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        forge_true: ["number", "NaN"],
+        forge_undefined: ["number", "NaN"],
+        forge_int32: ["number", "NaN"],
+        forge_cell: ["number", "NaN"],
+        forge_f32: ["number", "NaN"],
+        pure_nan: ["number", "NaN"],
+        normal_double: ["number", "1.5"],
+        echo_f64: ["number", "2.5"],
+        callback_return: ["number", "0"],
+        callback_arg: ["number", "NaN"],
+        read_f64: ["number", "NaN"],
+        read_f32: ["number", "NaN"],
+      },
+      exitCode: 0,
+    });
+  });
+
+  // JSVALUE_TO_DOUBLE must decode int32-tagged JSValues: JSC tags integral
+  // numbers as int32, so treating every numeric JSValue as double-encoded
+  // hands C an impure NaN instead of the number. The C-side observers report
+  // what the native code actually received, so these cannot pass by a
+  // JS -> C -> JS round trip cancelling an encode bug against a decode bug.
+  it("integral JS numbers reach C as the exact double, not NaN", async () => {
+    using dir = tempDir("bun-ffi-int32-double", {
+      "int32args.c": /* c */ `
+        /* 1 => C saw the expected value, 2 => C saw NaN, 3 => something else */
+        static int classify(double got, double expected) {
+          if (got == expected) return 1;
+          if (got != got) return 2;
+          return 3;
+        }
+        int int32_arg_seen_by_c(double x) { return classify(x, 42.0); }
+        int double_arg_seen_by_c(double x) { return classify(x, 1.5); }
+        int f32_int32_arg_seen_by_c(float x) { return classify(x, 7.0f); }
+        double echo_f64(double x) { return x; }
+
+        typedef double (*js_cb)(double);
+        int int32_callback_return_seen_by_c(js_cb cb) { return classify(cb(0.5), 3.0); }
+      `,
+      "fixture.js": /* js */ `
+        import { cc, JSCallback } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "int32args.c"),
+          symbols: {
+            int32_arg_seen_by_c: { args: ["f64"], returns: "int" },
+            double_arg_seen_by_c: { args: ["f64"], returns: "int" },
+            f32_int32_arg_seen_by_c: { args: ["f32"], returns: "int" },
+            echo_f64: { args: ["f64"], returns: "f64" },
+            int32_callback_return_seen_by_c: { args: ["ptr"], returns: "int" },
+          },
+        });
+
+        const results = {
+          int32_arg: symbols.int32_arg_seen_by_c(42),
+          double_arg: symbols.double_arg_seen_by_c(1.5),
+          f32_int32_arg: symbols.f32_int32_arg_seen_by_c(7),
+          echo_int32: [typeof symbols.echo_f64(7), String(symbols.echo_f64(7))],
+        };
+
+        const callback = new JSCallback(() => 3, { args: ["f64"], returns: "f64" });
+        results.int32_callback_return = symbols.int32_callback_return_seen_by_c(callback.ptr);
+        callback.close();
+
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        int32_arg: 1,
+        double_arg: 1,
+        f32_int32_arg: 1,
+        echo_int32: ["number", "7"],
+        int32_callback_return: 1,
+      },
+      exitCode: 0,
+    });
+  });
+
+  // napi_create_double takes the double from the addon verbatim, so it is the
+  // same boundary. cc()-compiled C resolves napi_* from the host process; that
+  // lookup is only exercised on POSIX today (see cc-fixture.c).
+  it.skipIf(isWindows)("impure NaNs through napi_create_double are purified", async () => {
+    using dir = tempDir("bun-ffi-impure-nan-napi", {
+      "impure_napi.c": /* c */ `
+        typedef struct napi_env_fake* napi_env_t;
+        typedef struct napi_value_fake* napi_value_t;
+        union caster { unsigned long long u; double d; };
+        extern int napi_create_double(napi_env_t env, double value, napi_value_t* result);
+        napi_value_t impure_from_napi(napi_env_t env) {
+          union caster c; c.u = 0xfffe000000000007ULL;
+          napi_value_t result;
+          napi_create_double(env, c.d, &result);
+          return result;
+        }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "impure_napi.c"),
+          symbols: {
+            impure_from_napi: { args: ["napi_env"], returns: "napi_value" },
+          },
+        });
+
+        const value = symbols.impure_from_napi();
+        console.log(JSON.stringify([typeof value, String(value)]));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const result = stdout.startsWith("[") ? JSON.parse(stdout) : stdout;
+    expect({ result, stderr, exitCode }).toMatchObject({
+      result: ["number", "NaN"],
+      exitCode: 0,
+    });
+  });
+});

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -650,20 +650,28 @@ describe.skipIf(isFFIUnavailable)("double <-> JSValue conversions", () => {
     });
   });
 
-  // napi_create_double takes the double from the addon verbatim, so it is the
-  // same boundary. cc()-compiled C resolves napi_* from the host process; that
-  // lookup is only exercised on POSIX today (see cc-fixture.c).
-  it.skipIf(isWindows)("impure NaNs through napi_create_double are purified", async () => {
+  // napi_create_double and napi_create_date take the double from the addon
+  // verbatim, so they are the same boundary. cc()-compiled C resolves napi_*
+  // from the host process; that lookup is only exercised on POSIX today (see
+  // cc-fixture.c).
+  it.skipIf(isWindows)("impure NaNs through napi_create_double and napi_create_date are purified", async () => {
     using dir = tempDir("bun-ffi-impure-nan-napi", {
       "impure_napi.c": /* c */ `
         typedef struct napi_env_fake* napi_env_t;
         typedef struct napi_value_fake* napi_value_t;
         union caster { unsigned long long u; double d; };
         extern int napi_create_double(napi_env_t env, double value, napi_value_t* result);
+        extern int napi_create_date(napi_env_t env, double time, napi_value_t* result);
         napi_value_t impure_from_napi(napi_env_t env) {
           union caster c; c.u = 0xfffe000000000007ULL;
           napi_value_t result;
           napi_create_double(env, c.d, &result);
+          return result;
+        }
+        napi_value_t impure_date_from_napi(napi_env_t env) {
+          union caster c; c.u = 0xfffe000000000007ULL;
+          napi_value_t result;
+          napi_create_date(env, c.d, &result);
           return result;
         }
       `,
@@ -675,11 +683,20 @@ describe.skipIf(isFFIUnavailable)("double <-> JSValue conversions", () => {
           source: path.join(import.meta.dir, "impure_napi.c"),
           symbols: {
             impure_from_napi: { args: ["napi_env"], returns: "napi_value" },
+            impure_date_from_napi: { args: ["napi_env"], returns: "napi_value" },
           },
         });
 
         const value = symbols.impure_from_napi();
-        console.log(JSON.stringify([typeof value, String(value)]));
+        // Unpurified, the Date constructor receives JSValue(true) and
+        // produces new Date(1) instead of an Invalid Date.
+        const date = symbols.impure_date_from_napi();
+        console.log(
+          JSON.stringify({
+            double: [typeof value, String(value)],
+            date: [date instanceof Date, String(date.getTime())],
+          }),
+        );
       `,
     });
 
@@ -692,9 +709,12 @@ describe.skipIf(isFFIUnavailable)("double <-> JSValue conversions", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const result = stdout.startsWith("[") ? JSON.parse(stdout) : stdout;
-    expect({ result, stderr, exitCode }).toMatchObject({
-      result: ["number", "NaN"],
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        double: ["number", "NaN"],
+        date: [true, "NaN"],
+      },
       exitCode: 0,
     });
   });

--- a/test/js/bun/ffi/ffi.test.fixture.callback.c
+++ b/test/js/bun/ffi/ffi.test.fixture.callback.c
@@ -98,6 +98,11 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 // if any but not all are set this value is a double precision number.
 #define NumberTag 0xfffe000000000000ll
 
+// The canonical quiet NaN (PureNaN.h). This is the only NaN that is safe to
+// NaN-box: any other payload can collide with the tag ranges above and decode
+// as a cell pointer, an immediate, or an Int32 instead of a double.
+#define PureNaN   0x7ff8000000000000ll
+
 typedef  void* JSCell;
 
 typedef union EncodedJSValue {
@@ -254,6 +259,11 @@ static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {
 static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
    EncodedJSValue res;
    res.asDouble = val;
+   // Mirrors JSC's purifyNaN(): a NaN payload taken from native memory would
+   // otherwise be NaN-boxed as-is and decode as a forged JSValue.
+   if (val != val) {
+     res.asInt64 = PureNaN;
+   }
    res.asInt64 += DoubleEncodeOffset;
    return res;
 }
@@ -293,6 +303,13 @@ static EncodedJSValue BOOLEAN_TO_JSVALUE(bool val) {
 
 
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) {
+  // Numbers that fit in an int32 are int32-tagged, not double-encoded
+  // (see JSVALUE_TO_INT64). Subtracting DoubleEncodeOffset from an
+  // int32-tagged value yields an impure NaN, not the number.
+  if (JSVALUE_IS_INT32(val)) {
+    return (double)JSVALUE_TO_INT32(val);
+  }
+
   val.asInt64 -= DoubleEncodeOffset;
   return val.asDouble;
 }

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -98,6 +98,11 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 // if any but not all are set this value is a double precision number.
 #define NumberTag 0xfffe000000000000ll
 
+// The canonical quiet NaN (PureNaN.h). This is the only NaN that is safe to
+// NaN-box: any other payload can collide with the tag ranges above and decode
+// as a cell pointer, an immediate, or an Int32 instead of a double.
+#define PureNaN   0x7ff8000000000000ll
+
 typedef  void* JSCell;
 
 typedef union EncodedJSValue {
@@ -254,6 +259,11 @@ static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {
 static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
    EncodedJSValue res;
    res.asDouble = val;
+   // Mirrors JSC's purifyNaN(): a NaN payload taken from native memory would
+   // otherwise be NaN-boxed as-is and decode as a forged JSValue.
+   if (val != val) {
+     res.asInt64 = PureNaN;
+   }
    res.asInt64 += DoubleEncodeOffset;
    return res;
 }
@@ -293,6 +303,13 @@ static EncodedJSValue BOOLEAN_TO_JSVALUE(bool val) {
 
 
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) {
+  // Numbers that fit in an int32 are int32-tagged, not double-encoded
+  // (see JSVALUE_TO_INT64). Subtracting DoubleEncodeOffset from an
+  // int32-tagged value yields an impure NaN, not the number.
+  if (JSVALUE_IS_INT32(val)) {
+    return (double)JSVALUE_TO_INT32(val);
+  }
+
   val.asInt64 -= DoubleEncodeOffset;
   return val.asDouble;
 }


### PR DESCRIPTION
### What

`bun:ffi` NaN-boxes native doubles without purifying them, so a well-typed C function returning an `f64` can hand JavaScript an arbitrary forged JSValue. The NaN payload picks what JS receives: `true`, `undefined`, an Int32, or a cell pointer whose address comes from native data (type confusion and an arbitrary read).

```js
import { cc } from "bun:ffi";
import { writeFileSync } from "node:fs";
writeFileSync("/tmp/impure-nan.c", `
typedef unsigned long long u64;
union caster { u64 u; double d; };
/* 0xfffe000000000007 + DoubleEncodeOffset == JSValue 0x7 == true */
double forge_true(void) { union caster c; c.u = 0xfffe000000000007ULL; return c.d; }
/* the mantissa becomes a cell pointer */
double forge_cell(void) { union caster c; c.u = 0xfffe000012345678ULL; return c.d; }
`);
const { symbols } = cc({ source: "/tmp/impure-nan.c", symbols: {
  forge_true: { args: [], returns: "f64" },
  forge_cell: { args: [], returns: "f64" },
}});
console.log(typeof symbols.forge_true(), symbols.forge_true()); // "boolean true"
console.log(typeof symbols.forge_cell());                       // dereferences 0x12345678
```

On `1.4.0-canary (942c22237)` this prints `boolean true`, then crashes dereferencing the forged cell:

```
AddressSanitizer: SEGV on unknown address
  #0 JSC::JSCell::isString() const JSCell.h:127
  rdi = 0x0001ffffe0000000   <- forged cell pointer decoded from the NaN payload
```

The relevant property is that the C code is memory-safe and in-contract: any native library that returns a double it read from attacker-controlled bytes (file, wire, database) becomes a JSValue forgery primitive.

### Cause

`DOUBLE_TO_JSVALUE` in `src/runtime/ffi/FFI.h` adds `DoubleEncodeOffset` to the raw bits with no NaN purification. JSC's JSVALUE64 encoding is only sound if every boxed double is a non-NaN or a purified NaN, which is why JSC purifies at every boundary where double bits come from outside the engine: Float64Array element loads (`TypedArrayAdaptors.h`), the structured-clone deserializer, and `JSValueMakeNumber` in its public C API. Bun skipped it on:

- `f64`/`f32` returns (the call trampoline)
- JSCallback `f64`/`f32` arguments (the callback trampoline uses the same macro)
- `read.f64` / `read.f32`
- `napi_create_double` and `napi_create_date` (an addon forwarding attacker bytes as a double has the same effect; V8 stores heap numbers so the same addon is harmless under Node)

While writing the regression test, the decode direction turned out to be broken too: `JSVALUE_TO_DOUBLE` never handled int32-tagged JSValues, so an integral JS number passed to an `f64`/`f32` argument (or returned from an `f64` JSCallback) reached C as an impure NaN instead of the number:

```js
// int arg_is_three(double x) { return x == 3.0 ? 1 : (x != x ? 2 : 3); }
symbols.arg_is_three(3)    // 2: C received NaN
symbols.arg_is_three(3.5)  // 1: fractional doubles were fine
```

The two defects cancelled on JS -> C -> JS round trips: the impure NaN produced by the bad decode was re-encoded back into the original int32 by the unpurified encode, so `echo_f64(3)` looked correct while the C code saw NaN. Purifying without fixing the decode would turn that accidental round trip into a visible NaN, so both are fixed together.

### Fix

- `DOUBLE_TO_JSVALUE`: canonicalize NaNs to `PureNaN` before adding `DoubleEncodeOffset`, mirroring `JSC::purifyNaN()`.
- `JSVALUE_TO_DOUBLE`: decode int32-tagged JSValues, like the neighboring `JSVALUE_TO_INT64` already does.
- `reader::f64` / `reader::f32` (`FFIObject.rs`): purify through a new `JSValue::purify_nan` helper.
- `napi_create_double` (`napi.cpp`): `jsNumber(purifyNaN(value))`, matching JSC's `JSValueMakeNumber`.
- `napi_create_date` (`napi_body.rs`): purify before the timestamp is boxed into the Date constructor's argument (flagged in review; with an impure NaN the unfixed constructor argument decodes as `JSValue(true)` and produces `new Date(1)`).
- `test/js/bun/ffi/ffi.test.fixture.*.c` are the committed `viewSource` dumps and are regenerated with the new header.

Same pattern, intentionally not changed here because each needs its own test harness: `v8::Number::New` in the V8 shim (`V8Number.cpp`) and the Postgres/MySQL binary `float8` decoders also box unpurified doubles whose bits come from untrusted input (a hostile server rather than a hostile library). Also noticed while reading but untouched: `UINT32_TO_JSVALUE` accepts `2^31` as an int32, so a `u32` return of exactly `2147483648` comes back as `-2147483648`.

### Verification

`test/js/bun/ffi/cc.test.ts`, `describe("double <-> JSValue conversions")`:

- every forged payload (`true`, `undefined`, Int32, cell pointer, widened f32 NaN) comes back as a plain `NaN` from f64/f32 returns, the JSCallback f64 argument, and `read.f64`/`read.f32`; ordinary doubles and the canonical quiet NaN are unaffected
- C-side observers confirm integral JS numbers arrive as the exact double, not NaN, for f64/f32 arguments and JSCallback f64 returns
- `napi_create_double` called with an impure NaN produces `NaN`, and `napi_create_date` produces an Invalid Date

All three fail on `1.4.0-canary (942c22237)`: the first crashes dereferencing the forged cell, the second reports that C saw NaN (`int32_arg: 2`), the third returns `boolean true`. All pass with this change on a debug ASAN build. The existing JSCallback round-trip matrix in `ffi.test.js` (48 cases) still passes.