### PR TITLE
install: make `bun update <name>` update catalog entries instead of adding a root dependency

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -582,11 +582,30 @@ fn for_each_catalog_object(
     Ok(())
 }
 
+/// Is `name` defined in any `catalog`/`catalogs` group?
+fn catalog_defines_package(root_package_json: &Expr, name: &[u8]) -> bool {
+    let mut found = false;
+    let _ = for_each_catalog_object(root_package_json, |_catalog_name, catalog_expr| {
+        if !found {
+            if let Some(obj) = catalog_expr.data.e_object() {
+                if obj.has_property(name) {
+                    found = true;
+                }
+            }
+        }
+        Ok(())
+    });
+    found
+}
+
 /// Records the original version of every catalog entry and, with `--latest`,
 /// rewrites each to `latest` in memory so the resolver fetches it.
+/// `names_filter` restricts recording to the named targets (every group
+/// defining a name, as in the interactive updater); `None` records everything.
 pub(crate) fn edit_catalogs_before_update(
     manager: &mut PackageManager,
     root_package_json: &Expr,
+    names_filter: Option<&[Box<[u8]>]>,
 ) -> Result<bool, bun_alloc::AllocError> {
     // see note in `edit_update_no_args` — always avoid the store
     let _guard = ExprDisabler::scope();
@@ -616,6 +635,15 @@ pub(crate) fn edit_catalogs_before_update(
             let Some(value) = &dep.value else { continue };
             if !matches!(value.data, bun_ast::ExprData::EString(_)) {
                 continue;
+            }
+
+            if let Some(filter) = names_filter {
+                let key_str = key
+                    .as_utf8_string_literal()
+                    .unwrap_or_else(|| bun_core::out_of_memory());
+                if !filter.iter().any(|n| strings::eql_long(n, key_str, true)) {
+                    continue;
+                }
             }
 
             let version_literal = value
@@ -904,6 +932,7 @@ pub(crate) fn edit(
             let mut i: usize = 0;
             'loop_: while i < updates.len() {
                 let request = &mut updates[i];
+                let mut matched_catalog_reference = false;
                 // order-insensitive scan: `FOUR` is fine here
                 'dependency_group: for list in DependencyGroup::FOUR.map(|g| g.prop) {
                     if let Some(query) = current_package_json.as_property(list) {
@@ -921,6 +950,11 @@ pub(crate) fn edit(
                                                     == dependency::Tag::Catalog
                                             },
                                         );
+
+                                    // The kept reference points at a catalog
+                                    // entry; that entry is the update target.
+                                    matched_catalog_reference |=
+                                        keep_catalog_reference && options.before_install;
 
                                     if request.package_id != INVALID_PACKAGE_ID
                                         && strings::eql_long(list, dependency_list, true)
@@ -1070,7 +1104,32 @@ pub(crate) fn edit(
                         }
                     }
                 }
+                if matched_catalog_reference {
+                    updates[i].is_catalog = true;
+                }
                 i += 1;
+            }
+        }
+    }
+
+    // Catalog named targets are handled by `edit_catalogs_*`, not the append
+    // block below. Classify only before install: post-install, a root-group
+    // match takes the `replacing` branch, which leaves `e_string` unset and
+    // must not be reclassified here.
+    if manager.subcommand == Subcommand::Update {
+        for request in updates.iter_mut() {
+            if options.before_install
+                && !request.is_catalog
+                && request.e_string.is_none()
+                && request.package_id == INVALID_PACKAGE_ID
+                && catalog_defines_package(current_package_json, request.get_name())
+            {
+                request.is_catalog = true;
+            }
+            // A catalog-only target occupies no dependency-group slot; a kept
+            // `catalog:` reference was already counted when it matched.
+            if request.is_catalog && request.e_string.is_none() {
+                remaining -= 1;
             }
         }
     }
@@ -1149,7 +1208,7 @@ pub(crate) fn edit(
         };
 
         for request in updates.iter_mut() {
-            if request.e_string.is_some() {
+            if request.e_string.is_some() || request.is_catalog {
                 continue;
             }
 

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -33,6 +33,9 @@ pub struct UpdateRequest {
     pub(crate) package_id: PackageID,
     pub(crate) is_aliased: bool,
     pub failed: bool,
+    /// The target lives only in a `catalog`/`catalogs` map; its catalog entry
+    /// is updated instead of adding a root dependency.
+    pub(crate) is_catalog: bool,
     /// This must be cloned to handle when the AST store resets.
     /// ARENA-owned (AST `Expr.Data` store) — raw pointer per LIFETIMES.tsv;
     /// only valid while the store that allocated it is alive.
@@ -49,6 +52,7 @@ impl Default for UpdateRequest {
             package_id: INVALID_PACKAGE_ID,
             is_aliased: false,
             failed: false,
+            is_catalog: false,
             e_string: None,
         }
     }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -596,12 +596,28 @@ fn update_package_json_and_install_with_manager_with_updates(
             .as_deref()
             .is_none_or(|t| t.iter().any(|w| w.is_root));
 
+        let catalog_request_names: Vec<Box<[u8]>> = manager
+            .update_requests
+            .iter()
+            .filter(|r| r.is_catalog)
+            .map(|r| Box::<[u8]>::from(r.get_name()))
+            .collect();
+
         if subcommand == Subcommand::Update
-            && manager.update_requests.is_empty()
+            && (manager.update_requests.is_empty() || !catalog_request_names.is_empty())
             && root_is_targeted
         {
+            let names_filter = if manager.update_requests.is_empty() {
+                None
+            } else {
+                Some(&catalog_request_names[..])
+            };
             let root_package_json_root: bun_ast::Expr = root_package_json.root;
-            if PackageJSONEditor::edit_catalogs_before_update(manager, &root_package_json_root)? {
+            if PackageJSONEditor::edit_catalogs_before_update(
+                manager,
+                &root_package_json_root,
+                names_filter,
+            )? {
                 editing_catalogs = true;
 
                 if manager.options.do_.contains(Do::UPDATE_TO_LATEST) {
@@ -671,21 +687,6 @@ fn update_package_json_and_install_with_manager_with_updates(
                     },
                 )?;
             }
-
-            if editing_catalogs
-                && manager.workspace_name_hash.is_none()
-                && manager.update_target_workspaces.is_none()
-            {
-                // running from root: catalogs live in this file.
-                let _ = PackageJSONEditor::edit_catalogs_after_update(
-                    manager,
-                    &new_package_json,
-                    EditOptions {
-                        exact_versions: manager.options.enable.exact_versions(),
-                        ..Default::default()
-                    },
-                )?;
-            }
         } else {
             let mut updates_slice: &mut [UpdateRequest] = &mut updates[..];
             PackageJSONEditor::edit(
@@ -699,6 +700,21 @@ fn update_package_json_and_install_with_manager_with_updates(
                         .options
                         .do_
                         .contains(Do::TRUST_DEPENDENCIES_FROM_ARGS),
+                    ..Default::default()
+                },
+            )?;
+        }
+
+        if editing_catalogs
+            && manager.workspace_name_hash.is_none()
+            && manager.update_target_workspaces.is_none()
+        {
+            // running from root: catalogs live in this file.
+            let _ = PackageJSONEditor::edit_catalogs_after_update(
+                manager,
+                &new_package_json,
+                EditOptions {
+                    exact_versions: manager.options.enable.exact_versions(),
                     ..Default::default()
                 },
             )?;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -727,8 +727,11 @@ impl Lockfile {
                                     continue;
                                 }
                                 let res = resolutions_of_yore[old_resolution as usize];
+                                // a `catalog:` reference keeps its literal; the
+                                // catalog definition is updated instead
                                 if res.tag != ResolutionTag::Npm
                                     || update.version.tag != dependency::Tag::DistTag
+                                    || dep.version.tag == dependency::Tag::Catalog
                                 {
                                     continue;
                                 }
@@ -782,8 +785,11 @@ impl Lockfile {
                                     continue;
                                 }
                                 let res = resolutions_of_yore[old_resolution as usize];
+                                // a `catalog:` reference keeps its literal; the
+                                // catalog definition is updated instead
                                 if res.tag != ResolutionTag::Npm
                                     || update.version.tag != dependency::Tag::DistTag
+                                    || dep.version.tag == dependency::Tag::Catalog
                                 {
                                     continue;
                                 }

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -549,10 +549,7 @@ describe("update", () => {
           },
         }),
       ),
-      write(
-        join(packageDir, "packages", "pkg1", "package.json"),
-        JSON.stringify({ name: "pkg1" }),
-      ),
+      write(join(packageDir, "packages", "pkg1", "package.json"), JSON.stringify({ name: "pkg1" })),
     ]);
     await runBunInstall(bunEnv, packageDir);
 

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -509,6 +509,237 @@ describe("update", () => {
       "no-deps": "catalog:",
       "a-dep": "catalog:a",
     });
+    // the referenced catalog entry is what gets updated; untargeted entries stay
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
+    expect(root.workspaces.catalogs).toEqual({ a: { "a-dep": "~1.0.1" } });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update <pkg> from a workspace updates the root catalog entry it references", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-named-from-ws");
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(join(packageDir, "packages", "pkg1"), "no-deps");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.dependencies).toBeUndefined();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.1.0" });
+    expect(root.workspaces.catalogs).toEqual({ a: { "a-dep": "~1.0.1" } });
+    expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+      "no-deps": "catalog:",
+      "a-dep": "catalog:a",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update <pkg> updates the catalog entry referenced by the root package.json itself", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-named-root-ref",
+          dependencies: { "no-deps": "catalog:" },
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: { "no-deps": "^1.0.0" },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({ name: "pkg1" }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "no-deps");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    // the reference is kept and the referenced entry is updated
+    expect(root.dependencies).toEqual({ "no-deps": "catalog:" });
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.1.0" });
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/32808
+  test("update <pkg> from root updates the catalog entry instead of adding a root dependency", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-named");
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "no-deps");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    // no spurious top-level dependency is synthesized for the catalog package
+    expect(root.dependencies).toBeUndefined();
+    // the targeted entry moves within range; the untargeted one is untouched
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.1.0" });
+    expect(root.workspaces.catalogs).toEqual({ a: { "a-dep": "~1.0.1" } });
+
+    expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+      "no-deps": "catalog:",
+      "a-dep": "catalog:a",
+    });
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+      name: "no-deps",
+      version: "1.1.0",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update <pkg> from root targets a named catalog entry", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-named-group");
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "a-dep");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.dependencies).toBeUndefined();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.0.0" });
+    expect(root.workspaces.catalogs).toEqual({ a: { "a-dep": "~1.0.10" } });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update <pkg> --latest from root bumps the catalog entry past its range, preserving the pin style", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await createUpdateMonorepo(packageDir, "catalog-update-named-latest");
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "no-deps", "--latest");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.dependencies).toBeUndefined();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
+    expect(root.workspaces.catalogs).toEqual({ a: { "a-dep": "~1.0.1" } });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update <pkg> --latest updates every catalog group defining the package; unconsumed entries are restored", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-named-groups",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: {
+              "no-deps": "^1.0.0",
+            },
+            catalogs: {
+              pinned: {
+                "no-deps": "1.0.1",
+              },
+              unused: {
+                "no-deps": "1.0.0",
+              },
+            },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: { "no-deps": "catalog:" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg2", "package.json"),
+        JSON.stringify({
+          name: "pkg2",
+          dependencies: { "no-deps": "catalog:pinned" },
+        }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "no-deps", "--latest");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.dependencies).toBeUndefined();
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^2.0.0" });
+    expect(root.workspaces.catalogs.pinned).toEqual({ "no-deps": "2.0.0" });
+    // no workspace consumes this entry, so it cannot resolve and is left as-is
+    expect(root.workspaces.catalogs.unused).toEqual({ "no-deps": "1.0.0" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update <pkg> prefers a root dependency over a same-named catalog entry", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-named-precedence",
+          dependencies: { "no-deps": "^1.0.0" },
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: { "no-deps": "^1.0.0" },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: { "no-deps": "catalog:" },
+        }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "no-deps");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    // the direct dependency is rewritten; the catalog entry is left alone
+    expect(root.dependencies).toEqual({ "no-deps": "^1.1.0" });
+    expect(root.workspaces.catalog).toEqual({ "no-deps": "^1.0.0" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("update <pkg> bumps an npm: aliased catalog entry, preserving the alias", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-named-alias",
+          workspaces: {
+            packages: ["packages/*"],
+            catalogs: {
+              a: { "my-no-deps": "npm:no-deps@^1.0.0" },
+            },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: { "my-no-deps": "catalog:a" },
+        }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "my-no-deps");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.dependencies).toBeUndefined();
+    expect(root.workspaces.catalogs).toEqual({ a: { "my-no-deps": "npm:no-deps@^1.1.0" } });
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #32808

### Problem

In a workspace monorepo, a package defined only in a `catalog`/`catalogs` map (and consumed by workspaces via `catalog:<name>`) could not be updated by name. `bun update <name>` ignored the catalog and appended a brand-new root `dependencies.<name>` at the latest version, bypassing both the catalog definition and its semver constraint.

```jsonc
// root package.json
{ "workspaces": { "packages": ["packages/*"], "catalogs": { "ai": { "baz": "~1.0.0" } } } }
// packages/server/package.json
{ "dependencies": { "baz": "catalog:ai" } }
```

`bun update baz` left `catalogs.ai.baz` untouched and added a spurious `"dependencies": { "baz": "^<latest>" }` to the root, so the workspace `catalog:ai` reference diverged from the new root dependency.

### Cause

`PackageJSONEditor::edit` (the named-update path) only scans the four root dependency groups. A catalog-only package matches none of them, so the append-new-dependency tail synthesizes a root entry that resolves to `latest`. The non-interactive catalog machinery (#36304, #36379, #36360) only runs for bare `bun update` (`update_requests.is_empty()`).

### Fix

Route named catalog-only targets through that existing machinery instead of synthesizing a root dependency:

- `edit` classifies a named target found in no root dependency group but defined in a `catalog`/`catalogs` map (`UpdateRequest.is_catalog`), so the append block leaves it alone. Classification happens only on the before-install pass; a name matched in a root dependency group keeps its root-dependency behavior and the catalog entry is left alone.
- `edit_catalogs_before_update` gains a `names_filter`: bare `bun update` still records every entry (`None`); a named update records only the targeted entries, and with `--latest` temporarily rewrites just those for resolution. A name defined in several catalog groups updates every group, matching `bun update -i`.
- The post-install `edit_catalogs_after_update` call now runs on the named path too (hoisted out of the no-args branch), writing resolved versions back into the catalog definition with the original pin style preserved, `npm:` aliases kept, and unresolved (unconsumed) entries restored.

Resolution-side re-targeting needs no changes: #36360's `UpdateRequest::contains_name` already re-resolves every named-update target, including `catalog:` dependencies.

After the fix, `bun update baz` updates `catalogs.ai.baz` in place (in range without `--latest`, past it with `--latest`), adds no root dependency, and leaves `catalog:ai` references intact.

### Background

A catalog is a version map in the workspace root package.json (`catalog` for the default group, `catalogs.<group>` for named ones, optionally nested under `workspaces`). Member workspaces reference entries with the `catalog:`/`catalog:<group>` protocol so one constraint is shared across the monorepo. The catalog definition is the single source of truth, which is why an update must edit it in place rather than materialize a root dependency.

### Verification

Six tests added to the `update` section of `test/cli/install/catalogs.test.ts`, alongside the existing non-interactive catalog-update coverage:

- named target in the default catalog: entry moves within range, no root dependency appears, untargeted entries untouched
- named target in a named catalog group
- `--latest` past the range, pin style preserved (`^1.0.0` to `^2.0.0`)
- `--latest` with the name in several groups: every consumed group updates per its own pin style; an unconsumed entry is restored
- name in both a root dependency group and a catalog: the root dependency is rewritten, the catalog entry untouched
- `npm:` aliased catalog entry: alias preserved (`npm:no-deps@^1.0.0` to `npm:no-deps@^1.1.0`)

All fail on main (the spurious root dependency appears) and pass with this change. Full `catalogs.test.ts` (24), `bun-update.test.ts` (38), and `bun-add.test.ts` (54) pass locally.
