### PR TITLE
webcrypto: fix deriveBits length 0 and non-byte-aligned truncation

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
@@ -62,7 +62,7 @@ void CryptoAlgorithm::generateKey(const CryptoAlgorithmParameters&, bool, Crypto
     exceptionCallback(NotSupportedError, ""_s);
 }
 
-void CryptoAlgorithm::deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t, VectorCallback&&, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&, WorkQueue&)
+void CryptoAlgorithm::deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t>, VectorCallback&&, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&, WorkQueue&)
 {
     exceptionCallback(NotSupportedError, ""_s);
 }
@@ -87,9 +87,22 @@ void CryptoAlgorithm::unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallb
     exceptionCallback(NotSupportedError, ""_s);
 }
 
-ExceptionOr<size_t> CryptoAlgorithm::getKeyLength(const CryptoAlgorithmParameters&)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithm::getKeyLength(const CryptoAlgorithmParameters&)
 {
     return Exception { NotSupportedError };
+}
+
+std::optional<Vector<uint8_t>> CryptoAlgorithm::extractDerivedBits(std::optional<size_t> length, Vector<uint8_t>&& secret)
+{
+    if (!length)
+        return WTF::move(secret);
+    auto lengthInBytes = (*length + 7) / 8;
+    if (lengthInBytes > secret.size())
+        return std::nullopt;
+    secret.shrink(lengthInBytes);
+    if (auto remainder = *length % 8)
+        secret.last() &= static_cast<uint8_t>(0xFF << (8 - remainder));
+    return WTF::move(secret);
 }
 
 template<typename ResultCallbackType, typename OperationType>

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.h
@@ -31,6 +31,7 @@
 #include "CryptoKeyUsage.h"
 #include "ExceptionOr.h"
 #include "JsonWebKey.h"
+#include <optional>
 #include <variant>
 #include <wtf/Function.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -69,16 +70,21 @@ public:
     virtual void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     virtual void digest(Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     virtual void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
-    virtual void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
+    virtual void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=169262
     virtual void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&);
     virtual void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&);
     virtual void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&);
     virtual void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&);
-    virtual ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&);
+    virtual ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&);
 
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, VectorCallback&&, ExceptionCallback&&, Function<ExceptionOr<Vector<uint8_t>>()>&&);
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, BoolCallback&&, ExceptionCallback&&, Function<ExceptionOr<bool>()>&&);
+
+    // Truncates `secret` to the first `length` bits, zeroing the unused trailing bits of the
+    // final byte, per https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits. A null
+    // `length` returns `secret` unchanged; a `length` larger than `secret` yields nullopt.
+    static std::optional<Vector<uint8_t>> extractDerivedBits(std::optional<size_t> length, Vector<uint8_t>&& secret);
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp
@@ -189,7 +189,7 @@ void CryptoAlgorithmAES_CBC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& 
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_CBC::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_CBC::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.h
@@ -58,7 +58,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp
@@ -189,7 +189,7 @@ void CryptoAlgorithmAES_CFB::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& 
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_CFB::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_CFB::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.h
@@ -49,7 +49,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesCbcCfbParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmAesCbcCfbParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp
@@ -198,7 +198,7 @@ void CryptoAlgorithmAES_CTR::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& 
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_CTR::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_CTR::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.h
@@ -77,7 +77,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesCtrParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmAesCtrParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp
@@ -237,7 +237,7 @@ void CryptoAlgorithmAES_GCM::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& 
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_GCM::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_GCM::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.h
@@ -49,7 +49,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp
@@ -179,7 +179,7 @@ void CryptoAlgorithmAES_KW::unwrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& da
     callback(result.releaseReturnValue());
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_KW::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_KW::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.h
@@ -48,7 +48,7 @@ private:
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
     void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&) final;
     void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformWrapKey(const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformUnwrapKey(const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp
@@ -66,7 +66,7 @@ void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameter
     callback(WTF::move(pair));
 }
 
-void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
     auto& ecParameters = downcast<CryptoAlgorithmEcdhKeyDeriveParams>(parameters);
 
@@ -90,22 +90,17 @@ void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters
         return;
     }
 
-    auto unifiedCallback = [callback = WTF::move(callback), exceptionCallback = WTF::move(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, size_t length) mutable {
+    auto unifiedCallback = [callback = WTF::move(callback), exceptionCallback = WTF::move(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, std::optional<size_t> length) mutable {
         if (!derivedKey) {
             exceptionCallback(OperationError, ""_s);
             return;
         }
-        if (!length) {
-            callback(WTF::move(*derivedKey));
-            return;
-        }
-        auto lengthInBytes = std::ceil(length / 8.);
-        if (lengthInBytes > (*derivedKey).size()) {
+        auto result = extractDerivedBits(length, WTF::move(*derivedKey));
+        if (!result) {
             exceptionCallback(OperationError, ""_s);
             return;
         }
-        (*derivedKey).shrink(lengthInBytes);
-        callback(WTF::move(*derivedKey));
+        callback(WTF::move(*result));
     };
 
     // This is a special case that can't use dispatchOperation() because it bundles

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.h
@@ -47,7 +47,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 };

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.cpp
@@ -53,8 +53,8 @@ void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTF::move(baseKey), length = *length]() -> ExceptionOr<Vector<uint8_t>> {
-            return length ? platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length) : Vector<uint8_t>();
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTF::move(baseKey), length = *length] {
+            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length);
         });
 }
 

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.cpp
@@ -45,16 +45,16 @@ CryptoAlgorithmIdentifier CryptoAlgorithmHKDF::identifier() const
     return s_identifier;
 }
 
-void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    if (!length || length % 8) {
+    if (!length || *length % 8) {
         exceptionCallback(OperationError, ""_s);
         return;
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTF::move(baseKey), length] {
-            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length);
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTF::move(baseKey), length = *length]() -> ExceptionOr<Vector<uint8_t>> {
+            return length ? platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length) : Vector<uint8_t>();
         });
 }
 
@@ -76,9 +76,9 @@ void CryptoAlgorithmHKDF::importKey(CryptoKeyFormat format, KeyData&& data, cons
     callback(CryptoKeyRaw::create(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), usages));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmHKDF::getKeyLength(const CryptoAlgorithmParameters&)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmHKDF::getKeyLength(const CryptoAlgorithmParameters&)
 {
-    return 0;
+    return std::optional<size_t>();
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.h
@@ -44,9 +44,9 @@ private:
     CryptoAlgorithmHKDF() = default;
     CryptoAlgorithmIdentifier identifier() const final;
 
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t);
 };

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
@@ -200,7 +200,7 @@ void CryptoAlgorithmHMAC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmHMAC::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmHMAC::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyHMAC::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.h
@@ -54,7 +54,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.cpp
@@ -45,16 +45,16 @@ CryptoAlgorithmIdentifier CryptoAlgorithmPBKDF2::identifier() const
     return s_identifier;
 }
 
-void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    if (!length || length % 8) {
+    if (!length || *length % 8) {
         exceptionCallback(OperationError, ""_s);
         return;
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmPbkdf2Params>(parameters)), baseKey = WTF::move(baseKey), length] {
-            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length);
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmPbkdf2Params>(parameters)), baseKey = WTF::move(baseKey), length = *length]() -> ExceptionOr<Vector<uint8_t>> {
+            return length ? platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length) : Vector<uint8_t>();
         });
 }
 
@@ -76,9 +76,9 @@ void CryptoAlgorithmPBKDF2::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(CryptoKeyRaw::create(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), usages));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmPBKDF2::getKeyLength(const CryptoAlgorithmParameters&)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmPBKDF2::getKeyLength(const CryptoAlgorithmParameters&)
 {
-    return 0;
+    return std::optional<size_t>();
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.cpp
@@ -53,8 +53,8 @@ void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& paramete
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmPbkdf2Params>(parameters)), baseKey = WTF::move(baseKey), length = *length]() -> ExceptionOr<Vector<uint8_t>> {
-            return length ? platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length) : Vector<uint8_t>();
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmPbkdf2Params>(parameters)), baseKey = WTF::move(baseKey), length = *length] {
+            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length);
         });
 }
 

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.h
@@ -44,9 +44,9 @@ private:
     CryptoAlgorithmPBKDF2() = default;
     CryptoAlgorithmIdentifier identifier() const final;
 
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmPbkdf2Params&, const CryptoKeyRaw&, size_t);
 };

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.cpp
@@ -70,7 +70,7 @@ std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const C
 }
 #endif
 
-void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
     if (baseKey->type() != CryptoKey::Type::Private) {
         exceptionCallback(ExceptionCode::InvalidAccessError, ""_s);
@@ -107,17 +107,12 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
             return;
         }
 #endif
-        if (!length) {
-            callback(WTF::move(*derivedKey));
-            return;
-        }
-        auto lengthInBytes = static_cast<size_t>(std::ceil(length / 8.));
-        if (lengthInBytes > (*derivedKey).size()) {
+        auto result = extractDerivedBits(length, WTF::move(*derivedKey));
+        if (!result) {
             exceptionCallback(ExceptionCode::OperationError, ""_s);
             return;
         }
-        (*derivedKey).shrink(lengthInBytes);
-        callback(WTF::move(*derivedKey));
+        callback(WTF::move(*result));
     };
     // This is a special case that can't use dispatchOperation() because it bundles
     // the result validation and callback dispatch into unifiedCallback.

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.h
@@ -38,7 +38,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 

--- a/src/jsc/bindings/webcrypto/CryptoKeyAES.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyAES.cpp
@@ -113,7 +113,7 @@ JsonWebKey CryptoKeyAES::exportJwk() const
     return result;
 }
 
-ExceptionOr<size_t> CryptoKeyAES::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoKeyAES::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     auto& aesParameters = downcast<CryptoAlgorithmAesKeyParams>(parameters);
     if (!lengthIsValid(aesParameters.length))

--- a/src/jsc/bindings/webcrypto/CryptoKeyAES.h
+++ b/src/jsc/bindings/webcrypto/CryptoKeyAES.h
@@ -63,7 +63,7 @@ public:
     const Vector<uint8_t>& key() const { return m_key; }
     JsonWebKey exportJwk() const;
 
-    static ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&);
+    static ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&);
 
 private:
     CryptoKeyAES(CryptoAlgorithmIdentifier, const Vector<uint8_t>& key, bool extractable, CryptoKeyUsageBitmap);

--- a/src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp
@@ -143,7 +143,7 @@ JsonWebKey CryptoKeyHMAC::exportJwk() const
     return result;
 }
 
-ExceptionOr<size_t> CryptoKeyHMAC::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoKeyHMAC::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     auto& aesParameters = downcast<CryptoAlgorithmHmacKeyParams>(parameters);
 

--- a/src/jsc/bindings/webcrypto/CryptoKeyHMAC.h
+++ b/src/jsc/bindings/webcrypto/CryptoKeyHMAC.h
@@ -59,7 +59,7 @@ public:
 
     CryptoAlgorithmIdentifier hashAlgorithmIdentifier() const { return m_hash; }
 
-    static ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&);
+    static ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&);
 
 private:
     CryptoKeyHMAC(const Vector<uint8_t>& key, CryptoAlgorithmIdentifier hash, bool extractable, CryptoKeyUsageBitmap);

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
@@ -38,6 +38,7 @@
 #include "JSDOMConvertBufferSource.h"
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMConvertInterface.h"
+#include "JSDOMConvertNullable.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertObject.h"
 #include "JSDOMConvertPromise.h"
@@ -193,7 +194,7 @@ static const HashTableValue JSSubtleCryptoPrototypeTableValues[] = {
     { "digest"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_digest, 2 } },
     { "generateKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_generateKey, 3 } },
     { "deriveKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_deriveKey, 5 } },
-    { "deriveBits"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_deriveBits, 3 } },
+    { "deriveBits"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_deriveBits, 2 } },
     { "importKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_importKey, 5 } },
     { "exportKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_exportKey, 2 } },
     { "wrapKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_wrapKey, 4 } },
@@ -455,7 +456,7 @@ static inline JSC::EncodedJSValue jsSubtleCryptoPrototypeFunction_deriveBitsBody
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    if (callFrame->argumentCount() < 3) [[unlikely]]
+    if (callFrame->argumentCount() < 2) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto algorithm = convert<IDLUnion<IDLObject, IDLDOMString>>(*lexicalGlobalObject, argument0.value());
@@ -463,8 +464,8 @@ static inline JSC::EncodedJSValue jsSubtleCryptoPrototypeFunction_deriveBitsBody
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
     auto baseKey = convert<IDLInterface<CryptoKey>>(*lexicalGlobalObject, argument1.value(), [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentTypeError(lexicalGlobalObject, scope, 1, "baseKey"_s, "SubtleCrypto"_s, "deriveBits"_s, "CryptoKey"_s); });
     RETURN_IF_EXCEPTION(throwScope, {});
-    EnsureStillAliveScope argument2 = callFrame->uncheckedArgument(2);
-    auto length = convert<IDLUnsignedLong>(*lexicalGlobalObject, argument2.value());
+    EnsureStillAliveScope argument2 = callFrame->argument(2);
+    auto length = convert<IDLNullable<IDLUnsignedLong>>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, {});
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLPromise<IDLArrayBuffer>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, [&]() -> decltype(auto) { return impl.deriveBits(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(algorithm), *baseKey, WTF::move(length), WTF::move(promise)); })));
 }

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -970,7 +970,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
         promise->reject(result.releaseException().code(), "Cannot get key length from derivedKeyType"_s);
         return;
     }
-    size_t length = result.releaseReturnValue();
+    std::optional<size_t> length = result.releaseReturnValue();
 
     auto importAlgorithm = CryptoAlgorithmRegistry::singleton().create(importParams->identifier);
     auto algorithm = CryptoAlgorithmRegistry::singleton().create(params->identifier);
@@ -1005,7 +1005,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
     RELEASE_AND_RETURN(scope, algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *scriptExecutionContext(), m_workQueue));
 }
 
-void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, unsigned length, Ref<DeferredPromise>&& promise)
+void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, std::optional<unsigned> length, Ref<DeferredPromise>&& promise)
 {
     auto& vm = state.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.h
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.h
@@ -30,6 +30,7 @@
 #include "ContextDestructionObserver.h"
 #include "CryptoKeyFormat.h"
 #include <JavaScriptCore/Strong.h>
+#include <optional>
 #include <variant>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -73,7 +74,7 @@ public:
     void digest(JSC::JSGlobalObject&, AlgorithmIdentifier&&, BufferSource&& data, Ref<DeferredPromise>&&);
     void generateKey(JSC::JSGlobalObject&, AlgorithmIdentifier&&, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&&);
     void deriveKey(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, AlgorithmIdentifier&& derivedKeyType, bool extractable, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&&);
-    void deriveBits(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, unsigned length, Ref<DeferredPromise>&&);
+    void deriveBits(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, std::optional<unsigned> length, Ref<DeferredPromise>&&);
     void importKey(JSC::JSGlobalObject&, KeyFormat, KeyDataVariant&&, AlgorithmIdentifier&&, bool extractable, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&&);
     void exportKey(KeyFormat, CryptoKey&, Ref<DeferredPromise>&&);
     void wrapKey(JSC::JSGlobalObject&, KeyFormat, CryptoKey&, CryptoKey& wrappingKey, AlgorithmIdentifier&& wrapAlgorithm, Ref<DeferredPromise>&&);

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.idl
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.idl
@@ -40,7 +40,7 @@ typedef (object or DOMString) AlgorithmIdentifier;
     [CallWith=CurrentGlobalObject] Promise<any> digest(AlgorithmIdentifier algorithm, BufferSource data);
     [CallWith=CurrentGlobalObject] Promise<any> generateKey(AlgorithmIdentifier algorithm, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
     [CallWith=CurrentGlobalObject] Promise<any> deriveKey(AlgorithmIdentifier algorithm, CryptoKey baseKey, AlgorithmIdentifier derivedKeyType, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
-    [CallWith=CurrentGlobalObject] Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm, CryptoKey baseKey, unsigned long length);
+    [CallWith=CurrentGlobalObject] Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm, CryptoKey baseKey, optional unsigned long? length = null);
     [CallWith=CurrentGlobalObject] Promise<CryptoKey> importKey(KeyFormat format, (BufferSource or JsonWebKey) keyData, AlgorithmIdentifier algorithm, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
     Promise<any> exportKey(KeyFormat format, CryptoKey key);
     [CallWith=CurrentGlobalObject] Promise<any> wrapKey(KeyFormat format, CryptoKey key, CryptoKey wrappingKey, AlgorithmIdentifier wrapAlgorithm);

--- a/test/js/bun/crypto/x25519-derive-bits.test.ts
+++ b/test/js/bun/crypto/x25519-derive-bits.test.ts
@@ -35,14 +35,25 @@ test("X25519 deriveBits with null length returns full output", async () => {
   expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
 });
 
-test("X25519 deriveBits with zero length returns full output", async () => {
+test("X25519 deriveBits with omitted length returns full output", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(bits.byteLength).toBe(32);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+// A zero length is distinct from a null length: it requests zero bits, not all of them.
+// https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits
+test("X25519 deriveBits with zero length returns zero bits", async () => {
   const { privateKey, publicKey } = await importX25519Keys();
 
   const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 0);
 
   expect(bits).toBeInstanceOf(ArrayBuffer);
-  expect(bits.byteLength).toBe(32);
-  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+  expect(bits.byteLength).toBe(0);
 });
 
 test("X25519 deriveBits with shorter length", async () => {
@@ -53,6 +64,21 @@ test("X25519 deriveBits with shorter length", async () => {
   expect(bits).toBeInstanceOf(ArrayBuffer);
   expect(bits.byteLength).toBe(16);
   expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result.slice(0, 32));
+});
+
+// A non-multiple-of-8 length returns the first `length` bits: the unused trailing bits of
+// the final byte must be zeroed. 0x27 & 0b11100000 == 0x20; 0x08 & 0b11100000 == 0x00.
+test("X25519 deriveBits zeroes the unused trailing bits of the last byte", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const alg = { name: "X25519", public: publicKey };
+  const [bits3, bits251] = await Promise.all([
+    crypto.subtle.deriveBits(alg, privateKey, 3),
+    crypto.subtle.deriveBits(alg, privateKey, 251),
+  ]);
+
+  expect(Buffer.from(bits3).toString("hex")).toBe("20");
+  expect(Buffer.from(bits251).toString("hex")).toBe(x25519Vector.result.slice(0, 62) + "00");
 });
 
 test("X25519 deriveBits with generated keys", async () => {

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -418,3 +418,122 @@ describe("AES-KW wrapKey/unwrapKey with jwk format", () => {
     expect(jwk.k).toBe("AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4_QA");
   });
 });
+
+// The WebIDL for deriveBits is `optional unsigned long? length = null`: `null` (and an
+// omitted/undefined argument) mean "the whole secret", while `0` asks for zero bits.
+// Bun used to treat `0` as the null sentinel and hand back the entire ECDH/X25519 shared
+// secret, and never zeroed the unused trailing bits of the last byte for lengths that
+// are not a multiple of 8. https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits
+describe("SubtleCrypto.deriveBits length", () => {
+  // Fixed P-256 pair so every value below is a known answer; all expectations in this
+  // block were produced by Node.js v26 against the same keys.
+  const ecPriv: JsonWebKey = {
+    kty: "EC",
+    crv: "P-256",
+    x: "bq-02N-hB7K4namaV9F4R30CuRDUhO_JlwjUS10Ns1o",
+    y: "Q2YhmQFI9uq8U1ZzzlmPy25Zar2wWz_jZh7I5QhAeW8",
+    d: "XVoo_2zmaH8lEJOdQMkGgMOIibOecvksDPBRXnhAKo8",
+  };
+  const ecPub: JsonWebKey = {
+    kty: "EC",
+    crv: "P-256",
+    x: "3DyR3pdz7BDZtoAVvm4Mn55Ashdl84LCJB9kcUI3IrQ",
+    y: "r6xDaTpWl7d958Y4HMq6OR4F8PLe1wl7m41I2ZX1yoU",
+  };
+  const ecSecret = "a2a0e8fbdc79f55e5178ee9850f05069d47876abbc1d4db453e6523e6574a17b";
+  const enc = new TextEncoder();
+  const hex = (b: ArrayBuffer) => Buffer.from(b).toString("hex");
+  const probe = (p: Promise<ArrayBuffer>) => p.then(hex, e => e.name);
+
+  async function importEcPair() {
+    const [priv, pub] = await Promise.all([
+      crypto.subtle.importKey("jwk", ecPriv, { name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits", "deriveKey"]),
+      crypto.subtle.importKey("jwk", ecPub, { name: "ECDH", namedCurve: "P-256" }, false, []),
+    ]);
+    return { name: "ECDH" as const, public: pub, priv };
+  }
+
+  it("declares length as optional", () => {
+    expect(crypto.subtle.deriveBits.length).toBe(2);
+  });
+
+  it("ECDH: distinguishes a null/omitted length from a zero length", async () => {
+    const { priv, ...alg } = await importEcPair();
+    expect({
+      null: await probe(crypto.subtle.deriveBits(alg, priv, null)),
+      undefined: await probe(crypto.subtle.deriveBits(alg, priv, undefined)),
+      omitted: await probe(crypto.subtle.deriveBits(alg, priv)),
+      zero: await probe(crypto.subtle.deriveBits(alg, priv, 0)),
+      exact: await probe(crypto.subtle.deriveBits(alg, priv, 256)),
+      tooLong: await probe(crypto.subtle.deriveBits(alg, priv, 257)),
+    }).toEqual({
+      null: ecSecret,
+      undefined: ecSecret,
+      omitted: ecSecret,
+      zero: "",
+      exact: ecSecret,
+      tooLong: "OperationError",
+    });
+  });
+
+  it("ECDH: zeroes the unused trailing bits when length is not a multiple of 8", async () => {
+    const { priv, ...alg } = await importEcPair();
+    const results: Record<number, string> = {};
+    for (const length of [1, 3, 9, 17, 33, 255]) {
+      results[length] = await probe(crypto.subtle.deriveBits(alg, priv, length));
+    }
+    expect(results).toEqual({
+      1: "80",
+      3: "a0",
+      9: "a280",
+      17: "a2a080",
+      33: "a2a0e8fb80",
+      255: "a2a0e8fbdc79f55e5178ee9850f05069d47876abbc1d4db453e6523e6574a17a",
+    });
+  });
+
+  it("HKDF/PBKDF2: a zero length yields zero bytes, a null length is an error", async () => {
+    const [hk, pb] = await Promise.all([
+      crypto.subtle.importKey("raw", enc.encode("secret"), "HKDF", false, ["deriveBits"]),
+      crypto.subtle.importKey("raw", enc.encode("secret"), "PBKDF2", false, ["deriveBits"]),
+    ]);
+    const hkAlg = { name: "HKDF", hash: "SHA-256", salt: enc.encode("salt"), info: enc.encode("info") };
+    const pbAlg = { name: "PBKDF2", hash: "SHA-256", salt: enc.encode("salt"), iterations: 10 };
+    expect({
+      "hkdf 0": await probe(crypto.subtle.deriveBits(hkAlg, hk, 0)),
+      "hkdf null": await probe(crypto.subtle.deriveBits(hkAlg, hk, null)),
+      "hkdf 7": await probe(crypto.subtle.deriveBits(hkAlg, hk, 7)),
+      "hkdf 16": await probe(crypto.subtle.deriveBits(hkAlg, hk, 16)),
+      "pbkdf2 0": await probe(crypto.subtle.deriveBits(pbAlg, pb, 0)),
+      "pbkdf2 null": await probe(crypto.subtle.deriveBits(pbAlg, pb, null)),
+      "pbkdf2 7": await probe(crypto.subtle.deriveBits(pbAlg, pb, 7)),
+      "pbkdf2 16": await probe(crypto.subtle.deriveBits(pbAlg, pb, 16)),
+    }).toEqual({
+      "hkdf 0": "",
+      "hkdf null": "OperationError",
+      "hkdf 7": "OperationError",
+      "hkdf 16": "f6d2",
+      "pbkdf2 0": "",
+      "pbkdf2 null": "OperationError",
+      "pbkdf2 7": "OperationError",
+      "pbkdf2 16": "2fb1",
+    });
+  });
+
+  // deriveKey(derivedKeyType: HKDF) has no inherent key length, so the entire shared
+  // secret must become the imported HKDF key; a derivedKeyType with a concrete length
+  // (AES-GCM 256) must still flow that length through.
+  it("deriveKey still derives the whole secret for length-less derived key types", async () => {
+    const { priv, ...alg } = await importEcPair();
+    const hkdfKey = await crypto.subtle.deriveKey(alg, priv, { name: "HKDF", hash: "SHA-256" }, false, ["deriveBits"]);
+    const bits = await crypto.subtle.deriveBits(
+      { name: "HKDF", hash: "SHA-256", salt: enc.encode("salt"), info: enc.encode("info") },
+      hkdfKey,
+      256,
+    );
+    expect(hex(bits)).toBe("823ff972ada0b090c2f03e1704d01d95bbf67629f44af00b23f5ab2c9e307afc");
+
+    const aesKey = await crypto.subtle.deriveKey(alg, priv, { name: "AES-GCM", length: 256 }, true, ["encrypt"]);
+    expect(hex(await crypto.subtle.exportKey("raw", aesKey))).toBe(ecSecret);
+  });
+});

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -499,6 +499,9 @@ describe("SubtleCrypto.deriveBits length", () => {
     ]);
     const hkAlg = { name: "HKDF", hash: "SHA-256", salt: enc.encode("salt"), info: enc.encode("info") };
     const pbAlg = { name: "PBKDF2", hash: "SHA-256", salt: enc.encode("salt"), iterations: 10 };
+    // A zero iteration count is an OperationError even when zero bits are requested;
+    // the zero-length path must still run the algorithm's parameter validation.
+    const pbIter0 = { ...pbAlg, iterations: 0 };
     expect({
       "hkdf 0": await probe(crypto.subtle.deriveBits(hkAlg, hk, 0)),
       "hkdf null": await probe(crypto.subtle.deriveBits(hkAlg, hk, null)),
@@ -508,6 +511,8 @@ describe("SubtleCrypto.deriveBits length", () => {
       "pbkdf2 null": await probe(crypto.subtle.deriveBits(pbAlg, pb, null)),
       "pbkdf2 7": await probe(crypto.subtle.deriveBits(pbAlg, pb, 7)),
       "pbkdf2 16": await probe(crypto.subtle.deriveBits(pbAlg, pb, 16)),
+      "pbkdf2 iterations 0 length 0": await probe(crypto.subtle.deriveBits(pbIter0, pb, 0)),
+      "pbkdf2 iterations 0 length 256": await probe(crypto.subtle.deriveBits(pbIter0, pb, 256)),
     }).toEqual({
       "hkdf 0": "",
       "hkdf null": "OperationError",
@@ -517,6 +522,8 @@ describe("SubtleCrypto.deriveBits length", () => {
       "pbkdf2 null": "OperationError",
       "pbkdf2 7": "OperationError",
       "pbkdf2 16": "2fb1",
+      "pbkdf2 iterations 0 length 0": "OperationError",
+      "pbkdf2 iterations 0 length 256": "OperationError",
     });
   });
 


### PR DESCRIPTION
Fixes #12343

### Problem

`crypto.subtle.deriveBits(algorithm, baseKey, 0)` returns the entire ECDH / X25519 shared secret instead of zero bits:

```js
const kp = await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);
const bits = await crypto.subtle.deriveBits({ name: "ECDH", public: kp.publicKey }, kp.privateKey, 0);
bits.byteLength; // Bun: 32 (the whole secret)   Node / spec: 0
```

The spec declares the argument as `optional unsigned long? length = null` (changed in w3c/webcrypto#345, which #12343 tracks). Bun's binding converts it as a required non-nullable `unsigned long`, so `null` collapses to `0`, and the algorithm implementations then use `length == 0` as the "return everything" sentinel. Any wrapper that computes `length` dynamically and can reach `0` silently receives the raw shared secret. The same sentinel causes three more divergences (all cross-checked against Node v26):

| call | Bun | Node / spec |
|---|---|---|
| `deriveBits(ecdh, key, 0)` | full 32-byte secret | empty `ArrayBuffer` |
| `deriveBits(ecdh, key)` (length omitted) | `TypeError: Not enough arguments` | full secret |
| `deriveBits(hkdf, key, 0)`, `deriveBits(pbkdf2, key, 0)` | `OperationError` | empty `ArrayBuffer` |
| `deriveBits(ecdh, key, n)` with `n % 8 != 0` | last byte not masked | unused trailing bits zeroed |

The last row is also security-relevant: a non-byte-aligned length returns more secret bits than requested. With a fixed P-256 pair, `deriveBits(..., 255)` gives `...6574a17b` on Bun and `...6574a17a` on Node (`0x7b & 0xfe`).

### Fix

Backport the current WebKit signatures so the length stays nullable end to end: `SubtleCrypto::deriveBits` and `CryptoAlgorithm::deriveBits` take `std::optional<size_t>`, and `getKeyLength` returns `ExceptionOr<std::optional<size_t>>` (HKDF and PBKDF2 report "no inherent length" as `nullopt` instead of `0`). The binding converts the argument with `IDLNullable<IDLUnsignedLong>`, so `null`, `undefined`, and an omitted argument all become `nullopt` while `0` stays `0`. `deriveBits.length` changes from 3 to 2 accordingly.

The ECDH and X25519 truncation now goes through one shared helper, `CryptoAlgorithm::extractDerivedBits`, which also zeroes the unused trailing bits of the final byte (`last &= 0xFF << (8 - length % 8)`). Upstream WebKit still omits that step; Node applies it (`masks[mod]` in `lib/internal/crypto/diffiehellman.js`) and the spec's "the first length bits of secret" requires it.

`deriveKey` behavior is unchanged: `getKeyLength` returning `0` for HKDF/PBKDF2 already meant "derive the whole secret", it now says so with `nullopt`.

### Verification

- `test/js/web/crypto/web-crypto.test.ts` gains a `SubtleCrypto.deriveBits length` block over a fixed P-256 pair. Every expected value was produced by Node v26 against the same keys: null/undefined/omitted/0/256/257, the masked outputs for 1/3/9/17/33/255 bits, HKDF/PBKDF2 with 0/null/7/16, PBKDF2 with a zero iteration count at lengths 0 and 256, and a `deriveKey` round trip through a length-less derived key type.
- `test/js/bun/crypto/x25519-derive-bits.test.ts`: the existing `"zero length returns full output"` test asserted the old behavior; it now asserts zero bytes. New tests cover an omitted length and trailing-bit masking against the RFC 7748 vector.

All of the new assertions fail on `main`. `test/js/deno/crypto/webcrypto.test.ts`, `test/regression/issue/24399.test.ts`, `test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts`, and the eight active `test-webcrypto-*.js` Node compat tests still pass.
