### PR TITLE
child_process: forward detached option in spawnSync

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -566,6 +566,7 @@ function spawnSync(file, args, options) {
       env: options[kBunEnv] || options.env || undefined,
       cwd: options.cwd || undefined,
       stdio: bunStdio,
+      detached: options.detached,
       windowsVerbatimArguments: options.windowsVerbatimArguments,
       windowsHide: options.windowsHide,
       argv0: options.args[0],

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -355,16 +355,16 @@ describe("spawnSync()", () => {
     expect(isValidSemver(stdout.trim())).toBe(true);
   });
 
-  it.if(!isWindows)("detached: true starts the child in a new process group", () => {
-    const pgidOf = (detached: boolean) =>
-      spawnSync("sh", ["-c", "ps -o pgid= -p $$"], { detached, encoding: "utf8" }).stdout.trim();
-    const parentPgid = spawnSync("ps", ["-o", "pgid=", "-p", String(process.pid)], {
-      encoding: "utf8",
-    }).stdout.trim();
+  it.if(isLinux)("detached: true starts the child in a new process group", () => {
+    // /proc/self/stat field 5 is pgrp; parse after the last ')' since comm may contain spaces.
+    const pgrp = (stat: string) => stat.slice(stat.lastIndexOf(")") + 2).split(" ")[2];
+    const childPgid = (detached: boolean) =>
+      pgrp(spawnSync("cat", ["/proc/self/stat"], { detached, encoding: "utf8" }).stdout);
+    const parentPgid = pgrp(fs.readFileSync("/proc/self/stat", "utf8"));
 
     expect(parentPgid).toMatch(/^\d+$/);
-    expect(pgidOf(false)).toBe(parentPgid);
-    const detachedPgid = pgidOf(true);
+    expect(childPgid(false)).toBe(parentPgid);
+    const detachedPgid = childPgid(true);
     expect(detachedPgid).toMatch(/^\d+$/);
     expect(detachedPgid).not.toBe(parentPgid);
   });

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -354,6 +354,20 @@ describe("spawnSync()", () => {
     const { stdout } = spawnSync("bun", ["-v"], { encoding: "utf8" });
     expect(isValidSemver(stdout.trim())).toBe(true);
   });
+
+  it.if(!isWindows)("detached: true starts the child in a new process group", () => {
+    const pgidOf = (detached: boolean) =>
+      spawnSync("sh", ["-c", "ps -o pgid= -p $$"], { detached, encoding: "utf8" }).stdout.trim();
+    const parentPgid = spawnSync("ps", ["-o", "pgid=", "-p", String(process.pid)], {
+      encoding: "utf8",
+    }).stdout.trim();
+
+    expect(parentPgid).toMatch(/^\d+$/);
+    expect(pgidOf(false)).toBe(parentPgid);
+    const detachedPgid = pgidOf(true);
+    expect(detachedPgid).toMatch(/^\d+$/);
+    expect(detachedPgid).not.toBe(parentPgid);
+  });
 });
 
 describe("execFileSync()", () => {


### PR DESCRIPTION
## Repro

```js
import { spawnSync } from "node:child_process";

const parentPgid = spawnSync("ps", ["-o", "pgid=", "-p", String(process.pid)]).stdout.toString().trim();
for (const detached of [false, true]) {
  const pgid = spawnSync("sh", ["-c", "ps -o pgid= -p $$"], { detached }).stdout.toString().trim();
  console.log(`detached=${detached} sameAsParent=${pgid === parentPgid}`);
}
```

Node:
```
detached=false sameAsParent=true
detached=true sameAsParent=false
```

Bun (before):
```
detached=false sameAsParent=true
detached=true sameAsParent=true
```

## Cause

`normalizeSpawnArguments` validates `options.detached` and returns it, and the async `ChildProcess#spawn` path forwards it to `Bun.spawn`. But `spawnSync()` builds its `Bun.spawnSync` options object without copying `detached` across, so the child stays in the parent's process group and session regardless of the option. `Bun.spawnSync({detached: true})` itself already calls `setsid()` correctly; only the `node:child_process` glue for the sync path drops it.

This matters because anything relying on detached semantics, like killing the child's whole process group with `kill(-pid)` or having the child survive the parent's terminal signals, silently gets non-detached behaviour. `kill(-pid)` aimed at the child's group lands on the parent's group.

## Fix

Forward `options.detached` to `Bun.spawnSync`, matching what the async path already does.

## Verification

New test in `test/js/node/child_process/child_process.test.ts` spawns with `detached: false` and `detached: true` and asserts the child's pgid equals the parent's only in the first case.

- Fails on current release (`USE_SYSTEM_BUN=1 bun test`): `expect("887").not.toBe("887")`
- Passes with the fix (`bun bd test`)