### PR TITLE
websocket: fail the client handshake on a missing subprotocol or an invalid Sec-WebSocket-Extensions response

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -2043,6 +2043,7 @@ pub enum ErrorCode {
     ProxyConnectionRefused = 35,
     ProxyTunnelFailed = 36,
     UnexpectedRsv1 = 37,
+    InvalidExtensionsHeader = 38,
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -89,7 +89,16 @@ fn unquote(value: &[u8]) -> &[u8] {
 /// In a response the parameter must carry a decimal value between 8 and 15
 /// (RFC 7692 §8.1.2); a missing, malformed, or out-of-range value is `None`.
 fn parse_window_bits(value: Option<&[u8]>) -> Option<u8> {
-    let bits = strings::parse_int::<u8>(unquote(value?), 10).ok()?;
+    let value = unquote(value?);
+    // The value's grammar is `1*DIGIT` without leading zeroes; `parse_int`
+    // alone would also accept a `+` sign, `_` separators, and leading zeroes.
+    if value.is_empty()
+        || !value.iter().all(u8::is_ascii_digit)
+        || (value.len() > 1 && value[0] == b'0')
+    {
+        return None;
+    }
+    let bits = strings::parse_int::<u8>(value, 10).ok()?;
     (WebSocketDeflate::Params::MIN_WINDOW_BITS..=WebSocketDeflate::Params::MAX_WINDOW_BITS)
         .contains(&bits)
         .then_some(bits)

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1544,6 +1544,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
             return;
         }
 
+        // The client requested one or more subprotocols but the server's 101
+        // did not select any. Both RFC 6455 §4.1 and the WHATWG "establish a
+        // WebSocket connection" algorithm require failing the connection.
         // SAFETY: short-lived `&self` read.
         if !protocol_header_seen && !unsafe { (*this).subprotocols.is_empty() } {
             // SAFETY: no `&mut Self` is live across this call.
@@ -1568,16 +1571,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
         if websocket_accept_header.value() != unsafe { &(&(*this).expected_accept)[..] } {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::MismatchWebsocketAcceptHeader) };
-            return;
-        }
-
-        // The client requested one or more subprotocols but the server's 101
-        // did not select any. Both RFC 6455 §4.1 and the WHATWG "establish a
-        // WebSocket connection" algorithm require failing the connection.
-        // SAFETY: `this` is live (caller contract); short-lived shared borrow.
-        if !protocol_header_seen && !unsafe { (*this).subprotocols.is_empty() } {
-            // SAFETY: no `&mut Self` is live across this call.
-            unsafe { Self::terminate(this, ErrorCode::MissingClientProtocol) };
             return;
         }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -74,6 +74,100 @@ pub(crate) struct DeflateNegotiationResult {
     pub params: WebSocketDeflate::Params,
 }
 
+/// Strips one layer of `"…"` quoting from an extension parameter value.
+/// RFC 6455 §9.1 requires the unescaped content of a quoted-string value to
+/// conform to the `token` ABNF, so no inner escapes need handling.
+fn unquote(value: &[u8]) -> &[u8] {
+    if value.len() >= 2 && value[0] == b'"' && value[value.len() - 1] == b'"' {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
+}
+
+/// Parses a `…_max_window_bits` value from an extension negotiation response.
+/// In a response the parameter must carry a decimal value between 8 and 15
+/// (RFC 7692 §8.1.2); a missing, malformed, or out-of-range value is `None`.
+fn parse_window_bits(value: Option<&[u8]>) -> Option<u8> {
+    let bits = strings::parse_int::<u8>(unquote(value?), 10).ok()?;
+    (WebSocketDeflate::Params::MIN_WINDOW_BITS..=WebSocketDeflate::Params::MAX_WINDOW_BITS)
+        .contains(&bits)
+        .then_some(bits)
+}
+
+/// Validates one `Sec-WebSocket-Extensions` response header value against the
+/// single `permessage-deflate; client_max_window_bits` offer we sent and
+/// accumulates the accepted parameters into `deflate`.
+///
+/// Returns `false` when the server lists an extension the client did not
+/// offer (RFC 6455 §4.1), accepts `permessage-deflate` more than once, or
+/// sends a `permessage-deflate` parameter that is unknown, repeated, or
+/// carries an invalid value (RFC 7692 §8.1). The caller must then fail the
+/// connection. The response may span several header lines; `deflate.enabled`
+/// persists across calls so a repeated `permessage-deflate` element anywhere
+/// in the response is rejected.
+fn accept_extensions_response(value: &[u8], deflate: &mut DeflateNegotiationResult) -> bool {
+    let mut elements = HeaderValueIterator::init(value);
+    while let Some(element) = elements.next() {
+        let mut parts = element.split(|b| *b == b';');
+        let name = strings::trim(parts.next().unwrap_or(b""), b" \t");
+        if name != b"permessage-deflate" || deflate.enabled {
+            return false;
+        }
+        deflate.enabled = true;
+
+        let mut seen_server_no_context_takeover = false;
+        let mut seen_client_no_context_takeover = false;
+        let mut seen_server_max_window_bits = false;
+        let mut seen_client_max_window_bits = false;
+        for part in parts {
+            let part = strings::trim(part, b" \t");
+            let (key, value) = match strings::index_of_char_usize(part, b'=') {
+                Some(i) => (
+                    strings::trim(&part[..i], b" \t"),
+                    Some(strings::trim(&part[i + 1..], b" \t")),
+                ),
+                None => (part, None),
+            };
+
+            match key {
+                // The `…_no_context_takeover` parameters carry no value
+                // (RFC 7692 §8.1.1).
+                b"server_no_context_takeover"
+                    if value.is_none() && !seen_server_no_context_takeover =>
+                {
+                    seen_server_no_context_takeover = true;
+                    deflate.params.server_no_context_takeover = 1;
+                }
+                b"client_no_context_takeover"
+                    if value.is_none() && !seen_client_no_context_takeover =>
+                {
+                    seen_client_no_context_takeover = true;
+                    deflate.params.client_no_context_takeover = 1;
+                }
+                b"server_max_window_bits" if !seen_server_max_window_bits => {
+                    seen_server_max_window_bits = true;
+                    let Some(bits) = parse_window_bits(value) else {
+                        return false;
+                    };
+                    deflate.params.server_max_window_bits = bits;
+                }
+                b"client_max_window_bits" if !seen_client_max_window_bits => {
+                    seen_client_max_window_bits = true;
+                    let Some(bits) = parse_window_bits(value) else {
+                        return false;
+                    };
+                    deflate.params.client_max_window_bits = bits;
+                }
+                // Anything else is a parameter that is not defined for use in
+                // a response, is repeated, or carries an unexpected value.
+                _ => return false,
+            }
+        }
+    }
+    true
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum State {
     Initializing,
@@ -1386,103 +1480,16 @@ impl<const SSL: bool> HTTPClient<SSL> {
                         header.name(),
                         b"Sec-WebSocket-Extensions",
                     ) {
-                        // Per RFC 6455 §9.1, the server MUST NOT respond with an
-                        // extension the client did not offer. Match upstream `ws`
-                        // (lib/websocket.js: "Server sent a Sec-WebSocket-Extensions
-                        // header but no extension was requested") and fail the
-                        // handshake instead of silently accepting it.
+                        // RFC 6455 §4.1 and RFC 7692 §8.1 require failing the
+                        // connection on an extension we did not offer or an
+                        // invalid `permessage-deflate` parameter, like `ws` does.
                         // SAFETY: short-lived read.
-                        if !unsafe { (*this).offered_permessage_deflate } {
+                        if !unsafe { (*this).offered_permessage_deflate }
+                            || !accept_extensions_response(header.value(), &mut deflate_result)
+                        {
                             // SAFETY: no `&mut Self` is live across this call.
-                            unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
+                            unsafe { Self::terminate(this, ErrorCode::InvalidExtensionsHeader) };
                             return;
-                        }
-                        // This is a simplified parser. A full parser would handle multiple extensions and quoted values.
-                        for ext_str in header.value().split(|b| *b == b',') {
-                            let mut ext_it = strings::trim(ext_str, b" \t").split(|b| *b == b';');
-                            let ext_name = strings::trim(ext_it.next().unwrap_or(b""), b" \t");
-                            if ext_name == b"permessage-deflate" {
-                                // RFC 7692 §5: the response must not list
-                                // permessage-deflate more than once (whether in
-                                // one header value or across several headers).
-                                if deflate_result.enabled {
-                                    // SAFETY: no `&mut Self` is live across this call.
-                                    unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
-                                    return;
-                                }
-                                deflate_result.enabled = true;
-                                for param_str in ext_it {
-                                    let mut param_it =
-                                        strings::trim(param_str, b" \t").split(|b| *b == b'=');
-                                    let key = strings::trim(param_it.next().unwrap_or(b""), b" \t");
-                                    let value =
-                                        strings::trim(param_it.next().unwrap_or(b""), b" \t");
-
-                                    if key == b"server_no_context_takeover" {
-                                        deflate_result.params.server_no_context_takeover = 1;
-                                    } else if key == b"client_no_context_takeover" {
-                                        deflate_result.params.client_no_context_takeover = 1;
-                                    } else if key == b"server_max_window_bits" {
-                                        if !value.is_empty() {
-                                            // Remove quotes if present
-                                            let trimmed_value = if value.len() >= 2
-                                                && value[0] == b'"'
-                                                && value[value.len() - 1] == b'"'
-                                            {
-                                                &value[1..value.len() - 1]
-                                            } else {
-                                                value
-                                            };
-
-                                            if let Ok(bits) =
-                                                strings::parse_int::<u8>(trimmed_value, 10)
-                                            {
-                                                if bits >= WebSocketDeflate::Params::MIN_WINDOW_BITS
-                                                    && bits
-                                                        <= WebSocketDeflate::Params::MAX_WINDOW_BITS
-                                                {
-                                                    deflate_result.params.server_max_window_bits =
-                                                        bits;
-                                                }
-                                            }
-                                        }
-                                    } else if key == b"client_max_window_bits" {
-                                        if !value.is_empty() {
-                                            // Remove quotes if present
-                                            let trimmed_value = if value.len() >= 2
-                                                && value[0] == b'"'
-                                                && value[value.len() - 1] == b'"'
-                                            {
-                                                &value[1..value.len() - 1]
-                                            } else {
-                                                value
-                                            };
-
-                                            if let Ok(bits) =
-                                                strings::parse_int::<u8>(trimmed_value, 10)
-                                            {
-                                                if bits >= WebSocketDeflate::Params::MIN_WINDOW_BITS
-                                                    && bits
-                                                        <= WebSocketDeflate::Params::MAX_WINDOW_BITS
-                                                {
-                                                    deflate_result.params.client_max_window_bits =
-                                                        bits;
-                                                }
-                                            }
-                                        } else {
-                                            // client_max_window_bits without value means use default (15)
-                                            deflate_result.params.client_max_window_bits = 15;
-                                        }
-                                    }
-                                }
-                            } else if !ext_name.is_empty() {
-                                // RFC 6455 §4.1: fail on an extension the client did
-                                // not offer; permessage-deflate is the only one we
-                                // offer. Empty elements (a trailing comma) are ok.
-                                // SAFETY: no `&mut Self` is live across this call.
-                                unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
-                                return;
-                            }
                         }
                     }
                 }

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1467,7 +1467,13 @@ impl<const SSL: bool> HTTPClient<SSL> {
                                         }
                                     }
                                 }
-                                break; // Found and parsed permessage-deflate, stop.
+                            } else if !ext_name.is_empty() {
+                                // RFC 6455 §4.1: fail on an extension the client did
+                                // not offer; permessage-deflate is the only one we
+                                // offer. Empty elements (a trailing comma) are ok.
+                                // SAFETY: no `&mut Self` is live across this call.
+                                unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
+                                return;
                             }
                         }
                     }
@@ -1538,6 +1544,16 @@ impl<const SSL: bool> HTTPClient<SSL> {
         if websocket_accept_header.value() != unsafe { &(&(*this).expected_accept)[..] } {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::MismatchWebsocketAcceptHeader) };
+            return;
+        }
+
+        // The client requested one or more subprotocols but the server's 101
+        // did not select any. Both RFC 6455 §4.1 and the WHATWG "establish a
+        // WebSocket connection" algorithm require failing the connection.
+        // SAFETY: `this` is live (caller contract); short-lived shared borrow.
+        if !protocol_header_seen && !unsafe { (*this).subprotocols.is_empty() } {
+            // SAFETY: no `&mut Self` is live across this call.
+            unsafe { Self::terminate(this, ErrorCode::MissingClientProtocol) };
             return;
         }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1402,6 +1402,14 @@ impl<const SSL: bool> HTTPClient<SSL> {
                             let mut ext_it = strings::trim(ext_str, b" \t").split(|b| *b == b';');
                             let ext_name = strings::trim(ext_it.next().unwrap_or(b""), b" \t");
                             if ext_name == b"permessage-deflate" {
+                                // RFC 7692 §5: the response must not list
+                                // permessage-deflate more than once (whether in
+                                // one header value or across several headers).
+                                if deflate_result.enabled {
+                                    // SAFETY: no `&mut Self` is live across this call.
+                                    unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
+                                    return;
+                                }
                                 deflate_result.enabled = true;
                                 for param_str in ext_it {
                                     let mut param_it =

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1832,6 +1832,10 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         didReceiveClose(CleanStatus::NotClean, 1006, "Proxy tunnel failed"_s, true);
         break;
     }
+    case Bun::WebSocketErrorCode::invalid_extensions_header: {
+        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid Sec-WebSocket-Extensions header"_s, true);
+        break;
+    }
     }
 
     // didReceiveClose already set m_state = CLOSED. The connect() ref

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1722,11 +1722,11 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::missing_client_protocol: {
-        didReceiveClose(CleanStatus::Clean, 1002, "Missing client protocol"_s);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Server sent no subprotocol"_s, true);
         break;
     }
     case Bun::WebSocketErrorCode::mismatch_client_protocol: {
-        didReceiveClose(CleanStatus::Clean, 1002, "Mismatch client protocol"_s);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Mismatch client protocol"_s, true);
         break;
     }
     case Bun::WebSocketErrorCode::timeout: {

--- a/src/jsc/bindings/webcore/WebSocketErrorCode.h
+++ b/src/jsc/bindings/webcore/WebSocketErrorCode.h
@@ -43,6 +43,7 @@ enum class WebSocketErrorCode : int32_t {
     proxy_connection_refused = 35,
     proxy_tunnel_failed = 36,
     unexpected_rsv1 = 37,
+    invalid_extensions_header = 38,
 };
 
 }

--- a/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
@@ -654,6 +654,11 @@ describe("Sec-WebSocket-Extensions response validation", () => {
     "permessage-deflate; server_max_window_bits=potato",
     "permessage-deflate; server_max_window_bits",
     "permessage-deflate; server_max_window_bits=",
+    // The value's grammar is `1*DIGIT` without leading zeroes: no sign,
+    // no digit separators, no leading zero.
+    "permessage-deflate; server_max_window_bits=+10",
+    "permessage-deflate; server_max_window_bits=1_0",
+    "permessage-deflate; server_max_window_bits=08",
     "permessage-deflate; client_max_window_bits=16",
     "permessage-deflate; client_max_window_bits",
     // The no_context_takeover parameters never carry a value.

--- a/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
@@ -1,5 +1,5 @@
 import { serve } from "bun";
-import { expect, setDefaultTimeout, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import crypto from "node:crypto";
 import net from "node:net";
 import { deflateRawSync, constants as zc } from "node:zlib";
@@ -570,3 +570,148 @@ test.each([false, true])(
     }
   },
 );
+
+// RFC 6455 section 4.1 requires the client to fail the connection when the
+// server indicates an extension that was not offered, and RFC 7692 section
+// 8.1 requires the same for a permessage-deflate response with an unknown
+// parameter or an invalid parameter value. Use a raw TCP server so the
+// Sec-WebSocket-Extensions response header is byte-exact.
+describe("Sec-WebSocket-Extensions response validation", () => {
+  type Outcome = { opened: boolean; message: string | null; extensions: string; code: number; reason: string };
+
+  // Completes a correct handshake, optionally answering with the given
+  // Sec-WebSocket-Extensions value, then sends `frame`. Resolves once the
+  // client either receives the frame or observes the connection close.
+  async function negotiate(extensionsValue: string | null, frame: Buffer): Promise<Outcome> {
+    let request = Buffer.alloc(0);
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        error() {},
+        data(socket, data) {
+          request = Buffer.concat([request, data]);
+          const end = request.indexOf("\r\n\r\n");
+          if (end === -1) return;
+          const key = /Sec-WebSocket-Key: *([A-Za-z0-9+/=]+)/i.exec(request.subarray(0, end).toString())?.[1];
+          if (!key) {
+            socket.end();
+            return;
+          }
+          const hasher = new Bun.CryptoHasher("sha1");
+          hasher.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+          let response =
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${hasher.digest("base64")}\r\n`;
+          if (extensionsValue !== null) {
+            response += `Sec-WebSocket-Extensions: ${extensionsValue}\r\n`;
+          }
+          socket.write(response + "\r\n");
+          socket.write(frame);
+          socket.flush();
+        },
+      },
+    });
+
+    const client = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+    const { promise, resolve } = Promise.withResolvers<Outcome>();
+    let opened = false;
+    client.onopen = () => {
+      opened = true;
+    };
+    client.onerror = () => {};
+    client.onmessage = event => {
+      resolve({ opened, message: event.data as string, extensions: client.extensions, code: 0, reason: "" });
+    };
+    client.onclose = event => {
+      resolve({ opened, message: null, extensions: client.extensions, code: event.code, reason: event.reason });
+    };
+    try {
+      return await promise;
+    } finally {
+      client.close();
+    }
+  }
+
+  // An unmasked, uncompressed text frame: FIN + text opcode, 5-byte payload.
+  const helloFrame = Buffer.from([0x81, 0x05, ...Buffer.from("hello")]);
+
+  const invalid = [
+    // The client only ever offers permessage-deflate.
+    "x-never-offered",
+    "permessage-deflate, x-never-offered",
+    "x-never-offered, permessage-deflate",
+    "permessage-deflate, permessage-deflate",
+    // Parameters that RFC 7692 does not define for use in a response.
+    "permessage-deflate; bogus_param=1",
+    "permessage-deflate; threshold=1024",
+    // window bits must be a decimal integer between 8 and 15, and a response
+    // (unlike an offer) must always carry the value.
+    "permessage-deflate; server_max_window_bits=20",
+    "permessage-deflate; server_max_window_bits=7",
+    "permessage-deflate; server_max_window_bits=potato",
+    "permessage-deflate; server_max_window_bits",
+    "permessage-deflate; server_max_window_bits=",
+    "permessage-deflate; client_max_window_bits=16",
+    "permessage-deflate; client_max_window_bits",
+    // The no_context_takeover parameters never carry a value.
+    "permessage-deflate; server_no_context_takeover=1",
+    "permessage-deflate; client_no_context_takeover=true",
+    // A parameter must not be repeated within an element.
+    "permessage-deflate; server_max_window_bits=10; server_max_window_bits=11",
+    "permessage-deflate; client_no_context_takeover; client_no_context_takeover",
+  ];
+
+  test.each(invalid)("fails the connection for %j", async value => {
+    expect(await negotiate(value, helloFrame)).toEqual({
+      opened: false,
+      message: null,
+      extensions: "",
+      code: 1002,
+      reason: "Invalid Sec-WebSocket-Extensions header",
+    });
+  });
+
+  const valid: [header: string | null, extensions: string][] = [
+    [null, ""],
+    ["permessage-deflate", "permessage-deflate"],
+    [
+      "permessage-deflate; server_no_context_takeover; client_no_context_takeover",
+      "permessage-deflate; server_no_context_takeover; client_no_context_takeover",
+    ],
+    [
+      "permessage-deflate; server_max_window_bits=10; client_max_window_bits=12",
+      "permessage-deflate; server_max_window_bits=10; client_max_window_bits=12",
+    ],
+    // A quoted parameter value is legal (RFC 6455 section 9.1) and 15 is the default.
+    [
+      'permessage-deflate; server_max_window_bits="9"; client_max_window_bits=15',
+      "permessage-deflate; server_max_window_bits=9",
+    ],
+  ];
+
+  test.each(valid)("accepts %j", async (value, extensions) => {
+    expect(await negotiate(value, helloFrame)).toEqual({
+      opened: true,
+      message: "hello",
+      extensions,
+      code: 0,
+      reason: "",
+    });
+  });
+
+  test("still inflates frames after a validated negotiation", async () => {
+    // RSV1 + FIN + text opcode, with a raw-deflate payload per RFC 7692.
+    const compressed = deflateRawSync("hello");
+    const frame = Buffer.concat([Buffer.from([0xc1, compressed.length]), compressed]);
+    expect(await negotiate("permessage-deflate; server_no_context_takeover", frame)).toEqual({
+      opened: true,
+      message: "hello",
+      extensions: "permessage-deflate; server_no_context_takeover",
+      code: 0,
+      reason: "",
+    });
+  });
+});

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -12,7 +12,7 @@ async function createTestServer(
   let port: number;
 
   await new Promise<void>(resolve => {
-    server.listen(0, () => {
+    server.listen(0, "127.0.0.1", () => {
       port = (server.address() as any).port;
       resolve();
     });
@@ -69,7 +69,7 @@ async function createTestServer(
 }
 
 function connect(port: number, protocols: string[] | undefined) {
-  const url = `ws://localhost:${port}`;
+  const url = `ws://127.0.0.1:${port}`;
   // `undefined` means "no protocols argument at all", i.e. the default options.
   return protocols === undefined ? new WebSocket(url) : new WebSocket(url, protocols);
 }
@@ -245,7 +245,7 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
     await using server = await createTestServer([]);
     const { promise: closePromise, resolve: resolveClose } = Promise.withResolvers<CloseEvent>();
 
-    const ws = new WebSocket(`ws://localhost:${server.port}`, ["chat", "echo"]);
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}`, ["chat", "echo"]);
     const onopenMock = mock(() => {});
     ws.onopen = onopenMock;
     ws.onclose = close => resolveClose(close);
@@ -259,7 +259,7 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
     expect(onopenMock).not.toHaveBeenCalled();
 
     const { promise: openPromise, resolve: resolveOpen, reject } = Promise.withResolvers<void>();
-    const bare = new WebSocket(`ws://localhost:${server.port}`);
+    const bare = new WebSocket(`ws://127.0.0.1:${server.port}`);
     try {
       bare.onopen = () => resolveOpen();
       bare.onerror = reject;
@@ -315,7 +315,7 @@ describe("WebSocket strict RFC 6455 extension handling", () => {
   it("should still accept a plain permessage-deflate response", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Extensions: permessage-deflate"]);
     const { promise: openPromise, resolve: resolveOpen, reject } = Promise.withResolvers();
-    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}`);
     try {
       ws.onopen = () => resolveOpen();
       ws.onerror = reject;

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -2,97 +2,120 @@ import { describe, expect, it, mock } from "bun:test";
 import crypto from "node:crypto";
 import net from "node:net";
 
-describe("WebSocket strict RFC 6455 subprotocol handling", () => {
-  async function createTestServer(
-    responseHeaders: string[],
-  ): Promise<{ port: number; [Symbol.asyncDispose]: () => Promise<void> }> {
-    const server = net.createServer();
-    let port: number;
+// A byte-controlled RFC 6455 server: replies with a valid 101 plus whatever
+// extra response headers the test crafts. Used to exercise the client-side
+// handshake response validation in process_response().
+async function createTestServer(
+  responseHeaders: string[],
+): Promise<{ port: number; [Symbol.asyncDispose]: () => Promise<void> }> {
+  const server = net.createServer();
+  let port: number;
 
-    await new Promise<void>(resolve => {
-      server.listen(0, () => {
-        port = (server.address() as any).port;
-        resolve();
-      });
+  await new Promise<void>(resolve => {
+    server.listen(0, () => {
+      port = (server.address() as any).port;
+      resolve();
     });
+  });
 
-    server.on("connection", socket => {
-      // Raw test server: tolerate client aborts, surface anything unexpected.
-      socket.on("error", (err: NodeJS.ErrnoException) => {
-        if (err.code !== "ECONNRESET" && err.code !== "EPIPE" && err.code !== "ECONNABORTED") throw err;
-      });
-      let requestData = "";
+  server.on("connection", socket => {
+    // Raw test server: tolerate client aborts, surface anything unexpected.
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code !== "ECONNRESET" && err.code !== "EPIPE" && err.code !== "ECONNABORTED") throw err;
+    });
+    let requestData = "";
 
-      socket.on("data", data => {
-        requestData += data.toString();
+    socket.on("data", data => {
+      requestData += data.toString();
 
-        if (requestData.includes("\r\n\r\n")) {
-          const lines = requestData.split("\r\n");
-          let websocketKey = "";
+      if (requestData.includes("\r\n\r\n")) {
+        const lines = requestData.split("\r\n");
+        let websocketKey = "";
 
-          for (const line of lines) {
-            if (line.startsWith("Sec-WebSocket-Key:")) {
-              websocketKey = line.split(":")[1].trim();
-              break;
-            }
+        for (const line of lines) {
+          if (line.startsWith("Sec-WebSocket-Key:")) {
+            websocketKey = line.split(":")[1].trim();
+            break;
           }
-
-          const acceptKey = crypto
-            .createHash("sha1")
-            .update(websocketKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
-            .digest("base64");
-
-          const response = [
-            "HTTP/1.1 101 Switching Protocols",
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            `Sec-WebSocket-Accept: ${acceptKey}`,
-            ...responseHeaders,
-            "\r\n",
-          ].join("\r\n");
-
-          socket.write(response);
         }
-      });
+
+        const acceptKey = crypto
+          .createHash("sha1")
+          .update(websocketKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+
+        const response = [
+          "HTTP/1.1 101 Switching Protocols",
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          `Sec-WebSocket-Accept: ${acceptKey}`,
+          ...responseHeaders,
+          "\r\n",
+        ].join("\r\n");
+
+        socket.write(response);
+      }
     });
+  });
 
-    return {
-      port: port!,
-      [Symbol.asyncDispose]: async () => {
-        server.close();
-      },
-    };
+  return {
+    port: port!,
+    [Symbol.asyncDispose]: async () => {
+      server.close();
+    },
+  };
+}
+
+function connect(port: number, protocols: string[] | undefined) {
+  const url = `ws://localhost:${port}`;
+  // `undefined` means "no protocols argument at all", i.e. the default options.
+  return protocols === undefined ? new WebSocket(url) : new WebSocket(url, protocols);
+}
+
+// A failed handshake must never reach `open`, must surface exactly one
+// `error` event, and must close with `wasClean: false`.
+async function expectConnectionFailure(
+  port: number,
+  protocols: string[] | undefined,
+  expectedCode = 1002,
+  expectedReason = "Mismatch client protocol",
+) {
+  const { promise: closePromise, resolve: resolveClose, reject: rejectClose } = Promise.withResolvers<CloseEvent>();
+
+  const ws = connect(port, protocols);
+  const onerrorMock = mock(() => {});
+  ws.onopen = () => rejectClose(new Error("handshake unexpectedly succeeded: open event fired"));
+  ws.onerror = onerrorMock;
+  ws.onclose = resolveClose;
+
+  try {
+    const close = await closePromise;
+    expect(onerrorMock).toHaveBeenCalledTimes(1);
+    expect({ code: close.code, reason: close.reason, wasClean: close.wasClean }).toEqual({
+      code: expectedCode,
+      reason: expectedReason,
+      wasClean: false,
+    });
+  } finally {
+    ws.terminate();
   }
+}
 
-  async function expectConnectionFailure(port: number, protocols: string[], expectedCode = 1002) {
-    const { promise: closePromise, resolve: resolveClose } = Promise.withResolvers();
-
-    const ws = new WebSocket(`ws://localhost:${port}`, protocols);
-    const onopenMock = mock(() => {});
-    ws.onopen = onopenMock;
-
-    ws.onclose = close => {
-      expect(close.code).toBe(expectedCode);
-      expect(close.reason).toBe("Mismatch client protocol");
-      resolveClose();
-    };
-
-    await closePromise;
-    expect(onopenMock).not.toHaveBeenCalled();
+async function expectConnectionSuccess(port: number, protocols: string[] | undefined, expectedProtocol: string) {
+  const { promise: openPromise, resolve: resolveOpen, reject } = Promise.withResolvers();
+  const ws = connect(port, protocols);
+  try {
+    ws.onopen = () => resolveOpen();
+    ws.onerror = reject;
+    ws.onclose = e => reject(new Error(`closed: code=${e.code} reason=${e.reason}`));
+    await openPromise;
+    expect(ws.protocol).toBe(expectedProtocol);
+  } finally {
+    ws.terminate();
   }
+}
 
-  async function expectConnectionSuccess(port: number, protocols: string[], expectedProtocol: string) {
-    const { promise: openPromise, resolve: resolveOpen, reject } = Promise.withResolvers();
-    const ws = new WebSocket(`ws://localhost:${port}`, protocols);
-    try {
-      ws.onopen = () => resolveOpen();
-      ws.onerror = reject;
-      await openPromise;
-      expect(ws.protocol).toBe(expectedProtocol);
-    } finally {
-      ws.terminate();
-    }
-  }
+describe("WebSocket strict RFC 6455 subprotocol handling", () => {
   // Multiple protocols in single header (comma-separated) - should fail
   it("should reject multiple comma-separated protocols", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Protocol: chat, echo"]);
@@ -156,7 +179,30 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
     await expectConnectionFailure(server.port, ["chat", "echo"]);
   });
 
+  // RFC 6455 §4.1 / WHATWG "establish a WebSocket connection" step 4: if
+  // the client requested subprotocols, a 101 that selects none of them
+  // must fail the connection.
+  it("should reject a response with no Sec-WebSocket-Protocol when protocols were requested", async () => {
+    await using server = await createTestServer([]);
+    await expectConnectionFailure(server.port, ["chat", "echo"], 1002, "Server sent no subprotocol");
+  });
+
+  it("should reject a response with no Sec-WebSocket-Protocol when a single protocol was requested", async () => {
+    await using server = await createTestServer([]);
+    await expectConnectionFailure(server.port, ["chat"], 1002, "Server sent no subprotocol");
+  });
+
   // Valid cases - should succeed
+  it("should accept a response with no Sec-WebSocket-Protocol when none was requested", async () => {
+    await using server = await createTestServer([]);
+    await expectConnectionSuccess(server.port, undefined, "");
+  });
+
+  it("should accept a response with no Sec-WebSocket-Protocol when the protocol list is empty", async () => {
+    await using server = await createTestServer([]);
+    await expectConnectionSuccess(server.port, [], "");
+  });
+
   it("should accept single valid protocol (first in client list)", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Protocol: chat"]);
     await expectConnectionSuccess(server.port, ["chat", "echo", "binary"], "chat");
@@ -218,5 +264,57 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
     } finally {
       bare.terminate();
     }
+  });
+});
+
+// RFC 6455 §4.1 step 4: a Sec-WebSocket-Extensions response that indicates an
+// extension not present in the client's handshake must fail the connection.
+// The default client offers only permessage-deflate.
+describe("WebSocket strict RFC 6455 extension handling", () => {
+  it("should reject an extension the client never offered", async () => {
+    await using server = await createTestServer(["Sec-WebSocket-Extensions: x-bogus-ext"]);
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+  });
+
+  it("should reject an unoffered extension listed after permessage-deflate", async () => {
+    await using server = await createTestServer(["Sec-WebSocket-Extensions: permessage-deflate, x-bogus-ext"]);
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+  });
+
+  it("should reject an unoffered extension listed before permessage-deflate", async () => {
+    await using server = await createTestServer(["Sec-WebSocket-Extensions: x-bogus-ext, permessage-deflate"]);
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+  });
+
+  it("should reject an unoffered extension carrying parameters", async () => {
+    await using server = await createTestServer(["Sec-WebSocket-Extensions: x-bogus-ext; foo=bar"]);
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+  });
+
+  it("should still accept a plain permessage-deflate response", async () => {
+    await using server = await createTestServer(["Sec-WebSocket-Extensions: permessage-deflate"]);
+    const { promise: openPromise, resolve: resolveOpen, reject } = Promise.withResolvers();
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    try {
+      ws.onopen = () => resolveOpen();
+      ws.onerror = reject;
+      ws.onclose = e => reject(new Error(`closed: code=${e.code} reason=${e.reason}`));
+      await openPromise;
+      expect(ws.extensions).toContain("permessage-deflate");
+    } finally {
+      ws.terminate();
+    }
+  });
+
+  it("should still accept permessage-deflate with parameters", async () => {
+    await using server = await createTestServer([
+      "Sec-WebSocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover",
+    ]);
+    await expectConnectionSuccess(server.port, undefined, "");
+  });
+
+  it("should ignore empty list elements such as a trailing comma", async () => {
+    await using server = await createTestServer(["Sec-WebSocket-Extensions: permessage-deflate,"]);
+    await expectConnectionSuccess(server.port, undefined, "");
   });
 });

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -291,6 +291,22 @@ describe("WebSocket strict RFC 6455 extension handling", () => {
     await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
   });
 
+  // RFC 7692 §5: the response must not list permessage-deflate more than once.
+  it("should reject a duplicate permessage-deflate in one header", async () => {
+    await using server = await createTestServer([
+      "Sec-WebSocket-Extensions: permessage-deflate; server_max_window_bits=12, permessage-deflate; server_max_window_bits=10",
+    ]);
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+  });
+
+  it("should reject permessage-deflate repeated across two Sec-WebSocket-Extensions headers", async () => {
+    await using server = await createTestServer([
+      "Sec-WebSocket-Extensions: permessage-deflate",
+      "Sec-WebSocket-Extensions: permessage-deflate",
+    ]);
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+  });
+
   it("should still accept a plain permessage-deflate response", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Extensions: permessage-deflate"]);
     const { promise: openPromise, resolve: resolveOpen, reject } = Promise.withResolvers();

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -275,22 +275,22 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
 describe("WebSocket strict RFC 6455 extension handling", () => {
   it("should reject an extension the client never offered", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Extensions: x-bogus-ext"]);
-    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid Sec-WebSocket-Extensions header");
   });
 
   it("should reject an unoffered extension listed after permessage-deflate", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Extensions: permessage-deflate, x-bogus-ext"]);
-    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid Sec-WebSocket-Extensions header");
   });
 
   it("should reject an unoffered extension listed before permessage-deflate", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Extensions: x-bogus-ext, permessage-deflate"]);
-    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid Sec-WebSocket-Extensions header");
   });
 
   it("should reject an unoffered extension carrying parameters", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Extensions: x-bogus-ext; foo=bar"]);
-    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid Sec-WebSocket-Extensions header");
   });
 
   // RFC 7692 §5: the response must not list permessage-deflate more than once.
@@ -298,7 +298,7 @@ describe("WebSocket strict RFC 6455 extension handling", () => {
     await using server = await createTestServer([
       "Sec-WebSocket-Extensions: permessage-deflate; server_max_window_bits=12, permessage-deflate; server_max_window_bits=10",
     ]);
-    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid Sec-WebSocket-Extensions header");
   });
 
   it("should reject permessage-deflate repeated across two Sec-WebSocket-Extensions headers", async () => {
@@ -306,7 +306,7 @@ describe("WebSocket strict RFC 6455 extension handling", () => {
       "Sec-WebSocket-Extensions: permessage-deflate",
       "Sec-WebSocket-Extensions: permessage-deflate",
     ]);
-    await expectConnectionFailure(server.port, undefined, 1002, "Invalid response");
+    await expectConnectionFailure(server.port, undefined, 1002, "Invalid Sec-WebSocket-Extensions header");
   });
 
   it("should still accept a plain permessage-deflate response", async () => {

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -251,8 +251,11 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
     ws.onclose = close => resolveClose(close);
 
     const close = await closePromise;
-    expect(close.code).toBe(1002);
-    expect(close.reason).toBe("Missing client protocol");
+    expect({ code: close.code, reason: close.reason, wasClean: close.wasClean }).toEqual({
+      code: 1002,
+      reason: "Server sent no subprotocol",
+      wasClean: false,
+    });
     expect(onopenMock).not.toHaveBeenCalled();
 
     const { promise: openPromise, resolve: resolveOpen, reject } = Promise.withResolvers<void>();

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -61,7 +61,9 @@ async function createTestServer(
   return {
     port: port!,
     [Symbol.asyncDispose]: async () => {
-      server.close();
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      });
     },
   };
 }


### PR DESCRIPTION
### Problem

RFC 6455 section 4.1 and the WHATWG "establish a WebSocket connection" algorithm both require the client to fail the WebSocket connection when the server's 101 response either:

1. does not select one of the subprotocols the client requested, or
2. indicates an extension the client's handshake did not offer.

RFC 7692 section 8.1 adds a third case for the one extension Bun offers: a `permessage-deflate` response that carries a parameter not defined for use in a response, a repeated parameter, or a parameter with an invalid value must also fail the connection.

Bun's client opened the connection in all of these cases. The parameter one is the dangerous one: extension parameters define how subsequent frames are compressed, and an accepted-but-ignored `server_max_window_bits=20` (out of range, so Bun silently kept its default of 15) means a conforming server can compress with a window the client never agreed to. That surfaces later as inflate failures and abrupt 1006 disconnects instead of a clean handshake failure at the one moment it is debuggable.

A fourth, related bug: the subprotocol-mismatch failure was the only handshake failure that skipped the `error` event and reported `wasClean: true`.

### Repro

Against a raw TCP server that replies with a valid 101 plus the crafted header (node `ws`, Chrome, and Firefox fail all of these):

```js
// 1. server omits Sec-WebSocket-Protocol entirely
new WebSocket(url, ["aaa", "bbb"]);
// Bun: fires open, ws.protocol === ""

// 2. server replies `Sec-WebSocket-Extensions: x-bogus-ext` (never offered)
new WebSocket(url);
// Bun: fires open

// 3. server replies `Sec-WebSocket-Extensions: permessage-deflate; bogus_param=1`
new WebSocket(url);
// Bun: fires open

// 4. server replies `Sec-WebSocket-Extensions: permessage-deflate; server_max_window_bits=20`
new WebSocket(url);
// Bun: fires open and inflates with the 15-bit default the server did not pick

// 5. server replies `Sec-WebSocket-Protocol: zzz` (never offered)
new WebSocket(url, ["aaa", "bbb"]);
// Bun: no error event, close { code: 1002, wasClean: true }
```

After this PR, Bun fails 1 through 4 with an `error` event followed by a `close` event with `wasClean: false` and a descriptive 1002 reason, and 5 gets the same event semantics as every other handshake failure.

### Cause

- `process_response` tracked `protocol_header_seen` but never checked it after the header loop, so "client requested protocols, server confirmed none" was never detected. The `missing_client_protocol` error code had existed in the enum the whole time with nothing emitting it. Hardening round 11 (#33072) has since landed that detection on main, so it is no longer part of this diff; it also means the broken close semantics in the third bullet below became reachable for the first time.
- The `Sec-WebSocket-Extensions` guard only fired when the client offered no extensions. The default client offers `permessage-deflate`, so any other token in the response was silently ignored. The parameter loop had no rejection path at all: unknown keys fell through an if/else chain with no final else, and a missing, malformed, or out-of-range `*_max_window_bits` value just skipped the assignment and left the default.
- In `WebSocket::didFailWithErrorCode`, the `missing_client_protocol` and `mismatch_client_protocol` arms passed `CleanStatus::Clean` and omitted `isConnectionError`, unlike every sibling handshake-failure arm, so no `error` event fired and `CloseEvent.wasClean` was `true`.

### What does this PR do?

`src/http_jsc/websocket_client/WebSocketUpgradeClient.rs`

- The inline extensions loop is replaced by `accept_extensions_response()`: the response must contain exactly one `permessage-deflate` element (RFC 7692 section 5 forbids accepting it twice, whether in one header value or across several headers), and its parameters must be the four RFC 7692 defines, each at most once. `server_no_context_takeover` and `client_no_context_takeover` take no value. `server_max_window_bits` and `client_max_window_bits` require a decimal value between 8 and 15 in a response (only an offer may omit the value). Anything else terminates the handshake.
- The happy path is unchanged: an accepted response still lands in `DeflateNegotiationResult`, `ws.extensions`, and the inflater.

`src/http_jsc/websocket_client.rs`, `src/jsc/bindings/webcore/WebSocketErrorCode.h`, `src/jsc/bindings/webcore/WebSocket.cpp`

- New `invalid_extensions_header` error code, so extension failures close with 1002 and the reason `Invalid Sec-WebSocket-Extensions header` (the wording `ws` uses) instead of the generic `Invalid response`.
- `missing_client_protocol` and `mismatch_client_protocol` now use `CleanStatus::NotClean` and `isConnectionError = true` like the other handshake-failure arms: the `error` event fires and `wasClean` is `false`. The previously unreachable `missing_client_protocol` reason string is now "Server sent no subprotocol" (the wording `ws` uses).

This cannot reject Bun's own server: the `Sec-WebSocket-Extensions` line a `Bun.serve` 101 produces is `permessage-deflate` plus an optional `client_no_context_takeover` or `client_max_window_bits=N` and an optional `server_no_context_takeover` or `server_max_window_bits=N`, always valued and in range (`packages/bun-uws/src/WebSocketExtensions.h`).

**Not changed, on purpose.** Two more divergences from the same report are deliberate, tested Bun behaviors, so I left them for a maintainer call rather than bundling a breaking change in here:

- Bun reports handshake failures as `close` code 1002 with a descriptive reason; the spec and Node use 1006 with an empty reason. Every existing test in `websocket-subprotocol-strict.test.ts` asserts the 1002 + reason shape.
- `binaryType` defaults to `"nodebuffer"` and throws `SyntaxError` on an out-of-enum assignment; the spec says `"blob"` and silently ignore. Both are explicitly asserted in `websocket-client.test.ts`.

### How did you verify your code works?

`test/js/web/websocket/websocket-subprotocol-strict.test.ts`: two missing-subprotocol cases, a "strict RFC 6455 extension handling" describe (six rejections plus three should-still-succeed controls), and the shared `expectConnectionFailure` helper asserts exactly one `error` event, `wasClean: false`, and the close reason, and rejects the instant `open` fires. The eleven pre-existing subprotocol-mismatch tests thereby become the regression tests for the event-semantics fix.

`test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts`: a "Sec-WebSocket-Extensions response validation" describe against a byte-controlled raw 101 that also sends a frame, alongside the RSV1 frame tests main added in #33395. Twenty invalid responses (unoffered extension names, a duplicated element, unknown parameters, out-of-range, malformed, missing, signed, separator-bearing, leading-zero, and repeated window bits, valued no_context_takeover) must produce no `open`, no message, and a 1002 close with the new reason. Five valid responses, including a quoted parameter value and no extensions header at all, must open, deliver the frame, and report the negotiated `ws.extensions`. A final case round-trips a real RSV1 deflate frame after negotiation.

Against the rebased base (`src/` reverted to `main`, tests from this branch, which is what the two files prove between them):

```
bun bd test websocket-subprotocol-strict.test.ts websocket-permessage-deflate-edge-cases.test.ts
# src/ at main:  40 fail, 29 pass
# this branch:   69 pass,  0 fail
```

Every in-tree test that passes a client subprotocol connects to a server that echoes one back (`Bun.serve` and `ws.Server` both select the first offered protocol by default), so none are affected by the new check. The adjacent suites (`regression/issue/29684.test.ts`, `websocket-permessage-deflate*.test.ts`, `websocket-custom-headers.test.ts`, `websocket-accept-header-validation.test.ts`, `websocket-close-connecting.test.ts`, `websocket-proxy.test.ts`, `test-ws-bidir-proxy.test.ts`, `websocket.test.js`, `first_party/ws/ws.test.ts`) have the same pass/fail set before and after the change; the handful of pre-existing failures in them (external-network hosts, the 30 documented timeouts in `ws.test.ts`) are identical with `src/` stashed.


### Rebase notes

Rebased onto `main` after several WebSocket changes landed there. The conflicts and how they were resolved:

- **Error-code discriminant collision.** #33395 took `37` for `unexpected_rsv1` in both `WebSocketErrorCode.h` and the mirrored Rust `ErrorCode` enum, and this branch had taken `37` for `invalid_extensions_header`. Those two enums are an FFI pair (Rust sends the `i32`, C++ switches on it), so a mismatch would report the wrong error. The landed value keeps `37` and `invalid_extensions_header` moved to `38`, in both files.
- **Duplicate subprotocol check.** #33072 independently added the same "client requested subprotocols, server selected none" guard this branch had. The upstream one is kept and this branch's copy is deleted; its RFC citation moved onto the surviving check, which had no comment.
- **Reason-string assertion.** The test #33072 added asserts `reason === "Missing client protocol"`, which this branch renames to `"Server sent no subprotocol"` (the old wording reads as if the client were at fault; `ws` uses the new one). That string was unreachable until #33072 landed, so nothing in the wild can depend on it. The assertion is updated and strengthened to also check `wasClean: false`, which is the semantics this branch fixes. It was the only assertion on that string in the repo.
- **Test file append collision.** #33395, later #34105, and this branch all appended blocks to the end of `websocket-permessage-deflate-edge-cases.test.ts`. All are kept.

The full WebSocket suite passes on the rebased branch, plus the pre-existing external-network and proxy-sandbox failures noted above, unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 20 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 40 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts test/js/web/websocket/websocket-subprotocol-strict.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f4a143933)

test/js/web/websocket/websocket-subprotocol-strict.test.ts:
90 |   ws.onerror = onerrorMock;
91 |   ws.onclose = resolveClose;
92 | 
93 |   try {
94 |     const close = await closePromise;
95 |     expect(onerrorMock).toHaveBeenCalledTimes(1);
                             ^
error: expect(received).toHaveBeenCalledTimes(expected)

Expected number of calls: 1
Received number of calls: 0

      at expectConnectionFailure (/workspace/bun/test/js/web/websocket/websocket-subprotocol-strict.test.ts:95:25)
      at async <anonymous> (/workspace/bun/test/js/web/websocket/websocket-subprotocol-strict.test.ts:124:11)
(fail) WebSocket stri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (97a17c79e)

test/js/web/websocket/websocket-subprotocol-strict.test.ts:
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols [7.45ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols with spaces [1.87ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols (3 protocols) [1.71ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (same value) [1.61ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (different values) [1.58ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject three Sec-WebSocket-Protocol headers [3.03ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject empty Sec-WebSocket-Protocol header [1.59ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject Sec-WebSocket-Protocol with only comma [1.53ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject Sec-WebSocket-Protocol with
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts test/js/web/websocket/websocket-subprotocol-strict.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f4a143933)

test/js/web/websocket/websocket-subprotocol-strict.test.ts:
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols [401.89ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols with spaces [67.57ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols (3 protocols) [56.86ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (same value) [50.98ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 687ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[3/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[4/13] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[5/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[6/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[7/13] gen cpp.rs (cppbind)
[7/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (curr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/websocket_client.rs                   |   1 +
 .../websocket_client/WebSocketUpgradeClient.rs     | 193 ++++++++------
 src/jsc/bindings/webcore/WebSocket.cpp             |   8 +-
 src/jsc/bindings/webcore/WebSocketErrorCode.h      |   1 +
 ...websocket-permessage-deflate-edge-cases.test.ts | 152 ++++++++++-
 .../websocket/websocket-subprotocol-strict.test.ts | 285 +++++++++++++++------
 6 files changed, 474 insertions(+), 166 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 20

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/http_jsc/websocket_client.rs                              1      1     22
src/http_jsc/websocket_client/WebSocketUpgradeClient.rs       7      8     22
src/jsc/bindings/webcore/WebSocket.cpp                        4      1     22
src/jsc/bindings/webcore/WebSocketErrorCode.h                 1      1     22
…bsocket/websocket-permessage-deflate-edge-cases.test.ts      4      3     10
…t/js/web/websocket/websocket-subprotocol-strict.test.ts      6      8     15
```

</details>

<!-- robobun:evidence:end -->
