### PR TITLE
node:fs: apply the string encoding in write/writeSync and other Node compat fixes

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -605,7 +605,11 @@ function asyncWrap(fn: any, name: string) {
         if (typeof length !== "number") length = buffer.byteLength - offset;
         if (typeof position !== "number") position = null;
       } else {
-        // filehandle.write(string[, position[, encoding]]): `length` is the encoding.
+        // filehandle.write(string[, position[, encoding]]): `length` is the
+        // encoding. Node rejects a non-string before it validates the encoding.
+        if (typeof buffer !== "string") {
+          throw $ERR_INVALID_ARG_TYPE("buffer", ["string", "Buffer", "TypedArray", "DataView"], buffer);
+        }
         validateEncoding(buffer, length);
       }
       try {

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -3,7 +3,13 @@ const types = require("node:util/types");
 const EventEmitter = require("node:events");
 const fs = require("internal/fs/binding") as $ZigGeneratedClasses.NodeJSFS;
 const { glob } = require("internal/fs/glob");
-const { validateInteger, validateBoolean, validateObject, validateAbortSignal } = require("internal/validators");
+const {
+  validateInteger,
+  validateBoolean,
+  validateObject,
+  validateAbortSignal,
+  validateEncoding,
+} = require("internal/validators");
 
 const constants = $processBindingConstants.fs;
 
@@ -598,6 +604,9 @@ function asyncWrap(fn: any, name: string) {
         }
         if (typeof length !== "number") length = buffer.byteLength - offset;
         if (typeof position !== "number") position = null;
+      } else {
+        // filehandle.write(string[, position[, encoding]]): `length` is the encoding.
+        validateEncoding(buffer, length);
       }
       try {
         this[kRef]();

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1178,6 +1178,18 @@ class Dir {
     this.#handle = -1;
   }
 
+  // Like node, disposing an already-closed Dir is a no-op rather than
+  // ERR_DIR_CLOSED so `using`/`await using` compose with an explicit close().
+  [Symbol.dispose]() {
+    if (this.#handle < 0) return;
+    this.closeSync();
+  }
+
+  async [Symbol.asyncDispose]() {
+    if (this.#handle < 0) return;
+    await this.close();
+  }
+
   get path() {
     if (!(#path in this)) throw $ERR_INVALID_THIS("Dir");
     return this.#path;

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -5,6 +5,7 @@ const types = require("node:util/types");
 const {
   validateFunction,
   validateInteger,
+  validateEncoding,
   getValidatedPath,
   throwIfNullBytesInFileName,
 } = require("internal/validators");
@@ -276,7 +277,9 @@ var access = function access(path, mode, callback) {
       callback(null, bytesWritten, buffer);
     }
 
-    if ($isTypedArrayView(buffer)) {
+    // $isTypedArrayView excludes DataView, so a DataView would fall through
+    // to the string signature. Use Node's predicate, like writeSync below.
+    if (types.isArrayBufferView(buffer)) {
       callback ||= position || length || offsetOrOptions;
       ensureCallback(callback);
 
@@ -292,6 +295,10 @@ var access = function access(path, mode, callback) {
       return;
     }
 
+    if (typeof buffer !== "string") {
+      throw $ERR_INVALID_ARG_TYPE("buffer", ["string", "Buffer", "TypedArray", "DataView"], buffer);
+    }
+
     if (!$isCallable(position)) {
       if ($isCallable(offsetOrOptions)) {
         position = offsetOrOptions;
@@ -302,6 +309,8 @@ var access = function access(path, mode, callback) {
       length = "utf8";
     }
 
+    // Node validates the encoding (synchronously) before the callback.
+    validateEncoding(buffer, length);
     callback = position;
     ensureCallback(callback);
 
@@ -499,6 +508,8 @@ var access = function access(path, mode, callback) {
       if (typeof buffer !== "string") {
         throw $ERR_INVALID_ARG_TYPE("buffer", ["string", "Buffer", "TypedArray", "DataView"], buffer);
       }
+      // writeSync(fd, string[, position[, encoding]]): `length` is the encoding.
+      validateEncoding(buffer, length);
       return fs.writeSync(fd, buffer, offsetOrOptions, length);
     } catch (err) {
       // Node's fs binding reports sync write failures by assigning the error

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3855,8 +3855,9 @@ pub mod args {
                             args.encoding = Encoding::assert(current, ctx, args.encoding)?;
                             arguments.eat();
                             // `bv` was converted to UTF-8 before the encoding
-                            // argument was parsed; re-encode it now.
-                            if args.encoding != Encoding::Utf8 {
+                            // argument was parsed; re-encode it now. Node
+                            // treats the "buffer" encoding name as UTF-8 here.
+                            if !matches!(args.encoding, Encoding::Utf8 | Encoding::Buffer) {
                                 if let Some(encoded) =
                                     StringOrBuffer::from_js_with_encoding(ctx, bv, args.encoding)?
                                 {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3838,16 +3838,31 @@ pub mod args {
                     // fs.write(fd, string[, position[, encoding]], callback)
                     _ => {
                         if current.is_number() {
-                            args.position = Some(i52::from_js(current));
-                            arguments.eat();
-                            let Some(next) = arguments.next() else {
-                                break 'parse;
-                            };
-                            current = next;
+                            let position = i52::from_js(current);
+                            if position >= 0 {
+                                args.position = Some(position);
+                            }
                         }
+                        // Node consumes the position slot whatever its type
+                        // (null, undefined, a non-number); the encoding is
+                        // strictly the next argument.
+                        arguments.eat();
+                        let Some(next) = arguments.next() else {
+                            break 'parse;
+                        };
+                        current = next;
                         if current.is_string() {
                             args.encoding = Encoding::assert(current, ctx, args.encoding)?;
                             arguments.eat();
+                            // `bv` was converted to UTF-8 before the encoding
+                            // argument was parsed; re-encode it now.
+                            if args.encoding != Encoding::Utf8 {
+                                if let Some(encoded) =
+                                    StringOrBuffer::from_js_with_encoding(ctx, bv, args.encoding)?
+                                {
+                                    args.buffer = encoded;
+                                }
+                            }
                         }
                     }
                 }
@@ -4713,14 +4728,13 @@ pub mod ret {
                     Ok(array)
                 }
                 Readdir::Buffers(items) => {
-                    // `JSValue.fromAny(_, []Buffer, _)` — generic-slice arm:
-                    // build an empty array, push `item.toJS(globalObject)` for
-                    // each. Ownership of every `Buffer`'s bytes transfers to
-                    // JSC via `MarkedArrayBuffer::to_js`; the boxed slice
+                    // Node returns `Buffer[]` for `{ encoding: "buffer" }`, not
+                    // `Uint8Array[]`. Ownership of every `Buffer`'s bytes
+                    // transfers to JSC via `to_node_buffer`; the boxed slice
                     // itself is freed when `items` drops.
                     let array = JSValue::create_empty_array(global_object, items.len())?;
                     for (i, item) in items.iter().enumerate() {
-                        let res = item.to_js(global_object)?;
+                        let res = item.to_node_buffer(global_object);
                         if res == JSValue::ZERO {
                             return Ok(JSValue::ZERO);
                         }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1736,17 +1736,29 @@ impl FileSystemFlags {
         let js_type = val.js_type();
         if js_type.is_string_like() {
             let str = val.get_zig_string(ctx)?;
+            // Node's stringToFlags throws ERR_INVALID_ARG_VALUE for every
+            // unrecognized flag string.
             if str.len == 0 {
-                return Err(ctx.throw_invalid_arguments(format_args!(
-                    "Expected flags to be a non-empty string. Learn more at https://nodejs.org/api/fs.html#fs_file_system_flags",
-                )));
+                return Err(ctx
+                    .err(
+                        jsc::ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "Expected flags to be a non-empty string. Learn more at https://nodejs.org/api/fs.html#fs_file_system_flags",
+                        ),
+                    )
+                    .throw());
             }
             // it's definitely wrong when the string is super long
             else if str.len > 12 {
-                return Err(ctx.throw_invalid_arguments(format_args!(
-                    "Invalid flag '{}'. Learn more at https://nodejs.org/api/fs.html#fs_file_system_flags",
-                    str
-                )));
+                return Err(ctx
+                    .err(
+                        jsc::ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "Invalid flag '{}'. Learn more at https://nodejs.org/api/fs.html#fs_file_system_flags",
+                            str
+                        ),
+                    )
+                    .throw());
             }
 
             let flags: Option<i32> = 'brk: {
@@ -1774,10 +1786,15 @@ impl FileSystemFlags {
             };
 
             let Some(flags) = flags else {
-                return Err(ctx.throw_invalid_arguments(format_args!(
-                    "Invalid flag '{}'. Learn more at https://nodejs.org/api/fs.html#fs_file_system_flags",
-                    str
-                )));
+                return Err(ctx
+                    .err(
+                        jsc::ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "Invalid flag '{}'. Learn more at https://nodejs.org/api/fs.html#fs_file_system_flags",
+                            str
+                        ),
+                    )
+                    .throw());
             };
 
             return Ok(Some(FileSystemFlags(flags)));

--- a/test/js/node/fs/dir.test.ts
+++ b/test/js/node/fs/dir.test.ts
@@ -201,3 +201,43 @@ describe("opendirSync string encoding shorthand", () => {
     }
   });
 });
+
+// Node's Dir implements Symbol.dispose / Symbol.asyncDispose so it composes
+// with `using` / `await using`. Disposing an already-closed Dir is a no-op.
+describe("Dir explicit resource management", () => {
+  let dirname: string;
+  beforeEach(() => {
+    dirname = path.join(os.tmpdir(), "opendir-dispose-" + String(Math.random() * 100).substring(0, 6));
+    fs.mkdirSync(dirname);
+    fs.writeFileSync(path.join(dirname, "entry.txt"), "x");
+  });
+  afterEach(() => {
+    fs.rmSync(dirname, { recursive: true, force: true });
+  });
+
+  it("`using` closes the directory at scope exit", () => {
+    let dir!: fs.Dir;
+    {
+      using d = fs.opendirSync(dirname);
+      dir = d;
+      expect(d.readSync()?.name).toBe("entry.txt");
+    }
+    expect(() => dir.readSync()).toThrow(expect.objectContaining({ code: "ERR_DIR_CLOSED" }));
+  });
+
+  it("`await using` closes the directory at scope exit", async () => {
+    let dir!: fs.Dir;
+    {
+      await using d = await fs.promises.opendir(dirname);
+      dir = d;
+    }
+    expect(() => dir.readSync()).toThrow(expect.objectContaining({ code: "ERR_DIR_CLOSED" }));
+  });
+
+  it("disposing an already-closed Dir does not throw", async () => {
+    const dir = fs.opendirSync(dirname);
+    dir.closeSync();
+    expect(() => dir[Symbol.dispose]()).not.toThrow();
+    await expect(dir[Symbol.asyncDispose]()).resolves.toBeUndefined();
+  });
+});

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1179,6 +1179,23 @@ it("readdirSync throws when given a file path with trailing slash", () => {
   }
 });
 
+// Node returns Buffer[] for { encoding: "buffer" }, not Uint8Array[].
+it("readdir with { encoding: 'buffer' } returns Buffer entries", async () => {
+  using dir = tempDir("readdir-buffer-entries", { "a.txt": "", "b.txt": "" });
+  const summarize = (entries: Buffer[]) =>
+    entries.map(entry => [Buffer.isBuffer(entry), entry.toString("utf8")]).sort((a, b) => (a[1] < b[1] ? -1 : 1));
+  const expected = [
+    [true, "a.txt"],
+    [true, "b.txt"],
+  ];
+  expect(summarize(readdirSync(String(dir), { encoding: "buffer" }))).toEqual(expected);
+  expect(summarize(readdirSync(String(dir), { encoding: "buffer", recursive: true }))).toEqual(expected);
+  expect(summarize(await promises.readdir(String(dir), { encoding: "buffer" }))).toEqual(expected);
+  expect(
+    summarize((await promisify(fs.readdir)(String(dir), { encoding: "buffer" } as const)) as unknown as Buffer[]),
+  ).toEqual(expected);
+});
+
 // The error cleanup path previously called MarkedArrayBuffer.destroy() on
 // structs stored by-value inside the entries ArrayList, which passed interior
 // ArrayList pointers to the allocator (freeing entries.items.ptr for index 0 and
@@ -1480,6 +1497,40 @@ describe("writeSync", () => {
       expect(count).toBe(4);
     }
     closeSync(fd);
+  });
+
+  // writeSync(fd, string[, position[, encoding]]): the encoding used to be
+  // parsed but never applied, so utf16le/hex/base64/latin1 all wrote raw UTF-8.
+  it("honors the encoding argument for strings", () => {
+    const dest = join(tmpdirSync(), "writeSync-string-encoding.bin");
+    const cases: [args: unknown[], expected: Buffer][] = [
+      [["abc", 0, "utf16le"], Buffer.from("abc", "utf16le")],
+      // Node consumes the position slot whatever its type; the encoding is
+      // always the following argument.
+      [["abc", null, "ucs2"], Buffer.from("abc", "utf16le")],
+      [["abc", undefined, "utf16le"], Buffer.from("abc", "utf16le")],
+      [["61626364", 0, "hex"], Buffer.from("abcd")],
+      [["aGk=", null, "base64"], Buffer.from("hi")],
+      [["\u00ff", 0, "latin1"], Buffer.from([0xff])],
+      // A lone string in the position slot is not an encoding.
+      [["ab", "utf16le"], Buffer.from("ab")],
+      [["abc", 0], Buffer.from("abc")],
+      [["abc"], Buffer.from("abc")],
+    ];
+    for (const [args, expected] of cases) {
+      const fd = openSync(dest, "w");
+      let written: number;
+      try {
+        written = (writeSync as Function)(fd, ...args);
+      } finally {
+        closeSync(fd);
+      }
+      expect({ args, written, bytes: [...readFileSync(dest)] }).toEqual({
+        args,
+        written: expected.length,
+        bytes: [...expected],
+      });
+    }
   });
 });
 
@@ -3480,6 +3531,36 @@ describe("fs.write", () => {
     });
   });
 
+  // Same bug as the writeSync case: the encoding was parsed but never applied.
+  it("honors a non-utf8 encoding for strings", async () => {
+    const expected = [...Buffer.from("bun", "utf16le")];
+    const dest = join(tmpdirSync(), "fs-write-string-encoding.bin");
+
+    // fs.write(fd, string, position, encoding, callback)
+    {
+      const fd = fs.openSync(dest, "w");
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      fs.write(fd, "bun", null, "utf16le", (err, written) => (err ? reject(err) : resolve(written)));
+      try {
+        expect(await promise).toBe(6);
+      } finally {
+        closeSync(fd);
+      }
+      expect([...readFileSync(dest)]).toEqual(expected);
+    }
+
+    // filehandle.write(string, position, encoding)
+    {
+      const handle = await promises.open(dest, "w");
+      try {
+        expect((await handle.write("bun", 0, "utf16le")).bytesWritten).toBe(6);
+      } finally {
+        await handle.close();
+      }
+      expect([...readFileSync(dest)]).toEqual(expected);
+    }
+  });
+
   it("should work with (fd, string, position, callback)", done => {
     const path = `${tmpdir()}/bun-fs-write-4-${Date.now()}.txt`;
     const fd = fs.openSync(path, "w");
@@ -3906,6 +3987,15 @@ it("open flags verification", async () => {
   expect(() => fs.open(__filename, 4294967298.5, () => {})).toThrow(
     RangeError(`The value of "flags" is out of range. It must be an integer. Received 4294967298.5`),
   );
+});
+
+// Node's stringToFlags throws ERR_INVALID_ARG_VALUE for every unrecognized
+// flag string; Bun threw ERR_INVALID_ARG_TYPE.
+it("an unrecognized flag string throws ERR_INVALID_ARG_VALUE", () => {
+  for (const flag of ["bogus", "", "z", Buffer.alloc(32, "w").toString()]) {
+    expect(() => fs.openSync(__filename, flag)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+    expect(() => fs.open(__filename, flag, () => {})).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+  }
 });
 
 it("open mode verification", async () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1512,6 +1512,9 @@ describe("writeSync", () => {
       [["61626364", 0, "hex"], Buffer.from("abcd")],
       [["aGk=", null, "base64"], Buffer.from("hi")],
       [["\u00ff", 0, "latin1"], Buffer.from([0xff])],
+      // Node writes UTF-8 for the "buffer" encoding name; it must not fall
+      // into the latin1-narrowing path.
+      [["\u00e9", 0, "buffer"], Buffer.from([0xc3, 0xa9])],
       // A lone string in the position slot is not an encoding.
       [["ab", "utf16le"], Buffer.from("ab")],
       [["abc", 0], Buffer.from("abc")],

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1515,6 +1515,9 @@ describe("writeSync", () => {
       // Node writes UTF-8 for the "buffer" encoding name; it must not fall
       // into the latin1-narrowing path.
       [["\u00e9", 0, "buffer"], Buffer.from([0xc3, 0xa9])],
+      // Same for a 16-bit string, which would otherwise hit a separate
+      // low-byte-narrowing encoder (U+4E2D -> 0x2d).
+      [["a\u00e9\u4e2d", 0, "buffer"], Buffer.from([0x61, 0xc3, 0xa9, 0xe4, 0xb8, 0xad])],
       // A lone string in the position slot is not an encoding.
       [["ab", "utf16le"], Buffer.from("ab")],
       [["abc", 0], Buffer.from("abc")],

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3567,6 +3567,31 @@ describe("fs.write", () => {
     }
   });
 
+  // Node rejects a non-string, non-view buffer with ERR_INVALID_ARG_TYPE
+  // before validating the encoding against it. `{ length: 3 }` with "hex"
+  // would otherwise be rejected by validateEncoding with the wrong code.
+  it("rejects a non-string, non-view buffer before the encoding is validated", async () => {
+    const dest = join(tmpdirSync(), "fs-write-buffer-type.bin");
+    const badBuffer = { length: 3 } as unknown as string;
+    const fd = fs.openSync(dest, "w");
+    try {
+      expect(() => fs.write(fd, badBuffer, 0, "hex", () => {})).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+      expect(() => fs.writeSync(fd, badBuffer, 0, "hex")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    } finally {
+      closeSync(fd);
+    }
+    const handle = await promises.open(dest, "w");
+    try {
+      const outcome = await handle.write(badBuffer, 0, "hex").then(
+        () => "resolved",
+        err => err.code,
+      );
+      expect(outcome).toBe("ERR_INVALID_ARG_TYPE");
+    } finally {
+      await handle.close();
+    }
+  });
+
   it("should work with (fd, string, position, callback)", done => {
     const path = `${tmpdir()}/bun-fs-write-4-${Date.now()}.txt`;
     const fd = fs.openSync(path, "w");

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -134,6 +134,22 @@ if (process.argv.length === 2 &&
         globalThis.gc ??= () => Bun.gc(true);
         break;
       }
+      if ((flag === "--expose-externalize-string" || flag === "--expose_externalize_string") && process.versions.bun) {
+        // V8's externalized-string test helpers. JavaScriptCore has no string
+        // externalization to force, so the create/externalize helpers are
+        // identity/no-op; isOneByteString answers the representation-independent
+        // question V8's helper answers (are all code units <= 0xFF).
+        globalThis.createExternalizableString ??= s => `${s}`;
+        globalThis.createExternalizableTwoByteString ??= s => `${s}`;
+        globalThis.externalizeString ??= () => {};
+        globalThis.isOneByteString ??= s => {
+          for (let i = 0; i < s.length; i++) {
+            if (s.charCodeAt(i) > 0xff) return false;
+          }
+          return true;
+        };
+        break;
+      }
       if (flag === "--expose-internals" && process.versions.bun) {
         process.env.SKIP_FLAG_CHECK = "1";
         // Serve require("internal/*") from bun's internal module registry

--- a/test/js/node/test/parallel/test-fs-write.js
+++ b/test/js/node/test/parallel/test-fs-write.js
@@ -19,12 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Bun: upstream runs this under the --expose_externalize_string V8 flag and
-// uses the createExternalizableString / externalizeString / isOneByteString
-// globals it exposes. Externalized strings are a V8 representation with no
-// JavaScriptCore equivalent, so that flag comment and those calls are
-// removed here; every fs assertion (the writeSync latin1/utf8/ucs2 writes
-// and their read-backs) is kept unchanged from upstream.
+// Flags: --expose_externalize_string
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -40,9 +35,32 @@ const fn4 = tmpdir.resolve('write4.txt');
 const expected = 'ümlaut.';
 const constants = fs.constants;
 
+const {
+  createExternalizableString,
+  createExternalizableTwoByteString,
+  externalizeString,
+  isOneByteString,
+} = globalThis;
+
+assert.notStrictEqual(createExternalizableString, undefined);
+assert.notStrictEqual(createExternalizableTwoByteString, undefined);
+assert.notStrictEqual(externalizeString, undefined);
+assert.notStrictEqual(isOneByteString, undefined);
+
+// Account for extra globals exposed by --expose_externalize_string.
+common.allowGlobals(
+  createExternalizableString,
+  createExternalizableTwoByteString,
+  externalizeString,
+  isOneByteString,
+  globalThis.x,
+);
+
 {
   // Must be a unique string.
-  const expected = 'ümlaut sechzig';
+  const expected = createExternalizableString('ümlaut sechzig');
+  externalizeString(expected);
+  assert.strictEqual(isOneByteString(expected), true);
   const fd = fs.openSync(fn, 'w');
   fs.writeSync(fd, expected, 0, 'latin1');
   fs.closeSync(fd);
@@ -51,7 +69,9 @@ const constants = fs.constants;
 
 {
   // Must be a unique string.
-  const expected = 'ümlaut neunzig';
+  const expected = createExternalizableString('ümlaut neunzig');
+  externalizeString(expected);
+  assert.strictEqual(isOneByteString(expected), true);
   const fd = fs.openSync(fn, 'w');
   fs.writeSync(fd, expected, 0, 'utf8');
   fs.closeSync(fd);
@@ -60,7 +80,9 @@ const constants = fs.constants;
 
 {
   // Must be a unique string.
-  const expected = 'Zhōngwén 1';
+  const expected = createExternalizableString('Zhōngwén 1');
+  externalizeString(expected);
+  assert.strictEqual(isOneByteString(expected), false);
   const fd = fs.openSync(fn, 'w');
   fs.writeSync(fd, expected, 0, 'ucs2');
   fs.closeSync(fd);
@@ -69,7 +91,9 @@ const constants = fs.constants;
 
 {
   // Must be a unique string.
-  const expected = 'Zhōngwén 2';
+  const expected = createExternalizableString('Zhōngwén 2');
+  externalizeString(expected);
+  assert.strictEqual(isOneByteString(expected), false);
   const fd = fs.openSync(fn, 'w');
   fs.writeSync(fd, expected, 0, 'utf8');
   fs.closeSync(fd);

--- a/test/js/node/test/parallel/test-fs-write.js
+++ b/test/js/node/test/parallel/test-fs-write.js
@@ -1,0 +1,191 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Bun: upstream runs this under the --expose_externalize_string V8 flag and
+// uses the createExternalizableString / externalizeString / isOneByteString
+// globals it exposes. Externalized strings are a V8 representation with no
+// JavaScriptCore equivalent, so that flag comment and those calls are
+// removed here; every fs assertion (the writeSync latin1/utf8/ucs2 writes
+// and their read-backs) is kept unchanged from upstream.
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+
+const fn = tmpdir.resolve('write.txt');
+const fn2 = tmpdir.resolve('write2.txt');
+const fn3 = tmpdir.resolve('write3.txt');
+const fn4 = tmpdir.resolve('write4.txt');
+const expected = 'ümlaut.';
+const constants = fs.constants;
+
+{
+  // Must be a unique string.
+  const expected = 'ümlaut sechzig';
+  const fd = fs.openSync(fn, 'w');
+  fs.writeSync(fd, expected, 0, 'latin1');
+  fs.closeSync(fd);
+  assert.strictEqual(fs.readFileSync(fn, 'latin1'), expected);
+}
+
+{
+  // Must be a unique string.
+  const expected = 'ümlaut neunzig';
+  const fd = fs.openSync(fn, 'w');
+  fs.writeSync(fd, expected, 0, 'utf8');
+  fs.closeSync(fd);
+  assert.strictEqual(fs.readFileSync(fn, 'utf8'), expected);
+}
+
+{
+  // Must be a unique string.
+  const expected = 'Zhōngwén 1';
+  const fd = fs.openSync(fn, 'w');
+  fs.writeSync(fd, expected, 0, 'ucs2');
+  fs.closeSync(fd);
+  assert.strictEqual(fs.readFileSync(fn, 'ucs2'), expected);
+}
+
+{
+  // Must be a unique string.
+  const expected = 'Zhōngwén 2';
+  const fd = fs.openSync(fn, 'w');
+  fs.writeSync(fd, expected, 0, 'utf8');
+  fs.closeSync(fd);
+  assert.strictEqual(fs.readFileSync(fn, 'utf8'), expected);
+}
+
+fs.open(fn, 'w', 0o644, common.mustSucceed((fd) => {
+  const done = common.mustSucceed((written) => {
+    assert.strictEqual(written, Buffer.byteLength(expected));
+    fs.closeSync(fd);
+    const found = fs.readFileSync(fn, 'utf8');
+    fs.unlinkSync(fn);
+    assert.strictEqual(found, expected);
+  });
+
+  const written = common.mustSucceed((written) => {
+    assert.strictEqual(written, 0);
+    fs.write(fd, expected, 0, 'utf8', done);
+  });
+
+  fs.write(fd, '', 0, 'utf8', written);
+}));
+
+const args = constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC;
+fs.open(fn2, args, 0o644, common.mustSucceed((fd) => {
+  const done = common.mustSucceed((written) => {
+    assert.strictEqual(written, Buffer.byteLength(expected));
+    fs.closeSync(fd);
+    const found = fs.readFileSync(fn2, 'utf8');
+    fs.unlinkSync(fn2);
+    assert.strictEqual(found, expected);
+  });
+
+  const written = common.mustSucceed((written) => {
+    assert.strictEqual(written, 0);
+    fs.write(fd, expected, 0, 'utf8', done);
+  });
+
+  fs.write(fd, '', 0, 'utf8', written);
+}));
+
+fs.open(fn3, 'w', 0o644, common.mustSucceed((fd) => {
+  const done = common.mustSucceed((written) => {
+    assert.strictEqual(written, Buffer.byteLength(expected));
+    fs.closeSync(fd);
+  });
+
+  fs.write(fd, expected, done);
+}));
+
+
+[false, 'test', {}, [], null, undefined].forEach((i) => {
+  assert.throws(
+    () => fs.write(i, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+  assert.throws(
+    () => fs.writeSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+});
+
+[
+  false, 5, {}, [], null, undefined, true, 5n, () => {}, Symbol(), new Map(),
+  new String('notPrimitive'),
+  { [Symbol.toPrimitive]: (hint) => 'amObject' },
+  { toString() { return 'amObject'; } },
+  Promise.resolve('amPromise'),
+  common.mustNotCall(),
+].forEach((data) => {
+  assert.throws(
+    () => fs.write(1, data, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /"buffer"/
+    }
+  );
+  assert.throws(
+    () => fs.writeSync(1, data),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /"buffer"/
+    }
+  );
+});
+
+{
+  // Regression test for https://github.com/nodejs/node/issues/38168
+  const fd = fs.openSync(fn4, 'w');
+
+  assert.throws(
+    () => fs.writeSync(fd, 'abc', 0, 'hex'),
+    {
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: /'encoding' is invalid for data of length 3/
+    }
+  );
+
+  assert.throws(
+    () => fs.writeSync(fd, 'abc', 0, 'hex', common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: /'encoding' is invalid for data of length 3/
+    }
+  );
+
+  assert.strictEqual(fs.writeSync(fd, 'abcd', 0, 'hex'), 2);
+
+  fs.write(fd, 'abcd', 0, 'hex', common.mustSucceed((written) => {
+    assert.strictEqual(written, 2);
+    fs.closeSync(fd);
+  }));
+}


### PR DESCRIPTION
Four `node:fs` divergences from Node, found by a differential run against Node v26.3.0. The headline is silent data corruption: the `encoding` argument of `fs.writeSync(fd, string, position, encoding)` was parsed and then ignored.

### 1. `fs.write` / `fs.writeSync` / `filehandle.write` ignore the string encoding

```js
const fd = fs.openSync(p, "w");
fs.writeSync(fd, "abc", 0, "utf16le");
// Node: writes 6 bytes  61 00 62 00 63 00
// Bun:  writes 3 bytes  61 62 63          (raw UTF-8, encoding ignored)
```

Same for `hex`, `base64`, `latin1`, `ascii`, and for the async `fs.write(fd, string, position, encoding, cb)` and `filehandle.write(string, position, encoding)`, which share the argument parser.

**Cause:** `args::Write::from_js` in `src/runtime/node/node_fs.rs` parses the encoding into `args.encoding`, but the string was already converted to UTF-8 by `StringOrBuffer::from_js` a few lines earlier, and `write_inner` / `pwrite_inner` only ever look at `args.buffer.slice()`. A second bug hid the first for some spellings: the parser only advanced past the position slot when it held a *number*, so `fs.writeSync(fd, "abc", null, "utf16le")` never even reached the encoding argument. Node's `WriteString` binding takes the position from `args[2]` regardless of its type and the encoding strictly from `args[3]`.

**Fix:** consume the position slot whatever its type (using it only when it is a number, and only when non-negative, matching the sibling Buffer arm), then, once the encoding is known, re-encode the string with `StringOrBuffer::from_js_with_encoding`. That helper is the same path `writeFileSync(p, s, "utf16le")` (which already worked) and `Buffer.from(s, enc)` use, and it already matches Node byte-for-byte for every encoding. The one encoding name the re-encode must not apply to is `"buffer"`: Node's `StringBytes::Write` treats `BUFFER` the same as `UTF8`, while the in-tree string encoder's `Buffer` arm is a verbatim latin1 / low-byte copy, so `writeSync(fd, "\u00e9", 0, "buffer")` would have written 1 byte instead of Node's 2. The re-encode therefore skips both `Encoding::Utf8` and `Encoding::Buffer`, keeping the original UTF-8 conversion for both, and the test table covers the `"buffer"` name for both 8-bit and 16-bit source strings. The one exception is the `"buffer"` encoding name: Node writes UTF-8 for it (`writeSync(fd, "\u00e9", 0, "buffer")` writes `c3 a9`), while the encoder's `Buffer` arm is a verbatim latin1 / low-byte copy, so it is excluded from the re-encode and keeps the original UTF-8 conversion.

### 2. `fs.readdir` with `{ encoding: "buffer" }` returns `Uint8Array[]`, not `Buffer[]`

```js
const r = fs.readdirSync(dir, { encoding: "buffer" });
Buffer.isBuffer(r[0]); // Node: true   Bun: false (plain Uint8Array)
```

**Cause:** `ret::Readdir::to_js` used `MarkedArrayBuffer::to_js`, which builds a plain `Uint8Array`. The sibling `StringOrBuffer::to_js` (used by `readFile`, `readlink`, `realpath`) already uses `to_node_buffer`, which goes through `JSBufferSubclassStructure`.

**Fix:** use `to_node_buffer` there too. Both transfer ownership of the mimalloc-backed bytes to JSC via the same deallocator, so it is a drop-in. This covers the sync, async, callback, and recursive variants, which all funnel through `Readdir::to_js`.

### 3. `fs.Dir` is not disposable

```js
using d = fs.opendirSync(dir); // Bun: TypeError, d[Symbol.dispose] is undefined
```

Node's `Dir` prototype has `Symbol.dispose` and `Symbol.asyncDispose` (and both are no-ops when the directory is already closed, so they compose with an explicit `close()`).

**Fix:** add both to the `Dir` class in `src/js/node/fs.ts`, delegating to `closeSync()` / `close()` behind an already-closed guard, using the same `this.#handle >= 0` check the class's `Symbol.asyncIterator` already uses.

### 4. An unrecognized flag string throws `ERR_INVALID_ARG_TYPE`

```js
fs.openSync(p, "bogus");
// Node: TypeError [ERR_INVALID_ARG_VALUE]
// Bun:  TypeError [ERR_INVALID_ARG_TYPE]
```

Node's `stringToFlags` throws `ERR_INVALID_ARG_VALUE` for every unrecognized flag string (including the empty string). `FileSystemFlags::from_js` used the `ERR_INVALID_ARG_TYPE` helper. Code that switches on `err.code` gets the wrong branch.

**Fix:** switch the three string-flag error sites to `ErrorCode::INVALID_ARG_VALUE`. The messages are unchanged.

### 5. Three more `fs.write` gaps, surfaced by vendoring Node's `test-fs-write.js`

Node's `test/parallel/test-fs-write.js` was missing from the vendored Node test suite. It is Node's own regression test for this exact bug class (its [nodejs/node#38168](https://github.com/nodejs/node/issues/38168) block asserts `fs.writeSync(fd, 'abcd', 0, 'hex')` returns 2). Vendoring it surfaced three more gaps on `fs.write`'s string path, all fixed here:

- **`validateEncoding` was never called.** Node rejects an odd-length string written with the `hex` encoding (`ERR_INVALID_ARG_VALUE`, `is invalid for data of length N`) from `write`, `writeSync`, and `filehandle.write`. The C++ validator already existed in `NodeValidator.cpp` and was exported from `internal/validators` with no callers; this wires it into the three string write paths where Node calls it. Messages are byte-identical to Node v26.3.0.
- **`fs.write` was missing `writeSync`'s `typeof buffer !== "string"` check**, so `new String('x')` (and every other non-string, non-view value) reached the native parser through the string signature instead of throwing `ERR_INVALID_ARG_TYPE`.
- **`fs.write` branched on `$isTypedArrayView`, which excludes `DataView`**, so `fs.write(fd, dataView, offset, length, cb)` was silently parsed as the `(position, encoding)` string signature. It now uses Node's `isArrayBufferView` predicate, matching the `writeSync` sibling one function below.

### Tests

- `test/js/node/fs/fs.test.ts`: a table of `writeSync(fd, string, ...)` argument shapes whose expected bytes were each produced by Node v26.3.0; the async `fs.write` + `filehandle.write` variants; `readdir` `{ encoding: "buffer" }` across the sync / recursive / promise / callback entry points; the flag error code for `openSync` and `open`.
- `test/js/node/fs/dir.test.ts`: `using`, `await using`, and disposing an already-closed `Dir`.
- `test/js/node/test/parallel/test-fs-write.js`: Node's upstream test, vendored via `bun node:test:cp`. On the unfixed build it fails on its first assertion (`'ümlaut sechzig'` written with `latin1` reads back as `'Ã¼mlaut sechzig'`); with the fix it exits 0. The file is byte-for-byte identical to `nodejs/node@main` with no local patch. Upstream runs it under V8's `--expose_externalize_string` flag; the `createExternalizableString` / `externalizeString` / `isOneByteString` helpers it needs are V8 test globals with no JavaScriptCore equivalent (present upstream since at least Node v22), so they are polyfilled in `test/js/node/test/common/index.js` next to the existing `--expose-gc` polyfill. The test file stays unmodified, and any other vendored Node test that uses that flag works without a local patch.

All fail on the current build and pass with the fix. The vendored Node suites `test-fs-write-sync`, `test-fs-write-sync-optional-params`, `test-fs-write-optional-params`, `test-fs-write-buffer`, `test-fs-open`, `test-fs-open-numeric-flags`, `test-fs-readdir*`, `test-fs-opendir`, and `test-fs-promises-file-handle-{write,append-file,dispose}` still pass.

### Out of scope, noted for completeness

- `readdirSync(dir, { withFileTypes: true, encoding: "buffer" })`: Node returns `Dirent[]` with `Buffer` names; Bun ignores `withFileTypes` when the encoding is `buffer` and returns a flat array (now of `Buffer`s instead of `Uint8Array`s). Matching Node needs a `Dirent` variant whose `name` is a `Buffer`, a larger change than the one-line swap here. That half is #30482, and #30484 already has a fix open for it (the `Dirent` name representation, the `args::Readdir::tag` precedence, and `NodeDirent.cpp`). The two PRs touch disjoint code: #30484 does not change `ret::Readdir::Buffers` conversion, and this PR does not touch `Dirent`, so neither replaces the other.
- Flag strings are case-insensitive in Bun (`"A+"` opens; Node throws `ERR_INVALID_ARG_VALUE`). The uppercase aliases are hand-enumerated in `FILE_SYSTEM_FLAGS_MAP` and date back to the original implementation, so I left that deliberate leniency for a maintainer to decide on rather than silently tightening it. #32966 now does exactly that: it rewrites `FileSystemFlags::from_js` to match Node's `stringToFlags` (case-sensitive, exhaustive, always `ERR_INVALID_ARG_VALUE`) and subsumes the small `types.rs` error-code change in this PR, so whichever of the two lands second rebases that hunk away. The rest of this PR is independent of #32966.





