### PR TITLE
server: preserve request Content-Type in request.blob()

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4008,7 +4008,7 @@ where
                         .request_weakref
                         .get()
                         .and_then(|req| Body::BodyMixin::get_fetch_headers(req));
-                    let _ = Body::Value::resolve(&mut old, body, global_this, headers); // TODO: properly propagate exception upwards
+                    let _ = Body::Value::resolve(&mut old, body, global_this, headers);
                 }
                 return;
             }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4002,7 +4002,13 @@ where
                 if matches!(old, Body::Value::Locked(_)) {
                     let _exit = vm.enter_event_loop_scope();
 
-                    let _ = Body::Value::resolve(&mut old, body, global_this, None); // TODO: properly propagate exception upwards
+                    // Carry the request Content-Type onto the resolved Blob;
+                    // `resolve` reads it from the request's fetch headers.
+                    let headers = this
+                        .request_weakref
+                        .get()
+                        .and_then(|req| Body::BodyMixin::get_fetch_headers(req));
+                    let _ = Body::Value::resolve(&mut old, body, global_this, headers); // TODO: properly propagate exception upwards
                 }
                 return;
             }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3246,3 +3246,33 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
     signalCode: null,
   });
 });
+
+// https://github.com/oven-sh/bun/issues/32801
+it("request.blob() preserves the request body Content-Type", async () => {
+  const types = [
+    "application/json;charset=utf-8",
+    "image/png",
+    "application/octet-stream",
+    "text/csv",
+  ];
+
+  await using server = serve({
+    port: 0,
+    async fetch(request) {
+      const blob = await request.blob();
+      return new Response(blob.type);
+    },
+  });
+
+  const received: string[] = [];
+  for (const type of types) {
+    const res = await fetch(server.url, {
+      method: "POST",
+      body: new File(['"name"'], "file.json", { type }),
+    });
+    received.push(await res.text());
+  }
+
+  // Before the fix, each body collapsed to the "text/plain;charset=utf-8" fallback.
+  expect(received).toEqual(types);
+});

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3268,6 +3268,5 @@ it("request.blob() preserves the request body Content-Type", async () => {
     received.push(await res.text());
   }
 
-  // Before the fix, each body collapsed to the "text/plain;charset=utf-8" fallback.
   expect(received).toEqual(types);
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3249,12 +3249,7 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
 
 // https://github.com/oven-sh/bun/issues/32801
 it("request.blob() preserves the request body Content-Type", async () => {
-  const types = [
-    "application/json;charset=utf-8",
-    "image/png",
-    "application/octet-stream",
-    "text/csv",
-  ];
+  const types = ["application/json;charset=utf-8", "image/png", "application/octet-stream", "text/csv"];
 
   await using server = serve({
     port: 0,


### PR DESCRIPTION
Fixes #32801

### Repro

```ts
await using server = Bun.serve({
  port: 0,
  async fetch(request) {
    return new Response((await request.blob()).type);
  },
});

const res = await fetch(server.url, {
  method: "POST",
  body: new File(['"name"'], "file.json", { type: "application/json;charset=utf-8" }),
});
console.log(await res.text());
// expected: application/json;charset=utf-8
// actual:   text/plain;charset=utf-8
```

Every content type collapsed to the `text/plain;charset=utf-8` fallback, regardless of what the client sent.

### Cause

When a `Bun.serve` handler reads the request body with `request.blob()`, the body is in the `Locked` state and is resolved asynchronously once the bytes arrive, in `on_buffered_body_chunk` (`src/runtime/server/RequestContext.rs`). That call passed `None` for the headers argument of `Body::Value::resolve`, so the `Content-Type` header was never consulted and the Blob fell back to `text/plain;charset=utf-8`.

The fetch client path already does this correctly, passing the response's fetch headers into `resolve`.

### Fix

Pass the request object's fetch headers into `resolve` (reached via `request_weakref`), mirroring the fetch client. `resolve` reads the `Content-Type` from them and sets it on the resolved Blob.

Note: the sibling `resolve` call in `on_start_buffering` keeps `None`. That branch is only reached when the body is not `Locked` (its guard is the exact negation of the condition that makes the body `Locked`), so it never produces a Blob and passing headers there would be dead code.

### Verification

`test/js/bun/http/serve.test.ts` POSTs a `File` with four distinct types and asserts `(await request.blob()).type` round-trips each one.

- Fails before the fix: all four types come back as `text/plain;charset=utf-8`.
- Passes after.