### PR TITLE
bun outdated: show in-range updates when installed >= `latest` dist-tag

### DIFF
--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -558,9 +558,9 @@ impl OutdatedCommand {
                 let has_filtered_latest = latest.latest_is_filtered();
 
                 let update_result = update_version.unwrap();
-                let latest_is_newer = current_version
-                    .order(actual_latest.version, string_buf, &manifest.string_buf)
-                    == core::cmp::Ordering::Less;
+                let latest_is_newer =
+                    current_version.order(actual_latest.version, string_buf, &manifest.string_buf)
+                        == core::cmp::Ordering::Less;
                 // An in-range update can exist even when the installed version is
                 // at or ahead of the `latest` dist-tag (prereleases, `next` lines),
                 // and `bun update` would apply it, so surface the row here too.

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -553,14 +553,25 @@ impl OutdatedCommand {
                 };
 
                 let current_version = resolution.npm().version;
-                if current_version.order(actual_latest.version, string_buf, &manifest.string_buf)
-                    != core::cmp::Ordering::Less
-                {
-                    continue;
-                }
 
                 let has_filtered_update = update_version.latest_is_filtered();
                 let has_filtered_latest = latest.latest_is_filtered();
+
+                let update_result = update_version.unwrap();
+                let latest_is_newer = current_version
+                    .order(actual_latest.version, string_buf, &manifest.string_buf)
+                    == core::cmp::Ordering::Less;
+                // An in-range update can exist even when the installed version is
+                // at or ahead of the `latest` dist-tag (prereleases, `next` lines),
+                // and `bun update` would apply it, so surface the row here too.
+                let update_is_newer = update_result.is_some_and(|uv| {
+                    current_version.order(uv.version, string_buf, &manifest.string_buf)
+                        == core::cmp::Ordering::Less
+                });
+                if !latest_is_newer && !update_is_newer {
+                    continue;
+                }
+
                 if has_filtered_update || has_filtered_latest {
                     has_filtered_versions = true;
                 }
@@ -587,7 +598,7 @@ impl OutdatedCommand {
                 }
 
                 version_buf.clear();
-                if let Some(uv) = update_version.unwrap() {
+                if let Some(uv) = update_result {
                     write!(version_buf, "{}", uv.version.fmt(&manifest.string_buf))
                         .expect("OOM writing version");
                 } else {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -8597,12 +8597,9 @@ describe("outdated", () => {
   });
 
   test("shows in-range update when installed version is ahead of `latest` dist-tag", async () => {
-    // prereleases-1 publishes 1.0.0-future.{0,1,4,5,7} with the `latest`
-    // dist-tag pointing at 1.0.0-future.4. Lock 1.0.0-future.5 (a version
-    // newer than `latest`), then widen the range so that 1.0.0-future.7
-    // becomes an available in-range update. Previously `bun outdated` hid
-    // this row because `current >= latest`, even though `bun update` would
-    // move to 1.0.0-future.7.
+    // prereleases-1 publishes 1.0.0-future.{0,1,4,5,7} with `latest` at
+    // 1.0.0-future.4. Lock 1.0.0-future.5 (newer than `latest`), then widen
+    // the range so 1.0.0-future.7 is an available in-range update.
     await write(
       packageJson,
       JSON.stringify({
@@ -8641,9 +8638,8 @@ describe("outdated", () => {
   });
 
   test("shows in-range update when `latest` dist-tag points at an older stable line", async () => {
-    // prereleases-2 publishes 0.5.0 as `latest` and a 1.0.0-next.* line.
-    // Installing any 1.0.0-next.* means `current > latest` and the row was
-    // previously hidden even though a newer in-range prerelease exists.
+    // prereleases-2 publishes 0.5.0 as `latest` and a 1.0.0-next.* line, so
+    // installing any 1.0.0-next.* puts `current > latest`.
     await write(
       packageJson,
       JSON.stringify({

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -8595,6 +8595,85 @@ describe("outdated", () => {
     // The catalog grouping should show which workspaces use it
     expect(out).toMatch(/catalog.*workspace-a.*workspace-b|workspace-b.*workspace-a/);
   });
+
+  test("shows in-range update when installed version is ahead of `latest` dist-tag", async () => {
+    // prereleases-1 publishes 1.0.0-future.{0,1,4,5,7} with the `latest`
+    // dist-tag pointing at 1.0.0-future.4. Lock 1.0.0-future.5 (a version
+    // newer than `latest`), then widen the range so that 1.0.0-future.7
+    // becomes an available in-range update. Previously `bun outdated` hid
+    // this row because `current >= latest`, even though `bun update` would
+    // move to 1.0.0-future.7.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "prereleases-1": "1.0.0-future.5",
+        },
+      }),
+    );
+    await runBunInstall(env, packageDir);
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "prereleases-1": "^1.0.0-future.5",
+        },
+      }),
+    );
+    await runBunInstall(env, packageDir);
+
+    // Lockfile must still pin 1.0.0-future.5 (sticky resolution).
+    const installed = await file(join(packageDir, "node_modules", "prereleases-1", "package.json")).json();
+    expect(installed.version).toBe("1.0.0-future.5");
+
+    const out = await runBunOutdated(env, packageDir);
+    expect(out).toContain("prereleases-1");
+    expect(out).toContain("1.0.0-future.5");
+    expect(out).toContain("1.0.0-future.7");
+
+    // `bun update` applies exactly the update `bun outdated` just surfaced.
+    await runBunUpdate(env, packageDir);
+    const updated = await file(join(packageDir, "node_modules", "prereleases-1", "package.json")).json();
+    expect(updated.version).toBe("1.0.0-future.7");
+  });
+
+  test("shows in-range update when `latest` dist-tag points at an older stable line", async () => {
+    // prereleases-2 publishes 0.5.0 as `latest` and a 1.0.0-next.* line.
+    // Installing any 1.0.0-next.* means `current > latest` and the row was
+    // previously hidden even though a newer in-range prerelease exists.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "prereleases-2": "1.0.0-next.1",
+        },
+      }),
+    );
+    await runBunInstall(env, packageDir);
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "prereleases-2": "^1.0.0-next.1",
+        },
+      }),
+    );
+    await runBunInstall(env, packageDir);
+
+    const installed = await file(join(packageDir, "node_modules", "prereleases-2", "package.json")).json();
+    expect(installed.version).toBe("1.0.0-next.1");
+
+    const out = await runBunOutdated(env, packageDir);
+    expect(out).toContain("prereleases-2");
+    expect(out).toContain("1.0.0-next.1");
+    expect(out).toContain("1.0.0-next.23");
+  });
 });
 
 // TODO: setup registry to run across multiple test files, then move this and a few other describe

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1828,7 +1828,10 @@ export class VerdaccioRegistry {
 
   async start(silent: boolean = true) {
     await rm(join(dirname(this.configPath), "htpasswd"), { force: true });
-    this.process = fork(require.resolve("verdaccio/bin/verdaccio"), ["-c", this.configPath, "-l", `${this.port}`], {
+    // Bind to 0.0.0.0 so the server is reachable regardless of whether the
+    // resolver picks IPv4 or IPv6 for `localhost` (some environments bind
+    // `localhost` to ::1 only, which bun's HTTP client then can't reach).
+    this.process = fork(require.resolve("verdaccio/bin/verdaccio"), ["-c", this.configPath, "-l", `0.0.0.0:${this.port}`], {
       silent,
       // Prefer using a release build of Bun since it's faster
       execPath: isCI ? bunExe() : Bun.which("bun") || bunExe(),


### PR DESCRIPTION
## What

`bun outdated` skipped any row where the installed version was `>=` the `latest` dist-tag, even when a newer version satisfying the dependency range existed. That means packages shipping on a `next` / `canary` tag (with `latest` pointing at an older stable line), or any installed prerelease newer than `latest`, were silently omitted from the table while `bun update` would still upgrade them.

Addresses the `bun outdated` half of #16570.

## Repro

```sh
# registry has prereleases-1 versions 1.0.0-future.{0,1,4,5,7}
# with dist-tag latest = 1.0.0-future.4
echo '{"dependencies":{"prereleases-1":"1.0.0-future.5"}}' > package.json
bun install
echo '{"dependencies":{"prereleases-1":"^1.0.0-future.5"}}' > package.json
bun install        # sticky lockfile keeps 1.0.0-future.5
bun outdated       # prints nothing (installed 1.0.0-future.5 >= latest 1.0.0-future.4)
bun update         # moves to 1.0.0-future.7
```

`bun outdated` and `bun update` disagree: `update` finds 1.0.0-future.7, `outdated` says there's nothing.

## Cause

`src/runtime/cli/outdated_command.rs` filtered purely on `current_version < latest_dist_tag`. The in-range "Update" column (computed via `find_best_version`, the same function `bun update` uses) was never consulted for the row-visibility decision.

## Fix

Also keep the row when the best in-range version is newer than what's installed, so the table shows exactly the updates `bun update` would apply.

## Tests

Two new cases in the `outdated` describe block of `bun-install-registry.test.ts` covering an installed prerelease ahead of `latest`, and a `latest` tag that points at an older stable line than the installed `next`-style version. Both assert the row appears and that `bun update` moves to the version `bun outdated` now reports.

Also binds the verdaccio test helper to `0.0.0.0` so the registry is reachable on hosts where `localhost` resolves to `::1` for the listener while bun's HTTP client uses IPv4.
