### PR TITLE
bunfig: validate coverageThreshold keys, enforce only the listed metrics, name the missed threshold

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -230,7 +230,7 @@ The coverage threshold. By default, no threshold is set. If your test suite does
 coverageThreshold = 0.9
 ```
 
-You can set separate thresholds for line and function coverage. Bun accepts a `statements` key but does not currently enforce it.
+You can set separate thresholds for line and function coverage. Only the metrics you list are enforced. Bun accepts a `statements` key but does not currently enforce it.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]

--- a/docs/test/code-coverage.mdx
+++ b/docs/test/code-coverage.mdx
@@ -68,7 +68,7 @@ coverageThreshold = 0.9
 coverageThreshold = { lines = 0.9, functions = 0.9 }
 ```
 
-Setting either key makes `bun test --coverage` exit with a non-zero exit code when line or function coverage is below its threshold; a key you omit keeps the `0.9` default. Bun accepts a `statements` key but does not currently enforce it. Outside `--parallel`, the check only runs when the `text` reporter is enabled (the default); a run with only `--coverage-reporter=lcov` currently exits 0 regardless of the threshold.
+Setting either key makes `bun test --coverage` exit with a non-zero exit code when line or function coverage is below its threshold, whichever coverage reporters are enabled. Only the keys you list are enforced. Bun accepts a `statements` key but does not currently enforce it.
 
 ## Coverage Reporters
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -499,22 +499,35 @@ impl<'a> Parser<'a> {
                         }
 
                         self.expect(&expr, ExprTag::EObject)?;
-                        if let Some(functions) = expr.get(b"functions") {
-                            self.expect(&functions, ExprTag::ENumber)?;
-                            self.ctx.test_options.coverage.fractions.functions =
-                                functions.as_number().expect("infallible: type checked");
-                            self.ctx.test_options.coverage.fail_on_low_coverage = true;
-                        }
-                        if let Some(lines) = expr.get(b"lines") {
-                            self.expect(&lines, ExprTag::ENumber)?;
-                            self.ctx.test_options.coverage.fractions.lines =
-                                lines.as_number().expect("infallible: type checked");
-                            self.ctx.test_options.coverage.fail_on_low_coverage = true;
-                        }
-                        if let Some(stmts) = expr.get(b"statements") {
-                            self.expect(&stmts, ExprTag::ENumber)?;
-                            self.ctx.test_options.coverage.fractions.stmts =
-                                stmts.as_number().expect("infallible: type checked");
+                        // A metric the object leaves out stays 0 and so never fails.
+                        self.ctx.test_options.coverage.fractions.functions = 0.0;
+                        self.ctx.test_options.coverage.fractions.lines = 0.0;
+                        self.ctx.test_options.coverage.fractions.stmts = 0.0;
+
+                        let obj = expr.data.e_object().expect("infallible: variant checked");
+                        for prop in obj.properties.slice() {
+                            let key_expr = prop.key.as_ref().expect("infallible: prop has key");
+                            let ExprData::EString(key) = &key_expr.data else {
+                                continue;
+                            };
+                            let value = prop.value.as_ref().expect("infallible: prop has value");
+                            self.expect(value, ExprTag::ENumber)?;
+                            let v = value.as_number().expect("infallible: type checked");
+
+                            if key.eql_comptime(b"functions") || key.eql_comptime(b"function") {
+                                self.ctx.test_options.coverage.fractions.functions = v;
+                            } else if key.eql_comptime(b"lines") || key.eql_comptime(b"line") {
+                                self.ctx.test_options.coverage.fractions.lines = v;
+                            } else if key.eql_comptime(b"statements")
+                                || key.eql_comptime(b"statement")
+                            {
+                                self.ctx.test_options.coverage.fractions.stmts = v;
+                            } else {
+                                return self.add_error(
+                                    key_expr.loc,
+                                    b"coverageThreshold keys must be \"lines\", \"functions\", or \"statements\"",
+                                );
+                            }
                             self.ctx.test_options.coverage.fail_on_low_coverage = true;
                         }
                     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2661,11 +2661,32 @@ impl TestCommand {
 
         let should_fail_on_no_tests = !ctx.test_options.pass_with_no_tests
             && (failed_to_find_any_tests || summary.did_label_filter_out_all_tests());
+        let coverage_below_threshold = coverage_options.enabled
+            && coverage_options.fractions.failing
+            && coverage_options.fail_on_low_coverage;
+        if coverage_below_threshold {
+            // A metric the config left out holds 0 and is not enforced.
+            let thresholds = coverage_options.fractions;
+            match (thresholds.functions > 0.0, thresholds.lines > 0.0) {
+                (true, true) => pretty_errorln!(
+                    "<r><red>error<r><d>:<r> Coverage is below the configured <b>test.coverageThreshold<r> (functions: {:.2}%, lines: {:.2}%)",
+                    thresholds.functions * 100.0,
+                    thresholds.lines * 100.0
+                ),
+                (true, false) => pretty_errorln!(
+                    "<r><red>error<r><d>:<r> Function coverage is below the configured <b>test.coverageThreshold<r> of {:.2}%",
+                    thresholds.functions * 100.0
+                ),
+                _ => pretty_errorln!(
+                    "<r><red>error<r><d>:<r> Line coverage is below the configured <b>test.coverageThreshold<r> of {:.2}%",
+                    thresholds.lines * 100.0
+                ),
+            }
+            Output::flush();
+        }
         if should_fail_on_no_tests
             || summary.fail > 0
-            || (coverage_options.enabled
-                && coverage_options.fractions.failing
-                && coverage_options.fail_on_low_coverage)
+            || coverage_below_threshold
             || !write_snapshots_success
             || reporter.jest.unhandled_errors_between_tests > 0
         {

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -3,6 +3,25 @@ import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import path from "path";
 
+/// Runs `bun test --coverage <args>` in `dir` and returns the normalized
+/// output plus the lcov report, if one was written.
+async function runCoverage(dir: string, args: string[] = []) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", ...args],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  let lcov: string | null = null;
+  const lcovFile = Bun.file(path.join(dir, "coverage", "lcov.info"));
+  if (await lcovFile.exists()) {
+    lcov = normalizeBunSnapshot(await lcovFile.text(), dir);
+  }
+  return { stdout, stderr: normalizeBunSnapshot(stderr, dir), exitCode, lcov };
+}
+
 test("coverage crash", () => {
   using dir = tempDir("cov", {
     "demo.test.ts": `class Y {
@@ -537,6 +556,146 @@ All files      |  100.00 |  100.00 |
 Ran 1 test across 1 file."
 `);
   expect(result.exitCode).toBe(0);
+});
+
+// math.ts covers 1 of 2 functions: `add` runs, `neverCalled` never does.
+const thresholdFixture = {
+  "math.ts": `export function add(a: number, b: number) {
+  return a + b;
+}
+export function neverCalled() {
+  return 42;
+}
+`,
+  "math.test.ts": `import { test, expect } from "bun:test";
+import { add } from "./math";
+test("add", () => {
+  expect(add(1, 2)).toBe(3);
+});
+`,
+};
+
+test.concurrent("coverageThreshold is enforced for every reporter, not only text", async () => {
+  using dir = tempDir("cov-threshold-reporters", {
+    "bunfig.toml": `
+[test]
+coverageThreshold = { lines = 0.9, functions = 0.9 }
+coverageSkipTestFiles = true
+`,
+    ...thresholdFixture,
+  });
+
+  for (const reporter of ["lcov", "text"] as const) {
+    const { stderr, exitCode } = await runCoverage(dir, [`--coverage-reporter=${reporter}`]);
+    expect({
+      reporter,
+      error: stderr.includes(
+        "error: Coverage is below the configured test.coverageThreshold (functions: 90.00%, lines: 90.00%)",
+      ),
+      exitCode,
+    }).toEqual({ reporter, error: true, exitCode: 1 });
+  }
+});
+
+test.concurrent("coverageThreshold is enforced with coverageReporter = []", async () => {
+  // https://github.com/oven-sh/bun/issues/32118
+  using dir = tempDir("cov-threshold-no-reporters", {
+    "bunfig.toml": `
+[test]
+coverageReporter = []
+coverageThreshold = { functions = 0.9 }
+coverageSkipTestFiles = true
+`,
+    ...thresholdFixture,
+  });
+
+  const { stderr, exitCode } = await runCoverage(dir);
+  expect({
+    error: stderr.includes("error: Function coverage is below the configured test.coverageThreshold of 90.00%"),
+    exitCode,
+  }).toEqual({ error: true, exitCode: 1 });
+});
+
+test.concurrent("coverageThreshold that is met exits 0 with the lcov reporter", async () => {
+  using dir = tempDir("cov-threshold-met", {
+    "bunfig.toml": `
+[test]
+coverageThreshold = { lines = 0.25, functions = 0.25 }
+coverageSkipTestFiles = true
+`,
+    ...thresholdFixture,
+  });
+
+  const { stderr, exitCode } = await runCoverage(dir, ["--coverage-reporter=lcov"]);
+  expect({ stderr: stderr.includes("test.coverageThreshold"), exitCode }).toEqual({ stderr: false, exitCode: 0 });
+});
+
+test.concurrent("coverageThreshold accepts the singular key spellings", async () => {
+  using dir = tempDir("cov-threshold-singular", {
+    "bunfig.toml": `
+[test]
+coverageThreshold = { line = 0.9, function = 0.9 }
+coverageSkipTestFiles = true
+`,
+    ...thresholdFixture,
+  });
+
+  const { stderr, exitCode } = await runCoverage(dir);
+  expect({
+    error: stderr.includes(
+      "error: Coverage is below the configured test.coverageThreshold (functions: 90.00%, lines: 90.00%)",
+    ),
+    exitCode,
+  }).toEqual({ error: true, exitCode: 1 });
+});
+
+test.concurrent("coverageThreshold only enforces the metrics it names", async () => {
+  // 1/2 functions are covered. A lines-only threshold must not enforce a
+  // hidden default functions threshold.
+  using dir = tempDir("cov-threshold-lines-only", {
+    "bunfig.toml": `
+[test]
+coverageThreshold = { lines = 0.25 }
+coverageSkipTestFiles = true
+`,
+    ...thresholdFixture,
+  });
+
+  const { stderr, exitCode } = await runCoverage(dir);
+  expect({ stderr: stderr.includes("test.coverageThreshold"), exitCode }).toEqual({ stderr: false, exitCode: 0 });
+});
+
+test.concurrent("a lines-only coverageThreshold failure names line coverage", async () => {
+  using dir = tempDir("cov-threshold-lines-only-fail", {
+    "bunfig.toml": `
+[test]
+coverageThreshold = { lines = 0.99 }
+coverageSkipTestFiles = true
+`,
+    ...thresholdFixture,
+  });
+
+  const { stderr, exitCode } = await runCoverage(dir);
+  expect({
+    error: stderr.includes("error: Line coverage is below the configured test.coverageThreshold of 99.00%"),
+    exitCode,
+  }).toEqual({ error: true, exitCode: 1 });
+});
+
+test.concurrent("coverageThreshold rejects unknown keys", async () => {
+  using dir = tempDir("cov-threshold-unknown-key", {
+    "bunfig.toml": `
+[test]
+coverageThreshold = { branches = 0.9 }
+`,
+    ...thresholdFixture,
+  });
+
+  const { stderr, exitCode } = await runCoverage(dir);
+  expect({
+    error: stderr.includes('coverageThreshold keys must be "lines", "functions", or "statements"'),
+    exitCode,
+  }).toEqual({ error: true, exitCode: 1 });
 });
 
 test("coveragePathIgnorePatterns - ignore all files", () => {

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -4,22 +4,17 @@ import { readFileSync } from "node:fs";
 import path from "path";
 
 /// Runs `bun test --coverage <args>` in `dir` and returns the normalized
-/// output plus the lcov report, if one was written.
+/// stderr and the exit code.
 async function runCoverage(dir: string, args: string[] = []) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--coverage", ...args],
     cwd: dir,
     env: bunEnv,
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  let lcov: string | null = null;
-  const lcovFile = Bun.file(path.join(dir, "coverage", "lcov.info"));
-  if (await lcovFile.exists()) {
-    lcov = normalizeBunSnapshot(await lcovFile.text(), dir);
-  }
-  return { stdout, stderr: normalizeBunSnapshot(stderr, dir), exitCode, lcov };
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  return { stderr: normalizeBunSnapshot(stderr, dir), exitCode };
 }
 
 test("coverage crash", () => {


### PR DESCRIPTION
Fixes #4267
Fixes #7367
Fixes #32118

### Problem
- `coverageThreshold = { line = 0.9, function = 0.9 }` in bunfig enforces nothing. The parser (`src/bunfig/bunfig.rs`) only reads the plural keys and ignores any other key, so the singular spelling the docs showed for years is a silent no-op (#4267, #7367).
- `coverageThreshold = { lines = 0.1 }` also enforces the hidden `Fraction::default()` values for the metrics it does not name (0.9 functions, 0.75 statements).
- A run that misses the threshold exits 1 with no message.

### Fix
- The parser iterates the object's keys. It accepts `lines`/`line`, `functions`/`function` and `statements`/`statement`, and rejects any other key with a parse error. Only the listed metrics are enforced: the others are set to 0.
- `bun test` prints which threshold the run missed, for example `error: Coverage is below the configured test.coverageThreshold (functions: 99.00%, lines: 99.00%)` (`src/runtime/cli/test_command.rs`).
- `docs/test/code-coverage.mdx` and `docs/runtime/bunfig.mdx` no longer describe the 0.9 default for omitted keys and the lcov-only bypass as current behavior.
- Verified: `test/cli/test/coverage.test.ts` (seven new `coverageThreshold` tests, six fail on 1.4.3-canary) and `test/cli/test/parallel.test.ts -t coverage`.

### Background
- `coverageThreshold` takes a number (all metrics) or an object with per-metric fractions. `bun test --coverage` exits 1 when any file is below a configured fraction.
- The lcov-only threshold bypass from #32118 was fixed on main by #40678 while this PR was open. The tests for it are kept here and now also assert the message.

<details><summary>Notes</summary>

This PR used to carry two `src/sourcemap_jsc/CodeCoverage.rs` changes as well: the inclusive last line of a never-called function (#31484) and `DA` hit counts as execution counts instead of byte counts. Those are dropped here. #38282 and #41528 each rewrite that loop and cover the never-called function case (verified by running this PR's old tests against both). Execution counts are in #41528 and in #35725. The old snapshot updates that came from those changes are reverted to main's values.

Supersedes #31485 and #32121 (both closed).

</details>
