### PR TITLE
node:http: allow Trailer header on chunked ServerResponse and emit trailers on the wire

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -100,8 +100,10 @@ public:
      * Will start timeout if stream reaches totalSize or write failure.
      * keepCorked: if true, skip the trailing uncork so the caller can batch
      * more writes (used by upgrade() to batch the handshake with the first
-     * WebSocket frames). */
-    bool internalEnd(std::string_view data, uint64_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false, bool keepCorked = false) {
+     * WebSocket frames).
+     * trailer: pre-rendered "Name: value\r\n..." lines written between the
+     * terminating 0-chunk and the final CRLF (chunked responses only). */
+    bool internalEnd(std::string_view data, uint64_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false, bool keepCorked = false, std::string_view trailer = {}) {
         /* Write status if not already done */
         writeStatus(HTTP_200_OK);
 
@@ -140,8 +142,14 @@ public:
             this->write(data, nullptr);
 
 
-            /* Terminating 0 chunk */
-            Super::write("0\r\n\r\n", 5);
+            /* Terminating 0 chunk (with trailer fields when provided) */
+            if (trailer.empty()) {
+                Super::write("0\r\n\r\n", 5);
+            } else {
+                Super::write("0\r\n", 3);
+                Super::write(trailer.data(), trailer.length());
+                Super::write("\r\n", 2);
+            }
             httpResponseData->markDone(this);
 
             /* We need to check if we should close this socket here now */
@@ -459,7 +467,7 @@ public:
     }
 
     /* End the response with an optional data chunk. Always starts a timeout. */
-    void end(std::string_view data = {}, bool closeConnection = false) {
+    void end(std::string_view data = {}, bool closeConnection = false, std::string_view trailer = {}) {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         /* 204/304 responses carry no body framing at all: no Content-Length,
@@ -497,7 +505,7 @@ public:
         /* Do not auto-write a Content-Length header when the user already wrote
          * a Content-Length or an explicit Transfer-Encoding header (a message
          * must not carry both, see RFC 9112 §6.2). */
-        internalEnd(data, data.length(), false, !(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER | HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)), closeConnection);
+        internalEnd(data, data.length(), false, !(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER | HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)), closeConnection, false, trailer);
     }
 
     /* Try and end the response. Returns [true, true] on success.
@@ -508,7 +516,7 @@ public:
     }
 
     /* Write the end of chunked encoded stream */
-    bool sendTerminatingChunk(bool closeConnection = false) {
+    bool sendTerminatingChunk(bool closeConnection = false, std::string_view trailer = {}) {
         writeStatus(HTTP_200_OK);
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
         if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED | HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER))) {
@@ -525,7 +533,7 @@ public:
         /* This will be sent always when state is HTTP_WRITE_CALLED inside internalEnd, so no need to write the terminating 0 chunk here */
         /* Super::write("\r\n0\r\n\r\n", 7); */
 
-        return internalEnd({nullptr, 0}, 0, false, false, closeConnection);
+        return internalEnd({nullptr, 0}, 0, false, false, closeConnection, false, trailer);
     }
 
     void flushHeaders(bool flushImmediately = false) {

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -147,7 +147,7 @@ public:
                 Super::write("0\r\n\r\n", 5);
             } else {
                 Super::write("0\r\n", 3);
-                Super::write(trailer.data(), trailer.length());
+                Super::write(trailer.data(), (int) trailer.length());
                 Super::write("\r\n", 2);
             }
             httpResponseData->markDone(this);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1349,7 +1349,6 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
 
 function _writeHead(statusCode, reason, obj, response) {
   const originalStatusCode = statusCode;
-  let hasContentLength = response.hasHeader("content-length");
   statusCode |= 0;
   if (statusCode < 100 || statusCode > 999) {
     throw $ERR_HTTP_INVALID_STATUS_CODE(format("%s", originalStatusCode));
@@ -1383,16 +1382,6 @@ function _writeHead(statusCode, reason, obj, response) {
         if (length % 2 !== 0) {
           throw $ERR_INVALID_ARG_VALUE("headers", obj);
         }
-        // Test non-chunked message does not have trailer header set,
-        // message will be terminated by the first empty line after the
-        // header fields, regardless of the header fields present in the
-        // message, and thus cannot contain a message body or 'trailers'.
-        if (
-          (response.chunkedEncoding !== true || response.hasHeader("content-length")) &&
-          (response._trailer || response.hasHeader("trailer"))
-        ) {
-          throw $ERR_HTTP_TRAILER_INVALID("Trailers are invalid with this transfer encoding");
-        }
         // Headers in obj should override previous headers but still
         // allow explicit duplicates. To do so, we first remove any
         // existing conflicts, then use appendHeader.
@@ -1417,11 +1406,30 @@ function _writeHead(statusCode, reason, obj, response) {
         if (k) response.setHeader(k, obj[k]);
       }
     }
-    if (
-      (response.chunkedEncoding !== true || response.hasHeader("content-length")) &&
-      (response._trailer || response.hasHeader("trailer"))
-    ) {
-      // remove the invalid content-length or trailer header
+  }
+
+  updateHasBody(response, statusCode);
+
+  // Test non-chunked message does not have trailer header set,
+  // message will be terminated by the first empty line after the
+  // header fields, regardless of the header fields present in the
+  // message, and thus cannot contain a message body or 'trailers'.
+  // Mirrors the framing decision in Node.js's _storeHeader(): the response
+  // is chunked unless a Content-Length is present, the response carries no
+  // body (204/304/1xx/HEAD), chunked encoding is not the default, or the
+  // user removed Transfer-Encoding.
+  if (response._trailer || response.hasHeader("trailer")) {
+    const hasContentLength = response.hasHeader("content-length");
+    const te = response.getHeader("transfer-encoding");
+    const willBeChunked =
+      response.chunkedEncoding === true ||
+      (te !== undefined && chunkExpression.test(te)) ||
+      (te === undefined &&
+        !hasContentLength &&
+        response._hasBody &&
+        response.useChunkedEncodingByDefault &&
+        !response._removedTE);
+    if (!willBeChunked) {
       if (hasContentLength) {
         response.removeHeader("trailer");
       } else {
@@ -1430,8 +1438,6 @@ function _writeHead(statusCode, reason, obj, response) {
       throw $ERR_HTTP_TRAILER_INVALID("Trailers are invalid with this transfer encoding");
     }
   }
-
-  updateHasBody(response, statusCode);
 }
 
 Object.defineProperty(NodeHTTPServerSocket, "name", { value: "Socket" });
@@ -1572,7 +1578,10 @@ function renderNativeHeaders(res) {
     } else if (res._removedTE) {
       closeDelimited = true;
       res[kMustCloseConnection] = true;
-    } else if (res._removedContLen) {
+    } else if (res._removedContLen || res._trailer || res[kOutHeaders]?.["trailer"] !== undefined) {
+      // Node's _storeHeader: a Trailer header (`state.trailer`) suppresses the
+      // auto Content-Length and selects chunked framing so the trailer can be
+      // emitted after the terminating chunk.
       forceChunked = true;
     }
   }
@@ -2004,6 +2013,7 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     // and will not throw or emit an error
     return true;
   }
+  const trailer = this._trailer;
   if (headerState !== NodeHTTPHeaderState.sent) {
     handle.cork(() => {
       handle.writeHead(
@@ -2017,13 +2027,13 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
 
       // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/_http_outgoing.js#L987
-      this._contentLength = handle.end(chunk, encoding, undefined, strictContentLength(this));
+      this._contentLength = handle.end(chunk, encoding, undefined, strictContentLength(this), trailer);
     });
   } else {
     // If there's no data but you already called end, then you're done.
     // We can ignore it in that case.
     if (!(!chunk && handle.ended) && !handle.aborted) {
-      handle.end(chunk, encoding, undefined, strictContentLength(this));
+      handle.end(chunk, encoding, undefined, strictContentLength(this), trailer);
     }
   }
   this._header = " ";

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1414,21 +1414,22 @@ function _writeHead(statusCode, reason, obj, response) {
   // message will be terminated by the first empty line after the
   // header fields, regardless of the header fields present in the
   // message, and thus cannot contain a message body or 'trailers'.
-  // Mirrors the framing decision in Node.js's _storeHeader(): the response
-  // is chunked unless a Content-Length is present, the response carries no
-  // body (204/304/1xx/HEAD), chunked encoding is not the default, or the
-  // user removed Transfer-Encoding.
+  // Mirrors the framing decision in Node.js's _storeHeader(): a no-body
+  // response (204/304/1xx/HEAD) is never chunk-framed regardless of the
+  // Transfer-Encoding header; otherwise the response is chunked unless a
+  // Content-Length is present, chunked encoding is not the default
+  // (HTTP/1.0), or the user removed Transfer-Encoding.
   if (response._trailer || response.hasHeader("trailer")) {
     const hasContentLength = response.hasHeader("content-length");
     const te = response.getHeader("transfer-encoding");
     const willBeChunked =
-      response.chunkedEncoding === true ||
-      (te !== undefined && chunkExpression.test(te)) ||
-      (te === undefined &&
-        !hasContentLength &&
-        response._hasBody &&
-        response.useChunkedEncodingByDefault &&
-        !response._removedTE);
+      response._hasBody &&
+      (response.chunkedEncoding === true ||
+        (te !== undefined && chunkExpression.test(te)) ||
+        (te === undefined &&
+          !hasContentLength &&
+          response.useChunkedEncodingByDefault &&
+          !response._removedTE));
     if (!willBeChunked) {
       if (hasContentLength) {
         response.removeHeader("trailer");
@@ -1578,10 +1579,14 @@ function renderNativeHeaders(res) {
     } else if (res._removedTE) {
       closeDelimited = true;
       res[kMustCloseConnection] = true;
-    } else if (res._removedContLen || res._trailer || res[kOutHeaders]?.["trailer"] !== undefined) {
+    } else if (
+      res._removedContLen ||
+      ((res._trailer || res[kOutHeaders]?.["trailer"] !== undefined) && res.useChunkedEncodingByDefault)
+    ) {
       // Node's _storeHeader: a Trailer header (`state.trailer`) suppresses the
       // auto Content-Length and selects chunked framing so the trailer can be
-      // emitted after the terminating chunk.
+      // emitted after the terminating chunk. Never chunk-frame an HTTP/1.0
+      // response (uWS refuses to, so advertising it would corrupt the body).
       forceChunked = true;
     }
   }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1426,10 +1426,7 @@ function _writeHead(statusCode, reason, obj, response) {
       response._hasBody &&
       (response.chunkedEncoding === true ||
         (te !== undefined && chunkExpression.test(te)) ||
-        (te === undefined &&
-          !hasContentLength &&
-          response.useChunkedEncodingByDefault &&
-          !response._removedTE));
+        (te === undefined && !hasContentLength && response.useChunkedEncodingByDefault && !response._removedTE));
     if (!willBeChunked) {
       if (hasContentLength) {
         response.removeHeader("trailer");

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1428,11 +1428,7 @@ function _writeHead(statusCode, reason, obj, response) {
         (te !== undefined && chunkExpression.test(te)) ||
         (te === undefined && !hasContentLength && response.useChunkedEncodingByDefault && !response._removedTE));
     if (!willBeChunked) {
-      if (hasContentLength) {
-        response.removeHeader("trailer");
-      } else {
-        response.removeHeader("content-length");
-      }
+      // Like Node.js's _storeHeader: throw with the headers left intact.
       throw $ERR_HTTP_TRAILER_INVALID("Trailers are invalid with this transfer encoding");
     }
   }
@@ -2015,7 +2011,10 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     // and will not throw or emit an error
     return true;
   }
-  const trailer = this._trailer;
+  // `_trailer` defaults to "", and res.end() is the per-request hot path: pass
+  // undefined so the native trailer decode is skipped entirely when there are
+  // no trailers, instead of round-tripping an empty JS string through the FFI.
+  const trailer = this._trailer || undefined;
   if (headerState !== NodeHTTPHeaderState.sent) {
     handle.cork(() => {
       handle.writeHead(

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1461,6 +1461,18 @@ impl NodeHTTPResponse {
             break 'brk None;
         };
 
+        let mut trailer = crate::node::StringOrBuffer::EMPTY;
+        if IS_END && arguments.len() > 4 && arguments[4].is_string() {
+            if !crate::node::StringOrBuffer::from_js_with_encoding_into(
+                &mut trailer,
+                global_object,
+                arguments[4],
+                crate::node::Encoding::Latin1,
+            )? {
+                trailer = crate::node::StringOrBuffer::EMPTY;
+            }
+        }
+
         // Construct in place — returning
         // `JsResult<Option<StringOrBuffer>>` by value here lowered to ~128B of
         // `vmovups` stack copies per `res.end()`; the `_into` out-param form
@@ -1568,10 +1580,18 @@ impl NodeHTTPResponse {
             raw_response.clear_timeout();
             self.update_flags(|f| f.insert(Flags::ENDED));
             let raw_response = self.raw_response.get().unwrap();
+            let trailer_bytes = trailer.slice();
+            let close = state.is_http_connection_close();
             if !state.is_http_write_called() || !bytes.is_empty() {
-                raw_response.end(bytes, state.is_http_connection_close());
+                if trailer_bytes.is_empty() {
+                    raw_response.end(bytes, close);
+                } else {
+                    raw_response.end_with_trailer(bytes, trailer_bytes, close);
+                }
+            } else if trailer_bytes.is_empty() {
+                raw_response.end_stream(close);
             } else {
-                raw_response.end_stream(state.is_http_connection_close());
+                raw_response.end_stream_with_trailer(trailer_bytes, close);
             }
             self.on_request_complete();
 

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -123,6 +123,21 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
+    pub fn end_with_trailer(&mut self, data: &[u8], trailer: &[u8], close_connection: bool) {
+        // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
+        unsafe {
+            c::uws_res_end_with_trailer(
+                Self::ssl_flag(),
+                self.downcast(),
+                data.as_ptr(),
+                data.len(),
+                trailer.as_ptr(),
+                trailer.len(),
+                close_connection,
+            );
+        }
+    }
+
     pub fn try_end(&mut self, data: &[u8], total: usize, close_: bool) -> bool {
         // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
         unsafe {
@@ -517,6 +532,19 @@ impl<const SSL: bool> Response<SSL> {
         c::uws_res_end_stream(Self::ssl_flag(), self.as_raw(), close_connection)
     }
 
+    pub fn end_stream_with_trailer(&mut self, trailer: &[u8], close_connection: bool) {
+        // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
+        unsafe {
+            c::uws_res_end_stream_with_trailer(
+                Self::ssl_flag(),
+                self.downcast(),
+                trailer.as_ptr(),
+                trailer.len(),
+                close_connection,
+            );
+        }
+    }
+
     /// Run `handler` while the response is corked.
     pub fn corked<F: FnOnce()>(&mut self, f: F) {
         // Safe fn item: nested local thunk, only coerced to the C-ABI
@@ -787,6 +815,19 @@ impl AnyResponse {
         any_dispatch!(self, |r| r.end(data, close_connection))
     }
 
+    pub fn end_with_trailer(self, data: &[u8], trailer: &[u8], close_connection: bool) {
+        match self {
+            AnyResponse::SSL(ptr) => {
+                TLSResponse::as_handle(ptr).end_with_trailer(data, trailer, close_connection)
+            }
+            AnyResponse::TCP(ptr) => {
+                TCPResponse::as_handle(ptr).end_with_trailer(data, trailer, close_connection)
+            }
+            // HTTP/1.1 chunked trailers do not apply to H3 body framing.
+            AnyResponse::H3(ptr) => H3Response::as_handle(ptr).end(data, close_connection),
+        }
+    }
+
     pub fn should_close_connection(self) -> bool {
         any_dispatch!(self, |r| r.should_close_connection())
     }
@@ -901,6 +942,18 @@ impl AnyResponse {
 
     pub fn end_stream(self, close_connection: bool) {
         any_dispatch!(self, |r| r.end_stream(close_connection))
+    }
+
+    pub fn end_stream_with_trailer(self, trailer: &[u8], close_connection: bool) {
+        match self {
+            AnyResponse::SSL(ptr) => {
+                TLSResponse::as_handle(ptr).end_stream_with_trailer(trailer, close_connection)
+            }
+            AnyResponse::TCP(ptr) => {
+                TCPResponse::as_handle(ptr).end_stream_with_trailer(trailer, close_connection)
+            }
+            AnyResponse::H3(ptr) => H3Response::as_handle(ptr).end_stream(close_connection),
+        }
     }
 
     pub fn corked<F: FnOnce()>(self, f: F) {
@@ -1050,6 +1103,22 @@ pub mod c {
             res: *mut uws_res,
             data: *const u8,
             length: usize,
+            close_connection: bool,
+        );
+        pub(crate) fn uws_res_end_with_trailer(
+            ssl: i32,
+            res: *mut uws_res,
+            data: *const u8,
+            length: usize,
+            trailer: *const u8,
+            trailer_length: usize,
+            close_connection: bool,
+        );
+        pub(crate) fn uws_res_end_stream_with_trailer(
+            ssl: i32,
+            res: *mut uws_res,
+            trailer: *const u8,
+            trailer_length: usize,
             close_connection: bool,
         );
         pub(crate) safe fn uws_res_flush_headers(

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1183,6 +1183,46 @@ extern "C"
     }
   }
 
+  void uws_res_end_with_trailer(int ssl, uws_res_r res, const char *data, size_t length,
+                                const char *trailer, size_t trailer_length,
+                                bool close_connection)
+  {
+    if (ssl)
+    {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->clearOnWritableAndAborted();
+      uwsRes->end(stringViewFromC(data, length), close_connection,
+                  stringViewFromC(trailer, trailer_length));
+    }
+    else
+    {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->clearOnWritableAndAborted();
+      uwsRes->end(stringViewFromC(data, length), close_connection,
+                  stringViewFromC(trailer, trailer_length));
+    }
+  }
+
+  void uws_res_end_stream_with_trailer(int ssl, uws_res_r res,
+                                       const char *trailer, size_t trailer_length,
+                                       bool close_connection)
+  {
+    if (ssl)
+    {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->clearOnWritableAndAborted();
+      uwsRes->sendTerminatingChunk(close_connection,
+                                   stringViewFromC(trailer, trailer_length));
+    }
+    else
+    {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->clearOnWritableAndAborted();
+      uwsRes->sendTerminatingChunk(close_connection,
+                                   stringViewFromC(trailer, trailer_length));
+    }
+  }
+
   void uws_res_pause(int ssl, uws_res_r res)
   {
     if (ssl)

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3751,13 +3751,13 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
 });
 
 describe("ServerResponse trailers", () => {
-  async function rawGet(port: number): Promise<string> {
+  async function rawGet(port: number, httpVersion: "1.0" | "1.1" = "1.1"): Promise<string> {
     const { promise, resolve, reject } = Promise.withResolvers<string>();
     let wire = "";
     const socket = connect(port, "127.0.0.1");
     socket.on("error", reject);
     socket.on("connect", () => {
-      socket.write("GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n");
+      socket.write(`GET / HTTP/${httpVersion}\r\nHost: a\r\nConnection: close\r\n\r\n`);
     });
     socket.on("data", d => {
       wire += d.toString("latin1");
@@ -3821,6 +3821,31 @@ describe("ServerResponse trailers", () => {
     }
   });
 
+  it("addTrailers before writeHead() with no body does not throw", async () => {
+    // https://github.com/oven-sh/bun/issues/26171
+    let serverError: unknown;
+    const server = createServer((req, res) => {
+      req.resume();
+      try {
+        res.addTrailers({ "Content-MD5": "7895bf4b8828b55ceaf47747b4bca667" });
+        res.writeHead(200);
+        res.end();
+      } catch (e) {
+        serverError = e;
+        res.destroy();
+      }
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const wire = await rawGet((server.address() as AddressInfo).port);
+      expect(serverError).toBeUndefined();
+      expect(wire).toContain("Transfer-Encoding: chunked\r\n");
+      expect(wire).toContain("\r\n0\r\nContent-MD5: 7895bf4b8828b55ceaf47747b4bca667\r\n\r\n");
+    } finally {
+      server.close();
+    }
+  });
+
   it("writeHead with Trailer and Content-Length throws ERR_HTTP_TRAILER_INVALID", async () => {
     let thrown: unknown;
     const server = createServer((req, res) => {
@@ -3837,6 +3862,74 @@ describe("ServerResponse trailers", () => {
     try {
       await rawGet((server.address() as AddressInfo).port);
       expect((thrown as NodeJS.ErrnoException)?.code).toBe("ERR_HTTP_TRAILER_INVALID");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("writeHead with Trailer on a 204 throws even with an explicit Transfer-Encoding: chunked", async () => {
+    // A no-body status (204/304/1xx) is never chunk-framed and can never emit
+    // a terminating chunk, so a Trailer header is invalid even when the user
+    // also set Transfer-Encoding: chunked.
+    let thrown: unknown;
+    const server = createServer((req, res) => {
+      req.resume();
+      try {
+        res.writeHead(204, { "Trailer": "x-t", "Transfer-Encoding": "chunked" });
+      } catch (e) {
+        thrown = e;
+      }
+      res.removeHeader("Trailer");
+      res.end();
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      await rawGet((server.address() as AddressInfo).port);
+      expect((thrown as NodeJS.ErrnoException)?.code).toBe("ERR_HTTP_TRAILER_INVALID");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("writeHead with Trailer on an HTTP/1.0 request throws ERR_HTTP_TRAILER_INVALID", async () => {
+    // HTTP/1.0 responses are never chunk-framed (useChunkedEncodingByDefault
+    // is false), so trailers cannot be emitted.
+    let thrown: unknown;
+    const server = createServer((req, res) => {
+      req.resume();
+      try {
+        res.writeHead(200, { Trailer: "x-t" });
+      } catch (e) {
+        thrown = e;
+      }
+      res.removeHeader("Trailer");
+      res.end("body");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      await rawGet((server.address() as AddressInfo).port, "1.0");
+      expect((thrown as NodeJS.ErrnoException)?.code).toBe("ERR_HTTP_TRAILER_INVALID");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("a Trailer header on an HTTP/1.0 response never advertises chunked framing", async () => {
+    // The implicit-header path (setHeader + end, no writeHead) must not force
+    // chunked framing for an HTTP/1.0 response: uWS refuses to chunk-frame
+    // ancient requests, so advertising Transfer-Encoding: chunked while the
+    // body is written raw would produce an unparseable response.
+    const server = createServer((req, res) => {
+      req.resume();
+      res.setHeader("Trailer", "x-t");
+      res.end("body");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const wire = await rawGet((server.address() as AddressInfo).port, "1.0");
+      expect(wire).not.toContain("Transfer-Encoding:");
+      expect(wire).toContain("Content-Length: 4\r\n");
+      expect(wire.endsWith("\r\n\r\nbody")).toBe(true);
     } finally {
       server.close();
     }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3749,3 +3749,96 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
   c.outputData.push({ data: "y", encoding: "utf8", callback: null });
   expect(d.outputData.length).toBe(0);
 });
+
+describe("ServerResponse trailers", () => {
+  async function rawGet(port: number): Promise<string> {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    let wire = "";
+    const socket = connect(port, "127.0.0.1");
+    socket.on("error", reject);
+    socket.on("connect", () => {
+      socket.write("GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n");
+    });
+    socket.on("data", d => {
+      wire += d.toString("latin1");
+    });
+    socket.on("close", () => resolve(wire));
+    return promise;
+  }
+
+  it("writeHead with a Trailer header on a chunked response does not throw", async () => {
+    let serverError: unknown;
+    const server = createServer((req, res) => {
+      req.resume();
+      try {
+        res.writeHead(200, { Trailer: "x-t" });
+        res.write("body");
+        res.addTrailers({ "x-t": "tv" });
+        res.end();
+      } catch (e) {
+        serverError = e;
+        res.destroy();
+      }
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const wire = await rawGet((server.address() as AddressInfo).port);
+      expect(serverError).toBeUndefined();
+      // Trailer header is advertised and the response is chunked.
+      expect(wire).toContain("Trailer: x-t\r\n");
+      expect(wire).toContain("Transfer-Encoding: chunked\r\n");
+      expect(wire).not.toContain("Content-Length:");
+      // Body chunk, terminating 0-chunk, trailer field, final CRLF.
+      expect(wire).toContain("\r\n4\r\nbody\r\n0\r\nx-t: tv\r\n\r\n");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("addTrailers followed by a one-shot end() emits a chunked response with the trailer", async () => {
+    let serverError: unknown;
+    const server = createServer((req, res) => {
+      req.resume();
+      try {
+        res.writeHead(200, { Trailer: "x-t" });
+        res.addTrailers({ "x-t": "tv" });
+        res.end("body");
+      } catch (e) {
+        serverError = e;
+        res.destroy();
+      }
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const wire = await rawGet((server.address() as AddressInfo).port);
+      expect(serverError).toBeUndefined();
+      // A Trailer header forces chunked framing even for a one-shot end().
+      expect(wire).toContain("Transfer-Encoding: chunked\r\n");
+      expect(wire).not.toContain("Content-Length:");
+      expect(wire).toContain("\r\n4\r\nbody\r\n0\r\nx-t: tv\r\n\r\n");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("writeHead with Trailer and Content-Length throws ERR_HTTP_TRAILER_INVALID", async () => {
+    let thrown: unknown;
+    const server = createServer((req, res) => {
+      req.resume();
+      try {
+        res.writeHead(200, { "Trailer": "x-t", "Content-Length": "4" });
+      } catch (e) {
+        thrown = e;
+      }
+      res.removeHeader("Trailer");
+      res.end("body");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      await rawGet((server.address() as AddressInfo).port);
+      expect((thrown as NodeJS.ErrnoException)?.code).toBe("ERR_HTTP_TRAILER_INVALID");
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #26171

## What does this PR do?

Fixes server-side response trailers in `node:http`: `writeHead(200, {Trailer: 'x-t'})` threw `ERR_HTTP_TRAILER_INVALID` on a plain HTTP/1.1 chunked response, so trailers (gRPC-web status, checksums, server-timing) could not be emitted at all. Calling `addTrailers()` before `writeHead()` threw for the same reason (#26171).

### Reproduction

```js
import http from 'node:http';
import net from 'node:net';
const srv = http.createServer((q, r) => {
  q.resume();
  r.writeHead(200, { Trailer: 'x-t' });   // <-- throws ERR_HTTP_TRAILER_INVALID
  r.write('body');
  r.addTrailers({ 'x-t': 'tv' });
  r.end();
});
srv.listen(0, '127.0.0.1', () => {
  const s = net.connect(srv.address().port);
  s.on('connect', () => s.write('GET / HTTP/1.1\r\nHost:a\r\n\r\n'));
  s.on('data', d => process.stdout.write(d));
});
```

Before: `ERR_HTTP_TRAILER_INVALID (headersSent=false)`, nothing on the wire.
After (matches Node.js exactly):
```
HTTP/1.1 200 OK
Trailer: x-t
Date: ...
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

4
body
0
x-t: tv

```

### Cause

Two separate bugs:

1. `_writeHead` in `src/js/node/_http_server.ts` rejected a `Trailer` header (or a pending `_trailer` from `addTrailers()`) whenever `response.chunkedEncoding !== true`. On the native server path `chunkedEncoding` is always still `false` at `writeHead` time (the framing decision is deferred to `renderNativeHeaders` / uWS), so the check fired for every response that advertised a trailer. Node.js only performs this check in `_storeHeader`, after the chunked-vs-Content-Length decision.

2. Even if `writeHead` accepted the header, the native path never emitted trailers: `ServerResponse.end()` did not forward `_trailer` to the native handle, and uWS's `internalEnd` wrote a hardcoded `0\r\n\r\n` terminator.

### Fix

- Replace the premature `chunkedEncoding` check in `_writeHead` with the same framing decision Node.js's `_storeHeader` makes: a no-body status (204/304/1xx/HEAD) is never chunk-framed; otherwise the response is chunked unless it carries an explicit `Content-Length`, chunked encoding is not the default (HTTP/1.0), or the user removed `Transfer-Encoding`.
- In `renderNativeHeaders`, force chunked framing when a trailer is pending, so a one-shot `end(body)` is not framed with an auto `Content-Length`. Gated on `useChunkedEncodingByDefault` so an HTTP/1.0 response never advertises chunked framing uWS will not produce.
- Forward `this._trailer` through `handle.end()` as a new fifth argument; `NodeHTTPResponse::write_or_end` reads it and calls new `uws_res_end_with_trailer` / `uws_res_end_stream_with_trailer` shims that write `0\r\n<trailers>\r\n` as the chunked terminator.

### Intentionally out of scope

On the implicit-header path (a handler that uses `setHeader()` + `end()` without ever calling `writeHead()`), the native server does not run `_writeHead`, so its trailer validation is skipped. With an explicit `Content-Length` alongside a `Trailer` header there, the trailer is silently dropped instead of throwing `ERR_HTTP_TRAILER_INVALID` like Node.js. This PR does not change that behavior: the wire bytes are identical to before this PR, and the root cause is the pre-existing gap that the implicit-header path never runs `writeHead`'s validation at all, which is broader than trailers and needs its own change (making `renderNativeHeaders` a validator that can throw from inside `handle.cork()`). Left for a focused follow-up.

Relatedly, `writeHead(200, {'Content-Length': '4', 'Transfer-Encoding': 'chunked', Trailer: 'x-t'})` no longer throws. Not throwing matches Node.js (its `matchHeader` selects chunked from the Transfer-Encoding header regardless of Content-Length), so this PR does not re-add a `!hasContentLength` guard there. On that self-contradictory input (RFC 9112 6.2 forbids carrying both), uWS lets Content-Length win and writes the body raw while the chunked header is advertised, so the trailer is dropped. That CL-wins-over-TE framing is pre-existing and unrelated to trailers: `writeHead({CL, TE: 'chunked'})` with no trailer produced the same output before this PR, and Node's own output for it is also malformed (it sends both headers). Changing which header wins is an HTTP-server-wide framing decision, not a trailer fix, so it is not made here.

### Relationship to #32488

#32488 also adds response-trailer emission (via a `nodeHttpResponseTrailers` field on `HttpResponseData`, a different mechanism from the trailer argument this PR threads through `handle.end()`), so whichever lands first, the other's emission plumbing needs a small rebase. #32488 does not change the `_writeHead` validation, so both reported repros (`writeHead(200, {Trailer})` and `addTrailers()` before `writeHead()`) still throw there; the `_writeHead` fix in this PR is needed either way.

### Verification

New tests in `test/js/node/http/node-http.test.ts`:

- `writeHead(200, {Trailer})` + `write()` + `addTrailers()` + `end()` emits a chunked response with trailer fields on the wire.
- `writeHead(200, {Trailer})` + `addTrailers()` + one-shot `end(body)` forces chunked framing and emits the trailer.
- `addTrailers()` before `writeHead(200)` with no body (the #26171 repro) does not throw and emits the trailer.
- `writeHead(200, {Trailer, 'Content-Length'})` still throws `ERR_HTTP_TRAILER_INVALID`.
- `writeHead(204, {Trailer, 'Transfer-Encoding': 'chunked'})` throws: a no-body status can never carry a terminating chunk.
- `writeHead(200, {Trailer})` on an HTTP/1.0 request throws.
- A `Trailer` header on an HTTP/1.0 response never advertises `Transfer-Encoding: chunked`.

The vendored Node test `test-http-server-de-chunked-trailer.js` continues to pass.


