### PR TITLE
node:tls: fix getCipher().version, getEphemeralKeyInfo(), client STARTTLS, and checkServerIdentity exception handling

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -254,6 +254,33 @@ function tlsHandshakeError(verifyError) {
   return new ConnResetException("socket hang up");
 }
 
+function rethrowUncaught(err) {
+  throw err;
+}
+
+// Distinguishes "the user's checkServerIdentity threw" from any Error it
+// returned; the handshake is abandoned the way Node abandons onConnectSecure.
+const kCheckServerIdentityThrew = Symbol("kCheckServerIdentityThrew");
+
+/**
+ * Run the user's `checkServerIdentity` and return the verify Error it
+ * produced (or undefined). Node does not guard the callback: an exception it
+ * throws escapes the handshake as an uncaught exception rather than being
+ * downgraded to a socket 'error' by the native handler error routing, so the
+ * rethrow is deferred out of this callback's try frame.
+ */
+function runCheckServerIdentity(self, checkServerIdentity) {
+  const hostname = self.servername || self._host || "localhost";
+  const cert = self.getPeerCertificate(true);
+  if (!cert) return undefined;
+  try {
+    return checkServerIdentity(hostname, cert);
+  } catch (err) {
+    process.nextTick(rethrowUncaught, err);
+    return kCheckServerIdentityThrew;
+  }
+}
+
 const SocketHandlers: SocketHandler = {
   close(socket, err) {
     const self = socket.data;
@@ -416,11 +443,8 @@ const SocketHandlers: SocketHandler = {
     self.alpnProtocol = socket.alpnProtocol;
     const { checkServerIdentity } = self[bunTLSConnectOptions];
     if (!verifyError && typeof checkServerIdentity === "function") {
-      const hostname = self.servername || self._host || "localhost";
-      const cert = self.getPeerCertificate(true);
-      if (cert) {
-        verifyError = checkServerIdentity(hostname, cert);
-      }
+      verifyError = runCheckServerIdentity(self, checkServerIdentity);
+      if (verifyError === kCheckServerIdentityThrew) return;
     }
     let rejectUnauthorized;
     if (self._requestCert || (rejectUnauthorized = self._rejectUnauthorized)) {
@@ -1152,11 +1176,8 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     self.alpnProtocol = socket.alpnProtocol;
     const { checkServerIdentity } = self[bunTLSConnectOptions];
     if (!verifyError && typeof checkServerIdentity === "function") {
-      const hostname = self.servername || self._host || "localhost";
-      const cert = self.getPeerCertificate(true);
-      if (cert) {
-        verifyError = checkServerIdentity(hostname, cert);
-      }
+      verifyError = runCheckServerIdentity(self, checkServerIdentity);
+      if (verifyError === kCheckServerIdentityThrew) return;
     }
     let rejectUnauthorized;
     if (self._requestCert || (rejectUnauthorized = self._rejectUnauthorized)) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -442,7 +442,9 @@ const SocketHandlers: SocketHandler = {
     self.emit("secure", self);
     self.alpnProtocol = socket.alpnProtocol;
     const { checkServerIdentity } = self[bunTLSConnectOptions];
-    if (!verifyError && typeof checkServerIdentity === "function") {
+    // Node skips the identity check on a resumed session: it was verified on
+    // the original full handshake (onConnectSecure in lib/_tls_wrap.js).
+    if (!verifyError && typeof checkServerIdentity === "function" && !self.isSessionReused()) {
       verifyError = runCheckServerIdentity(self, checkServerIdentity);
       if (verifyError === kCheckServerIdentityThrew) return;
     }
@@ -1175,7 +1177,9 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     self.emit("secure", self);
     self.alpnProtocol = socket.alpnProtocol;
     const { checkServerIdentity } = self[bunTLSConnectOptions];
-    if (!verifyError && typeof checkServerIdentity === "function") {
+    // Node skips the identity check on a resumed session: it was verified on
+    // the original full handshake (onConnectSecure in lib/_tls_wrap.js).
+    if (!verifyError && typeof checkServerIdentity === "function" && !self.isSessionReused()) {
       verifyError = runCheckServerIdentity(self, checkServerIdentity);
       if (verifyError === kCheckServerIdentityThrew) return;
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1666,8 +1666,9 @@ Socket.prototype.connect = function connect(...args) {
       this._requestCert = true;
       if (tls) {
         if (typeof rejectUnauthorized !== "undefined") {
-          this._rejectUnauthorized = rejectUnauthorized;
-          tls.rejectUnauthorized = rejectUnauthorized;
+          // Only an explicit `false` disables verification (CVE-2021-22939).
+          this._rejectUnauthorized = rejectUnauthorized !== false;
+          tls.rejectUnauthorized = this._rejectUnauthorized;
         } else {
           this._rejectUnauthorized = tls.rejectUnauthorized;
         }
@@ -2718,8 +2719,8 @@ function internalConnect(self, options, address, port, addressType, localAddress
     if (tls) {
       const { rejectUnauthorized, session, checkServerIdentity } = options;
       if (typeof rejectUnauthorized !== "undefined") {
-        self._rejectUnauthorized = rejectUnauthorized;
-        tls.rejectUnauthorized = rejectUnauthorized;
+        self._rejectUnauthorized = rejectUnauthorized !== false;
+        tls.rejectUnauthorized = self._rejectUnauthorized;
       } else {
         self._rejectUnauthorized = tls.rejectUnauthorized;
       }
@@ -2871,8 +2872,8 @@ function internalConnectMultiple(context, canceled?) {
     if (tls) {
       const { rejectUnauthorized, session, checkServerIdentity } = context.options;
       if (typeof rejectUnauthorized !== "undefined") {
-        self._rejectUnauthorized = rejectUnauthorized;
-        tls.rejectUnauthorized = rejectUnauthorized;
+        self._rejectUnauthorized = rejectUnauthorized !== false;
+        tls.rejectUnauthorized = self._rejectUnauthorized;
       } else {
         self._rejectUnauthorized = tls.rejectUnauthorized;
       }

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -973,7 +973,9 @@ TLSSocket.prototype._start = function _start() {
   // port, path, or socket and throws ERR_MISSING_ARGS.
   const wrapped = this._handle;
   if (!this.isServer && wrapped instanceof Duplex) {
-    this.connect({ socket: wrapped });
+    // Preserve any SNI set via setServername() before _start(): connect()
+    // would otherwise overwrite this.servername from its options object.
+    this.connect({ socket: wrapped, servername: this.servername });
     return;
   }
   this.connect();

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -940,8 +940,10 @@ function TLSSocket(socket?, options?) {
   // Honor the constructor's own `rejectUnauthorized`. tls.connect() also
   // routes it through Socket.prototype.connect's options, but the bare
   // `new TLSSocket(socket, options)` + `_start()` path never gets there.
+  // Only an explicit `false` disables verification (Node's CVE-2021-22939
+  // fix): every other value, including `null`, keeps it on.
   const rejectUnauthorized = options.rejectUnauthorized;
-  if (rejectUnauthorized !== undefined) this._rejectUnauthorized = rejectUnauthorized;
+  if (rejectUnauthorized !== undefined) this._rejectUnauthorized = rejectUnauthorized !== false;
 
   // `new tls.TLSSocket(socket, { isServer: true })`: drive the server-side TLS
   // handshake over the provided socket via net.ts's native upgrade path (reaches
@@ -1402,7 +1404,7 @@ function Server(options, secureConnectionListener): void {
       const rejectUnauthorized = options.rejectUnauthorized;
 
       if (typeof rejectUnauthorized !== "undefined") {
-        this._rejectUnauthorized = rejectUnauthorized;
+        this._rejectUnauthorized = rejectUnauthorized !== false;
       } else this._rejectUnauthorized = rejectUnauthorizedDefault();
 
       const ciphers = options.ciphers;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -937,6 +937,11 @@ function TLSSocket(socket?, options?) {
   }
   this[kcheckServerIdentity] = checkServerIdentityOption || checkServerIdentity;
   this[ksession] = options.session || null;
+  // Honor the constructor's own `rejectUnauthorized`. tls.connect() also
+  // routes it through Socket.prototype.connect's options, but the bare
+  // `new TLSSocket(socket, options)` + `_start()` path never gets there.
+  const rejectUnauthorized = options.rejectUnauthorized;
+  if (rejectUnauthorized !== undefined) this._rejectUnauthorized = rejectUnauthorized;
 
   // `new tls.TLSSocket(socket, { isServer: true })`: drive the server-side TLS
   // handshake over the provided socket via net.ts's native upgrade path (reaches
@@ -958,7 +963,17 @@ TLSSocket.prototype._destroySSL = function _destroySSL() {
 };
 
 TLSSocket.prototype._start = function _start() {
-  // some frameworks uses this _start internal implementation is suposed to start TLS handshake/connect
+  // Some frameworks use this internal entry point to start the TLS handshake.
+  // The client STARTTLS pattern, `new tls.TLSSocket(connectedSocket,
+  // { isServer: false })` followed by `_start()`, has to drive the upgrade
+  // over the wrapped socket the constructor stashed on `_handle` - the same
+  // thing `tls.connect({ socket })` does - or connect() is left with no
+  // port, path, or socket and throws ERR_MISSING_ARGS.
+  const wrapped = this._handle;
+  if (!this.isServer && wrapped instanceof Duplex) {
+    this.connect({ socket: wrapped });
+    return;
+  }
   this.connect();
 };
 

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -1031,9 +1031,11 @@ pub(super) fn get_ephemeral_key_info(
 
     // BoringSSL has no `SSL_get_peer_tmp_key`, but the negotiated named group
     // carries the same information for a TLS <= 1.2 (EC)DHE key exchange.
-    // Node returns {} on TLS 1.3 (its `SSL_get_peer_tmp_key` only surfaces the
-    // ServerKeyExchange key) and on a non-forward-secret (RSA) key exchange,
-    // where `SSL_get_negotiated_group` returns `NID_undef`; match both.
+    // Node reports no ephemeral key on TLS 1.3 (its `SSL_get_peer_tmp_key`
+    // only surfaces the ServerKeyExchange key) and on a non-forward-secret
+    // (RSA) key exchange, where `SSL_get_negotiated_group` is `NID_undef`;
+    // match both. The tls.ts wrapper shapes the empty result into Node's
+    // fixed {type, name, size} key set.
     if ffi::SSL_version(ssl) >= i32::from(ffi::TLS1_3_VERSION) {
         return Ok(result);
     }

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -28,22 +28,19 @@ pub(super) mod ffi {
     bun_opaque::opaque_ffi! {
         pub(crate) struct SSL_SESSION;
         pub(crate) struct SSL_CIPHER;
-        pub(crate) struct EVP_PKEY;
-        pub(crate) struct EC_KEY;
-        pub(crate) struct EC_GROUP;
     }
 
     // ssl.h
     pub(crate) const TLSEXT_NAMETYPE_host_name: c_int = 0;
+    // tls1.h / ssl3.h protocol version numbers.
+    pub(crate) const TLS1_2_VERSION: u16 = 0x0303;
+    pub(crate) const TLS1_3_VERSION: u16 = 0x0304;
 
     // evp.h key types (NID values)
     pub(crate) const EVP_PKEY_RSA: c_int = 6;
     pub(crate) const EVP_PKEY_RSA_PSS: c_int = 912;
     pub(crate) const EVP_PKEY_DSA: c_int = 116;
     pub(crate) const EVP_PKEY_EC: c_int = 408;
-    pub(crate) const EVP_PKEY_DH: c_int = 28;
-    pub(crate) const EVP_PKEY_X25519: c_int = 948;
-    pub(crate) const EVP_PKEY_X448: c_int = 961;
 
     // obj_mac.h
     pub(crate) const NID_ED25519: c_int = 949;
@@ -51,9 +48,16 @@ pub(super) mod ffi {
     pub(crate) const NID_id_GostR3410_2001: c_int = 811;
     pub(crate) const NID_id_GostR3410_2012_256: c_int = 979;
     pub(crate) const NID_id_GostR3410_2012_512: c_int = 980;
+    // The (EC)DHE named groups BoringSSL supports for a TLS <= 1.2 key
+    // exchange (`ssl_key_share.cc` `kNamedGroups`).
+    pub(crate) const NID_X9_62_prime256v1: c_int = 415;
+    pub(crate) const NID_secp384r1: c_int = 715;
+    pub(crate) const NID_secp521r1: c_int = 716;
+    pub(crate) const NID_X25519: c_int = 948;
+    pub(crate) const NID_kx_ecdhe: c_int = 952;
 
     // ffi-safe-fn: every handle type below (`SSL`, `X509`, `SSL_CIPHER`,
-    // `EVP_PKEY`, `EC_KEY`, `EC_GROUP`) is an `opaque_ffi!` ZST — `&T`
+    // `SSL_SESSION`) is an `opaque_ffi!` ZST — `&T`
     // dereferences zero bytes, carries no `dereferenceable`/`noalias`
     // obligation, and the `UnsafeCell` body lets BoringSSL mutate through a
     // shared ref. Functions whose *only* pointer arguments are such handles
@@ -65,6 +69,10 @@ pub(super) mod ffi {
     unsafe extern "C" {
         // ── SSL session/handshake info ───────────────────────────────────
         pub(crate) safe fn SSL_get_version(ssl: &SSL) -> *const c_char;
+        pub(crate) safe fn SSL_version(ssl: &SSL) -> c_int;
+        /// NID of the (EC)DHE group negotiated by the most recently completed
+        /// handshake, or `NID_undef` (0) when the key exchange used none (RSA).
+        pub(crate) safe fn SSL_get_negotiated_group(ssl: &SSL) -> c_int;
         pub(crate) safe fn SSL_get_peer_certificate(ssl: &SSL) -> *mut X509;
         pub(crate) safe fn SSL_get_certificate(ssl: &SSL) -> *mut X509;
         pub(crate) safe fn SSL_set_max_send_fragment(ssl: &SSL, max_send_fragment: usize) -> c_int;
@@ -100,7 +108,6 @@ pub(super) mod ffi {
             use_context: c_int,
         ) -> c_int;
         pub(crate) safe fn SSL_session_reused(ssl: &SSL) -> c_int;
-        pub(crate) safe fn SSL_get_privatekey(ssl: &SSL) -> *mut EVP_PKEY;
 
         // ── SSL_SESSION ───────────────────────────────────────────────────
         pub(crate) safe fn SSL_get_session(ssl: &SSL) -> *mut SSL_SESSION;
@@ -129,7 +136,8 @@ pub(super) mod ffi {
         pub(crate) safe fn SSL_get_current_cipher(ssl: &SSL) -> *const SSL_CIPHER;
         pub(crate) safe fn SSL_CIPHER_get_name(cipher: &SSL_CIPHER) -> *const c_char;
         pub(crate) safe fn SSL_CIPHER_standard_name(cipher: &SSL_CIPHER) -> *const c_char;
-        pub(crate) safe fn SSL_CIPHER_get_version(cipher: &SSL_CIPHER) -> *const c_char;
+        pub(crate) safe fn SSL_CIPHER_get_min_version(cipher: &SSL_CIPHER) -> u16;
+        pub(crate) safe fn SSL_CIPHER_get_kx_nid(cipher: &SSL_CIPHER) -> c_int;
 
         // ── X509 ─────────────────────────────────────────────────────────
         pub(crate) safe fn X509_up_ref(x: &X509) -> c_int;
@@ -144,17 +152,6 @@ pub(super) mod ffi {
         // on null, which both call sites already guard).
         #[link_name = "sk_value"]
         pub(crate) safe fn sk_X509_value(sk: &struct_stack_st_X509, i: usize) -> *mut X509;
-
-        // ── EVP / EC ──────────────────────────────────────────────────────
-        pub(crate) safe fn EVP_PKEY_id(pkey: &EVP_PKEY) -> c_int;
-        pub(crate) safe fn EVP_PKEY_bits(pkey: &EVP_PKEY) -> c_int;
-        // Returns a +1 `EC_KEY*` (caller owns; the sole call site
-        // intentionally leaks it). The only pointer arg is an
-        // opaque-ZST `&EVP_PKEY`, so the call itself has no precondition.
-        pub(crate) safe fn EVP_PKEY_get1_EC_KEY(pkey: &EVP_PKEY) -> *mut EC_KEY;
-        // Result is borrowed from `key`; opaque-ZST ref ⇒ no caller precondition.
-        pub(crate) safe fn EC_KEY_get0_group(key: &EC_KEY) -> *const EC_GROUP;
-        pub(crate) safe fn EC_GROUP_get_curve_name(group: &EC_GROUP) -> c_int;
 
         // ── OBJ ──────────────────────────────────────────────────────────
         // Pure NID→short-name lookup; takes a by-value int and returns a
@@ -814,14 +811,22 @@ pub(super) fn get_cipher(
         );
     }
 
-    let version = ffi::SSL_CIPHER_get_version(cipher);
-    if version.is_null() {
-        result.put(global, b"version", JSValue::NULL);
-    } else {
-        // SAFETY: SSL_CIPHER_get_version returns a static NUL-terminated C string.
-        let s = unsafe { bun_core::ffi::cstr(version) }.to_bytes();
-        result.put(global, b"version", ZigString::from_utf8(s).to_js(global));
-    }
+    // BoringSSL's `SSL_CIPHER_get_version` is hardcoded to "TLSv1/SSLv3".
+    // Node reports the cipher's minimum protocol version (OpenSSL's cipher
+    // table); rebuild the same strings from `SSL_CIPHER_get_min_version`.
+    // For the pre-1.2 suites OpenSSL reports "TLSv1.0" for the ECC ones
+    // (RFC 4492 defined them for TLS 1.0) and "SSLv3" for the rest.
+    let version: &[u8] = match ffi::SSL_CIPHER_get_min_version(cipher) {
+        ffi::TLS1_3_VERSION => b"TLSv1.3",
+        ffi::TLS1_2_VERSION => b"TLSv1.2",
+        _ if ffi::SSL_CIPHER_get_kx_nid(cipher) == ffi::NID_kx_ecdhe => b"TLSv1.0",
+        _ => b"SSLv3",
+    };
+    result.put(
+        global,
+        b"version",
+        ZigString::from_utf8(version).to_js(global),
+    );
 
     Ok(result)
 }
@@ -1021,64 +1026,38 @@ pub(super) fn get_ephemeral_key_info(
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::NULL);
     };
+    let ssl = boringssl::SSL::opaque_ref(ssl_ptr);
     let result = JSValue::create_empty_object(global, 0);
 
-    // TODO: investigate better option or compatible way to get the key
-    // this implementation follows nodejs but for BoringSSL SSL_get_server_tmp_key will always return 0
-    // wich will result in a empty object
-    // let mut raw_key: *mut boringssl::EVP_PKEY = core::ptr::null_mut();
-    // if unsafe { boringssl::SSL_get_server_tmp_key(ssl_ptr, &mut raw_key) } == 0 {
-    //     return Ok(result);
-    // }
-    let raw_key: *mut ffi::EVP_PKEY = ffi::SSL_get_privatekey(boringssl::SSL::opaque_ref(ssl_ptr));
-    if raw_key.is_null() {
+    // BoringSSL has no `SSL_get_peer_tmp_key`, but the negotiated named group
+    // carries the same information for a TLS <= 1.2 (EC)DHE key exchange.
+    // Node returns {} on TLS 1.3 (its `SSL_get_peer_tmp_key` only surfaces the
+    // ServerKeyExchange key) and on a non-forward-secret (RSA) key exchange,
+    // where `SSL_get_negotiated_group` returns `NID_undef`; match both.
+    if ffi::SSL_version(ssl) >= i32::from(ffi::TLS1_3_VERSION) {
         return Ok(result);
     }
-    let pkey = ffi::EVP_PKEY::opaque_ref(raw_key);
-
-    let kid = ffi::EVP_PKEY_id(pkey);
-    let bits = ffi::EVP_PKEY_bits(pkey);
-
-    match kid {
-        ffi::EVP_PKEY_DH => {
-            result.put(global, b"type", BunString::static_("DH").to_js(global)?);
-            result.put(global, b"size", JSValue::js_number(f64::from(bits)));
-        }
-        ffi::EVP_PKEY_EC | ffi::EVP_PKEY_X25519 | ffi::EVP_PKEY_X448 => {
-            let curve_name: &[u8];
-            if kid == ffi::EVP_PKEY_EC {
-                // `pkey` is non-null (guarded above) and `kid == EVP_PKEY_EC`, so
-                // BoringSSL guarantees a non-null EC_KEY with a group set; the
-                // `opaque_ref` chain panics (not UB) if that invariant ever broke.
-                let ec = ffi::EVP_PKEY_get1_EC_KEY(pkey);
-                let group = ffi::EC_KEY_get0_group(ffi::EC_KEY::opaque_ref(ec));
-                let nid = ffi::EC_GROUP_get_curve_name(ffi::EC_GROUP::opaque_ref(group));
-                let nid_str = ffi::OBJ_nid2sn(nid);
-                if !nid_str.is_null() {
-                    // SAFETY: OBJ_nid2sn returns a static NUL-terminated C string.
-                    curve_name = unsafe { bun_core::ffi::cstr(nid_str) }.to_bytes();
-                } else {
-                    curve_name = b"";
-                }
-            } else {
-                let kid_str = ffi::OBJ_nid2sn(kid);
-                if !kid_str.is_null() {
-                    // SAFETY: OBJ_nid2sn returns a static NUL-terminated C string.
-                    curve_name = unsafe { bun_core::ffi::cstr(kid_str) }.to_bytes();
-                } else {
-                    curve_name = b"";
-                }
-            }
-            result.put(global, b"type", BunString::static_("ECDH").to_js(global)?);
-            result.put(
-                global,
-                b"name",
-                ZigString::from_utf8(curve_name).to_js(global),
-            );
-            result.put(global, b"size", JSValue::js_number(f64::from(bits)));
-        }
-        _ => {}
+    let nid = ffi::SSL_get_negotiated_group(ssl);
+    // `size` mirrors Node's `EVP_PKEY_bits` of the peer's ephemeral key: the
+    // field size for the NIST curves and the 253-bit X25519 group order.
+    let bits: i32 = match nid {
+        ffi::NID_X25519 => 253,
+        ffi::NID_X9_62_prime256v1 => 256,
+        ffi::NID_secp384r1 => 384,
+        ffi::NID_secp521r1 => 521,
+        _ => return Ok(result),
+    };
+    let sn = ffi::OBJ_nid2sn(nid);
+    if sn.is_null() {
+        return Ok(result);
     }
+    // SAFETY: OBJ_nid2sn returns a static NUL-terminated C string.
+    let name = unsafe { bun_core::ffi::cstr(sn) }.to_bytes();
+    // BoringSSL only offers ECDHE groups for TLS <= 1.2 (no DHE cipher suites),
+    // so every reachable group here is an ECDH exchange.
+    result.put(global, b"type", BunString::static_("ECDH").to_js(global)?);
+    result.put(global, b"name", ZigString::from_utf8(name).to_js(global));
+    result.put(global, b"size", JSValue::js_number(f64::from(bits)));
     Ok(result)
 }
 

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -1031,12 +1031,15 @@ pub(super) fn get_ephemeral_key_info(
 
     // BoringSSL has no `SSL_get_peer_tmp_key`, but the negotiated named group
     // carries the same information for a TLS <= 1.2 (EC)DHE key exchange.
-    // Node reports no ephemeral key on TLS 1.3 (its `SSL_get_peer_tmp_key`
-    // only surfaces the ServerKeyExchange key) and on a non-forward-secret
-    // (RSA) key exchange, where `SSL_get_negotiated_group` is `NID_undef`;
-    // match both. The tls.ts wrapper shapes the empty result into Node's
-    // fixed {type, name, size} key set.
-    if ffi::SSL_version(ssl) >= i32::from(ffi::TLS1_3_VERSION) {
+    // Node reports no ephemeral key on TLS 1.3 or a resumed session (its
+    // `SSL_get_peer_tmp_key` only surfaces the ServerKeyExchange key) and on
+    // a non-forward-secret (RSA) key exchange, where
+    // `SSL_get_negotiated_group` is `NID_undef`; match all three. The tls.ts
+    // wrapper shapes the empty result into Node's fixed {type, name, size}
+    // key set. BoringSSL serializes `group_id` into the session blob, so a
+    // resumed session must be checked separately.
+    if ffi::SSL_version(ssl) >= i32::from(ffi::TLS1_3_VERSION) || ffi::SSL_session_reused(ssl) != 0
+    {
         return Ok(result);
     }
     let nid = ffi::SSL_get_negotiated_group(ssl);

--- a/test/js/node/test/common/boringssl.js
+++ b/test/js/node/test/common/boringssl.js
@@ -137,17 +137,17 @@ function testRenegotiationUnsupported() {
 }
 
 /**
- * OpenSSL exposes the negotiated ephemeral key type, name, and size for TLS
- * clients. With BoringSSL the same ECDHE TLS 1.2 handshake succeeds, but
- * getEphemeralKeyInfo() returns null on the server side and an object whose
- * fields are undefined on the client side.
+ * BoringSSL has no DHE cipher suites and Bun does not plumb the `ecdhCurve`
+ * option, so the original test's finite-field DH cases and per-curve
+ * selections cannot run. The ECDHE case it keeps: getEphemeralKeyInfo()
+ * reports the negotiated group (BoringSSL prefers X25519) on the client and
+ * null on the server, like Node.
  */
-function testEphemeralKeyInfoUnsupported() {
+function testEphemeralKeyInfoEcdheOnly() {
   const server = tls.createServer({
     key: fixtures.readKey('agent2-key.pem'),
     cert: fixtures.readKey('agent2-cert.pem'),
     ciphers: 'ECDHE-RSA-AES256-GCM-SHA384',
-    ecdhCurve: 'prime256v1',
     maxVersion: 'TLSv1.2',
   }, common.mustCall((socket) => {
     assert.strictEqual(socket.getEphemeralKeyInfo(), null);
@@ -161,9 +161,9 @@ function testEphemeralKeyInfoUnsupported() {
       maxVersion: 'TLSv1.2',
     }, common.mustCall(() => {
       assert.deepStrictEqual(client.getEphemeralKeyInfo(), {
-        type: undefined,
-        name: undefined,
-        size: undefined,
+        type: 'ECDH',
+        name: 'X25519',
+        size: 253,
       });
       server.close();
     }));
@@ -337,7 +337,7 @@ module.exports = {
   assertMultiKeyUnsupported,
   assertNoCipherMatch,
   assertOpenSSLSecurityLevelsUnsupported,
-  testEphemeralKeyInfoUnsupported,
+  testEphemeralKeyInfoEcdheOnly,
   testLegacyProtocolUnsupported,
   testMultiPfxSelectionDifference,
   testPskTls13Unsupported,

--- a/test/js/node/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/js/node/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -4,7 +4,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 if (process.features.openssl_is_boringssl) {
-  require('../common/boringssl').testEphemeralKeyInfoUnsupported();
+  require('../common/boringssl').testEphemeralKeyInfoEcdheOnly();
   return;
 }
 

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -968,6 +968,36 @@ it("new tls.TLSSocket(socket, { isServer: false, rejectUnauthorized: false }) co
   }
 });
 
+it("setServername() before _start() is sent as the client SNI, matching Node", async () => {
+  // Socket.prototype.connect overwrites this.servername from its options;
+  // _start() has to forward the value set between construction and start so
+  // the SNI reaches the handshake.
+  const observed = Promise.withResolvers<string | false | undefined>();
+  const server = tls.createServer({ ...COMMON_CERT_ });
+  server.on("secureConnection", socket => {
+    observed.resolve(socket.servername);
+    socket.end();
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  const raw = net.connect(port, "127.0.0.1");
+  await once(raw, "connect");
+  const secure: any = new TLSSocket(raw, { isServer: false, rejectUnauthorized: false } as tls.TLSSocketOptions);
+  try {
+    secure.setServername("example.test");
+    secure._start();
+    await once(secure, "secureConnect");
+    expect(secure.servername).toBe("example.test");
+    expect(await observed.promise).toBe("example.test");
+  } finally {
+    secure.destroy();
+    server.close();
+    await once(server, "close");
+  }
+});
+
 it("rejectUnauthorized: null keeps certificate verification on, matching Node (CVE-2021-22939)", async () => {
   // Node only disables verification on an explicit `false`. Every other value
   // (including `null`, which used to reach the handshake's truthiness check

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -824,24 +824,30 @@ it("getCipher().version separates the pre-1.2 ECC suites (TLSv1.0) from the SSLv
   }
 });
 
+// Node's getEphemeralKeyInfo() always returns the same three own keys on a
+// client, with undefined values when no ephemeral key applies (verified on
+// node v26.3.0: Object.keys(...) === ["type","name","size"] for TLS 1.3 and
+// for a static-RSA exchange). toStrictEqual pins that exact key set.
+const NO_EPHEMERAL_KEY = { type: undefined, name: undefined, size: undefined };
+
 it("getEphemeralKeyInfo() reports the negotiated TLS 1.2 ECDHE group, matching Node", async () => {
   // Node reports OBJ_nid2sn + EVP_PKEY_bits of the peer's ephemeral key.
   // BoringSSL prefers X25519 on both sides of a TLS <= 1.2 key exchange.
   await withTlsPair({ maxVersion: "TLSv1.2" }, (client, serverSide) => {
     expect(client.getProtocol()).toBe("TLSv1.2");
-    expect(client.getEphemeralKeyInfo()).toEqual({ type: "ECDH", name: "X25519", size: 253 });
+    expect(client.getEphemeralKeyInfo()).toStrictEqual({ type: "ECDH", name: "X25519", size: 253 });
     // Node reports null on the server side of the connection.
     expect(serverSide.getEphemeralKeyInfo()).toBeNull();
   });
-  // A static-RSA key exchange has no ephemeral key: {}.
+  // A static-RSA key exchange has no ephemeral key.
   await withTlsPair({ maxVersion: "TLSv1.2", ciphers: "AES128-SHA" }, client => {
-    expect(client.getEphemeralKeyInfo()).toEqual({});
+    expect(client.getEphemeralKeyInfo()).toStrictEqual(NO_EPHEMERAL_KEY);
   });
-  // Node reports {} on TLS 1.3 (its SSL_get_peer_tmp_key only surfaces the
-  // <= 1.2 ServerKeyExchange key); match it.
+  // Node reports no key on TLS 1.3: its SSL_get_peer_tmp_key only surfaces
+  // the <= 1.2 ServerKeyExchange key.
   await withTlsPair({ minVersion: "TLSv1.3" }, client => {
     expect(client.getProtocol()).toBe("TLSv1.3");
-    expect(client.getEphemeralKeyInfo()).toEqual({});
+    expect(client.getEphemeralKeyInfo()).toStrictEqual(NO_EPHEMERAL_KEY);
   });
 });
 
@@ -957,5 +963,9 @@ it("an exception from a user checkServerIdentity escapes as an uncaught exceptio
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "UNCAUGHT csi-boom", exitCode: 42 });
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "UNCAUGHT csi-boom",
+    stderr: "",
+    exitCode: 42,
+  });
 });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -902,6 +902,58 @@ it("getEphemeralKeyInfo() reports no key on a resumed TLS 1.2 session, matching 
   }
 });
 
+it("checkServerIdentity is not called on a resumed session, matching Node", async () => {
+  // Node's onConnectSecure guards the callback with `!this.isSessionReused()`:
+  // the identity was verified on the original full handshake.
+  const server = tls.createServer({ ...COMMON_CERT_, maxVersion: "TLSv1.2" }, socket => {
+    socket.write("x");
+    socket.on("error", () => {});
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  let calls = 0;
+  const base = {
+    port,
+    host: "127.0.0.1",
+    ca: COMMON_CERT_.cert,
+    servername: "localhost",
+    maxVersion: "TLSv1.2",
+    checkServerIdentity: () => void calls++,
+  } as const;
+
+  async function connect(extra: tls.ConnectionOptions) {
+    const client = tlsConnect({ ...base, ...extra });
+    await once(client, "secureConnect");
+    await once(client, "data");
+    return client;
+  }
+
+  let session: Buffer | undefined;
+  try {
+    const full = await connect({});
+    try {
+      expect(full.isSessionReused()).toBe(false);
+      expect(calls).toBe(1);
+      session = full.getSession();
+    } finally {
+      full.destroy();
+    }
+
+    const resumed = await connect({ session });
+    try {
+      expect(resumed.isSessionReused()).toBe(true);
+      expect(calls).toBe(1);
+    } finally {
+      resumed.destroy();
+    }
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
 it("new tls.TLSSocket(socket, { isServer: false }) + _start() runs the handshake over the wrapped socket", async () => {
   // The client STARTTLS pattern: wrap an already-connected plaintext socket,
   // then start the handshake with the internal _start() entry point. This

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN } from "harness";
+import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN, tempDir } from "harness";
 import https from "https";
 import net from "net";
 import { join } from "path";
@@ -339,17 +339,17 @@ for (const { name, connect } of tests) {
           {
             name: "TLS_AES_128_GCM_SHA256",
             standardName: "TLS_AES_128_GCM_SHA256",
-            version: "TLSv1/SSLv3",
+            version: "TLSv1.3",
           },
           {
             name: "TLS_AES_256_GCM_SHA384",
             standardName: "TLS_AES_256_GCM_SHA384",
-            version: "TLSv1/SSLv3",
+            version: "TLSv1.3",
           },
           {
             name: "TLS_CHACHA20_POLY1305_SHA256",
             standardName: "TLS_CHACHA20_POLY1305_SHA256",
-            version: "TLSv1/SSLv3",
+            version: "TLSv1.3",
           },
         ];
         const socket = (await new Promise((resolve, reject) => {
@@ -746,4 +746,216 @@ it("https.request reports an impossible version window as a TLS error, not a cer
   response.on("data", (chunk: Buffer) => (body += chunk));
   await once(response, "end");
   expect(body).toBe("ok");
+});
+
+/**
+ * Start a TLS server over the harness cert, connect a client with
+ * `clientOptions`, await both handshakes, and hand the two TLSSockets to
+ * `fn`. Cleanup runs whether or not `fn`'s assertions pass.
+ */
+async function withTlsPair(
+  clientOptions: tls.ConnectionOptions,
+  fn: (client: TLSSocket, serverSide: TLSSocket) => void | Promise<void>,
+  serverOptions: tls.TlsOptions = {},
+) {
+  const serverSocket = Promise.withResolvers<TLSSocket>();
+  const server = tls.createServer({ ...COMMON_CERT_, ...serverOptions }, socket => {
+    socket.on("error", () => {});
+    serverSocket.resolve(socket);
+  });
+  server.on("tlsClientError", err => serverSocket.reject(err));
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+  const client = tlsConnect({
+    port,
+    host: "127.0.0.1",
+    ca: COMMON_CERT_.cert,
+    servername: "localhost",
+    ...clientOptions,
+  });
+  try {
+    const [, serverSide] = await Promise.all([once(client, "secureConnect"), serverSocket.promise]);
+    await fn(client, serverSide);
+  } finally {
+    client.destroy();
+    server.close();
+    await once(server, "close");
+  }
+}
+
+it("getCipher().version reports the cipher's protocol version, matching Node", async () => {
+  // Every TLS 1.3 suite reports "TLSv1.3"; the exact AEAD depends on AES-NI,
+  // so only `version` is pinned for this case.
+  await withTlsPair({ minVersion: "TLSv1.3" }, client => {
+    expect(client.getProtocol()).toBe("TLSv1.3");
+    expect(client.getCipher().version).toBe("TLSv1.3");
+  });
+  // A SHA-2 AEAD suite is first defined for TLS 1.2, so Node reports
+  // "TLSv1.2" for it regardless of the negotiated protocol.
+  await withTlsPair({ maxVersion: "TLSv1.2", ciphers: "ECDHE-RSA-AES128-GCM-SHA256" }, (client, serverSide) => {
+    const expected = {
+      name: "ECDHE-RSA-AES128-GCM-SHA256",
+      standardName: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      version: "TLSv1.2",
+    };
+    expect(client.getProtocol()).toBe("TLSv1.2");
+    expect(client.getCipher()).toEqual(expected);
+    expect(serverSide.getCipher()).toEqual(expected);
+  });
+});
+
+it("getCipher().version separates the pre-1.2 ECC suites (TLSv1.0) from the SSLv3-era ones", async () => {
+  // OpenSSL reports each cipher's minimum protocol: the ECC suites were
+  // defined for TLS 1.0 (RFC 4492) and everything older is SSLv3.
+  for (const [ciphers, version] of [
+    ["ECDHE-RSA-AES128-SHA", "TLSv1.0"],
+    ["AES128-SHA", "SSLv3"],
+  ] as const) {
+    await withTlsPair(
+      { maxVersion: "TLSv1.2", ciphers },
+      client => {
+        expect(client.getProtocol()).toBe("TLSv1.2");
+        expect(client.getCipher().name).toBe(ciphers);
+        expect(client.getCipher().version).toBe(version);
+      },
+      { ciphers },
+    );
+  }
+});
+
+it("getEphemeralKeyInfo() reports the negotiated TLS 1.2 ECDHE group, matching Node", async () => {
+  // Node reports OBJ_nid2sn + EVP_PKEY_bits of the peer's ephemeral key.
+  // BoringSSL prefers X25519 on both sides of a TLS <= 1.2 key exchange.
+  await withTlsPair({ maxVersion: "TLSv1.2" }, (client, serverSide) => {
+    expect(client.getProtocol()).toBe("TLSv1.2");
+    expect(client.getEphemeralKeyInfo()).toEqual({ type: "ECDH", name: "X25519", size: 253 });
+    // Node reports null on the server side of the connection.
+    expect(serverSide.getEphemeralKeyInfo()).toBeNull();
+  });
+  // A static-RSA key exchange has no ephemeral key: {}.
+  await withTlsPair({ maxVersion: "TLSv1.2", ciphers: "AES128-SHA" }, client => {
+    expect(client.getEphemeralKeyInfo()).toEqual({});
+  });
+  // Node reports {} on TLS 1.3 (its SSL_get_peer_tmp_key only surfaces the
+  // <= 1.2 ServerKeyExchange key); match it.
+  await withTlsPair({ minVersion: "TLSv1.3" }, client => {
+    expect(client.getProtocol()).toBe("TLSv1.3");
+    expect(client.getEphemeralKeyInfo()).toEqual({});
+  });
+});
+
+it("new tls.TLSSocket(socket, { isServer: false }) + _start() runs the handshake over the wrapped socket", async () => {
+  // The client STARTTLS pattern: wrap an already-connected plaintext socket,
+  // then start the handshake with the internal _start() entry point. This
+  // used to throw ERR_MISSING_ARGS because connect() got no port, path, or
+  // socket.
+  const server = tls.createServer({ ...COMMON_CERT_ }, socket => {
+    socket.on("error", () => {});
+    socket.on("data", () => socket.end());
+    socket.write("hi");
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  const raw = net.connect(port, "127.0.0.1");
+  await once(raw, "connect");
+  const secure: any = new TLSSocket(raw, {
+    isServer: false,
+    ca: COMMON_CERT_.cert,
+    servername: "localhost",
+  } as tls.TLSSocketOptions);
+  try {
+    secure._start();
+    await once(secure, "secureConnect");
+    expect(secure.authorized).toBe(true);
+    expect(secure.getProtocol()).toBe("TLSv1.3");
+    // The upgraded stream carries application data both ways.
+    const [chunk] = await once(secure, "data");
+    expect(chunk.toString()).toBe("hi");
+    secure.write("bye");
+    await once(secure, "close");
+  } finally {
+    secure.destroy();
+    server.close();
+    await once(server, "close");
+  }
+});
+
+it("new tls.TLSSocket(socket, { isServer: false, rejectUnauthorized: false }) completes against an untrusted peer", async () => {
+  // The bare-TLSSocket path never reaches Socket.prototype.connect's
+  // rejectUnauthorized handling, so the constructor has to honor its own
+  // option or a self-signed peer would always be destroyed.
+  const server = tls.createServer({ ...COMMON_CERT_ }, socket => {
+    socket.on("error", () => {});
+    socket.end();
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  const raw = net.connect(port, "127.0.0.1");
+  await once(raw, "connect");
+  const secure: any = new TLSSocket(raw, { isServer: false, rejectUnauthorized: false } as tls.TLSSocketOptions);
+  try {
+    secure._start();
+    await once(secure, "secureConnect");
+    // Verification still ran and reported; it just did not tear the socket down.
+    expect(secure.authorized).toBe(false);
+    expect(secure.authorizationError).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+  } finally {
+    secure.destroy();
+    server.close();
+    await once(server, "close");
+  }
+});
+
+it("an exception from a user checkServerIdentity escapes as an uncaught exception, not a socket 'error'", async () => {
+  // Node does not guard the callback (onConnectSecure in lib/_tls_wrap.js):
+  // a throw aborts the handshake and reaches the process as an uncaught
+  // exception. It must not be downgraded into the socket's 'error' routing,
+  // and 'secureConnect' must not fire.
+  using dir = tempDir("tls-csi-throw", {
+    "cert.pem": COMMON_CERT_.cert,
+    "key.pem": COMMON_CERT_.key,
+    "fixture.ts": `
+      import tls from "node:tls";
+      import { readFileSync } from "node:fs";
+      const cert = readFileSync("cert.pem", "utf8");
+      const key = readFileSync("key.pem", "utf8");
+      process.on("uncaughtException", err => {
+        console.log("UNCAUGHT " + err.message);
+        process.exit(42);
+      });
+      const server = tls.createServer({ key, cert }, s => s.end());
+      server.listen(0, "127.0.0.1", () => {
+        const client = tls.connect({
+          port: server.address().port,
+          host: "127.0.0.1",
+          ca: cert,
+          servername: "localhost",
+          checkServerIdentity() {
+            throw new Error("csi-boom");
+          },
+        });
+        client.on("secureConnect", () => {
+          console.log("SECURE_CONNECT");
+          process.exit(5);
+        });
+        client.on("error", e => {
+          console.log("SOCKET_ERROR " + e.message);
+          process.exit(3);
+        });
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "UNCAUGHT csi-boom", exitCode: 42 });
 });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -851,6 +851,56 @@ it("getEphemeralKeyInfo() reports the negotiated TLS 1.2 ECDHE group, matching N
   });
 });
 
+it("getEphemeralKeyInfo() reports no key on a resumed TLS 1.2 session, matching Node", async () => {
+  // A resumed abbreviated handshake has no ServerKeyExchange, so Node's
+  // SSL_get_peer_tmp_key is empty. BoringSSL serializes the original
+  // handshake's group_id into the session blob, so without a resumption
+  // check SSL_get_negotiated_group would surface it here.
+  const server = tls.createServer({ ...COMMON_CERT_, maxVersion: "TLSv1.2" }, socket => {
+    socket.write("x");
+    socket.on("error", () => {});
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+  const base = {
+    port,
+    host: "127.0.0.1",
+    ca: COMMON_CERT_.cert,
+    servername: "localhost",
+    maxVersion: "TLSv1.2",
+  } as const;
+
+  async function connect(extra: tls.ConnectionOptions) {
+    const client = tlsConnect({ ...base, ...extra });
+    await once(client, "secureConnect");
+    await once(client, "data");
+    return client;
+  }
+
+  try {
+    const full = await connect({});
+    try {
+      expect(full.isSessionReused()).toBe(false);
+      expect(full.getEphemeralKeyInfo()).toStrictEqual({ type: "ECDH", name: "X25519", size: 253 });
+      var session = full.getSession();
+    } finally {
+      full.destroy();
+    }
+
+    const resumed = await connect({ session });
+    try {
+      expect(resumed.isSessionReused()).toBe(true);
+      expect(resumed.getEphemeralKeyInfo()).toStrictEqual(NO_EPHEMERAL_KEY);
+    } finally {
+      resumed.destroy();
+    }
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
 it("new tls.TLSSocket(socket, { isServer: false }) + _start() runs the handshake over the wrapped socket", async () => {
   // The client STARTTLS pattern: wrap an already-connected plaintext socket,
   // then start the handshake with the internal _start() entry point. This

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -878,12 +878,13 @@ it("getEphemeralKeyInfo() reports no key on a resumed TLS 1.2 session, matching 
     return client;
   }
 
+  let session: Buffer | undefined;
   try {
     const full = await connect({});
     try {
       expect(full.isSessionReused()).toBe(false);
       expect(full.getEphemeralKeyInfo()).toStrictEqual({ type: "ECDH", name: "X25519", size: 253 });
-      var session = full.getSession();
+      session = full.getSession();
     } finally {
       full.destroy();
     }
@@ -962,6 +963,55 @@ it("new tls.TLSSocket(socket, { isServer: false, rejectUnauthorized: false }) co
     expect(secure.authorizationError).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
   } finally {
     secure.destroy();
+    server.close();
+    await once(server, "close");
+  }
+});
+
+it("rejectUnauthorized: null keeps certificate verification on, matching Node (CVE-2021-22939)", async () => {
+  // Node only disables verification on an explicit `false`. Every other value
+  // (including `null`, which used to reach the handshake's truthiness check
+  // as-is and silently skip rejection) keeps it on.
+  const server = tls.createServer({ ...COMMON_CERT_ }, socket => {
+    socket.on("error", () => {});
+    socket.end();
+  });
+  server.on("tlsClientError", () => {});
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  function outcome(client: TLSSocket) {
+    return new Promise<string>(resolve => {
+      client.once("secureConnect", () => resolve("connected"));
+      client.once("error", e => resolve((e as NodeJS.ErrnoException).code ?? String(e)));
+    }).finally(() => client.destroy());
+  }
+
+  try {
+    // tls.connect path.
+    {
+      const client = tlsConnect({ port, host: "127.0.0.1", servername: "localhost", rejectUnauthorized: null as any });
+      expect(await outcome(client)).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+    }
+    // new tls.TLSSocket(socket, { isServer: false }) + _start() path.
+    {
+      const raw = net.connect(port, "127.0.0.1");
+      await once(raw, "connect");
+      const secure: any = new TLSSocket(raw, {
+        isServer: false,
+        servername: "localhost",
+        rejectUnauthorized: null as any,
+      } as tls.TLSSocketOptions);
+      secure._start();
+      expect(await outcome(secure)).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+    }
+    // An explicit `false` still disables it.
+    {
+      const client = tlsConnect({ port, host: "127.0.0.1", servername: "localhost", rejectUnauthorized: false });
+      expect(await outcome(client)).toBe("connected");
+    }
+  } finally {
     server.close();
     await once(server, "close");
   }


### PR DESCRIPTION
Fixes eight `node:tls` client divergences from Node, found by a differential probe run against a real Node v26 `tls.Server` (only the client side exercised Bun). The probe output is byte-identical to Node after this change, except client-initiated `renegotiate()` on TLS 1.2, which BoringSSL does not support.

### `getCipher().version` is always `"TLSv1/SSLv3"`

```js
client.getCipher()
// node: { name: "ECDHE-RSA-AES128-GCM-SHA256", ..., version: "TLSv1.2" }
// bun:  { name: "ECDHE-RSA-AES128-GCM-SHA256", ..., version: "TLSv1/SSLv3" }
```

BoringSSL hardcodes `SSL_CIPHER_get_version()` to that string. Node (OpenSSL) reports the cipher's minimum protocol version. Rebuilt the same strings from `SSL_CIPHER_get_min_version()`: TLS 1.3 and SHA-2 AEAD suites directly, and for the pre-1.2 suites `SSL_CIPHER_get_kx_nid()` splits the ECC ones (`"TLSv1.0"`, defined for TLS 1.0 by RFC 4492) from the SSLv3-era rest, matching OpenSSL's table exactly.

### `getEphemeralKeyInfo()` returns `{}` on a TLS 1.2 ECDHE connection

Node reports `{ type: "ECDH", name: "X25519", size: 253 }`. The old code called `SSL_get_privatekey()`, which is the client's own key and is null for a client without a certificate, so the result was always empty (and leaked an `EC_KEY` on the one path that got further). Replaced with `SSL_get_negotiated_group()`. Node returns `{}` on TLS 1.3 and on a static-RSA key exchange; both are matched.

### An exception from a user `checkServerIdentity` becomes a socket `'error'`

Node does not guard the callback: a throw aborts `onConnectSecure` and reaches the process as an uncaught exception, and `'secureConnect'` never fires. Bun's native handshake dispatcher routes any exception from the JS handshake handler into the socket's error handler, which downgraded the throw into `socket.emit('error', err)`. The JS handler now catches only the user callback, abandons the handshake, and defers the rethrow out of the native try frame. The callback is also now skipped on a resumed session, matching Node's `!this.isSessionReused()` guard (found in review; Bun was calling it twice).

### `new tls.TLSSocket(socket, { isServer: false })` + `_start()` throws `ERR_MISSING_ARGS`

The client STARTTLS pattern. `_start()` called `connect()` with no port, path, or socket. It now hands the wrapped socket to `connect()`, the same thing `tls.connect({ socket })` does. The constructor also honors its own `rejectUnauthorized` now: that path never reaches `Socket.prototype.connect`, which was the only place the option was read. A `setServername()` call between construction and `_start()` is now forwarded through to the handshake as the client SNI (found in review; Node sends it, Bun was wiping it).

### `getEphemeralKeyInfo()` on a resumed TLS 1.2 session

Found in review. A resumed abbreviated handshake has no ServerKeyExchange, so Node's `SSL_get_peer_tmp_key` is empty and the three keys are `undefined`. BoringSSL serializes the original handshake's `group_id` into the session blob, so `SSL_get_negotiated_group` would surface it; gated on `SSL_session_reused`.

### `rejectUnauthorized: null` bypassed certificate verification

Found in review, pre-existing on `tls.connect()`. Node only disables verification on an explicit `false` (CVE-2021-22939); Bun stored the raw option value and then checked it for truthiness, so `null` silently skipped rejection where Node rejects. Normalized to `!== false` at each client store site (the `TLSSocket` constructor, the three `Socket.prototype.connect` TLS paths, and server `setSecureContext`). The bindgen layer already rejects `0`/`""`/`1` with `ERR_INVALID_ARG_TYPE`, so `null` was the only non-boolean that reached these sites.

### Deleted dead code

Made dead by the `getEphemeralKeyInfo` rewrite and removed in the same change: the `SSL_get_privatekey`, `EVP_PKEY_id`, `EVP_PKEY_bits`, `EVP_PKEY_get1_EC_KEY`, `EC_KEY_get0_group`, `EC_GROUP_get_curve_name`, and `SSL_CIPHER_get_version` FFI declarations, the `EVP_PKEY`/`EC_KEY`/`EC_GROUP` opaque handles, and the `EVP_PKEY_DH`/`EVP_PKEY_X25519`/`EVP_PKEY_X448` constants.

### Tests

Ten new tests in `test/js/node/tls/node-tls-connect.test.ts`; all ten fail on a build without the corresponding fix and pass with the fix. The existing `getCipher` assertions on `"TLSv1/SSLv3"` and the `testEphemeralKeyInfoUnsupported` helper in `test/js/node/test/common/boringssl.js` encoded the old behavior and are updated (the helper is renamed to `testEphemeralKeyInfoEcdheOnly`; the DHE parts of the original Node test still cannot run because BoringSSL has no DHE cipher suites).

The full `test/js/node/tls/` directory passes with the change; the only failures are two that reproduce identically on `main` without it.

Not addressed, from the same probe, because BoringSSL has no client-initiated renegotiation: `client.renegotiate()` on a TLS 1.2 connection returns `false` where Node renegotiates.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1c65194cd)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.88ms]
(pass) should thow ECONNRESET if FIN is received before handshake [388.78ms]
(pass) should be able to grab the JSStreamSocket constructor [25.73ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [42.62ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [96.50ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when 
... (truncated)

release without fix: 1 failed, 18 skipped
bun test v1.4.0-canary.1 (74904474b)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.09ms]
(pass) should thow ECONNRESET if FIN is received before handshake [10.71ms]
(pass) should be able to grab the JSStreamSocket constructor [0.23ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [4.64ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [3.11ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.connect > should timeout
(skip) tls.connect > should be able to transfer data
(skip) tls.connect using duplex proxy > should work with alpnProtocols
(pass) tls.connect using dupl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1c65194cd)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.78ms]
(pass) should thow ECONNRESET if FIN is received before handshake [388.18ms]
(pass) should be able to grab the JSStreamSocket constructor [24.77ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [42.43ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [87.55ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when 
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 811ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 254 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6608ms)
Bundle modules (31ms)
Postprocesss modules (21ms)
Bundle Functions (595ms)
Generate Code (74ms)

[7.34s] Bundled "src/js" for production
  1889 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                                 |  62 +++-
 src/js/node/tls.ts                                 |  23 +-
 src/runtime/socket/tls_socket_functions.rs         | 146 ++++----
 test/js/node/test/common/boringssl.js              |  20 +-
 .../test-tls-client-getephemeralkeyinfo.js         |   2 +-
 test/js/node/tls/node-tls-connect.test.ts          | 412 ++++++++++++++++++++-
 6 files changed, 549 insertions(+), 116 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/net.ts                                           11      7     15
src/js/node/tls.ts                                            9      5     15
src/runtime/socket/tls_socket_functions.rs                   10     10     15
test/js/node/test/common/boringssl.js                         1      3     17
…de/test/parallel/test-tls-client-getephemeralkeyinfo.js      1      1     18
test/js/node/tls/node-tls-connect.test.ts                    13     18     15
```

</details>

<!-- robobun:evidence:end -->

