### PR TITLE
structuredClone: fix back-references after BigInt, CryptoKey, and X509Certificate

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3429,6 +3429,13 @@ private:
         return i;
     }
 
+    // The readConstantPoolIndex byte width also depends on the pool size matching the
+    // serializer's, so an extra or missing entry desyncs the byte stream, not just the index.
+    void addToObjectPool(JSValue value)
+    {
+        m_objectPool.appendWithCrashOnOverflow(value);
+    }
+
     static bool readString(const uint8_t*& ptr, const uint8_t* end, String& str, unsigned length, bool is8Bit)
     {
         if (length >= std::numeric_limits<int32_t>::max() / sizeof(char16_t))
@@ -4884,13 +4891,13 @@ private:
         case FalseObjectTag: {
             BooleanObject* obj = BooleanObject::create(m_lexicalGlobalObject->vm(), m_globalObject->booleanObjectStructure());
             obj->setInternalValue(m_lexicalGlobalObject->vm(), jsBoolean(false));
-            m_gcBuffer.appendWithCrashOnOverflow(obj);
+            addToObjectPool(obj);
             return obj;
         }
         case TrueObjectTag: {
             BooleanObject* obj = BooleanObject::create(m_lexicalGlobalObject->vm(), m_globalObject->booleanObjectStructure());
             obj->setInternalValue(m_lexicalGlobalObject->vm(), jsBoolean(true));
-            m_gcBuffer.appendWithCrashOnOverflow(obj);
+            addToObjectPool(obj);
             return obj;
         }
         case DoubleTag: {
@@ -4906,7 +4913,7 @@ private:
             if (!read(d))
                 return JSValue();
             NumberObject* obj = constructNumber(m_globalObject, jsNumber(purifyNaN(d)));
-            m_gcBuffer.appendWithCrashOnOverflow(obj);
+            addToObjectPool(obj);
             return obj;
         }
         case BigIntObjectTag: {
@@ -4915,7 +4922,7 @@ private:
                 return JSValue();
             ASSERT(bigInt.isBigInt());
             BigIntObject* obj = BigIntObject::create(m_lexicalGlobalObject->vm(), m_globalObject, bigInt);
-            m_gcBuffer.appendWithCrashOnOverflow(obj);
+            addToObjectPool(obj);
             return obj;
         }
         case DateTag: {
@@ -5030,13 +5037,13 @@ private:
             if (!readStringData(cachedString))
                 return JSValue();
             StringObject* obj = constructString(m_lexicalGlobalObject->vm(), m_globalObject, cachedString->jsString(m_lexicalGlobalObject));
-            m_gcBuffer.appendWithCrashOnOverflow(obj);
+            addToObjectPool(obj);
             return obj;
         }
         case EmptyStringObjectTag: {
             VM& vm = m_lexicalGlobalObject->vm();
             StringObject* obj = constructString(vm, m_globalObject, jsEmptyString(vm));
-            m_gcBuffer.appendWithCrashOnOverflow(obj);
+            addToObjectPool(obj);
             return obj;
         }
         case RegExpTag: {
@@ -5089,12 +5096,12 @@ private:
             return ErrorInstance::create(m_lexicalGlobalObject, WTF::move(message), toErrorType(serializedErrorType), { line, column }, WTF::move(sourceURL), WTF::move(stackString));
         }
         case ObjectReferenceTag: {
-            auto index = readConstantPoolIndex(m_gcBuffer);
-            if (!index || *index >= m_gcBuffer.size()) {
+            auto index = readConstantPoolIndex(m_objectPool);
+            if (!index || *index >= static_cast<uint32_t>(m_objectPool.size())) {
                 fail();
                 return JSValue();
             }
-            return m_gcBuffer.at(*index);
+            return m_objectPool.at(*index);
         }
         case MessagePortReferenceTag: {
             uint32_t index;
@@ -5185,7 +5192,7 @@ private:
                 return JSValue();
             }
             JSValue result = JSArrayBuffer::create(m_lexicalGlobalObject->vm(), structure, WTF::move(arrayBuffer));
-            m_gcBuffer.appendWithCrashOnOverflow(result);
+            addToObjectPool(result);
             return result;
         }
         case ResizableArrayBufferTag: {
@@ -5202,7 +5209,7 @@ private:
                 return JSValue();
             }
             JSValue result = JSArrayBuffer::create(m_lexicalGlobalObject->vm(), structure, WTF::move(arrayBuffer));
-            m_gcBuffer.appendWithCrashOnOverflow(result);
+            addToObjectPool(result);
             return result;
         }
         case ArrayBufferTransferTag: {
@@ -5232,7 +5239,7 @@ private:
             m_sharedBuffers->at(index).shareWith(arrayBufferContents);
             auto buffer = ArrayBuffer::create(WTF::move(arrayBufferContents));
             JSValue result = getJSValue(buffer.get());
-            m_gcBuffer.appendWithCrashOnOverflow(result);
+            addToObjectPool(result);
             return result;
         }
         case ArrayBufferViewTag: {
@@ -5241,7 +5248,7 @@ private:
                 fail();
                 return JSValue();
             }
-            m_gcBuffer.appendWithCrashOnOverflow(arrayBufferView);
+            addToObjectPool(arrayBufferView);
             return arrayBufferView;
         }
 #if ENABLE(WEB_CRYPTO)
@@ -5342,6 +5349,10 @@ private:
     const uint8_t* const m_end;
     unsigned m_version;
     Vector<CachedString> m_constantPool;
+    // Mirrors CloneSerializer's m_objectPool: ObjectReferenceTag indexes into this.
+    // Only values the serializer passed to recordObject() may be appended here (via
+    // addToObjectPool), in the same order, or every later back-reference is wrong.
+    MarkedArgumentBuffer m_objectPool;
     // Vector<Ref<ImageData>> m_imageDataPool;
     const Vector<RefPtr<MessagePort>>& m_messagePorts;
     ArrayBufferContentsArray* m_arrayBufferContents;
@@ -5408,7 +5419,7 @@ DeserializationResult CloneDeserializer::deserialize()
             JSArray* outArray = constructEmptyArray(m_globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), length);
             if (scope.exception()) [[unlikely]]
                 goto error;
-            m_gcBuffer.appendWithCrashOnOverflow(outArray);
+            addToObjectPool(outArray);
             outputObjectStack.append(outArray);
         }
         arrayStartVisitMember:
@@ -5459,7 +5470,7 @@ DeserializationResult CloneDeserializer::deserialize()
             if (outputObjectStack.size() > maximumFilterRecursion)
                 return std::make_pair(JSValue(), SerializationReturnCode::StackOverflowError);
             JSObject* outObject = constructEmptyObject(m_lexicalGlobalObject, m_globalObject->objectPrototype());
-            m_gcBuffer.appendWithCrashOnOverflow(outObject);
+            addToObjectPool(outObject);
             outputObjectStack.append(outObject);
         }
         objectStartVisitMember:
@@ -5502,7 +5513,7 @@ DeserializationResult CloneDeserializer::deserialize()
             if (outputObjectStack.size() > maximumFilterRecursion)
                 return std::make_pair(JSValue(), SerializationReturnCode::StackOverflowError);
             JSMap* map = JSMap::create(m_lexicalGlobalObject->vm(), m_globalObject->mapStructure());
-            m_gcBuffer.appendWithCrashOnOverflow(map);
+            addToObjectPool(map);
             outputObjectStack.append(map);
             mapStack.append(map);
             goto mapDataStartVisitEntry;
@@ -5534,7 +5545,7 @@ DeserializationResult CloneDeserializer::deserialize()
             if (outputObjectStack.size() > maximumFilterRecursion)
                 return std::make_pair(JSValue(), SerializationReturnCode::StackOverflowError);
             JSSet* set = JSSet::create(m_lexicalGlobalObject->vm(), m_globalObject->setStructure());
-            m_gcBuffer.appendWithCrashOnOverflow(set);
+            addToObjectPool(set);
             outputObjectStack.append(set);
             setStack.append(set);
             goto setDataStartVisitEntry;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2014,6 +2014,8 @@ private:
                 const bool isTransferCompatible = m_forTransfer == SerializationForCrossProcessTransfer::Yes ? cloneable.isForTransfer : true;
                 const bool isStorageCompatible = m_forStorage == SerializationForStorage::Yes ? cloneable.isForStorage : true;
                 if (!isTransferCompatible || !isStorageCompatible) {
+                    if (!startObjectInternal(obj)) // handle duplicates
+                        return true;
                     write(ObjectTag);
                     write(TerminatorTag);
                     return true;

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -3,6 +3,7 @@ import { openSync } from "fs";
 import { bunEnv, tls } from "harness";
 import { bunExe } from "js/bun/shell/test_builder";
 import { X509Certificate } from "node:crypto";
+import { BlockList } from "node:net";
 import { join } from "path";
 function jscSerializeRoundtrip(value: any) {
   const serialized = serialize(value);
@@ -447,6 +448,15 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       const c = structuredCloneFn([b, b]);
       expect(c[0].valueOf()).toBe(5n);
       expect(c[1]).toBe(c[0]);
+    });
+
+    // Serializing a non-storable Bun cloneable (BlockList) for storage writes an
+    // empty-object placeholder; the serializer must still record it in its pool.
+    test("a duplicated object after a net.BlockList keeps its identity", () => {
+      const o = { x: 1 };
+      const c = structuredCloneFn([new BlockList(), o, o]);
+      expect(c[1]).toEqual({ x: 1 });
+      expect(c[2]).toBe(c[1]);
     });
 
     test("a back-reference past 255 interleaved BigInts", () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -399,3 +399,60 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
     });
   }
 });
+
+// A repeated object is serialized as an ObjectReferenceTag holding an index into the
+// serializer's object pool. The deserializer must rebuild that pool entry-for-entry:
+// any value it appends that the serializer did not record (BigInt primitives,
+// CryptoKey, X509Certificate) shifts every later back-reference, and the index byte
+// width depends on the pool size, so a big enough mismatch desyncs the whole stream.
+for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSerializeRoundtripCrossProcess]) {
+  describe(`${structuredCloneFn.name}: object pool back-references`, () => {
+    test.each([
+      ["heap BigInt", 1n],
+      ["zero BigInt", 0n],
+      ["200-bit BigInt", 2n ** 200n],
+      ["BigInt object", Object(7n)],
+    ])("a duplicated object after a %s keeps its identity", (_name, bigint) => {
+      const o = { x: 1 };
+      const c = structuredCloneFn([bigint, o, o]);
+      expect(c[1]).toEqual({ x: 1 });
+      expect(c[2]).toBe(c[1]);
+    });
+
+    test("a circular reference after a BigInt resolves to itself", () => {
+      const s: any = {};
+      s.self = s;
+      const d = structuredCloneFn([1n, s]);
+      expect(d[1].self).toBe(d[1]);
+    });
+
+    test("a duplicated BigInt object keeps its identity", () => {
+      const b = Object(5n);
+      const c = structuredCloneFn([b, b]);
+      expect(c[0].valueOf()).toBe(5n);
+      expect(c[1]).toBe(c[0]);
+    });
+
+    test("a back-reference past 255 interleaved BigInts", () => {
+      const o = { marker: "hello" };
+      const input: unknown[] = [o];
+      for (let i = 0; i < 300; i++) input.push((1n << 64n) + BigInt(i));
+      input.push(o);
+      const c = structuredCloneFn(input);
+      expect(c[300]).toBe((1n << 64n) + 299n);
+      expect(c[301]).toEqual({ marker: "hello" });
+      expect(c[301]).toBe(c[0]);
+    });
+  });
+}
+
+describe("structuredClone object pool back-references after platform objects", () => {
+  test("a duplicated object after a CryptoKey keeps its identity", async () => {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 128 }, true, ["encrypt", "decrypt"]);
+    const o = { x: 1 };
+    const c = structuredClone([key, o, o]);
+    expect(c[0]).toBeInstanceOf(CryptoKey);
+    expect(c[1]).toEqual({ x: 1 });
+    expect(c[2]).toBe(c[1]);
+  });
+});

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,7 +1,8 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { bunEnv } from "harness";
+import { bunEnv, tls } from "harness";
 import { bunExe } from "js/bun/shell/test_builder";
+import { X509Certificate } from "node:crypto";
 import { join } from "path";
 function jscSerializeRoundtrip(value: any) {
   const serialized = serialize(value);
@@ -461,13 +462,27 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
   });
 }
 
-describe("structuredClone object pool back-references after platform objects", () => {
-  test("a duplicated object after a CryptoKey keeps its identity", async () => {
-    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 128 }, true, ["encrypt", "decrypt"]);
-    const o = { x: 1 };
-    const c = structuredClone([key, o, o]);
-    expect(c[0]).toBeInstanceOf(CryptoKey);
-    expect(c[1]).toEqual({ x: 1 });
-    expect(c[2]).toBe(c[1]);
+// CryptoKey and X509Certificate are the platform objects the deserializer appends to
+// m_gcBuffer for GC protection without the serializer having recorded them.
+for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSerializeRoundtripCrossProcess]) {
+  describe(`${structuredCloneFn.name}: object pool back-references after platform objects`, () => {
+    test("a duplicated object after a CryptoKey keeps its identity", async () => {
+      const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 128 }, true, ["encrypt", "decrypt"]);
+      const o = { x: 1 };
+      const c = structuredCloneFn([key, o, o]);
+      expect(c[0]).toBeInstanceOf(CryptoKey);
+      expect(c[1]).toEqual({ x: 1 });
+      expect(c[2]).toBe(c[1]);
+    });
+
+    test("a duplicated object after an X509Certificate keeps its identity", () => {
+      const cert = new X509Certificate(tls.cert);
+      const o = { x: 1 };
+      const c = structuredCloneFn([cert, o, o]);
+      expect(c[0]).toBeInstanceOf(X509Certificate);
+      expect(c[0].subject).toBe(cert.subject);
+      expect(c[1]).toEqual({ x: 1 });
+      expect(c[2]).toBe(c[1]);
+    });
   });
-});
+}

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -426,6 +426,21 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       expect(d[1].self).toBe(d[1]);
     });
 
+    // https://github.com/oven-sh/bun/issues/16547
+    test("a TypedArray and DataView sharing an ArrayBuffer, after a BigInt", () => {
+      const bf = new ArrayBuffer(128);
+      const typed = new Int32Array(bf);
+      typed[0] = 0x1234;
+      const dataview = new DataView(bf);
+      const c = structuredCloneFn({ bigint: 123456789n, bf, typed, dataview });
+      expect(c.bigint).toBe(123456789n);
+      expect(c.typed).toBeInstanceOf(Int32Array);
+      expect(c.typed[0]).toBe(0x1234);
+      expect(c.typed.length).toBe(32);
+      expect(c.typed.buffer).toBe(c.bf);
+      expect(c.dataview.buffer).toBe(c.bf);
+    });
+
     test("a duplicated BigInt object keeps its identity", () => {
       const b = Object(5n);
       const c = structuredCloneFn([b, b]);


### PR DESCRIPTION
Fixes #16547

### Problem

`structuredClone` (and everything on the same serializer: `postMessage`, `Worker`, `MessageChannel`, `BroadcastChannel`, `bun:jsc` `serialize`/`deserialize`) silently resolves back-references to the wrong value once the graph contains a `BigInt`:

```js
const o = { x: 1 };
const c = structuredClone([1n, o, o]);
// node:  c[1] === c[2]   (identity preserved)
// bun:   c[2] === 1n     (the back-reference resolves to the BigInt)

const s = {}; s.self = s;
const d = structuredClone([1n, s]);
// node:  d[1].self === d[1]     bun: false
```

When the mis-resolved value is the wrong type for the site that references it, deserialization fails outright. That is the shape reported in #16547: a `TypedArray` or `DataView` sharing an `ArrayBuffer` that also appears elsewhere in the graph, with a `BigInt` anywhere before it:

```js
const bf = new ArrayBuffer(128);
const data = { bigint: 123456789n, bf, typed: new Int32Array(bf) };
structuredClone(data);
// node: works          bun: TypeError: Unable to deserialize data.
```

The view's back-reference to its buffer lands on the `BigInt` instead, which `readArrayBufferView` rejects. The same thing happens after a `CryptoKey` or a `node:crypto` `X509Certificate`. And because the back-reference index is written with a byte width derived from the pool size on each side, once the two counts straddle 255 the reader pulls the wrong number of bytes and the whole stream desyncs:

```js
const o = { marker: "hello" };
const a = [o, ...Array.from({ length: 254 }, (_, i) => BigInt(i + 1)), o];
structuredClone(a);
// node: works          bun: TypeError: Unable to deserialize data.
```

No error in the identity cases: wrong values and wrong identities come back silently.

### Cause

`CloneSerializer` assigns each recordable object a sequential index in its object pool and writes later occurrences as `ObjectReferenceTag <index>`. `CloneDeserializer` reused `m_gcBuffer`, its GC protection buffer, as the pool that `ObjectReferenceTag` indexes into.

Several deserializer paths append to `m_gcBuffer` purely for GC protection, for values the serializer never records in its pool: primitive BigInts (`readBigInt`, three sites), `CryptoKeyTag`, `X509CertificateTag`, `WasmMemoryTag`, and `BigIntObjectTag` (which appended twice: the inner BigInt plus the wrapper). Every such append shifts all subsequent back-references by one, and grows the apparent pool size that `readConstantPoolIndex` uses to pick the index byte width.

Upstream WebKit fixed this bug class in 2023 by giving the deserializer a dedicated `m_objectPool` that mirrors the serializer's exactly; Bun's fork predates that.

One serializer-side site shares the class. A Bun cloneable that opts out of for-storage or for-transfer serialization (for example `net.BlockList` through `bun:jsc` `serialize`) was written as an empty-object placeholder `ObjectTag` without going through `startObjectInternal`, while the deserializer's generic `ObjectTag` handler does pool the placeholder. Same mismatch, from the other side.

### Fix

Port the essential part of the upstream fix: `CloneDeserializer` gets a dedicated `MarkedArgumentBuffer m_objectPool`, populated via a new `addToObjectPool()` at exactly the 14 tag sites that correspond to a serializer-side `recordObject()` (the Boolean/Number/BigInt/String object wrappers, the ArrayBuffer variants, ArrayBufferView, Array, Object, Map, Set). `ObjectReferenceTag` now indexes into that. The GC-protection-only appends (BigInt primitives, CryptoKey, X509Certificate, WebAssembly.Memory) stay on `m_gcBuffer`, which is no longer read.

The one serializer-side change records the non-storable placeholder through `startObjectInternal` like every other pooled object, which also preserves the identity of a non-storable cloneable that appears more than once.

Everything else is deserializer-only. The serializer's pool and index widths were otherwise always correct, so previously serialized bytes deserialize correctly, with one exception that predates this PR: a for-storage blob produced by an older Bun that contained such a placeholder followed by a back-reference had the mismatch written into the bytes at serialization time, so no reader can repair it.

### Verification

33 new tests in `test/js/web/workers/structured-clone.test.ts` (duplicate identity and circular references after heap/zero/200-bit BigInts and BigInt objects, a duplicated BigInt object, the `TypedArray`/`DataView` sharing an `ArrayBuffer` from #16547, the 255-boundary desync, and a duplicate after a `CryptoKey`, after an `X509Certificate`, and after a non-storable `net.BlockList`), each run through `structuredClone`, `bun:jsc` `serialize`/`deserialize` in-process, and a cross-process round trip.

32 of the 33 fail on the current release (`Unable to deserialize data.`, wrong identities, wrong values) and all 33 pass with the fix; the one that passes both ways is the `net.BlockList` case through plain `structuredClone`, which never takes the placeholder path. The 313 pre-existing tests across the four structured-clone test files still pass.


