### PR TITLE
Bun.serve websocket: deliver queued publish() messages when unsubscribing from last topic

### DIFF
--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -358,7 +358,7 @@ namespace Bun {
 
       maxPayloadLength?: number; // default: 16 * 1024 * 1024 = 16 MB
       idleTimeout?: number; // default: 120 (seconds)
-      backpressureLimit?: number; // default: 1024 * 1024 = 1 MB
+      backpressureLimit?: number; // default: 16 * 1024 * 1024 = 16 MB
       closeOnBackpressureLimit?: boolean; // default: false
       sendPings?: boolean; // default: true
       publishToSelf?: boolean; // default: false

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -327,6 +327,10 @@ public:
 
         /* Free us as subscribers if we unsubscribed from our last topic */
         if (ok && last) {
+            /* Flush queued publish() messages before the Subscriber is freed.
+             * freeSubscriber unlinks without draining, which would otherwise
+             * drop messages that publish() already accepted this tick. */
+            webSocketContextData->topicTree->drain(webSocketData->subscriber);
             webSocketContextData->topicTree->freeSubscriber(webSocketData->subscriber);
             webSocketData->subscriber = nullptr;
         }

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -387,6 +387,80 @@ describe("Server", () => {
     expect(subscriptions).toContain("topic3");
   });
 
+  it.concurrent("publish() then unsubscribe() from last topic in same tick delivers queued messages", async () => {
+    const aDone = Promise.withResolvers<string[]>();
+    const bDone = Promise.withResolvers<string[]>();
+    const ready = { a: Promise.withResolvers<void>(), b: Promise.withResolvers<void>() };
+    const publishResults: number[] = [];
+
+    using server = serve({
+      port: 0,
+      fetch(req, server) {
+        const id = new URL(req.url).searchParams.get("id")!;
+        if (server.upgrade(req, { data: { id } })) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          ws.subscribe("room");
+          ws.send("ready");
+        },
+        message(ws, msg) {
+          if (msg !== "go") return;
+          for (let i = 0; i < 5; i++) {
+            publishResults.push(server.publish("room", "msg" + i));
+          }
+          // Unsubscribing from the only topic used to free the uWS Subscriber
+          // without draining its queued publish() messages, dropping them.
+          ws.unsubscribe("room");
+          // Sentinel: once this arrives, anything queued for this socket
+          // has either been delivered ahead of it or dropped.
+          ws.send("done");
+        },
+      },
+    });
+
+    const collect = (id: "a" | "b", done: PromiseWithResolvers<string[]>, isDone: (data: string) => boolean) => {
+      const received: string[] = [];
+      const ws = new WebSocket(`ws://localhost:${server.port}/?id=${id}`);
+      ws.onmessage = e => {
+        const data = e.data as string;
+        if (data === "ready") return ready[id].resolve();
+        received.push(data);
+        if (isDone(data)) done.resolve([...received]);
+      };
+      const fail = (e: unknown) => {
+        ready[id].reject(e);
+        done.reject(e);
+      };
+      ws.onerror = fail;
+      ws.onclose = () => fail(new Error("closed before done"));
+      return ws;
+    };
+
+    // A never unsubscribes and never receives "done"; resolve once the full batch arrives.
+    const a = collect("a", aDone, data => data === "msg4");
+    // B must wait for the sentinel so we capture everything delivered before it.
+    const b = collect("b", bDone, data => data === "done");
+    try {
+      await Promise.all([ready.a.promise, ready.b.promise]);
+      b.send("go");
+
+      const [aReceived, bReceived] = await Promise.all([aDone.promise, bDone.promise]);
+      // publish() reported the message as queued for every call
+      expect(publishResults).toEqual([4, 4, 4, 4, 4]);
+      // A never unsubscribed; it must receive the full batch.
+      expect(aReceived).toEqual(["msg0", "msg1", "msg2", "msg3", "msg4"]);
+      // B unsubscribed in the same tick; it must still receive the batch
+      // that publish() had already accepted before the unsubscribe.
+      expect(bReceived).toEqual(["msg0", "msg1", "msg2", "msg3", "msg4", "done"]);
+    } finally {
+      a.onclose = b.onclose = null;
+      a.close();
+      b.close();
+    }
+  });
+
   describe("websocket", () => {
     test("open", done => ({
       open(ws) {


### PR DESCRIPTION
## Problem

`publish()` queues messages per subscriber in the uWS TopicTree; they are flushed at the end of the event loop tick. When a `ServerWebSocket` calls `unsubscribe()` on its last topic in the same tick as a `publish()`, the subscriber object is freed with its undrained queue still attached, so messages that `publish()` had already accepted (and returned a non-zero byte count for) are silently discarded.

```js
// inside a message handler
for (let i = 0; i < 5; i++) server.publish("room", "msg" + i);  // each returns 4
ws.unsubscribe("room");  // ws was only subscribed to "room"
// ws receives none of msg0..msg4
```

Keeping *any* other topic subscription on the same socket makes the messages arrive, which shows the loss is a subscriber-lifetime artifact rather than a delivery policy.

## Cause

`WebSocket::unsubscribe()` calls `TopicTree::freeSubscriber()` when the last topic is removed. `freeSubscriber()` unlinks the subscriber from the drainable list without draining it and then deletes it, dropping any messages still referenced by `messageIndices[]`.

## Fix

Drain the subscriber before freeing it in `WebSocket::unsubscribe()`. The other two `freeSubscriber` call sites are unaffected: `end()` sends a close frame via `send()`, which drains first; the TCP `onClose` path has no live socket to write to.

Also corrects the `backpressureLimit` default in `docs/runtime/http/websockets.mdx` (16 MB, matching `WebSocketServerContext.rs` and the type docs; it said 1 MB).

## Rebase note

This PR originally also rewrote the `publish()` return-value JSDoc in `packages/bun-types/serve.d.ts` to describe the (then) real behavior: the documented `0`/`-1` backpressure returns were unreachable and `publish()` always returned the byte count.

That is no longer the case. #32889 landed on `main` and fixes the underlying contract for real: `publish()` now aggregates the per-subscriber `SendStatus` out of uWS and returns `0`/`-1` on backpressure, and it updated the JSDoc accordingly. The `serve.d.ts` changes here described the pre-#32889 behavior and are superseded, so they were dropped during the rebase. The remaining diff is the unsubscribe lifetime fix, its regression test, and the `backpressureLimit` doc correction, none of which overlap with #32889.

## Verification

Re-verified against `main` after the rebase onto #32889 and later.

```
# test file built with the fix reverted (origin/main's WebSocket.h)
(fail) Server > publish() then unsubscribe() from last topic in same tick delivers queued messages
  expect(bReceived).toEqual(["msg0","msg1","msg2","msg3","msg4","done"])
  Received: ["done"]

$ bun bd test test/js/bun/websocket/websocket-server.test.ts -t "publish\(\) then unsubscribe"
(pass) Server > publish() then unsubscribe() from last topic in same tick delivers queued messages
```
