### PR TITLE
dns: fix the address-family interleave used by the fetch/connect path

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -295,6 +295,7 @@ export function getJS2NativeRust() {
   const handExported = new Set<string>([
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_interleaveAddressesForTesting",
   ]);
 
   const srcRoot = path.resolve(import.meta.dir, "..");

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -85,6 +85,12 @@ export const iniInternals = {
   loadNpmrc: $newRustFunction("ini.rs", "IniTestingAPIs.loadNpmrcFromJS", 2),
 };
 
+export const dnsInternals = {
+  interleaveAddresses: $newRustFunction("runtime/dns_jsc/dns.rs", "internal.interleaveAddressesForTesting", 1) as (
+    families: number[],
+  ) => { family: number; index: number }[],
+};
+
 export const cssInternals = {
   minifyTestWithOptions: $newRustFunction("css_internals.rs", "minifyTestWithOptions", 3),
   minifyErrorTestWithOptions: $newRustFunction("css_internals.rs", "minifyErrorTestWithOptions", 3),

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2611,6 +2611,52 @@ pub mod internal {
         pub addr: SockaddrStorage,
     }
 
+    /// Reorder `results` in place so address families alternate, keeping the
+    /// first entry in place and preserving relative order within each family.
+    /// With `CONCURRENT_CONNECTIONS` parallel connect attempts in usockets this
+    /// guarantees both families are represented in the first batch, so a host
+    /// with broken IPv6 but a reachable A record (or the reverse) still
+    /// connects quickly instead of waiting for kernel SYN-retry exhaustion on
+    /// every address of the unreachable family.
+    pub(crate) fn interleave_addresses(results: &mut [ResultEntry]) {
+        let count = results.len();
+        if count < 2 {
+            return;
+        }
+        let first_family = results[0].info.ai_family;
+        let other_family = if first_family == netc::AF_INET6 {
+            netc::AF_INET
+        } else {
+            netc::AF_INET6
+        };
+        // Alternate starting from the second slot; at each slot, if the family
+        // does not match `want`, pull the next matching entry forward by
+        // rotating the tail so relative order within each family is preserved.
+        let mut want = other_family;
+        for idx in 1..count {
+            if results[idx].info.ai_family != want {
+                let mut found = None;
+                for j in (idx + 1)..count {
+                    if results[j].info.ai_family == want {
+                        found = Some(j);
+                        break;
+                    }
+                }
+                match found {
+                    Some(j) => results[idx..=j].rotate_right(1),
+                    // No more of the wanted family: the rest is homogeneous
+                    // and already in its original relative order.
+                    None => break,
+                }
+            }
+            want = if want == first_family {
+                other_family
+            } else {
+                first_family
+            };
+        }
+    }
+
     // re-order result to interleave ipv4 and ipv6 (also pack into a single allocation)
     fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
         let mut count: usize = 0;
@@ -2654,25 +2700,7 @@ pub mod internal {
         // SAFETY: every slot 0..count was written above
         let mut results: Box<[ResultEntry]> = unsafe { results.assume_init() };
 
-        // sort (interleave ipv4 and ipv6)
-        let mut want = netc::AF_INET6 as usize;
-        'outer: for idx in 0..count {
-            if results[idx].info.ai_family as usize == want {
-                continue;
-            }
-            for j in (idx + 1)..count {
-                if results[j].info.ai_family as usize == want {
-                    results.swap(idx, j);
-                    want = if want == netc::AF_INET6 as usize {
-                        netc::AF_INET as usize
-                    } else {
-                        netc::AF_INET6 as usize
-                    };
-                }
-            }
-            // the rest of the list is all one address family
-            break 'outer;
-        }
+        interleave_addresses(&mut results);
 
         // set up pointers
         for idx in 0..count {
@@ -2988,6 +3016,56 @@ pub mod internal {
             JSValue::js_number(GETADDRINFO_CALLS.load(Ordering::Relaxed) as f64),
         );
         Ok(object)
+    }
+
+    /// `bun:internal-for-testing` hook: given an array of address-family
+    /// numbers (4 or 6), return the order `interleave_addresses` would hand
+    /// to the connect path.
+    pub(crate) fn interleave_addresses_for_testing(
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let arguments = callframe.arguments();
+        if arguments.len() < 1 {
+            return Err(global_this.throw_not_enough_arguments("interleaveAddresses", 1, 0));
+        }
+        let input = arguments[0];
+        let len = input.get_length(global_this)? as u32;
+        let mut entries: Vec<ResultEntry> = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let fam = input.get_index(global_this, i)?.coerce_to_i32(global_this)?;
+            let mut info: AddrInfo = bun_core::ffi::zeroed();
+            info.ai_family = if fam == 6 {
+                netc::AF_INET6
+            } else {
+                netc::AF_INET
+            };
+            // Tag ai_flags with the original index so the test can observe
+            // relative ordering within a family, not just the family sequence.
+            info.ai_flags = i as _;
+            entries.push(ResultEntry {
+                info,
+                addr: bun_core::ffi::zeroed(),
+            });
+        }
+        interleave_addresses(&mut entries);
+        let out = JSValue::create_empty_array(global_this, entries.len())?;
+        for (i, entry) in (0u32..).zip(entries.iter()) {
+            let obj = JSValue::create_empty_object(global_this, 2);
+            let fam: i32 = if entry.info.ai_family == netc::AF_INET6 {
+                6
+            } else {
+                4
+            };
+            obj.put(global_this, b"family", JSValue::js_number(f64::from(fam)));
+            obj.put(
+                global_this,
+                b"index",
+                JSValue::js_number(f64::from(entry.info.ai_flags as i32)),
+            );
+            out.put_index(global_this, i, obj)?;
+        }
+        Ok(out)
     }
 
     pub(crate) fn getaddrinfo(
@@ -6085,4 +6163,8 @@ export_host_fn!(
 export_host_fn!(
     Resolver::get_runtime_default_result_order_option,
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption"
+);
+export_host_fn!(
+    internal::interleave_addresses_for_testing,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_interleaveAddressesForTesting"
 );

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3033,7 +3033,9 @@ pub mod internal {
         let len = input.get_length(global_this)? as u32;
         let mut entries: Vec<ResultEntry> = Vec::with_capacity(len as usize);
         for i in 0..len {
-            let fam = input.get_index(global_this, i)?.coerce_to_i32(global_this)?;
+            let fam = input
+                .get_index(global_this, i)?
+                .coerce_to_i32(global_this)?;
             let mut info: AddrInfo = bun_core::ffi::zeroed();
             info.ai_family = if fam == 6 {
                 netc::AF_INET6

--- a/test/js/bun/dns/dns-interleave.test.ts
+++ b/test/js/bun/dns/dns-interleave.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
 import { dnsInternals } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
 
 // When fetch()/Bun.connect() resolves a dual-stack hostname, the internal DNS
 // cache (used by the usockets connect path) packs the getaddrinfo result into

--- a/test/js/bun/dns/dns-interleave.test.ts
+++ b/test/js/bun/dns/dns-interleave.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { dnsInternals } from "bun:internal-for-testing";
+
+// When fetch()/Bun.connect() resolves a dual-stack hostname, the internal DNS
+// cache (used by the usockets connect path) packs the getaddrinfo result into
+// a flat array and is supposed to interleave address families so that, with
+// the four parallel connection attempts usockets opens, both families are
+// represented in the first batch. If the interleave is broken and the
+// resolver returned the AAAA records first (the default on most dual-stack
+// hosts), a network with broken IPv6 makes every initial attempt hang until
+// the kernel gives up on the SYN retries.
+//
+// This exercises the exact reorder routine that feeds usockets.
+
+const { interleaveAddresses } = dnsInternals;
+
+function families(input: number[]): number[] {
+  return interleaveAddresses(input).map(e => e.family);
+}
+
+function indices(input: number[]): number[] {
+  return interleaveAddresses(input).map(e => e.index);
+}
+
+describe("internal DNS connect-order interleave", () => {
+  test("AAAA-heavy result gets IPv4 into the first batch", () => {
+    // The motivating case: 4+ IPv6 addresses (all dead on a broken-v6 network)
+    // ahead of a single reachable IPv4 address. Without interleaving, the first
+    // CONCURRENT_CONNECTIONS (4) attempts are all IPv6.
+    const out = families([6, 6, 6, 6, 4]);
+    expect(out).toEqual([6, 4, 6, 6, 6]);
+    // The first four addresses (the first parallel-connect batch in usockets)
+    // must include both families.
+    expect(new Set(out.slice(0, 4))).toEqual(new Set([4, 6]));
+  });
+
+  test("A-heavy result gets IPv6 into the first batch", () => {
+    expect(families([4, 4, 4, 4, 6])).toEqual([4, 6, 4, 4, 4]);
+  });
+
+  test("already-grouped input alternates fully", () => {
+    expect(families([6, 6, 6, 4, 4, 4])).toEqual([6, 4, 6, 4, 6, 4]);
+    expect(families([4, 4, 4, 6, 6, 6])).toEqual([4, 6, 4, 6, 4, 6]);
+  });
+
+  test("first address stays first", () => {
+    // The resolver's ordering preference for the first address is respected.
+    expect(families([6, 4, 4, 4])[0]).toBe(6);
+    expect(families([4, 6, 6, 6])[0]).toBe(4);
+  });
+
+  test("already-interleaved input is unchanged", () => {
+    expect(indices([6, 4, 6, 4, 6, 4])).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(indices([4, 6, 4, 6])).toEqual([0, 1, 2, 3]);
+  });
+
+  test("single-family input is unchanged", () => {
+    expect(indices([6, 6, 6, 6])).toEqual([0, 1, 2, 3]);
+    expect(indices([4, 4, 4])).toEqual([0, 1, 2]);
+    expect(indices([4])).toEqual([0]);
+  });
+
+  test("relative order within each family is preserved", () => {
+    // Stable interleave: within the IPv6 group, original indices 0,1,2 stay
+    // in that order; same for IPv4 indices 3,4,5.
+    const out = interleaveAddresses([6, 6, 6, 4, 4, 4]);
+    const v6order = out.filter(e => e.family === 6).map(e => e.index);
+    const v4order = out.filter(e => e.family === 4).map(e => e.index);
+    expect(v6order).toEqual([0, 1, 2]);
+    expect(v4order).toEqual([3, 4, 5]);
+  });
+
+  test("uneven counts: extra addresses of one family go at the end", () => {
+    expect(families([6, 6, 6, 6, 6, 4, 4])).toEqual([6, 4, 6, 4, 6, 6, 6]);
+    expect(families([4, 6, 6, 6, 6, 6])).toEqual([4, 6, 6, 6, 6, 6]);
+  });
+
+  test("empty and single-element inputs", () => {
+    expect(families([])).toEqual([]);
+    expect(families([4])).toEqual([4]);
+    expect(families([6])).toEqual([6]);
+  });
+
+  test("every non-trivial dual-stack result has both families in the first four", () => {
+    // Exhaustive over small inputs: whenever both families are present and
+    // there are at least two addresses, the first min(4, n) must include both.
+    for (let n = 2; n <= 7; n++) {
+      for (let mask = 0; mask < 1 << n; mask++) {
+        const input: number[] = [];
+        for (let i = 0; i < n; i++) input.push(mask & (1 << i) ? 6 : 4);
+        if (!input.includes(4) || !input.includes(6)) continue;
+        const out = families(input);
+        const head = new Set(out.slice(0, Math.min(4, n)));
+        expect({ input, head: [...head].sort() }).toEqual({ input, head: [4, 6] });
+        // And it must be a permutation of the input.
+        expect(out.toSorted()).toEqual(input.toSorted());
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

The internal DNS cache in `src/runtime/dns_jsc/dns.rs` (used by `fetch()`, `Bun.connect()`, and every other uws outbound connect) packs `getaddrinfo()` results into a flat array and is supposed to interleave IPv4 and IPv6 so that the `CONCURRENT_CONNECTIONS` (4) parallel connect attempts in usockets cover both families. The interleave loop in `process_results()` never actually alternated:

```rust
let mut want = netc::AF_INET6 as usize;
'outer: for idx in 0..count {
    if results[idx].info.ai_family as usize == want {
        continue;                        // <- `want` is never toggled here
    }
    for j in (idx + 1)..count {
        if results[j].info.ai_family as usize == want {
            results.swap(idx, j);
            want = /* toggle */;
        }
    }
    break 'outer;                        // <- always breaks after the first mismatch
}
```

For the typical dual-stack `getaddrinfo()` output `[AAAA, AAAA, AAAA, AAAA, A]`:

| idx | results[idx] | want | action |
| --- | --- | --- | --- |
| 0 | AAAA | AF_INET6 | match, `continue` (want still AF_INET6) |
| 1 | AAAA | AF_INET6 | match, `continue` |
| 2 | AAAA | AF_INET6 | match, `continue` |
| 3 | AAAA | AF_INET6 | match, `continue` |
| 4 | A | AF_INET6 | mismatch, inner loop finds nothing, `break 'outer` |

Result: `[AAAA, AAAA, AAAA, AAAA, A]` unchanged. usockets then opens four parallel connects to the four AAAA addresses. On a network where IPv6 is advertised but unreachable (hotel/corporate Wi-Fi, mis-configured containers, half-deployed AAAA records, a destination whose IPv6 addresses are blackholed) none of those attempts fail hard; `fetch()` waits for kernel SYN-retry exhaustion on every one of them (about 130 seconds on Linux) before the A record is ever tried. Node, curl and browsers all mask this with Happy Eyeballs.

## Fix

Replace the loop with a stable interleave in a new `interleave_addresses()` helper:

* The first entry is left in place (whichever family the resolver preferred stays the preferred first attempt).
* From the second slot onward, at each position rotate the next address of the other family forward (`rotate_right(1)` over the tail), so relative order within each family is preserved.
* Stop as soon as one family is exhausted; the remainder is already in resolver order.

For `[AAAA, AAAA, AAAA, AAAA, A]` this yields `[AAAA, A, AAAA, AAAA, AAAA]`, and for `[AAAA, AAAA, AAAA, A, A, A]` it yields `[AAAA, A, AAAA, A, AAAA, A]`. With four parallel connect attempts, any dual-stack result now has both families in the first batch regardless of which family `getaddrinfo()` grouped first. This is the address-list construction RFC 8305 section 4 describes for Happy Eyeballs.

## Verification

The helper is exposed via `bun:internal-for-testing` as `dnsInternals.interleaveAddresses()`, and `test/js/bun/dns/dns-interleave.test.ts` asserts the exact output order for the cases above plus an exhaustive check over every family pattern of length 2 through 7 that both families appear in the first four positions.

```
$ bun bd test test/js/bun/dns/dns-interleave.test.ts
 10 pass
 0 fail
```

## Related

#29696 proposes removing the interleave entirely and preserving OS order. That change and this one both fix the "always forces AAAA first" behaviour (this change keeps whatever the resolver put first in slot 0). The difference is what happens when the resolver returns one family grouped first and that family is unreachable: preserving resolver order leaves the first four attempts all on the broken family, whereas interleaving guarantees the other family is tried in the first batch. A per-attempt connection timer (the rest of Happy Eyeballs) would make either ordering survive that case; until one exists in the usockets connect path, interleaving the four parallel attempts is what avoids the multi-minute stall.

## Not in this PR

* A per-attempt connection timeout in usockets (`autoSelectFamilyAttemptTimeout` equivalent for `fetch()`). The current design only advances past an address on a hard connect error.
* An `AggregateError` of per-address failures when every attempt fails.