### PR TITLE
node:crypto: accept BLAKE2 digests in createHmac and list them in getHashes()

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -2114,9 +2114,14 @@ const env_md_st_layout evp_md_blake2s256 = {
 
 } // namespace
 
-const EVP_MD* EVP_blake2s256_bun()
+extern "C" const EVP_MD* Bun__EVP_blake2s256()
 {
     return reinterpret_cast<const EVP_MD*>(&evp_md_blake2s256);
+}
+
+const EVP_MD* EVP_blake2s256_bun()
+{
+    return Bun__EVP_blake2s256();
 }
 
 // ============================================================================

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1899,6 +1899,221 @@ DataPointer DHPointer::stateless(const EVPKeyPointer& ourKey,
 }
 
 // ============================================================================
+// BLAKE2s-256
+//
+// BoringSSL provides EVP_blake2b256/EVP_blake2b512 but not BLAKE2s, which
+// Node.js (via OpenSSL) exposes as "blake2s256" for both createHash and
+// createHmac. Implement it here following RFC 7693 so the same EVP_MD* is
+// available to every consumer of getDigestByName (Hmac, hkdf, Sign/Verify)
+// rather than only createHash.
+//
+// State is POD and fits in EVP_MD_CTX::md_data, so EVP_MD_CTX_copy (memcpy)
+// is correct.
+
+namespace {
+
+constexpr unsigned BLAKE2S_CBLOCK = 64;
+constexpr unsigned BLAKE2S256_DIGEST_LENGTH = 32;
+
+struct BLAKE2S_CTX {
+    uint32_t h[8];
+    uint32_t t_low;
+    uint32_t t_high;
+    uint32_t block_used;
+    uint8_t block[BLAKE2S_CBLOCK];
+};
+
+static_assert(sizeof(BLAKE2S_CTX) <= EVP_MAX_MD_DATA_SIZE);
+
+// RFC 7693 section 2.6 (IV = SHA-256 IV)
+constexpr uint32_t kBlake2sIV[8] = {
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+};
+
+// RFC 7693 section 2.7
+constexpr uint8_t kBlake2sSigma[10 * 16] = {
+    // clang-format off
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
+    11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4,
+    7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8,
+    9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13,
+    2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9,
+    12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11,
+    13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10,
+    6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5,
+    10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0,
+    // clang-format on
+};
+
+inline uint32_t rotr32(uint32_t v, int n)
+{
+    return (v >> n) | (v << (32 - n));
+}
+
+inline uint32_t load32_le(const uint8_t* p)
+{
+    uint32_t v;
+    memcpy(&v, p, sizeof(v));
+    return v;
+}
+
+inline void store32_le(uint8_t* p, uint32_t v)
+{
+    memcpy(p, &v, sizeof(v));
+}
+
+// RFC 7693 section 3.1
+inline void blake2s_mix(uint32_t v[16], int a, int b, int c, int d, uint32_t x, uint32_t y)
+{
+    v[a] = v[a] + v[b] + x;
+    v[d] = rotr32(v[d] ^ v[a], 16);
+    v[c] = v[c] + v[d];
+    v[b] = rotr32(v[b] ^ v[c], 12);
+    v[a] = v[a] + v[b] + y;
+    v[d] = rotr32(v[d] ^ v[a], 8);
+    v[c] = v[c] + v[d];
+    v[b] = rotr32(v[b] ^ v[c], 7);
+}
+
+void blake2s_transform(BLAKE2S_CTX* ctx, const uint8_t block[BLAKE2S_CBLOCK], uint32_t num_bytes, int is_final_block)
+{
+    // RFC 7693 section 3.2
+    uint32_t v[16];
+    memcpy(v, ctx->h, sizeof(ctx->h));
+    memcpy(&v[8], kBlake2sIV, sizeof(kBlake2sIV));
+
+    ctx->t_low += num_bytes;
+    if (ctx->t_low < num_bytes) {
+        ctx->t_high++;
+    }
+    v[12] ^= ctx->t_low;
+    v[13] ^= ctx->t_high;
+
+    if (is_final_block) {
+        v[14] = ~v[14];
+    }
+
+    uint32_t m[16];
+    for (int i = 0; i < 16; i++) {
+        m[i] = load32_le(block + 4 * i);
+    }
+
+    for (int round = 0; round < 10; round++) {
+        const uint8_t* s = &kBlake2sSigma[16 * round];
+        blake2s_mix(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+        blake2s_mix(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+        blake2s_mix(v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+        blake2s_mix(v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+        blake2s_mix(v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+        blake2s_mix(v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+        blake2s_mix(v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+        blake2s_mix(v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+    }
+
+    for (int i = 0; i < 8; i++) {
+        ctx->h[i] ^= v[i] ^ v[i + 8];
+    }
+}
+
+void BLAKE2S256_Init(BLAKE2S_CTX* ctx)
+{
+    memset(ctx, 0, sizeof(*ctx));
+    memcpy(ctx->h, kBlake2sIV, sizeof(kBlake2sIV));
+    // RFC 7693 section 2.5
+    ctx->h[0] ^= 0x01010000 | BLAKE2S256_DIGEST_LENGTH;
+}
+
+void BLAKE2S256_Update(BLAKE2S_CTX* ctx, const void* in_data, size_t len)
+{
+    if (len == 0) {
+        return;
+    }
+
+    const uint8_t* data = reinterpret_cast<const uint8_t*>(in_data);
+    size_t todo = sizeof(ctx->block) - ctx->block_used;
+    if (todo > len) {
+        todo = len;
+    }
+    memcpy(&ctx->block[ctx->block_used], data, todo);
+    ctx->block_used += todo;
+    data += todo;
+    len -= todo;
+
+    if (!len) {
+        return;
+    }
+
+    blake2s_transform(ctx, ctx->block, BLAKE2S_CBLOCK, /*is_final_block=*/0);
+    ctx->block_used = 0;
+
+    while (len > BLAKE2S_CBLOCK) {
+        blake2s_transform(ctx, data, BLAKE2S_CBLOCK, /*is_final_block=*/0);
+        data += BLAKE2S_CBLOCK;
+        len -= BLAKE2S_CBLOCK;
+    }
+
+    memcpy(ctx->block, data, len);
+    ctx->block_used = len;
+}
+
+void BLAKE2S256_Final(uint8_t out[BLAKE2S256_DIGEST_LENGTH], BLAKE2S_CTX* ctx)
+{
+    memset(&ctx->block[ctx->block_used], 0, sizeof(ctx->block) - ctx->block_used);
+    blake2s_transform(ctx, ctx->block, ctx->block_used, /*is_final_block=*/1);
+    for (int i = 0; i < 8; i++) {
+        store32_le(out + 4 * i, ctx->h[i]);
+    }
+}
+
+void evp_blake2s256_init(EVP_MD_CTX* ctx)
+{
+    BLAKE2S256_Init(reinterpret_cast<BLAKE2S_CTX*>(ctx->md_data));
+}
+
+void evp_blake2s256_update(EVP_MD_CTX* ctx, const void* data, size_t len)
+{
+    BLAKE2S256_Update(reinterpret_cast<BLAKE2S_CTX*>(ctx->md_data), data, len);
+}
+
+void evp_blake2s256_final(EVP_MD_CTX* ctx, uint8_t* md)
+{
+    BLAKE2S256_Final(md, reinterpret_cast<BLAKE2S_CTX*>(ctx->md_data));
+}
+
+// Mirrors BoringSSL's private `struct env_md_st` layout
+// (crypto/fipsmodule/digest/internal.h).
+struct env_md_st_layout {
+    int type;
+    unsigned md_size;
+    uint32_t flags;
+    void (*init)(EVP_MD_CTX*);
+    void (*update)(EVP_MD_CTX*, const void*, size_t);
+    void (*final)(EVP_MD_CTX*, uint8_t*);
+    unsigned block_size;
+    unsigned ctx_size;
+};
+
+const env_md_st_layout evp_md_blake2s256 = {
+    NID_undef,
+    BLAKE2S256_DIGEST_LENGTH,
+    0,
+    evp_blake2s256_init,
+    evp_blake2s256_update,
+    evp_blake2s256_final,
+    BLAKE2S_CBLOCK,
+    sizeof(BLAKE2S_CTX),
+};
+
+} // namespace
+
+const EVP_MD* EVP_blake2s256_bun()
+{
+    return reinterpret_cast<const EVP_MD*>(&evp_md_blake2s256);
+}
+
+// ============================================================================
 // KDF
 
 const EVP_MD* getDigestByName(const WTF::StringView name)
@@ -1974,6 +2189,19 @@ const EVP_MD* getDigestByName(const WTF::StringView name)
         if (WTF::equalIgnoringASCIICase(remain, "128"_s)) {
             return EVP_sha1();
         }
+    }
+
+    // BoringSSL's EVP_get_digestbyname does not know about BLAKE2, but
+    // Node.js accepts "blake2b512" and "blake2s256" for both createHash
+    // and createHmac, so resolve them here for every consumer.
+    if (WTF::equalIgnoringASCIICase(name, "blake2b512"_s)) {
+        return EVP_blake2b512();
+    }
+    if (WTF::equalIgnoringASCIICase(name, "blake2s256"_s)) {
+        return EVP_blake2s256_bun();
+    }
+    if (WTF::equalIgnoringASCIICase(name, "blake2b256"_s)) {
+        return EVP_blake2b256();
     }
 
     // if (name == "ripemd160WithRSA"_s || name == "RSA-RIPEMD160"_s) {

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1927,8 +1927,14 @@ static_assert(sizeof(BLAKE2S_CTX) <= EVP_MAX_MD_DATA_SIZE);
 
 // RFC 7693 section 2.6 (IV = SHA-256 IV)
 constexpr uint32_t kBlake2sIV[8] = {
-    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    0x6a09e667,
+    0xbb67ae85,
+    0x3c6ef372,
+    0xa54ff53a,
+    0x510e527f,
+    0x9b05688c,
+    0x1f83d9ab,
+    0x5be0cd19,
 };
 
 // RFC 7693 section 2.7

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -1576,6 +1576,7 @@ Buffer<char> ExportChallenge(const char* input, size_t length);
 // KDF
 
 const EVP_MD* getDigestByName(const WTF::StringView name);
+const EVP_MD* EVP_blake2s256_bun();
 const EVP_CIPHER* getCipherByName(const WTF::StringView name);
 
 // Verify that the specified HKDF output length is valid for the given digest.

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -1219,6 +1219,20 @@ mod _impl {
             boringssl::c::EVP_MD_do_all_sorted(for_each_hash, (&raw mut hashes).cast::<c_void>());
         }
 
+        // Digests that createHash/createHmac accept but BoringSSL's
+        // EVP_MD_do_all_sorted does not enumerate. Node.js lists
+        // blake2b512, blake2s256, shake128, shake256; blake2b256 is a
+        // Bun extension that createHash already accepts.
+        for extra in [
+            b"blake2b256".as_slice(),
+            b"blake2b512",
+            b"blake2s256",
+            b"shake128",
+            b"shake256",
+        ] {
+            bun_core::handle_oom(hashes.put(extra, ()));
+        }
+
         let array = JSValue::create_empty_array(global, hashes.count())?;
 
         for (i, hash) in hashes.keys().iter().enumerate() {

--- a/src/sha_hmac/sha.rs
+++ b/src/sha_hmac/sha.rs
@@ -244,6 +244,12 @@ pub mod evp {
         Shake256,
     }
 
+    unsafe extern "C" {
+        // BoringSSL has no BLAKE2s; this EVP_MD lives in Bun's
+        // src/jsc/bindings/ncrypto.cpp.
+        safe fn Bun__EVP_blake2s256() -> *const ffi::EVP_MD;
+    }
+
     impl Algorithm {
         pub fn md(self) -> Option<*const ffi::EVP_MD> {
             // BoringSSL EVP_* md getters are `safe fn` returning a static const
@@ -251,6 +257,7 @@ pub mod evp {
             match self {
                 Algorithm::Blake2b256 => Some(ffi::EVP_blake2b256()),
                 Algorithm::Blake2b512 => Some(ffi::EVP_blake2b512()),
+                Algorithm::Blake2s256 => Some(Bun__EVP_blake2s256()),
                 Algorithm::Md4 => Some(ffi::EVP_md4()),
                 Algorithm::Md5 => Some(ffi::EVP_md5()),
                 Algorithm::Ripemd160 => Some(ffi::EVP_ripemd160()),

--- a/test/js/node/crypto/crypto-hmac-algorithm.test.ts
+++ b/test/js/node/crypto/crypto-hmac-algorithm.test.ts
@@ -19,9 +19,6 @@ test("createHmac works with various algorithm names", () => {
   ];
 
   const toRemove = [
-    "blake2b256",
-    "blake2b512",
-    "blake2s256",
     "md4",
     "sha512-224",
     "sha512-256",

--- a/test/js/node/crypto/crypto.hmac.test.ts
+++ b/test/js/node/crypto/crypto.hmac.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Hmac, createHmac, createSecretKey } from "crypto";
+import { Hmac, createHash, createHmac, createSecretKey, getHashes } from "crypto";
 import { PassThrough } from "stream";
 
 function testHmac(algo, key, data, expected) {
@@ -448,5 +448,106 @@ describe("crypto.Hmac", () => {
     expect(createHmac("sha256", buf).update("foo").digest()).toEqual(
       createHmac("sha256", keyObject).update("foo").digest(),
     );
+  });
+
+  // createHash accepts BLAKE2 digests but createHmac previously rejected them
+  // with ERR_CRYPTO_INVALID_DIGEST, and getHashes() omitted them. Vectors
+  // generated with Node.js.
+  describe("HMAC-BLAKE2", () => {
+    const longKey = Buffer.alloc(200, 0xaa);
+    const longData = Buffer.alloc(300, 0x61);
+    const vectors = [
+      {
+        algo: "blake2b512",
+        key: Buffer.alloc(0),
+        data: "",
+        hmac: "198cd2006f66ff83fbbd913f78aca2251caf4f19fe9475aade8cf2091b99a68466775177424f58286886cbae8229644cec747237d4b721735485e17372fdf59c",
+      },
+      {
+        algo: "blake2b512",
+        key: "key",
+        data: "The quick brown fox jumps over the lazy dog",
+        hmac: "92294f92c0dfb9b00ec9ae8bd94d7e7d8a036b885a499f149dfe2fd2199394aaaf6b8894a1730cccb2cd050f9bcf5062a38b51b0dab33207f8ef35ae2c9df51b",
+      },
+      {
+        algo: "blake2b512",
+        key: longKey,
+        data: "Test With Longer Than Block-Size Key",
+        hmac: "e9000fe6312bcc1775bb219504154a96906a4ec72fe5dfd280214804cc70e92cd2a6ee8e4c4a248725a1f6f430401e0f323db3f7d39b5dd5302837bbadd8326a",
+      },
+      {
+        algo: "blake2b512",
+        key: "key",
+        data: longData,
+        hmac: "75a175d7bd38de76897a99d5788387424cc46a515946550d806f5919b2b5c9be8adfcac0e5e666487e3f4938664c57d1588d35af8159b206fc73a56b74e97c2f",
+      },
+      {
+        algo: "blake2s256",
+        key: Buffer.alloc(0),
+        data: "",
+        hmac: "eaf4bb25938f4d20e72656bbbc7a9bf63c0c18537333c35bdb67db1402661acd",
+      },
+      {
+        algo: "blake2s256",
+        key: "key",
+        data: "The quick brown fox jumps over the lazy dog",
+        hmac: "f93215bb90d4af4c3061cd932fb169fb8bb8a91d0b4022baea1271e1323cd9a0",
+      },
+      {
+        algo: "blake2s256",
+        key: longKey,
+        data: "Test With Longer Than Block-Size Key",
+        hmac: "b1e4fdce261f7b6cc721a1b1118951ab4e1a292419cbf93a4c8f97441ff5c451",
+      },
+      {
+        algo: "blake2s256",
+        key: "key",
+        data: longData,
+        hmac: "ad8060720ec7504c430b638034fa099f931f514cdaf3d96e03192bfa1eb55290",
+      },
+    ];
+
+    for (const { algo, key, data, hmac } of vectors) {
+      testHmac(algo, key, data, hmac);
+    }
+
+    test("multi-chunk update matches single update", () => {
+      for (const algo of ["blake2b512", "blake2s256"]) {
+        const a = createHmac(algo, "key");
+        a.update("hello");
+        a.update(" ");
+        a.update("world");
+        const b = createHmac(algo, "key").update("hello world");
+        expect(a.digest("hex")).toBe(b.digest("hex"));
+      }
+    });
+
+    test("case-insensitive algorithm name", () => {
+      const lower = createHmac("blake2s256", "key").update("abc").digest("hex");
+      const upper = createHmac("BLAKE2S256", "key").update("abc").digest("hex");
+      expect(upper).toBe(lower);
+    });
+
+    test("createHash output is unchanged", () => {
+      expect(createHash("blake2b512").update("abc").digest("hex")).toBe(
+        "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923",
+      );
+      expect(createHash("blake2s256").update("abc").digest("hex")).toBe(
+        "508c5e8c327c14e2e1a72ba34eeb452f37458b209ed63a294d999b4c86675982",
+      );
+    });
+
+    test("getHashes lists BLAKE2 digests that createHash accepts", () => {
+      const hashes = getHashes();
+      expect(hashes).toContain("blake2b512");
+      expect(hashes).toContain("blake2s256");
+      expect(hashes).toContain("blake2b256");
+    });
+
+    test("blake2b256 HMAC (Bun extension)", () => {
+      const h = createHmac("blake2b256", "key").update("abc").digest("hex");
+      expect(h).toMatch(/^[0-9a-f]{64}$/);
+      expect(h).toBe(createHmac("blake2b256", "key").update("abc").digest("hex"));
+    });
   });
 });

--- a/test/js/node/crypto/crypto.hmac.test.ts
+++ b/test/js/node/crypto/crypto.hmac.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Hmac, createHash, createHmac, createSecretKey, getHashes } from "crypto";
+import { Hmac, createHash, createHmac, createSecretKey, getHashes, hkdfSync, pbkdf2Sync } from "crypto";
 import { PassThrough } from "stream";
 
 function testHmac(algo, key, data, expected) {
@@ -542,6 +542,29 @@ describe("crypto.Hmac", () => {
       expect(hashes).toContain("blake2b512");
       expect(hashes).toContain("blake2s256");
       expect(hashes).toContain("blake2b256");
+    });
+
+    // Node's own test-crypto-pbkdf2.js and test-crypto-hkdf.js iterate
+    // getHashes() through these APIs, so every listed name must work there
+    // too. Values from Node.js.
+    test.each([
+      ["blake2b512", "40b77cc2ee4b4c44eeb5babc299be14af5670e39ea3ce14c0fe70e6c99369886"],
+      ["blake2s256", "7b88e65e6e95a118bc995f681a391cbd7b46e0cf9750a81100f613add62d84be"],
+    ])("pbkdf2Sync accepts %s", (algo, expected) => {
+      expect(pbkdf2Sync("password", "salt", 2, 32, algo).toString("hex")).toBe(expected);
+    });
+
+    test.each([
+      ["blake2b512", "b3b27a54dac96f4819e8befbc643bd78b7882208b2e366043cbf47ab44b033a4"],
+      ["blake2s256", "b1a7297a13a0295c6c6c50e092617114e130fe45667ca5475ae49cf8536c5ad0"],
+    ])("hkdfSync accepts %s", (algo, expected) => {
+      expect(Buffer.from(hkdfSync(algo, "key", "salt", "info", 32)).toString("hex")).toBe(expected);
+    });
+
+    test("every getHashes() entry works with createHash", () => {
+      for (const name of getHashes()) {
+        expect(createHash(name).update("abc").digest("hex").length).toBeGreaterThan(0);
+      }
     });
 
     test("blake2b256 HMAC (Bun extension)", () => {


### PR DESCRIPTION
Fixes #20592

`createHash("blake2b512")` and `createHash("blake2s256")` already work and match Node byte for byte, but `createHmac()` with the same digest names throws `ERR_CRYPTO_INVALID_DIGEST` and `getHashes()` omits them. Feature-detection code that checks `getHashes()` takes the wrong branch, and any HMAC-BLAKE2 tag produced by Node cannot be recomputed on Bun.

```js
const crypto = require("node:crypto");
crypto.createHash("blake2s256").update("abc").digest("hex");
// "508c5e8c327c14e2e1a72ba34eeb452f..."  (matches Node)
crypto.createHmac("blake2s256", "key").update("abc").digest("hex");
// before: TypeError: Invalid digest: blake2s256  [ERR_CRYPTO_INVALID_DIGEST]
// after:  "0018bfddc0c878b3e270c6e5..."  (matches Node)
crypto.getHashes().includes("blake2s256");
// before: false    after: true
```

### Cause

Digest-name resolution is split across three places that disagree:

- `ncrypto::getDigestByName` (Hmac, hkdf, Sign, Verify) falls through to BoringSSL's `EVP_get_digestbyname`, whose lookup table has no BLAKE2 entries.
- The Rust `Algorithm::md()` (pbkdf2, `Bun.CryptoHasher`) returns `None` for `Blake2s256` because BoringSSL ships no BLAKE2s `EVP_MD`.
- `createHash` has a separate fallback to Rust-side hashers that the others lack.

### Fix

Add one BLAKE2s-256 `EVP_MD` and point every resolver at it:

- `ncrypto.cpp` gains a BLAKE2s-256 `EVP_MD` implemented per RFC 7693, mirroring BoringSSL's own BLAKE2b (`crypto/blake2/blake2.cc`). The state is POD and fits in `EVP_MD_CTX::md_data`, so `EVP_MD_CTX_copy` (memcpy) stays correct. It is exported as `Bun__EVP_blake2s256` for the Rust side.
- `getDigestByName` maps `blake2b256`/`blake2b512` to the existing BoringSSL singletons and `blake2s256` to the new one. This fixes `createHmac`, `hkdf`, `Sign`, and `Verify` in one place.
- The Rust `Algorithm::md()` maps `Blake2s256` to the same `EVP_MD`, which fixes `pbkdf2` and unifies `Bun.CryptoHasher`.
- `getHashes()` adds `blake2b256`, `blake2b512`, `blake2s256`, `shake128`, `shake256`: all already accepted by `createHash` but skipped by `EVP_MD_do_all_sorted` because they have `NID_undef`.

The new `EVP_MD` reinterprets a locally-defined struct that mirrors BoringSSL's `struct env_md_st` (`crypto/fipsmodule/digest/internal.h`). That layout is the one BoringSSL's own header comment says it keeps stable because consumers forward-declare it, and the known-answer tests here would catch any mismatch on the first `digest()` call. The alternative, patching the vendored BoringSSL, would add a maintained vendor patch for a single digest.

### Relationship to #32818

#32818 independently wires `blake2b256`/`blake2b512` into `getDigestByName` and `getHashes()` as part of a larger rsa-pss/ECDH change, but explicitly defers `blake2s256` because "BoringSSL has no BLAKE2s implementation at all". This PR closes that gap with the `EVP_MD`, so the overlapping hunks (the two blake2b name mappings and the `getHashes` additions) are a strict superset of what #32818 does for BLAKE2. Whichever lands second will need a trivial rebase in `getDigestByName` / `get_hashes` / `crypto.hmac.test.ts`.

### Verification

New tests in `test/js/node/crypto/crypto.hmac.test.ts` cover HMAC-BLAKE2b-512 and HMAC-BLAKE2s-256 against known-answer vectors generated with Node.js (empty key, short key, key longer than block size, input longer than block size), `pbkdf2Sync` and `hkdfSync` with both digests, case-insensitive names, multi-chunk updates, the `getHashes()` listing, and that every name `getHashes()` returns is accepted by `createHash`. All fail on the unmodified build with `ERR_CRYPTO_INVALID_DIGEST`. `createHash` output for both digests is pinned unchanged.

Node's own `test-crypto-pbkdf2.js`, `test-crypto-hkdf.js`, `test-crypto-oneshot-hash.js`, `test-crypto-hash.js`, and `test-crypto-hmac.js` (which iterate `getHashes()` through those APIs) all pass.
