### PR TITLE
webcrypto: validate the OKP JWK x parameter against d on import

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -119,23 +119,42 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importRaw(CryptoAlgorithmIdentifier identifie
     return create(identifier, namedCurve, usages & CryptoKeyUsageSign ? CryptoKeyType::Private : CryptoKeyType::Public, WTF::move(keyData), extractable, usages);
 }
 
-RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwkInternal(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages, bool onlyPublic)
+// RFC 8037 section 2: an OKP JWK carries a 32-byte `d` and a 32-byte `x`, and `x` must be the
+// public key derived from `d`. The publicFromPrivate helpers below assume 32-byte input.
+static bool checkPairedJwkKeys(CryptoKeyOKP::NamedCurve namedCurve, const Vector<uint8_t>& d, const Vector<uint8_t>& x)
+{
+    auto keySize = externalKeySizeInBytesFromNamedCurve(namedCurve);
+    if (d.size() != keySize || x.size() != keySize)
+        return false;
+
+    switch (namedCurve) {
+    case CryptoKeyOKP::NamedCurve::Ed25519:
+        return CryptoKeyOKP::ed25519PublicFromPrivate(d) == x;
+    case CryptoKeyOKP::NamedCurve::X25519:
+        return CryptoKeyOKP::x25519PublicFromPrivate(d) == x;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     if (!isPlatformSupportedCurve(namedCurve))
         return nullptr;
 
     switch (namedCurve) {
     case NamedCurve::Ed25519:
-        if (!keyData.d.isEmpty() && !onlyPublic) {
+        if (!keyData.d.isEmpty()) {
             if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageVerify | CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey))
                 return nullptr;
         } else {
             if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageSign | CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey))
                 return nullptr;
         }
-        if (keyData.kty != "OKP"_s)
-            return nullptr;
         if (keyData.crv != "Ed25519"_s)
+            return nullptr;
+        if (!keyData.alg.isNull() && keyData.alg != "EdDSA"_s && keyData.alg != "Ed25519"_s)
             return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "sig"_s)
             return nullptr;
@@ -145,8 +164,6 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwkInternal(CryptoAlgorithmIdentifier i
             return nullptr;
         break;
     case NamedCurve::X25519:
-        if (keyData.kty != "OKP"_s)
-            return nullptr;
         if (keyData.crv != "X25519"_s)
             return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "enc"_s)
@@ -158,15 +175,8 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwkInternal(CryptoAlgorithmIdentifier i
         break;
     }
 
-    if (!onlyPublic) {
-        if (!keyData.d.isNull()) {
-            // FIXME: Validate keyData.x is paired with keyData.d
-            auto d = base64URLDecode(keyData.d);
-            if (!d)
-                return nullptr;
-            return create(identifier, namedCurve, CryptoKeyType::Private, WTF::move(*d), extractable, usages);
-        }
-    }
+    if (keyData.kty != "OKP"_s)
+        return nullptr;
 
     if (keyData.x.isNull())
         return nullptr;
@@ -174,16 +184,15 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwkInternal(CryptoAlgorithmIdentifier i
     auto x = base64URLDecode(keyData.x);
     if (!x)
         return nullptr;
-    return create(identifier, namedCurve, CryptoKeyType::Public, WTF::move(*x), extractable, usages);
-}
 
-RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPublicJwk(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
-{
-    return importJwkInternal(identifier, namedCurve, WTF::move(keyData), extractable, usages, true);
-}
-RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
-{
-    return importJwkInternal(identifier, namedCurve, WTF::move(keyData), extractable, usages, false);
+    if (!keyData.d.isNull()) {
+        auto d = base64URLDecode(keyData.d);
+        if (!d || !checkPairedJwkKeys(namedCurve, *d, *x))
+            return nullptr;
+        return create(identifier, namedCurve, CryptoKeyType::Private, WTF::move(*d), extractable, usages);
+    }
+
+    return create(identifier, namedCurve, CryptoKeyType::Public, WTF::move(*x), extractable, usages);
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportRaw() const

--- a/src/jsc/bindings/webcrypto/CryptoKeyOKP.h
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKP.h
@@ -48,7 +48,6 @@ public:
 
     WEBCORE_EXPORT static ExceptionOr<CryptoKeyPair> generatePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap);
     WEBCORE_EXPORT static RefPtr<CryptoKeyOKP> importRaw(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
-    static RefPtr<CryptoKeyOKP> importPublicJwk(CryptoAlgorithmIdentifier, NamedCurve, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap);
     static RefPtr<CryptoKeyOKP> importJwk(CryptoAlgorithmIdentifier, NamedCurve, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap);
     static RefPtr<CryptoKeyOKP> importSpki(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
     static RefPtr<CryptoKeyOKP> importPkcs8(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
@@ -89,7 +88,6 @@ private:
     Vector<uint8_t> platformExportRaw() const;
     Vector<uint8_t> platformExportSpki() const;
     Vector<uint8_t> platformExportPkcs8() const;
-    static RefPtr<CryptoKeyOKP> importJwkInternal(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages, bool onlyPublic);
 
     NamedCurve m_curve;
     KeyMaterial m_data;

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -335,6 +335,104 @@ describe("Ed25519", () => {
   });
 });
 
+// RFC 8037 section 2: an OKP JWK must carry `x`, and for a private key it must be the
+// public key derived from `d`. Expectations below match Node.js v26 for these fixed JWKs.
+describe("OKP (Ed25519 / X25519) JWK import validation", () => {
+  const b64url = (hex: string) => Buffer.from(hex, "hex").toString("base64url");
+  const probe = (jwk: JsonWebKey, algName: string, usages: KeyUsage[], extractable = true) =>
+    crypto.subtle.importKey("jwk", jwk, { name: algName }, extractable, usages).then(
+      () => "accepted",
+      e => e.name,
+    );
+
+  // RFC 8032 section 7.1, test vector 1 (edWrongX is test vector 2's public key).
+  const edDHex = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+  const edXHex = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+  const edD = b64url(edDHex);
+  const edX = b64url(edXHex);
+  const edWrongX = b64url("3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c");
+  const edPub: JsonWebKey = { kty: "OKP", crv: "Ed25519", x: edX };
+  const edPriv: JsonWebKey = { ...edPub, d: edD };
+
+  // RFC 7748 section 6.1 (Alice's key pair; xWrongX is Bob's public key).
+  const xD = b64url("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a");
+  const xX = b64url("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a");
+  const xWrongX = b64url("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f");
+  const xPub: JsonWebKey = { kty: "OKP", crv: "X25519", x: xX };
+  const xPriv: JsonWebKey = { ...xPub, d: xD };
+
+  it("Ed25519 rejects a private JWK whose x is missing, truncated, or not derived from d", async () => {
+    expect({
+      "valid public": await probe(edPub, "Ed25519", ["verify"]),
+      "valid private": await probe(edPriv, "Ed25519", ["sign"]),
+      "d without x": await probe({ kty: "OKP", crv: "Ed25519", d: edD }, "Ed25519", ["sign"]),
+      "x does not match d": await probe({ ...edPriv, x: edWrongX }, "Ed25519", ["sign"]),
+      "x is not base64url": await probe({ ...edPriv, x: "!!!" }, "Ed25519", ["sign"]),
+      "x is truncated": await probe({ ...edPriv, x: edX.slice(0, 10) }, "Ed25519", ["sign"]),
+      "public x is truncated": await probe({ ...edPub, x: edX.slice(0, 10) }, "Ed25519", ["verify"]),
+      "d is 64 bytes": await probe({ ...edPub, d: b64url(edDHex + edXHex) }, "Ed25519", ["sign"]),
+      "d is truncated": await probe({ ...edPub, d: edD.slice(0, 10) }, "Ed25519", ["sign"]),
+    }).toEqual({
+      "valid public": "accepted",
+      "valid private": "accepted",
+      "d without x": "DataError",
+      "x does not match d": "DataError",
+      "x is not base64url": "DataError",
+      "x is truncated": "DataError",
+      "public x is truncated": "DataError",
+      "d is 64 bytes": "DataError",
+      "d is truncated": "DataError",
+    });
+  });
+
+  it("X25519 rejects a private JWK whose x is missing, truncated, or not derived from d", async () => {
+    expect({
+      "valid public": await probe(xPub, "X25519", []),
+      "valid private": await probe(xPriv, "X25519", ["deriveBits"]),
+      "d without x": await probe({ kty: "OKP", crv: "X25519", d: xD }, "X25519", ["deriveBits"]),
+      "x does not match d": await probe({ ...xPriv, x: xWrongX }, "X25519", ["deriveBits"]),
+      "x is truncated": await probe({ ...xPriv, x: xX.slice(0, 10) }, "X25519", ["deriveBits"]),
+      "public x is truncated": await probe({ ...xPub, x: xX.slice(0, 10) }, "X25519", []),
+    }).toEqual({
+      "valid public": "accepted",
+      "valid private": "accepted",
+      "d without x": "DataError",
+      "x does not match d": "DataError",
+      "x is truncated": "DataError",
+      "public x is truncated": "DataError",
+    });
+  });
+
+  it("Ed25519 rejects a JWK with a wrong kty or alg", async () => {
+    expect({
+      "kty EC": await probe({ ...edPriv, kty: "EC" }, "Ed25519", ["sign"]),
+      "alg ES256": await probe({ ...edPriv, alg: "ES256" }, "Ed25519", ["sign"]),
+      // `alg: ""` is present but invalid; only an absent `alg` may be skipped.
+      "alg empty string": await probe({ ...edPriv, alg: "" }, "Ed25519", ["sign"]),
+      "alg Ed25519": await probe({ ...edPriv, alg: "Ed25519" }, "Ed25519", ["sign"]),
+      "alg EdDSA": await probe({ ...edPriv, alg: "EdDSA" }, "Ed25519", ["sign"]),
+    }).toEqual({
+      "kty EC": "DataError",
+      "alg ES256": "DataError",
+      "alg empty string": "DataError",
+      "alg Ed25519": "accepted",
+      "alg EdDSA": "accepted",
+    });
+  });
+
+  // The alg check above is Ed25519-only: Node does not validate alg for X25519, and the
+  // kty/key_ops/ext rules for X25519 are covered by the "X25519 JWK import" block below.
+  it("X25519 does not validate alg", async () => {
+    expect({
+      "alg ES256": await probe({ ...xPriv, alg: "ES256" }, "X25519", ["deriveBits"]),
+      "kty EC": await probe({ ...xPriv, kty: "EC" }, "X25519", ["deriveBits"]),
+    }).toEqual({
+      "alg ES256": "accepted",
+      "kty EC": "DataError",
+    });
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/32613
 describe("AES-KW wrapKey/unwrapKey with jwk format", () => {
   // The serialized JWK is rarely a multiple of 8 bytes, which AES-KW (RFC 3394)
@@ -546,10 +644,12 @@ describe("SubtleCrypto.deriveBits length", () => {
 });
 
 describe("X25519 JWK import", () => {
+  // Alice's key pair from RFC 7748 section 6.1. `x` must be the public key derived from `d`,
+  // so the two stay in sync; an inconsistent pair is a DataError.
   const x25519Public: JsonWebKey = {
     kty: "OKP",
     crv: "X25519",
-    x: "hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr06uFD1q1y5Go",
+    x: "hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr066SpjqqbTmo",
   };
   const x25519Private: JsonWebKey = {
     ...x25519Public,


### PR DESCRIPTION
### Problem

`crypto.subtle.importKey("jwk", ...)` for Ed25519 and X25519 never reads the JWK's `x` parameter when `d` is present:

```js
const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
const jwk = await crypto.subtle.exportKey("jwk", kp.privateKey);
delete jwk.x;                                                           // or set it to another key's x
await crypto.subtle.importKey("jwk", jwk, { name: "Ed25519" }, true, ["sign"]);
// Bun: resolves   Node / spec: DataError
```

RFC 8037 section 2 requires `x` for every OKP JWK, and for a private key it must be the public key derived from `d`. In `CryptoKeyOKP::importJwk` the private-key branch decoded `d` and returned before the `x` checks (the `// FIXME: Validate keyData.x is paired with keyData.d` that is still in `main`), so `x` missing, truncated, not base64url, or belonging to a different key all imported successfully. Cross-checked against Node v26:

| JWK | Bun | Node / spec |
|---|---|---|
| Ed25519 / X25519: `d` present, `x` missing | accepted | `DataError` |
| Ed25519 / X25519: `x` not derived from `d` | accepted | `DataError` |
| Ed25519 / X25519: `x` truncated or not base64url | accepted | `DataError` |
| Ed25519: 64-byte `d` | accepted | `DataError` |
| Ed25519: `alg` other than `Ed25519` / `EdDSA` | accepted | `DataError` |

The inconsistent-key-pair case is the interesting one: exporting the resulting key hands back an `x` re-derived from `d`, so two consumers of the same JWK silently end up with different public keys.

### Fix

`importJwk` now requires a well-formed `x` before the private-key branch, and when `d` is present checks that `x` equals the public key derived from `d` (a new file-local `checkPairedJwkKeys`, built on the `ed25519PublicFromPrivate` / `x25519PublicFromPrivate` helpers that `exportKey` already uses). The Ed25519 arm gains the `alg` check, and `kty` is checked once for both curves instead of separately per arm. This matches the structure of the current WebKit `CryptoKeyOKP::importJwk`.

The size gate in `checkPairedJwkKeys` also rejects a 64-byte Ed25519 `d`, which previously slipped through because it matched the internal `seed || public` representation.

Deleted: `importPublicJwk` and the `importJwkInternal` `onlyPublic` flag had no callers; the three functions collapse into one `importJwk`.

### Rebase notes

This was rebased after #33072 ("Hardening round 11") landed in the same function. That PR independently added the `kty` / `use` / `key_ops` / `ext` checks to the X25519 arm, so those are no longer part of this diff — all of its checks are preserved as-is, and this PR now adds only the `x`-vs-`d` pairing, the Ed25519 `alg` check, and the dead-code removal. The duplicated `kty` check (one per switch arm) is collapsed into a single check covering both curves; behavior is identical, and the `rejects a JWK whose kty is not OKP` test still passes.

**One fixture in the `X25519 JWK import` tests from #33072 had to be corrected.** Its `x` was a corrupted copy of the RFC 7748 Alice public key:

```
fixture:   8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4e ae143d6ad72e46a
RFC 7748:  8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4e ba4a98eaa9b4e6a
```

so it does not pair with the fixture's `d`, and Node rejects that exact JWK with `DataError`. The `supersetOfUsages` case asserted `"imported"`, which only held because `x` was never validated — i.e. it was pinning the bug this PR fixes. The fixture now uses the real vector (verified by deriving it from `d` with `node:crypto`), which keeps the test's intent (a `key_ops` superset is accepted) and makes it pass both before and after this change.

### Verification

`test/js/web/crypto/web-crypto.test.ts` gains an `OKP (Ed25519 / X25519) JWK import validation` block using the RFC 8032 test vector 1 and RFC 7748 Alice key pairs. A 30-case differential over both curves (`x` missing / mismatched / truncated / non-base64url, 64-byte `d`, `alg`, `kty`, `crv`, `use`, `key_ops`, `ext`) is byte-identical to Node v26, including the negative contract that `alg` is not validated for X25519. Three of the four new tests fail on `main`; the fourth is a guard for the `kty` dedup.

`test/js/bun/crypto/x25519-derive-bits.test.ts`, `test/js/deno/crypto/webcrypto.test.ts`, `test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts`, `test/regression/issue/24399.test.ts` (10,281 tests) and the active `test-webcrypto-*.js` Node compat tests all pass. `node:crypto`'s own JWK import goes through a separate path and is unaffected.
