### PR TITLE
FileSink: return 0 from write() and undefined from flush() after end()

### DIFF
--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -978,7 +978,7 @@ impl FileSink {
 
     pub fn write(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
-            return streams::Writable::Done;
+            return streams::Writable::Owned(0);
         }
         // SAFETY(JsCell): `IOWriter::write` buffers/writes to fd; does not call JS.
         let rc = self.writer.with_mut(|w| w.write(data.slice()));
@@ -992,7 +992,7 @@ impl FileSink {
 
     pub fn write_latin1(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
-            return streams::Writable::Done;
+            return streams::Writable::Owned(0);
         }
         // SAFETY(JsCell): `IOWriter::write_latin1` buffers/writes; no JS.
         let rc = self.writer.with_mut(|w| w.write_latin1(data.slice()));
@@ -1001,7 +1001,7 @@ impl FileSink {
 
     pub fn write_utf16(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
-            return streams::Writable::Done;
+            return streams::Writable::Owned(0);
         }
         // SAFETY(JsCell): `IOWriter::write_utf16` buffers/writes; no JS.
         let rc = self.writer.with_mut(|w| w.write_utf16(data.slice16()));
@@ -1017,6 +1017,7 @@ impl FileSink {
         // goes via the stored `*mut FileSink` backref, not this borrow.
         match self.writer.with_mut(|w| w.flush()) {
             WriteResult::Done(written) => {
+                self.done.set(true);
                 self.written.set(self.written.get() + written as usize); // @truncate
                 self.writer.with_mut(|w| w.end());
                 sys::Result::Ok(())
@@ -1036,6 +1037,7 @@ impl FileSink {
                 sys::Result::Ok(())
             }
             WriteResult::Wrote(written) => {
+                self.done.set(true);
                 self.written.set(self.written.get() + written as usize); // @truncate
                 self.writer.with_mut(|w| w.end());
                 sys::Result::Ok(())
@@ -1097,6 +1099,7 @@ impl FileSink {
 
         match flush_result {
             WriteResult::Done(written) => {
+                self.done.set(true);
                 self.update_ref(false);
                 self.writer.with_mut(|w| w.end());
                 sys::Result::Ok(JSValue::js_number(written as f64))
@@ -1125,6 +1128,7 @@ impl FileSink {
                 sys::Result::Ok(unsafe { (*promise_result).to_js() })
             }
             WriteResult::Wrote(written) => {
+                self.done.set(true);
                 self.writer.with_mut(|w| w.end());
                 sys::Result::Ok(JSValue::js_number(written as f64))
             }

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -309,6 +309,46 @@ it.skipIf(!isPosix)("writing after end() fails during flush does not crash", asy
   await 1;
 });
 
+it("write() and flush() after end() return 0 and undefined, not boolean true", async () => {
+  const path = join(tmpdirSync(), "filesink-write-after-end.txt");
+  const writer = Bun.file(path).writer();
+
+  // write() may return a number synchronously (POSIX regular file) or a
+  // Promise<number> (Windows regular-file uv_fs_write); await either.
+  expect(await writer.write("hello")).toBe(5);
+  await Promise.resolve(writer.end());
+
+  // write()/flush() are typed `number | Promise<number>`. After end() they
+  // returned the boolean `true` because end_from_js() never set `done` on the
+  // synchronous success paths, so the call fell through to the already-ended
+  // IOWriter. Now they return 0 / undefined like every other sink.
+  expect(writer.write("world")).toBe(0);
+  expect(writer.flush()).toBeUndefined();
+
+  // The dropped write must not appear in the file.
+  expect(await Bun.file(path).text()).toBe("hello");
+
+  // Calling end() again is idempotent and must not throw.
+  await Promise.resolve(writer.end()).catch(() => {});
+});
+
+it("write() to an exited subprocess's stdin returns 0, not boolean true", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "process.exit(0)"],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
+
+  // The stdin FileSink's `done` is set by on_attached_process_exit. Writing
+  // to it returns 0 (nothing written), matching the HTTP/network sinks and
+  // the declared `number | Promise<number>` type.
+  expect(proc.stdin.write("late\n")).toBe(0);
+  await Promise.resolve(proc.stdin.end()).catch(() => {});
+});
+
 // On Windows the libuv write completion path re-enters JS (promise resolution)
 // while a `&mut WindowsStreamingWriter` is live, so without raw-ptr laundering
 // LLVM `noalias` lets release builds cache stale `is_done`/`parent` and


### PR DESCRIPTION
## Repro

```js
const writer = Bun.file("/tmp/out.txt").writer();
await writer.write("hello");   // → 5
await writer.end();
writer.write("world");         // → true   (boolean, typed number | Promise<number>)
writer.flush();                // → true
```

`FileSink.write()` and `flush()` after `end()` return the boolean `true`, against the declared `number | Promise<number>` return type.

## Cause

`FileSink::end()` / `end_from_js()` only set `self.done = true` on the `Err` and `Pending` flush results. On the synchronous `Done` / `Wrote` branches (the common case for a regular file) they call `writer.end()` on the underlying `IOWriter` but leave `self.done` false.

A subsequent `write()` then skips the `done` early-return and calls `writer.write()` on the already-ended `IOWriter`, which returns `WriteResult::Done(0)`. `to_result(Done(0))` → `Writable::Done` → `JSValue::TRUE`.

## Fix

- Set `self.done = true` on every terminal branch of `FileSink::end()` and `end_from_js()`.
- Make `write()` / `write_latin1()` / `write_utf16()` return `Writable::Owned(0)` instead of `Writable::Done` when the sink is done. `Owned(0)` converts to the number `0`, which is what the HTTP/H3/network sinks already return in the same situation.

With `done` now set, `flush()` after `end()` hits the existing `self.done` guard in `flush_from_js` and returns `undefined` instead of `true`.

No new exceptions are thrown and post-end writes are still silently ignored. Only the return values change, to match the documented `number | Promise<number>` type and the other sinks. (An earlier revision of this PR made write-after-end throw `ERR_STREAM_WRITE_AFTER_END`; that was removed per review as an unnecessary breaking change.)

## Verification

New tests in `test/js/bun/util/filesink.test.ts`:
- `write()` after `end()` returns `0` and `flush()` returns `undefined`; the post-end bytes do not appear in the file.
- `proc.stdin.write()` after the subprocess exits returns `0`.

Both fail on 1.4.0 (get `true`).

Related: the `Bun.serve` streaming-body-error `0\r\n\r\n` terminator half of the same fuzzer finding is handled in #32842.