### PR TITLE
Bun.serve: consume chunked trailer-part instead of rejecting it

### DIFF
--- a/packages/bun-uws/src/ChunkedEncoding.h
+++ b/packages/bun-uws/src/ChunkedEncoding.h
@@ -196,6 +196,15 @@ namespace uWS {
     constexpr uint64_t STATE_IS_TRAILERS = STATE_HAS_SIZE | STATE_IS_CHUNKED | STATE_WAITING_FOR_LF;
     constexpr uint64_t STATE_IS_TRAILERS_DONE = STATE_HAS_SIZE | STATE_WAITING_FOR_LF;
 
+    /* Framing-only trailer-part scan (Bun.serve path, no trailerSection buffer
+     * supplied): the bytes are counted against maxTrailerSectionSize and
+     * discarded. STATE_HAS_HEXDIG and STATE_IS_CHUNKED_EXTENSION are dead once
+     * STATE_HAS_SIZE is set, so they carry the two sub-state flags and the
+     * size field carries the byte counter. */
+    constexpr uint64_t STATE_TRAILER_SCAN       = STATE_HAS_SIZE | STATE_WAITING_FOR_LF | STATE_IS_CHUNKED_EXTENSION;
+    constexpr uint64_t STATE_TRAILER_LINE_START = STATE_HAS_HEXDIG;
+    constexpr uint64_t STATE_TRAILER_AFTER_CR   = STATE_IS_CHUNKED;
+
     /* Default cap on the raw size of a captured trailer section. Node counts
      * trailer bytes against the same max-header-size budget as request headers
      * in llhttp, so node:http callers thread the per-server maxHeaderSize
@@ -214,79 +223,94 @@ namespace uWS {
     }
 
     /* Returns next chunk (empty or not), or if all data was consumed, nullopt is returned. */
-    static std::optional<std::string_view> getNextChunk(std::string_view &data, uint64_t &state, bool trailer = false, uint64_t *chunkExtensionsConsumed = nullptr, std::string *trailerSection = nullptr, uint64_t maxTrailerSectionSize = MAX_TRAILER_SECTION_SIZE) {
-        /* node:http compat: the previous call emitted the fin chunk for a message
-         * whose trailer section completed; this call only resets the state and
-         * leaves the remaining bytes (the next request, or tunnel data) untouched. */
-        if (trailerSection && state == STATE_IS_TRAILERS_DONE) [[unlikely]] {
+    static std::optional<std::string_view> getNextChunk(std::string_view &data, uint64_t &state, uint64_t *chunkExtensionsConsumed = nullptr, std::string *trailerSection = nullptr, uint64_t maxTrailerSectionSize = MAX_TRAILER_SECTION_SIZE) {
+        /* The previous call emitted the fin chunk for a message whose trailer
+         * section completed; this call only resets the state and leaves the
+         * remaining bytes (the next request, or tunnel data) untouched. */
+        if (state == STATE_IS_TRAILERS_DONE) [[unlikely]] {
             state = 0;
             return std::nullopt;
         }
         while (data.length()) {
 
-            /* node:http compat: consume the trailer section that follows the final
-             * 0-size chunk, capturing its raw bytes so the server can populate
-             * req.trailers. The terminating empty chunk (fin) is only emitted once
-             * the whole section (including its final CRLF) has been consumed, so
-             * trailers are always available by the time the message completes. */
-            if (trailerSection && state == STATE_IS_TRAILERS) [[unlikely]] {
+            /* Trailer-part parsing (RFC 9112 7.1.2): entered after the
+             * last-chunk "0\r\n". The fin chunk is emitted only once the
+             * terminating empty line is seen. STATE_HAS_SIZE |
+             * STATE_WAITING_FOR_LF matches both trailer families
+             * (STATE_IS_TRAILERS, STATE_TRAILER_SCAN) and nothing else,
+             * since STATE_WAITING_FOR_LF is only ever set while the
+             * chunk-size line is incomplete, i.e. before STATE_HAS_SIZE is
+             * set. */
+            if ((state & (STATE_HAS_SIZE | STATE_WAITING_FOR_LF)) == (STATE_HAS_SIZE | STATE_WAITING_FOR_LF)) [[unlikely]] {
+                /* Capture path (node:http): raw bytes are appended to the
+                 * buffer so the server can populate req.trailers. */
+                if (trailerSection) {
+                    while (data.length()) {
+                        char c = data[0];
+                        trailerSection->push_back(c);
+                        data.remove_prefix(1);
+                        if (trailerSection->size() > maxTrailerSectionSize) [[unlikely]] {
+                            state = STATE_IS_TRAILER_OVERFLOW;
+                            return std::nullopt;
+                        }
+                        if (c == '\n') {
+                            /* Bare LF (no preceding CR captured) is a fatal parse error like
+                             * llhttp's HPE_CR_EXPECTED / HPE_INVALID_HEADER_TOKEN — otherwise
+                             * "0\r\n\n" waits for bytes forever. Strict CRLF matches
+                             * consumeHexNumber's own bare-LF rejection above. */
+                            size_t n = trailerSection->size();
+                            if (n < 2 || (*trailerSection)[n - 2] != '\r') {
+                                state = STATE_IS_ERROR;
+                                return std::nullopt;
+                            }
+                            if (isCompleteTrailerSection(*trailerSection)) {
+                                /* Message complete: emit the fin chunk. The next call sees
+                                 * STATE_IS_TRAILERS_DONE and resets to 0. */
+                                state = STATE_IS_TRAILERS_DONE;
+                                return std::string_view(nullptr, 0);
+                            }
+                        }
+                    }
+                    return std::nullopt;
+                }
+
+                /* Framing-only scan (Bun.serve, no trailerSection buffer):
+                 * bytes are discarded, counted against maxTrailerSectionSize,
+                 * and only CRLF framing is validated. CR not followed by LF
+                 * and bare LF are rejected so the end of the section cannot
+                 * desync with a stricter front-end. */
                 while (data.length()) {
-                    char c = data[0];
-                    trailerSection->push_back(c);
+                    unsigned char c = (unsigned char) data[0];
                     data.remove_prefix(1);
-                    if (trailerSection->size() > maxTrailerSectionSize) [[unlikely]] {
+                    uint64_t count = chunkSize(state) + 1;
+                    if (count > maxTrailerSectionSize) [[unlikely]] {
                         state = STATE_IS_TRAILER_OVERFLOW;
                         return std::nullopt;
                     }
-                    if (c == '\n') {
-                        /* Bare LF (no preceding CR captured) is a fatal parse error like
-                         * llhttp's HPE_CR_EXPECTED / HPE_INVALID_HEADER_TOKEN — otherwise
-                         * "0\r\n\n" waits for bytes forever. Strict CRLF matches
-                         * consumeHexNumber's own bare-LF rejection above. */
-                        size_t n = trailerSection->size();
-                        if (n < 2 || (*trailerSection)[n - 2] != '\r') {
+                    if (state & STATE_TRAILER_AFTER_CR) {
+                        if (c != '\n') {
                             state = STATE_IS_ERROR;
                             return std::nullopt;
                         }
-                        if (isCompleteTrailerSection(*trailerSection)) {
-                            /* Message complete: emit the fin chunk. The next call sees
-                             * STATE_IS_TRAILERS_DONE and resets to 0. */
+                        if (state & STATE_TRAILER_LINE_START) {
+                            /* Empty line: trailer-part complete. Emit fin. */
                             state = STATE_IS_TRAILERS_DONE;
                             return std::string_view(nullptr, 0);
                         }
+                        state = STATE_TRAILER_SCAN | STATE_TRAILER_LINE_START | count;
+                        continue;
                     }
-                }
-                return std::nullopt;
-            }
-
-            // if in "drop trailer mode", consume the terminator bytes after the
-            // zero-chunk. This is 2 bytes (\r\n) with no trailer, or 4 bytes
-            // (\r\n\r\n) with trailer=true. Upstream uWS consumed these bytes
-            // blindly, which let attackers smuggle a second request by placing
-            // arbitrary bytes (e.g. "X:POST /admin HTTP/1.1\r\n") where the
-            // final CRLF belongs. Strict validation closes that desync.
-            //
-            // chunkSize() starts at 2 or 4 and counts down as bytes arrive; its
-            // parity gives the expected byte (even -> \r, odd -> \n). The parity
-            // rule is the same for both initial sizes, so TCP segment
-            // boundaries that split the terminator are handled naturally.
-            if (((state & STATE_IS_CHUNKED) == 0) && hasChunkSize(state) && chunkSize(state)) {
-                while (data.length() && chunkSize(state)) {
-                    char expected = (chunkSize(state) & 1) ? '\n' : '\r';
-                    if (data[0] != expected) {
+                    if (c == '\r') {
+                        state = (state & ~STATE_SIZE_MASK) | STATE_TRAILER_AFTER_CR | count;
+                        continue;
+                    }
+                    if (c == '\n') {
                         state = STATE_IS_ERROR;
                         return std::nullopt;
                     }
-                    data.remove_prefix(1);
-                    decChunkSize(state, 1);
-
-                    if (chunkSize(state) == 0) {
-                        /* Terminator fully consumed — parsing is complete. */
-                        state = 0;
-                        return std::nullopt;
-                    }
+                    state = STATE_TRAILER_SCAN | count;
                 }
-                continue;
+                return std::nullopt;
             }
 
             if (!hasChunkSize(state)) {
@@ -295,25 +319,14 @@ namespace uWS {
                     return std::nullopt;
                 }
                 if (hasChunkSize(state) && chunkSize(state) == 2) {
-
-                    //printf("Setting state to trailer-parsing and emitting empty chunk\n");
-
-                    /* node:http compat: the message is not complete until the trailer
-                     * section has been consumed; capture it and emit the fin chunk
-                     * from the trailer-section branch above instead of here. */
-                    if (trailerSection) {
-                        state = STATE_IS_TRAILERS;
-                        continue;
-                    }
-
-                    // set trailer state and increase size to 4
-                    if (trailer) {
-                        state = 4 /*| STATE_IS_CHUNKED*/ | STATE_HAS_SIZE;
-                    } else {
-                        state = 2 /*| STATE_IS_CHUNKED*/ | STATE_HAS_SIZE;
-                    }
-
-                    return std::string_view(nullptr, 0);
+                    /* last-chunk ("0" [chunk-ext] CRLF) consumed. The message
+                     * is not complete until the trailer-part is consumed; fin
+                     * is emitted from the matching branch above once the
+                     * terminating CRLF is seen. With a trailerSection buffer
+                     * the bytes are captured for req.trailers; without one
+                     * (Bun.serve) they are scanned and discarded. */
+                    state = trailerSection ? STATE_IS_TRAILERS : (STATE_TRAILER_SCAN | STATE_TRAILER_LINE_START);
+                    continue;
                 }
                 if (!hasChunkSize(state)) [[unlikely]] {
                     /* Incomplete chunk-size line — need more data from the network. */
@@ -419,16 +432,15 @@ namespace uWS {
         std::string_view *data;
         std::optional<std::string_view> chunk;
         uint64_t *state;
-        bool trailer;
         uint64_t *chunkExtensionsConsumed;
         std::string *trailerSection;
         uint64_t maxTrailerSectionSize;
 
-        ChunkIterator(std::string_view *data, uint64_t *state, bool trailer = false, uint64_t *chunkExtensionsConsumed = nullptr, std::string *trailerSection = nullptr, uint64_t maxTrailerSectionSize = MAX_TRAILER_SECTION_SIZE) : data(data), state(state), trailer(trailer), chunkExtensionsConsumed(chunkExtensionsConsumed), trailerSection(trailerSection), maxTrailerSectionSize(maxTrailerSectionSize) {
-            chunk = uWS::getNextChunk(*data, *state, trailer, chunkExtensionsConsumed, trailerSection, maxTrailerSectionSize);
+        ChunkIterator(std::string_view *data, uint64_t *state, uint64_t *chunkExtensionsConsumed = nullptr, std::string *trailerSection = nullptr, uint64_t maxTrailerSectionSize = MAX_TRAILER_SECTION_SIZE) : data(data), state(state), chunkExtensionsConsumed(chunkExtensionsConsumed), trailerSection(trailerSection), maxTrailerSectionSize(maxTrailerSectionSize) {
+            chunk = uWS::getNextChunk(*data, *state, chunkExtensionsConsumed, trailerSection, maxTrailerSectionSize);
         }
 
-        ChunkIterator() : data(nullptr), state(nullptr), trailer(false), chunkExtensionsConsumed(nullptr), trailerSection(nullptr), maxTrailerSectionSize(MAX_TRAILER_SECTION_SIZE) {
+        ChunkIterator() : data(nullptr), state(nullptr), chunkExtensionsConsumed(nullptr), trailerSection(nullptr), maxTrailerSectionSize(MAX_TRAILER_SECTION_SIZE) {
 
         }
 
@@ -452,7 +464,7 @@ namespace uWS {
         }
 
         ChunkIterator &operator++() {
-            chunk = uWS::getNextChunk(*data, *state, trailer, chunkExtensionsConsumed, trailerSection, maxTrailerSectionSize);
+            chunk = uWS::getNextChunk(*data, *state, chunkExtensionsConsumed, trailerSection, maxTrailerSectionSize);
             return *this;
         }
 

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1295,7 +1295,7 @@ struct HttpResponseData;
                 if constexpr (!ConsumeMinimally) {
                     /* Go ahead and parse it (todo: better heuristics for emitting FIN to the app level) */
                     std::string_view dataToConsume(data, length);
-                    for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxBufferedHeaderSize)) {
+                    for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxBufferedHeaderSize)) {
                         /* llhttp errors at the offending extension byte, before any body bytes from
                          * that chunk reach the application; check before every dispatch. */
                         if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
@@ -1380,7 +1380,7 @@ public:
             } else if (isParsingChunkedEncoding(remainingStreamingBytes)) {
                  /* It's either chunked or with a content-length */
                 std::string_view dataToConsume(data, length);
-                for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxFallbackSize)) {
+                for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxFallbackSize)) {
                     if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                         return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                     }
@@ -1465,7 +1465,7 @@ public:
                     } else if (isParsingChunkedEncoding(remainingStreamingBytes)) {
                         /* It's either chunked or with a content-length */
                         std::string_view dataToConsume(data, length);
-                        for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxFallbackSize)) {
+                        for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxFallbackSize)) {
                             if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                                 return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                             }

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -645,4 +645,103 @@ describe.if(isPosix)("HTTP server handles fragmented requests", () => {
 
     server.stop();
   });
+
+  // RFC 7230 4.1: after the last-chunk "0\r\n" comes trailer-part (zero or
+  // more header lines) then the terminating CRLF. Those bytes belong to the
+  // current message, so Bun.serve must consume them (discarded, since no
+  // req.trailers is exposed here) and leave the keep-alive connection ready
+  // for the next request.
+  describe("chunked request trailer-part", () => {
+    async function drive(
+      bodyWrites: readonly string[],
+      { pipeline }: { pipeline: boolean },
+    ): Promise<{ paths: string[]; received: string }> {
+      const paths: string[] = [];
+      await using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          paths.push(new URL(req.url).pathname);
+          let body = "";
+          try {
+            body = await req.text();
+          } catch {}
+          return new Response("body=" + body + ".");
+        },
+      });
+      let received = "";
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        socket: {
+          data(_s, d) {
+            received += d.toString();
+          },
+          async open(s) {
+            s.write("POST /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n");
+            for (const segment of bodyWrites) {
+              s.write(segment);
+              s.flush();
+              // Yield to the I/O poll phase so the server sees each segment
+              // in its own recv() and the state machine actually resumes
+              // across packet boundaries.
+              await new Promise<void>(r => setImmediate(r));
+            }
+            if (pipeline) {
+              // Connection: close on the second request so the server closes
+              // after both responses are fully written; waiting on socket
+              // close avoids racing status-line counting against body
+              // delivery.
+              s.write("GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+              s.flush();
+            }
+          },
+          error(_s, err) {
+            reject(err);
+          },
+          close() {
+            resolve();
+          },
+        },
+      });
+      await promise;
+      return { paths, received };
+    }
+
+    test.concurrentIf(!isASAN).each([
+      ["one write", ["5\r\nhello\r\n0\r\nX-Trail: one\r\nX-More: two\r\n\r\n"]],
+      ["split mid trailer name", ["5\r\nhello\r\n0\r\nX", "-Trail: one\r\nX-More: two\r\n\r\n"]],
+      ["split after last-chunk", ["5\r\nhello\r\n0\r\n", "X-Trail: one\r\n", "X-More: two\r\n", "\r\n"]],
+      ["split on trailer CR", ["5\r\nhello\r\n0\r\nX-Trail: one\r", "\nX-More: two\r\n\r\n"]],
+      ["split on terminating CR", ["5\r\nhello\r\n0\r\nX-Trail: one\r\nX-More: two\r\n\r", "\n"]],
+      ["last-chunk with extension", ["5\r\nhello\r\n0;ext=v\r\nX-Trail: one\r\n\r\n"]],
+    ] as const)("consumes trailer-part and preserves keep-alive (%s)", async (_, bodyWrites) => {
+      const { paths, received } = await drive(bodyWrites, { pipeline: true });
+      expect({ paths, bodies: received.match(/body=[a-z]*\./g) ?? [] }).toEqual({
+        paths: ["/a", "/b"],
+        bodies: ["body=hello.", "body=."],
+      });
+    });
+
+    test.concurrentIf(!isASAN).each([
+      ["bare LF on a trailer line", "5\r\nhello\r\n0\r\nX-T: 9\n\r\n"],
+      ["CR not followed by LF", "5\r\nhello\r\n0\r\nX-T: 9\rZ\r\n\r\n"],
+    ])("rejects a malformed trailer-part (%s)", async (_, body) => {
+      const { paths, received } = await drive([body], { pipeline: false });
+      expect({ paths, status: received.match(/HTTP\/1\.1 \d+/)?.[0] }).toEqual({
+        paths: ["/a"],
+        status: "HTTP/1.1 400",
+      });
+    });
+
+    test.concurrentIf(!isASAN)("rejects a trailer-part larger than the header-size limit with 431", async () => {
+      const line = "X-T: " + Buffer.alloc(200, "v").toString() + "\r\n";
+      const trailer = Buffer.alloc(17 * 1024, line).toString();
+      const { paths, received } = await drive(["5\r\nhello\r\n0\r\n" + trailer + "\r\n"], { pipeline: true });
+      expect({ paths, status: received.match(/HTTP\/1\.1 \d+/)?.[0] }).toEqual({
+        paths: ["/a"],
+        status: "HTTP/1.1 431",
+      });
+    });
+  });
 });

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -660,11 +660,13 @@ describe("SPILL.TERM - invalid chunk terminators", () => {
     });
   });
 
-  // TE.TE desync: the last-chunk "0\r\n" must be followed by a strict "\r\n"
-  // (end-of-body). Consuming arbitrary bytes there lets an attacker smuggle a
-  // second request while an upstream proxy parses the same bytes as a valid
-  // trailer line. See https://github.com/oven-sh/bun/issues/29732.
-  test("rejects arbitrary bytes in place of final CRLF after zero-chunk", async () => {
+  // TE.TE desync (https://github.com/oven-sh/bun/issues/29732): upstream uWS
+  // blindly consumed two bytes after "0\r\n" as the terminating CRLF, so
+  // "0\r\nX:POST /admin ..." stripped "X:" and then parsed the rest as a
+  // second pipelined request. The bytes after the last-chunk are the RFC 7230
+  // trailer-part (header-field lines then an empty line); they belong to the
+  // current message, so "POST /admin ..." must never be seen as a request.
+  test("trailer-part bytes after zero-chunk are not parsed as a pipelined request", async () => {
     const urls: string[] = [];
     await using server = Bun.serve({
       port: 0,
@@ -679,12 +681,13 @@ describe("SPILL.TERM - invalid chunk terminators", () => {
 
     const client = net.connect(server.port, "127.0.0.1");
 
-    // The bytes "X:" replace the required "\r\n" after the zero-chunk.
-    // A vulnerable server consumes "X:" as the terminator and then parses
-    // "POST /admin HTTP/1.1" as a second (smuggled) request.
+    // Three trailer header-field lines and the terminating empty line.
+    // A vulnerable server that consumes "X:" as the terminator would then
+    // parse "POST /admin HTTP/1.1" as a second (smuggled) request.
     const smuggleAttempt =
       "POST / HTTP/1.1\r\n" +
       "Host: localhost\r\n" +
+      "Connection: close\r\n" +
       "Transfer-Encoding: chunked\r\n" +
       "\r\n" +
       "0\r\n" +
@@ -701,9 +704,8 @@ describe("SPILL.TERM - invalid chunk terminators", () => {
         responseData += data.toString();
       });
       client.on("close", () => {
-        expect(responseData).toContain("HTTP/1.1 400");
         // The smuggled second request must never reach the handler.
-        expect(urls).not.toContain("/admin");
+        expect(urls).toEqual(["/"]);
         // No ADMIN-ACCESS body should have been produced.
         expect(responseData).not.toContain("ADMIN-ACCESS");
         resolve();
@@ -712,8 +714,9 @@ describe("SPILL.TERM - invalid chunk terminators", () => {
     });
   });
 
-  test("rejects zero-chunk terminator with wrong first byte", async () => {
-    // First byte of the terminator must be '\r'. Anything else must be rejected.
+  test("rejects zero-chunk trailer line containing bare LF", async () => {
+    // A bare LF (not preceded by CR) in the trailer-part is rejected so that
+    // the end of the trailer section cannot desync with a stricter front-end.
     await using server = Bun.serve({
       port: 0,
       fetch() {
@@ -724,7 +727,8 @@ describe("SPILL.TERM - invalid chunk terminators", () => {
     const client = net.connect(server.port, "127.0.0.1");
 
     const maliciousRequest =
-      "POST / HTTP/1.1\r\n" + "Host: localhost\r\n" + "Transfer-Encoding: chunked\r\n" + "\r\n" + "0\r\n" + "A\n"; // 'A' instead of '\r'
+      // "A" opens a trailer field name; the bare LF after it is the violation.
+      "POST / HTTP/1.1\r\n" + "Host: localhost\r\n" + "Transfer-Encoding: chunked\r\n" + "\r\n" + "0\r\n" + "A\n";
 
     await new Promise<void>((resolve, reject) => {
       let responseData = "";
@@ -740,8 +744,8 @@ describe("SPILL.TERM - invalid chunk terminators", () => {
     });
   });
 
-  test("rejects zero-chunk terminator with CR but wrong second byte", async () => {
-    // Second byte of the terminator must be '\n'. Anything else must be rejected.
+  test("rejects CR not followed by LF in the trailer section", async () => {
+    // Every CR in the trailer-part must be immediately followed by LF.
     await using server = Bun.serve({
       port: 0,
       fetch() {
@@ -752,7 +756,8 @@ describe("SPILL.TERM - invalid chunk terminators", () => {
     const client = net.connect(server.port, "127.0.0.1");
 
     const maliciousRequest =
-      "POST / HTTP/1.1\r\n" + "Host: localhost\r\n" + "Transfer-Encoding: chunked\r\n" + "\r\n" + "0\r\n" + "\rA"; // '\r' followed by 'A' instead of '\n'
+      // The CR right after the last-chunk is followed by "A" rather than LF.
+      "POST / HTTP/1.1\r\n" + "Host: localhost\r\n" + "Transfer-Encoding: chunked\r\n" + "\r\n" + "0\r\n" + "\rA";
 
     await new Promise<void>((resolve, reject) => {
       let responseData = "";
@@ -810,14 +815,10 @@ describe("SPILL.TERM - invalid chunk terminators", () => {
   test("accepts zero-chunk with correct CRLF terminator split across segments", async () => {
     // Control for the fragmentation test above: a valid split must still work.
     //
-    // Tricky bit: the parser emits the FIN chunk as soon as it sees the
-    // zero-chunk size line (`0\r\n`) — before the terminator bytes are
-    // consumed. That means the server can respond to request 1 based on just
-    // the first segment. To prove the `\n` in the second segment *does* get
-    // validated (rather than being ignored or causing an error), we pipeline
-    // a second request after it: if the drop-trailer loop rejected the `\n`
-    // as malformed, the state would go to STATE_IS_ERROR, the connection
-    // would be torn down, and the pipelined GET would never complete.
+    // We pipeline a second request after the split terminator: if the
+    // trailer-part parser rejected the `\n` as malformed, the state would
+    // go to STATE_IS_ERROR, the connection would be torn down, and the
+    // pipelined GET would never complete.
     const seen: string[] = [];
     await using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
## Problem

`Bun.serve` receiving a valid chunked request body that carries a trailer section returns 200 for the request, then immediately responds 400 on the trailer bytes and tears down the keep-alive connection, dropping any pipelined request. A body truncated right after the last-chunk (`0\r\n` with no terminating CRLF) is also accepted as a complete message.

```js
import net from "node:net";
const paths = [];
const server = Bun.serve({
  port: 0,
  async fetch(req) { paths.push(new URL(req.url).pathname); return new Response("body=" + (await req.text()) + "."); },
});
const sock = net.connect(server.port, "127.0.0.1");
sock.on("connect", () => sock.write(
  "POST /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n" +
  "5\r\nhello\r\n0\r\nX-Trail: one\r\n\r\n" +
  "GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"));
```

Before: `paths: ["/a"]`, statuses `200`, `400`. After: `paths: ["/a","/b"]`, both `200`.

(`node:http` is already fixed as of #32488, which captures the trailer section into `req.trailers` and bounds it by `maxHeaderSize`. This PR is only about the `Bun.serve` path.)

## Cause

#32488's trailer-part parsing in `uWS::getNextChunk` is gated on a `trailerSection` buffer being supplied (`if constexpr (IsNodeHttp)` in `HttpContext.h`). `Bun.serve` passes `nullptr` because it exposes no `req.trailers` surface, so it still falls through to the old path that emits fin immediately after `0\r\n` and then expects the very next two bytes to be `\r\n`; the first trailer byte fails that check and `HttpParser` returns a chunked-encoding error for what is a well-formed message.

## Fix

When no `trailerSection` buffer is supplied, the decoder enters a framing-only trailer-part scan that discards header-field lines until the terminating empty line and only then emits fin. Bytes are counted in the size field and the scan fails with `STATE_IS_TRAILER_OVERFLOW` (→ 431) once `maxTrailerSectionSize` is exceeded, same as the capture path; the three `ChunkIterator` call sites already map that error.

Both trailer families dispatch on `STATE_HAS_SIZE | STATE_WAITING_FOR_LF` and share the `STATE_IS_TRAILERS_DONE` completion sentinel (the entry check no longer tests `trailerSection`). The scan's sub-state flags live on bits that are dead once `STATE_HAS_SIZE` is set: `STATE_IS_CHUNKED_EXTENSION` is the scan marker, `STATE_HAS_HEXDIG` is "at line start", and `STATE_IS_CHUNKED` is "prev was CR". Bare LF and CR not followed by LF are rejected so the end of the section cannot desync with a stricter front-end.

The vestigial `bool trailer` parameter on `getNextChunk` / `ChunkIterator` is removed (never passed `true` by any call site, and nothing reads it after this change).

## Pre-existing tests changed

The `request-smuggling.test.ts` SPILL.TERM test that asserted a 400 on `0\r\nX:...` against `Bun.serve` is updated: those bytes are the trailer-part of the current message, so the request succeeds while the embedded `POST /admin` still never reaches the handler (the security property the test exists for). Two sibling tests that described the removed fixed-width terminator are renamed to match the CRLF rules they now exercise; their payloads and 400 assertions are unchanged.

## Verification

```
bun bd test test/js/bun/http/http-server-chunking.test.ts    # +9 new, all pass
bun bd test test/js/bun/http/request-smuggling.test.ts       # 75 pass
bun bd test test/js/node/http/node-http-transfer-encoding.test.ts  # 23 pass (unchanged)
```

<details><summary>fail-before (packages/ reverted to origin/main)</summary>

```
(fail) consumes trailer-part and preserves keep-alive (one write / split mid trailer name / after last-chunk / on trailer CR / on terminating CR / last-chunk with extension)
  { paths: ["/a"], bodies: ["body=hello."] }
(fail) rejects a malformed trailer-part (bare LF / CR-not-LF)
  { paths: ["/a"], status: "HTTP/1.1 200" }   (fin emitted before the malformed byte is seen)
(fail) rejects a trailer-part larger than the header-size limit with 431
```

All 9 fail without the `ChunkedEncoding.h` change and pass with it.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 15 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/http-server-chunking.test.ts test/js/bun/http/request-smuggling.test.ts
bun test v1.4.0 (a37bd2e0e)

test/js/bun/http/http-server-chunking.test.ts:
(pass) HTTP server handles chunked transfer encoding > handles fragmented chunk terminators [440.34ms]
(pass) HTTP server handles chunked transfer encoding > rejects invalid terminator in fragmented reads [374.37ms]
(pass) HTTP server handles split chunk-size CRLF > handles lone CR at end of chunk-size line across TCP segments [480.56ms]
(pass) HTTP server handles split chunk-size CRLF > handles lone CR in chunk-size with extensions [471.60ms]
(pass) HTTP server handles split chunk-size CRLF > rejects chunk extensions that exceed the 16 KiB per-chunk cap [373.23ms]
(pass) HTTP server handles split chunk-size CRLF > accepts small chunk extensions on every chunk (cap is per chunk, not per message) [363.62ms]
(pass) HTTP server handles split chunk-size CRLF > rejects bare LF in chunk-size position (invalid byte not stranded) [369.67ms]
(pass) HTTP server handles split chunk-si
... (truncated)

release without fix: 20 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/http/http-server-chunking.test.ts:
269 | 
270 |     expect(stderr).toBe("");
271 |     const { received } = JSON.parse(stdout);
272 |     // Server must reject (413) and close the connection; it must not hand the
273 |     // request to fetch() (which would answer 200 "n=2").
274 |     expect(received).not.toContain("200");
                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "200"
Received: "HTTP/1.1 200 OK\r\ncontent-type: text/plain;charset=utf-8\r\nDate: Wed, 29 Jul 2026 06:15:39 GMT\r\nContent-Length: 3\r\n\r\nn=2"

      at <anonymous> (/workspace/bun/test/js/bun/http/http-server-chunking.test.ts:274:26)
(fail) HTTP server handles split chunk-size CRLF > rejects chunk extensions that exceed the 16 KiB per-chunk cap [18.33ms]
(pass) HTTP server handles split chunk-size CRLF > accepts small chunk extensions on every chunk (cap is per chunk, not per message) [19.97ms]
(pass) HTTP server handles split chunk-size CRLF > rejects bare LF in chunk-size position (invalid byte not stranded) [19.74ms]
715 |       ["split on trailer CR", ["5\r\nhello\r\n0\r\nX-Trail: on
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/http-server-chunking.test.ts test/js/bun/http/request-smuggling.test.ts
bun test v1.4.0 (a37bd2e0e)

test/js/bun/http/http-server-chunking.test.ts:
(pass) HTTP server handles chunked transfer encoding > handles fragmented chunk terminators [419.18ms]
(pass) HTTP server handles chunked transfer encoding > rejects invalid terminator in fragmented reads [382.11ms]
(pass) HTTP server handles split chunk-size CRLF > handles lone CR at end of chunk-size line across TCP segments [476.51ms]
(pass) HTTP server handles split chunk-size CRLF > handles lone CR in chunk-size with extensions [469.89ms]
(pass) HTTP server handles split chunk-size CRLF > rejects chunk extensions that exceed the 16 KiB per-chunk cap [376.82ms]
(pass) HTTP server handles split chunk-size CRLF > accepts small chunk extensions on every chunk (cap is per chunk, not per message) [374.84ms]
(pass) HTTP server handles split chunk-size CRLF > rejects bare LF in chunk-size position (invalid byte not stranded) [372.68ms]
(pass) HTTP server handles split chunk-si
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a37bd2e0e1
  features     baseline

22 deps, 108 codegen, 1171 objects in 866ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [8.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] gen ErrorCode+*.h
[4/1234] gen bindgenv2
[5/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[6/1234] fetch zlib
[zlib] up to date
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1234] gen .bind.ts → GeneratedBindings.cpp
[10/1234] fetch picohttpparser
[picohttpparser] up to date
[11/1234] fetch tinycc
[tinycc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/ChunkedEncoding.h        | 164 ++++++++++++++------------
 packages/bun-uws/src/HttpParser.h             |   6 +-
 test/js/bun/http/http-server-chunking.test.ts |  99 ++++++++++++++++
 test/js/bun/http/request-smuggling.test.ts    |  49 ++++----
 4 files changed, 215 insertions(+), 103 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 15

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
packages/bun-uws/src/ChunkedEncoding.h             7     14     33
packages/bun-uws/src/HttpParser.h                  3      2     33
test/js/bun/http/http-server-chunking.test.ts      6     10     21
test/js/bun/http/request-smuggling.test.ts         4      6     16
```

</details>

<!-- robobun:evidence:end -->