### PR TITLE
node:dns: invoke lookup callback with only the error on failure

### DIFF
--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -333,7 +333,7 @@ function lookup(hostname, options, callback) {
         err.hostname = hostname;
         err.message = `${syscall} ${err.code} ${hostname}`;
       }
-      callback(err, undefined, undefined);
+      callback(err);
     });
 }
 

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -308,6 +308,28 @@ test("dns.lookup bad (qedjp3f4q4jgjh4d6vaf3fd2hbfhg6upt2bscrfe.com)", () => {
   return promise;
 });
 
+test.each([
+  ["default", undefined],
+  ["{ all: true }", { all: true }],
+])("dns.lookup error callback is invoked with exactly one argument (%s)", (_, options) => {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const cb = function (err) {
+    try {
+      expect(arguments.length).toBe(1);
+      expect(err).toBeInstanceOf(Error);
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
+  };
+  if (options === undefined) {
+    dns.lookup("does-not-exist-zz.invalid", cb);
+  } else {
+    dns.lookup("does-not-exist-zz.invalid", options, cb);
+  }
+  return promise;
+});
+
 test("dns.lookup (example.com) with { all: true } #2675", () => {
   const { promise, resolve, reject } = Promise.withResolvers();
   dns.lookup("example.com", { all: true }, (err, address, family) => {


### PR DESCRIPTION
## Problem

When `dns.lookup()` fails, Node.js invokes the callback with exactly one argument: `callback(err)`. Bun was invoking it with three: `callback(err, undefined, undefined)`.

```js
import * as dns from "node:dns";
dns.lookup("does-not-exist-zz.invalid", function () {
  console.log(arguments.length + " args, err.code=" + arguments[0]?.code);
});
```

Node v26.3.0:
```
1 args, err.code=ENOTFOUND
```

Bun (before):
```
3 args, err.code=ENOTFOUND
```

Code that distinguishes success from failure via `arguments.length > 1` or `address !== undefined` (including some `util.promisify` shims and argument-counting compat layers) would see the failure path look like a broken success. The same applied to the `{ all: true }` variant.

## Fix

Call `callback(err)` with a single argument on the error path in `src/js/node/dns.ts`.

## Verification

New tests in `test/js/node/dns/node-dns.test.js` assert `arguments.length === 1` for both the default form and `{ all: true }`. They fail on current `main` with `Expected: 1, Received: 3` and pass with this change.