### PR TITLE
fetch: fix HTTP/1.1 client wire bugs with streamed request bodies

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2934,6 +2934,12 @@ impl<'a> HTTPClient<'a> {
         let was_empty = buffer.is_empty() && data.is_empty();
         if was_empty && ended {
             // nothing is buffered and the stream is done so we just release and detach
+            //
+            // An earlier flush already drained the terminating 0\r\n\r\n, so
+            // the request message is complete. Mark the stage Done for the
+            // keep-alive / redirect pooling gates, matching the
+            // `ended && !has_backpressure` exit below.
+            self.state.request_stage = RequestStage::Done;
             stream_buffer.release();
             self.request_stream_detach();
             if upgrade_state == HTTPUpgradeState::Upgraded {
@@ -3973,14 +3979,21 @@ impl<'a> HTTPClient<'a> {
             // wire, which the server then mis-parses. The redirect path
             // (do_redirect) already gates on request_stage == Done for exactly
             // this reason; mirror that gate here for the non-redirect
-            // completion path. `request_stage` alone is insufficient because
-            // a fully-sent small request parks at `.body` (see on_writable),
-            // so for byte-buffer bodies check the unsent slice instead.
-            // Stream/Sendfile are left as-is (they don't track an
-            // unsent slice here).
+            // completion path. `request_stage` alone is insufficient for
+            // byte-buffer bodies because a fully-sent small request parks at
+            // `.body` (see on_writable), so check the unsent slice instead.
+            //
+            // For a Stream the socket carries an incomplete chunked message
+            // (no terminating 0\r\n\r\n), so a pooled reuse writes the next
+            // request's line and credential headers INTO that body (RFC 9112
+            // section 9.3: the client must close instead). Both of
+            // write_to_stream's stream-complete exits set request_stage =
+            // Done, so Done is the reliable signal for Stream and Sendfile.
             let request_side_drained = match &self.state.original_request_body {
                 HTTPRequestBody::Bytes(_) => self.state.request_body.is_empty(),
-                _ => true,
+                HTTPRequestBody::Stream(_) | HTTPRequestBody::Sendfile(_) => {
+                    self.state.request_stage == RequestStage::Done
+                }
             };
 
             // The uSockets paused bit survives `state.reset()`; never hand a

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -627,16 +627,31 @@ impl<'a> Response<'a> {
                 *offset += buf.len();
                 Err(ParseResponseError::ShortRead)
             }
-            _ => Ok(Response {
-                minor_version: usize::try_from(minor_version).expect("int cast"),
-                status_code: u32::try_from(status_code).expect("int cast"),
-                // SAFETY: on success, ptr/len point into `buf`.
-                status: unsafe { bun_core::ffi::slice(status_ptr, status_len) },
-                headers: HeaderList {
-                    list: &src[0..num_headers.min(src.len())],
-                },
-                bytes_read: rc,
-            }),
+            _ => {
+                // RFC 9112 section 5.2: picohttpparser surfaces an obs-fold
+                // continuation line as a separate entry with an empty name.
+                // `Response` has no way to splice it back into the preceding
+                // field value, and silently dropping it corrupts the value
+                // (and, for Transfer-Encoding / Content-Length, the message
+                // framing). Treat the fold as malformed; Node does the same.
+                if src[0..num_headers.min(src.len())]
+                    .iter()
+                    .any(Header::is_multiline)
+                {
+                    bun_core::debug!("obs-fold in HTTP response:\n{}", BStr::new(buf));
+                    return Err(ParseResponseError::MalformedHttpResponse);
+                }
+                Ok(Response {
+                    minor_version: usize::try_from(minor_version).expect("int cast"),
+                    status_code: u32::try_from(status_code).expect("int cast"),
+                    // SAFETY: on success, ptr/len point into `buf`.
+                    status: unsafe { bun_core::ffi::slice(status_ptr, status_len) },
+                    headers: HeaderList {
+                        list: &src[0..num_headers.min(src.len())],
+                    },
+                    bytes_read: rc,
+                })
+            }
         }
     }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2132,6 +2132,15 @@ impl FetchTasklet {
         if self.signal_aborted() {
             return ResumableSinkBackpressure::Done;
         }
+        // An empty chunk is a no-op on every framing path. It must not reach
+        // the chunked framer below, which would serialize it as "0\r\n\r\n",
+        // the chunked-body TERMINATOR (RFC 9112 section 7.1), ending the
+        // message mid-upload. It must also never report Backpressure: nothing
+        // gets buffered, so the HTTP thread's report_drain (what resumes a
+        // paused sink) can never fire, and the upload stalls forever.
+        if data.is_empty() {
+            return ResumableSinkBackpressure::WantMore;
+        }
         // reshaped for borrowck — read sink HWM (Copy) before
         // borrowing the stream buffer so `self` is unborrowed during the
         // mutex critical section below.

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from "bun:test";
 import { createHash, randomFillSync } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:http";
+import net from "node:net";
 import { promisify } from "node:util";
 import { gzipSync } from "node:zlib";
 
@@ -499,4 +500,119 @@ test("fetching with Request object - issue #1527", async () => {
   } finally {
     server.closeAllConnections();
   }
+});
+
+// RFC 9112 section 7.1: a zero-size chunk ("0\r\n\r\n") is the chunked-body
+// terminator. A ReadableStream request body that yields an empty chunk (an
+// empty read, a flush, encode("")) must not be framed as one: that ends the
+// message there, silently truncating the upload and parking the rest of the
+// user's bytes at request-line position on the reused keep-alive connection.
+// Node emits no frame for an empty chunk; the expected wire below matches it.
+test.each([
+  [["AAAA", "", "BBBB"], "4\r\nAAAA\r\n4\r\nBBBB\r\n0\r\n\r\n"],
+  [["", "AAAA"], "4\r\nAAAA\r\n0\r\n\r\n"],
+])("an empty request body chunk %j is not framed as the chunked terminator", async (chunks, expectedWireBody) => {
+  // The last non-empty chunk marks the end of the upload: respond only once
+  // it and the real terminator have both arrived, so the full wire is captured.
+  const lastData = chunks.filter(Boolean).at(-1)!;
+  let recorded = Buffer.alloc(0);
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("data", d => {
+        recorded = Buffer.concat([recorded, d]);
+        const raw = recorded.toString("latin1");
+        if (raw.endsWith("0\r\n\r\n") && raw.includes(lastData)) {
+          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const encoder = new TextEncoder();
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    duplex: "half",
+    body: new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    }),
+  });
+  expect(await res.text()).toBe("ok");
+
+  const raw = recorded.toString("latin1");
+  const headers = raw.slice(0, raw.indexOf("\r\n\r\n"));
+  const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  expect({ transferEncoding: /^transfer-encoding: (.*)$/im.exec(headers)?.[1], body }).toEqual({
+    transferEncoding: "chunked",
+    body: expectedWireBody,
+  });
+});
+
+// The same empty-chunk hazard on the other framing path: with an explicit
+// Content-Length the body is sent raw, so an empty enqueue buffers nothing,
+// but it still reported backpressure -- pausing the request body stream to
+// wait for a drain event that can never arrive. The upload hung forever.
+test("an empty request body chunk does not stall a stream body sent with an explicit Content-Length", async () => {
+  let recorded = Buffer.alloc(0);
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("data", d => {
+        recorded = Buffer.concat([recorded, d]);
+        if (recorded.toString("latin1").endsWith("AAAABBBB")) {
+          sock.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        }
+      });
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const encoder = new TextEncoder();
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    duplex: "half",
+    headers: { "content-length": "8" },
+    body: new ReadableStream({
+      start(controller) {
+        for (const chunk of ["AAAA", "", "BBBB"]) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    }),
+  });
+  expect(await res.text()).toBe("ok");
+  const raw = recorded.toString("latin1");
+  expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("AAAABBBB");
+});
+
+// RFC 9112 section 5.2: an obs-fold continuation line in a response must be
+// joined into the preceding field value with SP, or the message rejected.
+// Accepting it while silently discarding the continuation is neither: it
+// corrupts the value ("Set-Cookie: sid=1;" CRLF " Secure; HttpOnly" used to
+// surface as "sid=1;") and, for a folded Transfer-Encoding / Content-Length,
+// changes the framing this client applies to the body. Node's fetch rejects
+// such responses; so does Bun now.
+test("a response with an obs-fold header continuation is rejected, not silently truncated", async () => {
+  await using server = net
+    .createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("data", () => {
+        sock.end("HTTP/1.1 200 OK\r\nSet-Cookie: sid=1;\r\n Secure; HttpOnly\r\nContent-Length: 2\r\n\r\nok");
+      });
+    })
+    .listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const outcome = await fetch(`http://127.0.0.1:${port}/`).then(
+    // On a regression this records the truncated Set-Cookie the bug produced.
+    r => ({ rejected: false as const, setCookie: r.headers.get("set-cookie") }),
+    e => ({ rejected: true as const, code: e.code }),
+  );
+  expect(outcome).toEqual({ rejected: true, code: "Malformed_HTTP_Response" });
 });

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -169,3 +169,140 @@ test("PUT with a ReadableStream body is not retried on keep-alive disconnect", a
     exitCode: 0,
   });
 });
+
+// A server may send its final response (401, 413, ...) while a chunked
+// ReadableStream request body is still uploading. That connection is then
+// mid-message: the terminating 0\r\n\r\n was never written, so the server is
+// still parsing it as the request body. It must be closed, never pooled --
+// a pooled reuse writes the NEXT fetch's request line and credential headers
+// (Authorization, Cookie) into the PREVIOUS request's body. Subprocess so the
+// poisoned pool can't leak into other tests.
+test("an early response to a streaming POST closes the socket instead of pooling it mid-chunked-body", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      const connections = [];
+      const server = net.createServer(sock => {
+        const rec = { bytes: [], responded: false };
+        connections.push(rec);
+        sock.on("error", () => {});
+        sock.on("data", d => {
+          rec.bytes.push(d);
+          if (!rec.responded) {
+            rec.responded = true;
+            // Final response long before the chunked upload is done.
+            sock.write("HTTP/1.1 401 Unauthorized\\r\\nContent-Length: 0\\r\\n\\r\\n");
+          } else {
+            // A second burst on an already-answered connection means the next
+            // request was written into the previous request's body. Reply with
+            // a marker status so the poisoned follow-up fetch observes it
+            // instead of hanging.
+            sock.write("HTTP/1.1 299 Poisoned\\r\\nContent-Length: 0\\r\\n\\r\\n");
+          }
+        });
+      });
+      server.listen(0, "127.0.0.1");
+      await new Promise(r => server.on("listening", r));
+      const url = "http://127.0.0.1:" + server.address().port + "/";
+
+      // One chunk, then stall: the chunked message never gets its terminator.
+      let stall;
+      const res1 = await fetch(url, {
+        method: "POST",
+        duplex: "half",
+        body: new ReadableStream({
+          pull(c) {
+            if (!stall) {
+              c.enqueue(new TextEncoder().encode("AAAA"));
+              stall = new Promise(() => {});
+            }
+            return stall;
+          },
+        }),
+      });
+      const res2 = await fetch(url, { headers: { Authorization: "Bearer SECRET" } });
+      const conn0 = Buffer.concat(connections[0].bytes).toString("latin1");
+      console.log(JSON.stringify({
+        status1: res1.status,
+        status2: res2.status,
+        connections: connections.length,
+        authLeakedIntoFirstBody: conn0.includes("Authorization: Bearer SECRET"),
+      }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    // Without the fix the 401'd connection is pooled: the second fetch is
+    // written onto it (connections === 1), its request line and Authorization
+    // header land inside request 1's chunked body on the wire, and it
+    // resolves with the server's second-burst reply (299) instead of 401.
+    result: { status1: 401, status2: 401, connections: 2, authLeakedIntoFirstBody: false },
+    exitCode: 0,
+  });
+});
+
+// Negative contract for the gate above: a streamed POST whose chunked body
+// completed (terminator written) before the response arrived must still hand
+// its connection back to the keep-alive pool.
+test("a completed streaming POST keeps its connection in the keep-alive pool", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      let connections = 0;
+      const server = net.createServer(sock => {
+        connections++;
+        sock.on("error", () => {});
+        let buf = "";
+        sock.on("data", d => {
+          buf += d.toString("latin1");
+          // One response per fully-received chunked message (terminator seen).
+          while (buf.includes("0\\r\\n\\r\\n")) {
+            buf = buf.slice(buf.indexOf("0\\r\\n\\r\\n") + 5);
+            sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\n\\r\\nok");
+          }
+        });
+      });
+      server.listen(0, "127.0.0.1");
+      await new Promise(r => server.on("listening", r));
+      const url = "http://127.0.0.1:" + server.address().port + "/";
+
+      const results = [];
+      for (let i = 0; i < 8; i++) {
+        const body = new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode("hello"));
+            c.close();
+          },
+        });
+        const res = await fetch(url, { method: "POST", duplex: "half", body });
+        results.push(res.status, await res.text());
+      }
+      console.log(JSON.stringify({ results, connections }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    result: { results: Array(8).fill([200, "ok"]).flat(), connections: 1 },
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
Fixes three deterministic HTTP/1.1 wire bugs in the `fetch()` client, all reproduced on `main` against a raw `node:net` byte-recording server with Node's behavior on identical input as the reference. The first two are request-smuggling-shaped.

### 1. An empty chunk in a streamed request body is framed as the chunked-body terminator

```js
await fetch(url, {
  method: "POST", duplex: "half",
  body: new ReadableStream({ start(c) {
    c.enqueue(enc.encode("AAAA")); c.enqueue(new Uint8Array(0)); c.enqueue(enc.encode("BBBB")); c.close();
  }}),
});
// bun wire:   4\r\nAAAA\r\n0\r\n\r\n4\r\nBBBB\r\n0\r\n\r\n
// node wire:  4\r\nAAAA\r\n4\r\nBBBB\r\n0\r\n\r\n
```

RFC 9112 section 7.1 defines a zero-size chunk as the body terminator. `write_request_data` formatted `{len:x}\r\n` + data + `\r\n` unconditionally, so a zero-length enqueue (an empty read, a flush, `encode("")`) serialized to literally `0\r\n\r\n` mid-message. A `node:http` server sees the upload silently truncated at `AAAA`, and the rest of the user's own bytes (`4\r\nBBBB\r\n0\r\n\r\n`) sit at request-line position on the reused keep-alive connection: a client-side desync primitive.

The same input on the other framing path (an explicit `Content-Length`, so the body is sent raw) already made the upload hang forever: the empty chunk buffered nothing, but `write_request_data` still reported backpressure, pausing the body stream to wait for a drain event the HTTP thread can never fire.

Fix: treat an empty chunk as a no-op that wants more data. Only `write_end_request` may emit the terminator, and a write that buffers nothing must not report backpressure.

### 2. An early final response during a streamed upload poisons the keep-alive pool

When a server answers (401, 413, ...) while a chunked `ReadableStream` body is still uploading, Bun stopped the upload but returned the connection, mid-request-message, to the pool. The next `fetch()` to that origin was then written into the unfinished request's body. Captured on the wire from the first (and only) connection:

```
POST / HTTP/1.1\r\n...Transfer-Encoding: chunked\r\n\r\n4\r\nAAAA\r\nGET / HTTP/1.1\r\nAuthorization: Bearer SECRET\r\n...
```

The second request's line and its `Authorization` header land inside the first request's chunked body. Node closes the connection and opens a fresh one.

Cause: the `request_side_drained` pooling gate in `send_progress_update_without_stage_check` only checked the unsent slice for byte-buffer bodies and hardcoded `true` for `Stream`/`Sendfile`. The in-code comment said as much ("Stream/Sendfile are left as-is"), and the redirect path (`do_redirect`) plus the `fetch-http2-client.test.ts` regression test for it already guard the 303 flavor of exactly this.

Fix: gate pooling on `request_stage == RequestStage::Done` for `Stream`/`Sendfile`, and set `Done` on both of `write_to_stream`'s "stream fully written" exits (previously only the `ended && !has_backpressure` one set it) so the signal is reliable. RFC 9112 section 9.3: a client that would otherwise still send the rest of the request must close the connection.

### 3. Obs-fold response header continuations are accepted but silently discarded

```
HTTP/1.1 200 OK\r\nSet-Cookie: sid=1;\r\n Secure; HttpOnly\r\n...
```

JS saw `set-cookie: "sid=1;"`. picohttpparser surfaces a folded continuation line as a separate header entry with an empty name (`Header::is_multiline`), and nothing in the client looked at it, so the `Secure; HttpOnly` attributes were dropped. The same applies to a folded `Transfer-Encoding` or `Content-Length`, which changes the framing Bun applies to the body relative to any compliant recipient of the same bytes.

RFC 9112 section 5.2 requires a recipient to either join the continuation with SP or reject the message; accepting it while discarding the continuation is neither. Node's fetch rejects such responses. `Response::parse_parts` now returns `MalformedHttpResponse` when a successful parse contains a fold, which covers every consumer (the fetch client, the CONNECT proxy envelope, the WebSocket upgrade response). Joining instead would need the joined value to be a contiguous slice, which this `Response` has no storage for; rejecting matches Node and is the conservative floor for a header shape no current server emits.

### Verification

- `test/js/web/fetch/client-fetch.test.ts`: the exact wire bytes of the chunked body with an empty chunk in each position, the explicit-Content-Length hang, and the obs-fold rejection.
- `test/js/web/fetch/fetch-keepalive.test.ts`: the early-401 case asserts the follow-up fetch opens a second TCP connection, gets 401 (not the server's "poisoned" marker status), and that `Authorization: Bearer SECRET` never appears in the first connection's bytes; a second test pins the negative contract that a completed streamed POST still pools.
- All new tests fail against `main`'s source and pass with the fix (0 flakes in 22 repeated runs of both files under a debug+ASAN build).
- `node:http`'s `ClientRequest` is a separate stack (`node:net` + llhttp) and already handles an empty `write()` correctly; unaffected.


### Related

Related: #19097 reports intermittent truncated multipart uploads from Bun (`MultipartStream: Stream ended unexpectedly` on the receiving server), which is the symptom bug 1 produces. Left as a non-closing reference because the reporter's transport (axios plus the `form-data` package, against an external backend) could not be confirmed to reach this code path; see the verification comment below.
