### PR TITLE
napi: return a status for unbalanced handle scope closes instead of aborting

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1056,6 +1056,11 @@ static napi_status throwErrorWithCStrings(napi_env env, const char* code_utf8, c
 {
     auto* globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Like napi_throw: throwing while an exception is already pending must not replace the
+    // pending exception. Node's NAPI_PREAMBLE reports napi_pending_exception and leaves it alone.
+    NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
 
     if (!msg_utf8) {
         return napi_set_last_error(env, napi_invalid_arg);
@@ -1065,6 +1070,7 @@ static napi_status throwErrorWithCStrings(napi_env env, const char* code_utf8, c
     WTF::String message = WTF::String::fromUTF8(msg_utf8);
 
     JSC::ErrorInstance* error = createErrorWithCode(vm, globalObject, code, message, type);
+    RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));
     env->scheduleException(error);
     return napi_set_last_error(env, napi_ok);
 }

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1058,8 +1058,8 @@ static napi_status throwErrorWithCStrings(napi_env env, const char* code_utf8, c
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Like napi_throw: throwing while an exception is already pending must not replace the
-    // pending exception. Node's NAPI_PREAMBLE reports napi_pending_exception and leaves it alone.
+    // Node's NAPI_PREAMBLE: throwing while an exception is already pending must not replace the
+    // pending exception; report napi_pending_exception and leave the first one alone.
     NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
 
     if (!msg_utf8) {

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -457,10 +457,11 @@ public:
         return static_cast<bool>(m_pendingException);
     }
 
-    // Mirrors Node's env->open_handle_scopes: the number of handle scopes the
-    // addon has opened via napi_open_handle_scope /
-    // napi_open_escapable_handle_scope and not yet closed. Bun's own handle
-    // scopes are strictly LIFO and are not counted here.
+    // Mirrors Node's env->open_handle_scopes: napi_open_handle_scope /
+    // napi_open_escapable_handle_scope calls the addon has not yet balanced with a close. This is
+    // a call counter, not the chain depth: a scope popped as collateral of an out-of-order
+    // ancestor close still counts until the addon closes it. Bun's own handle scopes are strictly
+    // LIFO and are not counted here.
     void didOpenAddonHandleScope() { m_openAddonHandleScopes++; }
 
     // Returns false (napi_handle_scope_mismatch) if the addon has closed more

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -457,6 +457,23 @@ public:
         return static_cast<bool>(m_pendingException);
     }
 
+    // Mirrors Node's env->open_handle_scopes: the number of handle scopes the
+    // addon has opened via napi_open_handle_scope /
+    // napi_open_escapable_handle_scope and not yet closed. Bun's own handle
+    // scopes are strictly LIFO and are not counted here.
+    void didOpenAddonHandleScope() { m_openAddonHandleScopes++; }
+
+    // Returns false (napi_handle_scope_mismatch) if the addon has closed more
+    // handle scopes than it opened.
+    bool didCloseAddonHandleScope()
+    {
+        if (m_openAddonHandleScopes == 0) {
+            return false;
+        }
+        m_openAddonHandleScopes--;
+        return true;
+    }
+
     inline Zig::GlobalObject* globalObject() const { return m_globalObject; }
     // `bun test --isolate` creates a fresh Zig::GlobalObject per file and
     // gcUnprotect()s the previous one. NapiEnv outlives its owning global —
@@ -585,6 +602,7 @@ private:
     Napi::HookSet m_cleanupHooks;
     JSC::Strong<JSC::Unknown> m_pendingException;
     size_t m_cleanupHookCounter = 0;
+    uint32_t m_openAddonHandleScopes = 0;
 
     WTF::Lock m_threadSafeFunctionsLock;
     WTF::HashSet<void*> m_threadSafeFunctions WTF_GUARDED_BY_LOCK(m_threadSafeFunctionsLock);

--- a/src/jsc/bindings/napi_handle_scope.cpp
+++ b/src/jsc/bindings/napi_handle_scope.cpp
@@ -115,6 +115,38 @@ NapiHandleScopeImpl* NapiHandleScope::open(Zig::GlobalObject* globalObject, bool
     return impl;
 }
 
+bool NapiHandleScope::closeIfOpen(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current)
+{
+    // `current` may already have been popped (and GC'd) by an earlier out-of-order close of one
+    // of its ancestors. Only compare it against the scopes still on the chain -- which are all
+    // kept alive through m_currentNapiHandleScopeImpl -- and dereference it only after a match.
+    auto* top = globalObject->m_currentNapiHandleScopeImpl.get();
+    bool onChain = false;
+    for (auto* open = top; open; open = open->parent()) {
+        if (open == current) {
+            onChain = true;
+            break;
+        }
+    }
+    if (!onChain) {
+        return false;
+    }
+    if (auto* parent = current->parent()) {
+        globalObject->m_currentNapiHandleScopeImpl.set(globalObject->vm(), globalObject, parent);
+    } else {
+        globalObject->m_currentNapiHandleScopeImpl.clear();
+    }
+    // Release every scope that was just popped (from the old top down to and including `current`)
+    // so a closed scope never keeps values alive. releaseHandles() nulls m_parent, so capture the
+    // next pointer first.
+    for (auto* popped = top; popped;) {
+        auto* next = popped == current ? nullptr : popped->parent();
+        popped->releaseHandles();
+        popped = next;
+    }
+    return true;
+}
+
 void NapiHandleScope::close(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current)
 {
     NAPI_LOG_CURRENT_FUNCTION;
@@ -122,14 +154,12 @@ void NapiHandleScope::close(Zig::GlobalObject* globalObject, NapiHandleScopeImpl
     if (!current) {
         return;
     }
+    // Fires when an addon leaves a handle scope open across a callback return (Node aborts on
+    // that too: the CHECK_EQ in napi_env__::CallIntoModule) or on a bug in Bun's own LIFO
+    // scopes. Out-of-order addon closes go through the tolerant NapiHandleScope__closeAddonScope.
     RELEASE_ASSERT_WITH_MESSAGE(current == globalObject->m_currentNapiHandleScopeImpl.get(),
         "Unbalanced napi_handle_scope opens and closes");
-    if (auto* parent = current->parent()) {
-        globalObject->m_currentNapiHandleScopeImpl.set(globalObject->vm(), globalObject, parent);
-    } else {
-        globalObject->m_currentNapiHandleScopeImpl.clear();
-    }
-    current->releaseHandles();
+    closeIfOpen(globalObject, current);
 }
 
 NapiHandleScope::NapiHandleScope(Zig::GlobalObject* globalObject)
@@ -151,6 +181,27 @@ extern "C" NapiHandleScopeImpl* NapiHandleScope__open(napi_env env, bool escapab
 extern "C" void NapiHandleScope__close(napi_env env, NapiHandleScopeImpl* current)
 {
     return NapiHandleScope::close(env->globalObject(), current);
+}
+
+extern "C" NapiHandleScopeImpl* NapiHandleScope__openAddonScope(napi_env env, bool escapable)
+{
+    auto* impl = NapiHandleScope::open(env->globalObject(), escapable);
+    // A null scope (opened during a GC sweep) is closed as a no-op, so don't count it.
+    if (impl) {
+        env->didOpenAddonHandleScope();
+    }
+    return impl;
+}
+
+extern "C" bool NapiHandleScope__closeAddonScope(napi_env env, NapiHandleScopeImpl* current)
+{
+    if (!env->didCloseAddonHandleScope()) {
+        return false;
+    }
+    // `current` may no longer be on the chain: closing one of its ancestors out of order already
+    // popped it. Node treats that as success too, so there is nothing left to do.
+    NapiHandleScope::closeIfOpen(env->globalObject(), current);
+    return true;
 }
 
 extern "C" void NapiHandleScope__append(napi_env env, JSC::EncodedJSValue value)

--- a/src/jsc/bindings/napi_handle_scope.cpp
+++ b/src/jsc/bindings/napi_handle_scope.cpp
@@ -154,9 +154,10 @@ void NapiHandleScope::close(Zig::GlobalObject* globalObject, NapiHandleScopeImpl
     if (!current) {
         return;
     }
-    // Fires when an addon leaves a handle scope open across a callback return (Node aborts on
-    // that too: the CHECK_EQ in napi_env__::CallIntoModule) or on a bug in Bun's own LIFO
-    // scopes. Out-of-order addon closes go through the tolerant NapiHandleScope__closeAddonScope.
+    // Fires on a bug in Bun's own strictly-LIFO handle scopes, or when an addon leaves a scope that
+    // is still on the chain open across a callback return. Node aborts on leaked addon scopes too
+    // (the CHECK_EQ in napi_env__::CallIntoModule); by counting instead of walking a chain it also
+    // catches a leak already popped by an out-of-order ancestor close, which Bun tolerates.
     RELEASE_ASSERT_WITH_MESSAGE(current == globalObject->m_currentNapiHandleScopeImpl.get(),
         "Unbalanced napi_handle_scope opens and closes");
     closeIfOpen(globalObject, current);

--- a/src/jsc/bindings/napi_handle_scope.h
+++ b/src/jsc/bindings/napi_handle_scope.h
@@ -82,8 +82,13 @@ public:
     // Create a new handle scope in the given environment
     static NapiHandleScopeImpl* open(Zig::GlobalObject* globalObject, bool escapable);
 
-    // Closes the most recently created handle scope in the given environment and restores the old one.
-    // Asserts that `current` is the active handle scope.
+    // If `current` is on the chain of open handle scopes, closes it -- along with any scopes
+    // opened after it that were not closed, matching V8's handle scope destructor -- and returns
+    // true. Otherwise returns false without changing anything.
+    static bool closeIfOpen(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current);
+
+    // Closes the most recently created handle scope in the given environment and restores the old
+    // one. Asserts that `current` is the active handle scope.
     static void close(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current);
 
 private:
@@ -94,9 +99,19 @@ private:
 // Create a new handle scope in the given environment
 extern "C" NapiHandleScopeImpl* NapiHandleScope__open(napi_env env, bool escapable);
 
-// Pop the most recently created handle scope in the given environment and restore the old one.
-// Asserts that `current` is the active handle scope.
+// Pop the handle scope `current`, which must still be open. Used for Bun's own handle scopes.
 extern "C" void NapiHandleScope__close(napi_env env, NapiHandleScopeImpl* current);
+
+// napi_open_handle_scope / napi_open_escapable_handle_scope: like NapiHandleScope__open, but
+// counts the scope against `env` so that NapiHandleScope__closeAddonScope can detect unbalanced
+// closes the way Node does.
+extern "C" NapiHandleScopeImpl* NapiHandleScope__openAddonScope(napi_env env, bool escapable);
+
+// napi_close_handle_scope / napi_close_escapable_handle_scope. Addons close handle scopes in
+// surprising orders, and Node returns a status instead of aborting, so unlike
+// NapiHandleScope__close this never asserts. Returns false if `env` has no addon-opened handle
+// scope left to close (napi_handle_scope_mismatch in Node) and true otherwise (napi_ok).
+extern "C" bool NapiHandleScope__closeAddonScope(napi_env env, NapiHandleScopeImpl* current);
 
 // Store a value in the active handle scope in the given environment
 extern "C" void NapiHandleScope__append(napi_env env, JSC::EncodedJSValue value);

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -191,10 +191,7 @@ unsafe extern "C" {
     pub(super) fn NapiHandleScope__open(env: *mut NapiEnv, escapable: bool)
     -> *mut NapiHandleScope;
     pub(super) fn NapiHandleScope__close(env: *mut NapiEnv, current: *mut NapiHandleScope);
-    fn NapiHandleScope__openAddonScope(
-        env: *mut NapiEnv,
-        escapable: bool,
-    ) -> *mut NapiHandleScope;
+    fn NapiHandleScope__openAddonScope(env: *mut NapiEnv, escapable: bool) -> *mut NapiHandleScope;
     fn NapiHandleScope__closeAddonScope(env: *mut NapiEnv, current: *mut NapiHandleScope) -> bool;
     fn NapiHandleScope__append(env: *mut NapiEnv, value: usize);
     fn NapiHandleScope__escape(handle_scope: *mut NapiHandleScope, value: usize) -> bool;

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -191,6 +191,11 @@ unsafe extern "C" {
     pub(super) fn NapiHandleScope__open(env: *mut NapiEnv, escapable: bool)
     -> *mut NapiHandleScope;
     pub(super) fn NapiHandleScope__close(env: *mut NapiEnv, current: *mut NapiHandleScope);
+    fn NapiHandleScope__openAddonScope(
+        env: *mut NapiEnv,
+        escapable: bool,
+    ) -> *mut NapiHandleScope;
+    fn NapiHandleScope__closeAddonScope(env: *mut NapiEnv, current: *mut NapiHandleScope) -> bool;
     fn NapiHandleScope__append(env: *mut NapiEnv, value: usize);
     fn NapiHandleScope__escape(handle_scope: *mut NapiHandleScope, value: usize) -> bool;
 }
@@ -216,10 +221,29 @@ impl NapiHandleScope {
     }
 
     /// Closes the given handle scope, releasing all values inside it, if it is safe to do so.
-    /// Asserts that self is the current handle scope in env.
+    /// Asserts that self is still an open handle scope in env. Only for Bun's own handle scopes,
+    /// which are strictly LIFO; addon scopes go through [`Self::close_addon`].
     pub(super) fn close(self_: *mut NapiHandleScope, env: &NapiEnv) {
         // SAFETY: NapiHandleScope__close handles null `current`.
         unsafe { NapiHandleScope__close(env.as_mut_ptr(), self_) }
+    }
+
+    /// [`napi_open_handle_scope`] / [`napi_open_escapable_handle_scope`]: like [`Self::open`],
+    /// but counted against `env` so that [`Self::close_addon`] can detect unbalanced closes.
+    pub(super) fn open_addon(env: &NapiEnv, escapable: bool) -> *mut NapiHandleScope {
+        // SAFETY: env is valid; C++ mutates env's scope stack (interior mutability).
+        unsafe { NapiHandleScope__openAddonScope(env.as_mut_ptr(), escapable) }
+    }
+
+    /// [`napi_close_handle_scope`] / [`napi_close_escapable_handle_scope`]. Node lets addons
+    /// close handle scopes out of order (which also discards any scopes opened after `self_`)
+    /// without aborting, so this never asserts. Returns `false` if the addon has already closed
+    /// every scope it opened, which Node reports as `napi_handle_scope_mismatch`.
+    #[must_use]
+    pub(super) fn close_addon(self_: *mut NapiHandleScope, env: &NapiEnv) -> bool {
+        // SAFETY: env is valid; `self_` is only compared against the scopes that are still open,
+        // never dereferenced, so a stale or already-closed pointer is harmless.
+        unsafe { NapiHandleScope__closeAddonScope(env.as_mut_ptr(), self_) }
     }
 
     /// Place a value in the handle scope. Must be done while returning any JS value into NAPI
@@ -1105,7 +1129,7 @@ pub(super) extern "C" fn napi_open_handle_scope(
     let env = get_env!(env_);
     env.check_gc();
     let result = get_out!(env, result_);
-    *result = NapiHandleScope::open(env, false);
+    *result = NapiHandleScope::open_addon(env, false);
     env.ok()
 }
 
@@ -1117,8 +1141,12 @@ pub(super) extern "C" fn napi_close_handle_scope(
     bun_output::scoped_log!(napi, "napi_close_handle_scope");
     let env = get_env!(env_);
     env.check_gc();
-    if !handle_scope.is_null() {
-        NapiHandleScope::close(handle_scope, env);
+    // napi_open_handle_scope returns a null (uncounted) scope during a GC sweep.
+    if handle_scope.is_null() {
+        return env.ok();
+    }
+    if !NapiHandleScope::close_addon(handle_scope, env) {
+        return NapiEnv::set_last_error(Some(env), NapiStatus::handle_scope_mismatch);
     }
     env.ok()
 }
@@ -1212,7 +1240,7 @@ pub(super) extern "C" fn napi_open_escapable_handle_scope(
     let env = get_env!(env_);
     env.check_gc();
     let result = get_out!(env, result_);
-    *result = NapiHandleScope::open(env, true);
+    *result = NapiHandleScope::open_addon(env, true);
     env.ok()
 }
 
@@ -1224,8 +1252,12 @@ pub(super) extern "C" fn napi_close_escapable_handle_scope(
     bun_output::scoped_log!(napi, "napi_close_escapable_handle_scope");
     let env = get_env!(env_);
     env.check_gc();
-    if !scope.is_null() {
-        NapiHandleScope::close(scope, env);
+    // napi_open_escapable_handle_scope returns a null (uncounted) scope during a GC sweep.
+    if scope.is_null() {
+        return env.ok();
+    }
+    if !NapiHandleScope::close_addon(scope, env) {
+        return NapiEnv::set_last_error(Some(env), NapiStatus::handle_scope_mismatch);
     }
     env.ok()
 }

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -513,6 +513,64 @@ test_napi_handle_scope_nesting(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// Node-API addons close handle scopes out of order, close them more times
+// than they opened them, or return without closing them at all. Node reports
+// a status for all of these (napi_handle_scope_mismatch at worst) and keeps
+// running; it never aborts the process.
+static napi_value
+test_napi_handle_scope_unbalanced_close(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope stdout_scope;
+#endif
+
+  {
+    // Closed in open order instead of reverse order.
+    napi_handle_scope a = nullptr, b = nullptr;
+    printf("out of order: open a -> %d\n", napi_open_handle_scope(env, &a));
+    printf("out of order: open b -> %d\n", napi_open_handle_scope(env, &b));
+    printf("out of order: close a -> %d\n", napi_close_handle_scope(env, a));
+    printf("out of order: close b -> %d\n", napi_close_handle_scope(env, b));
+  }
+
+  {
+    // Three nested scopes closed as a, c, b.
+    napi_handle_scope a = nullptr, b = nullptr, c = nullptr;
+    printf("shuffled: open a -> %d\n", napi_open_handle_scope(env, &a));
+    printf("shuffled: open b -> %d\n", napi_open_handle_scope(env, &b));
+    printf("shuffled: open c -> %d\n", napi_open_handle_scope(env, &c));
+    printf("shuffled: close a -> %d\n", napi_close_handle_scope(env, a));
+    printf("shuffled: close c -> %d\n", napi_close_handle_scope(env, c));
+    printf("shuffled: close b -> %d\n", napi_close_handle_scope(env, b));
+  }
+
+  {
+    // More closes than opens: the extra close is napi_handle_scope_mismatch.
+    napi_handle_scope a = nullptr;
+    printf("double close: open a -> %d\n", napi_open_handle_scope(env, &a));
+    printf("double close: close a -> %d\n", napi_close_handle_scope(env, a));
+    printf("double close: close a again -> %d\n",
+           napi_close_handle_scope(env, a));
+  }
+
+  {
+    // Escapable scopes share the same accounting.
+    napi_escapable_handle_scope a = nullptr, b = nullptr;
+    printf("escapable: open a -> %d\n",
+           napi_open_escapable_handle_scope(env, &a));
+    printf("escapable: open b -> %d\n",
+           napi_open_escapable_handle_scope(env, &b));
+    printf("escapable: close a -> %d\n",
+           napi_close_escapable_handle_scope(env, a));
+    printf("escapable: close b -> %d\n",
+           napi_close_escapable_handle_scope(env, b));
+    printf("escapable: close b again -> %d\n",
+           napi_close_escapable_handle_scope(env, b));
+  }
+
+  return ok(env);
+}
+
 // call this with a bunch (>10) of string arguments representing increasing
 // decimal numbers. ensures that the runtime does not let these arguments be
 // freed.
@@ -565,6 +623,44 @@ static napi_value test_napi_throw_with_nullptr(const Napi::CallbackInfo &info) {
   printf("napi_is_exception_pending -> %s\n",
          is_exception_pending ? "true" : "false");
 
+  return ok(env);
+}
+
+// Once an exception is pending, every further napi_throw_* must report
+// napi_pending_exception and leave the first exception in place instead of
+// silently replacing it (Node's NAPI_PREAMBLE).
+static napi_value
+test_napi_throw_with_pending_exception(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope stdout_scope;
+#endif
+
+  printf("napi_throw_error #1 -> %d\n",
+         napi_throw_error(env, "ERR_FIRST", "first"));
+  bool pending = false;
+  NODE_API_CALL(env, napi_is_exception_pending(env, &pending));
+  printf("exception pending -> %s\n", pending ? "true" : "false");
+  printf("napi_throw_error #2 -> %d\n",
+         napi_throw_error(env, "ERR_SECOND", "second"));
+  printf("napi_throw_type_error -> %d\n",
+         napi_throw_type_error(env, "ERR_THIRD", "third"));
+  printf("napi_throw_range_error -> %d\n",
+         napi_throw_range_error(env, "ERR_FOURTH", "fourth"));
+  printf("node_api_throw_syntax_error -> %d\n",
+         node_api_throw_syntax_error(env, "ERR_FIFTH", "fifth"));
+
+  napi_value err = nullptr, code = nullptr, msg = nullptr;
+  NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &err));
+  NODE_API_CALL(env, napi_get_named_property(env, err, "code", &code));
+  NODE_API_CALL(env, napi_get_named_property(env, err, "message", &msg));
+  char code_buf[64] = {0}, msg_buf[64] = {0};
+  size_t len = 0;
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, code, code_buf,
+                                                sizeof(code_buf), &len));
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, msg, msg_buf,
+                                                sizeof(msg_buf), &len));
+  printf("pending exception -> %s: %s\n", code_buf, msg_buf);
   return ok(env);
 }
 
@@ -2893,10 +2989,12 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_delete_property);
   REGISTER_FUNCTION(env, exports, test_napi_escapable_handle_scope);
   REGISTER_FUNCTION(env, exports, test_napi_handle_scope_nesting);
+  REGISTER_FUNCTION(env, exports, test_napi_handle_scope_unbalanced_close);
   REGISTER_FUNCTION(env, exports, test_napi_handle_scope_many_args);
   REGISTER_FUNCTION(env, exports, test_napi_ref);
   REGISTER_FUNCTION(env, exports, test_napi_run_script);
   REGISTER_FUNCTION(env, exports, test_napi_throw_with_nullptr);
+  REGISTER_FUNCTION(env, exports, test_napi_throw_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_extended_error_messages);
   REGISTER_FUNCTION(env, exports, bigint_to_i64);
   REGISTER_FUNCTION(env, exports, bigint_to_u64);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -513,10 +513,11 @@ test_napi_handle_scope_nesting(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
-// Node-API addons close handle scopes out of order, close them more times
-// than they opened them, or return without closing them at all. Node reports
-// a status for all of these (napi_handle_scope_mismatch at worst) and keeps
-// running; it never aborts the process.
+// Node-API addons close handle scopes out of order or close them more times
+// than they opened them. Node reports a status for both
+// (napi_handle_scope_mismatch at worst) and keeps running; it never aborts
+// the process. (Returning with a scope still open is different: Node aborts
+// on that too, so it is deliberately not covered here.)
 static napi_value
 test_napi_handle_scope_unbalanced_close(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -260,6 +260,12 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it("keeps the parent handle scope alive", async () => {
       await checkSameOutput("test_napi_handle_scope_nesting", []);
     });
+    it("returns a status for unbalanced closes instead of aborting", async () => {
+      const result = await checkSameOutput("test_napi_handle_scope_unbalanced_close", []);
+      // napi_ok == 0, napi_handle_scope_mismatch == 13
+      expect(result).toContain("out of order: close a -> 0");
+      expect(result).toContain("double close: close a again -> 13");
+    });
     it("exists when calling a napi constructor", async () => {
       await checkSameOutput("test_napi_class_constructor_handle_scope", []);
     });
@@ -650,6 +656,13 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
 
     it("does not throw with nullptr", async () => {
       await checkSameOutput("test_napi_throw_with_nullptr", []);
+    });
+
+    it("does not replace an already-pending exception", async () => {
+      const result = await checkSameOutput("test_napi_throw_with_pending_exception", []);
+      // napi_pending_exception == 10; the first exception must survive
+      expect(result).toContain("napi_throw_error #2 -> 10");
+      expect(result).toContain("pending exception -> ERR_FIRST: first");
     });
   });
   describe("napi_create_error functions", () => {


### PR DESCRIPTION
Two Node-API divergences from Node's documented contract, both on the misuse/error paths that every prebuilt native npm addon runs on Bun.

## 1. Out-of-order `napi_close_handle_scope` aborts the process

```c
napi_handle_scope a, b;
napi_open_handle_scope(env, &a);
napi_open_handle_scope(env, &b);
napi_close_handle_scope(env, a);   // closed out of order
napi_close_handle_scope(env, b);
```

Node returns `napi_ok` for all four and keeps running (and `napi_handle_scope_mismatch` for an extra close past zero). Bun hit

```
Unbalanced napi_handle_scope opens and closes
```

(`RELEASE_ASSERT_WITH_MESSAGE` in `NapiHandleScope::close`, `napi_handle_scope.cpp`) and took the whole process down with SIGABRT. Real addons close scopes in surprising orders on error paths, and N-API misuse by a third-party addon has to surface as an error status, not an uncatchable crash of the host.

**Cause:** Bun models open handle scopes as a parent-linked chain rooted at `m_currentNapiHandleScopeImpl` and asserted that the scope being closed is the top of the chain. Node keeps a per-env counter (`env->open_handle_scopes`): close decrements it and returns `napi_handle_scope_mismatch` at zero, and does not care about order.

**Fix:** `napi_open_handle_scope` / `napi_open_escapable_handle_scope` now count the scope against the env, and the corresponding closes go through a new `NapiHandleScope__closeAddonScope` that decrements the counter (returning `napi_handle_scope_mismatch` at zero) and then searches the chain for the scope instead of asserting. Closing a scope out of order also pops the scopes opened after it, matching V8's handle scope destructor, which is what addons are written against.

Bun's own handle scopes (`NapiHandleScope__open` / `__close`, the RAII wrapper, the `bun:ffi` TinyCC trampolines) are strictly LIFO and keep the strict path. The assertion still fires when an addon leaves a scope open across a callback return while it is still on the chain. Node aborts on leaked scopes too (the `CHECK_EQ` on `open_handle_scopes` in `napi_env__::CallIntoModule`), so that is not a new divergence, but the equivalence is not exact: Node counts instead of walking a chain, so it also catches the one compound case Bun tolerates, a leaked scope that an out-of-order ancestor close already popped. That case needs two misuses in one callback (Node aborts on the first), leaves only the per-env counter drifted by one, and never corrupts the chain; the only observable effect is a later excess close on that env returning `napi_ok` instead of `napi_handle_scope_mismatch`.

## 2. `napi_throw_error` while an exception is pending silently replaces it

Node's `NAPI_PREAMBLE` returns `napi_pending_exception` and leaves the first exception in place. Bun's `napi_throw` already did this, but `napi_throw_error`, `napi_throw_type_error`, `napi_throw_range_error`, and `node_api_throw_syntax_error` did not: they returned `napi_ok` and overwrote the pending exception, so the JS side saw the last error an addon's error path threw instead of the first.

**Fix:** move the pending-exception guard into the shared `throwErrorWithCStrings` helper so the whole family behaves like `napi_throw`.

## Verification

Both new tests in `test/napi/napi.test.ts` run the addon under real Node and Bun via `checkSameOutput` and diff the output.

Before (bun 1.4.0 and current main):

```
$ bun main.js test_napi_handle_scope_unbalanced_close
out of order: open a -> 0
out of order: open b -> 0
<SIGABRT, exit 134>

$ bun main.js test_napi_throw_with_pending_exception
napi_throw_error #1 -> 0
exception pending -> true
napi_throw_error #2 -> 0
napi_throw_type_error -> 0
napi_throw_range_error -> 0
node_api_throw_syntax_error -> 0
pending exception -> ERR_FIFTH: fifth
```

After, both match Node v26.3.0 byte for byte: statuses `0,0,0,0` for the out-of-order block, `13` (`napi_handle_scope_mismatch`) for the over-close, `10` (`napi_pending_exception`) for every throw after the first, and `ERR_FIRST: first` survives.

Full `test/napi/napi.test.ts`: 102 pass, 0 fail.

A third reported divergence, double `napi_wrap` returning a different status than Node, did not reproduce: Bun already returns `napi_ok` then `napi_invalid_arg` and preserves the first wrap, same as Node.


## Rebase note

Rebased onto main after #34009 (shared allocator / `NapiHandleScopeImpl::releaseHandles`) landed. That change adds an eager `releaseHandles()` when a scope is closed; this PR moves the pop logic into `closeIfOpen`. The merge resolution has `closeIfOpen` release every scope it pops (from the old chain top down to and including `current`), capturing `parent()` before each release since `releaseHandles()` nulls it. For Bun's own strictly-LIFO scopes that is exactly main's behavior (the loop runs once on `current == top`); for an out-of-order addon close it additionally releases the scopes that close discards. `test/napi/napi.test.ts`: 139 pass / 0 fail after the rebase.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->