### PR TITLE
webcrypto: distinguish deriveBits length 0 from null

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
@@ -62,7 +62,7 @@ void CryptoAlgorithm::generateKey(const CryptoAlgorithmParameters&, bool, Crypto
     exceptionCallback(NotSupportedError, ""_s);
 }
 
-void CryptoAlgorithm::deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t, VectorCallback&&, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&, WorkQueue&)
+void CryptoAlgorithm::deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t>, VectorCallback&&, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&, WorkQueue&)
 {
     exceptionCallback(NotSupportedError, ""_s);
 }
@@ -87,7 +87,7 @@ void CryptoAlgorithm::unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallb
     exceptionCallback(NotSupportedError, ""_s);
 }
 
-ExceptionOr<size_t> CryptoAlgorithm::getKeyLength(const CryptoAlgorithmParameters&)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithm::getKeyLength(const CryptoAlgorithmParameters&)
 {
     return Exception { NotSupportedError };
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.h
@@ -69,13 +69,13 @@ public:
     virtual void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     virtual void digest(Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     virtual void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
-    virtual void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
+    virtual void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=169262
     virtual void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&);
     virtual void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&);
     virtual void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&);
     virtual void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&);
-    virtual ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&);
+    virtual ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&);
 
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, VectorCallback&&, ExceptionCallback&&, Function<ExceptionOr<Vector<uint8_t>>()>&&);
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, BoolCallback&&, ExceptionCallback&&, Function<ExceptionOr<bool>()>&&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp
@@ -189,7 +189,7 @@ void CryptoAlgorithmAES_CBC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& 
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_CBC::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_CBC::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.h
@@ -58,7 +58,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp
@@ -189,7 +189,7 @@ void CryptoAlgorithmAES_CFB::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& 
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_CFB::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_CFB::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.h
@@ -49,7 +49,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesCbcCfbParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmAesCbcCfbParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp
@@ -198,7 +198,7 @@ void CryptoAlgorithmAES_CTR::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& 
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_CTR::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_CTR::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.h
@@ -77,7 +77,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesCtrParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmAesCtrParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp
@@ -237,7 +237,7 @@ void CryptoAlgorithmAES_GCM::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& 
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_GCM::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_GCM::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.h
@@ -49,7 +49,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp
@@ -179,7 +179,7 @@ void CryptoAlgorithmAES_KW::unwrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& da
     callback(result.releaseReturnValue());
 }
 
-ExceptionOr<size_t> CryptoAlgorithmAES_KW::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmAES_KW::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyAES::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.h
@@ -48,7 +48,7 @@ private:
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
     void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&) final;
     void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformWrapKey(const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformUnwrapKey(const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp
@@ -66,7 +66,7 @@ void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameter
     callback(WTF::move(pair));
 }
 
-void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
     auto& ecParameters = downcast<CryptoAlgorithmEcdhKeyDeriveParams>(parameters);
 
@@ -90,7 +90,7 @@ void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters
         return;
     }
 
-    auto unifiedCallback = [callback = WTF::move(callback), exceptionCallback = WTF::move(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, size_t length) mutable {
+    auto unifiedCallback = [callback = WTF::move(callback), exceptionCallback = WTF::move(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, std::optional<size_t> length) mutable {
         if (!derivedKey) {
             exceptionCallback(OperationError, ""_s);
             return;
@@ -99,7 +99,7 @@ void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters
             callback(WTF::move(*derivedKey));
             return;
         }
-        auto lengthInBytes = std::ceil(length / 8.);
+        auto lengthInBytes = std::ceil(*length / 8.);
         if (lengthInBytes > (*derivedKey).size()) {
             exceptionCallback(OperationError, ""_s);
             return;

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.h
@@ -47,7 +47,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 };

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.cpp
@@ -45,15 +45,19 @@ CryptoAlgorithmIdentifier CryptoAlgorithmHKDF::identifier() const
     return s_identifier;
 }
 
-void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    if (!length || length % 8) {
+    if (!length || *length % 8) {
         exceptionCallback(OperationError, ""_s);
+        return;
+    }
+    if (!*length) {
+        callback(Vector<uint8_t>());
         return;
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTF::move(baseKey), length] {
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTF::move(baseKey), length = *length] {
             return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length);
         });
 }
@@ -76,9 +80,9 @@ void CryptoAlgorithmHKDF::importKey(CryptoKeyFormat format, KeyData&& data, cons
     callback(CryptoKeyRaw::create(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), usages));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmHKDF::getKeyLength(const CryptoAlgorithmParameters&)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmHKDF::getKeyLength(const CryptoAlgorithmParameters&)
 {
-    return 0;
+    return std::optional<size_t>(std::nullopt);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHKDF.h
@@ -44,9 +44,9 @@ private:
     CryptoAlgorithmHKDF() = default;
     CryptoAlgorithmIdentifier identifier() const final;
 
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t);
 };

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
@@ -200,7 +200,7 @@ void CryptoAlgorithmHMAC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key
     callback(format, WTF::move(result));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmHMAC::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmHMAC::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     return CryptoKeyHMAC::getKeyLength(parameters);
 }

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.h
@@ -54,7 +54,7 @@ private:
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.cpp
@@ -45,15 +45,19 @@ CryptoAlgorithmIdentifier CryptoAlgorithmPBKDF2::identifier() const
     return s_identifier;
 }
 
-void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    if (!length || length % 8) {
+    if (!length || *length % 8) {
         exceptionCallback(OperationError, ""_s);
+        return;
+    }
+    if (!*length) {
+        callback(Vector<uint8_t>());
         return;
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmPbkdf2Params>(parameters)), baseKey = WTF::move(baseKey), length] {
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmPbkdf2Params>(parameters)), baseKey = WTF::move(baseKey), length = *length] {
             return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length);
         });
 }
@@ -76,9 +80,9 @@ void CryptoAlgorithmPBKDF2::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(CryptoKeyRaw::create(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), usages));
 }
 
-ExceptionOr<size_t> CryptoAlgorithmPBKDF2::getKeyLength(const CryptoAlgorithmParameters&)
+ExceptionOr<std::optional<size_t>> CryptoAlgorithmPBKDF2::getKeyLength(const CryptoAlgorithmParameters&)
 {
-    return 0;
+    return std::optional<size_t>(std::nullopt);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmPBKDF2.h
@@ -44,9 +44,9 @@ private:
     CryptoAlgorithmPBKDF2() = default;
     CryptoAlgorithmIdentifier identifier() const final;
 
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
+    ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmPbkdf2Params&, const CryptoKeyRaw&, size_t);
 };

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.cpp
@@ -70,7 +70,7 @@ std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const C
 }
 #endif
 
-void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
     if (baseKey->type() != CryptoKey::Type::Private) {
         exceptionCallback(ExceptionCode::InvalidAccessError, ""_s);
@@ -111,7 +111,7 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
             callback(WTF::move(*derivedKey));
             return;
         }
-        auto lengthInBytes = static_cast<size_t>(std::ceil(length / 8.));
+        auto lengthInBytes = static_cast<size_t>(std::ceil(*length / 8.));
         if (lengthInBytes > (*derivedKey).size()) {
             exceptionCallback(ExceptionCode::OperationError, ""_s);
             return;

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.h
@@ -38,7 +38,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 

--- a/src/jsc/bindings/webcrypto/CryptoKeyAES.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyAES.cpp
@@ -113,12 +113,12 @@ JsonWebKey CryptoKeyAES::exportJwk() const
     return result;
 }
 
-ExceptionOr<size_t> CryptoKeyAES::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoKeyAES::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     auto& aesParameters = downcast<CryptoAlgorithmAesKeyParams>(parameters);
     if (!lengthIsValid(aesParameters.length))
         return Exception { OperationError };
-    return aesParameters.length;
+    return std::optional<size_t>(aesParameters.length);
 }
 
 auto CryptoKeyAES::algorithm() const -> KeyAlgorithm

--- a/src/jsc/bindings/webcrypto/CryptoKeyAES.h
+++ b/src/jsc/bindings/webcrypto/CryptoKeyAES.h
@@ -63,7 +63,7 @@ public:
     const Vector<uint8_t>& key() const { return m_key; }
     JsonWebKey exportJwk() const;
 
-    static ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&);
+    static ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&);
 
 private:
     CryptoKeyAES(CryptoAlgorithmIdentifier, const Vector<uint8_t>& key, bool extractable, CryptoKeyUsageBitmap);

--- a/src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp
@@ -143,13 +143,13 @@ JsonWebKey CryptoKeyHMAC::exportJwk() const
     return result;
 }
 
-ExceptionOr<size_t> CryptoKeyHMAC::getKeyLength(const CryptoAlgorithmParameters& parameters)
+ExceptionOr<std::optional<size_t>> CryptoKeyHMAC::getKeyLength(const CryptoAlgorithmParameters& parameters)
 {
     auto& aesParameters = downcast<CryptoAlgorithmHmacKeyParams>(parameters);
 
     size_t result = aesParameters.length ? *(aesParameters.length) : getKeyLengthFromHash(aesParameters.hashIdentifier);
     if (result)
-        return result;
+        return std::optional<size_t>(result);
 
     return Exception { TypeError };
 }

--- a/src/jsc/bindings/webcrypto/CryptoKeyHMAC.h
+++ b/src/jsc/bindings/webcrypto/CryptoKeyHMAC.h
@@ -59,7 +59,7 @@ public:
 
     CryptoAlgorithmIdentifier hashAlgorithmIdentifier() const { return m_hash; }
 
-    static ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&);
+    static ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&);
 
 private:
     CryptoKeyHMAC(const Vector<uint8_t>& key, CryptoAlgorithmIdentifier hash, bool extractable, CryptoKeyUsageBitmap);

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
@@ -193,7 +193,7 @@ static const HashTableValue JSSubtleCryptoPrototypeTableValues[] = {
     { "digest"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_digest, 2 } },
     { "generateKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_generateKey, 3 } },
     { "deriveKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_deriveKey, 5 } },
-    { "deriveBits"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_deriveBits, 3 } },
+    { "deriveBits"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_deriveBits, 2 } },
     { "importKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_importKey, 5 } },
     { "exportKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_exportKey, 2 } },
     { "wrapKey"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSubtleCryptoPrototypeFunction_wrapKey, 4 } },
@@ -455,7 +455,7 @@ static inline JSC::EncodedJSValue jsSubtleCryptoPrototypeFunction_deriveBitsBody
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    if (callFrame->argumentCount() < 3) [[unlikely]]
+    if (callFrame->argumentCount() < 2) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto algorithm = convert<IDLUnion<IDLObject, IDLDOMString>>(*lexicalGlobalObject, argument0.value());
@@ -463,10 +463,13 @@ static inline JSC::EncodedJSValue jsSubtleCryptoPrototypeFunction_deriveBitsBody
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
     auto baseKey = convert<IDLInterface<CryptoKey>>(*lexicalGlobalObject, argument1.value(), [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentTypeError(lexicalGlobalObject, scope, 1, "baseKey"_s, "SubtleCrypto"_s, "deriveBits"_s, "CryptoKey"_s); });
     RETURN_IF_EXCEPTION(throwScope, {});
-    EnsureStillAliveScope argument2 = callFrame->uncheckedArgument(2);
-    auto length = convert<IDLUnsignedLong>(*lexicalGlobalObject, argument2.value());
-    RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLPromise<IDLArrayBuffer>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, [&]() -> decltype(auto) { return impl.deriveBits(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(algorithm), *baseKey, WTF::move(length), WTF::move(promise)); })));
+    EnsureStillAliveScope argument2 = callFrame->argument(2);
+    std::optional<size_t> length;
+    if (!argument2.value().isUndefinedOrNull()) {
+        length = convert<IDLUnsignedLong>(*lexicalGlobalObject, argument2.value());
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLPromise<IDLArrayBuffer>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, [&]() -> decltype(auto) { return impl.deriveBits(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(algorithm), *baseKey, length, WTF::move(promise)); })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsSubtleCryptoPrototypeFunction_deriveBits, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -970,7 +970,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
         promise->reject(result.releaseException().code(), "Cannot get key length from derivedKeyType"_s);
         return;
     }
-    size_t length = result.releaseReturnValue();
+    std::optional<size_t> length = result.releaseReturnValue();
 
     auto importAlgorithm = CryptoAlgorithmRegistry::singleton().create(importParams->identifier);
     auto algorithm = CryptoAlgorithmRegistry::singleton().create(params->identifier);
@@ -1005,7 +1005,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
     RELEASE_AND_RETURN(scope, algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *scriptExecutionContext(), m_workQueue));
 }
 
-void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, unsigned length, Ref<DeferredPromise>&& promise)
+void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, std::optional<size_t> length, Ref<DeferredPromise>&& promise)
 {
     auto& vm = state.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.h
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.h
@@ -73,7 +73,7 @@ public:
     void digest(JSC::JSGlobalObject&, AlgorithmIdentifier&&, BufferSource&& data, Ref<DeferredPromise>&&);
     void generateKey(JSC::JSGlobalObject&, AlgorithmIdentifier&&, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&&);
     void deriveKey(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, AlgorithmIdentifier&& derivedKeyType, bool extractable, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&&);
-    void deriveBits(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, unsigned length, Ref<DeferredPromise>&&);
+    void deriveBits(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, std::optional<size_t> length, Ref<DeferredPromise>&&);
     void importKey(JSC::JSGlobalObject&, KeyFormat, KeyDataVariant&&, AlgorithmIdentifier&&, bool extractable, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&&);
     void exportKey(KeyFormat, CryptoKey&, Ref<DeferredPromise>&&);
     void wrapKey(JSC::JSGlobalObject&, KeyFormat, CryptoKey&, CryptoKey& wrappingKey, AlgorithmIdentifier&& wrapAlgorithm, Ref<DeferredPromise>&&);

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.idl
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.idl
@@ -40,7 +40,7 @@ typedef (object or DOMString) AlgorithmIdentifier;
     [CallWith=CurrentGlobalObject] Promise<any> digest(AlgorithmIdentifier algorithm, BufferSource data);
     [CallWith=CurrentGlobalObject] Promise<any> generateKey(AlgorithmIdentifier algorithm, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
     [CallWith=CurrentGlobalObject] Promise<any> deriveKey(AlgorithmIdentifier algorithm, CryptoKey baseKey, AlgorithmIdentifier derivedKeyType, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
-    [CallWith=CurrentGlobalObject] Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm, CryptoKey baseKey, unsigned long length);
+    [CallWith=CurrentGlobalObject] Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm, CryptoKey baseKey, optional unsigned long? length = null);
     [CallWith=CurrentGlobalObject] Promise<CryptoKey> importKey(KeyFormat format, (BufferSource or JsonWebKey) keyData, AlgorithmIdentifier algorithm, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
     Promise<any> exportKey(KeyFormat format, CryptoKey key);
     [CallWith=CurrentGlobalObject] Promise<any> wrapKey(KeyFormat format, CryptoKey key, CryptoKey wrappingKey, AlgorithmIdentifier wrapAlgorithm);

--- a/test/js/bun/crypto/x25519-derive-bits.test.ts
+++ b/test/js/bun/crypto/x25519-derive-bits.test.ts
@@ -35,14 +35,13 @@ test("X25519 deriveBits with null length returns full output", async () => {
   expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
 });
 
-test("X25519 deriveBits with zero length returns full output", async () => {
+test("X25519 deriveBits with zero length returns empty output", async () => {
   const { privateKey, publicKey } = await importX25519Keys();
 
   const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 0);
 
   expect(bits).toBeInstanceOf(ArrayBuffer);
-  expect(bits.byteLength).toBe(32);
-  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+  expect(bits.byteLength).toBe(0);
 });
 
 test("X25519 deriveBits with shorter length", async () => {

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -418,3 +418,122 @@ describe("AES-KW wrapKey/unwrapKey with jwk format", () => {
     expect(jwk.k).toBe("AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4_QA");
   });
 });
+
+// deriveBits(alg, key, length) must distinguish between length === 0 (first 0 bits,
+// i.e. an empty buffer) and length == null/undefined/omitted (algorithm default).
+describe("deriveBits length 0 vs null", () => {
+  it("has .length of 2 (length argument is optional)", () => {
+    expect(crypto.subtle.deriveBits.length).toBe(2);
+  });
+
+  describe.each([
+    ["ECDH", { name: "ECDH", namedCurve: "P-256" }, 32],
+    ["X25519", { name: "X25519" }, 32],
+  ] as const)("%s", (label, genParams, fullBytes) => {
+    async function setup() {
+      const pair = await crypto.subtle.generateKey(genParams as any, false, ["deriveBits", "deriveKey"]);
+      const alg = { name: label, public: pair.publicKey } as any;
+      return { pair, alg };
+    }
+
+    it("length 0 returns an empty ArrayBuffer (not the full secret)", async () => {
+      const { pair, alg } = await setup();
+      const bits = await crypto.subtle.deriveBits(alg, pair.privateKey, 0);
+      expect(bits).toBeInstanceOf(ArrayBuffer);
+      expect(bits.byteLength).toBe(0);
+    });
+
+    it.each([["null", null] as const, ["undefined", undefined] as const])(
+      "length %s returns the full shared secret",
+      async (_, lengthArg) => {
+        const { pair, alg } = await setup();
+        const bits = await crypto.subtle.deriveBits(alg, pair.privateKey, lengthArg as any);
+        expect(bits.byteLength).toBe(fullBytes);
+      },
+    );
+
+    it("omitted length returns the full shared secret", async () => {
+      const { pair, alg } = await setup();
+      // @ts-expect-error types may not yet reflect optional length
+      const bits = await crypto.subtle.deriveBits(alg, pair.privateKey);
+      expect(bits.byteLength).toBe(fullBytes);
+    });
+
+    it("deriveKey with HKDF derivedKeyType still yields the full secret", async () => {
+      const { pair, alg } = await setup();
+      const full = await crypto.subtle.deriveBits(alg, pair.privateKey, null as any);
+      const key = await crypto.subtle.deriveKey(
+        alg,
+        pair.privateKey,
+        { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: new Uint8Array(0) } as any,
+        false,
+        ["deriveBits"],
+      );
+      const derived = await crypto.subtle.deriveBits(
+        { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: new Uint8Array(0) },
+        key,
+        fullBytes * 8,
+      );
+      const expected = await crypto.subtle.deriveBits(
+        { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: new Uint8Array(0) },
+        await crypto.subtle.importKey("raw", full, "HKDF", false, ["deriveBits"]),
+        fullBytes * 8,
+      );
+      expect(Buffer.from(derived).toString("hex")).toBe(Buffer.from(expected).toString("hex"));
+    });
+  });
+
+  describe.each([
+    [
+      "HKDF",
+      { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(8), info: new Uint8Array(0) },
+      "HKDF" as AlgorithmIdentifier,
+    ],
+    [
+      "PBKDF2",
+      { name: "PBKDF2", hash: "SHA-256", salt: new Uint8Array(8), iterations: 1 },
+      "PBKDF2" as AlgorithmIdentifier,
+    ],
+  ] as const)("%s", (label, deriveParams, importAlg) => {
+    async function importRaw() {
+      return crypto.subtle.importKey("raw", new Uint8Array(22), importAlg, false, ["deriveBits"]);
+    }
+
+    it("length 0 returns an empty ArrayBuffer", async () => {
+      const key = await importRaw();
+      const bits = await crypto.subtle.deriveBits(deriveParams as any, key, 0);
+      expect(bits).toBeInstanceOf(ArrayBuffer);
+      expect(bits.byteLength).toBe(0);
+    });
+
+    it.each([["null", null] as const, ["undefined", undefined] as const])(
+      "length %s rejects with OperationError",
+      async (_, lengthArg) => {
+        const key = await importRaw();
+        const err = await crypto.subtle.deriveBits(deriveParams as any, key, lengthArg as any).then(
+          () => null,
+          e => e,
+        );
+        expect(err).toBeInstanceOf(DOMException);
+        expect(err.name).toBe("OperationError");
+      },
+    );
+
+    it("omitted length rejects with OperationError", async () => {
+      const key = await importRaw();
+      // @ts-expect-error types may not yet reflect optional length
+      const err = await crypto.subtle.deriveBits(deriveParams as any, key).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBeInstanceOf(DOMException);
+      expect(err.name).toBe("OperationError");
+    });
+
+    it("nonzero length still derives correctly", async () => {
+      const key = await importRaw();
+      const bits = await crypto.subtle.deriveBits(deriveParams as any, key, 128);
+      expect(bits.byteLength).toBe(16);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`crypto.subtle.deriveBits(alg, key, length)` treated `length === 0` and `length == null` identically because the IDL binding coerced both to `size_t 0`, and the per-algorithm implementations used `!length` as the sentinel for "no length provided".

### Repro

```js
const ec = await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);
const r = await crypto.subtle.deriveBits({ name: "ECDH", public: ec.publicKey }, ec.privateKey, 0);
console.log(r.byteLength);
```

|  | Bun (before) | Node 26.3 / spec | Bun (after) |
|---|---|---|---|
| ECDH `length: 0` | **32** (full secret) | 0 | 0 |
| ECDH `length: null` | 32 | 32 | 32 |
| ECDH omitted | TypeError | 32 | 32 |
| X25519 `length: 0` | **32** (full secret) | 0 | 0 |
| HKDF `length: 0` | OperationError | empty | empty |
| HKDF `length: null` | OperationError | OperationError | OperationError |
| PBKDF2 `length: 0` | OperationError | empty | empty |

The ECDH/X25519 case is the security-sensitive one: code that computes a variable (possibly zero) number of bits from a key agreement and forwards that buffer onward would leak the entire raw shared secret instead of an empty slice.

### Cause

`JSSubtleCrypto.cpp` required 3 arguments and converted the third via `IDLUnsignedLong`, which maps `null` to `0`. Downstream, `CryptoAlgorithm::deriveBits` took a plain `size_t`, so `0` and "absent" were indistinguishable. `CryptoAlgorithmECDH`/`X25519` checked `if (!length)` to decide whether to return the full secret; `HKDF`/`PBKDF2` checked `if (!length || length % 8)` to reject.

The spec IDL is `optional unsigned long? length = null` (w3c/webcrypto#345), and the per-algorithm text says `null` means "algorithm default" while `0` means "first 0 bits".

### Fix

Thread `std::optional<size_t>` through `CryptoAlgorithm::deriveBits` and `getKeyLength` so the binding passes `std::nullopt` for `null`/`undefined`/omitted and an explicit `0` for `0`:

- `JSSubtleCrypto.cpp`: third arg is now optional; `isUndefinedOrNull()` yields `std::nullopt`, otherwise convert via `IDLUnsignedLong`. Function `.length` is now `2`.
- `CryptoAlgorithmECDH` / `X25519`: `!length` (now "has no value") still returns the full secret; `*length == 0` falls through to `shrink(0)`.
- `CryptoAlgorithmHKDF` / `PBKDF2`: `!length` still rejects; `*length == 0` returns an empty `Vector` without dispatching to the work queue.
- `getKeyLength` returns `ExceptionOr<std::optional<size_t>>`; HKDF/PBKDF2 now return `std::nullopt` (spec: "Return null") so `deriveKey` with an HKDF/PBKDF2 `derivedKeyType` keeps using the full secret from ECDH/X25519 rather than an empty one.

## How did you verify your code works?

- `bun bd test test/js/web/crypto/web-crypto.test.ts` (36 pass, 21 new tests covering 0 / null / undefined / omitted for ECDH, X25519, HKDF, PBKDF2, plus `deriveKey` with HKDF `derivedKeyType`)
- `bun bd test test/js/bun/crypto/x25519-derive-bits.test.ts` (10 pass; updated the zero-length test which previously asserted the buggy behaviour)
- `bun bd test test/js/deno/crypto/webcrypto.test.ts`, `test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts`, `test/js/node/test/parallel/test-webcrypto-derive{bits,key}-cfrg.js`, `test-webcrypto-wrap-unwrap.js`: no regressions
- `USE_SYSTEM_BUN=1 bun test test/js/web/crypto/web-crypto.test.ts -t "deriveBits length 0 vs null"` fails 9/21 on the released bun (fail-before)