### PR TITLE
Use forward slashes in source map sources on Windows

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1112,10 +1112,15 @@ impl<'a> LinkerContext<'a> {
 
                 // Note: the relative path lives in a local owned buffer
                 // (drops at scope exit).
-                let rel_path_storage;
+                let mut rel_path_storage;
                 let pretty: &[u8] = if path.is_file() {
                     rel_path_storage =
                         bun_paths::resolve_path::relative_alloc(chunk_abs_dir, path.text)?;
+                    // `sources` entries are URLs, so they always use forward slashes,
+                    // the same invariant `Path::pretty` holds (`assert_pretty_is_valid`).
+                    bun_paths::resolve_path::platform_to_posix_in_place::<u8>(
+                        &mut rel_path_storage,
+                    );
                     &rel_path_storage
                 } else {
                     path.pretty
@@ -1140,10 +1145,13 @@ impl<'a> LinkerContext<'a> {
 
                 let path = &sources[index as usize].path;
 
-                let rel_path_storage;
+                let mut rel_path_storage;
                 let pretty: &[u8] = if path.is_file() {
                     rel_path_storage =
                         bun_paths::resolve_path::relative_alloc(chunk_abs_dir, path.text)?;
+                    bun_paths::resolve_path::platform_to_posix_in_place::<u8>(
+                        &mut rel_path_storage,
+                    );
                     &rel_path_storage
                 } else {
                     path.pretty

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1075,6 +1075,18 @@ impl<'a> LinkerContext<'a> {
             .expect("TODO: handle error");
     }
 
+    /// The relative path from the chunk directory to a file source, as written
+    /// into the source map's `sources` array. `sources` entries are URLs, so the
+    /// host separator is normalized to `/` (the invariant `Path::pretty` holds).
+    fn source_map_relative_path(
+        chunk_abs_dir: &[u8],
+        source_abs_path: &[u8],
+    ) -> Result<Box<[u8]>, AllocError> {
+        let mut rel = bun_paths::resolve_path::relative_alloc(chunk_abs_dir, source_abs_path)?;
+        bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut rel);
+        Ok(rel)
+    }
+
     pub fn generate_source_map_for_chunk(
         &mut self,
         isolated_hash: u64,
@@ -1112,15 +1124,9 @@ impl<'a> LinkerContext<'a> {
 
                 // Note: the relative path lives in a local owned buffer
                 // (drops at scope exit).
-                let mut rel_path_storage;
+                let rel_path_storage;
                 let pretty: &[u8] = if path.is_file() {
-                    rel_path_storage =
-                        bun_paths::resolve_path::relative_alloc(chunk_abs_dir, path.text)?;
-                    // `sources` entries are URLs, so they always use forward slashes,
-                    // the same invariant `Path::pretty` holds (`assert_pretty_is_valid`).
-                    bun_paths::resolve_path::platform_to_posix_in_place::<u8>(
-                        &mut rel_path_storage,
-                    );
+                    rel_path_storage = Self::source_map_relative_path(chunk_abs_dir, path.text)?;
                     &rel_path_storage
                 } else {
                     path.pretty
@@ -1145,13 +1151,9 @@ impl<'a> LinkerContext<'a> {
 
                 let path = &sources[index as usize].path;
 
-                let mut rel_path_storage;
+                let rel_path_storage;
                 let pretty: &[u8] = if path.is_file() {
-                    rel_path_storage =
-                        bun_paths::resolve_path::relative_alloc(chunk_abs_dir, path.text)?;
-                    bun_paths::resolve_path::platform_to_posix_in_place::<u8>(
-                        &mut rel_path_storage,
-                    );
+                    rel_path_storage = Self::source_map_relative_path(chunk_abs_dir, path.text)?;
                     &rel_path_storage
                 } else {
                     path.pretty

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -446,3 +446,29 @@ describe.concurrent("sourcemap of a source with a truncated trailing UTF-8 seque
     });
   });
 });
+
+// `sources` entries in the emitted map are URLs: the path from the chunk
+// directory to each source must use forward slashes on every platform, never
+// the host path separator.
+test.concurrent("sourcemap sources use forward slashes on every platform", async () => {
+  using dir = tempDir("sourcemap-forward-slashes", {
+    "src/nested/in.js": `import { v } from "../dep.js";\nconsole.log(v);\n`,
+    "src/dep.js": `export const v = 1;\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--sourcemap=external", "--outdir=out", "src/nested/in.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ exitCode, stdout, stderr }).toEqual({
+    exitCode: 0,
+    stdout: expect.any(String),
+    stderr: expect.any(String),
+  });
+  // Two sources so both `sources` emission paths (first entry and the rest) are covered.
+  const map = await Bun.file(path.join(String(dir), "out", "in.js.map")).json();
+  expect(map.sources).toEqual(["../src/dep.js", "../src/nested/in.js"]);
+});


### PR DESCRIPTION
Fixes #14769

### Repro

`bun build --sourcemap` writes the host path separator into the `sources` entries of the emitted `.js.map`, so on Windows a source one directory above the out dir comes back as `..\in.js` instead of `../in.js`. Source map `sources` are URLs resolved against the map's location, where `\` is not a path separator; esbuild, which this code is ported from, explicitly converts to forward slashes here ("Make sure to always use forward slashes, even on Windows").

This is the bug reported in #14769: `bun build src/main.mjs --sourcemap=linked --outdir dist` on Windows produces a map whose `sources` all carry a `..\src\` prefix, and Chrome devtools shows the raw `..\src\main.mjs:5` in the console instead of resolving the frame back to `main.mjs:5`.

It is also what turned the Windows test lanes red. #32774 added the first test in the suite to pin an exact `sources` value, and it fails deterministically on all three Windows `test-bun` lanes (2019 x64, 2019 x64-baseline, 11 aarch64). From build 65191:

```
error: expect(received).toMatchObject(expected)

  {
    "sources": [
-     "../in.js",
+     "..\in.js",
    ],
  }

      at internal-sourcemap-roundtrip.test.ts:443:17
```

All six `sourcemap of a source with a truncated trailing UTF-8 sequence` variants fail the same way, on every retry. Main has not completed a Windows build since #32774 merged (each one since was superseded before the test lanes finished), so its next completed build, and every PR that merges main, hits this too.

### Cause

`LinkerContext::generate_source_map_for_chunk` computes each file source's relative path with `bun_paths::resolve_path::relative_alloc`, which uses the host separator (`platform::Auto`), and writes the result straight into the `sources` array.

Everywhere else an output-facing path is built, the tree already enforces forward slashes: `Path::pretty` carries a Windows debug assertion that it contains no backslashes (`assert_pretty_is_valid`), `dupe_alloc_fix_pretty` upholds it with `platform_to_posix_in_place`, and the dev server's source map writer plus the standalone module graph both normalize before emitting. The bundler's chunk source map writer is the one place that overrides `pretty` with a raw native relative path and skips the step. The non-file branch (`path.pretty`, virtual and plugin sources) already holds the invariant and is untouched.

### Fix

A new `source_map_relative_path` helper computes the relative path and calls `bun_paths::resolve_path::platform_to_posix_in_place` on it; both `sources` call sites (the first entry and the `source_indices[1..]` loop) go through it. The normalization is a compile-time no-op when the host separator is `/`, so POSIX output is byte-identical; on Windows the only change is `\` to `/` inside file-namespace `sources` entries.

### Verification

`test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts` gains a test that builds an entry in a nested directory with one import, so the two `sources` entries each cross multiple separators and between them cover both call sites, and pins them exactly:

```ts
expect(map.sources).toEqual(["../src/dep.js", "../src/nested/in.js"]);
```

Because the fixed function is a no-op on POSIX by construction, the failure is only observable on a Windows host. The three red Windows lanes in build 65191 above are the fail-before; the `sources: ["../in.js"]` assertions from #32774 and the new test are the regression coverage. The full roundtrip file, `bun-build-compile-sourcemap.test.ts`, `compile-sourcemap-internal.test.ts`, and the `snapshotSourceMap` bundler edge cases all pass with the change.

The `expectBundled` harness masks exactly this (`parsed.sources.map(a => a.replaceAll("\\", "/"))` at `expectBundled.ts:1617`), which is why no `test/bundler/` source map test ever caught it. Left in place since it also covers non-file `pretty` sources, which this change does not touch.
