### PR TITLE
structuredClone: share SharedArrayBuffers instead of deep-copying them

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1812,8 +1812,10 @@ private:
                 if (!startObjectInternal(obj)) // handle duplicates
                     return true;
 
-                if (arrayBuffer->isShared() && m_context == SerializationContext::WorkerPostMessage) {
-                    // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+                // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+                // Shared contents travel out of band (m_sharedBuffers), so wire-bytes-only consumers keep the
+                // deep-copy below: node:v8/bun:jsc serialize sets ForStorage, IPC sets ForCrossProcessTransfer.
+                if (arrayBuffer->isShared() && m_forStorage == SerializationForStorage::No && m_forTransfer == SerializationForCrossProcessTransfer::No) {
                     if (!JSC::Options::useSharedArrayBuffer()) {
                         code = SerializationReturnCode::DataCloneError;
                         return true;
@@ -6515,9 +6517,11 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     // #endif
     //             ));
     scope.releaseAssertNoException();
-    auto result = adoptRef(*new SerializedScriptValue(WTF::move(buffer), arrayBufferContentsArray.releaseReturnValue(), context == SerializationContext::WorkerPostMessage ? WTF::move(sharedBuffers) : nullptr
+    // The serializer alone decides whether m_sharedBuffers has entries; always hand them over
+    // so the attach condition cannot drift out of sync with the SharedArrayBufferTag gate.
+    auto result = adoptRef(*new SerializedScriptValue(WTF::move(buffer), arrayBufferContentsArray.releaseReturnValue(), WTF::move(sharedBuffers)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-        ,
+                                                                                                                            ,
         WTF::move(detachedCanvases)
 #endif
 #if ENABLE(WEB_RTC)

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,6 +1,6 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { bunEnv, bunExe, tls } from "harness";
+import { bunEnv, bunExe, tempDir, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
 import { join } from "path";
@@ -460,8 +460,6 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
   for (const [label, expr] of [
     ["ArrayBuffer", "new ArrayBuffer(2 ** 31)"],
     ["resizable ArrayBuffer", "new ArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
-    ["SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31)"],
-    ["growable SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
     ["Uint8Array", "new Uint8Array(2 ** 31)"],
   ] as const) {
     test(label, async () => {
@@ -488,6 +486,38 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
       });
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
       expect(["DataCloneError", "SKIP"]).toContain(stdout.trim());
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  // A SharedArrayBuffer is never copied into the serialization buffer: the clone maps the
+  // same data block (see the "structuredClone of SharedArrayBuffer" suite). So the 2GiB
+  // cap does not apply and cloning one at or above that size succeeds.
+  for (const [label, expr] of [
+    ["SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31)"],
+    ["growable SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
+  ] as const) {
+    test(`${label} is shared, not copied`, async () => {
+      const script = `
+        let buf;
+        try {
+          buf = ${expr};
+        } catch {
+          console.log("SKIP");
+          process.exit(0);
+        }
+        const clone = structuredClone(buf);
+        new Uint8Array(buf)[0] = 7;
+        console.log(clone instanceof SharedArrayBuffer && new Uint8Array(clone)[0] === 7 ? "SHARED" : "BAD");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(["SHARED", "SKIP"]).toContain(stdout.trim());
       expect(exitCode).toBe(0);
     });
   }
@@ -701,5 +731,128 @@ describe("structuredClone(Object.prototype)", () => {
   test("bun:jsc serialize/deserialize round-trips it too", () => {
     const cloned = deserialize(serialize(Object.prototype));
     expect(cloned).toEqual({});
+  });
+});
+
+// https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+// Serializing a SharedArrayBuffer (not for storage) yields a SharedArrayBuffer over the
+// same data block, never a plain ArrayBuffer deep copy.
+describe("structuredClone of SharedArrayBuffer", () => {
+  test("returns a SharedArrayBuffer mapping the same memory block", () => {
+    const src = new SharedArrayBuffer(8);
+    const clone = structuredClone(src);
+    expect(clone).toBeInstanceOf(SharedArrayBuffer);
+    expect(clone).not.toBe(src);
+    // writes through either object are visible through the other
+    new Uint8Array(src)[0] = 42;
+    new Uint8Array(clone)[1] = 7;
+    expect(Array.from(new Uint8Array(clone))).toEqual([42, 7, 0, 0, 0, 0, 0, 0]);
+    expect(Array.from(new Uint8Array(src))).toEqual([42, 7, 0, 0, 0, 0, 0, 0]);
+  });
+
+  test("Atomics on the clone are visible through the original", () => {
+    const src = new SharedArrayBuffer(8);
+    const clone = structuredClone(src);
+    Atomics.add(new Int32Array(clone), 0, 5);
+    expect(Atomics.load(new Int32Array(src), 0)).toBe(5);
+  });
+
+  test("a growable SharedArrayBuffer stays growable and tracks growth of the original", () => {
+    const src = new SharedArrayBuffer(8, { maxByteLength: 16 });
+    const clone = structuredClone(src);
+    expect(clone).toBeInstanceOf(SharedArrayBuffer);
+    expect(clone.growable).toBe(true);
+    expect(clone.maxByteLength).toBe(16);
+    src.grow(16);
+    expect(clone.byteLength).toBe(16);
+  });
+
+  test("a typed array viewing a SharedArrayBuffer clones with a shared buffer", () => {
+    const src = new SharedArrayBuffer(8);
+    const view = new Uint8Array(src, 2, 4);
+    const clone = structuredClone(view);
+    expect(clone.buffer).toBeInstanceOf(SharedArrayBuffer);
+    expect(clone.byteOffset).toBe(2);
+    expect(clone.length).toBe(4);
+    new Uint8Array(src)[2] = 9;
+    expect(clone[0]).toBe(9);
+  });
+
+  test("the same SharedArrayBuffer referenced twice deduplicates to one clone", () => {
+    const src = new SharedArrayBuffer(4);
+    const clone = structuredClone({ a: src, b: src });
+    expect(clone.a).toBeInstanceOf(SharedArrayBuffer);
+    expect(clone.a).toBe(clone.b);
+  });
+
+  test("shares alongside a transferred ArrayBuffer in the same graph", () => {
+    const sab = new SharedArrayBuffer(4);
+    const ab = new ArrayBuffer(4);
+    const clone = structuredClone({ sab, ab }, { transfer: [ab] });
+    expect(clone.sab).toBeInstanceOf(SharedArrayBuffer);
+    new Uint8Array(sab)[0] = 3;
+    expect(new Uint8Array(clone.sab)[0]).toBe(3);
+    expect(ab.byteLength).toBe(0);
+  });
+
+  test("a SharedArrayBuffer in the transfer list still throws DataCloneError", () => {
+    const sab = new SharedArrayBuffer(4);
+    expect(() => structuredClone(sab, { transfer: [sab] })).toThrow(
+      expect.objectContaining({ name: "DataCloneError" }),
+    );
+  });
+
+  // Shared contents travel out of band on the SerializedScriptValue, never in the wire
+  // bytes, so the two wire-bytes-only paths must keep producing an independent deep copy.
+  test("bun:jsc serialize across a process still deep-copies", () => {
+    const src = new SharedArrayBuffer(4);
+    new Uint8Array(src)[0] = 11;
+    const clone = jscSerializeRoundtripCrossProcess(src);
+    expect(clone).toBeInstanceOf(ArrayBuffer);
+    expect(clone).not.toBeInstanceOf(SharedArrayBuffer);
+    expect(new Uint8Array(clone)[0]).toBe(11);
+    new Uint8Array(src)[1] = 1;
+    expect(new Uint8Array(clone)[1]).toBe(0);
+  });
+
+  test("child_process IPC with advanced serialization still deep-copies", async () => {
+    using dir = tempDir("sab-ipc", {
+      "child.js": `
+        process.on("message", m => {
+          process.send({
+            isSAB: m.sab instanceof SharedArrayBuffer,
+            isAB: m.sab instanceof ArrayBuffer,
+            byte0: new Uint8Array(m.sab)[0],
+          });
+        });
+      `,
+      "parent.js": `
+        const { fork } = require("node:child_process");
+        const { join } = require("node:path");
+        const child = fork(join(__dirname, "child.js"), [], {
+          serialization: "advanced",
+          stdio: ["inherit", "inherit", "inherit", "ipc"],
+        });
+        child.on("error", e => { console.error(e); process.exit(1); });
+        child.on("exit", code => { if (code !== null && code !== 0) process.exit(1); });
+        const sab = new SharedArrayBuffer(4);
+        new Uint8Array(sab)[0] = 7;
+        child.on("message", reply => {
+          console.log(JSON.stringify(reply));
+          child.kill();
+        });
+        child.send({ sab });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ isSAB: false, isAB: true, byte0: 7 });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
`structuredClone` of a `SharedArrayBuffer` returned a plain, non-shared `ArrayBuffer` deep copy, silently destroying shared-memory semantics (`Atomics` on the clone are private no-ops, "shared" state diverges with no error). Growable `SharedArrayBuffer`s additionally came back as resizable non-shared `ArrayBuffer`s.

```js
const src = new SharedArrayBuffer(8);
const c = structuredClone(src);
console.log(c instanceof SharedArrayBuffer, c instanceof ArrayBuffer); // bun: false true    node: true false
new Uint8Array(src)[0] = 42;
console.log(new Uint8Array(c)[0]); // bun: 0    node: 42 (same memory block)
```

Per the [HTML structured serialization steps](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal), serializing a `SharedArrayBuffer` outside `forStorage` must yield a `SharedArrayBuffer` over the same data block. Node, and the existing `Worker.postMessage` path in Bun, both do.

### Cause

Two sites in `SerializedScriptValue.cpp` each gated shared-buffer handling on `SerializationContext::WorkerPostMessage`:

1. The serializer only emitted the `SharedArrayBufferTag` under that context, so `structuredClone` (which uses `SerializationContext::Default`) fell through to the plain `ArrayBuffer` deep-copy path.
2. `SerializedScriptValue::create` only attached the out-of-band shared contents to the result under that context, so fixing (1) alone made the deserializer see a tag with no backing vector and fail with "Unable to deserialize data."

### Fix

The shared `ArrayBufferContents` travel out of band on the `SerializedScriptValue` object (`m_sharedBuffers`), never in the wire bytes, so they only reach an in-process deserializer. The serializer gate is now "not for storage and not for cross-process transfer". The two consumers that use only the wire bytes already set exactly those flags, so their behavior is unchanged:

- `node:v8` / `bun:jsc` `serialize()` passes `SerializationForStorage::Yes` and keeps deep-copying.
- `child_process` IPC (advanced serialization) passes `SerializationForCrossProcessTransfer::Yes` and keeps deep-copying.

`SerializedScriptValue::create` now always hands the serializer's shared-buffer vector to the result (it is empty unless the serializer emitted the tag), so the attach condition cannot drift out of sync with the tag gate again.

This also fixes the other in-process callers that serialize with `SerializationContext::Default`, such as a typed array viewing a `SharedArrayBuffer`.

Intentionally unchanged:

- The sibling `WebAssembly.Module` / shared `WebAssembly.Memory` gates in the same function use the same `WorkerPostMessage` pattern, but they throw a loud `DataCloneError` today rather than silently corrupting, and deserve their own change and tests.
- Node throws `DataCloneError` for `v8.serialize(sab)` where Bun deep-copies; this PR does not change that.

### Tests

New `structuredClone of SharedArrayBuffer` suite in `test/js/web/workers/structured-clone.test.ts`:

- the clone is a `SharedArrayBuffer` over the same memory block (writes and `Atomics` visible through either object)
- a growable `SharedArrayBuffer` stays growable and tracks growth of the original
- a typed array viewing a `SharedArrayBuffer` clones with a shared `.buffer`
- the same `SharedArrayBuffer` referenced twice deduplicates to one clone
- a shared and a transferred `ArrayBuffer` coexist in one graph
- a `SharedArrayBuffer` in the transfer list still throws `DataCloneError`
- `bun:jsc` `serialize()` across a process and `child_process` IPC still deep-copy (negative contracts for the two new guards)

Two existing assertions in the ">= 2 GiB serialization buffer" suite certified the deep-copy: a 2 GiB `SharedArrayBuffer` used to hit the buffer cap and throw `DataCloneError`. Shared buffers are never copied into that buffer, so the cap cannot apply to them; those two cases now assert the clone is shared.

All 170 tests in the file pass, along with `bun-jsc.test.ts`, `worker_threads.test.ts`, `structuredClone-classes.test.ts`, `message-channel.test.ts`, the `node:worker_threads` SharedArrayBuffer compat tests, and the `spawn.ipc.*` suites.
