### PR TITLE
install: match npm's version resolution for prerelease ranges, || groups, and `*`

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1816,12 +1816,23 @@ impl PackageManifest {
             return FindVersionResult::Err(FindVersionError::NotFound);
         }
 
+        // `*` resolves to the `latest` dist-tag like npm does, so give it the
+        // dist-tag age filter: when `latest` is too recent it falls back to an
+        // older version from the same list (release or prerelease), which the
+        // range scans below cannot do for a range without a prerelease
+        // comparator.
+        if group.is_star() {
+            let latest =
+                self.find_by_dist_tag_with_filter(b"latest", minimum_release_age_ms, exclusions);
+            if !matches!(latest, FindVersionResult::Err(FindVersionError::NotFound)) {
+                return latest;
+            }
+        }
+
         if let Some(result) = self.find_by_dist_tag(b"latest") {
             // npm prefers the `latest` dist-tag over every other satisfying
-            // version whenever it satisfies the range, and accepts it
-            // unconditionally for `*` (which a prerelease-only package never
-            // satisfies otherwise).
-            if group.is_star() || group.satisfies(result.version, group_buf, &self.string_buf) {
+            // version whenever it satisfies the range.
+            if group.satisfies(result.version, group_buf, &self.string_buf) {
                 if Self::is_package_version_too_recent(result.package, min_age_ms) {
                     newest_filtered = Some(result.version);
                 }

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1628,9 +1628,13 @@ pub enum FindVersionResult<'a> {
 
 impl<'a> FindVersionResult<'a> {
     pub fn unwrap(self) -> Option<FindResult<'a>> {
+        self.found()
+    }
+
+    pub fn found(&self) -> Option<FindResult<'a>> {
         match self {
-            FindVersionResult::Found(result) => Some(result),
-            FindVersionResult::FoundWithFilter { result, .. } => Some(result),
+            FindVersionResult::Found(result) => Some(*result),
+            FindVersionResult::FoundWithFilter { result, .. } => Some(*result),
             FindVersionResult::Err(_) => None,
         }
     }
@@ -1796,11 +1800,13 @@ impl PackageManifest {
         };
         debug_assert!(self.pkg.has_extended_manifest);
 
-        let left = group.head.head.range.left;
         let mut newest_filtered: Option<Semver::Version> = None;
 
-        if left.op == Semver::range::Op::Eql {
-            let result = self.find_by_version(left.version);
+        // Fast path: the whole range is one exact version. An exact version
+        // that is only the first `||` alternative does not qualify; every
+        // alternative has to be evaluated.
+        if let Some(exact) = group.get_exact_version() {
+            let result = self.find_by_version(exact);
             if let Some(r) = result {
                 if Self::is_package_version_too_recent(r.package, min_age_ms) {
                     return FindVersionResult::Err(FindVersionError::TooRecent);
@@ -1811,39 +1817,31 @@ impl PackageManifest {
         }
 
         if let Some(result) = self.find_by_dist_tag(b"latest") {
-            if group.satisfies(result.version, group_buf, &self.string_buf) {
+            // npm prefers the `latest` dist-tag over every other satisfying
+            // version whenever it satisfies the range, and accepts it
+            // unconditionally for `*` (which a prerelease-only package never
+            // satisfies otherwise).
+            if group.is_star() || group.satisfies(result.version, group_buf, &self.string_buf) {
                 if Self::is_package_version_too_recent(result.package, min_age_ms) {
                     newest_filtered = Some(result.version);
                 }
                 if newest_filtered.is_none() {
-                    if group.flags.is_set(Semver::query::Flags::PRE) {
-                        if left
-                            .version
-                            .order(result.version, group_buf, &self.string_buf)
-                            == core::cmp::Ordering::Equal
-                        {
-                            return FindVersionResult::Found(result);
-                        }
-                    } else {
-                        return FindVersionResult::Found(result);
-                    }
+                    return FindVersionResult::Found(result);
                 }
             }
         }
 
-        if let Some(result) = self.search_version_list(
+        let from_releases = self.search_version_list(
             self.pkg.releases.keys.get(&self.versions),
             self.pkg.releases.values.get(&self.package_versions),
             group,
             group_buf,
             min_age_ms,
             &mut newest_filtered,
-        ) {
-            return result;
-        }
+        );
 
         if group.flags.is_set(Semver::query::Flags::PRE) {
-            if let Some(result) = self.search_version_list(
+            if let Some(from_prereleases) = self.search_version_list(
                 self.pkg.prereleases.keys.get(&self.versions),
                 self.pkg.prereleases.values.get(&self.package_versions),
                 group,
@@ -1851,8 +1849,31 @@ impl PackageManifest {
                 min_age_ms,
                 &mut newest_filtered,
             ) {
-                return result;
+                // npm picks the highest satisfying version overall: a range
+                // with a prerelease comparator can be satisfied by a
+                // prerelease that is higher than every satisfying release.
+                let prerelease_is_higher = match (
+                    from_releases.as_ref().and_then(|r| r.found()),
+                    from_prereleases.found(),
+                ) {
+                    (Some(release), Some(prerelease)) => {
+                        release.version.order(
+                            prerelease.version,
+                            &self.string_buf,
+                            &self.string_buf,
+                        ) == core::cmp::Ordering::Less
+                    }
+                    // the releases list had no satisfying version
+                    _ => true,
+                };
+                if prerelease_is_higher {
+                    return from_prereleases;
+                }
             }
+        }
+
+        if let Some(result) = from_releases {
+            return result;
         }
 
         if newest_filtered.is_some() {
@@ -1867,62 +1888,69 @@ impl PackageManifest {
         group: &Semver::query::Group,
         group_buf: &[u8],
     ) -> Option<FindResult<'_>> {
-        let left = group.head.head.range.left;
-        // Fast path: exact version
-        if left.op == Semver::range::Op::Eql {
-            return self.find_by_version(left.version);
+        // Fast path: the whole range is one exact version. An exact version
+        // that is only the first `||` alternative does not qualify; every
+        // alternative has to be evaluated.
+        if let Some(exact) = group.get_exact_version() {
+            return self.find_by_version(exact);
         }
 
         if let Some(result) = self.find_by_dist_tag(b"latest") {
-            if group.satisfies(result.version, group_buf, &self.string_buf) {
-                if group.flags.is_set(Semver::query::Flags::PRE) {
-                    if left
-                        .version
-                        .order(result.version, group_buf, &self.string_buf)
-                        == core::cmp::Ordering::Equal
-                    {
-                        // if prerelease, use latest if semver+tag match range exactly
-                        return Some(result);
-                    }
-                } else {
-                    return Some(result);
-                }
+            // npm prefers the `latest` dist-tag over every other satisfying
+            // version whenever it satisfies the range, and accepts it
+            // unconditionally for `*` (which a prerelease-only package never
+            // satisfies otherwise).
+            if group.is_star() || group.satisfies(result.version, group_buf, &self.string_buf) {
+                return Some(result);
             }
         }
 
-        {
-            // This list is sorted at serialization time.
-            let releases = self.pkg.releases.keys.get(&self.versions);
-            let mut i = releases.len();
-
-            while i > 0 {
-                let version = releases[i - 1];
-
-                if group.satisfies(version, group_buf, &self.string_buf) {
-                    return Some(FindResult {
-                        version,
-                        package: &self.pkg.releases.values.get(&self.package_versions)[i - 1],
-                    });
-                }
-                i -= 1;
-            }
-        }
+        let best_release = self.find_highest_satisfying(self.pkg.releases, group, group_buf);
 
         if group.flags.is_set(Semver::query::Flags::PRE) {
-            let prereleases = self.pkg.prereleases.keys.get(&self.versions);
-            let mut i = prereleases.len();
-            while i > 0 {
-                let version = prereleases[i - 1];
+            if let Some(prerelease) =
+                self.find_highest_satisfying(self.pkg.prereleases, group, group_buf)
+            {
+                // npm picks the highest satisfying version overall: a range
+                // with a prerelease comparator can be satisfied by a
+                // prerelease that is higher than every satisfying release.
+                return Some(match best_release {
+                    Some(release)
+                        if release.version.order(
+                            prerelease.version,
+                            &self.string_buf,
+                            &self.string_buf,
+                        ) == core::cmp::Ordering::Greater =>
+                    {
+                        release
+                    }
+                    _ => prerelease,
+                });
+            }
+        }
 
-                // This list is sorted at serialization time.
-                if group.satisfies(version, group_buf, &self.string_buf) {
-                    let packages = self.pkg.prereleases.values.get(&self.package_versions);
-                    return Some(FindResult {
-                        version,
-                        package: &packages[i - 1],
-                    });
-                }
-                i -= 1;
+        best_release
+    }
+
+    /// The list is sorted by version at serialization time, so the first
+    /// satisfying entry found while scanning backwards is the highest
+    /// satisfying version in the list.
+    fn find_highest_satisfying(
+        &self,
+        list: ExternVersionMap,
+        group: &Semver::query::Group,
+        group_buf: &[u8],
+    ) -> Option<FindResult<'_>> {
+        let versions = list.keys.get(&self.versions);
+        let mut i = versions.len();
+        while i > 0 {
+            i -= 1;
+            let version = versions[i];
+            if group.satisfies(version, group_buf, &self.string_buf) {
+                return Some(FindResult {
+                    version,
+                    package: &list.values.get(&self.package_versions)[i],
+                });
             }
         }
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1560,7 +1560,16 @@ impl PackageManifest {
             if group.satisfies(version, group_buf, &self.string_buf) {
                 let package = &packages[i];
                 if Self::is_package_version_too_recent(package, minimum_release_age_ms) {
-                    if newest_filtered.is_none() {
+                    // `newest_filtered` is shared by the release and
+                    // prerelease scans: keep the highest filtered version.
+                    let is_newer = match *newest_filtered {
+                        Some(existing) => {
+                            existing.order(version, &self.string_buf, &self.string_buf)
+                                == core::cmp::Ordering::Less
+                        }
+                        None => true,
+                    };
+                    if is_newer {
                         *newest_filtered = Some(version);
                     }
                     prev_package_blocked_from_age = Some(package);

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1822,8 +1822,16 @@ impl PackageManifest {
         if group.is_star_literal() {
             let latest =
                 self.find_by_dist_tag_with_filter(b"latest", minimum_release_age_ms, exclusions);
-            if !matches!(latest, FindVersionResult::Err(FindVersionError::NotFound)) {
+            if latest.found().is_some() {
                 return latest;
+            }
+            // Every version in the `latest` channel is age-filtered: remember
+            // the newest one and fall through, so an old enough version from
+            // the other list can still match (and the scans can report it).
+            if latest.latest_is_filtered() {
+                if let Some(tag) = self.find_by_dist_tag(b"latest") {
+                    newest_filtered = Some(tag.version);
+                }
             }
         }
 
@@ -1849,6 +1857,7 @@ impl PackageManifest {
             &mut newest_filtered,
         );
 
+        let mut best = from_releases;
         if group.flags.is_set(Semver::query::Flags::PRE) {
             if let Some(from_prereleases) = self.search_version_list(
                 self.pkg.prereleases.keys.get(&self.versions),
@@ -1862,7 +1871,7 @@ impl PackageManifest {
                 // with a prerelease comparator can be satisfied by a
                 // prerelease that is higher than every satisfying release.
                 let prerelease_is_higher = match (
-                    from_releases.as_ref().and_then(|r| r.found()),
+                    best.as_ref().and_then(|r| r.found()),
                     from_prereleases.found(),
                 ) {
                     (Some(release), Some(prerelease)) => {
@@ -1876,12 +1885,26 @@ impl PackageManifest {
                     _ => true,
                 };
                 if prerelease_is_higher {
-                    return from_prereleases;
+                    best = Some(from_prereleases);
                 }
             }
         }
 
-        if let Some(result) = from_releases {
+        if let Some(result) = best {
+            // A newer satisfying version was skipped by the age filter in the
+            // other list (or was the `latest` dist-tag): report it.
+            if let (Some(found), Some(newer)) = (result.found(), newest_filtered) {
+                if found
+                    .version
+                    .order(newer, &self.string_buf, &self.string_buf)
+                    == core::cmp::Ordering::Less
+                {
+                    return FindVersionResult::FoundWithFilter {
+                        result: found,
+                        newest_filtered,
+                    };
+                }
+            }
             return result;
         }
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1816,12 +1816,10 @@ impl PackageManifest {
             return FindVersionResult::Err(FindVersionError::NotFound);
         }
 
-        // `*` resolves to the `latest` dist-tag like npm does, so give it the
-        // dist-tag age filter: when `latest` is too recent it falls back to an
-        // older version from the same list (release or prerelease), which the
-        // range scans below cannot do for a range without a prerelease
-        // comparator.
-        if group.is_star() {
+        // `*` means the `latest` dist-tag (like npm), so it takes the dist-tag
+        // age filter: a too recent `latest` falls back to an older version of
+        // the same list, which the range scans below skip for prereleases.
+        if group.is_star_literal() {
             let latest =
                 self.find_by_dist_tag_with_filter(b"latest", minimum_release_age_ms, exclusions);
             if !matches!(latest, FindVersionResult::Err(FindVersionError::NotFound)) {
@@ -1907,11 +1905,12 @@ impl PackageManifest {
         }
 
         if let Some(result) = self.find_by_dist_tag(b"latest") {
-            // npm prefers the `latest` dist-tag over every other satisfying
-            // version whenever it satisfies the range, and accepts it
-            // unconditionally for `*` (which a prerelease-only package never
-            // satisfies otherwise).
-            if group.is_star() || group.satisfies(result.version, group_buf, &self.string_buf) {
+            // npm prefers a satisfying `latest` dist-tag over every other
+            // satisfying version, and `*` accepts `latest` unconditionally
+            // (a prerelease-only package never satisfies `*` otherwise).
+            if group.is_star_literal()
+                || group.satisfies(result.version, group_buf, &self.string_buf)
+            {
                 return Some(result);
             }
         }

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -524,7 +524,10 @@ impl Group {
 
     #[inline]
     pub fn eql(&self, rhs: &Group) -> bool {
-        self.head.eql(&rhs.head)
+        // The literal `*` resolves differently from structurally identical
+        // ranges like `>=0.0.0` (it prefers the `latest` dist-tag), so
+        // star-ness is part of query equality.
+        self.is_star_literal() == rhs.is_star_literal() && self.head.eql(&rhs.head)
     }
 
     pub fn to_version(&self) -> Version {

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -350,6 +350,8 @@ pub struct Flags;
 impl Flags {
     pub const PRE: usize = 1;
     pub const BUILD: usize = 0;
+    /// The range literal was exactly `*`.
+    pub const STAR: usize = 2;
 }
 
 pub struct Group {
@@ -510,6 +512,14 @@ impl Group {
             && self.head.head.next.is_none()
             && left.version.is_zero()
             && !self.flags.is_set(Flags::BUILD)
+    }
+
+    /// The range literal was exactly `*`, unlike [`Group::is_star`] which also
+    /// matches equivalent shapes like `>=0.0.0` and `x`. npm only treats the
+    /// literal `*` as "the `latest` dist-tag".
+    #[inline]
+    pub fn is_star_literal(&self) -> bool {
+        self.flags.is_set(Flags::STAR)
     }
 
     #[inline]
@@ -849,6 +859,13 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
         tail: None,
         flags: FlagsBitSet::init_empty(),
     };
+
+    // npm special-cases the literal range `*` (it resolves to the `latest`
+    // dist-tag); record it here because the parsed form (`>=0.0.0`) is
+    // indistinguishable from ranges npm does not special-case, like `x`.
+    if strings::trim(input, &strings::WHITESPACE_CHARS) == b"*" {
+        list.flags.set_value(Flags::STAR, true);
+    }
 
     let mut token = Token::default();
 

--- a/test/cli/install/bun-install-version-resolution.test.ts
+++ b/test/cli/install/bun-install-version-resolution.test.ts
@@ -1,0 +1,234 @@
+import { file } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Checks that `bun install` picks the same version npm does for npm ranges.
+// Every expectation in this file was verified against npm 11 (and
+// npm-pick-manifest directly) using the same packuments served from a local
+// registry. The registry only has to serve packuments because resolution runs
+// with `--lockfile-only`, so tarballs are never requested.
+
+type Packages = Record<string, { versions: string[]; latest?: string }>;
+
+async function resolve(packages: Packages, dependencies: Record<string, string>) {
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const name = decodeURIComponent(new URL(req.url).pathname.slice(1));
+      const pkg = packages[name];
+      if (!pkg) return new Response("not found", { status: 404 });
+      return Response.json({
+        name,
+        "dist-tags": pkg.latest ? { latest: pkg.latest } : {},
+        versions: Object.fromEntries(
+          pkg.versions.map(version => [
+            version,
+            { name, version, dist: { tarball: `${server.url.origin}/${name}-${version}.tgz` } },
+          ]),
+        ),
+      });
+    },
+  });
+
+  using dir = tempDir("version-resolution", {
+    "package.json": JSON.stringify({ name: "test-pkg", version: "1.0.0", dependencies }),
+    "bunfig.toml": `[install]\ncache = false\nregistry = "${server.url.origin}/"\nsaveTextLockfile = true\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--lockfile-only"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  let resolved: Record<string, string> = {};
+  if (exitCode === 0) {
+    const lockfile = await file(join(String(dir), "bun.lock")).text();
+    const lock = JSON.parse(lockfile.replace(/,(\s*[\]}])/g, "$1"));
+    resolved = Object.fromEntries(
+      Object.entries(lock.packages as Record<string, string[]>).map(([name, entry]) => [
+        name,
+        entry[0].slice(name.length + 1),
+      ]),
+    );
+  }
+  return { resolved, stdout, stderr, exitCode };
+}
+
+describe.concurrent("bun install version resolution", () => {
+  // A satisfying prerelease that is higher than the best satisfying stable
+  // release must win. npm: 1.2.0-alpha.1
+  test("prerelease above the best matching stable is chosen", async () => {
+    const { resolved, stderr, exitCode } = await resolve(
+      { "pre-above-stable": { versions: ["1.1.1", "1.2.0-alpha.1", "2.0.0"], latest: "2.0.0" } },
+      { "pre-above-stable": "<1.2.0-alpha.2" },
+    );
+    expect(resolved["pre-above-stable"]).toBe("1.2.0-alpha.1");
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  });
+
+  // npm: 2.0.0-rc.1 (1.2.0 and 2.0.0-rc.1 both satisfy, the prerelease is higher)
+  test("prerelease upper bound is reachable when a lower stable also satisfies", async () => {
+    const { resolved } = await resolve(
+      { "rc-upper-bound": { versions: ["1.2.0", "2.0.0-rc.1", "3.0.0"], latest: "3.0.0" } },
+      { "rc-upper-bound": "<=2.0.0-rc.1" },
+    );
+    expect(resolved["rc-upper-bound"]).toBe("2.0.0-rc.1");
+  });
+
+  // npm: 2.1.0 for both spellings. The first `||` alternative being an exact
+  // version must not short-circuit the rest of the group.
+  test("exact version first in an || group still considers the other alternatives", async () => {
+    const { resolved } = await resolve(
+      { "or-exact": { versions: ["1.0.0", "2.0.0", "2.1.0"], latest: "2.1.0" } },
+      { "or-exact": "1.0.0 || ^2.0.0" },
+    );
+    expect(resolved["or-exact"]).toBe("2.1.0");
+  });
+
+  test("|| resolution does not depend on the order of alternatives", async () => {
+    const packages: Packages = { "or-reversed": { versions: ["1.0.0", "2.0.0", "2.1.0"], latest: "2.1.0" } };
+    const first = await resolve(packages, { "or-reversed": "1.0.0 || ^2.0.0" });
+    const second = await resolve(packages, { "or-reversed": "^2.0.0 || 1.0.0" });
+    expect(first.resolved["or-reversed"]).toBe("2.1.0");
+    expect(second.resolved["or-reversed"]).toBe("2.1.0");
+  });
+
+  // Same as above, but `latest` does not satisfy the range so the version
+  // lists have to be scanned. npm: 2.1.0
+  test("exact version first in an || group, latest dist-tag outside the range", async () => {
+    const { resolved } = await resolve(
+      { "or-scan": { versions: ["1.0.0", "2.0.0", "2.1.0", "3.0.0"], latest: "3.0.0" } },
+      { "or-scan": "1.0.0 || ^2.0.0" },
+    );
+    expect(resolved["or-scan"]).toBe("2.1.0");
+  });
+
+  // npm: 1.0.0. The exact alternative is the only one with a matching version.
+  test("exact version in an || group is used when it is the only match", async () => {
+    const { resolved } = await resolve(
+      { "or-only-exact": { versions: ["1.0.0", "2.0.0"], latest: "2.0.0" } },
+      { "or-only-exact": "1.0.0 || ^3.0.0" },
+    );
+    expect(resolved["or-only-exact"]).toBe("1.0.0");
+  });
+
+  // npm resolves `*` to the `latest` dist-tag. A package with only
+  // prereleases must install instead of failing with "No version matching".
+  test("star range on a package with only prereleases resolves to the latest dist-tag", async () => {
+    const { resolved, stderr, exitCode } = await resolve(
+      { "only-pre": { versions: ["1.0.0-beta.1", "1.0.0-beta.2"], latest: "1.0.0-beta.2" } },
+      { "only-pre": "*" },
+    );
+    expect(stderr).not.toContain("No version matching");
+    expect(resolved["only-pre"]).toBe("1.0.0-beta.2");
+    expect(exitCode).toBe(0);
+  });
+
+  // npm: 2.0.0-beta.1. For `*` the latest dist-tag wins even when it is a
+  // prerelease and stable versions exist.
+  test("star range follows a prerelease latest dist-tag", async () => {
+    const { resolved } = await resolve(
+      { "star-pre-latest": { versions: ["1.0.0", "2.0.0-beta.1"], latest: "2.0.0-beta.1" } },
+      { "star-pre-latest": "*" },
+    );
+    expect(resolved["star-pre-latest"]).toBe("2.0.0-beta.1");
+  });
+
+  test("star range on a package with stable versions resolves to latest", async () => {
+    const { resolved } = await resolve(
+      { "star-stable": { versions: ["1.0.0", "2.0.0"], latest: "2.0.0" } },
+      { "star-stable": "*" },
+    );
+    expect(resolved["star-stable"]).toBe("2.0.0");
+  });
+
+  // npm prefers a satisfying `latest` dist-tag over higher satisfying
+  // versions, for stable ranges and prerelease ranges alike.
+  test("a satisfying latest dist-tag is preferred over higher versions", async () => {
+    const held_back = await resolve(
+      { "held-back": { versions: ["1.0.0", "1.1.0", "1.2.0"], latest: "1.1.0" } },
+      { "held-back": "^1.0.0" },
+    );
+    expect(held_back.resolved["held-back"]).toBe("1.1.0");
+
+    const prerelease_latest = await resolve(
+      { "pre-latest": { versions: ["1.0.0-0", "1.0.0-8"], latest: "1.0.0-0" } },
+      { "pre-latest": "^1.0.0-0" },
+    );
+    expect(prerelease_latest.resolved["pre-latest"]).toBe("1.0.0-0");
+
+    // npm: 1.2.0. latest satisfies `<=2.0.0-rc.1`, so it wins over the higher
+    // satisfying prerelease.
+    const stable_latest_in_pre_range = await resolve(
+      { "rc-with-latest": { versions: ["1.2.0", "2.0.0-rc.1"], latest: "1.2.0" } },
+      { "rc-with-latest": "<=2.0.0-rc.1" },
+    );
+    expect(stable_latest_in_pre_range.resolved["rc-with-latest"]).toBe("1.2.0");
+
+    // npm: 1.2.4 (latest satisfies), not 1.3.0.
+    const pre_range_latest_stable = await resolve(
+      { "pre-range-latest": { versions: ["1.2.3-alpha.1", "1.2.4", "1.3.0"], latest: "1.2.4" } },
+      { "pre-range-latest": "^1.2.3-alpha.1" },
+    );
+    expect(pre_range_latest_stable.resolved["pre-range-latest"]).toBe("1.2.4");
+  });
+
+  test("star resolution to a prerelease survives a reinstall", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const name = decodeURIComponent(new URL(req.url).pathname.slice(1));
+        if (name !== "only-pre-lock") return new Response("not found", { status: 404 });
+        return Response.json({
+          name,
+          "dist-tags": { latest: "2.0.0-canary.7" },
+          versions: {
+            "2.0.0-canary.7": {
+              name,
+              version: "2.0.0-canary.7",
+              dist: { tarball: `${server.url.origin}/only-pre-lock-2.0.0-canary.7.tgz` },
+            },
+          },
+        });
+      },
+    });
+
+    using dir = tempDir("version-resolution-relock", {
+      "package.json": JSON.stringify({
+        name: "test-pkg",
+        version: "1.0.0",
+        dependencies: { "only-pre-lock": "*" },
+      }),
+      "bunfig.toml": `[install]\ncache = false\nregistry = "${server.url.origin}/"\nsaveTextLockfile = true\n`,
+    });
+
+    async function install() {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--lockfile-only"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    const first = await install();
+    expect(first.stderr).not.toContain("No version matching");
+    expect(first.exitCode).toBe(0);
+    const lockfile = await file(join(String(dir), "bun.lock")).text();
+    expect(lockfile).toContain("only-pre-lock@2.0.0-canary.7");
+
+    const second = await install();
+    expect(second.stderr).not.toContain("No version matching");
+    expect(second.exitCode).toBe(0);
+    expect(await file(join(String(dir), "bun.lock")).text()).toBe(lockfile);
+  });
+});

--- a/test/cli/install/bun-install-version-resolution.test.ts
+++ b/test/cli/install/bun-install-version-resolution.test.ts
@@ -1,7 +1,11 @@
 import { file } from "bun";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
+
+// `bun install` spawns are slow under the debug/ASAN build; use the same
+// timeout the other install test files use.
+setDefaultTimeout(1000 * 60 * 5);
 
 // Checks that `bun install` picks the same version npm does for npm ranges.
 // Every expectation in this file was verified against npm 11 (and
@@ -9,9 +13,9 @@ import { join } from "path";
 // registry. The registry only has to serve packuments because resolution runs
 // with `--lockfile-only`, so tarballs are never requested.
 
-type Packages = Record<string, { versions: string[]; latest?: string }>;
+type Packages = Record<string, { versions: string[]; latest?: string; time?: Record<string, string> }>;
 
-async function resolve(packages: Packages, dependencies: Record<string, string>) {
+async function resolve(packages: Packages, dependencies: Record<string, string>, minimumReleaseAgeSeconds?: number) {
   await using server = Bun.serve({
     port: 0,
     fetch(req) {
@@ -27,13 +31,16 @@ async function resolve(packages: Packages, dependencies: Record<string, string>)
             { name, version, dist: { tarball: `${server.url.origin}/${name}-${version}.tgz` } },
           ]),
         ),
+        ...(pkg.time ? { time: pkg.time } : {}),
       });
     },
   });
 
   using dir = tempDir("version-resolution", {
     "package.json": JSON.stringify({ name: "test-pkg", version: "1.0.0", dependencies }),
-    "bunfig.toml": `[install]\ncache = false\nregistry = "${server.url.origin}/"\nsaveTextLockfile = true\n`,
+    "bunfig.toml": `[install]\ncache = false\nregistry = "${server.url.origin}/"\nsaveTextLockfile = true\n${
+      minimumReleaseAgeSeconds !== undefined ? `minimumReleaseAge = ${minimumReleaseAgeSeconds}\n` : ""
+    }`,
   });
 
   await using proc = Bun.spawn({
@@ -44,32 +51,29 @@ async function resolve(packages: Packages, dependencies: Record<string, string>)
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
 
-  let resolved: Record<string, string> = {};
-  if (exitCode === 0) {
-    const lockfile = await file(join(String(dir), "bun.lock")).text();
-    const lock = JSON.parse(lockfile.replace(/,(\s*[\]}])/g, "$1"));
-    resolved = Object.fromEntries(
-      Object.entries(lock.packages as Record<string, string[]>).map(([name, entry]) => [
-        name,
-        entry[0].slice(name.length + 1),
-      ]),
-    );
-  }
-  return { resolved, stdout, stderr, exitCode };
+  const lockfile = await file(join(String(dir), "bun.lock")).text();
+  const lock = JSON.parse(lockfile.replace(/,(\s*[\]}])/g, "$1"));
+  const resolved: Record<string, string> = Object.fromEntries(
+    Object.entries(lock.packages as Record<string, string[]>).map(([name, entry]) => [
+      name,
+      entry[0].slice(name.length + 1),
+    ]),
+  );
+  return { resolved, stdout, stderr };
 }
 
 describe.concurrent("bun install version resolution", () => {
   // A satisfying prerelease that is higher than the best satisfying stable
   // release must win. npm: 1.2.0-alpha.1
   test("prerelease above the best matching stable is chosen", async () => {
-    const { resolved, stderr, exitCode } = await resolve(
+    const { resolved, stderr } = await resolve(
       { "pre-above-stable": { versions: ["1.1.1", "1.2.0-alpha.1", "2.0.0"], latest: "2.0.0" } },
       { "pre-above-stable": "<1.2.0-alpha.2" },
     );
-    expect(resolved["pre-above-stable"]).toBe("1.2.0-alpha.1");
     expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
+    expect(resolved["pre-above-stable"]).toBe("1.2.0-alpha.1");
   });
 
   // npm: 2.0.0-rc.1 (1.2.0 and 2.0.0-rc.1 both satisfy, the prerelease is higher)
@@ -121,13 +125,12 @@ describe.concurrent("bun install version resolution", () => {
   // npm resolves `*` to the `latest` dist-tag. A package with only
   // prereleases must install instead of failing with "No version matching".
   test("star range on a package with only prereleases resolves to the latest dist-tag", async () => {
-    const { resolved, stderr, exitCode } = await resolve(
+    const { resolved, stderr } = await resolve(
       { "only-pre": { versions: ["1.0.0-beta.1", "1.0.0-beta.2"], latest: "1.0.0-beta.2" } },
       { "only-pre": "*" },
     );
     expect(stderr).not.toContain("No version matching");
     expect(resolved["only-pre"]).toBe("1.0.0-beta.2");
-    expect(exitCode).toBe(0);
   });
 
   // npm: 2.0.0-beta.1. For `*` the latest dist-tag wins even when it is a
@@ -146,6 +149,29 @@ describe.concurrent("bun install version resolution", () => {
       { "star-stable": "*" },
     );
     expect(resolved["star-stable"]).toBe("2.0.0");
+  });
+
+  // With minimumReleaseAge, `*` keeps the dist-tag fallback: a too recent
+  // latest falls back to an older version from the same list, including
+  // prereleases on a prerelease-only package.
+  test("star range with minimumReleaseAge falls back to an older prerelease", async () => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const { resolved, stderr } = await resolve(
+      {
+        "aged-pre": {
+          versions: ["1.0.0-beta.1", "1.0.0-beta.2"],
+          latest: "1.0.0-beta.2",
+          time: {
+            "1.0.0-beta.1": new Date(Date.now() - 10 * DAY_MS).toISOString(),
+            "1.0.0-beta.2": new Date(Date.now() - 60 * 1000).toISOString(),
+          },
+        },
+      },
+      { "aged-pre": "*" },
+      2 * 24 * 60 * 60,
+    );
+    expect(stderr).not.toContain("No version matching");
+    expect(resolved["aged-pre"]).toBe("1.0.0-beta.1");
   });
 
   // npm prefers a satisfying `latest` dist-tag over higher satisfying

--- a/test/cli/install/bun-install-version-resolution.test.ts
+++ b/test/cli/install/bun-install-version-resolution.test.ts
@@ -151,6 +151,19 @@ describe.concurrent("bun install version resolution", () => {
     expect(resolved["star-stable"]).toBe("2.0.0");
   });
 
+  // Only the literal `*` follows a prerelease latest dist-tag. npm resolves
+  // `>=0.0.0` and `x` with a plain satisfies check, which excludes
+  // prereleases, so both pick 1.0.0 here.
+  test("ranges equivalent to star do not follow a prerelease latest dist-tag", async () => {
+    const packages: Packages = {
+      "star-like": { versions: ["1.0.0", "2.0.0-beta.1"], latest: "2.0.0-beta.1" },
+    };
+    const gte_zero = await resolve(packages, { "star-like": ">=0.0.0" });
+    const x_range = await resolve(packages, { "star-like": "x" });
+    expect(gte_zero.resolved["star-like"]).toBe("1.0.0");
+    expect(x_range.resolved["star-like"]).toBe("1.0.0");
+  });
+
   // With minimumReleaseAge, `*` keeps the dist-tag fallback: a too recent
   // latest falls back to an older version from the same list, including
   // prereleases on a prerelease-only package.

--- a/test/cli/install/bun-install-version-resolution.test.ts
+++ b/test/cli/install/bun-install-version-resolution.test.ts
@@ -8,10 +8,8 @@ import { join } from "path";
 setDefaultTimeout(1000 * 60 * 5);
 
 // Checks that `bun install` picks the same version npm does for npm ranges.
-// Every expectation in this file was verified against npm 11 (and
-// npm-pick-manifest directly) using the same packuments served from a local
-// registry. The registry only has to serve packuments because resolution runs
-// with `--lockfile-only`, so tarballs are never requested.
+// Every expectation was verified against npm 11 / npm-pick-manifest with the
+// same packuments; `--lockfile-only` means tarballs are never requested.
 
 type Packages = Record<string, { versions: string[]; latest?: string; time?: Record<string, string> }>;
 

--- a/test/cli/install/bun-install-version-resolution.test.ts
+++ b/test/cli/install/bun-install-version-resolution.test.ts
@@ -292,4 +292,53 @@ describe.concurrent("bun install version resolution", () => {
     expect(second.exitCode).toBe(0);
     expect(await file(join(String(dir), "bun.lock")).text()).toBe(lockfile);
   });
+
+  // `*` and `>=0.0.0` parse to the same comparators but resolve differently
+  // when latest is a prerelease, so changing one to the other in package.json
+  // has to re-resolve instead of keeping the locked version.
+  test("changing between star and an equivalent range re-resolves", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const name = decodeURIComponent(new URL(req.url).pathname.slice(1));
+        if (name !== "star-relock") return new Response("not found", { status: 404 });
+        return Response.json({
+          name,
+          "dist-tags": { latest: "2.0.0-beta.1" },
+          versions: Object.fromEntries(
+            ["1.0.0", "2.0.0-beta.1"].map(version => [
+              version,
+              { name, version, dist: { tarball: `${server.url.origin}/star-relock-${version}.tgz` } },
+            ]),
+          ),
+        });
+      },
+    });
+
+    const packageJson = (range: string) =>
+      JSON.stringify({ name: "test-pkg", version: "1.0.0", dependencies: { "star-relock": range } });
+
+    using dir = tempDir("version-resolution-star-relock", {
+      "package.json": packageJson("*"),
+      "bunfig.toml": `[install]\ncache = false\nregistry = "${server.url.origin}/"\nsaveTextLockfile = true\n`,
+    });
+
+    async function install() {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--lockfile-only"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+      return await file(join(String(dir), "bun.lock")).text();
+    }
+
+    expect(await install()).toContain("star-relock@2.0.0-beta.1");
+
+    await Bun.write(join(String(dir), "package.json"), packageJson(">=0.0.0"));
+    expect(await install()).toContain("star-relock@1.0.0");
+  });
 });

--- a/test/cli/install/bun-install-version-resolution.test.ts
+++ b/test/cli/install/bun-install-version-resolution.test.ts
@@ -187,6 +187,28 @@ describe.concurrent("bun install version resolution", () => {
     expect(resolved["aged-pre"]).toBe("1.0.0-beta.1");
   });
 
+  // When every version in the latest dist-tag's prerelease channel is too
+  // recent, `*` still falls back to an old enough stable release.
+  test("star range with minimumReleaseAge falls back to a stable when the latest channel is too recent", async () => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const { resolved, stderr } = await resolve(
+      {
+        "aged-mixed": {
+          versions: ["1.0.0", "2.0.0-beta.1"],
+          latest: "2.0.0-beta.1",
+          time: {
+            "1.0.0": new Date(Date.now() - 365 * DAY_MS).toISOString(),
+            "2.0.0-beta.1": new Date(Date.now() - 60 * 1000).toISOString(),
+          },
+        },
+      },
+      { "aged-mixed": "*" },
+      2 * 24 * 60 * 60,
+    );
+    expect(stderr).not.toContain("minimum-release-age");
+    expect(resolved["aged-mixed"]).toBe("1.0.0");
+  });
+
   // npm prefers a satisfying `latest` dist-tag over higher satisfying
   // versions, for stable ranges and prerelease ranges alike.
   test("a satisfying latest dist-tag is preferred over higher versions", async () => {


### PR DESCRIPTION
`bun install` resolves three classes of npm ranges to different versions than npm, and fails an install npm completes. All of them come from `PackageManifest::find_best_version` / `find_best_version_with_filter` in `src/install/npm.rs`.

### Repro

Against a registry with the listed versions (`latest` as shown), `bun install --lockfile-only` picks:

| versions (latest) | range | npm 11 | bun |
|---|---|---|---|
| 1.1.1, 1.2.0-alpha.1, 2.0.0 (2.0.0) | `<1.2.0-alpha.2` | 1.2.0-alpha.1 | 1.1.1 |
| 1.2.0, 2.0.0-rc.1, 3.0.0 (3.0.0) | `<=2.0.0-rc.1` | 2.0.0-rc.1 | 1.2.0 |
| 1.0.0, 2.0.0, 2.1.0 (2.1.0) | `1.0.0 \|\| ^2.0.0` | 2.1.0 | 1.0.0 |
| 1.0.0-beta.1, 1.0.0-beta.2 (1.0.0-beta.2) | `*` | 1.0.0-beta.2 | error: `No version matching "*" found for specifier ... (but package exists)` |
| 1.0.0, 2.0.0-beta.1 (2.0.0-beta.1) | `*` | 2.0.0-beta.1 | 1.0.0 |

The fourth one is the worst: a package whose published versions are all prereleases (nightly/canary-only packages) aborts the whole install with `error: No version matching "*" found for specifier "<name>" (but package exists)`.

### Cause

- The exact-version fast path checked `group.head.head.range.left.op == Op::Eql`, which is true for the first `||` alternative of `1.0.0 || ^2.0.0`, so the rest of the group was never evaluated (order dependent: `^2.0.0 || 1.0.0` resolved to 2.1.0).
- The stable list was scanned first and prereleases only if no stable matched, so a satisfying prerelease above the best satisfying stable was never chosen. For prerelease ranges the `latest` dist-tag was also only honored when it compared equal to the range's left version, instead of npm's "prefer `latest` whenever it satisfies".
- `*` required `latest` to satisfy the group, which a prerelease never does without a prerelease comparator, so prerelease-only packages errored. npm treats the literal `*` as the `latest` dist-tag unconditionally.

### Fix

In both `find_best_version` and `find_best_version_with_filter`:

- gate the exact fast path on `Group::get_exact_version()` (single exact comparator, no `||`/`&&`/right bound)
- accept the `latest` dist-tag when it satisfies the range, matching npm-pick-manifest (and pnpm)
- accept the `latest` dist-tag unconditionally for the literal `*`. npm only does this for the literal `*` (not `>=0.0.0` or `x`, which parse to the same structure), so the parser records the literal in a new `Flags::STAR` bit (`Group::is_star_literal()`)
- under `minimumReleaseAge`, route `*` through the same dist-tag fallback `latest` uses, so a too recent `latest` falls back to an older version of the same release channel instead of failing
- search both the release and prerelease lists when the range opts into prereleases and take the higher satisfying version

### Verification

New suite `test/cli/install/bun-install-version-resolution.test.ts` (local registry, packuments only): 10 of 13 tests fail on bun before the fix, 13/13 after. Every expectation was produced by running npm 11 against the same packuments, not by assumption (npm is not pure `maxSatisfying`: it prefers a satisfying `latest`, which the tests also pin).

Cross-checked with the same harness that the existing prerelease matrix in `test/cli/install/bun-install-registry.test.ts` (prereleases-1 through prereleases-4, 34 expectations) is unchanged, and `minimum-release-age.test.ts`, `bun-install.test.ts`, `bun-add.test.ts`, `bun-update.test.ts` show no new failures.

Supersedes #30076, which fixes only the `||` fast path part of this.

<details>
<summary>npm 11 / npm-pick-manifest / node-semver / bun comparison after the fix</summary>

```
case                      range             latest          npm                  pickManifest    maxSatisfying   bun
pre-above-stable          <1.2.0-alpha.2    2.0.0           1.2.0-alpha.1        1.2.0-alpha.1   1.2.0-alpha.1   1.2.0-alpha.1
range-pre-upper           <=2.0.0-rc.1      3.0.0           2.0.0-rc.1           2.0.0-rc.1      2.0.0-rc.1      2.0.0-rc.1
vp                        <1.2.0-alpha.2    1.2.0           1.2.0-alpha.1        1.2.0-alpha.1   1.2.0-alpha.1   1.2.0-alpha.1
vp2                       <=2.0.0-rc.1      1.2.0           1.2.0                1.2.0           2.0.0-rc.1      1.2.0
or-exact                  1.0.0 || ^2.0.0   2.1.0           2.1.0                2.1.0           2.1.0           2.1.0
or-exact-rev              ^2.0.0 || 1.0.0   2.1.0           2.1.0                2.1.0           2.1.0           2.1.0
or-scan                   1.0.0 || ^2.0.0   3.0.0           2.1.0                2.1.0           2.1.0           2.1.0
or-only-exact             1.0.0 || ^3.0.0   2.0.0           1.0.0                1.0.0           1.0.0           1.0.0
only-pre                  *                 1.0.0-beta.2    1.0.0-beta.2         1.0.0-beta.2    null            1.0.0-beta.2
only-pre-no-latest        *                 (none)          ETARGET              ETARGET         null            error (same)
latest-held-back          ^1.0.0            1.1.0           1.1.0                1.1.0           1.2.0           1.1.0
exact                     1.0.0             2.0.0           1.0.0                1.0.0           1.0.0           1.0.0
star-stable               *                 2.0.0           2.0.0                2.0.0           2.0.0           2.0.0
star-pre-latest           *                 2.0.0-beta.1    2.0.0-beta.1         2.0.0-beta.1    1.0.0           2.0.0-beta.1
caret-pre-latest          ^1.0.0-0          1.0.0-0         1.0.0-0              1.0.0-0         1.0.0-8         1.0.0-0
pre-range-latest-stable   ^1.2.3-alpha.1    1.2.4           1.2.4                1.2.4           1.3.0           1.2.4
pre-above-latest-tag      ^1.0.0-future.5   1.0.0-future.4  1.0.0-future.7       1.0.0-future.7  1.0.0-future.7  1.0.0-future.7
pre-eq-latest-tag         ^1.0.0-future.4   1.0.0-future.4  1.0.0-future.4       1.0.0-future.4  1.0.0-future.7  1.0.0-future.4
gte-zero-pre-latest       >=0.0.0           2.0.0-beta.1    1.0.0                1.0.0           1.0.0           1.0.0
gte-zero-short            >=0               2.0.0-beta.1    1.0.0                1.0.0           1.0.0           1.0.0
x-pre-latest              x                 2.0.0-beta.1    1.0.0                1.0.0           1.0.0           1.0.0
gte-zero-only-pre         >=0.0.0           1.0.0-beta.2    ETARGET              ETARGET         null            error (same)
```

Before the fix, bun disagreed with npm on pre-above-stable (1.1.1), range-pre-upper (1.2.0), vp (1.1.1), or-exact (1.0.0), or-scan (1.0.0), only-pre (install error), star-pre-latest (1.0.0), and pre-range-latest-stable (1.3.0).

</details>
