### PR TITLE
bun test: fix inline snapshot conflict, beforeAll skip, and test.each title reporting

### DIFF
--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -817,6 +817,7 @@ pub(crate) fn step_group(
 ) -> JsResult<StepResult> {
     let _g = group_begin!();
     let buntest = buntest_strong.get();
+    let buntest_ptr = NonNull::from(&mut *buntest);
     let this = &mut buntest.execution;
 
     loop {
@@ -866,6 +867,26 @@ pub(crate) fn step_group(
             group_log::log(format_args!(
                 "stepGroup: all sequences failed, skipping to failure_skip_to group",
             ));
+            // A failed beforeAll jumps past its tests. Those still have to
+            // reach the reporter as skipped, or they vanish from the console,
+            // the JUnit report, and the summary counts.
+            for skipped_group in (this.group_index + 1)..failure_skip_to {
+                let (sequence_start, sequence_end) = {
+                    let group = &this.groups[skipped_group];
+                    (group.sequence_start, group.sequence_end)
+                };
+                for sequence_index in sequence_start..sequence_end {
+                    let sequence = &mut this.sequences[sequence_index];
+                    if sequence.test_entry.is_none() || sequence.result != Result::Pending {
+                        continue;
+                    }
+                    sequence.result = match sequence.entry_mode() {
+                        ScopeMode::Todo => Result::Todo,
+                        _ => Result::Skip,
+                    };
+                    Execution::on_sequence_completed(buntest_ptr, sequence);
+                }
+            }
             this.group_index = failure_skip_to;
         } else {
             group_log::log(format_args!("stepGroup: not all sequences failed, advancing to next group"));

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -880,8 +880,12 @@ pub(crate) fn step_group(
                     if sequence.test_entry.is_none() || sequence.result != Result::Pending {
                         continue;
                     }
+                    // Keep this in sync with the `next_item.base.mode` match in
+                    // step_sequence_one so an unreached test reports the same
+                    // way it would have if the beforeAll had not failed.
                     sequence.result = match sequence.entry_mode() {
                         ScopeMode::Todo => Result::Todo,
+                        ScopeMode::FilteredOut => Result::SkippedBecauseLabel,
                         _ => Result::Skip,
                     };
                     Execution::on_sequence_completed(buntest_ptr, sequence);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1104,10 +1104,9 @@ impl Expect {
             let line = core::ffi::c_ulong::from(srcloc.line);
             let col = core::ffi::c_ulong::from(srcloc.column);
 
-            // Two recordings for the same call site must agree. Detecting the
-            // conflict here fails the test itself; `write_inline_snapshots` only
-            // runs after the whole file, where it can no longer be attributed to
-            // a test and every reporter has already counted it as passing.
+            // Detect a value conflict at record time so the test itself fails;
+            // `write_inline_snapshots` runs after the whole file, too late to
+            // attribute the failure to a test or correct the reporter counts.
             if let Some(conflicting_value) =
                 runner
                     .snapshots

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1101,10 +1101,34 @@ impl Expect {
                 );
             }
 
+            let line = core::ffi::c_ulong::from(srcloc.line);
+            let col = core::ffi::c_ulong::from(srcloc.column);
+
+            // Two recordings for the same call site must agree. Detecting the
+            // conflict here fails the test itself; `write_inline_snapshots` only
+            // runs after the whole file, where it can no longer be attributed to
+            // a test and every reporter has already counted it as passing.
+            if let Some(conflicting_value) =
+                runner
+                    .snapshots
+                    .take_conflicting_inline_snapshot(file_id, line, col, &pretty_value)
+            {
+                let signature = Self::get_signature(fn_name, "", false);
+                let diff_format = DiffFormatter {
+                    received_string: Some(&pretty_value),
+                    expected_string: Some(&conflicting_value),
+                    global_this: Some(global_this),
+                    ..Default::default()
+                };
+                return Err(global_this.throw_pretty(format_args!(
+                    "{signature}\n\nMultiple inline snapshots on the same line must all have the same value:\n{diff_format}\n"
+                )));
+            }
+
             // 2. save to write later
             runner.snapshots.add_inline_snapshot_to_write(file_id, super::snapshot::InlineSnapshotToWrite {
-                line: core::ffi::c_ulong::from(srcloc.line),
-                col: core::ffi::c_ulong::from(srcloc.column),
+                line,
+                col,
                 value: core::mem::take(&mut pretty_value).into_boxed_slice(),
                 has_matchers: property_matchers.is_some(),
                 is_added: result.is_none(),

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -584,6 +584,15 @@ fn consume_arg(
     Ok(())
 }
 
+/// Inspect `value` onto `out` on a single line. Test titles must stay on one
+/// line; a multi-line name corrupts the console layout and JUnit output.
+fn write_inspected(global_this: &JSGlobalObject, value: JSValue, out: &mut Vec<u8>) {
+    let mut formatter = crate::test_runner::expect::make_formatter(global_this);
+    formatter.single_line = true;
+    // formatter cleanup handled by Drop.
+    write!(out, "{}", value.to_fmt(&mut formatter)).unwrap();
+}
+
 /// Generate test label by positionally injecting parameters with printf formatting
 pub(crate) fn format_label(
     global_this: &JSGlobalObject,
@@ -638,9 +647,7 @@ pub(crate) fn format_label(
                         let owned_slice = value.to_slice_or_null(global_this)?;
                         list.extend_from_slice(owned_slice.slice());
                     } else {
-                        let mut formatter = crate::test_runner::expect::make_formatter(global_this);
-                        // formatter cleanup handled by Drop.
-                        write!(&mut list, "{}", value.to_fmt(&mut formatter)).unwrap();
+                        write_inspected(global_this, value, &mut list);
                     }
                     idx = var_end;
                     continue;
@@ -662,26 +669,48 @@ pub(crate) fn format_label(
 
             match label[idx + 1] {
                 b's' => {
-                    consume_arg(
-                        global_this,
-                        !current_arg.is_empty() && current_arg.js_type().is_string(),
-                        &mut idx,
-                        &mut args_idx,
-                        &mut list,
-                        current_arg,
-                        b"%s",
-                    )?;
+                    // util.format's `%s` (what jest-each delegates to) never
+                    // leaves the literal specifier: strings pass through
+                    // verbatim, everything else goes through the inspector.
+                    if !current_arg.is_empty() && current_arg.js_type().is_string() {
+                        consume_arg(
+                            global_this,
+                            true,
+                            &mut idx,
+                            &mut args_idx,
+                            &mut list,
+                            current_arg,
+                            b"%s",
+                        )?;
+                    } else {
+                        write_inspected(global_this, current_arg, &mut list);
+                        idx += 1;
+                        args_idx += 1;
+                    }
                 }
                 b'i' => {
-                    consume_arg(
-                        global_this,
-                        current_arg.is_any_int(),
-                        &mut idx,
-                        &mut args_idx,
-                        &mut list,
-                        current_arg,
-                        b"%i",
-                    )?;
+                    // util.format's `%i` is parseInt, so a non-integral number
+                    // truncates instead of leaving the literal specifier.
+                    if current_arg.is_number() && !current_arg.is_any_int() {
+                        let number = current_arg.as_number();
+                        if number.is_finite() {
+                            write!(&mut list, "{}", number.trunc()).unwrap();
+                        } else {
+                            list.extend_from_slice(b"NaN");
+                        }
+                        idx += 1;
+                        args_idx += 1;
+                    } else {
+                        consume_arg(
+                            global_this,
+                            current_arg.is_any_int(),
+                            &mut idx,
+                            &mut args_idx,
+                            &mut list,
+                            current_arg,
+                            b"%i",
+                        )?;
+                    }
                 }
                 b'd' => {
                     consume_arg(
@@ -716,9 +745,7 @@ pub(crate) fn format_label(
                     args_idx += 1;
                 }
                 b'p' => {
-                    let mut formatter = crate::test_runner::expect::make_formatter(global_this);
-                    let value_fmt = current_arg.to_fmt(&mut formatter);
-                    write!(&mut list, "{}", value_fmt).unwrap();
+                    write_inspected(global_this, current_arg, &mut list);
                     idx += 1;
                     args_idx += 1;
                 }

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -358,6 +358,25 @@ impl<'a> Snapshots<'a> {
         Ok(())
     }
 
+    /// Returns the value already queued at `(line, col)` when it differs from
+    /// `value`, removing every entry queued for that call site so
+    /// `write_inline_snapshots` leaves the source file untouched.
+    pub fn take_conflicting_inline_snapshot(
+        &mut self,
+        file_id: FileId,
+        line: c_ulong,
+        col: c_ulong,
+        value: &[u8],
+    ) -> Option<Box<[u8]>> {
+        let list = self.inline_snapshots_to_write.get_mut(&file_id)?;
+        let index = list
+            .iter()
+            .position(|e| e.line == line && e.col == col && !strings::eql(&e.value, value))?;
+        let existing = list.swap_remove(index).value;
+        list.retain(|e| !(e.line == line && e.col == col));
+        Some(existing)
+    }
+
     pub fn write_inline_snapshots(&mut self) -> Result<bool, Error> {
         // `success` is a Cell so the per-iteration error-check guard
         // closure can flip it without holding a &mut across the loop body.

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -882,7 +882,22 @@ describe("bun test", () => {
       });
       expect(stderr).toContain(`%`);
     });
-    test.todo("check formatting for %p", () => {});
+    test("check formatting for %p", () => {
+      const stderr = runTest({
+        args: [],
+        input: `
+          import { test, expect } from "bun:test";
+
+          test.each([[{ foo: "bar" }], [[1, 2]], ["str"], [1.5]])("pretty: %p", () => {});
+        `,
+      });
+      // %p must inspect its argument onto a single line; a multi-line test
+      // name breaks the console layout and JUnit consumers.
+      expect(stderr).toContain('pretty: { foo: "bar" }');
+      expect(stderr).toContain("pretty: [ 1, 2 ]");
+      expect(stderr).toContain('pretty: "str"');
+      expect(stderr).toContain("pretty: 1.5");
+    });
 
     describe("$variable syntax", () => {
       test("should replace $variables with object properties in test names", () => {

--- a/test/js/bun/test/failure-skip.test.ts
+++ b/test/js/bun/test/failure-skip.test.ts
@@ -102,4 +102,35 @@ describe("failure-skip", async () => {
     expect(report).toInclude('skipped="2"');
     expect(exitCode).toBe(1);
   });
+
+  // A test filtered out by -t must stay in the "filtered out" bucket even
+  // when its scope's beforeAll throws, not get promoted to a regular skip.
+  test("a failing beforeAll keeps -t filtered-out tests suppressed", async () => {
+    using dir = tempDir("failure-skip-filter", {
+      "filter.test.ts": `
+        import { test, describe, beforeAll } from "bun:test";
+        describe("d", () => {
+          beforeAll(() => {
+            throw new Error("boom");
+          });
+          test("yes-match", () => {});
+          test("no-thanks", () => {});
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "-t", "yes-match", "filter.test.ts"],
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: String(dir),
+      env: bunEnv,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toMatch(/\(skip\) d > yes-match\b/);
+    expect(stderr).not.toInclude("(skip) d > no-thanks");
+    expect(stderr).toInclude("1 skip");
+    // fail(hook) + skip(yes-match); the filtered-out test is not counted
+    expect(stderr).toInclude("Ran 2 tests across 1 file");
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/test/failure-skip.test.ts
+++ b/test/js/bun/test/failure-skip.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readFileSync } from "fs";
+import { join } from "path";
 
 async function testFailureSkip(failurePoints: string[]): Promise<string[]> {
   const result = await Bun.spawn({
@@ -69,5 +71,35 @@ describe("failure-skip", async () => {
     expect(await testFailureSkip(["afterall2"])).toMatchInlineSnapshot(
       `"beforeall1,beforeall2,beforeeach1,beforeeach2,test1,aftereach1,aftereach2,beforeeach1,beforeeach2,test2,aftereach1,aftereach2,afterall1,afterall2"`,
     );
+  });
+
+  // A failing beforeAll must still report the tests it skipped. They used to
+  // vanish from the console, the summary counts, and the JUnit report.
+  test("a failing beforeAll reports its tests as skipped", async () => {
+    using dir = tempDir("failure-skip-report", {});
+    const junit = join(String(dir), "junit.xml");
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "test",
+        "--reporter=junit",
+        "--reporter-outfile=" + junit,
+        import.meta.dir + "/failure-skip.fixture.ts",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...bunEnv, FAILURE_POINTS: "beforeall1" },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toMatch(/\(skip\) test\b/);
+    expect(stderr).toMatch(/\(skip\) test1\b/);
+    expect(stderr).toInclude("2 skip");
+    expect(stderr).toInclude("1 fail");
+    expect(stderr).toInclude("Ran 3 tests across 1 file");
+    const report = readFileSync(junit, "utf-8");
+    expect(report).toInclude('tests="3"');
+    expect(report).toInclude('failures="1"');
+    expect(report).toInclude('skipped="2"');
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/test/failure-skip.test.ts
+++ b/test/js/bun/test/failure-skip.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
 import { readFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 async function testFailureSkip(failurePoints: string[]): Promise<string[]> {

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 const NUMBERS = [
   [1, 1, 2],
@@ -56,4 +57,34 @@ describe.each(["some", "cool", "strings"])("works with describe: %s", s => {
 
 describe("does not return zero", () => {
   expect(it.each([1, 2])("wat", () => {})).toBeUndefined();
+});
+
+// %s and %i with a non-integer number were left as the literal specifier, and
+// %p / $var produced multi-line test names, which corrupts the JUnit output.
+test("title specifiers substitute every number and stay on one line", async () => {
+  using dir = tempDir("jest-each-titles", {
+    "titles.test.ts": `
+      import { test } from "bun:test";
+      test.each([[1.5]])("s=%s", () => {});
+      test.each([[1.5]])("i=%i", () => {});
+      test.each([[1.5]])("d=%d", () => {});
+      test.each([[1.5]])("f=%f", () => {});
+      test.each([[{ a: 1 }]])("p=%p", () => {});
+      test.each([[{ a: 1 }]])("sobj=%s", () => {});
+      test.each([{ a: { b: 2 } }])("var=$a", () => {});
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "titles.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  for (const title of ["s=1.5", "i=1", "d=1.5", "f=1.5", "p={ a: 1 }", "sobj={ a: 1 }", "var={ b: 2 }"]) {
+    expect(stderr).toInclude(`(pass) ${title}`);
+  }
+  expect(stderr).toInclude("7 pass");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -619,18 +619,26 @@ Date)
     );
   });
   it("should error trying to update the same line twice", async () => {
-    await tester.testError(
-      {
-        msg: "error: Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value",
-      },
-      /*js*/ `
-        function oops(a) {expect(a).toMatchInlineSnapshot()}
-        test("whoops", () => {
-          oops(1);
-          oops(2);
-        });
-      `,
-    );
+    const code = /*js*/ `
+      function oops(a) {expect(a).toMatchInlineSnapshot()}
+      test("whoops", () => {
+        oops(1);
+        oops(2);
+      });
+    `;
+    const thefile = tester.tmpfile(code);
+    const junit = tester.tmpdir + "/" + thefile + ".junit.xml";
+    const res = await tester.spawn(["--reporter=junit", "--reporter-outfile=" + junit], thefile);
+    const err = res.stderr.toString();
+    expect(err).toInclude("Multiple inline snapshots on the same line must all have the same value");
+    // The conflict has to fail the test itself so the reporters, the JUnit
+    // output, and the exit code all agree.
+    expect(err).toInclude("(fail) whoops");
+    expect(err).toInclude("0 pass");
+    expect(err).toInclude("1 fail");
+    expect(readFileSync(junit, "utf-8")).toInclude('failures="1"');
+    expect(tester.readfile(thefile)).toEqual(code);
+    expect(res.exitCode).toBe(1);
 
     // fun trick:
     // function oops(a) {expect(a).toMatchInlineSnapshot('1')}

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -317,10 +317,9 @@ for (const inlineSnapshot of [false, true]) {
         );
       });
 
-      // This is the only test in the file not registered through
-      // SnapshotTester.test, so it needs the same debug-aware timeout. When
-      // it times out, its in-flight toMatchSnapshot() lands on whichever test
-      // runs next, silently appending a bogus entry to this file's snapshot.
+      // This test does the most child spawns in the file (4 update calls) and
+      // needs the debug-aware timeout SnapshotTester.test applies, or it times
+      // out and leaks a stray toMatchSnapshot() onto the next test's counter.
       test(
         "grow file for new snapshot",
         async () => {

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -317,27 +317,35 @@ for (const inlineSnapshot of [false, true]) {
         );
       });
 
-      test("grow file for new snapshot", async () => {
-        const t4 = new SnapshotTester(inlineSnapshot);
-        await t4.update(/*js*/ `
+      // This is the only test in the file not registered through
+      // SnapshotTester.test, so it needs the same debug-aware timeout. When
+      // it times out, its in-flight toMatchSnapshot() lands on whichever test
+      // runs next, silently appending a bogus entry to this file's snapshot.
+      test(
+        "grow file for new snapshot",
+        async () => {
+          const t4 = new SnapshotTester(inlineSnapshot);
+          await t4.update(/*js*/ `
               test("abc", () => { expect("hello").toMatchSnapshot() });
             `);
-        await t4.update(
-          /*js*/ `
+          await t4.update(
+            /*js*/ `
                 test("abc", () => { expect("hello").toMatchSnapshot() });
                 test("def", () => { expect("goodbye").toMatchSnapshot() });
               `,
-          { shouldNotError: true, shouldGrow: true },
-        );
-        await t4.update(/*js*/ `
+            { shouldNotError: true, shouldGrow: true },
+          );
+          await t4.update(/*js*/ `
               test("abc", () => { expect("hello").toMatchSnapshot() });
               test("def", () => { expect("hello").toMatchSnapshot() });
             `);
-        await t4.update(/*js*/ `
+          await t4.update(/*js*/ `
               test("abc", () => { expect("goodbye").toMatchSnapshot() });
               test("def", () => { expect("hello").toMatchSnapshot() });
             `);
-      });
+        },
+        isDebug ? 100_000 : 5_000,
+      );
 
       const t2 = new SnapshotTester(inlineSnapshot);
       t2.test("backtick in test name", `test("\`", () => {expect("abc").toMatchSnapshot();})`);

--- a/test/regression/issue/12782.test.ts
+++ b/test/regression/issue/12782.test.ts
@@ -32,14 +32,17 @@ test("12782", async () => {
     error: Environment variable FOO is not set
         at <anonymous> (file:NN:NN)
     (fail) (unnamed)
+    (skip) foo > should not run
+    (skip) foo > inner describe > should not run
 
     test/regression/issue/12782.bar.fixture.ts:
     (pass) bar > should not run
     (pass) bar > inner describe > should not run
 
      2 pass
+     2 skip
      1 fail
-    Ran 3 tests across 2 files."
+    Ran 5 tests across 2 files."
   `);
   expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
Three `bun test` reporter correctness bugs. Each is deterministic, each has a test that fails on current main and passes with the fix.

## 1. A failing inline snapshot reports as passing

```ts
import { test, expect } from "bun:test";
test("t", () => { for (const v of [1, 2]) expect(v).toMatchInlineSnapshot(); });
```

On current main this prints `error: Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value`, exits 1, and never modifies the source file, while the reporter says `1 pass / 0 fail / snapshots: +1 added` and the JUnit report says `tests="1" failures="0"`. CI keyed on JUnit or test summaries shows green for a run whose exit code is red, and the failing test is recorded as passing.

Cause: the conflict is only detected by `Snapshots::write_inline_snapshots`, which runs after the whole test run, when it can no longer be attributed to a test. `Expect::inline_snapshot` pushes onto `inline_snapshots_to_write` blindly and returns `Ok(undefined)`, so the test is marked Pass.

Fix: check the pending queue for an existing entry at the same `(line, col)` at record time. If a different value is already queued, throw from the matcher, so the test itself fails and the summary, the JUnit report, and the exit code all agree. The queued entries for that call site are removed so the source file is still left untouched.

## 2. Tests vanish when a beforeAll hook throws

```ts
import { test, beforeAll } from "bun:test";
beforeAll(() => { throw new Error("boom") });
test("a", () => {});
test("b", () => {});
```

On current main this reports one `(fail) (unnamed)` and `Ran 1 test across 1 file`. Tests `a` and `b` are absent from the console output, the summary counts, and the JUnit report. `docs/test/lifecycle.mdx` says "all tests in this scope will be skipped".

Cause: on a beforeAll failure, `step_group` jumps `group_index` straight to `failure_skip_to`, so the jumped-over sequences never reach `on_sequence_completed` and never hit the reporter.

Fix: before taking the jump, report each jumped-over test sequence as skipped (or todo, for `test.todo`). Only hook groups have `failure_skip_to > group_index + 1` (`Order.rs`), so the loop is a no-op for ordinary failing test groups, and hook sequences in the range (a second beforeAll) are not reported as testcases. Execution order is unchanged; `failure-skip.test.ts`'s existing ordering snapshots all still pass.

## 3. test.each title formatting

```ts
test.each([[1.5]])("i %i", () => {});          // title "i %i"   (not substituted)
test.each([[1.5]])("s %s", () => {});          // title "s %s"   (not substituted)
test.each([[{ a: 1 }]])("p %p", () => {});     // title "p {\n  a: 1,\n}"  (multi-line)
```

`%s` only substituted string arguments and `%i` only integral numbers; any other argument left the literal `%s`/`%i` in the test name. `%p` (and `$variable` for object values) printed the value through the multi-line formatter, producing multi-line test names that corrupt the console layout and break JUnit consumers.

jest-each delegates these to node's `util.format`, which Bun already implements with the expected results (`%s` of `1.5` is `"1.5"`, `%i` of `1.5` is `"1"`). Fix: route non-string `%s` arguments through the inspector on a single line, truncate non-integral numbers for `%i`, and format `%p`/`$variable`/`%s` objects on a single line. The never-written `test.todo("check formatting for %p")` in `test/cli/test/bun-test.test.ts` is implemented alongside the other specifier tests.

## Also

`grow file for new snapshot` in `snapshot.test.ts` is registered via a bare `test()` without the `isDebug ? 100_000 : 5_000` timeout that `SnapshotTester.test` applies. It does the most child spawns of any test in the file (4 `update()` calls), so under a debug build it times out at the default 5s, and the timed-out body's in-flight `toMatchSnapshot()` then lands on whichever test runs next, silently appending a bogus `backtick in test name 2` entry to the file's own committed snapshot. It now gets the same timeout the `SnapshotTester.test` registrations have.

A review comment caught that the catch-all in the beforeAll skip-reporting loop mapped `ScopeMode::FilteredOut` to `Result::Skip`, where the normal path (`step_sequence_one`) maps it to `Result::SkippedBecauseLabel`. With a `-t` filter and a throwing `beforeAll` in the same scope, a filtered-out test was printed as a regular skip and counted in `summary.skip` instead of staying suppressed. Fixed with a `ScopeMode::FilteredOut => Result::SkippedBecauseLabel` arm and covered by `a failing beforeAll keeps -t filtered-out tests suppressed`.

`test/regression/issue/12782.test.ts` snapshots the reporter output for a fixture with a throwing `beforeAll`, so its inline snapshot is updated for the two tests that are now reported as skipped (`2 skip`, `Ran 5 tests`). Execution is unchanged; the fixture's tests still do not run. This was the only test in the repository whose expectation captures a failing-hook reporter line, and the only real failure in the CI run at f5dd9fa.

## Verification

Each test fails on the released binary and passes with the fix:

- `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` `should error trying to update the same line twice`: strengthened from an error-string check (which already passed, because the error string existed, just not attributed to the test) to assert `(fail) whoops`, `0 pass`, `1 fail`, `failures="1"` in JUnit, and that the source file is unchanged.
- `test/js/bun/test/failure-skip.test.ts` `a failing beforeAll reports its tests as skipped`: asserts both tests appear as `(skip)`, `2 skip`, `Ran 3 tests`, and `tests="3" failures="1" skipped="2"` in JUnit.
- `test/js/bun/test/jest-each.test.ts` `title specifiers substitute every number and stay on one line`: asserts the exact `(pass)` line for each specifier.
- `test/cli/test/bun-test.test.ts` `check formatting for %p`.
- `test/js/bun/test/failure-skip.test.ts` `a failing beforeAll keeps -t filtered-out tests suppressed`: asserts the `-t` filtered-out test never prints a `(skip)` line and is not counted (`1 skip`, `Ran 2 tests`). Fails on main (the test vanishes entirely) and without the `FilteredOut` arm (it shows as a regular skip, `2 skip`, `Ran 3 tests`).

Also ran `test/js/bun/test/{test-test,bun_test,jest-hooks,dots,concurrent,concurrent_immediate,only-failures,describe,test-failing,expect}.test.*`, `test/js/junit-reporter/junit.test.js`, and `test/cli/test/{bun-test,isolation}.test.ts` against the debug build; no regressions. No committed `.snap` file anywhere in `test/` has a multi-line key, so the `%p` title change cannot orphan an existing snapshot.


