### PR TITLE
Report a build error when a macro returns an unsupported platform object

### DIFF
--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -598,22 +598,23 @@ impl<'a> Run<'a> {
             T::Double => self.coerce(T::Double, value),
             T::String => self.coerce(T::String, value),
             T::Promise => self.coerce(T::Promise, value),
-            _ => {
-                let name = value.get_class_info_name().unwrap_or(b"unknown");
-
-                self.log.add_error_fmt(
-                    Some(self.source),
-                    self.caller.loc,
-                    // `JSType` derives `Debug` (not `IntoStaticStr`).
-                    format_args!(
-                        "cannot coerce {} ({:?}) to Bun's AST. Please return a simpler type",
-                        bstr::BStr::new(name),
-                        value.js_type(),
-                    ),
-                );
-                Err(MacroError::MacroFailed)
-            }
+            _ => Err(self.unsupported_value_error(value)),
         }
+    }
+
+    fn unsupported_value_error(&mut self, value: JSValue) -> MacroError {
+        let name = value.get_class_info_name().unwrap_or(b"unknown");
+        self.log.add_error_fmt(
+            Some(self.source),
+            self.caller.loc,
+            // `JSType` derives `Debug` (not `IntoStaticStr`).
+            format_args!(
+                "cannot coerce {} ({:?}) to Bun's AST. Please return a simpler type",
+                bstr::BStr::new(name),
+                value.js_type(),
+            ),
+        );
+        MacroError::MacroFailed
     }
 
     // Runtime `tag` param — every call site in `run` already matches once.
@@ -678,7 +679,7 @@ impl<'a> Run<'a> {
                         .map_err(|_| MacroError::MacroFailed);
                 }
 
-                return Ok(Expr::init(E::EString::EMPTY, self.caller.loc));
+                return Err(self.unsupported_value_error(value));
             }
 
             T::Boolean => {
@@ -875,16 +876,7 @@ impl<'a> Run<'a> {
             _ => {}
         }
 
-        self.log.add_error_fmt(
-            Some(self.source),
-            self.caller.loc,
-            // `JSType` derives `Debug` (not `IntoStaticStr`).
-            format_args!(
-                "cannot coerce {:?} to Bun's AST. Please return a simpler type",
-                value.js_type(),
-            ),
-        );
-        Err(MacroError::MacroFailed)
+        Err(self.unsupported_value_error(value))
     }
 }
 

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -133,6 +133,33 @@ test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
 });
 
+// Platform objects other than Response/Request/Blob have no AST representation, so returning
+// one from a macro must fail the build. It used to silently inline "" at every call site.
+test.concurrent.each([
+  ["Headers", `new Headers({ "x-bun": "1" })`, "Headers"],
+  ["FormData", `new FormData()`, "FormData"],
+  ["an object with nested Headers", `{ list: [new Headers({ "x-bun": "1" })] }`, "Headers"],
+])("macro returning %s is a build error", async (_label, expression, className) => {
+  using dir = tempDir("macro-platform-object", {
+    "macro.ts": `export function getValue() {\n  return ${expression};\n}\n`,
+    "index.ts": `import { getValue } from "./macro.ts" with { type: "macro" };\nconsole.log(JSON.stringify(getValue()));\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toMatchObject({
+    stderr: expect.stringContaining(`cannot coerce ${className}`),
+    exitCode: 1,
+  });
+  // The bundle must not be emitted with the macro call replaced by an empty string.
+  expect(stdout).not.toContain('""');
+});
+
 // A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside
 // JSC__JSValue__putToPropertyKey take a path that can throw, so the binding must check for
 // an exception. BUN_JSC_validateExceptionChecks=1 aborts the child if the check is missing.


### PR DESCRIPTION
### Problem
- A macro that returns a platform object other than `Response`, `Request`, or `Blob` (`Headers`, `FormData`, ...) is inlined as `""` at every call site. The build succeeds with wrong constants baked in. On 1.4.1, `bun build` of a file that calls `export function f() { return new Headers(); }` emits `console.log(JSON.stringify(""))` and exits 0.
- The cause is the `T::Private` arm of `Run::coerce` in `src/js_parser_jsc/Macro.rs`. After the `Response`/`Request`/`Blob` downcasts miss, it returns `Ok(Expr::init(E::EString::EMPTY, ..))`. Every other unsupported return type (Symbol, Date, function, `URL` through its custom inspect hook) already reports `cannot coerce <Class> (<JSType>) to Bun's AST. Please return a simpler type`.

### Fix
- The fall-through now reports that same build error. The message formatting moves into `Run::unsupported_value_error`, and the two existing error sites call it too, so the bottom-of-`coerce` path gains the class name it lacked.
- Correct because `docs/bundler/macros.mdx` ("Serializability") says instances of classes other than those three are not serializable. A build error is the documented contract. A silent placeholder is the worst outcome for a build-time inliner.
- Verified: `test/bundler/transpiler/macro-test.test.ts` gains three cases (`Headers`, `FormData`, an object with nested `Headers`). They fail on 1.4.1 with `""` inlined and pass with this change. The rest of that file, `transpiler.test.js`, and the macro regression tests also pass.

### Background
- A macro runs at bundle time. `Run::coerce` turns its JS return value into an AST node by the formatter tag of the value. `T::Private` is the tag for a `DOMWrapper` cell, that is, a native platform object.
- `Response`/`Request` are reduced to their body `Blob`, and a `Blob` is inlined by its content type in `expr_from_blob`. Those three are the only platform objects with an AST shape.

<details><summary>Notes</summary>

The first version of this PR also fixed `expr_from_blob`, which compared the whole `Content-Type` against `application/json` and so demoted `application/json;charset=utf-8` to a base64 data URL. #40700 landed that fix on main through `MimeType::init`, so this PR now carries only the platform object change. #40700 keeps the type match case-sensitive on purpose, to agree with the runtime's blob classification, so the case-insensitive variant from an earlier revision of this PR is dropped too.

#40059 rewrites the whole coercion path and makes the fall-through impossible as a side effect. This is the small fix that can land ahead of it.

Probe on 1.4.1 of what each platform object becomes when returned from a macro:

```
new Headers({ "x-a": "b" })   =>  ""
new FormData()                =>  ""
{ list: [new Headers()] }     =>  { list: [""] }
new URL("https://bun.com")    =>  error: cannot coerce URL (JSType(238))
new URLSearchParams("a=1")    =>  error: cannot coerce JSType(241)
```

Related: #7115
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.04ms]
(pass) latin1 string [0.02ms]
(pass) ascii string [0.01ms]
(pass) type coercion [0.07ms]
(pass) escaping [0.30ms]
(pass) utf16 string [0.02ms]
(pass) import aliases [0.03ms]
(pass) default import [0.02ms]
(pass) namespace import [0.03ms]
(pass) ireturnapromise [0.09ms]
150 |     cwd: String(dir),
151 |     stdout: "pipe",
152 |     stderr: "pipe",
153 |   });
154 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
155 |   expect({ stdout, stderr, exitCode }).toMatchObject({
                                             ^
error: expect(received).toMatchObject(expected)

  {
-   "exitCode": 1,
-   "stderr": StringContaining "cannot coerce Headers",
+   "exitCode": 0,
+   "stderr": "",
+   "stdout": 
+ "// index.ts
+ console.log(JSON.stringify(""));
+ "
+ ,
  }

- Expected  - 2
+ Received  + 7

      at <anonymous> (/workspace/bun/test/bundler/transpiler/macro-test.test.ts:155:40)
(fail) macro returning Headers is a build error [20.23ms]
150 |     cwd: String(dir),
151 |     stdo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1a5755b823
  features     baseline

23 deps, 131 codegen, 1172 objects in 987ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen bindgenv2
[2/1244] gen ErrorCode+*.h
[3/1244] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[4/1244] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] gen .bind.ts → GeneratedBindings.cpp
[7/1243] fetch zlib
[zlib] up to date
[8/1243] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [215.00ms]
[9/1243] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[10/1243] gen ProcessBindingHTTPParser.lut.h

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser_jsc/Macro.rs                 | 44 ++++++++++++------------------
 test/bundler/transpiler/macro-test.test.ts | 27 ++++++++++++++++++
 2 files changed, 45 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser_jsc/Macro.rs                     11      9     11
test/bundler/transpiler/macro-test.test.ts      5      6     11
```

</details>

<!-- robobun:evidence:end -->