### PR TITLE
worker_threads: preserve error own properties, surface parse diagnostics, report exit code 1 on terminate()

### DIFF
--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -532,7 +532,21 @@ void Worker::dispatchErrorWithMessage(WTF::String message)
 bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSValue value)
 {
     auto& vm = JSC::getVM(workerGlobalObject);
+    // A concurrent terminate() can arm the TerminationException at any
+    // safepoint; ErrorInstance::getOwnPropertySlot (reached from the Error
+    // clone path inside SerializedScriptValue::create) does not check after
+    // materializeErrorInfoIfNeeded, so entering it mid-termination trips
+    // getOwnPropertyDescriptor's post-call assert. Bail to the string
+    // fallback before doing any JS-entering work once termination is armed.
+    if (vm.hasTerminationRequest()) [[unlikely]]
+        return false;
     auto scope = DECLARE_THROW_SCOPE(vm);
+    // The caller's dispatchEvent(error) on globalThis (WebWorker__dispatchError)
+    // runs user JS and can leave a pending exception.
+    if (scope.exception()) [[unlikely]] {
+        if (!scope.tryClearException())
+            return false;
+    }
 
     // Structured clone of an Error only carries name/message/stack and JSC's
     // own line/column/sourceURL. Node preserves the own enumerable properties
@@ -558,6 +572,10 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
             return false;
         }
         JSObject* props = JSC::constructEmptyObject(workerGlobalObject);
+        if (scope.exception()) [[unlikely]] {
+            (void)scope.tryClearException();
+            return false;
+        }
         for (const auto& key : keys) {
             // Carried by the Error clone itself; reattaching them would
             // only duplicate work.
@@ -582,13 +600,18 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
             }
         }
         JSObject* protoProps = JSC::constructEmptyObject(workerGlobalObject);
+        if (scope.exception()) [[unlikely]] {
+            (void)scope.tryClearException();
+            return false;
+        }
         JSObject* level = errorObject->getPrototypeDirect().getObject();
         auto* objectProto = workerGlobalObject->objectPrototype();
         while (level && level != objectProto) {
             JSC::PropertyNameArrayBuilder protoKeys(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
             level->methodTable()->getOwnPropertyNames(level, workerGlobalObject, protoKeys, JSC::DontEnumPropertiesMode::Include);
             if (scope.exception()) [[unlikely]] {
-                (void)scope.tryClearException();
+                if (!scope.tryClearException())
+                    return false;
                 break;
             }
             for (const auto& key : protoKeys) {
@@ -615,7 +638,8 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
                 if (level->methodTable()->getOwnPropertySlot(level, workerGlobalObject, key, slot))
                     dontEnum = slot.attributes() & static_cast<unsigned>(JSC::PropertyAttribute::DontEnum);
                 if (scope.exception()) [[unlikely]] {
-                    (void)scope.tryClearException();
+                    if (!scope.tryClearException())
+                        return false;
                     continue;
                 }
                 (dontEnum ? protoProps : props)->putDirect(vm, key, v);
@@ -646,10 +670,14 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
         (void)scope.tryClearException();
         return false;
     }
+    if (vm.hasTerminationRequest()) [[unlikely]]
+        return false;
 
     auto serialized = SerializedScriptValue::create(*workerGlobalObject, pair, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
-    if (scope.exception()) [[unlikely]]
-        (void)scope.tryClearException();
+    if (scope.exception()) [[unlikely]] {
+        if (!scope.tryClearException())
+            return false;
+    }
     if (!serialized && !ownProps.isUndefined()) {
         // A non-cloneable own property (WeakMap, Promise, nested function)
         // sank the pair; retry without the extras so the error itself is
@@ -659,18 +687,25 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
         // line/column/sourceURL own properties stripped.
         JSValue emptyProps = JSC::constructEmptyObject(workerGlobalObject);
         if (scope.exception()) [[unlikely]] {
-            (void)scope.tryClearException();
+            if (!scope.tryClearException())
+                return false;
             emptyProps = jsUndefined();
         }
         pair->putDirectIndex(workerGlobalObject, 1, emptyProps);
-        if (scope.exception()) [[unlikely]]
-            (void)scope.tryClearException();
+        if (scope.exception()) [[unlikely]] {
+            if (!scope.tryClearException())
+                return false;
+        }
         pair->putDirectIndex(workerGlobalObject, 2, jsUndefined());
-        if (scope.exception()) [[unlikely]]
-            (void)scope.tryClearException();
+        if (scope.exception()) [[unlikely]] {
+            if (!scope.tryClearException())
+                return false;
+        }
         serialized = SerializedScriptValue::create(*workerGlobalObject, pair, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
-        if (scope.exception()) [[unlikely]]
-            (void)scope.tryClearException();
+        if (scope.exception()) [[unlikely]] {
+            if (!scope.tryClearException())
+                return false;
+        }
     }
     if (!serialized)
         return false;

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -39,7 +39,9 @@
 #include <wtf/Scope.h>
 #include "SerializedScriptValue.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/JSMap.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/JSModuleLoader.h>
 #include "MessageEvent.h"
 #include "BunWorkerGlobalScope.h"
@@ -50,7 +52,6 @@
 #include "MessagePortPipe.h"
 #include "JSBroadcastChannel.h"
 #include "JSStructuredSerializeOptions.h"
-#include "BunClientData.h"
 
 namespace WebCore {
 
@@ -530,44 +531,208 @@ void Worker::dispatchErrorWithMessage(WTF::String message)
 
 bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSValue value)
 {
-    // This is the top of the stack for the worker's error dispatch: both the
-    // structured clone below (even in NonThrowing mode, serialization can run
-    // JS via getters/proxies and leave a pending exception) and the `code`
-    // property read must not propagate exceptions out of this function.
     auto& vm = JSC::getVM(workerGlobalObject);
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto serialized = SerializedScriptValue::create(*workerGlobalObject, value, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
-    CLEAR_IF_EXCEPTION(scope);
+    // Structured clone of an Error only carries name/message/stack and JSC's
+    // own line/column/sourceURL. Node preserves the own enumerable properties
+    // (code, errno, and anything user-added), so serialize them alongside the
+    // error and reattach them on the parent side.
+    JSValue ownProps = jsUndefined();
+    // Node's internal/error_serdes.js also walks the prototype chain and
+    // materializes what it finds there (`name` from Error.prototype, a `code`
+    // defined on a subclass prototype) as own properties on the receiving
+    // side. Inherited properties that were non-enumerable at their defining
+    // level travel in this second bag and are reattached non-enumerably.
+    JSValue protoDontEnumProps = jsUndefined();
+    if (auto* errorObject = dynamicDowncast<ErrorInstance>(value)) {
+        errorObject->materializeErrorInfoIfNeeded(vm);
+        if (scope.exception()) [[unlikely]] {
+            (void)scope.tryClearException();
+            return false;
+        }
+        JSC::PropertyNameArrayBuilder keys(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
+        errorObject->methodTable()->getOwnPropertyNames(errorObject, workerGlobalObject, keys, JSC::DontEnumPropertiesMode::Exclude);
+        if (scope.exception()) [[unlikely]] {
+            (void)scope.tryClearException();
+            return false;
+        }
+        JSObject* props = JSC::constructEmptyObject(workerGlobalObject);
+        for (const auto& key : keys) {
+            // Carried by the Error clone itself; reattaching them would
+            // only duplicate work.
+            if (key == vm.propertyNames->message || key == vm.propertyNames->stack
+                || key == vm.propertyNames->line || key == vm.propertyNames->column
+                || key == vm.propertyNames->sourceURL)
+                continue;
+            JSValue v = errorObject->get(workerGlobalObject, key);
+            if (scope.exception()) [[unlikely]] {
+                if (!scope.tryClearException())
+                    return false;
+                continue;
+            }
+            // Skip callables and symbols so one non-cloneable field doesn't
+            // make the whole error fall back to a bare string.
+            if (v.isCallable() || v.isSymbol())
+                continue;
+            props->putDirectMayBeIndex(workerGlobalObject, key, v);
+            if (scope.exception()) [[unlikely]] {
+                if (!scope.tryClearException())
+                    return false;
+            }
+        }
+        JSObject* protoProps = JSC::constructEmptyObject(workerGlobalObject);
+        JSObject* level = errorObject->getPrototypeDirect().getObject();
+        auto* objectProto = workerGlobalObject->objectPrototype();
+        while (level && level != objectProto) {
+            JSC::PropertyNameArrayBuilder protoKeys(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
+            level->methodTable()->getOwnPropertyNames(level, workerGlobalObject, protoKeys, JSC::DontEnumPropertiesMode::Include);
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                break;
+            }
+            for (const auto& key : protoKeys) {
+                if (key == vm.propertyNames->message || key == vm.propertyNames->stack
+                    || key == vm.propertyNames->line || key == vm.propertyNames->column
+                    || key == vm.propertyNames->sourceURL || JSC::parseIndex(key))
+                    continue;
+                // The nearest definition in the chain wins.
+                if (props->getDirect(vm, key) || protoProps->getDirect(vm, key))
+                    continue;
+                JSValue v = errorObject->get(workerGlobalObject, key);
+                if (scope.exception()) [[unlikely]] {
+                    if (!scope.tryClearException())
+                        return false;
+                    continue;
+                }
+                // Inherited values are a synthesized convenience: carry only
+                // cloneable primitives so one can never sink the pair and
+                // cost the error's real own properties.
+                if (!v.isPrimitive() || v.isSymbol())
+                    continue;
+                PropertySlot slot(level, PropertySlot::InternalMethodType::GetOwnProperty);
+                bool dontEnum = false;
+                if (level->methodTable()->getOwnPropertySlot(level, workerGlobalObject, key, slot))
+                    dontEnum = slot.attributes() & static_cast<unsigned>(JSC::PropertyAttribute::DontEnum);
+                if (scope.exception()) [[unlikely]] {
+                    (void)scope.tryClearException();
+                    continue;
+                }
+                (dontEnum ? protoProps : props)->putDirect(vm, key, v);
+            }
+            level = level->getPrototypeDirect().getObject();
+        }
+        ownProps = props;
+        protoDontEnumProps = protoProps;
+    }
+
+    auto* pair = constructEmptyArray(workerGlobalObject, nullptr, 3);
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return false;
+    }
+    pair->putDirectIndex(workerGlobalObject, 0, value);
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return false;
+    }
+    pair->putDirectIndex(workerGlobalObject, 1, ownProps);
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return false;
+    }
+    pair->putDirectIndex(workerGlobalObject, 2, protoDontEnumProps);
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return false;
+    }
+
+    auto serialized = SerializedScriptValue::create(*workerGlobalObject, pair, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
+    if (scope.exception()) [[unlikely]]
+        (void)scope.tryClearException();
+    if (!serialized && !ownProps.isUndefined()) {
+        // A non-cloneable own property (WeakMap, Promise, nested function)
+        // sank the pair; retry without the extras so the error itself is
+        // still delivered as an Error instance rather than a bare string.
+        // Keep an (empty) object in the props slot: its presence is how the
+        // parent knows the value was an Error and must have its JSC-internal
+        // line/column/sourceURL own properties stripped.
+        JSValue emptyProps = JSC::constructEmptyObject(workerGlobalObject);
+        if (scope.exception()) [[unlikely]] {
+            (void)scope.tryClearException();
+            emptyProps = jsUndefined();
+        }
+        pair->putDirectIndex(workerGlobalObject, 1, emptyProps);
+        if (scope.exception()) [[unlikely]]
+            (void)scope.tryClearException();
+        pair->putDirectIndex(workerGlobalObject, 2, jsUndefined());
+        if (scope.exception()) [[unlikely]]
+            (void)scope.tryClearException();
+        serialized = SerializedScriptValue::create(*workerGlobalObject, pair, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
+        if (scope.exception()) [[unlikely]]
+            (void)scope.tryClearException();
+    }
     if (!serialized)
         return false;
 
-    // Structured clone keeps only the standard Error fields
-    // (name/message/stack/line/column/sourceURL), but Node's worker 'error'
-    // event preserves `error.code` (lib/internal/error_serdes.js) and the
-    // vendored node tests assert on it (e.g. ERR_TRACE_EVENTS_UNAVAILABLE).
-    // Carry a string `code` across the thread boundary manually. If reading
-    // `code` throws (a throwing getter/proxy), drop the code and proceed.
-    String errorCode;
-    if (value.isObject() && !scope.exception()) {
-        JSValue codeValue = value.getObject()->getIfPropertyExists(workerGlobalObject, WebCore::builtinNames(vm).codePublicName());
-        if (!scope.exception() && codeValue && codeValue.isString())
-            errorCode = codeValue.toWTFString(workerGlobalObject);
-        CLEAR_IF_EXCEPTION(scope);
-    }
-
-    return postTaskToParent([protectedThis = Ref { *this }, serialized, errorCode = WTF::move(errorCode).isolatedCopy()](ScriptExecutionContext& context) {
+    scope.release();
+    return postTaskToParent([protectedThis = Ref { *this }, serialized](ScriptExecutionContext& context) {
         auto* globalObject = context.globalObject();
         auto& vm = JSC::getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
-        ErrorEvent::Init init;
         JSValue deserialized = serialized->deserialize(*globalObject, globalObject, SerializationErrorMode::NonThrowing);
         RETURN_IF_EXCEPTION(scope, );
-        if (!errorCode.isNull()) {
-            if (auto* errorObject = deserialized.getObject())
-                errorObject->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), JSC::jsString(vm, errorCode));
+
+        JSValue errorValue = deserialized;
+        if (auto* arr = dynamicDowncast<JSArray>(deserialized)) {
+            errorValue = arr->getIndex(globalObject, 0);
+            RETURN_IF_EXCEPTION(scope, );
+            JSValue propsValue = arr->getIndex(globalObject, 1);
+            RETURN_IF_EXCEPTION(scope, );
+            JSValue protoPropsValue = arr->getIndex(globalObject, 2);
+            RETURN_IF_EXCEPTION(scope, );
+            if (auto* errorObject = errorValue.getObject()) {
+                // A props slot (even an empty one) is only present when the
+                // worker threw an ErrorInstance.
+                if (auto* props = propsValue.getObject()) {
+                    // Node never exposes JSC's line/column/sourceURL on a
+                    // worker error; the Error clone wrote them as lazily
+                    // materialized own properties, so reify before deleting.
+                    if (auto* errorInstance = dynamicDowncast<ErrorInstance>(errorValue)) {
+                        errorInstance->materializeErrorInfoIfNeeded(vm);
+                        RETURN_IF_EXCEPTION(scope, );
+                        for (const auto* internalKey : { &vm.propertyNames->line, &vm.propertyNames->column, &vm.propertyNames->sourceURL }) {
+                            errorObject->deleteProperty(globalObject, *internalKey);
+                            RETURN_IF_EXCEPTION(scope, );
+                        }
+                    }
+                    JSC::PropertyNameArrayBuilder keys(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
+                    props->methodTable()->getOwnPropertyNames(props, globalObject, keys, JSC::DontEnumPropertiesMode::Exclude);
+                    RETURN_IF_EXCEPTION(scope, );
+                    for (const auto& key : keys) {
+                        JSValue v = props->get(globalObject, key);
+                        RETURN_IF_EXCEPTION(scope, );
+                        errorObject->putDirectMayBeIndex(globalObject, key, v);
+                        RETURN_IF_EXCEPTION(scope, );
+                    }
+                    // Properties materialized from the prototype chain that
+                    // were non-enumerable there stay non-enumerable, like Node.
+                    if (auto* protoProps = protoPropsValue.getObject()) {
+                        JSC::PropertyNameArrayBuilder protoKeys(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
+                        protoProps->methodTable()->getOwnPropertyNames(protoProps, globalObject, protoKeys, JSC::DontEnumPropertiesMode::Exclude);
+                        RETURN_IF_EXCEPTION(scope, );
+                        for (const auto& key : protoKeys) {
+                            JSValue v = protoProps->get(globalObject, key);
+                            RETURN_IF_EXCEPTION(scope, );
+                            errorObject->putDirect(vm, key, v, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+                        }
+                    }
+                }
+            }
         }
-        init.error = deserialized;
+
+        ErrorEvent::Init init;
+        init.error = errorValue;
 
         auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
         protectedThis->dispatchEvent(event);

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -532,32 +532,24 @@ void Worker::dispatchErrorWithMessage(WTF::String message)
 bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSValue value)
 {
     auto& vm = JSC::getVM(workerGlobalObject);
-    // A concurrent terminate() can arm the TerminationException at any
-    // safepoint; ErrorInstance::getOwnPropertySlot (reached from the Error
-    // clone path inside SerializedScriptValue::create) does not check after
-    // materializeErrorInfoIfNeeded, so entering it mid-termination trips
-    // getOwnPropertyDescriptor's post-call assert. Bail to the string
-    // fallback before doing any JS-entering work once termination is armed.
+    // ErrorInstance::getOwnPropertySlot (reached via SerializedScriptValue's
+    // Error clone path) does not check after materializeErrorInfoIfNeeded, so
+    // bail to the string fallback once termination is armed.
     if (vm.hasTerminationRequest()) [[unlikely]]
         return false;
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // The caller's dispatchEvent(error) on globalThis (WebWorker__dispatchError)
-    // runs user JS and can leave a pending exception.
+    // The caller's globalThis dispatchEvent(error) runs user JS first.
     if (scope.exception()) [[unlikely]] {
         if (!scope.tryClearException())
             return false;
     }
 
-    // Structured clone of an Error only carries name/message/stack and JSC's
-    // own line/column/sourceURL. Node preserves the own enumerable properties
-    // (code, errno, and anything user-added), so serialize them alongside the
-    // error and reattach them on the parent side.
+    // Structured clone of an Error only carries name/message/stack; carry own
+    // enumerable properties (code, errno, user fields) alongside it like Node.
     JSValue ownProps = jsUndefined();
-    // Node's internal/error_serdes.js also walks the prototype chain and
-    // materializes what it finds there (`name` from Error.prototype, a `code`
-    // defined on a subclass prototype) as own properties on the receiving
-    // side. Inherited properties that were non-enumerable at their defining
-    // level travel in this second bag and are reattached non-enumerably.
+    // Node's internal/error_serdes.js materializes prototype-chain properties
+    // too (name, a subclass code). Those that were non-enumerable at their
+    // defining level go in this second bag and stay non-enumerable.
     JSValue protoDontEnumProps = jsUndefined();
     if (auto* errorObject = dynamicDowncast<ErrorInstance>(value)) {
         errorObject->materializeErrorInfoIfNeeded(vm);
@@ -679,12 +671,9 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
             return false;
     }
     if (!serialized && !ownProps.isUndefined()) {
-        // A non-cloneable own property (WeakMap, Promise, nested function)
-        // sank the pair; retry without the extras so the error itself is
-        // still delivered as an Error instance rather than a bare string.
-        // Keep an (empty) object in the props slot: its presence is how the
-        // parent knows the value was an Error and must have its JSC-internal
-        // line/column/sourceURL own properties stripped.
+        // A non-cloneable own property sank the pair; retry without the extras
+        // so the error itself still arrives as an Error instance. Keep an
+        // empty props slot: its presence is what gates parent-side rehydration.
         JSValue emptyProps = JSC::constructEmptyObject(workerGlobalObject);
         if (scope.exception()) [[unlikely]] {
             if (!scope.tryClearException())

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -179,6 +179,10 @@ pub struct WebWorker {
     /// observed concurrently by `terminate_all_and_wait` / parent-thread FFI;
     /// producing `&mut WebWorker` while another thread holds `&WebWorker` is UB).
     exit_called: AtomicBool,
+    /// `requested_terminate` is also set by worker-side paths (uncaught
+    /// exception, process.exit). `shutdown()` uses this to know the request
+    /// came from the parent's `terminate()` so it can report exit code 1.
+    terminate_from_parent: AtomicBool,
 }
 
 #[repr(u8)]
@@ -361,6 +365,7 @@ pub fn terminate_all_and_wait(timeout_ms: u64) {
             let w = bun_ptr::ParentRef::from(nn);
             // live_workers::MUTEX held; list links written only under it.
             it = w.live_next.get();
+            w.terminate_from_parent.store(true, Ordering::Release);
             if w.requested_terminate.swap(true, Ordering::Release) {
                 continue;
             }
@@ -571,6 +576,7 @@ impl WebWorker {
             arena: JsCell::new(None),
             worker_env_loader: Cell::new(core::ptr::null_mut()),
             exit_called: AtomicBool::new(false),
+            terminate_from_parent: AtomicBool::new(false),
         }));
         // `worker` is non-null (just heap-allocated). Wrap once for the safe
         // shared reborrows below; the raw `worker` is still used for
@@ -691,6 +697,7 @@ impl WebWorker {
         // Only atomic / lock-guarded fields are touched cross-thread; never
         // `&mut WebWorker`.
         let this = bun_ptr::ParentRef::from(NonNull::new(this).expect("WebWorker FFI ptr"));
+        this.terminate_from_parent.store(true, Ordering::Release);
         if this.set_requested_terminate() {
             return;
         }
@@ -1215,6 +1222,7 @@ impl WebWorker {
     /// closure — see the note at the bottom of this fn.
     fn shutdown(&self) {
         jsc::mark_binding();
+        let was_running = self.status.get() == Status::Running;
         self.set_status(Status::Terminated);
         bun_analytics::features::workers_terminated.fetch_add(1, Ordering::Relaxed);
         log!("[{}] shutdown", self.execution_context_id);
@@ -1247,6 +1255,15 @@ impl WebWorker {
             // clear it so process.on('exit') handlers can run. teardownJSCVM
             // re-sets it for the JSC VM teardown.
             vm.jsc_vm().clear_has_termination_request();
+            // Node's terminate() resolves to 1 when it interrupts a running
+            // worker. Not requested_terminate: a worker-side uncaught sets that
+            // too after the user's exit handler may rewrite process.exitCode.
+            if was_running
+                && self.terminate_from_parent.load(Ordering::Acquire)
+                && !self.exit_called.load(Ordering::Relaxed)
+            {
+                vm.exit_handler.exit_code = 1;
+            }
             vm.is_shutting_down = true;
             vm.on_exit();
             if let Some(hooks) = runtime_hooks() {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1510,6 +1510,108 @@ impl WebWorker {
     }
 }
 
+/// Convert build/resolve diagnostics into a `SyntaxError` that survives
+/// `dispatchErrorWithValue`'s structured clone. The in-process shapes
+/// (`BuildMessage`, `AggregateError` of `BuildMessage`s) do not: `BuildMessage`
+/// is not cloneable, and the Error clone path drops `AggregateError.errors`,
+/// so the parent used to see a bare `Error("N errors building ...")` with no
+/// diagnostic text, file, or position.
+///
+/// The returned `SyntaxError` (matching Node) carries every diagnostic in its
+/// message as `text (file:line:col)`, plus an enumerable `.errors` array of
+/// plain `{message, position}` objects so the parent can access each
+/// diagnostic programmatically. Both ride across the thread boundary via
+/// `dispatchErrorWithValue`'s own-properties serialization.
+fn build_msgs_to_worker_error(
+    msgs: &[bun_ast::Msg],
+    global: &JSGlobalObject,
+) -> jsc::JsResult<JSValue> {
+    use core::fmt::Write as _;
+    debug_assert!(!msgs.is_empty());
+
+    let mut message = std::string::String::with_capacity(128);
+    for (i, msg) in msgs.iter().enumerate() {
+        if i > 0 {
+            message.push('\n');
+        }
+        message.push_str(&std::string::String::from_utf8_lossy(&msg.data.text));
+        if let Some(loc) = &msg.data.location {
+            let _ = write!(
+                message,
+                " ({}:{}:{})",
+                std::string::String::from_utf8_lossy(&loc.file),
+                loc.line,
+                loc.column,
+            );
+        }
+    }
+
+    let err = global.create_syntax_error_instance(format_args!("{}", message));
+
+    let errors = JSValue::create_array_from_iter(global, msgs.iter(), |msg| {
+        let entry = JSValue::create_empty_object(global, 2);
+        entry.put(
+            global,
+            b"message",
+            jsc::bun_string_jsc::create_utf8_for_js(global, &msg.data.text)?,
+        );
+        entry.put(
+            global,
+            b"position",
+            jsc::BuildMessage::generate_position_object(msg, global),
+        );
+        Ok(entry)
+    })?;
+    err.put(global, b"errors", errors);
+
+    Ok(err)
+}
+
+/// If `value` is a `BuildMessage` or an `AggregateError` that contains only
+/// `BuildMessage` entries (the shape the module loader produces on parse
+/// failure), return the cloneable `SyntaxError` built from those diagnostics.
+/// `ResolveMessage`s are not rewritten: a module-not-found error is not a
+/// syntax error, and `#onError` in `node:worker_threads` already reshapes the
+/// entry-point ModuleNotFound into Node's `MODULE_NOT_FOUND`.
+fn maybe_build_error_to_worker_error(
+    value: JSValue,
+    global: &JSGlobalObject,
+) -> jsc::JsResult<Option<JSValue>> {
+    let extract_build_msg = |v: JSValue| -> Option<bun_ast::Msg> {
+        v.as_::<crate::BuildMessage>().map(|bm| {
+            // SAFETY: `as_` returned a live `BuildMessage` cell; read-only on
+            // the worker (JS) thread that owns it.
+            unsafe { (*bm).msg.clone() }
+        })
+    };
+
+    if let Some(msg) = extract_build_msg(value) {
+        return Ok(Some(build_msgs_to_worker_error(&[msg], global)?));
+    }
+
+    if value.is_aggregate_error(global) {
+        let errors = value.get_errors_property(global);
+        if errors.is_array() {
+            let len = errors.get_length(global)? as u32;
+            if len > 0 {
+                let mut msgs: Vec<bun_ast::Msg> = Vec::with_capacity(len as usize);
+                for i in 0..len {
+                    let entry = errors.get_index(global, i)?;
+                    match extract_build_msg(entry) {
+                        Some(m) => msgs.push(m),
+                        // Not a loader-produced parse aggregate; let the
+                        // generic own-properties path handle it.
+                        None => return Ok(None),
+                    }
+                }
+                return Ok(Some(build_msgs_to_worker_error(&msgs, global)?));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
 fn on_unhandled_rejection(
     vm: &mut VirtualMachine,
     global_object: &JSGlobalObject,
@@ -1522,15 +1624,16 @@ fn on_unhandled_rejection(
         .to_error()
         .unwrap_or(error_instance_or_exception);
 
-    // A parse failure rejects with a BuildMessage, which doesn't survive structured
-    // clone. Node reports a SyntaxError; build a real one from the formatted parse
-    // error so the subtype reaches the parent intact.
-    if let Some(bm) = error_instance.as_::<crate::BuildMessage>() {
-        // SAFETY: as_ returned a live BuildMessage cell, read-only on the
-        // worker (JS) thread that owns it.
-        let text = unsafe { (*bm).msg.data.text.clone() };
-        error_instance =
-            global_object.create_syntax_error_instance(format_args!("{}", bstr::BStr::new(&text)));
+    // A parse failure rejects with a BuildMessage (or an AggregateError of
+    // them), neither of which survives the structured clone in
+    // dispatchErrorWithValue. Convert to a cloneable SyntaxError so the
+    // subtype and every diagnostic (text + file:line:col) reach the parent.
+    match maybe_build_error_to_worker_error(error_instance, global_object) {
+        Ok(Some(converted)) => error_instance = converted,
+        Ok(None) => {}
+        Err(_) => {
+            let _ = global_object.try_take_exception();
+        }
     }
 
     let mut array: Vec<u8> = Vec::new();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1534,12 +1534,12 @@ fn build_msgs_to_worker_error(
         if i > 0 {
             message.push('\n');
         }
-        message.push_str(&std::string::String::from_utf8_lossy(&msg.data.text));
+        let _ = write!(message, "{}", bstr::BStr::new(&msg.data.text));
         if let Some(loc) = &msg.data.location {
             let _ = write!(
                 message,
                 " ({}:{}:{})",
-                std::string::String::from_utf8_lossy(&loc.file),
+                bstr::BStr::new(&loc.file),
                 loc.line,
                 loc.column,
             );

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -126,6 +126,10 @@ pub struct WebWorker {
     /// Set by the parent (`notifyNeedTermination`) or by the worker itself
     /// (`exit`). The worker loop polls this between ticks.
     requested_terminate: AtomicBool,
+    /// `requested_terminate` is also set by worker-side paths (uncaught
+    /// exception, process.exit). `shutdown()` uses this to know the request
+    /// came from the parent's `terminate()` so it can report exit code 1.
+    terminate_from_parent: AtomicBool,
 
     /// The worker's `jsc.VirtualMachine`, or null before `startVM()` / after
     /// `shutdown()` nulls it. Lives inside `arena`. `vm_lock` must be held for
@@ -179,10 +183,6 @@ pub struct WebWorker {
     /// observed concurrently by `terminate_all_and_wait` / parent-thread FFI;
     /// producing `&mut WebWorker` while another thread holds `&WebWorker` is UB).
     exit_called: AtomicBool,
-    /// `requested_terminate` is also set by worker-side paths (uncaught
-    /// exception, process.exit). `shutdown()` uses this to know the request
-    /// came from the parent's `terminate()` so it can report exit code 1.
-    terminate_from_parent: AtomicBool,
 }
 
 #[repr(u8)]
@@ -569,6 +569,7 @@ impl WebWorker {
             live_next: Cell::new(core::ptr::null_mut()),
             live_prev: Cell::new(core::ptr::null_mut()),
             requested_terminate: AtomicBool::new(false),
+            terminate_from_parent: AtomicBool::new(false),
             vm: Cell::new(core::ptr::null_mut()),
             vm_lock: Mutex::new(),
             parent_poll_ref: JsCell::new(KeepAlive::init()),
@@ -576,7 +577,6 @@ impl WebWorker {
             arena: JsCell::new(None),
             worker_env_loader: Cell::new(core::ptr::null_mut()),
             exit_called: AtomicBool::new(false),
-            terminate_from_parent: AtomicBool::new(false),
         }));
         // `worker` is non-null (just heap-allocated). Wrap once for the safe
         // shared reborrows below; the raw `worker` is still used for

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1594,7 +1594,7 @@ fn maybe_build_error_to_worker_error(
         if errors.is_array() {
             let len = errors.get_length(global)? as u32;
             if len > 0 {
-                let mut msgs: Vec<bun_ast::Msg> = Vec::with_capacity(len as usize);
+                let mut msgs: Vec<bun_ast::Msg> = Vec::with_capacity((len as usize).min(16));
                 for i in 0..len {
                     let entry = errors.get_index(global, i)?;
                     match extract_build_msg(entry) {

--- a/test/js/node/worker_threads/eval-source-leak-fixture.js
+++ b/test/js/node/worker_threads/eval-source-leak-fixture.js
@@ -1,13 +1,15 @@
 // Create a worker with extremely large source code which completes instantly and the `eval` option
 // set to true. Ensure that the Blob created to hold the source code is not kept in memory after the
-// worker exits.
+// worker exits. The source must stay large: allocations this big are returned to the OS when freed,
+// so RSS growth means a real leak, while mid-sized ones sit in allocator-retained pages and do not.
 const { Worker } = require("node:worker_threads");
 
 const eachSizeMiB = 100;
 const iterations = 5;
 
 function test() {
-  const code = " ".repeat(eachSizeMiB * 1024 * 1024);
+  // Not " ".repeat(): String#repeat on this many bytes is very slow in debug JSC builds.
+  const code = Buffer.alloc(eachSizeMiB * 1024 * 1024, " ").toString();
   return new Promise((resolve, reject) => {
     const worker = new Worker(code, { eval: true });
     worker.on("exit", () => resolve());

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -334,7 +334,7 @@ describe("execArgv option", async () => {
   it("inherits the parent's execArgv when falsy or unspecified", async () => {
     await run("null", '["--smol"]\n');
     await run("0", '["--smol"]\n');
-  });
+  }, 20_000);
   it("provides empty execArgv when passed an empty array", async () => {
     // empty array should result in empty execArgv, not inherited from parent thread
     await run("[]", "[]\n");
@@ -345,19 +345,21 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
+// The fixture's leak check needs six workers with 100 MiB of source each (see
+// the sizing note in the fixture); that takes about 30s on a debug+ASAN
+// build, well over the default per-test budget, hence the explicit one.
 test("eval does not leak source code", async () => {
-  const proc = Bun.spawn({
+  await using proc = Bun.spawn({
     cmd: [bunExe(), "eval-source-leak-fixture.js"],
     env: bunEnv,
     cwd: __dirname,
     stderr: "pipe",
     stdout: "ignore",
   });
-  await proc.exited;
-  const errors = await proc.stderr.text();
+  const [errors, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
   if (errors.length > 0) throw new Error(errors);
-  expect(proc.exitCode).toBe(0);
-});
+  expect(exitCode).toBe(0);
+}, 90_000);
 
 describe("captured stdio backpressure", () => {
   // node flow control (lib/internal/worker/io.js): a writev batch's callback is
@@ -567,7 +569,7 @@ describe("environmentData", () => {
     expect(proc.exitCode).toBe(0);
     const out = await proc.stdout.text();
     expect(out).toBe("foo\n".repeat(5));
-  });
+  }, 30_000);
 
   test("can be used if parent thread had not imported worker_threads", async () => {
     const proc = Bun.spawn({
@@ -603,6 +605,239 @@ describe("error event", () => {
     const [err] = await once(worker, "error");
     expect(err).toBeInstanceOf(Error);
     expect(err.message).toMatch(/MessagePort \[EventTarget\] \{.*\}/s);
+  });
+
+  test("preserves own enumerable properties of the thrown Error", async () => {
+    const worker = new Worker(
+      /* js */ `
+      const err = new Error("boom");
+      err.code = "E_CUSTOM";
+      err.errno = -2;
+      err.extra = { path: "/tmp/x", n: 42 };
+      throw err;`,
+      { eval: true },
+    );
+    const [err] = await once(worker, "error");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("boom");
+    // Own properties must survive the thread boundary so pool libraries can
+    // switch on err.code / err.errno like they do in Node.
+    expect(err.code).toBe("E_CUSTOM");
+    expect(err.errno).toBe(-2);
+    expect(err.extra).toEqual({ path: "/tmp/x", n: 42 });
+  });
+
+  test("preserves the error's own name", async () => {
+    const worker = new Worker(
+      /* js */ `
+      class CustomError extends Error {
+        constructor(msg) { super(msg); this.name = "CustomError"; this.code = "E_SUB"; }
+      }
+      throw new CustomError("boom");`,
+      { eval: true },
+    );
+    const [err] = await once(worker, "error");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("CustomError");
+    expect(err.code).toBe("E_SUB");
+  });
+
+  // Node's internal/error_serdes.js materializes `name` as an own property of
+  // the parent-side error and never exposes JSC's line/column/sourceURL. The
+  // expected objects were taken verbatim from Node v26.3.0.
+  test.each([
+    [
+      "Error with custom props",
+      `const e = new Error("boom"); e.code = "E_CUSTOM"; e.extra = { foo: 42 }; throw e;`,
+      { own: ["code", "extra", "message", "name", "stack"], name: "Error", nameIsEnumerable: false },
+    ],
+    [
+      "built-in subclass",
+      `throw new TypeError("boom")`,
+      { own: ["message", "name", "stack"], name: "TypeError", nameIsEnumerable: false },
+    ],
+    [
+      "own enumerable name set by the constructor",
+      `class C extends Error { constructor(m) { super(m); this.name = "CustomError"; this.code = "E_SUB"; } } throw new C("boom");`,
+      { own: ["code", "message", "name", "stack"], name: "CustomError", nameIsEnumerable: true },
+    ],
+  ])("matches Node's own-key set: %s", async (_label, source, expected) => {
+    const worker = new Worker(source, { eval: true });
+    const [err] = await once(worker, "error");
+    expect({
+      own: Object.getOwnPropertyNames(err).sort(),
+      name: err.name,
+      nameIsEnumerable: Object.prototype.propertyIsEnumerable.call(err, "name"),
+    }).toEqual(expected);
+  });
+
+  // Bun's internal error codes (and any user class that puts `code` on a
+  // prototype) only expose `code` through the prototype chain; Node's
+  // internal/error_serdes.js walks the chain and materializes what it finds
+  // as own properties. The expected object is Node v26.3.0's output verbatim.
+  test("materializes a prototype-chain `code` as an own property, like Node", async () => {
+    const worker = new Worker(
+      /* js */ `
+      class AppErr extends Error {}
+      AppErr.prototype.code = "E_PROTO_CODE";
+      const err = new AppErr("boom");
+      err.own = 1;
+      throw err;`,
+      { eval: true },
+    );
+    const [err] = await once(worker, "error");
+    expect({
+      isError: err instanceof Error,
+      name: err.name,
+      code: err.code,
+      own: err.own,
+      ownKeys: Object.getOwnPropertyNames(err).sort(),
+      codeIsEnumerable: Object.prototype.propertyIsEnumerable.call(err, "code"),
+    }).toEqual({
+      isError: true,
+      name: "Error",
+      code: "E_PROTO_CODE",
+      own: 1,
+      ownKeys: ["code", "message", "name", "own", "stack"],
+      codeIsEnumerable: true,
+    });
+  });
+
+  test("drops non-cloneable own properties instead of losing the whole error", async () => {
+    const worker = new Worker(
+      /* js */ `
+      const err = new Error("boom");
+      err.code = "E_FN";
+      err.fn = () => {};
+      throw err;`,
+      { eval: true },
+    );
+    const [err] = await once(worker, "error");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("boom");
+    expect(err.code).toBe("E_FN");
+    expect(err.fn).toBeUndefined();
+  });
+
+  test("preserves integer-indexed own properties on the thrown Error", async () => {
+    const worker = new Worker(
+      /* js */ `
+      const err = new Error("boom");
+      err[0] = "zero";
+      err[2] = "two";
+      err.code = "E_IDX";
+      throw err;`,
+      { eval: true },
+    );
+    const [err] = await once(worker, "error");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("boom");
+    expect(err.code).toBe("E_IDX");
+    expect(err[0]).toBe("zero");
+    expect(err[2]).toBe("two");
+  });
+
+  test("a non-cloneable prototype `name` does not cost the error its own properties", async () => {
+    const worker = new Worker(
+      /* js */ `
+      class E extends Error {}
+      E.prototype.name = new WeakMap();
+      const err = new E("boom");
+      err.code = "E_PROTO";
+      throw err;`,
+      { eval: true },
+    );
+    const [err] = await once(worker, "error");
+    // The pathological prototype name must never sink the [error, props]
+    // serialization: the parent still gets a real Error and its own props.
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("boom");
+    expect(err.code).toBe("E_PROTO");
+    expect(err.name).toBe("Error");
+  });
+
+  test("still delivers an Error instance when own props include a WeakMap", async () => {
+    const worker = new Worker(
+      /* js */ `
+      const err = new Error("boom");
+      err.code = "E_WEAK";
+      err.cache = new WeakMap();
+      throw err;`,
+      { eval: true },
+    );
+    const [err] = await once(worker, "error");
+    // The WeakMap sinks the own-props clone; the error itself must still
+    // round-trip as an Error instance rather than falling back to a string.
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("boom");
+    expect(err.cache).toBeUndefined();
+  });
+
+  test("passes non-Error thrown objects through unchanged", async () => {
+    const worker = new Worker(`throw { code: "E_PLAIN", msg: "plain" };`, { eval: true });
+    const [err] = await once(worker, "error");
+    expect(err).toEqual({ code: "E_PLAIN", msg: "plain" });
+  });
+
+  test("passes thrown primitives through unchanged", async () => {
+    const worker = new Worker(`throw 42;`, { eval: true });
+    const [err] = await once(worker, "error");
+    expect(err).toBe(42);
+  });
+
+  test("passes thrown arrays through unchanged", async () => {
+    const worker = new Worker(`throw [1, "two", { three: 3 }];`, { eval: true });
+    const [err] = await once(worker, "error");
+    expect(err).toEqual([1, "two", { three: 3 }]);
+  });
+});
+
+describe("terminate()", () => {
+  test("resolves with exit code 1 for a running worker", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1e9)`, { eval: true });
+    await once(worker, "online");
+    const code = await worker.terminate();
+    expect(code).toBe(1);
+  });
+
+  test("emits exit event with code 1 for a terminated worker", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1e9)`, { eval: true });
+    await once(worker, "online");
+    const exitP = once(worker, "exit");
+    await worker.terminate();
+    const [code] = await exitP;
+    expect(code).toBe(1);
+  });
+
+  test("process.exit() in the worker wins over terminate()'s exit code", async () => {
+    const worker = new Worker(`process.exit(7)`, { eval: true });
+    const [code] = await once(worker, "exit");
+    expect(code).toBe(7);
+  });
+
+  test("resolves with undefined when the worker has already exited", async () => {
+    const worker = new Worker(`/* empty */`, { eval: true });
+    await once(worker, "exit");
+    const code = await worker.terminate();
+    expect(code).toBeUndefined();
+  });
+
+  test("resolves when called repeatedly after exit", async () => {
+    const worker = new Worker(`/* empty */`, { eval: true });
+    await once(worker, "exit");
+    // Before the fix the falsy exit code 0 fell through and awaited a close
+    // event that will never fire again, hanging forever.
+    expect(await worker.terminate()).toBeUndefined();
+    expect(await worker.terminate()).toBeUndefined();
+    expect(await worker.terminate()).toBeUndefined();
+  });
+
+  test("concurrent terminate() calls share the same resolution", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1e9)`, { eval: true });
+    await once(worker, "online");
+    const [a, b] = await Promise.all([worker.terminate(), worker.terminate()]);
+    expect(a).toBe(1);
+    expect(b).toBe(1);
   });
 });
 
@@ -684,7 +919,7 @@ describe("getHeapSnapshot", () => {
       code: "ERR_WORKER_NOT_RUNNING",
       message: "Worker instance not running",
     });
-  });
+  }, 20_000);
 
   test("resolves to a Stream.Readable with JSON text in V8 format", async () => {
     const worker = new Worker(
@@ -719,7 +954,7 @@ describe("getHeapSnapshot", () => {
       "trace_tree",
     ]);
     worker.postMessage(0);
-  });
+  }, 20_000);
 });
 
 test("failed Worker construction restores transferred FileHandles", async () => {
@@ -1446,7 +1681,7 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
       main_sees_FROM_B: null,
       main_sees_FROM_C: "c",
     });
-  });
+  }, 20_000);
 
   // Founding a store must not adopt another tree's value for a key the founding
   // thread already has.
@@ -1457,7 +1692,7 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
       B_sees_SHARED_KEY: "from-A",
       main_SHARED_KEY: "from-main",
     });
-  });
+  }, 20_000);
 
   // An accessor installed via defineProperty lands on the base object, but reads hit
   // the store first — so the store entry must go, or the getter is shadowed. (Node
@@ -1549,7 +1784,7 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
       main_sees_FROM_S1: "s1",
       main_sees_TO_DELETE: null,
     });
-  });
+  }, 20_000);
 
   // Founding a tree replaces process.env; Bun.env is reified from the same object
   // at startup and must not be left observing the orphaned pre-swap env.

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -789,6 +789,68 @@ describe("error event", () => {
     const worker = new Worker(`throw [1, "two", { three: 3 }];`, { eval: true });
     const [err] = await once(worker, "error");
     expect(err).toEqual([1, "two", { three: 3 }]);
+  });
+
+  // A worker module that fails to parse rejects worker-side with a BuildMessage
+  // (one error) or an AggregateError of them (several). Neither survives
+  // structured clone, so the parent used to see a bare
+  // Error("N errors building ...") with every diagnostic gone. Node delivers a
+  // SyntaxError naming the first diagnostic; Bun now delivers a SyntaxError
+  // whose message joins every diagnostic with its file:line:col and carries a
+  // structured-clone-safe `errors` array.
+  describe("module parse errors", () => {
+    test("surface as a SyntaxError with every diagnostic and location, not a bare summary", async () => {
+      using dir = tempDir("worker-parse-err", {
+        "w.mjs": "let x = 1; let x = 2;\nconst y = ;\n",
+      });
+      const file = join(String(dir), "w.mjs");
+      const worker = new Worker(file);
+      const [err] = await once(worker, "error");
+
+      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err.name).toBe("SyntaxError");
+      expect(err.message).not.toMatch(/^\d+ errors building/);
+      expect(err.message).toContain("already been declared");
+      expect(err.message).toContain("Unexpected");
+      // Each diagnostic carries file:line:col in the joined message.
+      expect(err.message).toContain(`${file}:1:`);
+      expect(err.message).toContain(`${file}:2:`);
+      // The per-diagnostic data is exposed as a cloneable array so the parent
+      // can act on each diagnostic programmatically (text + position).
+      expect(err.errors).toHaveLength(2);
+      expect(err.errors[0]).toEqual({
+        message: expect.stringContaining("already been declared"),
+        position: expect.objectContaining({ file, line: 1 }),
+      });
+      expect(err.errors[1]).toEqual({
+        message: expect.stringContaining("Unexpected"),
+        position: expect.objectContaining({ file, line: 2 }),
+      });
+    });
+
+    test("single parse error also surfaces as a located SyntaxError", async () => {
+      using dir = tempDir("worker-parse-err-1", {
+        "w.mjs": "const y = ;\n",
+      });
+      const file = join(String(dir), "w.mjs");
+      const worker = new Worker(file);
+      const [err] = await once(worker, "error");
+
+      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err.message).toContain("Unexpected");
+      expect(err.message).toContain(`${file}:1:`);
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].position).toEqual(expect.objectContaining({ file, line: 1 }));
+    });
+
+    test("the same shape reaches the parent for an eval worker", async () => {
+      const worker = new Worker("let x = 1; let x = 2; const y = ;", { eval: true });
+      const [err] = await once(worker, "error");
+      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err.message).not.toMatch(/^\d+ errors building/);
+      expect(err.errors).toHaveLength(2);
+      expect(err.errors[0].message).toContain("already been declared");
+    });
   });
 });
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -334,7 +334,7 @@ describe("execArgv option", async () => {
   it("inherits the parent's execArgv when falsy or unspecified", async () => {
     await run("null", '["--smol"]\n');
     await run("0", '["--smol"]\n');
-  }, 20_000);
+  });
   it("provides empty execArgv when passed an empty array", async () => {
     // empty array should result in empty execArgv, not inherited from parent thread
     await run("[]", "[]\n");
@@ -569,7 +569,7 @@ describe("environmentData", () => {
     expect(proc.exitCode).toBe(0);
     const out = await proc.stdout.text();
     expect(out).toBe("foo\n".repeat(5));
-  }, 30_000);
+  });
 
   test("can be used if parent thread had not imported worker_threads", async () => {
     const proc = Bun.spawn({
@@ -981,7 +981,7 @@ describe("getHeapSnapshot", () => {
       code: "ERR_WORKER_NOT_RUNNING",
       message: "Worker instance not running",
     });
-  }, 20_000);
+  });
 
   test("resolves to a Stream.Readable with JSON text in V8 format", async () => {
     const worker = new Worker(
@@ -1016,7 +1016,7 @@ describe("getHeapSnapshot", () => {
       "trace_tree",
     ]);
     worker.postMessage(0);
-  }, 20_000);
+  });
 });
 
 test("failed Worker construction restores transferred FileHandles", async () => {
@@ -1743,7 +1743,7 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
       main_sees_FROM_B: null,
       main_sees_FROM_C: "c",
     });
-  }, 20_000);
+  });
 
   // Founding a store must not adopt another tree's value for a key the founding
   // thread already has.
@@ -1754,7 +1754,7 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
       B_sees_SHARED_KEY: "from-A",
       main_SHARED_KEY: "from-main",
     });
-  }, 20_000);
+  });
 
   // An accessor installed via defineProperty lands on the base object, but reads hit
   // the store first — so the store entry must go, or the getter is shadowed. (Node
@@ -1846,7 +1846,7 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
       main_sees_FROM_S1: "s1",
       main_sees_TO_DELETE: null,
     });
-  }, 20_000);
+  });
 
   // Founding a tree replaces process.env; Bun.env is reified from the same object
   // at startup and must not be left observing the orphaned pre-swap env.

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -240,61 +240,22 @@ describe("web worker", () => {
     });
   });
 
-  test("worker with event listeners doesn't close event loop", done => {
-    const x = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), "worker-fixture-many-messages.js"],
-      env: bunEnv,
-      stdio: ["inherit", "pipe", "inherit"],
-    });
-
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
-    x.exited.then(async code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        done(new Error("exited with non-zero code"));
-      } else {
-        const text = await new Response(x.stdout).text();
-        if (!text.includes("done")) {
-          console.log({ text });
-          done(new Error("event loop killed early"));
-        } else {
-          done();
-        }
-      }
-    });
-  });
-
-  test("worker with event listeners doesn't close event loop 2", done => {
-    const x = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), "worker-fixture-many-messages2.js"],
-      env: bunEnv,
-      stdio: ["inherit", "pipe", "inherit"],
-    });
-
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
-    x.exited.then(async code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        done(new Error("exited with non-zero code"));
-      } else {
-        const text = await new Response(x.stdout).text();
-        if (!text.includes("done")) {
-          console.log({ text });
-          done(new Error("event loop killed early"));
-        } else {
-          done();
-        }
-      }
-    });
-  });
+  // A worker with a live message listener must keep the parent's event loop
+  // alive until "done"; if the loop dies early the child exits without
+  // printing it. Await the child's own exit rather than racing a wall-clock
+  // timer, which a debug/ASAN build loses.
+  test.each(["worker-fixture-many-messages.js", "worker-fixture-many-messages2.js"])(
+    "worker with event listeners doesn't close event loop (%s)",
+    async fixture => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), fixture],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "inherit"],
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect({ stdout, exitCode }).toEqual({ stdout: "done\n", exitCode: 0 });
+    },
+  );
 
   test("worker with process.exit", done => {
     const worker = new Worker(new URL("worker-fixture-process-exit.js", import.meta.url), {


### PR DESCRIPTION
Three Node compatibility fixes for `node:worker_threads` that worker pool libraries (piscina, tinypool, and by extension vitest) depend on, plus a fix for parse-error reporting.

## Repro

```js
import { Worker } from "node:worker_threads";

// 1. Error own properties lost
const w1 = new Worker(`throw Object.assign(new TypeError("boom"), {code:"EXX", extra:42});`, { eval: true });
w1.on("error", e => console.log(e.name, e.code, e.extra, Object.getOwnPropertyNames(e).sort().join(",")));
// node: TypeError EXX 42 code,extra,message,name,stack
// bun:  TypeError EXX undefined code,column,line,message,sourceURL,stack

// 2. terminate() exit code
const w2 = new Worker(`setInterval(() => {}, 1e9)`, { eval: true });
w2.on("online", () => w2.terminate().then(c => console.log(c)));   // node: 1   bun: 0

// 3. module parse errors lose every diagnostic
const w3 = new Worker("let x=1; let x=2; const y=;", { eval: true });
w3.on("error", e => console.log(e.name, JSON.stringify(e.message)));
// node: SyntaxError "Identifier 'x' has already been declared"
// bun:  Error "2 errors building \"blob:...\""   (no diagnostic, no file:line:col)
```

## Cause

**Error own properties:** `Worker::dispatchErrorWithValue` serializes the thrown value via `SerializedScriptValue::create`, whose `ErrorInstance` path follows the HTML structured-clone spec and only writes name/message/stack plus JSC's line/column/sourceURL. Any own property the user (or a Node API) put on the error, including `code`, `errno`, and custom context, is dropped, and the parent-side object exposes JSC-internal `line`/`column`/`sourceURL` own keys Node never does. Pool libraries switch on `err.code` / attached context, so error handling and logging silently degrade.

**terminate() exit code:** `WebWorker::shutdown()` reads the exit code from `vm.exit_handler.exit_code`, which nothing writes on the terminate path, so a terminated worker reported 0. Node sets the worker's exit code to 1 when `stopThread()` interrupts a running environment, which is how callers distinguish a natural exit from a kill.

**Module parse errors:** a worker module with parse errors rejects with a `BuildMessage` (one error) or an `AggregateError` of them (several). `BuildMessage` is not structured-cloneable, and the Error clone path drops `AggregateError.errors`, so the parent received `Error("N errors building ...")` with no diagnostic text, file, or position. In-process the same import yields an `AggregateError` with every diagnostic's `text` + `position`; the data exists worker-side and dies at the thread boundary.

## Fix

- `dispatchErrorWithValue` now snapshots the error's own enumerable string-keyed properties into a plain object, walks the prototype chain to materialize what Node's `internal/error_serdes.js` does (`name` from `Error.prototype`, a `code` defined on a subclass prototype), and serializes `[value, ownProps, protoDontEnumProps]`. On the parent side the tuple is unpacked, the properties are reattached with their original enumerability, and the JSC-internal `line`/`column`/`sourceURL` own properties are deleted so the own-key set matches Node's. Callables/symbols are skipped so one non-cloneable field does not force the string-message fallback; if a non-cloneable own property (WeakMap, Promise, nested function) sinks the pair, the error alone is retried so it still arrives as an `Error` instance. Non-Error thrown values round-trip unchanged inside the wrapper.
- `WebWorker` tracks `terminate_from_parent` so `shutdown()` reports exit code 1 only when the parent's `terminate()` interrupted a running worker (not when `process.exit()` or a worker-side uncaught set `requested_terminate`).
- `on_unhandled_rejection` now recognizes `BuildMessage` and `AggregateError<BuildMessage>` and replaces them with a `SyntaxError` whose message joins every diagnostic as `text (file:line:col)`, plus an enumerable `.errors` array of plain `{message, position}` objects. Both survive the own-properties serialization above, so the parent can act on each diagnostic programmatically. `ResolveMessage` (module-not-found) is left alone: it is not a syntax error and `#onError` already reshapes the entry-point case into Node's `MODULE_NOT_FOUND`.

One pair of tests in `test/js/web/workers/worker.test.ts` asserted the old timeout-racing shape and is rewritten to await the subprocess exit instead of racing a 1s wall clock that debug/ASAN builds lose.

## Verification

New tests in `test/js/node/worker_threads/worker_threads.test.ts` cover own-property preservation (custom properties, error subclass names, prototype-chain `code`, integer-indexed own properties, non-cloneable fields, WeakMap fallback), the Node own-key set (no `line`/`column`/`sourceURL`, `name` materialized as own), non-Error throws, `terminate()` exit code and concurrent-terminate semantics, and module parse-error reporting (single error, multiple errors, eval worker). All fail on the released build and pass on the debug build. `test/js/node/test/parallel/test-worker-*.js` all pass, including `test-worker-syntax-error.js` and `test-worker-syntax-error-file.js`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 20 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.0 (c8089ffda)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [11.49ms]
(pass) web worker > preload > string [146.86ms]
(pass) web worker > preload > array of 2 strings [146.17ms]
(pass) web worker > preload > array of string [140.04ms]
(pass) web worker > preload > error in preload doesn't crash parent [139.00ms]
(pass) web worker > worker [133.50ms]
(pass) web worker > worker-env [145.31ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [974.04ms]
(pass) web worker > worker-env with a lot of properties [342.38ms]
(pass) web worker > argv / execArgv defaults [143.98ms]
(pass) web worker > argv / execArgv options [149.22ms]
(pass) web worker > sending 50 messages should just work [183.80ms]
(pass) web worker > worker with event listeners doesn't close event loop (worker-fixture-many-messages.js) [523.11ms]
(pass) web worker > worker with event listeners doesn't close event 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6f634524d)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [6.98ms]
(pass) web worker > preload > string [6.18ms]
(pass) web worker > preload > array of 2 strings [5.32ms]
(pass) web worker > preload > array of string [3.76ms]
(pass) web worker > preload > error in preload doesn't crash parent [4.78ms]
(pass) web worker > worker [12.31ms]
(pass) web worker > worker-env [6.38ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [23.50ms]
(pass) web worker > worker-env with a lot of properties [5.43ms]
(pass) web worker > argv / execArgv defaults [4.79ms]
(pass) web worker > argv / execArgv options [2.86ms]
(pass) web worker > sending 50 messages should just work [6.27ms]
(pass) web worker > worker with event listeners doesn't close event loop (worker-fixture-many-messages.js) [15.83ms]
(pass) web worker > worker with event listeners doesn't close event loop (worker-fixture-many-messages2.js) [16.10ms]
(pass) web worker > worker with process.exit [18.52ms]
(pass) web worker > worker event > is fired with the right object [0.21ms]
(pass) web worker > error event > is fired with a st
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.0 (c8089ffda)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [21.03ms]
(pass) web worker > preload > string [173.33ms]
(pass) web worker > preload > array of 2 strings [194.17ms]
(pass) web worker > preload > array of string [185.95ms]
(pass) web worker > preload > error in preload doesn't crash parent [257.23ms]
(pass) web worker > worker [135.58ms]
(pass) web worker > worker-env [140.56ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1065.76ms]
(pass) web worker > worker-env with a lot of properties [390.75ms]
(pass) web worker > argv / execArgv defaults [153.13ms]
(pass) web worker > argv / execArgv options [157.22ms]
(pass) web worker > sending 50 messages should just work [186.84ms]
(pass) web worker > worker with event listeners doesn't close event loop (worker-fixture-many-messages.js) [668.13ms]
(pass) web worker > worker with event listeners doesn't close event
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 804ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen cpp.rs (cppbind)
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/Worker.cpp                | 245 ++++++++++++++--
 src/jsc/web_worker.rs                              | 138 ++++++++-
 .../worker_threads/eval-source-leak-fixture.js     |   6 +-
 test/js/node/worker_threads/worker_threads.test.ts | 309 ++++++++++++++++++++-
 test/js/web/workers/worker.test.ts                 |  71 ++---
 5 files changed, 669 insertions(+), 100 deletions(-)
```

</details>

**gate history** · 7 passed · 1 rejected · iteration 20

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/webcore/Worker.cpp                         21     41     44
src/jsc/web_worker.rs                                       16     22     44
test/js/node/worker_threads/eval-source-leak-fixture.js      1      2     45
test/js/node/worker_threads/worker_threads.test.ts           8     13     26
test/js/web/workers/worker.test.ts                           3      5     21
```

</details>

<!-- robobun:evidence:end -->