### PR TITLE
Request: dependent AbortSignal per spec; async_hooks: fix ALS disable/run leak and AsyncResource.bind

### DIFF
--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -25,6 +25,7 @@
 const setAsyncHooksEnabled = $newCppFunction("NodeAsyncHooks.cpp", "jsSetAsyncHooksEnabled", 1);
 const cleanupLater = $newCppFunction("NodeAsyncHooks.cpp", "jsCleanupLater", 0);
 const { validateFunction, validateString, validateObject } = require("internal/validators");
+const ArrayPrototypeUnshift = Array.prototype.unshift;
 
 // Only run during debug
 function assertValidAsyncContextArray(array: unknown): array is ReadonlyArray<any> | undefined {
@@ -306,7 +307,7 @@ class AsyncResource {
     if (thisArg === undefined) {
       const resource = this;
       bound = function (...args) {
-        (args as unknown[]).unshift(fn, this);
+        ArrayPrototypeUnshift.$call(args, fn, this);
         return resource.runInAsyncScope.$apply(resource, args);
       };
     } else {

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -74,8 +74,6 @@ function set(contextValue: ReadonlyArray<any> | undefined) {
 }
 
 class AsyncLocalStorage {
-  #disabled = false;
-
   constructor() {
     setAsyncHooksEnabled(true);
 
@@ -110,8 +108,6 @@ class AsyncLocalStorage {
 
   enterWith(store) {
     cleanupLater();
-    // we must renable it when asyncLocalStorage.enterWith() is called https://nodejs.org/api/async_context.html#asynclocalstoragedisable
-    this.#disabled = false;
     var context = get();
     if (!context) {
       set([this, store]);
@@ -146,9 +142,6 @@ class AsyncLocalStorage {
     var previous_value;
     var i = 0;
     var contextWasAlreadyInit = !context;
-    // we must renable it when asyncLocalStorage.run() is called https://nodejs.org/api/async_context.html#asynclocalstoragedisable
-    const wasDisabled = this.#disabled;
-    this.#disabled = false;
     if (contextWasAlreadyInit) {
       set((context = [this, store_value]));
     } else {
@@ -173,42 +166,43 @@ class AsyncLocalStorage {
     try {
       return callback(...args);
     } finally {
-      // Note: early `return` will prevent `throw` above from working. I think...
-      // Set AsyncContextFrame to undefined if we are out of context values
-      if (!wasDisabled) {
-        var context2 = get()! as any[]; // we make sure to .slice() before mutating
-        if (context2 === context && contextWasAlreadyInit) {
-          $assert(context2.length === 2, "context was mutated without copy");
-          set(undefined);
-        } else {
-          context2 = context2.slice(); // array is cloned here
-          $assert(context2[i] === this);
+      // The callback may have called disable() (clearing our entry and
+      // possibly the whole context) or enterWith() on other stores, so
+      // re-read the context and re-locate our entry before restoring.
+      var context2 = get() as any[] | undefined;
+      if (context2 === context && contextWasAlreadyInit) {
+        set(undefined);
+      } else if (context2) {
+        context2 = context2.slice();
+        var j = context2.indexOf(this);
+        if (j > -1) {
+          $assert(j % 2 === 0);
           if (hasPrevious) {
-            context2[i + 1] = previous_value;
-            set(context2);
+            context2[j + 1] = previous_value;
           } else {
-            // i wonder if this is a fair assert to make
-            context2.splice(i, 2);
-            $assert(context2.length % 2 === 0);
-            set(context2.length ? context2 : undefined);
+            context2.splice(j, 2);
           }
+        } else if (hasPrevious) {
+          context2.push(this, previous_value);
         }
-        $assert(
-          this.getStore() === previous_value,
-          "run: previous_value",
-          Bun.inspect(previous_value),
-          "was not restored, i see",
-          this.getStore(),
-        );
+        $assert(context2.length % 2 === 0);
+        set(context2.length ? context2 : undefined);
+      } else if (hasPrevious) {
+        set([this, previous_value]);
       }
+      $assert(
+        this.getStore() === previous_value,
+        "run: previous_value",
+        Bun.inspect(previous_value),
+        "was not restored, i see",
+        this.getStore(),
+      );
     }
   }
 
   disable() {
     $debug("disable " + (this as any).__id__);
     // In this case, we actually do want to mutate the context state
-    if (this.#disabled) return;
-    this.#disabled = true;
     var context = get() as any[];
     if (context) {
       var { length } = context;
@@ -224,8 +218,6 @@ class AsyncLocalStorage {
 
   getStore() {
     $debug("getStore " + (this as any).__id__);
-    // disabled AsyncLocalStorage always returns undefined https://nodejs.org/api/async_context.html#asynclocalstoragedisable
-    if (this.#disabled) return;
     var context = get();
     if (!context) return;
     var { length } = context;
@@ -295,7 +287,7 @@ class AsyncResource {
   }
 
   emitDestroy() {
-    //
+    return this;
   }
 
   runInAsyncScope(fn, thisArg, ...args) {
@@ -310,7 +302,24 @@ class AsyncResource {
 
   bind(fn, thisArg) {
     validateFunction(fn, "fn");
-    return this.runInAsyncScope.bind(this, fn, thisArg ?? this);
+    let bound;
+    if (thisArg === undefined) {
+      const resource = this;
+      bound = function (...args) {
+        (args as unknown[]).unshift(fn, this);
+        return resource.runInAsyncScope.$apply(resource, args);
+      };
+    } else {
+      bound = this.runInAsyncScope.bind(this, fn, thisArg);
+    }
+    $Object.$defineProperty(bound, "length", {
+      __proto__: null,
+      configurable: true,
+      enumerable: false,
+      value: fn.length,
+      writable: false,
+    });
+    return bound;
   }
 
   static bind(fn, type, thisArg) {

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -74,6 +74,16 @@ function set(contextValue: ReadonlyArray<any> | undefined) {
   return $putInternalField($asyncContext, 0, contextValue);
 }
 
+// Scan only key slots in the [key, value, key, value, ...] context array.
+// A plain indexOf could match a value slot when an AsyncLocalStorage
+// instance is itself stored as another store's value.
+function indexOfKey(context: any[], key: AsyncLocalStorage): number {
+  for (var i = 0, len = context.length; i < len; i += 2) {
+    if (context[i] === key) return i;
+  }
+  return -1;
+}
+
 class AsyncLocalStorage {
   constructor() {
     setAsyncHooksEnabled(true);
@@ -148,9 +158,8 @@ class AsyncLocalStorage {
     } else {
       // it's safe to mutate context now that it was cloned
       context = context!.slice();
-      i = context.indexOf(this);
+      i = indexOfKey(context, this);
       if (i > -1) {
-        $assert(i % 2 === 0);
         hasPrevious = true;
         previous_value = context[i + 1];
         context[i + 1] = store_value;
@@ -175,9 +184,8 @@ class AsyncLocalStorage {
         set(undefined);
       } else if (context2) {
         context2 = context2.slice();
-        var j = context2.indexOf(this);
+        var j = indexOfKey(context2, this);
         if (j > -1) {
-          $assert(j % 2 === 0);
           if (hasPrevious) {
             context2[j + 1] = previous_value;
           } else {

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -69,6 +69,10 @@ unsafe extern "C" {
     safe fn WebCore__AbortSignal__new(arg0: &JSGlobalObject) -> *mut AbortSignal;
     safe fn WebCore__AbortSignal__jsReason(arg0: &AbortSignal, arg1: &JSGlobalObject) -> JSValue;
     safe fn Bun__wrapAbortError(global_object: &JSGlobalObject, cause: JSValue) -> JSValue;
+    safe fn WebCore__AbortSignal__createFollowingSignal(
+        arg0: &JSGlobalObject,
+        parent: &AbortSignal,
+    ) -> *mut AbortSignal;
 }
 
 /// Abort-callback monomorphization for `listen`. Implement on your context type.
@@ -192,6 +196,16 @@ impl AbortSignal {
     pub fn new(global: &JSGlobalObject) -> *mut AbortSignal {
         crate::mark_binding!();
         WebCore__AbortSignal__new(global)
+    }
+
+    /// Creates a fresh signal that follows `parent` (per the DOM
+    /// "follow" algorithm): it aborts with `parent`'s reason when
+    /// `parent` aborts. Returns an owned ref.
+    pub fn create_following(global: &JSGlobalObject, parent: &AbortSignal) -> AbortSignalRef {
+        crate::mark_binding!();
+        let ptr = WebCore__AbortSignal__createFollowingSignal(global, parent);
+        // SAFETY: C++ leakRef() returns a +1 owned pointer.
+        unsafe { AbortSignalRef::adopt(ptr) }
     }
 
     /// Returns a borrowed handle to the internal Timeout, or null.

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -198,9 +198,10 @@ impl AbortSignal {
         WebCore__AbortSignal__new(global)
     }
 
-    /// Creates a fresh signal that follows `parent` (per the DOM
-    /// "follow" algorithm): it aborts with `parent`'s reason when
-    /// `parent` aborts. Returns an owned ref.
+    /// Creates a fresh dependent signal that aborts with `parent`'s
+    /// reason when `parent` aborts. The link is held in weak sets on
+    /// both sides so collecting the dependent leaves nothing on the
+    /// parent. Returns an owned ref.
     pub fn create_following(global: &JSGlobalObject, parent: &AbortSignal) -> AbortSignalRef {
         crate::mark_binding!();
         let ptr = WebCore__AbortSignal__createFollowingSignal(global, parent);

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -198,10 +198,9 @@ impl AbortSignal {
         WebCore__AbortSignal__new(global)
     }
 
-    /// Creates a fresh dependent signal that aborts with `parent`'s
-    /// reason when `parent` aborts. The link is held in weak sets on
-    /// both sides so collecting the dependent leaves nothing on the
-    /// parent. Returns an owned ref.
+    /// Creates a fresh dependent signal that aborts with `parent`'s reason.
+    /// The link is weak on both sides, so collecting the dependent leaves
+    /// nothing on the parent. Returns an owned ref.
     pub fn create_following(global: &JSGlobalObject, parent: &AbortSignal) -> AbortSignalRef {
         crate::mark_binding!();
         let ptr = WebCore__AbortSignal__createFollowingSignal(global, parent);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5581,11 +5581,9 @@ extern "C" WebCore::AbortSignal* WebCore__AbortSignal__new(JSC::JSGlobalObject* 
     return abortSignal.leakRef();
 }
 
-// Creates a new dependent AbortSignal that aborts when `parent` aborts
-// (with the same reason). Uses the source/dependent WeakListHashSet path
-// used by AbortSignal.any() so the link self-prunes when the dependent
-// is collected; the legacy signalFollow() would leave a permanent entry
-// in the parent's algorithm vector. Returns a +1 ref the caller owns.
+// Creates a dependent AbortSignal via AbortSignal::any() so the weak
+// source/dependent link self-prunes on collection (signalFollow() would
+// leave a permanent algorithm entry). Returns a +1 ref the caller owns.
 extern "C" WebCore::AbortSignal* WebCore__AbortSignal__createFollowingSignal(JSC::JSGlobalObject* globalObject, WebCore::AbortSignal* parent)
 {
     Zig::GlobalObject* thisObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5581,6 +5581,17 @@ extern "C" WebCore::AbortSignal* WebCore__AbortSignal__new(JSC::JSGlobalObject* 
     return abortSignal.leakRef();
 }
 
+// Creates a new AbortSignal that follows `parent` (aborts when `parent`
+// aborts, with the same reason). Returns a +1 ref that the caller owns.
+extern "C" WebCore::AbortSignal* WebCore__AbortSignal__createFollowingSignal(JSC::JSGlobalObject* globalObject, WebCore::AbortSignal* parent)
+{
+    Zig::GlobalObject* thisObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
+    auto* context = thisObject->scriptExecutionContext();
+    RefPtr<WebCore::AbortSignal> abortSignal = WebCore::AbortSignal::create(context);
+    abortSignal->signalFollow(*parent);
+    return abortSignal.leakRef();
+}
+
 extern "C" JSC::EncodedJSValue WebCore__AbortSignal__create(JSC::JSGlobalObject* globalObject)
 {
     Zig::GlobalObject* thisObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5581,15 +5581,19 @@ extern "C" WebCore::AbortSignal* WebCore__AbortSignal__new(JSC::JSGlobalObject* 
     return abortSignal.leakRef();
 }
 
-// Creates a new AbortSignal that follows `parent` (aborts when `parent`
-// aborts, with the same reason). Returns a +1 ref that the caller owns.
+// Creates a new dependent AbortSignal that aborts when `parent` aborts
+// (with the same reason). Uses the source/dependent WeakListHashSet path
+// used by AbortSignal.any() so the link self-prunes when the dependent
+// is collected; the legacy signalFollow() would leave a permanent entry
+// in the parent's algorithm vector. Returns a +1 ref the caller owns.
 extern "C" WebCore::AbortSignal* WebCore__AbortSignal__createFollowingSignal(JSC::JSGlobalObject* globalObject, WebCore::AbortSignal* parent)
 {
     Zig::GlobalObject* thisObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
     auto* context = thisObject->scriptExecutionContext();
-    RefPtr<WebCore::AbortSignal> abortSignal = WebCore::AbortSignal::create(context);
-    abortSignal->signalFollow(*parent);
-    return abortSignal.leakRef();
+    Vector<RefPtr<WebCore::AbortSignal>> sources;
+    sources.append(parent);
+    Ref<WebCore::AbortSignal> abortSignal = WebCore::AbortSignal::any(*context, sources);
+    return &abortSignal.leakRef();
 }
 
 extern "C" JSC::EncodedJSValue WebCore__AbortSignal__create(JSC::JSGlobalObject* globalObject)

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1381,10 +1381,17 @@ impl Request {
                         fields.insert(Fields::Signal);
                         if signal_.is_null() {
                             // explicit detach; leave `req.signal` as None
-                        } else if let Some(signal) = AbortSignal::ref_from_js(signal_) {
+                        } else if let Some(input_signal) = AbortSignal::from_js(signal_) {
                             // Keep it alive
                             signal_.ensure_still_alive();
-                            // `ref_from_js` already ref'd.
+                            // Per Fetch spec, each Request gets a new
+                            // AbortSignal that follows the input signal
+                            // rather than sharing the caller's object.
+                            // SAFETY: `from_js` returned a live borrow
+                            // owned by the JS wrapper held alive above.
+                            let signal = AbortSignal::create_following(global_this, unsafe {
+                                &*input_signal
+                            });
                             req.signal.set(Some(signal));
                         } else {
                             if !global_this.has_exception() {
@@ -1645,8 +1652,10 @@ impl Request {
         }
 
         if let Some(signal) = self.signal.get() {
-            // `AbortSignalRef::clone` → C++ `ref()`.
-            req.signal.set(Some(signal.clone()));
+            // Per Fetch spec, the clone's signal is a new AbortSignal
+            // that follows this request's signal.
+            req.signal
+                .set(Some(AbortSignal::create_following(global_this, signal)));
         }
         Ok(())
     }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1382,13 +1382,9 @@ impl Request {
                         if signal_.is_null() {
                             // explicit detach; leave `req.signal` as None
                         } else if let Some(input_signal) = AbortSignal::from_js(signal_) {
-                            // Keep it alive
                             signal_.ensure_still_alive();
-                            // Per Fetch spec, each Request gets a new
-                            // AbortSignal that follows the input signal
-                            // rather than sharing the caller's object.
-                            // SAFETY: `from_js` returned a live borrow
-                            // owned by the JS wrapper held alive above.
+                            // Fetch: store a fresh dependent signal, not the caller's object.
+                            // SAFETY: `from_js` returned a live borrow owned by the JS wrapper.
                             let signal = AbortSignal::create_following(global_this, unsafe {
                                 &*input_signal
                             });

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -87,3 +87,83 @@ test("AsyncResource.bind", () => {
   });
   expect(fn()).toBe(true);
 });
+
+test("AsyncLocalStorage.run after disable() does not leak the store", async () => {
+  const als = new AsyncLocalStorage<string>();
+  als.run("init", () => {});
+  als.disable();
+  als.run("leaked", () => {
+    expect(als.getStore()).toBe("leaked");
+  });
+  expect(als.getStore()).toBe(undefined);
+
+  const { promise, resolve } = Promise.withResolvers<string | undefined>();
+  setImmediate(() => resolve(als.getStore()));
+  expect(await promise).toBe(undefined);
+});
+
+test("AsyncLocalStorage.disable inside a nested run does not throw", () => {
+  const als = new AsyncLocalStorage<string>();
+  let innerResult: number | undefined;
+  als.run("outer", () => {
+    innerResult = als.run("inner", () => {
+      als.disable();
+      expect(als.getStore()).toBe(undefined);
+      return 42;
+    });
+    expect(als.getStore()).toBe("outer");
+  });
+  expect(innerResult).toBe(42);
+  expect(als.getStore()).toBe(undefined);
+});
+
+test("AsyncLocalStorage.disable inside run with another store active", () => {
+  const a = new AsyncLocalStorage<string>();
+  const b = new AsyncLocalStorage<string>();
+  b.enterWith("B");
+  a.run("A", () => {
+    expect(a.getStore()).toBe("A");
+    expect(b.getStore()).toBe("B");
+    a.disable();
+    expect(a.getStore()).toBe(undefined);
+    expect(b.getStore()).toBe("B");
+  });
+  expect(a.getStore()).toBe(undefined);
+  expect(b.getStore()).toBe("B");
+});
+
+test("AsyncResource.prototype.bind forwards call-site `this` when no thisArg is given", () => {
+  const ar = new AsyncResource("test");
+  function target(this: unknown) {
+    "use strict";
+    return this;
+  }
+  const bound = ar.bind(target);
+  const receiver = { bound };
+  expect(receiver.bound()).toBe(receiver);
+  expect(bound.call(123)).toBe(123);
+  expect(bound()).toBe(undefined);
+});
+
+test("AsyncResource.prototype.bind sets .length to the target's length", () => {
+  const ar = new AsyncResource("test");
+  const bound = ar.bind(function (_a: number, _b: number, _c: number) {});
+  expect(bound.length).toBe(3);
+  const boundWithThis = ar.bind(function (_a: number, _b: number) {}, {});
+  expect(boundWithThis.length).toBe(2);
+});
+
+test("AsyncResource.prototype.bind with explicit thisArg keeps that receiver", () => {
+  const ar = new AsyncResource("test");
+  const fixed = { tag: "fixed" };
+  function target(this: unknown) {
+    return this;
+  }
+  const bound = ar.bind(target, fixed);
+  expect(bound.call({ tag: "ignored" })).toBe(fixed);
+});
+
+test("AsyncResource.prototype.emitDestroy returns this", () => {
+  const ar = new AsyncResource("test");
+  expect(ar.emitDestroy()).toBe(ar);
+});

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -120,28 +120,38 @@ test("AsyncLocalStorage.disable inside a nested run does not throw", () => {
 test("AsyncLocalStorage.disable inside run with another store active", () => {
   const a = new AsyncLocalStorage<string>();
   const b = new AsyncLocalStorage<string>();
-  b.enterWith("B");
-  a.run("A", () => {
-    expect(a.getStore()).toBe("A");
-    expect(b.getStore()).toBe("B");
-    a.disable();
+  try {
+    b.enterWith("B");
+    a.run("A", () => {
+      expect(a.getStore()).toBe("A");
+      expect(b.getStore()).toBe("B");
+      a.disable();
+      expect(a.getStore()).toBe(undefined);
+      expect(b.getStore()).toBe("B");
+    });
     expect(a.getStore()).toBe(undefined);
     expect(b.getStore()).toBe("B");
-  });
-  expect(a.getStore()).toBe(undefined);
-  expect(b.getStore()).toBe("B");
+  } finally {
+    a.disable();
+    b.disable();
+  }
 });
 
 test("AsyncLocalStorage.run restores correctly when this store is another store's value", () => {
   const a = new AsyncLocalStorage();
   const b = new AsyncLocalStorage();
-  b.enterWith("x");
-  a.run("v", () => {
-    // Make `a` appear at an odd (value) slot in the context array.
-    b.enterWith(a);
-  });
-  expect(b.getStore()).toBe(a);
-  expect(a.getStore()).toBe(undefined);
+  try {
+    b.enterWith("x");
+    a.run("v", () => {
+      // Make `a` appear at an odd (value) slot in the context array.
+      b.enterWith(a);
+    });
+    expect(b.getStore()).toBe(a);
+    expect(a.getStore()).toBe(undefined);
+  } finally {
+    a.disable();
+    b.disable();
+  }
 });
 
 test("AsyncResource.prototype.bind forwards call-site `this` when no thisArg is given", () => {

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -132,6 +132,18 @@ test("AsyncLocalStorage.disable inside run with another store active", () => {
   expect(b.getStore()).toBe("B");
 });
 
+test("AsyncLocalStorage.run restores correctly when this store is another store's value", () => {
+  const a = new AsyncLocalStorage();
+  const b = new AsyncLocalStorage();
+  b.enterWith("x");
+  a.run("v", () => {
+    // Make `a` appear at an odd (value) slot in the context array.
+    b.enterWith(a);
+  });
+  expect(b.getStore()).toBe(a);
+  expect(a.getStore()).toBe(undefined);
+});
+
 test("AsyncResource.prototype.bind forwards call-site `this` when no thisArg is given", () => {
   const ar = new AsyncResource("test");
   function target(this: unknown) {

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -178,11 +178,9 @@ describe("RequestInit signal presence", () => {
 });
 
 describe("Request.signal is a new dependent signal", () => {
-  // https://fetch.spec.whatwg.org/#dom-request step 30/31: each Request gets a
-  // new AbortSignal that follows the input signal. Returning the caller's
-  // controller signal directly means request-scoped mutation (onabort,
-  // removeEventListener) reaches into the user's AbortController.
-
+  // https://fetch.spec.whatwg.org/#dom-request step 30/31: each Request gets
+  // a new AbortSignal following the input; sharing the caller's object would
+  // let request-scoped mutation reach into the user's AbortController.
   test("new Request(url, { signal }) returns a distinct signal", () => {
     const c = new AbortController();
     const req = new Request("https://example.com/", { signal: c.signal });

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -175,3 +175,80 @@ describe("RequestInit signal presence", () => {
     });
   });
 });
+
+describe("Request.signal is a new dependent signal", () => {
+  // https://fetch.spec.whatwg.org/#dom-request step 30/31: each Request gets a
+  // new AbortSignal that follows the input signal. Returning the caller's
+  // controller signal directly means request-scoped mutation (onabort,
+  // removeEventListener) reaches into the user's AbortController.
+
+  test("new Request(url, { signal }) returns a distinct signal", () => {
+    const c = new AbortController();
+    const req = new Request("https://example.com/", { signal: c.signal });
+    expect(req.signal).not.toBe(c.signal);
+    expect(req.signal).toBe(req.signal);
+  });
+
+  test("mutating request.signal does not affect the controller's signal", () => {
+    const c = new AbortController();
+    let controllerHandlerCalls = 0;
+    c.signal.onabort = () => {
+      controllerHandlerCalls++;
+    };
+    const req = new Request("https://example.com/", { signal: c.signal });
+    req.signal.onabort = null;
+    expect(c.signal.onabort).toBeInstanceOf(Function);
+    c.abort();
+    expect(controllerHandlerCalls).toBe(1);
+    expect(req.signal.aborted).toBe(true);
+  });
+
+  test("request.clone().signal is a distinct signal following the original", () => {
+    const c = new AbortController();
+    const req = new Request("https://example.com/", { signal: c.signal });
+    const cloned = req.clone();
+    expect(cloned.signal).not.toBe(req.signal);
+    expect(cloned.signal).not.toBe(c.signal);
+
+    let clonedAborted = false;
+    cloned.signal.addEventListener("abort", () => {
+      clonedAborted = true;
+    });
+    c.abort(new Error("stop"));
+    expect(clonedAborted).toBe(true);
+    expect(cloned.signal.aborted).toBe(true);
+    expect((cloned.signal.reason as Error).message).toBe("stop");
+  });
+
+  test("new Request(request) gets a distinct signal following the input request's signal", () => {
+    const c = new AbortController();
+    const r1 = new Request("https://example.com/", { signal: c.signal });
+    const r2 = new Request(r1);
+    expect(r2.signal).not.toBe(r1.signal);
+    expect(r2.signal).not.toBe(c.signal);
+    c.abort();
+    expect(r2.signal.aborted).toBe(true);
+  });
+
+  test("new Request(request, init) with init.signal uses a dependent of init.signal", () => {
+    const c1 = new AbortController();
+    const c2 = new AbortController();
+    const r1 = new Request("https://example.com/", { signal: c1.signal });
+    const r2 = new Request(r1, { signal: c2.signal });
+    expect(r2.signal).not.toBe(c2.signal);
+    expect(r2.signal).not.toBe(r1.signal);
+    c1.abort();
+    expect(r2.signal.aborted).toBe(false);
+    c2.abort();
+    expect(r2.signal.aborted).toBe(true);
+  });
+
+  test("dependent signal inherits already-aborted state", () => {
+    const c = new AbortController();
+    c.abort(new Error("early"));
+    const req = new Request("https://example.com/", { signal: c.signal });
+    expect(req.signal).not.toBe(c.signal);
+    expect(req.signal.aborted).toBe(true);
+    expect((req.signal.reason as Error).message).toBe("early");
+  });
+});

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -1,3 +1,4 @@
+import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import net from "node:net";
 
@@ -253,7 +254,6 @@ describe("Request.signal is a new dependent signal", () => {
   });
 
   test("dependent signals do not accumulate on a long-lived controller", () => {
-    const { heapStats } = require("bun:jsc");
     const c = new AbortController();
     const iterations = 2000;
 

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -251,4 +251,39 @@ describe("Request.signal is a new dependent signal", () => {
     expect(req.signal.aborted).toBe(true);
     expect((req.signal.reason as Error).message).toBe("early");
   });
+
+  test("dependent signals do not accumulate on a long-lived controller", () => {
+    const { heapStats } = require("bun:jsc");
+    const c = new AbortController();
+    const iterations = 2000;
+
+    const measure = () => {
+      for (let i = 0; i < iterations; i++) {
+        const req = new Request("https://example.com/", { signal: c.signal });
+        // Materialize the JS wrapper so the reachability path is exercised.
+        req.signal;
+      }
+      Bun.gc(true);
+    };
+
+    measure();
+    Bun.gc(true);
+    const baseline = heapStats().objectTypeCounts.AbortSignal || 0;
+    measure();
+    measure();
+    Bun.gc(true);
+    const after = heapStats().objectTypeCounts.AbortSignal || 0;
+    // If each Request's dependent signal were pinned by the parent, `after`
+    // would exceed baseline by ~iterations. Allow generous headroom for the
+    // controller's own signal and GC timing.
+    expect(after - baseline).toBeLessThan(iterations / 4);
+    // The controller still works after all that churn.
+    const req = new Request("https://example.com/", { signal: c.signal });
+    let fired = false;
+    req.signal.addEventListener("abort", () => {
+      fired = true;
+    });
+    c.abort();
+    expect(fired).toBe(true);
+  });
 });


### PR DESCRIPTION
## Request.signal must be a new dependent signal

```js
const c = new AbortController();
const q = new Request("https://x/", { signal: c.signal });
q.signal === c.signal;            // bun: true   spec/node: false
q.clone().signal === q.signal;    // bun: true   spec/node: false
q.signal.onabort = null;          // bun: silently wipes c.signal.onabort
```

Bun stored the caller's `AbortController.signal` object on the Request and handed it back from the `.signal` getter, so request-scoped mutation (setting `onabort`, `removeEventListener`, passing it into another consumer) reached into the user's controller and vice versa. Per the [Fetch spec](https://fetch.spec.whatwg.org/#dom-request) step 30/31, each Request gets a new `AbortSignal` that *follows* the input signal; `clone()` and `new Request(request)` do the same.

**Fix:** add a `WebCore__AbortSignal__createFollowingSignal` FFI that creates a fresh signal and calls `signalFollow(parent)` on it, and use it in the Request constructor and `clone_into` instead of storing the input signal directly. The dependent signal still aborts with the parent's reason (via WebCore's existing follow algorithm), so `fetch(new Request(url, { signal }))` continues to abort when the controller aborts.

## AsyncLocalStorage: `disable()` then `run()` leaks; `disable()` inside `run()` throws

```js
const als = new AsyncLocalStorage();
als.disable();
als.run("leaked", () => {});
als.getStore();                   // bun: "leaked"   node: undefined
setImmediate(() => als.getStore()); // bun: "leaked"  node: undefined
```

```js
als.run("outer", () => {
  als.run("inner", () => { als.disable(); return 42; });
  // bun: TypeError: undefined is not an object (evaluating 'get')
});
```

`run()`'s finally block was gated on `if (!wasDisabled)`, so when `disable()` had been called before `run()` the restoration was skipped entirely and the new value stayed in the async context permanently. Separately, the finally assumed `get()` could not return `undefined`, so calling `disable()` inside the callback (which clears the context) made the restore throw.

**Fix:** drop the `#disabled` flag. Node v26's `AsyncContextFrame` model has no such flag; `disable()` just removes the store's entry from the current frame, and `getStore()` simply looks it up. Bun's `disable()` already removes the entry from the context array (in place, matching Node's in-place frame delete), so `getStore()` needs no extra guard. `run()`'s finally now always runs, re-reads the context, re-locates this store via `indexOf` (it may have been removed or other stores may have been added), and restores the previous value.

This also makes `getStore()` inside an outer `run()` return the outer value again after `disable()` was called in an inner `run()`, matching Node.

## AsyncResource: `bind()` and `emitDestroy()`

```js
const ar = new AsyncResource("t");
const bound = ar.bind(function (a, b, c) { return this; });
bound.length;              // bun: 0   node: 3
({ bound }).bound();       // bun: AsyncResource   node: the receiver object
ar.emitDestroy();          // bun: undefined   node: ar
```

`bind(fn)` hard-bound `thisArg` to the AsyncResource instead of forwarding the call-site receiver when no `thisArg` was given, and never set `.length` on the returned function. `emitDestroy()` returned `undefined` instead of `this`.

**Fix:** when `thisArg` is `undefined`, return a wrapper that forwards the dynamic `this` to `runInAsyncScope`; always define `.length` as `fn.length` on the result. `emitDestroy()` returns `this`.

## Verification

All assertions verified against Node v26.3.0. New tests in `test/js/web/request/request.test.ts` and `test/js/node/async_hooks/async_hooks.node.test.ts` fail on current Bun and pass with this change. Existing async_hooks, AsyncLocalStorage, fetch abort, and node parallel `test-async-local-storage-*` / `test-async-hooks-*` suites continue to pass.