### PR TITLE
node:vm: reject invalid cachedData instead of crashing

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -38,6 +38,10 @@
 #include "JavaScriptCore/JSGlobalProxyInlines.h"
 #include "GCDefferalContext.h"
 #include "JSBuffer.h"
+#include "xxhash3.h"
+
+#include <wtf/MallocSpan.h>
+#include <JavaScriptCore/JSCBytecodeCacheVersion.h>
 
 #include <JavaScriptCore/DOMJITAbstractHeap.h>
 #include <JavaScriptCore/DFGAbstractHeap.h>
@@ -125,6 +129,77 @@ bool extractCachedData(JSValue cachedDataValue, WTF::Vector<uint8_t>& outCachedD
     }
 
     return false;
+}
+
+// Integrity header verified by unwrapCachedData before decodeCodeBlock sees the payload; same role as V8's SerializedCodeData header.
+struct CachedDataHeader {
+    uint32_t magic;
+    uint32_t payloadLength;
+    uint32_t sourceHash;
+    uint32_t jscVersion;
+    uint64_t payloadHash;
+};
+static_assert(sizeof(CachedDataHeader) == 24, "header layout is part of the cachedData format");
+
+static constexpr uint32_t cachedDataMagic = 0x436E7542; // "BunC"
+
+static uint64_t hashCachedDataPayload(std::span<const uint8_t> payload)
+{
+    return highway_xxhash3_64(payload.data(), payload.size(), 0);
+}
+
+JSC::JSUint8Array* createCachedDataBuffer(JSGlobalObject* globalObject, const JSC::SourceCode& source, std::span<const uint8_t> bytecode)
+{
+    JSC::JSUint8Array* buffer = WebCore::createUninitializedBuffer(globalObject, sizeof(CachedDataHeader) + bytecode.size());
+    if (!buffer) [[unlikely]] {
+        return nullptr;
+    }
+
+    const CachedDataHeader header {
+        .magic = cachedDataMagic,
+        .payloadLength = static_cast<uint32_t>(bytecode.size()),
+        .sourceHash = source.hash(),
+        .jscVersion = JSC::computeJSCBytecodeCacheVersion(),
+        .payloadHash = hashCachedDataPayload(bytecode),
+    };
+    uint8_t* data = buffer->typedVector();
+    memcpy(data, &header, sizeof(header));
+    if (!bytecode.empty()) {
+        memcpy(data + sizeof(header), bytecode.data(), bytecode.size());
+    }
+    return buffer;
+}
+
+RefPtr<JSC::CachedBytecode> unwrapCachedData(const JSC::SourceCode& source, std::span<const uint8_t> cachedData)
+{
+    if (cachedData.size() < sizeof(CachedDataHeader)) {
+        return nullptr;
+    }
+
+    CachedDataHeader header;
+    memcpy(&header, cachedData.data(), sizeof(header));
+    if (header.magic != cachedDataMagic) {
+        return nullptr;
+    }
+
+    std::span<const uint8_t> payload = cachedData.subspan(sizeof(CachedDataHeader));
+    if (payload.size() != header.payloadLength) {
+        return nullptr;
+    }
+    if (header.sourceHash != source.hash()) {
+        return nullptr;
+    }
+    if (header.jscVersion != JSC::computeJSCBytecodeCacheVersion()) {
+        return nullptr;
+    }
+    if (header.payloadHash != hashCachedDataPayload(payload)) {
+        return nullptr;
+    }
+
+    // Copy: decoded functions retain the Decoder for lazy code block decoding, so a borrowed span would dangle.
+    auto payloadCopy = WTF::MallocSpan<uint8_t, JSC::VMMalloc>::malloc(payload.size());
+    memcpySpan(payloadCopy.mutableSpan(), payload);
+    return JSC::CachedBytecode::create(WTF::move(payloadCopy), {});
 }
 
 JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, const ArgList& args, const SourceOrigin& sourceOrigin, CompileFunctionOptions&& options, JSC::SourceTaintedOrigin sourceTaintOrigin, JSC::JSScope* scope)
@@ -218,10 +293,13 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
 
     TriState bytecodeAccepted = TriState::Indeterminate;
 
-    if (!options.cachedData.isEmpty()) {
-        cachedBytecode = CachedBytecode::create(std::span(options.cachedData), nullptr, {});
-        SourceCodeKey key(sourceCode, {}, JSC::SourceCodeType::ProgramType, lexicallyScopedFeatures, JSC::JSParserScriptMode::Classic, JSC::DerivedContextType::None, JSC::EvalContextType::None, false, {}, std::nullopt);
-        unlinkedProgramCodeBlock = JSC::decodeCodeBlock<UnlinkedProgramCodeBlock>(vm, key, *cachedBytecode);
+    // Node treats a provided-but-empty cachedData buffer as rejected, not absent.
+    if (options.cachedDataProvided) {
+        cachedBytecode = unwrapCachedData(sourceCode, std::span(options.cachedData));
+        if (cachedBytecode) {
+            SourceCodeKey key(sourceCode, {}, JSC::SourceCodeType::ProgramType, lexicallyScopedFeatures, JSC::JSParserScriptMode::Classic, JSC::DerivedContextType::None, JSC::EvalContextType::None, false, {}, std::nullopt);
+            unlinkedProgramCodeBlock = JSC::decodeCodeBlock<UnlinkedProgramCodeBlock>(vm, key, *cachedBytecode);
+        }
         if (unlinkedProgramCodeBlock == nullptr) {
             bytecodeAccepted = TriState::False;
         } else {
@@ -262,7 +340,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
         if (options.produceCachedData) {
             RefPtr<JSC::CachedBytecode> producedBytecode = getBytecode(globalObject, JSC::SourceCodeType::ProgramType, sourceCode);
             if (producedBytecode) {
-                JSC::JSUint8Array* buffer = WebCore::createBuffer(globalObject, producedBytecode->span());
+                JSC::JSUint8Array* buffer = createCachedDataBuffer(globalObject, sourceCode, producedBytecode->span());
                 RETURN_IF_EXCEPTION(throwScope, nullptr);
                 Bun::putDirectNamed(vm, function, "cachedData"_s, buffer);
                 Bun::putDirectNamed(vm, function, "cachedDataProduced"_s, jsBoolean(true));
@@ -476,8 +554,7 @@ JSC::EncodedJSValue createCachedData(JSGlobalObject* globalObject, const JSC::So
         return throwVMError(globalObject, scope, "createCachedData failed"_s);
     }
 
-    std::span<const uint8_t> bytes = bytecode->span();
-    JSC::JSUint8Array* buffer = WebCore::createBuffer(globalObject, bytes);
+    JSC::JSUint8Array* buffer = createCachedDataBuffer(globalObject, source, bytecode->span());
     RETURN_IF_EXCEPTION(scope, {});
 
     if (!buffer) {
@@ -1959,8 +2036,10 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
         // The validators return false both for "absent" and for "threw".
         RETURN_IF_EXCEPTION(scope, false);
 
-        if (validateCachedData(globalObject, vm, scope, options, this->cachedData))
+        if (validateCachedData(globalObject, vm, scope, options, this->cachedData)) {
+            this->cachedDataProvided = true;
             any = true;
+        }
         RETURN_IF_EXCEPTION(scope, false);
 
         JSValue parsingContextValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "parsingContext"_s));

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -26,6 +26,8 @@ namespace NodeVM {
 
 RefPtr<JSC::CachedBytecode> getBytecode(JSGlobalObject* globalObject, JSC::SourceCodeType, const JSC::SourceCode& source);
 bool extractCachedData(JSValue cachedDataValue, WTF::Vector<uint8_t>& outCachedData);
+JSC::JSUint8Array* createCachedDataBuffer(JSGlobalObject* globalObject, const JSC::SourceCode& source, std::span<const uint8_t> bytecode);
+RefPtr<JSC::CachedBytecode> unwrapCachedData(const JSC::SourceCode& source, std::span<const uint8_t> cachedData);
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset);
 JSC::EncodedJSValue createCachedData(JSGlobalObject* globalObject, const JSC::SourceCode& source);
 bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Exception> exception, ThrowScope& throwScope);
@@ -69,6 +71,7 @@ public:
     JSGlobalObject* parsingContext = nullptr;
     JSValue contextExtensions {};
     bool produceCachedData = false;
+    bool cachedDataProvided = false;
 
     using BaseVMOptions::BaseVMOptions;
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -66,8 +66,10 @@ bool ScriptOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::
             any = true;
         RETURN_IF_EXCEPTION(scope, false);
 
-        if (validateCachedData(globalObject, vm, scope, options, this->cachedData))
+        if (validateCachedData(globalObject, vm, scope, options, this->cachedData)) {
+            this->cachedDataProvided = true;
             any = true;
+        }
         RETURN_IF_EXCEPTION(scope, false);
 
         // Handle importModuleDynamically option
@@ -169,17 +171,20 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
 
     WTF::Vector<uint8_t>& cachedData = script->cachedData();
 
-    if (!cachedData.isEmpty()) {
+    // Node treats a provided-but-empty cachedData buffer as rejected, not absent.
+    if (script->options().cachedDataProvided) {
         JSC::ProgramExecutable* executable = script->cachedExecutable();
         if (!executable) {
             executable = script->createExecutable();
         }
         ASSERT(executable);
 
-        JSC::LexicallyScopedFeatures lexicallyScopedFeatures = globalObject->globalScopeExtension() ? JSC::TaintedByWithScopeLexicallyScopedFeature : JSC::NoLexicallyScopedFeatures;
-        JSC::SourceCodeKey key(script->source(), {}, JSC::SourceCodeType::ProgramType, lexicallyScopedFeatures, JSC::JSParserScriptMode::Classic, JSC::DerivedContextType::None, JSC::EvalContextType::None, false, {}, std::nullopt);
-        Ref<JSC::CachedBytecode> cachedBytecode = JSC::CachedBytecode::create(std::span(cachedData), nullptr, {});
-        JSC::UnlinkedProgramCodeBlock* unlinkedBlock = JSC::decodeCodeBlock<UnlinkedProgramCodeBlock>(vm, key, WTF::move(cachedBytecode));
+        JSC::UnlinkedProgramCodeBlock* unlinkedBlock = nullptr;
+        if (RefPtr<JSC::CachedBytecode> cachedBytecode = unwrapCachedData(script->source(), std::span(cachedData))) {
+            JSC::LexicallyScopedFeatures lexicallyScopedFeatures = globalObject->globalScopeExtension() ? JSC::TaintedByWithScopeLexicallyScopedFeature : JSC::NoLexicallyScopedFeatures;
+            JSC::SourceCodeKey key(script->source(), {}, JSC::SourceCodeType::ProgramType, lexicallyScopedFeatures, JSC::JSParserScriptMode::Classic, JSC::DerivedContextType::None, JSC::EvalContextType::None, false, {}, std::nullopt);
+            unlinkedBlock = JSC::decodeCodeBlock<UnlinkedProgramCodeBlock>(vm, key, cachedBytecode.releaseNonNull());
+        }
 
         if (!unlinkedBlock) {
             script->cachedDataRejected(TriState::True);
@@ -200,6 +205,8 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
                 script->cachedDataRejected(TriState::True);
             }
         }
+        // unwrapCachedData owns its copy; nothing reads m_options.cachedData after this.
+        cachedData = {};
     } else if (script->options().produceCachedData)
         script->cacheBytecode();
 
@@ -266,8 +273,7 @@ JSC::JSUint8Array* NodeVMScript::getBytecodeBuffer()
         if (!m_cachedBytecode)
             return nullptr;
 
-        std::span<const uint8_t> bytes = m_cachedBytecode->span();
-        m_cachedBytecodeBuffer.set(vm(), this, WebCore::createBuffer(globalObject(), bytes));
+        m_cachedBytecodeBuffer.set(vm(), this, createCachedDataBuffer(globalObject(), m_source, m_cachedBytecode->span()));
         RETURN_IF_EXCEPTION(scope, nullptr);
         if (!m_cachedBytecodeBuffer) {
             return nullptr;

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -13,6 +13,7 @@ public:
     WTF::Vector<uint8_t> cachedData;
     std::optional<int64_t> timeout = std::nullopt;
     bool produceCachedData = false;
+    bool cachedDataProvided = false;
 
     using BaseVMOptions::BaseVMOptions;
 
@@ -77,7 +78,6 @@ public:
     WTF::Vector<uint8_t>& cachedData() { return m_options.cachedData; }
     JSC::ProgramExecutable* cachedExecutable() const { return m_cachedExecutable.get(); }
     bool cachedDataProduced() const { return m_cachedDataProduced; }
-    void cachedDataProduced(bool value) { m_cachedDataProduced = value; }
     TriState cachedDataRejected() const { return m_cachedDataRejected; }
     void cachedDataRejected(TriState value) { m_cachedDataRejected = value; }
 

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -112,7 +112,8 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
         WTF::move(sourceCode), moduleWrapper, initializeImportMeta);
     ptr->finishCreation(vm);
 
-    if (cachedData.isEmpty()) {
+    // Node treats a provided-but-empty cachedData buffer as rejected, not absent.
+    if (cachedDataValue.isUndefined()) {
         return ptr;
     }
 
@@ -126,11 +127,12 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
 
     // Decoding checks the format, the checksum and the source key. Linking would need
     // the module's JSModuleEnvironment, which does not exist yet.
-    LexicallyScopedFeatures lexicallyScopedFeatures = StrictModeLexicallyScopedFeature;
-    SourceCodeKey key(ptr->sourceCode(), {}, SourceCodeType::ModuleType, lexicallyScopedFeatures, JSParserScriptMode::Module, DerivedContextType::None, EvalContextType::None, false, {}, std::nullopt);
-    Ref<CachedBytecode> cachedBytecode = CachedBytecode::create(std::span(cachedData), nullptr, {});
-    if (decodeCodeBlock<UnlinkedModuleProgramCodeBlock>(vm, key, WTF::move(cachedBytecode)))
-        return ptr;
+    if (RefPtr<CachedBytecode> cachedBytecode = unwrapCachedData(ptr->sourceCode(), std::span(cachedData))) {
+        LexicallyScopedFeatures lexicallyScopedFeatures = StrictModeLexicallyScopedFeature;
+        SourceCodeKey key(ptr->sourceCode(), {}, SourceCodeType::ModuleType, lexicallyScopedFeatures, JSParserScriptMode::Module, DerivedContextType::None, EvalContextType::None, false, {}, std::nullopt);
+        if (decodeCodeBlock<UnlinkedModuleProgramCodeBlock>(vm, key, cachedBytecode.releaseNonNull()))
+            return ptr;
+    }
 
     throwError(globalObject, scope, ErrorCode::ERR_VM_MODULE_CACHED_DATA_REJECTED, "cachedData buffer was rejected"_s);
     return nullptr;
@@ -493,8 +495,12 @@ JSUint8Array* NodeVMSourceTextModule::cachedData(JSGlobalObject* globalObject)
     if (!m_cachedBytecodeBuffer) {
         RefPtr<CachedBytecode> cachedBytecode = bytecode(globalObject);
         RETURN_IF_EXCEPTION(scope, nullptr);
-        std::span<const uint8_t> bytes = cachedBytecode->span();
-        JSUint8Array* buffer = WebCore::createBuffer(globalObject, bytes);
+        // getBytecode can return null without throwing (serialization failure).
+        if (!cachedBytecode) [[unlikely]] {
+            throwVMError(globalObject, scope, "createCachedData failed"_s);
+            return nullptr;
+        }
+        JSUint8Array* buffer = createCachedDataBuffer(globalObject, m_sourceCode, cachedBytecode->span());
         RETURN_IF_EXCEPTION(scope, nullptr);
         m_cachedBytecodeBuffer.set(vm, this, buffer);
     }

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -385,6 +385,19 @@ function fingerprint(bytecode: Uint8Array, isPayload = true) {
   return { sha256: Bun.CryptoHasher.hash("sha256", copy, "hex"), bytes: copy.byteLength };
 }
 
+// node:vm cachedData wraps the JSC payload in a 24-byte integrity header (CachedDataHeader in
+// src/jsc/bindings/NodeVM.cpp) whose version and checksum fields also move on every WebKit upgrade. Strip it so the
+// vm entries pin the serialized bytecode alone, like the bundler outputs.
+function vmPayload(cachedData: Uint8Array) {
+  const headerSize = 24;
+  const payloadLength = new DataView(cachedData.buffer, cachedData.byteOffset, cachedData.byteLength).getUint32(
+    4,
+    true,
+  );
+  expect(cachedData.byteLength).toBe(headerSize + payloadLength);
+  return cachedData.subarray(headerSize);
+}
+
 describe("bytecode cache portability", () => {
   test("encoder output is identical on every platform", async () => {
     // The bundler builds are separate processes: start them all, then encode the in-process cases while they run.
@@ -392,13 +405,13 @@ describe("bytecode cache portability", () => {
     const outputs: Record<string, unknown> = {};
     // Program and module code blocks straight from the encoder, without the bundler in between.
     outputs["vm.Script features.js"] = fingerprint(
-      new vm.Script(featuresSource, { filename: "features.js", produceCachedData: true }).cachedData!,
+      vmPayload(new vm.Script(featuresSource, { filename: "features.js", produceCachedData: true }).cachedData!),
     );
     outputs["vm.Script shapes.js"] = fingerprint(
-      new vm.Script(shapesSource(), { filename: "shapes.js", produceCachedData: true }).cachedData!,
+      vmPayload(new vm.Script(shapesSource(), { filename: "shapes.js", produceCachedData: true }).cachedData!),
     );
     outputs["vm.Script records.js"] = fingerprint(
-      new vm.Script(recordsSource, { filename: "records.js", produceCachedData: true }).cachedData!,
+      vmPayload(new vm.Script(recordsSource, { filename: "records.js", produceCachedData: true }).cachedData!),
     );
     // A builtin (what `bun build --compile --bytecode` embeds for node:* / bun:* modules): @-intrinsics and the
     // builtin-executable entry, which user source never produces. Bun's own internal modules are not hashed here because
@@ -407,26 +420,35 @@ describe("bytecode cache portability", () => {
     outputs["builtin corpus"] = fingerprint(builtin.bytecode);
     outputs["builtin corpus strings"] = fingerprint(builtin.strings, false); // the external string table --compile embeds beside it
     outputs["vm.SourceTextModule module.js"] = fingerprint(
-      new vm.SourceTextModule(moduleSource, { identifier: "module.js" }).createCachedData(),
+      vmPayload(new vm.SourceTextModule(moduleSource, { identifier: "module.js" }).createCachedData()),
     );
     outputs["vm.Script big.js"] = fingerprint(
-      new vm.Script(bigSource(), { filename: "big.js", produceCachedData: true }).cachedData!,
+      vmPayload(new vm.Script(bigSource(), { filename: "big.js", produceCachedData: true }).cachedData!),
     );
     outputs["vm.Script source-forms.js"] = fingerprint(
-      new vm.Script(sourceFormsSource(), { filename: "source-forms.js", produceCachedData: true }).cachedData!,
+      vmPayload(
+        new vm.Script(sourceFormsSource(), { filename: "source-forms.js", produceCachedData: true }).cachedData!,
+      ),
     );
     const librarySource = (lib: string) => readFileSync(join(corpusDir, "../../node_modules", lib), "utf8");
     outputs["vm.Script lodash.js"] = fingerprint(
-      new vm.Script(librarySource("lodash/lodash.js"), { filename: "lodash.js", produceCachedData: true }).cachedData!,
+      vmPayload(
+        new vm.Script(librarySource("lodash/lodash.js"), { filename: "lodash.js", produceCachedData: true })
+          .cachedData!,
+      ),
     );
     outputs["vm.Script typescript.js"] = fingerprint(
-      new vm.Script(librarySource("typescript/lib/typescript.js"), {
-        filename: "typescript.js",
-        produceCachedData: true,
-      }).cachedData!,
+      vmPayload(
+        new vm.Script(librarySource("typescript/lib/typescript.js"), {
+          filename: "typescript.js",
+          produceCachedData: true,
+        }).cachedData!,
+      ),
     );
     outputs["vm.SourceTextModule acorn.mjs"] = fingerprint(
-      new vm.SourceTextModule(librarySource("acorn/dist/acorn.mjs"), { identifier: "acorn.mjs" }).createCachedData(),
+      vmPayload(
+        new vm.SourceTextModule(librarySource("acorn/dist/acorn.mjs"), { identifier: "acorn.mjs" }).createCachedData(),
+      ),
     );
     for (const [i, { name }] of bundlerBuilds.entries()) {
       const { js, jsc } = (await bundled)[i];

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1031,6 +1031,108 @@ describe("Script compiles its source once and links that in every context it run
   });
 });
 
+test("rejects corrupted cachedData instead of crashing", async () => {
+  // Corrupting, truncating, or extending createCachedData() output must set
+  // cachedDataRejected (or throw ERR_VM_MODULE_CACHED_DATA_REJECTED for modules)
+  // and recompile from source, like Node. Runs in a child process since the
+  // broken behavior is a process crash: a truncated tail leaves embedded
+  // self-relative offsets pointing past the copied buffer, which JSC's decoder
+  // dereferences without a bounds check.
+  const code = /* js */ `
+    const vm = require("node:vm");
+    const assert = require("node:assert");
+
+    function corruptions(good) {
+      const variants = [];
+      // Truncations: len-1, len/2, 16, 1. The len/2 case is the one that
+      // reliably reached the decoder's wild pointer arithmetic before the
+      // envelope check was added.
+      for (const cut of [good.length - 1, good.length >> 1, 16, 1]) {
+        variants.push(["truncate:" + cut, good.subarray(0, cut)]);
+      }
+      // 20 single-byte flips seeded deterministically across the buffer.
+      for (let i = 0; i < 20; i++) {
+        const copy = Buffer.from(good);
+        const off = Math.floor((i * (good.length - 1)) / 19);
+        copy[off] ^= 0xff;
+        variants.push(["flip@" + off, copy]);
+      }
+      variants.push(["extend", Buffer.concat([good, Buffer.from([0xde, 0xad])])]);
+      variants.push(["empty", Buffer.alloc(0)]);
+      variants.push(["zeros", Buffer.alloc(good.length)]);
+      variants.push(["fill", Buffer.alloc(good.length, 0x2a)]);
+      variants.push(["random", Buffer.from("fhqwhgads")]);
+      return variants;
+    }
+
+    {
+      const source = "function f(){return 1234} f()";
+      const good = new vm.Script(source).createCachedData();
+      for (const [label, cachedData] of corruptions(good)) {
+        const script = new vm.Script(source, { cachedData });
+        assert.strictEqual(script.cachedDataRejected, true, label);
+        assert.strictEqual(script.runInThisContext(), 1234, label);
+      }
+      const intact = new vm.Script(source, { cachedData: good });
+      assert.strictEqual(intact.cachedDataRejected, false);
+      assert.strictEqual(intact.runInThisContext(), 1234);
+      // Intact bytecode for a different source is also rejected (sourceHash).
+      const other = new vm.Script("1 + 1", { cachedData: good });
+      assert.strictEqual(other.cachedDataRejected, true);
+      assert.strictEqual(other.runInThisContext(), 2);
+      console.log("script ok");
+    }
+
+    {
+      const params = ["a"];
+      const source = "return a + 1234;";
+      const good = vm.compileFunction(source, params, { produceCachedData: true }).cachedData;
+      assert.ok(good.length > 0);
+      for (const [label, cachedData] of corruptions(good)) {
+        const fn = vm.compileFunction(source, params, { cachedData });
+        assert.strictEqual(fn.cachedDataRejected, true, label);
+        assert.strictEqual(fn(1), 1235, label);
+      }
+      const intact = vm.compileFunction(source, params, { cachedData: good });
+      assert.strictEqual(intact.cachedDataRejected, false);
+      assert.strictEqual(intact(1), 1235);
+      const other = vm.compileFunction("return a + 1;", params, { cachedData: good });
+      assert.strictEqual(other.cachedDataRejected, true);
+      assert.strictEqual(other(1), 2);
+      console.log("compileFunction ok");
+    }
+
+    {
+      const source = "export const value = 1234;";
+      const good = new vm.SourceTextModule(source).createCachedData();
+      for (const [label, cachedData] of corruptions(good)) {
+        assert.throws(() => new vm.SourceTextModule(source, { cachedData }), {
+          code: "ERR_VM_MODULE_CACHED_DATA_REJECTED",
+        }, label);
+      }
+      assert.throws(() => new vm.SourceTextModule("export const value = 5678;", { cachedData: good }), {
+        code: "ERR_VM_MODULE_CACHED_DATA_REJECTED",
+      });
+      new vm.SourceTextModule(source, { cachedData: good });
+      console.log("module ok");
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "script ok\ncompileFunction ok\nmodule ok\n",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
 describe("codeGeneration options", () => {
   test("disabling codeGeneration.strings should block eval and Function constructor", () => {
     const context = createContext(


### PR DESCRIPTION
### Problem

`new vm.Script(source, { cachedData })` with a buffer that is not an intact copy of `createCachedData()` output can crash the process. Truncation, the most common real-world cache corruption (partial write, stale file), is enough:

```js
import vm from "node:vm";
const src = "2 + 3";
const cd = new vm.Script(src).createCachedData();
for (const cut of [4, 16, cd.length >> 1, cd.length - 1]) {
  const s = new vm.Script(src, { cachedData: cd.subarray(0, cut) });
  console.log(cut, s.cachedDataRejected, s.runInNewContext());   // node: true/5 each; bun: SIGSEGV at len/2
}
```

```
panic(main thread): Segmentation fault at address 0x818585C26A4
```

A debug build reports the same input as an assertion inside JSC's bytecode decoder:

```
ASSERTION FAILED: addr >= cachedBytecodeSpan.data() && addr < std::to_address(cachedBytecodeSpan.end())
vendor/WebKit/Source/JavaScriptCore/runtime/CachedTypes.cpp(314) : ptrdiff_t JSC::Decoder::offsetOf(const void *)
```

Depending on which bytes differ the buffer can instead be silently accepted (`cachedDataRejected === false`). Node rejects and recompiles from source. `vm.compileFunction()` and `new vm.SourceTextModule()` accept the same option and behaved the same way.

### Cause

`options.cachedData` is only type-checked and then handed directly to `JSC::decodeCodeBlock()`. JSC's decoder derives pointers from self-relative offsets stored in the payload and expects its own serializer's output; there is no entry point that validates an arbitrary buffer (the format carries no length field and no checksum, and the staleness check itself reads payload-relative offsets). The entry header and `SourceCodeKey` are encoded first and the code block last, so a truncated tail leaves decoded offsets pointing past the exactly-sized copy: wild heap reads. V8 solves this in the layer that owns the format: the code cache carries a header with a magic number, version, source hash, payload length and payload checksum, and a mismatch is what sets `cachedDataRejected` in Node.

### Fix

Do the same in the `node:vm` bindings:

- `createCachedData()` and `produceCachedData` prepend a 24-byte `{ magic, payloadLength, sourceHash, jscVersion, payloadHash }` header (XXH3-64 of the serialized bytecode) to the buffer they hand to JS.
- `new vm.Script`, `vm.compileFunction`, and `new vm.SourceTextModule` verify every field before decoding. A buffer that is not byte for byte a previous `createCachedData()` output for the same source (corrupted, truncated, extended, for different source, or not produced by this Bun build) is rejected up front and takes the existing rejection path: `cachedDataRejected === true`, or `ERR_VM_MODULE_CACHED_DATA_REJECTED` for modules, and the source is compiled normally.
- The accepted payload is handed to JSC as an owned copy (main's `createOwnedCachedBytecode`, now file-local and reached only through `unwrapCachedData`), since JSC keeps the decoder alive for lazily decoded function bodies. For `vm.Script` the input `Vector` is released once that copy exists.

`cachedData` is only usable by the runtime that produced it (as in Node across V8 versions), so the format change does not invalidate anything that previously worked.

Defense-in-depth bounds checks inside JSC's decoder itself are in oven-sh/WebKit#368 (the decoder entry points reject short buffers and out-of-range embedded offsets instead of reading past the span); that lands via a WebKit version bump and is independent of this fix.

### Rebase notes

The branch is two commits plus a merge of current main.

- Conflicts with #38040 (vm.Script compiles once and links per context) and #40270 (portable bytecode cache, `getBytecode` takes a `SourceCodeType`): `constructScript` keys its cachedData block on `script->options().cachedDataProvided` inside main's restructured constructor. Main had independently added the `getBytecodeBuffer()` null guard and dropped the `cachedDataProduced(true)` override, so those parts of this PR collapsed into main's versions.
- Conflicts with #41083 (module cachedData validation is decode-only, no link-and-JIT step) and #40898 (restructured `bundler_bytecode_portable.test.ts`): kept main's shape for both, routed through `unwrapCachedData` and the `vmPayload` header-stripping helper respectively.
- Main then landed the payload-ownership fix on its own as `NodeVM::createOwnedCachedBytecode`, called directly by each consumer. The merge keeps that helper, makes it file-local, and has `unwrapCachedData` call it after the header checks, so every consumer still validates before JSC's decoder sees the bytes and none borrows caller memory.
- `test/bundler/bundler_bytecode_portable.test.ts` fingerprints `vm.Script`/`SourceTextModule` cachedData and masks JSC's version fields at fixed offsets, which the 24-byte header shifted. The vm entries strip the header before fingerprinting; the existing snapshot matches byte for byte with no update, which also confirms the JSC payload behind the header is unchanged.

### Tests

New test in `test/js/node/vm/vm.test.ts` runs a corruption matrix (`{len-1, len/2, 16, 1}` truncations, 20 single-byte flips seeded across the buffer, extension, unrelated bytes) through all three entry points in a child process, asserting each variant is rejected and the code still runs, that intact data is still accepted, and that intact data for a different source is rejected. Without the fix the child crashes with the panic above (release) or the `Decoder::offsetOf` assertion (debug), or accepts corrupted data.

Existing coverage still passes: the `cachedData` tests in `test/js/node/vm/vm.test.ts`, and `test-vm-cached-data.js` (cross-process produce/consume), `test-vm-createcacheddata.js`, `test-vm-module-cached-data.js`, `test-vm-basic.js` from the Node suite.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 16 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts, test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->



