### PR TITLE
bun:ffi: don't re-throw JSC's TerminationException from a JSCallback

### DIFF
--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -184,24 +184,26 @@ JSFFIFunction* JSFFIFunction::createForFFI(VM& vm, Zig::GlobalObject* globalObje
 
 } // namespace JSC
 
+// Shared tail for the FFI_Callback_* entry points: call back into JS and leave any exception
+// pending on the VM, like any other host function. Clearing + re-throwing it (the old NakedPtr
+// dance) violated VM::setException's precondition for worker.terminate()'s TerminationException
+// once the outermost VMEntryScope had already retired the termination request.
+static JSC::EncodedJSValue invokeFFICallback(Zig::GlobalObject* globalObject, JSC::JSFunction* function, JSC::MarkedArgumentBuffer& arguments)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsNull()));
+    return JSC::JSValue::encode(result);
+}
+
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
     JSC::MarkedArgumentBuffer arguments;
     for (size_t i = 0; i < argCount; ++i)
         arguments.appendWithCrashOnOverflow(JSC::JSValue::decode(args[i]));
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
 
 extern "C" void
@@ -214,160 +216,74 @@ FFI_Callback_threadsafe_call(FFICallbackFunctionWrapper& wrapper, size_t argCoun
 
     WebCore::ScriptExecutionContext::postTaskTo(wrapper.m_contextId, [argsVec = WTF::move(argsVec), protectedWrapper = Ref { wrapper }](WebCore::ScriptExecutionContext& ctx) mutable {
         auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(ctx.jsGlobalObject());
-        auto& vm = JSC::getVM(globalObject);
+        // The worker may have been terminated (or the VM begun shutting down) between
+        // enqueue and dispatch; never re-enter JS on a stopped global.
+        if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
+            return;
         JSC::MarkedArgumentBuffer arguments;
-        auto* function = protectedWrapper->m_function.get();
         for (size_t i = 0; i < argsVec.size(); ++i)
             arguments.appendWithCrashOnOverflow(JSC::JSValue::decode(argsVec[i]));
-        WTF::NakedPtr<JSC::Exception> exception;
-        JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-        if (exception) [[unlikely]] {
-            auto scope = DECLARE_THROW_SCOPE(vm);
-            scope.throwException(globalObject, exception);
-            return;
-        }
+        invokeFFICallback(globalObject, protectedWrapper->m_function.get(), arguments);
     });
 }
 
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_0(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
-
     JSC::MarkedArgumentBuffer arguments;
-
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
 
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_1(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
-
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
-
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
 
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_2(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
-
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
-
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
 
 extern "C" JSC::EncodedJSValue FFI_Callback_call_3(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
-
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
     arguments.append(JSC::JSValue::decode(args[2]));
-
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
 
 extern "C" JSC::EncodedJSValue FFI_Callback_call_4(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
-
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
     arguments.append(JSC::JSValue::decode(args[2]));
     arguments.append(JSC::JSValue::decode(args[3]));
-
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
 
 extern "C" JSC::EncodedJSValue FFI_Callback_call_5(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
-
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
     arguments.append(JSC::JSValue::decode(args[2]));
     arguments.append(JSC::JSValue::decode(args[3]));
     arguments.append(JSC::JSValue::decode(args[4]));
-
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
 
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_6(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
-
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
@@ -375,25 +291,12 @@ FFI_Callback_call_6(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::E
     arguments.append(JSC::JSValue::decode(args[3]));
     arguments.append(JSC::JSValue::decode(args[4]));
     arguments.append(JSC::JSValue::decode(args[5]));
-
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }
 
 extern "C" JSC::EncodedJSValue
 FFI_Callback_call_7(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-    auto* function = wrapper.m_function.get();
-    auto* globalObject = wrapper.globalObject.get();
-    auto& vm = JSC::getVM(globalObject);
-
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(JSC::JSValue::decode(args[0]));
     arguments.append(JSC::JSValue::decode(args[1]));
@@ -402,14 +305,5 @@ FFI_Callback_call_7(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::E
     arguments.append(JSC::JSValue::decode(args[4]));
     arguments.append(JSC::JSValue::decode(args[5]));
     arguments.append(JSC::JSValue::decode(args[6]));
-
-    WTF::NakedPtr<JSC::Exception> exception;
-    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, function, JSC::getCallData(function), JSC::jsUndefined(), arguments, exception);
-    if (exception) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        scope.throwException(globalObject, exception);
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(result);
+    return invokeFFICallback(wrapper.globalObject.get(), wrapper.m_function.get(), arguments);
 }

--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -185,9 +185,8 @@ JSFFIFunction* JSFFIFunction::createForFFI(VM& vm, Zig::GlobalObject* globalObje
 } // namespace JSC
 
 // Shared tail for the FFI_Callback_* entry points: call back into JS and leave any exception
-// pending on the VM, like any other host function. Clearing + re-throwing it (the old NakedPtr
-// dance) violated VM::setException's precondition for worker.terminate()'s TerminationException
-// once the outermost VMEntryScope had already retired the termination request.
+// pending on the VM, like any other host function. Never clear and re-throw here: re-installing
+// the TerminationException once the termination request is retired trips VM::setException.
 static JSC::EncodedJSValue invokeFFICallback(Zig::GlobalObject* globalObject, JSC::JSFunction* function, JSC::MarkedArgumentBuffer& arguments)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -215,10 +215,6 @@ FFI_Callback_threadsafe_call(FFICallbackFunctionWrapper& wrapper, size_t argCoun
 
     WebCore::ScriptExecutionContext::postTaskTo(wrapper.m_contextId, [argsVec = WTF::move(argsVec), protectedWrapper = Ref { wrapper }](WebCore::ScriptExecutionContext& ctx) mutable {
         auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(ctx.jsGlobalObject());
-        // The worker may have been terminated (or the VM begun shutting down) between
-        // enqueue and dispatch; never re-enter JS on a stopped global.
-        if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != JSC::ScriptExecutionStatus::Running) [[unlikely]]
-            return;
         JSC::MarkedArgumentBuffer arguments;
         for (size_t i = 0; i < argsVec.size(); ++i)
             arguments.appendWithCrashOnOverflow(JSC::JSValue::decode(argsVec[i]));

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -765,10 +765,9 @@ it.skipIf(isFFIUnavailable)("JSCallback tolerates worker.terminate() arriving in
         { returns: "void", args: [], threadsafe: true },
       );
 
-      // CFunction turns the callback's native function pointer back into a callable, so
-      // fire() re-enters JS through the native FFI trampoline. A threadsafe callback
-      // enqueues a task instead of calling synchronously, so it runs at the top of the
-      // worker's event loop once this module finishes evaluating.
+      // CFunction makes the callback's native function pointer callable from JS. A threadsafe
+      // JSCallback enqueues a task instead of running synchronously, so the callback runs at
+      // the top of the worker's event loop once this module finishes evaluating.
       const fire = new CFunction({ ptr: callback.ptr, returns: "void", args: [] });
       fire();
 

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe, isGlibcVersionAtLeast, tempDir } from "harness";
+import { bunEnv, bunExe, isArm64, isGlibcVersionAtLeast, isWindows, tempDir } from "harness";
 import { platform } from "os";
 
 import {
@@ -677,26 +677,49 @@ it(".ptr is not leaked", () => {
   }
 });
 
-it("JSCallback exceptions propagate out of the native call", () => {
-  const callback = new JSCallback(
-    () => {
-      throw new Error("boom");
-    },
-    { returns: "int32_t", args: [] },
-  );
-  const call = new CFunction({ ptr: callback.ptr, returns: "int32_t", args: [] });
-  try {
-    expect(call).toThrow("boom");
-  } finally {
-    callback.close();
-  }
+// TinyCC, which implements JSCallback and CFunction, is unavailable on Windows ARM64.
+const isFFIUnavailable = isWindows && isArm64;
+
+// Runs in a subprocess: `bun test`'s exit path does not finalize the CFunction's native handle,
+// which the ASan lane's leak checker then reports against this file.
+it.skipIf(isFFIUnavailable)("JSCallback exceptions propagate out of the native call", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { CFunction, JSCallback } from "bun:ffi";
+      const callback = new JSCallback(
+        () => {
+          throw new Error("boom");
+        },
+        { returns: "int32_t", args: [] },
+      );
+      const call = new CFunction({ ptr: callback.ptr, returns: "int32_t", args: [] });
+      try {
+        call();
+        console.log("did not throw");
+      } catch (e) {
+        console.log("caught", e.message);
+      }
+      call.close();
+      callback.close();`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "caught boom\n",
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
 });
 
-// worker.terminate() while the worker is inside a threadsafe JSCallback made FFI_Callback_*
-// clear and re-throw JSC's TerminationException, which trips
-// "ASSERTION FAILED: !isTerminationException(exception) || hasTerminationRequest()" in
-// JSC::VM::setException and re-enters JS on the terminated worker VM.
-it("JSCallback tolerates worker.terminate() arriving inside the callback", async () => {
+// worker.terminate() delivered inside a threadsafe JSCallback used to trip
+// "ASSERTION FAILED: !isTerminationException(exception) || hasTerminationRequest()"
+// in JSC::VM::setException on the worker thread and re-enter the terminated VM.
+it.skipIf(isFFIUnavailable)("JSCallback tolerates worker.terminate() arriving inside the callback", async () => {
   using dir = tempDir("ffi-jscallback-terminate", {
     "main.js": `
       import { join } from "node:path";
@@ -743,14 +766,13 @@ it("JSCallback tolerates worker.terminate() arriving inside the callback", async
       );
 
       // CFunction turns the callback's native function pointer back into a callable, so
-      // each fire() re-enters JS through the native FFI trampoline. A threadsafe callback
-      // enqueues a task instead of calling synchronously, so both run at the top of the
+      // fire() re-enters JS through the native FFI trampoline. A threadsafe callback
+      // enqueues a task instead of calling synchronously, so it runs at the top of the
       // worker's event loop once this module finishes evaluating.
       const fire = new CFunction({ ptr: callback.ptr, returns: "void", args: [] });
       fire();
-      fire();
 
-      // Keep the worker alive until the queued callback tasks run.
+      // Keep the worker alive until the queued callback task runs.
       setInterval(() => {}, 1000);
     `,
   });

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -711,7 +711,7 @@ it.skipIf(isFFIUnavailable)("JSCallback exceptions propagate out of the native c
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout, stderr, exitCode }).toEqual({
     stdout: "caught boom\n",
-    stderr: expect.any(String),
+    stderr: "",
     exitCode: 0,
   });
 });
@@ -785,11 +785,9 @@ it.skipIf(isFFIUnavailable)("JSCallback tolerates worker.terminate() arriving in
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // stderr is not asserted (debug builds write benign noise there), but including it in the
-  // received object surfaces the crash output whenever one of the other fields mismatches.
   expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
     stdout: "done\n",
-    stderr: expect.any(String),
+    stderr: "",
     exitCode: 0,
     signalCode: null,
   });

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -719,9 +719,7 @@ it("JSCallback tolerates worker.terminate() arriving inside the callback", async
       });
 
       // Wait until the worker thread is inside the native -> JS callback frame.
-      while (Atomics.load(flag, 0) === 0) {
-        await Bun.sleep(5);
-      }
+      await Atomics.waitAsync(flag, 0, 0).value;
 
       terminating = true;
       await worker.terminate();
@@ -738,6 +736,7 @@ it("JSCallback tolerates worker.terminate() arriving inside the callback", async
           // Tell the parent we are inside the native -> JS callback frame, then
           // spin until worker.terminate() delivers the TerminationException.
           Atomics.store(flag, 0, 1);
+          Atomics.notify(flag, 0);
           while (true) {}
         },
         { returns: "void", args: [], threadsafe: true },

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import { existsSync } from "fs";
-import { isGlibcVersionAtLeast } from "harness";
+import { bunEnv, bunExe, isGlibcVersionAtLeast, tempDir } from "harness";
 import { platform } from "os";
 
 import {
@@ -675,6 +675,103 @@ it(".ptr is not leaked", () => {
     expect(fn).not.toHaveProperty("ptr");
     expect(fn.ptr).toBeUndefined();
   }
+});
+
+it("JSCallback exceptions propagate out of the native call", () => {
+  const callback = new JSCallback(
+    () => {
+      throw new Error("boom");
+    },
+    { returns: "int32_t", args: [] },
+  );
+  const call = new CFunction({ ptr: callback.ptr, returns: "int32_t", args: [] });
+  try {
+    expect(call).toThrow("boom");
+  } finally {
+    callback.close();
+  }
+});
+
+// worker.terminate() while the worker is inside a threadsafe JSCallback made FFI_Callback_*
+// clear and re-throw JSC's TerminationException, which trips
+// "ASSERTION FAILED: !isTerminationException(exception) || hasTerminationRequest()" in
+// JSC::VM::setException and re-enters JS on the terminated worker VM.
+it("JSCallback tolerates worker.terminate() arriving inside the callback", async () => {
+  using dir = tempDir("ffi-jscallback-terminate", {
+    "main.js": `
+      import { join } from "node:path";
+      import { Worker } from "node:worker_threads";
+
+      const sab = new SharedArrayBuffer(4);
+      const flag = new Int32Array(sab);
+
+      const worker = new Worker(join(import.meta.dir, "worker.js"), { workerData: sab });
+      let terminating = false;
+      worker.on("error", err => {
+        console.error("worker error:", err);
+        process.exit(1);
+      });
+      worker.on("exit", code => {
+        if (!terminating) {
+          console.error("worker exited early:", code);
+          process.exit(1);
+        }
+      });
+
+      // Wait until the worker thread is inside the native -> JS callback frame.
+      while (Atomics.load(flag, 0) === 0) {
+        await Bun.sleep(5);
+      }
+
+      terminating = true;
+      await worker.terminate();
+      console.log("done");
+    `,
+    "worker.js": `
+      import { CFunction, JSCallback } from "bun:ffi";
+      import { workerData } from "node:worker_threads";
+
+      const flag = new Int32Array(workerData);
+
+      const callback = new JSCallback(
+        () => {
+          // Tell the parent we are inside the native -> JS callback frame, then
+          // spin until worker.terminate() delivers the TerminationException.
+          Atomics.store(flag, 0, 1);
+          while (true) {}
+        },
+        { returns: "void", args: [], threadsafe: true },
+      );
+
+      // CFunction turns the callback's native function pointer back into a callable, so
+      // each fire() re-enters JS through the native FFI trampoline. A threadsafe callback
+      // enqueues a task instead of calling synchronously, so both run at the top of the
+      // worker's event loop once this module finishes evaluating.
+      const fire = new CFunction({ ptr: callback.ptr, returns: "void", args: [] });
+      fire();
+      fire();
+
+      // Keep the worker alive until the queued callback tasks run.
+      setInterval(() => {}, 1000);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // stderr is not asserted (debug builds write benign noise there), but including it in the
+  // received object surfaces the crash output whenever one of the other fields mismatches.
+  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "done\n",
+    stderr: expect.any(String),
+    exitCode: 0,
+    signalCode: null,
+  });
 });
 
 const libPath =


### PR DESCRIPTION
### What

Calling `worker.terminate()` while the worker thread is inside a `bun:ffi` `JSCallback` makes the FFI callback glue re-throw JSC's own TerminationException. Assertion-enabled builds abort on the worker thread:

```
ASSERTION FAILED: !isTerminationException(exception) || hasTerminationRequest()
vendor/WebKit/Source/JavaScriptCore/runtime/VM.cpp(1072) : void JSC::VM::setException(Exception *)
```

Reproduces 5/5 with a debug build (no native library needed, `CFunction` over `cb.ptr` is enough):

```js
// worker.js: a threadsafe JSCallback that signals the parent, then spins
const callback = new JSCallback(() => { Atomics.store(flag, 0, 1); while (true) {} },
  { returns: "void", args: [], threadsafe: true });
const fire = new CFunction({ ptr: callback.ptr, returns: "void", args: [] });
fire();
// main.js: wait for flag[0], then worker.terminate()
```

The racier sibling of the same bug shows up as `ASSERTION FAILED: !exception()` in `ExceptionScope.h(61)` when the next queued callback task enters `Interpreter::executeCallImpl` with the re-thrown exception still pending.

### Cause

Every `FFI_Callback_*` entry point in `src/jsc/bindings/JSFFIFunction.cpp` called the JS function through the `NakedPtr<Exception>` overload of `profiledCall` (which clears the VM's exception) and then unconditionally re-threw it with `scope.throwException()`.

A threadsafe `JSCallback` runs from a posted event-loop task, so its `profiledCall` is the outermost VM entry. When `worker.terminate()` lands inside that callback, JSC throws the TerminationException, and the outermost `VMEntryScope` teardown retires the termination request (`VM::clearHasTerminationRequest`). Re-installing the engine's own TerminationException after that violates `VM::setException`'s precondition, and in a no-assert build it leaves a half-terminated worker VM with a stale pending TerminationException that the next JS entry trips over.

### Fix

The clear-and-rethrow round trip was an inlined, incorrect re-implementation of "leave the exception pending". Do that directly: all ten `FFI_Callback_*` entry points now share one `invokeFFICallback()` helper that uses the plain `profiledCall` overload and `RETURN_IF_EXCEPTION`, leaving whatever JSC threw (user exception or TerminationException) pending on the VM like any other host function.

- Nested case (JS -> native -> callback): unchanged, the pending exception still surfaces at the enclosing FFI call site.
- Top-of-event-loop case (threadsafe task): the task dispatcher already recognizes a pending TerminationException and stops the tick loop, which is the path every other task-based JS entry uses.

### Verification

Two tests in `test/js/bun/ffi/ffi.test.js`:

- `JSCallback tolerates worker.terminate() arriving inside the callback`: spawns the repro above as a child. Unfixed `bun-debug` aborts with the assertion (SIGABRT); fixed passes 10/10.
- `JSCallback exceptions propagate out of the native call`: pins the normal-exception contract (a throwing callback still raises at the FFI call site), identical before and after.

The assertion only exists in `ASSERT_ENABLED` JSC builds, so the release binary passes the first test before and after; debug/ASAN is where it distinguishes. Both tests are skipped on Windows ARM64, where TinyCC (and with it `JSCallback`/`CFunction`) is compiled out. The full existing `JSCallback`/`CFunction`/threadsafe-callback matrix in `ffi.test.js` passes with the change.

Related: #32780 and #32778 fix independent `JSCallback` bugs in the same functions (re-entering JS while a user exception is pending; trampoline freed under a native caller). This one is about the TerminationException specifically and composes with both, but whichever lands later needs a small rebase.

