### PR TITLE
glob: treat an unclosed `{` as a literal in match()

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -147,6 +147,7 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
 
     let mut brace_stack = BraceStack::default();
     let mut brace_budget = BRACE_BRANCH_BUDGET;
+    let has_unclosed = has_unclosed_brace(glob, state.glob_index);
     let matched = glob_match_impl(
         &mut state,
         glob,
@@ -154,6 +155,7 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
         path,
         &mut brace_stack,
         &mut brace_budget,
+        has_unclosed,
     );
 
     // TODO: consider just returning a bool
@@ -184,6 +186,7 @@ fn glob_match_impl(
     path: &[u8],
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
+    has_unclosed: bool,
 ) -> bool {
     'main_loop: while (state.glob_index as usize) < glob.len()
         || (state.path_index as usize) < path.len()
@@ -362,7 +365,20 @@ fn glob_match_impl(
                                     continue 'main_loop;
                                 }
                             }
-                            return match_brace(state, glob, path, brace_stack, brace_budget);
+                            // An unclosed `{` is a literal (bash/picomatch/minimatch semantics).
+                            // `has_unclosed` is a one-shot scan over the whole glob so the common
+                            // all-balanced case avoids re-scanning here.
+                            if has_unclosed && !has_closing_brace(glob, state.glob_index) {
+                                break 'to_else;
+                            }
+                            return match_brace(
+                                state,
+                                glob,
+                                path,
+                                brace_stack,
+                                brace_budget,
+                                has_unclosed,
+                            );
                         }
                         b',' => {
                             if state.brace_depth > 0 {
@@ -428,12 +444,58 @@ fn glob_match_impl(
     true
 }
 
+/// Returns `true` iff `glob[start..]` contains a `{` without a matching `}`.
+/// Mirrors `match_brace`'s scan (depth-counted, `[...]`-aware, `\`-escaped).
+fn has_unclosed_brace(glob: &[u8], start: u32) -> bool {
+    let mut i = start as usize;
+    let mut depth: u32 = 0;
+    let mut in_brackets = false;
+    while i < glob.len() {
+        match glob[i] {
+            b'{' if !in_brackets => depth += 1,
+            b'}' if !in_brackets => depth = depth.saturating_sub(1),
+            b'[' if !in_brackets => in_brackets = true,
+            b']' => in_brackets = false,
+            b'\\' => i += 1,
+            _ => {}
+        }
+        i += 1;
+    }
+    depth != 0
+}
+
+/// Returns `true` if the `{` at `glob[open_idx]` has a matching `}`.
+fn has_closing_brace(glob: &[u8], open_idx: u32) -> bool {
+    debug_assert_eq!(glob[open_idx as usize], b'{');
+    let mut i = open_idx as usize;
+    let mut depth: u32 = 0;
+    let mut in_brackets = false;
+    while i < glob.len() {
+        match glob[i] {
+            b'{' if !in_brackets => depth += 1,
+            b'}' if !in_brackets => {
+                depth -= 1;
+                if depth == 0 {
+                    return true;
+                }
+            }
+            b'[' if !in_brackets => in_brackets = true,
+            b']' => in_brackets = false,
+            b'\\' => i += 1,
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
 fn match_brace(
     state: &mut State,
     glob: &[u8],
     path: &[u8],
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
+    has_unclosed: bool,
 ) -> bool {
     let mut brace_depth: i32 = 0;
     let mut in_brackets = false;
@@ -464,6 +526,7 @@ fn match_brace(
                             branch_index,
                             brace_stack,
                             brace_budget,
+                            has_unclosed,
                         ) {
                             return true;
                         }
@@ -484,6 +547,7 @@ fn match_brace(
                         branch_index,
                         brace_stack,
                         brace_budget,
+                        has_unclosed,
                     ) {
                         return true;
                     }
@@ -513,6 +577,7 @@ fn match_brace_branch(
     branch_index: u32,
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
+    has_unclosed: bool,
 ) -> bool {
     if *brace_budget == 0 {
         return false;
@@ -539,6 +604,7 @@ fn match_brace_branch(
         path,
         brace_stack,
         brace_budget,
+        has_unclosed,
     );
 
     let _ = brace_stack.pop();

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -147,7 +147,8 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
 
     let mut brace_stack = BraceStack::default();
     let mut brace_budget = BRACE_BRANCH_BUDGET;
-    let has_unclosed = has_unclosed_brace(glob, state.glob_index);
+    // Empty (no allocation) for the common case where every `{` is closed.
+    let unclosed = unclosed_brace_indices(glob, state.glob_index);
     let matched = glob_match_impl(
         &mut state,
         glob,
@@ -155,7 +156,7 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
         path,
         &mut brace_stack,
         &mut brace_budget,
-        has_unclosed,
+        &unclosed,
     );
 
     // TODO: consider just returning a bool
@@ -186,7 +187,7 @@ fn glob_match_impl(
     path: &[u8],
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
-    has_unclosed: bool,
+    unclosed: &[u32],
 ) -> bool {
     'main_loop: while (state.glob_index as usize) < glob.len()
         || (state.path_index as usize) < path.len()
@@ -366,9 +367,7 @@ fn glob_match_impl(
                                 }
                             }
                             // An unclosed `{` is a literal (bash/picomatch/minimatch semantics).
-                            // `has_unclosed` is a one-shot scan over the whole glob so the common
-                            // all-balanced case avoids re-scanning here.
-                            if has_unclosed && !has_closing_brace(glob, state.glob_index) {
+                            if unclosed.binary_search(&state.glob_index).is_ok() {
                                 break 'to_else;
                             }
                             return match_brace(
@@ -377,7 +376,7 @@ fn glob_match_impl(
                                 path,
                                 brace_stack,
                                 brace_budget,
-                                has_unclosed,
+                                unclosed,
                             );
                         }
                         b',' => {
@@ -444,16 +443,15 @@ fn glob_match_impl(
     true
 }
 
-/// Returns `true` iff `glob[start..]` contains a `{` without a matching `}`.
-/// Mirrors `match_brace`'s scan (depth-counted, `[...]`-aware, `\`-escaped).
-fn has_unclosed_brace(glob: &[u8], start: u32) -> bool {
+/// Calls `f(index, byte)` for every `{` and `}` in `glob[start..]` that is a
+/// group delimiter: outside a `[...]` character class and not `\`-escaped,
+/// the same characters `match_brace` and `skip_branch` count.
+fn for_each_brace_delimiter(glob: &[u8], start: u32, mut f: impl FnMut(usize, u8)) {
     let mut i = start as usize;
-    let mut depth: u32 = 0;
     let mut in_brackets = false;
     while i < glob.len() {
         match glob[i] {
-            b'{' if !in_brackets => depth += 1,
-            b'}' if !in_brackets => depth = depth.saturating_sub(1),
+            c @ (b'{' | b'}') if !in_brackets => f(i, c),
             b'[' if !in_brackets => in_brackets = true,
             b']' => in_brackets = false,
             b'\\' => i += 1,
@@ -461,32 +459,37 @@ fn has_unclosed_brace(glob: &[u8], start: u32) -> bool {
         }
         i += 1;
     }
-    depth != 0
 }
 
-/// Returns `true` if the `{` at `glob[open_idx]` has a matching `}`.
-fn has_closing_brace(glob: &[u8], open_idx: u32) -> bool {
-    debug_assert_eq!(glob[open_idx as usize], b'{');
-    let mut i = open_idx as usize;
+/// Indices (ascending) of every `{` in `glob[start..]` with no matching `}`.
+/// Returns an empty, non-allocating `Vec` when every `{` is closed.
+fn unclosed_brace_indices(glob: &[u8], start: u32) -> Vec<u32> {
+    // Alloc-free pre-scan: patterns whose braces are balanced (the common
+    // case, including no braces at all) never reach the stack pass below.
     let mut depth: u32 = 0;
-    let mut in_brackets = false;
-    while i < glob.len() {
-        match glob[i] {
-            b'{' if !in_brackets => depth += 1,
-            b'}' if !in_brackets => {
-                depth -= 1;
-                if depth == 0 {
-                    return true;
-                }
-            }
-            b'[' if !in_brackets => in_brackets = true,
-            b']' => in_brackets = false,
-            b'\\' => i += 1,
-            _ => {}
+    for_each_brace_delimiter(glob, start, |_, c| {
+        if c == b'{' {
+            depth += 1;
+        } else {
+            depth = depth.saturating_sub(1);
         }
-        i += 1;
+    });
+    if depth == 0 {
+        return Vec::new();
     }
-    false
+
+    // `open` doubles as the scan stack and the result: a `}` pops the most
+    // recent open `{`, so whatever survives is unclosed, in push (ascending)
+    // order.
+    let mut open: Vec<u32> = Vec::new();
+    for_each_brace_delimiter(glob, start, |i, c| {
+        if c == b'{' {
+            open.push(u32::try_from(i).expect("int cast"));
+        } else {
+            let _ = open.pop();
+        }
+    });
+    open
 }
 
 fn match_brace(
@@ -495,7 +498,7 @@ fn match_brace(
     path: &[u8],
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
-    has_unclosed: bool,
+    unclosed: &[u32],
 ) -> bool {
     let mut brace_depth: i32 = 0;
     let mut in_brackets = false;
@@ -526,7 +529,7 @@ fn match_brace(
                             branch_index,
                             brace_stack,
                             brace_budget,
-                            has_unclosed,
+                            unclosed,
                         ) {
                             return true;
                         }
@@ -547,7 +550,7 @@ fn match_brace(
                         branch_index,
                         brace_stack,
                         brace_budget,
-                        has_unclosed,
+                        unclosed,
                     ) {
                         return true;
                     }
@@ -577,7 +580,7 @@ fn match_brace_branch(
     branch_index: u32,
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
-    has_unclosed: bool,
+    unclosed: &[u32],
 ) -> bool {
     if *brace_budget == 0 {
         return false;
@@ -604,7 +607,7 @@ fn match_brace_branch(
         path,
         brace_stack,
         brace_budget,
-        has_unclosed,
+        unclosed,
     );
 
     let _ = brace_stack.pop();

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -329,6 +329,40 @@ describe("Glob.match", () => {
     expect(glob.match("bde")).toBeTrue();
   });
 
+  test("unclosed `{` is treated as a literal", () => {
+    // bash, picomatch and minimatch all treat an unmatched `{` as a literal.
+    // It must not make the whole pattern unmatchable, and an unclosed group
+    // containing a comma must not be auto-closed into a brace expansion.
+    expect(new Glob("{").match("{")).toBeTrue();
+    expect(new Glob("{a").match("{a")).toBeTrue();
+    expect(new Glob("a{b").match("a{b")).toBeTrue();
+    expect(new Glob("a{b,c").match("a{b,c")).toBeTrue();
+    expect(new Glob("a{b,c").match("ab")).toBeFalse();
+    expect(new Glob("a{b,c").match("ac")).toBeFalse();
+
+    // Wildcards still work around the literal `{`.
+    expect(new Glob("*{").match("abc{")).toBeTrue();
+    expect(new Glob("a{b*").match("a{bcd")).toBeTrue();
+    expect(new Glob("a{b*").match("abcd")).toBeFalse();
+
+    // An escaped `}` does not close the group.
+    expect(new Glob("{a,b\\}").match("{a,b}")).toBeTrue();
+    expect(new Glob("{a,b\\}").match("a")).toBeFalse();
+
+    // Outer `{` unclosed → literal; inner balanced group still expands.
+    expect(new Glob("{a,{b,c}").match("{a,b")).toBeTrue();
+    expect(new Glob("{a,{b,c}").match("{a,c")).toBeTrue();
+    expect(new Glob("{a,{b,c}").match("a")).toBeFalse();
+    expect(new Glob("{{a,b}").match("{a")).toBeTrue();
+    expect(new Glob("{{a,b}").match("{b")).toBeTrue();
+    expect(new Glob("{{a,b}").match("a")).toBeFalse();
+
+    // A closed group followed by an unclosed `{`.
+    expect(new Glob("{a,b}{c").match("a{c")).toBeTrue();
+    expect(new Glob("{a,b}{c").match("b{c")).toBeTrue();
+    expect(new Glob("{a,b}{c").match("ac")).toBeFalse();
+  });
+
   test("deeply nested braces do not overflow depth counters", () => {
     const opens = Buffer.alloc(300, "{").toString();
     const closes = Buffer.alloc(300, "}").toString();
@@ -353,8 +387,8 @@ describe("Glob.match", () => {
     glob = new Glob("*{a," + opens + closes + "}");
     expect(glob.match("za")).toBeTrue();
 
-    // >32767 consecutive `{` overflows match_brace's group pre-scan counter.
-    // The group never closes, so nothing matches.
+    // 40,000 consecutive `{`, none closed — every `{` is a literal and the
+    // closing-brace pre-scan must not overflow its depth counter.
     glob = new Glob(Buffer.alloc(40_000, "{").toString());
     expect(glob.match("a")).toBeFalse();
     expect(glob.match("{")).toBeFalse();

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -387,11 +387,14 @@ describe("Glob.match", () => {
     glob = new Glob("*{a," + opens + closes + "}");
     expect(glob.match("za")).toBeTrue();
 
-    // 40,000 consecutive `{`, none closed — every `{` is a literal and the
-    // closing-brace pre-scan must not overflow its depth counter.
+    // 40,000 consecutive `{`, none closed, so every `{` is a literal. The
+    // unclosed-brace pre-scan must not overflow its depth counter, and
+    // matching must stay linear in the number of unclosed braces.
     glob = new Glob(Buffer.alloc(40_000, "{").toString());
     expect(glob.match("a")).toBeFalse();
     expect(glob.match("{")).toBeFalse();
+    expect(glob.match(Buffer.alloc(40_000, "{").toString())).toBeTrue();
+    expect(glob.match(Buffer.alloc(40_001, "{").toString())).toBeFalse();
   });
 
   // Most of the potential bugs when dealing with non-ASCII patterns is when the


### PR DESCRIPTION
## Problem

`Bun.Glob.match()` mishandles patterns with an unterminated `{`:

```js
new Bun.Glob("{").match("{")           // false, should be true
new Bun.Glob("a{b").match("a{b")       // false, should be true
new Bun.Glob("a{b,c").match("a{b,c")   // false, should be true
new Bun.Glob("a{b,c").match("ab")      // true,  should be false
```

Two wrong behaviours from one parse bug: an unclosed `{` with no comma makes the whole pattern unmatchable, and an unclosed `{` with a comma is silently auto-closed into a brace expansion (so a truncated pattern matches the wrong set of files).

bash, picomatch and minimatch all treat an unmatched `{` as a literal: `touch 'a{b'; echo a{b` prints `a{b`, and `picomatch("a{b")("a{b") === true`.

## Cause

In `src/glob/matcher.rs`, `match_brace` scans forward from `{` and fires `match_brace_branch` at each top-level `,` as it goes, then again at the closing `}`. If the closing `}` never arrives the loop falls off the end and returns `false`, but any branches already tried at commas have already recursed into `glob_match_impl`, where `skip_branch` walks to end-of-pattern and reports a match. Without a comma no branch is ever tried, so the whole pattern just fails.

## Fix

`r#match` does one upfront pass over the pattern that records the indices of every `{` with no matching `}` (depth-counted, `[...]`-aware, `\`-escaped, the same rules `match_brace` uses). When the matcher reaches a `{` in that set it falls through to the literal-byte path instead of entering brace matching, so `{` matches a literal `{`. An inner balanced group inside a literal outer `{` still expands (`{{a,b}` matches `{a` or `{b`, same as bash).

Balanced patterns, the common case, detect "nothing unclosed" in a cheap counting pass and never allocate the index list, so they pay one extra linear scan of the pattern and nothing per `{`. A pattern of N unclosed braces is consulted with a binary search per `{` rather than a rescan of the remaining pattern, so matching stays near-linear instead of quadratic.

## Verification

New test block in `test/js/bun/glob/match.test.ts` covers the four reported cases plus wildcards around a literal `{`, an escaped `}` that must not close the group, nested unclosed/closed combinations, a closed group followed by an unclosed `{`, and a 40,000-brace pattern matched against a 40,000-brace path.

```
bun bd test test/js/bun/glob/match.test.ts
# 27 pass, 0 fail
```

`path.matchesGlob` delegates to `Bun.Glob().match()` and picks up the same fix.

(Listed as out-of-scope in #32853's "Not in this PR" section; this is that follow-up.)
