### PR TITLE
bun:sqlite: fix lone-surrogate encoding, out-of-range BigInt binding, and stale column names

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -489,7 +489,28 @@ const results = query.all("hello", "goodbye");
 
 SQLite supports signed 64-bit integers, but JavaScript only supports signed 53-bit integers or arbitrary-precision integers with `bigint`.
 
-`bigint` input is supported everywhere, but by default `bun:sqlite` returns integers as `number` types. If you need to handle integers larger than 2^53, set the `safeIntegers` option to `true` when creating a `Database` instance. The option also validates that `bigint` values passed to `bun:sqlite` do not exceed 64 bits.
+`bigint` input is supported everywhere, but by default `bun:sqlite` returns integers as `number` types. If you need to handle integers larger than 2^53, set the `safeIntegers` option to `true` when creating a `Database` instance.
+
+Regardless of the `safeIntegers` setting, `bun:sqlite` throws a `RangeError` if a `bigint` value in a bound parameter does not fit in a signed 64-bit integer:
+
+```ts db.ts icon="/icons/typescript.svg"
+import { Database } from "bun:sqlite";
+
+const db = new Database(":memory:");
+db.run("CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)");
+
+const query = db.query("INSERT INTO test (value) VALUES ($value)");
+
+try {
+  query.run({ $value: BigInt(Number.MAX_SAFE_INTEGER) ** 2n });
+} catch (e) {
+  console.log(e.message);
+}
+```
+
+```txt
+BigInt value '81129638414606663681390495662081' is out of range
+```
 
 ### `safeIntegers: true`
 
@@ -507,27 +528,6 @@ console.log(result.max_int);
 
 ```txt
 9007199254741093n
-```
-
-When `safeIntegers` is `true`, `bun:sqlite` throws an error if a `bigint` value in a bound parameter exceeds 64 bits:
-
-```ts db.ts icon="/icons/typescript.svg" highlight={3}
-import { Database } from "bun:sqlite";
-
-const db = new Database(":memory:", { safeIntegers: true });
-db.run("CREATE TABLE test (id INTEGER PRIMARY KEY, value INTEGER)");
-
-const query = db.query("INSERT INTO test (value) VALUES ($value)");
-
-try {
-  query.run({ $value: BigInt(Number.MAX_SAFE_INTEGER) ** 2n });
-} catch (e) {
-  console.log(e.message);
-}
-```
-
-```txt
-BigInt value '81129638414606663681390495662081' is out of range
 ```
 
 ### `safeIntegers: false` (default)

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -2713,8 +2713,6 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexical
     CHECK_THIS
     CHECK_PREPARED
 
-    int count = sqlite3_column_count(castedThis->stmt);
-
     // We need to reset and step the statement to get fresh types,
     // but only do this for read-only statements to avoid side effects
     bool isReadOnly = sqlite3_stmt_readonly(castedThis->stmt) != 0;
@@ -2736,6 +2734,10 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexical
 
     // Step once to get to the first row (safe for read-only statements)
     int stepStatus = sqlite3_step(castedThis->stmt);
+
+    // Read the column count after the step: sqlite3_step() transparently
+    // re-prepares an expired statement, which can change the result shape.
+    int count = sqlite3_column_count(castedThis->stmt);
 
     // If we got a row, get types from it
     if (stepStatus == SQLITE_ROW) {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -509,8 +509,6 @@ public:
 
     bool need_update() { return version_db->version.load() != version; }
     void update_version() { version = version_db->version.load(); }
-    // Must be called right after sqlite3_step(), which is where SQLite
-    // transparently re-prepares an expired statement. `stmt` must be non-null.
     void updateColumnNamesIfNeeded(JSC::JSGlobalObject*);
 
     ~JSSQLStatement();
@@ -868,9 +866,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
 
 void JSSQLStatement::updateColumnNamesIfNeeded(JSC::JSGlobalObject* lexicalGlobalObject)
 {
-    // When the schema changes, sqlite3_step() re-prepares the statement behind our
-    // back, so the cached column names, validColumns, and result Structure can all
-    // describe a stale result shape (or the same value count under the old names).
+    // sqlite3_step() may transparently re-prepare under a changed result shape.
     const bool reprepared = sqlite3_stmt_status(stmt, SQLITE_STMTSTATUS_REPREPARE, 1) > 0;
     if (!hasExecuted || reprepared || need_update()) {
         initializeColumnNames(lexicalGlobalObject, this);
@@ -932,16 +928,12 @@ static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3
         if (roped->is8Bit() && roped->containsOnlyASCII()) {
             CHECK_BIND(sqlite3_bind_text(stmt, i, reinterpret_cast<const char*>(roped->span8().data()), roped->length(), SQLITE_TRANSIENT));
         } else {
-            // StringView::utf8() replaces lone surrogates with U+FFFD. sqlite3_bind_text16
-            // must not be used here: SQLite's UTF-16 decoder pairs a lone high surrogate with
-            // the next code unit (consuming it) and stores trailing ones as ill-formed UTF-8.
+            // Not sqlite3_bind_text16: SQLite's UTF-16 decoder stores lone surrogates as ill-formed UTF-8.
             auto utf8 = roped->utf8();
             CHECK_BIND(sqlite3_bind_text(stmt, i, utf8.data(), utf8.length(), SQLITE_TRANSIENT));
         }
 
     } else if (value.isHeapBigInt()) [[unlikely]] {
-        // SQLite integers are signed 64-bit. Reject anything that does not fit
-        // instead of letting JSBigInt::toBigInt64 silently wrap it modulo 2^64.
         JSBigInt* bigInt = value.asHeapBigInt();
         const auto min = JSBigInt::compare(bigInt, std::numeric_limits<int64_t>::min());
         const auto max = JSBigInt::compare(bigInt, std::numeric_limits<int64_t>::max());
@@ -2735,8 +2727,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexical
     // Step once to get to the first row (safe for read-only statements)
     int stepStatus = sqlite3_step(castedThis->stmt);
 
-    // Read the column count after the step: sqlite3_step() transparently
-    // re-prepares an expired statement, which can change the result shape.
+    // After the step: sqlite3_step() can re-prepare under a changed column count.
     int count = sqlite3_column_count(castedThis->stmt);
 
     // If we got a row, get types from it

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -926,11 +926,11 @@ static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3
         }
 
         if (roped->is8Bit() && roped->containsOnlyASCII()) {
-            CHECK_BIND(sqlite3_bind_text(stmt, i, reinterpret_cast<const char*>(roped->span8().data()), roped->length(), SQLITE_TRANSIENT));
+            CHECK_BIND(sqlite3_bind_text64(stmt, i, reinterpret_cast<const char*>(roped->span8().data()), roped->length(), SQLITE_TRANSIENT, SQLITE_UTF8));
         } else {
             // Not sqlite3_bind_text16: SQLite's UTF-16 decoder stores lone surrogates as ill-formed UTF-8.
             auto utf8 = roped->utf8();
-            CHECK_BIND(sqlite3_bind_text(stmt, i, utf8.data(), utf8.length(), SQLITE_TRANSIENT));
+            CHECK_BIND(sqlite3_bind_text64(stmt, i, utf8.data(), utf8.length(), SQLITE_TRANSIENT, SQLITE_UTF8));
         }
 
     } else if (value.isHeapBigInt()) [[unlikely]] {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -509,6 +509,9 @@ public:
 
     bool need_update() { return version_db->version.load() != version; }
     void update_version() { version = version_db->version.load(); }
+    // Must be called right after sqlite3_step(), which is where SQLite
+    // transparently re-prepares an expired statement. `stmt` must be non-null.
+    void updateColumnNamesIfNeeded(JSC::JSGlobalObject*);
 
     ~JSSQLStatement();
 
@@ -863,13 +866,24 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
     castedThis->_prototype.set(vm, castedThis, object);
 }
 
+void JSSQLStatement::updateColumnNamesIfNeeded(JSC::JSGlobalObject* lexicalGlobalObject)
+{
+    // When the schema changes, sqlite3_step() re-prepares the statement behind our
+    // back, so the cached column names, validColumns, and result Structure can all
+    // describe a stale result shape (or the same value count under the old names).
+    const bool reprepared = sqlite3_stmt_status(stmt, SQLITE_STMTSTATUS_REPREPARE, 1) > 0;
+    if (!hasExecuted || reprepared || need_update()) {
+        initializeColumnNames(lexicalGlobalObject, this);
+    }
+}
+
 void JSSQLStatement::destroy(JSC::JSCell* cell)
 {
     JSSQLStatement* thisObject = static_cast<JSSQLStatement*>(cell);
     thisObject->~JSSQLStatement();
 }
 
-static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3* db, sqlite3_stmt* stmt, int i, JSC::JSValue value, JSC::ThrowScope& scope, bool isSafeInteger)
+static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3* db, sqlite3_stmt* stmt, int i, JSC::JSValue value, JSC::ThrowScope& scope)
 {
     auto throwSQLiteError = [&]() -> void {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, WTF::String::fromUTF8(sqlite3_errmsg(db))));
@@ -917,31 +931,29 @@ static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3
 
         if (roped->is8Bit() && roped->containsOnlyASCII()) {
             CHECK_BIND(sqlite3_bind_text(stmt, i, reinterpret_cast<const char*>(roped->span8().data()), roped->length(), SQLITE_TRANSIENT));
-        } else if (!roped->is8Bit()) {
-            CHECK_BIND(sqlite3_bind_text16(stmt, i, roped->span16().data(), roped->length() * 2, SQLITE_TRANSIENT));
         } else {
+            // StringView::utf8() replaces lone surrogates with U+FFFD. sqlite3_bind_text16
+            // must not be used here: SQLite's UTF-16 decoder pairs a lone high surrogate with
+            // the next code unit (consuming it) and stores trailing ones as ill-formed UTF-8.
             auto utf8 = roped->utf8();
             CHECK_BIND(sqlite3_bind_text(stmt, i, utf8.data(), utf8.length(), SQLITE_TRANSIENT));
         }
 
     } else if (value.isHeapBigInt()) [[unlikely]] {
-        if (!isSafeInteger) {
+        // SQLite integers are signed 64-bit. Reject anything that does not fit
+        // instead of letting JSBigInt::toBigInt64 silently wrap it modulo 2^64.
+        JSBigInt* bigInt = value.asHeapBigInt();
+        const auto min = JSBigInt::compare(bigInt, std::numeric_limits<int64_t>::min());
+        const auto max = JSBigInt::compare(bigInt, std::numeric_limits<int64_t>::max());
+        if ((min == JSBigInt::ComparisonResult::GreaterThan || min == JSBigInt::ComparisonResult::Equal) && (max == JSBigInt::ComparisonResult::LessThan || max == JSBigInt::ComparisonResult::Equal)) [[likely]] {
             CHECK_BIND(sqlite3_bind_int64(stmt, i, JSBigInt::toBigInt64(value)));
         } else {
-            JSBigInt* bigInt = value.asHeapBigInt();
-            const auto min = JSBigInt::compare(bigInt, std::numeric_limits<int64_t>::min());
-            const auto max = JSBigInt::compare(bigInt, std::numeric_limits<int64_t>::max());
-            if ((min == JSBigInt::ComparisonResult::GreaterThan || min == JSBigInt::ComparisonResult::Equal) && (max == JSBigInt::ComparisonResult::LessThan || max == JSBigInt::ComparisonResult::Equal)) [[likely]] {
-                CHECK_BIND(sqlite3_bind_int64(stmt, i, JSBigInt::toBigInt64(value)));
-            } else {
-                auto bigIntString = bigInt->toString(lexicalGlobalObject, 10);
-                RETURN_IF_EXCEPTION(scope, false);
-                throwRangeError(lexicalGlobalObject, scope, makeString("BigInt value '"_s, bigIntString, "' is out of range"_s));
-                sqlite3_clear_bindings(stmt);
-                return false;
-            }
+            auto bigIntString = bigInt->toString(lexicalGlobalObject, 10);
+            RETURN_IF_EXCEPTION(scope, false);
+            throwRangeError(lexicalGlobalObject, scope, makeString("BigInt value '"_s, bigIntString, "' is out of range"_s));
+            sqlite3_clear_bindings(stmt);
+            return false;
         }
-
     } else if (JSC::JSArrayBufferView* buffer = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
         CHECK_BIND(sqlite3_bind_blob(stmt, i, buffer->vector(), buffer->byteLength(), SQLITE_TRANSIENT));
     } else {
@@ -953,7 +965,7 @@ static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3
 #undef CHECK_BIND
 }
 
-static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindingsMap& bindings, JSC::JSObject* target, JSC::ThrowScope& scope, sqlite3* db, VersionSqlite3* versionDB, sqlite3_stmt* stmt, bool safeIntegers, JSSQLStatement* statement)
+static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindingsMap& bindings, JSC::JSObject* target, JSC::ThrowScope& scope, sqlite3* db, VersionSqlite3* versionDB, sqlite3_stmt* stmt, JSSQLStatement* statement)
 {
     int count = 0;
 
@@ -1031,7 +1043,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
             }
             RETURN_IF_EXCEPTION(scope, {});
 
-            if (!rebindValue(globalObject, db, stmt, i + 1, value, scope, safeIntegers)) {
+            if (!rebindValue(globalObject, db, stmt, i + 1, value, scope)) {
                 return {};
             }
 
@@ -1059,7 +1071,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
 
             RETURN_IF_EXCEPTION(scope, {});
 
-            if (!rebindValue(globalObject, db, stmt, i + 1, value, scope, safeIntegers)) {
+            if (!rebindValue(globalObject, db, stmt, i + 1, value, scope)) {
                 return {};
             }
 
@@ -1110,7 +1122,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
 
             RETURN_IF_EXCEPTION(scope, {});
 
-            if (!rebindValue(globalObject, db, stmt, i + 1, value, scope, safeIntegers)) {
+            if (!rebindValue(globalObject, db, stmt, i + 1, value, scope)) {
                 return {};
             }
 
@@ -1122,7 +1134,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
     return jsNumber(count);
 }
 
-static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue values, JSC::ThrowScope& scope, sqlite3* db, VersionSqlite3* versionDB, sqlite3_stmt* stmt, SQLiteBindingsMap& bindings, bool safeIntegers, JSSQLStatement* statement)
+static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue values, JSC::ThrowScope& scope, sqlite3* db, VersionSqlite3* versionDB, sqlite3_stmt* stmt, SQLiteBindingsMap& bindings, JSSQLStatement* statement)
 {
     sqlite3_clear_bindings(stmt);
     JSC::JSArray* array = dynamicDowncast<JSC::JSArray>(values);
@@ -1130,7 +1142,7 @@ static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JS
 
     if (!array) {
         if (JSC::JSObject* object = values.getObject()) {
-            auto res = rebindObject(lexicalGlobalObject, bindings, object, scope, db, versionDB, stmt, safeIntegers, statement);
+            auto res = rebindObject(lexicalGlobalObject, bindings, object, scope, db, versionDB, stmt, statement);
             RETURN_IF_EXCEPTION(scope, {});
             return res;
         }
@@ -1166,7 +1178,7 @@ static JSC::JSValue rebindStatement(JSC::JSGlobalObject* lexicalGlobalObject, JS
             if (!value)
                 value = JSC::jsUndefined();
         }
-        if (!rebindValue(lexicalGlobalObject, db, stmt, i + 1, value, scope, safeIntegers)) {
+        if (!rebindValue(lexicalGlobalObject, db, stmt, i + 1, value, scope)) {
             return {};
         }
         RETURN_IF_EXCEPTION(scope, {});
@@ -1543,7 +1555,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
                 int count = sqlite3_bind_parameter_count(sql.stmt);
 
                 SQLiteBindingsMap bindings { static_cast<uint16_t>(count > -1 ? count : 0), strict };
-                JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, versionDB, sql.stmt, bindings, safeIntegers, nullptr);
+                JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, versionDB, sql.stmt, bindings, nullptr);
                 if (versionDB->handle() != db) [[unlikely]] {
                     // close() during binding deferred sqlite3_close via close_v2;
                     // finalizing sql.stmt on scope exit completes it.
@@ -2215,10 +2227,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionIterate, (JSC::JS
         castedThis->version_db->version++;
     }
 
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
-        RETURN_IF_EXCEPTION(scope, {});
-    }
+    castedThis->updateColumnNamesIfNeeded(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     JSValue result = jsNull();
     if (status == SQLITE_ROW) {
@@ -2267,10 +2277,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
         castedThis->version_db->version++;
     }
 
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
-        RETURN_IF_EXCEPTION(scope, {});
-    }
+    castedThis->updateColumnNamesIfNeeded(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     int columnCount = sqlite3_column_count(stmt);
     JSValue result = jsUndefined();
@@ -2360,10 +2368,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionGet, (JSC::JSGlob
         castedThis->version_db->version++;
     }
 
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
-        RETURN_IF_EXCEPTION(scope, {});
-    }
+    castedThis->updateColumnNamesIfNeeded(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     JSValue result = jsNull();
     if (status == SQLITE_ROW) {
@@ -2416,14 +2422,11 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
         castedThis->version_db->version++;
     }
 
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
-
-        if (scope.exception()) [[unlikely]] {
-            // Don't forget to reset before releasing the exception.
-            sqlite3_reset(stmt);
-            RELEASE_AND_RETURN(scope, {});
-        }
+    castedThis->updateColumnNamesIfNeeded(lexicalGlobalObject);
+    if (scope.exception()) [[unlikely]] {
+        // Don't forget to reset before releasing the exception.
+        sqlite3_reset(stmt);
+        RELEASE_AND_RETURN(scope, {});
     }
 
     size_t columnCount = sqlite3_column_count(stmt);
@@ -2505,12 +2508,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
         castedThis->version_db->version++;
     }
 
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
-        if (scope.exception()) [[unlikely]] {
-            sqlite3_reset(stmt);
-            RELEASE_AND_RETURN(scope, {});
-        }
+    castedThis->updateColumnNamesIfNeeded(lexicalGlobalObject);
+    if (scope.exception()) [[unlikely]] {
+        sqlite3_reset(stmt);
+        RELEASE_AND_RETURN(scope, {});
     }
 
     size_t columnCount = sqlite3_column_count(stmt);
@@ -2599,12 +2600,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
         castedThis->version_db->version++;
     }
 
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
-        if (scope.exception()) [[unlikely]] {
-            sqlite3_reset(stmt);
-            RELEASE_AND_RETURN(scope, {});
-        }
+    castedThis->updateColumnNamesIfNeeded(lexicalGlobalObject);
+    if (scope.exception()) [[unlikely]] {
+        sqlite3_reset(stmt);
+        RELEASE_AND_RETURN(scope, {});
     }
 
     while (status == SQLITE_ROW) {
@@ -2923,7 +2922,7 @@ JSC::JSValue JSSQLStatement::rebind(JSC::JSGlobalObject* lexicalGlobalObject, JS
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stmt = this->stmt;
 
-    auto val = rebindStatement(lexicalGlobalObject, values, scope, sqlite3_db_handle(stmt), this->version_db, stmt, this->m_bindingNames, this->useBigInt64, this);
+    auto val = rebindStatement(lexicalGlobalObject, values, scope, sqlite3_db_handle(stmt), this->version_db, stmt, this->m_bindingNames, this);
     RETURN_IF_EXCEPTION(scope, {});
 
     // A getter invoked while binding can finalize this statement; the callers

--- a/src/jsc/bindings/sqlite/lazy_sqlite3.h
+++ b/src/jsc/bindings/sqlite/lazy_sqlite3.h
@@ -24,7 +24,6 @@ typedef int (*lazy_sqlite3_bind_double_type)(sqlite3_stmt*, int, double);
 typedef int (*lazy_sqlite3_bind_int_type)(sqlite3_stmt*, int, int);
 typedef int (*lazy_sqlite3_bind_int64_type)(sqlite3_stmt*, int, sqlite3_int64);
 typedef int (*lazy_sqlite3_bind_null_type)(sqlite3_stmt*, int);
-typedef int (*lazy_sqlite3_bind_text_type)(sqlite3_stmt*, int, const char*, int, void (*)(void*));
 typedef int (*lazy_sqlite3_bind_text64_type)(sqlite3_stmt*, int, const char*, sqlite3_uint64, void (*)(void*), unsigned char encoding);
 typedef int (*lazy_sqlite3_bind_parameter_count_type)(sqlite3_stmt*);
 typedef int (*lazy_sqlite3_bind_parameter_index_type)(sqlite3_stmt*, const char* zName);
@@ -130,7 +129,6 @@ inline lazy_sqlite3_bind_int64_type lazy_sqlite3_bind_int64;
 inline lazy_sqlite3_bind_null_type lazy_sqlite3_bind_null;
 inline lazy_sqlite3_bind_parameter_count_type lazy_sqlite3_bind_parameter_count;
 inline lazy_sqlite3_bind_parameter_index_type lazy_sqlite3_bind_parameter_index;
-inline lazy_sqlite3_bind_text_type lazy_sqlite3_bind_text;
 inline lazy_sqlite3_bind_text64_type lazy_sqlite3_bind_text64;
 inline lazy_sqlite3_changes_type lazy_sqlite3_changes;
 inline lazy_sqlite3_changes64_type lazy_sqlite3_changes64;
@@ -225,7 +223,6 @@ inline lazy_sqlite3changeset_apply_type lazy_sqlite3changeset_apply;
 #define sqlite3_bind_null lazy_sqlite3_bind_null
 #define sqlite3_bind_parameter_count lazy_sqlite3_bind_parameter_count
 #define sqlite3_bind_parameter_index lazy_sqlite3_bind_parameter_index
-#define sqlite3_bind_text lazy_sqlite3_bind_text
 #define sqlite3_bind_text64 lazy_sqlite3_bind_text64
 #define sqlite3_changes lazy_sqlite3_changes
 #define sqlite3_changes64 lazy_sqlite3_changes64
@@ -361,7 +358,6 @@ inline int lazyLoadSQLite()
     lazy_sqlite3_bind_null = (lazy_sqlite3_bind_null_type)dlsym(sqlite3_handle, "sqlite3_bind_null");
     lazy_sqlite3_bind_parameter_count = (lazy_sqlite3_bind_parameter_count_type)dlsym(sqlite3_handle, "sqlite3_bind_parameter_count");
     lazy_sqlite3_bind_parameter_index = (lazy_sqlite3_bind_parameter_index_type)dlsym(sqlite3_handle, "sqlite3_bind_parameter_index");
-    lazy_sqlite3_bind_text = (lazy_sqlite3_bind_text_type)dlsym(sqlite3_handle, "sqlite3_bind_text");
     lazy_sqlite3_bind_text64 = (lazy_sqlite3_bind_text64_type)dlsym(sqlite3_handle, "sqlite3_bind_text64");
     lazy_sqlite3_changes = (lazy_sqlite3_changes_type)dlsym(sqlite3_handle, "sqlite3_changes");
     lazy_sqlite3_changes64 = (lazy_sqlite3_changes64_type)dlsym(sqlite3_handle, "sqlite3_changes64");

--- a/src/jsc/bindings/sqlite/lazy_sqlite3.h
+++ b/src/jsc/bindings/sqlite/lazy_sqlite3.h
@@ -25,7 +25,6 @@ typedef int (*lazy_sqlite3_bind_int_type)(sqlite3_stmt*, int, int);
 typedef int (*lazy_sqlite3_bind_int64_type)(sqlite3_stmt*, int, sqlite3_int64);
 typedef int (*lazy_sqlite3_bind_null_type)(sqlite3_stmt*, int);
 typedef int (*lazy_sqlite3_bind_text_type)(sqlite3_stmt*, int, const char*, int, void (*)(void*));
-typedef int (*lazy_sqlite3_bind_text16_type)(sqlite3_stmt*, int, const void*, int, void (*)(void*));
 typedef int (*lazy_sqlite3_bind_text64_type)(sqlite3_stmt*, int, const char*, sqlite3_uint64, void (*)(void*), unsigned char encoding);
 typedef int (*lazy_sqlite3_bind_parameter_count_type)(sqlite3_stmt*);
 typedef int (*lazy_sqlite3_bind_parameter_index_type)(sqlite3_stmt*, const char* zName);
@@ -132,7 +131,6 @@ inline lazy_sqlite3_bind_null_type lazy_sqlite3_bind_null;
 inline lazy_sqlite3_bind_parameter_count_type lazy_sqlite3_bind_parameter_count;
 inline lazy_sqlite3_bind_parameter_index_type lazy_sqlite3_bind_parameter_index;
 inline lazy_sqlite3_bind_text_type lazy_sqlite3_bind_text;
-inline lazy_sqlite3_bind_text16_type lazy_sqlite3_bind_text16;
 inline lazy_sqlite3_bind_text64_type lazy_sqlite3_bind_text64;
 inline lazy_sqlite3_changes_type lazy_sqlite3_changes;
 inline lazy_sqlite3_changes64_type lazy_sqlite3_changes64;
@@ -228,7 +226,6 @@ inline lazy_sqlite3changeset_apply_type lazy_sqlite3changeset_apply;
 #define sqlite3_bind_parameter_count lazy_sqlite3_bind_parameter_count
 #define sqlite3_bind_parameter_index lazy_sqlite3_bind_parameter_index
 #define sqlite3_bind_text lazy_sqlite3_bind_text
-#define sqlite3_bind_text16 lazy_sqlite3_bind_text16
 #define sqlite3_bind_text64 lazy_sqlite3_bind_text64
 #define sqlite3_changes lazy_sqlite3_changes
 #define sqlite3_changes64 lazy_sqlite3_changes64
@@ -365,7 +362,6 @@ inline int lazyLoadSQLite()
     lazy_sqlite3_bind_parameter_count = (lazy_sqlite3_bind_parameter_count_type)dlsym(sqlite3_handle, "sqlite3_bind_parameter_count");
     lazy_sqlite3_bind_parameter_index = (lazy_sqlite3_bind_parameter_index_type)dlsym(sqlite3_handle, "sqlite3_bind_parameter_index");
     lazy_sqlite3_bind_text = (lazy_sqlite3_bind_text_type)dlsym(sqlite3_handle, "sqlite3_bind_text");
-    lazy_sqlite3_bind_text16 = (lazy_sqlite3_bind_text16_type)dlsym(sqlite3_handle, "sqlite3_bind_text16");
     lazy_sqlite3_bind_text64 = (lazy_sqlite3_bind_text64_type)dlsym(sqlite3_handle, "sqlite3_bind_text64");
     lazy_sqlite3_changes = (lazy_sqlite3_changes_type)dlsym(sqlite3_handle, "sqlite3_changes");
     lazy_sqlite3_changes64 = (lazy_sqlite3_changes64_type)dlsym(sqlite3_handle, "sqlite3_changes64");

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2636,10 +2636,9 @@ it("decodes declared types leniently and accepts single-character declared types
 });
 
 describe("string parameters are encoded as well-formed UTF-8", () => {
-  // A lone surrogate must be replaced with U+FFFD, exactly like TextEncoder,
-  // node:sqlite, and better-sqlite3. The bind path must never hand raw UTF-16
-  // to SQLite: its decoder pairs a lone high surrogate with whatever code unit
-  // follows (consuming it) and stores trailing ones as ill-formed 3-byte runs.
+  // A lone surrogate must become U+FFFD, exactly like TextEncoder. SQLite's own
+  // UTF-16 decoder instead pairs a lone high surrogate with the following code
+  // unit (consuming it) and stores trailing ones as ill-formed 3-byte sequences.
   const cases = [
     ["lone high surrogate followed by a non-surrogate", "a\uD800b"],
     ["trailing lone high surrogate", "a\uD800"],
@@ -2747,6 +2746,34 @@ describe("prepared statements refresh cached column names after a schema change"
       b.run("ALTER TABLE t ADD COLUMN c TEXT DEFAULT 'x'");
     }
     expect(q.get()).toEqual({ a: 1, c: "x" });
+  });
+
+  it("schema change made by another process", async () => {
+    // https://github.com/oven-sh/bun/issues/1332
+    const file = tmpbase + `sqlite-xproc-${Date.now()}-${(Math.random() * 1e9) | 0}.db`;
+    using db = new Database(file, { create: true });
+    db.run("PRAGMA journal_mode = wal");
+    db.run("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, greeting TEXT)");
+    db.run("INSERT INTO foo (greeting) VALUES (?)", ["Welcome to bun!"]);
+    const q = db.query("SELECT * FROM foo");
+    expect(q.get()).toEqual({ id: 1, greeting: "Welcome to bun!" });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Database } = require("bun:sqlite");` +
+          `const d = new Database(${JSON.stringify(file)});` +
+          `d.run("ALTER TABLE foo RENAME COLUMN greeting TO greeting2");` +
+          `d.close();`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+
+    expect(q.get()).toEqual({ id: 1, greeting2: "Welcome to bun!" });
   });
 });
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2768,10 +2768,11 @@ describe("prepared statements refresh cached column names after a schema change"
           `d.close();`,
       ],
       env: bunEnv,
+      stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
 
     expect(q.get()).toEqual({ id: 1, greeting2: "Welcome to bun!" });
   });

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2775,6 +2775,25 @@ describe("prepared statements refresh cached column names after a schema change"
 
     expect(q.get()).toEqual({ id: 1, greeting2: "Welcome to bun!" });
   });
+
+  it("columnTypes reflects the new result shape after a schema change", () => {
+    using db = new Database(":memory:");
+    db.run("CREATE TABLE t (a INT)");
+    db.run("INSERT INTO t VALUES (1)");
+    const q = db.query("SELECT * FROM t");
+    expect(q.columnTypes).toEqual(["INTEGER"]);
+
+    // More columns: the array must grow, not stay truncated at the old count.
+    db.run("ALTER TABLE t ADD COLUMN b TEXT DEFAULT 'x'");
+    expect(q.columnTypes).toEqual(["INTEGER", "TEXT"]);
+
+    // Fewer columns: the array must shrink, not be padded with spurious "NULL"
+    // entries read from out-of-range column indexes.
+    db.run("DROP TABLE t");
+    db.run("CREATE TABLE t (z TEXT)");
+    db.run("INSERT INTO t VALUES ('y')");
+    expect(q.columnTypes).toEqual(["TEXT"]);
+  });
 });
 
 // The process-global SQLite database registry is shared by every Worker

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -108,8 +108,43 @@ describe("safeIntegers", () => {
     const query = db.query("INSERT INTO test (value) VALUES ($value)");
 
     expect(() => query.run({ $value: BigInt(Number.MAX_SAFE_INTEGER) ** 2n })).toThrow(RangeError);
+    // safeIntegers only controls how integers are returned. An out-of-range
+    // BigInt parameter is always rejected instead of being wrapped modulo 2^64.
     query.safeIntegers(false);
-    expect(() => query.run({ $value: BigInt(Number.MAX_SAFE_INTEGER) ** 2n })).not.toThrow(RangeError);
+    expect(() => query.run({ $value: BigInt(Number.MAX_SAFE_INTEGER) ** 2n })).toThrow(RangeError);
+  });
+
+  it("rejects BigInt parameters outside the signed 64-bit range in both modes", () => {
+    const outOfRange = [
+      2n ** 63n, // INT64_MAX + 1
+      -(2n ** 63n) - 1n, // INT64_MIN - 1
+      2n ** 64n + 5n, // previously wrapped to 5
+      -(2n ** 64n) - 5n, // previously wrapped to -5
+    ];
+    for (const safeIntegers of [false, true]) {
+      using db = new Database(":memory:", { safeIntegers });
+      const q = db.query("SELECT ? AS v");
+      for (const value of outOfRange) {
+        expect(() => q.get(value)).toThrow(RangeError);
+        expect(() => q.get(value)).toThrow(`BigInt value '${value}' is out of range`);
+      }
+    }
+  });
+
+  it("binds BigInt values at the signed 64-bit boundaries exactly in both modes", () => {
+    const inRange = [
+      [0n, "0"],
+      [2n ** 62n, "4611686018427387904"],
+      [2n ** 63n - 1n, "9223372036854775807"], // INT64_MAX
+      [-(2n ** 63n), "-9223372036854775808"], // INT64_MIN
+    ];
+    for (const safeIntegers of [false, true]) {
+      using db = new Database(":memory:", { safeIntegers });
+      for (const [value, text] of inRange) {
+        // CAST(... AS TEXT) reads the stored value back without Number precision loss.
+        expect(db.query("SELECT CAST(? AS TEXT) AS t").get(value)).toEqual({ t: text });
+      }
+    }
   });
 });
 
@@ -2553,15 +2588,14 @@ it("decodes non-UTF-8 column names leniently instead of dropping the column", ()
   db.close();
 });
 
-it("expands bound non-UTF-8 values in Statement#toString instead of returning an empty string", () => {
+it("expands bound values in Statement#toString instead of returning an empty string", () => {
   const db = new Database(":memory:");
   const stmt = db.prepare("SELECT ? AS x");
 
-  // A lone surrogate binds via sqlite3_bind_text16 and is stored by SQLite as
-  // invalid UTF-8. sqlite3_expanded_sql() then returns those bytes, which the
-  // strict decoder turned into a null string -> the whole toString() became "".
+  // A lone surrogate is sanitized to a single U+FFFD before it reaches SQLite,
+  // so the expanded SQL contains exactly one replacement character, never "".
   stmt.get("\uD800");
-  expect(String(stmt)).toBe("SELECT '\uFFFD\uFFFD\uFFFD' AS x");
+  expect(String(stmt)).toBe("SELECT '\uFFFD' AS x");
 
   // Valid values still round-trip.
   stmt.get("ok");
@@ -2599,6 +2633,121 @@ it("decodes declared types leniently and accepts single-character declared types
   s.all();
   expect(s.declaredTypes).toEqual(["INT\uFFFDGER"]);
   db.close();
+});
+
+describe("string parameters are encoded as well-formed UTF-8", () => {
+  // A lone surrogate must be replaced with U+FFFD, exactly like TextEncoder,
+  // node:sqlite, and better-sqlite3. The bind path must never hand raw UTF-16
+  // to SQLite: its decoder pairs a lone high surrogate with whatever code unit
+  // follows (consuming it) and stores trailing ones as ill-formed 3-byte runs.
+  const cases = [
+    ["lone high surrogate followed by a non-surrogate", "a\uD800b"],
+    ["trailing lone high surrogate", "a\uD800"],
+    ["lone low surrogate followed by a non-surrogate", "a\uDC00b"],
+    ["trailing lone low surrogate", "a\uDC00"],
+    ["only a lone high surrogate", "\uD800"],
+    ["well-formed surrogate pair", "a\uD83D\uDE00b"],
+    ["Latin-1 non-ASCII", "caf\u00E9"],
+    ["BMP non-Latin-1", "\u65E5\u672C\u8A9E"],
+  ];
+  const expectedHex = s => Buffer.from(new TextEncoder().encode(s)).toString("hex").toUpperCase();
+
+  it.each(cases)("%s, positional parameter", (_desc, input) => {
+    using db = new Database(":memory:");
+    expect(db.query("SELECT hex(CAST(? AS BLOB)) AS h, ? AS v").get(input, input)).toEqual({
+      h: expectedHex(input),
+      v: input.toWellFormed(),
+    });
+  });
+
+  it.each(cases)("%s, named parameter", (_desc, input) => {
+    using db = new Database(":memory:");
+    expect(db.query("SELECT hex(CAST($x AS BLOB)) AS h, $x AS v").get({ $x: input })).toEqual({
+      h: expectedHex(input),
+      v: input.toWellFormed(),
+    });
+  });
+
+  it.each(cases)("%s, db.run() exec path", (_desc, input) => {
+    using db = new Database(":memory:");
+    db.run("CREATE TABLE t (s TEXT)");
+    db.run("INSERT INTO t VALUES (?)", [input]);
+    expect(db.query("SELECT hex(CAST(s AS BLOB)) AS h, s AS v FROM t").get()).toEqual({
+      h: expectedHex(input),
+      v: input.toWellFormed(),
+    });
+  });
+
+  it("never writes bytes the database cannot round-trip as UTF-8", () => {
+    using db = new Database(":memory:");
+    // A lone high surrogate followed by "b" must NOT become U+10062 (the
+    // surrogate paired with the "b"), and a trailing one must NOT become the
+    // ill-formed CESU-8 bytes ED A0 80.
+    const h = s => db.query("SELECT hex(CAST(? AS BLOB)) AS h").get(s).h;
+    expect(h("a\uD800b")).toBe("61EFBFBD62");
+    expect(h("a\uD800")).toBe("61EFBFBD");
+  });
+});
+
+describe("prepared statements refresh cached column names after a schema change", () => {
+  // SQLite transparently re-prepares a statement when the schema changes. The
+  // cached column names and result object shape must be rebuilt to match.
+  it("ALTER TABLE ADD COLUMN issued through db.run()", () => {
+    using db = new Database(":memory:");
+    db.run("CREATE TABLE t (a INT)");
+    db.run("INSERT INTO t VALUES (1)");
+    const q = db.query("SELECT * FROM t");
+    expect(q.get()).toEqual({ a: 1 });
+
+    db.run("ALTER TABLE t ADD COLUMN b INT DEFAULT 42");
+    expect(q.get()).toEqual({ a: 1, b: 42 });
+    expect(q.all()).toEqual([{ a: 1, b: 42 }]);
+    expect(q.values()).toEqual([[1, 42]]);
+    expect(q.columnNames).toEqual(["a", "b"]);
+  });
+
+  it("DROP + CREATE with a renamed column does not mis-key the row", () => {
+    using db = new Database(":memory:");
+    db.run("CREATE TABLE t (a INT)");
+    db.run("INSERT INTO t VALUES (111)");
+    const q = db.query("SELECT * FROM t");
+    expect(q.get()).toEqual({ a: 111 });
+
+    // Same column count, different name. The new column's value must not be
+    // returned under the old column's name.
+    db.run("DROP TABLE t");
+    db.run("CREATE TABLE t (zzz TEXT)");
+    db.run("INSERT INTO t VALUES ('boom')");
+    expect(q.get()).toEqual({ zzz: "boom" });
+    expect(q.columnNames).toEqual(["zzz"]);
+  });
+
+  it("ALTER TABLE issued through a prepared statement", () => {
+    using db = new Database(":memory:");
+    db.run("CREATE TABLE t (a INT)");
+    db.run("INSERT INTO t VALUES (1)");
+    const q = db.query("SELECT * FROM t");
+    expect(q.get()).toEqual({ a: 1 });
+
+    using alter = db.prepare("ALTER TABLE t ADD COLUMN b INT DEFAULT 7");
+    alter.run();
+    expect(q.get()).toEqual({ a: 1, b: 7 });
+  });
+
+  it("schema change made by a second connection to the same file", () => {
+    const file = tmpbase + `sqlite-reprepare-${Date.now()}-${(Math.random() * 1e9) | 0}.db`;
+    using a = new Database(file, { create: true });
+    a.run("CREATE TABLE t (a INT)");
+    a.run("INSERT INTO t VALUES (1)");
+    const q = a.query("SELECT * FROM t");
+    expect(q.get()).toEqual({ a: 1 });
+
+    {
+      using b = new Database(file);
+      b.run("ALTER TABLE t ADD COLUMN c TEXT DEFAULT 'x'");
+    }
+    expect(q.get()).toEqual({ a: 1, c: "x" });
+  });
 });
 
 // The process-global SQLite database registry is shared by every Worker

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -5363,30 +5363,10 @@ describe("Unicode & Encoding Fuzzing Tests", () => {
       const result = await sql`SELECT text_data, description FROM unicode_fuzz WHERE id = ${i}`;
       expect(result).toHaveLength(1);
 
-      // SQLite's actual behavior with problematic Unicode:
-      // - Lone surrogates (\uD800, \uDFFF) bind via sqlite3_bind_text16 and are
-      //   stored by SQLite as invalid UTF-8 (WTF-8, e.g. ED A0 80). On read-back
-      //   those invalid bytes decode leniently to U+FFFD, matching node:sqlite.
-      // - BOM inverse (\uFFFE) is dropped by SQLite itself (stored as 0 bytes),
-      //   so it reads back as an empty string.
-      // - Null characters are preserved (not truncated).
-      const lenientlyReplaced: Record<string, string> = {
-        // 3 invalid bytes -> 3 replacement characters (maximal-subpart replacement)
-        "High surrogate (invalid alone)": "\uFFFD\uFFFD\uFFFD",
-        "Low surrogate (invalid alone)": "\uFFFD\uFFFD\uFFFD",
-      };
-      const droppedBySqlite = ["Byte order mark inverse"];
-
-      if (desc in lenientlyReplaced) {
-        // Invalid UTF-8 bytes decode leniently to U+FFFD rather than dropping the field.
-        expect(result[0].text_data).toBe(lenientlyReplaced[desc]);
-      } else if (droppedBySqlite.includes(desc)) {
-        // SQLite stores nothing for these, so they come back empty.
-        expect(result[0].text_data).toBe("");
-      } else {
-        // All other characters should be preserved exactly, including null bytes
-        expect(result[0].text_data).toBe(text);
-      }
+      // Strings are encoded to well-formed UTF-8 before binding (lone surrogates
+      // become U+FFFD, like TextEncoder), so everything else round-trips exactly,
+      // including embedded null bytes and the noncharacter U+FFFE.
+      expect(result[0].text_data).toBe(text.toWellFormed());
       expect(result[0].description).toBe(desc);
     }
 


### PR DESCRIPTION
Three binding-layer bugs in `bun:sqlite` where it diverges from `node:sqlite` and `better-sqlite3` running the same SQLite. The first two silently corrupt data.

### 1. Lone surrogates are stored as ill-formed UTF-8 and can consume the following character

```js
const { Database } = require("bun:sqlite");
const db = new Database(":memory:");
db.query("select hex(cast(? as blob)) h").get("a\ud800b").h // "61F09081A2": "a" + U+10062
db.query("select hex(cast(? as blob)) h").get("a\ud800").h  // "61EDA080":   "a" + raw CESU-8 surrogate bytes
// TextEncoder / node:sqlite / better-sqlite3: 61EFBFBD62, 61EFBFBD
```

`rebindValue` bound 16-bit strings with `sqlite3_bind_text16`, so SQLite's own UTF-16 decoder performed the conversion. That decoder pairs a lone high surrogate with whatever code unit follows (here `"b"`, producing U+10062 and consuming the `b`), and writes a trailing lone surrogate as the ill-formed 3-byte sequence `ED A0 80`. The database file then contains text that is not valid UTF-8, so other tools reading the file see corruption, and the stored text differs from the JS string in content as well as encoding.

Fix: always encode to UTF-8 with `WTF::StringView::utf8()`, which replaces lone surrogates with U+FFFD exactly like `TextEncoder` and every other string-to-bytes path in Bun, and bind with `sqlite3_bind_text`. `sqlite3_bind_text16` is no longer used, so its entry is removed from `lazy_sqlite3.h`.

This also fixes a second artifact of `bind_text16`: a string beginning with U+FEFF or U+FFFE used to have its first two bytes stripped by SQLite's UTF-16 BOM sniffer, so a bound `"\uFFFE"` came back as `""`. The test in `test/js/sql/sqlite-sql.test.ts` that documented both old behaviors is updated.

### 2. Out-of-range BigInt parameters are silently wrapped modulo 2^64

```js
db.query("select ? as v").get(2n ** 64n + 5n).v // 5
db.query("select ? as v").get(2n ** 63n).v      // -9223372036854775808
```

`rebindValue` only performed the int64 range check when `safeIntegers` was enabled; the default mode called `JSBigInt::toBigInt64`, which truncates to 64 bits. `node:sqlite` and `better-sqlite3` both throw a `RangeError` regardless of mode. better-sqlite3's `safeIntegers`, which Bun's option is modeled on, only controls how integers are returned, never whether BigInt input is validated. Silently storing `5` for `2n ** 64n + 5n` is the classic truncation bug for snowflake and other u64 identifiers.

Fix: always range-check the BigInt and throw the same `RangeError` the `safeIntegers` path already threw. The now-unused `safeIntegers`/`isSafeInteger` parameter is removed from the `rebindValue` / `rebindObject` / `rebindStatement` chain.

This is a behavior change. The previous behavior was covered by an `expect(...).not.toThrow(RangeError)` assertion and a sentence in `docs/runtime/sqlite.mdx`; both are updated here. If the silent wrapping was intentional, say so and I will revert this part.

### 3. A prepared statement's cached column names never refresh after SQLite re-prepares it

Fixes #1332

```js
db.run("create table t (a int)");
db.run("insert into t values (1)");
const q = db.query("select * from t");
q.get();                                             // { a: 1 }
db.run("alter table t add column b int default 42");
q.get();                                             // { a: 1 }   (want { a: 1, b: 42 })
q.values();                                          // [[1, 42]]  (values() reads the live column count)
```

After `DROP TABLE t; CREATE TABLE t (zzz TEXT)`, `q.get()` returns the new column's value under the old column's name, so any app that runs DDL at runtime can silently get mis-keyed rows.

`initializeColumnNames` is gated on a per-connection version counter that only increments when a non-read-only prepared statement steps. The multi-statement exec path used by `db.run()` / `db.exec()` never touches it, and schema changes made through another connection to the same file cannot touch it at all. Meanwhile SQLite transparently re-prepares the expired statement inside `sqlite3_step()`, so the live result shape and the cached column names and `Structure` diverge.

Fix: detect the re-prepare directly with `sqlite3_stmt_status(stmt, SQLITE_STMTSTATUS_REPREPARE, 1)` right after each `sqlite3_step()`. That works for any source of the schema change, including #1332's case of an `ALTER TABLE` issued by a separate process against a WAL database, which a per-connection counter can never observe. The six copies of the `!hasExecuted || need_update()` check are folded into one `updateColumnNamesIfNeeded` helper. `sqlite3_stmt_status` is added to `lazy_sqlite3.h` for the macOS dynamic-load path.

The `columnTypes` getter is a seventh `sqlite3_step()` site with the same class of bug: it captured `sqlite3_column_count` before the step, so after a schema change the returned array was truncated (more columns) or padded with spurious `"NULL"` entries read from out-of-range column indexes (fewer columns). The count is now read after the step.

### Not included

`new Database(path, {})` (and `{ readonly: false }`) failing with `SQLITE_MISUSE` because an options object zeroes the open flags was reported alongside these, but it already has an open PR, #32422, so it is not duplicated here.

### Performance

Release build (`--profile=release`, `bun-profile`), mitata, Xeon Platinum 8375C. Both binaries built from the same tree (`ffea69ae7c` base); the only difference is this PR's two `src/jsc/bindings/sqlite/` files. 3 interleaved rounds; mean of the per-run `avg` time.

| benchmark | before | after | Δ |
|---|---:|---:|---:|
| `SELECT * FROM t .all()` (200,000 rows × 5 cols) | 97.43 ms | 98.63 ms | +1.24% |
| `SELECT * FROM t .values()` (200,000 rows × 5 cols) | 96.52 ms | 96.94 ms | +0.44% |
| `SELECT * FROM s .all()` (100 rows × 3 cols) | 21.5 µs | 21.4 µs | -0.43% |
| INSERT 20,000× (2×ASCII str + int) — *unchanged path, noise control* | 23.30 ms | 23.43 ms | +0.57% |
| INSERT 20,000× (2×16-bit str + int) — *`bind_text16` → `utf8()` path* | 27.16 ms | 27.60 ms | +1.64% |
| INSERT 20,000× (2×BigInt + int) — *unconditional range check* | 24.13 ms | 23.46 ms | -2.77% |

Loading a large table via `.all()`/`.values()` is unchanged within noise. mitata's per-run min–max spread on the 200K-row `.all()` was 90–106 ms (±8%), so the +1.2% delta is well inside it. Structurally the new `sqlite3_stmt_status(…, SQLITE_STMTSTATUS_REPREPARE, 1)` call runs once per `.all()`/`.values()` invocation, not per row, so there is no added per-row work in the step loop.

The 16-bit string bind shows +1.6% against a +0.6% on the unchanged ASCII control; the residual ~1% is one extra temporary: `WTF::StringView::utf8()` allocates a `CString`, and `SQLITE_TRANSIENT` then copies it again, whereas `sqlite3_bind_text16` transcoded UTF-16→UTF-8 in place inside SQLite. BigInt binding is inside the noise band of the unchanged control.

<details><summary>Benchmark script</summary>

```js
import { run, bench, group } from "mitata";
import { Database } from "bun:sqlite";

const ROWS = 200_000;
const db = new Database(":memory:");
db.run("PRAGMA journal_mode = MEMORY");
db.run("PRAGMA synchronous = OFF");
db.run("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, email TEXT, blob TEXT, n INTEGER)");
{
  const ins = db.prepare("INSERT INTO t VALUES (?, ?, ?, ?, ?)");
  db.transaction(n => { for (let i = 0; i < n; i++) ins.run(i, `user ${i}`, `user${i}@example.com`, "ascii-payload-ascii-payload-ascii-payload", i * 7); })(ROWS);
}
const selAll = db.prepare("SELECT * FROM t");

group("read (per-row step path)", () => {
  bench(`.all()    [${ROWS} rows, 5 cols]`, () => selAll.all());
  bench(`.values() [${ROWS} rows, 5 cols]`, () => selAll.values());
});

const dbw = new Database(":memory:");
dbw.run("PRAGMA journal_mode = MEMORY");
dbw.run("PRAGMA synchronous = OFF");
dbw.run("CREATE TABLE w (a TEXT, b TEXT, c INTEGER)");
const insw = dbw.prepare("INSERT INTO w VALUES (?, ?, ?)");
const del = dbw.prepare("DELETE FROM w");
const asciiA = "the quick brown fox jumps over the lazy dog";
const asciiB = "hello world hello world hello world hello!!";
const wideA = "日本語テキスト — naïve façade résumé — Ω≈ç√∫";
const wideB = "emoji payload 😀😃😄😁😆🥹😂🤣😊😇 mixed";
const big = 9007199254740993n;

group("bind (rebindValue path)", () => {
  bench("INSERT 20k× (2×ASCII)",  () => { del.run(); for (let i = 0; i < 20_000; i++) insw.run(asciiA, asciiB, i); });
  bench("INSERT 20k× (2×16-bit)", () => { del.run(); for (let i = 0; i < 20_000; i++) insw.run(wideA, wideB, i); });
  bench("INSERT 20k× (2×BigInt)", () => { del.run(); for (let i = 0; i < 20_000; i++) insw.run(big, big + BigInt(i), i); });
});

const dbs = new Database(":memory:");
dbs.run("CREATE TABLE s (a INT, b INT, c INT)");
db.transaction(() => { const q = dbs.prepare("INSERT INTO s VALUES (?, ?, ?)"); for (let i = 0; i < 100; i++) q.run(i, i*2, i*3); })();
const selSmall = dbs.prepare("SELECT * FROM s");
group("read (small table)", () => { bench(".all() [100 rows, 3 cols]", () => selSmall.all()); });

await run();
```

</details>

### Rebase note

Rebased onto current `main` (third rebase; 21 commits touched these files since the previous base, including the `node:sqlite` implementation #32498, the close/finalize rework #36573/#36793, the bind re-entrancy fixes #37211/#37212, several dead-code and exception-check sweeps, and two docs passes). Conflicts and how they were resolved:

- `rebindValue` BigInt branch: `main` (#40410) added a `RETURN_IF_EXCEPTION` after `bigInt->toString()` inside the old `safeIntegers`-only range check. Kept that exception check inside this PR's now-unconditional range check.
- `rebindObject` / `rebindStatement` signatures: `main` (#37212) added a `VersionSqlite3* versionDB` parameter; this PR removes the `bool safeIntegers` parameter. The result has `versionDB` and no `safeIntegers`. The three call sites were merged the same way, keeping `main`'s `versionDB->handle() != db` close-during-bind checks.
- `rebindObject` slow path: `main` deleted the `getOwnPropertySlot` fallback branch that this PR had edited; took the deletion.
- `lazy_sqlite3.h`: `main` already provides `sqlite3_stmt_status` (with a fallback stub) and `sqlite3_bind_text64`, so this PR's header diff is now only the removal of the eight now-unused `sqlite3_bind_text` / `sqlite3_bind_text16` lines.
- `docs/runtime/sqlite.mdx`: `main`'s fact-check pass (#38899) already corrected "52-bit" to "53-bit" and the truncation wording; this PR's change on top is unchanged (drop the "`safeIntegers` also validates" sentence, move the `RangeError` example out of the `safeIntegers: true` subsection).

### Verification

All three reproduce on `bun v1.4.0` and on current `main`. In `test/js/bun/sqlite/sqlite.test.js`, 24 of the new or updated test cases fail with `src/` at `main` and pass with this change (160 of 161 pass under the debug+ASAN build; the one remaining failure, `#13082`, is a 99-iteration `Bun.gc(true)` loop that takes ~6.3 s under debug+ASAN and times out identically with `src/` at `main`). `test/js/sql/sqlite-sql.test.ts`, `test/js/bun/sqlite/column-types.test.js`, `test/js/bun/sqlite/sql-timezone.test.js`, `test/js/sql/sqlite-url-parsing.test.ts`, and `test/regression/issue/14709.test.ts` also pass. Two pre-existing debug-build timeouts in `sqlite-sql.test.ts` reproduce identically on a debug build of `main` without this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->
