### PR TITLE
websocket: validate close() arguments and reject unmasked client frames

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4443,8 +4443,10 @@ declare module "bun" {
 
     /**
      * Closes the WebSocket connection
-     * @param code A numeric value indicating the status code
-     * @param reason A human-readable string explaining why the connection is closing
+     * @param code A close code an endpoint is allowed to send (RFC 6455): `1000`-`1014` except
+     * the reserved `1004`-`1006`, or `3000`-`4999`. Any other code throws an `InvalidAccessError`.
+     * @param reason A human-readable string explaining why the connection is closing. Throws a
+     * `SyntaxError` if longer than 123 bytes of UTF-8
      */
     close(code?: number, reason?: string): void;
 

--- a/packages/bun-uws/src/WebSocketProtocol.h
+++ b/packages/bun-uws/src/WebSocketProtocol.h
@@ -437,6 +437,13 @@ public:
                     return;
                 }
             }
+            /* A server's SHORT_MESSAGE_HEADER includes the 4-byte masking key, but the mask
+             * bit is already visible once the 2-byte base header is in: an unmasked frame
+             * must be refused now, not spilled until enough of a masked header arrives. */
+            if (isServer && length >= 2 && !isMasked(src)) {
+                Impl::forceClose(wState, user, ERR_INVALID_MASKING);
+                return;
+            }
             if (length) {
                 memcpy(wState->state.spill, src, length);
                 wState->state.spillLength = length & 0xf;

--- a/packages/bun-uws/src/WebSocketProtocol.h
+++ b/packages/bun-uws/src/WebSocketProtocol.h
@@ -36,6 +36,7 @@ const std::string_view ERR_WEBSOCKET_TIMEOUT("WebSocket timed out from inactivit
 const std::string_view ERR_INVALID_TEXT("Received invalid UTF-8");
 const std::string_view ERR_TOO_BIG_MESSAGE_INFLATION("Received too big message, or other inflation error");
 const std::string_view ERR_INVALID_CLOSE_PAYLOAD("Received invalid close payload");
+const std::string_view ERR_INVALID_MASKING("Received an incorrectly masked frame");
 
 enum OpCode : unsigned char {
     CONTINUATION = 0,
@@ -238,6 +239,7 @@ protected:
     static inline unsigned char payloadLength(char *frame) {return ((unsigned char *) frame)[1] & 127;}
     static inline bool rsv23(char *frame) {return *((unsigned char *) frame) & 48;}
     static inline bool rsv1(char *frame) {return *((unsigned char *) frame) & 64;}
+    static inline bool isMasked(char *frame) {return ((unsigned char *) frame)[1] & 128;}
 
     template <int N>
     static inline void UnrolledXor(char * __restrict data, char * __restrict mask) {
@@ -403,6 +405,14 @@ public:
         if (wState->state.wantsHead) {
             parseNext:
             while (length >= SHORT_MESSAGE_HEADER) {
+
+                /* RFC 6455 5.1: a server must refuse unmasked frames, a client masked ones.
+                 * The MESSAGE_HEADER constants assume the mask bit matches our role, so a
+                 * mismatched frame would otherwise desync the parser. */
+                if (isMasked(src) != isServer) {
+                    Impl::forceClose(wState, user, ERR_INVALID_MASKING);
+                    return;
+                }
 
                 // invalid reserved bits / invalid opcodes / invalid control frames / set compressed frame
                 if ((rsv1(src) && !Impl::setCompressed(wState, user)) || rsv23(src) || (getOpCode(src) > 2 && getOpCode(src) < 8) ||

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -2464,13 +2464,16 @@ pub enum ReceiveState {
 }
 
 /// Map a status code received in a Close frame to the `(wire echo, JS dispatch)`
-/// pair. RFC 6455 §7.4.1: codes outside the legal on-wire set (`<1000`, the
-/// reserved `1004`–`1006`, and `1016`–`2999`) are a protocol error, so JS sees
-/// 1002. §7.1.5: the JS-visible code is otherwise the received one. The wire
-/// echo acknowledges a 1001 ("going away") with a normal-closure frame.
+/// pair. RFC 6455 §7.4.1-§7.4.2: codes outside the legal on-wire set (`<1000`,
+/// the reserved `1004`–`1006` and `1015`–`2999`, and the undefined `>4999`) are
+/// a protocol error, so JS sees 1002. §7.1.5: the JS-visible code is otherwise
+/// the received one. The wire echo acknowledges a 1001 ("going away") with a
+/// normal-closure frame.
 fn received_close_codes(received: u16) -> (u16, u16) {
-    let is_invalid =
-        received < 1000 || (1004..1007).contains(&received) || (1016..=2999).contains(&received);
+    let is_invalid = received < 1000
+        || (1004..1007).contains(&received)
+        || (1015..=2999).contains(&received)
+        || received > 4999;
     let dispatch = if is_invalid { 1002 } else { received };
     let echo = if dispatch == 1001 { 1000 } else { dispatch };
     (echo, dispatch)

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -118,6 +118,15 @@ static size_t getFramingOverhead(size_t payloadSize)
 
 const size_t maxReasonSizeInBytes = 123;
 
+// Close codes an endpoint may put on the wire (RFC 6455 7.4 + the IANA registry).
+// Deliberately the RFC endpoint set, not the browser's "1000 or 3000-4999":
+// non-browser clients legitimately send 1001 or 1011, and `ws` accepts the same set.
+static inline bool isValidCloseCodeForSending(uint16_t code)
+{
+    return (code >= 1000 && code <= 1014 && code != 1004 && code != 1005 && code != 1006)
+        || (code >= 3000 && code <= 4999);
+}
+
 static inline bool isValidProtocolCharacter(char16_t character)
 {
     // Hybi-10 says "(Subprotocol string must consist of) characters in the range U+0021 to U+007E not including
@@ -969,18 +978,18 @@ void WebSocket::failConnectingWebSocket()
 
 ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, const String& reason)
 {
-    int code = optionalCode ? optionalCode.value() : static_cast<int>(1000);
-    if (code == 1000) {
-        // LOG(Network, "WebSocket %p close() without code and reason", this);
-    } else {
-        // LOG(Network, "WebSocket %p close() code=%d reason='%s'", this, code, reason.utf8().data());
-        // if (!(code == WebSocketChannel::CloseEventCodeNormalClosure || (WebSocketChannel::CloseEventCodeMinimumUserDefined <= code && code <= WebSocketChannel::CloseEventCodeMaximumUserDefined)))
-        //     return Exception { InvalidAccessError };
-        if (reason.length() > maxReasonSizeInBytes) {
-            // scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "WebSocket close message is too long."_s);
-            return Exception { SyntaxError, "WebSocket close message is too long."_s };
-        }
+    // https://websockets.spec.whatwg.org/#dom-websocket-close
+    // Validation happens before the readyState checks: an invalid code or an
+    // over-long reason throws even on a CLOSING/CLOSED socket.
+    if (optionalCode && !isValidCloseCodeForSending(optionalCode.value()))
+        return Exception { InvalidAccessError, makeString("The close code must be a valid WebSocket close code (1000-1014, excluding the reserved codes 1004-1006, or in the range of 3000 to 4999). Received "_s, optionalCode.value(), '.') };
+    if (!reason.isEmpty()) {
+        // The limit is on the UTF-8 encoding of the reason, not its UTF-16 length.
+        auto utf8Reason = reason.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
+        if (utf8Reason.length() > maxReasonSizeInBytes)
+            return Exception { SyntaxError, makeString("The close reason must not be greater than "_s, maxReasonSizeInBytes, " UTF-8 bytes. Received "_s, utf8Reason.length(), " bytes."_s) };
     }
+    int code = optionalCode ? optionalCode.value() : static_cast<int>(1000);
 
     if (m_state == CLOSING || m_state == CLOSED)
         return {};
@@ -1778,7 +1787,9 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::invalid_utf8: {
-        didReceiveClose(CleanStatus::NotClean, 1003, "Server sent invalid UTF8"_s);
+        // RFC 6455 7.4.1: 1007 is "invalid frame payload data" (for example,
+        // non-UTF-8 in a text message); 1003 would mean an unsupported data type.
+        didReceiveClose(CleanStatus::NotClean, 1007, "Server sent invalid UTF8"_s);
         break;
     }
     case Bun::WebSocketErrorCode::tls_handshake_failed: {

--- a/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
@@ -72,7 +72,15 @@ describe.concurrent("unmasked client frames", () => {
         "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
         "\r\n",
     );
-    await upgraded.promise;
+    try {
+      await upgraded.promise;
+    } catch (error) {
+      // The disposable below (the only thing that stops the server) is never
+      // created when the handshake fails, so release everything here.
+      socket.destroy();
+      server.stop(true);
+      throw error;
+    }
 
     return {
       server,

--- a/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
@@ -21,6 +21,7 @@ describe.concurrent("unmasked client frames", () => {
   // upgrade, then exposes exactly what the server observed.
   async function connectRaw() {
     const received: unknown[] = [];
+    const messageListeners: (() => void)[] = [];
     const firstMessage = Promise.withResolvers<string>();
     const serverClose = Promise.withResolvers<{ code: number; reason: string }>();
     const server = serve({
@@ -33,6 +34,7 @@ describe.concurrent("unmasked client frames", () => {
         message(ws, message) {
           received.push(message);
           firstMessage.resolve(`message:${JSON.stringify(message)}`);
+          for (const notify of messageListeners) notify();
         },
         close(ws, code, reason) {
           serverClose.resolve({ code, reason });
@@ -89,6 +91,15 @@ describe.concurrent("unmasked client frames", () => {
       firstMessage: firstMessage.promise,
       serverClose: serverClose.promise,
       closed: closed.promise,
+      // Resolves once the server's message handler has run `count` times.
+      waitForMessages(count: number): Promise<void> {
+        if (received.length >= count) return Promise.resolve();
+        const { promise, resolve } = Promise.withResolvers<void>();
+        messageListeners.push(() => {
+          if (received.length >= count) resolve();
+        });
+        return promise;
+      },
       [Symbol.dispose]() {
         socket.destroy();
         server.stop(true);
@@ -134,14 +145,17 @@ describe.concurrent("unmasked client frames", () => {
     expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
   });
 
-  // Control: the same raw client with correct masking is parsed and delivered.
+  // Control: the same raw client with correct masking is parsed and delivered,
+  // and the connection survives delivery (a follow-up frame arrives too).
   // Raced against `closed` so a wrongly rejected frame fails the assertion
   // instead of hanging until the test times out.
   it("a masked text frame from the same raw client is delivered", async () => {
     using raw = await connectRaw();
     raw.socket.write(maskedFrame(0x1, Buffer.from("hi")));
     expect(await Promise.race([raw.firstMessage, raw.closed])).toBe('message:"hi"');
-    expect(raw.received).toEqual(["hi"]);
+    raw.socket.write(maskedFrame(0x1, Buffer.from("again")));
+    await Promise.race([raw.waitForMessages(2), raw.closed]);
+    expect(raw.received).toEqual(["hi", "again"]);
   });
 
   // Control: a masked frame whose 2-byte base header arrives on its own must
@@ -152,6 +166,8 @@ describe.concurrent("unmasked client frames", () => {
     await new Promise<void>(resolve => raw.socket.write(frame.subarray(0, 2), () => resolve()));
     raw.socket.write(frame.subarray(2));
     expect(await Promise.race([raw.firstMessage, raw.closed])).toBe('message:"hi"');
-    expect(raw.received).toEqual(["hi"]);
+    raw.socket.write(maskedFrame(0x1, Buffer.from("again")));
+    await Promise.race([raw.waitForMessages(2), raw.closed]);
+    expect(raw.received).toEqual(["hi", "again"]);
   });
 });

--- a/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
@@ -127,10 +127,12 @@ describe.concurrent("unmasked client frames", () => {
   });
 
   // Control: the same raw client with correct masking is parsed and delivered.
+  // Raced against `closed` so a wrongly rejected frame fails the assertion
+  // instead of hanging until the test times out.
   it("a masked text frame from the same raw client is delivered", async () => {
     using raw = await connectRaw();
     raw.socket.write(maskedFrame(0x1, Buffer.from("hi")));
-    expect(await raw.firstMessage).toBe('message:"hi"');
+    expect(await Promise.race([raw.firstMessage, raw.closed])).toBe('message:"hi"');
     expect(raw.received).toEqual(["hi"]);
   });
 
@@ -141,7 +143,7 @@ describe.concurrent("unmasked client frames", () => {
     const frame = maskedFrame(0x1, Buffer.from("hi"));
     await new Promise<void>(resolve => raw.socket.write(frame.subarray(0, 2), () => resolve()));
     raw.socket.write(frame.subarray(2));
-    expect(await raw.firstMessage).toBe('message:"hi"');
+    expect(await Promise.race([raw.firstMessage, raw.closed])).toBe('message:"hi"');
     expect(raw.received).toEqual(["hi"]);
   });
 });

--- a/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
@@ -42,10 +42,17 @@ describe.concurrent("unmasked client frames", () => {
 
     const socket = net.connect(server.port, "127.0.0.1");
     const closed = Promise.withResolvers<string>();
-    socket.on("close", () => closed.resolve("socket-closed-by-server"));
-    socket.on("error", () => closed.resolve("socket-closed-by-server"));
-
     const upgraded = Promise.withResolvers<void>();
+    socket.on("close", () => {
+      closed.resolve("socket-closed-by-server");
+      // No-op once the 101 already resolved it; fails the handshake fast otherwise.
+      upgraded.reject(new Error("socket closed before the 101 response"));
+    });
+    socket.on("error", (error: Error) => {
+      closed.resolve("socket-closed-by-server");
+      upgraded.reject(error);
+    });
+
     let buffered = Buffer.alloc(0);
     socket.on("data", (chunk: Buffer) => {
       buffered = Buffer.concat([buffered, chunk]);
@@ -104,8 +111,18 @@ describe.concurrent("unmasked client frames", () => {
 
   it("an unmasked close frame fails the connection instead of completing the handshake", async () => {
     using raw = await connectRaw();
-    // 4 extra bytes so the (server-role) parser has a full 6-byte header to look at.
+    // Trailing bytes so the parser sees a full server-role header in one read.
     raw.socket.write(Buffer.concat([unmaskedFrame(0x8, Buffer.alloc(0)), Buffer.alloc(4)]));
+    expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
+  });
+
+  // The mask bit is in the 2-byte base header. The server must not sit on a
+  // lone unmasked frame waiting for the 4 masking-key bytes that never come.
+  it("a lone 2-byte unmasked frame is rejected without waiting for more bytes", async () => {
+    using raw = await connectRaw();
+    raw.socket.write(unmaskedFrame(0x1, Buffer.alloc(0)));
+    expect(await raw.closed).toBe("socket-closed-by-server");
+    expect(raw.received).toEqual([]);
     expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
   });
 
@@ -113,6 +130,17 @@ describe.concurrent("unmasked client frames", () => {
   it("a masked text frame from the same raw client is delivered", async () => {
     using raw = await connectRaw();
     raw.socket.write(maskedFrame(0x1, Buffer.from("hi")));
+    expect(await raw.firstMessage).toBe('message:"hi"');
+    expect(raw.received).toEqual(["hi"]);
+  });
+
+  // Control: a masked frame whose 2-byte base header arrives on its own must
+  // be buffered (not rejected) until the masking key and payload follow.
+  it("a masked text frame split after the base header is still delivered", async () => {
+    using raw = await connectRaw();
+    const frame = maskedFrame(0x1, Buffer.from("hi"));
+    await new Promise<void>(resolve => raw.socket.write(frame.subarray(0, 2), () => resolve()));
+    raw.socket.write(frame.subarray(2));
     expect(await raw.firstMessage).toBe('message:"hi"');
     expect(raw.received).toEqual(["hi"]);
   });

--- a/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-unmasked-frames.test.ts
@@ -1,0 +1,119 @@
+// RFC 6455 section 5.1: a server MUST close the connection upon receiving a
+// frame that is not masked. Bun.serve's frame parser assumes the 4-byte masking
+// key is present, so an unmasked frame also desyncs everything that follows it;
+// it must never reach the message handler.
+import { serve } from "bun";
+import { describe, expect, it } from "bun:test";
+import net from "node:net";
+
+describe.concurrent("unmasked client frames", () => {
+  function maskedFrame(opcode: number, payload: Buffer): Buffer {
+    const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+    const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
+    return Buffer.concat([Buffer.from([0x80 | opcode, 0x80 | payload.length]), mask, masked]);
+  }
+
+  function unmaskedFrame(opcode: number, payload: Buffer): Buffer {
+    return Buffer.concat([Buffer.from([0x80 | opcode, payload.length]), payload]);
+  }
+
+  // Raw TCP WebSocket client against a Bun.serve websocket server: performs the
+  // upgrade, then exposes exactly what the server observed.
+  async function connectRaw() {
+    const received: unknown[] = [];
+    const firstMessage = Promise.withResolvers<string>();
+    const serverClose = Promise.withResolvers<{ code: number; reason: string }>();
+    const server = serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("upgrade failed", { status: 400 });
+      },
+      websocket: {
+        message(ws, message) {
+          received.push(message);
+          firstMessage.resolve(`message:${JSON.stringify(message)}`);
+        },
+        close(ws, code, reason) {
+          serverClose.resolve({ code, reason });
+        },
+      },
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    const closed = Promise.withResolvers<string>();
+    socket.on("close", () => closed.resolve("socket-closed-by-server"));
+    socket.on("error", () => closed.resolve("socket-closed-by-server"));
+
+    const upgraded = Promise.withResolvers<void>();
+    let buffered = Buffer.alloc(0);
+    socket.on("data", (chunk: Buffer) => {
+      buffered = Buffer.concat([buffered, chunk]);
+      const end = buffered.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      const head = buffered.subarray(0, end).toString();
+      socket.removeAllListeners("data");
+      if (head.startsWith("HTTP/1.1 101")) upgraded.resolve();
+      else upgraded.reject(new Error(`upgrade failed: ${head.split("\r\n")[0]}`));
+    });
+    socket.write(
+      "GET / HTTP/1.1\r\n" +
+        "Host: localhost\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Sec-WebSocket-Version: 13\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "\r\n",
+    );
+    await upgraded.promise;
+
+    return {
+      server,
+      socket,
+      received,
+      firstMessage: firstMessage.promise,
+      serverClose: serverClose.promise,
+      closed: closed.promise,
+      [Symbol.dispose]() {
+        socket.destroy();
+        server.stop(true);
+      },
+    };
+  }
+
+  // An unmasked zero-length frame is the worst case: the parser used to read
+  // the next frame's first 4 bytes as its masking key and deliver the empty
+  // message to `message()`.
+  it("an unmasked empty text frame is not delivered and fails the connection", async () => {
+    using raw = await connectRaw();
+    raw.socket.write(Buffer.concat([unmaskedFrame(0x1, Buffer.alloc(0)), maskedFrame(0x1, Buffer.from("hi"))]));
+    expect(await Promise.race([raw.closed, raw.firstMessage])).toBe("socket-closed-by-server");
+    expect(raw.received).toEqual([]);
+    expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
+  });
+
+  it("an unmasked text frame is not delivered and fails the connection", async () => {
+    using raw = await connectRaw();
+    // The trailing bytes are where the parser used to look for the payload
+    // after consuming "hell" as the masking key.
+    raw.socket.write(Buffer.concat([unmaskedFrame(0x1, Buffer.from("hello")), Buffer.from("XYZW")]));
+    expect(await Promise.race([raw.closed, raw.firstMessage])).toBe("socket-closed-by-server");
+    expect(raw.received).toEqual([]);
+    expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
+  });
+
+  it("an unmasked close frame fails the connection instead of completing the handshake", async () => {
+    using raw = await connectRaw();
+    // 4 extra bytes so the (server-role) parser has a full 6-byte header to look at.
+    raw.socket.write(Buffer.concat([unmaskedFrame(0x8, Buffer.alloc(0)), Buffer.alloc(4)]));
+    expect(await raw.serverClose).toEqual({ code: 1006, reason: "Received an incorrectly masked frame" });
+  });
+
+  // Control: the same raw client with correct masking is parsed and delivered.
+  it("a masked text frame from the same raw client is delivered", async () => {
+    using raw = await connectRaw();
+    raw.socket.write(maskedFrame(0x1, Buffer.from("hi")));
+    expect(await raw.firstMessage).toBe('message:"hi"');
+    expect(raw.received).toEqual(["hi"]);
+  });
+});

--- a/test/js/web/websocket/websocket-close-code.test.ts
+++ b/test/js/web/websocket/websocket-close-code.test.ts
@@ -1,0 +1,229 @@
+// WebSocket#close() argument validation and the close-code handling that
+// https://websockets.spec.whatwg.org/#dom-websocket-close and RFC 6455
+// section 7.4 require of the client. The base received-close-code matrix lives
+// in websocket.test.js ("WebSocket CloseEvent reports the received close
+// code"); this file holds the close() validation and the cases added with it.
+import { describe, expect, it } from "bun:test";
+import crypto from "node:crypto";
+import { createServer, type Socket } from "node:net";
+
+describe.concurrent("WebSocket close() argument validation", () => {
+  // Close codes an RFC 6455 endpoint must never put on the wire. close() has to
+  // reject them: the peer treats them as a protocol error.
+  const INVALID_CODES = [0, 999, 1004, 1005, 1006, 1015, 1016, 2999, 5000, 65535];
+  // Codes an endpoint may send (RFC 6455 7.4 + IANA). Unlike browsers, 1001-1014
+  // stay permitted: `ws` clients and Bun's inspector close with 1001/1011.
+  const VALID_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1011, 1012, 1014, 3000, 4999];
+  const LONG_REASON = Buffer.alloc(124, "R").toString();
+
+  // `constructor` is DOMException for InvalidAccessError, but the native
+  // SyntaxError for the reason-length check: Bun intentionally maps
+  // ExceptionCode::SyntaxError to a JS SyntaxError (JSDOMExceptionHandling.cpp).
+  function expectThrows(fn: () => void, constructor: Function, name: string, messageContains: string) {
+    let error: Error | undefined;
+    try {
+      fn();
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error).toBeInstanceOf(constructor);
+    expect(error!.name).toBe(name);
+    expect(error!.message).toContain(messageContains);
+  }
+
+  function upgradeServer(onClose?: (event: { code: number; reason: string }) => void) {
+    return Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("upgrade failed", { status: 400 });
+      },
+      websocket: {
+        message() {},
+        close(ws, code, reason) {
+          onClose?.({ code, reason });
+        },
+      },
+    });
+  }
+
+  async function open(server: Bun.Server) {
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    ws.onopen = () => resolve();
+    ws.onerror = () => reject(new Error("WebSocket failed to connect"));
+    ws.onclose = () => reject(new Error("WebSocket closed before open"));
+    await promise;
+    // The tests install their own close handlers (and close the socket).
+    ws.onerror = null;
+    ws.onclose = null;
+    return ws;
+  }
+
+  it("throws InvalidAccessError for close codes an endpoint must not send", async () => {
+    using server = upgradeServer();
+    const ws = await open(server);
+    try {
+      for (const code of INVALID_CODES) {
+        expectThrows(() => ws.close(code), DOMException, "InvalidAccessError", `Received ${code}`);
+        // Validation failed, so the socket must not have started closing.
+        expect(ws.readyState).toBe(WebSocket.OPEN);
+      }
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("throws SyntaxError when the reason is longer than 123 UTF-8 bytes", async () => {
+    using server = upgradeServer();
+    const ws = await open(server);
+    try {
+      expectThrows(() => ws.close(1000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
+      expectThrows(() => ws.close(undefined, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
+      // 62 two-byte characters: 62 UTF-16 code units but 124 UTF-8 bytes. The
+      // limit is on the encoded size.
+      expectThrows(() => ws.close(4000, "é".repeat(62)), SyntaxError, "SyntaxError", "124 bytes");
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("accepts a reason of exactly 123 UTF-8 bytes", async () => {
+    const serverGotClose = Promise.withResolvers<{ code: number; reason: string }>();
+    using server = upgradeServer(serverGotClose.resolve);
+    const ws = await open(server);
+    const reason = Buffer.alloc(123, "R").toString();
+    ws.close(3000, reason);
+    expect(await serverGotClose.promise).toEqual({ code: 3000, reason });
+  });
+
+  it("validates arguments even when the socket is already closed", async () => {
+    using server = upgradeServer();
+    const ws = await open(server);
+    const closed = new Promise(resolve => (ws.onclose = resolve));
+    ws.close();
+    await closed;
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+    expectThrows(() => ws.close(5000), DOMException, "InvalidAccessError", "Received 5000");
+    expectThrows(() => ws.close(1000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
+  });
+
+  it("validates arguments while the socket is still connecting", async () => {
+    using server = upgradeServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+    const opened = Promise.withResolvers<unknown>();
+    ws.onopen = opened.resolve;
+    // A close or error before open means the rejected close() still tore the
+    // connection attempt down.
+    ws.onerror = () => opened.reject(new Error("connection errored before open"));
+    ws.onclose = () => opened.reject(new Error("connection closed before open"));
+    expect(ws.readyState).toBe(WebSocket.CONNECTING);
+    expectThrows(() => ws.close(5000), DOMException, "InvalidAccessError", "Received 5000");
+    expectThrows(() => ws.close(3000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
+    expect(ws.readyState).toBe(WebSocket.CONNECTING);
+    await opened.promise;
+    ws.onclose = null;
+    ws.close();
+  });
+
+  describe.each(VALID_CODES)("close(%i) is allowed", code => {
+    it("and the code and reason reach the server", async () => {
+      const serverGotClose = Promise.withResolvers<{ code: number; reason: string }>();
+      using server = upgradeServer(serverGotClose.resolve);
+      const ws = await open(server);
+      const clientClosed = new Promise(resolve => (ws.onclose = e => resolve(e.code)));
+      ws.close(code, "bye");
+      expect(await serverGotClose.promise).toEqual({ code, reason: "bye" });
+      expect(await clientClosed).toBe(code);
+    });
+  });
+});
+
+describe.concurrent("WebSocket client and server-sent close frames", () => {
+  // Raw TCP server: complete the WS handshake, then run `afterUpgrade(socket)`.
+  function rawWsServer(afterUpgrade: (socket: Socket) => void) {
+    return new Promise<ReturnType<typeof createServer>>(resolveServer => {
+      const server = createServer(sock => {
+        let buf = "";
+        let upgraded = false;
+        sock.on("data", chunk => {
+          if (upgraded) {
+            sock.end();
+            return;
+          }
+          buf += chunk.toString("latin1");
+          if (!buf.includes("\r\n\r\n")) return;
+          const key = /Sec-WebSocket-Key:\s*(.*)\r\n/i.exec(buf)![1].trim();
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+            .digest("base64");
+          sock.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+              "Upgrade: websocket\r\n" +
+              "Connection: Upgrade\r\n" +
+              "Sec-WebSocket-Accept: " +
+              accept +
+              "\r\n\r\n",
+          );
+          upgraded = true;
+          afterUpgrade(sock);
+        });
+        sock.on("error", () => {});
+      });
+      server.listen(0, "127.0.0.1", () => resolveServer(server));
+    });
+  }
+
+  function closeFrame(code: number, reason = "") {
+    const r = Buffer.from(reason);
+    const f = Buffer.alloc(4 + r.length);
+    f[0] = 0x88;
+    f[1] = 2 + r.length;
+    f[2] = (code >> 8) & 0xff;
+    f[3] = code & 0xff;
+    r.copy(f, 4);
+    return f;
+  }
+
+  async function connectAndAwaitClose(server: ReturnType<typeof createServer>) {
+    const address = server.address() as import("node:net").AddressInfo;
+    const ws = new WebSocket(`ws://127.0.0.1:${address.port}`);
+    const { promise, resolve } = Promise.withResolvers<{ code: number; reason: string; wasClean: boolean }>();
+    ws.addEventListener("close", e => resolve({ code: e.code, reason: e.reason, wasClean: e.wasClean }));
+    ws.addEventListener("error", () => {});
+    const result = await promise;
+    await new Promise(r => server.close(r));
+    return result;
+  }
+
+  // RFC6455 §7.4.1-§7.4.2: 1015 is reserved and must not appear on the wire,
+  // and 5000-65535 is not defined, so a server sending one is reporting a
+  // protocol error and JS sees 1002. The in-range reserved bands (999,
+  // 1004-1006, 1016-2999) are covered in websocket.test.js.
+  describe.each([1015, 5000, 65535])("received close code %i", code => {
+    it("reports 1002", async () => {
+      const server = await rawWsServer(sock => sock.write(closeFrame(code)));
+      expect(await connectAndAwaitClose(server)).toEqual({ code: 1002, reason: "", wasClean: true });
+    });
+  });
+
+  // 1012-1014 are IANA-registered and legal on the wire.
+  it("received close code 1014 passes through unchanged", async () => {
+    const server = await rawWsServer(sock => sock.write(closeFrame(1014)));
+    expect(await connectAndAwaitClose(server)).toEqual({ code: 1014, reason: "", wasClean: true });
+  });
+
+  // RFC 6455 §7.4.1: 1007 is "received data inconsistent with the type of the
+  // message (e.g., non-UTF-8 data within a text message)". 1003 would mean an
+  // unsupported data type.
+  it("a text frame with invalid UTF-8 fails with 1007", async () => {
+    const server = await rawWsServer(sock => sock.write(Buffer.from([0x81, 0x02, 0xc3, 0x28])));
+    expect(await connectAndAwaitClose(server)).toEqual({
+      code: 1007,
+      reason: "Server sent invalid UTF8",
+      wasClean: false,
+    });
+  });
+});

--- a/test/js/web/websocket/websocket-close-code.test.ts
+++ b/test/js/web/websocket/websocket-close-code.test.ts
@@ -11,9 +11,10 @@ describe.concurrent("WebSocket close() argument validation", () => {
   // Close codes an RFC 6455 endpoint must never put on the wire. close() has to
   // reject them: the peer treats them as a protocol error.
   const INVALID_CODES = [0, 999, 1004, 1005, 1006, 1015, 1016, 2999, 5000, 65535];
-  // Codes an endpoint may send (RFC 6455 7.4 + IANA). Unlike browsers, 1001-1014
-  // stay permitted: `ws` clients and Bun's inspector close with 1001/1011.
-  const VALID_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1011, 1012, 1014, 3000, 4999];
+  // Every code an endpoint may send (RFC 6455 7.4 + IANA): 1000-1014 minus the
+  // reserved 1004-1006, plus the 3000-4999 boundaries. Unlike browsers, the
+  // 1001-1014 band stays permitted: `ws` clients and Bun's inspector use 1001/1011.
+  const VALID_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 3000, 4999];
   const LONG_REASON = Buffer.alloc(124, "R").toString();
 
   // `constructor` is DOMException for InvalidAccessError, but the native

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -40,22 +40,7 @@ describe.concurrent("WebSocket", () => {
   });
 
   it("should connect over https", async () => {
-    using server = Bun.serve({
-      port: 0,
-      tls: COMMON_CERT,
-      fetch(req, server) {
-        if (server.upgrade(req)) {
-          return;
-        }
-        return new Response("Upgrade failed :(", { status: 500 });
-      },
-      websocket: {
-        message() {},
-        open(ws) {},
-      },
-    });
-    // server.url.href is an https:// URL, accepted as an alias for wss://.
-    const ws = new WebSocket(server.url.href, { tls: { rejectUnauthorized: false } });
+    const ws = new WebSocket(TEST_WEBSOCKET_HOST.replaceAll("wss:", "https:"));
     await new Promise((resolve, reject) => {
       ws.onopen = resolve;
       ws.onerror = reject;
@@ -435,24 +420,7 @@ describe.concurrent("WebSocket", () => {
   });
 
   it("should send and receive messages", async () => {
-    using server = Bun.serve({
-      port: 0,
-      tls: COMMON_CERT,
-      fetch(req, server) {
-        if (server.upgrade(req)) {
-          return;
-        }
-        return new Response("Upgrade failed :(", { status: 500 });
-      },
-      websocket: {
-        message(ws, message) {
-          // echo
-          ws.send(message);
-        },
-        open(ws) {},
-      },
-    });
-    const ws = new WebSocket(server.url.href, { tls: { rejectUnauthorized: false } });
+    const ws = new WebSocket(TEST_WEBSOCKET_HOST);
     await new Promise((resolve, reject) => {
       ws.onopen = resolve;
       ws.onerror = reject;
@@ -1042,32 +1010,20 @@ describe("WebSocket CloseEvent reports the received close code", () => {
     expect(await connectAndAwaitClose(server)).toEqual({ code: 1001, reason: "", wasClean: true });
   });
 
-  describe.each([1000, 1002, 1003, 1007, 1011, 1014, 3000, 4000, 4999])("Close frame with code %i", code => {
+  describe.each([1000, 1002, 1003, 1007, 1011, 3000, 4000, 4999])("Close frame with code %i", code => {
     it("passes through unchanged", async () => {
       const server = await rawWsServer(sock => sock.write(closeFrame(code)));
       expect(await connectAndAwaitClose(server)).toEqual({ code, reason: "", wasClean: true });
     });
   });
 
-  // RFC6455 §7.4.1-§7.4.2: codes < 1000, the reserved 1004-1006 and 1015-2999
-  // ranges, and the undefined 5000-65535 range are not legal on the wire; a
-  // server that sends one is reporting a protocol error, so JS sees 1002.
-  describe.each([999, 1004, 1005, 1006, 1015, 1016, 2999, 5000, 65535])("reserved/invalid code %i", code => {
+  // RFC6455 §7.4.1: codes < 1000, the reserved 1004-1006 range, and 1016-2999
+  // are not legal on the wire; a server that sends one is reporting a protocol
+  // error, so JS sees 1002.
+  describe.each([999, 1004, 1005, 1006, 1016, 2999])("reserved/invalid code %i", code => {
     it("reports 1002", async () => {
       const server = await rawWsServer(sock => sock.write(closeFrame(code)));
       expect(await connectAndAwaitClose(server)).toEqual({ code: 1002, reason: "", wasClean: true });
-    });
-  });
-
-  // RFC 6455 §7.4.1: 1007 is "received data inconsistent with the type of the
-  // message (e.g., non-UTF-8 data within a text message)". 1003 would mean an
-  // unsupported data type.
-  it("a text frame with invalid UTF-8 fails with 1007", async () => {
-    const server = await rawWsServer(sock => sock.write(Buffer.from([0x81, 0x02, 0xc3, 0x28])));
-    expect(await connectAndAwaitClose(server)).toEqual({
-      code: 1007,
-      reason: "Server sent invalid UTF8",
-      wasClean: false,
     });
   });
 
@@ -1085,139 +1041,5 @@ describe("WebSocket CloseEvent reports the received close code", () => {
   it("abnormal close (socket destroyed without Close frame) reports wasClean=false", async () => {
     const server = await rawWsServer(sock => sock.destroy());
     expect(await connectAndAwaitClose(server)).toEqual({ code: 1006, reason: "Connection ended", wasClean: false });
-  });
-});
-
-// https://websockets.spec.whatwg.org/#dom-websocket-close
-describe.concurrent("WebSocket close() argument validation", () => {
-  // Close codes an RFC 6455 endpoint must never put on the wire. close() has to
-  // reject them: the peer treats them as a protocol error.
-  const INVALID_CODES = [0, 999, 1004, 1005, 1006, 1015, 1016, 2999, 5000, 65535];
-  // Codes an endpoint may send (RFC 6455 7.4 + IANA). Unlike browsers, 1001-1014
-  // stay permitted: `ws` clients and Bun's inspector close with 1001/1011.
-  const VALID_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1011, 1012, 1014, 3000, 4999];
-  const LONG_REASON = Buffer.alloc(124, "R").toString();
-
-  // `constructor` is DOMException for InvalidAccessError, but the native
-  // SyntaxError for the reason-length check: Bun intentionally maps
-  // ExceptionCode::SyntaxError to a JS SyntaxError (JSDOMExceptionHandling.cpp).
-  function expectThrows(fn, constructor, name, messageContains) {
-    let error;
-    try {
-      fn();
-    } catch (e) {
-      error = e;
-    }
-    expect(error).toBeInstanceOf(constructor);
-    expect(error.name).toBe(name);
-    expect(error.message).toContain(messageContains);
-  }
-
-  function upgradeServer(onClose) {
-    return Bun.serve({
-      port: 0,
-      fetch(req, server) {
-        if (server.upgrade(req)) return;
-        return new Response("upgrade failed", { status: 400 });
-      },
-      websocket: {
-        message() {},
-        close(ws, code, reason) {
-          onClose?.({ code, reason });
-        },
-      },
-    });
-  }
-
-  async function open(server) {
-    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
-    const { promise, resolve, reject } = Promise.withResolvers();
-    ws.onopen = () => resolve();
-    ws.onerror = () => reject(new Error("WebSocket failed to connect"));
-    ws.onclose = () => reject(new Error("WebSocket closed before open"));
-    await promise;
-    // The tests install their own close handlers (and close the socket).
-    ws.onerror = null;
-    ws.onclose = null;
-    return ws;
-  }
-
-  it("throws InvalidAccessError for close codes an endpoint must not send", async () => {
-    using server = upgradeServer();
-    const ws = await open(server);
-    try {
-      for (const code of INVALID_CODES) {
-        expectThrows(() => ws.close(code), DOMException, "InvalidAccessError", `Received ${code}`);
-        // Validation failed, so the socket must not have started closing.
-        expect(ws.readyState).toBe(WebSocket.OPEN);
-      }
-    } finally {
-      ws.close();
-    }
-  });
-
-  it("throws SyntaxError when the reason is longer than 123 UTF-8 bytes", async () => {
-    using server = upgradeServer();
-    const ws = await open(server);
-    try {
-      expectThrows(() => ws.close(1000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
-      expectThrows(() => ws.close(undefined, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
-      // 62 two-byte characters: 62 UTF-16 code units but 124 UTF-8 bytes. The
-      // limit is on the encoded size.
-      expectThrows(() => ws.close(4000, "é".repeat(62)), SyntaxError, "SyntaxError", "124 bytes");
-      expect(ws.readyState).toBe(WebSocket.OPEN);
-    } finally {
-      ws.close();
-    }
-  });
-
-  it("accepts a reason of exactly 123 UTF-8 bytes", async () => {
-    const serverGotClose = Promise.withResolvers();
-    using server = upgradeServer(serverGotClose.resolve);
-    const ws = await open(server);
-    const reason = Buffer.alloc(123, "R").toString();
-    ws.close(3000, reason);
-    expect(await serverGotClose.promise).toEqual({ code: 3000, reason });
-  });
-
-  it("validates arguments even when the socket is already closed", async () => {
-    using server = upgradeServer();
-    const ws = await open(server);
-    const closed = new Promise(resolve => (ws.onclose = resolve));
-    ws.close();
-    await closed;
-    expect(ws.readyState).toBe(WebSocket.CLOSED);
-    expectThrows(() => ws.close(5000), DOMException, "InvalidAccessError", "Received 5000");
-    expectThrows(() => ws.close(1000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
-  });
-
-  it("validates arguments while the socket is still connecting", async () => {
-    using server = upgradeServer();
-    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
-    const opened = Promise.withResolvers();
-    ws.onopen = opened.resolve;
-    // A close or error before open means the rejected close() still tore the
-    // connection attempt down.
-    ws.onerror = () => opened.reject(new Error("connection errored before open"));
-    ws.onclose = () => opened.reject(new Error("connection closed before open"));
-    expect(ws.readyState).toBe(WebSocket.CONNECTING);
-    expectThrows(() => ws.close(5000), DOMException, "InvalidAccessError", "Received 5000");
-    expectThrows(() => ws.close(3000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
-    expect(ws.readyState).toBe(WebSocket.CONNECTING);
-    await opened.promise;
-    ws.onclose = null;
-    ws.close();
-  });
-
-  describe.each(VALID_CODES)("close(%i) is allowed", code => {
-    it("and the code and reason reach the server", async () => {
-      const serverGotClose = Promise.withResolvers();
-      using server = upgradeServer(serverGotClose.resolve);
-      const ws = await open(server);
-      const clientClosed = new Promise(resolve => (ws.onclose = e => resolve(e.code)));
-      ws.close(code, "bye");
-      expect(await serverGotClose.promise).toEqual({ code, reason: "bye" });
-      expect(await clientClosed).toBe(code);
-    });
   });
 });

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -1102,7 +1102,11 @@ describe.concurrent("WebSocket close() argument validation", () => {
     const { promise, resolve, reject } = Promise.withResolvers();
     ws.onopen = () => resolve();
     ws.onerror = () => reject(new Error("WebSocket failed to connect"));
+    ws.onclose = () => reject(new Error("WebSocket closed before open"));
     await promise;
+    // The tests install their own close handlers (and close the socket).
+    ws.onerror = null;
+    ws.onclose = null;
     return ws;
   }
 

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -1010,20 +1010,32 @@ describe("WebSocket CloseEvent reports the received close code", () => {
     expect(await connectAndAwaitClose(server)).toEqual({ code: 1001, reason: "", wasClean: true });
   });
 
-  describe.each([1000, 1002, 1003, 1007, 1011, 3000, 4000, 4999])("Close frame with code %i", code => {
+  describe.each([1000, 1002, 1003, 1007, 1011, 1014, 3000, 4000, 4999])("Close frame with code %i", code => {
     it("passes through unchanged", async () => {
       const server = await rawWsServer(sock => sock.write(closeFrame(code)));
       expect(await connectAndAwaitClose(server)).toEqual({ code, reason: "", wasClean: true });
     });
   });
 
-  // RFC6455 §7.4.1: codes < 1000, the reserved 1004-1006 range, and 1016-2999
-  // are not legal on the wire; a server that sends one is reporting a protocol
-  // error, so JS sees 1002.
-  describe.each([999, 1004, 1005, 1006, 1016, 2999])("reserved/invalid code %i", code => {
+  // RFC6455 §7.4.1-§7.4.2: codes < 1000, the reserved 1004-1006 and 1015-2999
+  // ranges, and the undefined 5000-65535 range are not legal on the wire; a
+  // server that sends one is reporting a protocol error, so JS sees 1002.
+  describe.each([999, 1004, 1005, 1006, 1015, 1016, 2999, 5000, 65535])("reserved/invalid code %i", code => {
     it("reports 1002", async () => {
       const server = await rawWsServer(sock => sock.write(closeFrame(code)));
       expect(await connectAndAwaitClose(server)).toEqual({ code: 1002, reason: "", wasClean: true });
+    });
+  });
+
+  // RFC 6455 §7.4.1: 1007 is "received data inconsistent with the type of the
+  // message (e.g., non-UTF-8 data within a text message)". 1003 would mean an
+  // unsupported data type.
+  it("a text frame with invalid UTF-8 fails with 1007", async () => {
+    const server = await rawWsServer(sock => sock.write(Buffer.from([0x81, 0x02, 0xc3, 0x28])));
+    expect(await connectAndAwaitClose(server)).toEqual({
+      code: 1007,
+      reason: "Server sent invalid UTF8",
+      wasClean: false,
     });
   });
 
@@ -1041,5 +1053,135 @@ describe("WebSocket CloseEvent reports the received close code", () => {
   it("abnormal close (socket destroyed without Close frame) reports wasClean=false", async () => {
     const server = await rawWsServer(sock => sock.destroy());
     expect(await connectAndAwaitClose(server)).toEqual({ code: 1006, reason: "Connection ended", wasClean: false });
+  });
+});
+
+// https://websockets.spec.whatwg.org/#dom-websocket-close
+describe.concurrent("WebSocket close() argument validation", () => {
+  // Close codes an RFC 6455 endpoint must never put on the wire. close() has to
+  // reject them: the peer treats them as a protocol error.
+  const INVALID_CODES = [0, 999, 1004, 1005, 1006, 1015, 1016, 2999, 5000, 65535];
+  // Codes an endpoint may send (RFC 6455 7.4 + IANA). Unlike browsers, 1001-1014
+  // stay permitted: `ws` clients and Bun's inspector close with 1001/1011.
+  const VALID_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1011, 1012, 1014, 3000, 4999];
+  const LONG_REASON = Buffer.alloc(124, "R").toString();
+
+  // `constructor` is DOMException for InvalidAccessError, but the native
+  // SyntaxError for the reason-length check: Bun intentionally maps
+  // ExceptionCode::SyntaxError to a JS SyntaxError (JSDOMExceptionHandling.cpp).
+  function expectThrows(fn, constructor, name, messageContains) {
+    let error;
+    try {
+      fn();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(constructor);
+    expect(error.name).toBe(name);
+    expect(error.message).toContain(messageContains);
+  }
+
+  function upgradeServer(onClose) {
+    return Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("upgrade failed", { status: 400 });
+      },
+      websocket: {
+        message() {},
+        close(ws, code, reason) {
+          onClose?.({ code, reason });
+        },
+      },
+    });
+  }
+
+  async function open(server) {
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+    const { promise, resolve, reject } = Promise.withResolvers();
+    ws.onopen = () => resolve();
+    ws.onerror = () => reject(new Error("WebSocket failed to connect"));
+    await promise;
+    return ws;
+  }
+
+  it("throws InvalidAccessError for close codes an endpoint must not send", async () => {
+    using server = upgradeServer();
+    const ws = await open(server);
+    try {
+      for (const code of INVALID_CODES) {
+        expectThrows(() => ws.close(code), DOMException, "InvalidAccessError", `Received ${code}`);
+        // Validation failed, so the socket must not have started closing.
+        expect(ws.readyState).toBe(WebSocket.OPEN);
+      }
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("throws SyntaxError when the reason is longer than 123 UTF-8 bytes", async () => {
+    using server = upgradeServer();
+    const ws = await open(server);
+    try {
+      expectThrows(() => ws.close(1000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
+      expectThrows(() => ws.close(undefined, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
+      // 62 two-byte characters: 62 UTF-16 code units but 124 UTF-8 bytes. The
+      // limit is on the encoded size.
+      expectThrows(() => ws.close(4000, "é".repeat(62)), SyntaxError, "SyntaxError", "124 bytes");
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("accepts a reason of exactly 123 UTF-8 bytes", async () => {
+    const serverGotClose = Promise.withResolvers();
+    using server = upgradeServer(serverGotClose.resolve);
+    const ws = await open(server);
+    const reason = Buffer.alloc(123, "R").toString();
+    ws.close(3000, reason);
+    expect(await serverGotClose.promise).toEqual({ code: 3000, reason });
+  });
+
+  it("validates arguments even when the socket is already closed", async () => {
+    using server = upgradeServer();
+    const ws = await open(server);
+    const closed = new Promise(resolve => (ws.onclose = resolve));
+    ws.close();
+    await closed;
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+    expectThrows(() => ws.close(5000), DOMException, "InvalidAccessError", "Received 5000");
+    expectThrows(() => ws.close(1000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
+  });
+
+  it("validates arguments while the socket is still connecting", async () => {
+    using server = upgradeServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+    const opened = Promise.withResolvers();
+    ws.onopen = opened.resolve;
+    // A close or error before open means the rejected close() still tore the
+    // connection attempt down.
+    ws.onerror = () => opened.reject(new Error("connection errored before open"));
+    ws.onclose = () => opened.reject(new Error("connection closed before open"));
+    expect(ws.readyState).toBe(WebSocket.CONNECTING);
+    expectThrows(() => ws.close(5000), DOMException, "InvalidAccessError", "Received 5000");
+    expectThrows(() => ws.close(3000, LONG_REASON), SyntaxError, "SyntaxError", "123 UTF-8 bytes");
+    expect(ws.readyState).toBe(WebSocket.CONNECTING);
+    await opened.promise;
+    ws.onclose = null;
+    ws.close();
+  });
+
+  describe.each(VALID_CODES)("close(%i) is allowed", code => {
+    it("and the code and reason reach the server", async () => {
+      const serverGotClose = Promise.withResolvers();
+      using server = upgradeServer(serverGotClose.resolve);
+      const ws = await open(server);
+      const clientClosed = new Promise(resolve => (ws.onclose = e => resolve(e.code)));
+      ws.close(code, "bye");
+      expect(await serverGotClose.promise).toEqual({ code, reason: "bye" });
+      expect(await clientClosed).toBe(code);
+    });
   });
 });

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -40,7 +40,22 @@ describe.concurrent("WebSocket", () => {
   });
 
   it("should connect over https", async () => {
-    const ws = new WebSocket(TEST_WEBSOCKET_HOST.replaceAll("wss:", "https:"));
+    using server = Bun.serve({
+      port: 0,
+      tls: COMMON_CERT,
+      fetch(req, server) {
+        if (server.upgrade(req)) {
+          return;
+        }
+        return new Response("Upgrade failed :(", { status: 500 });
+      },
+      websocket: {
+        message() {},
+        open(ws) {},
+      },
+    });
+    // server.url.href is an https:// URL, accepted as an alias for wss://.
+    const ws = new WebSocket(server.url.href, { tls: { rejectUnauthorized: false } });
     await new Promise((resolve, reject) => {
       ws.onopen = resolve;
       ws.onerror = reject;
@@ -420,7 +435,24 @@ describe.concurrent("WebSocket", () => {
   });
 
   it("should send and receive messages", async () => {
-    const ws = new WebSocket(TEST_WEBSOCKET_HOST);
+    using server = Bun.serve({
+      port: 0,
+      tls: COMMON_CERT,
+      fetch(req, server) {
+        if (server.upgrade(req)) {
+          return;
+        }
+        return new Response("Upgrade failed :(", { status: 500 });
+      },
+      websocket: {
+        message(ws, message) {
+          // echo
+          ws.send(message);
+        },
+        open(ws) {},
+      },
+    });
+    const ws = new WebSocket(server.url.href, { tls: { rejectUnauthorized: false } });
     await new Promise((resolve, reject) => {
       ws.onopen = resolve;
       ws.onerror = reject;


### PR DESCRIPTION
Four RFC 6455 / WHATWG conformance fixes in WebSocket close and frame handling, from a fuzzing report that cross-checked Bun against byte-level RFC 6455 peers, node, and `ws`.

### 1. `WebSocket#close()` had no argument validation

```js
const ws = new WebSocket(url);
ws.close(5000);                  // no throw, 5000 goes on the wire (node/browsers: InvalidAccessError)
ws.close(1000, "R".repeat(124)); // no throw, and the reason is silently sent as empty
```

The spec check in `WebSocket::close` was commented out, and the reason-length check only ran when a code other than 1000 was passed, comparing UTF-16 code units instead of UTF-8 bytes. The native client then silently dropped reasons longer than 123 bytes before writing the frame.

`close()` now validates before any state transition:

- a code an endpoint must not send (RFC 6455 7.4: anything outside 1000-1014 minus the reserved 1004-1006, or 3000-4999) throws an `InvalidAccessError` DOMException
- a reason longer than 123 UTF-8 bytes throws a `SyntaxError`

One deliberate deviation from the browser whitelist (`1000` or `3000-4999`): the RFC endpoint codes 1001-1003 and 1007-1014 stay permitted. Bun's WebSocket already serves non-browser roles (`ping()`, `pong()`, `terminate()`, headers), the `ws` package (whose Bun shim forwards to this method) accepts exactly this set, and Bun's own inspector client closes with 1001. Tightening to the browser set would turn all of those into runtime throws. Every code the report flagged (999, 1005, 5000, and the over-long reason) is rejected either way. If full WHATWG strictness is preferred I can do that instead, but it needs a private path for the `ws` shim and a change to `bun-inspector-protocol`.

### 2. `Bun.serve` did not enforce client frame masking (RFC 6455 5.1 MUST)

The uWS parser computes the server's frame header size assuming the 4-byte masking key is present and never read the MASK bit. An unmasked client frame was parsed as if masked: the first payload bytes were consumed as the key, desyncing the frame stream, and an unmasked zero-length frame was delivered to `message()`. A server that mis-parses deliberately malformed frames instead of failing the connection is how request-smuggling-style bugs start.

The frame header validation now force-closes the connection when the mask bit does not match the role (`Received an incorrectly masked frame` is surfaced to the `close` handler), so a mismatched frame is never parsed or delivered. Bun's own WebSocket client always sets the mask bit, so Bun-to-Bun traffic is unaffected; this only rejects peers that violate the MUST.

### 3. Received close codes 1015 and 5000-65535 were surfaced verbatim

`received_close_codes` already mapped `<1000`, `1004-1006`, and `1016-2999` to 1002 (protocol error) but missed 1015 (reserved, must not appear on the wire) and everything above 4999 (not defined). Both now map to 1002 like the rest, matching node and `ws`.

### 4. Invalid UTF-8 in a text message reported 1003 instead of 1007

RFC 6455 7.4.1: 1007 is "received data inconsistent with the type of the message (e.g. non-UTF-8 within a text message)"; 1003 means an unsupported data type. One constant in the error-code table.

### Not addressed here

- `close()` still fires the close event from within the call and never observably enters `CLOSING`; that rework is #27259.
- On a protocol error (including invalid UTF-8), the client still hard-closes without sending a Close frame to the peer. Sending 1002/1007 first is a SHOULD and needs its own pass over the close state machine.
- `ServerWebSocket#close()` reason truncation (wire vs local callback disagreement).

### Tests

`test/js/web/websocket/websocket-close-code.test.ts` (new) covers close() argument validation (every rejected-code class, both reason-length failure modes plus the 123-byte boundary, validation ordering on CONNECTING and CLOSED sockets, and a wire round-trip for every permitted code) and the close-frame cases this PR changes, against a byte-level raw server: received 1015/5000/65535 report 1002, 1014 passes through, invalid UTF-8 reports 1007. The existing received-close-code matrix in websocket.test.js already covers the other reserved ranges and is untouched.

`test/js/bun/websocket/websocket-server-unmasked-frames.test.ts` (new) drives a raw TCP client through the upgrade and asserts unmasked text, empty, close, and lone 2-byte frames are never delivered and fail the connection, with masked and split-header controls.

With the fix reverted, 12 of the 27 new tests fail (no throw from close(5000), message("") delivered for an unmasked frame, code 5000 surfaced to JS, 1003 instead of 1007); all pass with it.
