### PR TITLE
Keep invalid percent escapes literal in Bun.serve route params and cookies

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -124,7 +124,7 @@ Bun.serve({
 });
 ```
 
-Bun automatically decodes percent-encoded route parameter values, including Unicode characters. Invalid Unicode is replaced with the Unicode replacement character (`\uFFFD`).
+Bun automatically decodes percent-encoded route parameter values, including Unicode characters. Invalid Unicode is replaced with the Unicode replacement character (`\uFFFD`). A `%` that is not followed by two hexadecimal digits is not an escape and is preserved literally.
 
 ### Static responses
 

--- a/src/jsc/bindings/decodeURIComponentSIMD.cpp
+++ b/src/jsc/bindings/decodeURIComponentSIMD.cpp
@@ -75,8 +75,10 @@ slow_path:
 
     while (cursor < end) {
         if (*cursor == '%') {
+            // A '%' not followed by two hex digits is not a percent-escape
+            // (RFC 3986 section 2.1); emit it literally and re-scan what follows.
             if (cursor + 2 >= end) {
-                result.append(replacementChar);
+                result.append('%');
                 cursor++;
                 continue;
             }
@@ -85,8 +87,8 @@ slow_path:
             uint8_t lowNibble = hexToInt(cursor[2]);
 
             if (highNibble > 15 || lowNibble > 15) {
-                result.append(replacementChar);
-                cursor += (cursor + 2 < end) ? 3 : 1;
+                result.append('%');
+                cursor++;
                 continue;
             }
 

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -203,6 +203,19 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`[]`);
   });
 
+  test("percent-decoding a cookie value keeps invalid escapes literal", () => {
+    // A "%" not followed by two hex digits is not a percent-escape
+    // (RFC 3986 section 2.1) and must pass through unchanged.
+    const map = new Bun.CookieMap("a=50%-off; b=caf%C3%A9; c=x%zz; d=100%25; e=abc%");
+    expect(Object.fromEntries(map)).toEqual({
+      a: "50%-off",
+      b: "café",
+      c: "x%zz",
+      d: "100%",
+      e: "abc%",
+    });
+  });
+
   test("can create CookieMap from object", () => {
     const map = new Bun.CookieMap({
       name: "value",

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -91,6 +91,26 @@ describe("path parameters", () => {
     expect(response).toContain("HTTP/1.1 200");
     expect(JSON.parse(response.slice(response.indexOf("\r\n\r\n") + 4))).toEqual({ id: expected, method: "GET" });
   });
+
+  // A "%" not followed by two hex digits is not a percent-escape (RFC 3986
+  // section 2.1) and must pass through literally without consuming the
+  // characters after it.
+  it.each([
+    ["50%-off", "50%-off"],
+    ["a%zzb", "a%zzb"],
+    ["abc%", "abc%"],
+    ["x%2", "x%2"],
+    ["a%%b", "a%%b"],
+    ["100%25", "100%"],
+    ["caf%C3%A9", "café"],
+  ])("percent-decodes route parameter %s", async (raw, expected) => {
+    const res = await fetch(new URL(`/users/${raw}`, server.url).href);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      id: expected,
+      method: "GET",
+    });
+  });
 });
 
 describe("HTTP methods", () => {

--- a/test/js/bun/http/decodeURIComponentSIMD.test.ts
+++ b/test/js/bun/http/decodeURIComponentSIMD.test.ts
@@ -355,48 +355,54 @@ describe("decodeURIComponentSIMD with UTF-8 byte input", () => {
       "a" + String.fromCodePoint(0xfffd) + "bA",
     );
   });
+
+  it("keeps an invalid escape literal in input bytes that also contain multi-byte characters", () => {
+    expect(decodeURIComponentSIMD(encoder.encode("é%zz"))).toBe("é%zz");
+    expect(decodeURIComponentSIMD(encoder.encode("%zzé"))).toBe("%zzé");
+  });
 });
 
-describe("decodeURIComponentSIMD edge cases", () => {
-  it("should handle cursor advancement correctly with invalid hex", () => {
-    // This test would fail because of the cursor advancement bug
-    // When it sees %GG, it only advances by 1 instead of 3, causing
-    // the GG to be treated as literal characters
-    expect(decodeURIComponentSIMD("%GG%20test")).toBe(String.fromCodePoint(0xfffd) + " " + "test");
+// A "%" not followed by two hex digits is not a percent-escape (RFC 3986
+// section 2.1). It must pass through literally without consuming the
+// characters after it.
+describe("decodeURIComponentSIMD invalid escapes", () => {
+  it("keeps a '%' followed by non-hex characters literal", () => {
+    expect(decodeURIComponentSIMD("%GG%20test")).toBe("%GG test");
+    expect(decodeURIComponentSIMD("50%-off")).toBe("50%-off");
+    expect(decodeURIComponentSIMD("a%zzb")).toBe("a%zzb");
   });
 
-  it("should handle multiple invalid sequences consecutively", () => {
-    // Similar cursor advancement issue
-    expect(decodeURIComponentSIMD("%ZZ%XX%YY")).toBe(String.fromCodePoint(0xfffd).repeat(3));
+  it("keeps consecutive invalid escapes literal", () => {
+    expect(decodeURIComponentSIMD("%ZZ%XX%YY")).toBe("%ZZ%XX%YY");
+    expect(decodeURIComponentSIMD("a%%b")).toBe("a%%b");
+    expect(decodeURIComponentSIMD("%%%")).toBe("%%%");
   });
 
-  it("should handle incomplete sequences at SIMD boundaries", () => {
-    // Create a string that puts a % character right at the SIMD boundary
-    // then follow it with invalid hex digits
-    const prefix = "a".repeat(15); // 15 bytes to align the % at boundary
-    expect(decodeURIComponentSIMD(prefix + "%GG")).toBe(prefix + String.fromCodePoint(0xfffd));
+  it("keeps a truncated escape at the end of the input literal", () => {
+    expect(decodeURIComponentSIMD("abc%")).toBe("abc%");
+    expect(decodeURIComponentSIMD("x%2")).toBe("x%2");
+    expect(decodeURIComponentSIMD("%")).toBe("%");
   });
 
-  it("should handle mixed valid/invalid sequences at SIMD boundaries", () => {
-    // This combines SIMD boundary alignment with the cursor advancement bug
-    const prefix = "a".repeat(15);
-    expect(decodeURIComponentSIMD(prefix + "%GG%20%HH%20")).toBe(
-      prefix + String.fromCodePoint(0xfffd) + " " + String.fromCodePoint(0xfffd) + " ",
-    );
+  it("handles invalid escapes at SIMD boundaries", () => {
+    const prefix = Buffer.alloc(15, "a").toString(); // aligns the % at the 16-byte boundary
+    expect(decodeURIComponentSIMD(prefix + "%GG")).toBe(prefix + "%GG");
+    expect(decodeURIComponentSIMD(prefix + "%GG%20%HH%20")).toBe(prefix + "%GG %HH ");
   });
 
-  it("should handle large sequences of invalid encodings", () => {
-    // This would really expose the cursor advancement issue
-    const input = "%GG".repeat(1000);
-    // it should be full of unicode replacement characters
-    expect(decodeURIComponentSIMD(input).length).toBe(String.fromCodePoint(0xfffd).repeat(1000).length);
+  it("handles large sequences of invalid escapes", () => {
+    const input = Buffer.alloc(3000, "%GG").toString();
+    expect(decodeURIComponentSIMD(input)).toBe(input);
   });
 
-  it("should handle invalid sequences followed by valid UTF-8", () => {
-    // This combines the cursor advancement bug with UTF-8 decoding
-    expect(decodeURIComponentSIMD("%GG%F0%9F%98%80")).toBe(
-      // replacement + replacement + smiley
-      String.fromCodePoint(0xfffd) + "😀",
-    );
+  it("decodes valid escapes adjacent to invalid ones", () => {
+    expect(decodeURIComponentSIMD("%GG%F0%9F%98%80")).toBe("%GG😀");
+    expect(decodeURIComponentSIMD("a%25b%zz")).toBe("a%b%zz");
+  });
+
+  it("still replaces decoded bytes that are not valid UTF-8 with U+FFFD", () => {
+    // These are well-formed %XX escapes whose decoded bytes are invalid UTF-8.
+    expect(decodeURIComponentSIMD("a%FFb")).toBe("a\uFFFDb");
+    expect(decodeURIComponentSIMD("a%C3x")).toBe("a\uFFFDx");
   });
 });

--- a/test/js/bun/util/cookie.test.js
+++ b/test/js/bun/util/cookie.test.js
@@ -342,7 +342,7 @@ describe("cookie.parse(str)", function () {
     expect(cookie.parse("\tfoo\t=\tbar\t")).toEqual({ foo: "bar" });
   });
 
-  it.failing("should return original value on escape error", function () {
+  it("should return original value on escape error", function () {
     expect(cookie.parse("foo=%1;bar=bar")).toEqual({ foo: "%1", bar: "bar" });
   });
 


### PR DESCRIPTION
`req.params` values and cookie values (`req.cookies`, `Bun.CookieMap`) are percent-decoded by `Bun::decodeURIComponentSIMD`. For a `%` not followed by two hex digits, the decoder emitted U+FFFD and then advanced the cursor past the `%` and the two characters after it, destroying data that was never part of an escape.

### Repro

```js
using srv = Bun.serve({
  port: 0,
  routes: { "/p/:v": req => new Response(req.params.v) },
});
// GET /p/50%-off -> "50\uFFFDff"   ("-o" consumed by a bogus escape)
// GET /p/a%zzb   -> "a\uFFFDb"
// GET /p/abc%    -> "abc\uFFFD"
// GET /p/x%2     -> "x\uFFFD2"

new Bun.CookieMap("discount=50%-off").get("discount"); // "50\uFFFDff"
```

Per RFC 3986 section 2.1 (and the WHATWG URL percent-decode algorithm), a `%` not followed by two hex digits is not an escape and passes through literally. Bun's routing docs say "Invalid unicode is replaced with the unicode replacement character", which is about the decoded bytes (a lone `%FF` is not valid UTF-8), not about a `%` that never formed an escape. In practice, any route parameter or cookie value containing a literal `%` was silently corrupted, and the adjacent characters were destroyed with it.

### Cause

In `src/jsc/bindings/decodeURIComponentSIMD.cpp`, the non-hex branch appended U+FFFD and did `cursor += 3`, and the truncated-escape branch (`%` or `%X` at the end of the input) appended U+FFFD as well.

### Fix

Both branches now append the literal `%` and advance by one, so the following characters are scanned normally. Valid `%XX` escapes are unchanged, and a well-formed escape whose decoded bytes are not valid UTF-8 (a lone `%FF`, an incomplete multibyte sequence) still becomes U+FFFD as documented.

`decodeURIComponentSIMD` has exactly three callers: `ServerRouteList` (`req.params`), `CookieMap` (`req.cookies` / `Bun.CookieMap`), and the `bun:internal-for-testing` export used by its unit test. Both user-facing surfaces get the same fix.

### Verification

- `test/js/bun/http/bun-serve-routes.test.ts`: end-to-end `req.params` table. Five of the seven rows fail on the unmodified build; `%25` and a valid UTF-8 escape are positive controls.
- `test/js/bun/http/decodeURIComponentSIMD.test.ts`: the existing "edge cases" describe asserted the U+FFFD-and-consume-3 behavior (its comments call it "the cursor advancement bug"). It is rewritten to assert literal pass-through, plus new cases for truncated escapes, consecutive `%`, adjacent valid escapes, and the preserved invalid-UTF-8 to U+FFFD path.
- `test/js/bun/cookie/cookie-map.test.ts`: `Bun.CookieMap` string parsing.
- `test/js/bun/util/cookie.test.js`: the ported `cookie` npm package suite's "should return original value on escape error" (`cookie.parse("foo=%1;bar=bar")` must give `{ foo: "%1", bar: "bar" }`) was marked `it.failing` as a known compatibility gap. This change makes it pass, so the marker is removed.

All four files pass with the fix (225 / 48 / 25 / 101) and the new assertions fail without it. `bun-serve-cookies.test.ts` (25) and the rest of `test/js/bun/cookie/` (150) also pass.

The routing docs gain one sentence stating that a `%` not followed by two hex digits is preserved literally.

Related: #32822 fixes HEAD dispatch for per-method route objects; it was reported together with this but is an independent change.


Rebased onto main after #33072 (hardening round 11), which added UTF-8 byte-input handling to `decodeURIComponentSIMD`. The two edited branches were untouched upstream; the conflicts were in adjacent tests and the routing doc (whose `\uFFFD` typo #33072's fact-check pass also fixed, so that commit dropped out). I kept the new upstream tests alongside mine and added one case in the UTF-8 byte-input describe that exercises an invalid escape in non-ASCII input, covering the intersection of the two changes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 13 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-map.test.ts test/js/bun/http/bun-serve-routes.test.ts test/js/bun/http/decodeURIComponentSIMD.test.ts test/js/bun/util/cookie.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0e97f6b97)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [36.02ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [8.70ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [9.22ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [5.36ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [6.48ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [9.53ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works wi
... (truncated)

release without fix: 33 failed, 18 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.14ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.10ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.15ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [34.59ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.25ms]
93 |   test("Cookie.isExpired() gives Max-Age precedence over Expires", () => {
94 |     const past = new Date(Date.now() - 1000);
95 |     const future = new Date(Date.now() + 86_400_000);
96 | 
97 |     // Max-Age wins over Expires regardless of which one the header listed first.
98 |     expect(new Bun.Cookie("name", "value", { maxAge: 3600, expires: past }).isExpired()).toBe(false);
                                                                                              ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/workspace/bun/test/js/bun/cookie/cookie-map.test.ts:98:90)
(fail) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Ma
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-map.test.ts test/js/bun/http/bun-serve-routes.test.ts test/js/bun/http/decodeURIComponentSIMD.test.ts test/js/bun/util/cookie.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0e97f6b97)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [5.35ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [5.63ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [5.59ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [3.43ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.11ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [5.96ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works wit
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 719ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 22s
[3/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[4/7] link bun-profile
[5/7] bun-profile --re
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/http/routing.mdx                   |  2 +-
 src/jsc/bindings/decodeURIComponentSIMD.cpp     |  8 +--
 test/js/bun/cookie/cookie-map.test.ts           | 13 +++++
 test/js/bun/http/bun-serve-routes.test.ts       | 20 ++++++++
 test/js/bun/http/decodeURIComponentSIMD.test.ts | 68 ++++++++++++++-----------
 test/js/bun/util/cookie.test.js                 |  2 +-
 6 files changed, 77 insertions(+), 36 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 13

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
docs/runtime/http/routing.mdx                        5      6     27
src/jsc/bindings/decodeURIComponentSIMD.cpp          1      1     27
test/js/bun/cookie/cookie-map.test.ts                1      1      9
test/js/bun/http/bun-serve-routes.test.ts            7      9     16
test/js/bun/http/decodeURIComponentSIMD.test.ts      4      2      8
test/js/bun/util/cookie.test.js                      2      1     10
```

</details>

<!-- robobun:evidence:end -->