### PR TITLE
util.inspect: fix numericSeparator corrupting exponent-form numbers

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1973,28 +1973,33 @@ function addNumericSeparatorEnd(integerString) {
 const remainingText = remaining => `... ${remaining} more item${remaining > 1 ? "s" : ""}`;
 
 function formatNumber(fn, number, numericSeparator) {
+  // Format -0 as '-0'. Checking `number === -0` won't distinguish 0 from -0.
+  // String(-0) === '0', so this must be checked before any String() conversion.
+  if (ObjectIs(number, -0)) {
+    return fn("-0", "number");
+  }
   if (!numericSeparator) {
-    // Format -0 as '-0'. Checking `number === -0` won't distinguish 0 from -0.
-    if (ObjectIs(number, -0)) {
-      return fn("-0", "number");
-    }
     return fn(`${number}`, "number");
   }
+
+  const numberString = String(number);
   const integer = MathTrunc(number);
-  const string = String(integer);
+
   if (integer === number) {
-    if (!NumberIsFinite(number) || StringPrototypeIncludes(string, "e")) {
-      return fn(string, "number");
+    if (!NumberIsFinite(number) || StringPrototypeIncludes(numberString, "e")) {
+      return fn(numberString, "number");
     }
-    return fn(`${addNumericSeparator(string)}`, "number");
+    return fn(addNumericSeparator(numberString), "number");
   }
-  if (NumberIsNaN(number)) {
-    return fn(string, "number");
+  if (NumberIsNaN(number) || StringPrototypeIncludes(numberString, "e")) {
+    return fn(numberString, "number");
   }
-  return fn(
-    `${addNumericSeparator(string)}.${addNumericSeparatorEnd(StringPrototypeSlice(String(number), string.length + 1))}`,
-    "number",
-  );
+
+  const decimalIndex = StringPrototypeIndexOf(numberString, ".");
+  const integerPart = StringPrototypeSlice(numberString, 0, decimalIndex);
+  const fractionalPart = StringPrototypeSlice(numberString, decimalIndex + 1);
+
+  return fn(`${addNumericSeparator(integerPart)}.${addNumericSeparatorEnd(fractionalPart)}`, "number");
 }
 
 function formatBigInt(fn, bigint, numericSeparator) {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -379,6 +379,50 @@ describe("util", () => {
     assert.strictEqual(util.styleText("red", "test"), "\u001b[31mtest\u001b[39m");
   });
 
+  describe("inspect numericSeparator", () => {
+    const sep = { numericSeparator: true };
+
+    it("does not corrupt numbers whose string form uses exponent notation", () => {
+      expect(util.inspect(1.23456e-7, sep)).toBe("1.23456e-7");
+      expect(util.inspect(-1.23456e-7, sep)).toBe("-1.23456e-7");
+      expect(util.inspect(1.23456789e-7, sep)).toBe("1.23456789e-7");
+      expect(util.inspect(1e-7, sep)).toBe("1e-7");
+      expect(util.inspect(1.5e21, sep)).toBe("1.5e+21");
+      expect(util.inspect(1e21, sep)).toBe("1e+21");
+    });
+
+    it("formats plain decimal numbers with separators", () => {
+      expect(util.inspect(123456789, sep)).toBe("123_456_789");
+      expect(util.inspect(-123456789, sep)).toBe("-123_456_789");
+      expect(util.inspect(1234.5678, sep)).toBe("1_234.567_8");
+      expect(util.inspect(123456789.12345678, sep)).toBe("123_456_789.123_456_78");
+      expect(util.inspect(-123456789.12345678, sep)).toBe("-123_456_789.123_456_78");
+      expect(util.inspect(123456789n, sep)).toBe("123_456_789n");
+    });
+
+    it("preserves -0", () => {
+      expect(util.inspect(-0, sep)).toBe("-0");
+      expect(util.inspect(-0)).toBe("-0");
+    });
+
+    it("preserves non-finite values", () => {
+      expect(util.inspect(NaN, sep)).toBe("NaN");
+      expect(util.inspect(Infinity, sep)).toBe("Infinity");
+      expect(util.inspect(-Infinity, sep)).toBe("-Infinity");
+    });
+
+    it("round-trips after removing separators", () => {
+      const cases = [1.23456e-7, -1.23456e-7, 1e-7, 1.5e21, 1e21, 1234.5678, -1234.5678, -0, 0, 123456789, -123456789];
+      const out = cases.map(n => util.inspect(n, sep));
+      expect(out.map(s => s.replaceAll("_", "")).map(Number)).toEqual(cases);
+    });
+
+    it("applies to util.format %d", () => {
+      expect(util.formatWithOptions(sep, "%d", 1.23456e-7)).toBe("1.23456e-7");
+      expect(util.formatWithOptions(sep, "%d", 123456789)).toBe("123_456_789");
+    });
+  });
+
   describe("getSystemErrorName", () => {
     for (const item of ["test", {}, []]) {
       it(`throws when passing: ${item}`, () => {


### PR DESCRIPTION
## Problem

`util.inspect` with `numericSeparator: true` corrupts numbers whose default string representation uses exponent notation:

```js
const util = require("util");
util.inspect(1.23456e-7, { numericSeparator: true });
// Bun:  '0.234_56e_-7'   (leading 1 replaced with 0, separator inside exponent)
// Node: '1.23456e-7'
```

Other affected inputs:

| Input | Bun (before) |
| --- | --- |
| `-1.23456e-7` | `'0..23_456_e-7'` |
| `1e-7` | `'0.-7'` |
| `-0` with `numericSeparator: true` | `'0'` |

This also leaks into `util.format('%d', ...)` / `util.formatWithOptions` via the same helper.

## Cause

`formatNumber` built the fractional part by slicing `String(number)` at `String(Math.trunc(number)).length + 1`. For `1.23456e-7`, `Math.trunc` yields `0`, so `String(integer)` is `"0"` while `String(number)` is `"1.23456e-7"`. The slice point (2) is unrelated to the actual `.` position, and the prefix printed is `"0"` rather than `"1"`. The trailing slice `"23456e-7"` is then fed to `addNumericSeparatorEnd`, which treats it as a pure digit run and inserts `_` inside `e-7`.

## Fix

Port the upstream Node.js `formatNumber`:

- derive the integer / fractional parts from `indexOf('.')` on `String(number)` rather than from `String(Math.trunc(number)).length`
- return `String(number)` unchanged when it contains `e` (the separator grouping is only sound for plain decimal strings)
- check for `-0` before any `String()` conversion so it renders as `"-0"` regardless of the `numericSeparator` option

## Verification

New tests in `test/js/node/util/util.test.js` cover exponent-form inputs (positive and negative), `-0`, non-finite values, plain decimals (unchanged), `util.formatWithOptions('%d', ...)`, and a round-trip check that removing `_` from every formatted value parses back to the original number.

```
$ bun bd test test/js/node/util/util.test.js
 198 pass
 0 fail
```

With `src/` stashed, the new tests fail with the corrupted output shown above.