### PR TITLE
bundler: handle nullish module.exports and top-level arguments in bundled CJS

### DIFF
--- a/packages/bun-plugin-svelte/test/index.test.ts
+++ b/packages/bun-plugin-svelte/test/index.test.ts
@@ -97,7 +97,7 @@ describe("when importing `.svelte.ts` files with CJS", () => {
     expect(ts).toBeDefined();
     const code = await ts!.text();
     expect(code).toContain("require_todo_cjs_svelte");
-    expect(code).toContain("var require_todo_cjs_svelte = __commonJS((exports, module) => {\n");
+    expect(code).toContain("var require_todo_cjs_svelte = __commonJS(function(exports, module) {\n");
   });
 });
 

--- a/src/bundler/linker_context/README.md
+++ b/src/bundler/linker_context/README.md
@@ -626,7 +626,7 @@ _CommonJS Wrapper Handling_ (`wrap = .cjs`):
 
 ```javascript
 // Generated wrapper structure:
-var require_moduleName = __commonJS((exports, module) => {
+var require_moduleName = __commonJS(function (exports, module) {
   // Original module code here with isolated scope
   exports.foo = 123;
 });

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -574,14 +574,19 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
                 // TODO: variants of the runtime functions
                 let body_stmts = bun_ast::StoreSlice::new_mut(stmts.all_stmts.as_mut_slice());
+                // The wrapper must be a regular function, not an arrow, so that a
+                // top-level `arguments` reference in the CommonJS body binds to the
+                // wrapper's own `arguments` object (Node and esbuild both allow it).
                 let cjs_args = Vec::<Expr>::from_slice(&[Expr::init(
-                    E::Arrow {
-                        args: bun_ast::StoreSlice::new(args.into_bump_slice()),
-                        body: G::FnBody {
-                            stmts: body_stmts,
-                            loc: bun_ast::Loc::EMPTY,
+                    E::Function {
+                        func: G::Fn {
+                            args: bun_ast::StoreSlice::new(args.into_bump_slice()),
+                            body: G::FnBody {
+                                stmts: body_stmts,
+                                loc: bun_ast::Loc::EMPTY,
+                            },
+                            ..Default::default()
                         },
-                        ..Default::default()
                     },
                     bun_ast::Loc::EMPTY,
                 )]);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -25,7 +25,9 @@ function __accessProp(key) {
 // also copy the properties to "module.exports" in addition to our module's
 // internal ESM export object.
 export var __reExport = (target, mod, secondTarget) => {
-  var keys = __getOwnPropNames(mod);
+  // An external CommonJS re-export target may set "module.exports" to null,
+  // undefined, or a primitive; only objects and functions have named exports.
+  var keys = (mod && typeof mod === "object") || typeof mod === "function" ? __getOwnPropNames(mod) : [];
   for (let key of keys)
     if (!__hasOwnProp.call(target, key) && key !== "default")
       __defProp(target, key, {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -69,12 +69,15 @@ export var __toESM = (mod, isNodeMode, target) => {
   // file that has been converted to a CommonJS file using a Babel-
   // compatible transform (i.e. "__esModule" has not been set), then set
   // "default" to the CommonJS "module.exports" for node compatibility.
-  for (let key of __getOwnPropNames(mod))
-    if (!__hasOwnProp.call(to, key))
-      __defProp(to, key, {
-        get: __accessProp.bind(mod, key),
-        enumerable: true,
-      });
+  // A CommonJS module may legitimately set "module.exports" to null,
+  // undefined, or a primitive; only objects and functions have named exports.
+  if ((mod && typeof mod === "object") || typeof mod === "function")
+    for (let key of __getOwnPropNames(mod))
+      if (!__hasOwnProp.call(to, key))
+        __defProp(to, key, {
+          get: __accessProp.bind(mod, key),
+          enumerable: true,
+        });
 
   if (canCache) cache.set(mod, to);
   return to;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -877,12 +877,13 @@ function toCommonJS(from: any) {
 
 function toESM(mod: any) {
   const to = Object.defineProperty(Object.create(null), "default", { value: mod, enumerable: true });
-  for (let key of Object.getOwnPropertyNames(mod))
-    if (!Object.prototype.hasOwnProperty.call(to, key))
-      Object.defineProperty(to, key, {
-        get: () => mod[key],
-        enumerable: true,
-      });
+  if ((mod && typeof mod === "object") || typeof mod === "function")
+    for (let key of Object.getOwnPropertyNames(mod))
+      if (!Object.prototype.hasOwnProperty.call(to, key))
+        Object.defineProperty(to, key, {
+          get: () => mod[key],
+          enumerable: true,
+        });
   return to;
 }
 

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -581,4 +581,29 @@ describe("bundler", () => {
       stdout: "[object Arguments]",
     },
   });
+
+  // Test 28: `export *` from an external package with nullish exports, format=cjs
+  // In CommonJS output the linker emits
+  //   __reExport(exports_entry, require("ext"), module.exports);
+  // with the raw, unwrapped require() result, so __reExport itself must
+  // tolerate a nullish module.exports. A bundled (non-external) CJS target is
+  // always wrapped in __toESM first, which is why the external case is the one
+  // that reaches __reExport with null.
+  itBundled("cjs/__reExport_external_null_module_exports", {
+    files: {
+      "/entry.js": /* js */ `
+        export * from "ext";
+        console.log("loaded ok");
+      `,
+    },
+    runtimeFiles: {
+      "/node_modules/ext/index.js": /* js */ `module.exports = null;`,
+    },
+    external: ["ext"],
+    target: "node",
+    format: "cjs",
+    run: {
+      stdout: "loaded ok",
+    },
+  });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -491,4 +491,94 @@ describe("bundler", () => {
       stdout: '{"hasMap":true,"same":true}',
     },
   });
+
+  // ============================================================================
+  // Tests for nullish module.exports
+  // A CJS dependency may legitimately set module.exports to null or undefined.
+  // __toESM must not pass a nullish value to Object.getOwnPropertyNames, or the
+  // whole bundle throws at import time. Node and esbuild both handle this.
+  // ============================================================================
+
+  // Test 24: module.exports = null, format=esm
+  itBundled("cjs/__toESM_module_exports_null", {
+    files: {
+      "/entry.js": /* js */ `
+        import z from "./z.cjs";
+        console.log("z is", z);
+      `,
+      "/z.cjs": /* js */ `
+        module.exports = null;
+      `,
+    },
+    target: "node",
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "z is null",
+    },
+  });
+
+  // Test 25: module.exports = null, format=cjs
+  itBundled("cjs/__toESM_module_exports_null_format_cjs", {
+    files: {
+      "/entry.js": /* js */ `
+        import z from "./z.cjs";
+        console.log("z is", z);
+      `,
+      "/z.cjs": /* js */ `
+        module.exports = null;
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    run: {
+      stdout: "z is null",
+    },
+  });
+
+  // Test 26: module.exports = undefined
+  itBundled("cjs/__toESM_module_exports_undefined", {
+    files: {
+      "/entry.js": /* js */ `
+        import u from "./u.cjs";
+        console.log("u is", u);
+      `,
+      "/u.cjs": /* js */ `
+        module.exports = undefined;
+      `,
+    },
+    target: "node",
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "u is undefined",
+    },
+  });
+
+  // ============================================================================
+  // Tests for the __commonJS wrapper function
+  // Node runs every CommonJS module inside a regular function, so a top-level
+  // `arguments` reference is legal. The wrapper passed to __commonJS must be a
+  // regular function (not an arrow) so `arguments` has a binding when the
+  // output format is ESM. esbuild emits a regular function here too.
+  // ============================================================================
+
+  // Test 27: top-level `arguments` inside a CJS module
+  itBundled("cjs/__commonJS_top_level_arguments", {
+    files: {
+      "/entry.js": /* js */ `
+        import tag from "./args.cjs";
+        console.log(tag);
+      `,
+      "/args.cjs": /* js */ `
+        module.exports = Object.prototype.toString.call(arguments);
+      `,
+    },
+    target: "node",
+    format: "esm",
+    outfile: "/out.mjs",
+    run: {
+      stdout: "[object Arguments]",
+    },
+  });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -493,10 +493,8 @@ describe("bundler", () => {
   });
 
   // ============================================================================
-  // Tests for nullish module.exports
-  // A CJS dependency may legitimately set module.exports to null or undefined.
-  // __toESM must not pass a nullish value to Object.getOwnPropertyNames, or the
-  // whole bundle throws at import time. Node and esbuild both handle this.
+  // Nullish module.exports: __toESM must not pass null/undefined to
+  // Object.getOwnPropertyNames or the bundle throws at import time.
   // ============================================================================
 
   // Test 24: module.exports = null, format=esm
@@ -556,11 +554,8 @@ describe("bundler", () => {
   });
 
   // ============================================================================
-  // Tests for the __commonJS wrapper function
-  // Node runs every CommonJS module inside a regular function, so a top-level
-  // `arguments` reference is legal. The wrapper passed to __commonJS must be a
-  // regular function (not an arrow) so `arguments` has a binding when the
-  // output format is ESM. esbuild emits a regular function here too.
+  // The __commonJS wrapper must be a regular function (not an arrow) so a
+  // top-level `arguments` reference in a CJS body has a binding in ESM output.
   // ============================================================================
 
   // Test 27: top-level `arguments` inside a CJS module
@@ -582,13 +577,9 @@ describe("bundler", () => {
     },
   });
 
-  // Test 28: `export *` from an external package with nullish exports, format=cjs
-  // In CommonJS output the linker emits
-  //   __reExport(exports_entry, require("ext"), module.exports);
-  // with the raw, unwrapped require() result, so __reExport itself must
-  // tolerate a nullish module.exports. A bundled (non-external) CJS target is
-  // always wrapped in __toESM first, which is why the external case is the one
-  // that reaches __reExport with null.
+  // Test 28: export * from an external package whose module.exports is null.
+  // CJS output emits __reExport(exports, require("ext"), module.exports) with
+  // the raw require() result, so __reExport itself must tolerate null.
   itBundled("cjs/__reExport_external_null_module_exports", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1160,7 +1160,7 @@ describe("bundler", () => {
     snapshotSourceMap: {
       "entry.js.map": {
         files: ["../node_modules/react/index.js", "../entry.js"],
-        mappingsExactMatch: "miBACA,WAAW,IAAQ,EAAE,ICDrB,eACA,QAAQ,IAAI,CAAK",
+        mappingsExactMatch: "2lBACA,WAAW,IAAQ,EAAE,ICDrB,eACA,QAAQ,IAAI,CAAK",
       },
     },
   });

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -57,9 +57,9 @@ describe("bundler", () => {
           "../entry.tsx",
         ],
         mappings: [
-          ["react.development.js:524:'getContextName'", "1:5567:nt"],
+          ["react.development.js:524:'getContextName'", "1:5623:nt"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:ar++"],
-          ["react.development.js:696:''Component'", '1:7629:\'Component "%s"'],
+          ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
           ["entry.tsx:6:'\"Content-Type\"'", '100:18808:"Content-Type"'],
           ["entry.tsx:11:'<html>'", "100:19062:void"],
           ["entry.tsx:23:'await'", "100:19161:await"],
@@ -67,7 +67,7 @@ describe("bundler", () => {
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221895,
+      "out/entry.js": 221969,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
+++ b/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
@@ -110,12 +110,14 @@ var __toESM = (mod, isNodeMode, target) => {
   }
   target = mod != null ? __create(__getProtoOf(mod)) : {};
   const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
-  for (let key of __getOwnPropNames(mod))
-    if (!__hasOwnProp.call(to, key))
-      __defProp(to, key, {
-        get: __accessProp.bind(mod, key),
-        enumerable: true
-      });
+  if (mod && typeof mod === "object" || typeof mod === "function") {
+    for (let key of __getOwnPropNames(mod))
+      if (!__hasOwnProp.call(to, key))
+        __defProp(to, key, {
+          get: __accessProp.bind(mod, key),
+          enumerable: true
+        });
+  }
   if (canCache)
     cache.set(mod, to);
   return to;
@@ -123,7 +125,7 @@ var __toESM = (mod, isNodeMode, target) => {
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 
 // node_modules/react/index.js
-var require_react = __commonJS((exports) => {
+var require_react = __commonJS(function(exports) {
   exports.useSyncExternalStore = () => 0;
   exports.useContext = () => 0;
   exports.createContext = () => ({});


### PR DESCRIPTION
Two CommonJS interop bugs in `bun build` output that make a bundle behave differently from the source it was built from. Both are in the machinery that wraps CommonJS modules for ESM consumption, and both match what Node and esbuild do.

### 1. A dependency with `module.exports = null` crashes the whole bundle at load time

```js
// entry.mjs
import z from "./z.cjs";
console.log("z is", z);
// z.cjs
module.exports = null;
```

Unbundled under node, under bun, and through esbuild this prints `z is null`. The `bun build --target=node` output (both `--format=esm` and `--format=cjs`) throws at import time:

```
TypeError: Cannot convert undefined or null to object
    at getOwnPropertyNames (<anonymous>)
    at __toESM (out.mjs:21:19)
```

**Cause:** the `__toESM` runtime helper guards `mod != null` when building the target object, then calls `__getOwnPropNames(mod)` unconditionally. `__toCommonJS`, fifteen lines below it in `src/runtime.js`, already has exactly the guard that's needed. A CommonJS module may legitimately set `module.exports` to null, undefined, or any primitive; only objects and functions have named exports to copy.

**Fix:** gate the named-export copy loop on `(mod && typeof mod === "object") || typeof mod === "function"`, the same shape `__toCommonJS` and esbuild's `__copyProps` use.

Two siblings had the same hole and get the same guard:

- `__reExport` in `src/runtime.js`. For a bundled CJS target the linker always interposes `__toESM` before `__reExport`, so the fix above covers it, but an **external** package in CommonJS output is emitted as a bare `__reExport(exports, require("pkg"), module.exports)` (plain `export * from "pkg"` never sets `CONTAINS_IMPORT_STAR`, so the external branch never sets the `WRAP_WITH_TO_ESM` record flag).
- `toESM` in `src/runtime/bake/hmr-module.ts`, which the file itself documents as mirroring `runtime.js`. Its sibling `toCommonJS` already had the guard.

### 2. Top-level `arguments` in a CommonJS module is a `ReferenceError` in ESM output

Node runs every CommonJS module inside a regular function, so a top-level `arguments` reference is legal (it is the five module-wrapper arguments). The linker emitted the `__commonJS` wrapper as an **arrow function**:

```js
var require_a = __commonJS((exports, module) => {
  console.log(arguments.length); // ReferenceError in ESM output
});
```

An arrow has no `arguments` binding, so in ESM output the identifier resolves to module scope and throws `ReferenceError: arguments is not defined`. esbuild emits a regular function here.

**Fix:** build an `E::Function` instead of an `E::Arrow` in `generateCodeForFileInChunkJS.rs`. Top-level `this` was already correct (the parser rewrites it to `exports`), so this only affects `arguments`.

### Tests

Five new tests in `test/bundler/bundler_cjs.test.ts` (the existing `__toESM` suite): `module.exports = null` in both output formats, `module.exports = undefined`, a top-level `arguments` reference, and `export * from` an external package whose `module.exports` is null. All five fail on the released bun and pass with this change; the 23 existing tests in the file still pass.

The `__toESM` guard and the function wrapper grow the minified runtime preamble by a fixed amount, so three existing assertions that pin exact byte offsets needed updating: the `mappingsExactMatch` in `edgecase/EmitInvalidSourceMap2`, two sourcemap positions plus `expectExactFilesize` in `npm/ReactSSR`, and the `react-compiler` snapshot. The sourcemaps themselves are still correct: the column shift is exactly the preamble length delta (+50 for the `__toESM` guard, +6 per `__commonJS` wrapper) and the mapped generated text at each position is unchanged. The `__reExport` and `hmr-module.ts` changes do not shift those tests because none of their bundles contains an `export * from` (so `__reExport` tree-shakes out) and the HMR runtime is not part of the bundled preamble.

`packages/bun-plugin-svelte/test/index.test.ts` asserted on the old arrow wrapper shape; updated to match. The generated-wrapper example in `src/bundler/linker_context/README.md` is updated too.
