### PR TITLE
Bun.serve websocket: make publish() return 0/-1 on subscriber backpressure

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -973,7 +973,7 @@ declare module "bun" {
      * @param data The data to send
      * @param compress Should the data be compressed? Ignored if the client does not support compression.
      *
-     * @returns 0 if the message was dropped, -1 if backpressure was applied, or the number of bytes sent.
+     * @returns 0 if the message was dropped for any subscriber (or there were no subscribers), -1 if backpressure was applied for any subscriber, or the number of bytes sent.
      *
      * @example
      *

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -225,13 +225,15 @@ public:
         /* Anything big bypasses corking efforts */
         if (message.length() >= LoopData::CORK_BUFFER_SIZE) {
             PublishStatus worst = PublishStatus::SUCCESS;
-            bool had = topicTree->publishBig(nullptr, topic, {message, opCode, compress}, [&worst](Subscriber *s, TopicTreeBigMessage &message) {
+            bool hasReceivers = false;
+            topicTree->publishBig(nullptr, topic, {message, opCode, compress}, [&worst, &hasReceivers](Subscriber *s, TopicTreeBigMessage &message) {
+                hasReceivers = true;
                 auto *ws = (WebSocket<SSL, true, int> *) s->user;
 
                 /* Send will drain if needed */
                 worst = WebSocket<SSL, true, int>::worseStatus(worst, (PublishStatus) ws->send(message.message, (OpCode)message.opCode, message.compress));
             });
-            return had ? worst : PublishStatus::DROPPED;
+            return hasReceivers ? worst : PublishStatus::DROPPED;
         } else {
             Topic *t = topicTree->lookupTopic(topic);
             if (!t) {

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -207,27 +207,46 @@ public:
         return std::move(*this);
     }
 
+    using PublishStatus = typename WebSocket<SSL, true, int>::SendStatus;
+
     /* Publishes a message to all websocket contexts - conceptually as if publishing to the one single
      * TopicTree of this app (technically there are many TopicTrees, however the concept is that one
      * app has one conceptual Topic tree) */
-    bool publish(std::string_view topic, std::string_view message, unsigned char opCode, bool compress = false) {
+    PublishStatus publish(std::string_view topic, std::string_view message, unsigned char opCode, bool compress = false) {
         return this->publish(topic, message, (OpCode)opCode, compress);
     }
 
     /* Publishes a message to all websocket contexts - conceptually as if publishing to the one single
      * TopicTree of this app (technically there are many TopicTrees, however the concept is that one
-     * app has one conceptual Topic tree) */
-    bool publish(std::string_view topic, std::string_view message, OpCode opCode, bool compress = false) {
+     * app has one conceptual Topic tree). Returns the aggregated SendStatus across all subscribers:
+     * DROPPED if the topic has no subscribers or any subscriber is over its backpressure limit,
+     * BACKPRESSURE if any subscriber has buffered data, otherwise SUCCESS. */
+    PublishStatus publish(std::string_view topic, std::string_view message, OpCode opCode, bool compress = false) {
         /* Anything big bypasses corking efforts */
         if (message.length() >= LoopData::CORK_BUFFER_SIZE) {
-            return topicTree->publishBig(nullptr, topic, {message, opCode, compress}, [](Subscriber *s, TopicTreeBigMessage &message) {
+            PublishStatus worst = PublishStatus::SUCCESS;
+            bool had = topicTree->publishBig(nullptr, topic, {message, opCode, compress}, [&worst](Subscriber *s, TopicTreeBigMessage &message) {
                 auto *ws = (WebSocket<SSL, true, int> *) s->user;
 
                 /* Send will drain if needed */
-                ws->send(message.message, (OpCode)message.opCode, message.compress);
+                worst = WebSocket<SSL, true, int>::worseStatus(worst, (PublishStatus) ws->send(message.message, (OpCode)message.opCode, message.compress));
             });
+            return had ? worst : PublishStatus::DROPPED;
         } else {
-            return topicTree->publish(nullptr, topic, {std::string(message), opCode, compress});
+            Topic *t = topicTree->lookupTopic(topic);
+            if (!t) {
+                return PublishStatus::DROPPED;
+            }
+            topicTree->publish(nullptr, topic, {std::string(message), opCode, compress});
+            /* publish() may have synchronously drained a subscriber; check backpressure after. */
+            PublishStatus worst = PublishStatus::SUCCESS;
+            bool hasReceivers = false;
+            for (Subscriber *s : *t) {
+                hasReceivers = true;
+                auto *ws = (WebSocket<SSL, true, int> *) s->user;
+                worst = WebSocket<SSL, true, int>::worseStatus(worst, (PublishStatus) ws->sendStatus());
+            }
+            return hasReceivers ? worst : PublishStatus::DROPPED;
         }
     }
 

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -216,11 +216,9 @@ public:
         return this->publish(topic, message, (OpCode)opCode, compress);
     }
 
-    /* Publishes a message to all websocket contexts - conceptually as if publishing to the one single
-     * TopicTree of this app (technically there are many TopicTrees, however the concept is that one
-     * app has one conceptual Topic tree). Returns the aggregated SendStatus across all subscribers:
-     * DROPPED if the topic has no subscribers or any subscriber is over its backpressure limit,
-     * BACKPRESSURE if any subscriber has buffered data, otherwise SUCCESS. */
+    /* Publishes a message to the app's one conceptual websocket Topic tree.
+     * Returns the worst subscriber SendStatus; no subscribers is DROPPED,
+     * then BACKPRESSURE beats SUCCESS. */
     PublishStatus publish(std::string_view topic, std::string_view message, OpCode opCode, bool compress = false) {
         /* Anything big bypasses corking efforts */
         if (message.length() >= LoopData::CORK_BUFFER_SIZE) {

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -391,12 +391,14 @@ public:
         /* Publish as sender, does not receive its own messages even if subscribed to relevant topics */
         if (message.length() >= LoopData::CORK_BUFFER_SIZE) {
             SendStatus worst = SUCCESS;
-            bool had = webSocketContextData->topicTree->publishBig(webSocketData->subscriber, topic, {message, opCode, compress}, [&worst](Subscriber *s, TopicTreeBigMessage &message) {
+            bool hasReceivers = false;
+            webSocketContextData->topicTree->publishBig(webSocketData->subscriber, topic, {message, opCode, compress}, [&worst, &hasReceivers](Subscriber *s, TopicTreeBigMessage &message) {
+                hasReceivers = true;
                 auto *ws = (WebSocket<SSL, true, int> *) s->user;
 
                 worst = worseStatus(worst, (SendStatus) ws->send(message.message, (OpCode)message.opCode, message.compress));
             });
-            return had ? worst : DROPPED;
+            return hasReceivers ? worst : DROPPED;
         } else {
             Topic *t = webSocketContextData->topicTree->lookupTopic(topic);
             if (!t) {

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -82,6 +82,30 @@ public:
         DROPPED
     };
 
+    /* Report what send() would return right now without actually sending:
+     * DROPPED when bufferedAmount is over maxBackpressure, BACKPRESSURE when
+     * there is any buffered data, otherwise SUCCESS. Used by publish() to
+     * surface per-subscriber backpressure to the caller. */
+    SendStatus sendStatus() {
+        WebSocketContextData<SSL, USERDATA> *webSocketContextData = getContextData();
+        size_t buffered = getBufferedAmount();
+        if (webSocketContextData->maxBackpressure && webSocketContextData->maxBackpressure < buffered) {
+            return DROPPED;
+        }
+        if (buffered > 0) {
+            return BACKPRESSURE;
+        }
+        return SUCCESS;
+    }
+
+    /* Fold a per-subscriber status into an aggregate: DROPPED beats
+     * BACKPRESSURE beats SUCCESS. */
+    static SendStatus worseStatus(SendStatus a, SendStatus b) {
+        if (a == DROPPED || b == DROPPED) return DROPPED;
+        if (a == BACKPRESSURE || b == BACKPRESSURE) return BACKPRESSURE;
+        return SUCCESS;
+    }
+
     size_t memoryCost() {
         return getBufferedAmount() + sizeof(WebSocket);
     }
@@ -349,28 +373,46 @@ public:
         }
     }
 
-    /* Publish a message to a topic according to MQTT rules and syntax. Returns success.
-     * We, the WebSocket, must be subscribed to the topic itself and if so - no message will be sent to ourselves.
-     * Use App::publish for an unconditional publish that simply publishes to whomever might be subscribed. */
-    bool publish(std::string_view topic, std::string_view message, OpCode opCode = OpCode::TEXT, bool compress = false) {
+    /* Publish a message to a topic according to MQTT rules and syntax. Returns the aggregated
+     * SendStatus across all receiving subscribers: DROPPED if the topic has no receivers or any
+     * receiver is over its backpressure limit, BACKPRESSURE if any receiver has buffered data,
+     * otherwise SUCCESS. We, the WebSocket, must be subscribed to the topic itself and if so - no
+     * message will be sent to ourselves. Use App::publish for an unconditional publish that simply
+     * publishes to whomever might be subscribed. */
+    SendStatus publish(std::string_view topic, std::string_view message, OpCode opCode = OpCode::TEXT, bool compress = false) {
         WebSocketContextData<SSL, USERDATA> *webSocketContextData = getContextData();
 
         /* We cannot be a subscriber of this topic if we are not a subscriber of anything */
         WebSocketData *webSocketData = (WebSocketData *) us_socket_ext((us_socket_t *) this);
         if (!webSocketData->subscriber) {
-            /* Failure, but still do return the number of subscribers */
-            return false;
+            return DROPPED;
         }
 
         /* Publish as sender, does not receive its own messages even if subscribed to relevant topics */
         if (message.length() >= LoopData::CORK_BUFFER_SIZE) {
-            return webSocketContextData->topicTree->publishBig(webSocketData->subscriber, topic, {message, opCode, compress}, [](Subscriber *s, TopicTreeBigMessage &message) {
+            SendStatus worst = SUCCESS;
+            bool had = webSocketContextData->topicTree->publishBig(webSocketData->subscriber, topic, {message, opCode, compress}, [&worst](Subscriber *s, TopicTreeBigMessage &message) {
                 auto *ws = (WebSocket<SSL, true, int> *) s->user;
 
-                ws->send(message.message, (OpCode)message.opCode, message.compress);
+                worst = worseStatus(worst, (SendStatus) ws->send(message.message, (OpCode)message.opCode, message.compress));
             });
+            return had ? worst : DROPPED;
         } else {
-            return webSocketContextData->topicTree->publish(webSocketData->subscriber, topic, {std::string(message), opCode, compress});
+            Topic *t = webSocketContextData->topicTree->lookupTopic(topic);
+            if (!t) {
+                return DROPPED;
+            }
+            webSocketContextData->topicTree->publish(webSocketData->subscriber, topic, {std::string(message), opCode, compress});
+            /* publish() may have synchronously drained a subscriber; check backpressure after. */
+            SendStatus worst = SUCCESS;
+            bool hasReceivers = false;
+            for (Subscriber *s : *t) {
+                if (s == webSocketData->subscriber) continue;
+                hasReceivers = true;
+                auto *ws = (WebSocket<SSL, true, int> *) s->user;
+                worst = worseStatus(worst, (SendStatus) ws->sendStatus());
+            }
+            return hasReceivers ? worst : DROPPED;
         }
     }
 };

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -82,10 +82,9 @@ public:
         DROPPED
     };
 
-    /* Report what send() would return right now without actually sending:
-     * DROPPED when bufferedAmount is over maxBackpressure, BACKPRESSURE when
-     * there is any buffered data, otherwise SUCCESS. Used by publish() to
-     * surface per-subscriber backpressure to the caller. */
+    /* Report what send() would return right now without sending: DROPPED over
+     * maxBackpressure, BACKPRESSURE if anything is buffered, else SUCCESS.
+     * publish() uses this to surface per-subscriber backpressure. */
     SendStatus sendStatus() {
         WebSocketContextData<SSL, USERDATA> *webSocketContextData = getContextData();
         size_t buffered = getBufferedAmount();
@@ -373,12 +372,9 @@ public:
         }
     }
 
-    /* Publish a message to a topic according to MQTT rules and syntax. Returns the aggregated
-     * SendStatus across all receiving subscribers: DROPPED if the topic has no receivers or any
-     * receiver is over its backpressure limit, BACKPRESSURE if any receiver has buffered data,
-     * otherwise SUCCESS. We, the WebSocket, must be subscribed to the topic itself and if so - no
-     * message will be sent to ourselves. Use App::publish for an unconditional publish that simply
-     * publishes to whomever might be subscribed. */
+    /* MQTT-style publish that never delivers to this WebSocket (the sender).
+     * Returns the worst receiver SendStatus; no receivers is DROPPED.
+     * Use App::publish for an unconditional broadcast. */
     SendStatus publish(std::string_view topic, std::string_view message, OpCode opCode = OpCode::TEXT, bool compress = false) {
         WebSocketContextData<SSL, USERDATA> *webSocketContextData = getContextData();
 

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -160,7 +160,7 @@ pub mod js {
 /// `ArrayBuffer` view must pass `buffer.slice().len()`, not the typed-array
 /// element count. `suffix` is `"bytes"` or `"bytes string"`.
 #[inline]
-fn send_status_to_js(
+pub(super) fn send_status_to_js(
     status: SendStatus,
     len: usize,
     op: &'static str,
@@ -266,8 +266,7 @@ impl ServerWebSocket {
 
     /// Route a publish through either the per-socket uWS handle (when
     /// `!publish_to_self && !closed`) or the app-wide broadcast, then map the
-    /// bool result to the JS number contract: success → `len & 0x7FFF_FFFF`,
-    /// failure → `0`.
+    /// aggregated `SendStatus` to the JS number contract shared with `send()`.
     #[inline]
     fn do_publish(
         &self,
@@ -279,16 +278,12 @@ impl ServerWebSocket {
         opcode: Opcode,
         compress: bool,
     ) -> JSValue {
-        let result = if !publish_to_self && !self.is_closed() {
+        let status = if !publish_to_self && !self.is_closed() {
             self.websocket().publish(topic, buffer, opcode, compress)
         } else {
             AnyWebSocket::publish_with_options(ssl, app, topic, buffer, opcode, compress)
         };
-        JSValue::js_number(if result {
-            (buffer.len() as u32 & 0x7FFF_FFFF) as f64
-        } else {
-            0.0
-        })
+        send_status_to_js(status, buffer.len(), "publish", "bytes")
     }
 
     /// Shared body for `subscribe` / `unsubscribe` / `isSubscribed`: identical

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3512,17 +3512,16 @@ impl AnyServer {
         message: &[u8],
         opcode: uws::Opcode,
         compress: bool,
-    ) -> bool {
+    ) -> uws::SendStatus {
         any_server_dispatch!(self, |s| match s.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` via
             // `bun_opaque::opaque_deref_mut` (const-asserted ZST/align-1).
             Some(app) =>
                 bun_opaque::opaque_deref_mut(app).publish(topic, message, opcode, compress),
-            // Defensive false
-            // here for the post-stop window; assert in debug to catch misuse.
+            // Defensive for the post-stop window; assert in debug to catch misuse.
             None => {
                 debug_assert!(false, "publish on server with no app");
-                false
+                uws::SendStatus::Dropped
             }
         })
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1681,19 +1681,20 @@ where
         let compress = compress_js.to_boolean();
 
         if let Some(buffer) = message_value.as_array_buffer(global) {
-            return Ok(JSValue::js_number(f64::from(
-                // if 0, return 0
-                // else return number of bytes sent
-                (AnyWebSocket::publish_with_options(
-                    SSL,
-                    app,
-                    topic_slice.slice(),
-                    buffer.slice(),
-                    uws_sys::Opcode::Binary,
-                    compress,
-                ) as i32)
-                    * ((buffer.len as u32 & 0x7FFF_FFFF) as i32), // length truncated to a non-negative i32
-            )));
+            let status = AnyWebSocket::publish_with_options(
+                SSL,
+                app,
+                topic_slice.slice(),
+                buffer.slice(),
+                uws_sys::Opcode::Binary,
+                compress,
+            );
+            return Ok(super::server_web_socket::send_status_to_js(
+                status,
+                buffer.slice().len(),
+                "publish",
+                "bytes",
+            ));
         }
 
         {
@@ -1706,19 +1707,22 @@ where
             // GC during `publish_with_options` could otherwise reclaim the bytes
             // `slice` borrows.
             let buffer = slice.slice();
-            let result = (AnyWebSocket::publish_with_options(
+            let status = AnyWebSocket::publish_with_options(
                 SSL,
                 app,
                 topic_slice.slice(),
                 buffer,
                 uws_sys::Opcode::Text,
                 compress,
-            ) as i32)
-                * ((buffer.len() as u32 & 0x7FFF_FFFF) as i32);
+            );
+            let result = super::server_web_socket::send_status_to_js(
+                status,
+                buffer.len(),
+                "publish",
+                "bytes",
+            );
             js_string.ensure_still_alive();
-            // if 0, return 0
-            // else return number of bytes sent
-            return Ok(JSValue::js_number(f64::from(result)));
+            return Ok(result);
         }
     }
 

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -8,7 +8,8 @@ use bun_http_types::Method::Method;
 use crate::socket_context::BunSocketContextOptions;
 use crate::web_socket::c::uws_ws;
 use crate::{
-    ListenSocket as UwsListenSocket, Opcode, Request, WebSocketBehavior, us_socket_t, uws_res,
+    ListenSocket as UwsListenSocket, Opcode, Request, SendStatus, WebSocketBehavior, us_socket_t,
+    uws_res,
 };
 
 // This file provides Rust bindings for the uWebSockets App class.
@@ -145,7 +146,7 @@ impl<const SSL: bool> App<SSL> {
         message: &[u8],
         opcode: Opcode,
         compress: bool,
-    ) -> bool {
+    ) -> SendStatus {
         // SAFETY: self is a valid *mut uws_app_t; slices are valid for the call.
         unsafe {
             c::uws_publish(
@@ -325,7 +326,7 @@ impl<const SSL: bool> App<SSL> {
         message: &[u8],
         opcode: Opcode,
         compress: bool,
-    ) -> bool {
+    ) -> SendStatus {
         // SAFETY: self is a valid app; slices valid for the call.
         unsafe {
             c::uws_publish(
@@ -634,7 +635,7 @@ pub mod c {
             message_length: usize,
             opcode: Opcode,
             compress: bool,
-        ) -> bool;
+        ) -> SendStatus;
         // safe: `uws_app_s` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so
         // `&mut uws_app_s` is ABI-identical to the C `uws_app_t*` (non-null,
         // no `noalias`/`readonly`). The C++ body only reads `app->getNativeHandle()`

--- a/src/uws_sys/WebSocket.rs
+++ b/src/uws_sys/WebSocket.rs
@@ -357,7 +357,13 @@ impl AnyWebSocket {
     //     return uws_ws_iterate_topics(ssl_flag, self.raw(), callback, user_data);
     // }
 
-    pub fn publish(self, topic: &[u8], message: &[u8], opcode: Opcode, compress: bool) -> SendStatus {
+    pub fn publish(
+        self,
+        topic: &[u8],
+        message: &[u8],
+        opcode: Opcode,
+        compress: bool,
+    ) -> SendStatus {
         let (ssl, ws) = self.split();
         // SAFETY: `ws` is a live uWS-owned socket (S012 opaque); ptr+len from &[u8].
         unsafe {

--- a/src/uws_sys/WebSocket.rs
+++ b/src/uws_sys/WebSocket.rs
@@ -147,7 +147,7 @@ impl<const SSL_FLAG: i32> NewWebSocket<SSL_FLAG> {
 
     // getTopicsAsJSArray: use AnyWebSocket::get_topics_as_js_array (src/runtime/socket/uws_jsc.rs)
 
-    pub fn publish(&mut self, topic: &[u8], message: &[u8]) -> bool {
+    pub fn publish(&mut self, topic: &[u8], message: &[u8]) -> SendStatus {
         // SAFETY: self.raw() is a live uWS-owned socket; ptr+len from &[u8].
         unsafe {
             c::uws_ws_publish(
@@ -167,7 +167,7 @@ impl<const SSL_FLAG: i32> NewWebSocket<SSL_FLAG> {
         message: &[u8],
         opcode: Opcode,
         compress: bool,
-    ) -> bool {
+    ) -> SendStatus {
         // SAFETY: self.raw() is a live uWS-owned socket; ptr+len from &[u8].
         unsafe {
             c::uws_ws_publish_with_options(
@@ -357,7 +357,7 @@ impl AnyWebSocket {
     //     return uws_ws_iterate_topics(ssl_flag, self.raw(), callback, user_data);
     // }
 
-    pub fn publish(self, topic: &[u8], message: &[u8], opcode: Opcode, compress: bool) -> bool {
+    pub fn publish(self, topic: &[u8], message: &[u8], opcode: Opcode, compress: bool) -> SendStatus {
         let (ssl, ws) = self.split();
         // SAFETY: `ws` is a live uWS-owned socket (S012 opaque); ptr+len from &[u8].
         unsafe {
@@ -381,7 +381,7 @@ impl AnyWebSocket {
         message: &[u8],
         opcode: Opcode,
         compress: bool,
-    ) -> bool {
+    ) -> SendStatus {
         // S012: `NewApp<SSL>` is a ZST opaque — route the `*mut → &mut` deref
         // through `bun_opaque::opaque_deref_mut` (caller still vouches that
         // `app` is the matching `uws_app_t*`; the `ssl` flag selects the
@@ -822,7 +822,7 @@ pub mod c {
             topic_length: usize,
             message: *const u8,
             message_length: usize,
-        ) -> bool;
+        ) -> SendStatus;
         pub(crate) fn uws_ws_publish_with_options(
             ssl: i32,
             ws: *mut RawWebSocket,
@@ -832,7 +832,7 @@ pub mod c {
             message_length: usize,
             opcode: Opcode,
             compress: bool,
-        ) -> bool;
+        ) -> SendStatus;
         pub(crate) safe fn uws_ws_get_buffered_amount(ssl: i32, ws: &mut RawWebSocket) -> usize;
         // Out-param `dest` is `&mut *mut u8` (non-null, valid for write); the C
         // shim only stores a pointer into socket-owned storage and returns its

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -591,21 +591,21 @@ extern "C"
     uWS::App *uwsApp = (uWS::App *)app;
     return uwsApp->numSubscribers(stringViewFromC(topic, topic_length));
   }
-  bool uws_publish(int ssl, uws_app_t *app, const char *topic,
-                   size_t topic_length, const char *message,
-                   size_t message_length, uws_opcode_t opcode, bool compress)
+  uws_sendstatus_t uws_publish(int ssl, uws_app_t *app, const char *topic,
+                               size_t topic_length, const char *message,
+                               size_t message_length, uws_opcode_t opcode, bool compress)
   {
     if (ssl)
     {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      return uwsApp->publish(stringViewFromC(topic, topic_length),
-                             stringViewFromC(message, message_length),
-                             (uWS::OpCode)(unsigned char)opcode, compress);
+      return (uws_sendstatus_t)uwsApp->publish(stringViewFromC(topic, topic_length),
+                                               stringViewFromC(message, message_length),
+                                               (uWS::OpCode)(unsigned char)opcode, compress);
     }
     uWS::App *uwsApp = (uWS::App *)app;
-    return uwsApp->publish(stringViewFromC(topic, topic_length),
-                           stringViewFromC(message, message_length),
-                           (uWS::OpCode)(unsigned char)opcode, compress);
+    return (uws_sendstatus_t)uwsApp->publish(stringViewFromC(topic, topic_length),
+                                             stringViewFromC(message, message_length),
+                                             (uWS::OpCode)(unsigned char)opcode, compress);
   }
   void *uws_get_native_handle(int ssl, uws_app_t *app)
   {
@@ -1061,41 +1061,41 @@ extern "C"
     }
   }
 
-  bool uws_ws_publish(int ssl, uws_websocket_t *ws, const char *topic,
-                      size_t topic_length, const char *message,
-                      size_t message_length)
+  uws_sendstatus_t uws_ws_publish(int ssl, uws_websocket_t *ws, const char *topic,
+                                  size_t topic_length, const char *message,
+                                  size_t message_length)
   {
     if (ssl)
     {
       TLSWebSocket *uws =
           (TLSWebSocket *)ws;
-      return uws->publish(stringViewFromC(topic, topic_length),
-                          stringViewFromC(message, message_length));
+      return (uws_sendstatus_t)uws->publish(stringViewFromC(topic, topic_length),
+                                            stringViewFromC(message, message_length));
     }
     TCPWebSocket *uws =
         (TCPWebSocket *)ws;
-    return uws->publish(stringViewFromC(topic, topic_length),
-                        stringViewFromC(message, message_length));
+    return (uws_sendstatus_t)uws->publish(stringViewFromC(topic, topic_length),
+                                          stringViewFromC(message, message_length));
   }
 
-  bool uws_ws_publish_with_options(int ssl, uws_websocket_t *ws,
-                                   const char *topic, size_t topic_length,
-                                   const char *message, size_t message_length,
-                                   uws_opcode_t opcode, bool compress)
+  uws_sendstatus_t uws_ws_publish_with_options(int ssl, uws_websocket_t *ws,
+                                               const char *topic, size_t topic_length,
+                                               const char *message, size_t message_length,
+                                               uws_opcode_t opcode, bool compress)
   {
     if (ssl)
     {
       TLSWebSocket *uws =
           (TLSWebSocket *)ws;
-      return uws->publish(stringViewFromC(topic, topic_length),
-                          stringViewFromC(message, message_length),
-                          (uWS::OpCode)(unsigned char)opcode, compress);
+      return (uws_sendstatus_t)uws->publish(stringViewFromC(topic, topic_length),
+                                            stringViewFromC(message, message_length),
+                                            (uWS::OpCode)(unsigned char)opcode, compress);
     }
     TCPWebSocket *uws =
         (TCPWebSocket *)ws;
-    return uws->publish(stringViewFromC(topic, topic_length),
-                        stringViewFromC(message, message_length),
-                        (uWS::OpCode)(unsigned char)opcode, compress);
+    return (uws_sendstatus_t)uws->publish(stringViewFromC(topic, topic_length),
+                                          stringViewFromC(message, message_length),
+                                          (uWS::OpCode)(unsigned char)opcode, compress);
   }
 
   size_t uws_ws_get_buffered_amount(int ssl, uws_websocket_t *ws)

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1209,10 +1209,8 @@ it("server.upgrade() with Sec-WebSocket-Protocol in options.headers does not use
   expect(exitCode).toBe(0);
 });
 
-// publish() fans out to N subscribers; it must report backpressure/drops the
-// same way ws.send() does for a single socket. Previously it always returned
-// the payload length as long as the topic had any subscriber, even when every
-// subscriber was over backpressureLimit and the data was being discarded.
+// publish() fans out to N subscribers and must report backpressure/drops the
+// same way ws.send() does for a single socket.
 describe("publish() return value reflects subscriber backpressure", () => {
   // One paused raw-TCP subscriber; the server-side handle is captured so the
   // test can compare publish() to send() on the same socket.
@@ -1251,6 +1249,7 @@ describe("publish() return value reflects subscriber backpressure", () => {
       const { promise, resolve, reject } = Promise.withResolvers<void>();
       sender.onopen = () => resolve();
       sender.onerror = e => reject(e);
+      sender.onclose = () => reject(new Error("sender closed before open"));
       await promise;
     }
 
@@ -1267,15 +1266,21 @@ describe("publish() return value reflects subscriber backpressure", () => {
           "Sec-WebSocket-Version: 13\r\n\r\n",
       );
     });
-    slow.once("data", (d: Buffer) => {
-      if (d.toString().includes(" 101 ")) {
+    // Buffer until the response headers are complete; the 101 may be split
+    // across TCP segments.
+    let response = "";
+    slow.on("data", (d: Buffer) => {
+      response += d.toString("latin1");
+      if (!response.includes("\r\n\r\n")) return;
+      if (response.includes(" 101 ")) {
         slow.pause();
         handshake.resolve();
       } else {
-        handshake.reject(new Error("upgrade failed: " + d.toString()));
+        handshake.reject(new Error("upgrade failed: " + response));
       }
     });
     slow.on("error", handshake.reject);
+    slow.on("close", () => handshake.reject(new Error("slow socket closed before upgrade")));
     try {
       await handshake.promise;
       await opened.slow.promise;
@@ -1284,7 +1289,6 @@ describe("publish() return value reflects subscriber backpressure", () => {
     } finally {
       sender.close();
       slow.destroy();
-      server.stop(true);
     }
   }
 

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1309,6 +1309,19 @@ describe("publish() return value reflects subscriber backpressure", () => {
     });
   });
 
+  it("ws.publish() returns 0 when the sender is the sole subscriber", async () => {
+    await withSlowSubscriber(({ sender }) => {
+      // "self" only has the sender subscribed; ws.publish() excludes the
+      // sender, so there are zero receivers on both the batched and direct
+      // send paths.
+      sender.subscribe("self");
+      expect({
+        small: sender.publish("self", Buffer.alloc(8000, "x").toString()),
+        big: sender.publish("self", Buffer.alloc(20000, "x").toString()),
+      }).toEqual({ small: 0, big: 0 });
+    });
+  });
+
   for (const [label, size] of [
     ["batched (<16KB)", 8000],
     ["direct (>=16KB)", 20000],

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1,8 +1,8 @@
-import type { Server, Subprocess, WebSocketHandler } from "bun";
+import type { Server, ServerWebSocket, Subprocess, WebSocketHandler } from "bun";
 import { serve, spawn } from "bun";
 import { afterEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, forceGuardMalloc, isWindows } from "harness";
-import { isIP } from "node:net";
+import net, { isIP } from "node:net";
 import path from "node:path";
 
 const strings = [
@@ -1207,4 +1207,166 @@ it("server.upgrade() with Sec-WebSocket-Protocol in options.headers does not use
     stderr: "",
   });
   expect(exitCode).toBe(0);
+});
+
+// publish() fans out to N subscribers; it must report backpressure/drops the
+// same way ws.send() does for a single socket. Previously it always returned
+// the payload length as long as the topic had any subscriber, even when every
+// subscriber was over backpressureLimit and the data was being discarded.
+describe("publish() return value reflects subscriber backpressure", () => {
+  // One paused raw-TCP subscriber; the server-side handle is captured so the
+  // test can compare publish() to send() on the same socket.
+  async function withSlowSubscriber(
+    run: (ctx: { server: Server; slow: ServerWebSocket<string>; sender: ServerWebSocket<string> }) => void,
+  ) {
+    const sockets: Record<string, ServerWebSocket<string>> = {};
+    const opened = { slow: Promise.withResolvers<void>(), sender: Promise.withResolvers<void>() };
+    await using server = serve<string, {}>({
+      port: 0,
+      websocket: {
+        backpressureLimit: 64 * 1024,
+        idleTimeout: 0,
+        open(ws) {
+          sockets[ws.data] = ws;
+          ws.subscribe("t");
+          opened[ws.data]?.resolve();
+        },
+        message() {},
+        close(ws) {
+          delete sockets[ws.data];
+        },
+      },
+      fetch(req, server) {
+        if (server.upgrade(req, { data: new URL(req.url).pathname.slice(1) })) return;
+        return new Response("no upgrade", { status: 400 });
+      },
+    });
+
+    // "sender": ws.publish() excludes the sender, so we need a second socket
+    // distinct from the slow subscriber to exercise the per-socket path.
+    const sender = new WebSocket(`ws://127.0.0.1:${server.port}/sender`);
+    sender.binaryType = "arraybuffer";
+    sender.onmessage = () => {};
+    {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      sender.onopen = () => resolve();
+      sender.onerror = e => reject(e);
+      await promise;
+    }
+
+    // "slow": raw RFC6455 client that handshakes then pauses its read side so
+    // the server accumulates backpressure for it.
+    const handshake = Promise.withResolvers<void>();
+    const slow = net.connect({ port: server.port, host: "127.0.0.1" }, () => {
+      slow.write(
+        "GET /slow HTTP/1.1\r\n" +
+          "Host: x\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+          "Sec-WebSocket-Version: 13\r\n\r\n",
+      );
+    });
+    slow.once("data", (d: Buffer) => {
+      if (d.toString().includes(" 101 ")) {
+        slow.pause();
+        handshake.resolve();
+      } else {
+        handshake.reject(new Error("upgrade failed: " + d.toString()));
+      }
+    });
+    slow.on("error", handshake.reject);
+    try {
+      await handshake.promise;
+      await opened.slow.promise;
+      await opened.sender.promise;
+      run({ server, slow: sockets.slow, sender: sockets.sender });
+    } finally {
+      sender.close();
+      slow.destroy();
+      server.stop(true);
+    }
+  }
+
+  function histogram(results: number[]) {
+    let positive = 0;
+    let dropped = 0;
+    let backpressure = 0;
+    let other = 0;
+    for (const r of results) {
+      if (r > 0) positive++;
+      else if (r === 0) dropped++;
+      else if (r === -1) backpressure++;
+      else other++;
+    }
+    return { positive, dropped, backpressure, other };
+  }
+
+  it("returns 0 when the topic has no subscribers", async () => {
+    await withSlowSubscriber(({ server, sender }) => {
+      expect(server.publish("no-such-topic", "x")).toBe(0);
+      expect(sender.publish("no-such-topic", "x")).toBe(0);
+    });
+  });
+
+  for (const [label, size] of [
+    ["batched (<16KB)", 8000],
+    ["direct (>=16KB)", 20000],
+  ] as const) {
+    it(`server.publish() ${label} reports dropped / backpressure`, async () => {
+      await withSlowSubscriber(({ server, slow }) => {
+        const payload = Buffer.alloc(size, "x").toString();
+        // Enough iterations to blow well past backpressureLimit regardless of
+        // how much the kernel accepts before blocking.
+        const N = 1000;
+        const results: number[] = [];
+        for (let i = 0; i < N; i++) results.push(server.publish("t", payload));
+        const h = histogram(results);
+        // ws.send() on the same over-limit socket agrees the data is dropped;
+        // publish() must have reported the same for the majority of calls.
+        expect({ sendProbe: slow.send("probe"), histogram: h }).toEqual({
+          sendProbe: 0,
+          histogram: { ...h, other: 0 },
+        });
+        expect(h.dropped).toBeGreaterThan(0);
+        // Every call returned one of the documented values.
+        expect(h.positive + h.backpressure + h.dropped).toBe(N);
+      });
+    });
+
+    it(`ws.publish() ${label} reports dropped / backpressure`, async () => {
+      await withSlowSubscriber(({ slow, sender }) => {
+        const payload = Buffer.alloc(size, "x").toString();
+        const N = 1000;
+        const results: number[] = [];
+        for (let i = 0; i < N; i++) results.push(sender.publish("t", payload));
+        const h = histogram(results);
+        expect({ sendProbe: slow.send("probe"), histogram: h }).toEqual({
+          sendProbe: 0,
+          histogram: { ...h, other: 0 },
+        });
+        expect(h.dropped).toBeGreaterThan(0);
+        expect(h.positive + h.backpressure + h.dropped).toBe(N);
+      });
+    });
+  }
+
+  it("ws.publishText() and ws.publishBinary() report dropped", async () => {
+    await withSlowSubscriber(({ slow, sender }) => {
+      const text = Buffer.alloc(8000, "x").toString();
+      const bin = Buffer.alloc(8000, 0x61);
+      let sawDroppedText = false;
+      let sawDroppedBinary = false;
+      for (let i = 0; i < 1000; i++) {
+        if (sender.publishText("t", text) === 0) sawDroppedText = true;
+        if (sender.publishBinary("t", bin) === 0) sawDroppedBinary = true;
+        if (sawDroppedText && sawDroppedBinary) break;
+      }
+      expect({ sawDroppedText, sawDroppedBinary, sendProbe: slow.send("probe") }).toEqual({
+        sawDroppedText: true,
+        sawDroppedBinary: true,
+        sendProbe: 0,
+      });
+    });
+  });
 });

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1211,7 +1211,7 @@ it("server.upgrade() with Sec-WebSocket-Protocol in options.headers does not use
 
 // publish() fans out to N subscribers and must report backpressure/drops the
 // same way ws.send() does for a single socket.
-describe("publish() return value reflects subscriber backpressure", () => {
+describe.concurrent("publish() return value reflects subscriber backpressure", () => {
   // One paused raw-TCP subscriber; the server-side handle is captured so the
   // test can compare publish() to send() on the same socket.
   async function withSlowSubscriber(


### PR DESCRIPTION
## Problem

`server.publish()` and `ws.publish()` are documented to return `0` when a message is dropped and `-1` when backpressure is applied (same contract as `ws.send()`). In practice they always returned the payload byte count as long as the topic had any subscriber, even when every subscriber was over `backpressureLimit` and the data was being silently discarded.

Applications had no way to detect or react to pub/sub backpressure.

## Repro

```js
// one subscriber that never reads; backpressureLimit: 64KB
for (let i = 0; i < 2000; i++) server.publish("t", "x".repeat(8000));
// every call returns 8000; ws.send("probe") on the same socket returns 0 (DROPPED)
```

Observed on 1.4.0:
```
publishReturnHistogram: { "8000": 2000 }
slow_getBufferedAmount: 73316         // > backpressureLimit
slow_send_probe_at_same_moment: 0      // ws.send() knows it's dropping
```

## Cause

`uWS::TopicTree::publish()` just queues a message index per subscriber and returns `bool` meaning "topic had at least one non-sender subscriber". The actual `ws->send()` runs later from the drain callback (or synchronously every 32 queued messages), and its `DROPPED`/`BACKPRESSURE` status is thrown away. `publishBig()` calls `send()` directly but also discards the status. The Rust layer mapped the `bool` to `len` or `0`.

## Fix

`App::publish()` and `WebSocket::publish()` now aggregate the worst-case `SendStatus` across all receiving subscribers:

- Big messages (>= 16 KB, `publishBig`): capture the `SendStatus` each `ws->send()` returns.
- Small messages (batched): after queueing, check each subscriber's `bufferedAmount` against its `maxBackpressure` (the same thresholds `send()` uses): over limit is `DROPPED`, nonzero is `BACKPRESSURE`, zero is `SUCCESS`.

`DROPPED` beats `BACKPRESSURE` beats `SUCCESS`; no topic or no eligible subscribers is `DROPPED` (unchanged JS value `0`).

The C shims and Rust FFI now return `SendStatus` instead of `bool`, and the JS bindings map it through the existing `send_status_to_js` helper so `publish()`/`publishText()`/`publishBinary()` share the exact `0` / `-1` / byte-count contract with `send()`.

## Verification

With the fix, the same flood reports drops that match `ws.send()`:

```
publishReturnHistogram: { "0": 1616, "8000": 352, "-1": 32 }
```

New tests in `test/js/bun/websocket/websocket-server.test.ts` cover `server.publish()` and `ws.publish()` on both the batched (<16 KB) and direct (>=16 KB) paths plus `publishText`/`publishBinary`, and assert the no-subscriber case still returns `0`. All fail on current `main` and pass with this change.