### PR TITLE
Bun.serve: do not kill the process when a Response body stream errors

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2109,8 +2109,12 @@ where
                 stream_log!("returned a promise");
                 this.drain_microtasks();
 
-                match promise.status() {
-                    jsc::js_promise::Status::Pending => {
+                // `MarkHandled` matters for the Rejected arm: the promise
+                // settled before any reaction was attached, so without the
+                // flag the VM would report it as an unhandled rejection even
+                // though handle_reject_stream consumes it here.
+                match promise.unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled) {
+                    jsc::PromiseResult::Pending => {
                         stream_log!("promise still Pending");
                         if !this.flags.has_written_status() {
                             response_stream.sink.on_first_write = None;
@@ -2144,7 +2148,7 @@ where
                         ); // TODO: properly propagate exception upwards
                         // the response_stream should be GC'd
                     }
-                    jsc::js_promise::Status::Fulfilled => {
+                    jsc::PromiseResult::Fulfilled(_) => {
                         stream_log!("promise Fulfilled");
                         let mut readable_ref =
                             core::mem::take(&mut this.response_body_readable_stream_ref);
@@ -2154,15 +2158,25 @@ where
                         stream.done(global_this);
                         readable_ref.deinit();
                     }
-                    jsc::js_promise::Status::Rejected => {
+                    jsc::PromiseResult::Rejected(err) => {
                         stream_log!("promise Rejected");
+                        // Consuming the rejection here is what keeps it out of
+                        // the unhandledRejection reporter, so surface it here.
+                        // DEBUG_MODE already reports it in handle_reject_stream.
+                        if !DEBUG_MODE
+                            && let Some(server) = this.server
+                            && !err.is_empty_or_undefined_or_null()
+                        {
+                            // SAFETY: BACKREF; see drain_microtasks() re: the
+                            // const→mut cast.
+                            unsafe {
+                                (*std::ptr::from_ref::<VirtualMachine>((*server).vm()).cast_mut())
+                                    .run_error_handler(err, None);
+                            }
+                        }
                         let mut readable_ref =
                             core::mem::take(&mut this.response_body_readable_stream_ref);
-                        Self::handle_reject_stream(
-                            this,
-                            global_this,
-                            promise.result(global_this.vm()),
-                        );
+                        Self::handle_reject_stream(this, global_this, err);
                         stream.cancel(global_this);
                         readable_ref.deinit();
                     }
@@ -2960,6 +2974,16 @@ where
         if !HTTP3 && ended_response {
             req.end_already_responded_stream();
             return;
+        }
+        // Body bytes were already written: close without the terminating chunk
+        // (RFC 9112 section 7) so the client sees an incomplete message, not a
+        // truncated body that looks like a complete, successful response.
+        if let Some(resp) = req.resp {
+            let state = resp.state();
+            if state.is_http_write_called() && state.is_response_pending() {
+                req.force_close();
+                return;
+            }
         }
         req.end_stream(req.should_close_connection());
     }

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -1,0 +1,137 @@
+// An error thrown by a ReadableStream used as a Response body must never
+// escape as a global unhandledRejection. Bun's default unhandledRejection
+// policy exits the process, so before the fix a single bad request took the
+// entire server down.
+//
+// argv[2]: variant name (see `sources` below)
+// argv[3]: "development" to run the server with development: true
+//
+// Prints a single JSON object on stdout and exits 0.
+import net from "node:net";
+
+const variant = process.argv[2];
+const development = process.argv[3] === "development";
+
+// Set by the mid-stream variant so it only errors once its chunk has provably
+// reached the client socket, i.e. after the 200 response is committed on the
+// wire. Called from the raw request's data handler below.
+let midStreamResolve: (() => void) | undefined;
+
+const sources: Record<string, () => ReadableStream> = {
+  // Already errored by the time Bun.serve starts rendering the body.
+  "pull-throw": () =>
+    new ReadableStream({
+      pull(c) {
+        c.enqueue("x");
+        throw new Error("boom");
+      },
+    }),
+  "pull-async-reject": () =>
+    new ReadableStream({
+      async pull(c) {
+        c.enqueue("x");
+        throw new Error("boom");
+      },
+    }),
+  "controller-error": () =>
+    new ReadableStream({
+      pull(c) {
+        c.enqueue("x");
+        c.error(new Error("boom"));
+      },
+    }),
+  "start-async-reject": () =>
+    new ReadableStream({
+      async start() {
+        throw new Error("boom");
+      },
+    }),
+  // highWaterMark: 0 defers the first pull() until the server's own reader
+  // asks for data, so the stream is still readable when the server commits to
+  // streaming and only errors inside the microtask drain that follows.
+  "deferred-pull-throw": () =>
+    new ReadableStream(
+      {
+        pull() {
+          throw new Error("boom");
+        },
+      },
+      { highWaterMark: 0 },
+    ),
+  // Errors only after a chunk has already been flushed to the client.
+  "mid-stream-reject": () =>
+    new ReadableStream({
+      async pull(c) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        midStreamResolve = resolve;
+        c.enqueue("chunk-a");
+        await promise;
+        throw new Error("boom");
+      },
+    }),
+};
+
+const source = sources[variant];
+if (!source) {
+  console.error(`unknown variant: ${variant}`);
+  process.exit(3);
+}
+
+// Counting instead of relying on the default exit-on-unhandledRejection
+// policy gives the test an exact number and keeps the process alive long
+// enough to observe the wire either way.
+let unhandled = 0;
+process.on("unhandledRejection", () => {
+  unhandled++;
+});
+
+let errorCb = 0;
+await using server = Bun.serve({
+  port: 0,
+  development,
+  error() {
+    errorCb++;
+    return new Response("err-body", { status: 500 });
+  },
+  fetch() {
+    return new Response(source());
+  },
+});
+
+// Sends one request over a raw socket and returns everything received before
+// the server closed the connection, so the test can assert on the HTTP
+// framing. A forced close (ECONNRESET) is an expected, asserted-on outcome
+// for the mid-stream variant, so socket errors are not fatal.
+function rawRequest(): Promise<string> {
+  const chunks: Buffer[] = [];
+  return new Promise(resolve => {
+    const sock = net.connect(server.port, "127.0.0.1", () => {
+      sock.write("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    });
+    sock.on("data", d => {
+      chunks.push(d);
+      if (Buffer.concat(chunks).includes("chunk-a")) midStreamResolve?.();
+    });
+    sock.on("error", () => {});
+    sock.on("close", () => resolve(Buffer.concat(chunks).toString("latin1")));
+  });
+}
+
+const wire = await rawRequest();
+// A second request proves the server is still accepting and answering.
+const secondWire = await rawRequest();
+
+// Cycle the event loop so any stray rejected promise reaches the
+// unhandledRejection reporter before we declare success.
+for (let i = 0; i < 10; i++) await Bun.sleep(0);
+
+console.log(
+  JSON.stringify({
+    statusLine: wire.split("\r\n")[0],
+    cleanChunkedTerminator: wire.endsWith("0\r\n\r\n"),
+    body: wire.split("\r\n\r\n").slice(1).join("\r\n\r\n"),
+    errorCb,
+    unhandled,
+    secondStatusLine: secondWire.split("\r\n")[0],
+  }),
+);

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -37,69 +37,114 @@ test.concurrent.each([
   "controller-error",
   "start-async-reject",
   "deferred-pull-throw",
-])("%s: the rejection is handled and the error is still reported", async variant => {
-  const { stdout, stderr, exitCode } = await runFixture(variant);
-  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-    result: {
-      statusLine: "HTTP/1.1 200 OK",
-      cleanChunkedTerminator: true,
-      body: "0\r\n\r\n",
-      errorCb: 0,
-      unhandled: 0,
-      secondStatusLine: "HTTP/1.1 200 OK",
-    },
-    exitCode: 0,
-  });
-  // With `development: false` the unhandledRejection report used to be the
-  // only place the error surfaced; it must still reach stderr without it.
-  expect(stderr).toContain("boom");
-});
+])(
+  "%s: the rejection is handled and the error is still reported",
+  async variant => {
+    const { stdout, stderr, exitCode } = await runFixture(variant);
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: {
+        statusLine: "HTTP/1.1 200 OK",
+        cleanChunkedTerminator: true,
+        body: "0\r\n\r\n",
+        errorCb: 0,
+        unhandled: 0,
+        secondStatusLine: "HTTP/1.1 200 OK",
+      },
+      exitCode: 0,
+    });
+    // With `development: false` the unhandledRejection report used to be the
+    // only place the error surfaced; it must still reach stderr without it.
+    expect(stderr).toContain("boom");
+  },
+  60_000,
+);
 
 // Same under `development: true` (the DEBUG RequestContext monomorphization).
-test.concurrent("pull-throw in development mode: the rejection is handled", async () => {
-  const { stdout, stderr, exitCode } = await runFixture("pull-throw", "development");
-  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-    result: {
-      statusLine: "HTTP/1.1 200 OK",
-      cleanChunkedTerminator: true,
-      body: "0\r\n\r\n",
-      errorCb: 0,
-      unhandled: 0,
-      secondStatusLine: "HTTP/1.1 200 OK",
-    },
-    exitCode: 0,
-  });
-  expect(stderr).toContain("boom");
-});
+test.concurrent(
+  "pull-throw in development mode: the rejection is handled",
+  async () => {
+    const { stdout, stderr, exitCode } = await runFixture("pull-throw", "development");
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: {
+        statusLine: "HTTP/1.1 200 OK",
+        cleanChunkedTerminator: true,
+        body: "0\r\n\r\n",
+        errorCb: 0,
+        unhandled: 0,
+        secondStatusLine: "HTTP/1.1 200 OK",
+      },
+      exitCode: 0,
+    });
+    expect(stderr).toContain("boom");
+  },
+  60_000,
+);
 
 // The body errors after a chunk has already been flushed to the client. The
 // 200 is irrevocable at that point, but the connection must be closed without
 // the terminating `0\r\n\r\n` chunk (RFC 9112 section 7) so the client can
 // tell the body is incomplete.
-test.concurrent("mid-stream error: the chunked body is not terminated as complete", async () => {
-  const { stdout, exitCode } = await runFixture("mid-stream-reject");
-  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-    result: {
-      statusLine: "HTTP/1.1 200 OK",
-      cleanChunkedTerminator: false,
-      body: "7\r\nchunk-a\r\n",
-      errorCb: 0,
-      unhandled: 0,
-      secondStatusLine: "HTTP/1.1 200 OK",
-    },
-    exitCode: 0,
-  });
-});
+//
+// No stderr assertion: a rejection on this path already had a reaction
+// attached (it never became an unhandledRejection), so there is no lost
+// report for this change to restore. `development: false` intentionally
+// keeps handle_reject_stream quiet here, which the existing
+// serve-direct-readable-stream.test.ts and serve-stream-reject-flush-leak
+// tests rely on. The development-mode variant below asserts the report.
+test.concurrent(
+  "mid-stream error: the chunked body is not terminated as complete",
+  async () => {
+    const { stdout, exitCode } = await runFixture("mid-stream-reject");
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: {
+        statusLine: "HTTP/1.1 200 OK",
+        cleanChunkedTerminator: false,
+        body: "7\r\nchunk-a\r\n",
+        errorCb: 0,
+        unhandled: 0,
+        secondStatusLine: "HTTP/1.1 200 OK",
+      },
+      exitCode: 0,
+    });
+  },
+  60_000,
+);
+
+// Under `development: true` (the default for a plain script) the mid-stream
+// error is reported by handle_reject_stream, and the connection must still be
+// aborted: development mode never has a dev_server() for a plain Bun.serve,
+// so the dev fallback page cannot swallow the force-close.
+test.concurrent(
+  "mid-stream error in development mode: reported and not terminated as complete",
+  async () => {
+    const { stdout, stderr, exitCode } = await runFixture("mid-stream-reject", "development");
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: {
+        statusLine: "HTTP/1.1 200 OK",
+        cleanChunkedTerminator: false,
+        body: "7\r\nchunk-a\r\n",
+        errorCb: 0,
+        unhandled: 0,
+        secondStatusLine: "HTTP/1.1 200 OK",
+      },
+      exitCode: 0,
+    });
+    expect(stderr).toContain("boom");
+  },
+  60_000,
+);
 
 // The whole point: with Bun's default unhandledRejection policy (no handler
 // installed), a single request whose Response body errors must not exit the
 // server process.
-test.concurrent("a stream body error does not kill the server process", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const server = Bun.serve({
+test.concurrent(
+  "a stream body error does not kill the server process",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const server = Bun.serve({
         port: 0,
         development: false,
         fetch() {
@@ -113,13 +158,15 @@ test.concurrent("a stream body error does not kill the server process", async ()
       for (let i = 0; i < 10; i++) await Bun.sleep(0);
       console.log("alive", res.status);
       server.stop(true);`,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "alive 200\n", exitCode: 0 });
-  // The error must still be surfaced to the operator.
-  expect(stderr).toContain("boom");
-});
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "alive 200\n", exitCode: 0 });
+    // The error must still be surfaced to the operator.
+    expect(stderr).toContain("boom");
+  },
+  60_000,
+);

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -1,0 +1,125 @@
+// A `Response` body backed by a `ReadableStream` whose source errors must not
+// take the whole server down. Before the fix:
+//   1. The rejection from the stream pump was never given a handler, so it
+//      reached the global unhandledRejection reporter, whose default policy
+//      exits the process: one bad request was a whole-process outage.
+//   2. With `development: false` that unhandled rejection was also the only
+//      thing that reported the error at all.
+//   3. A body that errored after chunks were already sent was still terminated
+//      with a clean `0\r\n\r\n`, so the client could not tell the truncated
+//      body apart from a complete one.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+const fixture = join(import.meta.dir, "serve-stream-body-error-fixture.ts");
+
+async function runFixture(variant: string, ...extra: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture, variant, ...extra],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// The wire-level contract for a stream source that errors before producing any
+// body bytes is unchanged: the Response's own status and headers go out with
+// an empty chunked body and the server `error()` callback is NOT invoked (see
+// "throw on pull renders headers, does not call error handler" in
+// serve.test.ts). What changes is that the rejection no longer reaches the
+// unhandledRejection reporter; it is reported directly instead.
+test.concurrent.each([
+  "pull-throw",
+  "pull-async-reject",
+  "controller-error",
+  "start-async-reject",
+  "deferred-pull-throw",
+])("%s: the rejection is handled and the error is still reported", async variant => {
+  const { stdout, stderr, exitCode } = await runFixture(variant);
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: true,
+      body: "0\r\n\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+  // With `development: false` the unhandledRejection report used to be the
+  // only place the error surfaced; it must still reach stderr without it.
+  expect(stderr).toContain("boom");
+});
+
+// Same under `development: true` (the DEBUG RequestContext monomorphization).
+test.concurrent("pull-throw in development mode: the rejection is handled", async () => {
+  const { stdout, stderr, exitCode } = await runFixture("pull-throw", "development");
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: true,
+      body: "0\r\n\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+  expect(stderr).toContain("boom");
+});
+
+// The body errors after a chunk has already been flushed to the client. The
+// 200 is irrevocable at that point, but the connection must be closed without
+// the terminating `0\r\n\r\n` chunk (RFC 9112 section 7) so the client can
+// tell the body is incomplete.
+test.concurrent("mid-stream error: the chunked body is not terminated as complete", async () => {
+  const { stdout, exitCode } = await runFixture("mid-stream-reject");
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: false,
+      body: "7\r\nchunk-a\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+});
+
+// The whole point: with Bun's default unhandledRejection policy (no handler
+// installed), a single request whose Response body errors must not exit the
+// server process.
+test.concurrent("a stream body error does not kill the server process", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const server = Bun.serve({
+        port: 0,
+        development: false,
+        fetch() {
+          return new Response(new ReadableStream({ pull() { throw new Error("boom"); } }));
+        },
+      });
+      const res = await fetch(server.url);
+      await res.arrayBuffer();
+      // Tick the event loop past the unhandledRejection checkpoint that used
+      // to exit the process before this line was reached.
+      for (let i = 0; i < 10; i++) await Bun.sleep(0);
+      console.log("alive", res.status);
+      server.stop(true);`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({ stdout: "alive 200\n", exitCode: 0 });
+  // The error must still be surfaced to the operator.
+  expect(stderr).toContain("boom");
+});

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -37,48 +37,40 @@ test.concurrent.each([
   "controller-error",
   "start-async-reject",
   "deferred-pull-throw",
-])(
-  "%s: the rejection is handled and the error is still reported",
-  async variant => {
-    const { stdout, stderr, exitCode } = await runFixture(variant);
-    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-      result: {
-        statusLine: "HTTP/1.1 200 OK",
-        cleanChunkedTerminator: true,
-        body: "0\r\n\r\n",
-        errorCb: 0,
-        unhandled: 0,
-        secondStatusLine: "HTTP/1.1 200 OK",
-      },
-      exitCode: 0,
-    });
-    // With `development: false` the unhandledRejection report used to be the
-    // only place the error surfaced; it must still reach stderr without it.
-    expect(stderr).toContain("boom");
-  },
-  60_000,
-);
+])("%s: the rejection is handled and the error is still reported", async variant => {
+  const { stdout, stderr, exitCode } = await runFixture(variant);
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: true,
+      body: "0\r\n\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+  // With `development: false` the unhandledRejection report used to be the
+  // only place the error surfaced; it must still reach stderr without it.
+  expect(stderr).toContain("boom");
+});
 
 // Same under `development: true` (the DEBUG RequestContext monomorphization).
-test.concurrent(
-  "pull-throw in development mode: the rejection is handled",
-  async () => {
-    const { stdout, stderr, exitCode } = await runFixture("pull-throw", "development");
-    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-      result: {
-        statusLine: "HTTP/1.1 200 OK",
-        cleanChunkedTerminator: true,
-        body: "0\r\n\r\n",
-        errorCb: 0,
-        unhandled: 0,
-        secondStatusLine: "HTTP/1.1 200 OK",
-      },
-      exitCode: 0,
-    });
-    expect(stderr).toContain("boom");
-  },
-  60_000,
-);
+test.concurrent("pull-throw in development mode: the rejection is handled", async () => {
+  const { stdout, stderr, exitCode } = await runFixture("pull-throw", "development");
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: true,
+      body: "0\r\n\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+  expect(stderr).toContain("boom");
+});
 
 // The body errors after a chunk has already been flushed to the client. The
 // 200 is irrevocable at that point, but the connection must be closed without
@@ -91,60 +83,50 @@ test.concurrent(
 // keeps handle_reject_stream quiet here, which the existing
 // serve-direct-readable-stream.test.ts and serve-stream-reject-flush-leak
 // tests rely on. The development-mode variant below asserts the report.
-test.concurrent(
-  "mid-stream error: the chunked body is not terminated as complete",
-  async () => {
-    const { stdout, exitCode } = await runFixture("mid-stream-reject");
-    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-      result: {
-        statusLine: "HTTP/1.1 200 OK",
-        cleanChunkedTerminator: false,
-        body: "7\r\nchunk-a\r\n",
-        errorCb: 0,
-        unhandled: 0,
-        secondStatusLine: "HTTP/1.1 200 OK",
-      },
-      exitCode: 0,
-    });
-  },
-  60_000,
-);
+test.concurrent("mid-stream error: the chunked body is not terminated as complete", async () => {
+  const { stdout, exitCode } = await runFixture("mid-stream-reject");
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: false,
+      body: "7\r\nchunk-a\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+});
 
 // Under `development: true` (the default for a plain script) the mid-stream
 // error is reported by handle_reject_stream, and the connection must still be
 // aborted: development mode never has a dev_server() for a plain Bun.serve,
 // so the dev fallback page cannot swallow the force-close.
-test.concurrent(
-  "mid-stream error in development mode: reported and not terminated as complete",
-  async () => {
-    const { stdout, stderr, exitCode } = await runFixture("mid-stream-reject", "development");
-    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
-      result: {
-        statusLine: "HTTP/1.1 200 OK",
-        cleanChunkedTerminator: false,
-        body: "7\r\nchunk-a\r\n",
-        errorCb: 0,
-        unhandled: 0,
-        secondStatusLine: "HTTP/1.1 200 OK",
-      },
-      exitCode: 0,
-    });
-    expect(stderr).toContain("boom");
-  },
-  60_000,
-);
+test.concurrent("mid-stream error in development mode: reported and not terminated as complete", async () => {
+  const { stdout, stderr, exitCode } = await runFixture("mid-stream-reject", "development");
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: false,
+      body: "7\r\nchunk-a\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+  expect(stderr).toContain("boom");
+});
 
 // The whole point: with Bun's default unhandledRejection policy (no handler
 // installed), a single request whose Response body errors must not exit the
 // server process.
-test.concurrent(
-  "a stream body error does not kill the server process",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const server = Bun.serve({
+test.concurrent("a stream body error does not kill the server process", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const server = Bun.serve({
         port: 0,
         development: false,
         fetch() {
@@ -158,15 +140,13 @@ test.concurrent(
       for (let i = 0; i < 10; i++) await Bun.sleep(0);
       console.log("alive", res.status);
       server.stop(true);`,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({ stdout: "alive 200\n", exitCode: 0 });
-    // The error must still be surfaced to the operator.
-    expect(stderr).toContain("boom");
-  },
-  60_000,
-);
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({ stdout: "alive 200\n", exitCode: 0 });
+  // The error must still be surfaced to the operator.
+  expect(stderr).toContain("boom");
+});


### PR DESCRIPTION
### Problem

Any error in a `ReadableStream` used as a `Response` body under `Bun.serve` (a `throw` in `pull()`, `controller.error(e)`, a rejected async `pull`/`start`) escaped as a **global unhandled rejection**, whose default policy exits the process. One bad request was a whole-process outage, reachable from completely ordinary code (a DB cursor erroring mid-stream, a file read failing, an upstream fetch aborting inside a proxied body).

```js
const server = Bun.serve({
  port: 0,
  fetch() {
    return new Response(new ReadableStream({
      pull(c) { c.enqueue("x"); throw new Error("boom"); },
    }));
  },
});
await fetch(server.url).then(r => r.arrayBuffer());
console.log("still alive"); // never prints: the process exits 1
```

```
error: boom
      at pull (repro.ts:5:26)
```

A second, independent bug: a body that errored **after chunks were already sent** was still terminated with a clean `0\r\n\r\n` chunk, so the client received a `200` with `curl` exit 0 and no way to tell the truncated body apart from a complete one.

### Cause

`do_render_stream` drains microtasks before inspecting the promise `assignToStream` returned, so for these sources the `readStreamIntoSink` pump has usually already rejected by then. The `Rejected` arm called `handle_reject_stream` directly without attaching a reaction or marking the promise as handled, so JSC reported it as unhandled. (The `Pending` arm attaches `on_reject_stream` via `then_with_value`, which does mark it handled, which is why only the synchronously-settling cases died.)

`handle_reject_stream` then unconditionally ended with `end_stream()`, which sends the terminating chunk.

### Fix (`src/runtime/server/RequestContext.rs`)

1. Unwrap the promise with `PromiseUnwrapMode::MarkHandled` (the same pattern `process_on_error_promise` already uses) so the rejection consumed by the `Rejected` arm is never reported as unhandled.
2. In production mode, report the consumed error through the VM's error reporter from that arm. The unhandled rejection used to be the only thing that surfaced it there; development mode already reports it inside `handle_reject_stream`.
3. In `handle_reject_stream`, once body bytes have been written (`HTTP_WRITE_CALLED`) and the response is still pending, `force_close()` the connection instead of sending the clean terminating chunk, so the client sees an incomplete message (RFC 9112 section 7).

Not changed, on purpose:

- A source that errors **before** any body bytes still sends the Response's own status and headers with an empty chunked body, and the server `error()` callback is still not invoked. That contract is pinned by the existing `serve.test.ts` "throw on pull renders headers, does not call error handler" tests, which were deliberately set to that expectation in #4251.
- A rejection that arrives on the **async** path (`on_reject_stream`, i.e. the source errors while `assignToStream`'s promise is still pending) already had a reaction attached, so it never became an unhandled rejection and `development: false` never reported it. Item 2 only restores the report that item 1 removes; it does not start reporting on the async path, which the existing `serve-direct-readable-stream.test.ts` ("parked rejecting pull()") and `serve-stream-reject-flush-leak.test.ts` tests pin to staying quiet. `development: true` (the default) already reports on both paths via `handle_reject_stream`, and a test covers that.

### Tests

`test/js/bun/http/serve-stream-body-error.test.ts` + fixture. 0/9 pass on the unfixed build, each failing on the signal it pins:
- 5 error-source variants (sync `pull` throw, async `pull` reject, `controller.error`, async `start` reject, `highWaterMark: 0` deferred pull): `unhandled` 1 -> 0, and the error still reaches stderr with `development: false`.
- the same under `development: true` (the debug `RequestContext` monomorphization).
- a literal process-survival test under the default unhandledRejection policy (exit 1 -> 0).
- a mid-stream error, in both `development` modes: the raw wire no longer ends in `0\r\n\r\n` after a body chunk, and `development: true` still reports it.

`test/js/bun/http/serve.test.ts`, `serve-direct-readable-stream.test.ts`, `serve-stream-reject-flush-leak.test.ts`, `async-iterator-stream.test.ts`, `body-stream.test.ts`, and `bun-server.test.ts` all pass unchanged (the 8 failures in the container are pre-existing IPv6/root/egress environment issues that fail identically on `main`).
