### PR TITLE
S3: fix signing-key cache collisions between distinct credential sets

### DIFF
--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -92,9 +92,9 @@ impl Default for MultiPartUploadOptions {
 use bun_collections::StringArrayHashMap;
 use bun_core::Mutex;
 
-/// Memoised SigV4 derived signing key, keyed by `(numeric_day,
-/// region+service+secret)`. The lock owns the data — the mutex wraps both
-/// `cache` and `date`.
+/// Memoised SigV4 derived signing key, keyed by `numeric_day` plus an
+/// unambiguous encoding of `(region, service, secret)`. The lock owns the
+/// data — the mutex wraps both `cache` and `date`.
 #[derive(Default)]
 pub struct AWSSignatureCache(Mutex<AWSSignatureCacheInner>);
 
@@ -484,10 +484,15 @@ impl S3Credentials {
             let mut hmac_sig_service2 = [0u8; bun_sha_hmac::hmac::EVP_MAX_MD_SIZE];
 
             let sig_date_region_service_req: [u8; DIGESTED_HMAC_256_LEN] = 'brk_sign: {
-                let key = buf_print(
-                    &mut tmp_buffer,
+                // Length-prefix `region` so the cache key is injective: a bare
+                // `region + service + secret` concat lets two distinct credential
+                // sets collide and reuse each other's derived signing key.
+                let mut cache_key_buffer = [0u8; 4096];
+                let cache_key = buf_print(
+                    &mut cache_key_buffer,
                     format_args!(
-                        "{}{}{}",
+                        "{}\n{}\n{}\n{}",
+                        region.len(),
                         BStr::new(region),
                         service_name,
                         BStr::new(&self.secret_access_key)
@@ -496,7 +501,7 @@ impl S3Credentials {
                 .map_err(|_| SignError::NoSpaceLeft)?;
                 // was `bun_jsc::VirtualMachine::get*().rare_data().aws_cache()`.
                 // Storage moved DOWN — `AWS_SIGNATURE_CACHE` is a process static here.
-                if let Some(cached) = aws_cache_get(date_result.numeric_day, key) {
+                if let Some(cached) = aws_cache_get(date_result.numeric_day, cache_key) {
                     break 'brk_sign cached;
                 }
                 // not cached yet lets generate a new one
@@ -538,20 +543,7 @@ impl S3Credentials {
                     [0..DIGESTED_HMAC_256_LEN]
                     .try_into()
                     .expect("infallible: size matches");
-                // The earlier `key` was a slice into `tmp_buffer`, which has since been
-                // overwritten by the `AWS4{secret}` buf_print, so recompute the correct
-                // `{region}{service}{secret}` key here before caching.
-                let key = buf_print(
-                    &mut tmp_buffer,
-                    format_args!(
-                        "{}{}{}",
-                        BStr::new(region),
-                        service_name,
-                        BStr::new(&self.secret_access_key)
-                    ),
-                )
-                .map_err(|_| SignError::NoSpaceLeft)?;
-                aws_cache_set(date_result.numeric_day, key, digest);
+                aws_cache_set(date_result.numeric_day, cache_key, digest);
                 break 'brk_sign digest;
             };
 

--- a/test/js/bun/s3/s3-signing-key-cache.test.ts
+++ b/test/js/bun/s3/s3-signing-key-cache.test.ts
@@ -21,14 +21,9 @@ function referenceSignature(presignedUrl: string, secretAccessKey: string): { go
     .filter(pair => !pair.startsWith("X-Amz-Signature="))
     .sort()
     .join("&");
-  const canonicalRequest = [
-    "GET",
-    url.pathname,
-    canonicalQuery,
-    `host:${url.host}\n`,
-    "host",
-    "UNSIGNED-PAYLOAD",
-  ].join("\n");
+  const canonicalRequest = ["GET", url.pathname, canonicalQuery, `host:${url.host}\n`, "host", "UNSIGNED-PAYLOAD"].join(
+    "\n",
+  );
   const stringToSign = [
     "AWS4-HMAC-SHA256",
     amzDate,

--- a/test/js/bun/s3/s3-signing-key-cache.test.ts
+++ b/test/js/bun/s3/s3-signing-key-cache.test.ts
@@ -1,0 +1,67 @@
+import { S3Client } from "bun";
+import { expect, test } from "bun:test";
+import { createHash, createHmac } from "node:crypto";
+
+// SigV4 derived signing key: HMAC chain over the secret, day, region, service.
+function deriveSigningKey(secret: string, day: string, region: string, service: string): Buffer {
+  const hmac = (key: string | Buffer, data: string) => createHmac("sha256", key).update(data).digest();
+  return hmac(hmac(hmac(hmac(`AWS4${secret}`, day), region), service), "aws4_request");
+}
+
+// Re-derive a presigned GET URL's signature from the secret, the way an S3
+// server verifies it, so we can tell which secret a URL was actually signed with.
+function referenceSignature(presignedUrl: string, secretAccessKey: string): { got: string; expected: string } {
+  const url = new URL(presignedUrl);
+  const got = url.searchParams.get("X-Amz-Signature")!;
+  const amzDate = url.searchParams.get("X-Amz-Date")!;
+  const [, day, region, service] = url.searchParams.get("X-Amz-Credential")!.split("/");
+  const canonicalQuery = url.search
+    .slice(1)
+    .split("&")
+    .filter(pair => !pair.startsWith("X-Amz-Signature="))
+    .sort()
+    .join("&");
+  const canonicalRequest = [
+    "GET",
+    url.pathname,
+    canonicalQuery,
+    `host:${url.host}\n`,
+    "host",
+    "UNSIGNED-PAYLOAD",
+  ].join("\n");
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    `${day}/${region}/${service}/aws4_request`,
+    createHash("sha256").update(canonicalRequest).digest("hex"),
+  ].join("\n");
+  const expected = createHmac("sha256", deriveSigningKey(secretAccessKey, day, region, service))
+    .update(stringToSign)
+    .digest("hex");
+  return { got, expected };
+}
+
+// https://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
+test("SigV4 reference key derivation matches the AWS documented example", () => {
+  expect(
+    deriveSigningKey("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20120215", "us-east-1", "iam").toString("hex"),
+  ).toBe("f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d");
+});
+
+test("clients with colliding region+secret concatenations do not share a signing key", () => {
+  const endpoint = "https://s3.example.com";
+  const bucket = "bkt";
+  // Distinct credential sets whose `region + "s3" + secret` concatenations are
+  // the same byte string ("rs3s3SECRETX"), which collided in the signing-key cache.
+  const a = new S3Client({ region: "r", accessKeyId: "AKIA1", secretAccessKey: "s3SECRETX", bucket, endpoint });
+  const b = new S3Client({ region: "rs3", accessKeyId: "AKIA2", secretAccessKey: "SECRETX", bucket, endpoint });
+
+  // `a` signs first so it populates the process-wide signing-key cache before `b`.
+  const sigA = referenceSignature(a.presign("key.txt", { method: "GET", expiresIn: 300 }), "s3SECRETX");
+  const sigB = referenceSignature(b.presign("key.txt", { method: "GET", expiresIn: 300 }), "SECRETX");
+
+  // Control: proves the reference verifier agrees with Bun's signer.
+  expect(sigA.got).toBe(sigA.expected);
+  // Fails when `b` signs with `a`'s cached derived key.
+  expect(sigB.got).toBe(sigB.expected);
+});


### PR DESCRIPTION
### Problem

The SigV4 derived-signing-key cache in `src/s3_signing/credentials.rs` is keyed on `region + service + secret` concatenated with no delimiter. Two different credential sets can therefore produce the same cache key:

```js
// "r"   + "s3" + "s3SECRETX"  ->  "rs3s3SECRETX"
// "rs3" + "s3" + "SECRETX"    ->  "rs3s3SECRETX"
const a = new S3Client({ region: "r",   accessKeyId: "AKIA1", secretAccessKey: "s3SECRETX", bucket, endpoint });
const b = new S3Client({ region: "rs3", accessKeyId: "AKIA2", secretAccessKey: "SECRETX",   bucket, endpoint });
a.presign("key.txt"); // populates the process-wide signing-key cache
b.presign("key.txt"); // signed with a's derived key -> 403 SignatureDoesNotMatch
```

The cache is process-global, so whichever client signs first wins the slot and every other client whose `region + "s3" + secret` collides with it signs with the wrong derived key from then on. `b` created alone signs correctly; the failure only appears once both clients exist in the same process.

### Fix

Length-prefix the region in the cache key so the encoding is injective (`{region.len()}\n{region}\n{service}\n{secret}`), and build the key once into its own buffer. The previous code rebuilt the key a second time before `aws_cache_set` because `tmp_buffer` had been reused for the `AWS4{secret}` HMAC input; giving the key a dedicated buffer removes that duplicate.

Two things deliberately stay out of the key:

- The access key ID. The SigV4 derived key is `HMAC(HMAC(HMAC(HMAC("AWS4" + secret, date), region), service), "aws4_request")` and does not depend on it.
- The date. `AWSSignatureCache::get` already rejects any `numeric_day` mismatch and `set` clears the map on rollover, so a key derived on one UTC day is never returned on another.

### Test

`test/js/bun/s3/s3-signing-key-cache.test.ts` presigns a URL with each of the two colliding clients and re-derives both signatures from the URL and the client's own secret with a node:crypto SigV4 implementation. Client `a` is the control proving the reference signer agrees with Bun's; client `b`'s assertion fails before the fix:

```
Expected: "ccab396f98cff3b03f338e17e55887f8496c1ca475cf01679c846fc7f7cb55d7"
Received: "20a7b5ccc661b984458b19a0be287cac77aea019d57907712fa12a044791e9f6"
```

The reference key derivation is itself pinned to the example in the AWS Signature Version 4 documentation (`f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d`), so the verifier is checked against a published vector rather than only against Bun.
