### PR TITLE
Bun.write: honour the mode option for every source type (string, TypedArray, Blob, Response, stream)

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1463,7 +1463,7 @@ impl BlobExt for Blob {
                             };
                         }
                     }
-                    match result {
+                    let fd = match result {
                         bun_sys::Result::Ok(result) => result,
                         bun_sys::Result::Err(err) => {
                             return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
@@ -1471,7 +1471,19 @@ impl BlobExt for Blob {
                                 err.with_path(path).to_js(global_this),
                             ));
                         }
+                    };
+                    // uv_fs_open only applies `mode` on create; fchmod covers existing files.
+                    if let Some(mode) = options.mode {
+                        if let bun_sys::Result::Err(err) = bun_sys::fchmod(fd, mode) {
+                            use bun_sys::FdExt as _;
+                            fd.close();
+                            return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                                global_this,
+                                err.with_path(path).to_js(global_this),
+                            ));
+                        }
                     }
+                    fd
                 };
 
                 let is_stdout_or_stderr = 'brk: {
@@ -1557,7 +1569,7 @@ impl BlobExt for Blob {
                 let stream_start = streams::Start::FileSink(streams::FileSinkOptions {
                     truncate: matches!(input_path, webcore::PathOrFileDescriptor::Path(_)),
                     mkdirp: options.mkdirp_if_not_exists.unwrap_or(true),
-                    mode: options.mode.unwrap_or(WRITE_PERMISSIONS),
+                    mode: options.mode,
                     input_path,
                     ..Default::default()
                 });
@@ -4327,6 +4339,15 @@ fn write_file_with_empty_source_to_destination(
                                         break 'err;
                                     }
                                     bun_sys::Result::Ok(f) => {
+                                        // open() applied `mode` through the umask; make it exact.
+                                        if let Some(m) = options.mode {
+                                            if let bun_sys::Result::Err(e) =
+                                                bun_sys::fchmod(f.fd(), m)
+                                            {
+                                                *err = e;
+                                                break 'err;
+                                            }
+                                        }
                                         let _ = f.close(); // close error is non-actionable
                                         return Ok(JSPromise::resolved_promise_value(
                                             ctx,
@@ -4347,6 +4368,26 @@ fn write_file_with_empty_source_to_destination(
                         err.to_js(ctx),
                     ),
                 );
+            }
+
+            if let Some(mode) = options.mode {
+                if let PathOrFileDescriptor::Path(path) = &file.pathlike {
+                    let chmod_result = node_fs.chmod(
+                        &node::fs::args::Chmod {
+                            path: PathLike::borrowed(path.slice()),
+                            mode,
+                        },
+                        node::fs::Flavor::Sync,
+                    );
+                    if let bun_sys::Result::Err(err) = chmod_result {
+                        return Ok(
+                            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                                ctx,
+                                err.to_js(ctx),
+                            ),
+                        );
+                    }
+                }
             }
         }
         store::Data::S3(s3) => {
@@ -4473,6 +4514,7 @@ pub(crate) fn write_file_with_source_destination(
                 write_file_promise,
                 WriteFilePromise::run,
                 options.mkdirp_if_not_exists.unwrap_or(true),
+                options.mode,
             ) {
                 Err(write_file_mod::WriteFileWindowsError::WriteFileWindowsDeinitialized) => {}
                 Err(write_file_mod::WriteFileWindowsError::Js(err)) => return Err(err),
@@ -4489,6 +4531,7 @@ pub(crate) fn write_file_with_source_destination(
                 write_file_promise,
                 WriteFilePromise::run,
                 options.mkdirp_if_not_exists.unwrap_or(true),
+                options.mode,
             )
             .expect("unreachable");
             // Defer promise creation until we're just about to schedule the task.
@@ -4810,6 +4853,7 @@ pub(crate) fn write_file_internal(
                             global_this,
                             pathlike,
                             &str,
+                            options.mode,
                             &mut needs_async,
                         )
                     } else {
@@ -4817,6 +4861,7 @@ pub(crate) fn write_file_internal(
                             global_this,
                             pathlike,
                             &str,
+                            options.mode,
                             &mut needs_async,
                         )
                     };
@@ -4841,6 +4886,7 @@ pub(crate) fn write_file_internal(
                             global_this,
                             pathlike,
                             buffer_view.byte_slice(),
+                            options.mode,
                             &mut needs_async,
                         )
                     } else {
@@ -4848,6 +4894,7 @@ pub(crate) fn write_file_internal(
                             global_this,
                             pathlike,
                             buffer_view.byte_slice(),
+                            options.mode,
                             &mut needs_async,
                         )
                     };
@@ -5068,6 +5115,7 @@ pub(crate) fn write_file_internal(
                             ),
                             promise: jsc::JSPromiseStrong::init(global_this),
                             mkdirp_if_not_exists: options.mkdirp_if_not_exists.unwrap_or(true),
+                            mode: options.mode,
                         }));
                     // SAFETY: re-borrow after the early-return paths.
                     let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
@@ -5255,13 +5303,14 @@ pub(crate) fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) ->
     )
 }
 
-const WRITE_PERMISSIONS: bun_sys::Mode = 0o664;
+pub(crate) const WRITE_PERMISSIONS: bun_sys::Mode = 0o664;
 
 #[cfg(not(windows))]
 fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
     global_this: &JSGlobalObject,
     pathlike: &PathOrFileDescriptor,
     str: &BunString,
+    mode: Option<bun_sys::Mode>,
     needs_async: &mut bool,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
@@ -5273,7 +5322,7 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
             // we deliberately don't use O_TRUNC here
             // it's a perf optimization
             bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK,
-            WRITE_PERMISSIONS,
+            mode.unwrap_or(WRITE_PERMISSIONS),
         ) {
             bun_sys::Result::Ok(result) => result,
             bun_sys::Result::Err(err) => {
@@ -5291,6 +5340,18 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
 
     // Declared before the truncate guard so it drops *after* it (close runs last).
     let _close = NEEDS_OPEN.then(|| bun_sys::CloseOnDrop::new(fd));
+
+    // open() only applies `mode` on create, and through the umask; fchmod makes it exact.
+    if NEEDS_OPEN {
+        if let Some(mode) = mode {
+            if let bun_sys::Result::Err(err) = bun_sys::fchmod(fd, mode) {
+                return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                    global_this,
+                    err.with_path(pathlike.path().slice()).to_js(global_this),
+                );
+            }
+        }
+    }
 
     // scopeguard's closure captures borrows at construction, conflicting
     // with later `written += ...` / `truncate = false`. Route through `Cell`
@@ -5346,6 +5407,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     global_this: &JSGlobalObject,
     pathlike: &PathOrFileDescriptor,
     bytes: &[u8],
+    mode: Option<bun_sys::Mode>,
     _needs_async: &mut bool,
 ) -> JSValue {
     let fd: Fd = if !NEEDS_OPEN {
@@ -5360,7 +5422,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
         match bun_sys::open(
             pathlike.path().slice_z(&mut file_path),
             flags,
-            WRITE_PERMISSIONS,
+            mode.unwrap_or(WRITE_PERMISSIONS),
         ) {
             bun_sys::Result::Ok(result) => result,
             bun_sys::Result::Err(err) => {
@@ -5382,6 +5444,17 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     let truncate = NEEDS_OPEN || bytes.is_empty();
     let mut written: usize = 0;
     let _close = NEEDS_OPEN.then(|| bun_sys::CloseOnDrop::new(fd));
+
+    if NEEDS_OPEN {
+        if let Some(mode) = mode {
+            if let bun_sys::Result::Err(err) = bun_sys::fchmod(fd, mode) {
+                return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                    global_this,
+                    err.with_path(pathlike.path().slice()).to_js(global_this),
+                );
+            }
+        }
+    }
 
     let mut remain = bytes;
     while !remain.is_empty() {
@@ -6653,6 +6726,10 @@ pub trait FileOpener: Sized {
     const OPEN_FLAGS: i32 = bun_sys::O::RDONLY;
     const OPENER_FLAGS: i32 = bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC;
 
+    /// Permission bits passed to `open(2)` when creating the file.
+    fn open_mode(&self) -> bun_sys::Mode {
+        crate::node::fs::DEFAULT_PERMISSION
+    }
     fn opened_fd(&self) -> Fd;
     fn set_opened_fd(&mut self, fd: Fd);
     fn set_errno(&mut self, e: crate::Error);
@@ -6728,6 +6805,7 @@ pub trait FileOpener: Sized {
             }
 
             self.set_open_callback(callback);
+            let open_mode = self.open_mode();
             let loop_ = self.loop_();
             let self_ptr: *mut Self = core::ptr::from_mut(self);
             // Derive `req` THROUGH `self_ptr` rather than via a fresh `self.req()`
@@ -6751,7 +6829,7 @@ pub trait FileOpener: Sized {
                     req,
                     path.as_ptr(),
                     Self::OPEN_FLAGS | Self::OPENER_FLAGS,
-                    node::fs::DEFAULT_PERMISSION as i32,
+                    open_mode as i32,
                     Some(wrapped_callback::<Self>),
                 )
             };
@@ -6774,12 +6852,9 @@ pub trait FileOpener: Sized {
 
         #[cfg(not(windows))]
         {
+            let open_mode = self.open_mode();
             loop {
-                match bun_sys::open(
-                    path,
-                    Self::OPEN_FLAGS | Self::OPENER_FLAGS,
-                    crate::node::fs::DEFAULT_PERMISSION,
-                ) {
+                match bun_sys::open(path, Self::OPEN_FLAGS | Self::OPENER_FLAGS, open_mode) {
                     bun_sys::Result::Ok(fd) => {
                         self.set_opened_fd(fd);
                         break;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5303,7 +5303,8 @@ pub(crate) fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) ->
     )
 }
 
-pub(crate) const WRITE_PERMISSIONS: bun_sys::Mode = 0o664;
+/// Default create mode. Not `DEFAULT_PERMISSION`: that is 0 on Windows, which libuv creates read-only.
+pub(crate) const WRITE_PERMISSIONS: bun_sys::Mode = 0o666;
 
 #[cfg(not(windows))]
 fn write_string_to_file_fast<const NEEDS_OPEN: bool>(

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -158,7 +158,8 @@ bun_io::impl_streaming_writer_parent! {
 
 pub struct Options {
     pub(crate) input_path: PathOrFileDescriptor,
-    pub(crate) mode: bun_sys::Mode,
+    /// `Bun.write(path, stream, { mode })`: applied exactly (fchmod) when `input_path` is a path.
+    pub(crate) mode: Option<bun_sys::Mode>,
     /// `Bun.write(path, stream)`: replace the file's contents.
     pub(crate) truncate: bool,
     /// `Bun.write(path, stream)`: create missing parent directories.
@@ -169,7 +170,7 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             input_path: PathOrFileDescriptor::Fd(Fd::INVALID),
-            mode: 0o664,
+            mode: None,
             truncate: false,
             mkdirp: false,
         }
@@ -636,7 +637,7 @@ impl FileSink {
                 Fd::cwd(),
                 &io_path,
                 options.flags(),
-                options.mode,
+                options.mode.unwrap_or(webcore::blob::WRITE_PERMISSIONS),
                 pollable_out,
                 is_socket_out,
                 self.force_sync.get(),
@@ -690,6 +691,14 @@ impl FileSink {
             }
             sys::Result::Ok(fd) => fd,
         };
+
+        // open() only applies `mode` on create, and through the umask; fchmod makes it exact.
+        if let (Some(mode), bun_io::PathOrFileDescriptor::Path(path)) = (options.mode, &io_path) {
+            if let sys::Result::Err(err) = sys::fchmod(fd, mode) {
+                fd.close();
+                return sys::Result::Err(err.with_path(*path));
+            }
+        }
 
         #[cfg(windows)]
         {

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -111,6 +111,7 @@ pub struct WriteFile {
     pub(crate) could_block: bool,
     pub(crate) close_after_io: bool,
     pub(crate) mkdirp_if_not_exists: bool,
+    pub(crate) mode: Option<sys::Mode>,
 }
 
 bun_threading::intrusive_work_task!(WriteFile, task);
@@ -124,6 +125,9 @@ impl FileOpener for WriteFile {
     const OPEN_FLAGS: i32 =
         bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC | bun_sys::O::NONBLOCK;
 
+    fn open_mode(&self) -> sys::Mode {
+        self.mode.unwrap_or(crate::node::fs::DEFAULT_PERMISSION)
+    }
     fn opened_fd(&self) -> Fd {
         self.opened_fd
     }
@@ -282,6 +286,7 @@ impl WriteFile {
         on_write_file_context: *mut c_void,
         on_complete_callback: WriteFileOnWriteFileCallback,
         mkdirp_if_not_exists: bool,
+        mode: Option<sys::Mode>,
     ) -> Result<WriteFile, Error> {
         let write_file = WriteFile {
             file_blob,
@@ -305,6 +310,7 @@ impl WriteFile {
             could_block: false,
             close_after_io: false,
             mkdirp_if_not_exists,
+            mode,
         };
         Ok(write_file)
     }
@@ -316,6 +322,7 @@ impl WriteFile {
         context: *mut C,
         callback: WriteFileOnWriteFileCallback,
         mkdirp_if_not_exists: bool,
+        mode: Option<sys::Mode>,
     ) -> Result<WriteFile, Error> {
         // The caller supplies a
         // `*mut c_void`-typed callback directly (see `WriteFilePromise::run`),
@@ -326,6 +333,7 @@ impl WriteFile {
             context.cast::<c_void>(),
             callback,
             mkdirp_if_not_exists,
+            mode,
         )
     }
 
@@ -434,6 +442,18 @@ impl WriteFile {
         }
 
         let fd = self.opened_fd;
+
+        if let Some(mode) = self.mode {
+            if self.is_allowed_to_close() {
+                if let bun_sys::Result::Err(err) = bun_sys::fchmod(fd, mode) {
+                    let err = err.with_path(self.pathlike().path().slice());
+                    self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                    self.system_error = Some(err.to_system_error().into());
+                    self.on_finish();
+                    return;
+                }
+            }
+        }
 
         self.could_block = 'brk: {
             if let Some(store) = self.file_blob.store.get().as_ref() {
@@ -580,6 +600,7 @@ mod windows_impl {
         pub(crate) on_complete_callback: WriteFileOnWriteFileCallback,
         pub(crate) on_complete_ctx: *mut c_void,
         pub(crate) mkdirp_if_not_exists: bool,
+        pub(crate) mode: Option<sys::Mode>,
         pub(crate) uv_bufs: [uv::uv_buf_t; 1],
 
         pub(crate) fd: uv::uv_file,
@@ -616,6 +637,7 @@ mod windows_impl {
             on_write_file_context: *mut c_void,
             on_complete_callback: WriteFileOnWriteFileCallback,
             mkdirp_if_not_exists: bool,
+            mode: Option<sys::Mode>,
         ) -> Result<*mut WriteFileWindows, WriteFileWindowsError> {
             let mkdirp = mkdirp_if_not_exists
                 && file_blob
@@ -633,6 +655,7 @@ mod windows_impl {
                 on_complete_ctx: on_write_file_context,
                 on_complete_callback,
                 mkdirp_if_not_exists: mkdirp,
+                mode,
                 io_request: bun_core::ffi::zeroed::<uv::fs_t>(),
                 uv_bufs: [uv::uv_buf_t {
                     base: null_mut(),
@@ -770,7 +793,7 @@ mod windows_impl {
                         | uv::O::NONBLOCK
                         | uv::O::SEQUENTIAL
                         | uv::O::TRUNC,
-                    0o644,
+                    (*this).mode.unwrap_or(0o644) as i32,
                     Some(Self::on_open),
                 )
             };
@@ -866,6 +889,21 @@ mod windows_impl {
 
             // SAFETY: `this` is live.
             unsafe { (*this).fd = i32::try_from(rc.int()).expect("int cast") };
+
+            // uv_fs_open only applies `mode` on create; fchmod covers existing files.
+            // SAFETY: `this` is live.
+            if let Some(mode) = unsafe { (*this).mode } {
+                // SAFETY: `this` is live; `fd` was just opened above.
+                if let sys::Result::Err(err) = sys::fchmod(Fd::from_uv(unsafe { (*this).fd }), mode)
+                {
+                    // SAFETY: `this` is live; `throw` consumes it.
+                    match unsafe { Self::throw(this, err) } {
+                        WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
+                        WriteFileWindowsError::Js(err) => crate::dispatch::fold(Err(err)),
+                    }
+                    return;
+                }
+            }
 
             // the loop must be copied
             // SAFETY: `this` is live; on `Err`, `*this` has been freed and is not accessed again.
@@ -1175,6 +1213,7 @@ mod windows_impl {
             context: *mut C,
             callback: WriteFileOnWriteFileCallback,
             mkdirp_if_not_exists: bool,
+            mode: Option<sys::Mode>,
         ) -> Result<*mut WriteFileWindows, WriteFileWindowsError> {
             // see `WriteFile::create` — caller supplies an erased
             // `*mut c_void` callback directly; `context` is just `.cast()`ed.
@@ -1185,6 +1224,7 @@ mod windows_impl {
                 context.cast::<c_void>(),
                 callback,
                 mkdirp_if_not_exists,
+                mode,
             )
         }
     }
@@ -1245,6 +1285,7 @@ pub struct WriteFileWaitFromLockedValueTask {
     pub global_this: bun_ptr::BackRef<JSGlobalObject>,
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) mkdirp_if_not_exists: bool,
+    pub(crate) mode: Option<sys::Mode>,
 }
 
 impl WriteFileWaitFromLockedValueTask {
@@ -1301,6 +1342,7 @@ impl WriteFileWaitFromLockedValueTask {
                     &mut file_blob,
                     &blob::WriteFileOptions {
                         mkdirp_if_not_exists: Some(this.mkdirp_if_not_exists),
+                        mode: this.mode,
                         ..Default::default()
                     },
                 ) {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1256,4 +1256,41 @@ describe.skipIf(isWindows).concurrent("Bun.write mode option", () => {
     await Bun.write(dest, "hello");
     expect(modeOf(dest)).toBe(0o751);
   });
+
+  // umask is process-global, so this runs in a child with umask 0 to make the
+  // raw create mode observable. Every path must match fs.writeFileSync (0o666).
+  test("default create mode does not depend on the payload size or write path", async () => {
+    using dir = tempDir("bun-write-mode", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("node:fs");
+          process.umask(0);
+          await Bun.write("small.txt", "x");
+          await Bun.write("large.bin", new Uint8Array(512 * 1024));
+          const writer = Bun.file("writer.txt").writer();
+          writer.write("x");
+          await writer.end();
+          fs.writeFileSync("node.txt", "x");
+          const modeOf = p => (fs.statSync(p).mode & 0o777).toString(8);
+          console.log(JSON.stringify({
+            small: modeOf("small.txt"),
+            large: modeOf("large.bin"),
+            writer: modeOf("writer.txt"),
+            node: modeOf("node.txt"),
+          }));
+        `,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ small: "666", large: "666", writer: "666", node: "666" });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1161,3 +1161,99 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     expect(f.name).toBe(filePath);
   });
 });
+
+describe.skipIf(isWindows).concurrent("Bun.write mode option", () => {
+  const modeOf = p => fs.statSync(p).mode & 0o777;
+  const large = Buffer.alloc(512 * 1024, "a").toString();
+  const stream = () =>
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("hello"));
+        controller.close();
+      },
+    });
+
+  // Factories, because a stream source can only be consumed once.
+  for (const [label, make] of [
+    ["small string", () => "hello"],
+    ["empty string", () => ""],
+    ["small Uint8Array", () => new Uint8Array([1, 2, 3])],
+    ["large string (async path)", () => large],
+    ["large Uint8Array (async path)", () => new Uint8Array(512 * 1024)],
+    ["Blob", () => new Blob(["hello"])],
+    ["empty Blob", () => new Blob([])],
+    ["ReadableStream", stream],
+    ["Response with a streaming body", () => new Response(stream())],
+  ]) {
+    test(`sets permissions on new file for ${label}`, async () => {
+      using dir = tempDir("bun-write-mode", {});
+      const dest = join(String(dir), "out.txt");
+      await Bun.write(dest, make(), { mode: 0o600 });
+      expect(modeOf(dest)).toBe(0o600);
+    });
+
+    test(`sets permissions on existing file for ${label}`, async () => {
+      using dir = tempDir("bun-write-mode", { "out.txt": "old" });
+      const dest = join(String(dir), "out.txt");
+      // The seed file's mode depends on the umask; pin it so the precondition holds.
+      fs.chmodSync(dest, 0o644);
+      expect(modeOf(dest)).not.toBe(0o600);
+      await Bun.write(dest, make(), { mode: 0o600 });
+      expect(modeOf(dest)).toBe(0o600);
+    });
+  }
+
+  test("sets permissions when destination is a Bun.file()", async () => {
+    using dir = tempDir("bun-write-mode", {});
+    const dest = join(String(dir), "out.txt");
+    await Bun.write(Bun.file(dest), "hello", { mode: 0o600 });
+    expect(modeOf(dest)).toBe(0o600);
+  });
+
+  test("sets permissions when parent directory must be created", async () => {
+    using dir = tempDir("bun-write-mode", {});
+    const dest = join(String(dir), "sub", "out.txt");
+    await Bun.write(dest, "hello", { mode: 0o600 });
+    expect(modeOf(dest)).toBe(0o600);
+  });
+
+  test("sets permissions when source is a Response body", async () => {
+    using dir = tempDir("bun-write-mode", {});
+    const dest = join(String(dir), "out.txt");
+    await Bun.write(dest, new Response("hello"), { mode: 0o600 });
+    expect(modeOf(dest)).toBe(0o600);
+  });
+
+  test("accepts mode 0", async () => {
+    using dir = tempDir("bun-write-mode", {});
+    const dest = join(String(dir), "out.txt");
+    await Bun.write(dest, "hello", { mode: 0o000 });
+    expect(modeOf(dest)).toBe(0o000);
+  });
+
+  // 0o646's group/other write bits are cleared by a typical umask, so only a
+  // post-open chmod can produce it. This is the path createPath recovery uses.
+  test("mode is not masked by the umask when the parent directory is created", async () => {
+    using dir = tempDir("bun-write-mode", {});
+    const dest = join(String(dir), "sub", "out.txt");
+    await Bun.write(dest, new Blob([]), { mode: 0o646 });
+    expect(modeOf(dest)).toBe(0o646);
+  });
+
+  test("omitted mode leaves default permissions", async () => {
+    using dir = tempDir("bun-write-mode", {});
+    const dest = join(String(dir), "out.txt");
+    const baseline = join(String(dir), "baseline.txt");
+    await Bun.write(baseline, "x");
+    await Bun.write(dest, "hello");
+    expect(modeOf(dest)).toBe(modeOf(baseline));
+  });
+
+  test("omitted mode leaves an existing file's permissions alone", async () => {
+    using dir = tempDir("bun-write-mode", { "out.txt": "old" });
+    const dest = join(String(dir), "out.txt");
+    fs.chmodSync(dest, 0o751);
+    await Bun.write(dest, "hello");
+    expect(modeOf(dest)).toBe(0o751);
+  });
+});

--- a/test/regression/issue/25903.test.ts
+++ b/test/regression/issue/25903.test.ts
@@ -141,7 +141,5 @@ describe.skipIf(isWindows)("Bun.write() mode option", () => {
   });
 }); // end describe.skipIf(isWindows)
 
-// Note: The mode option is fully respected for Bun.file() copy operations (the fix for #25903).
-// For direct string/buffer writes, mode support depends on the write path used internally.
-// The empty file creation path respects mode, but other direct write paths may use
-// the default permission (0o664). The tests above validate the Bun.file() copy path.
+// These tests validate the Bun.file() copy path. The string/buffer/Blob write paths
+// are covered by the "Bun.write mode option" suite in test/js/bun/io/bun-write.test.js.


### PR DESCRIPTION
### Problem
- `Bun.write(path, data, { mode })` documents `mode` as "set the permissions of the file", but only the BunFile-source copy path (`CopyFile`) reads it. String, TypedArray, Blob and Response sources ignore it: `Bun.write(p, "secret", { mode: 0o600 })` creates `p` as 0644. Still true on 1.4.2 and canary 1.4.3.
- Cause: `write_file()` parses the option into `WriteFileOptions`, but `write_string_to_file_fast` / `write_bytes_to_file_fast` (`src/runtime/webcore/Blob.rs`), the async `WriteFile` / `WriteFileWindows` openers and `WriteFileWaitFromLockedValueTask` (`blob/write_file.rs`) open with a hardcoded constant, the empty-source truncate path applies it on one branch only, and the streamed-body path (`FileSink`, used for `fetch()` responses and `ReadableStream` sources) hands it to `open(2)` only, so the umask and an existing file's mode win.
- The hardcoded defaults also disagree: the <256KB sync path and `Bun.file(p).writer()` create 0o664, every other path (and all of node:fs) 0o666 & ~umask. So the payload size changes the file mode.

### Fix
- Commit 1 threads `mode` through every path above, passes it to `open(2)`, and `fchmod`s after open when a mode was requested, so it also applies to existing files and is not masked by the umask. This is what `CopyFile::do_close` already does. `FileOpener` gains an `open_mode()` hook for `WriteFile`; `FileSink`'s `Options.mode` becomes an `Option` so the sink can tell an explicit mode from the default.
- Commit 2 (independent, drop it if 0664 is intentional) makes the two 0o664 defaults 0o666, so every path creates 0o666 & ~umask like `fs.writeFile`. No visible change under umask 022.
- With `mode` omitted no chmod is issued. Existing files keep their permissions.
- Verified: `test/js/bun/io/bun-write.test.js`, 26 new cases, 21 fail on 1.4.3. Also ran `filesink.test.ts`, the streamed-body `Bun.write` tests, and `test/regression/issue/25903.test.ts`.

### Background
- `Bun.write` has four write engines: a synchronous fast path for sources under 256KB, a thread-pool `WriteFile` (libuv `WriteFileWindows` on Windows) for larger ones, `CopyFile` for BunFile sources, and a `FileSink` pipe for streamed bodies. Each opens the destination itself, which is how they drifted.
- `open(2)`'s mode argument only applies when the call creates the file, and the kernel masks it with the process umask. An explicit `fchmod` is the only way to make a requested mode exact.

<details><summary>Notes</summary>

Repro (any umask):

```js
import * as fs from "node:fs";
for (const f of ["/tmp/bw-mode-str", "/tmp/bw-mode-copy", "/tmp/bw-mode-src"]) fs.rmSync(f, { force: true });
fs.writeFileSync("/tmp/bw-mode-src", "x");
await Bun.write("/tmp/bw-mode-str", "hello", { mode: 0o600 });
await Bun.write("/tmp/bw-mode-copy", Bun.file("/tmp/bw-mode-src"), { mode: 0o600 });
const m = f => (fs.statSync(f).mode & 0o777).toString(8);
console.log("string source ->", m("/tmp/bw-mode-str"));   // 644 before, 600 after
console.log("BunFile source ->", m("/tmp/bw-mode-copy")); // 600 both
```

Default-mode inconsistency, observable under `umask 0` (this is the new child-process test):

```
Bun.write(p, "x")                 -> 664 before, 666 after
Bun.write(p, 512 KiB Uint8Array)  -> 666 both
Bun.file(p).writer()              -> 664 before, 666 after
fs.writeFileSync(p, "x")          -> 666 both
```

Paths touched by commit 1 and what each did before:

- `write_string_to_file_fast` / `write_bytes_to_file_fast`: opened with `WRITE_PERMISSIONS`, ignored `mode`.
- `WriteFile` (POSIX, async): `FileOpener::get_fd_by_opening` with `DEFAULT_PERMISSION`. Now `open_mode()` returns the requested mode and `run_with_fd` fchmods (only for path destinations, `is_allowed_to_close()`).
- `WriteFileWindows::open`: literal `0o644` to `uv_fs_open`. Now passes the mode and fchmods in `on_open`, mirroring `CopyFileWindows`' `uv_fs_chmod`. libuv only honours the mode argument when `O_CREAT` actually creates the file.
- `WriteFileWaitFromLockedValueTask` (Request/Response bodies that are not yet available): dropped the option before re-entering `write_file_with_source_destination`.
- `write_file_with_empty_source_to_destination`: passed the mode to `open` only in the ENOENT/createPath recovery arm (still umask-masked) and ignored it when the file existed. Now fchmods in the recovery arm and chmods (via `NodeFS::chmod`, cross-platform) after a successful truncate.
- `pipe_readable_stream_to_blob` -> `FileSink::setup` (ReadableStream sources, `fetch()` and other streaming Response bodies): main had started passing `mode` to `open(2)` here, but with no fchmod, so `Bun.write("token.json", await fetch(url), { mode: 0o600 })` onto an existing 0644 file left it 0644. `FileSinkOptions.mode` is now `Option<Mode>`; `setup` opens with `unwrap_or(WRITE_PERMISSIONS)` and fchmods when it is `Some` and the sink opened the path itself (never for a caller-supplied fd). The Windows arm, which opens the fd before handing it to the sink, does the same.

`WRITE_PERMISSIONS` stays a literal instead of `DEFAULT_PERMISSION` because the latter is 0 on Windows and libuv creates a read-only file when the create mode lacks `_S_IWRITE`.

The new suite is `describe.skipIf(isWindows)`, like the existing copy-path mode suite in `test/regression/issue/25903.test.ts`: on Windows `mode` only maps to the read-only attribute, so exact POSIX mode assertions do not apply. The Windows code was checked with `cargo check --target x86_64-pc-windows-msvc`.

History: opened 2026-06-27 against 8706328b5, reviewed by two bots (8 threads, all resolved: Windows fchmod for existing files, createPath recovery arm, error path attachment, umask-independent test preconditions). Rebased onto d316760e8 on 2026-09-06; the conflicts were API drift only (by-ref `pathlike`, `bun_errno::from_errno`, `path_buffer_pool`, the `WriteFileWindowsError::Js` propagation that replaced the swallowed `JSTerminated` arms).

In this container five pre-existing tests in `bun-write.test.js` (256 MB copy / fd / pipe cases that spawn a debug+ASAN child) exceed the 5 s default timeout on both main and this branch; they pass in ~12 s each with `--timeout`, and they exercise `copy_file.rs`, which this PR does not touch.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/regression/issue/25903.test.ts, test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->
