### PR TITLE
node:crypto: reject conflicting hash/hashAlgorithm aliases in generateKeyPair('rsa-pss')

### DIFF
--- a/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
@@ -178,7 +178,7 @@ std::optional<RsaKeyPairJobCtx> RsaKeyPairJobCtx::fromJS(JSC::JSGlobalObject* gl
         RETURN_IF_EXCEPTION(scope, std::nullopt);
         hashView = hashString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, std::nullopt);
-        if (!hashAlgorithmView->isNull() && hashAlgorithmView != hashView) {
+        if (!hashAlgorithmView->isEmpty() && hashAlgorithmView != hashView) {
             ERR::INVALID_ARG_VALUE(scope, globalObject, "options.hash"_s, hashValue);
             return std::nullopt;
         }
@@ -192,14 +192,14 @@ std::optional<RsaKeyPairJobCtx> RsaKeyPairJobCtx::fromJS(JSC::JSGlobalObject* gl
         RETURN_IF_EXCEPTION(scope, std::nullopt);
         mgf1HashView = mgf1HashString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, std::nullopt);
-        if (!mgf1HashAlgorithmView->isNull() && mgf1HashAlgorithmView != mgf1HashView) {
+        if (!mgf1HashAlgorithmView->isEmpty() && mgf1HashAlgorithmView != mgf1HashView) {
             ERR::INVALID_ARG_VALUE(scope, globalObject, "options.mgf1Hash"_s, mgf1HashValue);
             return std::nullopt;
         }
     }
 
-    GCOwnedDataScope<WTF::StringView> hash = hashAlgorithmView->isNull() ? hashView : hashAlgorithmView;
-    GCOwnedDataScope<WTF::StringView> mgf1Hash = mgf1HashAlgorithmView->isNull() ? mgf1HashView : mgf1HashAlgorithmView;
+    GCOwnedDataScope<WTF::StringView> hash = hashAlgorithmView->isEmpty() ? hashView : hashAlgorithmView;
+    GCOwnedDataScope<WTF::StringView> mgf1Hash = mgf1HashAlgorithmView->isEmpty() ? mgf1HashView : mgf1HashAlgorithmView;
 
     ncrypto::Digest md = nullptr;
     ncrypto::Digest mgf1Md = nullptr;

--- a/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
@@ -156,9 +156,9 @@ std::optional<RsaKeyPairJobCtx> RsaKeyPairJobCtx::fromJS(JSC::JSGlobalObject* gl
     if (!hashAlgorithmValue.isUndefined()) {
         V::validateString(scope, globalObject, hashAlgorithmValue, "options.hashAlgorithm"_s);
         RETURN_IF_EXCEPTION(scope, std::nullopt);
-        hashString = hashAlgorithmValue.toString(globalObject);
+        hashAlgorithmString = hashAlgorithmValue.toString(globalObject);
         RETURN_IF_EXCEPTION(scope, std::nullopt);
-        hashView = hashString->view(globalObject);
+        hashAlgorithmView = hashAlgorithmString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, std::nullopt);
     }
     if (!mgf1HashAlgorithmValue.isUndefined()) {
@@ -166,7 +166,7 @@ std::optional<RsaKeyPairJobCtx> RsaKeyPairJobCtx::fromJS(JSC::JSGlobalObject* gl
         RETURN_IF_EXCEPTION(scope, std::nullopt);
         mgf1HashAlgorithmString = mgf1HashAlgorithmValue.toString(globalObject);
         RETURN_IF_EXCEPTION(scope, std::nullopt);
-        mgf1HashView = mgf1HashAlgorithmString->view(globalObject);
+        mgf1HashAlgorithmView = mgf1HashAlgorithmString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, std::nullopt);
     }
     if (!hashValue.isUndefined()) {

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1697,10 +1697,16 @@ describe("generateKeyPair('rsa-pss') deprecated hash aliases", () => {
   test.each([
     ["hash", "hashAlgorithm"],
     ["mgf1Hash", "mgf1HashAlgorithm"],
-  ])("matching %s / %s is not rejected by validation", (deprecated, modern) => {
+  ])("matching %s / %s is not rejected by validation", async (deprecated, modern) => {
     const options = { ...base, [deprecated]: "sha256", [modern]: "sha256" };
     // BoringSSL may still reject rsa-pss key generation, but never with the conflict error.
     expect(errorCode(() => generateKeyPairSync("rsa-pss", options as any))).not.toBe("ERR_INVALID_ARG_VALUE");
+
+    // Matching values pass validation, so the callback form does not throw; any failure
+    // (e.g. BoringSSL keygen) is delivered via the callback, never as the conflict error.
+    const { promise, resolve } = Promise.withResolvers<string | undefined>();
+    generateKeyPair("rsa-pss", options as any, (err: any) => resolve(err?.code));
+    expect(await promise).not.toBe("ERR_INVALID_ARG_VALUE");
   });
 });
 

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1708,6 +1708,16 @@ describe("generateKeyPair('rsa-pss') deprecated hash aliases", () => {
     generateKeyPair("rsa-pss", options as any, (err: any) => resolve(err?.code));
     expect(await promise).not.toBe("ERR_INVALID_ARG_VALUE");
   });
+
+  test.each([
+    ["hash", "hashAlgorithm"],
+    ["mgf1Hash", "mgf1HashAlgorithm"],
+  ])("%s set with an empty %s is not reported as a conflict", (deprecated, modern) => {
+    // Node's guard is truthiness-based (`modern && dep !== modern`), so an empty modern
+    // value is treated as unset: the deprecated value is used rather than flagged as a conflict.
+    const options = { ...base, [deprecated]: "sha256", [modern]: "" };
+    expect(errorCode(() => generateKeyPairSync("rsa-pss", options as any))).not.toBe("ERR_INVALID_ARG_VALUE");
+  });
 });
 
 test("Ed25519 should work", async () => {

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1672,6 +1672,38 @@ test.todo("RSA-PSS should work", async () => {
   }
 });
 
+// https://github.com/oven-sh/bun/issues/32835
+describe("generateKeyPair('rsa-pss') deprecated hash aliases", () => {
+  const base = { modulusLength: 512, saltLength: 16 };
+  const errorCode = (fn: () => void): string | undefined => {
+    try {
+      fn();
+    } catch (e: any) {
+      return e?.code;
+    }
+    return undefined;
+  };
+
+  test.each([
+    ["hash", "hashAlgorithm"],
+    ["mgf1Hash", "mgf1HashAlgorithm"],
+  ])("conflicting %s / %s throws ERR_INVALID_ARG_VALUE", (deprecated, modern) => {
+    const options = { ...base, [deprecated]: "sha256", [modern]: "sha1" };
+    // Argument validation runs synchronously before key generation for both entry points.
+    expect(errorCode(() => generateKeyPairSync("rsa-pss", options as any))).toBe("ERR_INVALID_ARG_VALUE");
+    expect(errorCode(() => generateKeyPair("rsa-pss", options as any, () => {}))).toBe("ERR_INVALID_ARG_VALUE");
+  });
+
+  test.each([
+    ["hash", "hashAlgorithm"],
+    ["mgf1Hash", "mgf1HashAlgorithm"],
+  ])("matching %s / %s is not rejected by validation", (deprecated, modern) => {
+    const options = { ...base, [deprecated]: "sha256", [modern]: "sha256" };
+    // BoringSSL may still reject rsa-pss key generation, but never with the conflict error.
+    expect(errorCode(() => generateKeyPairSync("rsa-pss", options as any))).not.toBe("ERR_INVALID_ARG_VALUE");
+  });
+});
+
 test("Ed25519 should work", async () => {
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
 


### PR DESCRIPTION
Fixes #32835

### Repro

```js
import crypto from "crypto";
for (const [name, options] of [
  ["hash vs hashAlgorithm", { modulusLength: 512, saltLength: 16, hash: "sha256", hashAlgorithm: "sha1" }],
  ["mgf1Hash vs mgf1HashAlgorithm", { modulusLength: 512, saltLength: 16, mgf1Hash: "sha256", mgf1HashAlgorithm: "sha1" }],
]) {
  try { crypto.generateKeyPairSync("rsa-pss", options); console.log(name, "=> no throw"); }
  catch (e) { console.log(name, "=>", e.code); }
}
```

Node rejects a deprecated alias (`hash`/`mgf1Hash`) that disagrees with its modern name (`hashAlgorithm`/`mgf1HashAlgorithm`) with `ERR_INVALID_ARG_VALUE`. Bun silently ignored the conflict (whichever branch ran last won) and proceeded with key generation.

### Cause

`RsaKeyPairJobCtx::fromJS` in `src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp` declares four view locals, but the alias branches wrote to the wrong ones:

- the `options.hashAlgorithm` branch assigned `hashString`/`hashView` instead of `hashAlgorithmString`/`hashAlgorithmView`
- the `options.mgf1HashAlgorithm` branch assigned `mgf1HashView` instead of `mgf1HashAlgorithmView`

So `hashAlgorithmView` and `mgf1HashAlgorithmView` were never assigned and stayed null. The guards `if (!hashAlgorithmView->isNull() && hashAlgorithmView != hashView)` (and the mgf1 equivalent) could therefore never fire, and the final `hashAlgorithmView->isNull() ? hashView : hashAlgorithmView` selection always picked the deprecated alias view.

### Fix

Route each branch to its own view local. The existing conflict checks and final selection then work. The comparison itself was already correct: `GCOwnedDataScope<StringView>` has no custom `operator!=`, so both operands convert to `WTF::StringView` and compare by content.

Both entry points (`generateKeyPairSync` and the callback form of `generateKeyPair`) run `fromJS` synchronously, so the error throws synchronously for both, matching Node.

### Verification

`ERR_INVALID_ARG_VALUE` / `The property 'options.hash' is invalid. Received 'sha256'`

Added tests to `test/js/node/crypto/crypto.key-objects.test.ts`. BoringSSL does not support rsa-pss key generation, so the tests assert the option validation that runs before keygen: conflicting values throw `ERR_INVALID_ARG_VALUE`, matching values are not rejected by validation.

- Fails before (released bun): the two conflict cases return `ERR_OSSL_UNSUPPORTED_ALGORITHM` instead of `ERR_INVALID_ARG_VALUE`.
- Passes after: all four cases pass, full file 87 pass / 0 fail.

Notes: the matching-value case (`test-crypto-keygen-duplicate-deprecated-option.js`) and the `DEP0154` deprecation warning for `hash`/`mgf1Hash` are preserved. The vendored `test-crypto-keygen.js` is entirely commented out and unrelated.