### PR TITLE
Bun.serve: fix HEAD and 204 response framing

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -112,11 +112,15 @@ public:
 
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
-        /* A no-body status (1xx / 204) must not carry a Content-Length header
-         * (RFC 9110 8.6). end() short-circuits on noBodyStatus, but tryEnd()
-         * reaches here directly with allowContentLength defaulted to true. */
+        /* A no-body status carries neither a Content-Length header (RFC 9110
+         * 8.6) nor any body bytes: RFC 9112 6.3 terminates the message at the
+         * blank line after the header fields regardless of what follows. end()
+         * already short-circuits on noBodyStatus; tryEnd() reaches here
+         * directly, so drop both the framing and the data. */
         if (httpResponseData->noBodyStatus) {
             allowContentLength = false;
+            data = {};
+            totalSize = 0;
         }
 
         /* In some cases, such as when refusing huge data we want to close the connection when drained */

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -112,11 +112,9 @@ public:
 
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
-        /* A no-body status carries neither a Content-Length header (RFC 9110
-         * 8.6) nor any body bytes: RFC 9112 6.3 terminates the message at the
-         * blank line after the header fields regardless of what follows. end()
-         * already short-circuits on noBodyStatus; tryEnd() reaches here
-         * directly, so drop both the framing and the data. */
+        /* A no-body status carries no Content-Length (RFC 9110 8.6) and no body
+         * bytes (RFC 9112 6.3 terminates it at the blank line). end() already
+         * short-circuits on noBodyStatus; tryEnd() reaches here directly. */
         if (httpResponseData->noBodyStatus) {
             allowContentLength = false;
             data = {};
@@ -429,12 +427,9 @@ public:
             return this;
         }
 
-        /* RFC 9110 8.6: a server MUST NOT send Content-Length in a response
-         * with a 1xx or 204 status, and such a response never has a body. The
-         * status line is the one point every response passes through, so
-         * record that here rather than at each caller. 304 also has no body
-         * but MAY carry a Content-Length; callers that want it suppressed for
-         * 304 (node:http) set noBodyStatus themselves. */
+        /* RFC 9110 8.6: a 1xx/204 MUST NOT carry Content-Length and has no
+         * body; record that at the one point every response passes through.
+         * 304 MAY carry one, so node:http sets noBodyStatus for it itself. */
         if (status.length() >= 3 && (status.length() == 3 || status[3] == ' ')
             && (status[0] == '1' || (status[0] == '2' && status[1] == '0' && status[2] == '4'))) {
             httpResponseData->noBodyStatus = true;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -112,6 +112,13 @@ public:
 
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
+        /* A no-body status (1xx / 204) must not carry a Content-Length header
+         * (RFC 9110 8.6). end() short-circuits on noBodyStatus, but tryEnd()
+         * reaches here directly with allowContentLength defaulted to true. */
+        if (httpResponseData->noBodyStatus) {
+            allowContentLength = false;
+        }
+
         /* In some cases, such as when refusing huge data we want to close the connection when drained */
         if (closeConnection) {
             /* We can only write the header once */
@@ -418,6 +425,17 @@ public:
             return this;
         }
 
+        /* RFC 9110 8.6: a server MUST NOT send Content-Length in a response
+         * with a 1xx or 204 status, and such a response never has a body. The
+         * status line is the one point every response passes through, so
+         * record that here rather than at each caller. 304 also has no body
+         * but MAY carry a Content-Length; callers that want it suppressed for
+         * 304 (node:http) set noBodyStatus themselves. */
+        if (status.length() >= 3 && (status.length() == 3 || status[3] == ' ')
+            && (status[0] == '1' || (status[0] == '2' && status[1] == '0' && status[2] == '4'))) {
+            httpResponseData->noBodyStatus = true;
+        }
+
         /* Update status */
         httpResponseData->state |= HttpResponseData<SSL>::HTTP_STATUS_CALLED;
 
@@ -441,6 +459,12 @@ public:
     /* Write an HTTP header with unsigned int value */
     HttpResponse *writeHeader(std::string_view key, uint64_t value) {
         writeStatus(HTTP_200_OK);
+
+        /* Every integer Content-Length write funnels through this overload;
+         * a 1xx / 204 response must not carry one (RFC 9110 8.6). */
+        if (getHttpResponseData()->noBodyStatus && key.length() == 14 && !strncasecmp(key.data(), "content-length", 14)) {
+            return this;
+        }
 
         Super::write(key.data(), (int) key.length());
         Super::write(": ", 2);

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -118,8 +118,9 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     uint8_t idleTimeout = 10; // default HTTP_TIMEOUT 10 seconds
     bool fromAncientRequest = false;
     bool isConnectRequest = false;
-    /* 204/304 responses must not carry any body framing (no Content-Length,
-     * no chunked encoding, no terminating chunk), see RFC 9110 6.4.1. */
+    /* When set, the response carries no body framing at all: no Content-Length,
+     * no chunked encoding, no terminating chunk. writeStatus() sets it for 1xx
+     * and 204 (RFC 9110 8.6); node:http additionally sets it for 304. */
     bool noBodyStatus = false;
     /* The response body is delimited by connection close: write it raw with
      * no Content-Length and no chunked framing, then close. Used by node:http

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -15,7 +15,7 @@ use crate::node::types::PathOrFileDescriptor;
 use crate::server::file_response_stream::StartOptions as FileResponseStreamOptions;
 use crate::server::jsc::{JSGlobalObject, JSValue, JsResult, VirtualMachine};
 
-use crate::server::{AnyServer, FileResponseStream, RangeRequest, write_status};
+use crate::server::{AnyServer, FileResponseStream, HTTPStatusText, RangeRequest, write_status};
 use crate::webcore::blob::store::Data as StoreData;
 use crate::webcore::body::Value as BodyValue;
 use crate::webcore::{Blob, FetchHeaders, Response};
@@ -490,13 +490,12 @@ impl FileRoute {
 
         // Bodiless statuses end here — before the range switch, so a 304 (which
         // can win over a satisfiable Range per RFC 9110 §13.2.2) doesn't emit
-        // Content-Range.
-        match status_code {
-            204 | 205 | 304 | 307 | 308 => {
-                resp.end_without_body(resp.should_close_connection());
-                return;
-            }
-            _ => {}
+        // Content-Range. Null-body statuses also include 1xx (RFC 9112 §6.3):
+        // FileResponseStream ships the file via sendfile/write(), so the body
+        // must never start; 307/308 redirect routes skip the file too.
+        if HTTPStatusText::is_null_body(status_code) || matches!(status_code, 307 | 308) {
+            resp.end_without_body(resp.should_close_connection());
+            return;
         }
 
         let (body_offset, body_len): (u64, Option<u64>) = match range {

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -488,11 +488,9 @@ impl FileRoute {
         resp.write_mark();
         this.write_headers(resp);
 
-        // Bodiless statuses end here — before the range switch, so a 304 (which
-        // can win over a satisfiable Range per RFC 9110 §13.2.2) doesn't emit
-        // Content-Range. Null-body statuses also include 1xx (RFC 9112 §6.3):
-        // FileResponseStream ships the file via sendfile/write(), so the body
-        // must never start; 307/308 redirect routes skip the file too.
+        // Bodiless statuses end before the range switch so a 304 emits no
+        // Content-Range. FileResponseStream ships via sendfile/write(), so a
+        // null-body status must never start it; 307/308 routes skip it too.
         if HTTPStatusText::is_null_body(status_code) || matches!(status_code, 307 | 308) {
             resp.end_without_body(resp.should_close_connection());
             return;

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -479,10 +479,6 @@ impl FileRoute {
                 break 'brk 206;
             }
 
-            if size == 0 && file_type == FileType::File && this.status_code == 200 {
-                break 'brk 204;
-            }
-
             this.status_code
         };
 

--- a/src/runtime/server/HTTPStatusText.rs
+++ b/src/runtime/server/HTTPStatusText.rs
@@ -1,3 +1,9 @@
+/// WHATWG Fetch "null body status": a Response with one of these status codes
+/// has a null body, so no body bytes reach the wire and HEAD frames like GET.
+pub const fn is_null_body(code: u16) -> bool {
+    matches!(code, 101 | 103 | 204 | 205 | 304)
+}
+
 pub fn get(code: u16) -> Option<&'static [u8]> {
     match code {
         100 => Some(b"100 Continue"),

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2452,10 +2452,7 @@ where
             body_value.to_blob_if_possible();
             !matches!(
                 body_value,
-                Body::Value::Used
-                    | Body::Value::Null
-                    | Body::Value::Empty
-                    | Body::Value::Error(_)
+                Body::Value::Used | Body::Value::Null | Body::Value::Empty | Body::Value::Error(_)
             )
         };
         // `fast_get`/`fast_has` take `&mut self` (FFI shim), so use the `_mut`
@@ -2479,8 +2476,7 @@ where
                         return;
                     }
                 }
-                if let Some(content_length) = headers.fast_get(jsc::HTTPHeaderName::ContentLength)
-                {
+                if let Some(content_length) = headers.fast_get(jsc::HTTPHeaderName::ContentLength) {
                     // Parse before renderMetadata(): doWriteHeaders() will fastRemove(.ContentLength)
                     // and deref the FetchHeaders, freeing the borrowed StringImpl.
                     let content_length_str = content_length.to_slice();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2423,10 +2423,10 @@ where
         let resp = this.resp.expect("infallible: resp bound");
         this.set_response(response);
 
-        // `render` drops the body for these statuses on GET, so HEAD must not
-        // derive framing from that body (or the user headers) either
+        // `render` drops the body for a null-body status on GET, so HEAD must
+        // not derive framing from that body (or the user headers) either
         // (RFC 9110 §9.3.2): render the exact metadata+framing GET would.
-        if matches!(response.status_code(), 101 | 103 | 204 | 205 | 304) {
+        if HTTPStatusText::is_null_body(response.status_code()) {
             Self::do_render_blob_corked(std::ptr::from_mut::<Self>(this));
             return;
         }
@@ -3683,7 +3683,7 @@ where
         ctx_log!("render");
         self.set_response(response);
 
-        if matches!(response.status_code(), 101 | 103 | 204 | 205 | 304) {
+        if HTTPStatusText::is_null_body(response.status_code()) {
             self.do_render_blob();
             return;
         }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2442,11 +2442,9 @@ where
         // SAFETY: BACKREF
         let global_this = server.global_this();
 
-        // A body, when present, decides the framing: GET puts its byte count
-        // on the wire and strips any handler-supplied Content-Length /
-        // Transfer-Encoding, so HEAD must report the same (RFC 9110 §9.3.2).
-        // Only a bodiless Response leaves those headers as the sole
-        // description of what a GET would have sent (issue #15355).
+        // GET strips the handler's Content-Length / Transfer-Encoding and frames
+        // from the body, so HEAD must too (RFC 9110 §9.3.2). Only a bodiless
+        // Response leaves those headers as what GET would have sent (#15355).
         let body_decides_framing = {
             let body_value = response.get_body_value();
             body_value.to_blob_if_possible();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2422,6 +2422,15 @@ where
 
         let resp = this.resp.expect("infallible: resp bound");
         this.set_response(response);
+
+        // `render` drops the body for these statuses on GET, so HEAD must not
+        // derive framing from that body (or the user headers) either
+        // (RFC 9110 §9.3.2): render the exact metadata+framing GET would.
+        if matches!(response.status_code(), 101 | 103 | 204 | 205 | 304) {
+            Self::do_render_blob_corked(std::ptr::from_mut::<Self>(this));
+            return;
+        }
+
         let Some(server) = this.server else {
             // server detached?
             this.render_metadata();
@@ -2432,43 +2441,63 @@ where
         };
         // SAFETY: BACKREF
         let global_this = server.global_this();
+
+        // A body, when present, decides the framing: GET puts its byte count
+        // on the wire and strips any handler-supplied Content-Length /
+        // Transfer-Encoding, so HEAD must report the same (RFC 9110 §9.3.2).
+        // Only a bodiless Response leaves those headers as the sole
+        // description of what a GET would have sent (issue #15355).
+        let body_decides_framing = {
+            let body_value = response.get_body_value();
+            body_value.to_blob_if_possible();
+            !matches!(
+                body_value,
+                Body::Value::Used
+                    | Body::Value::Null
+                    | Body::Value::Empty
+                    | Body::Value::Error(_)
+            )
+        };
         // `fast_get`/`fast_has` take `&mut self` (FFI shim), so use the `_mut`
         // accessor — `get_fetch_headers()` and `get_init_headers()` alias the
         // same `init.headers` field.
-        if let Some(headers) = response.get_init_headers_mut() {
-            // first respect the headers
-            if !HTTP3 {
-                if let Some(transfer_encoding) =
-                    headers.fast_get(jsc::HTTPHeaderName::TransferEncoding)
+        if !body_decides_framing {
+            if let Some(headers) = response.get_init_headers_mut() {
+                // first respect the headers
+                if !HTTP3 {
+                    if let Some(transfer_encoding) =
+                        headers.fast_get(jsc::HTTPHeaderName::TransferEncoding)
+                    {
+                        // fastGet() borrows the header map's StringImpl; renderMetadata() ->
+                        // doWriteHeaders() calls fastRemove(.TransferEncoding) and derefs the
+                        // FetchHeaders, freeing that StringImpl before we write it. Clone so
+                        // the bytes outlive renderMetadata().
+                        let transfer_encoding_str = transfer_encoding.to_slice_clone();
+                        this.render_metadata();
+                        resp.write_header(b"transfer-encoding", transfer_encoding_str.slice());
+                        this.end_without_body(this.should_close_connection());
+                        return;
+                    }
+                }
+                if let Some(content_length) = headers.fast_get(jsc::HTTPHeaderName::ContentLength)
                 {
-                    // fastGet() borrows the header map's StringImpl; renderMetadata() ->
-                    // doWriteHeaders() calls fastRemove(.TransferEncoding) and derefs the
-                    // FetchHeaders, freeing that StringImpl before we write it. Clone so
-                    // the bytes outlive renderMetadata().
-                    let transfer_encoding_str = transfer_encoding.to_slice_clone();
+                    // Parse before renderMetadata(): doWriteHeaders() will fastRemove(.ContentLength)
+                    // and deref the FetchHeaders, freeing the borrowed StringImpl.
+                    let content_length_str = content_length.to_slice();
+                    let len: usize = HTTP::parse_content_length(content_length_str.slice());
+                    drop(content_length_str);
+
                     this.render_metadata();
-                    resp.write_header(b"transfer-encoding", transfer_encoding_str.slice());
+                    // SAFETY: FFI handle
+                    resp.write_header_int(b"content-length", len as u64);
                     this.end_without_body(this.should_close_connection());
                     return;
                 }
             }
-            if let Some(content_length) = headers.fast_get(jsc::HTTPHeaderName::ContentLength) {
-                // Parse before renderMetadata(): doWriteHeaders() will fastRemove(.ContentLength)
-                // and deref the FetchHeaders, freeing the borrowed StringImpl.
-                let content_length_str = content_length.to_slice();
-                let len: usize = HTTP::parse_content_length(content_length_str.slice());
-                drop(content_length_str);
-
-                this.render_metadata();
-                // SAFETY: FFI handle
-                resp.write_header_int(b"content-length", len as u64);
-                this.end_without_body(this.should_close_connection());
-                return;
-            }
         }
-        // not content-length or transfer-encoding so we need to respect the body
+        // the body decides the framing (or there is neither a body nor a
+        // handler-supplied Content-Length / Transfer-Encoding header)
         let body_value = response.get_body_value();
-        body_value.to_blob_if_possible();
         match body_value {
             Body::Value::InternalBlob(_) | Body::Value::WTFStringImpl(_) => {
                 let mut blob = body_value.use_as_any_blob_allow_non_utf8_string();
@@ -3446,12 +3475,6 @@ where
             self.sendfile.remain
         } else {
             self.blob.size()
-        };
-
-        status = if status == 200 && size == 0 && !self.blob.is_detached() {
-            204
-        } else {
-            status
         };
 
         let (content_type, needs_content_type, content_type_needs_free) =

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -15,7 +15,7 @@ use bun_jsc::HTTPHeaderName;
 use bun_uws::{AnyRequest, AnyResponse};
 
 use crate::server::jsc::{JSGlobalObject, JSValue, JsResult};
-use crate::server::{AnyServer, write_status};
+use crate::server::{AnyServer, HTTPStatusText, write_status};
 use crate::webcore::body::Value as BodyValue;
 use crate::webcore::headers_ref::any_blob_content_type;
 use crate::webcore::{AnyBlob, FetchHeaders, InternalBlob, Response};
@@ -284,7 +284,15 @@ impl StaticRoute {
 
     fn render_metadata_and_end(&self, resp: AnyResponse) {
         self.render_metadata(resp);
-        resp.write_header_int(b"Content-Length", self.cached_blob_size);
+        // `do_render_blob_corked` drops the body for a null-body status, so
+        // HEAD reports the zero bytes GET actually sends (RFC 9110 §9.3.2).
+        // (For 1xx/204 uWS suppresses the Content-Length header entirely.)
+        let size = if HTTPStatusText::is_null_body(self.status_code) {
+            0
+        } else {
+            self.cached_blob_size
+        };
+        resp.write_header_int(b"Content-Length", size);
         resp.end_without_body(resp.should_close_connection());
     }
 
@@ -408,6 +416,13 @@ impl StaticRoute {
 
     fn do_render_blob_corked(&self, resp: AnyResponse, did_finish: &mut bool) {
         self.render_metadata(resp);
+        // A null-body status never puts body bytes on the wire, the same drop
+        // `render` and `FileRoute` already do. Writing them here with no
+        // Content-Length (uWS suppresses it for 1xx/204) desyncs keep-alive.
+        if HTTPStatusText::is_null_body(self.status_code) {
+            *did_finish = resp.try_end(b"", 0, resp.should_close_connection());
+            return;
+        }
         self.render_bytes(resp, did_finish);
     }
 

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -480,16 +480,7 @@ impl StaticRoute {
     }
 
     fn render_metadata(&self, resp: AnyResponse) {
-        let mut status = self.status_code;
-        let size = self.cached_blob_size;
-
-        status = if status == 200 && size == 0 && !self.blob.is_detached() {
-            204
-        } else {
-            status
-        };
-
-        self.do_write_status(status, resp);
+        self.do_write_status(self.status_code, resp);
         self.do_write_headers(resp);
     }
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -137,13 +137,11 @@ describe("Bun.file in serve routes", () => {
 
     it("serves empty file", async () => {
       const res = await fetch(new URL(`/empty.txt`, server.url));
-      expect(res.status).toBe(204);
+      // An empty file is a valid zero-byte representation: a plain 200 with
+      // `Content-Length: 0`, the same framing every other empty body form
+      // (`new Response("")`, `new Blob([])`, ...) gets.
+      expect(res.status).toBe(200);
       expect(await res.text()).toBe("");
-      // A server MUST NOT send a Content-Length header field in any response
-      // with a status code of 1xx (Informational) or 204 (No Content). A server
-      // MUST NOT send a Content-Length header field in any 2xx (Successful)
-      // response to a CONNECT request (Section 9.3.6).
-      expect(res.headers.get("Content-Length")).toBeNull();
 
       const headers = res.headers.toJSON();
       delete headers.date;
@@ -151,6 +149,7 @@ describe("Bun.file in serve routes", () => {
 
       expect(headers).toMatchInlineSnapshot(`
         {
+          "content-length": "0",
           "content-type": "text/plain;charset=utf-8",
         }
       `);
@@ -549,10 +548,36 @@ describe("Bun.file in serve routes", () => {
   });
 
   describe.concurrent("Special status codes", () => {
-    it("returns 204 for empty files with 200 status", async () => {
-      const res = await fetch(new URL(`/empty.txt`, server.url));
-      expect(res.status).toBe(204);
-      expect(await res.text()).toBe("");
+    // Bun used to rewrite the default 200 of an empty file-backed body to
+    // 204. No other empty body form got that treatment, HEAD of the same URL
+    // did not, and a server-invented 204 dropped the Content-Type.
+    it("returns 200 for empty files, for GET and HEAD alike", async () => {
+      for (const method of ["GET", "HEAD"]) {
+        const res = await fetch(new URL(`/empty.txt`, server.url), { method });
+        expect({ method, status: res.status, contentLength: res.headers.get("Content-Length") }).toEqual({
+          method,
+          status: 200,
+          contentLength: "0",
+        });
+        expect(await res.text()).toBe("");
+      }
+    });
+
+    it("returns 200 for empty files served from the fetch handler, for GET and HEAD alike", async () => {
+      const emptyPath = join(tempDir, "empty.txt");
+      using handlerServer = Bun.serve({
+        port: 0,
+        fetch: () => new Response(Bun.file(emptyPath)),
+      });
+      for (const method of ["GET", "HEAD"]) {
+        const res = await fetch(handlerServer.url, { method });
+        expect({ method, status: res.status, contentLength: res.headers.get("Content-Length") }).toEqual({
+          method,
+          status: 200,
+          contentLength: "0",
+        });
+        expect(await res.text()).toBe("");
+      }
     });
 
     it("preserves custom status for empty files", async () => {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1101,9 +1101,12 @@ describe("HEAD requests #15355", () => {
     //
     // Passing duplicate header entries makes FetchHeaders combine them via
     // makeString(), producing a fresh StringImpl owned solely by the map so the
-    // remove actually frees it. `Malloc=1` routes bmalloc through the system
-    // allocator so ASAN-enabled builds observe the use-after-free; release
-    // builds fall through and validate the header values round-trip.
+    // remove actually frees it. The bodies are null because HEAD only reads
+    // the handler-supplied framing headers for a bodiless Response (RFC 9110
+    // 9.3.2: a body's byte count is the framing authority, same as GET).
+    // `Malloc=1` routes bmalloc through the system allocator so ASAN-enabled
+    // builds observe the use-after-free; release builds fall through and
+    // validate the header values round-trip.
     test("transfer-encoding / content-length whose StringImpl is held only by the header map", async () => {
       await using proc = Bun.spawn({
         cmd: [
@@ -1115,14 +1118,14 @@ describe("HEAD requests #15355", () => {
               port: 0,
               fetch(req) {
                 if (req.url.endsWith("/te")) {
-                  return new Response("hello", {
+                  return new Response(null, {
                     headers: [
                       ["Transfer-Encoding", "gzip"],
                       ["Transfer-Encoding", "chunked"],
                     ],
                   });
                 }
-                return new Response("hello", {
+                return new Response(null, {
                   headers: [
                     ["Content-Length", "1"],
                     ["Content-Length", "2"],

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1101,12 +1101,11 @@ describe("HEAD requests #15355", () => {
     //
     // Passing duplicate header entries makes FetchHeaders combine them via
     // makeString(), producing a fresh StringImpl owned solely by the map so the
-    // remove actually frees it. The bodies are null because HEAD only reads
-    // the handler-supplied framing headers for a bodiless Response (RFC 9110
-    // 9.3.2: a body's byte count is the framing authority, same as GET).
-    // `Malloc=1` routes bmalloc through the system allocator so ASAN-enabled
-    // builds observe the use-after-free; release builds fall through and
-    // validate the header values round-trip.
+    // remove actually frees it. The bodies are null so this stays on the
+    // fastGet path: HEAD only reads the handler-supplied framing headers for a
+    // bodiless Response. `Malloc=1` routes bmalloc through the system
+    // allocator so ASAN-enabled builds observe the use-after-free; release
+    // builds fall through and validate the header values round-trip.
     test("transfer-encoding / content-length whose StringImpl is held only by the header map", async () => {
       await using proc = Bun.spawn({
         cmd: [

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1192,6 +1192,129 @@ it("does not write body bytes for null body statuses", async () => {
   }
 });
 
+describe("response framing", () => {
+  // Read the raw response head so that `Content-Length: 0` and an absent
+  // Content-Length are distinguishable (fetch normalizes the two cases away).
+  async function rawRequest(port: number, method: string): Promise<{ statusLine: string; headerNames: string[] }> {
+    const received: Buffer[] = [];
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+    await using connection = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data(socket, data) {
+          received.push(data);
+        },
+        end() {
+          resolve();
+        },
+        error(socket, error) {
+          reject(error);
+        },
+        close() {
+          resolve();
+        },
+      },
+    });
+    connection.write(`${method} / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`);
+    connection.flush();
+    await promise;
+    const raw = Buffer.concat(received).toString();
+    const headLines = raw.slice(0, raw.indexOf("\r\n\r\n")).split("\r\n");
+    return {
+      statusLine: headLines[0],
+      headerNames: headLines.slice(1).map(line => line.slice(0, line.indexOf(":")).toLowerCase()),
+    };
+  }
+
+  // https://github.com/oven-sh/bun/issues/20676
+  // RFC 9110 8.6: a server MUST NOT send a Content-Length header field in any
+  // response with a status code of 1xx or 204. The Response constructor only
+  // accepts 101 out of the 1xx range, so that is the 1xx witness.
+  describe.each(["GET", "HEAD"])("%s", method => {
+    it.each([101, 204])("a %i response carries no Content-Length header", async status => {
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: () => new Response(null, { status }),
+      });
+      const { statusLine, headerNames } = await rawRequest(server.port, method);
+      expect(statusLine).toStartWith(`HTTP/1.1 ${status} `);
+      expect(headerNames).not.toContain("content-length");
+      expect(headerNames).not.toContain("transfer-encoding");
+    });
+
+    // 205 MUST indicate a zero-length body (RFC 9110 15.3.6) and 304 MAY carry
+    // a Content-Length (RFC 9110 15.4.5) -- both keep the explicit 0.
+    it.each([205, 304])("a %i response keeps Content-Length: 0", async status => {
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: () => new Response(null, { status }),
+      });
+      const { statusLine, headerNames } = await rawRequest(server.port, method);
+      expect(statusLine).toStartWith(`HTTP/1.1 ${status} `);
+      expect(headerNames).toContain("content-length");
+    });
+  });
+
+  // RFC 9110 9.3.2: a HEAD response carries the same header fields a GET of
+  // the same target would have, minus the body. Each body form below used to
+  // derive HEAD's framing from a different source than GET's.
+  describe("HEAD mirrors GET", () => {
+    type Framing = { status: number; contentLength: string | null; transferEncoding: string | null; body: string };
+    async function framing(makeResponse: () => Response) {
+      using server = Bun.serve({ port: 0, fetch: () => makeResponse() });
+      const results: Record<string, Framing> = {};
+      for (const method of ["GET", "HEAD"]) {
+        const response = await fetch(server.url, { method });
+        results[method] = {
+          status: response.status,
+          contentLength: response.headers.get("content-length"),
+          transferEncoding: response.headers.get("transfer-encoding"),
+          body: await response.text(),
+        };
+      }
+      return results;
+    }
+
+    it("a handler-supplied Content-Length loses to the body's byte count on HEAD, same as GET", async () => {
+      const { GET, HEAD } = await framing(() => new Response("hi", { headers: { "Content-Length": "999" } }));
+      expect(GET).toEqual({ status: 200, contentLength: "2", transferEncoding: null, body: "hi" });
+      expect(HEAD).toEqual({ status: 200, contentLength: "2", transferEncoding: null, body: "" });
+    });
+
+    it("a handler-supplied Transfer-Encoding loses to the body's framing on HEAD, same as GET", async () => {
+      const { GET, HEAD } = await framing(() => new Response("hi", { headers: { "Transfer-Encoding": "chunked" } }));
+      expect(GET).toEqual({ status: 200, contentLength: "2", transferEncoding: null, body: "hi" });
+      expect(HEAD).toEqual({ status: 200, contentLength: "2", transferEncoding: null, body: "" });
+    });
+
+    // A null-body Response carries no framing of its own, so the
+    // handler-supplied Content-Length is the only description of what GET
+    // would have sent. HEAD handlers rely on that (issue #15355).
+    it("a handler-supplied Content-Length on a null body is still forwarded on HEAD", async () => {
+      const { GET, HEAD } = await framing(() => new Response(null, { headers: { "Content-Length": "999" } }));
+      expect(GET).toEqual({ status: 200, contentLength: "0", transferEncoding: null, body: "" });
+      expect(HEAD).toEqual({ status: 200, contentLength: "999", transferEncoding: null, body: "" });
+    });
+
+    it("a body on a no-body status is dropped from HEAD's framing, same as GET", async () => {
+      const { GET, HEAD } = await framing(() => new Response("body", { status: 204 }));
+      expect(GET).toEqual({ status: 204, contentLength: null, transferEncoding: null, body: "" });
+      expect(HEAD).toEqual({ status: 204, contentLength: null, transferEncoding: null, body: "" });
+    });
+
+    it("a handler-supplied Content-Length on a 204 is dropped on HEAD, same as GET", async () => {
+      const { GET, HEAD } = await framing(
+        () => new Response(null, { status: 204, headers: { "Content-Length": "999" } }),
+      );
+      expect(GET).toEqual({ status: 204, contentLength: null, transferEncoding: null, body: "" });
+      expect(HEAD).toEqual({ status: 204, contentLength: null, transferEncoding: null, body: "" });
+    });
+  });
+});
+
 it("should support multiple Set-Cookie headers", async () => {
   await runTest(
     {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1268,10 +1268,9 @@ describe("response framing", () => {
     });
   });
 
-  // A Response body on a null-body status never reaches the wire: RFC 9112 6.3
-  // terminates a 204/304 at the blank line after the header fields regardless
-  // of what follows, so stray body bytes desync keep-alive. The fetch-handler
-  // path already drops the body in `render`; the static `routes:` path must too.
+  // RFC 9112 6.3 terminates a 1xx/204/304 at the blank line after the header
+  // fields, so a stray Response body desyncs keep-alive. `render` already drops
+  // it on the `fetch` path; the static `routes:` path must too.
   describe.each(["routes", "fetch"] as const)("%s: a Response body on a null-body status is dropped", kind => {
     const cases: [status: number, method: string, contentLength: string | null][] = [
       [101, "GET", null],

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1193,9 +1193,11 @@ it("does not write body bytes for null body statuses", async () => {
 });
 
 describe("response framing", () => {
-  // Read the raw response head so that `Content-Length: 0` and an absent
-  // Content-Length are distinguishable (fetch normalizes the two cases away).
-  async function rawRequest(port: number, method: string): Promise<{ statusLine: string; headerNames: string[] }> {
+  type RawResponse = { statusLine: string; headerNames: string[]; headers: Record<string, string>; body: string };
+  // Read the raw response so that `Content-Length: 0` and an absent
+  // Content-Length are distinguishable (fetch normalizes the two cases away),
+  // and so body bytes smuggled after a no-body status's header block show up.
+  async function rawRequest(port: number, method: string): Promise<RawResponse> {
     const received: Buffer[] = [];
     const { resolve, reject, promise } = Promise.withResolvers<void>();
     await using connection = await Bun.connect({
@@ -1220,10 +1222,18 @@ describe("response framing", () => {
     connection.flush();
     await promise;
     const raw = Buffer.concat(received).toString();
-    const headLines = raw.slice(0, raw.indexOf("\r\n\r\n")).split("\r\n");
+    const headEnd = raw.indexOf("\r\n\r\n");
+    const headLines = raw.slice(0, headEnd).split("\r\n");
+    const headers: Record<string, string> = {};
+    for (const line of headLines.slice(1)) {
+      const colon = line.indexOf(":");
+      headers[line.slice(0, colon).toLowerCase()] = line.slice(colon + 1).trim();
+    }
     return {
       statusLine: headLines[0],
-      headerNames: headLines.slice(1).map(line => line.slice(0, line.indexOf(":")).toLowerCase()),
+      headerNames: Object.keys(headers),
+      headers,
+      body: raw.slice(headEnd + 4),
     };
   }
 
@@ -1255,6 +1265,61 @@ describe("response framing", () => {
       const { statusLine, headerNames } = await rawRequest(server.port, method);
       expect(statusLine).toStartWith(`HTTP/1.1 ${status} `);
       expect(headerNames).toContain("content-length");
+    });
+  });
+
+  // A Response body on a null-body status never reaches the wire: RFC 9112 6.3
+  // terminates a 204/304 at the blank line after the header fields regardless
+  // of what follows, so stray body bytes desync keep-alive. The fetch-handler
+  // path already drops the body in `render`; the static `routes:` path must too.
+  describe.each(["routes", "fetch"] as const)("%s: a Response body on a null-body status is dropped", kind => {
+    const cases: [status: number, method: string, contentLength: string | null][] = [
+      [101, "GET", null],
+      [101, "HEAD", null],
+      [204, "GET", null],
+      [204, "HEAD", null],
+      [205, "GET", "0"],
+      [205, "HEAD", "0"],
+      [304, "GET", "0"],
+      [304, "HEAD", "0"],
+    ];
+    it.each(cases)("%i %s", async (status, method, contentLength) => {
+      const makeResponse = () => new Response("data", { status });
+      using server = Bun.serve(
+        kind === "routes"
+          ? {
+              port: 0,
+              hostname: "127.0.0.1",
+              routes: { "/": makeResponse() },
+              fetch: () => new Response("unreachable", { status: 500 }),
+            }
+          : { port: 0, hostname: "127.0.0.1", fetch: makeResponse },
+      );
+      const { statusLine, headers, body } = await rawRequest(server.port, method);
+      expect({
+        statusLine: statusLine.slice(0, 12),
+        contentLength: headers["content-length"] ?? null,
+        body,
+      }).toEqual({ statusLine: `HTTP/1.1 ${status}`, contentLength, body: "" });
+    });
+  });
+
+  // `FileRoute` ships its body via sendfile / `HttpResponse::write()`, neither
+  // of which goes through `internalEnd`, so it needs its own null-body-status
+  // drop. 101 is the one null-body status its bodiless list was missing.
+  it.each(["GET", "HEAD"])("a Bun.file route on a null-body status serves no body bytes (%s)", async method => {
+    using dir = tempDir("framing-file-route", { "f.bin": "data" });
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      routes: { "/": new Response(Bun.file(join(String(dir), "f.bin")), { status: 101 }) },
+      fetch: () => new Response("unreachable", { status: 500 }),
+    });
+    const { statusLine, headers, body } = await rawRequest(server.port, method);
+    expect({ statusLine: statusLine.slice(0, 12), contentLength: headers["content-length"] ?? null, body }).toEqual({
+      statusLine: "HTTP/1.1 101",
+      contentLength: null,
+      body: "",
     });
   });
 


### PR DESCRIPTION
Three RFC violations in `Bun.serve`'s HTTP/1 response framing, all with the same shape: the HEAD path, the 204 path, and the empty-file path each derived framing independently of what GET puts on the wire. Review turned up a fourth member of the class: the static `routes:` paths (`StaticRoute`, `FileRoute`) put a null-body status's Response body bytes on the wire, which GET's `render()` drops.

### Repro

```js
// 1. Handler-supplied Content-Length: corrected on GET, forwarded verbatim on HEAD
using a = Bun.serve({ port: 0, fetch: () => new Response("hi", { headers: { "Content-Length": "999" } }) });
(await fetch(a.url)).headers.get("content-length");                     // "2"
(await fetch(a.url, { method: "HEAD" })).headers.get("content-length"); // "999"

// 2. Default-200 Response with an empty file body is rewritten to 204, but not on HEAD
require("fs").writeFileSync("/tmp/e", "");
using b = Bun.serve({ port: 0, fetch: () => new Response(Bun.file("/tmp/e")) });
(await fetch(b.url)).status;                     // 204
(await fetch(b.url, { method: "HEAD" })).status; // 200

// 3. Every 204 carries Content-Length: 0
using c = Bun.serve({ port: 0, fetch: () => new Response(null, { status: 204 }) });
// raw socket: HTTP/1.1 204 No Content\r\nDate: ...\r\nContent-Length: 0\r\n\r\n

// 4. A static route puts a null-body status's body bytes on the wire
using d = Bun.serve({ port: 0, routes: { "/": new Response("data", { status: 204 }) }, fetch: () => new Response(null) });
// raw socket: HTTP/1.1 204 No Content\r\n...Content-Length: 4\r\n\r\ndata
```

RFC 9110 9.3.2: a HEAD response carries the same header fields a GET of the same target would have. RFC 9110 8.6: a server MUST NOT send `Content-Length` in a response with a 1xx or 204 status (case 3 is issue #20676, where such a 204 is rejected as a framing error by a proxy). RFC 9112 6.3: a 1xx/204/304 is terminated by the blank line after the header fields regardless of what follows, so case 4's stray body bytes desync the next keep-alive response.

### Causes

1. `do_render_head_response` forwarded a handler-supplied `Content-Length` / `Transfer-Encoding` header before looking at the body. GET strips both (`render_metadata` -> `do_write_headers`) and frames from the body's byte count.
2. `render_metadata` rewrote 200 -> 204 when `size == 0 && !blob.is_detached()`. Every in-memory empty body (`""`, `Uint8Array(0)`, `new Blob([])`) happens to report `is_detached() == true`, so only the file / Blob-store forms got the rewrite, and the HEAD path (whose `self.blob` is never populated) never did. `StaticRoute` and `FileRoute` each carried a copy of the same rewrite.
3. `Bun.serve` never marked the uWS response as a no-body status, and uWS's `tryEnd` -> `internalEnd` path (unlike `end()`) never consulted `noBodyStatus`, so `render_bytes`'s `try_end("", 0)` always emitted `Content-Length: 0`.
4. The WHATWG null-body-status set `{101, 103, 204, 205, 304}` was spelled out inline at three sites and absent from two: `render()` dropped the body, but `StaticRoute` unconditionally sent its cached blob, and `FileRoute`'s bodiless list (`204 | 205 | 304 | 307 | 308`) was missing 1xx.

### Fix

- `uws::HttpResponse::writeStatus` records `noBodyStatus` for 1xx / 204 statuses (the existing flag `node:http` already sets for 204/304). `internalEnd` then drops the Content-Length, the data, and the totalSize, exactly what `end()` already does on its `noBodyStatus` short-circuit; `writeHeader(key, uint64_t)` skips an integer `Content-Length` too. 205 (MUST indicate a zero-length body, RFC 9110 15.3.6) and 304 (MAY carry one, 15.4.5) keep `Content-Length: 0`.
- `do_render_head_response` short-circuits null-body statuses to the same `render_metadata()` + empty `try_end` that GET's `render()` uses, instead of framing from the dropped body or the user headers.
- `do_render_head_response` honors a handler-supplied `Content-Length` / `Transfer-Encoding` only when the Response's body is null. A null body carries no framing of its own, so the header is the only description of what a GET would have sent; that is the escape hatch issue #15355 added for HEAD handlers and it is preserved (its tests still pass). A real body's byte count now wins for both methods.
- The 200 -> 204-on-empty rewrite is removed from `render_metadata`, `StaticRoute`, and `FileRoute`. An empty file is a valid zero-byte representation. The rewrite was undocumented, applied to only one of six empty body forms, never applied on HEAD, and produced the spec-violating `204 + Content-Length: 0`. Every empty body now frames as `200` with `Content-Length: 0`, as `new Response("")` already did.
- `StaticRoute` drops the body for a null-body status and its HEAD path reports `Content-Length: 0` (mirroring GET); `FileRoute`'s bodiless early return gains 1xx. `FileResponseStream` ships the file via sendfile / `write()`, neither of which goes through `internalEnd`, so `FileRoute` needs its own guard. The set now lives in one `HTTPStatusText::is_null_body` predicate used by all four paths.

### Existing tests updated

- `bun-server.test.ts` "transfer-encoding / content-length whose StringImpl is held only by the header map" used `new Response("hello", ...)` with duplicate `Transfer-Encoding` / `Content-Length` headers and asserted HEAD forwarded them, which is the behavior item 1 removes. The test exists to catch a use-after-free in the header fast path (`fastGet` -> `render_metadata` frees the `StringImpl` it borrowed); that path is now only reachable with a null body, so the fixture bodies became `null` and the assertions are unchanged.
- `bun-serve-file.test.ts` "serves empty file" and "returns 204 for empty files with 200 status" now assert `200` + `Content-Length: 0`, for GET and HEAD, on both the route and fetch-handler paths.

### Verification

Full framing matrix (raw socket, body form x GET/HEAD) before and after:

<details>

```
# before (bun 1.4.0 / main)
body                         GET                          HEAD
Response("hi")               200 CL=2                     200 CL=2
Response("")                 200 CL=0                     200 CL=0
Response(null)               200 CL=0                     200 CL=0
Response(Uint8Array(0))      200 CL=0                     200 CL=0
Response(new Blob([]))       200 CL=0                     200 CL=0
Bun.file(empty)              204 CL=0                     200 CL=0   <<<
Bun.file(full)               200 CL=10                    200 CL=10
"hi" + CL:999                200 CL=2                     200 CL=999 <<<
null + CL:999                200 CL=0                     200 CL=999
null status 204              204 CL=0                     204 CL=0   <<<
"body" status 204            204 CL=0                     204 CL=4   <<<
null status 304              304 CL=0                     304 CL=0
null status 205              205 CL=0                     205 CL=0
null status 101              101 CL=0                     101 CL=0   <<<

# after
Bun.file(empty)              200 CL=0                     200 CL=0
"hi" + CL:999                200 CL=2                     200 CL=2
null + CL:999                200 CL=0                     200 CL=999   (#15355, unchanged)
null status 204              204 CL=-                     204 CL=-
"body" status 204            204 CL=-                     204 CL=-
null status 304              304 CL=0                     304 CL=0
null status 205              205 CL=0                     205 CL=0
null status 101              101 CL=-                     101 CL=-

# routes vs fetch handler, Response("data", { status }), before -> after
204 routes  GET   204 CL=4 body="data"   ->  204 CL=-  body=""
204 routes  HEAD  204 CL=4               ->  204 CL=-
205 routes  GET   205 CL=4 body="data"   ->  205 CL=0  body=""
304 routes  GET   304 CL=4 body="data"   ->  304 CL=0  body=""
```

</details>

The new `describe("response framing")` in `serve.test.ts` has 24 assertions that fail on the unmodified build and 7 deliberate positive controls (205/304 keep `Content-Length: 0` on the `fetch` path; the null-body escape hatch still forwards the user header). `bun-serve-file.test.ts` (67), `bun-serve-static.test.ts` (34), `bun-serve-routes.test.ts` (41), `node-http.test.ts` (127), `proxy-stress-adversarial.test.ts` (151), `serve-http3.test.ts` (45) all pass.

Fixes #20676

Related: #32794 fixes the fourth framing divergence the same fuzzer found (`Bun.file(p).slice(a, b)` treated as `a..EOF`). Different root cause, but both touch `render_metadata`, so whichever lands second needs a small rebase.
