### PR TITLE
hash: use the full 64-bit seed in Bun.hash.xxHash3

### DIFF
--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -484,8 +484,7 @@ pub fn index_of_space_or_newline_or_non_ascii(haystack: &[u8]) -> Option<usize> 
 /// input — only the long-input stripe loop is vectorized and its per-64-bit-
 /// lane math does not depend on vector width.
 ///
-/// `seed` is the full 64-bit seed. Callers wanting the JS `@truncate(seed)`
-/// semantics must truncate before calling (as `HashObject` does).
+/// `seed` is the full 64-bit seed.
 #[inline(always)]
 pub fn xxhash3_64(seed: u64, input: &[u8]) -> u64 {
     // SAFETY: `input.ptr/len` are a valid readable range; for an empty slice

--- a/src/jsc/bindings/xxhash3.cpp
+++ b/src/jsc/bindings/xxhash3.cpp
@@ -627,8 +627,7 @@ namespace xxh3 {
 
 HWY_EXPORT(HashLong);
 
-// XXH3_64bits_withSeed. `seed` is the full 64-bit seed; callers that need the
-// JS `@truncate(seed)` semantics truncate before calling (HashObject does).
+// XXH3_64bits_withSeed. `seed` is the full 64-bit seed.
 static u64 Hash64(const u8* input, size_t len, u64 seed)
 {
     if (len <= 16) {

--- a/src/jsc/bindings/xxhash3_testing.cpp
+++ b/src/jsc/bindings/xxhash3_testing.cpp
@@ -10,6 +10,7 @@
 #include "xxhash3.h"
 #include "xxhash3_testing.h"
 
+#include "headers.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/JSBigInt.h>
@@ -40,15 +41,10 @@ BUN_DEFINE_HOST_FUNCTION(Bun__xxhash3_64_forTesting, (JSC::JSGlobalObject * glob
     uint64_t seed = 0;
     if (callFrame->argumentCount() > 1) {
         JSC::JSValue seedValue = callFrame->argument(1);
-        if (seedValue.isNumber()) {
-            // toBigUInt64 performs ToBigInt, which throws on a Number. ToUint32
-            // is a defined conversion (no float-cast UB for NaN/Inf/negatives)
-            // and matches the u32 truncation Bun.hash.xxHash3 applies anyway.
-            seed = seedValue.toUInt32(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
-        } else if (seedValue.isBigInt()) {
-            seed = seedValue.toBigUInt64(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
+        if (seedValue.isNumber() || seedValue.isBigInt()) {
+            // Use the exact conversion `Bun.hash.xxHash3` (hash_wrap) applies,
+            // so the two surfaces agree for every seed representation.
+            seed = JSC__JSValue__toUInt64NoTruncate(JSC::JSValue::encode(seedValue));
         } else if (!seedValue.isUndefined()) {
             // Per the (seed?: number | bigint) contract: undefined means "no
             // seed" (0); anything else is a mistaken call, so surface it.

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -47,7 +47,6 @@ bun_dns.workspace = true
 bun_dotenv.workspace = true
 bun_event_loop.workspace = true
 bun_glob.workspace = true
-bun_highway.workspace = true
 bun_http.workspace = true
 bun_http_jsc.workspace = true
 bun_http_types.workspace = true

--- a/src/runtime/api/HashObject.rs
+++ b/src/runtime/api/HashObject.rs
@@ -38,8 +38,8 @@ pub(crate) trait HashAlgorithm {
 
 // ──────────────────────────────────────────────────────────────────────────
 // Hasher impls — one unit struct per algorithm.
-// Each must produce output **bit-identical** to previous Bun releases
-// (pinned by the vector suite in test/js/bun/util/hash.test.js).
+// Each must produce output **bit-identical** to its reference algorithm,
+// pinned by the vector suite in test/js/bun/util/hash.test.js.
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct Wyhash;
@@ -110,13 +110,9 @@ pub(crate) struct XxHash3;
 impl HashAlgorithm for XxHash3 {
     type Output = u64;
     fn hash(seed: u64, input: &[u8]) -> u64 {
-        // Runtime-dispatched SIMD xxHash3 (Highway); see
-        // src/jsc/bindings/xxhash3.cpp. Output is bit-identical to the xxHash
-        // reference, pinned by the vector suite in test/js/bun/util/hash.test.js.
-        //
-        // The seed is truncated to u32 before widening back to XxHash3's
-        // native u64 — preserve that truncation for output stability.
-        bun_highway::xxhash3_64(seed as u32 as u64, input)
+        // XXH3_64bits_withSeed takes the full 64-bit seed; the kernel is the
+        // runtime-dispatched SIMD impl in src/jsc/bindings/xxhash3.cpp.
+        bun_hash::XxHash3::hash(seed, input)
     }
 }
 

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -54,6 +54,13 @@ it(`Bun.hash.xxHash3()`, () => {
   gcTick();
   expect(Bun.hash.xxHash3(new TextEncoder().encode("hello world"))).toBe(0xd447b1ea40e6988bn);
   gcTick();
+  // Test with seed larger than u32: XXH3_64bits_withSeed uses all 64 bits, so
+  // seed 2^32 must not collapse to seed 0 (which hashes "" to 0x2d06800538d394c2).
+  expect(Bun.hash.xxHash3("", 0n)).toBe(0x2d06800538d394c2n);
+  expect(Bun.hash.xxHash3("", 0x1_0000_0000n)).toBe(0x34b7a180c41f536fn);
+  // An exactly-representable Number seed above 2^32 is used in full too.
+  expect(Bun.hash.xxHash3("", 2 ** 32)).toBe(0x34b7a180c41f536fn);
+  gcTick();
 });
 it(`Bun.hash.murmur32v3()`, () => {
   expect(Bun.hash.murmur32v3("hello world")).toBe(0x5e928f0f);
@@ -137,13 +144,99 @@ describe("xxHash3 SIMD kernel", () => {
     }
   });
 
+  // Same input generator, but every seed needs more than 32 bits. Expected
+  // values come from the xxHash reference (XXH3_64bits_withSeed). The seeds
+  // cover: 2^32 (low 32 bits are zero, so a u32 truncation collapses it to the
+  // unseeded fast path), 2^32 + 42 (would collide with seed 42), a random
+  // 64-bit seed, and all bits set.
+  // [length, seed, expected]
+  const REFERENCE_64BIT_SEED = [
+    [0, 0x1_0000_0000n, 0x34b7a180c41f536fn],
+    [0, 0x1_0000_002an, 0x1eec14ff1bfafb7an],
+    [0, 0xdeadbeefcafebaben, 0x21605795bc1bc9c4n],
+    [0, 0xffffffffffffffffn, 0x4c093276ae47a555n],
+    [1, 0x1_0000_0000n, 0x76083b0812f63e66n],
+    [1, 0x1_0000_002an, 0x4787dccafeec6e52n],
+    [1, 0xdeadbeefcafebaben, 0x914a5d5f0cb39defn],
+    [1, 0xffffffffffffffffn, 0x9dd1943f75a68ec3n],
+    [3, 0x1_0000_0000n, 0xfa1f55661f405f0en],
+    [3, 0x1_0000_002an, 0x334789ce348f8f30n],
+    [3, 0xdeadbeefcafebaben, 0x201a4a464c313160n],
+    [3, 0xffffffffffffffffn, 0xc7209797f0b3f0b2n],
+    [8, 0x1_0000_0000n, 0x3f8c1b077159226cn],
+    [8, 0x1_0000_002an, 0x8eaeed133d5c99fbn],
+    [8, 0xdeadbeefcafebaben, 0xb362175be8ce7283n],
+    [8, 0xffffffffffffffffn, 0x176977e76b669459n],
+    [16, 0x1_0000_0000n, 0x2cea1730bd3b4f14n],
+    [16, 0x1_0000_002an, 0x4e6bc3e009e4c5ban],
+    [16, 0xdeadbeefcafebaben, 0x1d65946cf1e688f6n],
+    [16, 0xffffffffffffffffn, 0x7343404694b19f93n],
+    [17, 0x1_0000_0000n, 0x477041e817de75fbn],
+    [17, 0x1_0000_002an, 0x4a0e7cca2ac8bf41n],
+    [17, 0xdeadbeefcafebaben, 0x508784431f977d55n],
+    [17, 0xffffffffffffffffn, 0x6023b88d7c2c8a95n],
+    [64, 0x1_0000_0000n, 0x1ead349149a9c75dn],
+    [64, 0x1_0000_002an, 0xb406c9992d4c37c1n],
+    [64, 0xdeadbeefcafebaben, 0x868f02e01945550en],
+    [64, 0xffffffffffffffffn, 0x5ec12bd9b5c31ca0n],
+    [128, 0x1_0000_0000n, 0x022d53557314659an],
+    [128, 0x1_0000_002an, 0x695a773a4469a409n],
+    [128, 0xdeadbeefcafebaben, 0x15bb71a9e0c2e76cn],
+    [128, 0xffffffffffffffffn, 0x2ac2a3addb897e9an],
+    [129, 0x1_0000_0000n, 0x10f541264e0ab54cn],
+    [129, 0x1_0000_002an, 0x752fd7499752306en],
+    [129, 0xdeadbeefcafebaben, 0xaba4932ad6b61569n],
+    [129, 0xffffffffffffffffn, 0xb2b376bbec64b83en],
+    [200, 0x1_0000_0000n, 0xf1c19981126cb60en],
+    [200, 0x1_0000_002an, 0xbc9d3b30ee04493dn],
+    [200, 0xdeadbeefcafebaben, 0x594334aeb7e1e229n],
+    [200, 0xffffffffffffffffn, 0x380a4c82bfe8ad13n],
+    [240, 0x1_0000_0000n, 0x82b4a745e11a2284n],
+    [240, 0x1_0000_002an, 0x7538c1601784cb26n],
+    [240, 0xdeadbeefcafebaben, 0x4b699e262b946c53n],
+    [240, 0xffffffffffffffffn, 0xa3689d7835f72d8fn],
+    // Long-input path (> 240): a nonzero seed selects the derived custom
+    // secret, so a seed whose low 32 bits are zero must not fall back to the
+    // unseeded default secret.
+    [241, 0x1_0000_0000n, 0x233fdf5a3231abd4n],
+    [241, 0x1_0000_002an, 0x7f8d4ffecca0c8c4n],
+    [241, 0xdeadbeefcafebaben, 0x1828fc39f5dd61dan],
+    [241, 0xffffffffffffffffn, 0x302a3fc8ce1044c9n],
+    [256, 0x1_0000_0000n, 0x7f61e6e11d99a1f1n],
+    [256, 0x1_0000_002an, 0x4cd233e3f03449b8n],
+    [256, 0xdeadbeefcafebaben, 0x21b82d1205eddbcan],
+    [256, 0xffffffffffffffffn, 0xdd2eb8c75f9e6238n],
+    [1024, 0x1_0000_0000n, 0x7950e29cb545cf6en],
+    [1024, 0x1_0000_002an, 0x0b2904ef363f21a8n],
+    [1024, 0xdeadbeefcafebaben, 0x9f0406dc1ef68f04n],
+    [1024, 0xffffffffffffffffn, 0xd7aea37dc6b3021fn],
+    [4096, 0x1_0000_0000n, 0x421b68434e1cd82en],
+    [4096, 0x1_0000_002an, 0x121e40bb0906d661n],
+    [4096, 0xdeadbeefcafebaben, 0x28d85661e3715d8cn],
+    [4096, 0xffffffffffffffffn, 0xfa107e6d17eff164n],
+    // Multi-block.
+    [131072, 0x1_0000_0000n, 0xa6d7500df52ad0ban],
+    [131072, 0x1_0000_002an, 0xa21b7370adbdad08n],
+    [131072, 0xdeadbeefcafebaben, 0xa784652718de2161n],
+    [131072, 0xffffffffffffffffn, 0x7c00937f49671574n],
+  ];
+
+  it("matches the xxHash reference for 64-bit seeds across every length branch", () => {
+    for (const [len, seed, expected] of REFERENCE_64BIT_SEED) {
+      const input = makeInput(len);
+      expect(Bun.hash.xxHash3(input, seed)).toBe(expected);
+      expect(xxHash3ForTesting(input, seed)).toBe(expected);
+    }
+  });
+
   it("the dispatched kernel agrees with Bun.hash.xxHash3 on large inputs", () => {
-    // Bun.hash.xxHash3 truncates the seed to u32 (@truncate); use seeds that
-    // fit in u32 so both surfaces take the same seed. The hook accepts the seed
-    // as either a number or a bigint — both must agree.
+    // The hook accepts the seed as a number or a bigint; both representations
+    // must agree with each other and with Bun.hash.xxHash3, including seeds
+    // that need all 64 bits.
+    const seeds = [0, 1, 0xabcdef01, 2 ** 32, 0x1_0000_0000n, 0xdeadbeefcafebaben, 0xffffffffffffffffn];
     for (const len of [241, 256, 513, 1024, 65536, 131072]) {
-      for (const seed of [0, 1, 0xabcdef01]) {
-        const input = makeInput(len);
+      const input = makeInput(len);
+      for (const seed of seeds) {
         expect(xxHash3ForTesting(input, seed)).toBe(xxHash3ForTesting(input, BigInt(seed)));
         expect(Bun.hash.xxHash3(input, seed)).toBe(xxHash3ForTesting(input, seed));
       }


### PR DESCRIPTION
## What

`Bun.hash.xxHash3(data, seed)` truncated its seed to 32 bits before hashing, so the output was not `XXH3_64bits_withSeed(data, seed)` for any seed >= 2^32. Seeds that differ only above bit 31 silently collided:

```js
Bun.hash.xxHash3("", 0x1_0000_0000n).toString(16); // "2d06800538d394c2"  (== seed 0)
// XXH3_64bits_withSeed("", 2**32) per the xxHash reference: 34b7a180c41f536f
Bun.hash.xxHash3("abc", 2n ** 32n) === Bun.hash.xxHash3("abc", 0n); // true
```

`bun-types` already declares `xxHash3(data, seed?: bigint)` (the same contract as `xxHash64`, which does not truncate), and the hashing docs already say seeds above `Number.MAX_SAFE_INTEGER` should be passed as a BigInt. The implementation was the only part out of step, which matters for anything using a seeded XXH3 as a cross-system fingerprint, and it quietly shrinks the usable seed space to 2^32.

## Cause

`src/runtime/api/HashObject.rs` did `seed as u32 as u64` before calling the kernel:

```rust
bun_highway::xxhash3_64(seed as u32 as u64, input)
```

The truncation dates back to the pre-rewrite Zig, which declared the `xxHash3` wrapper as `seed: u32` while the `xxHash64` wrapper right above it correctly declared `seed: u64`. The Rust port preserved it, with a comment explaining that the truncation should be kept "for output stability". `Bun.hash.xxHash3` is the only consumer of xxHash3 in the codebase (nothing internal: no bundler, lockfile, or content-hash use), so the only outputs being stabilized were the incorrect ones.

The C++/Highway kernel already takes and uses the full 64-bit seed correctly; only the Rust call site truncated.

## Fix

- `src/runtime/api/HashObject.rs`: route `xxHash3` through `bun_hash::XxHash3::hash(seed, input)` like its `xxHash32`/`xxHash64` siblings, with no cast. That leaves `bun_highway` as an unused dependency of `bun_runtime`, so it is removed from its `Cargo.toml`.
- `src/jsc/bindings/xxhash3_testing.cpp`: the `xxHash3ForTesting` hook's Number-seed path used `toUInt32` explicitly "to match the u32 truncation Bun.hash.xxHash3 applies anyway". It now uses the same `JSC__JSValue__toUInt64NoTruncate` conversion `Bun.hash.xxHash3` uses, so the two surfaces agree for every seed representation.
- The comments in `xxhash3.cpp` and `highway/lib.rs` that described the truncation are updated.

Output for seeds below 2^32 (including the default) is unchanged; every pre-existing test in `hash.test.js` still passes on the unfixed binary.

## Verification

`test/js/bun/util/hash.test.js`:
- a new vector table (`REFERENCE_64BIT_SEED`) asserting both `Bun.hash.xxHash3` and `xxHash3ForTesting` against `XXH3_64bits_withSeed` values computed with the upstream xxHash reference library, covering every XXH3 length branch (0, 1-3, 4-8, 9-16, 17-128, 129-240, > 240, multi-block) with four 64-bit seeds. 2^32 is included specifically because its low 32 bits are zero, so the truncation sent long inputs down the unseeded default-secret fast path instead of deriving a custom secret.
- the "seed larger than u32" check the `xxHash64` test already had, added to the `xxHash3` test.
- the "kernel agrees with `Bun.hash.xxHash3`" test no longer restricts itself to seeds that fit in u32.

All three fail on the unfixed build:

```
error: expect(received).toBe(expected)
Expected: 3798682385128575855n   // 0x34b7a180c41f536f
Received: 3244421341483603138n   // 0x2d06800538d394c2, the seed-0 output
```

and pass with the fix (21 pass, 0 fail, 315 assertions).

Separately, 2000 randomized (input, seed) pairs with random content, random lengths up to 300 KB, and random full-range 64-bit seeds were cross-checked against the reference `XXH3_64bits_withSeed` with zero mismatches.
