### PR TITLE
bun build --compile: read NODE_ENV at runtime, set argv[0] to the executable path

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1614,13 +1614,6 @@ pub mod bv2_impl {
                 unsafe { Transpiler::for_worker(this_transpiler, arena, this_transpiler.log) };
 
             ct.options.target = Target::Browser;
-            // The cloned define table was computed for the parent's
-            // server-side target, which (unlike `Target::Browser`) doesn't get
-            // a default `process.env.NODE_ENV` define. Reset so
-            // `configure_defines()` below rebuilds it for the browser target;
-            // explicit user/`--production` defines are re-applied from
-            // `transform_options.define`.
-            ct.options.defines_loaded = false;
             ct.options.main_fields = Target::Browser
                 .default_main_fields()
                 .iter()
@@ -1655,7 +1648,21 @@ pub mod bv2_impl {
             // handled by `for_worker` + `wire_after_move`.
             boxed.wire_after_move();
 
-            boxed.configure_defines()?;
+            // The cloned define table was computed for the parent's
+            // server-side target, which (unlike `Target::Browser`) doesn't
+            // get a default `process.env.NODE_ENV` define. Rebuild it for the
+            // browser target via `load_defines` directly; the full
+            // `configure_defines()` would also re-run `run_env_loader()` on
+            // the shared env loader (double-emitting the ".env" stderr line
+            // and the analytics counter when `--env=inline`/a prefix is set).
+            // Explicit user/`--production` defines are re-applied from
+            // `transform_options.define`; `force_node_env`/`production` were
+            // already derived by the parent's `configure_defines` and are
+            // cloned by `for_worker`.
+            boxed.options.defines_loaded = false;
+            boxed
+                .options
+                .load_defines(boxed.arena, Some(boxed.env_mut()))?;
 
             // Re-project the resolver subset now that `target`/`conditions` etc.
             // have been overwritten for the browser.

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1614,6 +1614,13 @@ pub mod bv2_impl {
                 unsafe { Transpiler::for_worker(this_transpiler, arena, this_transpiler.log) };
 
             ct.options.target = Target::Browser;
+            // The cloned define table was computed for the parent's
+            // server-side target, which (unlike `Target::Browser`) doesn't get
+            // a default `process.env.NODE_ENV` define. Reset so
+            // `configure_defines()` below rebuilds it for the browser target;
+            // explicit user/`--production` defines are re-applied from
+            // `transform_options.define`.
+            ct.options.defines_loaded = false;
             ct.options.main_fields = Target::Browser
                 .default_main_fields()
                 .iter()
@@ -1648,8 +1655,6 @@ pub mod bv2_impl {
             // handled by `for_worker` + `wire_after_move`.
             boxed.wire_after_move();
 
-            // `configure_defines` early-returns on `options.defines_loaded` (cloned
-            // as `true`); kept for spec parity.
             boxed.configure_defines()?;
 
             // Re-project the resolver subset now that `target`/`conditions` etc.

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -954,38 +954,45 @@ pub fn defines_from_transform_options(
     }
 
     if behavior != api::DotEnvBehavior::LoadAllWithoutInlining {
-        let quoted_node_env: Box<[u8]> = 'brk: {
-            if let Some(node_env) = node_env {
-                if !node_env.is_empty() {
-                    if (strings::starts_with_char(node_env, b'"')
-                        && strings::ends_with_char(node_env, b'"'))
-                        || (strings::starts_with_char(node_env, b'\'')
-                            && strings::ends_with_char(node_env, b'\''))
-                    {
-                        break 'brk Box::from(node_env);
-                    }
+        // A browser bundle has no `process.env` at runtime, so `NODE_ENV` must
+        // be inlined. Server-side targets (`bun`/`node`, including `bun build
+        // --compile`) run against a real `process.env`; injecting a define there
+        // would freeze the build machine's `NODE_ENV` into the output. An
+        // explicit `--define` still wins either way via `get_or_put_value`.
+        if !target.is_server_side() {
+            let quoted_node_env: Box<[u8]> = 'brk: {
+                if let Some(node_env) = node_env {
+                    if !node_env.is_empty() {
+                        if (strings::starts_with_char(node_env, b'"')
+                            && strings::ends_with_char(node_env, b'"'))
+                            || (strings::starts_with_char(node_env, b'\'')
+                                && strings::ends_with_char(node_env, b'\''))
+                        {
+                            break 'brk Box::from(node_env);
+                        }
 
-                    // avoid allocating if we can
-                    if node_env == b"production" {
-                        break 'brk Box::from(b"\"production\"".as_slice());
-                    } else if node_env == b"development" {
-                        break 'brk Box::from(b"\"development\"".as_slice());
-                    } else if node_env == b"test" {
-                        break 'brk Box::from(b"\"test\"".as_slice());
-                    } else {
-                        let mut v = Vec::with_capacity(node_env.len() + 2);
-                        v.push(b'"');
-                        v.extend_from_slice(node_env);
-                        v.push(b'"');
-                        break 'brk v.into_boxed_slice();
+                        // avoid allocating if we can
+                        if node_env == b"production" {
+                            break 'brk Box::from(b"\"production\"".as_slice());
+                        } else if node_env == b"development" {
+                            break 'brk Box::from(b"\"development\"".as_slice());
+                        } else if node_env == b"test" {
+                            break 'brk Box::from(b"\"test\"".as_slice());
+                        } else {
+                            let mut v = Vec::with_capacity(node_env.len() + 2);
+                            v.push(b'"');
+                            v.extend_from_slice(node_env);
+                            v.push(b'"');
+                            break 'brk v.into_boxed_slice();
+                        }
                     }
                 }
-            }
-            Box::from(b"\"development\"".as_slice())
-        };
+                Box::from(b"\"development\"".as_slice())
+            };
 
-        user_defines.get_or_put_value(b"process.env.NODE_ENV", quoted_node_env.clone())?;
-        user_defines.get_or_put_value(b"process.env.BUN_ENV", quoted_node_env)?;
+            user_defines.get_or_put_value(b"process.env.NODE_ENV", quoted_node_env.clone())?;
+            user_defines.get_or_put_value(b"process.env.BUN_ENV", quoted_node_env)?;
+        }
 
         // Automatically set `process.browser` to `true` for browsers and false for node+js
         // This enables some extra dead code elimination
@@ -1432,6 +1439,24 @@ impl<'a> BundleOptions<'a> {
         self.rewrite_jest_for_tests
     }
 
+    /// The `NODE_ENV` value to assume when the env loader has no
+    /// `BUN_ENV`/`NODE_ENV`: `"test"` under `bun test`, `"production"` under
+    /// `--production`, else `"development"`. Shared between `load_defines`
+    /// (which inlines it as a define for browser targets) and
+    /// `Transpiler::configure_defines` (which uses it for the JSX dev/prod
+    /// decision on server-side targets, where no define is injected).
+    pub fn default_node_env(&self) -> &'static [u8] {
+        if self.is_test() {
+            return b"test";
+        }
+
+        if self.production {
+            return b"production";
+        }
+
+        b"development"
+    }
+
     pub fn set_production(&mut self, value: bool) {
         if self.force_node_env == ForceNodeEnv::Unspecified {
             self.production = value;
@@ -1674,23 +1699,11 @@ impl<'a> BundleOptions<'a> {
         // to outlive the `&mut loader_` we pass below, so it can't stay a borrow
         // into the loader). `Cow` keeps the literals zero-alloc — matters because
         // every VM with no `NODE_ENV` in its env hits the `"development"` arm.
-        let node_env: Option<Cow<[u8]>> = 'node_env: {
-            if let Some(e) = loader_.as_deref() {
-                if let Some(env_) = e.get_node_env() {
-                    break 'node_env Some(Cow::Owned(env_.to_vec()));
-                }
-            }
-
-            if self.is_test() {
-                break 'node_env Some(Cow::Borrowed(b"\"test\"".as_slice()));
-            }
-
-            if self.production {
-                break 'node_env Some(Cow::Borrowed(b"\"production\"".as_slice()));
-            }
-
-            Some(Cow::Borrowed(b"\"development\"".as_slice()))
-        };
+        let node_env: Option<Cow<[u8]>> =
+            Some(match loader_.as_deref().and_then(|e| e.get_node_env()) {
+                Some(env_) => Cow::Owned(env_.to_vec()),
+                None => Cow::Borrowed(self.default_node_env()),
+            });
         // reshaped for borrowck — node_env computed before passing self.log
         self.define = defines_from_transform_options(
             // No other `&mut Log` is live across this call (see `log_mut`

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1539,9 +1539,11 @@ impl<'a> BundleOptions<'a> {
             out_extensions: self.out_extensions.clone(),
             import_path_format: self.import_path_format,
             defines_loaded: self.defines_loaded,
-            // `Env.defaults: MultiArrayList` has no `Clone`; workers never read
-            // it (`configure_defines` early-returns on `defines_loaded`), so
-            // carry the scalars + an empty list.
+            // `Env.defaults: MultiArrayList` has no `Clone`. Workers either
+            // early-return in `configure_defines` on `defines_loaded`, or
+            // call `load_defines` directly (`initialize_client_transpiler`
+            // after retargeting to `Browser`); `defines_from_transform_options`
+            // handles empty `defaults` there. Carry scalars + an empty list.
             env: Env {
                 behavior: self.env.behavior,
                 prefix: self.env.prefix.clone(),

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -954,11 +954,13 @@ pub fn defines_from_transform_options(
     }
 
     if behavior != api::DotEnvBehavior::LoadAllWithoutInlining {
-        // A browser bundle has no `process.env` at runtime, so `NODE_ENV` must
-        // be inlined. Server-side targets (`bun`/`node`, including `bun build
-        // --compile`) run against a real `process.env`; injecting a define there
-        // would freeze the build machine's `NODE_ENV` into the output. An
-        // explicit `--define` still wins either way via `get_or_put_value`.
+        // A browser bundle has no `process.env` at runtime, so `NODE_ENV`
+        // must be inlined. Server-side targets (`bun`/`node`, including `bun
+        // build --compile`) run against a real `process.env`; injecting a
+        // define there would freeze the build machine's ambient `NODE_ENV`
+        // into the output. An explicit `--define` (and `--production`, which
+        // seeds `maybe_input_define` in `build_command.rs`) still wins either
+        // way via the `user_defines` insertion above.
         if !target.is_server_side() {
             let quoted_node_env: Box<[u8]> = 'brk: {
                 if let Some(node_env) = node_env {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -592,6 +592,22 @@ impl<'a> Transpiler<'a> {
                     }
                 }
             }
+        } else if self.options.env.behavior
+            != bun_options_types::schema::api::DotEnvBehavior::LoadAllWithoutInlining
+        {
+            // Server-side targets don't get a default `process.env.NODE_ENV`
+            // define (see `defines_from_transform_options`): the output runs
+            // against a real `process.env`. Resolve the same value here so the
+            // JSX dev/prod decision is unaffected by that.
+            let node_env = match self.env().get_node_env() {
+                Some(v) if !v.is_empty() => v,
+                _ => self.options.default_node_env(),
+            };
+            if node_env == b"production" {
+                is_production = true;
+            } else if node_env == b"development" {
+                is_development = true;
+            }
         }
 
         if is_development {

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1521,6 +1521,23 @@ pub(crate) fn add_import_meta_defines(
         DefineData::init_boolean(mode == Mode::ProductionStatic),
     )?;
 
+    // The server/SSR graphs target `bun`, for which
+    // `defines_from_transform_options` does not auto-inline
+    // `process.env.NODE_ENV`. Production is explicit here, so seed the
+    // define so dev-only branches (React, react-dom/server, ...) are
+    // still DCE'd. The client graph targets the browser and already gets
+    // this via `defines_from_transform_options`.
+    if side == Side::Server && mode != Mode::Development {
+        define.insert(
+            b"process.env.NODE_ENV",
+            DefineData::init_static_string(&MODE_PRODUCTION),
+        )?;
+        define.insert(
+            b"process.env.BUN_ENV",
+            DefineData::init_static_string(&MODE_PRODUCTION),
+        )?;
+    }
+
     Ok(())
 }
 

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1526,16 +1526,27 @@ pub(crate) fn add_import_meta_defines(
     // `process.env.NODE_ENV`. Production is explicit here, so seed the
     // define so dev-only branches (React, react-dom/server, ...) are
     // still DCE'd. The client graph targets the browser and already gets
-    // this via `defines_from_transform_options`.
+    // this via `defines_from_transform_options`. Skip when an explicit
+    // value is already present (e.g. env inlining put one in via
+    // `configure_defines()`); user-supplied `bundler_options.define` is
+    // applied after this call at both call sites, so that wins either way.
     if side == Side::Server && mode != Mode::Development {
-        define.insert(
-            b"process.env.NODE_ENV",
-            DefineData::init_static_string(&MODE_PRODUCTION),
-        )?;
-        define.insert(
-            b"process.env.BUN_ENV",
-            DefineData::init_static_string(&MODE_PRODUCTION),
-        )?;
+        for (tail, key) in [
+            (b"NODE_ENV" as &[u8], b"process.env.NODE_ENV" as &[u8]),
+            (b"BUN_ENV" as &[u8], b"process.env.BUN_ENV" as &[u8]),
+        ] {
+            let already_present = define.dots.get(tail).is_some_and(|entries| {
+                entries.iter().any(|d| {
+                    d.parts.len() == 3
+                        && &*d.parts[0] == b"process"
+                        && &*d.parts[1] == b"env"
+                        && &*d.parts[2] == tail
+                })
+            });
+            if !already_present {
+                define.insert(key, DefineData::init_static_string(&MODE_PRODUCTION))?;
+            }
+        }
     }
 
     Ok(())

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -84,6 +84,21 @@ impl BuildCommand {
 
         let compile_target = &ctx.bundler_options.compile_target;
 
+        // `--production` is documented as "Set NODE_ENV=production". For
+        // server-side targets the default `NODE_ENV` define is skipped (the
+        // bundle runs against a real `process.env`), so seed an explicit user
+        // define here to keep DCE of dev-only branches working. Prepended so
+        // a user-supplied `--define process.env.NODE_ENV=...` still wins.
+        if ctx.bundler_options.production {
+            let define = ctx.args.define.get_or_insert_with(Default::default);
+            define
+                .keys
+                .insert(0, Box::<[u8]>::from(b"process.env.NODE_ENV" as &[u8]));
+            define
+                .values
+                .insert(0, Box::<[u8]>::from(b"\"production\"" as &[u8]));
+        }
+
         if ctx.bundler_options.compile {
             let compile_define_keys = compile_target.define_keys();
             let compile_define_values = compile_target.define_values();

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -85,18 +85,21 @@ impl BuildCommand {
         let compile_target = &ctx.bundler_options.compile_target;
 
         // `--production` is documented as "Set NODE_ENV=production". For
-        // server-side targets the default `NODE_ENV` define is skipped (the
-        // bundle runs against a real `process.env`), so seed an explicit user
-        // define here to keep DCE of dev-only branches working. Prepended so
-        // a user-supplied `--define process.env.NODE_ENV=...` still wins.
+        // server-side targets the default `NODE_ENV`/`BUN_ENV` defines are
+        // skipped (the bundle runs against a real `process.env`), so seed
+        // explicit user defines here to keep DCE of dev-only branches
+        // working. Prepended so a user-supplied `--define` still wins.
         if ctx.bundler_options.production {
             let define = ctx.args.define.get_or_insert_with(Default::default);
-            define
-                .keys
-                .insert(0, Box::<[u8]>::from(b"process.env.NODE_ENV" as &[u8]));
-            define
-                .values
-                .insert(0, Box::<[u8]>::from(b"\"production\"" as &[u8]));
+            for key in [
+                b"process.env.NODE_ENV" as &[u8],
+                b"process.env.BUN_ENV" as &[u8],
+            ] {
+                define.keys.insert(0, Box::<[u8]>::from(key));
+                define
+                    .values
+                    .insert(0, Box::<[u8]>::from(b"\"production\"" as &[u8]));
+            }
         }
 
         if ctx.bundler_options.compile {

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -334,17 +334,15 @@ mod _impl {
         // argv also omits the script name
         let mut args_list: Vec<BunString> = Vec::with_capacity(args_count + 2);
 
-        if vm.standalone_module_graph.is_some() {
-            // Don't break user's code because they did process.argv.slice(2)
-            // Even if they didn't type "bun", we still want to add it as argv[0]
-            args_list.push(BunString::static_(b"bun"));
-        } else {
-            let exe_path = bun_core::self_exe_path().ok();
-            args_list.push(match exe_path {
-                Some(str_) => BunString::borrow_utf8(str_.as_bytes()),
-                None => BunString::static_(b"bun"),
-            });
-        }
+        // argv[0] is always the resolved path to the running executable. For a
+        // standalone (compiled) binary that executable *is* the program, so the
+        // `spawn(process.argv[0], ...)` self-re-exec idiom must point at it,
+        // not at whatever `bun` happens to be on `$PATH`.
+        let exe_path = bun_core::self_exe_path().ok();
+        args_list.push(match exe_path {
+            Some(str_) => BunString::borrow_utf8(str_.as_bytes()),
+            None => BunString::static_(b"bun"),
+        });
 
         // Per-platform path-separator literal suffixes.
         const EVAL_SUFFIX: &[u8] = if cfg!(windows) {

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -844,6 +844,49 @@ describe("bundler", () => {
     },
     run: { stdout: new Array(7).fill("true").join("\n") },
   });
+  // A compiled binary is a runtime artifact: `process.env.NODE_ENV` must read
+  // the runtime environment, not the build machine's. An explicit `--define`
+  // is tested separately in the ReactSSR cases above.
+  itBundled("compile/NodeEnvReadsRuntimeEnvironment", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        // Prove it wasn't inlined:
+        console.log((() => process.env.NODE_ENV).toString().includes("process.env.NODE_ENV"));
+        console.log(process.env.NODE_ENV);
+      `,
+    },
+    // Build with one value...
+    env: { NODE_ENV: "development" },
+    // ...and run with another.
+    run: { env: { NODE_ENV: "production" }, stdout: "true\nproduction" },
+  });
+  itBundled("compile/NodeEnvReadsRuntimeEnvironmentUnset", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `console.log(String(process.env.NODE_ENV));`,
+    },
+    env: { NODE_ENV: "development" },
+    // `bunEnv` strips NODE_ENV, so the runtime env has no NODE_ENV set.
+    run: { stdout: "undefined" },
+  });
+  // process.argv[0] in a compiled binary should be the resolved path to that
+  // binary (i.e. process.execPath), so `spawn(process.argv[0], ...)` re-execs
+  // the binary itself instead of whatever `bun` happens to be on $PATH.
+  itBundled("compile/Argv0IsExecPath", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import { realpathSync } from "node:fs";
+        const argv0 = process.argv[0];
+        const execPath = process.execPath;
+        console.log("argv0-matches-execPath:", argv0 === execPath);
+        console.log("argv0-is-absolute:", require("node:path").isAbsolute(argv0));
+        console.log("argv0-is-self:", realpathSync(argv0) === realpathSync(execPath));
+      `,
+    },
+    run: { stdout: "argv0-matches-execPath: true\nargv0-is-absolute: true\nargv0-is-self: true" },
+  });
   itBundled("compile/SourceMap", {
     target: "bun",
     compile: true,

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -192,6 +192,55 @@ describe("bundler", () => {
       NODE_ENV: "development",
     },
   });
+  // For server-side targets the bundle runs against a real `process.env`, so
+  // `NODE_ENV` must NOT be inlined by default: inlining would freeze the
+  // build machine's value into the output.
+  for (const target of ["bun", "node"] as const) {
+    itBundled("edgecase/NodeEnvNotInlined_" + target, {
+      files: {
+        "/entry.js": /* js */ `
+          capture(process.env.NODE_ENV);
+          capture(process.env.NODE_ENV === 'production');
+          capture(process.env.NODE_ENV === 'development');
+          capture(process.env.BUN_ENV);
+        `,
+      },
+      target,
+      // The build machine's NODE_ENV must not leak into the bundle.
+      env: { NODE_ENV: "production" },
+      capture: [
+        "process.env.NODE_ENV",
+        'process.env.NODE_ENV === "production"',
+        'process.env.NODE_ENV === "development"',
+        "process.env.BUN_ENV",
+      ],
+    });
+    // An explicit `--define` must still inline on server-side targets.
+    itBundled("edgecase/NodeEnvInlinedWithDefine_" + target, {
+      files: {
+        "/entry.js": /* js */ `
+          capture(process.env.NODE_ENV);
+          capture(process.env.NODE_ENV === 'production');
+        `,
+      },
+      target,
+      define: { "process.env.NODE_ENV": '"production"' },
+      capture: ['"production"', "true"],
+    });
+    // `--env=inline` must still inline on server-side targets.
+    itBundled("edgecase/NodeEnvInlinedWithEnvInline_" + target, {
+      files: {
+        "/entry.js": /* js */ `
+          capture(process.env.NODE_ENV);
+        `,
+      },
+      target,
+      dotenv: "inline",
+      env: { NODE_ENV: "staging" },
+      backend: "cli",
+      capture: ['"staging"'],
+    });
+  }
 
   itBundled("edgecase/StarExternal", {
     files: {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -240,6 +240,20 @@ describe("bundler", () => {
       backend: "cli",
       capture: ['"staging"'],
     });
+    // https://github.com/oven-sh/bun/issues/20183
+    // https://github.com/oven-sh/bun/issues/22820
+    itBundled("edgecase/NodeEnvNotInlinedAPIEnvDisable_" + target, {
+      files: {
+        "/entry.js": /* js */ `
+          capture(process.env.NODE_ENV);
+          capture(process.env.OTHER);
+        `,
+      },
+      target,
+      dotenv: "disable",
+      backend: "api",
+      capture: ["process.env.NODE_ENV", "process.env.OTHER"],
+    });
   }
 
   itBundled("edgecase/StarExternal", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -215,6 +215,22 @@ describe("bundler", () => {
         "process.env.BUN_ENV",
       ],
     });
+    // `--production` is an explicit opt-in documented as "set
+    // NODE_ENV=production", so it must still inline on server-side targets
+    // (enables DCE of `if (process.env.NODE_ENV !== 'production')` branches).
+    itBundled("edgecase/NodeEnvInlinedWithProduction_" + target, {
+      files: {
+        "/entry.js": /* js */ `
+          capture(process.env.NODE_ENV);
+          capture(process.env.NODE_ENV === 'production');
+          capture(process.env.NODE_ENV !== 'production');
+        `,
+      },
+      target,
+      production: true,
+      backend: "cli",
+      capture: ['"production"', "!0", "!1"],
+    });
     // An explicit `--define` must still inline on server-side targets.
     itBundled("edgecase/NodeEnvInlinedWithDefine_" + target, {
       files: {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -296,9 +296,7 @@ describe("bundler", () => {
       // Server chunk: not inlined (runtime read).
       expect(api.captureFile("out/entry.js")).toEqual(["process.env.NODE_ENV"]);
       // Browser chunk: inlined (no process in the browser).
-      const browserChunk = readdirSync(api.join("out")).find(
-        (f: string) => f.endsWith(".js") && f !== "entry.js",
-      );
+      const browserChunk = readdirSync(api.join("out")).find((f: string) => f.endsWith(".js") && f !== "entry.js");
       expect(browserChunk).toBeDefined();
       expect(api.captureFile(join("out", browserChunk!))).toEqual(['"development"']);
     },

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -292,7 +292,6 @@ describe("bundler", () => {
     outdir: "/out",
     env: { NODE_ENV: undefined },
     onAfterBundle(api) {
-      const { readdirSync } = require("node:fs");
       // Server chunk: not inlined (runtime read).
       expect(api.captureFile("out/entry.js")).toEqual(["process.env.NODE_ENV"]);
       // Browser chunk: inlined (no process in the browser).

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -272,6 +272,37 @@ describe("bundler", () => {
       capture: ["process.env.NODE_ENV", "process.env.OTHER"],
     });
   }
+  // An HTML import from a --target=bun build spins up a lazy browser
+  // transpiler. Its emitted chunk runs in a browser (no `process`), so
+  // NODE_ENV must still be inlined there even though the parent server
+  // bundle leaves it as a runtime read.
+  itBundled("edgecase/NodeEnvInlinedForBrowserChunkInServerBuild", {
+    files: {
+      "/entry.ts": /* js */ `
+        import html from "./index.html";
+        capture(process.env.NODE_ENV);
+        Bun.serve({ port: 0, routes: { "/": html } });
+      `,
+      "/index.html": `<!doctype html><script type="module" src="./client.ts"></script>`,
+      "/client.ts": /* js */ `
+        capture(process.env.NODE_ENV);
+      `,
+    },
+    target: "bun",
+    outdir: "/out",
+    env: { NODE_ENV: undefined },
+    onAfterBundle(api) {
+      const { readdirSync } = require("node:fs");
+      // Server chunk: not inlined (runtime read).
+      expect(api.captureFile("out/entry.js")).toEqual(["process.env.NODE_ENV"]);
+      // Browser chunk: inlined (no process in the browser).
+      const browserChunk = readdirSync(api.join("out")).find(
+        (f: string) => f.endsWith(".js") && f !== "entry.js",
+      );
+      expect(browserChunk).toBeDefined();
+      expect(api.captureFile(join("out", browserChunk!))).toEqual(['"development"']);
+    },
+  });
 
   itBundled("edgecase/StarExternal", {
     files: {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -224,12 +224,13 @@ describe("bundler", () => {
           capture(process.env.NODE_ENV);
           capture(process.env.NODE_ENV === 'production');
           capture(process.env.NODE_ENV !== 'production');
+          capture(process.env.BUN_ENV);
         `,
       },
       target,
       production: true,
       backend: "cli",
-      capture: ['"production"', "!0", "!1"],
+      capture: ['"production"', "!0", "!1", '"production"'],
     });
     // An explicit `--define` must still inline on server-side targets.
     itBundled("edgecase/NodeEnvInlinedWithDefine_" + target, {

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -82,9 +82,9 @@ describe("bundler", () => {
           process.exit(1);
         }
 
-        // argv[0] should be "bun" for standalone executables
-        if (process.argv[0] !== "bun") {
-          console.error("FAIL: Expected argv[0] to be 'bun', got", process.argv[0]);
+        // argv[0] should be the standalone executable's resolved path (same as execPath)
+        if (process.argv[0] !== process.execPath) {
+          console.error("FAIL: Expected argv[0] === process.execPath, got", process.argv[0], "vs", process.execPath);
           process.exit(1);
         }
 
@@ -141,8 +141,8 @@ describe("bundler", () => {
           process.exit(1);
         }
 
-        if (process.argv[0] !== "bun") {
-          console.error("FAIL: Expected argv[0] to be 'bun', got", process.argv[0]);
+        if (process.argv[0] !== process.execPath) {
+          console.error("FAIL: Expected argv[0] === process.execPath, got", process.argv[0], "vs", process.execPath);
           process.exit(1);
         }
 

--- a/test/regression/issue/22157.test.ts
+++ b/test/regression/issue/22157.test.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
     "index.js": /* js */ `
       import { parseArgs } from "node:util"
 
-      console.log(JSON.stringify(process.argv));
+      console.log(JSON.stringify({ argv: process.argv, execPath: process.execPath }));
 
       if (process.argv.length === 2) {
         // This should work - no extra executable name should cause parseArgs to throw
@@ -22,7 +22,7 @@ beforeAll(async () => {
           args: process.argv.slice(2),
         });
       } else {
-        // Expect: ["bun", "/$bunfs/root/..." or "B:/~BUN/root/...", "arg1", "arg2"]
+        // Expect: [<path to this executable>, "/$bunfs/root/..." or "B:/~BUN/root/...", "arg1", "arg2"]
         if (process.argv.length !== 4) {
           console.error("Expected 4 argv items, got", process.argv.length);
           process.exit(1);
@@ -68,12 +68,10 @@ test("issue 22157: compiled binary should not include executable name in process
   expect(stdout).toContain("SUCCESS");
 
   // Verify process.argv structure
-  const argvMatch = stdout.match(/\[.*?\]/);
-  expect(argvMatch).toBeTruthy();
-
-  const processArgv = JSON.parse(argvMatch![0]);
+  const { argv: processArgv, execPath } = JSON.parse(stdout.split("\n")[0]);
   expect(processArgv).toHaveLength(2);
-  expect(processArgv[0]).toBe("bun");
+  // argv[0] is the resolved path to the compiled executable itself.
+  expect(processArgv[0]).toBe(execPath);
   // Windows uses "B:/~BUN/root/", Unix uses "/$bunfs/root/"
   expect(processArgv[1]).toMatch(/(\$bunfs|~BUN).*root/);
 });


### PR DESCRIPTION
## What does this PR do?

Fixes two `bun build --compile` bugs surfaced by the execution-equivalence oracle (run the source with `bun entry.ts`, then run the compiled binary: any observable difference is a bug).

### 1. `process.env.NODE_ENV` was inlined at build time

```sh
$ echo 'console.log(process.env.NODE_ENV)' > e.ts && bun build --compile ./e.ts --outfile app
$ NODE_ENV=production ./app
development        # build machine's value baked in; runtime env ignored
```

`defines_from_transform_options` unconditionally injected a `process.env.NODE_ENV` define for every target, with the value resolved from the build machine's `NODE_ENV` (defaulting to `"development"`). That's correct for `--target=browser` (no `process.env` at runtime) but wrong for server-side targets: a compiled binary is a runtime artifact, and every `NODE_ENV`-gated branch (express prod mode, React jsx-dev vs prod, framework caches) was frozen to whatever the build machine had.

The default `NODE_ENV`/`BUN_ENV` define is now gated on `!target.is_server_side()`. `--compile` forces `target=bun`, so compiled binaries read the real `process.env` at runtime. An explicit `--define process.env.NODE_ENV=...` still inlines (same for `--env=inline`); `--target=browser` is unchanged; and the JSX dev/prod decision, which previously read back the define, now resolves `NODE_ENV` from the env loader directly for server-side targets so JSX output is unaffected.

Fixes #22368
Fixes #18855
Fixes #20183
Fixes #22820

### 2. `process.argv[0]` was the literal string `"bun"`

```sh
$ ./app
argv: ["bun", "/$bunfs/root/app"]   # argv[0] not a path at all
execPath: "/tmp/app"
```

`Bun__Process__createArgv` special-cased `standalone_module_graph.is_some()` to push the literal `"bun"` as `argv[0]`, while the non-standalone path used `self_exe_path()`. For a compiled binary the executable *is* the program, so `spawn(process.argv[0], ...)` must point at it, not at whatever `bun` happens to be on `$PATH`. Both paths now use `self_exe_path()`, matching `process.execPath`.

Fixes #18337

## How did you verify your code works?

New tests (fail on stock 1.4.0, pass on this branch):

- `bundler_compile.test.ts`: `compile/NodeEnvReadsRuntimeEnvironment`, `compile/NodeEnvReadsRuntimeEnvironmentUnset`, `compile/Argv0IsExecPath`
- `bundler_edgecase.test.ts`: `edgecase/NodeEnvNotInlined_{bun,node}` (+ positive cases for `--define`/`--env=inline`)
- `compile-argv.test.ts`: two existing tests that asserted `argv[0] === "bun"` updated to `argv[0] === process.execPath`

Re-ran the neighbouring suites that depend on the `NODE_ENV` define driving JSX mode: `bundler_jsx.test.ts`, `bundler_minify.test.ts -t ProductionMode`, `bundler_cjs2esm.test.ts -t NodeEnv`, `bundler_bun.test.ts`, `bundler_env.test.ts`. All pass.