### PR TITLE
bundler: compute content hash for sourcemap OutputFiles

### DIFF
--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -799,12 +799,13 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         chunk.final_rel_path.as_ref()
                     };
 
+                    let source_map_hash = ContentHasher::run(&output_source_map);
                     Some(output_files.insert_for_sourcemap_or_bytecode(
                         options::OutputFile::init(options::OutputFileInit {
                             data: options::OutputFileData::Buffer {
                                 data: output_source_map,
                             },
-                            hash: None,
+                            hash: Some(source_map_hash),
                             loader: Loader::Json,
                             input_loader: Loader::File,
                             output_path: source_map_final_rel_path.into_boxed_slice(),
@@ -952,12 +953,13 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         code_result.buffer = buf.into_boxed_slice();
                     }
 
+                    let source_map_hash = ContentHasher::run(&output_source_map);
                     sourcemap_output_file =
                         Some(options::OutputFile::init(options::OutputFileInit {
                             data: options::OutputFileData::Buffer {
                                 data: output_source_map,
                             },
-                            hash: None,
+                            hash: Some(source_map_hash),
                             loader: Loader::Json,
                             input_loader: Loader::File,
                             output_path: source_map_final_rel_path.into_boxed_slice(),

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -18,7 +18,7 @@ use crate::output_file::{
     BakeExtra, Index as OutputFileIndex, IndexOptional, Options as OutputFileInit,
     OptionsData as OutputFileData, SavedFile, Value as OutputFileValue,
 };
-use crate::{BundleV2, Chunk, cheap_prefix_normalizer};
+use crate::{BundleV2, Chunk, ContentHasher, cheap_prefix_normalizer};
 
 use bun_sys::{
     FdDirExt, PathOrFileDescriptor, WriteFileArgs, WriteFileData, WriteFileEncoding,
@@ -156,7 +156,7 @@ pub fn write_output_files_to_disk(
                             side: Some(options::Side::Client),
                             entry_point_index: None,
                             is_executable: false,
-                            hash: None,
+                            hash: Some(ContentHasher::run(&output_source_map)),
                             source_map_index: None,
                             bytecode_index: None,
                             module_info_index: None,
@@ -353,7 +353,7 @@ pub fn write_output_files_to_disk(
                     side: Some(options::Side::Client),
                     entry_point_index: None,
                     is_executable: false,
-                    hash: None,
+                    hash: Some(ContentHasher::run(&output_source_map)),
                     source_map_index: None,
                     bytecode_index: None,
                     module_info_index: None,

--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -72,8 +72,6 @@ exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"7gfnt0h
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"est79qzq"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
-
 exports[`Bun.build new Response(BuildArtifact) sets content type: response text 1`] = `
 "var __defProp = Object.defineProperty;
 var __returnValue = (v) => v;

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -312,7 +312,10 @@ describe("Bun.build", () => {
     expect(map.size).toBeGreaterThan(1);
     expect(path.relative(outdir, map.path)).toBe("index.js.map");
     expect(map.hash).toBeTruthy();
-    expect(map.hash).toMatchSnapshot("hash index.js.map");
+    // The sourcemap `sources` array contains paths relative to outdir (a temp
+    // dir), so the exact hash varies by machine and can't be snapshotted.
+    expect(map.hash).toMatch(/^[0-9a-z]{8}$/);
+    expect(map.hash).not.toBe("00000000");
     expect(map.kind).toBe("sourcemap");
     expect(map.loader).toBe("file");
     expect(map.sourcemap).toBe(null);


### PR DESCRIPTION
## Problem

Every sourcemap `OutputFile` is created with `hash: None`, which `OutputFile::init` stores as `0`. `Bun.build()` then reports `artifact.hash === "00000000"` for every sourcemap output, regardless of content:

```ts
const { outputs } = await Bun.build({ entrypoints: ["index.js"], sourcemap: "external", outdir });
const map = outputs.find(o => o.kind === "sourcemap");
map.hash; // "00000000", always
```

This was also the root cause of `Bun.serve` HTML imports serving every `.js.map` with `ETag: 0000000000000000` under `development: false`, which #32854 worked around at the serve layer (by hashing the blob bytes when `OutputFile.hash == 0`).

## Cause

JS and CSS chunks populate `OutputFile.hash` from `ContentHasher`, and bytecode hashes its bytes, but all four sites that construct a sourcemap `OutputFile` pass `hash: None`:

- `src/bundler/linker_context/generateChunksInParallel.rs` (linked/external sourcemap, and the standalone-inlined chunk path)
- `src/bundler/linker_context/writeOutputFilesToDisk.rs` (the same two shapes for the outdir path)

## Fix

Hash the serialized sourcemap bytes with `ContentHasher::run` at all four sites, the same way the bytecode sibling already hashes its bytes. `OutputFile.hash` is now populated for sourcemaps, so `BuildArtifact.hash` reports a real content hash and the serve-layer zero-hash fallback added in #32854 is no longer reached for sourcemaps (it stays as a defensive safety net for any other unhashed output).

## Tests

`test/bundler/bun-build-api.test.ts` `"BuildArtifact properties sourcemap"` previously snapshotted `map.hash` as `"00000000"` (literally asserting the bug). The sourcemap `sources` array contains outdir-relative paths that vary by machine, so the hash can't be stably snapshotted; the test now asserts the format and that it is not `"00000000"`.

Fails on main, passes with this change:

```
error: expect(received).not.toBe(expected)
Expected: not "00000000"
      at test/bundler/bun-build-api.test.ts:318:26
```

> Note: this PR originally also added a `Bun.serve` ETag test, but #32854 (merged since) already fixes the served ETag at the HTMLBundle layer, so that test can no longer demonstrate a failure without this diff and was dropped in the rebase onto current main.