### PR TITLE
node:child_process: kill() returns false after the child has exited

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1552,9 +1552,11 @@ class ChildProcess extends EventEmitter {
 
     const handle = this.#handle;
     if (handle) {
+      // Bun.spawn's `killed` is true once the process has exited or been
+      // terminated by a signal. Node treats kill() on a dead process as
+      // ESRCH: return false and leave `.killed` untouched.
       if (handle.killed) {
-        this.killed = true;
-        return true;
+        return false;
       }
 
       try {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -58,6 +58,70 @@ describe("ChildProcess.spawn()", () => {
     });
     expect(result).toBe(true);
   });
+
+  it("kill() on a running process returns true and sets .killed", async () => {
+    const child = spawn(bunExe(), ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore", env: bunEnv });
+    await new Promise((resolve, reject) => {
+      child.on("spawn", resolve);
+      child.on("error", reject);
+    });
+    try {
+      expect(child.killed).toBe(false);
+      expect(child.kill(0)).toBe(true);
+      expect(child.kill()).toBe(true);
+      expect(child.killed).toBe(true);
+    } finally {
+      child.kill("SIGKILL");
+    }
+    await new Promise(resolve => child.on("close", resolve));
+  });
+
+  it("kill() after the process has exited returns false and does not set .killed", async () => {
+    const child = spawn(bunExe(), ["-e", ""], { stdio: "ignore", env: bunEnv });
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    child.on("error", reject);
+    child.on("close", () => resolve());
+    await promise;
+
+    expect({
+      exitCode: child.exitCode,
+      "kill()": child.kill(),
+      "kill(0)": child.kill(0),
+      "kill('SIGTERM')": child.kill("SIGTERM"),
+      killed: child.killed,
+    }).toEqual({
+      exitCode: 0,
+      "kill()": false,
+      "kill(0)": false,
+      "kill('SIGTERM')": false,
+      killed: false,
+    });
+  });
+
+  it("kill() after the process was killed returns false but .killed stays true", async () => {
+    const child = spawn(bunExe(), ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore", env: bunEnv });
+    await new Promise((resolve, reject) => {
+      child.on("spawn", resolve);
+      child.on("error", reject);
+    });
+    expect(child.kill()).toBe(true);
+    expect(child.killed).toBe(true);
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    child.on("error", reject);
+    child.on("close", () => resolve());
+    await promise;
+
+    expect({
+      "kill()": child.kill(),
+      "kill(0)": child.kill(0),
+      killed: child.killed,
+    }).toEqual({
+      "kill()": false,
+      "kill(0)": false,
+      killed: true,
+    });
+  });
 });
 
 describe("spawn()", () => {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
 import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
 import { promisify } from "node:util";
 import path from "path";
 const debug = process.env.DEBUG ? console.log : () => {};
@@ -59,12 +60,14 @@ describe("ChildProcess.spawn()", () => {
     expect(result).toBe(true);
   });
 
+  // `errors` collects every "error" the child emits, including ones emitted by
+  // kill() after the awaited lifecycle events, and is asserted empty.
   it("kill() on a running process returns true and sets .killed", async () => {
     const child = spawn(bunExe(), ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore", env: bunEnv });
-    await new Promise((resolve, reject) => {
-      child.on("spawn", resolve);
-      child.on("error", reject);
-    });
+    const errors: unknown[] = [];
+    child.on("error", err => errors.push(err));
+    await once(child, "spawn");
+    const closed = once(child, "close");
     try {
       expect(child.killed).toBe(false);
       expect(child.kill(0)).toBe(true);
@@ -73,15 +76,15 @@ describe("ChildProcess.spawn()", () => {
     } finally {
       child.kill("SIGKILL");
     }
-    await new Promise(resolve => child.on("close", resolve));
+    await closed;
+    expect(errors).toEqual([]);
   });
 
   it("kill() after the process has exited returns false and does not set .killed", async () => {
     const child = spawn(bunExe(), ["-e", ""], { stdio: "ignore", env: bunEnv });
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    child.on("error", reject);
-    child.on("close", () => resolve());
-    await promise;
+    const errors: unknown[] = [];
+    child.on("error", err => errors.push(err));
+    await once(child, "close");
 
     expect({
       exitCode: child.exitCode,
@@ -89,37 +92,37 @@ describe("ChildProcess.spawn()", () => {
       "kill(0)": child.kill(0),
       "kill('SIGTERM')": child.kill("SIGTERM"),
       killed: child.killed,
+      errors,
     }).toEqual({
       exitCode: 0,
       "kill()": false,
       "kill(0)": false,
       "kill('SIGTERM')": false,
       killed: false,
+      errors: [],
     });
   });
 
   it("kill() after the process was killed returns false but .killed stays true", async () => {
     const child = spawn(bunExe(), ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore", env: bunEnv });
-    await new Promise((resolve, reject) => {
-      child.on("spawn", resolve);
-      child.on("error", reject);
-    });
+    const errors: unknown[] = [];
+    child.on("error", err => errors.push(err));
+    await once(child, "spawn");
+    const closed = once(child, "close");
     expect(child.kill()).toBe(true);
     expect(child.killed).toBe(true);
-
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    child.on("error", reject);
-    child.on("close", () => resolve());
-    await promise;
+    await closed;
 
     expect({
       "kill()": child.kill(),
       "kill(0)": child.kill(0),
       killed: child.killed,
+      errors,
     }).toEqual({
       "kill()": false,
       "kill(0)": false,
       killed: true,
+      errors: [],
     });
   });
 });


### PR DESCRIPTION
Fixes #29001. Supersedes #29002, which is unmergeable after the Zig to Rust migration and changes the Bun.spawn public API.

## Repro

```js
import { spawn } from "node:child_process";
const c = spawn("true", [], { stdio: "ignore" });
c.on("exit", () => {
  setTimeout(() => {
    console.log("kill() =", c.kill(), "| kill(0) =", c.kill(0), "| killed =", c.killed);
  }, 100);
});
```

Node: `kill() = false | kill(0) = false | killed = false`
Bun (before): `kill() = true | kill(0) = true | killed = true`

Node docs say `kill()` returns `true` only when the signal was successfully delivered, and `.killed` indicates a signal was successfully sent. `if (!child.kill(0))` is the documented liveness probe; on Bun it always claimed a dead child was alive.

## Cause

`ChildProcess.prototype.kill` branched on `handle.killed`, the Bun.spawn getter backed by `Process::has_killed()`, which is `true` for any terminated process (`Status::Exited | Status::Signaled`). When that was `true` it set `this.killed = true` and returned `true`. When it was `false`, `handle.kill()` was called, but `Subprocess::try_kill` short-circuits to `Ok(())` once `has_exited()` is `true`, so the JS layer saw success and again returned `true`. Either way, no `kill(2)` was issued and the return value was fabricated.

## Fix

Keep the check on `handle.killed` but invert the result: when the underlying process has already terminated, return `false` and leave `this.killed` untouched, matching Node's ESRCH path. The Bun.spawn API surface (`Subprocess#kill()`, `Subprocess#killed`) is unchanged.

## Verification

New tests in `test/js/node/child_process/child_process.test.ts` cover:

- `kill()` / `kill(0)` / `kill('SIGTERM')` on an already-exited child return `false` and leave `.killed === false`
- `kill()` on a running child still returns `true` and sets `.killed = true` (`kill(0)` included; Node sets `.killed` for signal 0 too)
- after a successful `kill()`, a second `kill()` post-exit returns `false` while `.killed` stays `true`

```
USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t "kill\(\)"
  2 fail (kill() after exited, kill() after killed)
bun bd test test/js/node/child_process/child_process.test.ts -t "kill\(\)"
  3 pass
```

Node parallel tests still pass: `test-child-process-kill.js`, `test-child-process-destroy.js`, `test-child-process-constructor.js`, `test-child-process-execfile.js`, `test-child-process-exec-timeout-*.js`, `test-child-process-*-kill-signal.js`.