### PR TITLE
Preserve AsyncLocalStorage context across MessagePort, Worker, AbortSignal.timeout, and BroadcastChannel events

### DIFF
--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -54,6 +54,7 @@ unsafe extern "C" {
     // the non-`repr(C)` interior of `EventLoopTimer` is irrelevant to FFI.
     #[allow(improper_ctypes)]
     safe fn WebCore__AbortSignal__getTimeout(arg0: &AbortSignal) -> *mut Timeout;
+    safe fn WebCore__AbortSignal__clearTimeoutAsyncContext(arg0: &AbortSignal);
     safe fn WebCore__AbortSignal__signal(
         arg0: &AbortSignal,
         arg1: &JSGlobalObject,
@@ -208,6 +209,13 @@ impl AbortSignal {
         // SAFETY: returned Timeout is owned by `self` and valid while `self` is held
         // (see doc comment).
         NonNull::new(ptr).map(|p| unsafe { p.as_ref() })
+    }
+
+    /// Release the async context snapshot AbortSignal.timeout() captured.
+    /// Every path that retires the timer without going through the C++
+    /// `cancelTimer()` must call this, or the snapshot stays a GC root.
+    pub fn clear_timeout_async_context(&self) {
+        WebCore__AbortSignal__clearTimeoutAsyncContext(self)
     }
 }
 
@@ -371,8 +379,10 @@ impl Timeout {
 
             // The signal and its handlers belong to a previous isolated test
             // file's global; firing now would run them against the new global.
-            // Drop the extra ref that signalAbort() would have released.
+            // Release the async context snapshot (this path never reaches
+            // cancelTimer()), then drop the extra ref signalAbort() would have.
             if (*this).generation != (*vm).test_isolation_generation {
+                (*(*this).signal).clear_timeout_async_context();
                 (*(*this).signal).unref();
                 return;
             }

--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -34,6 +34,28 @@ JSC::Structure* AsyncContextFrame::createStructure(JSC::VM& vm, JSC::JSGlobalObj
     return Structure::create(vm, globalObject, jsNull(), TypeInfo(ObjectType, StructureFlags), info());
 }
 
+JSValue AsyncContextFrame::currentContext(JSGlobalObject* globalObject)
+{
+    return globalObject->m_asyncContextData.get()->getInternalField(0);
+}
+
+AsyncContextFrameScope::AsyncContextFrameScope(JSGlobalObject* globalObject, JSValue context)
+{
+    if (!globalObject || !context || context.isUndefined())
+        return;
+    m_globalObject = globalObject;
+    auto* asyncContextData = globalObject->m_asyncContextData.get();
+    m_previousContext = asyncContextData->getInternalField(0);
+    asyncContextData->putInternalField(globalObject->vm(), 0, context);
+}
+
+AsyncContextFrameScope::~AsyncContextFrameScope()
+{
+    if (!m_globalObject)
+        return;
+    m_globalObject->m_asyncContextData.get()->putInternalField(m_globalObject->vm(), 0, m_previousContext);
+}
+
 JSValue AsyncContextFrame::withAsyncContextIfNeeded(JSGlobalObject* globalObject, JSValue callback)
 {
     JSValue context = globalObject->m_asyncContextData.get()->getInternalField(0);

--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -2,6 +2,7 @@
 #include "ZigGlobalObject.h"
 #include "AsyncContextFrame.h"
 #include <JavaScriptCore/InternalFieldTuple.h>
+#include <JavaScriptCore/StrongInlines.h>
 
 #if ASSERT_ENABLED
 #include <JavaScriptCore/IntegrityInlines.h>
@@ -34,9 +35,13 @@ JSC::Structure* AsyncContextFrame::createStructure(JSC::VM& vm, JSC::JSGlobalObj
     return Structure::create(vm, globalObject, jsNull(), TypeInfo(ObjectType, StructureFlags), info());
 }
 
-JSValue AsyncContextFrame::currentContext(JSGlobalObject* globalObject)
+void AsyncContextFrame::captureCurrentContext(JSGlobalObject* globalObject, JSC::Strong<JSC::Unknown>& slot)
 {
-    return globalObject->m_asyncContextData.get()->getInternalField(0);
+    JSValue context = globalObject->m_asyncContextData.get()->getInternalField(0);
+    // If there is no async context, do not snapshot it.
+    if (context.isUndefined())
+        return;
+    slot.set(globalObject->vm(), context);
 }
 
 AsyncContextFrameScope::AsyncContextFrameScope(JSGlobalObject* globalObject, JSValue context)

--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 #include "ZigGlobalObject.h"
 #include "AsyncContextFrame.h"
+#include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/InternalFieldTuple.h>
 #include <JavaScriptCore/StrongInlines.h>
 
@@ -33,6 +34,15 @@ AsyncContextFrame* AsyncContextFrame::create(JSGlobalObject* global, JSValue cal
 JSC::Structure* AsyncContextFrame::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     return Structure::create(vm, globalObject, jsNull(), TypeInfo(ObjectType, StructureFlags), info());
+}
+
+void AsyncContextFrame::captureCurrentContext(JSGlobalObject* globalObject, WebCore::JSValueInWrappedObject& slot)
+{
+    JSValue context = globalObject->m_asyncContextData.get()->getInternalField(0);
+    // If there is no async context, do not snapshot it.
+    if (context.isUndefined())
+        return;
+    slot.setWeakly(context);
 }
 
 void AsyncContextFrame::captureCurrentContext(JSGlobalObject* globalObject, JSC::Strong<JSC::Unknown>& slot)

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -34,7 +34,9 @@ public:
     // native-to-GC cycle. Only use the Strong overload when a GC-independent
     // release is guaranteed to run: AbortSignal.timeout() needs it (its abort
     // is observed through a dependent AbortSignal.any() signal's wrapper, not
-    // its own) and its timer heap guarantees cancelTimer() drops the handle.
+    // its own), and every path that retires its timer, including the Rust
+    // teardown paths that never reach cancelTimer(), calls
+    // clearTimeoutAsyncContext() to drop the handle.
     static void captureCurrentContext(JSC::JSGlobalObject* globalObject, WebCore::JSValueInWrappedObject& slot);
     static void captureCurrentContext(JSC::JSGlobalObject* globalObject, JSC::Strong<JSC::Unknown>& slot);
 

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -3,6 +3,7 @@
 #include "root.h"
 #include "BunClientData.h"
 #include <JavaScriptCore/CallData.h>
+#include <JavaScriptCore/Strong.h>
 #include <wtf/Noncopyable.h>
 
 class AsyncContextFrame : public JSC::JSNonFinalObject {
@@ -18,9 +19,16 @@ public:
     // When given a JSFunction that you want to call later, wrap it with this function
     static JSC::JSValue withAsyncContextIfNeeded(JSC::JSGlobalObject* globalObject, JSC::JSValue callback);
 
-    // The async context value AsyncLocalStorage is currently running with, or
-    // `undefined` when none is active. Pair with AsyncContextFrameScope.
-    static JSC::JSValue currentContext(JSC::JSGlobalObject* globalObject);
+    // Snapshots the currently-active async context (the value AsyncLocalStorage
+    // is running with) into `slot`, for AsyncContextFrameScope to restore later.
+    // No-op when there is none, so `slot` never allocates a GC handle for it.
+    //
+    // `slot` must be a Strong: the value has to stay alive for as long as the
+    // owner can still dispatch, and the owner's JS wrapper is not a reliable
+    // root for that (a MessageChannel's ports have no wrapper until .port1 is
+    // first read, and an AbortSignal.any() timeout source's wrapper can be
+    // collected while its timer is still pending).
+    static void captureCurrentContext(JSC::JSGlobalObject* globalObject, JSC::Strong<JSC::Unknown>& slot);
 
     // The following is JSC::call but
     // - it unwraps AsyncContextFrame
@@ -75,8 +83,8 @@ public:
 //
 // Use this around an event dispatch that happens asynchronously (from an
 // event-loop task) on behalf of a resource created earlier, passing the
-// AsyncContextFrame::currentContext() snapshot taken when the resource was
-// created. For a single callback, prefer withAsyncContextIfNeeded + call.
+// snapshot AsyncContextFrame::captureCurrentContext() took when the resource
+// was created. For a single callback, prefer withAsyncContextIfNeeded + call.
 //
 // A no-op when `context` is empty or undefined, mirroring
 // withAsyncContextIfNeeded's "no async context, no snapshot".

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -6,6 +6,10 @@
 #include <JavaScriptCore/Strong.h>
 #include <wtf/Noncopyable.h>
 
+namespace WebCore {
+class JSValueInWrappedObject;
+}
+
 class AsyncContextFrame : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
@@ -20,14 +24,18 @@ public:
     static JSC::JSValue withAsyncContextIfNeeded(JSC::JSGlobalObject* globalObject, JSC::JSValue callback);
 
     // Snapshots the currently-active async context (the value AsyncLocalStorage
-    // is running with) into `slot`, for AsyncContextFrameScope to restore later.
-    // No-op when there is none, so `slot` never allocates a GC handle for it.
+    // is running with) into `slot`, for AsyncContextFrameScope to restore
+    // around a later asynchronous event dispatch. No-op when there is none.
     //
-    // `slot` must be a Strong: the value has to stay alive for as long as the
-    // owner can still dispatch, and the owner's JS wrapper is not a reliable
-    // root for that (a MessageChannel's ports have no wrapper until .port1 is
-    // first read, and an AbortSignal.any() timeout source's wrapper can be
-    // collected while its timer is still pending).
+    // Prefer the JSValueInWrappedObject overload and visit `slot` from the
+    // owner's JS wrapper. The snapshot can reference that wrapper (the user's
+    // store may hold the resource), so rooting it with a JSC::Strong on an
+    // object whose wrapper holds a Ref back to it forms an uncollectable
+    // native-to-GC cycle. Only use the Strong overload when a GC-independent
+    // release is guaranteed to run: AbortSignal.timeout() needs it (its abort
+    // is observed through a dependent AbortSignal.any() signal's wrapper, not
+    // its own) and its timer heap guarantees cancelTimer() drops the handle.
+    static void captureCurrentContext(JSC::JSGlobalObject* globalObject, WebCore::JSValueInWrappedObject& slot);
     static void captureCurrentContext(JSC::JSGlobalObject* globalObject, JSC::Strong<JSC::Unknown>& slot);
 
     // The following is JSC::call but

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -3,6 +3,7 @@
 #include "root.h"
 #include "BunClientData.h"
 #include <JavaScriptCore/CallData.h>
+#include <wtf/Noncopyable.h>
 
 class AsyncContextFrame : public JSC::JSNonFinalObject {
 public:
@@ -16,6 +17,10 @@ public:
 
     // When given a JSFunction that you want to call later, wrap it with this function
     static JSC::JSValue withAsyncContextIfNeeded(JSC::JSGlobalObject* globalObject, JSC::JSValue callback);
+
+    // The async context value AsyncLocalStorage is currently running with, or
+    // `undefined` when none is active. Pair with AsyncContextFrameScope.
+    static JSC::JSValue currentContext(JSC::JSGlobalObject* globalObject);
 
     // The following is JSC::call but
     // - it unwraps AsyncContextFrame
@@ -63,4 +68,26 @@ public:
         , context(context_, JSC::WriteBarrierEarlyInit)
     {
     }
+};
+
+// RAII: installs `context` as the active async context (the value every
+// AsyncLocalStorage.getStore() reads) and restores the previous one on exit.
+//
+// Use this around an event dispatch that happens asynchronously (from an
+// event-loop task) on behalf of a resource created earlier, passing the
+// AsyncContextFrame::currentContext() snapshot taken when the resource was
+// created. For a single callback, prefer withAsyncContextIfNeeded + call.
+//
+// A no-op when `context` is empty or undefined, mirroring
+// withAsyncContextIfNeeded's "no async context, no snapshot".
+class AsyncContextFrameScope {
+    WTF_MAKE_NONCOPYABLE(AsyncContextFrameScope);
+
+public:
+    AsyncContextFrameScope(JSC::JSGlobalObject*, JSC::JSValue context);
+    ~AsyncContextFrameScope();
+
+private:
+    JSC::JSGlobalObject* m_globalObject { nullptr };
+    JSC::JSValue m_previousContext;
 };

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5620,6 +5620,11 @@ extern "C" WebCore::AbortSignalTimeout WebCore__AbortSignal__getTimeout(WebCore:
     return abortSignal->getTimeout();
 }
 
+extern "C" void WebCore__AbortSignal__clearTimeoutAsyncContext(WebCore::AbortSignal* abortSignal)
+{
+    abortSignal->clearTimeoutAsyncContext();
+}
+
 extern "C" WebCore::AbortSignal* WebCore__AbortSignal__ref(WebCore::AbortSignal* abortSignal)
 {
     abortSignal->ref();

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -27,6 +27,7 @@
 #include "AbortSignal.h"
 
 #include "AbortAlgorithm.h"
+#include "AsyncContextFrame.h"
 #include "DOMException.h"
 // #include "DOMTimer.h"
 #include "Event.h"
@@ -66,6 +67,11 @@ Ref<AbortSignal> AbortSignal::abort(JSDOMGlobalObject& globalObject, ScriptExecu
 Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t milliseconds)
 {
     auto signal = adoptRef(*new AbortSignal(&context));
+    // The abort fires from the timer heap, not from a JS caller, so snapshot
+    // the caller's async context now. Node does the equivalent through the
+    // setTimeout() that backs its AbortSignal.timeout().
+    if (auto* globalObject = context.jsGlobalObject())
+        signal->m_timeoutAsyncContext.setWeakly(AsyncContextFrame::currentContext(globalObject));
     signal->m_timeout = AbortSignal__Timeout__create(bunVM(context.vm()), signal.ptr(), milliseconds);
     ASSERT(signal->m_timeout);
     signal->ref();
@@ -216,6 +222,12 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     // Defer the deref until after all abort work is done so `this` stays
     // alive throughout.
     bool hadTimeout = m_timeout != nullptr;
+
+    // Restore the async context captured by AbortSignal.timeout(): the timer
+    // fires from the event loop with no active AsyncLocalStorage context.
+    // Undefined (and so a no-op) for every other abort path.
+    auto* context = scriptExecutionContext();
+    AsyncContextFrameScope asyncContextScope(context ? context->jsGlobalObject() : nullptr, m_timeoutAsyncContext.getValue());
 
     // 2. Set signal’s abort reason to reason if it is given; otherwise to a new "AbortError" DOMException.
     markAborted(reason);

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -158,6 +158,9 @@ void AbortSignal::cancelTimer()
     if (auto timeout = std::exchange(m_timeout, nullptr)) {
         AbortSignal__Timeout__deinit(timeout);
     }
+    // The timer can never fire past this point, so release the snapshot taken
+    // in timeout(); signalAbort() has already copied it into its restore scope.
+    m_timeoutAsyncContext.clear();
 }
 
 void AbortSignal::markAborted(JSC::JSValue reason)

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -71,7 +71,7 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t 
     // the caller's async context now. Node does the equivalent through the
     // setTimeout() that backs its AbortSignal.timeout().
     if (auto* globalObject = context.jsGlobalObject())
-        signal->m_timeoutAsyncContext.setWeakly(AsyncContextFrame::currentContext(globalObject));
+        AsyncContextFrame::captureCurrentContext(globalObject, signal->m_timeoutAsyncContext);
     signal->m_timeout = AbortSignal__Timeout__create(bunVM(context.vm()), signal.ptr(), milliseconds);
     ASSERT(signal->m_timeout);
     signal->ref();
@@ -230,7 +230,7 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     // fires from the event loop with no active AsyncLocalStorage context.
     // Undefined (and so a no-op) for every other abort path.
     auto* context = scriptExecutionContext();
-    AsyncContextFrameScope asyncContextScope(context ? context->jsGlobalObject() : nullptr, m_timeoutAsyncContext.getValue());
+    AsyncContextFrameScope asyncContextScope(context ? context->jsGlobalObject() : nullptr, m_timeoutAsyncContext.get());
 
     // 2. Set signal’s abort reason to reason if it is given; otherwise to a new "AbortError" DOMException.
     markAborted(reason);

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -158,6 +158,11 @@ void AbortSignal::cancelTimer()
     if (auto timeout = std::exchange(m_timeout, nullptr)) {
         AbortSignal__Timeout__deinit(timeout);
     }
+    clearTimeoutAsyncContext();
+}
+
+void AbortSignal::clearTimeoutAsyncContext()
+{
     // The timer can never fire past this point, so release the snapshot taken
     // in timeout(); signalAbort() has already copied it into its restore scope.
     m_timeoutAsyncContext.clear();

--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -139,6 +139,11 @@ public:
 
     AbortSignalTimeout getTimeout() const { return m_timeout; }
 
+    // Every path that retires the timeout (cancelTimer(), and the Rust timer
+    // teardown paths that unref the signal without reaching it) must call this
+    // so m_timeoutAsyncContext never outlives the timer as a GC root.
+    void clearTimeoutAsyncContext();
+
 private:
     enum class Aborted : bool {
         No,
@@ -205,7 +210,7 @@ private:
     JSValueInWrappedObject m_reason;
     // AbortSignal.timeout() only: the async context active when timeout() was
     // called, restored around the timer-driven abort and released by
-    // cancelTimer(). See AsyncContextFrame::captureCurrentContext.
+    // clearTimeoutAsyncContext(). See AsyncContextFrame::captureCurrentContext.
     JSC::Strong<JSC::Unknown> m_timeoutAsyncContext;
     CommonAbortReason m_commonReason { CommonAbortReason::None };
     Vector<NativeCallbackTuple, 2> m_native_callbacks;

--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -92,6 +92,7 @@ public:
     void runAbortSteps();
 
     const JSValueInWrappedObject& reason() const { return m_reason; }
+    const JSValueInWrappedObject& timeoutAsyncContext() const { return m_timeoutAsyncContext; }
     JSValue jsReason(JSC::JSGlobalObject& globalObject);
     CommonAbortReason commonReason() const { return m_commonReason; }
 
@@ -202,6 +203,9 @@ private:
     AbortSignalSet m_sourceSignals;
     AbortSignalSet m_dependentSignals;
     JSValueInWrappedObject m_reason;
+    // AbortSignal.timeout() only: the async context active when timeout() was
+    // called, restored around the timer-driven abort. See AsyncContextFrameScope.
+    JSValueInWrappedObject m_timeoutAsyncContext;
     CommonAbortReason m_commonReason { CommonAbortReason::None };
     Vector<NativeCallbackTuple, 2> m_native_callbacks;
     Vector<NativeCallbackTuple, 2>* m_nativeCallbacksBeingDispatched { nullptr };

--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -32,6 +32,7 @@
 #include "JSValueInWrappedObject.h"
 #include "JavaScriptCore/JSGlobalObject.h"
 #include "ZigGlobalObject.h"
+#include <JavaScriptCore/Strong.h>
 #include "wtf/DebugHeap.h"
 #include "wtf/FastMalloc.h"
 #include <wtf/Function.h>
@@ -92,7 +93,6 @@ public:
     void runAbortSteps();
 
     const JSValueInWrappedObject& reason() const { return m_reason; }
-    const JSValueInWrappedObject& timeoutAsyncContext() const { return m_timeoutAsyncContext; }
     JSValue jsReason(JSC::JSGlobalObject& globalObject);
     CommonAbortReason commonReason() const { return m_commonReason; }
 
@@ -204,8 +204,9 @@ private:
     AbortSignalSet m_dependentSignals;
     JSValueInWrappedObject m_reason;
     // AbortSignal.timeout() only: the async context active when timeout() was
-    // called, restored around the timer-driven abort. See AsyncContextFrameScope.
-    JSValueInWrappedObject m_timeoutAsyncContext;
+    // called, restored around the timer-driven abort and released by
+    // cancelTimer(). See AsyncContextFrame::captureCurrentContext.
+    JSC::Strong<JSC::Unknown> m_timeoutAsyncContext;
     CommonAbortReason m_commonReason { CommonAbortReason::None };
     Vector<NativeCallbackTuple, 2> m_native_callbacks;
     Vector<NativeCallbackTuple, 2>* m_nativeCallbacksBeingDispatched { nullptr };

--- a/src/jsc/bindings/webcore/BroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/BroadcastChannel.cpp
@@ -105,6 +105,8 @@ void BroadcastChannel::close()
     uint64_t prev = m_state.fetch_or(Closed, std::memory_order_acq_rel);
     if (prev & Closed)
         return;
+    // A closed channel can never dispatch again; release the creation snapshot.
+    m_creationAsyncContext.clear();
     BunBroadcastChannelRegistry::singleton().unsubscribe(m_name, *this);
 }
 

--- a/src/jsc/bindings/webcore/BroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/BroadcastChannel.cpp
@@ -96,7 +96,7 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
     }
     // Listeners observe the async context that was active when this channel
     // was created.
-    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.get());
+    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
     dispatchEvent(event.event);
 }
 

--- a/src/jsc/bindings/webcore/BroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/BroadcastChannel.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "BroadcastChannel.h"
 
+#include "AsyncContextFrame.h"
 #include "BunBroadcastChannelRegistry.h"
 #include "BunClientData.h"
 #include "EventNames.h"
@@ -45,6 +46,10 @@ BroadcastChannel::BroadcastChannel(ScriptExecutionContext& context, const String
     , m_contextId(context.identifier())
 {
     initializeWeakPtrFactory();
+    // dispatchMessage() runs from a posted task, not from a JS caller, so
+    // snapshot the creator's async context now (Node's AsyncWrap does the same).
+    if (auto* globalObject = context.jsGlobalObject())
+        m_creationAsyncContext.setWeakly(AsyncContextFrame::currentContext(globalObject));
     BunBroadcastChannelRegistry::singleton().subscribe(m_name, m_contextId, *this);
     jsRef(context.jsGlobalObject());
 }
@@ -89,6 +94,9 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
         RELEASE_ASSERT(vm.hasPendingTerminationException());
         return;
     }
+    // Listeners observe the async context that was active when this channel
+    // was created.
+    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
     dispatchEvent(event.event);
 }
 

--- a/src/jsc/bindings/webcore/BroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/BroadcastChannel.cpp
@@ -49,7 +49,7 @@ BroadcastChannel::BroadcastChannel(ScriptExecutionContext& context, const String
     // dispatchMessage() runs from a posted task, not from a JS caller, so
     // snapshot the creator's async context now (Node's AsyncWrap does the same).
     if (auto* globalObject = context.jsGlobalObject())
-        m_creationAsyncContext.setWeakly(AsyncContextFrame::currentContext(globalObject));
+        AsyncContextFrame::captureCurrentContext(globalObject, m_creationAsyncContext);
     BunBroadcastChannelRegistry::singleton().subscribe(m_name, m_contextId, *this);
     jsRef(context.jsGlobalObject());
 }
@@ -96,7 +96,7 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
     }
     // Listeners observe the async context that was active when this channel
     // was created.
-    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
+    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.get());
     dispatchEvent(event.event);
 }
 

--- a/src/jsc/bindings/webcore/BroadcastChannel.h
+++ b/src/jsc/bindings/webcore/BroadcastChannel.h
@@ -39,6 +39,7 @@
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObject.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -79,6 +80,8 @@ public:
     void jsRef(JSGlobalObject*);
     void jsUnref(JSGlobalObject*);
 
+    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
+
 private:
     friend class BunBroadcastChannelRegistry;
 
@@ -101,6 +104,10 @@ private:
 
     const String m_name;
     const ScriptExecutionContextIdentifier m_contextId;
+
+    // The async context active when the channel was created, restored around
+    // dispatchMessage(). See AsyncContextFrameScope.
+    JSValueInWrappedObject m_creationAsyncContext;
 
     std::atomic<uint64_t> m_state { 0 };
 

--- a/src/jsc/bindings/webcore/BroadcastChannel.h
+++ b/src/jsc/bindings/webcore/BroadcastChannel.h
@@ -39,8 +39,8 @@
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObject.h"
 #include "ScriptExecutionContext.h"
-#include <JavaScriptCore/Strong.h>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
@@ -80,6 +80,8 @@ public:
     void jsRef(JSGlobalObject*);
     void jsUnref(JSGlobalObject*);
 
+    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
+
 private:
     friend class BunBroadcastChannelRegistry;
 
@@ -104,8 +106,8 @@ private:
     const ScriptExecutionContextIdentifier m_contextId;
 
     // The async context active when the channel was created, restored around
-    // dispatchMessage(). See AsyncContextFrame::captureCurrentContext.
-    JSC::Strong<JSC::Unknown> m_creationAsyncContext;
+    // dispatchMessage(). Visited by JSBroadcastChannel::visitChildrenImpl.
+    JSValueInWrappedObject m_creationAsyncContext;
 
     std::atomic<uint64_t> m_state { 0 };
 

--- a/src/jsc/bindings/webcore/BroadcastChannel.h
+++ b/src/jsc/bindings/webcore/BroadcastChannel.h
@@ -39,8 +39,8 @@
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
-#include "JSValueInWrappedObject.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/Strong.h>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
@@ -80,8 +80,6 @@ public:
     void jsRef(JSGlobalObject*);
     void jsUnref(JSGlobalObject*);
 
-    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
-
 private:
     friend class BunBroadcastChannelRegistry;
 
@@ -106,8 +104,8 @@ private:
     const ScriptExecutionContextIdentifier m_contextId;
 
     // The async context active when the channel was created, restored around
-    // dispatchMessage(). See AsyncContextFrameScope.
-    JSValueInWrappedObject m_creationAsyncContext;
+    // dispatchMessage(). See AsyncContextFrame::captureCurrentContext.
+    JSC::Strong<JSC::Unknown> m_creationAsyncContext;
 
     std::atomic<uint64_t> m_state { 0 };
 

--- a/src/jsc/bindings/webcore/JSAbortSignalCustom.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignalCustom.cpp
@@ -81,6 +81,7 @@ template<typename Visitor>
 void JSAbortSignal::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     wrapped().reason().visit(visitor);
+    wrapped().timeoutAsyncContext().visit(visitor);
     wrapped().visitAbortAlgorithms(visitor);
 }
 

--- a/src/jsc/bindings/webcore/JSAbortSignalCustom.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignalCustom.cpp
@@ -81,7 +81,6 @@ template<typename Visitor>
 void JSAbortSignal::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     wrapped().reason().visit(visitor);
-    wrapped().timeoutAsyncContext().visit(visitor);
     wrapped().visitAbortAlgorithms(visitor);
 }
 

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -421,6 +421,19 @@ JSC::GCClient::IsoSubspace* JSBroadcastChannel::subspaceForImpl(JSC::VM& vm)
         [](auto& spaces, auto&& space) { spaces.m_subspaceForBroadcastChannel = std::forward<decltype(space)>(space); });
 }
 
+template<typename Visitor>
+void JSBroadcastChannel::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSBroadcastChannel>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    // Set once in the BroadcastChannel constructor (before this wrapper
+    // exists) and never mutated afterwards, so no output constraint is needed.
+    thisObject->wrapped().creationAsyncContext().visit(visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSBroadcastChannel);
+
 void JSBroadcastChannel::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     auto* thisObject = uncheckedDowncast<JSBroadcastChannel>(cell);

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -421,19 +421,6 @@ JSC::GCClient::IsoSubspace* JSBroadcastChannel::subspaceForImpl(JSC::VM& vm)
         [](auto& spaces, auto&& space) { spaces.m_subspaceForBroadcastChannel = std::forward<decltype(space)>(space); });
 }
 
-template<typename Visitor>
-void JSBroadcastChannel::visitChildrenImpl(JSCell* cell, Visitor& visitor)
-{
-    auto* thisObject = uncheckedDowncast<JSBroadcastChannel>(cell);
-    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
-    Base::visitChildren(thisObject, visitor);
-    // Set once in the BroadcastChannel constructor (before this wrapper
-    // exists) and never mutated afterwards, so no output constraint is needed.
-    thisObject->wrapped().creationAsyncContext().visit(visitor);
-}
-
-DEFINE_VISIT_CHILDREN(JSBroadcastChannel);
-
 void JSBroadcastChannel::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     auto* thisObject = uncheckedDowncast<JSBroadcastChannel>(cell);

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -428,7 +428,8 @@ void JSBroadcastChannel::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     // Set once in the BroadcastChannel constructor (before this wrapper
-    // exists) and never mutated afterwards, so no output constraint is needed.
+    // exists) and only ever cleared afterwards (on close()), so it can never
+    // acquire a new value post-marking: no output constraint is needed.
     thisObject->wrapped().creationAsyncContext().visit(visitor);
 }
 

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.h
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.h
@@ -43,6 +43,7 @@ public:
     static BroadcastChannel* toWrapped(JSC::VM&, JSC::JSValue);
 
     DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.h
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.h
@@ -43,7 +43,6 @@ public:
     static BroadcastChannel* toWrapped(JSC::VM&, JSC::JSValue);
 
     DECLARE_INFO;
-    DECLARE_VISIT_CHILDREN;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/src/jsc/bindings/webcore/JSMessageChannelCustom.cpp
+++ b/src/jsc/bindings/webcore/JSMessageChannelCustom.cpp
@@ -41,6 +41,12 @@ void JSMessageChannel::visitAdditionalChildrenInGCThread(Visitor& visitor)
     visitor.addOpaqueRoot(WTF::getPtr(wrapped().port2()));
     // addWebCoreOpaqueRoot(visitor, wrapped().port1());
     // addWebCoreOpaqueRoot(visitor, wrapped().port2());
+
+    // port1/port2 have no JSMessagePort wrapper until first read (the getters
+    // are lazy), so until then this is the only visitor that can keep the
+    // ports' captured async context alive.
+    wrapped().port1().creationAsyncContext().visit(visitor);
+    wrapped().port2().creationAsyncContext().visit(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMessageChannel);

--- a/src/jsc/bindings/webcore/JSMessagePortCustom.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePortCustom.cpp
@@ -34,7 +34,6 @@ using namespace JSC;
 template<typename Visitor>
 void JSMessagePort::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().creationAsyncContext().visit(visitor);
     // If we have a locally entangled port, we can directly mark it as reachable. Ports that are remotely entangled are marked in-use by markActiveObjectsForContext().
     if (auto* port = wrapped().locallyEntangledPort()) {
         visitor.addOpaqueRoot(port);

--- a/src/jsc/bindings/webcore/JSMessagePortCustom.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePortCustom.cpp
@@ -34,6 +34,7 @@ using namespace JSC;
 template<typename Visitor>
 void JSMessagePort::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
+    wrapped().creationAsyncContext().visit(visitor);
     // If we have a locally entangled port, we can directly mark it as reachable. Ports that are remotely entangled are marked in-use by markActiveObjectsForContext().
     if (auto* port = wrapped().locallyEntangledPort()) {
         visitor.addOpaqueRoot(port);

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -944,19 +944,6 @@ JSC::GCClient::IsoSubspace* JSWorker::subspaceForImpl(JSC::VM& vm)
         [](auto& spaces, auto&& space) { spaces.m_subspaceForWorker = std::forward<decltype(space)>(space); });
 }
 
-template<typename Visitor>
-void JSWorker::visitChildrenImpl(JSCell* cell, Visitor& visitor)
-{
-    auto* thisObject = uncheckedDowncast<JSWorker>(cell);
-    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
-    Base::visitChildren(thisObject, visitor);
-    // Set once in the Worker constructor (before this wrapper exists) and
-    // never mutated afterwards, so no output constraint is needed for it.
-    thisObject->wrapped().creationAsyncContext().visit(visitor);
-}
-
-DEFINE_VISIT_CHILDREN(JSWorker);
-
 void JSWorker::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     auto* thisObject = uncheckedDowncast<JSWorker>(cell);

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -944,6 +944,19 @@ JSC::GCClient::IsoSubspace* JSWorker::subspaceForImpl(JSC::VM& vm)
         [](auto& spaces, auto&& space) { spaces.m_subspaceForWorker = std::forward<decltype(space)>(space); });
 }
 
+template<typename Visitor>
+void JSWorker::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSWorker>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    // Set once in the Worker constructor (before this wrapper exists) and
+    // never mutated afterwards, so no output constraint is needed for it.
+    thisObject->wrapped().creationAsyncContext().visit(visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSWorker);
+
 void JSWorker::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     auto* thisObject = uncheckedDowncast<JSWorker>(cell);

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -951,7 +951,8 @@ void JSWorker::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     // Set once in the Worker constructor (before this wrapper exists) and
-    // never mutated afterwards, so no output constraint is needed for it.
+    // only ever cleared afterwards (when the worker reaches Closed), so it
+    // can never acquire a new value post-marking: no output constraint needed.
     thisObject->wrapped().creationAsyncContext().visit(visitor);
 }
 

--- a/src/jsc/bindings/webcore/JSWorker.h
+++ b/src/jsc/bindings/webcore/JSWorker.h
@@ -43,6 +43,7 @@ public:
     static Worker* toWrapped(JSC::VM&, JSC::JSValue);
 
     DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/src/jsc/bindings/webcore/JSWorker.h
+++ b/src/jsc/bindings/webcore/JSWorker.h
@@ -43,7 +43,6 @@ public:
     static Worker* toWrapped(JSC::VM&, JSC::JSValue);
 
     DECLARE_INFO;
-    DECLARE_VISIT_CHILDREN;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -217,9 +217,6 @@ void MessagePort::close()
     // it in hasPendingActivity()); marking our side Closed is sufficient.
     m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
 
-    // A closed port can never dispatch again; release the creation snapshot.
-    m_creationAsyncContext.clear();
-
     // Release the self-reference taken by jsRef() (set when .onmessage is
     // assigned or .ref() is called from JS). The JS .close() binding calls
     // jsUnref() first, so m_hasRef is already false on that path; we only
@@ -256,6 +253,8 @@ void MessagePort::close()
         });
     } else {
         removeAllEventListeners();
+        // dispatchCloseEvent() would have released it, but this path can't reach it.
+        m_creationAsyncContext.clear();
     }
 }
 
@@ -273,8 +272,12 @@ void MessagePort::dispatchCloseEvent()
     auto* globalObject = defaultGlobalObject(context->globalObject());
     // Bypass the m_isDetached guard in MessagePort::dispatchEvent — the deferred
     // close task runs after m_isDetached is set.
-    if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) == ScriptExecutionStatus::Running)
+    if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) == ScriptExecutionStatus::Running) {
+        AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
         EventTarget::dispatchEvent(Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    }
+    // The one-shot close event was the last possible dispatch; release the snapshot.
+    m_creationAsyncContext.clear();
 }
 
 void MessagePort::peerClosed()

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -29,6 +29,7 @@
 #include <wtf/SetForScope.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
 
+#include "AsyncContextFrame.h"
 #include "BunClientData.h"
 #include "EventNames.h"
 #include "JSMessagePort.h"
@@ -63,6 +64,11 @@ MessagePort::MessagePort(ScriptExecutionContext& context, Ref<MessagePortPipe>&&
     // listening port keeps its thread alive until closed or unref'd); otherwise a
     // buffered message could be lost if its listener is added late.
     onDidChangeListener = &MessagePort::onDidChangeListenerImpl;
+
+    // Message delivery happens from a posted task, not from a JS caller, so
+    // snapshot the creator's async context now (Node's AsyncWrap does the same).
+    if (auto* globalObject = context.jsGlobalObject())
+        m_creationAsyncContext.setWeakly(AsyncContextFrame::currentContext(globalObject));
 }
 
 MessagePort::~MessagePort()
@@ -355,6 +361,10 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
 
     if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != ScriptExecutionStatus::Running)
         return;
+
+    // Listeners (and any MessagePort entangled out of this message) observe
+    // the async context that was active when this port was created.
+    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
 
     auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
     if (scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -217,6 +217,9 @@ void MessagePort::close()
     // it in hasPendingActivity()); marking our side Closed is sufficient.
     m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
 
+    // A closed port can never dispatch again; release the creation snapshot.
+    m_creationAsyncContext.clear();
+
     // Release the self-reference taken by jsRef() (set when .onmessage is
     // assigned or .ref() is called from JS). The JS .close() binding calls
     // jsUnref() first, so m_hasRef is already false on that path; we only
@@ -305,6 +308,9 @@ TransferredMessagePort MessagePort::disentangle()
     // there would be nothing to unref.
     removeAllEventListeners();
     m_hasMessageEventListener = false;
+
+    // A transferred-away port is inert; release the creation snapshot.
+    m_creationAsyncContext.clear();
 
     // Release the self-reference taken by jsRef() on the sending side. After
     // transfer this object is inert (the receiving side gets a fresh

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -362,10 +362,6 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
     if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != ScriptExecutionStatus::Running)
         return;
 
-    // Listeners (and any MessagePort entangled out of this message) observe
-    // the async context that was active when this port was created.
-    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
-
     auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
     if (scope.exception()) [[unlikely]] {
         RELEASE_ASSERT(vm->hasPendingTerminationException());
@@ -373,6 +369,10 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
     }
 
     auto event = MessageEvent::create(*context.jsGlobalObject(), message.message.releaseNonNull(), {}, {}, {}, WTF::move(ports));
+    // Listeners observe the async context that was active when this port was
+    // created. entanglePorts() above stays outside: Node deserializes a
+    // message's transferred ports before restoring the receiver's context.
+    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
     dispatchEvent(event.event);
 }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -68,7 +68,7 @@ MessagePort::MessagePort(ScriptExecutionContext& context, Ref<MessagePortPipe>&&
     // Message delivery happens from a posted task, not from a JS caller, so
     // snapshot the creator's async context now (Node's AsyncWrap does the same).
     if (auto* globalObject = context.jsGlobalObject())
-        m_creationAsyncContext.setWeakly(AsyncContextFrame::currentContext(globalObject));
+        AsyncContextFrame::captureCurrentContext(globalObject, m_creationAsyncContext);
 }
 
 MessagePort::~MessagePort()
@@ -372,7 +372,7 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
     // Listeners observe the async context that was active when this port was
     // created. entanglePorts() above stays outside: Node deserializes a
     // message's transferred ports before restoring the receiver's context.
-    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
+    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.get());
     dispatchEvent(event.event);
 }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -249,11 +249,15 @@ void MessagePort::close()
         context->postTask([protectedThis = Ref { *this }](ScriptExecutionContext&) {
             protectedThis->dispatchCloseEvent();
             protectedThis->removeAllEventListeners();
+            // close() set m_isDetached, so this is the last possible dispatch;
+            // release the creation snapshot. Kept out of dispatchCloseEvent()
+            // because peerClosed() reaches that without detaching and can still
+            // deliver buffered messages if a listener is added afterwards.
+            protectedThis->m_creationAsyncContext.clear();
             protectedThis->m_closeEventPending.store(false, std::memory_order_release);
         });
     } else {
         removeAllEventListeners();
-        // dispatchCloseEvent() would have released it, but this path can't reach it.
         m_creationAsyncContext.clear();
     }
 }
@@ -276,8 +280,6 @@ void MessagePort::dispatchCloseEvent()
         AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
         EventTarget::dispatchEvent(Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No));
     }
-    // The one-shot close event was the last possible dispatch; release the snapshot.
-    m_creationAsyncContext.clear();
 }
 
 void MessagePort::peerClosed()

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -372,7 +372,7 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
     // Listeners observe the async context that was active when this port was
     // created. entanglePorts() above stays outside: Node deserializes a
     // message's transferred ports before restoring the receiver's context.
-    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.get());
+    AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
     dispatchEvent(event.event);
 }
 

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -41,9 +41,9 @@
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
-#include "JSValueInWrappedObject.h"
 #include "MessagePortPipe.h"
 #include "MessageWithMessagePorts.h"
+#include <JavaScriptCore/Strong.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
@@ -116,8 +116,6 @@ public:
     // Report the actual loop-ref state (matches Node's uv_has_ref), not the intent flag.
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }
 
-    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
-
 private:
     MessagePort(ScriptExecutionContext&, Ref<MessagePortPipe>&&, uint8_t side);
 
@@ -144,8 +142,8 @@ private:
     const uint8_t m_side { 0 };
 
     // The async context active when the port was created, restored around
-    // dispatchOneMessage(). See AsyncContextFrameScope.
-    JSValueInWrappedObject m_creationAsyncContext;
+    // dispatchOneMessage(). See AsyncContextFrame::captureCurrentContext.
+    JSC::Strong<JSC::Unknown> m_creationAsyncContext;
 
     bool m_started { false };
     bool m_isDetached { false };

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -41,6 +41,7 @@
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObject.h"
 #include "MessagePortPipe.h"
 #include "MessageWithMessagePorts.h"
 #include <wtf/WeakPtr.h>
@@ -115,6 +116,8 @@ public:
     // Report the actual loop-ref state (matches Node's uv_has_ref), not the intent flag.
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }
 
+    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
+
 private:
     MessagePort(ScriptExecutionContext&, Ref<MessagePortPipe>&&, uint8_t side);
 
@@ -139,6 +142,10 @@ private:
     // mutator. close()/disentangle() flip pipe-side state bits instead.
     const Ref<MessagePortPipe> m_pipe;
     const uint8_t m_side { 0 };
+
+    // The async context active when the port was created, restored around
+    // dispatchOneMessage(). See AsyncContextFrameScope.
+    JSValueInWrappedObject m_creationAsyncContext;
 
     bool m_started { false };
     bool m_isDetached { false };

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -41,9 +41,9 @@
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObject.h"
 #include "MessagePortPipe.h"
 #include "MessageWithMessagePorts.h"
-#include <JavaScriptCore/Strong.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
@@ -116,6 +116,8 @@ public:
     // Report the actual loop-ref state (matches Node's uv_has_ref), not the intent flag.
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }
 
+    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
+
 private:
     MessagePort(ScriptExecutionContext&, Ref<MessagePortPipe>&&, uint8_t side);
 
@@ -142,8 +144,9 @@ private:
     const uint8_t m_side { 0 };
 
     // The async context active when the port was created, restored around
-    // dispatchOneMessage(). See AsyncContextFrame::captureCurrentContext.
-    JSC::Strong<JSC::Unknown> m_creationAsyncContext;
+    // dispatchOneMessage(). Visited by JSMessagePort and, until a first
+    // .port1/.port2 read creates that wrapper, by JSMessageChannel.
+    JSValueInWrappedObject m_creationAsyncContext;
 
     bool m_started { false };
     bool m_isDetached { false };

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -643,6 +643,8 @@ bool Worker::dispatchExit(int32_t exitCode)
             }
 
             protectedThis->m_state.store(State::Closed);
+            // A Closed worker never dispatches again; release the creation snapshot.
+            protectedThis->m_creationAsyncContext.clear();
             WebWorker__releaseParentPollRef(protectedThis->impl_);
             // protectedThis (and the JSWorker GC cell, if still rooted) keep us
             // alive across the close-event dispatch; both deref on the parent

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -111,7 +111,7 @@ Worker::Worker(ScriptExecutionContext& context, WorkerOptions&& options)
     // caller, so snapshot the creator's async context now (Node's AsyncWrap
     // does the same for its Worker/MessagePort handles).
     if (auto* globalObject = context.jsGlobalObject())
-        m_creationAsyncContext.setWeakly(AsyncContextFrame::currentContext(globalObject));
+        AsyncContextFrame::captureCurrentContext(globalObject, m_creationAsyncContext);
 }
 
 ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const String& urlInit, WorkerOptions&& options)
@@ -366,7 +366,7 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         // Listeners observe the async context that was active at new Worker().
         // drainInbox's entanglePorts() stays outside: Node deserializes a
         // message's transferred ports before restoring the receiver's context.
-        AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
+        AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.get());
         dispatchEvent(event);
     });
     if (reschedule) {
@@ -477,7 +477,7 @@ void Worker::dispatchOnline(Zig::GlobalObject* workerGlobalObject)
     postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext& context) {
         if (protectedThis->hasEventListeners(eventNames().openEvent)) {
             auto event = Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No);
-            AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
+            AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.get());
             protectedThis->dispatchEvent(event);
         }
     });
@@ -535,7 +535,7 @@ void Worker::dispatchErrorWithMessage(WTF::String message)
         init.message = message;
 
         auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
-        AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
+        AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.get());
         protectedThis->dispatchEvent(event);
     });
 }
@@ -582,7 +582,7 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
         init.error = deserialized;
 
         auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
-        AsyncContextFrameScope asyncContextScope(globalObject, protectedThis->m_creationAsyncContext.getValue());
+        AsyncContextFrameScope asyncContextScope(globalObject, protectedThis->m_creationAsyncContext.get());
         protectedThis->dispatchEvent(event);
     });
 }
@@ -638,7 +638,7 @@ bool Worker::dispatchExit(int32_t exitCode)
 
             if (protectedThis->hasEventListeners(eventNames().closeEvent)) {
                 auto event = CloseEvent::create(exitCode == 0, static_cast<unsigned short>(exitCode), exitCode == 0 ? "Worker terminated normally"_s : "Worker exited abnormally"_s);
-                AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
+                AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.get());
                 protectedThis->EventTargetWithInlineData::dispatchEvent(event);
             }
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -363,6 +363,9 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         return;
     }
     bool reschedule = drainInbox(m_toParent, globalObject, context, [&](Event& event) {
+        // Listeners observe the async context that was active at new Worker().
+        // drainInbox's entanglePorts() stays outside: Node deserializes a
+        // message's transferred ports before restoring the receiver's context.
         AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
         dispatchEvent(event);
     });

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "Worker.h"
 
+#include "AsyncContextFrame.h"
 #include "BunClientData.h"
 #include "ErrorCode.h"
 #include "ErrorEvent.h"
@@ -106,6 +107,11 @@ Worker::Worker(ScriptExecutionContext& context, WorkerOptions&& options)
     , m_parentContextId(context.identifier())
     , m_clientIdentifier(ScriptExecutionContext::generateIdentifier())
 {
+    // Parent-side events are dispatched from posted tasks, not from a JS
+    // caller, so snapshot the creator's async context now (Node's AsyncWrap
+    // does the same for its Worker/MessagePort handles).
+    if (auto* globalObject = context.jsGlobalObject())
+        m_creationAsyncContext.setWeakly(AsyncContextFrame::currentContext(globalObject));
 }
 
 ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const String& urlInit, WorkerOptions&& options)
@@ -357,6 +363,7 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         return;
     }
     bool reschedule = drainInbox(m_toParent, globalObject, context, [&](Event& event) {
+        AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
         dispatchEvent(event);
     });
     if (reschedule) {
@@ -464,9 +471,10 @@ void Worker::dispatchOnline(Zig::GlobalObject* workerGlobalObject)
         m_state.store(State::Running);
     }
 
-    postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext&) {
+    postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext& context) {
         if (protectedThis->hasEventListeners(eventNames().openEvent)) {
             auto event = Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No);
+            AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
             protectedThis->dispatchEvent(event);
         }
     });
@@ -519,11 +527,12 @@ void Worker::fireEarlyMessages(Zig::GlobalObject* workerGlobalObject)
 
 void Worker::dispatchErrorWithMessage(WTF::String message)
 {
-    postTaskToParent([protectedThis = Ref { *this }, message = message.isolatedCopy()](ScriptExecutionContext&) {
+    postTaskToParent([protectedThis = Ref { *this }, message = message.isolatedCopy()](ScriptExecutionContext& context) {
         ErrorEvent::Init init;
         init.message = message;
 
         auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
+        AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
         protectedThis->dispatchEvent(event);
     });
 }
@@ -570,6 +579,7 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
         init.error = deserialized;
 
         auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
+        AsyncContextFrameScope asyncContextScope(globalObject, protectedThis->m_creationAsyncContext.getValue());
         protectedThis->dispatchEvent(event);
     });
 }
@@ -602,7 +612,7 @@ bool Worker::dispatchExit(int32_t exitCode)
     return ScriptExecutionContext::postTaskTo(
         m_parentContextId,
         [this] { this->deref(); },
-        [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext&) {
+        [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
             // Closing → dispatch 'close' → Closed. The split lets 'close'/'exit'
             // handlers observe threadId == -1 and isOnline() == false while
             // postMessage() (gated only on Closed) still accepts and drops the
@@ -625,6 +635,7 @@ bool Worker::dispatchExit(int32_t exitCode)
 
             if (protectedThis->hasEventListeners(eventNames().closeEvent)) {
                 auto event = CloseEvent::create(exitCode == 0, static_cast<unsigned short>(exitCode), exitCode == 0 ? "Worker terminated normally"_s : "Worker exited abnormally"_s);
+                AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
                 protectedThis->EventTargetWithInlineData::dispatchEvent(event);
             }
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -366,7 +366,7 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         // Listeners observe the async context that was active at new Worker().
         // drainInbox's entanglePorts() stays outside: Node deserializes a
         // message's transferred ports before restoring the receiver's context.
-        AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.get());
+        AsyncContextFrameScope asyncContextScope(globalObject, m_creationAsyncContext.getValue());
         dispatchEvent(event);
     });
     if (reschedule) {
@@ -477,7 +477,7 @@ void Worker::dispatchOnline(Zig::GlobalObject* workerGlobalObject)
     postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext& context) {
         if (protectedThis->hasEventListeners(eventNames().openEvent)) {
             auto event = Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No);
-            AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.get());
+            AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
             protectedThis->dispatchEvent(event);
         }
     });
@@ -535,7 +535,7 @@ void Worker::dispatchErrorWithMessage(WTF::String message)
         init.message = message;
 
         auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
-        AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.get());
+        AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
         protectedThis->dispatchEvent(event);
     });
 }
@@ -582,7 +582,7 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
         init.error = deserialized;
 
         auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
-        AsyncContextFrameScope asyncContextScope(globalObject, protectedThis->m_creationAsyncContext.get());
+        AsyncContextFrameScope asyncContextScope(globalObject, protectedThis->m_creationAsyncContext.getValue());
         protectedThis->dispatchEvent(event);
     });
 }
@@ -638,7 +638,7 @@ bool Worker::dispatchExit(int32_t exitCode)
 
             if (protectedThis->hasEventListeners(eventNames().closeEvent)) {
                 auto event = CloseEvent::create(exitCode == 0, static_cast<unsigned short>(exitCode), exitCode == 0 ? "Worker terminated normally"_s : "Worker exited abnormally"_s);
-                AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.get());
+                AsyncContextFrameScope asyncContextScope(context.jsGlobalObject(), protectedThis->m_creationAsyncContext.getValue());
                 protectedThis->EventTargetWithInlineData::dispatchEvent(event);
             }
 

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -27,6 +27,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "JSValueInWrappedObject.h"
 #include "MessageWithMessagePorts.h"
 #include "WorkerOptions.h"
 #include <JavaScriptCore/RuntimeFlags.h>
@@ -129,6 +130,8 @@ public:
     ScriptExecutionContextIdentifier clientIdentifier() const { return m_clientIdentifier; }
     WorkerOptions& options() { return m_options; }
 
+    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
+
     // -- Worker-thread entry points (each posts to m_parentContextId) --------
     void dispatchOnline(Zig::GlobalObject* workerGlobalObject);
     void fireEarlyMessages(Zig::GlobalObject* workerGlobalObject);
@@ -175,6 +178,11 @@ private:
     void drainToParent(ScriptExecutionContext&);
 
     WorkerOptions m_options;
+
+    // The async context active at `new Worker()`. Every parent-side event
+    // dispatch (message, open, error, close) runs from a posted task and
+    // restores this around it. See AsyncContextFrameScope.
+    JSValueInWrappedObject m_creationAsyncContext;
 
     // Messages posted before the worker reaches Running are queued here and
     // flushed by fireEarlyMessages(). The Pending→Running transition happens

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -31,6 +31,7 @@
 #include "WorkerOptions.h"
 #include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/RuntimeFlags.h>
+#include <JavaScriptCore/Strong.h>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/AtomStringHash.h>

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -29,8 +29,8 @@
 #include "EventTarget.h"
 #include "MessageWithMessagePorts.h"
 #include "WorkerOptions.h"
+#include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/RuntimeFlags.h>
-#include <JavaScriptCore/Strong.h>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/AtomStringHash.h>
@@ -129,6 +129,8 @@ public:
     ScriptExecutionContextIdentifier clientIdentifier() const { return m_clientIdentifier; }
     WorkerOptions& options() { return m_options; }
 
+    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
+
     // -- Worker-thread entry points (each posts to m_parentContextId) --------
     void dispatchOnline(Zig::GlobalObject* workerGlobalObject);
     void fireEarlyMessages(Zig::GlobalObject* workerGlobalObject);
@@ -178,8 +180,8 @@ private:
 
     // The async context active at `new Worker()`. Every parent-side event
     // dispatch (message, open, error, close) runs from a posted task and
-    // restores this around it. See AsyncContextFrame::captureCurrentContext.
-    JSC::Strong<JSC::Unknown> m_creationAsyncContext;
+    // restores this around it. Visited by JSWorker::visitChildrenImpl.
+    JSValueInWrappedObject m_creationAsyncContext;
 
     // Messages posted before the worker reaches Running are queued here and
     // flushed by fireEarlyMessages(). The Pending→Running transition happens

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -27,7 +27,6 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "JSValueInWrappedObject.h"
 #include "MessageWithMessagePorts.h"
 #include "WorkerOptions.h"
 #include <JavaScriptCore/RuntimeFlags.h>
@@ -130,8 +129,6 @@ public:
     ScriptExecutionContextIdentifier clientIdentifier() const { return m_clientIdentifier; }
     WorkerOptions& options() { return m_options; }
 
-    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
-
     // -- Worker-thread entry points (each posts to m_parentContextId) --------
     void dispatchOnline(Zig::GlobalObject* workerGlobalObject);
     void fireEarlyMessages(Zig::GlobalObject* workerGlobalObject);
@@ -181,8 +178,8 @@ private:
 
     // The async context active at `new Worker()`. Every parent-side event
     // dispatch (message, open, error, close) runs from a posted task and
-    // restores this around it. See AsyncContextFrameScope.
-    JSValueInWrappedObject m_creationAsyncContext;
+    // restores this around it. See AsyncContextFrame::captureCurrentContext.
+    JSC::Strong<JSC::Unknown> m_creationAsyncContext;
 
     // Messages posted before the worker reaches Running are queued here and
     // flushed by fireEarlyMessages(). The Pending→Running transition happens

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1238,7 +1238,12 @@ impl All {
                 let signal = (*t).signal;
                 (*t).signal = core::ptr::null_mut();
                 if !signal.is_null() {
-                    crate::jsc::abort_signal::AbortSignal::opaque_ref(signal).unref();
+                    let signal = crate::jsc::abort_signal::AbortSignal::opaque_ref(signal);
+                    // This path never reaches cancelTimer(), so release the
+                    // async context snapshot timeout() captured; the unref
+                    // below may not be the last reference.
+                    signal.clear_timeout_async_context();
+                    signal.unref();
                 }
             }
         }

--- a/test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts
@@ -15,22 +15,30 @@ describe.concurrent("AsyncLocalStorage passes context to callbacks", () => {
 
   for (const filepath of files) {
     const file = basename(filepath).replaceAll("async-context-", "").replaceAll(".js", "");
-    test(file, async () => {
-      async function run(exe) {
-        const { exited } = Bun.spawn({
-          cmd: [exe, filepath],
-          stdout: "inherit",
-          stderr: "inherit",
-          env: bunEnv,
-        });
+    // Spawning a worker creates a fresh JSC VM and module graph; on an ASAN
+    // debug build the full round-trip-and-terminate brushes past the 5s
+    // default when this whole suite is running concurrently.
+    const timeout = file.startsWith("worker_threads") ? 30_000 : undefined;
+    test(
+      file,
+      async () => {
+        async function run(exe) {
+          const { exited } = Bun.spawn({
+            cmd: [exe, filepath],
+            stdout: "inherit",
+            stderr: "inherit",
+            env: bunEnv,
+          });
 
-        if (await exited) {
-          throw new Error(`${basename(exe)} failed in ${filepath}`);
+          if (await exited) {
+            throw new Error(`${basename(exe)} failed in ${filepath}`);
+          }
         }
-      }
 
-      await Promise.all([run(bunExe()), run(nodeExe())]);
-    });
+        await Promise.all([run(bunExe()), run(nodeExe())]);
+      },
+      timeout,
+    );
   }
 
   for (const filepath of todos) {

--- a/test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts
@@ -6,7 +6,7 @@ import { basename, join } from "path";
 describe.concurrent("AsyncLocalStorage passes context to callbacks", () => {
   let files = [...new Glob(join(import.meta.dir, "async-context", "async-context-*.js")).scanSync()];
 
-  let todos = ["async-context-worker_threads-message.js"];
+  let todos: string[] = [];
   if (isASAN && isBroken && isLinux) {
     todos.push("async-context-dns-resolveTxt.js");
   }

--- a/test/js/node/async_hooks/async-context/async-context-abort-signal-any.js
+++ b/test/js/node/async_hooks/async-context/async-context-abort-signal-any.js
@@ -1,0 +1,32 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+// Neither runtime keeps the event loop alive for a pending AbortSignal.timeout().
+const keepAlive = setInterval(() => {}, 50);
+
+// AbortSignal.any([AbortSignal.timeout(ms), ...]) is the common
+// "timeout-or-cancel" shape. Nothing references the inner timeout signal from
+// JS afterwards, so its captured context must not depend on its JS wrapper
+// (or on a direct abort listener, which it never gets) staying alive.
+let combined;
+asyncLocalStorage.run({ test: "AbortSignal.any" }, () => {
+  combined = AbortSignal.any([AbortSignal.timeout(10)]);
+});
+
+combined.addEventListener("abort", () => {
+  clearInterval(keepAlive);
+  const store = asyncLocalStorage.getStore();
+  if (store?.test !== "AbortSignal.any") {
+    console.error("FAIL: AbortSignal.any abort listener lost the timeout's context, got", store);
+    process.exit(1);
+  }
+  process.exit(0);
+});
+
+if (typeof Bun !== "undefined") {
+  Bun.gc(true);
+  Bun.gc(true);
+  Bun.gc(true);
+}

--- a/test/js/node/async_hooks/async-context/async-context-abort-signal-timeout.js
+++ b/test/js/node/async_hooks/async-context/async-context-abort-signal-timeout.js
@@ -1,0 +1,19 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+// The internal timer behind AbortSignal.timeout() does not keep the event
+// loop alive, in Node or in Bun.
+const keepAlive = setInterval(() => {}, 50);
+
+asyncLocalStorage.run({ test: "AbortSignal.timeout" }, () => {
+  AbortSignal.timeout(1).addEventListener("abort", () => {
+    clearInterval(keepAlive);
+    if (asyncLocalStorage.getStore()?.test !== "AbortSignal.timeout") {
+      console.error("FAIL: AbortSignal.timeout abort listener lost context");
+      process.exit(1);
+    }
+    process.exit(0);
+  });
+});

--- a/test/js/node/async_hooks/async-context/async-context-broadcast-channel.js
+++ b/test/js/node/async_hooks/async-context/async-context-broadcast-channel.js
@@ -1,0 +1,28 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+// Message handlers observe the async context that was active when the
+// receiving BroadcastChannel was created, not the one active at
+// addEventListener() or postMessage() time.
+const receiver = asyncLocalStorage.run(
+  { test: "BroadcastChannel" },
+  () => new BroadcastChannel("async-context-broadcast-channel"),
+);
+const sender = new BroadcastChannel("async-context-broadcast-channel");
+
+receiver.onmessage = () => {
+  const store = asyncLocalStorage.getStore();
+  receiver.close();
+  sender.close();
+  if (store?.test !== "BroadcastChannel") {
+    console.error("FAIL: BroadcastChannel message handler lost context, got", store);
+    process.exit(1);
+  }
+  process.exit(0);
+};
+
+asyncLocalStorage.run({ test: "postMessage" }, () => {
+  sender.postMessage("test");
+});

--- a/test/js/node/async_hooks/async-context/async-context-message-channel-close.js
+++ b/test/js/node/async_hooks/async-context/async-context-message-channel-close.js
@@ -1,0 +1,22 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+// A MessagePort's deferred 'close' event observes the async context that was
+// active when the port was created, same as its 'message' handlers, not the
+// context active at close() time.
+const { port1 } = asyncLocalStorage.run({ test: "MessageChannel" }, () => new MessageChannel());
+
+port1.addEventListener("close", () => {
+  const store = asyncLocalStorage.getStore();
+  if (store?.test !== "MessageChannel") {
+    console.error("FAIL: MessagePort close handler lost context, got", store);
+    process.exit(1);
+  }
+  process.exit(0);
+});
+
+asyncLocalStorage.run({ test: "close" }, () => {
+  port1.close();
+});

--- a/test/js/node/async_hooks/async-context/async-context-message-channel-gc.js
+++ b/test/js/node/async_hooks/async-context/async-context-message-channel-gc.js
@@ -1,0 +1,31 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+// The captured creation context must survive a full GC that runs after
+// asyncLocalStorage.run() has returned but before either port has ever been
+// read (at which point no MessagePort JS wrapper exists yet to root it).
+function makeChannel() {
+  return asyncLocalStorage.run({ test: "MessageChannel" }, () => new MessageChannel());
+}
+const channel = makeChannel();
+
+if (typeof Bun !== "undefined") {
+  Bun.gc(true);
+  Bun.gc(true);
+  Bun.gc(true);
+}
+
+channel.port1.onmessage = () => {
+  const store = asyncLocalStorage.getStore();
+  channel.port1.close();
+  channel.port2.close();
+  if (store?.test !== "MessageChannel") {
+    console.error("FAIL: MessagePort message handler lost context after GC, got", store);
+    process.exit(1);
+  }
+  process.exit(0);
+};
+
+channel.port2.postMessage("test");

--- a/test/js/node/async_hooks/async-context/async-context-message-channel.js
+++ b/test/js/node/async_hooks/async-context/async-context-message-channel.js
@@ -1,0 +1,24 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+// Message handlers observe the async context that was active when the
+// MessageChannel was created, not the one active at addEventListener()
+// or postMessage() time.
+const { port1, port2 } = asyncLocalStorage.run({ test: "MessageChannel" }, () => new MessageChannel());
+
+port1.onmessage = () => {
+  const store = asyncLocalStorage.getStore();
+  port1.close();
+  port2.close();
+  if (store?.test !== "MessageChannel") {
+    console.error("FAIL: MessagePort message handler lost context, got", store);
+    process.exit(1);
+  }
+  process.exit(0);
+};
+
+asyncLocalStorage.run({ test: "postMessage" }, () => {
+  port2.postMessage("test");
+});

--- a/test/js/node/async_hooks/async-context/async-context-message-channel.js
+++ b/test/js/node/async_hooks/async-context/async-context-message-channel.js
@@ -5,15 +5,24 @@ const asyncLocalStorage = new AsyncLocalStorage();
 
 // Message handlers observe the async context that was active when the
 // MessageChannel was created, not the one active at addEventListener()
-// or postMessage() time.
+// or postMessage() time. Continuations registered inside the handler
+// (await, queueMicrotask) keep it too.
 const { port1, port2 } = asyncLocalStorage.run({ test: "MessageChannel" }, () => new MessageChannel());
 
-port1.onmessage = () => {
-  const store = asyncLocalStorage.getStore();
+port1.onmessage = async () => {
+  const stores = [asyncLocalStorage.getStore()];
+  await Promise.resolve();
+  stores.push(asyncLocalStorage.getStore());
+  await new Promise(resolve =>
+    queueMicrotask(() => {
+      stores.push(asyncLocalStorage.getStore());
+      resolve();
+    }),
+  );
   port1.close();
   port2.close();
-  if (store?.test !== "MessageChannel") {
-    console.error("FAIL: MessagePort message handler lost context, got", store);
+  if (!stores.every(store => store?.test === "MessageChannel")) {
+    console.error("FAIL: MessagePort message handler lost context, got", stores);
     process.exit(1);
   }
   process.exit(0);

--- a/test/js/web/workers/message-port-closed-leak.test.ts
+++ b/test/js/web/workers/message-port-closed-leak.test.ts
@@ -128,6 +128,68 @@ describe("MessagePortChannel closed port", () => {
     }, 60_000);
   }
 
+  // The async context a MessagePort captures at creation (for AsyncLocalStorage
+  // propagation) must not GC-root the port's own JS wrapper: a store that
+  // references the port, a realistic tracing shape, would otherwise form an
+  // uncollectable cycle (impl -> captured context -> store -> wrapper -> Ref<impl>).
+  test("an AsyncLocalStorage store referencing its own MessagePorts does not leak them", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { AsyncLocalStorage } = require("async_hooks");
+          const { heapStats } = require("bun:jsc");
+          const als = new AsyncLocalStorage();
+          const COUNT = 128;
+
+          function portCount() {
+            Bun.gc(true);
+            Bun.gc(true);
+            Bun.gc(true);
+            return heapStats().objectTypeCounts.MessagePort ?? 0;
+          }
+
+          const held = [];
+          for (let i = 0; i < COUNT; i++) {
+            als.run({ port1: null, port2: null }, () => {
+              const { port1, port2 } = new MessageChannel();
+              const store = als.getStore();
+              store.port1 = port1;
+              store.port2 = port2;
+              held.push(port1, port2);
+            });
+          }
+
+          const live = portCount();
+          if (live < 2 * COUNT) {
+            console.error("FAIL: heapStats did not count the live MessagePorts, saw", live);
+            process.exit(1);
+          }
+
+          held.length = 0;
+          const survived = portCount();
+          if (survived > COUNT) {
+            console.error("FAIL:", survived, "of", live, "MessagePorts survived GC");
+            process.exit(1);
+          }
+          console.log("PASS:", survived, "of", live, "survived");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: expect.stringContaining("PASS"),
+      stderr: "",
+      exitCode: 0,
+    });
+  }, 60_000);
+
   // Closing a port whose inbox holds a transferred port whose inbox holds a transferred
   // port whose... must not overflow the native stack. ~TransferredMessagePort calls
   // pipe->close(), which drops the inbox, whose destruction calls ~TransferredMessagePort


### PR DESCRIPTION
## Summary

`AsyncLocalStorage` context is silently lost across four async boundaries that Node preserves. Each prints `undefined` on Bun and the stored value on Node v26.3.0:

```js
import { AsyncLocalStorage } from "node:async_hooks";
import { Worker } from "node:worker_threads";
const als = new AsyncLocalStorage();

// 1) AbortSignal.timeout(): the "abort" listener loses the store
als.run("S1", () =>
  AbortSignal.timeout(1).addEventListener("abort", () => console.log("timeout:", als.getStore())));

// 2) MessageChannel: port handlers lose the store
als.run("S2", () => {
  const { port1, port2 } = new MessageChannel();
  port1.onmessage = () => console.log("port:", als.getStore());
  port2.postMessage(1);
});

// 3) worker_threads: the parent's "message" handler loses the store
als.run("S3", () => {
  const w = new Worker("require('worker_threads').parentPort.postMessage(1)", { eval: true });
  w.on("message", () => console.log("worker:", als.getStore()));
});
```

`BroadcastChannel` has the same bug (it is the same pattern), so it is fixed here too.

`AsyncLocalStorage` is what tracing/APM and request-context libraries are built on, and these boundaries do not error when the store is dropped; downstream code just sees `undefined` and attributes work to the wrong request. `AbortSignal.timeout` in particular is common inside instrumented `fetch` wrappers.

## Cause

Nothing in `src/jsc/bindings/webcore/` references `AsyncContextFrame`. All four objects dispatch their events from posted event-loop tasks, not from the user's JS stack:

- `AbortSignal.timeout` fires from the per-VM timer heap (`AbortSignal.rs` `Timeout::dispatch` -> `AbortSignal::signalAbort` -> `runAbortSteps`)
- `MessagePort` from `MessagePortPipe::drainAndDispatch` -> `MessagePort::dispatchOneMessage`
- `Worker` (parent side) from `Worker::drainToParent` and the other `postTaskToParent` lambdas
- `BroadcastChannel` from the `BunBroadcastChannelRegistry` fan-out -> `BroadcastChannel::dispatchMessage`

By the time `dispatchEvent` runs, `m_asyncContextData[0]` is whatever the event loop left there, which is `undefined`. The synchronous dispatches that already work (`AbortController.abort()`, `EventEmitter.emit()`) work because the caller's context is still on the stack.

The semantic to match, verified empirically against Node v26.3.0: listeners observe the async context that was active when the resource was created (`AbortSignal.timeout()` call, `new MessageChannel()`, `new Worker()`, `new BroadcastChannel()`), not the one at listener registration and not the one at `postMessage()`. That follows from Node's `AsyncWrap`: `AsyncWrap::AsyncReset` captures `async_context_frame::current()` into `context_frame_` at construction and `MakeCallback` restores it. `AbortSignal.timeout()` gets the same result from the internal `setTimeout` that backs it.

## Fix

- Each impl snapshots the active async context at construction (for `AbortSignal`, at `timeout()`, its only asynchronous entry point) via a new `AsyncContextFrame::captureCurrentContext()`.
- For `MessagePort`, `Worker`, and `BroadcastChannel` the snapshot lives in a `JSValueInWrappedObject` visited from the object's JS wrapper, the same mechanism `AbortSignal::m_reason` uses. That is deliberate: the snapshot can transitively reference the object's own wrapper (the user's store may hold the resource), so a `JSC::Strong` there would be an uncollectable native-to-GC cycle, and their owners already keep the wrapper alive for exactly as long as the object can observably dispatch. The one gap is `MessageChannel`, whose ports have no `JSMessagePort` wrapper until `.port1`/`.port2` is first read, so `JSMessageChannel::visitAdditionalChildrenInGCThread` also visits both ports' captured contexts.
- `AbortSignal.timeout()` alone uses a `JSC::Strong`. It is the one case where the wrapper is not a reliable root (the abort is observed through a dependent `AbortSignal.any()` signal whose wrapper, not its own, stays alive) and the one case where a `Strong` cannot form an uncollectable cycle, because the timer heap guarantees `cancelTimer()` releases it on every terminal path, independent of GC reachability. The invariant is documented once, on `captureCurrentContext`.
- All four release the snapshot at the point the object can last dispatch: `cancelTimer()`, `MessagePort::close()`/`disentangle()`, `BroadcastChannel::close()`, and the `Worker` close task.
- A new `AsyncContextFrameScope` RAII class in `AsyncContextFrame.{h,cpp}` swaps `m_asyncContextData[0]` to the captured value around the asynchronous dispatch and restores the previous one. It is a no-op when the captured value is undefined, mirroring `withAsyncContextIfNeeded`.
- Restore sites: `AbortSignal::signalAbort` (only timeout signals ever have a captured value, so `AbortController.abort()` still runs listeners in the aborting caller's context), `MessagePort::dispatchOneMessage`, `BroadcastChannel::dispatchMessage`, and every parent-side `Worker` dispatch (message, open, error, close).

Intentionally unchanged: the worker-side `WorkerGlobalScope` message event (`parentPort.on("message")` inside a worker). Its receiving port is created at worker bootstrap, before any user code runs, so there is no async context to capture in Node either. Also unchanged: a `MessagePort` transferred inside another message's payload does not inherit the receiving resource's context. Verified against Node v26.3.0, which behaves the same way because it deserializes the transferred ports before restoring the receiver's context; the `AsyncContextFrameScope` at each dispatch site therefore wraps only the event dispatch, not the port entanglement.

## Test plan

`test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts` runs every `async-context/async-context-*.js` fixture under both Bun and Node and requires both to exit 0, so each fixture doubles as a Node parity check.

- Adds `async-context-abort-signal-timeout.js`, `async-context-message-channel.js`, and `async-context-broadcast-channel.js`. The MessageChannel and BroadcastChannel fixtures also assert the discriminator (creation context wins over the `postMessage()` caller's context), which Node passes.
- Un-skips the existing `test.todo` for `async-context-worker_threads-message.js`, which covers the parent's `message` and `exit` events.

Before the fix, all four fixtures pass under Node and fail under Bun; after, `bun bd test test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts` is 78 pass / 0 fail. The abort, broadcast-channel, message-channel, message-port leak, `AsyncLocalStorage.test.ts`, and Worker suites show no new failures, and the captured context survives forced full `Bun.gc(true)` cycles between creation and dispatch.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts

<!-- robobun:evidence:end -->