### PR TITLE
test: stop asserting an OCSP URI on the live bun.sh certificate

### DIFF
--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -308,10 +308,11 @@ for (const { name, connect } of tests) {
         expect(cert.subject.CN).toBe("bun.sh");
         expect(cert.subjectaltname).toContain("DNS:bun.sh");
         expect(cert.infoAccess).toBeDefined();
-        // we just check the types this can change over time
+        // The live cert's AIA contents change on reissue (public CAs stopped
+        // including OCSP URIs in 2025), so only assert the stable CA Issuers
+        // entry here; exact parsing is covered by the fixed-fixture x509 tests.
         const infoAccess = cert.infoAccess as NodeJS.Dict<string[]>;
-        expect(infoAccess["OCSP - URI"]).toBeDefined();
-        expect(infoAccess["CA Issuers - URI"]).toBeDefined();
+        expect(infoAccess["CA Issuers - URI"]).toEqual(expect.arrayContaining([expect.stringMatching(/^https?:\/\//)]));
         expect(cert.ca).toBeFalse();
         expect(cert.bits).toBeInteger();
         // These can change:


### PR DESCRIPTION
`node-tls-connect.test.ts > should have peer certificate` is currently failing on every CI lane, on main and on every open PR (for example https://buildkite.com/bun/bun/builds/65076):

```
313 |         expect(infoAccess["OCSP - URI"]).toBeDefined();
                                               ^
error: expect(received).toBeDefined()

Received: undefined
```

### Cause

The test connects to the live `bun.sh:443` and asserts fields of whatever certificate the host presents. bun.sh's certificate was reissued (Google Trust Services `WE1`, valid to Sep 2026) and its Authority Information Access extension now carries only a CA Issuers entry, with no OCSP responder URI:

```
Authority Information Access:
    CA Issuers - URI:http://i.pki.goog/we1.crt
```

Public CAs (Let's Encrypt, Google Trust Services) stopped including OCSP URIs in newly issued certificates in 2025 in favor of CRLs, so the field is not coming back. The comment above the assertion already says the contents "can change over time"; this is that.

### Fix

Drop the `OCSP - URI` assertion. Keep the `CA Issuers - URI` one, strengthened from `toBeDefined()` to "a non-empty array of http(s) URIs".

This loses no meaningful coverage: the exact `infoAccess` key/value parsing (including the OCSP key) is already tested hermetically against fixed fixtures in `test/js/node/test/parallel/test-tls-translate-peer-certificate.js`, `test/js/node/test/parallel/test-crypto-x509.js`, and `test/regression/issue/21274.test.ts`. The live test only needs to prove the end-to-end shape.

### Verification

To reproduce without depending on the live host, I minted a leaf certificate matching the live one's identity and AIA (`CN=bun.sh`, SAN `bun.sh, *.bun.sh`, AIA with a CA Issuers entry and no OCSP entry) and served it on `bun.sh:443` through an `/etc/hosts` override.

- Unmodified test: both variants fail at line 313 with the exact output above.
- With this change: `bun bd test test/js/node/tls/node-tls-connect.test.ts` passes the whole file, 30 pass / 1 skip (intentional) / 0 fail.

No other test asserts on the live bun.sh certificate's contents; every other `getPeerCertificate()` test in the suite uses a local fixture cert.
