### PR TITLE
http: don't retry a fetch with a ReadableStream body on keep-alive disconnect

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2886,10 +2886,9 @@ impl<'a> HTTPClient<'a> {
 
     pub fn write_to_stream<const IS_SSL: bool>(&mut self, socket: HttpSocket<IS_SSL>, data: &[u8]) {
         bun_core::scoped_log!(fetch, "flushStream");
-        // Never write body bytes before the request headers: drain_queued_writes
-        // can reach this via the not-yet-opened socket start_() registers in the
-        // abort tracker, and request_sent_len still indexes the header buffer.
-        // The data stays buffered; on_writable's Body/ProxyBody arm re-flushes.
+        // Never write body bytes before the request headers: drain_queued_writes can
+        // reach this via the not-yet-opened socket start_() puts in the abort tracker,
+        // and request_sent_len still indexes headers. on_writable's Body arm re-flushes.
         if !matches!(
             self.state.request_stage,
             RequestStage::Body | RequestStage::ProxyBody

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1899,6 +1899,10 @@ impl<'a> HTTPClient<'a> {
 
         if self.allow_retry
             && self.method.is_idempotent()
+            // Only a Bytes body can be rebuilt from `original_request_body`.
+            // Stream/Sendfile bodies are consumed as they are written, so a
+            // retry would silently replay a truncated request.
+            && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
             && self.state.response_stage != ResponseStage::Body
             && self.state.response_stage != ResponseStage::BodyChunk
         {
@@ -2882,6 +2886,16 @@ impl<'a> HTTPClient<'a> {
 
     pub fn write_to_stream<const IS_SSL: bool>(&mut self, socket: HttpSocket<IS_SSL>, data: &[u8]) {
         bun_core::scoped_log!(fetch, "flushStream");
+        // Never write body bytes before the request headers: drain_queued_writes
+        // can reach this via the not-yet-opened socket start_() registers in the
+        // abort tracker, and request_sent_len still indexes the header buffer.
+        // The data stays buffered; on_writable's Body/ProxyBody arm re-flushes.
+        if !matches!(
+            self.state.request_stage,
+            RequestStage::Body | RequestStage::ProxyBody
+        ) {
+            return;
+        }
         // reshaped for borrowck — copy out the Copy bits we need
         // (`upgrade_state`, the stream-buffer NonNull, `ended`) so the
         // `&mut self.state.original_request_body` borrow is dropped before any

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { tls } from "harness";
+import { bunEnv, bunExe, tls } from "harness";
 
 test("keepalive", async () => {
   using server = Bun.serve({
@@ -71,4 +71,102 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
   // connection, which cannot have the same client port.
   const plain = await get();
   expect(plain).not.toBe(overrideA);
+});
+
+// An idempotent request (PUT) on a reused keep-alive connection that the peer
+// resets is transparently retried, but a ReadableStream body is consumed as it
+// is uploaded and cannot be replayed: the already written chunks are gone, so a
+// retry silently sends a truncated body, and flushing the still-draining stream
+// onto the retry's not-yet-opened socket put body bytes ahead of the headers
+// and panicked with "range start index N out of range for slice of length M"
+// in send_initial_request_payload. Runs in a subprocess: the panic aborts the
+// whole process.
+test("PUT with a ReadableStream body is not retried on keep-alive disconnect", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const CRLF = String.fromCharCode(13, 10);
+      let warmRequests = 0;
+      let streamRequests = 0;
+
+      const server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          open(socket) { socket.data = { buffer: "" }; },
+          data(socket, data) {
+            socket.data.buffer += data.toString("latin1");
+            if (!socket.data.buffer.includes(CRLF)) return;
+            if (socket.data.buffer.startsWith("PUT /warm")) {
+              // Wait for the full 4-byte body before replying keep-alive.
+              const i = socket.data.buffer.indexOf(CRLF + CRLF);
+              if (i < 0 || socket.data.buffer.length < i + 4 + 4) return;
+              warmRequests++;
+              socket.data.buffer = "";
+              socket.write("HTTP/1.1 200 OK" + CRLF + "Content-Length: 2" + CRLF + "Connection: keep-alive" + CRLF + CRLF + "ok");
+              return;
+            }
+            if (socket.data.buffer.startsWith("PUT /stream")) {
+              streamRequests++;
+              socket.data.buffer = "";
+              // Reset the connection mid-upload.
+              socket.terminate();
+            }
+          },
+          close() {},
+          error() {},
+          drain() {},
+        },
+      });
+
+      const base = "http://127.0.0.1:" + server.port;
+      const chunk = new Uint8Array(1024);
+      const streamBody = () => {
+        let pending = 32;
+        return new ReadableStream({
+          pull(c) {
+            if (pending-- <= 0) return c.close();
+            c.enqueue(chunk);
+          },
+        });
+      };
+
+      const errors = [];
+      for (let i = 0; i < 4; i++) {
+        // Park a keep-alive connection so the stream PUT reuses it.
+        await (await fetch(base + "/warm", { method: "PUT", body: "warm" })).text();
+        try {
+          await fetch(base + "/stream", { method: "PUT", body: streamBody(), duplex: "half" });
+          errors.push(null);
+        } catch (e) {
+          errors.push(e && (e.code || e.name));
+        }
+      }
+
+      server.stop();
+      console.log(JSON.stringify({ warmRequests, streamRequests, errors }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // If the subprocess crashed there is no JSON; surface the raw output instead.
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    // Without the fix every attempt is retried on a fresh connection, so the
+    // server sees each PUT /stream twice (streamRequests === 8).
+    result: {
+      warmRequests: 4,
+      streamRequests: 4,
+      errors: ["ECONNRESET", "ECONNRESET", "ECONNRESET", "ECONNRESET"],
+    },
+    exitCode: 0,
+  });
 });

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -73,14 +73,9 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
   expect(plain).not.toBe(overrideA);
 });
 
-// An idempotent request (PUT) on a reused keep-alive connection that the peer
-// resets is transparently retried, but a ReadableStream body is consumed as it
-// is uploaded and cannot be replayed: the already written chunks are gone, so a
-// retry silently sends a truncated body, and flushing the still-draining stream
-// onto the retry's not-yet-opened socket put body bytes ahead of the headers
-// and panicked with "range start index N out of range for slice of length M"
-// in send_initial_request_payload. Runs in a subprocess: the panic aborts the
-// whole process.
+// A reused keep-alive connection reset during a streaming PUT must reject with
+// ECONNRESET, not retry: the stream body is already consumed, and the retry
+// panicked in send_initial_request_payload. Subprocess: the panic aborts the process.
 test("PUT with a ReadableStream body is not retried on keep-alive disconnect", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -109,6 +104,10 @@ test("PUT with a ReadableStream body is not retried on keep-alive disconnect", a
               return;
             }
             if (socket.data.buffer.startsWith("PUT /stream")) {
+              // Wait for the full headers plus at least one body byte so the
+              // stream body has actually started being consumed before the reset.
+              const i = socket.data.buffer.indexOf(CRLF + CRLF);
+              if (i < 0 || socket.data.buffer.length <= i + 4) return;
               streamRequests++;
               socket.data.buffer = "";
               // Reset the connection mid-upload.


### PR DESCRIPTION
### What does this PR do?

`fetch()` with an idempotent method (PUT) and a `ReadableStream` body, sent over a reused keep-alive connection that the peer resets mid-upload, aborts the whole Bun process:

```
panic: range start index 1031 out of range for slice of length 172
```

in `send_initial_request_payload` (`src/http/lib.rs`), at `&temporary_send_buffer[self.state.request_sent_len..]`. Any upstream, proxy, or load balancer that resets a reused connection mid-upload can kill a Bun client this way.

Repro (panics 4/4 on `bun 1.4.0` and current main, exits 0 with this PR):

<details>
<summary>repro.ts</summary>

```ts
const RESP = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok";
const srv = Bun.listen<{ buf: string; req: number; n: number }>({
  hostname: "127.0.0.1", port: 0,
  socket: {
    open(s) { s.data = { buf: "", req: 0, n: 0 }; },
    data(s, raw) {
      const d = s.data;
      if (d.req === 0) {                 // request 1: read fully, reply, keep alive
        d.buf += raw.toString("latin1");
        const i = d.buf.indexOf("\r\n\r\n"); if (i < 0) return;
        const cl = Number(d.buf.slice(0, i).match(/content-length: (\d+)/i)?.[1] ?? 0);
        if (d.buf.length < i + 4 + cl) return;
        d.req = 1; d.buf = ""; s.write(RESP); return;
      }
      d.n += raw.length;                 // request 2 (reused conn): RST mid-upload
      if (d.n > 8000) s.terminate();
    }, close() {}, error() {}, drain() {},
  },
});
const url = `http://127.0.0.1:${srv.port}/x`;
const CHUNK = new Uint8Array(1024);
const stream = () => { let n = 256; return new ReadableStream({ pull(c) { if (n-- <= 0) return c.close(); c.enqueue(CHUNK); } }); };
await fetch(url, { method: "PUT", body: new Uint8Array(64) }); // park a keep-alive connection
for (let i = 0; i < 20; i++) {
  await fetch(url, { method: "PUT", body: stream(), duplex: "half" }).catch(() => {});
}
console.log("SURVIVED");
```

</details>

### Cause

1. `HTTPClient::on_close` takes the idempotent retry regardless of the body type. A `ReadableStream` body is consumed as it is uploaded, so the retry replays a truncated body to begin with.
2. The retry's `start_()` registers its still-connecting socket in the abort tracker (needed so an abort during a slow connect is honored). The JS side is still pushing chunks from the first attempt, so `drain_queued_writes` finds that socket and `write_to_stream` writes a body frame to it before `on_open` / the request headers. On loopback the TCP connect has already completed so the write succeeds and `request_sent_len` advances by the frame size. `on_open` then runs `send_initial_request_payload`, which slices the freshly rebuilt 172-byte header buffer at index 1031.

`1031` is exactly one chunked frame of the 1024-byte chunk (`400\r\n` + 1024 + `\r\n`); switching the repro to 512-byte chunks moves the panic index to exactly 519, confirming the body frame lands before the headers.

### Fix

- `on_close`: only take the idempotent retry when the body is `HTTPRequestBody::Bytes`. `Stream` and `Sendfile` bodies are consumed as they are written and cannot be replayed; Go's `net/http` (`Request.isReplayable`) and curl apply the same rule. The request now fails with `ECONNRESET` like any other non-retryable request. The `GET`/bodyless retry behavior is unchanged (covered by the existing `test/regression/issue/28706.test.ts`).
- `write_to_stream`: park until `request_stage` is `Body` or `ProxyBody`, mirroring the existing `upgrade_state == Pending` park in the same function. Body bytes must never reach the socket ahead of the request line, and `request_sent_len` still indexes the header buffer at that point. The buffered data is re-flushed by `on_writable`'s `Body` arm once the headers are out.

### How did you verify your code works?

New test in `test/js/web/fetch/fetch-keepalive.test.ts` (spawns a subprocess since the bug aborts the process). Without the fix it fails on the debug build with `streamRequests: 8` instead of `4` (every attempt retried) and on a release build it additionally hits the panic. With the fix it passes 3/3. `test/regression/issue/28706.test.ts` and the stream-body / duplex / proxy / redirect / fetch-upgrade suites still pass.
