### PR TITLE
http: accept asterisk-form request targets

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -326,6 +326,12 @@ namespace uWS
         {
             std::string_view url = getUrl();
             if (url.length() && url[0] != '/') {
+                /* Asterisk-form routes as the root: HttpRouter assumes a leading "/"
+                 * and strips the first byte, so a verbatim "*foo" would alias a
+                 * static "/foo" route. getFullUrl() still exposes the target verbatim. */
+                if (url[0] == '*') {
+                    return "/";
+                }
                 size_t schemeLength = 0;
                 if (url.length() >= 7 && strncasecmp(url.data(), "http://", 7) == 0) {
                     schemeLength = 7;
@@ -595,14 +601,15 @@ namespace uWS
             }
 
 
-            /* RFC 9112 3: exactly one SP separates method and request-target. Accept
-             * origin-form ("/...") and asterisk-form ("*", RFC 9112 3.2.4); like
-             * Node (llhttp), any method may carry asterisk-form, delivered verbatim. */
-            bool isOriginOrAsteriskForm = (__builtin_expect(data[0] == 32 && (data[1] == '/' || data[1] == '*'), 1));
-            bool isConnect = !isOriginOrAsteriskForm && ((data - start) == 7 && data[0] == 32 && memcmp(start, "CONNECT", 7) == 0);
+            /* RFC 9112 3: exactly one SP separates method and request-target. Beyond
+             * origin-form ("/..."), accept asterisk-form ("*", RFC 9112 3.2.4); like
+             * Node (llhttp), any method may carry it and it is delivered verbatim. */
+            bool isOriginForm = (__builtin_expect(data[0] == 32 && data[1] == '/', 1));
+            bool isConnect = !isOriginForm && ((data - start) == 7 && data[0] == 32 && memcmp(start, "CONNECT", 7) == 0);
+            bool isAsteriskForm = !isOriginForm && !isConnect && data[0] == 32 && data[1] == '*';
             /* Also accept proxy-style absolute URLs (http://... or https://...) as valid request targets */
-            bool isProxyStyleURL = !isOriginOrAsteriskForm && !isConnect && data[0] == 32 && isHTTPorHTTPSPrefixForProxies(data + 1, end) == 1;
-            if (isOriginOrAsteriskForm || isConnect || isProxyStyleURL) [[likely]] {
+            bool isProxyStyleURL = !isOriginForm && !isConnect && !isAsteriskForm && data[0] == 32 && isHTTPorHTTPSPrefixForProxies(data + 1, end) == 1;
+            if (isOriginForm || isConnect || isAsteriskForm || isProxyStyleURL) [[likely]] {
                 header.key = {start, (size_t) (data - start)};
                 data++;
                 if(!isValidMethod(header.key, useStrictMethodValidation)) {

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -595,10 +595,9 @@ namespace uWS
             }
 
 
-            /* RFC 9112 3: exactly one SP separates method and request-target.
-             * Accept origin-form ("/...") and asterisk-form ("*", RFC 9112 3.2.4,
-             * e.g. `OPTIONS * HTTP/1.1`). Like Node.js (llhttp), any method may
-             * carry an asterisk-form target and it is delivered verbatim. */
+            /* RFC 9112 3: exactly one SP separates method and request-target. Accept
+             * origin-form ("/...") and asterisk-form ("*", RFC 9112 3.2.4); like
+             * Node (llhttp), any method may carry asterisk-form, delivered verbatim. */
             bool isOriginOrAsteriskForm = (__builtin_expect(data[0] == 32 && (data[1] == '/' || data[1] == '*'), 1));
             bool isConnect = !isOriginOrAsteriskForm && ((data - start) == 7 && data[0] == 32 && memcmp(start, "CONNECT", 7) == 0);
             /* Also accept proxy-style absolute URLs (http://... or https://...) as valid request targets */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -595,12 +595,15 @@ namespace uWS
             }
 
 
-            /* RFC 9112 3: exactly one SP separates method and request-target */
-            bool isHTTPMethod = (__builtin_expect(data[0] == 32 && data[1] == '/', 1));
-            bool isConnect = !isHTTPMethod && ((data - start) == 7 && data[0] == 32 && memcmp(start, "CONNECT", 7) == 0);
+            /* RFC 9112 3: exactly one SP separates method and request-target.
+             * Accept origin-form ("/...") and asterisk-form ("*", RFC 9112 3.2.4,
+             * e.g. `OPTIONS * HTTP/1.1`). Like Node.js (llhttp), any method may
+             * carry an asterisk-form target and it is delivered verbatim. */
+            bool isOriginOrAsteriskForm = (__builtin_expect(data[0] == 32 && (data[1] == '/' || data[1] == '*'), 1));
+            bool isConnect = !isOriginOrAsteriskForm && ((data - start) == 7 && data[0] == 32 && memcmp(start, "CONNECT", 7) == 0);
             /* Also accept proxy-style absolute URLs (http://... or https://...) as valid request targets */
-            bool isProxyStyleURL = !isHTTPMethod && !isConnect && data[0] == 32 && isHTTPorHTTPSPrefixForProxies(data + 1, end) == 1;
-            if (isHTTPMethod || isConnect || isProxyStyleURL) [[likely]] {
+            bool isProxyStyleURL = !isOriginOrAsteriskForm && !isConnect && data[0] == 32 && isHTTPorHTTPSPrefixForProxies(data + 1, end) == 1;
+            if (isOriginOrAsteriskForm || isConnect || isProxyStyleURL) [[likely]] {
                 header.key = {start, (size_t) (data - start)};
                 data++;
                 if(!isValidMethod(header.key, useStrictMethodValidation)) {

--- a/test/js/node/http/node-http-asterisk-form-target.test.ts
+++ b/test/js/node/http/node-http-asterisk-form-target.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
+
+// RFC 9112 3.2.4: the asterisk-form request-target ("*") identifies the
+// server as a whole and is sent by `OPTIONS * HTTP/1.1`. The request-line
+// parser only accepted targets beginning with "/", so asterisk-form requests
+// were answered with 400 Bad Request before ever reaching the handler. Node
+// (llhttp) delivers them with `req.url === "*"`, for any method, so Bun does
+// the same.
+
+async function writeAndCollect(port: number, requestLine: string) {
+  const client = net.connect(port);
+  try {
+    client.on("error", () => {});
+    const chunks: Buffer[] = [];
+    client.on("data", chunk => chunks.push(chunk));
+    const closed = once(client, "close");
+    client.write(`${requestLine}\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+    await closed;
+    return Buffer.concat(chunks).toString();
+  } finally {
+    client.destroy();
+  }
+}
+
+describe("node:http server", () => {
+  // llhttp accepts asterisk-form for any method, not only OPTIONS.
+  test.each(["OPTIONS", "GET"])("delivers `%s * HTTP/1.1` to the handler with url '*'", async method => {
+    const { promise: handled, resolve } = Promise.withResolvers<{ method: string; url: string }>();
+    await using server = http
+      .createServer((req, res) => {
+        resolve({ method: req.method!, url: req.url! });
+        res.end("hi");
+      })
+      .listen(0);
+    await once(server, "listening");
+
+    const wire = await writeAndCollect((server.address() as net.AddressInfo).port, `${method} * HTTP/1.1`);
+    expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(wire).toEndWith("\r\n\r\nhi");
+    expect(await handled).toEqual({ method, url: "*" });
+  });
+
+  test("an asterisk-form target with a query is delivered verbatim, like Node", async () => {
+    const { promise: handled, resolve } = Promise.withResolvers<string>();
+    await using server = http
+      .createServer((req, res) => {
+        resolve(req.url!);
+        res.end();
+      })
+      .listen(0);
+    await once(server, "listening");
+
+    const wire = await writeAndCollect((server.address() as net.AddressInfo).port, "OPTIONS *?a=1 HTTP/1.1");
+    expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(await handled).toBe("*?a=1");
+  });
+});
+
+describe("Bun.serve", () => {
+  // Bun.serve shares the same request-line parser, so it was rejecting
+  // asterisk-form targets too.
+  test("delivers `OPTIONS * HTTP/1.1` to fetch()", async () => {
+    const { promise: handled, resolve } = Promise.withResolvers<string>();
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        resolve(req.method);
+        return new Response("hi");
+      },
+    });
+
+    const wire = await writeAndCollect(server.port, "OPTIONS * HTTP/1.1");
+    expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(await handled).toBe("OPTIONS");
+  });
+});

--- a/test/js/node/http/node-http-asterisk-form-target.test.ts
+++ b/test/js/node/http/node-http-asterisk-form-target.test.ts
@@ -3,12 +3,8 @@ import { once } from "node:events";
 import http from "node:http";
 import net from "node:net";
 
-// RFC 9112 3.2.4: the asterisk-form request-target ("*") identifies the
-// server as a whole and is sent by `OPTIONS * HTTP/1.1`. The request-line
-// parser only accepted targets beginning with "/", so asterisk-form requests
-// were answered with 400 Bad Request before ever reaching the handler. Node
-// (llhttp) delivers them with `req.url === "*"`, for any method, so Bun does
-// the same.
+// RFC 9112 3.2.4: the asterisk-form request-target (`OPTIONS * HTTP/1.1`).
+// Node (llhttp) delivers it verbatim as `req.url === "*"` for any method.
 
 async function writeAndCollect(port: number, requestLine: string) {
   const client = net.connect(port);
@@ -60,8 +56,7 @@ describe("node:http server", () => {
 });
 
 describe("Bun.serve", () => {
-  // Bun.serve shares the same request-line parser, so it was rejecting
-  // asterisk-form targets too.
+  // Bun.serve shares the same request-line parser as node:http.
   test("delivers `OPTIONS * HTTP/1.1` to fetch()", async () => {
     const { promise: handled, resolve } = Promise.withResolvers<string>();
     await using server = Bun.serve({

--- a/test/js/node/http/node-http-asterisk-form-target.test.ts
+++ b/test/js/node/http/node-http-asterisk-form-target.test.ts
@@ -53,6 +53,42 @@ describe("node:http server", () => {
     expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
     expect(await handled).toBe("*?a=1");
   });
+
+  test("delivers `CONNECT * HTTP/1.1` as a tunnel, not as pipelined HTTP", async () => {
+    const { promise: connected, resolve } = Promise.withResolvers<{ url: string; tunneled: Promise<string> }>();
+    await using server = http.createServer();
+    server.on("connect", (req, socket) => {
+      const { promise: tunneled, resolve: gotBytes } = Promise.withResolvers<string>();
+      socket.on("data", chunk => {
+        gotBytes(chunk.toString());
+        socket.end();
+      });
+      socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      resolve({ url: req.url!, tunneled });
+    });
+    await once(server.listen(0), "listening");
+
+    const client = net.connect((server.address() as net.AddressInfo).port);
+    try {
+      client.on("error", () => {});
+      const chunks: Buffer[] = [];
+      client.on("data", chunk => chunks.push(chunk));
+      const closed = once(client, "close");
+      client.write("CONNECT * HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+      const { url, tunneled } = await connected;
+      expect(url).toBe("*");
+
+      // These bytes must be delivered on the tunnel. If CONNECT lost tunnel
+      // mode they would be fed back into the HTTP parser as a second request.
+      client.write("raw tunnel payload\r\n");
+      expect(await tunneled).toBe("raw tunnel payload\r\n");
+      await closed;
+      expect(Buffer.concat(chunks).toString()).toBe("HTTP/1.1 200 Connection Established\r\n\r\n");
+    } finally {
+      client.destroy();
+    }
+  });
 });
 
 describe("Bun.serve", () => {
@@ -70,5 +106,28 @@ describe("Bun.serve", () => {
     const wire = await writeAndCollect(server.port, "OPTIONS * HTTP/1.1");
     expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
     expect(await handled).toBe("OPTIONS");
+  });
+
+  // HttpRouter assumes an origin-form target and strips the leading byte, so
+  // an asterisk-form target must route as the root: a verbatim "*admin" would
+  // otherwise segment identically to "/admin" and invoke the static route.
+  test("an asterisk-form target cannot alias a static route", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/admin": () => new Response("admin") },
+      fetch: () => new Response("fallback"),
+    });
+
+    // Precondition: the static route exists and origin-form reaches it.
+    expect(await writeAndCollect(server.port, "GET /admin HTTP/1.1")).toEndWith("\r\n\r\nadmin");
+
+    for (const target of ["*", "*admin", "*/admin"]) {
+      const wire = await writeAndCollect(server.port, `GET ${target} HTTP/1.1`);
+      expect({ target, status: wire.split("\r\n")[0], body: wire.split("\r\n\r\n")[1] }).toEqual({
+        target,
+        status: "HTTP/1.1 200 OK",
+        body: "fallback",
+      });
+    }
   });
 });


### PR DESCRIPTION
### Repro

`OPTIONS * HTTP/1.1` (the asterisk-form request target, RFC 9112 3.2.4) is answered with `400 Bad Request` by the parser and never reaches the request handler. Node.js delivers it with `req.url === "*"`.

```js
const http = require("http"), net = require("net");
const server = http.createServer((req, res) => {
  console.log("handler:", req.method, JSON.stringify(req.url));
  res.end("ok");
});
server.listen(0, () => {
  const c = net.connect(server.address().port);
  c.on("data", d => console.log("client saw:", JSON.stringify(d.toString().split("\r\n")[0])));
  c.write("OPTIONS * HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
});
```

```
node: handler: OPTIONS "*"
      client saw: "HTTP/1.1 200 OK"
bun:  client saw: "HTTP/1.1 400 Bad Request"
```

`Bun.serve` rejects it the same way (same parser).

### Cause

`consumeRequestLine` in `packages/bun-uws/src/HttpParser.h` only admits three target shapes: origin-form (a target beginning with `/`), CONNECT's authority-form, and proxy-style absolute URLs (`http://...` / `https://...`). Anything else falls through to `HTTP_HEADER_PARSER_ERROR_INVALID_REQUEST` and a 400, so asterisk-form never parses.

### Fix

Two parts.

`consumeRequestLine` accepts `*` as the first character of a request-target, as a fourth form in the existing cascade, checked after CONNECT so that `CONNECT * HTTP/1.1` keeps its tunnel classification. Like Node (llhttp), any method may carry an asterisk-form target and it is delivered verbatim. The origin-form fast path is unchanged.

`getUrlForRouting()` normalizes asterisk-form targets to `/` before routing. `HttpRouter::getUrlSegment` assumes an origin-form URL and unconditionally strips the leading byte, so routing a verbatim `*admin` would segment it identically to `/admin` and match a static `Bun.serve` route registered as `/admin`, a route-confusion vector. That aliasing was verified against an intermediate build carrying only the parser change (`GET *admin` invoked the `/admin` handler, where it was 400-rejected before); with the normalization an asterisk-form target can only route as the root. Nothing else reads `getUrlForRouting()`: both `node:http`'s `req.url` and `Bun.serve`'s `Request.url` come from `getFullUrl()`, so they stay verbatim. Credit to review for catching this: an earlier revision routed the target verbatim.

`GET /admin`, absolute-form, CONNECT authority-form, and non-asterisk invalid targets (`GET badtarget`) are all unchanged.

### Verification

`test/js/node/http/node-http-asterisk-form-target.test.ts`:

- `OPTIONS *` and `GET *` on a `node:http` server assert `req.url === "*"` and the `200 OK` status line on the wire; `*?a=1` is delivered verbatim.
- `CONNECT * HTTP/1.1` asserts the `connect` event fires with `req.url === "*"` and that bytes written after the handshake arrive as opaque tunnel data rather than being parsed as a second request.
- `OPTIONS *` reaches a `Bun.serve` `fetch()` handler.
- Route-confusion regression: `GET *`, `GET *admin`, and `GET */admin` against a server with a static `/admin` route all reach the `/*` fallback, never `/admin`.

On an unfixed build 5 of 6 fail immediately with `Received: "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n"`; the `CONNECT *` test guards the cascade ordering and already passes on main. All 6 pass with the fix. The existing proxy-style, CONNECT, malformed-method, and header-overflow parser tests are unaffected.
