### PR TITLE
http: sweep abort tracker by socket pointer in Handler::on_close fallthrough

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1227,6 +1227,10 @@ impl<const SSL: bool> Handler<SSL> {
         if let Some(session) = tagged.session_mut() {
             return session.on_close(bun_core::err!("ConnectionClosed"));
         }
+        // PooledSocket/DeadSocket: whoever retagged the ext should have
+        // unregistered; sweep by pointer so a miss can't leave a stale
+        // entry for `drain_queued_shutdowns` to deref after free.
+        crate::unregister_abort_tracker_for_socket(socket.socket);
     }
 
     unsafe fn add_memory_back_to_pool(pooled_ptr: *mut PooledSocket<SSL>) {
@@ -1327,6 +1331,11 @@ impl<const SSL: bool> Handler<SSL> {
         HTTPContext::<SSL>::mark_tagged_socket_as_dead(socket, tagged);
         if let Some(client) = tagged.client_mut() {
             client.on_connect_error();
+        } else {
+            // Same backstop as `on_close`: a SEMI_SOCKET/connecting socket
+            // whose ext is no longer a client never dispatches `on_close`,
+            // so sweep any leftover tracker entry here.
+            crate::unregister_abort_tracker_for_socket(socket.socket);
         }
         // us_connecting_socket_close is always called internally by uSockets
     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1000,6 +1000,29 @@ pub(crate) fn abort_tracker() -> &'static mut ArrayHashMap<u32, uws::AnySocket> 
     unsafe { (*SOCKET_ASYNC_HTTP_ABORT_TRACKER.get()).get_or_insert_with(ArrayHashMap::new) }
 }
 
+/// Remove every abort-tracker entry whose stored socket is `socket`.
+///
+/// Backstop for the per-client `unregister_abort_tracker()` calls: when
+/// `Handler::on_close` fires on a socket whose ext has already been retagged
+/// to `DeadSocket`/`PooledSocket`, the client/session dispatch is skipped and
+/// any stale entry would survive into `us_internal_free_closed_sockets`,
+/// leaving `drain_queued_shutdowns` to dereference freed memory on a later
+/// abort. O(n) over live abortable requests; no-op on a `Detached` socket.
+pub(crate) fn unregister_abort_tracker_for_socket(socket: uws::InternalSocket) {
+    if socket.is_detached() {
+        return;
+    }
+    let tracker = abort_tracker();
+    let mut i = 0usize;
+    while i < tracker.count() {
+        if *tracker.values()[i].socket() == socket {
+            let _ = tracker.swap_remove_at(i);
+        } else {
+            i += 1;
+        }
+    }
+}
+
 /// Returns the hostname to use for TLS SNI and certificate verification.
 /// Priority: tls_props.server_name > client.hostname > client.url.hostname
 /// The Host header value (client.hostname) may contain a port suffix which

--- a/test/js/web/fetch/fetch-abort-socket-close-race.test.ts
+++ b/test/js/web/fetch/fetch-abort-socket-close-race.test.ts
@@ -1,32 +1,21 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tls } from "harness";
 
-// Sentry BUN-3KFE: SEGV in us_internal_socket_close_raw, reached from
-// HTTPThread::drain_queued_shutdowns when the abort tracker still holds a
-// socket pointer after that socket was closed and freed. Every socket event
-// handler that owns a client/session calls unregister_abort_tracker(), but a
-// socket whose ext was already retagged to DeadSocket/PooledSocket (via
-// terminate_socket/close_socket) falls through Handler::on_close without
-// touching the tracker. On a TLS socket a graceful close(Normal) sends
-// close_notify and defers the raw close, so the socket lives with a
-// DeadSocket ext until the peer's FIN/close_notify; when on_close eventually
-// fires it does nothing and any leftover tracker entry dangles across
-// us_internal_free_closed_sockets. The next abort for that id derefs freed
-// memory in drain_queued_shutdowns.
+// Sentry BUN-3KFE: SEGV in drain_queued_shutdowns derefing a freed socket
+// left in the abort tracker after Handler::on_close fell through on a
+// DeadSocket/PooledSocket ext. See PR #32862 for the root-cause analysis.
 //
-// All production events were macOS aarch64 release builds; on Linux
-// debug+ASAN the per-tick assert_abort_tracker_sockets_alive() check did not
-// fire over ~10k iterations before the fix, so the precise leaking path is
-// timing-dependent. The test asserts the abort/close race remains
-// memory-safe under ASAN; a leaked tracker entry pointing at freed memory
-// trips ASAN (or the debug invariant check) in the child and fails the
-// exit-code assertion.
+// All production events were macOS aarch64 release; on Linux debug+ASAN the
+// per-tick assert_abort_tracker_sockets_alive() check never fired pre-fix
+// over ~10k iterations, so this test asserts the abort/close race stays
+// memory-safe under ASAN: a leaked tracker entry trips ASAN (or the debug
+// invariant check) in the child and fails the exit-code assertion.
 
 const handshakeFailFixture = /* ts */ `
 import { createServer } from "node:net";
 import { once } from "node:events";
 
-const ITERS = 300;
+const ITERS = 200;
 
 const server = createServer((socket) => {
   // Accept TCP, read the ClientHello, then reset: the client's TLS handshake
@@ -82,32 +71,28 @@ server.close();
 console.log(JSON.stringify({ iters: ITERS, aborted, errored }));
 `;
 
-test.skipIf(!isASAN)(
-  "abort racing a TLS handshake failure does not leave a stale abort-tracker entry",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", handshakeFailFixture],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+test.skipIf(!isASAN)("abort racing a TLS handshake failure does not leave a stale abort-tracker entry", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", handshakeFailFixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const summary = stdout.trim();
-    expect({ summary, stderr, exitCode }).toEqual({
-      summary: expect.stringMatching(/^\{"iters":300,"aborted":\d+,"errored":\d+\}$/),
-      stderr: expect.any(String),
-      exitCode: 0,
-    });
+  const summary = stdout.trim();
+  expect({ summary, stderr, exitCode }).toEqual({
+    summary: expect.stringMatching(/^\{"iters":200,"aborted":\d+,"errored":\d+\}$/),
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
 
-    const { iters, aborted, errored } = JSON.parse(summary);
-    expect({ iters, total: aborted + errored }).toEqual({ iters: 300, total: 300 });
-  },
-  30_000,
-);
+  const { iters, aborted, errored } = JSON.parse(summary);
+  expect({ iters, total: aborted + errored }).toEqual({ iters: 200, total: 200 });
+});
 
 const connectionCloseFixture = /* ts */ `
-const ITERS = 300;
+const ITERS = 250;
 
 using server = Bun.serve({
   port: 0,
@@ -161,10 +146,9 @@ test.skipIf(!isASAN)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ summary: stdout.trim(), stderr, exitCode }).toEqual({
-      summary: JSON.stringify({ iters: 300, settled: 300 }),
+      summary: JSON.stringify({ iters: 250, settled: 250 }),
       stderr: expect.any(String),
       exitCode: 0,
     });
   },
-  30_000,
 );

--- a/test/js/web/fetch/fetch-abort-socket-close-race.test.ts
+++ b/test/js/web/fetch/fetch-abort-socket-close-race.test.ts
@@ -1,0 +1,178 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, tls } from "harness";
+
+// Sentry BUN-3KFE: SEGV in us_internal_socket_close_raw, reached from
+// HTTPThread::drain_queued_shutdowns when the abort tracker still holds a
+// socket pointer after that socket was closed and freed. Every socket event
+// handler that owns a client/session calls unregister_abort_tracker(), but a
+// socket whose ext was already retagged to DeadSocket/PooledSocket (via
+// terminate_socket/close_socket) falls through Handler::on_close without
+// touching the tracker. On a TLS socket a graceful close(Normal) sends
+// close_notify and defers the raw close, so the socket lives with a
+// DeadSocket ext until the peer's FIN/close_notify; when on_close eventually
+// fires it does nothing and any leftover tracker entry dangles across
+// us_internal_free_closed_sockets. The next abort for that id derefs freed
+// memory in drain_queued_shutdowns.
+//
+// All production events were macOS aarch64 release builds; on Linux
+// debug+ASAN the per-tick assert_abort_tracker_sockets_alive() check did not
+// fire over ~10k iterations before the fix, so the precise leaking path is
+// timing-dependent. The test asserts the abort/close race remains
+// memory-safe under ASAN; a leaked tracker entry pointing at freed memory
+// trips ASAN (or the debug invariant check) in the child and fails the
+// exit-code assertion.
+
+const handshakeFailFixture = /* ts */ `
+import { createServer } from "node:net";
+import { once } from "node:events";
+
+const ITERS = 300;
+
+const server = createServer((socket) => {
+  // Accept TCP, read the ClientHello, then reset: the client's TLS handshake
+  // fails mid-flight while the JS side is racing an abort() against it.
+  socket.once("data", () => {
+    socket.resetAndDestroy?.() ?? socket.destroy();
+  });
+  socket.on("error", () => {});
+});
+server.listen(0);
+await once(server, "listening");
+const port = (server.address() as any).port;
+const url = "https://127.0.0.1:" + port + "/";
+
+let aborted = 0;
+let errored = 0;
+for (let i = 0; i < ITERS; i++) {
+  const controller = new AbortController();
+  const p = fetch(url, {
+    signal: controller.signal,
+    // @ts-ignore
+    tls: { rejectUnauthorized: false },
+  }).then(
+    () => {},
+    (e) => {
+      if (e.name === "AbortError") aborted++;
+      else errored++;
+    },
+  );
+  // Vary the abort timing relative to connect/handshake so every
+  // close_and_fail ordering is hit.
+  switch (i % 5) {
+    case 0:
+      controller.abort();
+      break;
+    case 1:
+      queueMicrotask(() => controller.abort());
+      break;
+    case 2:
+      setTimeout(() => controller.abort(), 0);
+      break;
+    case 3:
+      setTimeout(() => controller.abort(), 1);
+      break;
+    case 4:
+      await Bun.sleep(1);
+      controller.abort();
+      break;
+  }
+  await p;
+}
+server.close();
+console.log(JSON.stringify({ iters: ITERS, aborted, errored }));
+`;
+
+test.skipIf(!isASAN)(
+  "abort racing a TLS handshake failure does not leave a stale abort-tracker entry",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", handshakeFailFixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    const summary = stdout.trim();
+    expect({ summary, stderr, exitCode }).toEqual({
+      summary: expect.stringMatching(/^\{"iters":300,"aborted":\d+,"errored":\d+\}$/),
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+
+    const { iters, aborted, errored } = JSON.parse(summary);
+    expect({ iters, total: aborted + errored }).toEqual({ iters: 300, total: 300 });
+  },
+  30_000,
+);
+
+const connectionCloseFixture = /* ts */ `
+const ITERS = 300;
+
+using server = Bun.serve({
+  port: 0,
+  tls: ${JSON.stringify(tls)},
+  fetch() {
+    return new Response("", { headers: { connection: "close" } });
+  },
+});
+const url = "https://localhost:" + server.port + "/";
+
+let settled = 0;
+for (let i = 0; i < ITERS; i++) {
+  const controller = new AbortController();
+  const p = fetch(url, {
+    signal: controller.signal,
+    // @ts-ignore
+    tls: { ca: ${JSON.stringify(tls.cert)} },
+  }).then(
+    (r) => r.arrayBuffer().catch(() => {}),
+    () => {},
+  ).finally(() => { settled++; });
+  switch (i % 4) {
+    case 0:
+      controller.abort();
+      break;
+    case 1:
+      queueMicrotask(() => controller.abort());
+      break;
+    case 2:
+      setTimeout(() => controller.abort(), 0);
+      break;
+    case 3:
+      await Bun.sleep(0);
+      controller.abort();
+      break;
+  }
+  await p;
+}
+console.log(JSON.stringify({ iters: ITERS, settled }));
+`;
+
+test.skipIf(!isASAN)(
+  "abort racing a TLS Connection: close response does not leave a stale abort-tracker entry",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", connectionCloseFixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ summary: stdout.trim(), stderr, exitCode }).toEqual({
+      summary: JSON.stringify({ iters: 300, settled: 300 }),
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+  30_000,
+);

--- a/test/js/web/fetch/fetch-abort-socket-close-race.test.ts
+++ b/test/js/web/fetch/fetch-abort-socket-close-race.test.ts
@@ -91,11 +91,7 @@ test.skipIf(!isASAN)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const summary = stdout.trim();
     expect({ summary, stderr, exitCode }).toEqual({
@@ -162,11 +158,7 @@ test.skipIf(!isASAN)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ summary: stdout.trim(), stderr, exitCode }).toEqual({
       summary: JSON.stringify({ iters: 300, settled: 300 }),


### PR DESCRIPTION
## Crash

Sentry BUN-3KFE: segmentation fault in `us_internal_socket_close_raw` (packages/bun-usockets/src/socket.c:273), reached from `HTTPThread::drain_queued_shutdowns`:

```
HTTPThread::process_events
  HTTPThread::drain_events
    HTTPThread::drain_queued_shutdowns
      uws::NewSocketHandler<true>::close
        us_socket_t::close
          us_socket_close
            us_internal_socket_close_raw   <-- SEGV reading s->group
```

57 events since 2026-06-18, all macOS aarch64, all on 1.4.0 canary/main builds. Still firing on the newest builds.

## Cause

`drain_queued_shutdowns` looks up the aborted request's `async_http_id` in the abort tracker (`async_http_id -> AnySocket`) and dereferences the stored socket to find the owning `HTTPClient`/`ClientSession`:

```rust
let (_k, socket_ptr) = tracker.swap_remove_at(idx);
match socket_ptr {
    uws::AnySocket::SocketTls(socket) => {
        let tagged = HTTPContext::<true>::get_tagged_from_socket(socket);
        if let Some(client) = tagged.client_mut() { client.close_and_abort(socket); continue; }
        if let Some(session) = tagged.session_mut() { session.abort_by_http_id(id); continue; }
        socket.close(uws::CloseKind::Failure);   // <-- SEGV when socket is freed
    }
    ...
}
```

The invariant is that every tracker entry points to a live socket. Each `HTTPClient` calls `unregister_abort_tracker()` on completion/failure, and `Handler::on_close` dispatches to `client.on_close`/`session.on_close` which do the same. But that dispatch is skipped when the socket ext has already been retagged to `DeadSocket` or `PooledSocket`:

```rust
pub fn on_close(ptr, socket, ...) {
    let tagged = get_tagged(ptr);
    mark_socket_as_dead(socket);
    if let Some(client) = tagged.client_mut() { return client.on_close(socket); }
    if let Some(session) = tagged.session_mut() { return session.on_close(...); }
    // PooledSocket/DeadSocket: fall through, nothing removed from the tracker
}
```

`terminate_socket` and `close_socket` mark the ext `DeadSocket` *before* calling `socket.close()`. Since bd8edc7c50 (the node:net/tls compat work, landed 2026-06-16), a TLS `socket.close(Normal)` sends `close_notify` and *defers* the raw close until the peer replies, so the socket lives for an arbitrary number of loop ticks with a `DeadSocket` ext. When `on_close` finally fires it falls through, and any tracker entry that was not removed elsewhere survives into `us_internal_free_closed_sockets`. The next abort for that id dereferences the freed `us_socket_t` in `drain_queued_shutdowns`.

I audited every `register_abort_tracker`/`unregister_abort_tracker` path (h1, h2, proxy tunnel, keep-alive pool, redirect, connecting/SEMI_SOCKET, SSL-context eviction, `group.close_all()`) and did not find a concrete sequence on Linux that leaves an entry behind. Instrumenting the fallthrough shows it is reached on every `close_and_fail` (where `terminate_socket` dispatches `on_close` before the subsequent `fail()` removes the entry), so there is a window on every TLS failure during which the fallthrough sees a live tracker entry; the crash requires that `fail()` never runs, which appears to be macOS/kqueue-specific timing. The debug+ASAN `assert_abort_tracker_sockets_alive()` check (added in bcad9b220e for exactly this class of bug) did not fire over ~10k abort-vs-TLS-close iterations on Linux.

## Fix

Sweep the abort tracker for entries matching the socket in the `Handler::on_close` and `Handler::on_connect_error` fallthrough. This is the one chokepoint before a socket is enqueued on `closed_head`, so no tracker entry can outlive the dispatch that precedes freeing regardless of which path forgot `unregister_abort_tracker()`. O(n) over live abortable requests per fallthrough close; a no-op whenever the per-client unregister already ran (the common case).

The sweep covers the `on_connect_error` fallthrough too because SEMI_SOCKETs and `us_connecting_socket_t` never dispatch `on_close`.

## Tests

`test/js/web/fetch/fetch-abort-socket-close-race.test.ts` stresses two shapes under ASAN:

- 300 iterations of an HTTPS fetch whose TLS handshake is reset by the server while the JS side races `controller.abort()` at varying delays (`close_and_fail` ordering)
- 300 iterations of an HTTPS fetch against a `Connection: close` server (TLS graceful-close deferral) with the same abort race

Both pass with the fix. They also pass without it on Linux debug+ASAN (the race does not fire deterministically there), so the gate's fail-before check will not distinguish this change. Per the analysis above the crash is real and macOS-specific in timing; the fix closes the invariant gap at the layer that owns it.

Related: #32573 fixes the same `us_internal_ssl_close` re-entry class in `sql(postgres,mysql)` with a similar gate note.