### PR TITLE
worker_threads: fix Worker.terminate() hanging on a worker that exited with code 0

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -570,8 +570,11 @@ class Worker extends EventEmitter {
       this.#worker.addEventListener("close", event => callback(null, event.code), { once: true });
     }
 
+    // Presence check, not truthiness: a clean exit sets #onExitPromise to the
+    // numeric code 0, which is falsy. Treating that as "not yet exited" would
+    // wait for a second 'close' event that already fired and hang forever.
     const onExitPromise = this.#onExitPromise;
-    if (onExitPromise) {
+    if (onExitPromise !== undefined) {
       return $isPromise(onExitPromise) ? onExitPromise : Promise.$resolve(onExitPromise);
     }
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -627,4 +627,40 @@ test("FileHandles nested in Map and Set workerData are transferred", async () =>
   // and Set entries deserialized to the same single instance
   expect(fh.fd).toBe(-1);
   expect(message).toEqual({ sameInstance: true, text: "hello" });
+});
+
+// terminate() on a worker that already exited with code 0 hung forever: the
+// clean exit code 0 is falsy, so the truthiness guard in terminate() fell
+// through and waited on a 'close' event that had already fired. Surfaced by
+// https://github.com/oven-sh/bun/issues/32828 (the repro's terminate() cleanup).
+test("terminate() resolves for a worker that already exited with code 0", async () => {
+  using dir = tempDir("worker-terminate-after-exit", {
+    "index.mjs": `
+      import { Worker } from "node:worker_threads";
+      import { once } from "node:events";
+      const worker = new Worker("process.exit(0);", { eval: true });
+      const [code] = await once(worker, "exit");
+      console.log("EXITCODE:" + code);
+      const result = await Promise.race([
+        worker.terminate().then(v => "TERM:" + v),
+        new Promise(r => setTimeout(() => r("HANG"), 3000).unref()),
+      ]);
+      console.log(result);
+      process.exit(result === "TERM:0" ? 0 : 1);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // stderr kept in the object so it surfaces on failure; toMatchObject does not
+  // assert on it (debug/ASAN lanes can emit benign warnings).
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({
+    stdout: "EXITCODE:0\nTERM:0",
+    exitCode: 0,
+  });
 });


### PR DESCRIPTION
## Summary

`worker.terminate()` hangs forever when called on a worker that has already exited with exit code **0** (the common case). This is independent of how the worker exited (`process.exit(0)`, natural drain, or `parentPort.close()`), and it is exactly what the cleanup step in #32828's reproduction hits.

## Repro

```js
// repro.mjs
import { Worker } from "node:worker_threads";
import { once } from "node:events";

const worker = new Worker("process.exit(0);", { eval: true });
await once(worker, "exit");          // worker has now exited with code 0
console.log("calling terminate()...");
await worker.terminate();            // Node: resolves. Bun: hangs forever.
console.log("done");
```

Node prints `done` and exits. Bun prints `calling terminate()...` and hangs.

## Cause

`Worker.terminate()` (`src/js/node/worker_threads.ts`) guards its early-return path with a truthiness check:

```js
const onExitPromise = this.#onExitPromise;
if (onExitPromise) {
  return $isPromise(onExitPromise) ? onExitPromise : Promise.$resolve(onExitPromise);
}
```

After a worker exits, `#onClose` stores the numeric exit code in `#onExitPromise`. A clean exit stores `0`, which is falsy, so the guard is skipped. `terminate()` then falls through to the slow path, registers a *new* `close` listener and calls `this.#worker.terminate()` on an already-closed worker. The `close` event already fired once, so the new listener never runs and the returned promise never settles.

A non-zero exit code (e.g. `2`) already worked, because the code is truthy and the early return fires. The existing test `worker with process.exit (delay) and terminate` only covers the non-zero case.

## Fix

Gate on presence, not truthiness:

```js
if (onExitPromise !== undefined) {
  return $isPromise(onExitPromise) ? onExitPromise : Promise.$resolve(onExitPromise);
}
```

`#onExitPromise` is `undefined` before the worker exits/terminates, a number once it has exited, or a pending promise while a terminate is in flight, so `!== undefined` is the correct "already settled or in flight" check. This keeps Bun's existing behavior of resolving `terminate()` with the exit code (so `expect(code).toBe(2)` still holds) and extends it to code `0`.

## Scope / relationship to #32828

The primary symptom in #32828 (`parentPort.close()` not winding the worker down) is already being addressed more completely by #30549 (`close()`/`ref()`/`unref()`/`hasRef()`), so this PR deliberately does not touch that path. It fixes only the separate `terminate()` hang, which #30549 does not address and which #32828's repro hits once the worker has wound down with code 0.

## Verification

```
# without the fix (release)
$ bun test worker_threads.test.ts -t "already exited with code 0"
(fail) terminate() resolves for a worker that already exited with code 0  (times out / hangs)

# with the fix (bun bd)
(pass) terminate() resolves for a worker that already exited with code 0
```

The new test spawns a worker that exits with code 0 and asserts `terminate()` resolves (a grace timer in the fixture turns the hang into a clean failure instead of a timeout).