### PR TITLE
node:http: validate strictContentLength before flushing the header block

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -14,8 +14,8 @@ const {
   validateBoolean,
   validateInteger,
   validateFunction,
-  isUint8Array,
 } = require("internal/validators");
+const { isAnyArrayBuffer, isArrayBufferView } = require("node:util/types");
 const { ConnResetException, hasObserver, startPerf, stopPerf } = require("internal/shared");
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
@@ -173,9 +173,9 @@ function strictContentLength(response) {
 // (unterminated) headers are already corked, so the client gets a partial message.
 function checkStrictContentLength(strictCL, handle, chunk, encoding, fromEnd) {
   if (strictCL === undefined) return;
-  // Measure only the chunk types Node's write_() accepts; anything else keeps
-  // its existing chunk-type error from the native write/end path.
-  if (chunk && typeof chunk !== "string" && !isUint8Array(chunk)) return;
+  // Measure only the chunk types the native write/end accepts as body bytes
+  // (string or any ArrayBuffer-like); anything else keeps its native chunk-type error.
+  if (chunk && typeof chunk !== "string" && !isArrayBufferView(chunk) && !isAnyArrayBuffer(chunk)) return;
   const len = chunk ? (typeof chunk === "string" ? Buffer.byteLength(chunk, encoding) : chunk.byteLength) : 0;
   // The http2 allowHTTP1 fallback installs a JS shim handle without getBytesWritten.
   const written = (handle.getBytesWritten?.() ?? 0) + len;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -15,7 +15,7 @@ const {
   validateInteger,
   validateFunction,
 } = require("internal/validators");
-const { isAnyArrayBuffer, isArrayBufferView } = require("node:util/types");
+const { isAnyArrayBuffer, isArrayBufferView, isStringObject } = require("node:util/types");
 const { ConnResetException, hasObserver, startPerf, stopPerf } = require("internal/shared");
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
@@ -173,10 +173,15 @@ function strictContentLength(response) {
 // (unterminated) headers are already corked, so the client gets a partial message.
 function checkStrictContentLength(strictCL, handle, chunk, encoding, fromEnd) {
   if (strictCL === undefined) return;
-  // Measure only the chunk types the native write/end accepts as body bytes
-  // (string or any ArrayBuffer-like); anything else keeps its native chunk-type error.
-  if (chunk && typeof chunk !== "string" && !isArrayBufferView(chunk) && !isAnyArrayBuffer(chunk)) return;
-  const len = chunk ? (typeof chunk === "string" ? Buffer.byteLength(chunk, encoding) : chunk.byteLength) : 0;
+  // Measure only the chunk types the native write/end accepts as body bytes;
+  // anything else falls through and keeps its native chunk-type error.
+  let len = 0;
+  if (chunk) {
+    if (typeof chunk === "string") len = Buffer.byteLength(chunk, encoding);
+    else if (isArrayBufferView(chunk) || isAnyArrayBuffer(chunk)) len = chunk.byteLength;
+    else if (isStringObject(chunk)) len = Buffer.byteLength(String(chunk), encoding);
+    else return;
+  }
   // The http2 allowHTTP1 fallback installs a JS shim handle without getBytesWritten.
   const written = (handle.getBytesWritten?.() ?? 0) + len;
   if (fromEnd ? written !== strictCL : written > strictCL) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -175,7 +175,9 @@ function strictContentLength(response) {
 function checkStrictContentLength(strictCL, handle, chunk, encoding, fromEnd) {
   if (strictCL === undefined) return;
   const len = chunk ? (typeof chunk === "string" ? Buffer.byteLength(chunk, encoding) : chunk.byteLength) : 0;
-  const written = handle.getBytesWritten() + len;
+  // Optional chain: the http2 allowHTTP1 fallback installs a JS shim handle
+  // (http2.ts createHttp1FallbackResponseHandle) without getBytesWritten.
+  const written = (handle.getBytesWritten?.() ?? 0) + len;
   if (fromEnd ? written !== strictCL : written > strictCL) {
     throw $ERR_HTTP_CONTENT_LENGTH_MISMATCH(
       `Response body's content-length of ${written} byte(s) does not match the content-length of ${strictCL} byte(s) set in header`,

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -167,6 +167,22 @@ function strictContentLength(response) {
   }
 }
 
+// Like Node's write_(), validate strictContentLength before the native
+// handle.writeHead() puts bytes on the wire: the native write/end check runs
+// after writeHead has already emitted the status line + headers (without the
+// terminating CRLF), so a throw there leaves the client with a syntactically
+// incomplete message it will block on forever.
+function checkStrictContentLength(strictCL, handle, chunk, encoding, fromEnd) {
+  if (strictCL === undefined) return;
+  const len = chunk ? (typeof chunk === "string" ? Buffer.byteLength(chunk, encoding) : chunk.byteLength) : 0;
+  const written = handle.getBytesWritten() + len;
+  if (fromEnd ? written !== strictCL : written > strictCL) {
+    throw $ERR_HTTP_CONTENT_LENGTH_MISMATCH(
+      `Response body's content-length of ${written} byte(s) does not match the content-length of ${strictCL} byte(s) set in header`,
+    );
+  }
+}
+
 const ServerResponse_writeDeprecated = function _write(chunk, encoding, callback) {
   if ($isCallable(encoding)) {
     callback = encoding;
@@ -2004,7 +2020,9 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     // and will not throw or emit an error
     return true;
   }
+  const strictCL = strictContentLength(this);
   if (headerState !== NodeHTTPHeaderState.sent) {
+    checkStrictContentLength(strictCL, handle, chunk, encoding, true);
     handle.cork(() => {
       handle.writeHead(
         this[kSnapshotStatusCode] ?? this.statusCode,
@@ -2017,13 +2035,13 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
 
       // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/_http_outgoing.js#L987
-      this._contentLength = handle.end(chunk, encoding, undefined, strictContentLength(this));
+      this._contentLength = handle.end(chunk, encoding, undefined, strictCL);
     });
   } else {
     // If there's no data but you already called end, then you're done.
     // We can ignore it in that case.
     if (!(!chunk && handle.ended) && !handle.aborted) {
-      handle.end(chunk, encoding, undefined, strictContentLength(this));
+      handle.end(chunk, encoding, undefined, strictCL);
     }
   }
   this._header = " ";
@@ -2141,7 +2159,9 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
     return true;
   }
 
+  const strictCL = strictContentLength(this);
   if (this[headerStateSymbol] !== NodeHTTPHeaderState.sent) {
+    checkStrictContentLength(strictCL, handle, chunk, encoding, false);
     handle.cork(() => {
       handle.writeHead(
         this[kSnapshotStatusCode] ?? this.statusCode,
@@ -2152,10 +2172,10 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
       // If handle.writeHead throws, we don't want headersSent to be set to true.
       // So we set it here.
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
-      result = handle.write(chunk, encoding, allowWritesToContinue.bind(this), strictContentLength(this));
+      result = handle.write(chunk, encoding, allowWritesToContinue.bind(this), strictCL);
     });
   } else {
-    result = handle.write(chunk, encoding, allowWritesToContinue.bind(this), strictContentLength(this));
+    result = handle.write(chunk, encoding, allowWritesToContinue.bind(this), strictCL);
   }
 
   if (result < 0) {
@@ -2308,7 +2328,9 @@ ServerResponse.prototype._send = function (data, encoding, callback, _byteLength
     return OutgoingMessagePrototype._send.$apply(this, arguments);
   }
 
+  const strictCL = strictContentLength(this);
   if (this[headerStateSymbol] !== NodeHTTPHeaderState.sent) {
+    checkStrictContentLength(strictCL, handle, data, encoding, false);
     handle.cork(() => {
       handle.writeHead(
         this[kSnapshotStatusCode] ?? this.statusCode,
@@ -2316,10 +2338,10 @@ ServerResponse.prototype._send = function (data, encoding, callback, _byteLength
         renderNativeHeaders(this),
       );
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
-      handle.write(data, encoding, callback, strictContentLength(this));
+      handle.write(data, encoding, callback, strictCL);
     });
   } else {
-    handle.write(data, encoding, callback, strictContentLength(this));
+    handle.write(data, encoding, callback, strictCL);
   }
 };
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -14,6 +14,7 @@ const {
   validateBoolean,
   validateInteger,
   validateFunction,
+  isUint8Array,
 } = require("internal/validators");
 const { ConnResetException, hasObserver, startPerf, stopPerf } = require("internal/shared");
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
@@ -167,16 +168,16 @@ function strictContentLength(response) {
   }
 }
 
-// Like Node's write_(), validate strictContentLength before the native
-// handle.writeHead() puts bytes on the wire: the native write/end check runs
-// after writeHead has already emitted the status line + headers (without the
-// terminating CRLF), so a throw there leaves the client with a syntactically
-// incomplete message it will block on forever.
+// Match Node's write_(): enforce strictContentLength before handle.writeHead()
+// flushes the header block. The native write/end check throws only after the
+// (unterminated) headers are already corked, so the client gets a partial message.
 function checkStrictContentLength(strictCL, handle, chunk, encoding, fromEnd) {
   if (strictCL === undefined) return;
+  // Measure only the chunk types Node's write_() accepts; anything else keeps
+  // its existing chunk-type error from the native write/end path.
+  if (chunk && typeof chunk !== "string" && !isUint8Array(chunk)) return;
   const len = chunk ? (typeof chunk === "string" ? Buffer.byteLength(chunk, encoding) : chunk.byteLength) : 0;
-  // Optional chain: the http2 allowHTTP1 fallback installs a JS shim handle
-  // (http2.ts createHttp1FallbackResponseHandle) without getBytesWritten.
+  // The http2 allowHTTP1 fallback installs a JS shim handle without getBytesWritten.
   const written = (handle.getBytesWritten?.() ?? 0) + len;
   if (fromEnd ? written !== strictCL : written > strictCL) {
     throw $ERR_HTTP_CONTENT_LENGTH_MISMATCH(

--- a/test/js/node/http/node-http-strict-content-length.test.ts
+++ b/test/js/node/http/node-http-strict-content-length.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { once } from "node:events";
 import http from "node:http";
 import net from "node:net";
-import { once } from "node:events";
 
 // When res.strictContentLength is set and the first end()/write() call
 // detects a mismatch, Node throws before any bytes reach the wire. Bun was

--- a/test/js/node/http/node-http-strict-content-length.test.ts
+++ b/test/js/node/http/node-http-strict-content-length.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "bun:test";
 import { once } from "node:events";
 import http from "node:http";
+import http2 from "node:http2";
 import net from "node:net";
+import tls from "node:tls";
+import { tls as tlsCert } from "harness";
 
 // When res.strictContentLength is set and the first end()/write() call
 // detects a mismatch, Node throws before any bytes reach the wire. Bun was
@@ -11,15 +14,26 @@ import net from "node:net";
 // uncork, leaving the client with a syntactically incomplete HTTP message it
 // would block on until its own timeout.
 
+// The server hard-closes via res.socket.destroy(), which on some platforms
+// surfaces as RST -> ECONNRESET on the client. once(sock, "close") would
+// reject on that 'error' even with a no-op listener, so wait on 'close'
+// directly.
+function waitForClose(sock: net.Socket): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  sock.on("close", () => resolve());
+  return promise;
+}
+
 async function requestRaw(port: number): Promise<string> {
   const sock = net.connect(port, "127.0.0.1");
   sock.setNoDelay(true);
   const chunks: Buffer[] = [];
   sock.on("data", d => chunks.push(Buffer.from(d)));
   sock.on("error", () => {});
+  const closed = waitForClose(sock);
   await once(sock, "connect");
   sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
-  await once(sock, "close");
+  await closed;
   return Buffer.concat(chunks).toString("binary");
 }
 
@@ -137,4 +151,61 @@ test("strictContentLength: end() with no chunk and unmet Content-Length throws b
     headersSent: true,
     wire: "",
   });
+});
+
+// The http2 allowHTTP1 fallback drives ServerResponse with a JS shim handle
+// (createHttp1FallbackResponseHandle in http2.ts) that has no
+// getBytesWritten(), so the pre-flush check must not assume a native handle.
+
+async function h2FallbackRequestRaw(port: number): Promise<string> {
+  const sock = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false, ALPNProtocols: ["http/1.1"] });
+  const chunks: Buffer[] = [];
+  sock.on("data", d => chunks.push(Buffer.from(d)));
+  sock.on("error", () => {});
+  const closed = waitForClose(sock);
+  await once(sock, "secureConnect");
+  sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  await closed;
+  return Buffer.concat(chunks).toString("binary");
+}
+
+test("strictContentLength: http2 allowHTTP1 fallback with matching length succeeds", async () => {
+  const { promise: handled, resolve, reject } = Promise.withResolvers<void>();
+  await using server = http2.createSecureServer({ ...tlsCert, allowHTTP1: true }, (req, res) => {
+    try {
+      res.strictContentLength = true;
+      res.writeHead(200, { "content-length": "10" });
+      res.end("1234567890");
+      resolve();
+    } catch (e) {
+      reject(e);
+    }
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  const wire = await h2FallbackRequestRaw((server.address() as net.AddressInfo).port);
+  await handled;
+
+  expect(wire).toContain("1234567890");
+});
+
+test("strictContentLength: http2 allowHTTP1 fallback mismatch throws the right error", async () => {
+  const { promise: handled, resolve, reject } = Promise.withResolvers<string>();
+  await using server = http2.createSecureServer({ ...tlsCert, allowHTTP1: true }, (req, res) => {
+    res.strictContentLength = true;
+    res.writeHead(200, { "content-length": "10" });
+    try {
+      res.end("hi");
+      reject(new Error("end() should have thrown"));
+      return;
+    } catch (e: any) {
+      resolve(`${e.constructor.name}:${e.code}`);
+    }
+    res.socket!.destroy();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  await h2FallbackRequestRaw((server.address() as net.AddressInfo).port);
+
+  expect(await handled).toBe("Error:ERR_HTTP_CONTENT_LENGTH_MISMATCH");
 });

--- a/test/js/node/http/node-http-strict-content-length.test.ts
+++ b/test/js/node/http/node-http-strict-content-length.test.ts
@@ -169,6 +169,41 @@ test("strictContentLength: an invalid chunk still throws the chunk-type error, n
   expect(await handled).toBe("ERR_INVALID_ARG_TYPE");
 });
 
+// Bun's native write/end accepts every ArrayBuffer-like type (not just
+// Uint8Array), so the pre-flush check must measure all of them too.
+test.each([
+  ["DataView", () => new DataView(new ArrayBuffer(2))],
+  ["ArrayBuffer", () => new ArrayBuffer(2)],
+  ["SharedArrayBuffer", () => new SharedArrayBuffer(2)],
+  ["Int8Array", () => new Int8Array(2)],
+  ["Uint8ClampedArray", () => new Uint8ClampedArray(2)],
+  ["Float32Array", () => new Float32Array(2)],
+] as const)(
+  "strictContentLength: a short %s end() throws before any bytes reach the wire",
+  async (_name, makeChunk) => {
+    const { promise: handled, resolve, reject } = Promise.withResolvers<string>();
+    await using server = http.createServer((req, res) => {
+      req.resume();
+      res.strictContentLength = true;
+      res.writeHead(200, { "content-length": "100" });
+      try {
+        res.end(makeChunk() as any);
+        reject(new Error("end() should have thrown"));
+        return;
+      } catch (e: any) {
+        resolve(e.code);
+      }
+      setImmediate(() => res.socket!.end());
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+
+    const wire = await requestRaw((server.address() as net.AddressInfo).port);
+    const code = await handled;
+
+    expect({ code, wire }).toEqual({ code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH", wire: "" });
+  },
+);
+
 // The http2 allowHTTP1 fallback drives ServerResponse with a JS shim handle
 // (createHttp1FallbackResponseHandle in http2.ts) that has no
 // getBytesWritten(), so the pre-flush check must not assume a native handle.

--- a/test/js/node/http/node-http-strict-content-length.test.ts
+++ b/test/js/node/http/node-http-strict-content-length.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
+import { tls as tlsCert } from "harness";
 import { once } from "node:events";
 import http from "node:http";
 import http2 from "node:http2";
 import net from "node:net";
 import tls from "node:tls";
-import { tls as tlsCert } from "harness";
 
 // When res.strictContentLength is set and the first end()/write() call
 // detects a mismatch, Node throws before any bytes reach the wire. Bun was

--- a/test/js/node/http/node-http-strict-content-length.test.ts
+++ b/test/js/node/http/node-http-strict-content-length.test.ts
@@ -6,18 +6,12 @@ import http2 from "node:http2";
 import net from "node:net";
 import tls from "node:tls";
 
-// When res.strictContentLength is set and the first end()/write() call
-// detects a mismatch, Node throws before any bytes reach the wire. Bun was
-// calling handle.writeHead() inside the same cork block as handle.end()/
-// handle.write(), so the throw happened *after* the status line and headers
-// (without the terminating blank line) were already buffered and flushed on
-// uncork, leaving the client with a syntactically incomplete HTTP message it
-// would block on until its own timeout.
+// A strictContentLength mismatch on the first end()/write() must throw before
+// any bytes reach the wire; throwing after the header block is corked leaves
+// the client a response with no terminating CRLFCRLF to block on forever.
 
-// The server hard-closes via res.socket.destroy(), which on some platforms
-// surfaces as RST -> ECONNRESET on the client. once(sock, "close") would
-// reject on that 'error' even with a no-op listener, so wait on 'close'
-// directly.
+// Resolve on 'close' without once(): once() rejects if the socket ever emits
+// 'error' (e.g. an RST from the server) before closing.
 function waitForClose(sock: net.Socket): Promise<void> {
   const { promise, resolve } = Promise.withResolvers<void>();
   sock.on("close", () => resolve());
@@ -50,9 +44,8 @@ test("strictContentLength: short end() throws before any bytes reach the wire", 
     } catch (e: any) {
       resolve({ code: e.code, headersSent: res.headersSent });
     }
-    // Close the underlying connection on a later tick so any already-flushed
-    // bytes reach the client before the socket goes away.
-    setImmediate(() => res.socket!.destroy());
+    // FIN a tick later so any erroneously-flushed bytes reach the client first.
+    setImmediate(() => res.socket!.end());
   });
   await once(server.listen(0, "127.0.0.1"), "listening");
 
@@ -61,8 +54,8 @@ test("strictContentLength: short end() throws before any bytes reach the wire", 
 
   expect({ ...result, wire }).toEqual({
     code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
-    // writeHead() already marked headers as sent (like Node.js); the point is
-    // that nothing was actually *flushed*.
+    // writeHead() marks headers as sent (like Node.js); the invariant under
+    // test is that nothing was actually *flushed*.
     headersSent: true,
     wire: "",
   });
@@ -81,7 +74,7 @@ test("strictContentLength: over-long write() throws before any bytes reach the w
     } catch (e: any) {
       resolve({ code: e.code, headersSent: res.headersSent });
     }
-    setImmediate(() => res.socket!.destroy());
+    setImmediate(() => res.socket!.end());
   });
   await once(server.listen(0, "127.0.0.1"), "listening");
 
@@ -108,8 +101,7 @@ test("strictContentLength: response can be recovered after a rejected end()", as
     } catch (e: any) {
       resolve(e.code);
     }
-    // Nothing was flushed, so a subsequent end() with the right length
-    // produces a well-formed response.
+    // Nothing was flushed, so a correct-length end() still forms a valid response.
     res.end("1234567890");
   });
   await once(server.listen(0, "127.0.0.1"), "listening");
@@ -139,7 +131,7 @@ test("strictContentLength: end() with no chunk and unmet Content-Length throws b
     } catch (e: any) {
       resolve({ code: e.code, headersSent: res.headersSent });
     }
-    setImmediate(() => res.socket!.destroy());
+    setImmediate(() => res.socket!.end());
   });
   await once(server.listen(0, "127.0.0.1"), "listening");
 
@@ -151,6 +143,30 @@ test("strictContentLength: end() with no chunk and unmet Content-Length throws b
     headersSent: true,
     wire: "",
   });
+});
+
+test("strictContentLength: an invalid chunk still throws the chunk-type error, not a length mismatch", async () => {
+  const { promise: handled, resolve, reject } = Promise.withResolvers<string>();
+  await using server = http.createServer((req, res) => {
+    req.resume();
+    res.strictContentLength = true;
+    res.writeHead(200, { "content-length": "10" });
+    try {
+      // A duck-typed non-buffer: measuring its byteLength (3 !== 10) would
+      // misreport this as a Content-Length mismatch.
+      res.end({ byteLength: 3 } as any);
+      reject(new Error("end() should have thrown"));
+      return;
+    } catch (e: any) {
+      resolve(e.code);
+    }
+    setImmediate(() => res.socket!.end());
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  await requestRaw((server.address() as net.AddressInfo).port);
+
+  expect(await handled).toBe("ERR_INVALID_ARG_TYPE");
 });
 
 // The http2 allowHTTP1 fallback drives ServerResponse with a JS shim handle
@@ -201,7 +217,7 @@ test("strictContentLength: http2 allowHTTP1 fallback mismatch throws the right e
     } catch (e: any) {
       resolve(`${e.constructor.name}:${e.code}`);
     }
-    res.socket!.destroy();
+    setImmediate(() => res.socket!.end());
   });
   await once(server.listen(0, "127.0.0.1"), "listening");
 

--- a/test/js/node/http/node-http-strict-content-length.test.ts
+++ b/test/js/node/http/node-http-strict-content-length.test.ts
@@ -1,0 +1,140 @@
+import { test, expect } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+import { once } from "node:events";
+
+// When res.strictContentLength is set and the first end()/write() call
+// detects a mismatch, Node throws before any bytes reach the wire. Bun was
+// calling handle.writeHead() inside the same cork block as handle.end()/
+// handle.write(), so the throw happened *after* the status line and headers
+// (without the terminating blank line) were already buffered and flushed on
+// uncork, leaving the client with a syntactically incomplete HTTP message it
+// would block on until its own timeout.
+
+async function requestRaw(port: number): Promise<string> {
+  const sock = net.connect(port, "127.0.0.1");
+  sock.setNoDelay(true);
+  const chunks: Buffer[] = [];
+  sock.on("data", d => chunks.push(Buffer.from(d)));
+  sock.on("error", () => {});
+  await once(sock, "connect");
+  sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  await once(sock, "close");
+  return Buffer.concat(chunks).toString("binary");
+}
+
+test("strictContentLength: short end() throws before any bytes reach the wire", async () => {
+  const { promise: handled, resolve, reject } = Promise.withResolvers<{ code: string; headersSent: boolean }>();
+  await using server = http.createServer((req, res) => {
+    req.resume();
+    res.strictContentLength = true;
+    res.writeHead(200, { "content-length": "10" });
+    try {
+      res.end("hi");
+      reject(new Error("end() should have thrown"));
+      return;
+    } catch (e: any) {
+      resolve({ code: e.code, headersSent: res.headersSent });
+    }
+    // Close the underlying connection on a later tick so any already-flushed
+    // bytes reach the client before the socket goes away.
+    setImmediate(() => res.socket!.destroy());
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  const wire = await requestRaw((server.address() as net.AddressInfo).port);
+  const result = await handled;
+
+  expect({ ...result, wire }).toEqual({
+    code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+    // writeHead() already marked headers as sent (like Node.js); the point is
+    // that nothing was actually *flushed*.
+    headersSent: true,
+    wire: "",
+  });
+});
+
+test("strictContentLength: over-long write() throws before any bytes reach the wire", async () => {
+  const { promise: handled, resolve, reject } = Promise.withResolvers<{ code: string; headersSent: boolean }>();
+  await using server = http.createServer((req, res) => {
+    req.resume();
+    res.strictContentLength = true;
+    res.writeHead(200, { "content-length": "5" });
+    try {
+      res.write("hello world");
+      reject(new Error("write() should have thrown"));
+      return;
+    } catch (e: any) {
+      resolve({ code: e.code, headersSent: res.headersSent });
+    }
+    setImmediate(() => res.socket!.destroy());
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  const wire = await requestRaw((server.address() as net.AddressInfo).port);
+  const result = await handled;
+
+  expect({ ...result, wire }).toEqual({
+    code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+    headersSent: true,
+    wire: "",
+  });
+});
+
+test("strictContentLength: response can be recovered after a rejected end()", async () => {
+  const { promise: handled, resolve, reject } = Promise.withResolvers<string>();
+  await using server = http.createServer((req, res) => {
+    req.resume();
+    res.strictContentLength = true;
+    res.writeHead(200, { "content-length": "10" });
+    try {
+      res.end("hi");
+      reject(new Error("end() should have thrown"));
+      return;
+    } catch (e: any) {
+      resolve(e.code);
+    }
+    // Nothing was flushed, so a subsequent end() with the right length
+    // produces a well-formed response.
+    res.end("1234567890");
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  const port = (server.address() as net.AddressInfo).port;
+  const res = await fetch(`http://127.0.0.1:${port}/`);
+  const body = await res.text();
+  const code = await handled;
+
+  expect({ code, status: res.status, body }).toEqual({
+    code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+    status: 200,
+    body: "1234567890",
+  });
+});
+
+test("strictContentLength: end() with no chunk and unmet Content-Length throws before flushing headers", async () => {
+  const { promise: handled, resolve, reject } = Promise.withResolvers<{ code: string; headersSent: boolean }>();
+  await using server = http.createServer((req, res) => {
+    req.resume();
+    res.strictContentLength = true;
+    res.writeHead(200, { "content-length": "10" });
+    try {
+      res.end();
+      reject(new Error("end() should have thrown"));
+      return;
+    } catch (e: any) {
+      resolve({ code: e.code, headersSent: res.headersSent });
+    }
+    setImmediate(() => res.socket!.destroy());
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  const wire = await requestRaw((server.address() as net.AddressInfo).port);
+  const result = await handled;
+
+  expect({ ...result, wire }).toEqual({
+    code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+    headersSent: true,
+    wire: "",
+  });
+});

--- a/test/js/node/http/node-http-strict-content-length.test.ts
+++ b/test/js/node/http/node-http-strict-content-length.test.ts
@@ -169,8 +169,9 @@ test("strictContentLength: an invalid chunk still throws the chunk-type error, n
   expect(await handled).toBe("ERR_INVALID_ARG_TYPE");
 });
 
-// Bun's native write/end accepts every ArrayBuffer-like type (not just
-// Uint8Array), so the pre-flush check must measure all of them too.
+// Bun's native write/end accepts every ArrayBuffer-like type and boxed String
+// objects (not just strings and Uint8Array), so the pre-flush check must
+// measure all of them too.
 test.each([
   ["DataView", () => new DataView(new ArrayBuffer(2))],
   ["ArrayBuffer", () => new ArrayBuffer(2)],
@@ -178,6 +179,8 @@ test.each([
   ["Int8Array", () => new Int8Array(2)],
   ["Uint8ClampedArray", () => new Uint8ClampedArray(2)],
   ["Float32Array", () => new Float32Array(2)],
+  ["String object", () => new String("hi")],
+  ["derived String object", () => new (class extends String {})("hi")],
 ] as const)(
   "strictContentLength: a short %s end() throws before any bytes reach the wire",
   async (_name, makeChunk) => {

--- a/test/js/node/http/node-http-strict-content-length.test.ts
+++ b/test/js/node/http/node-http-strict-content-length.test.ts
@@ -207,6 +207,41 @@ test.each([
   },
 );
 
+// Like Node's end(), a falsy chunk is treated as "no chunk" (Node gates
+// write_() and its type validation behind `if (chunk)`), so these report an
+// unmet Content-Length, not an invalid chunk type, with nothing on the wire.
+test.each([
+  ["0", () => 0],
+  ["false", () => false],
+  ["NaN", () => NaN],
+  ["0n", () => 0n],
+  ["an empty string", () => ""],
+] as const)(
+  "strictContentLength: end() with a falsy chunk (%s) throws a mismatch before any bytes reach the wire",
+  async (_name, makeChunk) => {
+    const { promise: handled, resolve, reject } = Promise.withResolvers<string>();
+    await using server = http.createServer((req, res) => {
+      req.resume();
+      res.strictContentLength = true;
+      res.writeHead(200, { "content-length": "10" });
+      try {
+        res.end(makeChunk() as any);
+        reject(new Error("end() should have thrown"));
+        return;
+      } catch (e: any) {
+        resolve(e.code);
+      }
+      setImmediate(() => res.socket!.end());
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+
+    const wire = await requestRaw((server.address() as net.AddressInfo).port);
+    const code = await handled;
+
+    expect({ code, wire }).toEqual({ code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH", wire: "" });
+  },
+);
+
 // The http2 allowHTTP1 fallback drives ServerResponse with a JS shim handle
 // (createHttp1FallbackResponseHandle in http2.ts) that has no
 // getBytesWritten(), so the pre-flush check must not assume a native handle.


### PR DESCRIPTION
## Problem

With `res.strictContentLength = true`, a first `res.end()` or `res.write()` whose byte count violates the declared `Content-Length` throws `ERR_HTTP_CONTENT_LENGTH_MISMATCH` in both Bun and Node.js. Node.js runs that check before any bytes leave the process, so the client sees a clean connection error and can retry. Bun had already flushed the status line and headers (without the terminating blank line) before the throw, so the client received a syntactically incomplete HTTP/1.1 message and blocked in `read()` until its own timeout.

### Reproduction

```js
import http from 'node:http';
import net from 'node:net';
const srv = http.createServer((q, r) => {
  r.strictContentLength = true;
  r.writeHead(200, { 'content-length': '10' });
  try { r.end('hi'); } catch (e) { console.log('threw', e.code); }
});
srv.listen(0, '127.0.0.1', () => {
  const s = net.connect(srv.address().port);
  let wire = '';
  s.on('connect', () => s.write('GET / HTTP/1.1\r\nHost:a\r\n\r\n'));
  s.on('data', d => wire += d);
  setTimeout(() => {
    console.log({ wireBytes: wire.length, terminated: wire.includes('\r\n\r\n') });
    process.exit(0);
  }, 1200);
});
```

Bun (before):
```
threw ERR_HTTP_CONTENT_LENGTH_MISMATCH
{ wireBytes: 121, terminated: false }
```

Node.js:
```
threw ERR_HTTP_CONTENT_LENGTH_MISMATCH
{ wireBytes: 0, terminated: false }
```

## Cause

`ServerResponse.prototype.end` / `write` / `_send` flush the first response as:

```js
handle.cork(() => {
  handle.writeHead(status, message, headers);   // emits status line + headers, no CRLFCRLF
  handle.end(chunk, encoding, cb, strictCL);     // throws on mismatch
});
```

The native content-length check in `NodeHTTPResponse::write_or_end` runs after `writeHead()` has already pushed the header lines into the uWS response. When it throws, `cork()` re-throws the exception to JS, but the corked bytes are still flushed on uncork.

## Fix

Validate the byte count in JS before `handle.writeHead()` for the three sites that send headers on a first body write. The check mirrors Node's `write_()` (`fromEnd ? total !== CL : total > CL`) and:

- measures exactly the chunk types the native write/end accepts as body bytes: strings, any ArrayBuffer-like value (via `isArrayBufferView` / `isAnyArrayBuffer` from `node:util/types`), and boxed `String` objects (`isStringObject`). Anything else falls through and keeps the chunk-type error the native path already raises.
- treats a falsy chunk as "no chunk", like Node's `end()` (which gates `write_()` and its type validation behind a truthiness test), so `end(0)` reports an unmet `Content-Length` rather than an argument-type error.
- optional-chains `handle.getBytesWritten?.()`, since the http2 `allowHTTP1` fallback installs a JS shim handle without that method.

The native check still receives `strictCL`, so subsequent writes after the headers have been flushed keep their existing enforcement. The thrown error now carries the full Node.js message text.

## Verification

New `test/js/node/http/node-http-strict-content-length.test.ts` drives the server over a raw `net` socket and asserts zero bytes on the wire for:
- `end('hi')` with `Content-Length: 10` (the reported case)
- `write('hello world')` with `Content-Length: 5` (the sibling write path)
- `end()` with no chunk and an unmet `Content-Length`
- every other chunk type the native path accepts (`DataView`, `ArrayBuffer`, `SharedArrayBuffer`, `Int8Array`, `Uint8ClampedArray`, `Float32Array`, `new String(...)`, a `String` subclass)
- every falsy chunk value (`0`, `false`, `NaN`, `0n`, `""`), which Node treats as no chunk
- a follow-up `end()` with the correct length still produces a well-formed response
- an invalid (non-buffer) chunk still surfaces `ERR_INVALID_ARG_TYPE`, not a length mismatch
- the `http2.createSecureServer({ allowHTTP1: true })` HTTP/1.1 fallback (shim handle, no native `getBytesWritten`), both matching and mismatched lengths

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http-strict-content-length.test.ts
  3 pass  17 fail   (partial header block on the wire)
$ bun bd test test/js/node/http/node-http-strict-content-length.test.ts
  20 pass  0 fail
```

`test/js/node/test/parallel/test-http-content-length-mismatch.js` and `test/js/bun/test/parallel/test-http-strictContentLength-should-work-on-server.ts` continue to pass.
