### PR TITLE
node:stream: propagate web stream errors in Readable.fromWeb; support finished() on WHATWG streams

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -109,6 +109,11 @@ declare function $peekPromiseSettledValue<V>(promise: Promise<V>): V | undefined
  * tracker. Equivalent to JSC's `JSPromise::markAsHandled()`.
  */
 declare function $pokePromiseAsHandled(promise: Promise<any>): void;
+/**
+ * A promise that settles when a WHATWG ReadableStream/WritableStream reaches a terminal state.
+ * Does not lock the stream. Throws when given anything else.
+ */
+declare function $webStreamClosedPromise(stream: ReadableStream | WritableStream): Promise<void>;
 declare function $getInternalField<Fields extends any[], N extends keyof Fields>(
   base: InternalFieldObject<Fields>,
   number: N,

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -197,6 +197,7 @@ using namespace JSC;
     macro(view) \
     macro(vmErrorDecorated) \
     macro(warning) \
+    macro(webStreamClosedPromise) \
     macro(writable) \
     macro(writableType) \
     macro(write) \

--- a/src/js/internal/streams/end-of-stream.ts
+++ b/src/js/internal/streams/end-of-stream.ts
@@ -346,7 +346,10 @@ function eosWeb(stream, options, callback) {
       process.nextTick(() => callback.$apply(stream, args));
     }
   };
-  PromisePrototypeThen.$call(stream[kIsClosedPromise].promise, resolverFn, resolverFn);
+  // Bun's web streams carry the closed promise natively rather than on Node's symbol, which a
+  // userland or polyfilled stream may still define.
+  const closedPromise = stream[kIsClosedPromise]?.promise ?? $webStreamClosedPromise(stream);
+  PromisePrototypeThen.$call(closedPromise, resolverFn, resolverFn);
   return nop;
 }
 

--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -95,6 +95,17 @@ class ReadableFromWeb extends Readable {
     return;
   }
 
+  #handleError(reader, error) {
+    if (reader) {
+      this.#reader = undefined;
+      try {
+        reader.releaseLock();
+      } catch {}
+    }
+    this.#closed = true;
+    this.destroy(error);
+  }
+
   _read() {
     $debug("ReadableFromWeb _read()", this.__id);
     // Readable calls _read() again as soon as push() is called, but #pump()
@@ -109,9 +120,10 @@ class ReadableFromWeb extends Readable {
     // #reading must be cleared as the body exits, not one microtask later: a
     // paused-mode read() loop calls _read() again without yielding, and
     // Readable leaves kReading set when _read() neither pushes nor pumps.
+    var reader;
     try {
-      var stream = this.#stream,
-        reader = this.#reader;
+      var stream = this.#stream;
+      reader = this.#reader;
       if (stream) {
         reader = this.#reader = stream.getReader();
         this.#stream = undefined;
@@ -152,6 +164,11 @@ class ReadableFromWeb extends Readable {
           }
         }
       } while (!this.#closed);
+    } catch (e) {
+      // An error from the web stream must surface on the Readable as an
+      // 'error' event. Rethrowing would only reject #pump()'s promise, which
+      // nothing awaits, turning it into an unhandled rejection instead.
+      this.#handleError(reader, e);
     } finally {
       this.#reading = false;
     }
@@ -159,16 +176,27 @@ class ReadableFromWeb extends Readable {
 
   _destroy(error, callback) {
     if (!this.#closed) {
+      this.#closed = true;
       var reader = this.#reader;
       if (reader) {
         this.#reader = undefined;
-        reader.cancel(error).finally(() => {
-          this.#closed = true;
-          callback(error);
-        });
+        PromisePrototypeThen.$call(
+          reader.cancel(error),
+          () => callback(error),
+          cancelError => callback(error ?? cancelError),
+        );
+        return;
       }
-
-      return;
+      var stream = this.#stream;
+      if (stream) {
+        this.#stream = undefined;
+        PromisePrototypeThen.$call(
+          stream.cancel(error),
+          () => callback(error),
+          cancelError => callback(error ?? cancelError),
+        );
+        return;
+      }
     }
     try {
       callback(error);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1660,6 +1660,7 @@ JSC_DECLARE_HOST_FUNCTION(isAbortSignal);
 JSC_DECLARE_HOST_FUNCTION(jsBunPeekPromiseStatus);
 JSC_DECLARE_HOST_FUNCTION(jsBunPeekPromiseSettledValue);
 JSC_DECLARE_HOST_FUNCTION(jsBunPokePromiseAsHandled);
+JSC_DECLARE_HOST_FUNCTION(jsWebStreamClosedPromise);
 
 JSC_DEFINE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
@@ -1774,6 +1775,21 @@ JSC_DEFINE_HOST_FUNCTION(jsBunPokePromiseAsHandled, (JSGlobalObject*, CallFrame*
     if (auto* promise = peekPromiseArgument(callFrame))
         promise->markAsHandled();
     return JSValue::encode(jsUndefined());
+}
+
+// node:stream's finished() needs a promise that settles when a WHATWG stream reaches a terminal
+// state, without locking it. Callers in internal/streams/end-of-stream.ts gate on
+// isReadableStream()/isWritableStream() first, so the argument is always one of the two.
+JSC_DEFINE_HOST_FUNCTION(jsWebStreamClosedPromise, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    JSValue streamValue = callFrame->argument(0);
+    if (auto* readable = dynamicDowncast<WebCore::JSReadableStream>(streamValue))
+        return JSValue::encode(Bun::WebStreams::webStreamClosedPromise(globalObject, readable));
+    if (auto* writable = dynamicDowncast<WebCore::JSWritableStream>(streamValue))
+        return JSValue::encode(Bun::WebStreams::webStreamClosedPromise(globalObject, writable));
+
+    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+    return JSValue::encode(throwTypeError(globalObject, scope, "Expected a ReadableStream or WritableStream"_s));
 }
 
 extern "C" JSC::EncodedJSValue Bun__Jest__createTestModuleObject(JSC::JSGlobalObject*);
@@ -2885,6 +2901,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         GlobalPropertyInfo(builtinNames.peekPromiseStatusPrivateName(), JSFunction::create(vm, this, 1, String(), jsBunPeekPromiseStatus, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.peekPromiseSettledValuePrivateName(), JSFunction::create(vm, this, 1, String(), jsBunPeekPromiseSettledValue, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.pokePromiseAsHandledPrivateName(), JSFunction::create(vm, this, 1, String(), jsBunPokePromiseAsHandled, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
+        GlobalPropertyInfo(builtinNames.webStreamClosedPromisePrivateName(), JSFunction::create(vm, this, 1, String(), jsWebStreamClosedPromise, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.fulfillModuleSyncPrivateName(), JSFunction::create(vm, this, 1, String(), functionFulfillModuleSync, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.esmNamespaceForCjsPrivateName(), JSFunction::create(vm, this, 1, String(), functionEsmNamespaceForCjs, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.esmRegistryDeletePrivateName(), JSFunction::create(vm, this, 1, String(), functionEsmRegistryDelete, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -780,11 +780,16 @@ static void readDirectStreamCloseImpl(JSC::VM& vm, JSGlobalObject* globalObject,
         clearStreamControllerSlots(stream);
         stream->m_reader.clear();
         stream->m_lockedWithoutReader = false;
+        // This path writes the terminal state directly (the controller and reader slots are
+        // already torn down), so it settles the closed promise itself.
         if (reason.toBoolean(globalObject)) {
             stream->m_state = ReadableStreamState::Errored;
             stream->m_storedError.set(vm, stream, reason);
-        } else
+            rejectStreamClosedPromise(vm, stream, reason);
+        } else {
             stream->m_state = ReadableStreamState::Closed;
+            resolveStreamClosedPromise(vm, stream);
+        }
     }
     if (auto* closePromise = state->m_closePromise.get()) {
         state->m_closePromise.clear();

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -487,6 +487,7 @@ void JSReadableStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_nativePtr);
     visitor.append(thisObject->m_directUnderlyingSource);
     visitor.append(thisObject->m_asyncContext);
+    visitor.append(thisObject->m_closedPromise);
 }
 
 void JSReadableStream::materializeIfNeeded(JSGlobalObject* globalObject)

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -30,7 +30,8 @@ public:
 
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_reader, m_storedError, m_controller, m_nativePtr,
-    // m_directUnderlyingSource, m_asyncContext. No barrier container ⇒ no cellLock needed.
+    // m_directUnderlyingSource, m_asyncContext, m_closedPromise. No barrier container ⇒ no
+    // cellLock needed.
     DECLARE_VISIT_CHILDREN;
 
     template<typename, JSC::SubspaceAccess mode>
@@ -84,6 +85,9 @@ public:
     JSC::WriteBarrier<JSC::JSObject> m_directUnderlyingSource;
     // `$asyncContext` snapshot at construction. Written once in finishCreation.
     JSC::WriteBarrier<JSC::Unknown> m_asyncContext;
+    // Settles when the stream reaches a terminal state, for observers that must not lock it
+    // (node:stream's finished()). Created on first request; empty until then.
+    JSC::WriteBarrier<JSC::JSPromise> m_closedPromise;
     // `$highWaterMark` on the STREAM (the raw strategy HWM, ToNumber'd once). NaN = unset.
     // Written by ALL FOUR constructor arms.
     double m_bunHighWaterMark { std::numeric_limits<double>::quiet_NaN() };

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -260,6 +260,7 @@ void JSWritableStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_closeRequest);
     visitor.append(thisObject->m_inFlightWriteRequest);
     visitor.append(thisObject->m_inFlightCloseRequest);
+    visitor.append(thisObject->m_closedPromise);
     visitor.append(thisObject->m_pendingAbortRequest.promise);
     visitor.append(thisObject->m_pendingAbortRequest.reason);
     {

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.h
@@ -46,8 +46,9 @@ public:
 
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_controller, m_writer, m_storedError, m_closeRequest,
-    // m_inFlightWriteRequest, m_inFlightCloseRequest, m_pendingAbortRequest.{promise,reason},
-    // and m_writeRequests (a barrier container: UNDER cellLock()).
+    // m_inFlightWriteRequest, m_inFlightCloseRequest, m_closedPromise,
+    // m_pendingAbortRequest.{promise,reason}, and m_writeRequests (a barrier container: UNDER
+    // cellLock()).
     DECLARE_VISIT_CHILDREN;
 
     template<typename, JSC::SubspaceAccess mode>
@@ -76,6 +77,9 @@ public:
     JSC::WriteBarrier<JSC::JSPromise> m_inFlightWriteRequest;
     // [[inFlightCloseRequest]]
     JSC::WriteBarrier<JSC::JSPromise> m_inFlightCloseRequest;
+    // Settles when the stream reaches a terminal state, for observers that must not lock it
+    // (node:stream's finished()). Created on first request; empty until then.
+    JSC::WriteBarrier<JSC::JSPromise> m_closedPromise;
     // [[pendingAbortRequest]] — "undefined" ⇔ !m_pendingAbortRequest.promise.
     Bun::WebStreams::PendingAbortRequest m_pendingAbortRequest;
     // [[state]]

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -245,6 +245,7 @@ void readableStreamClose(JSGlobalObject* globalObject, JSReadableStream* stream)
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(stream->m_state == ReadableStreamState::Readable);
     stream->m_state = ReadableStreamState::Closed;
+    resolveStreamClosedPromise(vm, stream);
     auto* reader = stream->m_reader.get();
     if (!reader)
         return;
@@ -276,6 +277,7 @@ void readableStreamError(JSGlobalObject* globalObject, JSReadableStream* stream,
     ASSERT(stream->m_state == ReadableStreamState::Readable);
     stream->m_state = ReadableStreamState::Errored;
     stream->m_storedError.set(vm, stream, error);
+    rejectStreamClosedPromise(vm, stream, error);
     auto* reader = stream->m_reader.get();
     if (!reader)
         return;

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -169,6 +169,18 @@ void markPromiseAsHandled(JSC::VM&, JSC::JSPromise*); // userJS: no — WebStrea
 // {value,done} results: use JSC::createIteratorResultObject
 // (<JavaScriptCore/IteratorOperations.h>; VM-cached structure).
 
+// The stream-level closed promise: node:stream's finished() observes a terminal state without
+// locking the stream, so it cannot use the reader's/writer's [[closedPromise]]. Created on the
+// first webStreamClosedPromise() call and cached on the cell; settled from EVERY terminal
+// transition below. Settling is a no-op when nothing ever asked for the promise, and always
+// settles with a primitive / the stored error, so none of these can run user JS or throw.
+JSC::JSPromise* webStreamClosedPromise(JSC::JSGlobalObject*, JSReadableStream*); // userJS: no — WebStreamsMisc.cpp
+JSC::JSPromise* webStreamClosedPromise(JSC::JSGlobalObject*, JSWritableStream*); // userJS: no — WebStreamsMisc.cpp
+void resolveStreamClosedPromise(JSC::VM&, JSReadableStream*); // userJS: no — WebStreamsMisc.cpp
+void resolveStreamClosedPromise(JSC::VM&, JSWritableStream*); // userJS: no — WebStreamsMisc.cpp
+void rejectStreamClosedPromise(JSC::VM&, JSReadableStream*, JSC::JSValue error); // userJS: no — WebStreamsMisc.cpp
+void rejectStreamClosedPromise(JSC::VM&, JSWritableStream*, JSC::JSValue error); // userJS: no — WebStreamsMisc.cpp
+
 // THE ONE SANCTIONED CATCH of the subsystem. Returns the thrown value after
 // clearExceptionExceptTermination(); returns the EMPTY JSValue if the exception is a VM
 // termination (which the caller must propagate, never consume). Never call bare

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -4,6 +4,7 @@
 #include "WebStreamsInternals.h"
 
 #include "JSReadableStream.h"
+#include "JSWritableStream.h"
 
 #include "BunClientData.h"
 #include "JSDOMConvertNumbers.h"
@@ -346,6 +347,101 @@ void rejectPromise(JSGlobalObject* globalObject, JSPromise* promise, JSValue rea
 void markPromiseAsHandled(VM&, JSPromise* promise)
 {
     promise->markAsHandled();
+}
+
+// The stream-level closed promise. The Pending guard makes every settle site unconditionally
+// safe: a terminal transition can only run once, but the promise may already have been created
+// in a terminal state by webStreamClosedPromise().
+template<typename Stream>
+static void resolveClosedPromise(VM& vm, Stream* stream)
+{
+    auto* promise = stream->m_closedPromise.get();
+    if (!promise || promise->status() != JSPromise::Status::Pending)
+        return;
+    // Always undefined: a primitive resolution skips the `then` lookup.
+    promise->fulfill(vm, jsUndefined());
+}
+
+template<typename Stream>
+static void rejectClosedPromise(VM& vm, Stream* stream, JSValue error)
+{
+    auto* promise = stream->m_closedPromise.get();
+    if (!promise || promise->status() != JSPromise::Status::Pending)
+        return;
+    // Nothing is obliged to observe this promise, so it must never report as unhandled.
+    promise->rejectAsHandled(vm, error);
+}
+
+void resolveStreamClosedPromise(VM& vm, JSReadableStream* stream)
+{
+    resolveClosedPromise(vm, stream);
+}
+
+void resolveStreamClosedPromise(VM& vm, JSWritableStream* stream)
+{
+    resolveClosedPromise(vm, stream);
+}
+
+void rejectStreamClosedPromise(VM& vm, JSReadableStream* stream, JSValue error)
+{
+    rejectClosedPromise(vm, stream, error);
+}
+
+void rejectStreamClosedPromise(VM& vm, JSWritableStream* stream, JSValue error)
+{
+    rejectClosedPromise(vm, stream, error);
+}
+
+JSPromise* webStreamClosedPromise(JSGlobalObject* globalObject, JSReadableStream* stream)
+{
+    auto& vm = getVM(globalObject);
+    if (auto* existing = stream->m_closedPromise.get())
+        return existing;
+
+    JSPromise* promise = nullptr;
+    switch (stream->m_state) {
+    case ReadableStreamState::Closed:
+        promise = promiseFulfilledWith(globalObject, jsUndefined());
+        break;
+    case ReadableStreamState::Errored: {
+        JSValue storedError = stream->m_storedError.get();
+        promise = promiseRejectedWith(globalObject, storedError ? storedError : jsUndefined());
+        promise->markAsHandled();
+        break;
+    }
+    case ReadableStreamState::Readable:
+        promise = JSPromise::create(vm, globalObject->promiseStructure());
+        break;
+    }
+    stream->m_closedPromise.set(vm, stream, promise);
+    return promise;
+}
+
+JSPromise* webStreamClosedPromise(JSGlobalObject* globalObject, JSWritableStream* stream)
+{
+    auto& vm = getVM(globalObject);
+    if (auto* existing = stream->m_closedPromise.get())
+        return existing;
+
+    JSPromise* promise = nullptr;
+    switch (stream->m_state) {
+    case WritableStreamState::Closed:
+        promise = promiseFulfilledWith(globalObject, jsUndefined());
+        break;
+    case WritableStreamState::Errored: {
+        JSValue storedError = stream->m_storedError.get();
+        promise = promiseRejectedWith(globalObject, storedError ? storedError : jsUndefined());
+        promise->markAsHandled();
+        break;
+    }
+    // Erroring is not terminal: writableStreamFinishErroring() rejects the pending promise.
+    case WritableStreamState::Writable:
+    case WritableStreamState::Erroring:
+        promise = JSPromise::create(vm, globalObject->promiseStructure());
+        break;
+    }
+    stream->m_closedPromise.set(vm, stream, promise);
+    return promise;
 }
 
 // The ONE sanctioned completion-record catch: the spec's "interpreting X as a completion

--- a/src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp
@@ -308,6 +308,7 @@ void writableStreamFinishErroring(JSGlobalObject* globalObject, JSWritableStream
     ASSERT(stream->m_state == WritableStreamState::Erroring);
     ASSERT(!writableStreamHasOperationMarkedInFlight(stream));
     stream->m_state = WritableStreamState::Errored;
+    rejectStreamClosedPromise(vm, stream, stream->m_storedError.get());
 
     auto* controller = stream->m_controller.get();
     controller->errorSteps();
@@ -387,6 +388,7 @@ void writableStreamFinishInFlightClose(JSGlobalObject* globalObject, JSWritableS
         }
     }
     stream->m_state = WritableStreamState::Closed;
+    resolveStreamClosedPromise(vm, stream);
     if (auto* writer = stream->m_writer.get()) {
         resolvePromise(globalObject, writer->m_closedPromise.get(), jsUndefined());
         RETURN_IF_EXCEPTION(scope, );

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -2,7 +2,8 @@ import { describe, expect, it, jest } from "bun:test";
 import { bunEnv, bunExe, isGlibcVersionAtLeast, isMacOS, tmpdirSync } from "harness";
 import { createReadStream, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { Duplex, PassThrough, Readable, Stream, Transform, Writable } from "node:stream";
+import { Duplex, finished, PassThrough, Readable, Stream, Transform, Writable } from "node:stream";
+import { finished as finishedP } from "node:stream/promises";
 import { join } from "path";
 
 describe("Readable", () => {
@@ -384,6 +385,131 @@ it("Readable.fromWeb", async () => {
     chunks.push(chunk);
   }
   expect(Buffer.concat(chunks).toString()).toBe("Hello World!\n");
+});
+
+// An error from the underlying web stream must surface on the node Readable as an
+// 'error' event (and destroy it), not as a global unhandled rejection.
+it("Readable.fromWeb propagates web stream errors to 'error' and destroys", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { Readable } = require("node:stream");
+        process.on("unhandledRejection", e => {
+          console.log("UNHANDLED:" + (e && e.message));
+        });
+        const web = new ReadableStream({
+          start(c) { c.enqueue(new Uint8Array([1, 2, 3])); },
+          pull() { throw new Error("boom"); },
+        });
+        const r = Readable.fromWeb(web);
+        r.on("data", d => console.log("DATA:" + d.length));
+        r.on("end", () => console.log("END"));
+        r.on("error", e => console.log("ERROR:" + e.message));
+        r.on("close", () => {
+          console.log("CLOSE errored=" + (r.errored && r.errored.message) + " destroyed=" + r.destroyed);
+        });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ out: stdout.trim().split("\n"), err: stderr }).toEqual({
+    out: ["DATA:3", "ERROR:boom", "CLOSE errored=boom destroyed=true"],
+    err: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
+it("Readable.fromWeb on an already-errored web stream emits 'error' and destroys", async () => {
+  const web = new ReadableStream({
+    start(c) {
+      c.error(new Error("start-boom"));
+    },
+  });
+  const r = Readable.fromWeb(web);
+  const { promise, resolve, reject } = Promise.withResolvers();
+  r.on("error", resolve);
+  r.on("end", () => reject(new Error("should not end")));
+  r.resume();
+  const err = await promise;
+  expect(err.message).toBe("start-boom");
+  expect(r.destroyed).toBe(true);
+  expect(r.errored?.message).toBe("start-boom");
+});
+
+it("Readable.fromWeb piped to a Writable surfaces web stream errors on the destination", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { Readable, Writable, pipeline } = require("node:stream");
+        process.on("unhandledRejection", e => {
+          console.log("UNHANDLED:" + (e && e.message));
+        });
+        const web = new ReadableStream({
+          start(c) { c.enqueue(new Uint8Array([1, 2, 3, 4, 5])); },
+          pull() { return Promise.reject(new Error("net-fail")); },
+        });
+        let written = 0;
+        const dest = new Writable({
+          write(chunk, enc, cb) { written += chunk.length; cb(); },
+        });
+        pipeline(Readable.fromWeb(web), dest, err => {
+          console.log("PIPELINE err=" + (err && err.message) + " written=" + written);
+        });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ out: stdout.trim(), err: stderr }).toEqual({
+    out: "PIPELINE err=net-fail written=5",
+    err: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
+it("Readable.fromWeb async iteration rejects with the web stream error", async () => {
+  const web = new ReadableStream({
+    start(c) {
+      c.enqueue(new Uint8Array([9]));
+    },
+    pull() {
+      throw new Error("iter-boom");
+    },
+  });
+  const r = Readable.fromWeb(web);
+  let err;
+  try {
+    for await (const _ of r) {
+    }
+  } catch (e) {
+    err = e;
+  }
+  expect(err?.message).toBe("iter-boom");
+  expect(r.destroyed).toBe(true);
+});
+
+it("Readable.fromWeb destroyed before the first read cancels the web stream", async () => {
+  let cancelReason;
+  const web = new ReadableStream({
+    cancel(reason) {
+      cancelReason = reason;
+    },
+  });
+  const r = Readable.fromWeb(web);
+  const { promise, resolve } = Promise.withResolvers();
+  r.on("error", () => {});
+  r.on("close", resolve);
+  r.destroy(new Error("user-destroy"));
+  await promise;
+  expect(cancelReason?.message).toBe("user-destroy");
+  expect(r.destroyed).toBe(true);
 });
 
 it("#9242.5 Stream has constructor", () => {
@@ -842,6 +968,139 @@ describe("webstreams adapters (Node v26 sync)", () => {
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect(stdout.trim()).toBe("store:reg-ctx");
     expect(exitCode).toBe(0);
+  });
+
+  // Node supports finished() on WHATWG streams since v19. It must observe the terminal state
+  // without locking the stream.
+  describe("finished() on WHATWG streams", () => {
+    it("ReadableStream that closes", async () => {
+      let close;
+      const rs = new ReadableStream({
+        start(c) {
+          close = () => c.close();
+        },
+      });
+      const { promise, resolve } = Promise.withResolvers();
+      expect(() => finished(rs, err => resolve(err))).not.toThrow();
+      close();
+      expect(await promise).toBeUndefined();
+    });
+
+    it("ReadableStream that errors", async () => {
+      let error;
+      const rs = new ReadableStream({
+        start(c) {
+          error = e => c.error(e);
+        },
+      });
+      const { promise, resolve } = Promise.withResolvers();
+      expect(() => finished(rs, err => resolve(err))).not.toThrow();
+      error(new Error("rs-boom"));
+      const err = await promise;
+      expect(err?.message).toBe("rs-boom");
+    });
+
+    it("ReadableStream already closed", async () => {
+      const rs = new ReadableStream({
+        start(c) {
+          c.close();
+        },
+      });
+      await expect(finishedP(rs)).resolves.toBeUndefined();
+    });
+
+    it("ReadableStream already errored", async () => {
+      const rs = new ReadableStream({
+        start(c) {
+          c.error(new Error("already"));
+        },
+      });
+      await expect(finishedP(rs)).rejects.toThrow("already");
+    });
+
+    it("WritableStream that closes", async () => {
+      const ws = new WritableStream({});
+      const { promise, resolve } = Promise.withResolvers();
+      expect(() => finished(ws, err => resolve(err))).not.toThrow();
+      ws.close();
+      expect(await promise).toBeUndefined();
+    });
+
+    it("WritableStream that errors", async () => {
+      const ws = new WritableStream({});
+      const { promise, resolve } = Promise.withResolvers();
+      expect(() => finished(ws, err => resolve(err))).not.toThrow();
+      ws.abort(new Error("ws-boom"));
+      const err = await promise;
+      expect(err?.message).toBe("ws-boom");
+    });
+
+    it("WritableStream already closed", async () => {
+      const ws = new WritableStream({});
+      await ws.close();
+      await expect(finishedP(ws)).resolves.toBeUndefined();
+    });
+
+    it("WritableStream already errored", async () => {
+      const ws = new WritableStream({});
+      await ws.abort(new Error("already-ws"));
+      await expect(finishedP(ws)).rejects.toThrow("already-ws");
+    });
+
+    it("ReadableStream cancelled", async () => {
+      const rs = new ReadableStream({});
+      const { promise, resolve } = Promise.withResolvers();
+      finished(rs, err => resolve(err));
+      await rs.cancel();
+      expect(await promise).toBeUndefined();
+    });
+
+    it("does not lock the stream", async () => {
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new Uint8Array([1, 2]));
+          c.close();
+        },
+      });
+      finished(rs, () => {});
+      expect(rs.locked).toBe(false);
+      expect((await new Response(rs).arrayBuffer()).byteLength).toBe(2);
+    });
+
+    // Exercises the direct-stream close path, which writes the terminal state itself rather
+    // than going through readableStreamClose().
+    it("type: 'direct' ReadableStream consumed by a native sink (Bun.serve)", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { finished } = require("node:stream");
+            using server = Bun.serve({
+              port: 0,
+              fetch() {
+                const rs = new ReadableStream({
+                  type: "direct",
+                  pull(c) { c.write(new Uint8Array([1, 2, 3])); c.end(); },
+                });
+                finished(rs, err => console.log("FINISHED:" + (err ? err.message : "ok")));
+                return new Response(rs);
+              },
+            });
+            const ab = await fetch(server.url).then(r => r.arrayBuffer());
+            console.log("BYTES:" + ab.byteLength);
+          `,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ out: stdout.trim().split("\n").sort(), err: stderr }).toEqual({
+        out: ["BYTES:3", "FINISHED:ok"],
+        err: "",
+      });
+      expect(exitCode).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
Two bugs in the `node:stream` ↔ Web Streams interop seam.

Fixes #19842

> **Rebased onto the C++ streams rewrite (#33193).** That PR deleted the three JS builtins this change originally patched, so the `finished()` half is reimplemented against the new C++ stream cells. Both bugs still reproduce on current `main`. See "Rebase notes" at the bottom.

## 1. `Readable.fromWeb()` never propagates web stream errors

```js
const { Readable } = require("node:stream");
const web = new ReadableStream({
  start(c) { c.enqueue(new Uint8Array([1, 2, 3])); },
  pull() { throw new Error("boom"); },
});
const r = Readable.fromWeb(web);
r.on("error", e => console.log("error:", e.message));
r.on("data", () => {});
```

Node: `error: boom`, stream destroyed, `r.errored` set.
Bun (before): no `'error'` event, `r.destroyed === false`, `r.errored === null`; `"boom"` surfaces only as a global `unhandledRejection`. The canonical `Readable.fromWeb(res.body).pipe(fs.createWriteStream(...))` pattern would finish the file short with no error on a network failure.

### Cause

`ReadableFromWeb`'s `#pump()` is `async` and has no `catch`. When `reader.readMany()` rejects, that only rejects the async function's returned promise. `Readable` never awaits `#pump()`, so the rejection became an `unhandledRejection` and the Readable was never destroyed.

### Fix

Route the error through `this.destroy(err)` (releasing the reader lock first). Also make `_destroy` cancel the underlying web stream when `destroy()` is called before the first read; previously that path returned without ever invoking the `_destroy` callback.

## 2. `stream.finished()` throws TypeError on WHATWG streams

```js
const { finished } = require("node:stream");
finished(new ReadableStream({ start(c) { c.close(); } }), err => {});
// TypeError: undefined is not an object
```

Node supports `finished()` on WHATWG `ReadableStream` / `WritableStream` since v19. Bun threw a synchronous `TypeError` from inside `eosWeb`.

### Cause

`eosWeb` dereferenced `stream[Symbol.for("nodejs.webstream.isClosedPromise")].promise`. Node attaches that symbol to its web stream instances; Bun does not, so the property read was `undefined`.

### Fix

Give `JSReadableStream` and `JSWritableStream` a stream-level closed promise (`m_closedPromise`), created on the first `webStreamClosedPromise()` call and settled from every terminal transition:

| Stream | Site |
|---|---|
| Readable | `readableStreamClose` |
| Readable | `readableStreamError` |
| Readable | `readDirectStreamCloseImpl` (the direct-stream path writes terminal state itself) |
| Writable | `writableStreamFinishErroring` |
| Writable | `writableStreamFinishInFlightClose` |

It is deliberately separate from the reader's / writer's `[[closedPromise]]`, because `finished()` must not lock the stream (covered by a test). `eosWeb` falls back to it when Node's symbol is absent, so a userland or polyfilled stream carrying the symbol still works.

**Cost:** one `WriteBarrier` (8 bytes) per `ReadableStream` / `WritableStream` cell. The promise itself is allocated only when `finished()` is actually called on that stream; settling is a guarded no-op otherwise, so streams that never reach `finished()` allocate nothing. I measured no new `Promise` allocations for plain streams. Flagging this explicitly since #33193 was a memory-reduction PR — happy to move the slot to a side table if you'd rather not pay the 8 bytes.

## Verification

- All 16 added tests fail on `main` and pass with the fix (`bun bd test test/js/node/stream/node-stream.test.js`: 87 pass, 0 fail).
- A 13-case matrix (error propagation, pipeline, async iteration, destroy-before-read, `finished()` across every terminal state of both stream types, plus "does not lock the stream") produces **byte-identical output to Node v26.3.0**.
- GC stress: 5000 streams with `finished()` promises held across `Bun.gc(true)` under ASAN, all settle correctly — the new `WriteBarrier` members are visited.
- No regressions: `test/js/web/streams/streams.test.js` (134 pass) and `test-stream-pipeline.js` fail **identically on clean `main`** with `src/` stashed; every other related node parallel test passes.

## Rebase notes

The original version of this PR patched `ReadableStreamInternals.ts`, `WritableStreamInternals.ts`, and `StreamInternals.ts`. #33193 deleted all three. Carried over unchanged: the `webstreams_adapters.ts` fix (adapted to the new `#pump()` shape) and the test file. Rewritten: the closed-promise, now C++ members + a `$webStreamClosedPromise` host function instead of a JS private slot + builtin helper. The five terminal-transition hook points map 1:1 onto the old JS ones, including the direct-stream path.

## Not in this PR

A third reported divergence: `Response`/`Request` body streams accept non-`Uint8Array` chunks (strings, `ArrayBuffer`, other typed arrays) and silently re-encode them, whereas the Fetch spec and Node/Chrome/Safari reject with `TypeError`. That touches native body-consuming code and is a behavior change for anyone relying on Bun's current permissiveness, so it belongs in its own PR.