### PR TITLE
Bun.serve: serve HEAD requests with the GET handler in per-method route objects

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -329,6 +329,7 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
     entry: *mut T,
     path: &[u8],
     method: http_method::Optional,
+    path_has_user_head_route: bool,
 ) where
     T: StaticRouteLike<SSL>,
 {
@@ -381,9 +382,9 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
 
     let user_data = entry.cast::<core::ffi::c_void>();
     // Only answer HEAD from an entry that serves GET (HEAD must mirror GET,
-    // RFC 9110 section 9.3.2) or that is registered for HEAD itself. A later
-    // registration for the same method and path replaces an earlier one in uWS.
-    if serves_head(&method) {
+    // RFC 9110 section 9.3.2) or HEAD itself, and never displace an explicit HEAD
+    // handler route: uWS keeps the last registration for the same method and path.
+    if !path_has_user_head_route && serves_head(&method) {
         app.head(path, Some(head::<SSL, T>), user_data);
     }
     match method {
@@ -423,6 +424,7 @@ pub(crate) fn apply_static_route_h3<T>(
     entry: *mut T,
     path: &[u8],
     method: http_method::Optional,
+    path_has_user_head_route: bool,
 ) where
     T: StaticRouteLike<false>,
 {
@@ -458,7 +460,7 @@ pub(crate) fn apply_static_route_h3<T>(
         };
     }
 
-    if serves_head(&method) {
+    if !path_has_user_head_route && serves_head(&method) {
         app.head(path, entry, head::<T>);
     }
     match method {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -380,7 +380,12 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
     }
 
     let user_data = entry.cast::<core::ffi::c_void>();
-    app.head(path, Some(head::<SSL, T>), user_data);
+    // Only answer HEAD from an entry that serves GET (HEAD must mirror GET,
+    // RFC 9110 section 9.3.2) or that is registered for HEAD itself. A later
+    // registration for the same method and path replaces an earlier one in uWS.
+    if serves_head(&method) {
+        app.head(path, Some(head::<SSL, T>), user_data);
+    }
     match method {
         http_method::Optional::Any => {
             app.any(path, Some(handler::<SSL, T>), user_data);
@@ -390,6 +395,16 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
             while let Some(method_) = iter.next() {
                 app.method(method_, path, Some(handler::<SSL, T>), user_data);
             }
+        }
+    }
+}
+
+/// Whether a static route registered for `method` should also answer HEAD.
+fn serves_head(method: &http_method::Optional) -> bool {
+    match method {
+        http_method::Optional::Any => true,
+        http_method::Optional::Method(set) => {
+            set.contains(Method::GET) || set.contains(Method::HEAD)
         }
     }
 }
@@ -443,7 +458,9 @@ pub(crate) fn apply_static_route_h3<T>(
         };
     }
 
-    app.head(path, entry, head::<T>);
+    if serves_head(&method) {
+        app.head(path, entry, head::<T>);
+    }
     match method {
         http_method::Optional::Any => app.any(path, entry, handler::<T>),
         http_method::Optional::Method(m) => {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -909,6 +909,10 @@ impl ServerConfig {
                         Method::TRACE,
                     ];
                     let mut found = false;
+                    // HEAD must behave like GET without a body (RFC 9110 section 9.3.2),
+                    // so a route object with a GET handler and no HEAD entry also answers HEAD.
+                    let mut derived_head_route: Option<UserRouteBuilder> = None;
+                    let mut has_head_route = false;
                     for method in METHODS {
                         let method_name = bun_core::String::static_(method.as_str());
                         if let Some(function) = value.get_own(global, &method_name)? {
@@ -918,16 +922,27 @@ impl ServerConfig {
                             found = true;
 
                             if function.is_callable() {
+                                let callback = function.with_async_context_if_needed(global);
                                 args.user_routes_to_build.push(UserRouteBuilder {
                                     route: RouteDeclaration {
                                         path: ZBox::from_bytes(&*path),
                                         method: RouteMethod::Specific(method),
                                     },
-                                    callback: Strong::create(
-                                        function.with_async_context_if_needed(global),
-                                        global,
-                                    ),
+                                    callback: Strong::create(callback, global),
                                 });
+                                match method {
+                                    Method::GET => {
+                                        derived_head_route = Some(UserRouteBuilder {
+                                            route: RouteDeclaration {
+                                                path: ZBox::from_bytes(&*path),
+                                                method: RouteMethod::Specific(Method::HEAD),
+                                            },
+                                            callback: Strong::create(callback, global),
+                                        });
+                                    }
+                                    Method::HEAD => has_head_route = true,
+                                    _ => {}
+                                }
                             } else if let Some(html_route) =
                                 AnyRoute::from_js(global, &path, function, &mut *init_ctx)?
                             {
@@ -939,7 +954,16 @@ impl ServerConfig {
                                     route: html_route,
                                     method: http_method::Optional::Method(method_set),
                                 });
+                                if method == Method::HEAD {
+                                    has_head_route = true;
+                                }
                             }
+                        }
+                    }
+
+                    if let Some(builder) = derived_head_route {
+                        if !has_head_route {
+                            args.user_routes_to_build.push(builder);
                         }
                     }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2193,15 +2193,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // An explicit HEAD handler route must stay the HEAD handler for its
             // path: uWS keeps the last registration for a method and path, and
             // static routes register after user routes.
-            let path_has_user_head_route = self.user_routes.iter().any(|route| {
-                match &route.route.method {
-                    server_config::RouteMethod::Specific(method) => {
-                        *method == http_method::Method::HEAD
-                            && route.route.path.as_bytes() == &*entry.path
-                    }
-                    server_config::RouteMethod::Any => false,
-                }
-            });
+            let path_has_user_head_route =
+                self.user_routes
+                    .iter()
+                    .any(|route| match &route.route.method {
+                        server_config::RouteMethod::Specific(method) => {
+                            *method == http_method::Method::HEAD
+                                && route.route.path.as_bytes() == &*entry.path
+                        }
+                        server_config::RouteMethod::Any => false,
+                    });
 
             // Each `p`/`r` is the live `RefPtr<_>` stored in `entry.route`;
             // `app`/`h3_app` are the live uWS app handles owned by `self`.

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2190,6 +2190,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 should_add_chrome_devtools_json_route = false;
             }
 
+            // An explicit HEAD handler route must stay the HEAD handler for its
+            // path: uWS keeps the last registration for a method and path, and
+            // static routes register after user routes.
+            let path_has_user_head_route = self.user_routes.iter().any(|route| {
+                match &route.route.method {
+                    server_config::RouteMethod::Specific(method) => {
+                        *method == http_method::Method::HEAD
+                            && route.route.path.as_bytes() == &*entry.path
+                    }
+                    server_config::RouteMethod::Any => false,
+                }
+            });
+
             // Each `p`/`r` is the live `RefPtr<_>` stored in `entry.route`;
             // `app`/`h3_app` are the live uWS app handles owned by `self`.
             match &entry.route {
@@ -2200,6 +2213,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         p.as_ptr(),
                         &entry.path,
                         entry.method,
+                        path_has_user_head_route,
                     );
                     if Self::HAS_H3 {
                         if let Some(h3_app) = self.h3_app {
@@ -2210,6 +2224,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 p.as_ptr(),
                                 &entry.path,
                                 entry.method,
+                                path_has_user_head_route,
                             );
                         }
                     }
@@ -2221,6 +2236,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         p.as_ptr(),
                         &entry.path,
                         entry.method,
+                        path_has_user_head_route,
                     );
                     if Self::HAS_H3 {
                         if let Some(h3_app) = self.h3_app {
@@ -2231,6 +2247,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 p.as_ptr(),
                                 &entry.path,
                                 entry.method,
+                                path_has_user_head_route,
                             );
                         }
                     }
@@ -2242,6 +2259,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         r.as_ptr(),
                         &entry.path,
                         entry.method,
+                        path_has_user_head_route,
                     );
                     if Self::HAS_H3 {
                         if let Some(h3_app) = self.h3_app {
@@ -2252,6 +2270,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 r.as_ptr(),
                                 &entry.path,
                                 entry.method,
+                                path_has_user_head_route,
                             );
                         }
                     }

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -193,6 +193,26 @@ describe("implicit HEAD for per-method route objects", () => {
     expect(res.status).toBe(200);
   });
 
+  test("an explicit HEAD handler takes precedence over a static GET Response", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/static-get": {
+          GET: new Response("get-static"),
+          HEAD: () => new Response(null, { headers: { "x-callable-head": "1" } }),
+        },
+      },
+    });
+
+    const head = await fetch(new URL("/static-get", server.url), { method: "HEAD" });
+    expect(head.headers.get("x-callable-head")).toBe("1");
+    expect(head.status).toBe(200);
+
+    const get = await fetch(new URL("/static-get", server.url));
+    expect(await get.text()).toBe("get-static");
+    expect(get.status).toBe(200);
+  });
+
   test("a static Response for another method does not capture HEAD away from GET", async () => {
     await using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -108,6 +108,86 @@ describe("HTTP methods", () => {
   });
 });
 
+describe("implicit HEAD for per-method route objects", () => {
+  // HEAD must return the same representation as GET without the body
+  // (RFC 9110 section 9.3.2).
+  test("HEAD is served by the GET handler when no HEAD handler is declared", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/m": { GET: () => new Response("hello-get") },
+        "/*": () => new Response("from-catch-all"),
+      },
+    });
+
+    const get = await fetch(new URL("/m", server.url));
+    expect(await get.text()).toBe("hello-get");
+    expect(get.status).toBe(200);
+
+    const head = await fetch(new URL("/m", server.url), { method: "HEAD" });
+    expect(await head.text()).toBe("");
+    expect(head.headers.get("content-length")).toBe("9");
+    expect(head.status).toBe(200);
+
+    // Other methods still fall through to the next matching route.
+    const post = await fetch(new URL("/m", server.url), { method: "POST" });
+    expect(await post.text()).toBe("from-catch-all");
+  });
+
+  test("HEAD does not 404 when there is no later route to fall through to", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/only-get": { GET: () => new Response("ok") } },
+    });
+
+    const res = await fetch(new URL("/only-get", server.url), { method: "HEAD" });
+    expect(await res.text()).toBe("");
+    expect(res.headers.get("content-length")).toBe("2");
+    expect(res.status).toBe(200);
+  });
+
+  test("the GET handler observes the real request method", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/echo": { GET: req => new Response("body", { headers: { "x-seen-method": req.method } }) },
+      },
+    });
+
+    const res = await fetch(new URL("/echo", server.url), { method: "HEAD" });
+    expect(res.headers.get("x-seen-method")).toBe("HEAD");
+    expect(res.headers.get("content-length")).toBe("4");
+    expect(await res.text()).toBe("");
+    expect(res.status).toBe(200);
+  });
+
+  test("an explicit HEAD handler takes precedence over the GET handler", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/explicit": {
+          GET: () => new Response("get-body"),
+          HEAD: () => new Response(null, { headers: { "x-explicit-head": "1" } }),
+        },
+      },
+    });
+
+    const res = await fetch(new URL("/explicit", server.url), { method: "HEAD" });
+    expect(res.headers.get("x-explicit-head")).toBe("1");
+    expect(res.status).toBe(200);
+  });
+
+  test("HEAD is not derived for route objects without a GET handler", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/post-only": { POST: () => new Response("p") } },
+    });
+
+    const res = await fetch(new URL("/post-only", server.url), { method: "HEAD" });
+    expect(res.status).toBe(404);
+  });
+});
+
 describe("static responses", () => {
   let server: Server;
 

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -177,6 +177,44 @@ describe("implicit HEAD for per-method route objects", () => {
     expect(res.status).toBe(200);
   });
 
+  test("an explicit static HEAD Response takes precedence over the GET handler", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/explicit-static": {
+          GET: () => new Response("get-body"),
+          HEAD: new Response(null, { headers: { "x-static-head": "1" } }),
+        },
+      },
+    });
+
+    const res = await fetch(new URL("/explicit-static", server.url), { method: "HEAD" });
+    expect(res.headers.get("x-static-head")).toBe("1");
+    expect(res.status).toBe(200);
+  });
+
+  test("a static Response for another method does not capture HEAD away from GET", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/mixed": {
+          GET: () => new Response("hello-get"),
+          POST: new Response("static-post-response"),
+        },
+      },
+    });
+
+    const head = await fetch(new URL("/mixed", server.url), { method: "HEAD" });
+    expect(await head.text()).toBe("");
+    expect(head.headers.get("content-length")).toBe("9");
+    expect(head.status).toBe(200);
+
+    const get = await fetch(new URL("/mixed", server.url));
+    expect(await get.text()).toBe("hello-get");
+    const post = await fetch(new URL("/mixed", server.url), { method: "POST" });
+    expect(await post.text()).toBe("static-post-response");
+  });
+
   test("HEAD is not derived for route objects without a GET handler", async () => {
     await using server = Bun.serve({
       port: 0,
@@ -185,6 +223,20 @@ describe("implicit HEAD for per-method route objects", () => {
 
     const res = await fetch(new URL("/post-only", server.url), { method: "HEAD" });
     expect(res.status).toBe(404);
+  });
+
+  test("HEAD is not derived for a static Response under a non-GET method", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/post-only-static": { POST: new Response("post-only") } },
+    });
+
+    const head = await fetch(new URL("/post-only-static", server.url), { method: "HEAD" });
+    expect(head.status).toBe(404);
+
+    const post = await fetch(new URL("/post-only-static", server.url), { method: "POST" });
+    expect(await post.text()).toBe("post-only");
+    expect(post.status).toBe(200);
   });
 });
 


### PR DESCRIPTION
A `routes` value of the per-method object form never answers HEAD unless a `HEAD` key is spelled out. A HEAD request to that path is served by whatever matches next, so HEAD and GET on the same URL return different representations, or it 404s when nothing else matches.

### Repro

```js
using srv = Bun.serve({
  port: 0,
  routes: {
    "/m": { GET: () => new Response("hello-get") },
    "/*": () => new Response("from-catch-all"),
  },
});
// GET  /m -> 200, Content-Length: 9  ("hello-get")
// HEAD /m -> 200, Content-Length: 14 (the "/*" route's "from-catch-all")
// ...and with no "/*" route, HEAD /m -> 404
```

RFC 9110 section 9.3.2 requires HEAD to return the same header fields a GET of the same target would. Every other `Bun.serve` route form already derives HEAD from GET: plain function routes (registered for any method), static `Response` / `Bun.file` routes (which register a dedicated HEAD handler), and the `fetch` fallback. Only the per-method object form is missing it, and an intermediary that caches based on a HEAD probe gets a different answer than GET.

### Cause

Three sites, same class. Note that `HttpRouter::add` removes an existing handler for the same method, pattern, and priority before inserting, so the last registration for a method and path wins, and `set_routes` registers static routes after user routes.

1. `ServerConfig::from_js` turns each key of a per-method route object into a user route registered for that one method only. Nothing registers the path under HEAD, so the router never matches it.
2. `apply_static_route` registered a HEAD handler for every static entry regardless of its declared methods, so a static `Response` under a non-GET key both answers HEAD on its own and captures HEAD away from a sibling GET handler:

```js
using a = Bun.serve({ port: 0, routes: {
  "/m": { GET: () => new Response("hello-get"), POST: new Response("static-post-response") },
}});
// GET  /m -> Content-Length: 9
// HEAD /m -> Content-Length: 20   (the POST response's framing)

using b = Bun.serve({ port: 0, routes: { "/p": { POST: new Response("p") } } });
// GET /p -> 404,  HEAD /p -> 200
```

3. For the same reason, a static `Response` under the GET key silently displaced an explicit callable HEAD handler on the same path:

```js
using c = Bun.serve({ port: 0, routes: {
  "/m": { GET: new Response("g"), HEAD: () => new Response(null, { headers: { "x-h": "1" } }) },
}});
// HEAD /m -> Content-Length: 1, no x-h header; the HEAD handler never runs
```

### Fix

- When a per-method route object has a callable GET handler and no HEAD entry, register the GET handler under HEAD as well. The request context is created with `method == HEAD`, so the existing HEAD rendering path strips the body and reports the Content-Length GET would have produced; the handler observes `req.method === "HEAD"`, the same as a plain function route does today.
- `apply_static_route` (and its HTTP/3 twin) register the implicit HEAD handler only for an entry that serves any method, GET, or HEAD, and never for a path that already has an explicit HEAD handler route. A static `Response` under a non-GET, non-HEAD key no longer answers or captures HEAD, and a static GET `Response` no longer displaces a declared HEAD handler.

With that, an explicit `HEAD` key, handler or static `Response`, always takes precedence, and other methods are unchanged: they still fall through to later routes, which is how per-method routes compose with a `"/*"` catch-all.

### Verification

New `describe("implicit HEAD for per-method route objects")` in `test/js/bun/http/bun-serve-routes.test.ts` with nine tests. Six fail on the unmodified build:

- HEAD falls through to the `"/*"` catch-all instead of the GET handler
- HEAD 404s when there is no catch-all
- the `req.method` and Content-Length the GET handler observes
- `{ GET: handler, POST: new Response(...) }` answers HEAD with the POST response's framing
- `{ POST: new Response(...) }` answers HEAD at all
- `{ GET: new Response(...), HEAD: handler }` drops the explicit HEAD handler

The other three are positive controls: an explicit HEAD handler over a GET handler, an explicit static HEAD `Response`, and a route object with no GET handler.

`bun-serve-routes.test.ts` (50), `bun-serve-static.test.ts` (34), `serve-http3.test.ts` (45), `bun-serve-file.test.ts` (66), `serve-if-none-match.test.ts` (17), and `bun-serve-html-manifest.test.ts` (4) all pass. `serve.test.ts` and `bun-server.test.ts` have the same failures as the unmodified build (environment dependent: IPv6, privileged ports).

Related: #32800 fixes HEAD response framing (what goes on the wire for a HEAD response). This fixes HEAD route dispatch (which handler a HEAD request reaches). The two change disjoint files. #32823 fixes the route-parameter percent-decoder, reported together with this but independent.
