### PR TITLE
node:tls: don't emit tlsClientError for permitted-but-unverified client certs

### DIFF
--- a/src/js/node/_http2_upgrade.ts
+++ b/src/js/node/_http2_upgrade.ts
@@ -222,8 +222,8 @@ function socketHandshake(
     if (verifyError) {
       tlsSocket.authorized = false;
       tlsSocket.authorizationError = verifyError.code || verifyError.message;
-      ctx.server.emit("tlsClientError", verifyError, tlsSocket);
       if (rejectUnauthorized ?? tlsSocket._rejectUnauthorized) {
+        ctx.server.emit("tlsClientError", verifyError, tlsSocket);
         tlsSocket.emit("secure", tlsSocket);
         tlsSocket.destroy(verifyError);
         return;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -794,8 +794,8 @@ const ServerHandlers: SocketHandler<NetSocket> = {
       if (verifyError) {
         self.authorized = false;
         self.authorizationError = verifyError.code || verifyError.message;
-        server?.emit("tlsClientError", verifyError, self);
         if (self._rejectUnauthorized) {
+          server?.emit("tlsClientError", verifyError, self);
           // if we reject we still need to emit secure
           self.emit("secure", self);
           // No error argument: the socket has no 'error' listener yet, so destroy(err)

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -823,6 +823,51 @@ it("leaves socket.authorized false unless a client certificate was requested and
   }
 });
 
+it("requestCert + rejectUnauthorized:false emits only secureConnection for an unverified client cert", async () => {
+  // Node.js: when the client certificate fails verification but the server was
+  // configured to allow that (rejectUnauthorized:false), only 'secureConnection'
+  // fires with authorized:false; 'tlsClientError' is reserved for handshakes the
+  // server policy actually rejects.
+  const fixtures = join(import.meta.dir, "fixtures");
+  const agent1Key = readFileSync(join(fixtures, "agent1-key.pem"), "utf8");
+  const agent1Cert = readFileSync(join(fixtures, "agent1-cert.pem"), "utf8");
+  const ca1 = readFileSync(join(fixtures, "ca1-cert.pem"), "utf8");
+  // agent2 is self-signed (not under ca1), so the server cannot verify it.
+  const agent2Key = readFileSync(join(fixtures, "agent2-key.pem"), "utf8");
+  const agent2Cert = readFileSync(join(fixtures, "agent2-cert.pem"), "utf8");
+
+  const events: unknown[] = [];
+  const server: Server = createServer({
+    key: agent1Key,
+    cert: agent1Cert,
+    ca: [ca1],
+    requestCert: true,
+    rejectUnauthorized: false,
+  });
+  server.on("tlsClientError", (err: NodeJS.ErrnoException) => {
+    events.push(["tlsClientError", err.code ?? err.message]);
+  });
+  server.on("secureConnection", socket => {
+    events.push(["secureConnection", { authorized: socket.authorized, authorizationError: socket.authorizationError }]);
+    socket.end();
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const { port } = server.address() as AddressInfo;
+  const client = connect({ port, host: "127.0.0.1", key: agent2Key, cert: agent2Cert, rejectUnauthorized: false });
+  client.on("error", () => {});
+  try {
+    await once(client, "close");
+    expect(events).toEqual([
+      ["secureConnection", { authorized: false, authorizationError: "DEPTH_ZERO_SELF_SIGNED_CERT" }],
+    ]);
+  } finally {
+    client.destroy();
+    server.close();
+  }
+});
+
 it("createServer({pfx, requestCert}) verifies client certificates against the pfx-embedded CA", async () => {
   // agent1.pfx bundles agent1's key/cert plus ca1; a server built from it must
   // be able to verify a client certificate signed by that embedded CA.


### PR DESCRIPTION
## What

With `{requestCert: true, rejectUnauthorized: false}` a `tls.Server` asks the client for a certificate but explicitly admits connections whose certificate fails verification, exposing the result through `socket.authorized` / `socket.authorizationError` so the application can decide what to do. This is the standard "optional mTLS" / "decide in the handler" configuration.

Bun was emitting `tlsClientError` with the verification error **and then also** emitting `secureConnection` for the same socket. Node emits only `secureConnection` with `authorized: false` in this configuration; `tlsClientError` is reserved for handshakes the server policy actually rejects.

Application code that (reasonably) treats `tlsClientError` as fatal would tear down connections that were explicitly configured to be allowed, and error monitoring would see phantom TLS failures for every optional-cert client.

## Reproduction

```js
import tls from "node:tls";
// server: requestCert:true, rejectUnauthorized:false, trusts ca1
// client: presents a self-signed cert (not under ca1)
const events = [];
server.on("tlsClientError", err => events.push(["tlsClientError", err.code]));
server.on("secureConnection", s => events.push(["secureConnection", { authorized: s.authorized, authorizationError: s.authorizationError }]));
```

Node:
```
[["secureConnection",{"authorized":false,"authorizationError":"DEPTH_ZERO_SELF_SIGNED_CERT"}]]
```

Bun before:
```
[["tlsClientError","DEPTH_ZERO_SELF_SIGNED_CERT"],["secureConnection",{"authorized":false,"authorizationError":"DEPTH_ZERO_SELF_SIGNED_CERT"}]]
```

## Fix

The server-side handshake handler in `src/js/node/net.ts` emitted `tlsClientError` unconditionally before checking `_rejectUnauthorized`. Move that emit inside the `_rejectUnauthorized` branch so a permitted-but-unverified client reaches `secureConnection` without a spurious error event. The mirrored handshake handler in `src/js/node/_http2_upgrade.ts` had the same shape and is fixed the same way.

The `rejectUnauthorized: true` path is unchanged: a failing client certificate still produces `tlsClientError` (carrying the verification error) and the connection is dropped before `secureConnection`.

## Verification

New test in `test/js/node/tls/node-tls-server.test.ts` records the exact event sequence for `{requestCert:true, rejectUnauthorized:false}` with a self-signed client cert and asserts only `secureConnection` fires. Fails on current `main` with the extra `tlsClientError` entry; passes with the fix. The existing `rejects an unverifiable client certificate by default when requestCert is true` test in `node-tls-cert.test.ts` continues to pass, confirming the reject path still emits `tlsClientError`.