### PR TITLE
Bun.Transpiler: add variables and functions to the replMode result object

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2503,9 +2503,12 @@ declare module "bun" {
      * - The IIFE returns a `{ __proto__: null, value, variables, functions }` result object:
      *   - `value`: the completion value of the snippet (always an own property, even when undefined)
      *   - `variables`: names declared by the snippet (`var`/`let`/`const`/`function`/`class`/import bindings), as an array of strings
-     *   - `functions`: printed source of the snippet's function declarations and side-effect-free
-     *     top-level declarations, re-declared as `var` so running the string in a fresh `node:vm`
-     *     context re-creates them (for persisting evaluations across VMs)
+     *   - `functions`: printed source of the snippet's replayable declarations: function
+     *     declarations, plus classes and `var`/`let`/`const` declarations whose initializers have
+     *     no side effects and only read bindings the string itself declares. Everything is
+     *     re-declared as `var`, so evaluating the string in a fresh `node:vm` context re-creates
+     *     them (for resuming a session on a new VM). Function bodies are not analyzed: a replayed
+     *     function that closed over non-replayable state throws when called, not when defined.
      *
      * @example
      * ```js

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2504,11 +2504,12 @@ declare module "bun" {
      *   - `value`: the completion value of the snippet (always an own property, even when undefined)
      *   - `variables`: names declared by the snippet (`var`/`let`/`const`/`function`/`class`/import bindings), as an array of strings
      *   - `functions`: printed source of the snippet's replayable declarations: function
-     *     declarations, plus classes and `var`/`let`/`const` declarations whose initializers have
-     *     no side effects and only read bindings the string itself declares. Everything is
-     *     re-declared as `var`, so evaluating the string in a fresh `node:vm` context re-creates
-     *     them (for resuming a session on a new VM). Function bodies are not analyzed: a replayed
-     *     function that closed over non-replayable state throws when called, not when defined.
+     *     declarations, plus only those classes and `var`/`let`/`const` declarations that have no
+     *     side effects when evaluated and only read bindings the string itself declares.
+     *     Everything is re-declared as `var`, so evaluating the string in a fresh `node:vm`
+     *     context re-creates them (for resuming a session on a new VM). Function bodies are not
+     *     analyzed: a replayed function that closed over non-replayable state throws when called,
+     *     not when defined.
      *
      * @example
      * ```js

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2506,10 +2506,10 @@ declare module "bun" {
      *   - `functions`: printed source of the snippet's replayable declarations: function
      *     declarations, plus only those classes and `var`/`let`/`const` declarations that have no
      *     side effects when evaluated and only read bindings the string itself declares.
-     *     Everything is re-declared as `var`, so evaluating the string in a fresh `node:vm`
-     *     context re-creates them (for resuming a session on a new VM). Function bodies are not
-     *     analyzed: a replayed function that closed over non-replayable state throws when called,
-     *     not when defined.
+     *     Function declarations are printed as-is; classes and `let`/`const` are re-declared as
+     *     `var`, so evaluating the string in a fresh `node:vm` context re-creates all of them
+     *     (for resuming a session on a new VM). Function bodies are not analyzed: a replayed
+     *     function that closed over non-replayable state throws when called, not when defined.
      *
      * @example
      * ```js

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2499,8 +2499,22 @@ declare module "bun" {
      * Enable REPL mode transforms:
      * - Wraps top-level inputs that appear to be object literals (inputs starting with '{' without trailing ';') in parentheses
      * - Hoists all declarations as var for REPL persistence across vm.runInContext calls
-     * - Wraps last expression in { __proto__: null, value: expr } for result capture
      * - Wraps code in sync/async IIFE to avoid parentheses around object literals
+     * - The IIFE returns a `{ __proto__: null, value, variables, functions }` result object:
+     *   - `value`: the completion value of the snippet (always an own property, even when undefined)
+     *   - `variables`: names declared by the snippet (`var`/`let`/`const`/`function`/`class`/import bindings), as an array of strings
+     *   - `functions`: printed source of the snippet's function declarations and side-effect-free
+     *     top-level declarations, re-declared as `var` so running the string in a fresh `node:vm`
+     *     context re-creates them (for persisting evaluations across VMs)
+     *
+     * @example
+     * ```js
+     * const transpiler = new Bun.Transpiler({ loader: "tsx", replMode: true });
+     * const ctx = vm.createContext({});
+     * const out = vm.runInContext(transpiler.transformSync("function inc(n) { return n + 1 }"), ctx);
+     * out.variables; // ["inc"]
+     * out.functions; // "function inc(n) {\n  return n + 1;\n}\n"
+     * ```
      *
      * @default false
      */

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -11,7 +11,7 @@ use bun_collections::{ArrayHashMap, StringArrayHashMap, StringHashMap};
 use crate::runtime;
 use crate::{
     CharFreq, ExportsKind, Expr, InlinedEnumValue, LocRef, NamedExport, NamedImport, Part, Range,
-    Ref, Scope, SlotCounts, StoreStr, Target,
+    Ref, Scope, SlotCounts, StmtNodeList, StoreStr, Target,
 };
 
 use crate::part::List as PartList;
@@ -19,6 +19,19 @@ use crate::symbol::List as SymbolList;
 type ImportRecordList<'a> = crate::import_record::List<'a>;
 
 pub type TopLevelSymbolToParts = ArrayHashMap<Ref, AstVec<u32>, AutoContext, AstAlloc>;
+
+/// REPL mode: which top-level statements are safe to re-run on a fresh VM
+/// (function declarations and side-effect-free declarations), plus the string
+/// literal in the result wrapper that receives their printed source.
+#[derive(Clone, Copy)]
+pub struct ReplFunctions {
+    /// The `E::String` expression (the wrapper object's `functions` value)
+    /// whose data is replaced with the printed source of `stmts`.
+    pub string_expr: Expr,
+    /// Arena-owned list of statements to print. They alias statements that are
+    /// also in `parts`; both passes only read them.
+    pub stmts: StmtNodeList,
+}
 
 pub struct Ast<'a> {
     pub approximate_newline_count: usize,
@@ -50,6 +63,13 @@ pub struct Ast<'a> {
     /// These are stored at the AST level instead of on individual AST nodes so
     /// they can be manipulated efficiently without a full AST traversal
     pub import_records: ImportRecordList<'a>,
+
+    /// REPL mode only (`ParserOptions.repl_mode`): the statements whose printed
+    /// source becomes the `functions` string of the REPL result wrapper, plus
+    /// the `E::String` slot inside that wrapper to write it into. Filled in by
+    /// `js_printer::print_ast` right before the main print pass, because only
+    /// the printer owns a renamer over the symbol table.
+    pub repl_functions: Option<ReplFunctions>,
 
     // `hashbang`/`directive` are slices into source text. `StoreStr` records
     // them under the same lifetime-erased contract as `StoreRef`.
@@ -116,6 +136,7 @@ impl<'a> Ast<'a> {
             export_keyword: Range::NONE,
             top_level_await_keyword: Range::NONE,
             import_records: ImportRecordList::new_in(arena),
+            repl_functions: None,
             hashbang: StoreStr::EMPTY,
             directive: None,
             parts: PartList::new_in(arena),

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -66,9 +66,10 @@ pub struct Ast<'a> {
 
     /// REPL mode only (`ParserOptions.repl_mode`): the statements whose printed
     /// source becomes the `functions` string of the REPL result wrapper, plus
-    /// the `E::String` slot inside that wrapper to write it into. Filled in by
-    /// `js_printer::print_ast` right before the main print pass, because only
-    /// the printer owns a renamer over the symbol table.
+    /// the `E::String` slot inside that wrapper to write it into. Set by the
+    /// parser's REPL transform (`P::to_ast`); `js_printer::print_ast` then
+    /// prints `stmts` into the `string_expr` slot right before the main print
+    /// pass, because only the printer has a renamer over the symbol table.
     pub repl_functions: Option<ReplFunctions>,
 
     // `hashbang`/`directive` are slices into source text. `StoreStr` records

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5408,7 +5408,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    fn binding_can_be_removed_if_unused_without_dce_check(&mut self, binding: Binding) -> bool {
+    pub(crate) fn binding_can_be_removed_if_unused_without_dce_check(
+        &mut self,
+        binding: Binding,
+    ) -> bool {
         match binding.data {
             js_ast::b::B::BArray(bi) => {
                 for item in bi.items.slice() {
@@ -5782,7 +5785,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.expr_can_be_removed_if_unused_without_dce_check(expr)
     }
 
-    fn expr_can_be_removed_if_unused_without_dce_check(&mut self, expr: &Expr) -> bool {
+    pub(crate) fn expr_can_be_removed_if_unused_without_dce_check(&mut self, expr: &Expr) -> bool {
         if !self.stack_check.is_safe_to_recurse() || self.reported_stack_overflow.get() {
             self.report_stack_overflow(expr.loc);
             return false;
@@ -8608,11 +8611,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // REPL mode transforms
-        if self.options.repl_mode {
+        let repl_functions = if self.options.repl_mode {
             // `apply_repl_transforms` is declared in ast::repl_transforms as an
             // `impl P` mixin.
-            self.apply_repl_transforms(parts, arena)?;
-        }
+            self.apply_repl_transforms(parts, arena)?
+        } else {
+            None
+        };
 
         let mut top_level_symbols_to_parts = bun_ast::ast_result::TopLevelSymbolToParts::default();
 
@@ -8794,6 +8799,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             symbols,
             parts: parts_list,
             import_records,
+            repl_functions,
 
             // ── Remaining fields spelled out explicitly. Previously
             //    `..Default::default()` constructed a

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -4,15 +4,22 @@
 //! - Wraps the last expression in { value: expr } for result capture
 //! - Wraps code with await in async IIFE with variable hoisting
 //! - Hoists declarations for variable persistence across REPL lines
+//!
+//! The IIFE always returns a `{ __proto__: null, value, variables, functions }`
+//! object: `value` is the completion value (own property, possibly undefined),
+//! `variables` is the list of names the snippet declares, and `functions` is
+//! the printed source of the snippet's replayable declarations (filled in by
+//! `js_printer::print_ast` via `Ast.repl_functions`).
 
 use bun_alloc::Arena as Bump;
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_collections::VecExt;
 
 use bun_ast as js_ast;
+use bun_ast::ast_result::ReplFunctions;
 use bun_ast::flags;
 use bun_ast::stmt::Data as StmtData;
-use bun_ast::{B, Binding, E, Expr, ExprNodeList, G, S, Stmt};
+use bun_ast::{B, Binding, E, Expr, ExprNodeList, G, Ref, S, Stmt};
 
 use crate::p::P;
 
@@ -21,14 +28,17 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// This transforms code for interactive evaluation:
     /// - Wraps the last expression in { value: expr } for result capture
     /// - Wraps code with await in async IIFE with variable hoisting
+    ///
+    /// Returns the statements to print into the result wrapper's `functions`
+    /// string (stored on `Ast.repl_functions`), if any.
     pub fn apply_repl_transforms<'bump>(
         &mut self,
         parts: &mut BumpVec<'bump, js_ast::Part>,
         bump: &'bump Bump,
-    ) -> Result<(), bun_alloc::AllocError> {
+    ) -> Result<Option<ReplFunctions>, bun_alloc::AllocError> {
         // Skip transform if there's a top-level return (indicates module pattern)
         if self.has_top_level_return {
-            return Ok(());
+            return Ok(None);
         }
 
         // Collect all statements
@@ -38,7 +48,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
         }
 
         if total_stmts_count == 0 {
-            return Ok(());
+            return Ok(None);
         }
 
         // Collect all statements into a single array
@@ -73,14 +83,23 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
         all_stmts: &[Stmt],
         bump: &'bump Bump,
         is_async: bool,
-    ) -> Result<(), bun_alloc::AllocError> {
+    ) -> Result<Option<ReplFunctions>, bun_alloc::AllocError> {
         if all_stmts.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
 
         // Lists for hoisted declarations and inner statements
         let mut hoisted_stmts = BumpVec::<Stmt>::with_capacity_in(all_stmts.len(), bump);
         let mut inner_stmts = BumpVec::<Stmt>::with_capacity_in(all_stmts.len(), bump);
+
+        // Names the snippet declares, in source order (the `variables` array of
+        // the result wrapper).
+        let mut declared_names = BumpVec::<&'static [u8]>::new_in(bump);
+        // Declarations that are safe to re-run on a fresh VM: function
+        // declarations, classes, and locals whose initializers have no side
+        // effects. Printed into the wrapper's `functions` string. Everything is
+        // emitted in `var`-persistable form so the string can be replayed as-is.
+        let mut serializable_stmts = BumpVec::<Stmt>::new_in(bump);
 
         // Process each statement - hoist all declarations for REPL persistence
         for stmt in all_stmts.iter() {
@@ -98,6 +117,30 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                             decl.binding,
                             &mut hoisted_decl_list,
                         )?;
+                    }
+
+                    for decl in hoisted_decl_list.iter() {
+                        if let B::B::BIdentifier(ident) = decl.binding.data {
+                            repl_push_unique_name(
+                                &mut declared_names,
+                                self.repl_symbol_name(ident.r#ref),
+                            );
+                        }
+                    }
+
+                    // `const x = 1` / `let y = [1]` are replayable; re-declare
+                    // them as `var` so the printed source persists onto a vm
+                    // context just like the REPL evaluation itself does.
+                    if self.repl_local_is_serializable(&local) {
+                        let decls: &mut [G::Decl] = bump.alloc_slice_copy(local.decls.slice());
+                        serializable_stmts.push(self.s(
+                            S::Local {
+                                kind: S::Kind::KVar,
+                                decls: G::DeclList::from_arena_slice(decls),
+                                ..Default::default()
+                            },
+                            stmt.loc,
+                        ));
                     }
 
                     if !hoisted_decl_list.is_empty() {
@@ -134,6 +177,8 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // Inner: this.funcName = funcName; function funcName() {}
                     if let Some(name_loc) = func.func.name {
                         let name_ref = name_loc.ref_;
+                        // Function declarations are always replayable.
+                        serializable_stmts.push(*stmt);
                         hoisted_stmts.push(self.s(
                             S::Local {
                                 kind: S::Kind::KVar,
@@ -158,6 +203,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                         let name_str: &[u8] = self.symbols[name_ref.inner_index() as usize]
                             .original_name
                             .slice();
+                        repl_push_unique_name(&mut declared_names, name_str);
                         let this_dot = self.new_expr(
                             E::Dot {
                                 target: this_expr,
@@ -199,6 +245,12 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // Inner: ClassName = class ClassName {}
                     if let Some(name_loc) = class.class.class_name {
                         let name_ref = name_loc.ref_;
+                        repl_push_unique_name(
+                            &mut declared_names,
+                            self.repl_symbol_name(name_ref),
+                        );
+                        // Must be checked before `class.class` is moved out below.
+                        let is_serializable = self.class_can_be_removed_if_unused(&class.class);
                         hoisted_stmts.push(self.s(
                             S::Local {
                                 kind: S::Kind::KVar,
@@ -220,6 +272,28 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                         // S::Class store entry is dead after this rewrite, so move it out.
                         let class_value = core::mem::take(&mut class.class);
                         let class_expr = self.new_expr(class_value, stmt.loc);
+                        if is_serializable {
+                            // Serialize as `var ClassName = class ClassName {}` so the
+                            // printed source persists onto a vm context when replayed.
+                            let binding = Binding::alloc(
+                                bump,
+                                B::Identifier { r#ref: name_ref },
+                                name_loc.loc,
+                            );
+                            let decls: &mut [G::Decl] =
+                                bump.alloc_slice_fill_with(1, |_| G::Decl {
+                                    binding,
+                                    value: Some(class_expr),
+                                });
+                            serializable_stmts.push(self.s(
+                                S::Local {
+                                    kind: S::Kind::KVar,
+                                    decls: G::DeclList::from_arena_slice(decls),
+                                    ..Default::default()
+                                },
+                                stmt.loc,
+                            ));
+                        }
                         let class_id = self.new_expr(
                             E::Identifier {
                                 ref_: name_ref,
@@ -275,6 +349,28 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
 
                     // `items` is an arena-owned `StoreSlice<ClauseItem>` valid for 'a.
                     let import_items: &[bun_ast::ClauseItem] = import_data.items.slice();
+
+                    // Record the names this import binds in the REPL context.
+                    // The synthesized namespace ref for named imports is
+                    // internal, so only `import * as X` reports `namespace_ref`.
+                    if !import_data.star_name_loc.is_empty() {
+                        repl_push_unique_name(
+                            &mut declared_names,
+                            self.repl_symbol_name(import_data.namespace_ref),
+                        );
+                    }
+                    if let Some(default_name) = import_data.default_name {
+                        repl_push_unique_name(
+                            &mut declared_names,
+                            self.repl_symbol_name(default_name.ref_),
+                        );
+                    }
+                    for item in import_items {
+                        repl_push_unique_name(
+                            &mut declared_names,
+                            self.repl_symbol_name(item.name.ref_),
+                        );
+                    }
 
                     if !import_data.star_name_loc.is_empty() {
                         // import * as X from 'mod' -> var X = await import('mod')
@@ -466,8 +562,46 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
             }
         }
 
-        // Wrap the last expression in return { value: expr }
-        self.repl_wrap_last_expression_with_return(&mut inner_stmts, bump);
+        // Build the `variables` array: the names this snippet declared.
+        let mut name_items = BumpVec::<Expr>::with_capacity_in(declared_names.len(), bump);
+        for name in declared_names.iter() {
+            name_items.push(self.new_expr(
+                E::String {
+                    data: (*name).into(),
+                    ..Default::default()
+                },
+                bun_ast::Loc::EMPTY,
+            ));
+        }
+        let variables_expr = self.new_expr(
+            E::Array {
+                items: ExprNodeList::from_bump_vec(name_items),
+                is_single_line: true,
+                ..Default::default()
+            },
+            bun_ast::Loc::EMPTY,
+        );
+
+        // Placeholder for the printed source of `serializable_stmts`; the
+        // printer fills it in through `Ast.repl_functions`.
+        let functions_expr = self.new_expr(
+            E::String {
+                ..Default::default()
+            },
+            bun_ast::Loc::EMPTY,
+        );
+        let repl_functions = if serializable_stmts.is_empty() {
+            None
+        } else {
+            Some(ReplFunctions {
+                string_expr: functions_expr,
+                stmts: bun_ast::StoreSlice::new_mut(serializable_stmts.into_bump_slice_mut()),
+            })
+        };
+
+        // Wrap the last expression in return { value: expr, ... }; without a
+        // trailing expression, append the wrapper with an undefined `value`.
+        self.repl_finish_with_return(&mut inner_stmts, bump, variables_expr, functions_expr);
 
         // Create the IIFE: (() => { ...inner_stmts... })() or (async () => { ... })()
         let inner_slice: &mut [Stmt] = inner_stmts.into_bump_slice_mut();
@@ -513,7 +647,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
             parts.truncate(1);
         }
 
-        Ok(())
+        Ok(repl_functions)
     }
 
     /// Convert named imports to individual var assignments from the dynamic import
@@ -631,34 +765,49 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
         Ok(())
     }
 
-    /// Wrap the last expression in return { value: expr }
-    fn repl_wrap_last_expression_with_return<'bump>(
+    /// Wrap the last trailing expression statement in
+    /// `return { __proto__: null, value, variables, functions }`. When the
+    /// snippet has no trailing expression, append the same `return` with an
+    /// undefined `value` so the wrapper is always the completion value.
+    fn repl_finish_with_return<'bump>(
         &mut self,
         inner_stmts: &mut BumpVec<'bump, Stmt>,
         bump: &'bump Bump,
+        variables: Expr,
+        functions: Expr,
     ) {
-        if !inner_stmts.is_empty() {
-            let mut last_idx: usize = inner_stmts.len();
-            while last_idx > 0 {
-                last_idx -= 1;
-                let last_stmt = inner_stmts[last_idx];
-                match last_stmt.data {
-                    StmtData::SEmpty(_) | StmtData::SComment(_) => continue,
-                    StmtData::SExpr(expr_data) => {
-                        // Wrap in return { value: expr }
-                        let wrapped = self.repl_wrap_expr_in_value_object(expr_data.value, bump);
-                        inner_stmts[last_idx] = self.s(
-                            S::Return {
-                                value: Some(wrapped),
-                            },
-                            last_stmt.loc,
-                        );
-                        break;
-                    }
-                    _ => break,
+        let mut last_idx: usize = inner_stmts.len();
+        while last_idx > 0 {
+            last_idx -= 1;
+            let last_stmt = inner_stmts[last_idx];
+            match last_stmt.data {
+                StmtData::SEmpty(_) | StmtData::SComment(_) => continue,
+                StmtData::SExpr(expr_data) => {
+                    // Wrap in return { value: expr, ... }
+                    let wrapped = self.repl_wrap_expr_in_value_object(
+                        Some(expr_data.value),
+                        variables,
+                        functions,
+                        bump,
+                    );
+                    inner_stmts[last_idx] = self.s(
+                        S::Return {
+                            value: Some(wrapped),
+                        },
+                        last_stmt.loc,
+                    );
+                    return;
                 }
+                _ => break,
             }
         }
+        let wrapped = self.repl_wrap_expr_in_value_object(None, variables, functions, bump);
+        inner_stmts.push(self.s(
+            S::Return {
+                value: Some(wrapped),
+            },
+            bun_ast::Loc::EMPTY,
+        ));
     }
 
     /// Extract individual identifiers from a binding pattern for hoisting
@@ -689,11 +838,47 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
         Ok(())
     }
 
-    /// Create { __proto__: null, value: expr } wrapper object
-    /// Uses null prototype to create a clean data object
-    fn repl_wrap_expr_in_value_object<'bump>(&mut self, expr: Expr, bump: &'bump Bump) -> Expr {
+    /// Resolve a symbol `Ref` minted by this parser to its source-level name.
+    #[inline]
+    fn repl_symbol_name(&self, r#ref: Ref) -> &'static [u8] {
+        // `original_name` is an arena-owned `StoreStr`; `.slice()` detaches the
+        // borrow from `self.symbols` (same contract as the hoisting code above).
+        self.symbols[r#ref.inner_index() as usize]
+            .original_name
+            .slice()
+    }
+
+    /// Whether every binding and initializer of a `var`/`let`/`const`
+    /// statement is free of side effects, so re-evaluating its printed source
+    /// on a fresh VM is safe.
+    fn repl_local_is_serializable(&mut self, local: &S::Local) -> bool {
+        for decl in local.decls.slice() {
+            if !self.binding_can_be_removed_if_unused_without_dce_check(decl.binding) {
+                return false;
+            }
+            if let Some(value) = &decl.value {
+                if !self.expr_can_be_removed_if_unused_without_dce_check(value) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Create the `{ __proto__: null, value, variables, functions }` result
+    /// wrapper. Uses a null prototype to create a clean data object. `value`
+    /// is always an own property (undefined when the snippet has no trailing
+    /// expression) so consumers can unwrap it unconditionally.
+    fn repl_wrap_expr_in_value_object<'bump>(
+        &mut self,
+        value: Option<Expr>,
+        variables: Expr,
+        functions: Expr,
+        bump: &'bump Bump,
+    ) -> Expr {
+        let loc = value.map_or(bun_ast::Loc::EMPTY, |value| value.loc);
         // G::Property is non-Copy (owns Vec) → use bump Vec instead of alloc_slice_copy.
-        let mut properties = BumpVec::<G::Property>::with_capacity_in(2, bump);
+        let mut properties = BumpVec::<G::Property>::with_capacity_in(4, bump);
         // __proto__: null - creates null-prototype object
         properties.push(G::Property {
             key: Some(self.new_expr(
@@ -701,21 +886,46 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     data: b"__proto__".into(),
                     ..Default::default()
                 },
-                expr.loc,
+                loc,
             )),
-            value: Some(self.new_expr(E::Null {}, expr.loc)),
+            value: Some(self.new_expr(E::Null {}, loc)),
             ..Default::default()
         });
         // value: expr - the actual result value
+        let value_expr = value.unwrap_or_else(|| self.new_expr(E::Undefined {}, loc));
         properties.push(G::Property {
             key: Some(self.new_expr(
                 E::String {
                     data: b"value".into(),
                     ..Default::default()
                 },
-                expr.loc,
+                loc,
             )),
-            value: Some(expr),
+            value: Some(value_expr),
+            ..Default::default()
+        });
+        // variables: ["a", "b"] - names declared by the snippet
+        properties.push(G::Property {
+            key: Some(self.new_expr(
+                E::String {
+                    data: b"variables".into(),
+                    ..Default::default()
+                },
+                loc,
+            )),
+            value: Some(variables),
+            ..Default::default()
+        });
+        // functions: "..." - printed source of the replayable declarations
+        properties.push(G::Property {
+            key: Some(self.new_expr(
+                E::String {
+                    data: b"functions".into(),
+                    ..Default::default()
+                },
+                loc,
+            )),
+            value: Some(functions),
             ..Default::default()
         });
         let prop_list = G::PropertyList::from_bump_vec(properties);
@@ -724,7 +934,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                 properties: prop_list,
                 ..Default::default()
             },
-            expr.loc,
+            loc,
         )
     }
 
@@ -858,6 +1068,15 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
             }
             B::B::BMissing(_) => self.new_expr(E::Missing {}, binding.loc),
         }
+    }
+}
+
+/// Append `name` unless it is already present: keeps `variables` in source
+/// order without duplicates (e.g. `var x = 1; var x = 2`).
+#[inline]
+fn repl_push_unique_name<'bump>(names: &mut BumpVec<'bump, &'static [u8]>, name: &'static [u8]) {
+    if !names.iter().any(|existing| *existing == name) {
+        names.push(name);
     }
 }
 

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -1049,10 +1049,11 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
             | ExprData::EImportMeta(_)
             // Function bodies are deferred, not evaluated by the declaration.
             | ExprData::EFunction(_)
-            | ExprData::EArrow(_)
-            // Import bindings resolve through the module namespace.
-            | ExprData::EImportIdentifier(_)
-            | ExprData::ECommonjsExportIdentifier(_) => true,
+            | ExprData::EArrow(_) => true,
+            // Import bindings are never part of the serialized source (import
+            // statements are not replayable), so an eager read of one cannot
+            // be satisfied on a fresh VM.
+            ExprData::EImportIdentifier(_) | ExprData::ECommonjsExportIdentifier(_) => false,
             ExprData::EIdentifier(ex) => {
                 // Unbound identifiers resolve against the replaying context's
                 // globals, the same way the original evaluation did.

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -245,10 +245,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // Inner: ClassName = class ClassName {}
                     if let Some(name_loc) = class.class.class_name {
                         let name_ref = name_loc.ref_;
-                        repl_push_unique_name(
-                            &mut declared_names,
-                            self.repl_symbol_name(name_ref),
-                        );
+                        repl_push_unique_name(&mut declared_names, self.repl_symbol_name(name_ref));
                         // Must be checked before `class.class` is moved out below.
                         let is_serializable = self.class_can_be_removed_if_unused(&class.class);
                         hoisted_stmts.push(self.s(

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -1101,9 +1101,14 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     && self.repl_eager_refs_are_admitted(&ex.right, admitted)
             }
             // `/* @__PURE__ */ f(x)`: the target and arguments are still
-            // evaluated when the declaration runs.
+            // evaluated when the declaration runs. A pure-annotated IIFE also
+            // runs its (unanalyzed) body eagerly, so inline function targets
+            // are rejected outright.
             ExprData::ECall(ex) => {
-                self.repl_eager_refs_are_admitted(&ex.target, admitted)
+                !matches!(
+                    ex.target.data,
+                    ExprData::EArrow(_) | ExprData::EFunction(_)
+                ) && self.repl_eager_refs_are_admitted(&ex.target, admitted)
                     && ex
                         .args
                         .slice()
@@ -1111,7 +1116,10 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                         .all(|arg| self.repl_eager_refs_are_admitted(arg, admitted))
             }
             ExprData::ENew(ex) => {
-                self.repl_eager_refs_are_admitted(&ex.target, admitted)
+                !matches!(
+                    ex.target.data,
+                    ExprData::EArrow(_) | ExprData::EFunction(_)
+                ) && self.repl_eager_refs_are_admitted(&ex.target, admitted)
                     && ex
                         .args
                         .slice()
@@ -1123,8 +1131,9 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     }
 
     /// `repl_eager_refs_are_admitted` for a class body: `extends`, computed
-    /// keys, field initializers, and static blocks all run when the
-    /// declaration is evaluated.
+    /// keys, static field initializers, and static blocks all run when the
+    /// declaration is evaluated. Instance field initializers only run at
+    /// construction but are checked the same way, conservatively.
     fn repl_class_eager_refs_are_admitted(&self, class: &G::Class, admitted: &[Ref]) -> bool {
         if let Some(extends) = &class.extends {
             if !self.repl_eager_refs_are_admitted(extends, admitted) {

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -144,12 +144,8 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // `const x = 1` / `let y = [1]` are replayable; re-declare
                     // them as `var` so the printed source persists onto a vm
                     // context just like the REPL evaluation itself does.
-                    if self.repl_local_is_serializable(&local, &admitted_refs) {
-                        for decl in hoisted_decl_list.iter() {
-                            if let B::B::BIdentifier(ident) = decl.binding.data {
-                                admitted_refs.push(self.repl_follow_ref(ident.r#ref));
-                            }
-                        }
+                    // On success its bindings are admitted for later reads.
+                    if self.repl_local_is_serializable(&local, &mut admitted_refs) {
                         let decls: &mut [G::Decl] = bump.alloc_slice_copy(local.decls.slice());
                         serializable_stmts.push(self.s(
                             S::Local {
@@ -435,6 +431,65 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                             },
                             stmt.loc,
                         ));
+
+                        // import X, * as ns from 'mod' -> var X; X = ns.default
+                        // (the namespace was just assigned above)
+                        if let Some(default_name) = import_data.default_name {
+                            let default_ref = default_name.ref_;
+                            hoisted_stmts.push(self.s(
+                                S::Local {
+                                    kind: S::Kind::KVar,
+                                    decls: repl_one_decl(
+                                        bump,
+                                        Binding::alloc(
+                                            bump,
+                                            B::Identifier { r#ref: default_ref },
+                                            default_name.loc,
+                                        ),
+                                    ),
+                                    ..Default::default()
+                                },
+                                stmt.loc,
+                            ));
+                            let ns_ref_expr = self.new_expr(
+                                E::Identifier {
+                                    ref_: import_data.namespace_ref,
+                                    ..Default::default()
+                                },
+                                stmt.loc,
+                            );
+                            let dot_default = self.new_expr(
+                                E::Dot {
+                                    target: ns_ref_expr,
+                                    name: b"default".into(),
+                                    name_loc: stmt.loc,
+                                    ..Default::default()
+                                },
+                                stmt.loc,
+                            );
+                            let left = self.new_expr(
+                                E::Identifier {
+                                    ref_: default_ref,
+                                    ..Default::default()
+                                },
+                                default_name.loc,
+                            );
+                            let assign = self.new_expr(
+                                E::Binary {
+                                    op: js_ast::OpCode::BinAssign,
+                                    left,
+                                    right: dot_default,
+                                },
+                                stmt.loc,
+                            );
+                            inner_stmts.push(self.s(
+                                S::SExpr {
+                                    value: assign,
+                                    ..Default::default()
+                                },
+                                stmt.loc,
+                            ));
+                        }
                     } else if let Some(default_name) = import_data.default_name {
                         // import X from 'mod' -> var X = (await import('mod')).default
                         // import X, { a } from 'mod' -> var __ns = await import('mod'); var X = __ns.default; var a = __ns.a;
@@ -873,26 +928,85 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// Whether a `var`/`let`/`const` statement can be re-run on a fresh VM:
     /// not a `using` declaration (replaying one as `var` would drop its
     /// disposal semantics), every binding and initializer is free of side
-    /// effects, and everything the initializers read eagerly is declared by
-    /// the serialized source itself (`admitted`).
-    fn repl_local_is_serializable(&mut self, local: &S::Local, admitted: &[Ref]) -> bool {
+    /// effects, and everything it reads eagerly (initializers, destructuring
+    /// defaults, computed pattern keys) is declared by the serialized source
+    /// itself (`admitted`).
+    ///
+    /// Declarators are checked left to right and admit their bindings as they
+    /// go, so `const a = 1, b = a` is replayable. On success the statement's
+    /// bindings stay in `admitted`; on failure `admitted` is rolled back and
+    /// the whole statement is dropped (declaration statements are kept atomic
+    /// rather than split per declarator).
+    fn repl_local_is_serializable<'bump>(
+        &mut self,
+        local: &S::Local,
+        admitted: &mut BumpVec<'bump, Ref>,
+    ) -> bool {
         if local.kind.is_using() {
             return false;
         }
+        let admitted_before = admitted.len();
         for decl in local.decls.slice() {
-            if !self.binding_can_be_removed_if_unused_without_dce_check(decl.binding) {
+            if !self.binding_can_be_removed_if_unused_without_dce_check(decl.binding)
+                || !self.repl_binding_eager_refs_are_admitted(decl.binding, admitted)
+            {
+                admitted.truncate(admitted_before);
                 return false;
             }
             if let Some(value) = &decl.value {
-                if !self.expr_can_be_removed_if_unused_without_dce_check(value) {
-                    return false;
-                }
-                if !self.repl_eager_refs_are_admitted(value, admitted) {
+                if !self.expr_can_be_removed_if_unused_without_dce_check(value)
+                    || !self.repl_eager_refs_are_admitted(value, admitted)
+                {
+                    admitted.truncate(admitted_before);
                     return false;
                 }
             }
+            // Later declarators in this statement may read this one.
+            self.repl_admit_binding_refs(decl.binding, admitted);
         }
         true
+    }
+
+    /// Record every name a binding pattern declares as admitted.
+    fn repl_admit_binding_refs<'bump>(&self, binding: Binding, admitted: &mut BumpVec<'bump, Ref>) {
+        match binding.data {
+            B::B::BIdentifier(ident) => {
+                admitted.push(self.repl_follow_ref(ident.r#ref));
+            }
+            B::B::BArray(array) => {
+                for item in array.items.slice() {
+                    self.repl_admit_binding_refs(item.binding, admitted);
+                }
+            }
+            B::B::BObject(object) => {
+                for property in object.properties.slice() {
+                    self.repl_admit_binding_refs(property.value, admitted);
+                }
+            }
+            B::B::BMissing(_) => {}
+        }
+    }
+
+    /// `repl_eager_refs_are_admitted` for a binding pattern: destructuring
+    /// evaluates computed keys and default values when the declaration runs.
+    fn repl_binding_eager_refs_are_admitted(&self, binding: Binding, admitted: &[Ref]) -> bool {
+        match binding.data {
+            B::B::BIdentifier(_) | B::B::BMissing(_) => true,
+            B::B::BArray(array) => array.items.slice().iter().all(|item| {
+                self.repl_binding_eager_refs_are_admitted(item.binding, admitted)
+                    && item
+                        .default_value
+                        .is_none_or(|value| self.repl_eager_refs_are_admitted(&value, admitted))
+            }),
+            B::B::BObject(object) => object.properties.slice().iter().all(|property| {
+                (property.flags.contains(flags::Property::IsSpread)
+                    || self.repl_eager_refs_are_admitted(&property.key, admitted))
+                    && self.repl_binding_eager_refs_are_admitted(property.value, admitted)
+                    && property
+                        .default_value
+                        .is_none_or(|value| self.repl_eager_refs_are_admitted(&value, admitted))
+            }),
+        }
     }
 
     /// Follow symbol links (e.g. merged `var` redeclarations) to the
@@ -1008,24 +1122,43 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     }
 
     /// `repl_eager_refs_are_admitted` for a class body: `extends`, computed
-    /// keys, and field initializers all run when the declaration is evaluated.
+    /// keys, field initializers, and static blocks all run when the
+    /// declaration is evaluated.
     fn repl_class_eager_refs_are_admitted(&self, class: &G::Class, admitted: &[Ref]) -> bool {
         if let Some(extends) = &class.extends {
             if !self.repl_eager_refs_are_admitted(extends, admitted) {
                 return false;
             }
         }
-        class.properties.iter().all(|property| {
-            property
-                .key
-                .is_none_or(|key| self.repl_eager_refs_are_admitted(&key, admitted))
-                && property
-                    .value
-                    .is_none_or(|value| self.repl_eager_refs_are_admitted(&value, admitted))
-                && property
-                    .initializer
-                    .is_none_or(|init| self.repl_eager_refs_are_admitted(&init, admitted))
-        })
+        for property in class.properties.iter() {
+            if property.kind == G::PropertyKind::ClassStaticBlock {
+                // A static block body is a statement list; rather than walk it
+                // for admitted refs, only accept the trivially empty case.
+                let is_empty = property
+                    .class_static_block_ref()
+                    .is_none_or(|block| block.stmts.slice().is_empty());
+                if !is_empty {
+                    return false;
+                }
+                continue;
+            }
+            if let Some(key) = &property.key {
+                if !self.repl_eager_refs_are_admitted(key, admitted) {
+                    return false;
+                }
+            }
+            if let Some(value) = &property.value {
+                if !self.repl_eager_refs_are_admitted(value, admitted) {
+                    return false;
+                }
+            }
+            if let Some(initializer) = &property.initializer {
+                if !self.repl_eager_refs_are_admitted(initializer, admitted) {
+                    return false;
+                }
+            }
+        }
+        true
     }
 
     /// Create the `{ __proto__: null, value, variables, functions }` result

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -1072,7 +1072,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
 /// order without duplicates (e.g. `var x = 1; var x = 2`).
 #[inline]
 fn repl_push_unique_name<'bump>(names: &mut BumpVec<'bump, &'static [u8]>, name: &'static [u8]) {
-    if !names.iter().any(|existing| *existing == name) {
+    if !names.contains(&name) {
         names.push(name);
     }
 }

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -347,19 +347,21 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // `items` is an arena-owned `StoreSlice<ClauseItem>` valid for 'a.
                     let import_items: &[bun_ast::ClauseItem] = import_data.items.slice();
 
-                    // Record the names this import binds in the REPL context.
-                    // The synthesized namespace ref for named imports is
-                    // internal, so only `import * as X` reports `namespace_ref`.
-                    if !import_data.star_name_loc.is_empty() {
-                        repl_push_unique_name(
-                            &mut declared_names,
-                            self.repl_symbol_name(import_data.namespace_ref),
-                        );
-                    }
+                    // Record the names this import binds in the REPL context,
+                    // in grammar order: the default binding always precedes a
+                    // namespace or named clause. The synthesized namespace ref
+                    // for named imports is internal, so only `import * as X`
+                    // reports `namespace_ref`.
                     if let Some(default_name) = import_data.default_name {
                         repl_push_unique_name(
                             &mut declared_names,
                             self.repl_symbol_name(default_name.ref_),
+                        );
+                    }
+                    if !import_data.star_name_loc.is_empty() {
+                        repl_push_unique_name(
+                            &mut declared_names,
+                            self.repl_symbol_name(import_data.namespace_ref),
                         );
                     }
                     for item in import_items {

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -1100,32 +1100,10 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                 self.repl_eager_refs_are_admitted(&ex.left, admitted)
                     && self.repl_eager_refs_are_admitted(&ex.right, admitted)
             }
-            // `/* @__PURE__ */ f(x)`: the target and arguments are still
-            // evaluated when the declaration runs. A pure-annotated IIFE also
-            // runs its (unanalyzed) body eagerly, so inline function targets
-            // are rejected outright.
-            ExprData::ECall(ex) => {
-                !matches!(
-                    ex.target.data,
-                    ExprData::EArrow(_) | ExprData::EFunction(_)
-                ) && self.repl_eager_refs_are_admitted(&ex.target, admitted)
-                    && ex
-                        .args
-                        .slice()
-                        .iter()
-                        .all(|arg| self.repl_eager_refs_are_admitted(arg, admitted))
-            }
-            ExprData::ENew(ex) => {
-                !matches!(
-                    ex.target.data,
-                    ExprData::EArrow(_) | ExprData::EFunction(_)
-                ) && self.repl_eager_refs_are_admitted(&ex.target, admitted)
-                    && ex
-                        .args
-                        .slice()
-                        .iter()
-                        .all(|arg| self.repl_eager_refs_are_admitted(arg, admitted))
-            }
+            // A `/* @__PURE__ */` call or `new` (the only kind that passes the
+            // purity gate) still runs a callee body that is never analyzed, so
+            // it can read bindings the serialized source does not declare.
+            ExprData::ECall(_) | ExprData::ENew(_) => false,
             _ => false,
         }
     }

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -100,6 +100,19 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
         // effects. Printed into the wrapper's `functions` string. Everything is
         // emitted in `var`-persistable form so the string can be replayed as-is.
         let mut serializable_stmts = BumpVec::<Stmt>::new_in(bump);
+        // Symbols the `functions` string itself declares. An initializer is
+        // only replayable if every binding it reads eagerly is in this set;
+        // otherwise the printed source would throw a ReferenceError on a
+        // fresh VM (e.g. `let a = effect(); let b = a` must not emit
+        // `var b = a`). Function declarations are hoisted, so seed them all.
+        let mut admitted_refs = BumpVec::<Ref>::new_in(bump);
+        for stmt in all_stmts.iter() {
+            if let StmtData::SFunction(func) = stmt.data {
+                if let Some(name_loc) = func.func.name {
+                    admitted_refs.push(self.repl_follow_ref(name_loc.ref_));
+                }
+            }
+        }
 
         // Process each statement - hoist all declarations for REPL persistence
         for stmt in all_stmts.iter() {
@@ -131,7 +144,12 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // `const x = 1` / `let y = [1]` are replayable; re-declare
                     // them as `var` so the printed source persists onto a vm
                     // context just like the REPL evaluation itself does.
-                    if self.repl_local_is_serializable(&local) {
+                    if self.repl_local_is_serializable(&local, &admitted_refs) {
+                        for decl in hoisted_decl_list.iter() {
+                            if let B::B::BIdentifier(ident) = decl.binding.data {
+                                admitted_refs.push(self.repl_follow_ref(ident.r#ref));
+                            }
+                        }
                         let decls: &mut [G::Decl] = bump.alloc_slice_copy(local.decls.slice());
                         serializable_stmts.push(self.s(
                             S::Local {
@@ -247,7 +265,12 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                         let name_ref = name_loc.ref_;
                         repl_push_unique_name(&mut declared_names, self.repl_symbol_name(name_ref));
                         // Must be checked before `class.class` is moved out below.
-                        let is_serializable = self.class_can_be_removed_if_unused(&class.class);
+                        let is_serializable = self.class_can_be_removed_if_unused(&class.class)
+                            && self
+                                .repl_class_eager_refs_are_admitted(&class.class, &admitted_refs);
+                        if is_serializable {
+                            admitted_refs.push(self.repl_follow_ref(name_ref));
+                        }
                         hoisted_stmts.push(self.s(
                             S::Local {
                                 kind: S::Kind::KVar,
@@ -847,10 +870,15 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
             .slice()
     }
 
-    /// Whether every binding and initializer of a `var`/`let`/`const`
-    /// statement is free of side effects, so re-evaluating its printed source
-    /// on a fresh VM is safe.
-    fn repl_local_is_serializable(&mut self, local: &S::Local) -> bool {
+    /// Whether a `var`/`let`/`const` statement can be re-run on a fresh VM:
+    /// not a `using` declaration (replaying one as `var` would drop its
+    /// disposal semantics), every binding and initializer is free of side
+    /// effects, and everything the initializers read eagerly is declared by
+    /// the serialized source itself (`admitted`).
+    fn repl_local_is_serializable(&mut self, local: &S::Local, admitted: &[Ref]) -> bool {
+        if local.kind.is_using() {
+            return false;
+        }
         for decl in local.decls.slice() {
             if !self.binding_can_be_removed_if_unused_without_dce_check(decl.binding) {
                 return false;
@@ -859,9 +887,145 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                 if !self.expr_can_be_removed_if_unused_without_dce_check(value) {
                     return false;
                 }
+                if !self.repl_eager_refs_are_admitted(value, admitted) {
+                    return false;
+                }
             }
         }
         true
+    }
+
+    /// Follow symbol links (e.g. merged `var` redeclarations) to the
+    /// canonical `Ref`.
+    fn repl_follow_ref(&self, r#ref: Ref) -> Ref {
+        let mut r#ref = r#ref;
+        let mut symbol = &self.symbols[r#ref.inner_index() as usize];
+        while symbol.has_link() {
+            r#ref = symbol.link.get();
+            symbol = &self.symbols[r#ref.inner_index() as usize];
+        }
+        r#ref
+    }
+
+    /// Whether every identifier `expr` reads when evaluated refers to a
+    /// binding the serialized `functions` source declares itself (`admitted`)
+    /// or to a global, which the replaying context provides. Without this, a
+    /// pure initializer like `let b = a` could reference a sibling that was
+    /// excluded for having side effects and throw a ReferenceError on replay.
+    ///
+    /// Only called on expressions that already passed
+    /// `expr_can_be_removed_if_unused_without_dce_check`, so the variant
+    /// space is the side-effect-free subset; anything else is rejected.
+    /// Function and arrow bodies are skipped: the declaration does not
+    /// evaluate them.
+    fn repl_eager_refs_are_admitted(&self, expr: &Expr, admitted: &[Ref]) -> bool {
+        use js_ast::ExprData;
+        match &expr.data {
+            // No eager identifier reads.
+            ExprData::ENull(_)
+            | ExprData::EUndefined(_)
+            | ExprData::EMissing(_)
+            | ExprData::EBoolean(_)
+            | ExprData::EBranchBoolean(_)
+            | ExprData::ENumber(_)
+            | ExprData::EBigInt(_)
+            | ExprData::EString(_)
+            | ExprData::EThis(_)
+            | ExprData::ERegExp(_)
+            | ExprData::EImportMeta(_)
+            // Function bodies are deferred, not evaluated by the declaration.
+            | ExprData::EFunction(_)
+            | ExprData::EArrow(_)
+            // Import bindings resolve through the module namespace.
+            | ExprData::EImportIdentifier(_)
+            | ExprData::ECommonjsExportIdentifier(_) => true,
+            ExprData::EIdentifier(ex) => {
+                // Unbound identifiers resolve against the replaying context's
+                // globals, the same way the original evaluation did.
+                self.symbols[ex.ref_.inner_index() as usize].kind
+                    == js_ast::symbol::Kind::Unbound
+                    || admitted.contains(&self.repl_follow_ref(ex.ref_))
+            }
+            ExprData::EInlinedEnum(ex) => self.repl_eager_refs_are_admitted(&ex.value, admitted),
+            ExprData::EDot(ex) => self.repl_eager_refs_are_admitted(&ex.target, admitted),
+            ExprData::ESpread(ex) => self.repl_eager_refs_are_admitted(&ex.value, admitted),
+            ExprData::EClass(ex) => self.repl_class_eager_refs_are_admitted(ex, admitted),
+            ExprData::EIf(ex) => {
+                self.repl_eager_refs_are_admitted(&ex.test_, admitted)
+                    && self.repl_eager_refs_are_admitted(&ex.yes, admitted)
+                    && self.repl_eager_refs_are_admitted(&ex.no, admitted)
+            }
+            ExprData::EArray(ex) => ex
+                .items
+                .slice()
+                .iter()
+                .all(|item| self.repl_eager_refs_are_admitted(item, admitted)),
+            ExprData::EObject(ex) => ex.properties.slice().iter().all(|property| {
+                property
+                    .key
+                    .is_none_or(|key| self.repl_eager_refs_are_admitted(&key, admitted))
+                    && property
+                        .value
+                        .is_none_or(|value| self.repl_eager_refs_are_admitted(&value, admitted))
+            }),
+            ExprData::ETemplate(ex) => {
+                ex.tag.is_none()
+                    && ex
+                        .parts()
+                        .iter()
+                        .all(|part| self.repl_eager_refs_are_admitted(&part.value, admitted))
+            }
+            ExprData::EUnary(ex) => {
+                // `typeof x` never throws, even for an undeclared `x`.
+                (ex.op == js_ast::OpCode::UnTypeof
+                    && matches!(ex.value.data, ExprData::EIdentifier(_)))
+                    || self.repl_eager_refs_are_admitted(&ex.value, admitted)
+            }
+            ExprData::EBinary(ex) => {
+                self.repl_eager_refs_are_admitted(&ex.left, admitted)
+                    && self.repl_eager_refs_are_admitted(&ex.right, admitted)
+            }
+            // `/* @__PURE__ */ f(x)`: the target and arguments are still
+            // evaluated when the declaration runs.
+            ExprData::ECall(ex) => {
+                self.repl_eager_refs_are_admitted(&ex.target, admitted)
+                    && ex
+                        .args
+                        .slice()
+                        .iter()
+                        .all(|arg| self.repl_eager_refs_are_admitted(arg, admitted))
+            }
+            ExprData::ENew(ex) => {
+                self.repl_eager_refs_are_admitted(&ex.target, admitted)
+                    && ex
+                        .args
+                        .slice()
+                        .iter()
+                        .all(|arg| self.repl_eager_refs_are_admitted(arg, admitted))
+            }
+            _ => false,
+        }
+    }
+
+    /// `repl_eager_refs_are_admitted` for a class body: `extends`, computed
+    /// keys, and field initializers all run when the declaration is evaluated.
+    fn repl_class_eager_refs_are_admitted(&self, class: &G::Class, admitted: &[Ref]) -> bool {
+        if let Some(extends) = &class.extends {
+            if !self.repl_eager_refs_are_admitted(extends, admitted) {
+                return false;
+            }
+        }
+        class.properties.iter().all(|property| {
+            property
+                .key
+                .is_none_or(|key| self.repl_eager_refs_are_admitted(&key, admitted))
+                && property
+                    .value
+                    .is_none_or(|value| self.repl_eager_refs_are_admitted(&value, admitted))
+                && property
+                    .initializer
+                    .is_none_or(|init| self.repl_eager_refs_are_admitted(&init, admitted))
+        })
     }
 
     /// Create the `{ __proto__: null, value, variables, functions }` result

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7793,6 +7793,88 @@ pub fn get_source_map_builder<const IS_BUN_PLATFORM: bool>(
 // Top-level print entry points
 // ───────────────────────────────────────────────────────────────────────────
 
+/// REPL mode second pass: print `Ast.repl_functions.stmts` (function
+/// declarations and side-effect-free declarations, pre-filtered by the
+/// parser's REPL transform) and store the source in the `functions` string of
+/// the REPL result wrapper, so the tree's own print pass emits it as a string
+/// literal. Borrows `symbols` through its own short-lived `NoOpRenamer` and
+/// hands them back for the main pass. On error the literal stays empty.
+fn print_repl_functions_source<'a, const ASCII_ONLY: bool>(
+    bump: &'a bun_alloc::Arena,
+    tree: &'a Ast,
+    symbols: js_ast::symbol::Map,
+    source: &'a bun_ast::Source,
+    opts: &Options<'a>,
+    repl_functions: &bun_ast::ast_result::ReplFunctions,
+) -> js_ast::symbol::Map {
+    let Some(mut slot) = repl_functions.string_expr.data.e_string() else {
+        return symbols;
+    };
+    // `NoOpRenamer` owns its `Map` and a `Printer` pins that borrow, so the
+    // map could not be handed back for the main pass. Instead the sub-pass
+    // renamer gets a bitwise alias of `symbols` parked in `ManuallyDrop`
+    // (the same pattern `get_source_map_builder` uses for a borrowed
+    // `line_offset_tables`).
+    //
+    // SAFETY: `shadow` aliases `symbols`, which is neither accessed nor moved
+    // until this renamer (and the `Printer` borrowing it) is gone; the alias
+    // is never dropped, so the buffers are freed exactly once, by the main
+    // pass's renamer.
+    let shadow: js_ast::symbol::Map = unsafe { core::ptr::read(&symbols) };
+    let mut sub_renamer = core::mem::ManuallyDrop::new(rename::NoOpRenamer::init(shadow, source));
+    // Only formatting-relevant options carry over: no source maps, module
+    // info, or transpiler cache for this pass.
+    let mut sub_opts = Options {
+        indent: opts.indent,
+        target: opts.target,
+        minify_whitespace: opts.minify_whitespace,
+        minify_syntax: opts.minify_syntax,
+        print_dce_annotations: opts.print_dce_annotations,
+        transform_only: opts.transform_only,
+        module_type: opts.module_type,
+        input_module_type: opts.input_module_type,
+        ..Options::default()
+    };
+    let source_map_builder = get_source_map_builder::<ASCII_ONLY>(
+        GenerateSourceMap::Disable,
+        &mut sub_opts,
+        source,
+        tree,
+    );
+    let mut buffer_printer = BufferPrinter::init(BufferWriter::init());
+    let mut printed = true;
+    {
+        let mut printer =
+            Printer::<&mut BufferPrinter, ASCII_ONLY, false, ASCII_ONLY, false, false>::init(
+                &mut buffer_printer,
+                bump,
+                tree.import_records.as_slice(),
+                sub_opts,
+                sub_renamer.to_renamer(),
+                source_map_builder,
+            );
+        for stmt in repl_functions.stmts.slice() {
+            if printer
+                .print_stmt(*stmt, TopLevel::init(IsTopLevel::Yes))
+                .is_err()
+                || printer.writer.get_error().is_err()
+            {
+                printed = false;
+                break;
+            }
+            printer.print_semicolon_if_needed();
+        }
+        if printed && printer.writer.done().is_err() {
+            printed = false;
+        }
+    }
+    if printed {
+        slot.data =
+            bun_ast::StoreStr::new(bump.alloc_slice_copy(buffer_printer.ctx.get_written()));
+    }
+    symbols
+}
+
 pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOURCE_MAP: bool>(
     _writer: W,
     bump: &'a bun_alloc::Arena,
@@ -7803,6 +7885,22 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
 ) -> Result<usize, bun_core::Error> {
     let _restore =
         bun_crash_handler::scoped_action(bun_crash_handler::Action::Print(source.path.text));
+
+    // REPL mode: print the replayable declarations into the result wrapper's
+    // `functions` string literal before the tree itself is printed. The symbol
+    // map is only borrowed by that pass's renamer and is returned for the main
+    // renamer built below.
+    let symbols = match &tree.repl_functions {
+        Some(repl_functions) => print_repl_functions_source::<ASCII_ONLY>(
+            bump,
+            tree,
+            symbols,
+            source,
+            &opts,
+            repl_functions,
+        ),
+        None => symbols,
+    };
 
     // `Renamer<'r,'src>` is invariant in `'src` (it holds `&'r mut`
     // NoOpRenamer<'src>`), so the two arms must agree on `'src`; constructing the

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7869,8 +7869,7 @@ fn print_repl_functions_source<'a, const ASCII_ONLY: bool>(
         }
     }
     if printed {
-        slot.data =
-            bun_ast::StoreStr::new(bump.alloc_slice_copy(buffer_printer.ctx.get_written()));
+        slot.data = bun_ast::StoreStr::new(bump.alloc_slice_copy(buffer_printer.ctx.get_written()));
     }
     symbols
 }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7798,7 +7798,7 @@ pub fn get_source_map_builder<const IS_BUN_PLATFORM: bool>(
 /// parser's REPL transform) and store the source in the `functions` string of
 /// the REPL result wrapper, so the tree's own print pass emits it as a string
 /// literal. Borrows `symbols` through its own short-lived `NoOpRenamer` and
-/// hands them back for the main pass. On error the literal stays empty.
+/// hands them back for the main pass.
 fn print_repl_functions_source<'a, const ASCII_ONLY: bool>(
     bump: &'a bun_alloc::Arena,
     tree: &'a Ast,
@@ -7806,9 +7806,9 @@ fn print_repl_functions_source<'a, const ASCII_ONLY: bool>(
     source: &'a bun_ast::Source,
     opts: &Options<'a>,
     repl_functions: &bun_ast::ast_result::ReplFunctions,
-) -> js_ast::symbol::Map {
+) -> Result<js_ast::symbol::Map, bun_core::Error> {
     let Some(mut slot) = repl_functions.string_expr.data.e_string() else {
-        return symbols;
+        return Ok(symbols);
     };
     // `NoOpRenamer` owns its `Map` and a `Printer` pins that borrow, so the
     // map could not be handed back for the main pass. Instead the sub-pass
@@ -7842,7 +7842,6 @@ fn print_repl_functions_source<'a, const ASCII_ONLY: bool>(
         tree,
     );
     let mut buffer_printer = BufferPrinter::init(BufferWriter::init());
-    let mut printed = true;
     {
         let mut printer =
             Printer::<&mut BufferPrinter, ASCII_ONLY, false, ASCII_ONLY, false, false>::init(
@@ -7854,24 +7853,14 @@ fn print_repl_functions_source<'a, const ASCII_ONLY: bool>(
                 source_map_builder,
             );
         for stmt in repl_functions.stmts.slice() {
-            if printer
-                .print_stmt(*stmt, TopLevel::init(IsTopLevel::Yes))
-                .is_err()
-                || printer.writer.get_error().is_err()
-            {
-                printed = false;
-                break;
-            }
+            printer.print_stmt(*stmt, TopLevel::init(IsTopLevel::Yes))?;
+            printer.writer.get_error()?;
             printer.print_semicolon_if_needed();
         }
-        if printed && printer.writer.done().is_err() {
-            printed = false;
-        }
+        printer.writer.done()?;
     }
-    if printed {
-        slot.data = bun_ast::StoreStr::new(bump.alloc_slice_copy(buffer_printer.ctx.get_written()));
-    }
-    symbols
+    slot.data = bun_ast::StoreStr::new(bump.alloc_slice_copy(buffer_printer.ctx.get_written()));
+    Ok(symbols)
 }
 
 pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOURCE_MAP: bool>(
@@ -7897,7 +7886,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
             source,
             &opts,
             repl_functions,
-        ),
+        )?,
         None => symbols,
     };
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7820,7 +7820,7 @@ fn print_repl_functions_source<'a, const ASCII_ONLY: bool>(
     // until this renamer (and the `Printer` borrowing it) is gone; the alias
     // is never dropped, so the buffers are freed exactly once, by the main
     // pass's renamer.
-    let shadow: js_ast::symbol::Map = unsafe { core::ptr::read(&symbols) };
+    let shadow: js_ast::symbol::Map = unsafe { core::ptr::read(&raw const symbols) };
     let mut sub_renamer = core::mem::ManuallyDrop::new(rename::NoOpRenamer::init(shadow, source));
     // Only formatting-relevant options carry over: no source maps, module
     // info, or transpiler cache for this pass.

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -105,6 +105,10 @@ pub struct NoOpRenamer<'a> {
     // every transpile (require-cache.test.ts "files transpiled and loaded don't
     // leak the output source code" — `await import()` re-transpiles each
     // iteration, so the leak compounds to OOM).
+    //
+    // One deliberate exception: `print_repl_functions_source` parks a
+    // `NoOpRenamer` over a never-dropped (`ManuallyDrop`) bitwise alias of the
+    // Map; the owned Map still reaches the main pass and is freed exactly once.
     pub symbols: symbol::Map,
     pub source: &'a bun_ast::Source,
 }

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -328,6 +328,11 @@ describe("Bun.Transpiler replMode", () => {
         expect(code).toMatch(/variables: \["def",\s*"a",\s*"c",\s*"ns"\]/);
       });
 
+      test("default + namespace import lists names in source order", () => {
+        const code = transpiler.transformSync('import def, * as ns from "mod"');
+        expect(code).toMatch(/variables: \["def",\s*"ns"\]/);
+      });
+
       test("expression statements declare nothing", async () => {
         const result = await runRepl("1 + 2");
         expect(result).toEqual({ value: 3, variables: [], functions: "" });

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -331,6 +331,10 @@ describe("Bun.Transpiler replMode", () => {
       test("default + namespace import lists names in source order", () => {
         const code = transpiler.transformSync('import def, * as ns from "mod"');
         expect(code).toMatch(/variables: \["def",\s*"ns"\]/);
+        // Both bindings are hoisted and assigned: the default comes off the
+        // namespace that was just awaited.
+        expect(code).toContain("var def");
+        expect(code).toContain("def = ns.default");
       });
 
       test("expression statements declare nothing", async () => {
@@ -395,6 +399,36 @@ describe("Bun.Transpiler replMode", () => {
         const fresh = vm.createContext({});
         vm.runInContext(result.functions, fresh);
         expect(vm.runInContext("copy", fresh)).toBe(1);
+      });
+
+      test("later declarators may read earlier ones in the same statement", async () => {
+        const result = await runRepl("const a = 1, b = a, c = [a, b]; c");
+        expect(result.functions).toContain("var a = 1, b = a, c = [a, b]");
+
+        const fresh = vm.createContext({});
+        vm.runInContext(result.functions, fresh);
+        expect(vm.runInContext("[a, b, c]", fresh)).toEqual([1, 1, [1, 1]]);
+      });
+
+      test("destructuring defaults reading an excluded binding are excluded", async () => {
+        const ctx = vm.createContext({ effect: () => 41 });
+        // `[x = a] = []` evaluates `a` (not replayable) when replayed.
+        const code = transpiler.transformSync("let a = effect(); const [x = a] = []; x");
+        const result = await vm.runInContext(code, ctx);
+        expect(result.value).toBe(41);
+        expect(result.variables).toEqual(["a", "x"]);
+        expect(result.functions).toBe("");
+      });
+
+      test("classes with non-empty static blocks are not serialized", async () => {
+        // A static block body runs when the class is evaluated; it is not
+        // analyzed for references (here it reads `a`, which is not
+        // replayable), so such a class is never replayed.
+        const ctx = vm.createContext({ effect: () => 41 });
+        const code = transpiler.transformSync("let a = effect(); class S { static { a } }");
+        const result = await vm.runInContext(code, ctx);
+        expect(result.variables).toEqual(["a", "S"]);
+        expect(result.functions).toBe("");
       });
 
       test("using declarations are never serialized", () => {

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -85,33 +85,33 @@ describe("Bun.Transpiler replMode", () => {
 
     test("simple expression returns value object", async () => {
       const result = await runRepl("42");
-      expect(result).toEqual({ value: 42 });
+      expect(result).toEqual({ value: 42, variables: [], functions: "" });
     });
 
     test("arithmetic expression", async () => {
       const result = await runRepl("2 + 3 * 4");
-      expect(result).toEqual({ value: 14 });
+      expect(result).toEqual({ value: 14, variables: [], functions: "" });
     });
 
     test("string expression", async () => {
       const result = await runRepl('"hello world"');
-      expect(result).toEqual({ value: "hello world" });
+      expect(result).toEqual({ value: "hello world", variables: [], functions: "" });
     });
 
     test("object literal (auto-detected)", async () => {
       // Object literals don't need parentheses - the transpiler auto-detects them
       const result = await runRepl("{a: 1, b: 2}");
-      expect(result).toEqual({ value: { a: 1, b: 2 } });
+      expect(result).toEqual({ value: { a: 1, b: 2 }, variables: [], functions: "" });
     });
 
     test("array literal", async () => {
       const result = await runRepl("[1, 2, 3]");
-      expect(result).toEqual({ value: [1, 2, 3] });
+      expect(result).toEqual({ value: [1, 2, 3], variables: [], functions: "" });
     });
 
     test("await expression", async () => {
       const result = await runRepl("await Promise.resolve(100)");
-      expect(result).toEqual({ value: 100 });
+      expect(result).toEqual({ value: 100, variables: [], functions: "" });
     });
 
     test("await with variable", async () => {
@@ -122,7 +122,7 @@ describe("Bun.Transpiler replMode", () => {
 
       const code2 = transpiler.transformSync("x * 2");
       const result = await vm.runInContext(code2, ctx);
-      expect(result).toEqual({ value: 20 });
+      expect(result).toEqual({ value: 20, variables: [], functions: "" });
     });
   });
 
@@ -212,9 +212,12 @@ describe("Bun.Transpiler replMode", () => {
       // With semicolon, it's explicitly a block statement
       const code = transpiler.transformSync("{x: 1};");
       // The output should NOT treat this as an object literal
-      // It should be a block with a labeled statement, no value wrapper
-      expect(code).not.toContain("value:");
+      // It should be a block with a labeled statement and no completion value
+      // (the wrapper's own `value` property stays undefined)
       expect(code).toContain("x:");
+      const result = await runRepl("{x: 1};");
+      expect("value" in result).toBe(true);
+      expect(result).toEqual({ value: undefined, variables: [], functions: "" });
     });
 
     test("whitespace around object literal is handled", async () => {
@@ -252,7 +255,7 @@ describe("Bun.Transpiler replMode", () => {
       const code = transpiler.transformSync("await 1; await 2; await 3");
       const result = await vm.runInContext(code, ctx);
       // Last expression should be wrapped
-      expect(result).toEqual({ value: 3 });
+      expect(result).toEqual({ value: 3, variables: [], functions: "" });
     });
 
     test("destructuring assignment persists", async () => {
@@ -287,6 +290,112 @@ describe("Bun.Transpiler replMode", () => {
       const result = transpiler.transformSync("const fn = async () => await 1");
       // await inside arrow function doesn't trigger TLA transform
       expect(result).not.toMatch(/^\(async\s*\(\)/);
+    });
+  });
+
+  describe("result metadata", () => {
+    const transpiler = new Bun.Transpiler({ loader: "tsx", replMode: true });
+
+    async function runRepl(code: string, context?: object) {
+      const ctx = vm.createContext(context ?? { console, Promise });
+      return await vm.runInContext(transpiler.transformSync(code), ctx);
+    }
+
+    describe("variables", () => {
+      test("lists declared names in source order", async () => {
+        const result = await runRepl("var a = 1; let b = 2, c = 3; const d = await Promise.resolve(4)");
+        expect(result.variables).toEqual(["a", "b", "c", "d"]);
+      });
+
+      test("destructuring declarations list every bound name", async () => {
+        const result = await runRepl("const { a, b: [c, ...d], ...rest } = { a: 1, b: [2, 3], e: 4 }");
+        expect(result.variables).toEqual(["a", "c", "d", "rest"]);
+      });
+
+      test("function and class declarations are listed", async () => {
+        const result = await runRepl("function foo() {} class Bar {}");
+        expect(result.variables).toEqual(["foo", "Bar"]);
+      });
+
+      test("duplicate declarations are listed once", async () => {
+        const result = await runRepl("var x = 1; var x = 2; x");
+        expect(result.value).toBe(2);
+        expect(result.variables).toEqual(["x"]);
+      });
+
+      test("import bindings are listed, internal namespace refs are not", () => {
+        const code = transpiler.transformSync('import def, { a, b as c } from "mod"; import * as ns from "other"');
+        expect(code).toMatch(/variables: \["def",\s*"a",\s*"c",\s*"ns"\]/);
+      });
+
+      test("expression statements declare nothing", async () => {
+        const result = await runRepl("1 + 2");
+        expect(result).toEqual({ value: 3, variables: [], functions: "" });
+      });
+    });
+
+    describe("functions", () => {
+      test("captures replayable declarations that restore a fresh context", async () => {
+        const result = await runRepl("function add(a, b) { return a + b } const base = 10; add(base, 5)");
+        expect(result.value).toBe(15);
+        expect(result.variables).toEqual(["add", "base"]);
+        expect(result.functions).toContain("function add(a, b)");
+        // Pure `const`/`let` declarations are re-printed as `var` so replaying
+        // the source persists them onto a vm context.
+        expect(result.functions).toContain("var base = 10");
+
+        const fresh = vm.createContext({});
+        vm.runInContext(result.functions, fresh);
+        expect(vm.runInContext("add(base, 32)", fresh)).toBe(42);
+      });
+
+      test("classes are serialized as var assignments", async () => {
+        const result = await runRepl("class Counter { constructor() { this.n = 3 } }");
+        expect(result.functions).toContain("var Counter = class Counter");
+
+        const fresh = vm.createContext({});
+        vm.runInContext(result.functions, fresh);
+        expect(vm.runInContext("new Counter().n", fresh)).toBe(3);
+      });
+
+      test("declarations with side effects are excluded", async () => {
+        const ctx = vm.createContext({ effect: () => 123 });
+        const code = transpiler.transformSync(
+          "const pure = [1, 2]; const impure = effect(); function f() { return effect() }",
+        );
+        const result = await vm.runInContext(code, ctx);
+        expect(result.variables).toEqual(["pure", "impure", "f"]);
+        expect(result.functions).toContain("var pure = [1, 2]");
+        expect(result.functions).toContain("function f()");
+        expect(result.functions).not.toContain("impure");
+      });
+
+      test("declaration-only input still returns the wrapper", async () => {
+        const result = await runRepl("function later() { return 7 }");
+        // No completion value, but `value` stays an own property and the
+        // metadata is observable.
+        expect("value" in result).toBe(true);
+        expect(result.value).toBeUndefined();
+        expect(result.variables).toEqual(["later"]);
+        expect(result.functions).toContain("function later()");
+      });
+
+      test("TypeScript annotations are stripped from the printed source", async () => {
+        const result = await runRepl("const n: number = 1; function id<T>(x: T): T { return x }");
+        expect(result.functions).not.toContain(": number");
+        expect(result.functions).not.toContain("<T>");
+        expect(result.functions).toContain("var n = 1");
+        expect(result.functions).toContain("function id(x)");
+      });
+
+      test("async transform() returns the same metadata as transformSync()", async () => {
+        const code = await transpiler.transform("const q = 1; function g() {} q");
+        const result = await vm.runInContext(code, vm.createContext({}));
+        expect(result.value).toBe(1);
+        expect(result.variables).toEqual(["q", "g"]);
+        expect(result.functions).toContain("var q = 1");
+        expect(result.functions).toContain("function g()");
+      });
     });
   });
 

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -375,6 +375,37 @@ describe("Bun.Transpiler replMode", () => {
         expect(result.functions).not.toContain("impure");
       });
 
+      test("declarations reading an excluded binding are excluded too", async () => {
+        const ctx = vm.createContext({ effect: () => 41 });
+        // `a` has a side effect, so `b` (which reads `a` when evaluated) and
+        // `c` (which reads `b`) cannot be replayed; `copy` only reads `ok`.
+        const code = transpiler.transformSync(
+          "const ok = 1; let a = effect(); let b = a; let c = [b]; const copy = ok; b",
+        );
+        const result = await vm.runInContext(code, ctx);
+        expect(result.value).toBe(41);
+        expect(result.variables).toEqual(["ok", "a", "b", "c", "copy"]);
+        expect(result.functions).toContain("var ok = 1");
+        expect(result.functions).toContain("var copy = ok");
+        expect(result.functions).not.toContain("var a =");
+        expect(result.functions).not.toContain("var b =");
+        expect(result.functions).not.toContain("var c =");
+
+        // The whole string evaluates on an empty context.
+        const fresh = vm.createContext({});
+        vm.runInContext(result.functions, fresh);
+        expect(vm.runInContext("copy", fresh)).toBe(1);
+      });
+
+      test("using declarations are never serialized", () => {
+        // With `target: "bun"` a non-null `using` reaches the REPL transform
+        // unlowered; replaying it as a plain `var` would drop its disposal
+        // semantics, so it must not be captured even with a pure initializer.
+        const bunTarget = new Bun.Transpiler({ loader: "tsx", replMode: true, target: "bun" });
+        const code = bunTarget.transformSync("using res = { d: 1 }; 1");
+        expect(code).toContain('functions: ""');
+      });
+
       test("declaration-only input still returns the wrapper", async () => {
         const result = await runRepl("function later() { return 7 }");
         // No completion value, but `value` stays an own property and the

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -439,6 +439,19 @@ describe("Bun.Transpiler replMode", () => {
         expect(code).not.toContain("var x = foo");
       });
 
+      test("pure-annotated IIFEs are not serialized", async () => {
+        // The call runs the arrow body eagerly (here it reads `a`, which is
+        // not replayable); bodies are not analyzed, so the call is rejected.
+        const ctx = vm.createContext({ effect: () => 41 });
+        const code = transpiler.transformSync(
+          "let a = effect(); const x = /* @__PURE__ */ (() => a)(); const ok = 1; x",
+        );
+        const result = await vm.runInContext(code, ctx);
+        expect(result.value).toBe(41);
+        expect(result.functions).toContain("var ok = 1");
+        expect(result.functions).not.toContain("var x");
+      });
+
       test("using declarations are never serialized", () => {
         // With `target: "bun"` a non-null `using` reaches the REPL transform
         // unlowered; replaying it as a plain `var` would drop its disposal

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -431,6 +431,14 @@ describe("Bun.Transpiler replMode", () => {
         expect(result.functions).toBe("");
       });
 
+      test("declarations reading an import binding are excluded", () => {
+        // Import statements are never part of the `functions` string, so a
+        // declaration that eagerly reads an import binding cannot be replayed.
+        const code = transpiler.transformSync('import { foo } from "mod"; const x = foo; const y = 1');
+        expect(code).toContain("var y = 1");
+        expect(code).not.toContain("var x = foo");
+      });
+
       test("using declarations are never serialized", () => {
         // With `target: "bun"` a non-null `using` reaches the REPL transform
         // unlowered; replaying it as a plain `var` would drop its disposal

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -439,17 +439,26 @@ describe("Bun.Transpiler replMode", () => {
         expect(code).not.toContain("var x = foo");
       });
 
-      test("pure-annotated IIFEs are not serialized", async () => {
-        // The call runs the arrow body eagerly (here it reads `a`, which is
-        // not replayable); bodies are not analyzed, so the call is rejected.
+      test("pure-annotated calls are never serialized", async () => {
+        // A call runs a body that is not analyzed: the IIFE and `f()` both
+        // read `a`, which is not replayable, so neither `x` nor `y` can be.
         const ctx = vm.createContext({ effect: () => 41 });
         const code = transpiler.transformSync(
-          "let a = effect(); const x = /* @__PURE__ */ (() => a)(); const ok = 1; x",
+          "let a = effect(); function f() { return a } " +
+            "const x = /* @__PURE__ */ (() => a)(); const y = /* @__PURE__ */ f(); const ok = 1; x",
         );
         const result = await vm.runInContext(code, ctx);
         expect(result.value).toBe(41);
+        expect(result.functions).toContain("function f()");
         expect(result.functions).toContain("var ok = 1");
         expect(result.functions).not.toContain("var x");
+        expect(result.functions).not.toContain("var y");
+
+        // Defining `f` is safe even though calling it in a fresh context is
+        // not; the string itself must evaluate cleanly.
+        const fresh = vm.createContext({});
+        vm.runInContext(result.functions, fresh);
+        expect(vm.runInContext("ok", fresh)).toBe(1);
       });
 
       test("using declarations are never serialized", () => {


### PR DESCRIPTION
### What

`Bun.Transpiler({ replMode: true })` output now always evaluates to a result object with two new properties:

```js
{ __proto__: null, value, variables, functions }
```

- `value`: the snippet's completion value. Always an own property (undefined when the snippet has no trailing expression).
- `variables`: the names the snippet declares (`var`/`let`/`const`/`function`/`class`/import bindings), as an array of strings in source order.
- `functions`: printed source of the snippet's replayable declarations (function declarations, plus classes and locals whose initializers have no side effects and only read bindings the string itself declares), re-declared as `var`. Running the string in a fresh `node:vm` context re-creates them, so a REPL can accumulate these per evaluation and replay them to resume a session on a new VM. Function bodies are not analyzed: a replayed function that closed over non-replayable state throws when called, not when defined.

```js
const t = new Bun.Transpiler({ loader: "tsx", replMode: true });
const r = vm.runInContext(t.transformSync("function add(a, b) { return a + b } const base = 10; add(base, 5)"), ctx);
r.value;     // 15
r.variables; // ["add", "base"]
r.functions; // "function add(a, b) {\n  return a + b;\n}\nvar base = 10;\n"

vm.runInContext(r.functions, freshCtx); // restores add and base
```

### How

- `js_parser/repl_transforms.rs`: while hoisting declarations it now also collects the declared names (emitted as an array literal in the wrapper) and the statements that are safe to re-run: function declarations, classes that pass `class_can_be_removed_if_unused`, and locals whose bindings and initializers pass `expr_can_be_removed_if_unused_without_dce_check` and whose eagerly evaluated identifier reads are satisfied by the serialized declarations themselves (so `let a = effect(); let b = a` serializes neither, and the string never throws a ReferenceError when evaluated). `using` declarations are never serialized since replaying one as `var` would drop disposal. `let`/`const`/`class` are re-declared as `var` in that list so the replayed source persists onto a vm context the same way the REPL evaluation itself does. The wrapper `return` is now always emitted, with `value: undefined` when there is no trailing expression.
- `Ast.repl_functions` (new, `None` outside replMode) carries that statement list plus the `E::String` literal to fill.
- `js_printer::print_ast` runs a second print pass over those statements right before printing the tree and stores the result in that string literal. The pass uses its own `NoOpRenamer` over a `ManuallyDrop` alias of the symbol map (a `Printer` pins its renamer's borrow, so the map could not be handed back otherwise); this is the same pattern `get_source_map_builder` uses for a borrowed `line_offset_tables`.

Non-REPL printing is untouched: the only change on that path is one `Option` check in `print_ast`.

### Compatibility

`bun repl` evaluates this same wrapper and unwraps `.value` as an own property, which is why `value` is always present; its behavior is unchanged (declaration-only lines still print `undefined`). The wrapper previously was only returned when the last statement was an expression, so the existing `repl-transform.test.ts` assertions on the exact object shape were updated in this PR.

### Verification

- `bun bd test test/js/bun/transpiler/repl-transform.test.ts`: 51 pass (the new assertions fail without the src change).
- `bun bd test test/js/bun/repl/repl.test.ts`: 117 pass (end-to-end `bun repl`).
- `bun bd test test/bundler/transpiler/transpiler.test.js`: 171 pass, 0 fail.
- `bun test test/integration/bun-types/bun-types.test.ts`: 12 pass.

