### PR TITLE
node:child_process: match Node's spawnSync result shape when the spawn fails

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -507,13 +507,13 @@ function spawnSync(file, args, options) {
     );
     error.spawnargs = ArrayPrototypeSlice.$call(options.args, 1);
     return {
-      signal: null,
-      status: null,
-      output: [null, null, null],
-      pid: 0,
-      stdout: null,
-      stderr: null,
       error,
+      status: null,
+      signal: null,
+      output: null,
+      pid: 0,
+      stdout: undefined,
+      stderr: undefined,
     };
   }
 
@@ -546,6 +546,7 @@ function spawnSync(file, args, options) {
   }
 
   var error;
+  var result;
   try {
     var {
       stdout = null,
@@ -573,39 +574,39 @@ function spawnSync(file, args, options) {
       killSignal: options.killSignal,
       maxBuffer: options.maxBuffer,
     });
+
+    // When stdio is redirected to a file descriptor, Bun.spawnSync returns the fd number
+    // instead of the actual output. We should treat this as no output available.
+    const outputStdout = typeof stdout === "number" ? null : stdout;
+    const outputStderr = typeof stderr === "number" ? null : stderr;
+
+    result = {
+      status: exitCode ?? null,
+      signal: signalCode ?? null,
+      // TODO: Need to expose extra pipes from Bun.spawnSync to child_process
+      output: [null, outputStdout, outputStderr],
+      pid,
+    };
   } catch (err) {
     error = err;
-    stdout = null;
-    stderr = null;
+    result = {
+      error: err,
+      status: null,
+      signal: null,
+      output: null,
+      pid: 0,
+    };
   }
 
-  // When stdio is redirected to a file descriptor, Bun.spawnSync returns the fd number
-  // instead of the actual output. We should treat this as no output available.
-  const outputStdout = typeof stdout === "number" ? null : stdout;
-  const outputStderr = typeof stderr === "number" ? null : stderr;
-
-  const result = {
-    signal: signalCode ?? null,
-    status: exitCode,
-    // TODO: Need to expose extra pipes from Bun.spawnSync to child_process
-    output: [null, outputStdout, outputStderr],
-    pid,
-  };
-
-  if (error) {
-    result.error = error;
+  if (result.output && encoding && encoding !== "buffer") {
+    for (let i = 0; i < result.output.length; i++) {
+      if (!result.output[i]) continue;
+      result.output[i] = result.output[i].toString(encoding);
+    }
   }
 
-  if (outputStdout && encoding && encoding !== "buffer") {
-    result.output[1] = result.output[1]?.toString(encoding);
-  }
-
-  if (outputStderr && encoding && encoding !== "buffer") {
-    result.output[2] = result.output[2]?.toString(encoding);
-  }
-
-  result.stdout = result.output[1];
-  result.stderr = result.output[2];
+  result.stdout = result.output?.[1];
+  result.stderr = result.output?.[2];
 
   if (exitedDueToTimeout && error == null) {
     result.error = new SystemError(

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -465,10 +465,62 @@ it("spawnSync(does-not-exist)", () => {
   const x = spawnSync("does-not-exist");
   expect(x.error?.code).toEqual("ENOENT");
   expect(x.error.path).toEqual("does-not-exist");
-  expect(x.signal).toEqual(null);
-  expect(x.output).toEqual([null, null, null]);
-  expect(x.stdout).toEqual(null);
-  expect(x.stderr).toEqual(null);
+  expect(x.error.syscall).toEqual("spawnSync does-not-exist");
+  expect(x.error.spawnargs).toEqual([]);
+  // Node.js sets status/signal to null, output to null, pid to 0, and
+  // stdout/stderr to undefined when the spawn itself fails.
+  expect({
+    status: x.status,
+    signal: x.signal,
+    output: x.output,
+    pid: x.pid,
+    stdout: x.stdout,
+    stderr: x.stderr,
+  }).toStrictEqual({
+    status: null,
+    signal: null,
+    output: null,
+    pid: 0,
+    stdout: undefined,
+    stderr: undefined,
+  });
+  expect("status" in x).toBe(true);
+  expect("stdout" in x).toBe(true);
+});
+
+it("spawnSync(does-not-exist) status is strictly null", () => {
+  // `r.status === null` is the documented way to detect that no exit code
+  // exists; user code commonly does `process.exit(r.status)`.
+  const r = spawnSync("definitely-not-a-real-binary-xyz");
+  expect(r.status === null).toBe(true);
+  expect(r.status === undefined).toBe(false);
+  expect(typeof r.pid).toBe("number");
+});
+
+it("execFileSync(does-not-exist) error carries spawnSync result shape", () => {
+  let err: any;
+  try {
+    execFileSync("does-not-exist");
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err.code).toBe("ENOENT");
+  expect({
+    status: err.status,
+    signal: err.signal,
+    output: err.output,
+    pid: err.pid,
+    stdout: err.stdout,
+    stderr: err.stderr,
+  }).toStrictEqual({
+    status: null,
+    signal: null,
+    output: null,
+    pid: 0,
+    stdout: undefined,
+    stderr: undefined,
+  });
 });
 
 // https://github.com/oven-sh/bun/issues/32067


### PR DESCRIPTION
## Problem

When the underlying spawn fails (e.g. `ENOENT`, `EACCES`), `spawnSync` from `node:child_process` returns a result object whose shape diverges from Node.js:

```js
import { spawnSync } from "node:child_process";
const r = spawnSync("definitely-not-a-real-binary-xyz");
```

| field | Node.js v26 | Bun (before) |
| --- | --- | --- |
| `status` | `null` | `undefined` |
| `pid` | `0` | `undefined` |
| `output` | `null` | `[null, null, null]` |
| `stdout` / `stderr` | `undefined` | `null` |

The load-bearing one is `status`. Node documents it as "the exit code of the subprocess, or `null` if the subprocess terminated due to a signal" and always sets it to `null` on spawn failure. Bun left it `undefined`, so `r.status === null` (the documented check for "no exit code") was `false`, and code that does `process.exit(r.status)` passed `undefined`.

## Cause

`src/js/node/child_process.ts` catches the error thrown by `Bun.spawnSync` and falls through to the same result-object construction as the success path, but `exitCode`, `signalCode`, and `pid` are never assigned in the catch branch, and `output` is unconditionally built as a three-element array.

Node's `internal/child_process` `spawnSync` receives `{error, status: null, signal: null, output: null, pid: 0}` from the native layer when spawn fails, then derives `result.stdout = result.output?.[1]` and `result.stderr = result.output?.[2]`, which are `undefined` when `output` is `null`.

## Fix

- When `Bun.spawnSync` throws, build the result as `{error, status: null, signal: null, output: null, pid: 0}`.
- Derive `stdout`/`stderr` as `result.output?.[1]` / `result.output?.[2]` so they are `undefined` when `output` is `null`, matching Node's wrapper.
- On the success path, coerce `exitCode` via `?? null` and order keys `status, signal, output, pid` to match Node.
- Bring the `windowsBatchFileError` early-return into the same shape.

This also fixes the error object thrown by `execFileSync`/`execSync`, which copies these fields onto the error via `Object.assign`.

## Verification

```
$ bun-debug /tmp/repro.mjs
keys: error,status,signal,output,pid,stdout,stderr
pid: number | status===null: true | 'status' in r: true | output: null | stdout: undefined | error: ENOENT
```

Identical to `node /tmp/repro.mjs`.

All `test/js/node/test/parallel/test-child-process-spawnsync*.js` and `test-child-process-exec*sync*.js` pass.