### PR TITLE
node:dns: preserve TXT record boundaries and report NODATA as ENODATA

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -582,7 +582,9 @@ impl struct_nameinfo {
         // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
         let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
         if status != ARES_SUCCESS {
-            this.on_nameinfo(Error::get(status), timeouts, None);
+            // `ares_getnameinfo` backs `lookupService()`; report like node's
+            // uv_getnameinfo path, not like a `resolve*()` query.
+            this.on_nameinfo(Error::get_for_lookup(status), timeouts, None);
             return;
         }
         this.on_nameinfo(None, timeouts, Some(struct_nameinfo { node, service }));
@@ -659,7 +661,9 @@ impl AddrInfo {
     ) {
         // SAFETY: ctx was passed as *mut T to the ares call that registered this thunk.
         let this = unsafe { bun_core::callback_ctx::<T>(ctx) };
-        this.on_addr_info(Error::get(status), timeouts, addr_info);
+        // `ares_getaddrinfo` backs the c-ares `lookup()` backend; report like
+        // node's uv_getaddrinfo path, not like a `resolve*()` query.
+        this.on_addr_info(Error::get_for_lookup(status), timeouts, addr_info);
     }
 
     /// FFI destroy — frees a c-ares-allocated addrinfo chain.
@@ -1355,33 +1359,24 @@ pub struct struct_ares_txt_reply {
     pub length: usize,
 }
 
-impl AresReply for struct_ares_txt_reply {
-    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
-        // SAFETY: caller upholds the `AresReply::parse` contract; thin FFI forward.
-        unsafe { ares_parse_txt_reply(abuf, alen, out) }
-    }
-}
-
-impl struct_ares_txt_reply {
-    /// Safe view of the c-ares-owned TXT record bytes.
-    #[inline]
-    pub fn txt_bytes(&self) -> &[u8] {
-        if self.txt.is_null() {
-            &[]
-        } else {
-            // SAFETY: c-ares allocates `txt` as `length` bytes that live until
-            // `ares_free_data` on the list head; `&self` is the shorter borrow.
-            unsafe { core::slice::from_raw_parts(self.txt, self.length) }
-        }
-    }
-}
-
 #[repr(C)]
 pub struct struct_ares_txt_ext {
     pub next: *mut struct_ares_txt_ext,
     pub txt: *mut u8,
     pub length: usize,
+    /// 1 on the first character-string of a TXT resource record, 0 on the
+    /// rest. A single TXT RR may carry several character-strings; this is the
+    /// only way to recover the record boundaries from the flat list.
     pub record_start: u8,
+}
+
+// The `_ext` parser is the one that preserves RR boundaries (`record_start`);
+// `ares_parse_txt_reply` flattens every character-string into one list.
+impl AresReply for struct_ares_txt_ext {
+    unsafe fn parse(abuf: *const u8, alen: c_int, out: *mut *mut Self) -> c_int {
+        // SAFETY: caller upholds the `AresReply::parse` contract; thin FFI forward.
+        unsafe { ares_parse_txt_reply_ext(abuf, alen, out) }
+    }
 }
 
 impl struct_ares_txt_ext {
@@ -1448,7 +1443,7 @@ pub struct struct_any_reply {
     pub aaaa_reply: Option<Box<hostent_with_ttls>>,
     pub mx_reply: *mut struct_ares_mx_reply,
     pub ns_reply: *mut struct_hostent,
-    pub txt_reply: *mut struct_ares_txt_reply,
+    pub txt_reply: *mut struct_ares_txt_ext,
     pub srv_reply: *mut struct_ares_srv_reply,
     pub ptr_reply: *mut struct_hostent,
     pub naptr_reply: *mut struct_ares_naptr_reply,
@@ -1552,7 +1547,7 @@ impl struct_any_reply {
         }
 
         // SAFETY: see `ares_parse_mx_reply` call above.
-        result = unsafe { ares_parse_txt_reply(abuf, alen, &raw mut reply.txt_reply) };
+        result = unsafe { ares_parse_txt_reply_ext(abuf, alen, &raw mut reply.txt_reply) };
         if result == ARES_SUCCESS {
             any_success = true;
         } else {
@@ -2001,12 +1996,10 @@ impl Error {
         }
     }
 
+    /// Faithful `ARES_*` status -> [`Error`] mapping, used by the `resolve*()`
+    /// query paths, which (like node's `cares_wrap.cc`) report the c-ares
+    /// status verbatim. The lookup family goes through [`Error::get_for_lookup`].
     pub fn get(rc: i32) -> Option<Error> {
-        // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/errors.js#L807-L815
-        if rc == ARES_ENODATA || rc == ARES_ENONAME {
-            return Self::get(ARES_ENOTFOUND);
-        }
-
         if rc == 0 {
             return None;
         }
@@ -2020,6 +2013,17 @@ impl Error {
         // SAFETY: `n` is in `1..=ARES_ENOSERVER`; `Error` is `#[repr(i32)]` with
         // contiguous discriminants `1..=ARES_ENOSERVER`.
         Some(unsafe { core::mem::transmute::<i32, Error>(n as i32) })
+    }
+
+    /// [`Error::get`] plus node's `lookup()`/`lookupService()` folding: NODATA
+    /// and NONAME become the fabricated ENOTFOUND, mirroring how node reports
+    /// libuv `EAI_NODATA`/`EAI_NONAME` on the getaddrinfo/getnameinfo family.
+    /// https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/errors.js#L807-L815
+    pub fn get_for_lookup(rc: i32) -> Option<Error> {
+        match Self::get(rc) {
+            Some(Error::ENODATA | Error::ENONAME) => Some(Error::ENOTFOUND),
+            other => other,
+        }
     }
 }
 

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -2015,9 +2015,8 @@ impl Error {
         Some(unsafe { core::mem::transmute::<i32, Error>(n as i32) })
     }
 
-    /// [`Error::get`] plus node's `lookup()`/`lookupService()` folding: NODATA
-    /// and NONAME become the fabricated ENOTFOUND, mirroring how node reports
-    /// libuv `EAI_NODATA`/`EAI_NONAME` on the getaddrinfo/getnameinfo family.
+    /// [`Error::get`] plus node's `lookup()`/`lookupService()` folding: NODATA and
+    /// NONAME become the fabricated ENOTFOUND, as on node's getaddrinfo/getnameinfo path.
     /// https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/errors.js#L807-L815
     pub fn get_for_lookup(rc: i32) -> Option<Error> {
         match Self::get(rc) {

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -245,7 +245,7 @@ impl_cares_linked!(
     c_ares::struct_ares_caa_reply,
     c_ares::struct_ares_srv_reply,
     c_ares::struct_ares_mx_reply,
-    c_ares::struct_ares_txt_reply,
+    c_ares::struct_ares_txt_ext,
     c_ares::struct_ares_naptr_reply,
 );
 
@@ -366,35 +366,69 @@ pub(crate) fn mx_reply_to_js(
     Ok(obj)
 }
 
-// ── struct_ares_txt_reply ──────────────────────────────────────────────────
+// ── struct_ares_txt_ext ────────────────────────────────────────────────────
+// c-ares hands back one list node per TXT *character-string*; `record_start`
+// marks the first string of each resource record. Node groups the strings of
+// one record together (see `ParseTxtReply` in node's `cares_wrap.cc`).
+
 pub(crate) fn txt_reply_to_js_response(
-    this: &mut c_ares::struct_ares_txt_reply,
+    this: &mut c_ares::struct_ares_txt_ext,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    cares_list_to_js_array(this, global_this, txt_reply_to_js)
-}
-
-pub(crate) fn txt_reply_to_js(
-    this: &mut c_ares::struct_ares_txt_reply,
-    global_this: &JSGlobalObject,
-) -> JsResult<JSValue> {
-    let array = JSValue::create_empty_array(global_this, 1)?;
-    let value = this.txt_bytes();
-    array.put_index(global_this, 0, utf8_to_js(global_this, value)?)?;
-    Ok(array)
+    // resolveTxt: one inner array of character-strings per TXT record.
+    txt_records_to_js(this, global_this, |record, _| Ok(record))
 }
 
 pub(crate) fn txt_reply_to_js_for_any(
-    this: &mut c_ares::struct_ares_txt_reply,
+    this: &mut c_ares::struct_ares_txt_ext,
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    let array =
-        cares_list_to_js_array(this, global_this, |node, g| utf8_to_js(g, node.txt_bytes()))?;
-    let obj = JSValue::create_empty_object(global_this, 1);
-    obj.put(global_this, b"entries", array);
-    Ok(obj)
+    // resolveAny: one `{ entries: [...] }` object per TXT record. The caller
+    // (`any_reply_append_all`) appends the `type` field to each.
+    txt_records_to_js(this, global_this, |record, g| {
+        let obj = JSValue::create_empty_object(g, 1);
+        obj.put(g, b"entries", record);
+        Ok(obj)
+    })
+}
+
+/// Walk the TXT list grouping character-strings into one array per resource
+/// record; `wrap` turns each per-record array into the value pushed onto the
+/// result.
+fn txt_records_to_js(
+    head: &mut c_ares::struct_ares_txt_ext,
+    global_this: &JSGlobalObject,
+    wrap: impl Fn(JSValue, &JSGlobalObject) -> JsResult<JSValue>,
+) -> JsResult<JSValue> {
+    let records = JSValue::create_empty_array(global_this, 0)?;
+    let mut record_count: u32 = 0;
+    let mut record = JSValue::create_empty_array(global_this, 0)?;
+    let mut strings_in_record: u32 = 0;
+
+    let mut p: *mut c_ares::struct_ares_txt_ext = head;
+    while !p.is_null() {
+        // SAFETY: `p` walks the c-ares-owned linked list (CAresLinked invariant).
+        let node = unsafe { &mut *p };
+        // The head node is always tagged; `strings_in_record > 0` stops it
+        // from flushing an empty leading record.
+        if node.record_start != 0 && strings_in_record > 0 {
+            records.put_index(global_this, record_count, wrap(record, global_this)?)?;
+            record_count += 1;
+            record = JSValue::create_empty_array(global_this, 0)?;
+            strings_in_record = 0;
+        }
+        record.put_index(
+            global_this,
+            strings_in_record,
+            utf8_to_js(global_this, node.txt_bytes())?,
+        )?;
+        strings_in_record += 1;
+        p = node.next();
+    }
+    records.put_index(global_this, record_count, wrap(record, global_this)?)?;
+    Ok(records)
 }
 
 // ── struct_ares_naptr_reply ────────────────────────────────────────────────
@@ -598,8 +632,8 @@ pub(crate) fn any_reply_to_js(
     }
     if !this.txt_reply.is_null() {
         // SAFETY: non-null c-ares-owned linked list head.
-        // txt is the only reply type with the `to_js_for_any` shape (an `entries`
-        // wrapper object) instead of the plain `to_js_response` shape.
+        // txt is the only reply type with the `to_js_for_any` shape (an array of
+        // per-record `entries` objects) instead of the plain `to_js_response` shape.
         let response =
             txt_reply_to_js_for_any(unsafe { &mut *this.txt_reply }, global_this, b"txt")?;
         any_reply_append_all(global_this, array, &mut i, response, b"txt")?;

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -367,9 +367,8 @@ pub(crate) fn mx_reply_to_js(
 }
 
 // ── struct_ares_txt_ext ────────────────────────────────────────────────────
-// c-ares hands back one list node per TXT *character-string*; `record_start`
-// marks the first string of each resource record. Node groups the strings of
-// one record together (see `ParseTxtReply` in node's `cares_wrap.cc`).
+// c-ares returns one node per TXT character-string; `record_start` tags each
+// record's first string. Node groups per record (cares_wrap.cc ParseTxtReply).
 
 pub(crate) fn txt_reply_to_js_response(
     this: &mut c_ares::struct_ares_txt_ext,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3406,7 +3406,7 @@ impl_cares_record_type!(
     super::cares_jsc::soa_reply_to_js_response
 );
 impl_cares_record_type!(
-    c_ares::struct_ares_txt_reply,
+    c_ares::struct_ares_txt_ext,
     "txt",
     "queryTxt",
     PendingTxtCacheCares,
@@ -3616,7 +3616,7 @@ type SrvPendingCache =
 type SoaPendingCache =
     HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_soa_reply>, 32>;
 type TxtPendingCache =
-    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_txt_reply>, 32>;
+    HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_txt_ext>, 32>;
 type NaptrPendingCache =
     HiveArray<resolve_info_request::PendingCacheKey<c_ares::struct_ares_naptr_reply>, 32>;
 type MxPendingCache =
@@ -5043,7 +5043,7 @@ impl Resolver {
                 self.do_resolve_cares::<c_ares::struct_ares_srv_reply>(name.slice(), global_this)
             }
             RecordType::TXT => {
-                self.do_resolve_cares::<c_ares::struct_ares_txt_reply>(name.slice(), global_this)
+                self.do_resolve_cares::<c_ares::struct_ares_txt_ext>(name.slice(), global_this)
             }
         }
     }
@@ -5358,7 +5358,7 @@ impl Resolver {
         global_resolve_txt,
         resolve_txt,
         "resolveTxt",
-        c_ares::struct_ares_txt_reply,
+        c_ares::struct_ares_txt_ext,
         false
     );
     resolve_record_fn!(

--- a/test/js/node/dns/node-dns-local-server.test.ts
+++ b/test/js/node/dns/node-dns-local-server.test.ts
@@ -51,9 +51,7 @@ beforeAll(async () => {
       for (const t of types) {
         for (const rr of zone[t]) {
           // TXT RDATA: each character-string is length-prefixed.
-          const rdata = Buffer.concat(
-            rr.map(s => Buffer.concat([Buffer.from([s.length]), Buffer.from(s, "ascii")])),
-          );
+          const rdata = Buffer.concat(rr.map(s => Buffer.concat([Buffer.from([s.length]), Buffer.from(s, "ascii")])));
           const rrHeader = Buffer.alloc(12);
           rrHeader.writeUInt16BE(0xc00c, 0); // NAME: pointer back to the qname at offset 12
           rrHeader.writeUInt16BE(TYPE[t], 2);
@@ -127,9 +125,7 @@ describe("an empty NOERROR answer (NODATA)", () => {
 
   test("resolve4 reports ENODATA (callback)", async () => {
     const { promise, resolve, reject } = Promise.withResolvers<string | undefined>();
-    resolver.resolve4("onlytxt.bun.test", err =>
-      err ? resolve(err.code) : reject(new Error("expected an error")),
-    );
+    resolver.resolve4("onlytxt.bun.test", err => (err ? resolve(err.code) : reject(new Error("expected an error"))));
     expect(await promise).toBe("ENODATA");
   });
 

--- a/test/js/node/dns/node-dns-local-server.test.ts
+++ b/test/js/node/dns/node-dns-local-server.test.ts
@@ -1,0 +1,166 @@
+// node:dns Resolver tests against an in-process authoritative UDP DNS server
+// (RFC 1035). Deterministic: every query goes to 127.0.0.1, never the network.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import dgram from "node:dgram";
+import * as dns from "node:dns";
+import * as dns_promises from "node:dns/promises";
+import { once } from "node:events";
+
+// zone: name -> { TYPE: [rrdata, ...] }. A TXT rrdata is the array of
+// <character-string>s carried by ONE resource record (RFC 1035 section 3.3.14).
+const ZONES: Record<string, Record<string, string[][]>> = {
+  "txt.bun.test": {
+    TXT: [
+      ["hello", "world"], // one RR split into two character-strings
+      ["single"],
+    ],
+  },
+  // Exists (has TXT) but has no address records: an A query is NODATA.
+  "onlytxt.bun.test": { TXT: [["only"]] },
+};
+const TYPE: Record<string, number> = { TXT: 16 };
+const TYPENAME: Record<number, string> = { 16: "TXT", 255: "ANY" };
+
+let server: dgram.Socket;
+let serverList: string[];
+let resolver: dns.Resolver;
+let promiseResolver: InstanceType<typeof dns_promises.Resolver>;
+
+beforeAll(async () => {
+  server = dgram.createSocket("udp4");
+  server.on("message", (msg, rinfo) => {
+    // QNAME starts at offset 12: length-prefixed labels ending with a 0 byte.
+    let off = 12;
+    const labels: string[] = [];
+    while (msg[off] !== 0) {
+      labels.push(msg.toString("ascii", off + 1, off + 1 + msg[off]));
+      off += 1 + msg[off];
+    }
+    off += 1;
+    const qtype = msg.readUInt16BE(off);
+    const question = msg.subarray(12, off + 4);
+
+    const zone = ZONES[labels.join(".").toLowerCase()];
+    let rcode = 0;
+    const answers: Buffer[] = [];
+    if (!zone) {
+      rcode = 3; // NXDOMAIN
+    } else {
+      const wanted = TYPENAME[qtype];
+      const types = wanted === "ANY" ? Object.keys(zone) : zone[wanted] ? [wanted] : [];
+      for (const t of types) {
+        for (const rr of zone[t]) {
+          // TXT RDATA: each character-string is length-prefixed.
+          const rdata = Buffer.concat(
+            rr.map(s => Buffer.concat([Buffer.from([s.length]), Buffer.from(s, "ascii")])),
+          );
+          const rrHeader = Buffer.alloc(12);
+          rrHeader.writeUInt16BE(0xc00c, 0); // NAME: pointer back to the qname at offset 12
+          rrHeader.writeUInt16BE(TYPE[t], 2);
+          rrHeader.writeUInt16BE(1, 4); // class IN
+          rrHeader.writeUInt32BE(60, 6); // TTL
+          rrHeader.writeUInt16BE(rdata.length, 10);
+          answers.push(Buffer.concat([rrHeader, rdata]));
+        }
+      }
+      // The name exists but has no RRs of this type: NOERROR with 0 answers.
+    }
+
+    const header = Buffer.alloc(12);
+    msg.copy(header, 0, 0, 2); // echo the query id
+    header.writeUInt16BE(0x8180 | rcode, 2); // QR=1 RD=1 RA=1
+    header.writeUInt16BE(1, 4); // QDCOUNT
+    header.writeUInt16BE(answers.length, 6); // ANCOUNT
+    server.send(Buffer.concat([header, question, ...answers]), rinfo.port, rinfo.address);
+  });
+  server.bind(0, "127.0.0.1");
+  await once(server, "listening");
+
+  serverList = ["127.0.0.1:" + (server.address() as dgram.AddressInfo).port];
+  resolver = new dns.Resolver({ timeout: 2000, tries: 2 });
+  resolver.setServers(serverList);
+  promiseResolver = new dns_promises.Resolver({ timeout: 2000, tries: 2 });
+  promiseResolver.setServers(serverList);
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("resolveTxt", () => {
+  // A TXT resource record longer than 255 bytes is split into several
+  // <character-string>s; node returns one inner array per record so the
+  // standard SPF/DKIM/DMARC reassembly `entries.map(e => e.join(""))` works.
+  test("groups the character-strings of one record together (promises)", async () => {
+    expect(await promiseResolver.resolveTxt("txt.bun.test")).toEqual([["hello", "world"], ["single"]]);
+  });
+
+  test("groups the character-strings of one record together (callback)", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<string[][]>();
+    resolver.resolveTxt("txt.bun.test", (err, records) => (err ? reject(err) : resolve(records)));
+    expect(await promise).toEqual([["hello", "world"], ["single"]]);
+  });
+
+  test("resolveAny yields one TXT entry object per record", async () => {
+    expect(await promiseResolver.resolveAny("txt.bun.test")).toEqual([
+      { entries: ["hello", "world"], type: "TXT" },
+      { entries: ["single"], type: "TXT" },
+    ]);
+  });
+});
+
+describe("an empty NOERROR answer (NODATA)", () => {
+  // "The name exists but has no records of this type" must surface as
+  // ENODATA, distinct from NXDOMAIN's ENOTFOUND: consumers make different
+  // cache/retry/fallback decisions for the two.
+  test("resolve4 rejects with ENODATA (promises)", async () => {
+    const err: any = await promiseResolver.resolve4("onlytxt.bun.test").then(
+      () => null,
+      e => e,
+    );
+    expect({ code: err?.code, syscall: err?.syscall, hostname: err?.hostname }).toEqual({
+      code: "ENODATA",
+      syscall: "queryA",
+      hostname: "onlytxt.bun.test",
+    });
+  });
+
+  test("resolve4 reports ENODATA (callback)", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<string | undefined>();
+    resolver.resolve4("onlytxt.bun.test", err =>
+      err ? resolve(err.code) : reject(new Error("expected an error")),
+    );
+    expect(await promise).toBe("ENODATA");
+  });
+
+  test("a nonexistent name is still ENOTFOUND", async () => {
+    expect(
+      await promiseResolver.resolve4("nxdomain.bun.test").then(
+        () => null,
+        (e: any) => e.code,
+      ),
+    ).toBe("ENOTFOUND");
+  });
+
+  test("lookup() through the c-ares backend still folds NODATA into ENOTFOUND", async () => {
+    // node's dns.lookup() (getaddrinfo family) reports both "no such name" and
+    // "no address records" as ENOTFOUND; only the resolve*() query paths keep
+    // the verbatim c-ares status. The c-ares lookup backend uses the
+    // module-level server list, so point it at the local server for this test.
+    const saved = dns.getServers();
+    dns.setServers(serverList);
+    try {
+      const lookupCode = (name: string) =>
+        Bun.dns.lookup(name, { backend: "c-ares" }).then(
+          () => null,
+          (e: any) => e.code,
+        );
+      expect(await Promise.all([lookupCode("onlytxt.bun.test"), lookupCode("nxdomain.bun.test")])).toEqual([
+        "DNS_ENOTFOUND",
+        "DNS_ENOTFOUND",
+      ]);
+    } finally {
+      dns.setServers(saved);
+    }
+  });
+});

--- a/test/js/node/dns/node-dns-local-server.test.ts
+++ b/test/js/node/dns/node-dns-local-server.test.ts
@@ -86,9 +86,9 @@ afterAll(() => {
 });
 
 describe("resolveTxt", () => {
-  // A TXT resource record longer than 255 bytes is split into several
-  // <character-string>s; node returns one inner array per record so the
-  // standard SPF/DKIM/DMARC reassembly `entries.map(e => e.join(""))` works.
+  // https://github.com/oven-sh/bun/issues/21370: a TXT record longer than 255
+  // bytes is split into several <character-string>s; node returns one inner
+  // array per record so `entries.map(e => e.join(""))` reassembles it.
   test("groups the character-strings of one record together (promises)", async () => {
     expect(await promiseResolver.resolveTxt("txt.bun.test")).toEqual([["hello", "world"], ["single"]]);
   });

--- a/test/js/node/dns/node-dns-local-server.test.ts
+++ b/test/js/node/dns/node-dns-local-server.test.ts
@@ -138,11 +138,9 @@ describe("an empty NOERROR answer (NODATA)", () => {
     ).toBe("ENOTFOUND");
   });
 
-  test("lookup() through the c-ares backend still folds NODATA into ENOTFOUND", async () => {
-    // node's dns.lookup() (getaddrinfo family) reports both "no such name" and
-    // "no address records" as ENOTFOUND; only the resolve*() query paths keep
-    // the verbatim c-ares status. The c-ares lookup backend uses the
-    // module-level server list, so point it at the local server for this test.
+  test("lookup() through the c-ares backend folds both NODATA and NXDOMAIN into ENOTFOUND", async () => {
+    // The c-ares lookup backend uses the module-level server list (a per-instance
+    // Resolver has no lookup()), so point the global at the local server.
     const saved = dns.getServers();
     dns.setServers(serverList);
     try {


### PR DESCRIPTION
Fixes #21370

### What does this PR do?

Fixes two `node:dns` divergences from Node.js in the c-ares `resolve*()` paths. Both are data-affecting, not just cosmetic.

**1. `resolveTxt` destroys TXT resource-record boundaries**

A single TXT RR longer than 255 bytes is carried as several `<character-string>`s (RFC 1035 section 3.3.14). Node returns one inner array per RR so the standard SPF/DKIM/DMARC reassembly `entries.map(e => e.join(""))` works. Bun parsed TXT replies with `ares_parse_txt_reply`, which hands back one flat list node per `<character-string>` and loses the record boundaries, so every string came back as its own one-element array. Any consumer joining the inner arrays gets a wrong record.

Against a local authoritative server serving one 2-string TXT RR plus one 1-string TXT RR:

| API | Node v26 | Bun 1.4.0 (before) |
| --- | --- | --- |
| `resolveTxt` | `[["hello","world"],["single"]]` | `[["hello"],["world"],["single"]]` |
| `resolveAny` | `[{entries:["hello","world"],type:"TXT"},{entries:["single"],type:"TXT"}]` | `[{entries:["hello","world","single"],type:"TXT"}]` |

Fix: parse with `ares_parse_txt_reply_ext` (the struct and extern were already declared in `c_ares.rs`, just unused) and group the character-strings by its `record_start` tag, the same way Node's `cares_wrap.cc` `ParseTxtReply` does. `resolveAny` uses the same grouping: one `{ entries, type: "TXT" }` object per record.

**2. An empty NOERROR answer (NODATA) was reported as `ENOTFOUND`**

`resolve4()` of a name that exists but has no A records rejected with `ENOTFOUND`, making it indistinguishable from NXDOMAIN. Node reports `ENODATA`, and callers rely on the distinction (a name that exists but has no records of a type calls for different cache / retry / fallback behaviour than one that does not exist).

The cause was `c_ares::Error::get()`, which folded `ARES_ENODATA` and `ARES_ENONAME` into `ENOTFOUND` with a citation of Node's [`errors.js` `dnsException`](https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/errors.js#L807-L815). That Node rule only applies to the numeric libuv `EAI_*` codes, i.e. the `dns.lookup()` / `lookupService()` (getaddrinfo / getnameinfo) family. Node's c-ares query path (`cares_wrap.cc` `ToErrorCodeString`) reports the status verbatim. Because `Error::get` feeds every c-ares callback, Bun was applying the lookup rule to the `resolve*()` paths too.

Fix: `Error::get` is now the faithful `ARES_*` status mapping, and the folding moves to the two callbacks that actually are the lookup family (`ares_getaddrinfo`, `ares_getnameinfo`) via a new `Error::get_for_lookup`. `dns.lookup()` therefore still reports `ENOTFOUND` for both NXDOMAIN and NODATA, matching Node. That path matters: on Linux the c-ares backend is the default for `dns.lookup()`. Real NXDOMAIN is still `ENOTFOUND` on every path.

### Reproduction

Self-contained: the script embeds its own authoritative UDP server, so it runs anywhere with no external network.

<details>
<summary>repro.mjs</summary>

```js
import dgram from "node:dgram";

function decodeQName(msg, offset) {
  const labels = [];
  let o = offset;
  while (msg[o] !== 0) { labels.push(msg.subarray(o + 1, o + 1 + msg[o]).toString("ascii")); o += 1 + msg[o]; }
  return { name: labels.join("."), end: o + 1 };
}
// one TXT RR carrying two character-strings, plus a second single-string RR;
// onlytxt.test.zone exists but has no A records (A query -> NODATA).
const ZONES = {
  "txt.test.zone": { TXT: [["hello", "world"], ["single"]] },
  "onlytxt.test.zone": { TXT: [["only"]] },
};
const server = dgram.createSocket("udp4");
server.on("message", (msg, rinfo) => {
  const { name, end } = decodeQName(msg, 12);
  const qtype = msg.readUInt16BE(end);
  const question = msg.subarray(12, end + 4);
  const zone = ZONES[name.toLowerCase()];
  let rcode = 0;
  const answers = [];
  if (!zone) rcode = 3;
  else if (qtype === 16 && zone.TXT) for (const rr of zone.TXT) {
    const rdata = Buffer.concat(rr.map(s => Buffer.concat([Buffer.from([s.length]), Buffer.from(s)])));
    const h = Buffer.alloc(12);
    h.writeUInt16BE(0xc00c, 0); h.writeUInt16BE(16, 2); h.writeUInt16BE(1, 4);
    h.writeUInt32BE(60, 6); h.writeUInt16BE(rdata.length, 10);
    answers.push(Buffer.concat([h, rdata]));
  }
  const h = Buffer.alloc(12);
  msg.copy(h, 0, 0, 2);
  h.writeUInt16BE(0x8180 | rcode, 2); h.writeUInt16BE(1, 4); h.writeUInt16BE(answers.length, 6);
  server.send(Buffer.concat([h, question, ...answers]), rinfo.port, rinfo.address);
});
await new Promise(r => server.bind(0, "127.0.0.1", r));

const { default: dns } = await import("node:dns/promises");
const R = new dns.Resolver();
R.setServers(["127.0.0.1:" + server.address().port]);
console.log("resolveTxt :", JSON.stringify(await R.resolveTxt("txt.test.zone")));
console.log("nodata     :", await R.resolve4("onlytxt.test.zone").then(r => r, e => e.code));
console.log("nxdomain   :", await R.resolve4("nope.test.zone").then(r => r, e => e.code));
server.close();
```
</details>

```
# node v26.3.0
resolveTxt : [["hello","world"],["single"]]
nodata     : ENODATA
nxdomain   : ENOTFOUND

# bun 1.4.0 (before)
resolveTxt : [["hello"],["world"],["single"]]
nodata     : ENOTFOUND
nxdomain   : ENOTFOUND

# bun (this PR)
resolveTxt : [["hello","world"],["single"]]
nodata     : ENODATA
nxdomain   : ENOTFOUND
```

### How did you verify your code works?

`test/js/node/dns/node-dns-local-server.test.ts` runs against an in-process authoritative UDP DNS server (no external network). It covers `resolveTxt` (promise and callback), `resolveAny`, the `ENODATA` / `ENOTFOUND` distinction (promise and callback), plus two negative contracts: real NXDOMAIN is still `ENOTFOUND`, and `lookup()` through the c-ares backend still folds NODATA into `ENOTFOUND`.

- Before the fix the file is 5 fail / 2 pass (the 2 passes are the negative contracts); after, 7 / 7 pass.
- All 12 `test/js/node/test/parallel/test-dns-*.js` that exercise a local mock server still pass, as do `dns-tcp-bidirectional-poll.test.ts` and `dns-lookup-keepalive.test.ts`. The network-dependent `node-dns.test.js` / `resolve-dns.test.ts` failure sets are byte-for-byte identical before and after (the sandbox has no external DNS).

The now-unused `struct_ares_txt_reply` declaration, its `ares_parse_txt_reply` extern, and the `ares_txt_reply` alias are kept: `c_ares.rs` mirrors the c-ares header and already carries other unused mirror declarations (for example `struct_ares_uri_reply`). The Bun-specific `AresReply` and `txt_bytes` impls that the change orphaned are removed.