### PR TITLE
process: match Node exit code semantics; fix node:events captureRejections

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -135,10 +135,22 @@ function emitError(emitter, args) {
 }
 
 function addCatch(emitter, promise, type, args) {
-  promise.then(undefined, function (err) {
-    // The callback is called with nextTick to avoid a follow-up rejection from this promise.
-    process.nextTick(emitUnhandledRejectionOrErr, emitter, err, type, args);
-  });
+  if (!emitter[kCapture]) {
+    return;
+  }
+  // The listener may return any thenable, not only a real Promise, and the
+  // `then` getter (or the call itself) may throw; route that to "error".
+  try {
+    const then = promise.then;
+    if (typeof then === "function") {
+      then.$call(promise, undefined, function (err) {
+        // The callback is called with nextTick to avoid a follow-up rejection from this promise.
+        process.nextTick(emitUnhandledRejectionOrErr, emitter, err, type, args);
+      });
+    }
+  } catch (err) {
+    emitter.emit("error", err);
+  }
 }
 
 function emitUnhandledRejectionOrErr(emitter, err, type, args) {
@@ -229,7 +241,7 @@ const emitWithRejectionCapture = function emit(type, ...args) {
         result = handler.$apply(this, args);
         break;
     }
-    if (result !== undefined && $isPromise(result)) {
+    if (result !== undefined && result !== null) {
       addCatch(this, result, type, args);
     }
   }
@@ -823,6 +835,9 @@ Object.defineProperties(EventEmitter, {
       validateBoolean(value, "EventEmitter.captureRejections");
 
       EventEmitterPrototype[kCapture] = value;
+      // Instances whose EventEmitter constructor never ran (util.inherits)
+      // dispatch through the prototype's emit; keep it in sync.
+      EventEmitterPrototype.emit = value ? emitWithRejectionCapture : emitWithoutRejectionCapture;
     },
     enumerable: true,
   },

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -836,8 +836,14 @@ Object.defineProperties(EventEmitter, {
 
       EventEmitterPrototype[kCapture] = value;
       // Instances whose EventEmitter constructor never ran (util.inherits)
-      // dispatch through the prototype's emit; keep it in sync.
-      EventEmitterPrototype.emit = value ? emitWithRejectionCapture : emitWithoutRejectionCapture;
+      // dispatch through the prototype's emit; keep it in sync. Never clobber
+      // a user-installed prototype emit (Node's setter only flips [kCapture]).
+      if (
+        EventEmitterPrototype.emit === emitWithRejectionCapture ||
+        EventEmitterPrototype.emit === emitWithoutRejectionCapture
+      ) {
+        EventEmitterPrototype.emit = value ? emitWithRejectionCapture : emitWithoutRejectionCapture;
+      }
     },
     enumerable: true,
   },

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -367,8 +367,8 @@ unsafe extern "C" {
     ) -> c_int;
     safe fn Bun__emitHandledPromiseEvent(global: &JSGlobalObject, promise: JSValue) -> bool;
 
-    safe fn Process__dispatchOnBeforeExit(global: &JSGlobalObject, code: u8);
-    safe fn Process__dispatchOnExit(global: &JSGlobalObject, code: u8);
+    safe fn Process__dispatchOnBeforeExit(global: &JSGlobalObject, code: i32);
+    safe fn Process__dispatchOnExit(global: &JSGlobalObject, code: i32);
     safe fn Bun__closeAllSQLiteDatabasesForTermination();
     safe fn Bun__WebView__closeAllForTermination();
     safe fn Zig__GlobalObject__destructOnExit(global: &JSGlobalObject);
@@ -482,18 +482,28 @@ pub fn is_smol_mode() -> bool {
 
 #[derive(Default)]
 pub struct ExitHandler {
-    pub exit_code: u8,
+    /// `process.exitCode` / the argument to `process.exit()`. Node stores
+    /// this in an int32 slot, so the raw value (e.g. `-1`, `300`) survives
+    /// for the getter and the `beforeExit`/`exit` event arguments; only the
+    /// final `exit(2)` masks it to 0-255.
+    pub exit_code: i32,
 }
 
 impl ExitHandler {
     #[unsafe(no_mangle)]
-    pub extern "C" fn Bun__getExitCode(vm: &VirtualMachine) -> u8 {
+    pub extern "C" fn Bun__getExitCode(vm: &VirtualMachine) -> i32 {
         vm.exit_handler.exit_code
     }
 
     #[unsafe(no_mangle)]
-    pub extern "C" fn Bun__setExitCode(vm: &mut VirtualMachine, code: u8) {
+    pub extern "C" fn Bun__setExitCode(vm: &mut VirtualMachine, code: i32) {
         vm.exit_handler.exit_code = code;
+    }
+
+    /// The status to hand to `exit(2)`: the low 8 bits, matching what the OS
+    /// reports for out-of-range codes like `-1` (255) or `300` (44).
+    pub fn os_exit_code(&self) -> u32 {
+        (self.exit_code & 0xff) as u32
     }
 
     /// Note: spec calls `this.exit_handler.dispatchOnExit()` from a
@@ -1591,7 +1601,7 @@ impl VirtualMachine {
             self.gc_controller.deinit();
             self.destroy();
         }
-        bun_core::Global::exit(u32::from(self.exit_handler.exit_code))
+        bun_core::Global::exit(self.exit_handler.os_exit_code())
     }
 }
 
@@ -3251,7 +3261,7 @@ impl VirtualMachine {
         }
     }
 
-    /// Routes an unhandled promise rejection to the configured handler, bumping the unhandled-error counter.
+    /// Routes an unhandled promise rejection to the configured `--unhandled-rejections` handler.
     pub fn unhandled_rejection(
         &mut self,
         global_object: &JSGlobalObject,
@@ -3277,7 +3287,7 @@ impl VirtualMachine {
         };
         // Wrapper over the `Bun__handleUnhandledRejection` FFI call (returns
         // whether a JS handler claimed it). Captures `global_object` / `reason`
-        // / `promise` so the six branches below stay concise.
+        // / `promise` so the branches below stay concise.
         let handle_unhandled =
             || -> bool { Bun__handleUnhandledRejection(global_object, reason, promise) > 0 };
         let emit_warning = |this: &mut Self| {
@@ -3292,67 +3302,45 @@ impl VirtualMachine {
         };
 
         match self.unhandled_rejections_mode() {
-            Mode::Bun => {
-                if handle_unhandled() {
-                    return;
+            // Node's default: with no `unhandledRejection` listener the
+            // rejection is raised as an uncaught exception. `uncaught_exception`
+            // reports the error and sets the exit code to 1 if nothing handles it.
+            Mode::Bun | Mode::Throw => {
+                if !handle_unhandled() {
+                    let wrapped = wrap_unhandled_rejection_error_for_uncaught_exception(
+                        global_object,
+                        reason,
+                    );
+                    let _ = self.uncaught_exception(global_object, wrapped, true);
                 }
-                // continue to default handler
+                drain(self);
             }
             Mode::None => {
                 let _ = handle_unhandled();
-                drain(self);
-                return; // ignore the unhandled rejection
+                drain(self); // ignore the unhandled rejection
             }
             Mode::Warn => {
                 let _ = handle_unhandled();
                 emit_warning(self);
                 drain(self);
-                return;
             }
             Mode::WarnWithErrorCode => {
-                let handled = handle_unhandled();
-                if !handled {
+                if !handle_unhandled() {
                     emit_warning(self);
                     self.exit_handler.exit_code = 1;
                 }
                 drain(self);
-                if handled {
-                    return;
-                }
-                return;
             }
             Mode::Strict => {
                 let wrapped =
                     wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason);
                 let _ = self.uncaught_exception(global_object, wrapped, true);
-                let handled = handle_unhandled();
-                if !handled {
+                if !handle_unhandled() {
                     emit_warning(self);
                 }
                 drain(self);
-                return;
-            }
-            Mode::Throw => {
-                if handle_unhandled() {
-                    drain(self);
-                    return;
-                }
-                let wrapped =
-                    wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason);
-                if self.uncaught_exception(global_object, wrapped, true) {
-                    drain(self);
-                    return;
-                }
-                // continue to default handler — but RETURN if this drain
-                // errors (the VM is dead; don't bump the counter or invoke the
-                // handler).
-                if self.event_loop_mut().drain_microtasks().is_err() {
-                    return;
-                }
             }
         }
-        self.unhandled_error_counter += 1;
-        (self.on_unhandled_rejection)(self, global_object, reason);
     }
 
     /// After a hot reload, surfaces the entry-point promise's rejection (if any) and re-arms the watcher.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1715,7 +1715,7 @@ pub struct RuntimeHooks {
     /// it returns and the caller `panic!`s. Lives in `bun_runtime::node`
     /// (forward-dep cycle), so [`uncaught_exception`] reaches it through this
     /// slot instead of the linker.
-    pub process_exit: unsafe fn(global: *mut JSGlobalObject, code: u8),
+    pub process_exit: unsafe fn(global: *mut JSGlobalObject, code: i32),
     /// `node_cluster_binding.handleInternalMessageChild(global, data)`.
     pub handle_ipc_internal_child: unsafe fn(global: *mut JSGlobalObject, data: JSValue),
     /// `node_cluster_binding.child_singleton.deinit()`.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3261,7 +3261,7 @@ impl VirtualMachine {
         }
     }
 
-    /// Routes an unhandled promise rejection to the configured `--unhandled-rejections` handler.
+    /// Routes an unhandled promise rejection to the configured handler, bumping the unhandled-error counter.
     pub fn unhandled_rejection(
         &mut self,
         global_object: &JSGlobalObject,
@@ -3287,7 +3287,7 @@ impl VirtualMachine {
         };
         // Wrapper over the `Bun__handleUnhandledRejection` FFI call (returns
         // whether a JS handler claimed it). Captures `global_object` / `reason`
-        // / `promise` so the branches below stay concise.
+        // / `promise` so the six branches below stay concise.
         let handle_unhandled =
             || -> bool { Bun__handleUnhandledRejection(global_object, reason, promise) > 0 };
         let emit_warning = |this: &mut Self| {
@@ -3302,45 +3302,64 @@ impl VirtualMachine {
         };
 
         match self.unhandled_rejections_mode() {
-            // Node's default: with no `unhandledRejection` listener the
-            // rejection is raised as an uncaught exception. `uncaught_exception`
-            // reports the error and sets the exit code to 1 if nothing handles it.
-            Mode::Bun | Mode::Throw => {
-                if !handle_unhandled() {
-                    let wrapped = wrap_unhandled_rejection_error_for_uncaught_exception(
-                        global_object,
-                        reason,
-                    );
-                    let _ = self.uncaught_exception(global_object, wrapped, true);
+            Mode::Bun => {
+                if handle_unhandled() {
+                    return;
                 }
-                drain(self);
+                // continue to default handler
             }
             Mode::None => {
                 let _ = handle_unhandled();
-                drain(self); // ignore the unhandled rejection
+                drain(self);
+                return; // ignore the unhandled rejection
             }
             Mode::Warn => {
                 let _ = handle_unhandled();
                 emit_warning(self);
                 drain(self);
+                return;
             }
             Mode::WarnWithErrorCode => {
-                if !handle_unhandled() {
+                let handled = handle_unhandled();
+                if !handled {
                     emit_warning(self);
                     self.exit_handler.exit_code = 1;
                 }
                 drain(self);
+                if handled {
+                    return;
+                }
+                return;
             }
             Mode::Strict => {
                 let wrapped =
                     wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason);
                 let _ = self.uncaught_exception(global_object, wrapped, true);
-                if !handle_unhandled() {
+                let handled = handle_unhandled();
+                if !handled {
                     emit_warning(self);
                 }
                 drain(self);
+                return;
+            }
+            Mode::Throw => {
+                if handle_unhandled() {
+                    drain(self);
+                    return;
+                }
+                let wrapped =
+                    wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason);
+                if self.uncaught_exception(global_object, wrapped, true) {
+                    drain(self);
+                }
+                // `uncaught_exception` already reported the error and set the
+                // exit code to 1 when nothing handled it; falling through to
+                // the default handler would report it a second time.
+                return;
             }
         }
+        self.unhandled_error_counter += 1;
+        (self.on_unhandled_rejection)(self, global_object, reason);
     }
 
     /// After a hot reload, surfaces the entry-point promise's rejection (if any) and re-arms the watcher.

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3312,10 +3312,12 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
 {
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    uint8_t exitCode = 0;
+    // The raw int32 code is carried through the worker exit path so the
+    // parent's worker.on("exit", code) sees it; the main thread masks at exit(2).
+    int32_t exitCode = 0;
     JSValue arg0 = callFrame->argument(0);
     if (arg0.isAnyInt()) {
-        exitCode = static_cast<uint8_t>(arg0.toInt32(globalObject) % 256);
+        exitCode = arg0.toInt32(globalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -159,8 +159,8 @@ namespace JSCastingHelpers = JSC::JSCastingHelpers;
 
 JSC_DECLARE_HOST_FUNCTION(Process_functionCwd);
 
-extern "C" uint8_t Bun__getExitCode(void*);
-extern "C" uint8_t Bun__setExitCode(void*, uint8_t);
+extern "C" int32_t Bun__getExitCode(void*);
+extern "C" void Bun__setExitCode(void*, int32_t);
 extern "C" bool Bun__closeChildIPC(JSGlobalObject*);
 
 extern "C" bool Bun__GlobalObject__connectedIPC(JSGlobalObject*);
@@ -820,7 +820,7 @@ extern "C" double Bun__readOriginTimerStart(void*);
 extern "C" void Bun__VirtualMachine__exitDuringUncaughtException(void*);
 
 // https://github.com/nodejs/node/blob/1936160c31afc9780e4365de033789f39b7cbc0c/src/api/hooks.cc#L49
-extern "C" void Process__dispatchOnBeforeExit(Zig::GlobalObject* globalObject, uint8_t exitCode)
+extern "C" void Process__dispatchOnBeforeExit(Zig::GlobalObject* globalObject, int32_t exitCode)
 {
     if (!globalObject->hasProcessObject()) {
         return;
@@ -839,14 +839,14 @@ extern "C" void Process__dispatchOnBeforeExit(Zig::GlobalObject* globalObject, u
     }
 }
 
-extern "C" void Process__dispatchOnExit(Zig::GlobalObject* globalObject, uint8_t exitCode)
+extern "C" void Process__dispatchOnExit(Zig::GlobalObject* globalObject, int32_t exitCode)
 {
     if (!globalObject->hasProcessObject()) {
         return;
     }
 
     auto* process = globalObject->processObject();
-    if (exitCode > 0)
+    if (exitCode != 0)
         process->m_isExitCodeObservable = true;
     dispatchExitInternal(globalObject, process, exitCode);
 }
@@ -865,13 +865,17 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionExit, (JSC::JSGlobalObject * globalObje
     auto* zigGlobal = defaultGlobalObject(globalObject);
     auto process = zigGlobal->processObject();
 
-    auto code = callFrame->argument(0);
+    // Node only assigns process.exitCode when an argument was passed, so a
+    // bare process.exit() keeps any previously assigned code.
+    if (callFrame->argumentCount() > 0) {
+        setProcessExitCodeInner(globalObject, process, callFrame->uncheckedArgument(0));
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
 
-    setProcessExitCodeInner(globalObject, process, code);
-    RETURN_IF_EXCEPTION(throwScope, {});
+    Process__dispatchOnExit(zigGlobal, Bun__getExitCode(bunVM(zigGlobal)));
 
+    // An "exit" listener may reassign process.exitCode; Node re-reads it here.
     auto exitCode = Bun__getExitCode(bunVM(zigGlobal));
-    Process__dispatchOnExit(zigGlobal, exitCode);
 
     // process.reallyExit(exitCode);
     auto reallyExitVal = process->get(globalObject, Identifier::fromString(vm, "reallyExit"_s));
@@ -2014,23 +2018,30 @@ JSC_DEFINE_CUSTOM_GETTER(processExitCode, (JSC::JSGlobalObject * lexicalGlobalOb
 bool setProcessExitCodeInner(JSC::JSGlobalObject* lexicalGlobalObject, Process* process, JSValue code)
 {
     auto throwScope = DECLARE_THROW_SCOPE(process->vm());
+    void* ptr = process->globalObject()->bunVM();
 
-    if (!code.isUndefinedOrNull()) {
-        if (code.isString() && !code.getString(lexicalGlobalObject).isEmpty()) {
-            auto num = code.toNumber(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
-            if (!std::isnan(num)) {
-                code = jsNumber(num);
-            }
-        }
-        ssize_t exitCodeInt;
-        Bun::V::validateInteger(throwScope, lexicalGlobalObject, code, "code"_s, jsUndefined(), jsUndefined(), &exitCodeInt);
-        RETURN_IF_EXCEPTION(throwScope, false);
-
-        process->m_isExitCodeObservable = true;
-        void* ptr = process->globalObject()->bunVM();
-        Bun__setExitCode(ptr, static_cast<uint8_t>(exitCodeInt % 256));
+    if (code.isUndefinedOrNull()) {
+        // Node resets process.exitCode back to unset on a nullish assignment.
+        process->m_isExitCodeObservable = false;
+        Bun__setExitCode(ptr, 0);
+        return true;
     }
+
+    if (code.isString() && !code.getString(lexicalGlobalObject).isEmpty()) {
+        auto num = code.toNumber(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!std::isnan(num)) {
+            code = jsNumber(num);
+        }
+    }
+    ssize_t exitCodeInt;
+    Bun::V::validateInteger(throwScope, lexicalGlobalObject, code, "code"_s, jsUndefined(), jsUndefined(), &exitCodeInt);
+    RETURN_IF_EXCEPTION(throwScope, false);
+
+    process->m_isExitCodeObservable = true;
+    // Node stores process.exitCode in an int32 slot; only the final exit(2)
+    // masks to 0-255, so the getter and the "exit" event keep the raw value.
+    Bun__setExitCode(ptr, static_cast<int32_t>(exitCodeInt));
     return true;
 }
 JSC_DEFINE_CUSTOM_SETTER(setProcessExitCode, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName))

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -662,7 +662,9 @@ ZIG_DECL size_t Bun__WebSocketClientTLS__memoryCost(WebSocketClientTLS* arg0);
 
 #ifdef __cplusplus
 
-ZIG_DECL /*[[noreturn]]*/ void Bun__Process__exit(JSC::JSGlobalObject* arg0, int32_t arg1); // TODO(@190n) figure out why with a real [[noreturn]] annotation this trips ASan before calling the function
+// `[[noreturn]]` is deliberately left as a comment: the real attribute trips
+// ASan before the function is even called (@190n).
+ZIG_DECL /*[[noreturn]]*/ void Bun__Process__exit(JSC::JSGlobalObject* arg0, int32_t arg1);
 ZIG_DECL JSC::EncodedJSValue Bun__Process__createArgv(JSC::JSGlobalObject* arg0);
 ZIG_DECL JSC::EncodedJSValue Bun__Process__createArgv0(JSC::JSGlobalObject* arg0);
 ZIG_DECL JSC::EncodedJSValue Bun__Process__getCwd(JSC::JSGlobalObject* arg0);

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -662,7 +662,7 @@ ZIG_DECL size_t Bun__WebSocketClientTLS__memoryCost(WebSocketClientTLS* arg0);
 
 #ifdef __cplusplus
 
-ZIG_DECL /*[[noreturn]]*/ void Bun__Process__exit(JSC::JSGlobalObject* arg0, uint8_t arg1); // TODO(@190n) figure out why with a real [[noreturn]] annotation this trips ASan before calling the function
+ZIG_DECL /*[[noreturn]]*/ void Bun__Process__exit(JSC::JSGlobalObject* arg0, int32_t arg1); // TODO(@190n) figure out why with a real [[noreturn]] annotation this trips ASan before calling the function
 ZIG_DECL JSC::EncodedJSValue Bun__Process__createArgv(JSC::JSGlobalObject* arg0);
 ZIG_DECL JSC::EncodedJSValue Bun__Process__createArgv0(JSC::JSGlobalObject* arg0);
 ZIG_DECL JSC::EncodedJSValue Bun__Process__getCwd(JSC::JSGlobalObject* arg0);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1250,7 +1250,7 @@ impl WebWorker {
                 // is step 3 below).
                 rare.close_all_socket_groups(unsafe { &*vm_ptr });
             }
-            exit_code = i32::from(vm.exit_handler.exit_code);
+            exit_code = vm.exit_handler.exit_code;
             global_object = Some(vm.global);
         }
 

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -305,7 +305,7 @@ pub fn on_resolve_entry_point_result(
         );
     }
     // SAFETY: bun_vm() never null for a Bun-owned global.
-    bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
+    bun_core::Global::exit(global.bun_vm().as_mut().exit_handler.os_exit_code());
 }
 
 // HOST_EXPORT(Bun__onRejectEntryPointResult)
@@ -328,7 +328,7 @@ pub fn on_reject_entry_point_result(
         );
     }
     // SAFETY: bun_vm() never null for a Bun-owned global.
-    bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
+    bun_core::Global::exit(global.bun_vm().as_mut().exit_handler.os_exit_code());
 }
 
 // ─── bindgenv2 dispatch shims (`bindgen_*_dispatch*`) ────────────────────────

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1238,7 +1238,7 @@ fn body_mixin_get_blob(
 ///
 /// # Safety
 /// `global` is the live VM global.
-unsafe fn process_exit(global: *mut JSGlobalObject, code: u8) {
+unsafe fn process_exit(global: *mut JSGlobalObject, code: i32) {
     // SAFETY: per fn contract — `global` is the live VM global. The deref is
     // performed once here in the hook shim so the user-facing `process::exit`
     // can take a safe `&JSGlobalObject`.

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -49,9 +49,9 @@ pub(crate) extern "C" fn get_exec_argv(global: &JSGlobalObject) -> JSValue {
 
 // @190n: this may need to be noreturn
 #[unsafe(export_name = "Bun__Process__exit")]
-pub extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
+pub extern "C" fn exit(global_object: &JSGlobalObject, code: i32) {
     let vm = global_object.bun_vm().as_mut();
-    vm.exit_handler.exit_code = i32::from(code);
+    vm.exit_handler.exit_code = code;
     if let Some(worker) = vm.worker_ref() {
         // @190n: we may need to use requestTerminate or throwTerminationException
         // instead to terminate the worker sooner

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -51,7 +51,7 @@ pub(crate) extern "C" fn get_exec_argv(global: &JSGlobalObject) -> JSValue {
 #[unsafe(export_name = "Bun__Process__exit")]
 pub extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
     let vm = global_object.bun_vm().as_mut();
-    vm.exit_handler.exit_code = code;
+    vm.exit_handler.exit_code = i32::from(code);
     if let Some(worker) = vm.worker_ref() {
         // @190n: we may need to use requestTerminate or throwTerminationException
         // instead to terminate the worker sooner

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -850,7 +850,7 @@ describe("EventEmitter captureRejections", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "error kaboom\n", stderr: "", exitCode: 0 });
+    expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({ stdout: "error kaboom\n", stderr: "", exitCode: 0 });
   });
 
   test("the global setting does not retroactively apply to an existing default emitter", async () => {
@@ -873,7 +873,11 @@ describe("EventEmitter captureRejections", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "unhandledRejection kaboom\n", stderr: "", exitCode: 0 });
+    expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({
+      stdout: "unhandledRejection kaboom\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });
 

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -849,8 +849,8 @@ describe("EventEmitter captureRejections", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({ stdout: "error kaboom\n", exitCode: 0 });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "error kaboom\n", stderr: "", exitCode: 0 });
   });
 
   test("the global setting does not retroactively apply to an existing default emitter", async () => {
@@ -872,8 +872,8 @@ describe("EventEmitter captureRejections", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({ stdout: "unhandledRejection kaboom\n", exitCode: 0 });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "unhandledRejection kaboom\n", stderr: "", exitCode: 0 });
   });
 });
 

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -1,5 +1,6 @@
 import { sleep } from "bun";
 import { describe, expect, mock, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { createRequire } from "module";
 
 // this is also testing that imports with default and named imports in the same statement work
@@ -774,6 +775,105 @@ describe("EventEmitter captureRejections", () => {
     await sleep(5);
 
     expect(handled).toEqual(null);
+  });
+
+  test("it captures a plain thenable returned by a listener", async () => {
+    const myEmitter = new EventEmitter({ captureRejections: true });
+    const err = new Error("kaboom");
+    const seen: Error[] = [];
+    const thenGets: number[] = [];
+
+    myEmitter.on("error", e => seen.push(e));
+    myEmitter.on("action", () => {
+      const obj = {};
+      Object.defineProperty(obj, "then", {
+        get: () => {
+          thenGets.push(1);
+          return (_res: unknown, rej: (e: Error) => void) => rej(err);
+        },
+      });
+      return obj;
+    });
+
+    myEmitter.emit("action");
+
+    // Promises/A+ allows exactly one `then` lookup, done synchronously by emit.
+    expect(thenGets).toEqual([1]);
+    // The rejection is delivered to "error" one tick later.
+    await new Promise<void>(resolve => process.nextTick(resolve));
+    expect(seen).toEqual([err]);
+  });
+
+  test("a throwing `then` getter is routed to the error event", () => {
+    const myEmitter = new EventEmitter({ captureRejections: true });
+    const err = new Error("kaboom");
+    const seen: Error[] = [];
+
+    myEmitter.on("error", e => seen.push(e));
+    myEmitter.on("action", () => {
+      const obj = {};
+      Object.defineProperty(obj, "then", {
+        get: () => {
+          throw err;
+        },
+      });
+      return obj;
+    });
+
+    myEmitter.emit("action");
+
+    expect(seen).toEqual([err]);
+  });
+
+  // `EventEmitter.captureRejections = true` is process-global, so both cases
+  // run in a subprocess.
+  test("the global setting applies to instances whose constructor never ran", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { EventEmitter } = require("node:events");
+        const { inherits } = require("node:util");
+        function NoConstructor() {}
+        inherits(NoConstructor, EventEmitter);
+        EventEmitter.captureRejections = true;
+        const ee = new NoConstructor();
+        ee.on("action", async () => { throw new Error("kaboom"); });
+        ee.on("error", e => console.log("error", e.message));
+        process.on("unhandledRejection", e => console.log("unhandledRejection", e.message));
+        ee.emit("action");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "error kaboom\n", exitCode: 0 });
+  });
+
+  test("the global setting does not retroactively apply to an existing default emitter", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { EventEmitter } = require("node:events");
+        const ee = new EventEmitter();
+        ee.on("action", async () => { throw new Error("kaboom"); });
+        ee.on("error", e => console.log("error", e.message));
+        EventEmitter.captureRejections = true;
+        process.on("unhandledRejection", e => console.log("unhandledRejection", e.message));
+        ee.emit("action");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "unhandledRejection kaboom\n", exitCode: 0 });
   });
 });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -7,7 +7,7 @@ import { basename, join, resolve } from "path";
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
 
 /**
- * Helper function to run inline fixture code and return stdout and exit code
+ * Helper function to run inline fixture code and return stdout, stderr, and exit code
  */
 async function runInlineFixture(script, expectedStdout = null, expectedCode = 0) {
   using dir = tempDir("process-test", {
@@ -21,14 +21,14 @@ async function runInlineFixture(script, expectedStdout = null, expectedCode = 0)
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   if (expectedStdout !== null) {
     expect(stdout).toBe(expectedStdout);
   }
   expect(exitCode).toBe(expectedCode);
 
-  return { stdout, exitCode };
+  return { stdout, stderr, exitCode };
 }
 
 it("process", () => {
@@ -865,7 +865,7 @@ describe.concurrent(() => {
   // Node's default unhandled-rejection mode is `throw`: with no
   // `unhandledRejection` listener, the rejection is raised as an uncaught
   // exception with origin "unhandledRejection". A `uncaughtException` listener
-  // then handles it and the process keeps running.
+  // then handles it, the event loop keeps running, and the process exits 0.
   it("routes an unhandled rejection through the uncaughtException machinery", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -876,16 +876,17 @@ describe.concurrent(() => {
         process.on("uncaughtException", (err, origin) => console.log("uncaught", err.message, origin));
         process.on("exit", code => console.log("exit", code));
         Promise.reject(new Error("rej"));
-        setTimeout(() => console.log("timer"), 1);
+        setImmediate(() => console.log("immediate"));
         `,
       ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({
-      stdout: "monitor rej unhandledRejection\nuncaught rej unhandledRejection\ntimer\nexit 0\n",
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "monitor rej unhandledRejection\nuncaught rej unhandledRejection\nimmediate\nexit 0\n",
+      stderr: "",
       exitCode: 0,
     });
   });
@@ -1022,6 +1023,20 @@ describe("process.exitCode", () => {
     );
   });
 
+  // Node's int32 slot wraps at the int32 boundary (2**31 becomes -2**31).
+  it("setter wraps at the int32 boundary like Node", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+
+      process.exitCode = 2 ** 31;
+      console.log("get", process.exitCode);
+    `,
+      "get -2147483648\nexit -2147483648 -2147483648\n",
+      0,
+    );
+  });
+
   it("setter resets on null and undefined", async () => {
     await runInlineFixture(
       `
@@ -1132,6 +1147,21 @@ describe("process.exitCode", () => {
       9,
     );
   });
+
+  // A worker thread has no OS exit status, so Node hands the raw int32 code
+  // to the parent's worker.on("exit"). Both spellings must agree.
+  for (const body of ["process.exit(300)", "process.exitCode = 300"]) {
+    it(`a worker's out-of-range exit code reaches the parent unmasked (${body})`, async () => {
+      await runInlineFixture(
+        `
+        const { Worker } = require("node:worker_threads");
+        new Worker(${JSON.stringify(body)}, { eval: true }).on("exit", (code) => console.log("exit", code));
+      `,
+        "exit 300\n",
+        0,
+      );
+    });
+  }
 
   it("property access on undefined", async () => {
     await runInlineFixture(

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -862,14 +862,15 @@ describe.concurrent(() => {
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
-  // Node's default unhandled-rejection mode is `throw`: with no
-  // `unhandledRejection` listener, the rejection is raised as an uncaught
-  // exception with origin "unhandledRejection". A `uncaughtException` listener
-  // then handles it, the event loop keeps running, and the process exits 0.
-  it("routes an unhandled rejection through the uncaughtException machinery", async () => {
+  // Under --unhandled-rejections=throw (Node's default) a rejection with no
+  // `unhandledRejection` listener is raised as an uncaught exception with
+  // origin "unhandledRejection". A `uncaughtException` listener then handles
+  // it, the event loop keeps running, and the process exits 0.
+  it("--unhandled-rejections=throw routes a rejection through the uncaughtException machinery", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
+        "--unhandled-rejections=throw",
         "-e",
         `
         process.on("uncaughtExceptionMonitor", (err, origin) => console.log("monitor", err.message, origin));
@@ -884,17 +885,18 @@ describe.concurrent(() => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({
+    expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({
       stdout: "monitor rej unhandledRejection\nuncaught rej unhandledRejection\nimmediate\nexit 0\n",
       stderr: "",
       exitCode: 0,
     });
   });
 
-  it("a truly unhandled rejection reports the error once and emits exit with 1", async () => {
+  it("--unhandled-rejections=throw reports a truly unhandled rejection exactly once", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
+        "--unhandled-rejections=throw",
         "-e",
         `
         process.on("exit", code => console.log("exit", code, process.exitCode));
@@ -906,8 +908,8 @@ describe.concurrent(() => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // The fatal path must print the error exactly once (it used to be
-    // reported twice under --unhandled-rejections=throw).
+    // The fatal path of the `throw` arm used to fall through to a second
+    // error report after `uncaught_exception` had already printed one.
     expect({ stdout, reports: stderr.match(/error: rej/g), exitCode }).toEqual({
       stdout: "exit 1 1\n",
       reports: ["error: rej"],

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -862,6 +862,58 @@ describe.concurrent(() => {
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
+  // Node's default unhandled-rejection mode is `throw`: with no
+  // `unhandledRejection` listener, the rejection is raised as an uncaught
+  // exception with origin "unhandledRejection". A `uncaughtException` listener
+  // then handles it and the process keeps running.
+  it("routes an unhandled rejection through the uncaughtException machinery", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        process.on("uncaughtExceptionMonitor", (err, origin) => console.log("monitor", err.message, origin));
+        process.on("uncaughtException", (err, origin) => console.log("uncaught", err.message, origin));
+        process.on("exit", code => console.log("exit", code));
+        Promise.reject(new Error("rej"));
+        setTimeout(() => console.log("timer"), 1);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({
+      stdout: "monitor rej unhandledRejection\nuncaught rej unhandledRejection\ntimer\nexit 0\n",
+      exitCode: 0,
+    });
+  });
+
+  it("a truly unhandled rejection reports the error once and emits exit with 1", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        process.on("exit", code => console.log("exit", code, process.exitCode));
+        Promise.reject(new Error("rej"));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The fatal path must print the error exactly once (it used to be
+    // reported twice under --unhandled-rejections=throw).
+    expect({ stdout, reports: stderr.match(/error: rej/g), exitCode }).toEqual({
+      stdout: "exit 1 1\n",
+      reports: ["error: rej"],
+      exitCode: 1,
+    });
+  });
+
   it("aborts when the uncaughtException handler throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")], {
       stderr: "pipe",
@@ -939,6 +991,54 @@ describe("process.exitCode", () => {
     );
   });
 
+  // Node stores process.exitCode in an int32 slot, so the getter and the
+  // "beforeExit"/"exit" event arguments keep the raw value; only the final
+  // exit(2) masks to 0-255.
+  it("setter negative", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+      process.on("beforeExit", (code) => console.log("beforeExit", code, process.exitCode));
+
+      process.exitCode = -1;
+      console.log("get", process.exitCode);
+    `,
+      "get -1\nbeforeExit -1 -1\nexit -1 -1\n",
+      255,
+    );
+  });
+
+  it("setter above 255", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+      process.on("beforeExit", (code) => console.log("beforeExit", code, process.exitCode));
+
+      process.exitCode = 300;
+      console.log("get", process.exitCode);
+    `,
+      "get 300\nbeforeExit 300 300\nexit 300 300\n",
+      44,
+    );
+  });
+
+  it("setter resets on null and undefined", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+
+      process.exitCode = 5;
+      process.exitCode = null;
+      console.log("after null", process.exitCode);
+      process.exitCode = 7;
+      process.exitCode = undefined;
+      console.log("after undefined", process.exitCode);
+    `,
+      "after null undefined\nafter undefined undefined\nexit 0 undefined\n",
+      0,
+    );
+  });
+
   it("exit", async () => {
     await runInlineFixture(
       `
@@ -962,6 +1062,74 @@ describe("process.exitCode", () => {
     `,
       "exit 3 3\n",
       3,
+    );
+  });
+
+  it("exit above 255 keeps the raw value for the event", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+
+      process.exit(300);
+    `,
+      "exit 300 300\n",
+      44,
+    );
+  });
+
+  // process.exit() without an argument must not touch process.exitCode,
+  // while an explicit nullish argument resets it back to unset.
+  it("exit with no argument keeps the assigned code", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+
+      process.exitCode = 5;
+      process.exit();
+    `,
+      "exit 5 5\n",
+      5,
+    );
+  });
+
+  it("exit with undefined resets the assigned code", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+
+      process.exitCode = 5;
+      process.exit(undefined);
+    `,
+      "exit 0 undefined\n",
+      0,
+    );
+  });
+
+  it("exit with null resets the assigned code", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+
+      process.exitCode = 5;
+      process.exit(null);
+    `,
+      "exit 0 undefined\n",
+      0,
+    );
+  });
+
+  // Node re-reads process.exitCode after the "exit" listeners run, so a
+  // listener can override the code passed to process.exit().
+  it("an exit listener can override the code passed to process.exit", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => { console.log("exit1", code); process.exitCode = 9; });
+      process.on("exit", (code) => { console.log("exit2", code); });
+
+      process.exit(2);
+    `,
+      "exit1 2\nexit2 2\n",
+      9,
     );
   });
 


### PR DESCRIPTION
From a differential fuzz report comparing Bun against Node (v26.3.0) on process-lifecycle semantics. The report had five divergences; this PR fixes three (the exit-code ones) plus two `node:events` bugs found while verifying it. The other two are deliberately not in this PR: #1 (a worker thread's exit suppressing the parent's `exit` event) is the same root cause and fix as the already-open #32264, and #4 (unhandled rejections never reaching the `uncaughtException` machinery in the default mode) was implemented here, caused two `bun --hot` regressions in review, and was backed out (details below).

## Repro

```js
// 1. exit code > 255 / negative: the getter and the event arg lose the raw value
process.exitCode = -1;  // node getter: -1   bun: 255
process.exitCode = 300; // node exit/beforeExit arg: 300   bun: 44

// 2. nullish assignment does not reset (node resets to unset, status 0)
process.exitCode = 5; process.exitCode = null; // node getter: undefined, status 0   bun: 5, status 5
process.exitCode = 5; process.exit(null);      // node: status 0   bun: status 5

// 3. an exit listener's write is ignored by process.exit(N)
process.on("exit", () => { process.exitCode = 9; });
process.exit(2);  // node: status 9   bun: status 2
```

## Cause

`process.exitCode` was backed by a `u8` on the VM (`exit_handler.exit_code`) and masked to 0-255 at assignment time, so the raw value was gone by the time the getter or the `beforeExit`/`exit` events read it. Node stores it in an int32 slot and masks only at the actual `exit(2)` (it wraps at the int32 boundary too: `2**31` reads back as `-2147483648` on Node v26.3.0, which a test pins). `Process_functionExit` also read the code once before emitting `exit`, so a listener reassigning it was ignored (Node re-reads), and a nullish assignment was a no-op (Node resets to unset). `Process_functionReallyExit` still narrowed the code back to a `u8`, which only mattered for workers: the parent's `worker.on("exit", code)` saw 44 for `process.exit(300)` while the `process.exitCode = 300` spelling produced 300. Both now produce the raw 300, matching Node.

## node:events captureRejections (verified against Node stage by stage)

- `EventEmitter.captureRejections = true` (the global) was ignored by instances whose `EventEmitter` constructor never ran (the `util.inherits` pattern), because Bun chooses the capturing vs non-capturing `emit` at construction. The global setter now keeps `EventEmitter.prototype.emit` in sync (without clobbering a user-installed prototype wrapper), and `addCatch` gates on `emitter[kCapture]` at emit time like Node. That gate is load-bearing: Node does not retroactively capture for an already-constructed default emitter, and a test covers that negative contract.
- `addCatch` only handled real Promises (`$isPromise`). Node duck-types `.then` on any non-nullish listener return value inside a try/catch, so plain thenables are captured and a throwing `then` getter is routed to the `error` event. Both cases were silently dropped.

## --unhandled-rejections=throw double error report

The `throw` arm's unhandled path called `uncaught_exception()` (which reports the error and sets the exit code) and then still fell through to the default printer, so a truly unhandled rejection under `--unhandled-rejections=throw` was reported twice. The fall-through is gone. Covered by a fail-before test.

## Backed out: routing the default unhandled-rejection mode through uncaughtException

Node's default raises an unhandled rejection as an uncaught exception, so `uncaughtExceptionMonitor` and a `uncaughtException` listener can handle it. Bun's default mode skips that machinery entirely; `bun --unhandled-rejections=throw` already matches Node exactly (verified identical in every listener combination). Merging the default into the `throw` arm was the obvious fix and this PR originally shipped it, but review and verification found that `uncaught_exception()` carries invariants only its existing callers satisfy, and the default path violates them:

- `bun --hot` calls `on_before_exit()` after every drain, which arms the one-shot `exit_on_uncaught_exception` guard that nothing resets, so the second reload's error hard-exited the watcher.
- A second, distinct `--hot` regression in `hot.test.ts`'s sourcemap tests (verified green with main's `src/` and red with this PR's via a src-for-src swap).
- In a worker, that guard's `process_exit` hook returns instead of exiting, and the guard then `panic!`s the whole process.
- `UnhandledRejectionScope` callers (HTMLRewriter) that override `on_unhandled_rejection` get bypassed by an installed `uncaughtException` listener and leak `exit_code = 1`.

All four are latent today on the opt-in `throw`/`strict` arms (which already call `uncaught_exception()`); the change made them the default. Changing the default needs `uncaught_exception()` hardened for the `--hot` loop, workers, and capture scopes first, which is its own PR. The review threads on `src/jsc/VirtualMachine.rs` have the full analysis of each.

## Intentionally out of scope

- The parent's `process.on("exit")` being suppressed after a `worker_threads` Worker ran: #32264 (same `processIsExiting` process-global static, already open).
- The default unhandled-rejection routing, per the section above.
- Worker exit codes outside 0..65535 are still wrong in the parent (`process.exit(-1)` in a worker reports 65535; Node reports -1): the worker exit code reaches `node:worker_threads` through a `CloseEvent` whose `code` is an `unsigned short`. That transport predates this PR (it previously masked to a u8) and needs a non-`CloseEvent` channel.

## Verification

12 new tests in `test/js/node/process/process.test.js` and 5 in `test/js/node/events/event-emitter.test.ts`; 13 of the 17 fail on the unfixed build (the other 4 are negative contracts or regression guards that must not change). Every expected value was taken from Node v26.3.0. `test/cli/hot/hot.test.ts` (all 4 sourcemap tests) and the `--hot` error-reload probe were re-verified green against the final head.

<details>
<summary>Node parallel tests re-verified against the debug build (all pass)</summary>

`test-event-capture-rejections.js`, `test-process-exit-code-validation.js`, `test-process-exit{,-recursive,-handler,-from-before-exit}.js`, `test-process-beforeexit{,-throw-exit}.js`, `test-promise-unhandled-{default,error,flag,throw,throw-handler,silent,silent-no-hook,warn-no-hook,issue-43655}.js`, `test-promises-{unhandled-rejections,unhandled-proxy-rejections,unhandled-symbol-rejections,warning-on-unhandled-rejection}.js`, `test-promise-handled-rejection-no-warning.js`, `test-worker-{on-process-exit,nested-on-process-exit,exit-from-uncaught-exception,uncaught-exception-async}.js`, `test-unhandled-exception-with-worker-inuse.js`, `test-util-callbackify.js`, `test-queue-microtask.js`, all `test-event-emitter-*.js`, plus `test/js/node/promise/reject-tostring.test.ts` and `test/js/bun/spawn/exit-code.test.ts`.
</details>
