### PR TITLE
node:dns: reject instead of throwing for resolve*("")

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -715,11 +715,10 @@ pub trait ChannelContainer: Sized {
     fn set_channel(&self, channel: *mut Channel);
 }
 
-/// Trait for `Channel::resolve`: ties a lookup-name string to its NSType and
+/// Trait for `Channel::resolve`: ties a record type to its c-ares `NSType` and
 /// the `extern "C"` parse-thunk used as the ares_callback.
 /// The dns_jsc consumer impls it per (T, record-type).
 pub trait ResolveHandler: Sized {
-    const LOOKUP_NAME: &'static [u8];
     const NS_TYPE: NSType;
     /// The `ares_callback`-compatible thunk that parses the reply and forwards
     /// to `Self`.
@@ -844,10 +843,10 @@ impl Channel {
     }
 
     pub fn resolve<T: ResolveHandler>(&mut self, name: &[u8], ctx: &mut T) {
-        if name.len() >= 1023
-            || name.contains(&0)
-            || (name.is_empty() && !(T::LOOKUP_NAME == b"ns" || T::LOOKUP_NAME == b"soa"))
-        {
+        // The 1024-byte stack buffer and c-ares's char* API need a bounded,
+        // NUL-free name. An empty name is valid (the root zone) and goes
+        // through to the configured servers, matching Node.js.
+        if name.len() >= 1023 || name.contains(&0) {
             // SAFETY: thunk handles ARES_EBADNAME path.
             unsafe {
                 T::raw_callback(

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -5010,13 +5010,6 @@ impl Resolver {
         }
         // SAFETY: `to_js_string` returns a live *mut JSString rooted by `name_value`.
         let name_str = name_value.to_js_string(global_this)?;
-        if name_str.length() == 0 {
-            return Err(global_this.throw_invalid_argument_type(
-                "resolve",
-                "name",
-                "non-empty string",
-            ));
-        }
         let name = name_str.to_slice_clone(global_this)?;
 
         match record_type {
@@ -5255,7 +5248,7 @@ impl Resolver {
 }
 
 macro_rules! resolve_record_fn {
-    ($global:ident, $method:ident, $jsname:literal, $ty:ty, $allow_empty:expr) => {
+    ($global:ident, $method:ident, $jsname:literal, $ty:ty) => {
         // JSC-ABI shim emitted by `export_host_fn!` at module scope (see `global_resolve`).
         pub fn $global(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
             global_resolver(global_this).$method(global_this, callframe)
@@ -5277,13 +5270,6 @@ macro_rules! resolve_record_fn {
             }
             // SAFETY: `to_js_string` returns a live *mut JSString rooted by `name_value`.
             let name_str = name_value.to_js_string(global_this)?;
-            if !$allow_empty && name_str.length() == 0 {
-                return Err(global_this.throw_invalid_argument_type(
-                    $jsname,
-                    "hostname",
-                    "non-empty string",
-                ));
-            }
             let name = name_str.to_slice_clone(global_this)?;
             self.do_resolve_cares::<$ty>(name.slice(), global_this)
         }
@@ -5308,65 +5294,51 @@ impl Resolver {
         global_resolve_srv,
         resolve_srv,
         "resolveSrv",
-        c_ares::struct_ares_srv_reply,
-        false
+        c_ares::struct_ares_srv_reply
     );
     resolve_record_fn!(
         global_resolve_soa,
         resolve_soa,
         "resolveSoa",
-        c_ares::struct_ares_soa_reply,
-        true
+        c_ares::struct_ares_soa_reply
     );
     resolve_record_fn!(
         global_resolve_caa,
         resolve_caa,
         "resolveCaa",
-        c_ares::struct_ares_caa_reply,
-        false
+        c_ares::struct_ares_caa_reply
     );
-    resolve_record_fn!(global_resolve_ns, resolve_ns, "resolveNs", NsHostent, true);
-    resolve_record_fn!(
-        global_resolve_ptr,
-        resolve_ptr,
-        "resolvePtr",
-        PtrHostent,
-        false
-    );
+    resolve_record_fn!(global_resolve_ns, resolve_ns, "resolveNs", NsHostent);
+    resolve_record_fn!(global_resolve_ptr, resolve_ptr, "resolvePtr", PtrHostent);
     resolve_record_fn!(
         global_resolve_cname,
         resolve_cname,
         "resolveCname",
-        CnameHostent,
-        false
+        CnameHostent
     );
     resolve_record_fn!(
         global_resolve_mx,
         resolve_mx,
         "resolveMx",
-        c_ares::struct_ares_mx_reply,
-        false
+        c_ares::struct_ares_mx_reply
     );
     resolve_record_fn!(
         global_resolve_naptr,
         resolve_naptr,
         "resolveNaptr",
-        c_ares::struct_ares_naptr_reply,
-        false
+        c_ares::struct_ares_naptr_reply
     );
     resolve_record_fn!(
         global_resolve_txt,
         resolve_txt,
         "resolveTxt",
-        c_ares::struct_ares_txt_reply,
-        false
+        c_ares::struct_ares_txt_reply
     );
     resolve_record_fn!(
         global_resolve_any,
         resolve_any,
         "resolveAny",
-        c_ares::struct_any_reply,
-        false
+        c_ares::struct_any_reply
     );
 
     pub fn do_resolve_cares<T: CAresRecordType>(

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -712,7 +712,6 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
 // `T::RAW_CALLBACK` parses the raw DNS reply and calls back into
 // `on_cares_complete`.
 impl<T: CAresRecordType> c_ares::ResolveHandler for ResolveInfoRequest<T> {
-    const LOOKUP_NAME: &'static [u8] = T::TYPE_NAME.as_bytes();
     const NS_TYPE: c_ares::NSType = T::NS_TYPE;
     unsafe extern "C" fn raw_callback(
         ctx: *mut c_void,

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -572,3 +572,89 @@ describe("hostnames containing NUL bytes", () => {
     expect(["127.0.0.1", "::1"]).toContain(address);
   });
 });
+
+describe("empty hostname", () => {
+  // Node.js passes "" through to c-ares; it is a string so ERR_INVALID_ARG_TYPE
+  // is wrong, and a promise-returning API must reject rather than throw.
+  const resolverOptions = { timeout: 250, tries: 1 };
+  const unreachable = ["127.0.0.1:1"];
+
+  const promiseMethods = [
+    "resolve",
+    "resolve4",
+    "resolve6",
+    "resolveAny",
+    "resolveCaa",
+    "resolveCname",
+    "resolveMx",
+    "resolveNaptr",
+    "resolvePtr",
+    "resolveSrv",
+    "resolveTxt",
+  ];
+
+  it.each(promiseMethods)("dns.promises.Resolver#%s('') rejects asynchronously", async method => {
+    const resolver = new dns_promises.Resolver(resolverOptions);
+    resolver.setServers(unreachable);
+
+    let returned;
+    expect(() => {
+      returned = resolver[method]("");
+    }).not.toThrow();
+    expect(returned).toBeInstanceOf(Promise);
+
+    let rejection;
+    await returned.then(
+      () => {},
+      err => {
+        rejection = err;
+      },
+    );
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection).not.toBeInstanceOf(TypeError);
+    expect(rejection.code).not.toBe("ERR_INVALID_ARG_TYPE");
+  });
+
+  it.each(promiseMethods)("dns.promises.%s('') does not throw synchronously", method => {
+    // Module-level functions use the system resolver; the result of the
+    // root-zone query depends on the environment, so only assert that the
+    // call returns a Promise instead of throwing ERR_INVALID_ARG_TYPE.
+    let returned;
+    expect(() => {
+      returned = dns_promises[method]("");
+    }).not.toThrow();
+    expect(returned).toBeInstanceOf(Promise);
+    returned.catch(() => {});
+  });
+
+  it.each(promiseMethods)("dns.%s('') does not throw synchronously", method => {
+    expect(() => {
+      dns[method]("", () => {});
+    }).not.toThrow();
+  });
+
+  it.each(promiseMethods)("dns.Resolver#%s('') invokes the callback", async method => {
+    const resolver = new dns.Resolver(resolverOptions);
+    resolver.setServers(unreachable);
+
+    const { promise, resolve } = Promise.withResolvers();
+    expect(() => {
+      resolver[method]("", (err, result) => resolve({ err, result }));
+    }).not.toThrow();
+
+    const { err } = await promise;
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(TypeError);
+    expect(err.code).not.toBe("ERR_INVALID_ARG_TYPE");
+  });
+
+  it("non-string hostname still throws ERR_INVALID_ARG_TYPE synchronously", () => {
+    const resolver = new dns_promises.Resolver(resolverOptions);
+    expect(() => resolver.resolve4(123)).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(() => dns.resolve4(123, () => {})).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
+});

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -650,11 +650,7 @@ describe("empty hostname", () => {
 
   it("non-string hostname still throws ERR_INVALID_ARG_TYPE synchronously", () => {
     const resolver = new dns_promises.Resolver(resolverOptions);
-    expect(() => resolver.resolve4(123)).toThrow(
-      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-    );
-    expect(() => dns.resolve4(123, () => {})).toThrow(
-      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-    );
+    expect(() => resolver.resolve4(123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+    expect(() => dns.resolve4(123, () => {})).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -615,24 +615,6 @@ describe("empty hostname", () => {
     expect(rejection.code).not.toBe("ERR_INVALID_ARG_TYPE");
   });
 
-  it.each(promiseMethods)("dns.promises.%s('') does not throw synchronously", method => {
-    // Module-level functions use the system resolver; the result of the
-    // root-zone query depends on the environment, so only assert that the
-    // call returns a Promise instead of throwing ERR_INVALID_ARG_TYPE.
-    let returned;
-    expect(() => {
-      returned = dns_promises[method]("");
-    }).not.toThrow();
-    expect(returned).toBeInstanceOf(Promise);
-    returned.catch(() => {});
-  });
-
-  it.each(promiseMethods)("dns.%s('') does not throw synchronously", method => {
-    expect(() => {
-      dns[method]("", () => {});
-    }).not.toThrow();
-  });
-
   it.each(promiseMethods)("dns.Resolver#%s('') invokes the callback", async method => {
     const resolver = new dns.Resolver(resolverOptions);
     resolver.setServers(unreachable);

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,7 +1,9 @@
-import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { isWindows } from "harness";
+import dgram from "node:dgram";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
+import { once } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as util from "node:util";
@@ -576,8 +578,30 @@ describe("hostnames containing NUL bytes", () => {
 describe("empty hostname", () => {
   // Node.js passes "" through to c-ares; it is a string so ERR_INVALID_ARG_TYPE
   // is wrong, and a promise-returning API must reject rather than throw.
-  const resolverOptions = { timeout: 250, tries: 1 };
-  const unreachable = ["127.0.0.1:1"];
+  //
+  // Every test points at a local mock DNS server that answers everything with
+  // SERVFAIL. ESERVFAIL can only come from that reply, so it also proves the
+  // query was actually sent instead of being short-circuited locally.
+  const resolverOptions = { timeout: 5000, tries: 1 };
+  let udp;
+  let servers;
+
+  beforeAll(async () => {
+    udp = dgram.createSocket("udp4");
+    udp.on("message", (query, rinfo) => {
+      const reply = Buffer.from(query);
+      reply[2] |= 0x80; // QR = response
+      reply[3] = (reply[3] & 0xf0) | 0x02; // RCODE = SERVFAIL
+      udp.send(reply, rinfo.port, rinfo.address);
+    });
+    udp.bind(0, "127.0.0.1");
+    await once(udp, "listening");
+    servers = [`127.0.0.1:${udp.address().port}`];
+  });
+
+  afterAll(() => {
+    udp.close();
+  });
 
   const promiseMethods = [
     "resolve",
@@ -588,14 +612,16 @@ describe("empty hostname", () => {
     "resolveCname",
     "resolveMx",
     "resolveNaptr",
+    "resolveNs",
     "resolvePtr",
+    "resolveSoa",
     "resolveSrv",
     "resolveTxt",
   ];
 
   it.each(promiseMethods)("dns.promises.Resolver#%s('') rejects asynchronously", async method => {
     const resolver = new dns_promises.Resolver(resolverOptions);
-    resolver.setServers(unreachable);
+    resolver.setServers(servers);
 
     let returned;
     expect(() => {
@@ -603,31 +629,27 @@ describe("empty hostname", () => {
     }).not.toThrow();
     expect(returned).toBeInstanceOf(Promise);
 
-    let rejection;
-    await returned.then(
-      () => {},
-      err => {
-        rejection = err;
-      },
+    const err = await returned.then(
+      () => null,
+      e => e,
     );
-    expect(rejection).toBeInstanceOf(Error);
-    expect(rejection).not.toBeInstanceOf(TypeError);
-    expect(rejection.code).not.toBe("ERR_INVALID_ARG_TYPE");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe("ESERVFAIL");
   });
 
   it.each(promiseMethods)("dns.Resolver#%s('') invokes the callback", async method => {
     const resolver = new dns.Resolver(resolverOptions);
-    resolver.setServers(unreachable);
+    resolver.setServers(servers);
 
     const { promise, resolve } = Promise.withResolvers();
     expect(() => {
       resolver[method]("", (err, result) => resolve({ err, result }));
     }).not.toThrow();
 
-    const { err } = await promise;
+    const { err, result } = await promise;
+    expect(result).toBeUndefined();
     expect(err).toBeInstanceOf(Error);
-    expect(err).not.toBeInstanceOf(TypeError);
-    expect(err.code).not.toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.code).toBe("ESERVFAIL");
   });
 
   it("non-string hostname still throws ERR_INVALID_ARG_TYPE synchronously", () => {


### PR DESCRIPTION
## What

`dns.promises.resolve4("")` (and every other `resolve*` with an empty hostname) threw a synchronous `TypeError [ERR_INVALID_ARG_TYPE]`. A promise-returning API should reject, and the callback form should invoke the callback; a synchronous throw escapes `.catch(...)` entirely and the callback is never called.

```js
import dnsp from "node:dns/promises";
const r = new dnsp.Resolver();
try {
  await r.resolve4("").catch(e => console.log("rejected:", e.code));
} catch (e) {
  console.log("sync throw:", e.code);
}
```

Before: `sync throw: ERR_INVALID_ARG_TYPE`
After (and Node.js): `rejected: ENOTFOUND` (or whatever the configured server returns)

## Why

An empty hostname is still a string, so `ERR_INVALID_ARG_TYPE` was the wrong error, and the throw was synchronous from functions whose contract is to return a Promise. Node.js passes the empty string through to c-ares, which delivers the resulting DNS error asynchronously.

Bun had an "empty names are invalid, except for NS and SOA" rule duplicated at two layers, and this PR removes both:

1. `src/runtime/dns_jsc/dns.rs`: `Resolver::resolve` and the `resolve_record_fn!` macro had a `length == 0` guard (carrying an `$allow_empty` flag that exempted `resolveNs`/`resolveSoa`) which threw the synchronous `ERR_INVALID_ARG_TYPE`.
2. `src/cares_sys/c_ares.rs`: `Channel::resolve` had the same `ns`/`soa` allowlist one layer down. It short-circuited every other `resolve*("")` to a locally synthesized `ENOTFOUND` without ever contacting the configured server (caught in review; Node.js always sends the query). Only the bounds checks that protect the 1024-byte stack buffer remain. `LOOKUP_NAME` existed solely for this allowlist, so it is removed with it.

Non-string arguments still throw `ERR_INVALID_ARG_TYPE` synchronously, matching Node.js.

## Verification

New tests in `test/js/node/dns/node-dns.test.js` run a local mock DNS server that answers everything with SERVFAIL, and for all 13 `resolve*` methods assert:

- `dns.promises.Resolver#<method>("")` does not throw, and rejects with `code === "ESERVFAIL"`
- `dns.Resolver#<method>("", cb)` does not throw, and invokes the callback with `code === "ESERVFAIL"`
- non-string hostnames still throw `ERR_INVALID_ARG_TYPE` synchronously

`ESERVFAIL` can only come from the mock server's reply, so the assertion also proves the query was actually sent for every record type rather than answered locally (layer 2 above). No external network, no hardcoded ports, no timeout dependence. The identical cases run against Node v26.3.0 produce the same 26 results.
