### PR TITLE
spawn: leave stdio[i]='ignore' closed in the child for i >= 3

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -635,7 +635,8 @@ impl Stdio {
             )));
         }
 
-        // Instead of writing an empty blob, lets just make it /dev/null
+        // Nothing to write: treat an empty blob the same as "ignore"
+        // (/dev/null at fds 0-2, left closed at extra slots).
         if blob.fast_size() == 0 {
             *self = Stdio::Ignore;
             return Ok(());

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -564,7 +564,13 @@ pub mod posix_spawn {
             for action in &act.actions {
                 match action.kind {
                     bun_spawn::FileActionType::Close => {
-                        posix_actions.close(Fd::from_native(action.fds[0]))?;
+                        // Darwin's posix_spawn fails the whole spawn with EBADF
+                        // if an addclose fd is not open. A fd the parent does
+                        // not have open is already absent from the child.
+                        let fd = Fd::from_native(action.fds[0]);
+                        if sys::fcntl(fd, system::F_GETFD, 0).is_ok() {
+                            posix_actions.close(fd)?;
+                        }
                     }
                     bun_spawn::FileActionType::Dup2 => {
                         posix_actions.dup2(

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -408,13 +408,6 @@ pub mod posix_spawn {
             }))
         }
 
-        pub(crate) fn close(&mut self, fd: Fd) -> sys::Result<()> {
-            // SAFETY: self.actions is live
-            spawn_errno(errno_from_posix_spawn(unsafe {
-                system::posix_spawn_file_actions_addclose(&raw mut self.actions, fd.native())
-            }))
-        }
-
         pub(crate) fn dup2(&mut self, fd: Fd, newfd: Fd) -> sys::Result<()> {
             if fd == newfd {
                 return self.inherit(fd);
@@ -564,13 +557,10 @@ pub mod posix_spawn {
             for action in &act.actions {
                 match action.kind {
                     bun_spawn::FileActionType::Close => {
-                        // Darwin's posix_spawn fails the whole spawn with EBADF
-                        // if an addclose fd is not open. A fd the parent does
-                        // not have open is already absent from the child.
-                        let fd = Fd::from_native(action.fds[0]);
-                        if sys::fcntl(fd, system::F_GETFD, 0).is_ok() {
-                            posix_actions.close(fd)?;
-                        }
+                        // Redundant: POSIX_SPAWN_CLOEXEC_DEFAULT (always set on
+                        // this path) closes any fd without an open/dup2/inherit
+                        // action. Darwin also fails the whole spawn with EBADF
+                        // when an addclose fd is not open, so never register one.
                     }
                     bun_spawn::FileActionType::Dup2 => {
                         posix_actions.dup2(

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -905,7 +905,11 @@ pub unsafe fn spawn_process_posix(
                 extra_fds.push(ExtraPipe::Unavailable);
             }
             PosixStdio::Ignore => {
-                actions.open_z(fileno, c"/dev/null", bun_sys::O::RDWR as u32, 0o664)?;
+                // For fd >= 3, "ignore" leaves the fd closed in the child
+                // (unlike fd 0-2 where POSIX requires a valid fd, so those
+                // get /dev/null). Explicitly close in case an earlier action
+                // or the close-range floor would otherwise leave it open.
+                actions.close(fileno)?;
                 extra_fds.push(ExtraPipe::Unavailable);
             }
             PosixStdio::Path(path) => {

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -905,10 +905,9 @@ pub unsafe fn spawn_process_posix(
                 extra_fds.push(ExtraPipe::Unavailable);
             }
             PosixStdio::Ignore => {
-                // For fd >= 3, "ignore" leaves the fd closed in the child
-                // (unlike fd 0-2 where POSIX requires a valid fd, so those
-                // get /dev/null). Explicitly close in case an earlier action
-                // or the close-range floor would otherwise leave it open.
+                // Node leaves "ignore" at an extra slot closed in the child;
+                // only fds 0-2 need a /dev/null placeholder. Close explicitly:
+                // the post-exec close-range floor only covers higher fds.
                 actions.close(fileno)?;
                 extra_fds.push(ExtraPipe::Unavailable);
             }

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -609,3 +609,41 @@ it.skipIf(isWindows)("extra stdio pipes are not double-closed on GC", async () =
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "OK", stderr: "", exitCode: 0 });
 });
+
+// For fd 0-2, "ignore" opens /dev/null. For fd >= 3, Node leaves the fd
+// closed; Bun used to open /dev/null on the slot, so children probing
+// "is fd N open?" observed a different answer than under Node.
+it.if(!isWindows)("stdio[i] = 'ignore' for i >= 3 leaves the fd closed in the child", async () => {
+  // Portable open/closed probe via shell redirection: redirecting a closed
+  // fd fails with EBADF. Uses "true" (not ":") because redirection errors on
+  // POSIX special built-ins abort the shell.
+  const probe = `
+for fd in 0 3 4 5; do
+  if { true >&$fd; } 2>/dev/null || { true <&$fd; } 2>/dev/null; then
+    echo "fd$fd=OPEN"
+  else
+    echo "fd$fd=CLOSED"
+  fi
+done
+`;
+
+  // fd 3 and 4 are ignored; fd 5 is a pipe so the close-range floor is
+  // above the ignored slots and cannot mask the bug.
+  const stdio = ["ignore", "pipe", "pipe", "ignore", "ignore", "pipe"] as const;
+  const expected = ["fd0=OPEN", "fd3=CLOSED", "fd4=CLOSED", "fd5=OPEN"];
+
+  const sync = spawnSync("sh", ["-c", probe], { stdio: [...stdio], env: bunEnv });
+  expect(sync.stderr?.toString()).toBe("");
+  expect(sync.stdout?.toString().trim().split("\n")).toEqual(expected);
+  expect(sync.status).toBe(0);
+
+  // Async spawn goes through the same native path.
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  const child = spawn("sh", ["-c", probe], { stdio: [...stdio], env: bunEnv });
+  let out = "";
+  child.stdout!.on("data", d => (out += d));
+  child.on("error", reject);
+  child.on("close", () => resolve(out));
+  const asyncOut = await promise;
+  expect(asyncOut.trim().split("\n")).toEqual(expected);
+});


### PR DESCRIPTION
## Repro

```js
const { spawnSync } = require("child_process");
const r = spawnSync("sh", ["-c", `
for fd in 3 4 5; do
  if { true >&\$fd; } 2>/dev/null || { true <&\$fd; } 2>/dev/null; then
    echo "fd\$fd=OPEN"
  else
    echo "fd\$fd=CLOSED"
  fi
done
`], { stdio: ["ignore", "pipe", "pipe", "ignore", "ignore", "pipe"] });
console.log(r.stdout.toString().trim());
```

Node:
```
fd3=CLOSED
fd4=CLOSED
fd5=OPEN
```

Bun (before):
```
fd3=OPEN
fd4=OPEN
fd5=OPEN
```

fd 3 and 4 were `/dev/null` open RDWR in the child.

## Cause

For fd 0, 1 and 2, `"ignore"` opens `/dev/null` because POSIX requires those descriptors to be valid. Bun applied the same treatment to extra stdio slots (fd >= 3): the `PosixStdio::Ignore` arm of the `extra_fds` loop in `spawn_process_posix` registered an `open` action for `/dev/null` on that fd. In Node, `"ignore"` at an extra slot leaves the fd closed. A child that probes "is fd N open?" (common in fd-passing protocols) therefore observed a different answer under Bun.

## Fix

Two parts.

`spawn_process.rs`: register a `close` action for the ignored slot instead of opening `/dev/null`. The explicit close is needed because the post-exec `close_range` floor in `bun-spawn.cpp` is set from the highest *target* fd across all file actions, so a later `"pipe"` slot (as in the repro with fd 5) would otherwise leave a lower ignored slot inheriting whatever the parent had there.

`posix_spawn.rs`: the non-PTY macOS path goes through the system `posix_spawn`, and Darwin fails the whole spawn with `EBADF` when a `posix_spawn_file_actions_addclose` target is not an open fd at the moment the action runs in the child. (The `bun-spawn.cpp` child path used on Linux, FreeBSD and macOS PTY spawns ignores a failed `close(2)`.) The ignored slot's fd number is usually not open in the parent, so this made every macOS spawn with an ignored extra slot fail. The Darwin action converter now registers no `addclose` actions at all: it only ever sees lists built by `spawn_process_posix`, which always sets `POSIX_SPAWN_CLOEXEC_DEFAULT` on macOS, and under that flag any fd without an `open`/`dup2`/`inherit` action is closed at exec anyway, so every `addclose` there is redundant. The now unused Darwin `addclose` wrapper is deleted. The explicit close actions in `spawn_process_posix` stay, since on the bun-spawn path (no `CLOEXEC_DEFAULT`, close-range floor only above the highest target) they are what actually closes the ignored slot.

This applies to both `spawn` and `spawnSync` from `node:child_process`, and to `Bun.spawn`/`Bun.spawnSync` with `stdio: [..., "ignore", ...]` or `null` at index >= 3.

## Verification

New test in `test/js/node/child_process/child_process.test.ts` spawns `sh` with `stdio: ["ignore", "pipe", "pipe", "ignore", "ignore", "pipe"]` for both `spawnSync` and async `spawn`, and asserts fd 3 and 4 are closed while fd 0 and 5 are open.

```
# fail-before
$ USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t "'ignore' for i >= 3"
  fd3=OPEN, fd4=OPEN   (fail)

# pass-after
$ bun bd test test/js/node/child_process/child_process.test.ts -t "'ignore' for i >= 3"
  1 pass  0 fail
```

Identical output to Node v26 confirmed. The existing extra-stdio tests (`it accepts stdio passthrough`, `spawn with an fd number at Darwin OPEN_MAX`, `does not close caller-owned fds passed as extra stdio`) and Node's `test-child-process-spawnsync*.js` suite still pass.

