### PR TITLE
glob: honour backslash escapes of non-special characters in scan()

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1863,7 +1863,7 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
         !filepath.is_empty() && filepath[0] == b'.'
     }
 
-    const SYNTAX_TOKENS: &'static [u8] = b"*[{?!";
+    const SYNTAX_TOKENS: &'static [u8] = b"*[{?!\\";
 
     fn check_special_syntax(pattern: &[u8]) -> bool {
         strings::index_of_any(pattern, Self::SYNTAX_TOKENS).is_some()
@@ -1942,7 +1942,9 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
                             // We also don't need to look for the `!` token,
                             // because that only applies negation if at the
                             // beginning of the string.
-                            b'[' | b'{' | b'?' | b'*' => break 'out_of_check_wildcard_filepath,
+                            b'[' | b'{' | b'?' | b'*' | b'\\' => {
+                                break 'out_of_check_wildcard_filepath
+                            }
                             _ => {}
                         }
                     }

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1863,7 +1863,9 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
         !filepath.is_empty() && filepath[0] == b'.'
     }
 
-    const SYNTAX_TOKENS: &'static [u8] = b"*[{?!\\";
+    // `\` is an escape on POSIX; on Windows it is a path separator and
+    // only reaches a component slice as a trailing sep, so skip it there.
+    const SYNTAX_TOKENS: &'static [u8] = if IS_WINDOWS { b"*[{?!" } else { b"*[{?!\\" };
 
     fn check_special_syntax(pattern: &[u8]) -> bool {
         strings::index_of_any(pattern, Self::SYNTAX_TOKENS).is_some()
@@ -1942,9 +1944,8 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
                             // We also don't need to look for the `!` token,
                             // because that only applies negation if at the
                             // beginning of the string.
-                            b'[' | b'{' | b'?' | b'*' | b'\\' => {
-                                break 'out_of_check_wildcard_filepath;
-                            }
+                            b'[' | b'{' | b'?' | b'*' => break 'out_of_check_wildcard_filepath,
+                            b'\\' if !IS_WINDOWS => break 'out_of_check_wildcard_filepath,
                             _ => {}
                         }
                     }

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1943,7 +1943,7 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
                             // because that only applies negation if at the
                             // beginning of the string.
                             b'[' | b'{' | b'?' | b'*' | b'\\' => {
-                                break 'out_of_check_wildcard_filepath
+                                break 'out_of_check_wildcard_filepath;
                             }
                             _ => {}
                         }

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -628,6 +628,9 @@ describe.skipIf(isWindows)("backslash escapes non-special characters", () => {
       "foo.t s": "x",
     });
   });
+  afterAll(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
 
   // `\x` quotes `x` whether or not `x` is special, so scan must agree with match.
   test.each([
@@ -644,6 +647,13 @@ describe.skipIf(isWindows)("backslash escapes non-special characters", () => {
     for (const name of expected) {
       expect(glob.match(name)).toBe(true);
     }
+  });
+
+  // `\\` is one literal `\`, so the on-disk name without a backslash must not match.
+  test("escaped backslash requires a literal backslash in the name", () => {
+    const glob = new Glob("sp\\\\ ace.txt");
+    expect(glob.match("sp ace.txt")).toBe(false);
+    expect(glob.match("sp\\ ace.txt")).toBe(true);
   });
 
   test("absolute path", async () => {

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -23,7 +23,7 @@
 import { Glob, GlobScanOptions } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import fg from "fast-glob";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import * as fs from "node:fs";
 import * as path from "path";
 import { createTempDirectoryWithBrokenSymlinks, prepareEntries, tempFixturesDir } from "./util";
@@ -615,6 +615,41 @@ describe("literal fast path", async () => {
     const glob = new Glob("packages/foo");
     const entries = await Array.fromAsync(glob.scan({ cwd: tempdir }));
     expect(entries.sort()).toEqual([`packages${path.sep}foo`].sort());
+  });
+});
+
+// On Windows `\` is a path separator, not an escape character.
+describe.skipIf(isWindows)("backslash escapes non-special characters", () => {
+  let cwd = "";
+  beforeAll(() => {
+    cwd = tempDirWithFiles("glob-scan-backslash-escape", {
+      "sp ace.txt": "x",
+      "d r": { "f.txt": "x" },
+      "foo.t s": "x",
+    });
+  });
+
+  // `\x` quotes `x` whether or not `x` is special, so scan must agree with match.
+  test.each([
+    ["literal component", "sp\\ ace.txt", ["sp ace.txt"]],
+    ["*.ext component", "*.t\\ s", ["foo.t s"]],
+    ["directory component", "d\\ r/*.txt", ["d r/f.txt"]],
+    ["under **", "**/sp\\ ace.txt", ["sp ace.txt"]],
+    ["escaped backslash is literal", "sp\\\\ ace.txt", []],
+  ])("%s", async (_, pattern, expected) => {
+    const glob = new Glob(pattern);
+    const sync = Array.from(glob.scanSync({ cwd })).sort();
+    const async = (await Array.fromAsync(glob.scan({ cwd }))).sort();
+    expect({ sync, async }).toEqual({ sync: expected, async: expected });
+    for (const name of expected) {
+      expect(glob.match(name)).toBe(true);
+    }
+  });
+
+  test("absolute path", async () => {
+    const glob = new Glob(path.posix.join(cwd, "sp\\ ace.txt"));
+    const entries = await Array.fromAsync(glob.scan());
+    expect(entries).toEqual([path.join(cwd, "sp ace.txt")]);
   });
 });
 


### PR DESCRIPTION
## Problem

`Bun.Glob.scan()` / `scanSync()` return nothing for a pattern with a backslash-escaped non-special character, while `Bun.Glob.match()` on the same pattern says it matches:

```js
// files: "sp ace.txt", "st*ar.txt"
new Bun.Glob("sp\\ ace.txt").match("sp ace.txt");              // true
[...new Bun.Glob("sp\\ ace.txt").scanSync({ cwd })];           // []      (wrong)
[...new Bun.Glob("st\\*ar.txt").scanSync({ cwd })];            // ["st*ar.txt"]  (ok)
```

POSIX, bash and fast-glob all treat `\x` as quoting `x` whether or not `x` is a glob metacharacter, and Bun's own matcher already does the same. Only the scanner disagrees, so `scan` and `match` are inconsistent with each other.

## Cause

`GlobWalker::check_special_syntax` in `src/glob/GlobWalker.rs` only looks for `*[{?!` when classifying a pattern component. A component like `sp\ ace.txt` contains none of those, so it is tagged `SyntaxHint::Literal` and routed through the literal fast paths: `match_wildcard_literal` (raw byte equality) and the `statat()` shortcut, both of which compare / open the filename with the backslash still in it. Escaping a special character (`st\*ar.txt`) happens to work because the `*` trips `check_special_syntax`, the component gets `SyntaxHint::None`, and matching falls through to the real matcher which unescapes correctly.

The `*.ext` fast path has the same blind spot: its bailout set is `[{?*`, so `*.t\ s` is tagged `WildcardFilepath` and compared as raw bytes.

## Fix

Add `\` to `SYNTAX_TOKENS` and to the `WildcardFilepath` bailout set, so any component that contains a backslash is classified as `SyntaxHint::None` and matched via the full matcher (`glob::match`), which already strips `\` before any following character. On Windows `\` is a path separator and is consumed before component classification, so this change is a no-op there.

## Verification

Added `describe("backslash escapes non-special characters")` to `test/js/bun/glob/scan.test.ts` covering a literal component, a `*.ext` component, an escaped directory component, a `**/` recursion, an absolute path, and a `\\` negative control. On `main` 5 of the 6 cases fail (empty result); with this change all pass. Full `scan.test.ts` (178 tests) and `match.test.ts` (26 tests) remain green.

#32853 noted this divergence in its "not in this PR" section; this change addresses it.