### PR TITLE
Bun.serve websocket: deliver ws.publish() from sockets with no subscriptions

### DIFF
--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -378,17 +378,16 @@ public:
     SendStatus publish(std::string_view topic, std::string_view message, OpCode opCode = OpCode::TEXT, bool compress = false) {
         WebSocketContextData<SSL, USERDATA> *webSocketContextData = getContextData();
 
-        /* We cannot be a subscriber of this topic if we are not a subscriber of anything */
+        /* A sender with no Subscriber (never subscribed to anything) still publishes; nullptr
+         * is a valid "exclude nobody" sender for TopicTree (App::publish relies on this). */
         WebSocketData *webSocketData = (WebSocketData *) us_socket_ext((us_socket_t *) this);
-        if (!webSocketData->subscriber) {
-            return DROPPED;
-        }
+        Subscriber *sender = webSocketData->subscriber;
 
         /* Publish as sender, does not receive its own messages even if subscribed to relevant topics */
         if (message.length() >= LoopData::CORK_BUFFER_SIZE) {
             SendStatus worst = SUCCESS;
             bool hasReceivers = false;
-            webSocketContextData->topicTree->publishBig(webSocketData->subscriber, topic, {message, opCode, compress}, [&worst, &hasReceivers](Subscriber *s, TopicTreeBigMessage &message) {
+            webSocketContextData->topicTree->publishBig(sender, topic, {message, opCode, compress}, [&worst, &hasReceivers](Subscriber *s, TopicTreeBigMessage &message) {
                 hasReceivers = true;
                 auto *ws = (WebSocket<SSL, true, int> *) s->user;
 
@@ -400,12 +399,12 @@ public:
             if (!t) {
                 return DROPPED;
             }
-            webSocketContextData->topicTree->publish(webSocketData->subscriber, topic, {std::string(message), opCode, compress});
+            webSocketContextData->topicTree->publish(sender, topic, {std::string(message), opCode, compress});
             /* publish() may have synchronously drained a subscriber; check backpressure after. */
             SendStatus worst = SUCCESS;
             bool hasReceivers = false;
             for (Subscriber *s : *t) {
-                if (s == webSocketData->subscriber) continue;
+                if (s == sender) continue;
                 hasReceivers = true;
                 auto *ws = (WebSocket<SSL, true, int> *) s->user;
                 worst = worseStatus(worst, (SendStatus) ws->sendStatus());

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -865,9 +865,7 @@ describe("ServerWebSocket", () => {
     }
   });
   // With the default publishToSelf: false, a ws.publish() from a socket that has never
-  // subscribed to anything must still deliver to other subscribers. Previously this was
-  // a silent no-op because uWS's per-socket publish required the sender to have a
-  // Subscriber object.
+  // subscribed to anything must still deliver to other subscribers.
   describe("publish() from a socket not subscribed to anything", () => {
     const big = Buffer.alloc(20 * 1024, "x").toString();
     const cases = [

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -903,15 +903,23 @@ describe("ServerWebSocket", () => {
           },
         });
         const url = `ws://${server.hostname}:${server.port}/`;
+        // A socket that errors or closes before the server's open() handler ran would
+        // otherwise leave one of the awaited slots pending until the test timeout.
+        const fail = (who: string) => (ev: Event) => {
+          const err = new Error(`${who} websocket ${ev.type}`);
+          subscribed.reject(err);
+          published.reject(err);
+          received.reject(err);
+        };
         const sub = new WebSocket(url);
         sub.binaryType = "arraybuffer";
         sub.onmessage = e => received.resolve(e.data);
-        sub.onerror = e => received.reject(e);
+        sub.onerror = sub.onclose = fail("subscriber");
         await subscribed.promise;
         expect(server.subscriberCount("chat")).toBe(1);
         const pub = new WebSocket(url);
         pub.onmessage = e => received.reject(new Error("publisher must not receive: " + e.data));
-        pub.onerror = e => received.reject(e);
+        pub.onerror = pub.onclose = fail("publisher");
 
         const ret = await published.promise;
         expect(ret).toBe(Buffer.byteLength(payload));

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -864,6 +864,68 @@ describe("ServerWebSocket", () => {
       }));
     }
   });
+  // With the default publishToSelf: false, a ws.publish() from a socket that has never
+  // subscribed to anything must still deliver to other subscribers. Previously this was
+  // a silent no-op because uWS's per-socket publish required the sender to have a
+  // Subscriber object.
+  describe("publish() from a socket not subscribed to anything", () => {
+    const big = Buffer.alloc(20 * 1024, "x").toString();
+    const cases = [
+      ["publish", "publish", "small-text"],
+      ["publishText", "publishText", "small-text"],
+      ["publishBinary", "publishBinary", Buffer.from("small-binary")],
+      ["publish (>= cork buffer)", "publish", big],
+    ] as const;
+    for (const [label, method, payload] of cases) {
+      it.concurrent(label, async () => {
+        const subscribed = Promise.withResolvers<void>();
+        const received = Promise.withResolvers<string | ArrayBuffer>();
+        const published = Promise.withResolvers<number>();
+        let nextId = 0;
+        using server = serve({
+          port: 0,
+          fetch(req, server) {
+            if (server.upgrade(req, { data: { id: nextId++ } })) return;
+            return new Response();
+          },
+          websocket: {
+            open(ws) {
+              if (ws.data.id === 0) {
+                ws.subscribe("chat");
+                subscribed.resolve();
+              } else {
+                expect(ws.isSubscribed("chat")).toBe(false);
+                // @ts-expect-error dynamic method dispatch
+                published.resolve(ws[method]("chat", payload));
+              }
+            },
+            message() {},
+          },
+        });
+        const url = `ws://${server.hostname}:${server.port}/`;
+        const sub = new WebSocket(url);
+        sub.binaryType = "arraybuffer";
+        sub.onmessage = e => received.resolve(e.data);
+        sub.onerror = e => received.reject(e);
+        await subscribed.promise;
+        expect(server.subscriberCount("chat")).toBe(1);
+        const pub = new WebSocket(url);
+        pub.onmessage = e => received.reject(new Error("publisher must not receive: " + e.data));
+        pub.onerror = e => received.reject(e);
+
+        const ret = await published.promise;
+        expect(ret).toBe(Buffer.byteLength(payload));
+        const got = await received.promise;
+        if (typeof payload === "string") {
+          expect(got).toBe(payload);
+        } else {
+          expect(Buffer.from(got as ArrayBuffer)).toEqual(Buffer.from(payload));
+        }
+        sub.close();
+        pub.close();
+      });
+    }
+  });
   describe("ping()", () => {
     test("(no argument)", done => ({
       open(ws) {


### PR DESCRIPTION
## Problem

With the default `publishToSelf: false`, `ws.publish(topic, msg)` from a `ServerWebSocket` that has never subscribed to any topic is a silent no-op: it returns `0` and delivers to nobody, even when other sockets are subscribed to `topic`.

```js
using server = Bun.serve({
  port: 0,
  websocket: {
    message(ws, m) {
      if (m === "subscribe") { ws.subscribe("chat"); ws.send("subscribed"); }
      if (m === "publish") ws.send("ret=" + ws.publish("chat", "hello"));
    },
  },
  fetch: (req, s) => (s.upgrade(req) ? undefined : new Response()),
});
// client A: sends "subscribe" -> subscribed to "chat"
// client B: sends "publish"  -> never subscribed to anything
```

Observed:
```
subscriberCount('chat') = 1
publisher's ws.publish('chat', ...) returned -> ret=0
subscriber received: ["subscribed"]
```

Either setting `publishToSelf: true` or having the publisher subscribe to any *unrelated* topic first makes the same call deliver, so the result depended on publisher state that has nothing to do with the target topic. This silently breaks write-only producers (admin/bot sockets that post to a room without listening).

## Cause

`ServerWebSocket::do_publish` routes the `publishToSelf: false` case through uWS `WebSocket::publish`, which early-returns `false` when `webSocketData->subscriber` is null:

https://github.com/oven-sh/bun/blob/8706328b5d3f8bf7c61488ee44c51a1dcc3e9f3e/packages/bun-uws/src/WebSocket.h#L358-L363

The `Subscriber` object is only created on the first `subscribe()` call, so a socket that has never subscribed has no `Subscriber` and hits this guard.

## Fix

`TopicTree::publish` / `publishBig` only use the `sender` argument for `sender != s` comparison against each subscriber and already accept `nullptr` (this is exactly what `App::publish` passes). Pass `webSocketData->subscriber` through unconditionally: when it is null the comparison trivially never matches, which is correct since a sender with no subscriptions can never receive a published message anyway.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test websocket-server.test.ts -t "not subscribed to anything"
(fail) ... publish                   Expected: 10     Received: 0
(fail) ... publishText               Expected: 10     Received: 0
(fail) ... publishBinary             Expected: 12     Received: 0
(fail) ... publish (>= cork buffer)  Expected: 20480  Received: 0

$ bun bd test websocket-server.test.ts -t "not subscribed to anything"
(pass) ... publish
(pass) ... publishText
(pass) ... publishBinary
(pass) ... publish (>= cork buffer)
```

The new tests cover `publish` / `publishText` / `publishBinary` and both the small-message and big-message (>= 16 KB, `publishBig`) code paths, and assert the publisher does not receive its own message.