### PR TITLE
node:net: reject connect() while a connect is already in flight with EALREADY

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -47,7 +47,7 @@ const ArrayPrototypeJoin = Array.prototype.join;
 const ArrayPrototypePush = Array.prototype.push;
 const MathMax = Math.max;
 
-const { UV_ECANCELED, UV_ETIMEDOUT } = process.binding("uv");
+const { UV_EALREADY, UV_ECANCELED, UV_ETIMEDOUT } = process.binding("uv");
 const isWindows = process.platform === "win32";
 
 const getDefaultAutoSelectFamily = $rust("node_net_binding.rs", "getDefaultAutoSelectFamily");
@@ -1278,11 +1278,18 @@ function kConnectPipe(self, req, address) {
 }
 
 function kConnectDispatch(self, req, opts) {
+  const handle = self._handle;
+  // libuv's uv_tcp_connect rejects a handle whose connect_req is already in
+  // flight. readyState 2 is that state natively; without this, doConnect
+  // tears the in-flight attempt down and silently starts over.
+  if (handle.readyState === 2) {
+    return UV_EALREADY;
+  }
   // Node's TCPWrap returns errno for sync uv_*_connect failure and defers
   // oncomplete; doConnect instead fires connectError inside this call. Bracket
   // it so connectError hands the errno back here instead of re-entering.
   req.dispatching = true;
-  const promise = doConnect(self._handle, opts);
+  const promise = doConnect(handle, opts);
   req.dispatching = false;
   promise.catch(_reason => {
     // eat this so there's no unhandledRejection

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -47,7 +47,7 @@ const ArrayPrototypeJoin = Array.prototype.join;
 const ArrayPrototypePush = Array.prototype.push;
 const MathMax = Math.max;
 
-const { UV_EALREADY, UV_ECANCELED, UV_ETIMEDOUT } = process.binding("uv");
+const { UV_ECANCELED, UV_ETIMEDOUT } = process.binding("uv");
 const isWindows = process.platform === "win32";
 
 const getDefaultAutoSelectFamily = $rust("node_net_binding.rs", "getDefaultAutoSelectFamily");
@@ -112,6 +112,10 @@ const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
 const upgradeDuplexToTLS = $newRustFunction("runtime/socket/socket.rs", "jsUpgradeDuplexToTLS", 2);
 const isNamedPipeSocket = $newRustFunction("runtime/socket/socket.rs", "jsIsNamedPipeSocket", 1);
 const getBufferedAmount = $newRustFunction("runtime/socket/socket.rs", "jsGetBufferedAmount", 1);
+
+// process.binding("uv").UV_EALREADY cannot be used here: on Windows it is the
+// MSVC CRT errno, which util.getSystemErrorName (the UV_E table) rejects.
+const ealreadyErrorCode = $newRustFunction("node_util_binding.rs", "ealreadyErrorCode", 0);
 
 const bunTlsSymbol = Symbol.for("::buntls::");
 const bunSocketServerOptions = Symbol.for("::bunnetserveroptions::");
@@ -1283,7 +1287,7 @@ function kConnectDispatch(self, req, opts) {
   // flight. readyState 2 is that state natively; without this, doConnect
   // tears the in-flight attempt down and silently starts over.
   if (handle.readyState === 2) {
-    return UV_EALREADY;
+    return ealreadyErrorCode();
   }
   // Node's TCPWrap returns errno for sync uv_*_connect failure and defers
   // oncomplete; doConnect instead fires connectError inside this call. Bracket

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -39,6 +39,14 @@ pub(crate) fn enobufs_error_code(
     Ok(JSValue::js_number_from_int32(-UV_E::NOBUFS))
 }
 
+#[bun_jsc::host_fn]
+pub(crate) fn ealready_error_code(
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(JSValue::js_number_from_int32(-UV_E::ALREADY))
+}
+
 /// `extractedSplitNewLines` for ASCII/Latin1 strings. Panics if passed a non-string.
 /// Returns `undefined` if param is utf8 or utf16 and not fully ascii.
 ///

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
+import os from "node:os";
 
-// libuv's value differs per platform (-114 on Linux, -37 on macOS, -4084 on
-// Windows); read it the same way net.ts does so the assertion stays exact.
-const { UV_EALREADY } = process.binding("uv");
+// libuv's UV_EALREADY is -errno on POSIX and a fixed synthetic on Windows
+// (uv/errno.h). process.binding("uv").UV_EALREADY is not usable here: on
+// Windows it reports the MSVC CRT errno, which getSystemErrorName rejects.
+const UV_EALREADY = isWindows ? -4084 : -os.constants.errno.EALREADY;
 
 async function runNetFixture(source: string) {
   await using proc = Bun.spawn({

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -44,11 +44,9 @@ describe.concurrent("socket.connect() re-entry", () => {
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "first second", stderr, exitCode: 0 });
   });
 
-  // Node rejects a connect() issued while the previous one is still in flight
-  // with EALREADY (libuv: handle->connect_req != NULL) and destroys the
-  // socket. The in-flight attempt must never emit 'connect'. Any connect()
-  // after the EALREADY destroy is dropped by the `connecting` guard, so two
-  // and three calls produce the same single error.
+  // Node rejects connect() while a prior connect is in flight with EALREADY
+  // and destroys the socket; further connect()s are dropped by the `connecting`
+  // guard, so two and three calls produce the same single error.
   it.each([
     ["one extra connect()", 1],
     ["two extra connect()s", 2],

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -1,76 +1,120 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
+// libuv's value differs per platform (-114 on Linux, -37 on macOS, -4084 on
+// Windows); read it the same way net.ts does so the assertion stays exact.
+const { UV_EALREADY } = process.binding("uv");
+
+async function runNetFixture(source: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
 // connect_finish must tear down a still-live previous native socket before
 // reusing the wrapper, not alias two native sockets onto one ext slot.
-describe.concurrent("socket.connect() on an already-connected socket", () => {
-  it("does not crash and emits connect for the new connection", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const { createServer, connect } = require("node:net");
-          const srv = createServer(c => c.on("error", () => {})).listen(0, "127.0.0.1", () => {
-            const port = srv.address().port;
-            const s = connect(port, "127.0.0.1", () => {
-              process.stdout.write("first ");
-              s.once("connect", () => {
-                process.stdout.write("second");
-                s.destroy();
-                srv.close();
-              });
-              s.once("error", e => {
-                process.stdout.write("err:" + e.code);
-                srv.close();
-              });
-              s.connect(port, "127.0.0.1");
-            });
+describe.concurrent("socket.connect() re-entry", () => {
+  it("on an already-connected socket emits connect for the new connection", async () => {
+    const { stdout, stderr, exitCode } = await runNetFixture(`
+      const { createServer, connect } = require("node:net");
+      const srv = createServer(c => c.on("error", () => {})).listen(0, "127.0.0.1", () => {
+        const port = srv.address().port;
+        const s = connect(port, "127.0.0.1", () => {
+          process.stdout.write("first ");
+          s.once("connect", () => {
+            process.stdout.write("second");
+            s.destroy();
+            srv.close();
           });
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          s.once("error", e => {
+            process.stdout.write("err:" + e.code);
+            srv.close();
+          });
+          s.connect(port, "127.0.0.1");
+        });
+      });
+    `);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "first second", stderr, exitCode: 0 });
   });
 
-  it("does not crash when reconnecting while the first connect is still in flight", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const { createServer, connect } = require("node:net");
-          const srv = createServer(c => c.on("error", () => {})).listen(0, "127.0.0.1", () => {
-            const port = srv.address().port;
-            const s = connect(port, "127.0.0.1");
-            // Second connect while the first is still connecting.
-            s.connect(port, "127.0.0.1");
-            s.once("connect", () => {
-              process.stdout.write("connect");
-              s.destroy();
-              srv.close();
-            });
-            s.once("error", e => {
-              process.stdout.write("err:" + e.code);
-              s.destroy();
-              srv.close();
-            });
-          });
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Node emits EALREADY here; Bun drops the first in-flight connect and
-    // completes the second. Either is acceptable so long as the process
-    // exits cleanly.
-    expect(["connect", "err:EALREADY"]).toContain(stdout);
+  // Node rejects a connect() issued while the previous one is still in flight
+  // with EALREADY (libuv: handle->connect_req != NULL) and destroys the
+  // socket. The in-flight attempt must never emit 'connect'. Any connect()
+  // after the EALREADY destroy is dropped by the `connecting` guard, so two
+  // and three calls produce the same single error.
+  it.each([
+    ["one extra connect()", 1],
+    ["two extra connect()s", 2],
+  ])("while still connecting errors with EALREADY (%s)", async (_name, extra) => {
+    const { stdout, stderr, exitCode } = await runNetFixture(`
+      const { createServer, connect } = require("node:net");
+      const srv = createServer(c => c.on("error", () => {})).listen(0, "127.0.0.1", () => {
+        const port = srv.address().port;
+        const events = [];
+        const s = connect(port, "127.0.0.1");
+        for (let i = 0; i < ${extra}; i++) s.connect(port, "127.0.0.1");
+        // 'connect' must never fire; destroy so a regression still reaches
+        // 'close' and reports the wrong event list instead of hanging.
+        s.on("connect", () => {
+          events.push("connect");
+          s.destroy();
+        });
+        s.on("error", e => {
+          const { name, message, code, errno, syscall, address, port } = e;
+          events.push({ name, message, code, errno, syscall, address, port });
+        });
+        s.on("close", hadError => {
+          events.push("close:" + hadError);
+          process.stdout.write(JSON.stringify({ port, events }));
+          srv.close();
+        });
+      });
+    `);
     expect({ stderr, exitCode }).toEqual({ stderr, exitCode: 0 });
+    const { port, events } = JSON.parse(stdout);
+    expect(events).toEqual([
+      {
+        name: "Error",
+        message: `connect EALREADY 127.0.0.1:${port}`,
+        code: "EALREADY",
+        errno: UV_EALREADY,
+        syscall: "connect",
+        address: "127.0.0.1",
+        port,
+      },
+      "close:true",
+    ]);
+  });
+
+  // The abandoned first attempt's connect callback must never fire; neither
+  // may the rejected second attempt's.
+  it("does not invoke either attempt's connect callback", async () => {
+    const { stdout, stderr, exitCode } = await runNetFixture(`
+      const { createServer, connect } = require("node:net");
+      const srv = createServer(c => c.on("error", () => {})).listen(0, "127.0.0.1", () => {
+        const port = srv.address().port;
+        const events = [];
+        const s = connect(port, "127.0.0.1", () => events.push("cb1"));
+        s.connect(port, "127.0.0.1", () => events.push("cb2"));
+        // Neither callback may fire; destroy so a regression still reaches
+        // 'close' and reports the wrong event list instead of hanging.
+        s.on("connect", () => s.destroy());
+        s.on("error", e => events.push("error:" + e.code));
+        s.on("close", () => {
+          process.stdout.write(JSON.stringify(events));
+          srv.close();
+        });
+      });
+    `);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify(["error:EALREADY"]),
+      stderr,
+      exitCode: 0,
+    });
   });
 });


### PR DESCRIPTION
Reported by a `node:net` differential fuzzer: calling `socket.connect()` again while the socket is still connecting.

### Repro

```js
import net from "node:net";
const srv = net.createServer().listen(0, "127.0.0.1", () => {
  const s = net.connect(srv.address().port, "127.0.0.1");
  s.connect(srv.address().port, "127.0.0.1");   // second connect() while still CONNECTING
  s.on("error", e => console.log("error:", e.code));
  s.on("ready", () => { console.log("ready"); s.end(); });
  setTimeout(() => process.exit(0), 1500);
});
```

Node (v26): `error: EALREADY`, then `close` with `hadError = true`, exit 0.
Bun before this PR: `ready`. The first in-flight attempt is silently torn down and the second succeeds. No error ever fires.

The fuzzer also reported that this shape aborts the process on 1.4.0 (`panic: No handlers set on Socket`) and trips `assertion failed: prev.socket.get().is_detached()` in `connect_finish` on debug builds. Both were already fixed on main by #32739 and do not reproduce on the current canary; the build the fuzzer ran predates that merge. What this PR fixes is the remaining behavioral divergence.

### Cause

In Node, `internalConnect` calls `self._handle.connect(req, address, port)`, which lands in libuv:

```c
if (handle->connect_req != NULL)
  return UV_EALREADY;
```

so the second `connect()` on a still-connecting handle gets a synchronous `UV_EALREADY`, and `internalConnect` destroys the socket with `new ExceptionWithHostPort(err, "connect", address, port)`.

Bun's equivalent boundary is `kConnectDispatch` in `src/js/node/net.ts`, which calls straight into `doConnect`. That path was written for reconnect-after-close (and, since #32739, tolerates a still-live previous handle by detaching it), so it replaced the in-flight attempt instead of rejecting.

### Fix

`kConnectDispatch` returns the `EALREADY` errno when `handle.readyState === 2`, the native "connect dispatched but not yet established" state. That is exactly libuv's `connect_req != NULL` check at the same layer, and it covers both `kConnectTcp` and `kConnectPipe` through the one shared dispatch. `internalConnect`'s existing `if (err)` path then destroys the socket with the same error object Node produces.

The errno is sourced from a new `ealreadyErrorCode()` in `node_util_binding.rs` (returning `-UV_E::ALREADY`), not from `process.binding("uv").UV_EALREADY`. `ExceptionWithHostPort` derives `code` and `message` from `errno` through `util.getSystemErrorName`, which reads the Rust `UV_E` table, so the errno has to come from that same table or the two can never agree. They do agree on POSIX, but on Windows `ProcessBindingUV.cpp` exposes `UV_<NAME>` as the negated host CRT errno (`EALREADY` is 103 in the MSVC CRT) while libuv and `UV_E` use the synthetic `-4084`, and `getSystemErrorName(-103)` there produces `"Unknown system error -103"`. `child_process.ts` already works around the same divergence with `etimedoutErrorCode()` / `enobufsErrorCode()` from the same file; this adds the third one next to them.

Observable result matches Node exactly:

```
["second-connect-returned","error:EALREADY syscall=connect","close hadErr=true"]   # node v26.3.0
["second-connect-returned","error:EALREADY syscall=connect","close hadErr=true"]   # bun with this PR
```

The already-connected case is unchanged: Node reconnects and emits `connect` again there, and Bun already matched (via #32739), which the existing test in this file pins.

### Verification

`test/js/node/net/socket-reconnect-live.test.ts` (the file #32739 added):

- The connecting-state case previously accepted either outcome (`expect(["connect", "err:EALREADY"]).toContain(stdout)`, which could not fail for this change). It now asserts the full Node contract with `toEqual`: exactly one `error` carrying `name`/`message`/`code`/`errno`/`syscall`/`address`/`port`, then `close` with `hadError = true`, no `connect` event, exit 0. The expected `errno` is derived the way libuv defines it (`-os.constants.errno.EALREADY` on POSIX, `-4084` on Windows per `uv/errno.h`).
- A three-`connect()` variant: Node produces exactly one EALREADY because the destroy clears `connecting` and drops the queued third attempt; Bun now does too.
- Neither the first nor the second attempt's connect callback fires.
- The already-connected reconnect test is unchanged and still passes.

All three new assertions fail against an unmodified build with a clear `["connect", "close:false"]` diff (not a timeout) and pass with the change. `test/js/node/net/` and the 44 ported `test-net-connect*`/`test-net-reconnect*`/`test-net-autoselectfamily*`/`test-tls-connect*` node tests were run with the change; the only failures are pre-existing in this environment (they fail identically on an unmodified build) and unrelated.

### Intentionally excluded

- `tlsSocket.connect(port, host)` re-entry never reaches this guard: it throws `TypeError: socket must be an instance of net.Socket or Duplex` first, because `TLSSocket.prototype[buntls]` returns the socket's own `_handle` as a `socket:` option once one exists. That is a pre-existing bug with a different root cause (it predates this code path entirely).
- The `process.binding("uv")` Windows value divergence described above is pre-existing and much broader than EALREADY: on Windows every `UV_<NAME>` there is the MSVC CRT errno rather than libuv's synthetic value, so it also disagrees with Node for `UV_ENOENT`, `UV_ETIMEDOUT`, and the rest. `net.ts` still reads `UV_ETIMEDOUT` and `UV_ECANCELED` from it on the family-autoselection paths (same bug class, Windows-only, unreported, unreachable from this PR's tests). The real fix is for `ProcessBindingUV.cpp` to use the libuv values on Windows, which changes ~80 constants across the whole compat surface and belongs in its own PR.