### PR TITLE
node:http2: don't kill the process on a malformed HEADERS block sent to a server

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2238,6 +2238,10 @@ enum StreamState {
   // The native side fully closed and freed the stream (state 7 delivered): there is
   // nothing left to send on the wire for it.
   NativeClosed = 1 << 6, // 1000000 = 64
+  // The server stream has been handed to user code (the 'stream' event or the pushStream
+  // callback). Until then no 'error' listener can exist, so stream errors must not be emitted:
+  // node never constructs the JS stream object before a complete header block arrives.
+  Delivered = 1 << 7, // 10000000 = 128
 }
 // native.writeStream() return-value flag (mirrors WRITE_FLUSHED_WITHOUT_CALLBACK in
 // h2_frame_parser.rs): the chunk was handed to the socket without queueing and the engine did
@@ -2711,6 +2715,16 @@ class Http2Stream extends Duplex {
     // and req.on('error') regardless of which dispatch path reached _destroy first.
     if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL) {
       err = session?.[kSessionDestroyError] ?? $ERR_HTTP2_STREAM_ERROR(nameForErrorCode[rstCode] || rstCode);
+    }
+    // A server stream user code was never handed (e.g. the peer's header block failed to decode,
+    // so the 'stream' event never fired) cannot have an 'error' listener; emitting would raise an
+    // uncaught exception any peer can trigger. The session already reported the protocol error.
+    if (
+      err != null &&
+      this instanceof ServerHttp2Stream &&
+      (this[bunHTTP2StreamStatus] & StreamState.Delivered) === 0
+    ) {
+      err = null;
     }
 
     this[bunHTTP2Session] = null;
@@ -3317,6 +3331,9 @@ class ServerHttp2Stream extends Http2Stream {
     // writable side is already ended when the callback runs; respond() then forces endStream so
     // END_STREAM rides on the response HEADERS frame.
     if (pushedStream) {
+      // The callback is how user code receives the pushed stream; from here on it may have an
+      // 'error' listener.
+      pushedStream[bunHTTP2StreamStatus] |= StreamState.Delivered;
       if (headers[HTTP2_HEADER_METHOD] === HTTP2_METHOD_HEAD) {
         pushedStream[kHeadRequest] = true;
         pushedStream.end();
@@ -4165,7 +4182,7 @@ class ServerHttp2Session extends Http2Session {
         // and wrote it back AFTER the emit, we'd clobber any bits set by the
         // user handler — in particular, losing WantTrailer/FinalCalled breaks
         // any later `sendTrailers()` with ERR_HTTP2_TRAILERS_NOT_READY.
-        stream[bunHTTP2StreamStatus] |= StreamState.StreamResponded;
+        stream[bunHTTP2StreamStatus] |= StreamState.StreamResponded | StreamState.Delivered;
         if (onServerStreamCreatedChannel.hasSubscribers) {
           onServerStreamCreatedChannel.publish({ stream, headers });
         }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -498,7 +498,7 @@ describe.concurrent("header block decoding errors (RFC 9113 §4.3)", () => {
       stderr: expect.not.stringContaining("ERR_HTTP2"),
       exitCode: 0,
     });
-  });
+  }, 30_000);
 
   // Same guard, second hand-off point: a pushStream() whose PUSH_PROMISE headers fail native
   // validation destroys the not-yet-delivered pushed stream with the validation error. Only the
@@ -549,7 +549,7 @@ describe.concurrent("header block decoding errors (RFC 9113 §4.3)", () => {
       stderr: expect.not.stringContaining("ERR_INVALID_HTTP_TOKEN"),
       exitCode: 0,
     });
-  });
+  }, 30_000);
 });
 
 // ── Client-side conformance: a raw byte-level HTTP/2 *server* drives a Bun `node:http2`

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -500,6 +500,85 @@ describe.concurrent("header block decoding errors (RFC 9113 §4.3)", () => {
     });
   }, 30_000);
 
+  // Same sink, reached by PROTOCOL_ERROR instead of COMPRESSION_ERROR: a HEADERS frame without
+  // END_HEADERS followed by anything other than a CONTINUATION on the same stream is a connection
+  // error (RFC 9113 §6.10). The stream was created for the HEADERS frame but never announced.
+  test("a non-CONTINUATION frame during header assembly does not kill the server process", async () => {
+    const fixture = String.raw`
+      const http2 = require("node:http2");
+      const net = require("node:net");
+      const server = http2.createServer((req, res) => res.end("ok"));
+      server.on("sessionError", () => {});
+      server.listen(0, "127.0.0.1", () => {
+        const port = server.address().port;
+        const raw = net.connect(port, "127.0.0.1", () => {
+          const preface = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
+          const settings = Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]);
+          // HEADERS (stream 1, END_STREAM, NOT END_HEADERS) with a valid one-byte HPACK fragment,
+          // then a DATA frame on stream 3 where CONTINUATION(stream 1) was required.
+          const block = Buffer.from([0x82]);
+          const headers = Buffer.alloc(9);
+          headers.writeUIntBE(block.length, 0, 3);
+          headers[3] = 0x01;
+          headers[4] = 0x01;
+          headers.writeUInt32BE(1, 5);
+          const data = Buffer.alloc(9 + 1);
+          data.writeUIntBE(1, 0, 3);
+          data[3] = 0x00;
+          data[4] = 0x01;
+          data.writeUInt32BE(3, 5);
+          data[9] = 0x78;
+          raw.write(Buffer.concat([preface, settings, headers, block, data]));
+        });
+        let received = Buffer.alloc(0);
+        raw.on("data", d => (received = Buffer.concat([received, d])));
+        raw.on("error", () => {});
+        raw.on("close", () => {
+          let goawayCode = -1;
+          for (let i = 0; i + 9 <= received.length; i += 9 + received.readUIntBE(i, 3)) {
+            if (received[i + 3] === 0x07) {
+              goawayCode = received.readUInt32BE(i + 9 + 4);
+              break;
+            }
+          }
+          console.log("goaway", goawayCode);
+          const client = http2.connect("http://127.0.0.1:" + port);
+          client.on("error", err => {
+            console.error(err);
+            process.exit(3);
+          });
+          const req = client.request({ ":path": "/" });
+          req.setEncoding("utf8");
+          let body = "";
+          req.on("data", c => (body += c));
+          req.on("error", err => {
+            console.error(err);
+            process.exit(4);
+          });
+          req.on("end", () => {
+            console.log("second request", body);
+            client.close();
+            server.close();
+          });
+          req.end();
+        });
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // PROTOCOL_ERROR (0x1) on the wire, and the process survived to serve the second request.
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "goaway 1\nsecond request ok\n",
+      stderr: expect.not.stringContaining("ERR_HTTP2"),
+      exitCode: 0,
+    });
+  }, 30_000);
+
   // Same guard, second hand-off point: a pushStream() whose PUSH_PROMISE headers fail native
   // validation destroys the not-yet-delivered pushed stream with the validation error. Only the
   // pushStream callback reports it; emitting 'error' on that stream was an uncaught exception.

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -491,7 +491,13 @@ describe("header block decoding errors (RFC 9113 §4.3)", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // COMPRESSION_ERROR (0x9) on the wire, and the process survived to serve the second request.
-    expect({ stdout, exitCode }).toEqual({ stdout: "goaway 9\nsecond request ok\n", exitCode: 0 });
+    // stderr is in the diff for debugging but only asserted not to carry the uncaught stream
+    // error (debug/ASAN builds write benign warnings to it).
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "goaway 9\nsecond request ok\n",
+      stderr: expect.not.stringContaining("ERR_HTTP2"),
+      exitCode: 0,
+    });
   });
 });
 

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -422,6 +422,79 @@ describe("frame size limit (checklist §4.2)", () => {
   });
 });
 
+describe("header block decoding errors (RFC 9113 §4.3)", () => {
+  // The stream is rejected before the 'stream' event ever fires, so no user code can have
+  // attached an 'error' listener to it. The error must stay at the connection level
+  // (GOAWAY COMPRESSION_ERROR) instead of being raised as an uncaught exception that kills
+  // the process. Run in a child so a regression shows up as the child dying, not this runner.
+  test("an undecodable HEADERS block does not kill the server process", async () => {
+    const fixture = String.raw`
+      const http2 = require("node:http2");
+      const net = require("node:net");
+      const server = http2.createServer((req, res) => res.end("ok"));
+      server.listen(0, "127.0.0.1", () => {
+        const port = server.address().port;
+        // Raw prior-knowledge h2c client: preface, empty SETTINGS, then a HEADERS frame
+        // (END_HEADERS | END_STREAM, stream 1) whose payload is not a valid HPACK block.
+        const raw = net.connect(port, "127.0.0.1", () => {
+          const preface = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
+          const settings = Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]);
+          const block = Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff]);
+          const headers = Buffer.alloc(9);
+          headers.writeUIntBE(block.length, 0, 3);
+          headers[3] = 0x01;
+          headers[4] = 0x05;
+          headers.writeUInt32BE(1, 5);
+          raw.write(Buffer.concat([preface, settings, headers, block]));
+        });
+        let received = Buffer.alloc(0);
+        raw.on("data", d => (received = Buffer.concat([received, d])));
+        raw.on("error", () => {});
+        // The server answers with GOAWAY and closes the connection; only then prove the
+        // process is still alive and still serving by completing a real request.
+        raw.on("close", () => {
+          let goawayCode = -1;
+          for (let i = 0; i + 9 <= received.length; i += 9 + received.readUIntBE(i, 3)) {
+            if (received[i + 3] === 0x07) {
+              goawayCode = received.readUInt32BE(i + 9 + 4);
+              break;
+            }
+          }
+          console.log("goaway", goawayCode);
+          const client = http2.connect("http://127.0.0.1:" + port);
+          client.on("error", err => {
+            console.error(err);
+            process.exit(3);
+          });
+          const req = client.request({ ":path": "/" });
+          req.setEncoding("utf8");
+          let body = "";
+          req.on("data", c => (body += c));
+          req.on("error", err => {
+            console.error(err);
+            process.exit(4);
+          });
+          req.on("end", () => {
+            console.log("second request", body);
+            client.close();
+            server.close();
+          });
+          req.end();
+        });
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // COMPRESSION_ERROR (0x9) on the wire, and the process survived to serve the second request.
+    expect({ stdout, exitCode }).toEqual({ stdout: "goaway 9\nsecond request ok\n", exitCode: 0 });
+  });
+});
+
 // ── Client-side conformance: a raw byte-level HTTP/2 *server* drives a Bun `node:http2`
 // client and asserts the client's wire behavior (push stream states, SETTINGS ack ordering).
 

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -499,6 +499,57 @@ describe("header block decoding errors (RFC 9113 §4.3)", () => {
       exitCode: 0,
     });
   });
+
+  // Same guard, second hand-off point: a pushStream() whose PUSH_PROMISE headers fail native
+  // validation destroys the not-yet-delivered pushed stream with the validation error. Only the
+  // pushStream callback reports it; emitting 'error' on that stream was an uncaught exception.
+  test("a pushStream() validation error is reported through the callback, not as an uncaught 'error'", async () => {
+    const fixture = String.raw`
+      const http2 = require("node:http2");
+      const server = http2.createServer();
+      server.on("stream", stream => {
+        stream.pushStream({ ":path": "/p", "bad header": "x" }, err => {
+          console.log("pushStream callback", err ? err.code : null);
+          stream.respond({ ":status": 200 });
+          stream.end("main");
+        });
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const client = http2.connect("http://127.0.0.1:" + server.address().port);
+        client.on("error", err => {
+          console.error(err);
+          process.exit(3);
+        });
+        client.on("stream", pushed => pushed.on("error", () => {}));
+        const req = client.request({ ":path": "/" });
+        req.setEncoding("utf8");
+        let body = "";
+        req.on("data", c => (body += c));
+        req.on("error", err => {
+          console.error(err);
+          process.exit(4);
+        });
+        req.on("end", () => {
+          console.log("response", body);
+          client.close();
+          server.close();
+        });
+        req.end();
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "pushStream callback ERR_INVALID_HTTP_TOKEN\nresponse main\n",
+      stderr: expect.not.stringContaining("ERR_INVALID_HTTP_TOKEN"),
+      exitCode: 0,
+    });
+  });
 });
 
 // ── Client-side conformance: a raw byte-level HTTP/2 *server* drives a Bun `node:http2`

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -422,7 +422,7 @@ describe("frame size limit (checklist §4.2)", () => {
   });
 });
 
-describe("header block decoding errors (RFC 9113 §4.3)", () => {
+describe.concurrent("header block decoding errors (RFC 9113 §4.3)", () => {
   // The stream is rejected before the 'stream' event ever fires, so no user code can have
   // attached an 'error' listener to it. The error must stay at the connection level
   // (GOAWAY COMPRESSION_ERROR) instead of being raised as an uncaught exception that kills


### PR DESCRIPTION
### What

A single malformed HEADERS frame (an undecodable HPACK block, ~50 raw TCP bytes) sent to a `node:http2` server kills the whole process with an uncaught exception. Any peer that can open a TCP connection to an h2/h2c Bun server can trigger it. Node and Bun 1.4.0 both survive the same bytes; this is a regression on main from the http2 inbound rewrite (#31584).

```js
// h2c server + raw prior-knowledge client in one file
import http2 from "node:http2";
import net from "node:net";
const srv = http2.createServer((req, res) => res.end("ok"));
srv.listen(0, () => {
  const s = net.connect(srv.address().port, () => {
    const pre = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
    const settings = Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]); // empty SETTINGS
    const bad = Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff]); // invalid HPACK block
    const hdr = Buffer.alloc(9);
    hdr.writeUIntBE(bad.length, 0, 3);
    hdr[3] = 0x01; // HEADERS
    hdr[4] = 0x05; // END_HEADERS | END_STREAM
    hdr.writeUInt32BE(1, 5);
    s.write(Buffer.concat([pre, settings, hdr, bad]));
  });
  setTimeout(() => { console.log("server survived"); process.exit(0); }, 1500);
});
```

```
error: Stream closed with error code NGHTTP2_COMPRESSION_ERROR
 code: "ERR_HTTP2_STREAM_ERROR"

      at _destroy (node:http2:1690:31)
      ...
      at emitStreamErrorNT (node:http2:2202:21)
```

Node prints `server survived`.

### Why

Bun creates the JS `ServerHttp2Stream` eagerly in the `streamStart` handler, before the header block is decoded. When the block fails to decode, the engine sends GOAWAY (COMPRESSION_ERROR) and the session is destroyed with that code, which tears down every open stream, including the one that was never announced: the `'stream'` event never fired, so no user code ever saw it and nothing can be listening for `'error'` on it.

`emitStreamErrorNT` already guards on `listenerCount("error")` and passes no error to `destroy()`, but `Http2Stream._destroy` then re-synthesizes `ERR_HTTP2_STREAM_ERROR` from the stream's `rstCode` (set from the session destroy code) and hands it to the destroy callback, which emits `'error'` on a stream with no listener: an uncaught exception, process dead.

Node cannot hit this because it only constructs the JS `Http2Stream` object once a complete, valid header block has been decoded (`onSessionHeaders`); a stream rejected earlier has no JS object to emit on.

### Fix

`src/js/node/http2.ts`:

- Add a `Delivered` bit to the stream state, set at the two points where a `ServerHttp2Stream` is handed to user code: the `'stream'` event in `streamHeaders`, and the `pushStream()` success callback.
- In `Http2Stream._destroy`, drop the error for a server stream that was never delivered. Nothing user side can observe it, matching Node, where the object would not exist.

The connection-level handling is unchanged: GOAWAY with COMPRESSION_ERROR still goes on the wire (RFC 9113 4.3) and the server still emits `'sessionError'`. Delivered streams are unaffected, so a stream the user does hold and leaves without an `'error'` listener still throws like Node.

This also covers the same class on the `pushStream()` error path, where the not-yet-delivered pushed stream was destroyed with the validation error (which only the callback should report).

### Verification

Two new tests in `test/js/node/http2/h2-conformance.test.ts`, one per hand-off point, each running the server in a child process so a regression shows up as the child dying:

- malformed HEADERS over a raw socket: asserts the GOAWAY carries COMPRESSION_ERROR and the process survives to serve a second request. Fails on main (the child dies with the uncaught `ERR_HTTP2_STREAM_ERROR`).
- `pushStream()` whose headers fail native validation: asserts the error reaches only the callback and the main response still completes. Also fails on main (uncaught `ERR_INVALID_HTTP_TOKEN` emitted on the never-delivered pushed stream).

```
bun bd test test/js/node/http2/h2-conformance.test.ts
 25 pass, 0 fail
```

`test/js/node/http2/node-http2.test.js` (287 pass) and the rest of the http2 suite are unaffected.



### Rebase against main

Rebased over the `_destroy` and `pushStream()` changes that landed on main (the session-destroy-error preference in `_destroy`, and the HEAD/`endStream` handling in `pushStream()`). Both are kept: the undelivered-stream guard runs after `_destroy` has chosen between `session[kSessionDestroyError]` and the generic stream error, and the `Delivered` bit is set inside the existing `if (pushedStream)` block in `pushStream()` (which also covers the null-guard review nit). Fail-before and pass-after re-verified on the rebased tree.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 9 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0a6a3527d)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [480.50ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [165.94ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [166.20ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [260.01ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (920045624)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [13.70ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [4.04ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [3.35ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [2.85ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [1.47ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [2.75ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.53ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [1.20ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [1.25ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0a6a3527d)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [816.90ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [235.07ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [271.46ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [275.51ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1044ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (9817ms)
Bundle modules (154ms)
Postprocesss modules (195ms)
Bundle Functions (929ms)
Generate Code (138ms)

[11.25s] Bundled "src/js" for production
  1968 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current ver
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |  19 ++-
 test/js/node/http2/h2-conformance.test.ts | 209 ++++++++++++++++++++++++++++++
 2 files changed, 227 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 9

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                          17      7     24
test/js/node/http2/h2-conformance.test.ts      9     11     23
```

</details>

<!-- robobun:evidence:end -->