### PR TITLE
node:crypto: support X9.62 hybrid point format in ECDH

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -3690,6 +3690,20 @@ bool ECPointPointer::setFromBuffer(const Buffer<const unsigned char>& buffer,
     const EC_GROUP* group)
 {
     if (!point_) return false;
+    // BoringSSL does not decode the X9.62 hybrid form (0x06/0x07). Hybrid is
+    // the uncompressed encoding with a redundant y-parity bit, so rewrite the
+    // prefix to 0x04 and verify the parity bit matches the encoded Y.
+    if (buffer.len > 0 && (buffer.data[0] & ~1u) == POINT_CONVERSION_HYBRID) {
+        size_t field_len = (EC_GROUP_get_degree(group) + 7) / 8;
+        if (buffer.len != 1 + 2 * field_len) return false;
+        if ((buffer.data[0] & 1) != (buffer.data[buffer.len - 1] & 1)) return false;
+        WTF::Vector<uint8_t, 256> tmp;
+        if (!tmp.tryGrow(buffer.len)) return false;
+        memcpy(tmp.begin(), buffer.data, buffer.len);
+        tmp[0] = POINT_CONVERSION_UNCOMPRESSED;
+        return EC_POINT_oct2point(
+            group, point_.get(), tmp.begin(), tmp.size(), nullptr);
+    }
     return EC_POINT_oct2point(
         group, point_.get(), buffer.data, buffer.len, nullptr);
 }

--- a/src/jsc/bindings/node/crypto/JSECDH.cpp
+++ b/src/jsc/bindings/node/crypto/JSECDH.cpp
@@ -55,6 +55,19 @@ point_conversion_form_t JSECDH::getFormat(JSC::JSGlobalObject* globalObject, JSC
     return POINT_CONVERSION_UNCOMPRESSED;
 }
 
+// BoringSSL's EC_POINT_point2oct does not implement POINT_CONVERSION_HYBRID.
+// Hybrid is the uncompressed layout (0x04 || X || Y) with the prefix replaced
+// by 0x06|y_bit, so encode as uncompressed and fix up the leading byte.
+size_t JSECDH::pointToBuffer(const EC_GROUP* group, const EC_POINT* point, point_conversion_form_t form, uint8_t* buf, size_t len)
+{
+    point_conversion_form_t effective = form == POINT_CONVERSION_HYBRID ? POINT_CONVERSION_UNCOMPRESSED : form;
+    size_t written = EC_POINT_point2oct(group, point, effective, buf, len, nullptr);
+    if (form == POINT_CONVERSION_HYBRID && buf != nullptr && written > 0) {
+        buf[0] = static_cast<uint8_t>(POINT_CONVERSION_HYBRID | (buf[written - 1] & 1));
+    }
+    return written;
+}
+
 EncodedJSValue JSECDH::getPublicKey(JSGlobalObject* globalObject, ThrowScope& scope, JSValue encodingValue, JSValue formatValue)
 {
     point_conversion_form_t form = JSECDH::getFormat(globalObject, scope, formatValue);
@@ -69,7 +82,7 @@ EncodedJSValue JSECDH::getPublicKey(JSGlobalObject* globalObject, ThrowScope& sc
     }
 
     // Calculate the length needed for the result
-    size_t bufLen = EC_POINT_point2oct(group, pubKey, form, nullptr, 0, nullptr);
+    size_t bufLen = JSECDH::pointToBuffer(group, pubKey, form, nullptr, 0);
     if (bufLen == 0) {
         throwError(globalObject, scope, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "Failed to determine size for public key encoding"_s);
         return {};
@@ -83,7 +96,7 @@ EncodedJSValue JSECDH::getPublicKey(JSGlobalObject* globalObject, ThrowScope& sc
     }
 
     // Encode the point to the buffer
-    if (EC_POINT_point2oct(group, pubKey, form, static_cast<unsigned char*>(result->data()), bufLen, nullptr) == 0) {
+    if (JSECDH::pointToBuffer(group, pubKey, form, static_cast<unsigned char*>(result->data()), bufLen) == 0) {
         throwError(globalObject, scope, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "Failed to encode public key"_s);
         return {};
     }

--- a/src/jsc/bindings/node/crypto/JSECDH.h
+++ b/src/jsc/bindings/node/crypto/JSECDH.h
@@ -50,6 +50,7 @@ public:
     JSC::EncodedJSValue getPublicKey(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSValue encodingValue, JSC::JSValue formatValue);
 
     static point_conversion_form_t getFormat(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSValue formatValue);
+    static size_t pointToBuffer(const EC_GROUP* group, const EC_POINT* point, point_conversion_form_t form, uint8_t* buf, size_t len);
 
 private:
     JSECDH(JSC::VM& vm, JSC::Structure* structure, ncrypto::ECKeyPointer&& key, const EC_GROUP* group)

--- a/src/jsc/bindings/node/crypto/JSECDHConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSECDHConstructor.cpp
@@ -118,7 +118,7 @@ JSC_DEFINE_HOST_FUNCTION(jsECDHConvertKey, (JSC::JSGlobalObject * lexicalGlobalO
         return Bun::ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "Failed to convert Buffer to EC_POINT"_s);
     }
 
-    size_t size = EC_POINT_point2oct(group, point, form, nullptr, 0, nullptr);
+    size_t size = JSECDH::pointToBuffer(group, point, form, nullptr, 0);
     if (size == 0) {
         return ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "Failed to get public key length"_s);
     }
@@ -129,7 +129,7 @@ JSC_DEFINE_HOST_FUNCTION(jsECDHConvertKey, (JSC::JSGlobalObject * lexicalGlobalO
         return {};
     }
 
-    if (!EC_POINT_point2oct(group, point, form, buf.begin(), buf.size(), nullptr)) {
+    if (!JSECDH::pointToBuffer(group, point, form, buf.begin(), buf.size())) {
         return ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "Failed to get public key"_s);
     }
 

--- a/test/js/node/crypto/ecdh.test.ts
+++ b/test/js/node/crypto/ecdh.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { createECDH, ECDH, getCurves } from "node:crypto";
 
 // Helper function to generate test key pairs for various curves
@@ -265,4 +265,108 @@ test("ECDH - computeSecret throws when only a public key is set (no private key)
   expect(carolSecret).toBeInstanceOf(Buffer);
   expect(carolSecret.length).toBeGreaterThan(0);
   expect(carolSecret.toString("hex")).toBe(aliceSecret.toString("hex"));
+});
+
+describe("ECDH hybrid point format", () => {
+  // X9.62 hybrid: prefix 0x06|y_bit, followed by X || Y (same layout as uncompressed 0x04).
+  // Known-good P-256 hybrid point emitted by Node.js (prefix 0x07 => y is odd).
+  const knownHybrid =
+    "0710fc112b0b2d57a701d22b1dc7f9aad0d66dd8ab6eaf71e0e6531ba136f4f14072ff13402beadb679e9d9636600f806070f22ad44b23ac0e2a75cd605c9e4d8f";
+  const knownUncompressed = "04" + knownHybrid.slice(2);
+  const knownCompressed = "03" + knownHybrid.slice(2, 66);
+
+  test.each(["prime256v1", "secp384r1", "secp521r1"])("getPublicKey/generateKeys emit hybrid on %s", curve => {
+    const ecdh = createECDH(curve);
+    const gen = ecdh.generateKeys(undefined, "hybrid");
+    const hyb = ecdh.getPublicKey(undefined, "hybrid");
+    const unc = ecdh.getPublicKey(undefined, "uncompressed");
+
+    expect(gen.equals(hyb)).toBe(true);
+    expect(hyb.length).toBe(unc.length);
+    expect(unc[0]).toBe(0x04);
+    // Hybrid prefix is 0x06 | (Y's least-significant bit).
+    expect(hyb[0]).toBe(0x06 | (unc[unc.length - 1] & 1));
+    // Coordinates after the prefix byte are identical.
+    expect(hyb.subarray(1).equals(unc.subarray(1))).toBe(true);
+  });
+
+  test("ECDH.convertKey round-trips hybrid with a known vector", () => {
+    expect(ECDH.convertKey(knownHybrid, "prime256v1", "hex", "hex", "uncompressed")).toBe(knownUncompressed);
+    expect(ECDH.convertKey(knownHybrid, "prime256v1", "hex", "hex", "compressed")).toBe(knownCompressed);
+    expect(ECDH.convertKey(knownHybrid, "prime256v1", "hex", "hex", "hybrid")).toBe(knownHybrid);
+    expect(ECDH.convertKey(knownUncompressed, "prime256v1", "hex", "hex", "hybrid")).toBe(knownHybrid);
+    expect(ECDH.convertKey(knownCompressed, "prime256v1", "hex", "hex", "hybrid")).toBe(knownHybrid);
+  });
+
+  test.each(["prime256v1", "secp384r1", "secp521r1"])("ECDH.convertKey round-trips hybrid on %s", curve => {
+    const ecdh = createECDH(curve);
+    ecdh.generateKeys();
+    const unc = ecdh.getPublicKey("hex", "uncompressed");
+    const cmp = ecdh.getPublicKey("hex", "compressed");
+    const hyb = ecdh.getPublicKey("hex", "hybrid");
+
+    expect(ECDH.convertKey(unc, curve, "hex", "hex", "hybrid")).toBe(hyb);
+    expect(ECDH.convertKey(cmp, curve, "hex", "hex", "hybrid")).toBe(hyb);
+    expect(ECDH.convertKey(hyb, curve, "hex", "hex", "uncompressed")).toBe(unc);
+    expect(ECDH.convertKey(hyb, curve, "hex", "hex", "compressed")).toBe(cmp);
+    expect(ECDH.convertKey(hyb, curve, "hex", "hex", "hybrid")).toBe(hyb);
+  });
+
+  test("computeSecret and setPublicKey accept a hybrid-encoded peer key", () => {
+    const bob = createECDH("prime256v1");
+    bob.generateKeys();
+    const fromHybrid = bob.computeSecret(knownHybrid, "hex");
+    const fromUncompressed = bob.computeSecret(knownUncompressed, "hex");
+    expect(fromHybrid.equals(fromUncompressed)).toBe(true);
+    expect(fromHybrid.length).toBe(32);
+
+    const carol = createECDH("prime256v1");
+    carol.generateKeys();
+    carol.setPublicKey(knownHybrid, "hex");
+    expect(carol.getPublicKey("hex", "uncompressed")).toBe(knownUncompressed);
+    expect(carol.getPublicKey("hex", "hybrid")).toBe(knownHybrid);
+  });
+
+  test.each(["prime256v1", "secp384r1", "secp521r1"])(
+    "computeSecret agrees when the peer key is hybrid on %s",
+    curve => {
+      const alice = createECDH(curve);
+      const bob = createECDH(curve);
+      alice.generateKeys();
+      bob.generateKeys();
+
+      const aliceHybrid = alice.getPublicKey(undefined, "hybrid");
+      const bobHybrid = bob.getPublicKey(undefined, "hybrid");
+
+      const aliceSecret = alice.computeSecret(bobHybrid);
+      const bobSecret = bob.computeSecret(aliceHybrid);
+      const reference = alice.computeSecret(bob.getPublicKey());
+
+      expect(aliceSecret.equals(bobSecret)).toBe(true);
+      expect(aliceSecret.equals(reference)).toBe(true);
+    },
+  );
+
+  test("rejects hybrid input whose y-parity bit does not match Y", () => {
+    // knownHybrid has prefix 0x07 (y odd); 0x06 with the same coordinates is invalid.
+    const badHybrid = "06" + knownHybrid.slice(2);
+    expect(() => ECDH.convertKey(badHybrid, "prime256v1", "hex", "hex", "uncompressed")).toThrow(
+      expect.objectContaining({ code: "ERR_CRYPTO_OPERATION_FAILED" }),
+    );
+
+    const bob = createECDH("prime256v1");
+    bob.generateKeys();
+    expect(() => bob.computeSecret(badHybrid, "hex")).toThrow(
+      expect.objectContaining({ code: "ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY" }),
+    );
+  });
+
+  test("rejects hybrid input with wrong length", () => {
+    // Valid hybrid prefix but truncated body.
+    const truncated = Buffer.from(knownHybrid, "hex").subarray(0, 33);
+    expect(truncated[0]).toBe(0x07);
+    expect(() => ECDH.convertKey(truncated, "prime256v1", null, "hex", "uncompressed")).toThrow(
+      expect.objectContaining({ code: "ERR_CRYPTO_OPERATION_FAILED" }),
+    );
+  });
 });


### PR DESCRIPTION
## What does this PR do?

BoringSSL's `EC_POINT_point2oct`/`EC_POINT_oct2point` do not implement `POINT_CONVERSION_HYBRID` (the enum value exists, but the implementation in `oct.cc.inc` only accepts compressed and uncompressed). OpenSSL, which Node.js links against, supports it. As a result every ECDH path touching the hybrid format failed:

```js
import * as crypto from "node:crypto";
const a = crypto.createECDH("prime256v1"); a.generateKeys();
a.getPublicKey("hex", "hybrid");
// bun:  ERR_CRYPTO_OPERATION_FAILED Failed to determine size for public key encoding
// node: 0699aa4fc205b7b3...

const hyb = "0710fc112b0b2d57a701d22b1dc7f9aad0d66dd8ab6eaf71e0e6531ba136f4f14072ff13402beadb679e9d9636600f806070f22ad44b23ac0e2a75cd605c9e4d8f";
const b = crypto.createECDH("prime256v1"); b.generateKeys();
b.computeSecret(hyb, "hex");
// bun:  ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY Public key is not valid for specified curve
// node: <Buffer ...>
```

`ECDH.convertKey` to or from `"hybrid"` and `setPublicKey` with a hybrid-encoded key threw the same way.

## Fix

The X9.62 hybrid encoding is the uncompressed layout (`0x04 || X || Y`) with the prefix byte replaced by `0x06 | (Y & 1)`. So:

* **Input** (`ECPointPointer::setFromBuffer`, shared by `computeSecret`, `setPublicKey`, `ECDH.convertKey`): on a `0x06`/`0x07` prefix, verify the length is `1 + 2*field_len` and that the y-parity bit in the prefix matches the least significant bit of Y (OpenSSL enforces this too), then hand BoringSSL the same bytes with the prefix rewritten to `0x04`.
* **Output** (new `JSECDH::pointToBuffer`, shared by `getPublicKey`, `generateKeys`, `ECDH.convertKey`): encode as uncompressed and fix up the prefix byte.

## How did you verify your code works?

New tests in `test/js/node/crypto/ecdh.test.ts` cover `getPublicKey`/`generateKeys`/`convertKey`/`computeSecret`/`setPublicKey` in hybrid form on prime256v1/secp384r1/secp521r1, a known-good hybrid vector produced by Node.js, and rejection of a mismatched y-parity bit and a truncated body. All 27 tests pass with the change; 11 of them throw on the released binary.