### PR TITLE
HTMLRewriter: distinguish empty from absent attributes, throw on invalid arguments

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -143,9 +143,9 @@ macro_rules! lol_content_ops {
             global_object: &JSGlobalObject,
             content: ZigString,
             content_options: Option<ContentOptions>,
-        ) -> JSValue {
+        ) -> JsResult<JSValue> {
             let Some(raw) = lolhtml::$Raw::from_ptr(self.$field.get()) else {
-                return $null_ret;
+                return Ok($null_ret);
             };
             let content_slice = content.to_slice();
             if callback(
@@ -155,9 +155,10 @@ macro_rules! lol_content_ops {
             )
             .is_err()
             {
-                return create_lolhtml_error(global_object);
+                let err = create_lolhtml_error(global_object);
+                return Err(global_object.throw_value(err));
             }
-            this_object
+            Ok(this_object)
         }
 
         $(
@@ -168,7 +169,7 @@ macro_rules! lol_content_ops {
                 global_object: &JSGlobalObject,
                 content: ZigString,
                 content_options: Option<ContentOptions>,
-            ) -> JSValue {
+            ) -> JsResult<JSValue> {
                 self.content_handler(
                     lolhtml::$Raw::$name,
                     call_frame.this(),
@@ -187,7 +188,7 @@ macro_rules! lol_content_ops {
                 call_frame: &CallFrame,
             ) -> JsResult<JSValue> {
                 let (content, opts) = eat_content_args(global, call_frame)?;
-                Ok(self.$name_(call_frame, global, content, opts))
+                self.$name_(call_frame, global, content, opts)
             }
         )*
     };
@@ -1623,6 +1624,20 @@ fn html_string_value(
     html_string_to_js(input, global_object)
 }
 
+/// lol-html's optional string getters (`lol_html_element_get_attribute`,
+/// `lol_html_doctype_*_get`) signal "absent" with a NULL `data` pointer; a
+/// present-but-empty value comes back with a non-null pointer and `len == 0`.
+/// Map only the former to `null` so `<div a="">` reads as `""`, not `null`.
+fn html_string_or_null(
+    input: lolhtml::HTMLString,
+    global_object: &JSGlobalObject,
+) -> JsResult<JSValue> {
+    if input.ptr.is_null() {
+        return Ok(JSValue::NULL);
+    }
+    html_string_to_js(input, global_object)
+}
+
 // ─────────────────────────── TextChunk ───────────────────────────────────
 
 #[bun_jsc::JsClass(no_construct, no_finalize, no_constructor)]
@@ -1717,42 +1732,27 @@ impl DocType {
 
     /// The doctype name.
     #[bun_jsc::host_fn(getter)]
-    pub fn name(&self, global_object: &JSGlobalObject) -> JSValue {
+    pub fn name(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         let Some(dt) = lolhtml::DocType::from_ptr(self.doctype.get()) else {
-            return JSValue::UNDEFINED;
+            return Ok(JSValue::UNDEFINED);
         };
-        let owned = dt.get_name();
-        let str = owned.slice();
-        if str.is_empty() {
-            return JSValue::NULL;
-        }
-        ZigString::init(str).to_js(global_object)
+        html_string_or_null(dt.get_name(), global_object)
     }
 
     #[bun_jsc::host_fn(getter)]
-    pub fn system_id(&self, global_object: &JSGlobalObject) -> JSValue {
+    pub fn system_id(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         let Some(dt) = lolhtml::DocType::from_ptr(self.doctype.get()) else {
-            return JSValue::UNDEFINED;
+            return Ok(JSValue::UNDEFINED);
         };
-        let owned = dt.get_system_id();
-        let str = owned.slice();
-        if str.is_empty() {
-            return JSValue::NULL;
-        }
-        ZigString::init(str).to_js(global_object)
+        html_string_or_null(dt.get_system_id(), global_object)
     }
 
     #[bun_jsc::host_fn(getter)]
-    pub fn public_id(&self, global_object: &JSGlobalObject) -> JSValue {
+    pub fn public_id(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         let Some(dt) = lolhtml::DocType::from_ptr(self.doctype.get()) else {
-            return JSValue::UNDEFINED;
+            return Ok(JSValue::UNDEFINED);
         };
-        let owned = dt.get_public_id();
-        let str = owned.slice();
-        if str.is_empty() {
-            return JSValue::NULL;
-        }
-        ZigString::init(str).to_js(global_object)
+        html_string_or_null(dt.get_public_id(), global_object)
     }
 
     #[bun_jsc::host_fn(method)]
@@ -2167,7 +2167,7 @@ impl Element {
             return Ok(JSValue::NULL);
         };
         if function.is_undefined_or_null() || !function.is_callable() {
-            return Ok(ZigString::init_utf8(b"Expected a function").to_js(global_object));
+            return Err(global_object.throw_type_error(format_args!("Expected a function")));
         }
 
         // `protected()` takes the gcProtect ref up front; if registration
@@ -2203,24 +2203,21 @@ impl Element {
             return Ok(JSValue::NULL);
         };
         let slice = name.to_slice();
-        let attr = el.get_attribute(slice.slice());
-
-        if attr.len == 0 {
-            return Ok(JSValue::NULL);
-        }
-
-        html_string_to_js(attr, global_object)
+        html_string_or_null(el.get_attribute(slice.slice()), global_object)
     }
 
     /// Returns a boolean indicating whether an attribute exists on the element.
-    pub fn has_attribute_(&self, global: &JSGlobalObject, name: ZigString) -> JSValue {
+    pub fn has_attribute_(&self, global: &JSGlobalObject, name: ZigString) -> JsResult<JSValue> {
         let Some(el) = lolhtml::Element::from_ptr(self.element.get()) else {
-            return JSValue::FALSE;
+            return Ok(JSValue::FALSE);
         };
         let slice = name.to_slice();
         match el.has_attribute(slice.slice()) {
-            Ok(b) => JSValue::from(b),
-            Err(_) => create_lolhtml_error(global),
+            Ok(b) => Ok(JSValue::from(b)),
+            Err(_) => {
+                let err = create_lolhtml_error(global);
+                Err(global.throw_value(err))
+            }
         }
     }
 
@@ -2231,9 +2228,9 @@ impl Element {
         global_object: &JSGlobalObject,
         name_: ZigString,
         value_: ZigString,
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         let Some(el) = lolhtml::Element::from_ptr(self.element.get()) else {
-            return JSValue::UNDEFINED;
+            return Ok(JSValue::UNDEFINED);
         };
 
         // Mutating the attribute Vec (push → possible realloc) invalidates the
@@ -2246,9 +2243,10 @@ impl Element {
             .set_attribute(name_slice.slice(), value_slice.slice())
             .is_err()
         {
-            return create_lolhtml_error(global_object);
+            let err = create_lolhtml_error(global_object);
+            return Err(global_object.throw_value(err));
         }
-        call_frame.this()
+        Ok(call_frame.this())
     }
 
     /// Removes the attribute.
@@ -2257,9 +2255,9 @@ impl Element {
         call_frame: &CallFrame,
         global_object: &JSGlobalObject,
         name: ZigString,
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         let Some(el) = lolhtml::Element::from_ptr(self.element.get()) else {
-            return JSValue::UNDEFINED;
+            return Ok(JSValue::UNDEFINED);
         };
 
         // Vec::remove shifts trailing elements and shrinks len, leaving any
@@ -2268,9 +2266,10 @@ impl Element {
 
         let name_slice = name.to_slice();
         if el.remove_attribute(name_slice.slice()).is_err() {
-            return create_lolhtml_error(global_object);
+            let err = create_lolhtml_error(global_object);
+            return Err(global_object.throw_value(err));
         }
-        call_frame.this()
+        Ok(call_frame.this())
     }
 
     // ── instance-method arg-decode wrappers (attribute ops) ──────────────
@@ -2301,7 +2300,7 @@ impl Element {
         let args = call_frame.arguments_old::<1>();
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), args.slice());
         let name = eat_zig_string(&mut iter, global)?;
-        Ok(self.has_attribute_(global, name))
+        self.has_attribute_(global, name)
     }
 
     pub fn set_attribute(
@@ -2313,7 +2312,7 @@ impl Element {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), args.slice());
         let name = eat_zig_string(&mut iter, global)?;
         let value = eat_zig_string(&mut iter, global)?;
-        Ok(self.set_attribute_(call_frame, global, name, value))
+        self.set_attribute_(call_frame, global, name, value)
     }
 
     pub fn remove_attribute(
@@ -2324,7 +2323,7 @@ impl Element {
         let args = call_frame.arguments_old::<1>();
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), args.slice());
         let name = eat_zig_string(&mut iter, global)?;
-        Ok(self.remove_attribute_(call_frame, global, name))
+        self.remove_attribute_(call_frame, global, name)
     }
 
     lol_content_ops! { Element, element, JSValue::UNDEFINED;
@@ -2422,13 +2421,14 @@ impl Element {
     }
 
     #[bun_jsc::host_fn(getter)]
-    pub fn get_attributes(&self, global_object: &JSGlobalObject) -> JSValue {
+    pub fn get_attributes(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         let Some(el) = lolhtml::Element::from_ptr(self.element.get()) else {
-            return JSValue::UNDEFINED;
+            return Ok(JSValue::UNDEFINED);
         };
 
         let Some(iter) = el.attributes() else {
-            return create_lolhtml_error(global_object);
+            let err = create_lolhtml_error(global_object);
+            return Err(global_object.throw_value(err));
         };
         let attr_iter = bun_core::heap::into_raw(Box::new(AttributeIterator {
             ref_count: Cell::new(1),
@@ -2444,7 +2444,7 @@ impl Element {
         self.attribute_iterators.with_mut(|v| v.push(attr_iter));
         // SAFETY: attr_iter is live (refcount==2 now); ownership is shared with
         // the GC wrapper via the intrusive refcount (`finalize` → `deref`).
-        unsafe { AttributeIterator::to_js_ptr(attr_iter, global_object) }
+        Ok(unsafe { AttributeIterator::to_js_ptr(attr_iter, global_object) })
     }
 }
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -796,3 +796,191 @@ payloads.forEach(type => {
     expect(calls).toBeGreaterThan(0);
   });
 });
+
+// lol-html reports an absent attribute with a NULL pointer and a
+// present-but-empty one with an empty string; they are not the same thing.
+describe("getAttribute distinguishes empty from absent", () => {
+  it("returns '' for present-but-empty and boolean attributes", async () => {
+    let got;
+    await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          got = {
+            explicitEmpty: el.getAttribute("a"),
+            boolean: el.getAttribute("b"),
+            valued: el.getAttribute("c"),
+            absent: el.getAttribute("zzz"),
+            hasExplicitEmpty: el.hasAttribute("a"),
+            hasBoolean: el.hasAttribute("b"),
+            hasAbsent: el.hasAttribute("zzz"),
+          };
+        },
+      })
+      .transform(new Response('<div a="" b c="v">t</div>'))
+      .text();
+    expect(got).toEqual({
+      explicitEmpty: "",
+      boolean: "",
+      valued: "v",
+      absent: null,
+      hasExplicitEmpty: true,
+      hasBoolean: true,
+      hasAbsent: false,
+    });
+  });
+
+  it("agrees with the attributes iterator", async () => {
+    let got;
+    await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          got = { iter: [...el.attributes], get: el.getAttribute("a") };
+        },
+      })
+      .transform(new Response('<div a="">t</div>'))
+      .text();
+    expect(got).toEqual({ iter: [["a", ""]], get: "" });
+  });
+
+  it("round-trips an attribute set to the empty string", async () => {
+    let got;
+    await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.setAttribute("x", "");
+          got = { value: el.getAttribute("x"), has: el.hasAttribute("x") };
+        },
+      })
+      .transform(new Response("<div>t</div>"))
+      .text();
+    expect(got).toEqual({ value: "", has: true });
+  });
+
+  it("removeAttribute works on a present-but-empty attribute", async () => {
+    let got;
+    await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.removeAttribute("a");
+          got = { value: el.getAttribute("a"), has: el.hasAttribute("a") };
+        },
+      })
+      .transform(new Response('<div a="">t</div>'))
+      .text();
+    expect(got).toEqual({ value: null, has: false });
+  });
+});
+
+describe("doctype publicId/systemId distinguish empty from absent", () => {
+  function readDoctype(html) {
+    let got;
+    new HTMLRewriter()
+      .onDocument({
+        doctype(d) {
+          got = { name: d.name, publicId: d.publicId, systemId: d.systemId };
+        },
+      })
+      .transform(html);
+    return got;
+  }
+
+  it("present but empty", () => {
+    expect(readDoctype('<!DOCTYPE html PUBLIC "" ""><div></div>')).toEqual({
+      name: "html",
+      publicId: "",
+      systemId: "",
+    });
+  });
+
+  it("absent", () => {
+    expect(readDoctype("<!DOCTYPE html><div></div>")).toEqual({
+      name: "html",
+      publicId: null,
+      systemId: null,
+    });
+  });
+
+  it("present with values", () => {
+    expect(
+      readDoctype(
+        '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"><div></div>',
+      ),
+    ).toEqual({
+      name: "html",
+      publicId: "-//W3C//DTD HTML 4.01//EN",
+      systemId: "http://www.w3.org/TR/html4/strict.dtd",
+    });
+  });
+});
+
+describe("invalid arguments throw instead of returning an error value", () => {
+  it("setAttribute with a forbidden character in the name throws", () => {
+    expect(() =>
+      new HTMLRewriter()
+        .on("div", {
+          element(el) {
+            el.setAttribute("a b", "1");
+          },
+        })
+        .transform(new Response("<div>t</div>")),
+    ).toThrow("character is forbidden in the attribute name");
+  });
+
+  it("setAttribute with an empty name throws", () => {
+    expect(() =>
+      new HTMLRewriter()
+        .on("div", {
+          element(el) {
+            el.setAttribute("", "1");
+          },
+        })
+        .transform(new Response("<div>t</div>")),
+    ).toThrow("Attribute name can't be empty.");
+  });
+
+  it("setAttribute failure leaves the element unchanged", async () => {
+    let after;
+    const out = await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          try {
+            el.setAttribute("a b", "1");
+          } catch {}
+          after = [...el.attributes];
+        },
+      })
+      .transform(new Response('<div x="1">t</div>'))
+      .text();
+    expect(after).toEqual([["x", "1"]]);
+    expect(out).toBe('<div x="1">t</div>');
+  });
+
+  it("setAttribute with an invalid name throws on string input too", () => {
+    expect(() =>
+      new HTMLRewriter()
+        .on("div", {
+          element(el) {
+            el.setAttribute("a b", "1");
+          },
+        })
+        .transform("<div>t</div>"),
+    ).toThrow("character is forbidden in the attribute name");
+  });
+
+  it("onEndTag with a non-function throws a TypeError", () => {
+    let err;
+    try {
+      new HTMLRewriter()
+        .on("div", {
+          element(el) {
+            el.onEndTag("nope");
+          },
+        })
+        .transform(new Response("<div>t</div>"));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.message).toBe("Expected a function");
+  });
+});


### PR DESCRIPTION
Two verified divergences from lol-html / Cloudflare Workers in the `HTMLRewriter` binding layer, both in `src/runtime/api/html_rewriter.rs`. Found by a differential fuzz run against `html-rewriter-wasm` (the same lol-html library Bun wraps), so each is a binding bug, not a parser disagreement.

### 1. `getAttribute()` returns `null` for present-but-empty attributes

```js
new HTMLRewriter().on("div", {
  element(e) {
    console.log(e.getAttribute("a"), e.getAttribute("b"), e.hasAttribute("b"));
  },
}).transform(new Response('<div a="" b>t</div>'));
// lol-html / Workers:  ""  ""  true
// bun 1.4.0:           null  null  true
```

`get_attribute_` treated `attr.len == 0` as "not found". lol-html's C API signals absence with a NULL `data` pointer and returns a non-null pointer with `len == 0` for a present-but-empty value ([`lol_html_element_get_attribute` doc](https://github.com/cloudflare/lol-html/blob/master/c-api/src/element.rs): "The `data` field will be NULL if an attribute with the given name doesn't exist"). So `<div a="">` and every boolean attribute (`disabled`, `checked`, `selected`, ...) read as `null` even though `hasAttribute()` said `true`, and `getAttribute` disagreed with `element.attributes` (which already yielded `["a", ""]`) on the same element.

The doctype `publicId` / `systemId` getters used the same `is_empty()` check, so `<!DOCTYPE html PUBLIC "" "">` reported `null` / `null` instead of `""` / `""`.

Fix: a shared `html_string_or_null` helper that maps only a NULL pointer to `null`, used by `getAttribute` and the three doctype getters.

### 2. `setAttribute()` with an invalid name returns an `Error` instead of throwing

```js
const r = e.setAttribute("a b", "1"); // invalid attribute name
// lol-html / Workers: throws
// bun 1.4.0: returns an Error instance, no throw, attribute silently not set
```

`set_attribute_` built the lol-html error and `return`ed it as a value through a `-> JSValue` binding. The same shape existed in `removeAttribute`, `hasAttribute`, the `attributes` getter, every content op (`before`/`after`/`replace`/`prepend`/`append`/`setInnerContent` on `Element`/`Comment`/`TextChunk`/`EndTag`/`DocEnd` via the `lol_content_ops!` macro), and `onEndTag` with a non-function argument, which returned the string `"Expected a function"`. All of these now return `JsResult<JSValue>` and throw, matching the `setTagName`, `EndTag.name`, and `Comment.text` setters that already threw in the same file.

`transform()`'s internal `Ok(error_value)` returns are untouched: `transform_` already converts those to a throw via `out.to_error()`.

### Verification

12 tests added to `test/js/workerd/html-rewriter.test.js`. 8 fail on `main` and pass with this change; the other 4 pin the behavior that must not change (absent still `null`, valued attributes, `removeAttribute` of an empty attribute, the element left unmodified after a failed `setAttribute`).

```
# main
 48 pass, 8 fail
# this branch
 56 pass, 0 fail
```

`test/js/web/html/html-rewriter-doctype.test.ts`, `test/regression/issue/htmlrewriter-additional-bugs.test.ts`, `test/js/workerd/html-rewriter-end-error.test.ts`, and `test/js/workerd/html-rewriter-leak.test.ts` still pass.
