### PR TITLE
structuredClone: keep the serializer and deserializer reference pools in sync

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -568,8 +568,13 @@ const uint8_t cryptoKeyOKPOpNameTagMaximumValue = 1;
  * Version 11. added support for Blob's memory cost.
  * Version 12. added support for agent cluster ID.
  * Version 13. added support for ErrorInstance objects.
+ * Version 14. Date, RegExp, Error, DOMException, CryptoKey, KeyObject, X509Certificate,
+ * and Bun cloneable types are recorded in the object reference pool on both sides.
  */
-[[maybe_unused]] static constexpr unsigned CurrentVersion = 13;
+[[maybe_unused]] static constexpr unsigned CurrentVersion = 14;
+// Deserializers must not pool the version 14 terminal types for older payloads,
+// whose writers never counted them, or the pool indices stop matching the writer's.
+[[maybe_unused]] static constexpr unsigned FirstVersionWithPooledTerminals = 14;
 [[maybe_unused]] static constexpr unsigned TerminatorTag = 0xFFFFFFFF;
 [[maybe_unused]] static constexpr unsigned StringPoolTag = 0xFFFFFFFE;
 [[maybe_unused]] static constexpr unsigned NonIndexPropertiesTag = 0xFFFFFFFD;
@@ -1589,6 +1594,8 @@ private:
     void dumpDOMException(JSObject* obj, SerializationReturnCode& code)
     {
         if (auto* exception = JSDOMException::toWrapped(m_lexicalGlobalObject->vm(), obj)) {
+            if (!startObjectInternal(obj)) // handle duplicates
+                return;
             write(DOMExceptionTag);
             write(exception->message());
             write(exception->name());
@@ -1631,6 +1638,8 @@ private:
         if (value.isObject()) {
             auto* obj = asObject(value);
             if (auto* dateObject = dynamicDowncast<DateInstance>(obj)) {
+                if (!startObjectInternal(dateObject)) // handle duplicates
+                    return true;
                 write(DateTag);
                 write(dateObject->internalNumber());
                 return true;
@@ -1710,12 +1719,16 @@ private:
             //     return true;
             // }
             if (auto* regExp = dynamicDowncast<RegExpObject>(obj)) {
+                if (!startObjectInternal(regExp)) // handle duplicates
+                    return true;
                 write(RegExpTag);
                 write(regExp->regExp()->pattern());
                 write(String::fromLatin1(JSC::Yarr::flagsString(regExp->regExp()->flags()).data()));
                 return true;
             }
             if (auto* errorInstance = dynamicDowncast<ErrorInstance>(obj)) {
+                if (!startObjectInternal(errorInstance)) // handle duplicates
+                    return true;
                 auto& vm = m_lexicalGlobalObject->vm();
                 auto errorTypeValue = errorInstance->get(m_lexicalGlobalObject, vm.propertyNames->name);
                 RETURN_IF_EXCEPTION(scope, false);
@@ -1850,6 +1863,8 @@ private:
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
+                if (!startObjectInternal(obj)) // handle duplicates
+                    return true;
                 write(CryptoKeyTag);
                 Vector<uint8_t> serializedKey;
                 // Vector<URLKeepingBlobAlive> dummyBlobHandles;
@@ -2010,12 +2025,12 @@ private:
             // write bun types
             auto _cloneable = StructuredCloneableSerialize::fromJS(value);
             if (_cloneable) {
+                if (!startObjectInternal(obj)) // handle duplicates
+                    return true;
                 auto cloneable = _cloneable.value();
                 const bool isTransferCompatible = m_forTransfer == SerializationForCrossProcessTransfer::Yes ? cloneable.isForTransfer : true;
                 const bool isStorageCompatible = m_forStorage == SerializationForStorage::Yes ? cloneable.isForStorage : true;
                 if (!isTransferCompatible || !isStorageCompatible) {
-                    if (!startObjectInternal(obj)) // handle duplicates
-                        return true;
                     write(ObjectTag);
                     write(TerminatorTag);
                     return true;
@@ -2029,10 +2044,10 @@ private:
             }
 
             if (auto* x509 = dynamicDowncast<Bun::JSX509Certificate>(obj)) {
-                write(Bun__X509CertificateTag);
                 X509* cert = x509->m_x509.get();
 
-                // Get the size needed for the DER encoding
+                // Encode before touching the output so a DER failure leaves no
+                // partially written tag and no stale object pool entry behind.
                 int size = i2d_X509(cert, nullptr);
                 if (size <= 0)
                     return false;
@@ -2041,20 +2056,21 @@ private:
                 der.reserveInitialCapacity(size);
                 der.grow(size);
 
-                // Get pointer to where we should write
                 unsigned char* der_ptr = der.begin();
-
-                // Write the DER encoding
-                if (i2d_X509(cert, &der_ptr) != size) {
+                if (i2d_X509(cert, &der_ptr) != size)
                     return false;
-                }
 
+                if (!startObjectInternal(x509)) // handle duplicates
+                    return true;
+                write(Bun__X509CertificateTag);
                 write(der);
 
                 return true;
             }
 
             if (auto* keyObject = dynamicDowncast<Bun::JSKeyObject>(obj)) {
+                if (!startObjectInternal(keyObject)) // handle duplicates
+                    return true;
                 write(Bun__KeyObjectTag);
 
                 auto& handle = keyObject->handle();
@@ -3438,6 +3454,14 @@ private:
         m_objectPool.appendWithCrashOnOverflow(value);
     }
 
+    // Date, RegExp, Error, and the other version 14 terminal types are only counted by
+    // the serializer's pool from version 14 on, so older payloads must not pool them here.
+    void addTerminalToObjectPool(JSValue value)
+    {
+        if (m_version >= FirstVersionWithPooledTerminals)
+            addToObjectPool(value);
+    }
+
     static bool readString(const uint8_t*& ptr, const uint8_t* end, String& str, unsigned length, bool is8Bit)
     {
         if (length >= std::numeric_limits<int32_t>::max() / sizeof(char16_t))
@@ -4674,7 +4698,9 @@ private:
         }
 
         if (buffer.size() == 0) {
-            return Bun::JSX509Certificate::create(m_lexicalGlobalObject->vm(), defaultGlobalObject(m_globalObject)->m_JSX509CertificateClassStructure.get(m_globalObject));
+            auto* cert_obj = Bun::JSX509Certificate::create(m_lexicalGlobalObject->vm(), defaultGlobalObject(m_globalObject)->m_JSX509CertificateClassStructure.get(m_globalObject));
+            addTerminalToObjectPool(cert_obj);
+            return cert_obj;
         }
         ncrypto::ClearErrorOnReturn clear_error_on_return;
         X509* ptr = nullptr;
@@ -4690,6 +4716,7 @@ private:
         auto* domGlobalObject = defaultGlobalObject(m_globalObject);
         auto* cert_obj = Bun::JSX509Certificate::create(m_lexicalGlobalObject->vm(), domGlobalObject->m_JSX509CertificateClassStructure.get(domGlobalObject), m_globalObject, WTF::move(cert_ptr));
         m_gcBuffer.appendWithCrashOnOverflow(cert_obj);
+        addTerminalToObjectPool(cert_obj);
 
         return cert_obj;
     }
@@ -4715,7 +4742,9 @@ private:
 
             KeyObject keyObject = KeyObject::create(WTF::move(keyData));
             Structure* structure = globalObject->m_JSSecretKeyObjectClassStructure.get(m_globalObject);
-            return JSSecretKeyObject::create(vm, structure, m_globalObject, WTF::move(keyObject));
+            auto* obj = JSSecretKeyObject::create(vm, structure, m_globalObject, WTF::move(keyObject));
+            addTerminalToObjectPool(obj);
+            return obj;
         }
         case CryptoKeyType::Public:
         case CryptoKeyType::Private: {
@@ -4740,7 +4769,9 @@ private:
                 }
                 auto keyObject = KeyObject::create(CryptoKeyType::Public, ncrypto::EVPKeyPointer(pkey));
                 Structure* structure = globalObject->m_JSPublicKeyObjectClassStructure.get(m_globalObject);
-                return JSPublicKeyObject::create(vm, structure, m_globalObject, WTF::move(keyObject));
+                auto* obj = JSPublicKeyObject::create(vm, structure, m_globalObject, WTF::move(keyObject));
+                addTerminalToObjectPool(obj);
+                return obj;
             }
 
             EVP_PKEY* pkey = PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr);
@@ -4750,7 +4781,9 @@ private:
             }
             auto keyObject = KeyObject::create(CryptoKeyType::Private, ncrypto::EVPKeyPointer(pkey));
             Structure* structure = globalObject->m_JSPrivateKeyObjectClassStructure.get(m_globalObject);
-            return JSPrivateKeyObject::create(vm, structure, m_globalObject, WTF::move(keyObject));
+            auto* obj = JSPrivateKeyObject::create(vm, structure, m_globalObject, WTF::move(keyObject));
+            addTerminalToObjectPool(obj);
+            return obj;
         }
         }
     }
@@ -4764,7 +4797,9 @@ private:
         if (!readStringData(name))
             return JSValue();
         auto exception = DOMException::create(message->string(), name->string());
-        return getJSValue(exception);
+        JSValue wrapper = getJSValue(exception);
+        addTerminalToObjectPool(wrapper);
+        return wrapper;
     }
 
     JSValue readBigInt()
@@ -4868,6 +4903,7 @@ private:
                 fail();
                 return JSValue();
             }
+            addTerminalToObjectPool(deserialized);
             return deserialized;
         }
 
@@ -4931,7 +4967,9 @@ private:
             double d;
             if (!read(d))
                 return JSValue();
-            return DateInstance::create(m_lexicalGlobalObject->vm(), m_globalObject->dateStructure(), d);
+            DateInstance* obj = DateInstance::create(m_lexicalGlobalObject->vm(), m_globalObject->dateStructure(), d);
+            addTerminalToObjectPool(obj);
+            return obj;
         }
         // case FileTag: {
         //     RefPtr<File> file;
@@ -5062,7 +5100,9 @@ private:
             }
             VM& vm = m_lexicalGlobalObject->vm();
             RegExp* regExp = RegExp::create(vm, pattern->string(), reFlags.value());
-            return RegExpObject::create(vm, m_globalObject->regExpStructure(), regExp);
+            RegExpObject* obj = RegExpObject::create(vm, m_globalObject->regExpStructure(), regExp);
+            addTerminalToObjectPool(obj);
+            return obj;
         }
         case ErrorInstanceTag: {
             SerializableErrorType serializedErrorType;
@@ -5095,7 +5135,9 @@ private:
                 fail();
                 return JSValue();
             }
-            return ErrorInstance::create(m_lexicalGlobalObject, WTF::move(message), toErrorType(serializedErrorType), { line, column }, WTF::move(sourceURL), WTF::move(stackString));
+            auto* obj = ErrorInstance::create(m_lexicalGlobalObject, WTF::move(message), toErrorType(serializedErrorType), { line, column }, WTF::move(sourceURL), WTF::move(stackString));
+            addTerminalToObjectPool(obj);
+            return obj;
         }
         case ObjectReferenceTag: {
             auto index = readConstantPoolIndex(m_objectPool);
@@ -5277,6 +5319,7 @@ private:
                 return JSValue();
             }
             m_gcBuffer.appendWithCrashOnOverflow(cryptoKey);
+            addTerminalToObjectPool(cryptoKey);
             return cryptoKey;
         }
 #endif

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2044,9 +2044,11 @@ private:
             }
 
             if (auto* x509 = dynamicDowncast<Bun::JSX509Certificate>(obj)) {
+                if (checkForDuplicate(x509))
+                    return true;
                 X509* cert = x509->m_x509.get();
 
-                // Encode before touching the output so a DER failure leaves no
+                // Encode before recording or writing so a DER failure leaves no
                 // partially written tag and no stale object pool entry behind.
                 int size = i2d_X509(cert, nullptr);
                 if (size <= 0)
@@ -2060,8 +2062,7 @@ private:
                 if (i2d_X509(cert, &der_ptr) != size)
                     return false;
 
-                if (!startObjectInternal(x509)) // handle duplicates
-                    return true;
+                recordObject(x509);
                 write(Bun__X509CertificateTag);
                 write(der);
 

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,7 +1,6 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { bunEnv, tls } from "harness";
-import { bunExe } from "js/bun/shell/test_builder";
+import { bunEnv, bunExe, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
 import { join } from "path";

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -2,9 +2,32 @@ import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
 import { bunEnv, tls } from "harness";
 import { bunExe } from "js/bun/shell/test_builder";
-import { X509Certificate } from "node:crypto";
+import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
 import { join } from "path";
+
+// Terminal object types that were never entered into the structured clone object
+// reference pool, so duplicated references to them came back as distinct copies.
+// `[label, make, expected constructor]`.
+const identityCases: [string, () => object, Function][] = [
+  ["Date", () => new Date(5), Date],
+  ["RegExp", () => /abc/gi, RegExp],
+  ["Error", () => new Error("boom"), Error],
+  ["EvalError", () => new EvalError("boom"), EvalError],
+  ["RangeError", () => new RangeError("boom"), RangeError],
+  ["ReferenceError", () => new ReferenceError("boom"), ReferenceError],
+  ["SyntaxError", () => new SyntaxError("boom"), SyntaxError],
+  ["TypeError", () => new TypeError("boom"), TypeError],
+  ["URIError", () => new URIError("boom"), URIError],
+  ["DOMException", () => new DOMException("boom", "NotFoundError"), DOMException],
+  ["Blob", () => new Blob(["hi"], { type: "text/plain" }), Blob],
+  ["File", () => new File(["hi"], "a.txt", { type: "text/plain" }), File],
+  ["X509Certificate", () => new X509Certificate(tls.cert), X509Certificate],
+  ["secret KeyObject", () => createSecretKey(Buffer.from("0123456789abcdef")), KeyObject],
+  ["public KeyObject", () => createPublicKey(tls.key), KeyObject],
+  ["private KeyObject", () => createPrivateKey(tls.key), KeyObject],
+];
+
 function jscSerializeRoundtrip(value: any) {
   const serialized = serialize(value);
   const cloned = deserialize(serialized);
@@ -164,6 +187,69 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         expect(cloned.has(value)).toBe(true);
       }
     });
+
+    // The cross-process transport only adds a process hop over the in-process byte round
+    // trip; it is covered once for the whole matrix outside this loop instead of here.
+    if (structuredCloneFn !== jscSerializeRoundtripCrossProcess) {
+      // Two references to the same object must deserialize to the same object:
+      // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+      describe("duplicated references preserve identity", () => {
+        test.each(identityCases)("%s", (_label, make, ctor) => {
+          const value = make();
+          const cloned = structuredCloneFn([value, value]);
+          expect(cloned[0]).toBeInstanceOf(ctor);
+          expect(cloned[0]).not.toBe(value);
+          expect(cloned[0]).toBe(cloned[1]);
+        });
+
+        test("CryptoKey", async () => {
+          const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt"]);
+          const cloned = structuredCloneFn([key, key]);
+          expect(cloned[0]).toBeInstanceOf(CryptoKey);
+          expect(cloned[0]).not.toBe(key);
+          expect(cloned[0]).toBe(cloned[1]);
+        });
+
+        test("same object reachable through object, array, Map, and Set paths", () => {
+          const d = new Date(7);
+          const e = new TypeError("boom");
+          const cloned = structuredCloneFn({ a: { d, e }, b: [d, e], map: new Map([["d", d]]), set: new Set([e]) });
+          expect(cloned.a.d).toBe(cloned.b[0]);
+          expect(cloned.a.e).toBe(cloned.b[1]);
+          expect(cloned.map.get("d")).toBe(cloned.a.d);
+          expect(cloned.set.has(cloned.a.e)).toBe(true);
+        });
+
+        // Types that already preserved identity must keep doing so.
+        test("control: already-pooled types", () => {
+          const obj = { x: 1 };
+          const arr = [1];
+          const map = new Map();
+          const set = new Set();
+          const buffer = new ArrayBuffer(4);
+          const view = new Uint8Array(buffer);
+          const num = Object(1);
+          const str = Object("s");
+          const bool = Object(true);
+          const bigint = Object(123n);
+          const cloned = structuredCloneFn([
+            [obj, obj],
+            [arr, arr],
+            [map, map],
+            [set, set],
+            [buffer, buffer],
+            [view, view],
+            [num, num],
+            [str, str],
+            [bool, bool],
+            [bigint, bigint],
+          ]);
+          for (const [first, second] of cloned) {
+            expect(first).toBe(second);
+          }
+        });
+      });
+    }
 
     describe("bun blobs work", () => {
       test("simple", async () => {
@@ -496,3 +582,53 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
     });
   });
 }
+
+describe("reference pool survives a process boundary", () => {
+  // One subprocess hop covering the whole identity matrix.
+  test("duplicated references preserve identity for every type", () => {
+    const values = identityCases.map(([, make]) => make());
+    const cloned = jscSerializeRoundtripCrossProcess(values.map(value => [value, value]));
+    for (let i = 0; i < identityCases.length; i++) {
+      expect(cloned[i][0]).toBeInstanceOf(identityCases[i][2]);
+      expect(cloned[i][0]).toBe(cloned[i][1]);
+    }
+  });
+});
+
+// Version 13 payloads were written before Date, RegExp, Error, and the other terminal
+// types were entered into the object reference pool. The deserializer must not pool
+// them for version < 14 or its indices stop matching what the writer counted.
+describe("deserializing a version 13 payload", () => {
+  const version13 = (base64: string) => {
+    const bytes = Buffer.from(base64, "base64");
+    // Sanity: the first four bytes of a payload are its little-endian version.
+    expect(bytes.readUint32LE(0)).toBe(13);
+    return deserialize(bytes);
+  };
+
+  // serialize([new Date(5), { tag: "first" }, { tag: "second" }, <ref first>, <ref second>])
+  // written by Bun 1.4.0. Pooling the Date unconditionally would shift the two
+  // back-references onto the Date and `first`.
+  test("back-references after a Date are not shifted by the version 14 behavior", () => {
+    const cloned = version13(
+      "DQAAAAEFAAAAAAAAAAsAAAAAAAAUQAEAAAACAwAAgHRhZxAFAACAZmlyc3T/////AgAAAAL+////ABAGAACAc2Vjb25k/////wMAAAATAQQAAAATAv////8=",
+    );
+    expect(cloned[0]).toBeInstanceOf(Date);
+    expect(+cloned[0]).toBe(5);
+    expect(cloned[1]).toEqual({ tag: "first" });
+    expect(cloned[2]).toEqual({ tag: "second" });
+    expect(cloned[3]).toBe(cloned[1]);
+    expect(cloned[4]).toBe(cloned[2]);
+  });
+
+  // serialize([new Date(5), new Date(5)]) written by Bun 1.4.0. The identity relationship
+  // was never in the version 13 payload, so it cannot be recovered.
+  test("duplicated Date references in old payloads stay distinct", () => {
+    const cloned = version13("DQAAAAECAAAAAAAAAAsAAAAAAAAUQAEAAAALAAAAAAAAFED/////");
+    expect(cloned[0]).toBeInstanceOf(Date);
+    expect(cloned[1]).toBeInstanceOf(Date);
+    expect(+cloned[0]).toBe(5);
+    expect(+cloned[1]).toBe(5);
+    expect(cloned[0]).not.toBe(cloned[1]);
+  });
+});


### PR DESCRIPTION
## Summary

`structuredClone`, `postMessage`, and `bun:jsc`'s `serialize`/`deserialize` share one serializer (`SerializedScriptValue.cpp`). It loses object identity for several serializable types: the same `Date` referenced twice comes back as two distinct `Date`s. HTML's StructuredSerializeInternal requires the memory map to cover every serialized object, and Node preserves all of these.

```js
const d = new Date(5);
const c = structuredClone([d, d]);
console.log(c[0] === c[1]); // Bun: false; Node and the HTML spec: true
```

The same applies to `RegExp`, every `Error` subclass, `DOMException`, `CryptoKey`, node's `KeyObject`, `X509Certificate`, and `Blob` / `File`.

## Cause

A repeated object is serialized as `ObjectReferenceTag <index>` into the serializer's object pool, and the deserializer rebuilds that pool entry for entry (#32791 gave it a dedicated `m_objectPool` for exactly this). None of the types above were ever entered into the pool on either side, so a repeat reference is simply serialized again as a fresh copy.

## Fix

Record them on both sides, 1:1, and bump the serialization format version.

Serializer (`CloneSerializer::dumpIfTerminal`): `startObjectInternal` for `DateInstance`, `RegExpObject`, `ErrorInstance`, `DOMException`, `CryptoKey`, `KeyObject`, `X509Certificate`, and the Bun cloneable types (`Blob`, `BlockList`). For the Bun cloneables this generalizes the change #32791 made on the for-transfer/for-storage placeholder path to the compatible path as well. The `X509Certificate` branch now encodes the DER before touching the output, so an `i2d_X509` failure no longer leaves a partially written tag behind.

Deserializer: a matching `addTerminalToObjectPool` call at each of those tag readers, gated on `m_version >= 14`. Version 13 writers did not count these types, so the reader must not pool them for version 13 payloads or the pool indices stop matching.

`CurrentVersion` goes from 13 to 14. Version 13 payloads (for example those persisted with `bun:jsc` `serialize`) keep deserializing correctly, and version 14 payloads are rejected by older readers through the existing `version > CurrentVersion` check instead of being silently misread.

Out of scope: `WebAssembly.Module` and `WebAssembly.Memory` also lose identity, but they are tracked in a separate side table on both sides (so there is no corruption), upstream WebKit behaves the same way, and fixing them is an unrelated mechanism.

Builds on #32791, which fixed the other half of this bug class: back-references corrupted by pool entries the deserializer recorded but the serializer never did (`BigInt`, `CryptoKey`, `X509Certificate`).

## Tests

Added to `test/js/web/workers/structured-clone.test.ts`:

- an identity test for every affected type, run through `structuredClone` and the in-process `bun:jsc` round trip, plus one cross-process round trip covering the whole matrix,
- a shared-reference test reaching the same `Date` and `TypeError` through object, array, `Map`, and `Set` paths,
- version 13 payload fixtures (serialized by Bun 1.4.0) proving old `bun:jsc` data still deserializes correctly and that the version gate is load-bearing,
- a control test asserting the already pooled types keep their identity.

Without the fix, 37 of the new tests fail and the 165 existing tests in the file (including the ones added by #32791) pass; with it, all 202 pass.
