### PR TITLE
structuredClone: throw DataCloneError for a detached ArrayBuffer

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1784,7 +1784,9 @@ private:
             }
             if (auto* arrayBuffer = toPossiblySharedArrayBuffer(vm, obj)) {
                 if (arrayBuffer->isDetached()) {
-                    code = SerializationReturnCode::ValidationError;
+                    // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+                    // IsDetachedBuffer(value) => throw a "DataCloneError" DOMException (not a TypeError).
+                    code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
                 auto index = m_transferredArrayBuffers.find(obj);

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -269,6 +269,25 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
             structuredCloneFn(buffer, { transfer: [buffer] });
           }).toThrow(DOMException);
         });
+        // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+        // Serializing (not transferring) a detached ArrayBuffer must throw a
+        // "DataCloneError" DOMException, not a TypeError.
+        test("Serializing a detached ArrayBuffer throws DataCloneError", () => {
+          const buffer = new ArrayBuffer(8);
+          structuredCloneFn(buffer, { transfer: [buffer] }); // detach it
+          expect(buffer.byteLength).toBe(0);
+          for (const value of [buffer, { buffer }, [buffer], new Map([["k", buffer]])]) {
+            let error: unknown;
+            try {
+              structuredCloneFn(value);
+            } catch (e) {
+              error = e;
+            }
+            expect(error).toBeInstanceOf(DOMException);
+            expect((error as DOMException).name).toBe("DataCloneError");
+            expect((error as DOMException).code).toBe(DOMException.DATA_CLONE_ERR);
+          }
+        });
         test("Transferring a non-transferable platform object fails", () => {
           const blob = new Blob();
           expect(() => {


### PR DESCRIPTION
## Summary

Serializing a graph that contains a detached `ArrayBuffer` threw a plain `TypeError` instead of a `"DataCloneError"` `DOMException`. The [HTML structured serialize algorithm](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal) requires `DataCloneError` here, and Node, Chrome, Firefox, and Safari all throw it. Code that branches on `DataCloneError` (the standard "unclonable value" signal, e.g. retry-without-transfer fallbacks) takes the wrong branch on Bun.

## Reproduction

```js
const ab = new ArrayBuffer(8);
structuredClone(ab, { transfer: [ab] }); // detach it
try { structuredClone({ ab }); } catch (e) { console.log(e.name); }
// Bun: "TypeError"   Node / browsers: "DataCloneError"
```

Before the fix:

```
TypeError: Unable to deserialize data.
```

## Cause

The detached check in `CloneSerializer::dumpIfTerminal` set `SerializationReturnCode::ValidationError`, which `maybeThrowExceptionIfSerializationFailed` maps to a `TypeError`:

```cpp
if (auto* arrayBuffer = toPossiblySharedArrayBuffer(vm, obj)) {
    if (arrayBuffer->isDetached()) {
        code = SerializationReturnCode::ValidationError;  // -> TypeError
```

Upstream WebKit uses `DataCloneError` at this exact site. Bun's port of `SerializedScriptValue.cpp` (#3637, 2023) predates that upstream change and kept the old code.

## Fix

Set `SerializationReturnCode::DataCloneError` instead. One line; no wire format change.

This covers every entry point that shares the serializer: `structuredClone`, `Worker`/`MessagePort` `postMessage`, `bun:jsc` `serialize`, and `node:v8` `serialize`.

Detached ArrayBuffers reached through a typed array or `DataView` already threw `DataCloneError` (they hit the `isOutOfBounds` check first), as did a detached buffer passed in the transfer list; only a direct reference to a detached `ArrayBuffer` in the serialized graph was wrong.

Not changed: a `MessagePort` that appears in the graph but not in the transfer list still throws `TypeError`. That path also uses `ValidationError`, but it matches current upstream WebKit, so it is out of scope here.

## Verification

The new test in `test/js/web/workers/structured-clone.test.ts` serializes a detached `ArrayBuffer` bare, inside an object, inside an array, and inside a `Map`, and asserts the thrown value is a `DOMException` named `DataCloneError` with `code === DOMException.DATA_CLONE_ERR`.

<details>
<summary>Before (unfixed) and after</summary>

```
# USE_SYSTEM_BUN=1 bun test structured-clone.test.ts -t "Serializing a detached ArrayBuffer"
error: expect(received).toBeInstanceOf(expected)
Expected constructor: [class DOMException]
TypeError: Unable to deserialize data.
(fail) structuredClone > transferables > Serializing a detached ArrayBuffer throws DataCloneError

# bun bd test structured-clone.test.ts
162 pass, 0 fail
```

</details>
