### PR TITLE
expect: fix toBeCloseTo opposite-sign Infinity and toMatchObject Date/Error/Set/Map leaves

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1630,6 +1630,23 @@ bool Bun__deepMatch(
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();
 
+    // Jest's subsetEquality only recurses into plain key-bearing objects on the
+    // subset side. Date, Error, Set and Map are compared with deep equals; two
+    // unequal Dates have no enumerable own properties and would otherwise
+    // vacuously match.
+    switch (subsetObj->type()) {
+    case JSDateType:
+    case ErrorInstanceType:
+    case JSSetType:
+    case JSMapType: {
+        Vector<std::pair<JSValue, JSValue>, 16> stack;
+        MarkedArgumentBuffer args;
+        RELEASE_AND_RETURN(throwScope, (Bun__deepEquals<false, enableAsymmetricMatchers>(globalObject, objValue, subsetValue, args, stack, throwScope, true)));
+    }
+    default:
+        break;
+    }
+
     PropertyNameArrayBuilder subsetProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
     subsetObj->getPropertyNames(globalObject, subsetProps, DontEnumPropertiesMode::Exclude);
     RETURN_IF_EXCEPTION(throwScope, false);

--- a/src/runtime/test_runner/expect/toBeCloseTo.rs
+++ b/src/runtime/test_runner/expect/toBeCloseTo.rs
@@ -45,24 +45,19 @@ impl Expect {
             return Err(global.throw_invalid_argument_type("expect", "received", "number"));
         }
 
-        let mut expected = expected_.as_number();
-        let mut received = received_.as_number();
-
-        if expected == f64::NEG_INFINITY {
-            expected = -expected;
-        }
-
-        if received == f64::NEG_INFINITY {
-            received = -received;
-        }
-
-        if expected == f64::INFINITY && received == f64::INFINITY {
-            return Ok(JSValue::UNDEFINED);
-        }
+        let expected = expected_.as_number();
+        let received = received_.as_number();
 
         let expected_diff = 10.0_f64.powf(-precision) / 2.0;
         let actual_diff = (received - expected).abs();
-        let mut pass = actual_diff < expected_diff;
+        // Infinity - Infinity and (-Infinity) - (-Infinity) are NaN, so the
+        // difference comparison would never pass. Match jest: two infinities
+        // of the same sign are "close"; opposite signs (or one finite) are not.
+        let mut pass = if received.is_infinite() && expected.is_infinite() {
+            received == expected
+        } else {
+            actual_diff < expected_diff
+        };
 
         let not = this.flags.get().not();
         if not {

--- a/src/runtime/test_runner/expect/toBeCloseTo.rs
+++ b/src/runtime/test_runner/expect/toBeCloseTo.rs
@@ -48,16 +48,18 @@ impl Expect {
         let expected = expected_.as_number();
         let received = received_.as_number();
 
-        let expected_diff = 10.0_f64.powf(-precision) / 2.0;
-        let actual_diff = (received - expected).abs();
         // Infinity - Infinity and (-Infinity) - (-Infinity) are NaN, so the
         // difference comparison would never pass. Match jest: two infinities
-        // of the same sign are "close"; opposite signs (or one finite) are not.
-        let mut pass = if received.is_infinite() && expected.is_infinite() {
-            received == expected
-        } else {
-            actual_diff < expected_diff
-        };
+        // of the same sign are "close" and report a zero diff; opposite signs
+        // go through the normal diff computation (|Inf - -Inf| is Inf).
+        let (expected_diff, actual_diff, mut pass) =
+            if received.is_infinite() && received == expected {
+                (0.0, 0.0, true)
+            } else {
+                let expected_diff = 10.0_f64.powf(-precision) / 2.0;
+                let actual_diff = (received - expected).abs();
+                (expected_diff, actual_diff, actual_diff < expected_diff)
+            };
 
         let not = this.flags.get().not();
         if not {
@@ -101,12 +103,25 @@ impl Expect {
         // SUFFIX_FMT into the `format_args!` call (or make `throw!` a macro).
         if not {
             let signature = get_signature("toBeCloseTo", "<green>expected<r>, precision", true);
+            // Jest omits the precision/difference block when the received
+            // difference is 0 (exact match or same-sign infinities).
+            if actual_diff == 0.0 {
+                return this.throw_fmt(
+                    global,
+                    signature,
+                    SUFFIX_FMT,
+                    format_args!(
+                        "\n\nExpected: not <green>{}<r>\nReceived: <red>{}<r>\n",
+                        expected_fmt, received_fmt
+                    ),
+                );
+            }
             return this.throw_fmt(
                 global,
                 signature,
                 SUFFIX_FMT,
                 format_args!(
-                    "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n\nExpected precision: {}\nExpected difference: \\< <green>{}<r>\nReceived difference: <red>{}<r>\n",
+                    "\n\nExpected: not <green>{}<r>\nReceived: <red>{}<r>\n\nExpected precision: {}\nExpected difference: not \\< <green>{}<r>\nReceived difference: <red>{}<r>\n",
                     expected_fmt, received_fmt, precision, expected_diff, actual_diff
                 ),
             );

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3528,6 +3528,80 @@ describe("expect()", () => {
       expect(a1).not.toMatchObject({ 1: 1 });
       expect(a1).toMatchObject(a1);
     });
+
+    // Jest's subsetEquality treats Date/Error/Set/Map on the expected side as
+    // leaf values compared with equals(), not recursed into by key.
+    test("Date/Error/Set/Map leaf values are compared, not subset-matched", () => {
+      expect({ d: new Date(5) }).toMatchObject({ d: new Date(5) });
+      expect({ d: new Date(5) }).not.toMatchObject({ d: new Date(6) });
+      expect({ a: { d: new Date(5) } }).toMatchObject({ a: { d: new Date(5) } });
+      expect({ a: { d: new Date(5) } }).not.toMatchObject({ a: { d: new Date(6) } });
+      expect({ a: [new Date(5)] }).toMatchObject({ a: [new Date(5)] });
+      expect({ a: [new Date(5)] }).not.toMatchObject({ a: [new Date(6)] });
+      expect({ d: { x: 1 } }).not.toMatchObject({ d: new Date(5) });
+      expect({ d: new Date(5) }).not.toMatchObject({ d: { x: 1 } });
+
+      expect({ e: new Error("x") }).toMatchObject({ e: new Error("x") });
+      expect({ e: new Error("x") }).not.toMatchObject({ e: new Error("y") });
+      expect({ e: new TypeError("x") }).not.toMatchObject({ e: new Error("y") });
+
+      expect({ s: new Set([1, 2]) }).toMatchObject({ s: new Set([1, 2]) });
+      expect({ s: new Set([1, 2]) }).not.toMatchObject({ s: new Set([1, 3]) });
+      expect({ s: new Set([1, 2, 3]) }).not.toMatchObject({ s: new Set([1, 2]) });
+
+      expect({ m: new Map([[1, 2]]) }).toMatchObject({ m: new Map([[1, 2]]) });
+      expect({ m: new Map([[1, 2]]) }).not.toMatchObject({ m: new Map([[1, 3]]) });
+
+      expect(new Date(5)).toMatchObject(new Date(5));
+      expect(new Date(5)).not.toMatchObject(new Date(6));
+      expect(new Set([1])).toMatchObject(new Set([1]));
+      expect(new Set([1])).not.toMatchObject(new Set([2]));
+    });
+
+    if (isBun) {
+      test("Bun.deepMatch Date/Error/Set/Map leaf values", () => {
+        expect(Bun.deepMatch({ d: new Date(5) }, { d: new Date(5) })).toBe(true);
+        expect(Bun.deepMatch({ d: new Date(5) }, { d: new Date(6) })).toBe(false);
+        expect(Bun.deepMatch({ e: new Error("x") }, { e: new Error("x") })).toBe(true);
+        expect(Bun.deepMatch({ e: new Error("x") }, { e: new Error("y") })).toBe(false);
+        expect(Bun.deepMatch({ s: new Set([1, 2]) }, { s: new Set([1, 2]) })).toBe(true);
+        expect(Bun.deepMatch({ s: new Set([1, 2]) }, { s: new Set([1, 3]) })).toBe(false);
+        expect(Bun.deepMatch({ m: new Map([[1, 2]]) }, { m: new Map([[1, 2]]) })).toBe(true);
+        expect(Bun.deepMatch({ m: new Map([[1, 2]]) }, { m: new Map([[1, 3]]) })).toBe(false);
+      });
+    }
+  });
+
+  describe("toBeCloseTo()", () => {
+    it.each([
+      [0, 0],
+      [0, 0.001],
+      [1.23, 1.229],
+      [1.23, 1.226],
+      [1.23, 1.225],
+      [1.23, 1.234],
+      [Infinity, Infinity],
+      [-Infinity, -Infinity],
+    ])("expect(%p).toBeCloseTo(%p)", (a, b) => {
+      expect(a).toBeCloseTo(b);
+      expect(b).toBeCloseTo(a);
+      expect(() => expect(a).not.toBeCloseTo(b)).toThrow();
+      expect(() => expect(b).not.toBeCloseTo(a)).toThrow();
+    });
+
+    it.each([
+      [Infinity, -Infinity],
+      [-Infinity, Infinity],
+      [Infinity, 1.23],
+      [-Infinity, -1.23],
+      [0, 0.01],
+      [1, 1.23],
+    ])("expect(%p).not.toBeCloseTo(%p)", (a, b) => {
+      expect(a).not.toBeCloseTo(b);
+      expect(b).not.toBeCloseTo(a);
+      expect(() => expect(a).toBeCloseTo(b)).toThrow();
+      expect(() => expect(b).toBeCloseTo(a)).toThrow();
+    });
   });
 
   describe("toMatch()", () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3602,6 +3602,18 @@ describe("expect()", () => {
       expect(() => expect(a).toBeCloseTo(b)).toThrow();
       expect(() => expect(b).toBeCloseTo(a)).toThrow();
     });
+
+    test(".not failure on same-sign Infinity has no NaN in the message", () => {
+      let err;
+      try {
+        expect(Infinity).not.toBeCloseTo(Infinity);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeDefined();
+      expect(String(err.message)).not.toContain("NaN");
+      expect(String(err.message)).toContain("Expected: not ");
+    });
   });
 
   describe("toMatch()", () => {


### PR DESCRIPTION
Fixes #15673

Two jest-compat false-greens in `bun:test` matchers: assertions that pass under `bun test` but fail the same test under jest 30.

### `toBeCloseTo` opposite-sign Infinity

```js
expect(-Infinity).toBeCloseTo(Infinity)          // bun: pass, jest: fail
expect(Infinity).not.toBeCloseTo(Infinity)       // bun: pass, jest: fail
```

`toBeCloseTo` normalized `-Infinity` to `Infinity` on both sides before the `both infinite → close` check, so opposite-sign infinities matched. The early return that followed also bypassed the `.not` flag entirely. The `expect.closeTo` asymmetric matcher already had the correct per-sign check; this makes the direct matcher match it (and jest): two infinities are close only if they are the same sign, and the result goes through the normal `.not` inversion.

### `toMatchObject` Date/Error/Set/Map leaves

```js
expect({ d: new Date(5) }).toMatchObject({ d: new Date(6) })    // bun: pass, jest: fail
expect({ s: new Set([1]) }).toMatchObject({ s: new Set([2]) })  // bun: pass, jest: fail
expect(new Date(5)).toMatchObject(new Date(6))                  // bun: pass, jest: fail
```

`Bun__deepMatch` recursed into any pair of objects by enumerable key. `Date`, `Error`, `Set`, and `Map` have no own enumerable properties, so the subset loop was vacuous and any two instances matched. Jest's `subsetEquality` [excludes these](https://github.com/jestjs/jest/blob/main/packages/expect-utils/src/utils.ts) via `isObjectWithKeys` and falls through to `equals()` for them.

Added the same guard at the top of `Bun__deepMatch`: when the subset side is one of these four types, route through `Bun__deepEquals<false, enableAsymmetricMatchers>` instead of key enumeration. This reaches every caller of the shared engine: `toMatchObject`, `toMatchSnapshot`/`toMatchInlineSnapshot` property matchers, `expect.objectContaining`, and `Bun.deepMatch`.

### Verification

Every new assertion in `expect.test.js` was cross-checked against jest 30 (all pass there).

```
# fail-before
USE_SYSTEM_BUN=1 bun test test/js/bun/test/expect.test.js -t "toBeCloseTo\(\)"
  4 fail (Infinity/-Infinity + .not)
USE_SYSTEM_BUN=1 bun test test/js/bun/test/expect.test.js -t "Date/Error/Set/Map leaf"
  2 fail

# fail-after
bun bd test test/js/bun/test/expect.test.js -t "toBeCloseTo\(\)"
  14 pass, 0 fail
bun bd test test/js/bun/test/expect.test.js -t "Date/Error/Set/Map leaf"
  2 pass, 0 fail
bun bd test test/js/bun/test/expect.test.js -t "toMatchObject"
  7 pass, 0 fail
```

Full `expect.test.js` run: 413 pass; the one pre-existing `deepEquals Set/Map stress test` debug-build timeout reproduces on main without this diff (also noted in #32311).

### Not in this PR

The same differential turned up three further false-greens that touch different subsystems and belong in separate PRs: `toThrow` comparing `Error#cause`, `expect.assertions(-1)` throwing synchronously, and `.rejects.toThrow` on a non-Error rejection.

Routing Set/Map through `deepEquals` is stricter than jest for one edge: a plain-object Set element or Map value with extra keys on the received side (`expect({s: new Set([{a:1, b:2}])}).toMatchObject({s: new Set([{a:1}])})` passes in jest because `iterableEquality` threads `subsetEquality` into element comparison). That needs a subset-aware Set/Map iterator with any-to-any element matching and belongs in a follow-up; this PR closes the false-green, which is the more important direction.
