### PR TITLE
FileSystemRouter: do not let percent-decoding change URL structure

### DIFF
--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -41,56 +41,60 @@ impl URLPath {
 // percent-encoded path, which is the rare case.
 
 pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::DecodeError> {
-    let mut decoded_pathname: &[u8] = possibly_encoded_pathname_;
-    let mut decoded_storage: Option<Box<[u8]>> = None;
-    if strings::index_of_char(decoded_pathname, b'%').is_some() {
-        // The in-place decode buffer is capped at 16384 bytes of input.
-        let capped = &possibly_encoded_pathname_[..possibly_encoded_pathname_.len().min(16384)];
+    // Split path from query on the first *literal* '?' before any decoding:
+    // an encoded '%3F' must not start the query, and `QueryStringMap` already
+    // percent-decodes each query name/value exactly once.
+    let question_mark_i = strings::index_of_char(possibly_encoded_pathname_, b'?')
+        .map_or(possibly_encoded_pathname_.len(), |i| i as usize);
+    let raw_path: &[u8] = &possibly_encoded_pathname_[..question_mark_i];
+    let raw_query: &[u8] = &possibly_encoded_pathname_[question_mark_i..];
 
+    let mut decoded_storage: Option<Box<[u8]>> = None;
+
+    // `pathname` is the decoded path followed by the untouched raw query;
+    // `path_end` is where the query begins inside it. When nothing in the path
+    // needs decoding, `pathname` borrows the input directly.
+    let (pathname, path_end): (&[u8], usize) = if strings::index_of_char(raw_path, b'%').is_some() {
+        // The in-place decode buffer is capped at 16384 bytes of input.
+        let capped = &raw_path[..raw_path.len().min(16384)];
+
+        // Validate the path before allocating for the query: a malformed
+        // escape must not allocate query-sized storage first.
         let mut buf: Vec<u8> = Vec::with_capacity(capped.len());
-        let n = PercentEncoding::decode_fault_tolerant::<_, true>(&mut buf, capped)?;
+        // `PRESERVE_STRUCTURE` keeps `%2F`/`%25` encoded so an escaped slash
+        // can't cross a route segment boundary; `QueryStringMap` decodes those
+        // two escapes per captured param value as the single applied decode.
+        let n = PercentEncoding::decode_fault_tolerant::<_, true, true>(&mut buf, capped)?;
         debug_assert!(n as usize <= buf.len());
         buf.truncate(n as usize);
-        // Freeze into a heap-stable Box and park it in `decoded_storage` before
-        // borrowing: the slice fields in the returned URLPath borrow from this
-        // allocation, and the Box is later moved into that same URLPath, so the
-        // borrow is valid for the struct's whole lifetime (Box heap address is
-        // stable across moves). NLL releases the local borrow after the last
-        // use of `decoded_pathname` in the struct-literal field initialisers,
-        // before `_decoded_storage` is moved.
+        // The slicing below assumes a non-empty path with a leading byte to
+        // skip; an input like "%PUBLIC_URL%" (consumed entirely by the
+        // fault-tolerant decoder) decodes to nothing.
+        if buf.is_empty() {
+            buf.push(b'/');
+        }
+        let path_end = buf.len();
+        buf.extend_from_slice(raw_query);
+        // Freeze into a heap-stable Box before borrowing: the URLPath slice
+        // fields borrow this allocation and the Box is moved into that same
+        // URLPath, so the borrow stays valid (Box addresses survive moves).
         decoded_storage = Some(buf.into_boxed_slice());
-        decoded_pathname = decoded_storage.as_deref().unwrap();
-    }
+        (decoded_storage.as_deref().unwrap(), path_end)
+    } else {
+        (possibly_encoded_pathname_, raw_path.len())
+    };
 
-    // The slicing below assumes a non-empty pathname with a leading byte to
-    // skip. An empty input (or an input like "%PUBLIC_URL%" that the fault-
-    // tolerant decoder consumes entirely) would otherwise index out of bounds.
-    if decoded_pathname.is_empty() {
-        decoded_pathname = b"/";
-        decoded_storage = None;
-    }
+    let path_part = &pathname[..path_end];
 
-    let mut question_mark_i: i32 = -1;
     let mut period_i: i32 = -1;
-
     let mut last_slash: i32 = -1;
 
-    let mut i: i32 = i32::try_from(decoded_pathname.len()).expect("int cast") - 1;
+    let mut i: i32 = i32::try_from(path_part.len()).expect("int cast") - 1;
 
     while i >= 0 {
-        let c = decoded_pathname[usize::try_from(i).expect("int cast")];
+        let c = path_part[usize::try_from(i).expect("int cast")];
 
         match c {
-            b'?' => {
-                question_mark_i = question_mark_i.max(i);
-                if question_mark_i < period_i {
-                    period_i = -1;
-                }
-
-                if last_slash > question_mark_i {
-                    last_slash = -1;
-                }
-            }
             b'.' => {
                 period_i = period_i.max(i);
             }
@@ -109,28 +113,16 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
 
     // .js.map
     //    ^
-    let extname: &[u8] = 'brk: {
-        if question_mark_i > -1 && period_i > -1 {
-            period_i += 1;
-            break 'brk &decoded_pathname[usize::try_from(period_i).expect("int cast")
-                ..usize::try_from(question_mark_i).expect("int cast")];
-        } else if period_i > -1 {
-            period_i += 1;
-            break 'brk &decoded_pathname[usize::try_from(period_i).expect("int cast")..];
-        } else {
-            break 'brk &[];
-        }
+    let extname: &[u8] = if period_i > -1 {
+        &path_part[usize::try_from(period_i + 1).expect("int cast")..]
+    } else {
+        &[]
     };
 
-    // `path` is the pathname without the leading byte and without the query
-    // string. When the input begins with '?' the end index is 0, so clamp the
-    // start to avoid a 1..0 slice.
-    let path_end: usize = if question_mark_i < 0 {
-        decoded_pathname.len()
-    } else {
-        usize::try_from(question_mark_i).expect("int cast")
-    };
-    let mut path: &[u8] = &decoded_pathname[1.min(path_end)..path_end];
+    // `path` is the path part without the leading byte and never includes the
+    // query string. When the input begins with '?' the end index is 0, so
+    // clamp the start to avoid a 1..0 slice.
+    let mut path: &[u8] = &path_part[1.min(path_end)..];
 
     // For a source map (`foo.js.map`), strip the trailing `.map` so the path
     // names the mapped file — but only when an inner extension exists.
@@ -153,18 +145,9 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
     }
 
     Ok(URLPath {
-        pathname: extend(decoded_pathname),
-        path: extend(if decoded_pathname.len() == 1 {
-            b"."
-        } else {
-            path
-        }),
-        query_string: extend(if question_mark_i > -1 {
-            &decoded_pathname
-                [usize::try_from(question_mark_i).expect("int cast")..decoded_pathname.len()]
-        } else {
-            b""
-        }),
+        pathname: extend(pathname),
+        path: extend(if path_end == 1 { b"." } else { path }),
+        query_string: extend(&pathname[path_end..]),
         _decoded_storage: decoded_storage,
     })
 }

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -602,15 +602,11 @@ impl FileSystemRouter {
         // `URLPath::parse` percent-decoded — in that case nothing borrows `path_bytes`
         // anymore and `path` is swapped for the decode buffer below.
         let path_bytes: &[u8] = unsafe { bun_ptr::detach_lifetime(path.slice()) };
-        let mut url_path = match URLPath::parse(path_bytes) {
-            Ok(v) => v,
-            Err(err) => {
-                return Err(global_this.throw(format_args!(
-                    "{} parsing path: {}",
-                    bun_url::Error::from(err).name(),
-                    bstr::BStr::new(path.slice())
-                )));
-            }
+        // A path with a malformed percent escape cannot name any route.
+        // `match()` is typed as `MatchedRoute | null`, so a bad URL (trivially
+        // reachable from `router.match(request)`) must not throw.
+        let Ok(mut url_path) = URLPath::parse(path_bytes) else {
+            return Ok(JSValue::NULL);
         };
         let mut params = route_param::List::default();
         // `defer params.deinit(allocator)` → Drop

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -996,10 +996,16 @@ impl QueryStringMap {
 
             let name_hash: u64 = wyhash(name_slice);
 
+            // `URLPath::parse` decoded every escape in the path except the
+            // `%2F`/`%25` PRESERVE_STRUCTURE kept, so decoding those here is
+            // the single decode applied to a captured param value.
             let value_slice = result.raw_value(scanner.pathname.pathname);
-            value.length = u32::try_from(value_slice.len()).unwrap();
             value.offset = buf_writer_pos;
-            buf.extend_from_slice(value_slice);
+            value.length = PercentEncoding::decode(&mut buf, value_slice).unwrap_or_else(|_| {
+                buf.truncate(buf_writer_pos as usize);
+                buf.extend_from_slice(value_slice);
+                u32::try_from(value_slice.len()).unwrap()
+            });
             buf_writer_pos += value.length;
 
             list.push(Param {
@@ -1344,7 +1350,7 @@ impl PercentEncoding {
         writer: &mut impl bun_core::io::Write,
         input: &[u8],
     ) -> Result<u32, DecodeError> {
-        Self::decode_fault_tolerant::<_, false>(writer, input)
+        Self::decode_fault_tolerant::<_, false, false>(writer, input)
     }
 
     /// Decode percent-encoded input into allocated memory.
@@ -1367,7 +1373,14 @@ impl PercentEncoding {
         Self::decode(&mut w, input)
     }
 
-    pub fn decode_fault_tolerant<W: bun_core::io::Write, const FAULT_TOLERANT: bool>(
+    /// `PRESERVE_STRUCTURE` copies `%2F` and `%25` through verbatim so route
+    /// matchers that split the output on `/` never see a decoded slash, and
+    /// so the per-value decode of a captured segment is the only decode.
+    pub fn decode_fault_tolerant<
+        W: bun_core::io::Write,
+        const FAULT_TOLERANT: bool,
+        const PRESERVE_STRUCTURE: bool,
+    >(
         writer: &mut W,
         input: &[u8],
     ) -> Result<u32, DecodeError> {
@@ -1406,10 +1419,15 @@ impl PercentEncoding {
                         }
                     }
 
-                    writer.write_byte(
-                        (strings::to_ascii_hex_value(input[i + 1]) << 4)
-                            | strings::to_ascii_hex_value(input[i + 2]),
-                    )?;
+                    let decoded = (strings::to_ascii_hex_value(input[i + 1]) << 4)
+                        | strings::to_ascii_hex_value(input[i + 2]);
+                    if PRESERVE_STRUCTURE && matches!(decoded, b'/' | b'%') {
+                        writer.write_all(&input[i..i + 3])?;
+                        i += 3;
+                        written += 3;
+                        continue;
+                    }
+                    writer.write_byte(decoded)?;
                     i += 3;
                     written += 1;
                     continue;

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -671,11 +671,9 @@ it(".params decodes percent escapes in a route segment exactly once", () => {
 
   const escaped = router.match("/posts/%252e%252e%252fetc")!;
   expect(escaped.name).toBe("/posts/[id]");
-  expect(escaped.pathname).toBe("/posts/%2e%2e%2fetc");
   expect(escaped.params.id).toBe("%2e%2e%2fetc");
 
   const percent = router.match("/posts/100%2525")!;
-  expect(percent.pathname).toBe("/posts/100%25");
   expect(percent.params.id).toBe("100%25");
 });
 
@@ -928,11 +926,13 @@ it(".query drops a pair with a malformed percent escape without shifting later p
   });
 
   for (const [current, expected] of [
-    ["/posts?a=x%25zz&b=hello", { b: "hello" }],
-    ["/posts?a=xy%25zz&b=hello&c=3", { b: "hello", c: "3" }],
-    ["/posts?a=%25zz&b=hello", { b: "hello" }],
-    ["/shows/123?a=x%25zz&b=ok", { id: "123", b: "ok" }],
-    ["/shows/123?a=xy%25zz&b=ok&c=3", { id: "123", b: "ok", c: "3" }],
+    ["/posts?a=x%zz&b=hello", { b: "hello" }],
+    ["/posts?a=xy%zz&b=hello&c=3", { b: "hello", c: "3" }],
+    ["/posts?a=%zz&b=hello", { b: "hello" }],
+    ["/shows/123?a=x%zz&b=ok", { id: "123", b: "ok" }],
+    ["/shows/123?a=xy%zz&b=ok&c=3", { id: "123", b: "ok", c: "3" }],
+    // %25zz is a valid escape: it decodes to a literal "%zz".
+    ["/posts?a=x%25zz&b=hello", { a: "x%zz", b: "hello" }],
   ] as const) {
     expect({ input: current, query: router.match(current)!.query }).toEqual({ input: current, query: expected });
   }
@@ -948,9 +948,11 @@ it(".query keeps the route parameter when a percent-encoded query name decodes t
 
   for (const [current, expected] of [
     ["/posts/123?id=999", { id: "123" }],
-    ["/posts/123?%2569d=999", { id: "123" }],
-    ["/posts/123?%2569d=999&other=1", { id: "123", other: "1" }],
-    ["/posts/123?other=1&%2569d=999", { id: "123", other: "1" }],
+    ["/posts/123?%69d=999", { id: "123" }],
+    ["/posts/123?%69d=999&other=1", { id: "123", other: "1" }],
+    ["/posts/123?other=1&%69d=999", { id: "123", other: "1" }],
+    // %2569d decodes once to the name "%69d", not "id".
+    ["/posts/123?%2569d=999", { "id": "123", "%69d": "999" }],
   ] as const) {
     expect({ input: current, query: router.match(current)!.query }).toEqual({ input: current, query: expected });
   }
@@ -1027,3 +1029,88 @@ it.skipIf(isWindows || isMacOS)(
     expect(exitCode).toBe(0);
   },
 );
+
+it("match() does not let a percent-encoded '/' cross a route segment boundary", () => {
+  // Routing splits the path on '/'. Decoding %2F before that split let
+  // `/admin%2Fpanel` select the nested `/admin/panel` route instead of the
+  // `[file]` parameter; only the captured param value may be decoded.
+  const { dir } = make(["[file].tsx", "admin/panel.tsx", "posts/[id].tsx", "index.tsx"]);
+  const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+  const m = (p: string) => {
+    const r = router.match(p);
+    return r ? { name: r.name, params: r.params } : null;
+  };
+
+  expect({
+    encodedSlash: m("/admin%2Fpanel"),
+    encodedSlashLower: m("/admin%2fpanel"),
+    literalSlash: m("/admin/panel"),
+    nonStatic: m("/he%2Fllo"),
+    nestedDynamic: m("/posts/a%2Fb"),
+    // %25 must stay encoded too, or the per-param decode would then read the
+    // following bytes as a fresh escape (double decode).
+    encodedPercent: m("/posts/%2541"),
+    mixed: m("/posts/%25%2F"),
+  }).toEqual({
+    encodedSlash: { name: "/[file]", params: { file: "admin/panel" } },
+    encodedSlashLower: { name: "/[file]", params: { file: "admin/panel" } },
+    literalSlash: { name: "/admin/panel", params: {} },
+    nonStatic: { name: "/[file]", params: { file: "he/llo" } },
+    nestedDynamic: { name: "/posts/[id]", params: { id: "a/b" } },
+    encodedPercent: { name: "/posts/[id]", params: { id: "%41" } },
+    mixed: { name: "/posts/[id]", params: { id: "%/" } },
+  });
+});
+
+it("match() returns null for a malformed percent escape instead of throwing", () => {
+  // The declared return type is `MatchedRoute | null`. A server that does
+  // `router.match(request)` on a raw incoming URL must not be brought down
+  // by a malformed escape in either the path or the query.
+  const { dir } = make(["index.tsx", "[file].tsx"]);
+  const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+  // Malformed escape in the path: no route can match.
+  for (const p of ["/%e", "/foo%", "/%zz"]) {
+    expect(router.match(p)).toBeNull();
+  }
+  // Malformed escape in the query: the path part is fine, so the route
+  // still matches.
+  for (const p of ["/ok?%=1", "/ok?x=%", "/ok?x=%e"]) {
+    expect(router.match(p)?.name).toBe("/[file]");
+  }
+});
+
+it("match() splits path and query before percent-decoding", () => {
+  // Decoding the query before splitting it into name/value pairs turned an
+  // encoded '&'/'=' into a real delimiter and double-decoded '%25'; an
+  // encoded '?' in the path likewise started a spurious query string.
+  const { dir } = make(["p.tsx", "posts/[id].tsx"]);
+  const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+  const q = (p: string) => {
+    const r = router.match(p);
+    return r ? { name: r.name, params: r.params, query: r.query } : null;
+  };
+
+  expect({
+    encodedAmpAndEq: q("/p?a=b%26c%3Dd"),
+    doubleEncoded: q("/p?a=%2520"),
+    encodedQuestionInPath: q("/posts/a%3Fb"),
+    encodedQuestionInPathWithQuery: q("/posts/a%3Fb?c=1"),
+    literalQuestionInQueryValue: q("/p?a=b?c=d"),
+    // https://github.com/oven-sh/bun/issues/8384
+    encodedQuestionInQueryValue: q("/p?prompt=test%3ftest"),
+  }).toEqual({
+    encodedAmpAndEq: { name: "/p", params: {}, query: { a: "b&c=d" } },
+    doubleEncoded: { name: "/p", params: {}, query: { a: "%20" } },
+    encodedQuestionInPath: { name: "/posts/[id]", params: { id: "a?b" }, query: { id: "a?b" } },
+    encodedQuestionInPathWithQuery: {
+      name: "/posts/[id]",
+      params: { id: "a?b" },
+      query: { id: "a?b", c: "1" },
+    },
+    literalQuestionInQueryValue: { name: "/p", params: {}, query: { a: "b?c=d" } },
+    encodedQuestionInQueryValue: { name: "/p", params: {}, query: { prompt: "test?test" } },
+  });
+});


### PR DESCRIPTION
## What

`Bun.FileSystemRouter.match()` percent-decoded the whole raw input before doing any structural parsing. One root cause, several user-visible bugs:

| input | before | after |
| :-- | :-- | :-- |
| `/admin%2Fpanel` (pages: `[file].tsx`, `admin/panel.tsx`) | matches **`/admin/panel`** | matches `/[file]`, `params.file === "admin/panel"` |
| `/he%2Fllo` (pages: `[file].tsx`) | `null` | matches `/[file]`, `params.file === "he/llo"` |
| `/ok?%=1`, `/%e`, `/foo%` | **throws** `DecodingError` | `null` for a path escape, matches normally if the bad escape is only in the query |
| `/p?a=b%26c%3Dd` | `{ a: "b", c: "d" }` | `{ a: "b&c=d" }` |
| `/p?a=%2520` | `{ a: " " }` (double-decoded) | `{ a: "%20" }` |
| `/posts/a%3Fb` | `params.id === "a"`, `query.b === ""` | `params.id === "a?b"` |
| `/posts/%2541` | `params.id === "A"` (double-decoded) | `params.id === "%41"` |

The first row is security-adjacent: an encoded `/` in a single URL segment could select a nested static route the author never exposed to that traffic. The throw case breaks any server doing `router.match(request)` on raw incoming URLs, since the declared return type is `MatchedRoute | null`.

## Cause

`URLPath::parse` called `PercentEncoding::decode_fault_tolerant` on the entire input, then scanned the decoded bytes for `?` and `/`. So `%2F` became a real segment boundary, `%3F` started a fake query string, the real query string was decoded once here and then again per-name/value in `QueryStringMap`, and any malformed escape (including in the query) aborted the parse, which the caller surfaced as a thrown `Error`.

## Fix

- Split path from query on the first literal `?` of the raw input. The query string is kept verbatim; `QueryStringMap` already performs the single per-pair decode.
- Decode the path with `%2F` and `%25` left encoded (new `PRESERVE_STRUCTURE` mode on `decode_fault_tolerant`). `%2F` must stay encoded so it cannot create a segment boundary; `%25` must stay encoded so the per-value decode of a captured param doesn't read the following two bytes as a fresh escape. With both preserved, that per-value decode is the single decode applied, matching Next's semantics (match on segment boundaries, `decodeURIComponent` each captured value once).
- Return `null` from `match()` when the path part is undecodable instead of throwing.

## Verification

`bun bd test test/js/bun/util/filesystem_router.test.ts` passes the three new tests and all existing ones, except the pre-existing debug-build timeout of the 600k-iteration wyhash birthday search, which also times out on `main` under ASAN.

All three new tests fail on the released binary (route-confusion, throw-on-bad-escape, query double-decode).


Fixes #8384

## Rebase onto #33072

#33072 fixed the param double-decode bug by removing the per-value `PercentEncoding::decode()` call on pathname params in `QueryStringMap::init_with_scanner`. This PR had fixed the same bug differently, by making `URLPath::parse` preserve `%25` so that (still-present) per-value decode was the single one applied. With both changes stacked, the `%2F`/`%25` escapes that `PRESERVE_STRUCTURE` keeps for route segmentation were never decoded for the captured param value, so `params.file` came back as `"admin%2Fpanel"` instead of `"admin/panel"`.

Resolution: keep this PR's approach, since #33072's cannot prevent `%2F` from crossing a segment boundary (the parse-then-segment order is the whole point). The per-value decode of pathname params is restored; because `PRESERVE_STRUCTURE` output only ever contains `%2F`/`%2f`/`%25` as its percent sequences, that decode is exactly the single decode applied and cannot fail. #33072's two `.pathname` assertions (which observed the internal representation, now structure-preserved) are dropped; its `.params.id` decode-once assertions are kept and still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesystem_router.test.ts

<!-- robobun:evidence:end -->