### PR TITLE
Fix off-by-one source map columns after a non-ASCII character

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3063,6 +3063,9 @@ impl Source {
         state.to_error_position(scan_line_end(contents, offset))
     }
 
+    /// Byte offset of 1-based (`line`, `col`) in `source_contents`, resuming the
+    /// scan from (`start_line`, `start_col`). Columns count UTF-16 code units,
+    /// the convention of JSC stack traces and source-map mappings.
     pub fn line_col_to_byte_offset(
         source_contents: &[u8],
         start_line: u64,
@@ -3102,7 +3105,7 @@ impl Source {
                     column_number = 1;
                 }
                 _ => {
-                    column_number += 1;
+                    column_number += if c > 0xFFFF { 2 } else { 1 };
                 }
             }
 

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -506,15 +506,6 @@ impl<'a> Snapshots<'a> {
                 bun_core::scoped_log!(inline_snapshot, "-> Found byte {}", next_start);
 
                 let (final_start, final_end, needs_pre_comma): (i32, i32, bool) = 'blk: {
-                    if !file_text[next_start..].is_empty() {
-                        match file_text[next_start] {
-                            b' ' | b'.' => {
-                                // work around off-by-1 error in `expect("§").toMatchInlineSnapshot()`
-                                next_start += 1;
-                            }
-                            _ => {}
-                        }
-                    }
                     let fn_name = ils.kind;
                     if !strings::starts_with(&file_text[next_start..], fn_name) {
                         log.add_error_fmt(

--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -212,18 +212,17 @@ impl LineOffsetTable {
                 line_byte_offset = offset;
             }
 
-            if c > 0x7F && columns_for_non_ascii.is_empty() {
+            // `byte_offset_to_first_non_ascii` doubles as the "line has non-ASCII"
+            // flag (`i32::MAX as u32` = none so far). The extend below appends this
+            // byte's entry; seeding one here too would shift every later column by one.
+            if c > 0x7F && byte_offset_to_first_non_ascii == i32::MAX as u32 {
                 debug_assert!(remaining.as_ptr() as usize >= base);
-                // we have a non-ASCII character, so we need to keep track of the
-                // mapping from byte offsets to UTF-16 code unit counts
-                // Scratch is empty here with 256 inline slots, so this never reallocs.
-                columns_for_non_ascii.push(column);
                 column_byte_offset = offset - line_byte_offset;
                 byte_offset_to_first_non_ascii = column_byte_offset;
             }
 
             // Update the per-byte column offsets
-            if !columns_for_non_ascii.is_empty() {
+            if byte_offset_to_first_non_ascii != i32::MAX as u32 {
                 let line_bytes_so_far = offset - line_byte_offset;
                 let need = (line_bytes_so_far - column_byte_offset + 1) as usize;
                 columns_for_non_ascii.extend(core::iter::repeat_n(column, need));

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isASAN, isDebug, tempDirWithFiles, tempDirWithFilesAnon } from "harness";
 import path, { join } from "path";
+import { SourceMapConsumer } from "source-map";
 import { buildNoThrow } from "./buildNoThrow";
 
 describe("Bun.build", () => {
@@ -906,6 +907,46 @@ describe.concurrent("sourcemap boolean values", () => {
 
     const jsText = await jsOutput!.text();
     expect(jsText).toContain("//# sourceMappingURL=index.js.map");
+  });
+});
+
+describe.concurrent("sourcemap positions", () => {
+  // Source-map columns count UTF-16 code units. Tokens after the first
+  // non-ASCII character on a line (Latin-1, astral, CJK) must still map to
+  // their exact original column.
+  test("original columns after non-ASCII characters on the same line", async () => {
+    const source = [
+      `export function a1() { throw new Error("A"); } export const za = "e";`,
+      `export const zb = "é"; export function b1() { throw new Error("B"); }`,
+      `export const zc = "🎉"; export function c1() { throw new Error("C"); }`,
+      `export const zd = "汉字 wörld"; export function d1() { throw new Error("D"); }`,
+      ``,
+    ].join("\n");
+    const dir = tempDirWithFiles("build-sourcemap-unicode-columns", { "in.ts": source });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "in.ts")],
+      outdir: join(dir, "out"),
+      sourcemap: "external",
+    });
+    expect(build.success).toBe(true);
+
+    const generated = await build.outputs.find(o => o.kind === "entry-point")!.text();
+    const map = await build.outputs.find(o => o.kind === "sourcemap")!.json();
+
+    // 1-based line, 0-based UTF-16 column: the convention `source-map` uses on
+    // both sides of originalPositionFor.
+    const lineColumn = (text: string, index: number) => {
+      const before = text.slice(0, index);
+      return { line: before.split("\n").length, column: index - (before.lastIndexOf("\n") + 1) };
+    };
+
+    await SourceMapConsumer.with(map, null, consumer => {
+      for (const token of ['new Error("A")', 'new Error("B")', 'new Error("C")', 'new Error("D")']) {
+        const { line, column } = consumer.originalPositionFor(lineColumn(generated, generated.indexOf(token)));
+        expect({ token, line, column }).toEqual({ token, ...lineColumn(source, source.indexOf(token)) });
+      }
+    });
   });
 });
 

--- a/test/js/bun/sourcemap/internal-sourcemap.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 // Runtime-transpiled modules store an InternalSourceMap blob (varint stream +
 // sync points) instead of expanding VLQ into a Mapping.List. These tests pin
@@ -106,6 +107,44 @@ describe("InternalSourceMap", () => {
     // `a1` being the all-ASCII control.
     const frames = [...stdout.matchAll(/at ([a-d]1) \(.*index\.ts:(\d+):(\d+)\)/g)].map(m => `${m[1]} ${m[2]}:${m[3]}`);
     expect(frames).toEqual(["a1", "b1", "c1", "d1"].map((fn, i) => `${fn} ${i + 1}:${lines[i].indexOf("Error(") + 1}`));
+    expect(exited).toBe(0);
+  });
+
+  // `toMatchInlineSnapshot` resolves its call site from the remapped stack
+  // position, which counts UTF-16 code units. An astral character earlier on
+  // the line made the updater land past the callee and fail with
+  // "Could not find 'toMatchInlineSnapshot' here".
+  test("inline snapshot call sites resolve after astral characters on the same line", async () => {
+    const fixture = [
+      `import { test, expect } from "bun:test";`,
+      `test("astral", () => {`,
+      `  expect("𐀁").toMatchInlineSnapshot();`,
+      `  expect("𐀁𐀂").toMatchInlineSnapshot();`,
+      `});`,
+      ``,
+    ].join("\n");
+    using dir = tempDir("inline-snapshot-astral", { "astral.test.ts": fixture });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "-u", "astral.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Failed to update inline snapshot");
+    expect(await Bun.file(join(String(dir), "astral.test.ts")).text()).toBe(
+      [
+        `import { test, expect } from "bun:test";`,
+        `test("astral", () => {`,
+        '  expect("𐀁").toMatchInlineSnapshot(`"𐀁"`);',
+        '  expect("𐀁𐀂").toMatchInlineSnapshot(`"𐀁𐀂"`);',
+        `});`,
+        ``,
+      ].join("\n"),
+    );
     expect(exited).toBe(0);
   });
 

--- a/test/js/bun/sourcemap/internal-sourcemap.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap.test.ts
@@ -104,9 +104,7 @@ describe("InternalSourceMap", () => {
     expect(stderr).toBe("");
     // Each frame must point at its line's `Error` in 1-based UTF-16 columns,
     // `a1` being the all-ASCII control.
-    const frames = [...stdout.matchAll(/at ([a-d]1) \(.*index\.ts:(\d+):(\d+)\)/g)].map(
-      m => `${m[1]} ${m[2]}:${m[3]}`,
-    );
+    const frames = [...stdout.matchAll(/at ([a-d]1) \(.*index\.ts:(\d+):(\d+)\)/g)].map(m => `${m[1]} ${m[2]}:${m[3]}`);
     expect(frames).toEqual(["a1", "b1", "c1", "d1"].map((fn, i) => `${fn} ${i + 1}:${lines[i].indexOf("Error(") + 1}`));
     expect(exited).toBe(0);
   });

--- a/test/js/bun/sourcemap/internal-sourcemap.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap.test.ts
@@ -84,6 +84,33 @@ describe("InternalSourceMap", () => {
     expect(exited).toBe(0);
   });
 
+  // Source-map columns count UTF-16 code units. A non-ASCII character earlier
+  // on the line (Latin-1, astral, CJK) must not shift the remapped columns of
+  // the tokens that follow it.
+  test("columns after a non-ASCII character on the same line remap exactly", async () => {
+    const lines = [
+      `const za = "e"; function a1() { return new Error("A").stack!; }`,
+      `const zb = "é"; function b1() { return new Error("B").stack!; }`,
+      `const zc = "🎉"; function c1() { return new Error("C").stack!; }`,
+      `const zd = "汉字 héllo wörld"; function d1() { return new Error("D").stack!; }`,
+      `console.log(a1());`,
+      `console.log(b1());`,
+      `console.log(c1());`,
+      `console.log(d1());`,
+    ];
+
+    const { stdout, stderr, exited } = await run({ "index.ts": lines.join("\n") + "\n" });
+
+    expect(stderr).toBe("");
+    // Each frame must point at its line's `Error` in 1-based UTF-16 columns,
+    // `a1` being the all-ASCII control.
+    const frames = [...stdout.matchAll(/at ([a-d]1) \(.*index\.ts:(\d+):(\d+)\)/g)].map(
+      m => `${m[1]} ${m[2]}:${m[3]}`,
+    );
+    expect(frames).toEqual(["a1", "b1", "c1", "d1"].map((fn, i) => `${fn} ${i + 1}:${lines[i].indexOf("Error(") + 1}`));
+    expect(exited).toBe(0);
+  });
+
   // Minified-shape: a single ~12KB line with thousands of mappings forces the
   // bit-packed `gc_w` lane wide and the absolute SyncEntry.gen_col into the
   // thousands, while `gl_mask` is all-zeros. Stack column must still remap to

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -503,7 +503,6 @@ describe("inline snapshots", () => {
           expect("b").toMatchInlineSnapshot(${v("", bad, '`"b"`')});
           expect("§<-1l").toMatchInlineSnapshot(${v("", bad, '`"§<-1l"`')});
           expect("𐀁").toMatchInlineSnapshot(${v("", bad, '`"𐀁"`')});
-          expect("𐀁𐀂").toMatchInlineSnapshot(${v("", bad, '`"𐀁𐀂"`')});
           expect( "m ") . toMatchInlineSnapshot ( ${v("", bad, '`"m "`')}) ;
           expect("§§§").     toMatchInlineSnapshot(${v("", bad, '`"§§§"`')}) ;
         });

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -503,6 +503,7 @@ describe("inline snapshots", () => {
           expect("b").toMatchInlineSnapshot(${v("", bad, '`"b"`')});
           expect("§<-1l").toMatchInlineSnapshot(${v("", bad, '`"§<-1l"`')});
           expect("𐀁").toMatchInlineSnapshot(${v("", bad, '`"𐀁"`')});
+          expect("𐀁𐀂").toMatchInlineSnapshot(${v("", bad, '`"𐀁𐀂"`')});
           expect( "m ") . toMatchInlineSnapshot ( ${v("", bad, '`"m "`')}) ;
           expect("§§§").     toMatchInlineSnapshot(${v("", bad, '`"§§§"`')}) ;
         });


### PR DESCRIPTION
Fixes two halves of the same unit confusion: source-map original columns were off by one on any line containing a non-ASCII character, and the inline-snapshot updater consumed those columns in the wrong units.

### Problem

Every token after the first non-ASCII character on a line gets an original column that is one too small. This affects `bun build --sourcemap` output and Bun's own runtime stack-trace remapping, which go through the same table.

```ts
// in.ts
export function a1() { throw new Error("A"); } export const za = "e";
export const zb = "é"; export function b1() { throw new Error("B"); }
```

```
bun build in.ts --sourcemap=external
originalPositionFor(generated `new Error("B")`) -> line 2, column 51
ground truth in UTF-16 code units (and esbuild on the same input)   -> column 52
```

Runtime form, two files identical except `"é"` vs `"e"` (same UTF-16 layout), bun 1.4.0:

```
rt_ascii.ts:  at b1 (/tmp/rt_ascii.ts:1:41)      at /tmp/rt_ascii.ts:1:54
rt_uni.ts:    at b1 (/tmp/rt_uni.ts:1:40)        at /tmp/rt_uni.ts:1:53
```

So every reported `file:line:column` on a line containing any non-ASCII character (an emoji in a string, an accented name, a CJK comment) is off by one, silently.

### Cause 1: `LineOffsetTable::generate`

The per-line byte-offset to UTF-16-column table starts at the first non-ASCII byte. When the loop saw that first non-ASCII character it pushed `column`, and then the shared "update the per-byte column offsets" extend appended an entry for the same byte again. With that duplicate at index 0, `columns_for_non_ascii[byte - byte_offset_to_first_non_ascii]` returns the previous byte's column for every byte after the first non-ASCII character. The error is exactly one column per line no matter how many non-ASCII characters follow or how wide they are, because only the first one is double counted.

esbuild's `GenerateLineOffsetTables`, which this code ports, only starts the (nil) slice at that point and lets the shared loop append the entry. The seed push existed here because `columns_for_non_ascii.is_empty()` doubled as the "line has non-ASCII" flag. The Zig version had the same seed push, so this predates the Rust port.

Fix: use the existing ASCII sentinel on `byte_offset_to_first_non_ascii` (`i32::MAX as u32`, already documented on the field and reset at each newline) as the per-line flag and drop the seed push, so the first non-ASCII character is appended exactly once. ASCII-only lines never build this table and are unaffected.

### Cause 2: the inline snapshot updater consumed those columns as code points

CI caught this one: with the columns corrected, `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` failed on every platform, only on this fixture line:

```
expect("𐀁").toMatchInlineSnapshot();
error: Failed to update inline snapshot: Could not find 'toMatchInlineSnapshot' here
```

`toMatchInlineSnapshot` resolves its call site from the remapped stack position (UTF-16 code units), but `Source::line_col_to_byte_offset` advanced one column per code point. For an astral character (2 UTF-16 units, 1 code point) the computed byte offset lands one code point past the callee. Two existing behaviors hid this:

- the LineOffsetTable bug above shifted the column one unit left, which cancelled the code-point overshoot exactly when the line had one astral character, and
- for Latin-1/BMP characters the updater skipped a leading `' '` or `'.'`, a workaround whose comment says "work around off-by-1 error in `expect("§").toMatchInlineSnapshot()`".

It was never hidden for lines with two or more astral characters. On released bun:

```
expect("𐀁𐀂").toMatchInlineSnapshot();
error: Failed to update inline snapshot: Could not find 'toMatchInlineSnapshot' here
    at /tmp/ilstest/a.test.ts:4:17
```

Fix: `line_col_to_byte_offset` counts UTF-16 code units (astral code points advance the column by 2), and the now-dead `' '`/`'.'` workaround is removed.

### Tests

- `test/js/bun/sourcemap/internal-sourcemap.test.ts`
  - Runtime stacks: one function per line with Latin-1, astral, and CJK text before its `new Error`, plus an all-ASCII control line; each frame must report the 1-based UTF-16 column of `Error`.
  - Inline snapshots: `bun test -u` on a fixture whose `toMatchInlineSnapshot()` calls follow one and two astral characters must rewrite both call sites. The two-astral line fails outright on released bun with the error above.
- `test/bundler/bun-build-api.test.ts`: `Bun.build` with `sourcemap: "external"`; `SourceMapConsumer.originalPositionFor` of each `new Error(...)` must equal the token's UTF-16 position in the source.

The existing `expect("𐀁").toMatchInlineSnapshot()` fixture in `snapshot.test.ts` (the one that caught cause 2 in CI) still covers the single-astral shape and is unchanged.

All of the new tests fail on bun 1.4.0 and current main (by exactly one column: `51` vs `52`, `b1 2:43` vs `2:44`, including the astral stack frame, which would be off by more than one if this were byte counting) and pass with the fix. `test/js/bun/sourcemap/`, `test/bundler/compile-sourcemap-internal.test.ts`, `test/bundler/bun-build-compile-sourcemap.test.ts`, `test/bake/dev/sourcemap.test.ts`, and the snapshot suite pass locally.
