### PR TITLE
glob: treat an unterminated `[` as a literal in match()

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -147,6 +147,7 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
 
     let mut brace_stack = BraceStack::default();
     let mut brace_budget = BRACE_BRANCH_BUDGET;
+    let last_rbracket = find_last_rbracket(glob);
     let matched = glob_match_impl(
         &mut state,
         glob,
@@ -154,6 +155,7 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
         path,
         &mut brace_stack,
         &mut brace_budget,
+        last_rbracket,
     );
 
     // TODO: consider just returning a bool
@@ -184,6 +186,7 @@ fn glob_match_impl(
     path: &[u8],
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
+    last_rbracket: Option<u32>,
 ) -> bool {
     'main_loop: while (state.glob_index as usize) < glob.len()
         || (state.path_index as usize) < path.len()
@@ -272,6 +275,13 @@ fn glob_match_impl(
                         }
                         b'[' => {
                             if (state.path_index as usize) < path.len() {
+                                // No `]` left in the pattern: provably unterminated, so the
+                                // `[` is a literal. Skipping the scan keeps a run of
+                                // unterminated `[`s linear instead of quadratic.
+                                if !may_close_bracket(last_rbracket, state.glob_index) {
+                                    break 'to_else;
+                                }
+
                                 let open_bracket_index = state.glob_index;
                                 state.glob_index += 1;
 
@@ -365,11 +375,18 @@ fn glob_match_impl(
                                     continue 'main_loop;
                                 }
                             }
-                            return match_brace(state, glob, path, brace_stack, brace_budget);
+                            return match_brace(
+                                state,
+                                glob,
+                                path,
+                                brace_stack,
+                                brace_budget,
+                                last_rbracket,
+                            );
                         }
                         b',' => {
                             if state.brace_depth > 0 {
-                                skip_branch(state, glob);
+                                skip_branch(state, glob, last_rbracket);
                                 continue 'main_loop;
                             } else {
                                 break 'to_else;
@@ -377,7 +394,7 @@ fn glob_match_impl(
                         }
                         b'}' => {
                             if state.brace_depth > 0 {
-                                skip_branch(state, glob);
+                                skip_branch(state, glob, last_rbracket);
                                 continue 'main_loop;
                             } else {
                                 break 'to_else;
@@ -437,6 +454,7 @@ fn match_brace(
     path: &[u8],
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
+    last_rbracket: Option<u32>,
 ) -> bool {
     let mut brace_depth: i32 = 0;
     let mut in_brackets = false;
@@ -467,6 +485,7 @@ fn match_brace(
                             branch_index,
                             brace_stack,
                             brace_budget,
+                            last_rbracket,
                         ) {
                             return true;
                         }
@@ -487,6 +506,7 @@ fn match_brace(
                         branch_index,
                         brace_stack,
                         brace_budget,
+                        last_rbracket,
                     ) {
                         return true;
                     }
@@ -494,7 +514,8 @@ fn match_brace(
                 }
             }
             b'[' => {
-                if !in_brackets && bracket_is_closed(glob, state.glob_index as usize) {
+                if !in_brackets && bracket_is_closed(glob, state.glob_index as usize, last_rbracket)
+                {
                     in_brackets = true;
                 }
             }
@@ -516,6 +537,7 @@ fn match_brace_branch(
     branch_index: u32,
     brace_stack: &mut BraceStack,
     brace_budget: &mut u32,
+    last_rbracket: Option<u32>,
 ) -> bool {
     if *brace_budget == 0 {
         return false;
@@ -542,6 +564,7 @@ fn match_brace_branch(
         path,
         brace_stack,
         brace_budget,
+        last_rbracket,
     );
 
     let _ = brace_stack.pop();
@@ -549,7 +572,7 @@ fn match_brace_branch(
     matched
 }
 
-fn skip_branch(state: &mut State, glob: &[u8]) {
+fn skip_branch(state: &mut State, glob: &[u8], last_rbracket: Option<u32>) {
     let mut in_brackets = false;
     // `state.brace_depth` only counts groups entered via `match_brace_branch`,
     // so nesting merely scanned over while skipping is tracked locally, not in state.
@@ -572,7 +595,8 @@ fn skip_branch(state: &mut State, glob: &[u8]) {
                 }
             }
             b'[' => {
-                if !in_brackets && bracket_is_closed(glob, state.glob_index as usize) {
+                if !in_brackets && bracket_is_closed(glob, state.glob_index as usize, last_rbracket)
+                {
                     in_brackets = true;
                 }
             }
@@ -586,13 +610,43 @@ fn skip_branch(state: &mut State, glob: &[u8]) {
 
 use bun_paths::is_sep_native as is_separator;
 
+/// Index of the last `]` in `glob` that a left-to-right, escape-aware scan can
+/// reach. A `[` at or past this index can never be terminated. This is an
+/// over-approximation (a first-position `]` is counted even though it is a
+/// literal class member), which only costs a scan, never a wrong answer.
+fn find_last_rbracket(glob: &[u8]) -> Option<u32> {
+    let mut last = None;
+    let mut i = 0;
+    while i < glob.len() {
+        match glob[i] {
+            b']' => {
+                last = Some(i as u32);
+                i += 1;
+            }
+            b'\\' => i += 2,
+            _ => i += 1,
+        }
+    }
+    last
+}
+
+/// Whether a `]` terminating the `[` at `open_idx` can exist at all. `false`
+/// means the bracket is provably unterminated without scanning its body.
+#[inline(always)]
+fn may_close_bracket(last_rbracket: Option<u32>, open_idx: u32) -> bool {
+    last_rbracket.is_some_and(|last| last > open_idx)
+}
+
 /// Returns whether the `[` at `glob[open_idx]` begins a bracket expression
 /// that is terminated by a matching `]`. Per POSIX fnmatch, a `]` immediately
 /// following `[` (or `[!`/`[^`) is a literal class member, not a terminator,
 /// and an unterminated `[` matches a literal `[` rather than being an error.
 #[inline]
-fn bracket_is_closed(glob: &[u8], open_idx: usize) -> bool {
+fn bracket_is_closed(glob: &[u8], open_idx: usize, last_rbracket: Option<u32>) -> bool {
     debug_assert!(glob[open_idx] == b'[');
+    if !may_close_bracket(last_rbracket, open_idx as u32) {
+        return false;
+    }
     let mut i = open_idx + 1;
     if i < glob.len() && (glob[i] == b'^' || glob[i] == b'!') {
         i += 1;

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -272,6 +272,7 @@ fn glob_match_impl(
                         }
                         b'[' => {
                             if (state.path_index as usize) < path.len() {
+                                let open_bracket_index = state.glob_index;
                                 state.glob_index += 1;
 
                                 let mut negated = false;
@@ -285,13 +286,16 @@ fn glob_match_impl(
 
                                 let mut first = true;
                                 let mut is_match = false;
+                                let mut closed = false;
 
                                 // source unicode char to match against the target + its byte length in `path`
                                 let (c, len) = decode_wtf8_rune_at(path, state.path_index as usize);
 
-                                while (state.glob_index as usize) < glob.len()
-                                    && (first || glob[state.glob_index as usize] != b']')
-                                {
+                                while (state.glob_index as usize) < glob.len() {
+                                    if !first && glob[state.glob_index as usize] == b']' {
+                                        closed = true;
+                                        break;
+                                    }
                                     // Get low ( ͡° ͜ʖ ͡°), and unescape it
                                     let mut low: u32 = glob[state.glob_index as usize] as u32;
                                     let mut low_len: u8 = 1;
@@ -301,7 +305,7 @@ fn glob_match_impl(
                                         glob,
                                         &mut state.glob_index,
                                     ) {
-                                        return false; // Invalid pattern!
+                                        break; // trailing `\`: unterminated
                                     }
 
                                     // skip past the target char
@@ -311,24 +315,22 @@ fn glob_match_impl(
                                         && glob[state.glob_index as usize] == b'-'
                                         && glob[state.glob_index as usize + 1] != b']'
                                     {
-                                        'blk: {
-                                            state.glob_index += 1;
+                                        state.glob_index += 1;
 
-                                            let mut high: u32 =
-                                                glob[state.glob_index as usize] as u32;
-                                            let mut high_len: u8 = 1;
-                                            if !get_unicode(
-                                                &mut high,
-                                                &mut high_len,
-                                                glob,
-                                                &mut state.glob_index,
-                                            ) {
-                                                return false; // Invalid pattern!
-                                            }
-
-                                            state.glob_index += u32::from(high_len);
-                                            break 'blk high;
+                                        let mut high: u32 =
+                                            glob[state.glob_index as usize] as u32;
+                                        let mut high_len: u8 = 1;
+                                        if !get_unicode(
+                                            &mut high,
+                                            &mut high_len,
+                                            glob,
+                                            &mut state.glob_index,
+                                        ) {
+                                            break; // trailing `\`: unterminated
                                         }
+
+                                        state.glob_index += u32::from(high_len);
+                                        high
                                     } else {
                                         low
                                     };
@@ -340,8 +342,10 @@ fn glob_match_impl(
                                     first = false;
                                 }
 
-                                if state.glob_index as usize >= glob.len() {
-                                    return false; // Invalid pattern!
+                                if !closed {
+                                    // POSIX: an unterminated `[` matches itself literally.
+                                    state.glob_index = open_bracket_index;
+                                    break 'to_else;
                                 }
 
                                 state.glob_index += 1;
@@ -491,7 +495,7 @@ fn match_brace(
                 }
             }
             b'[' => {
-                if !in_brackets {
+                if !in_brackets && bracket_is_closed(glob, state.glob_index as usize) {
                     in_brackets = true;
                 }
             }
@@ -569,7 +573,7 @@ fn skip_branch(state: &mut State, glob: &[u8]) {
                 }
             }
             b'[' => {
-                if !in_brackets {
+                if !in_brackets && bracket_is_closed(glob, state.glob_index as usize) {
                     in_brackets = true;
                 }
             }
@@ -582,6 +586,31 @@ fn skip_branch(state: &mut State, glob: &[u8]) {
 }
 
 use bun_paths::is_sep_native as is_separator;
+
+/// Returns whether the `[` at `glob[open_idx]` begins a bracket expression
+/// that is terminated by a matching `]`. Per POSIX fnmatch, a `]` immediately
+/// following `[` (or `[!`/`[^`) is a literal class member, not a terminator,
+/// and an unterminated `[` matches a literal `[` rather than being an error.
+#[inline]
+fn bracket_is_closed(glob: &[u8], open_idx: usize) -> bool {
+    debug_assert!(glob[open_idx] == b'[');
+    let mut i = open_idx + 1;
+    if i < glob.len() && (glob[i] == b'^' || glob[i] == b'!') {
+        i += 1;
+    }
+    // `]` in the first position is a literal class member.
+    if i < glob.len() && glob[i] == b']' {
+        i += 1;
+    }
+    while i < glob.len() {
+        match glob[i] {
+            b']' => return true,
+            b'\\' => i += 2,
+            _ => i += 1,
+        }
+    }
+    false
+}
 
 #[inline(always)]
 fn unescape(c: &mut u8, glob: &[u8], glob_index: &mut u32) -> bool {

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -317,8 +317,7 @@ fn glob_match_impl(
                                     {
                                         state.glob_index += 1;
 
-                                        let mut high: u32 =
-                                            glob[state.glob_index as usize] as u32;
+                                        let mut high: u32 = glob[state.glob_index as usize] as u32;
                                         let mut high_len: u8 = 1;
                                         if !get_unicode(
                                             &mut high,

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -92,6 +92,50 @@ describe("Glob.match", () => {
     expect(new Glob("x.{ts,[,]foo}").match("x.ts")).toBeTrue();
   });
 
+  test("unterminated [ matches itself literally (POSIX)", () => {
+    // POSIX fnmatch 2.13.1: if `[` does not introduce a bracket expression
+    // (no closing `]`), the `[` shall match itself. bash, minimatch, and
+    // picomatch all agree.
+    expect(new Glob("[").match("[")).toBeTrue();
+    expect(new Glob("[").match("a")).toBeFalse();
+    expect(new Glob("[a").match("[a")).toBeTrue();
+    expect(new Glob("[a").match("a")).toBeFalse();
+    expect(new Glob("x[y").match("x[y")).toBeTrue();
+    expect(new Glob("x[y").match("xay")).toBeFalse();
+    expect(new Glob("a[").match("a[")).toBeTrue();
+    expect(new Glob("[abc").match("[abc")).toBeTrue();
+    expect(new Glob("[abc").match("a")).toBeFalse();
+    // Closed bracket still behaves as a character class.
+    expect(new Glob("[abc]").match("a")).toBeTrue();
+    expect(new Glob("[abc]").match("[abc]")).toBeFalse();
+
+    // A `]` immediately after `[` (or `[!`/`[^`) is a literal member, so
+    // `[]`, `[!]`, `[^]` are all unterminated and match themselves.
+    expect(new Glob("[]").match("[]")).toBeTrue();
+    expect(new Glob("[!]").match("[!]")).toBeTrue();
+    expect(new Glob("[^]").match("[^]")).toBeTrue();
+    expect(new Glob("[!").match("[!")).toBeTrue();
+    expect(new Glob("[!a").match("[!a")).toBeTrue();
+    // `[]a]` is a terminated class containing `]` and `a`.
+    expect(new Glob("[]a]").match("]")).toBeTrue();
+    expect(new Glob("[]a]").match("a")).toBeTrue();
+    expect(new Glob("[]a]").match("[]a]")).toBeFalse();
+
+    // Literal `[` participates in wildcard backtracking like any other char.
+    expect(new Glob("*[").match("abc[")).toBeTrue();
+    expect(new Glob("*[").match("abc")).toBeFalse();
+    expect(new Glob("x[y*").match("x[yz")).toBeTrue();
+
+    // Unterminated `[` inside brace branches: the `[` is literal and must
+    // not swallow the `,` or `}` that delimit the branch.
+    expect(new Glob("{[,a}").match("[")).toBeTrue();
+    expect(new Glob("{[,a}").match("a")).toBeTrue();
+    expect(new Glob("{a,[}b").match("[b")).toBeTrue();
+    expect(new Glob("{a,[}b").match("ab")).toBeTrue();
+    expect(new Glob("x{[a,b}y").match("x[ay")).toBeTrue();
+    expect(new Glob("x{[a,b}y").match("xby")).toBeTrue();
+  });
+
   test("no early globstar lock-in", () => {
     // see https://github.com/oven-sh/bun/issues/14934
     expect(new Glob(`**/*abc*`).match(`a/abc`)).toBeTrue();

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -136,6 +136,20 @@ describe("Glob.match", () => {
     expect(new Glob("x{[a,b}y").match("xby")).toBeTrue();
   });
 
+  test("a run of unterminated [ stays linear", () => {
+    // Every `[` is unterminated (no `]` anywhere), so each is a literal.
+    // A naive per-`[` scan-to-end would be quadratic and time this test out.
+    const opens = Buffer.alloc(100_000, "[").toString();
+    expect(new Glob(opens).match(opens)).toBeTrue();
+    expect(new Glob(opens).match(opens.slice(1))).toBeFalse();
+    // The brace scanner classifies every `[` in the group the same way.
+    expect(new Glob(`{${opens},x}`).match(opens)).toBeTrue();
+    expect(new Glob(`{${opens},x}`).match("x")).toBeTrue();
+    // A single trailing `]` closes the run into one class containing `[`.
+    expect(new Glob("[[[[[]").match("[")).toBeTrue();
+    expect(new Glob("[[[[[]").match("a")).toBeFalse();
+  });
+
   test("no early globstar lock-in", () => {
     // see https://github.com/oven-sh/bun/issues/14934
     expect(new Glob(`**/*abc*`).match(`a/abc`)).toBeTrue();


### PR DESCRIPTION
## Problem

An unterminated `[` in a glob pattern makes the entire pattern unmatchable:

```js
new Bun.Glob('[').match('[')      // false, expected true
new Bun.Glob('[a').match('[a')    // false, expected true
new Bun.Glob('x[y').match('x[y')  // false, expected true
```

POSIX fnmatch 2.13.1: "If an open bracket introduces a bracket expression ... but does not introduce a bracket expression, the `[` shall match the character itself." bash, picomatch, and minimatch all treat an unterminated `[` as a literal:

```js
require('minimatch').minimatch('[', '[')   // true
require('picomatch')('[')('[')             // true
```

This bites any glob naming a file that contains `[`, e.g. Next.js dynamic routes (`[id].tsx`, `[...slug].tsx`).

## Cause

In `src/glob/matcher.rs`, the `[` arm of `glob_match_impl` scans forward for a closing `]` and on reaching end-of-pattern does `return false; // Invalid pattern!`, aborting the whole match with no backtracking.

The brace-group scanners (`match_brace` / `skip_branch`) unconditionally set `in_brackets` on `[`, so an unterminated `[` inside a brace branch (`{[,a}`) swallows the `,` and `}` delimiters and the group never closes.

## Fix

`glob_match_impl`: save the `[` index before scanning; if end-of-pattern is reached without a closing `]`, rewind to the `[` and fall through to the literal-byte path.

`match_brace` / `skip_branch`: only enter `in_brackets` mode when a closing `]` exists after the `[` (via `bracket_is_closed`), so a lone `[` inside a brace branch is treated as a literal and the branch's `,` / `}` delimiters are still recognised.

To keep this linear, `r#match` precomputes the index of the last escape-reachable `]` once per call (`find_last_rbracket`). A `[` at or past that index can never be terminated, so both the class parser and the brace scanners classify it as a literal in O(1). Without the bound, N consecutive unterminated `[` would each rescan the tail of the pattern (O(N^2)). Closed brackets still take a single parse pass with no extra lookahead.

## Verification

New test blocks in `test/js/bun/glob/match.test.ts`:

- the reported cases plus `[]` / `[!]` / `[^]` (whose first-position `]` is a literal member, so also unterminated), wildcard backtracking through a literal `[`, and unterminated `[` inside brace branches
- a run of 100,000 unterminated `[` (self-match and inside a brace group), which would time out if the per-`[` scan were quadratic

All cases cross-checked against minimatch and picomatch.

```
bun bd test test/js/bun/glob/match.test.ts
# 28 pass, 0 fail
```

Existing `bash wildmatch` tests (`[]-]`, `[]]`, `[\]a\-]`) continue to pass, confirming terminated bracket expressions with a leading literal `]` are unaffected.

Related: #32894 is the sibling fix for an unterminated `{`.
