### PR TITLE
glob: match explicitly-named dotfiles and resolve literal paths through symlinks

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1765,6 +1765,7 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
         let mut child = self.make_set();
         let comps = &self.pattern_components;
         let len: u32 = u32::try_from(comps.len()).expect("int cast");
+        let hidden = !self.dot && Self::starts_with_dot(entry_name);
         let mut it = active.iterator::<true, true>();
         while let Some(i) = it.next() {
             let idx: u32 = u32::try_from(i).expect("int cast");
@@ -1786,8 +1787,12 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
             ) {
                 child.set(self.normalize_idx(idx + bump) as usize);
                 // At `**/X` boundaries, keep the outer `**` alive unless
-                // idx+2 is itself `**` (whose recursion already covers it).
-                if bump == 2 && comps[(idx + 2) as usize].syntax_hint != SyntaxHint::Double {
+                // idx+2 is itself `**` (whose recursion already covers it)
+                // or the entry is hidden (a `**` must not traverse dotdirs).
+                if bump == 2
+                    && !hidden
+                    && comps[(idx + 2) as usize].syntax_hint != SyntaxHint::Double
+                {
                     child.set(idx as usize);
                 }
             }

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1910,8 +1910,11 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
         let joined = work_item_logical_path(&subdir_entry_name);
         let entry_start: u32 =
             u32::try_from(joined.len() - strings::basename(joined).len()).unwrap();
-        self.workbuf
-            .push(WorkItem::new_symlink(subdir_entry_name, active, entry_start));
+        self.workbuf.push(WorkItem::new_symlink(
+            subdir_entry_name,
+            active,
+            entry_start,
+        ));
         Ok(())
     }
 

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1041,11 +1041,22 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                             continue;
                         }
                         bun_sys::FileKind::SymLink => {
-                            if self.walker.follow_symlinks {
-                                if !self.walker.eval_impl(&active, entry_name) {
-                                    continue;
-                                }
+                            // Follow the link when follow_symlinks is enabled, or
+                            // when the pattern names this segment literally. The
+                            // followSymlinks option governs wildcard traversal,
+                            // not explicitly-spelled path segments.
+                            let follow_active: Option<ComponentSet> =
+                                if self.walker.follow_symlinks {
+                                    self.walker
+                                        .eval_impl(&active, entry_name)
+                                        .then(|| active.clone().expect("OOM"))
+                                } else {
+                                    let subset =
+                                        self.walker.eval_literal_subset(&active, entry_name);
+                                    (subset.count() != 0).then_some(subset)
+                                };
 
+                            if let Some(follow_active) = follow_active {
                                 let subdir_parts: &[&[u8]] = &[dir_dir_path, entry_name];
                                 let subdir_entry_name = self.walker.join(subdir_parts)?;
                                 let joined = work_item_logical_path(&subdir_entry_name);
@@ -1055,7 +1066,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
 
                                 self.walker.workbuf.push(WorkItem::new_symlink(
                                     subdir_entry_name,
-                                    active,
+                                    follow_active,
                                     entry_start,
                                 ));
                                 continue;
@@ -1129,7 +1140,16 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                     }
                                 }
                                 bun_sys::FileKind::SymLink => {
-                                    if self.walker.follow_symlinks {
+                                    let follow_active: Option<ComponentSet> =
+                                        if self.walker.follow_symlinks {
+                                            Some(active.clone().expect("OOM"))
+                                        } else {
+                                            let subset = self
+                                                .walker
+                                                .eval_literal_subset(&active, entry_name);
+                                            (subset.count() != 0).then_some(subset)
+                                        };
+                                    if let Some(follow_active) = follow_active {
                                         let subdir_parts: &[&[u8]] = &[dir_dir_path, entry_name];
                                         let subdir_entry_name = self.walker.join(subdir_parts)?;
                                         let joined = work_item_logical_path(&subdir_entry_name);
@@ -1139,7 +1159,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                         .unwrap();
                                         self.walker.workbuf.push(WorkItem::new_symlink(
                                             subdir_entry_name,
-                                            active,
+                                            follow_active,
                                             entry_start,
                                         ));
                                     } else if !self.walker.only_files {
@@ -1601,12 +1621,11 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
         is_last: bool,
         add: &mut bool,
     ) -> Option<u32> {
-        if !self.dot && Self::starts_with_dot(entry_name) {
-            return None;
-        }
         if (self.is_ignored)(entry_name) {
             return None;
         }
+
+        let hidden = !self.dot && Self::starts_with_dot(entry_name);
 
         // Handle double wildcard `**`, this could possibly
         // propagate the `**` to the directory's children
@@ -1622,6 +1641,11 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
                 // children
                 if (component_idx + 1) as usize == self.pattern_components.len() - 1 {
                     *add = true;
+                    // Matched via the explicit next segment; don't keep the
+                    // wildcard recursion alive through a hidden directory.
+                    if hidden {
+                        return None;
+                    }
                     return Some(0);
                 }
 
@@ -1634,6 +1658,11 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
                 return Some(2);
             }
 
+            // `**` on its own does not match dotfiles without `dot: true`.
+            if hidden {
+                return None;
+            }
+
             if is_last {
                 *add = true;
             }
@@ -1641,6 +1670,8 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
             return Some(0);
         }
 
+        // For non-`**` components the dot check lives in match_pattern_impl,
+        // which lets patterns that explicitly start with `.` through.
         let matches = self.match_pattern_impl(pattern, entry_name);
         if matches {
             if is_last {
@@ -1688,7 +1719,12 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
 
     fn match_pattern_impl(&self, pattern_component: &Component, filepath: &[u8]) -> bool {
         log!("matchPatternImpl: {}", bstr::BStr::new(filepath));
-        if !self.dot && Self::starts_with_dot(filepath) {
+        // A pattern segment that itself starts with a literal `.` opts into
+        // matching dotfiles for that segment, regardless of the `dot` flag.
+        if !self.dot
+            && Self::starts_with_dot(filepath)
+            && !Self::starts_with_dot(pattern_component.pattern_slice(&self.pattern))
+        {
             return false;
         }
         if (self.is_ignored)(filepath) {
@@ -1791,6 +1827,22 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
             }
         }
         false
+    }
+
+    /// Subset of `active` whose components are non-wildcard literals that
+    /// match `entry_name`. Used to descend into a symlinked directory that the
+    /// pattern names explicitly even when `follow_symlinks` is off.
+    fn eval_literal_subset(&self, active: &ComponentSet, entry_name: &[u8]) -> ComponentSet {
+        let mut subset = self.make_set();
+        let mut it = active.iterator::<true, true>();
+        while let Some(idx) = it.next() {
+            let comp = &self.pattern_components[idx];
+            if comp.syntax_hint == SyntaxHint::Literal && self.match_pattern_impl(comp, entry_name)
+            {
+                subset.set(idx);
+            }
+        }
+        subset
     }
 
     #[inline]

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1810,9 +1810,19 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
     }
 
     fn eval_impl(&self, active: &ComponentSet, entry_name: &[u8]) -> bool {
+        let comps = &self.pattern_components;
         let mut it = active.iterator::<true, true>();
         while let Some(idx) = it.next() {
-            if self.match_pattern_impl(&self.pattern_components[idx], entry_name) {
+            let comp = &comps[idx];
+            if self.match_pattern_impl(comp, entry_name) {
+                return true;
+            }
+            // Mirror match_pattern_dir's `**/X` peek so the SymLink/Unknown
+            // pre-filter doesn't drop entries eval_dir would accept.
+            if comp.syntax_hint == SyntaxHint::Double
+                && idx + 1 < comps.len()
+                && self.match_pattern_impl(&comps[idx + 1], entry_name)
+            {
                 return true;
             }
         }

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1045,16 +1045,15 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                             // when the pattern names this segment literally. The
                             // followSymlinks option governs wildcard traversal,
                             // not explicitly-spelled path segments.
-                            let follow_active: Option<ComponentSet> =
-                                if self.walker.follow_symlinks {
-                                    self.walker
-                                        .eval_impl(&active, entry_name)
-                                        .then(|| active.clone().expect("OOM"))
-                                } else {
-                                    let subset =
-                                        self.walker.eval_literal_subset(&active, entry_name);
-                                    (subset.count() != 0).then_some(subset)
-                                };
+                            let follow_active: Option<ComponentSet> = if self.walker.follow_symlinks
+                            {
+                                self.walker
+                                    .eval_impl(&active, entry_name)
+                                    .then(|| active.clone().expect("OOM"))
+                            } else {
+                                let subset = self.walker.eval_literal_subset(&active, entry_name);
+                                (subset.count() != 0).then_some(subset)
+                            };
 
                             if let Some(follow_active) = follow_active {
                                 let subdir_parts: &[&[u8]] = &[dir_dir_path, entry_name];

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1056,18 +1056,11 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                             };
 
                             if let Some(follow_active) = follow_active {
-                                let subdir_parts: &[&[u8]] = &[dir_dir_path, entry_name];
-                                let subdir_entry_name = self.walker.join(subdir_parts)?;
-                                let joined = work_item_logical_path(&subdir_entry_name);
-                                let entry_start: u32 =
-                                    u32::try_from(joined.len() - strings::basename(joined).len())
-                                        .unwrap();
-
-                                self.walker.workbuf.push(WorkItem::new_symlink(
-                                    subdir_entry_name,
+                                self.walker.push_symlink_work_item(
+                                    dir_dir_path,
+                                    entry_name,
                                     follow_active,
-                                    entry_start,
-                                ));
+                                )?;
                                 continue;
                             }
 
@@ -1149,18 +1142,11 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                                             (subset.count() != 0).then_some(subset)
                                         };
                                     if let Some(follow_active) = follow_active {
-                                        let subdir_parts: &[&[u8]] = &[dir_dir_path, entry_name];
-                                        let subdir_entry_name = self.walker.join(subdir_parts)?;
-                                        let joined = work_item_logical_path(&subdir_entry_name);
-                                        let entry_start: u32 = u32::try_from(
-                                            joined.len() - strings::basename(joined).len(),
-                                        )
-                                        .unwrap();
-                                        self.walker.workbuf.push(WorkItem::new_symlink(
-                                            subdir_entry_name,
+                                        self.walker.push_symlink_work_item(
+                                            dir_dir_path,
+                                            entry_name,
                                             follow_active,
-                                            entry_start,
-                                        ));
+                                        )?;
                                     } else if !self.walker.only_files {
                                         if self.walker.eval_file(&active, entry_name) {
                                             match self
@@ -1912,6 +1898,21 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
 
         // For SENTINEL, bun_join already included trailing NUL in the slice it returned.
         Ok(bun_join::<SENTINEL>(subdir_parts))
+    }
+
+    fn push_symlink_work_item(
+        &mut self,
+        dir_path: &[u8],
+        entry_name: &[u8],
+        active: ComponentSet,
+    ) -> Result<(), AllocError> {
+        let subdir_entry_name = self.join(&[dir_path, entry_name])?;
+        let joined = work_item_logical_path(&subdir_entry_name);
+        let entry_start: u32 =
+            u32::try_from(joined.len() - strings::basename(joined).len()).unwrap();
+        self.workbuf
+            .push(WorkItem::new_symlink(subdir_entry_name, active, entry_start));
+        Ok(())
     }
 
     #[inline]

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1046,6 +1046,24 @@ describe.skipIf(!canCreateDirSymlink)("literal path segment through a symlinked 
     expect(scan("linkdir/file.txt")).toEqual(["linkdir/file.txt"]);
   });
 
+  // The SymLink (and DT_UNKNOWN) readdir arms pre-filter entries through
+  // eval_impl before eval_dir runs. eval_impl must therefore admit the same
+  // `**/.X` peek that eval_dir does, or a symlinked `.dotdir` (and a real
+  // `.dotdir` reported as DT_UNKNOWN on NFS/overlayfs/FUSE) would be dropped
+  // before the explicit-dot logic ever sees it.
+  test("**/.dotdir peek works when .dotdir is a symlink", () => {
+    using dir = tempDir("glob-scan-symlink-dotdir", {
+      "realdir/inner.txt": "x",
+    });
+    fs.symlinkSync("realdir", path.join(String(dir), ".dotdir"), "dir");
+    const cwd = String(dir);
+    const scan = (p: string, opts: GlobScanOptions) => norm(Array.from(new Glob(p).scanSync({ cwd, ...opts })));
+
+    expect(scan("**/.dotdir/inner.txt", { followSymlinks: true })).toEqual([".dotdir/inner.txt"]);
+    expect(scan(".dotdir/inner.txt", { followSymlinks: true })).toEqual([".dotdir/inner.txt"]);
+    expect(scan(".dotdir/inner.txt", { followSymlinks: false })).toEqual([".dotdir/inner.txt"]);
+  });
+
   test("symlink cycles do not loop when reached via a literal segment", () => {
     using dir = tempDir("glob-scan-symlink-cycle", {
       "top/file.txt": "x",

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1066,9 +1066,7 @@ describe("literal path segment through a symlinked directory", () => {
     }
     // `top` is reached literally; the `loop -> .` symlink inside is only ever
     // reached via `**`, which must not follow it with followSymlinks:false.
-    const result = norm(
-      Array.from(new Glob("top/**/*.txt").scanSync({ cwd: String(dir), followSymlinks: false })),
-    );
+    const result = norm(Array.from(new Glob("top/**/*.txt").scanSync({ cwd: String(dir), followSymlinks: false })));
     expect(result).toEqual(["top/file.txt"]);
   });
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -936,3 +936,152 @@ test("scan handles a cwd with redundant trailing separators when following symli
   );
   expect(exitCode).toBe(0);
 });
+
+// A pattern segment that spells out a leading `.` is an explicit request for
+// that dotfile/dot-directory, so the `dot: false` default must not hide it.
+// This matches bash, picomatch, minimatch and fast-glob.
+describe("explicit dotfile segments match without dot:true", () => {
+  const norm = (a: string[]) => a.map(p => p.replaceAll("\\", "/")).sort();
+  const files = {
+    ".dotdir/inner.txt": "x",
+    ".dotdir/.hidden.txt": "x",
+    ".env": "x",
+    "sub/.dotdir/inner.txt": "x",
+    "sub/visible.txt": "x",
+    "visible.txt": "x",
+  };
+
+  test.each([
+    [".dotdir/inner.txt", [".dotdir/inner.txt"]],
+    [".dotdir/*.txt", [".dotdir/inner.txt"]],
+    [".*/inner.txt", [".dotdir/inner.txt"]],
+    [".env", [".env"]],
+    [".*", [".env"]],
+    ["**/.dotdir/inner.txt", [".dotdir/inner.txt", "sub/.dotdir/inner.txt"]],
+    ["sub/.dotdir/*.txt", ["sub/.dotdir/inner.txt"]],
+  ])("pattern %j finds explicitly-named dotfiles", (pattern, expected) => {
+    using dir = tempDir("glob-scan-explicit-dot", files);
+    const result = Array.from(new Glob(pattern).scanSync({ cwd: String(dir) }));
+    expect(norm(result)).toEqual(expected.sort());
+  });
+
+  test.each([
+    ["*", ["visible.txt"]],
+    ["*.txt", ["visible.txt"]],
+    ["*/inner.txt", []],
+    ["**/inner.txt", []],
+    ["**/*.txt", ["visible.txt", "sub/visible.txt"]],
+  ])("wildcard pattern %j still hides dotfiles by default", (pattern, expected) => {
+    using dir = tempDir("glob-scan-wildcard-dot", files);
+    const result = Array.from(new Glob(pattern).scanSync({ cwd: String(dir) }));
+    expect(norm(result)).toEqual(expected.sort());
+  });
+
+  test("async scan finds explicitly-named dotfiles", async () => {
+    using dir = tempDir("glob-scan-explicit-dot-async", files);
+    const result = await Array.fromAsync(new Glob(".dotdir/inner.txt").scan({ cwd: String(dir) }));
+    expect(norm(result)).toEqual([".dotdir/inner.txt"]);
+  });
+});
+
+// `followSymlinks` controls whether wildcard traversal descends through
+// symlinked directories. A segment that names the symlink literally is an
+// explicit path the user wrote; it should resolve regardless, matching
+// fast-glob and bash.
+describe("literal path segment through a symlinked directory", () => {
+  const norm = (a: string[]) => a.map(p => p.replaceAll("\\", "/")).sort();
+
+  function makeTree(prefix: string) {
+    const dir = tempDir(prefix, {
+      "realdir/file.txt": "x",
+      "realdir/nested/deep.txt": "x",
+      "plain/file.txt": "x",
+    });
+    try {
+      fs.symlinkSync("realdir", path.join(String(dir), "linkdir"), "dir");
+    } catch (err: any) {
+      if (err.code === "EPERM" || err.code === "EACCES") {
+        dir[Symbol.dispose]();
+        return null;
+      }
+      throw err;
+    }
+    return dir;
+  }
+
+  test("literal segment resolves through a symlink with followSymlinks:false", () => {
+    const dir = makeTree("glob-scan-symlink-literal");
+    if (dir === null) return;
+    try {
+      const cwd = String(dir);
+      const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: false })));
+
+      expect(scan("linkdir/file.txt")).toEqual(["linkdir/file.txt"]);
+      expect(scan("linkdir/*.txt")).toEqual(["linkdir/file.txt"]);
+      expect(scan("linkdir/nested/deep.txt")).toEqual(["linkdir/nested/deep.txt"]);
+      expect(scan("linkdir/**/*.txt")).toEqual(["linkdir/file.txt", "linkdir/nested/deep.txt"]);
+    } finally {
+      dir[Symbol.dispose]();
+    }
+  });
+
+  test("wildcard segment still respects followSymlinks:false", () => {
+    const dir = makeTree("glob-scan-symlink-wildcard");
+    if (dir === null) return;
+    try {
+      const cwd = String(dir);
+      const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: false })));
+
+      expect(scan("*/file.txt")).toEqual(["plain/file.txt", "realdir/file.txt"]);
+      expect(scan("**/file.txt")).toEqual(["plain/file.txt", "realdir/file.txt"]);
+      expect(scan("link*/file.txt")).toEqual([]);
+    } finally {
+      dir[Symbol.dispose]();
+    }
+  });
+
+  test("followSymlinks:true still traverses via wildcards", () => {
+    const dir = makeTree("glob-scan-symlink-follow");
+    if (dir === null) return;
+    try {
+      const cwd = String(dir);
+      const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: true })));
+
+      expect(scan("*/file.txt")).toEqual(["linkdir/file.txt", "plain/file.txt", "realdir/file.txt"]);
+      expect(scan("linkdir/file.txt")).toEqual(["linkdir/file.txt"]);
+    } finally {
+      dir[Symbol.dispose]();
+    }
+  });
+
+  test("symlink cycles do not loop when reached via a literal segment", () => {
+    using dir = tempDir("glob-scan-symlink-cycle", {
+      "top/file.txt": "x",
+    });
+    try {
+      fs.symlinkSync(".", path.join(String(dir), "top", "loop"), "dir");
+    } catch (err: any) {
+      if (err.code === "EPERM" || err.code === "EACCES") return;
+      throw err;
+    }
+    // `top` is reached literally; the `loop -> .` symlink inside is only ever
+    // reached via `**`, which must not follow it with followSymlinks:false.
+    const result = norm(
+      Array.from(new Glob("top/**/*.txt").scanSync({ cwd: String(dir), followSymlinks: false })),
+    );
+    expect(result).toEqual(["top/file.txt"]);
+  });
+
+  test("async scan resolves a literal path through a symlink", async () => {
+    const dir = makeTree("glob-scan-symlink-literal-async");
+    if (dir === null) return;
+    try {
+      const result = await Array.fromAsync(
+        new Glob("linkdir/file.txt").scan({ cwd: String(dir), followSymlinks: false }),
+      );
+      expect(norm(result)).toEqual(["linkdir/file.txt"]);
+    } finally {
+      dir[Symbol.dispose]();
+    }
+  });
+});

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -945,6 +945,7 @@ describe("explicit dotfile segments match without dot:true", () => {
   const files = {
     ".dotdir/inner.txt": "x",
     ".dotdir/.hidden.txt": "x",
+    ".dotdir/foo/.dotdir/inner.txt": "x",
     ".env": "x",
     "sub/.dotdir/inner.txt": "x",
     "sub/visible.txt": "x",
@@ -957,6 +958,9 @@ describe("explicit dotfile segments match without dot:true", () => {
     [".*/inner.txt", [".dotdir/inner.txt"]],
     [".env", [".env"]],
     [".*", [".env"]],
+    // `**` may advance to an explicit `.dotdir` segment but must not itself
+    // recurse through a hidden dir: `.dotdir/foo/.dotdir/inner.txt` must not
+    // match since the only decomposition needs `**` to consume `.dotdir/foo`.
     ["**/.dotdir/inner.txt", [".dotdir/inner.txt", "sub/.dotdir/inner.txt"]],
     ["sub/.dotdir/*.txt", ["sub/.dotdir/inner.txt"]],
   ])("pattern %j finds explicitly-named dotfiles", (pattern, expected) => {

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -988,7 +988,18 @@ describe("explicit dotfile segments match without dot:true", () => {
 // symlinked directories. A segment that names the symlink literally is an
 // explicit path the user wrote; it should resolve regardless, matching
 // fast-glob and bash.
-describe("literal path segment through a symlinked directory", () => {
+const canCreateDirSymlink = (() => {
+  using probe = tempDir("glob-scan-symlink-probe", { "target/x": "" });
+  try {
+    fs.symlinkSync("target", path.join(String(probe), "link"), "dir");
+    return true;
+  } catch (err: any) {
+    if (err.code === "EPERM" || err.code === "EACCES") return false;
+    throw err;
+  }
+})();
+
+describe.skipIf(!canCreateDirSymlink)("literal path segment through a symlinked directory", () => {
   const norm = (a: string[]) => a.map(p => p.replaceAll("\\", "/")).sort();
 
   function makeTree(prefix: string) {
@@ -997,73 +1008,45 @@ describe("literal path segment through a symlinked directory", () => {
       "realdir/nested/deep.txt": "x",
       "plain/file.txt": "x",
     });
-    try {
-      fs.symlinkSync("realdir", path.join(String(dir), "linkdir"), "dir");
-    } catch (err: any) {
-      if (err.code === "EPERM" || err.code === "EACCES") {
-        dir[Symbol.dispose]();
-        return null;
-      }
-      throw err;
-    }
+    fs.symlinkSync("realdir", path.join(String(dir), "linkdir"), "dir");
     return dir;
   }
 
   test("literal segment resolves through a symlink with followSymlinks:false", () => {
-    const dir = makeTree("glob-scan-symlink-literal");
-    if (dir === null) return;
-    try {
-      const cwd = String(dir);
-      const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: false })));
+    using dir = makeTree("glob-scan-symlink-literal");
+    const cwd = String(dir);
+    const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: false })));
 
-      expect(scan("linkdir/file.txt")).toEqual(["linkdir/file.txt"]);
-      expect(scan("linkdir/*.txt")).toEqual(["linkdir/file.txt"]);
-      expect(scan("linkdir/nested/deep.txt")).toEqual(["linkdir/nested/deep.txt"]);
-      expect(scan("linkdir/**/*.txt")).toEqual(["linkdir/file.txt", "linkdir/nested/deep.txt"]);
-    } finally {
-      dir[Symbol.dispose]();
-    }
+    expect(scan("linkdir/file.txt")).toEqual(["linkdir/file.txt"]);
+    expect(scan("linkdir/*.txt")).toEqual(["linkdir/file.txt"]);
+    expect(scan("linkdir/nested/deep.txt")).toEqual(["linkdir/nested/deep.txt"]);
+    expect(scan("linkdir/**/*.txt")).toEqual(["linkdir/file.txt", "linkdir/nested/deep.txt"]);
   });
 
   test("wildcard segment still respects followSymlinks:false", () => {
-    const dir = makeTree("glob-scan-symlink-wildcard");
-    if (dir === null) return;
-    try {
-      const cwd = String(dir);
-      const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: false })));
+    using dir = makeTree("glob-scan-symlink-wildcard");
+    const cwd = String(dir);
+    const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: false })));
 
-      expect(scan("*/file.txt")).toEqual(["plain/file.txt", "realdir/file.txt"]);
-      expect(scan("**/file.txt")).toEqual(["plain/file.txt", "realdir/file.txt"]);
-      expect(scan("link*/file.txt")).toEqual([]);
-    } finally {
-      dir[Symbol.dispose]();
-    }
+    expect(scan("*/file.txt")).toEqual(["plain/file.txt", "realdir/file.txt"]);
+    expect(scan("**/file.txt")).toEqual(["plain/file.txt", "realdir/file.txt"]);
+    expect(scan("link*/file.txt")).toEqual([]);
   });
 
   test("followSymlinks:true still traverses via wildcards", () => {
-    const dir = makeTree("glob-scan-symlink-follow");
-    if (dir === null) return;
-    try {
-      const cwd = String(dir);
-      const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: true })));
+    using dir = makeTree("glob-scan-symlink-follow");
+    const cwd = String(dir);
+    const scan = (p: string) => norm(Array.from(new Glob(p).scanSync({ cwd, followSymlinks: true })));
 
-      expect(scan("*/file.txt")).toEqual(["linkdir/file.txt", "plain/file.txt", "realdir/file.txt"]);
-      expect(scan("linkdir/file.txt")).toEqual(["linkdir/file.txt"]);
-    } finally {
-      dir[Symbol.dispose]();
-    }
+    expect(scan("*/file.txt")).toEqual(["linkdir/file.txt", "plain/file.txt", "realdir/file.txt"]);
+    expect(scan("linkdir/file.txt")).toEqual(["linkdir/file.txt"]);
   });
 
   test("symlink cycles do not loop when reached via a literal segment", () => {
     using dir = tempDir("glob-scan-symlink-cycle", {
       "top/file.txt": "x",
     });
-    try {
-      fs.symlinkSync(".", path.join(String(dir), "top", "loop"), "dir");
-    } catch (err: any) {
-      if (err.code === "EPERM" || err.code === "EACCES") return;
-      throw err;
-    }
+    fs.symlinkSync(".", path.join(String(dir), "top", "loop"), "dir");
     // `top` is reached literally; the `loop -> .` symlink inside is only ever
     // reached via `**`, which must not follow it with followSymlinks:false.
     const result = norm(Array.from(new Glob("top/**/*.txt").scanSync({ cwd: String(dir), followSymlinks: false })));
@@ -1071,15 +1054,10 @@ describe("literal path segment through a symlinked directory", () => {
   });
 
   test("async scan resolves a literal path through a symlink", async () => {
-    const dir = makeTree("glob-scan-symlink-literal-async");
-    if (dir === null) return;
-    try {
-      const result = await Array.fromAsync(
-        new Glob("linkdir/file.txt").scan({ cwd: String(dir), followSymlinks: false }),
-      );
-      expect(norm(result)).toEqual(["linkdir/file.txt"]);
-    } finally {
-      dir[Symbol.dispose]();
-    }
+    using dir = makeTree("glob-scan-symlink-literal-async");
+    const result = await Array.fromAsync(
+      new Glob("linkdir/file.txt").scan({ cwd: String(dir), followSymlinks: false }),
+    );
+    expect(norm(result)).toEqual(["linkdir/file.txt"]);
   });
 });


### PR DESCRIPTION
## What

Fixes two cases where `Bun.Glob.scan()` silently returns an empty result for patterns that look obviously correct and work in every reference implementation (bash, picomatch, minimatch, fast-glob):

```js
// 1. Explicitly-named dotfile segment
new Bun.Glob(".dotdir/inner.txt").scanSync(".")
// before: []              (dot:false hides an EXPLICITLY-named dotfile)
// after:  [".dotdir/inner.txt"]

// 2. Literal path segment through a symlinked directory
new Bun.Glob("linkdir/file.txt").scanSync(".")   // linkdir -> realdir
// before: []              (followSymlinks:false blocks even a literal path)
// after:  ["linkdir/file.txt"]
```

Both are silent empty results, not errors. Glob is how people select files for builds, tests, deploys and uploads, so "no matches" quietly excludes files. A project that lives behind a symlink (pnpm layouts, mounted volumes, `/tmp` on macOS) or a config that names a dotfile explicitly would process nothing.

## Why

**Explicit dotfiles.** `match_pattern_dir` and `match_pattern_impl` in `GlobWalker.rs` rejected any entry whose name starts with `.` whenever `dot: false`, without looking at the pattern segment. The ecosystem convention is that the `dot` option only governs whether *wildcards* match dotfiles; a segment whose pattern text itself starts with `.` is an explicit request for that name and matches regardless:

| pattern | candidate | picomatch | minimatch | fast-glob | bash | bun before | bun after |
|---|---|---|---|---|---|---|---|
| `.dotdir/inner.txt` | `.dotdir/inner.txt` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ |
| `.*/inner.txt` | `.dotdir/inner.txt` | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ |
| `*/inner.txt` | `.dotdir/inner.txt` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
| `**/inner.txt` | `.dotdir/inner.txt` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |

**Literal path through a symlink.** The `SymLink` arm of the directory iterator only descended when `follow_symlinks` was set. But `followSymlinks` is documented (and implemented everywhere else) as a *wildcard-traversal* option: whether `*`/`**` should walk through symlinked directories. A segment that names the symlink literally is an explicit path the user wrote; fast-glob resolves it regardless of `followSymbolicLinks`:

| pattern | fast-glob `followSymbolicLinks:false` | bun `followSymlinks:false` before | bun after |
|---|---|---|---|
| `linkdir/file.txt` | `["linkdir/file.txt"]` | `[]` | `["linkdir/file.txt"]` |
| `linkdir/*.txt` | `["linkdir/file.txt"]` | `[]` | `["linkdir/file.txt"]` |
| `*/file.txt` | `["realdir/file.txt"]` | `["realdir/file.txt"]` | `["realdir/file.txt"]` |
| `**/file.txt` | `["realdir/file.txt"]` | `["realdir/file.txt"]` | `["realdir/file.txt"]` |

## How

- `match_pattern_impl`: bypass the dot filter when the pattern component's own text starts with `.`.
- `match_pattern_dir`: move the dot check after the `**`-advances-to-next-segment check so `**/.dotdir/...` can advance; `**` on its own still never descends through a hidden entry.
- `SymLink` entry handling: when `follow_symlinks` is off, compute the subset of active components that are `SyntaxHint::Literal` and match the entry name; if non-empty, push the symlink work item with *only* that subset. Wildcard components stay out of the propagated set, so `*`/`**` still respect `followSymlinks:false` and cycles reached via wildcards cannot loop.

## Tests

Added to `test/js/bun/glob/scan.test.ts`: positive cases for each fix plus negative cases proving wildcards still hide dotfiles, wildcards still respect `followSymlinks:false`, and a `loop -> .` symlink cycle reached via `**` under a literally-named parent does not recurse.

```
# before (USE_SYSTEM_BUN=1):  9 fail / 9 pass
# after  (bun bd):            18 pass
# full test/js/bun/glob/scan.test.ts: 190 pass, 0 fail
```

## Not in this PR

Four other `Bun.Glob` divergences from the ecosystem surfaced alongside these, all in the pattern matcher rather than the walker: single-item `{a}` braces expanding instead of being literal, unterminated `{` and `[` not falling back to literal, and `scan()` not honouring the same backslash escaping as `match()`. Those live in `src/glob/matcher.rs` / component classification and deserve their own change.

Fixes #28021 (the `Bun.Glob` scanner-level dot suppression described there; the `fs.glob` symptom was separately sidestepped by the minimatch port in #31830, but `Bun.Glob` itself still had the bug).
