### PR TITLE
node:worker_threads: implement resourceLimits and enforce maxOldGenerationSizeMb

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -421,7 +421,16 @@ declare module "bun" {
      * @default true
      */
     // trackUnmanagedFds?: boolean;
-    // resourceLimits?: import("worker_threads").ResourceLimits;
+
+    /**
+     * Resource limits for the worker's JS engine, in megabytes, with the same
+     * shape as Node.js. `maxOldGenerationSizeMb` caps the worker's heap: a
+     * worker whose heap is still above it after a full garbage collection is
+     * terminated and emits an `ERR_WORKER_OUT_OF_MEMORY` error event. The
+     * other fields are accepted for Node.js compatibility and reported back
+     * through `resourceLimits`, but are not enforced.
+     */
+    resourceLimits?: import("node:worker_threads").ResourceLimits;
 
     /**
      * An array of module specifiers to preload in the worker.
@@ -492,6 +501,13 @@ declare module "bun" {
      * This value is unique for each `Worker` instance inside a single process.
      */
     threadId: number;
+
+    /**
+     * The JS engine resource constraints this worker was created with, or
+     * an empty object once the worker has stopped. Inside the worker thread,
+     * it is available as `require('node:worker_threads').resourceLimits`.
+     */
+    readonly resourceLimits: import("node:worker_threads").ResourceLimits;
   }
 
   interface Env {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -80,6 +80,7 @@ const {
   9: _setEntryEvaluatedHook,
   10: _isNodeWorker,
   11: _setParentPort,
+  12: resourceLimits,
 } = $cpp("Worker.cpp", "createNodeWorkerThreadsBinding") as [
   unknown,
   number,
@@ -93,6 +94,7 @@ const {
   (hook: () => void) => void,
   boolean,
   (port: MessagePort) => void,
+  Record<string, number>,
 ];
 
 type NodeWorkerOptions = import("node:worker_threads").WorkerOptions;
@@ -316,8 +318,6 @@ Object.defineProperty(MessagePort.prototype, kInspectCustom, {
   enumerable: false,
   configurable: true,
 });
-
-let resourceLimits = {};
 
 const BUN_WORKER_STDIO_KEY = "@@bunWorkerThreadsStdio";
 const BUN_WORKER_MESSAGING_KEY = "@@bunWorkerThreadsMessaging";
@@ -1150,6 +1150,11 @@ class Worker extends EventEmitter {
 
   get threadName() {
     return this.#exited ? null : this.#name;
+  }
+
+  get resourceLimits() {
+    // Read back from the single native parse; {} once the worker stopped.
+    return this.#worker.resourceLimits;
   }
 
   ref() {

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -378,5 +378,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INSPECTOR_NOT_CONNECTED", Error],
   ["ERR_INSPECTOR_NOT_WORKER", Error],
   ["ERR_INSPECTOR_COMMAND", Error],
+  ["ERR_WORKER_OUT_OF_MEMORY", Error],
 ];
 export default errors;

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -321,6 +321,31 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
             RETURN_IF_EXCEPTION(throwScope, {});
         }
 
+        JSValue resourceLimitsValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "resourceLimits"_s));
+        RETURN_IF_EXCEPTION(throwScope, {});
+        // As in Node's parseResourceLimits: non-objects, functions and non-number fields are ignored.
+        if (resourceLimitsValue && resourceLimitsValue.isObject() && !resourceLimitsValue.isCallable()) {
+            auto* limitsObject = asObject(resourceLimitsValue);
+            WorkerResourceLimits limits;
+            auto readLimit = [&](ASCIILiteral key, double& out, std::optional<double> floor = std::nullopt) -> bool {
+                JSValue value = limitsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, key));
+                if (throwScope.exception())
+                    return false;
+                if (value && value.isNumber())
+                    out = floor ? std::max(value.asNumber(), *floor) : value.asNumber();
+                return true;
+            };
+            if (!readLimit("maxYoungGenerationSizeMb"_s, limits.maxYoungGenerationSizeMb)) return {};
+            // Node floors this one at 2 MB (MathMax(value, 2)).
+            if (!readLimit("maxOldGenerationSizeMb"_s, limits.maxOldGenerationSizeMb, 2.0)) return {};
+            if (!readLimit("codeRangeSizeMb"_s, limits.codeRangeSizeMb)) return {};
+            if (!readLimit("stackSizeMb"_s, limits.stackSizeMb)) return {};
+            // Node replaces a non-positive stack size with its 4 MB default.
+            if (!(limits.stackSizeMb > 0))
+                limits.stackSizeMb = 4;
+            options.resourceLimits = limits;
+        }
+
         JSValue execArgvValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "execArgv"_s));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (execArgvValue && execArgvValue.pureToBoolean() != TriState::False) {
@@ -431,6 +456,19 @@ JSC_DEFINE_CUSTOM_GETTER(jsWorker_threadIdGetter, (JSGlobalObject * lexicalGloba
     return JSValue::encode(jsNumber(worker.clientIdentifier() - 1));
 }
 
+JSC_DEFINE_CUSTOM_GETTER(jsWorker_resourceLimitsGetter, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))
+{
+    auto* castedThis = dynamicDowncast<JSWorker>(JSValue::decode(thisValue));
+    if (!castedThis) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    auto& worker = castedThis->wrapped();
+    // Node reports {} once the thread has exited (the proxy is already Closing inside the OOM 'error' handler).
+    if (worker.hasExited())
+        return JSValue::encode(constructEmptyObject(lexicalGlobalObject));
+    return JSValue::encode(createResourceLimitsObject(lexicalGlobalObject, worker.contextProxy().options().resourceLimits));
+}
+
 /* Hash table for prototype */
 
 static const HashTableValue JSWorkerPrototypeTableValues[] = {
@@ -440,6 +478,7 @@ static const HashTableValue JSWorkerPrototypeTableValues[] = {
     { "onmessageerror"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsWorker_onmessageerror, setJSWorker_onmessageerror } },
     { "postMessage"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWorkerPrototypeFunction_postMessage, 1 } },
     { "ref"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWorkerPrototypeFunction_ref, 0 } },
+    { "resourceLimits"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete, NoIntrinsic, { HashTableValue::GetterSetterType, jsWorker_resourceLimitsGetter, nullptr } },
     { "terminate"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWorkerPrototypeFunction_terminate, 0 } },
     { "threadId"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete, NoIntrinsic, { HashTableValue::GetterSetterType, jsWorker_threadIdGetter, nullptr } },
     { "unref"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWorkerPrototypeFunction_unref, 0 } },

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -134,7 +134,7 @@ void Worker::dispatchEvent(Event& event)
     EventTargetWithInlineData::dispatchEvent(event);
 }
 
-void Worker::dispatchCloseEvent(Event& event)
+void Worker::dispatchExitEvent(Event& event)
 {
     EventTargetWithInlineData::dispatchEvent(event);
 }
@@ -202,6 +202,17 @@ extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionSetParentPort);
+
+JSObject* createResourceLimitsObject(JSGlobalObject* globalObject, const WorkerResourceLimits& limits)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto* object = constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);
+    object->putDirect(vm, Identifier::fromString(vm, "maxYoungGenerationSizeMb"_s), jsNumber(limits.maxYoungGenerationSizeMb));
+    object->putDirect(vm, Identifier::fromString(vm, "maxOldGenerationSizeMb"_s), jsNumber(limits.maxOldGenerationSizeMb));
+    object->putDirect(vm, Identifier::fromString(vm, "codeRangeSizeMb"_s), jsNumber(limits.codeRangeSizeMb));
+    object->putDirect(vm, Identifier::fromString(vm, "stackSizeMb"_s), jsNumber(limits.stackSizeMb));
+    return object;
+}
 
 JSC_DEFINE_HOST_FUNCTION(jsReceiveMessageOnPort, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
@@ -344,7 +355,11 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
 
     bool isNodeWorker = proxy && proxy->options().kind == WorkerOptions::Kind::Node;
 
-    JSObject* array = constructEmptyArray(globalObject, nullptr, 12);
+    // Node: `{}` on the main thread, the limits this thread was created with inside a worker.
+    JSObject* resourceLimits = proxy ? createResourceLimitsObject(globalObject, proxy->options().resourceLimits) : constructEmptyObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSObject* array = constructEmptyArray(globalObject, nullptr, 13);
     RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 0, workerData);
     array->putDirectIndex(globalObject, 1, threadId);
@@ -358,6 +373,7 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     array->putDirectIndex(globalObject, 9, JSFunction::create(vm, globalObject, 1, "setEntryEvaluatedHook"_s, jsFunctionSetEntryEvaluatedHook, ImplementationVisibility::Public, NoIntrinsic));
     array->putDirectIndex(globalObject, 10, jsBoolean(isNodeWorker));
     array->putDirectIndex(globalObject, 11, JSFunction::create(vm, globalObject, 1, "setParentPort"_s, jsFunctionSetParentPort, ImplementationVisibility::Public, NoIntrinsic));
+    array->putDirectIndex(globalObject, 12, resourceLimits);
     return array;
 }
 

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -33,6 +33,7 @@
 
 namespace JSC {
 class JSGlobalObject;
+class JSObject;
 class JSValue;
 }
 
@@ -66,9 +67,9 @@ public:
     void setKeepAlive(bool);
 
     // Node worker_threads: 'message'/'error'/'messageerror' are not delivered once terminate() was
-    // called; 'close' (which carries the exit code) always is.
+    // called; 'close' (with the exit code) and the out-of-memory 'error' preceding it always are.
     void dispatchEvent(Event&) final;
-    void dispatchCloseEvent(Event&);
+    void dispatchExitEvent(Event&);
 
     const String& name() const { return m_name; }
     // Both identifiers are process-unique; threadId is derived from the worker's.
@@ -95,6 +96,8 @@ private:
 };
 
 JSC::JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject);
+// Shared by the in-worker `resourceLimits` export and the worker.resourceLimits getter (JSWorker.cpp).
+JSC::JSObject* createResourceLimitsObject(JSC::JSGlobalObject*, const WorkerResourceLimits&);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionPostMessage);
 

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -38,6 +38,7 @@
 #include "SerializedScriptValue.h"
 #include "Worker.h"
 #include "ZigGlobalObject.h"
+#include <JavaScriptCore/HeapObserver.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -68,7 +69,8 @@ void* WebWorker__create(
     BunString* preloadModulesPtr,
     size_t preloadModulesLen);
 // Raise a TerminationException in the worker VM at its next safepoint and wake its loop. Any thread.
-void WebWorker__requestTermination(void*);
+// False if the thread was already stopping.
+bool WebWorker__requestTermination(void*);
 // Toggle the keep-alive this worker holds on the parent event loop. Parent thread.
 void WebWorker__setRef(void*, bool);
 // Release that keep-alive. Parent thread.
@@ -80,6 +82,67 @@ void WebWorker__join(void*);
 void WebWorker__deref(void*);
 
 } // extern "C"
+
+// ---- resourceLimits ------------------------------------------------------------------------------
+
+// didGarbageCollect runs on whichever thread finished the collection (possibly JSC's collector thread, which has no per-thread Bun state), before the mutator resumes.
+class WorkerHeapLimitObserver final : public JSC::HeapObserver {
+    WTF_MAKE_TZONE_ALLOCATED(WorkerHeapLimitObserver);
+
+public:
+    WorkerHeapLimitObserver(WorkerMessagingProxy& proxy, JSC::VM& vm, void* workerThread, size_t limitBytes)
+        : m_proxy(proxy)
+        , m_vm(vm)
+        , m_workerThread(workerThread)
+        , m_limitBytes(limitBytes)
+    {
+    }
+
+private:
+    void willGarbageCollect() final {}
+
+    void didGarbageCollect(JSC::CollectionScope scope) final
+    {
+        // Only a full collection's survivor size is the live set; an eden collection's is not.
+        if (scope != JSC::CollectionScope::Full)
+            return;
+        if (m_proxy.m_heapLimitDisarmed.load(std::memory_order_acquire))
+            return;
+        if (m_vm.heap.sizeAfterLastFullCollection() <= m_limitBytes)
+            return;
+        // A thread that is already stopping (terminate(), process.exit()) keeps its own reason.
+        if (!WebWorker__requestTermination(m_workerThread))
+            return;
+        m_proxy.m_stoppedByHeapLimit.store(true, std::memory_order_release);
+    }
+
+    WorkerMessagingProxy& m_proxy;
+    JSC::VM& m_vm;
+    void* const m_workerThread;
+    const size_t m_limitBytes;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerHeapLimitObserver);
+
+void WorkerMessagingProxy::installHeapLimitObserver(JSC::VM& vm, void* workerThread)
+{
+    size_t limitBytes = m_options.resourceLimits.heapLimitBytes();
+    if (!limitBytes)
+        return;
+    ASSERT(!m_heapLimitObserver);
+    m_heapLimitObserver = makeUnique<WorkerHeapLimitObserver>(*this, vm, workerThread, limitBytes);
+    vm.heap.addObserver(m_heapLimitObserver.get());
+}
+
+extern "C" void WebWorker__installHeapLimitObserver(WorkerMessagingProxy* proxy, Zig::GlobalObject* globalObject, void* workerThread)
+{
+    proxy->installHeapLimitObserver(JSC::getVM(globalObject), workerThread);
+}
+
+extern "C" void WebWorker__disarmHeapLimitObserver(WorkerMessagingProxy* proxy)
+{
+    proxy->disarmHeapLimitObserver();
+}
 
 WorkerMessagingProxy::WorkerMessagingProxy(Worker& workerObject, ScriptExecutionContext& parentContext, WorkerOptions&& options)
     : m_scriptExecutionContext(&parentContext)
@@ -516,6 +579,10 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal(int32_t exitCode, 
     // Web Worker's 'close' event keeps 0 for that case (documented).
     if (m_options.kind == WorkerOptions::Kind::Node && stoppedByParent)
         exitCode = 1;
+    // Node: ERR_WORKER_OUT_OF_MEMORY always comes with exit code 1.
+    const bool stoppedByHeapLimit = m_stoppedByHeapLimit.load(std::memory_order_acquire);
+    if (stoppedByHeapLimit)
+        exitCode = 1;
 
     // Closing while 'close' dispatches so handlers observe threadId == -1 / !isOnline() but a
     // postMessage() from inside them is still accepted and dropped (browser/Node behaviour).
@@ -531,9 +598,20 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal(int32_t exitCode, 
     // task then finds it empty.
     drainMessagesToWorkerObject(*m_scriptExecutionContext, DrainBudget::UntilEmpty);
 
-    if (RefPtr workerObject = m_workerObject; workerObject && workerObject->hasEventListeners(eventNames().closeEvent)) {
-        auto event = CloseEvent::create(exitCode == 0, static_cast<unsigned short>(exitCode), exitCode == 0 ? "Worker terminated normally"_s : "Worker exited abnormally"_s);
-        workerObject->dispatchCloseEvent(event);
+    if (RefPtr workerObject = m_workerObject) {
+        // Node emits 'error' (with worker.resourceLimits already {}) and then 'exit' for a worker that hit its heap limit.
+        if (stoppedByHeapLimit && workerObject->hasEventListeners(eventNames().errorEvent)) {
+            ErrorEvent::Init init;
+            // An empty message makes worker_threads.ts emit `error` itself, keeping its `code`.
+            init.error = Bun::createError(m_scriptExecutionContext->globalObject(), Bun::ErrorCode::ERR_WORKER_OUT_OF_MEMORY,
+                "Worker terminated due to reaching memory limit: JS heap out of memory"_s);
+            auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
+            workerObject->dispatchExitEvent(event);
+        }
+        if (workerObject->hasEventListeners(eventNames().closeEvent)) {
+            auto event = CloseEvent::create(exitCode == 0, static_cast<unsigned short>(exitCode), exitCode == 0 ? "Worker terminated normally"_s : "Worker exited abnormally"_s);
+            workerObject->dispatchExitEvent(event);
+        }
     }
 
     releaseWorkerThread();

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -50,6 +50,7 @@ namespace WebCore {
 
 class Event;
 class Worker;
+class WorkerHeapLimitObserver;
 
 // The only object shared between a Worker (parent thread, script-visible) and the thread that runs
 // its global scope. Created with the Worker; outlives both the Worker object and the thread.
@@ -107,6 +108,11 @@ public:
     void workerGlobalScopeDestroyed(int32_t exitCode, bool stoppedByParent);
     void drainMessagesToWorkerGlobalScope(ScriptExecutionContext&);
 
+    // No-op without a configured resourceLimits heap limit; a limit hit stops the thread like terminate() and reports ERR_WORKER_OUT_OF_MEMORY.
+    void installHeapLimitObserver(JSC::VM&, void* workerThread);
+    // The collections run by exit handlers and teardown must not be reported as running out of memory.
+    void disarmHeapLimitObserver() { m_heapLimitDisarmed.store(true, std::memory_order_release); }
+
     // -- Either thread ---------------------------------------------------------------------------
     WorkerOptions& options() { return m_options; }
     ScriptExecutionContextIdentifier workerContextIdentifier() const { return m_workerContextIdentifier; }
@@ -144,6 +150,12 @@ private:
     void* m_workerThread { nullptr };
 
     std::atomic<State> m_state { State::Pending };
+
+    // The observer runs on whichever thread finished a collection (hence the atomics) and is never unregistered: this proxy outlives the heap it watches.
+    friend class WorkerHeapLimitObserver;
+    std::unique_ptr<WorkerHeapLimitObserver> m_heapLimitObserver;
+    std::atomic<bool> m_heapLimitDisarmed { false };
+    std::atomic<bool> m_stoppedByHeapLimit { false };
 
     // Pending -> Running happens under this lock so a task posted while Pending is either queued here
     // (and run by workerGlobalScopeStarted) or posted directly, never lost.

--- a/src/jsc/bindings/webcore/WorkerOptions.h
+++ b/src/jsc/bindings/webcore/WorkerOptions.h
@@ -8,6 +8,29 @@
 
 namespace WebCore {
 
+// node:worker_threads resourceLimits (-1 = not set, as in Node). JSC has a single heap per VM, so the generation sizes together cap the heap size after each full collection; the other two are only reported back.
+struct WorkerResourceLimits {
+    double maxYoungGenerationSizeMb { -1 };
+    double maxOldGenerationSizeMb { -1 };
+    double codeRangeSizeMb { -1 };
+    double stackSizeMb { 4 };
+
+    // 0 when no heap limit is configured.
+    size_t heapLimitBytes() const
+    {
+        if (!(maxOldGenerationSizeMb > 0) || !std::isfinite(maxOldGenerationSizeMb))
+            return 0;
+        double mb = maxOldGenerationSizeMb;
+        if (maxYoungGenerationSizeMb > 0 && std::isfinite(maxYoungGenerationSizeMb))
+            mb += maxYoungGenerationSizeMb;
+        double bytes = mb * 1024.0 * 1024.0;
+        // Casting a double beyond size_t's range is undefined behaviour.
+        if (bytes >= static_cast<double>(std::numeric_limits<size_t>::max()))
+            return std::numeric_limits<size_t>::max();
+        return static_cast<size_t>(bytes);
+    }
+};
+
 struct WorkerOptions {
     enum class Kind : uint8_t {
         // Created by the global Worker constructor
@@ -38,6 +61,8 @@ struct WorkerOptions {
     Vector<String> argv;
     // If nullopt, inherit execArgv from the parent thread
     std::optional<Vector<String>> execArgv;
+    // Defaults (no heap limit) when no resourceLimits object was passed.
+    WorkerResourceLimits resourceLimits;
 };
 
 } // namespace WebCore

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -103,7 +103,7 @@ pub struct WebWorker {
     worker_env_loader: Cell<*mut bun_dotenv::Loader>,
     /// `process.exit(code)` ran; later error paths must not overwrite its code.
     exit_called: AtomicBool,
-    /// The parent asked this thread to stop (`worker.terminate()` or an exiting
+    /// Stopped from outside (`worker.terminate()`, the heap limit or an exiting
     /// parent) while its VM was live — as opposed to the thread stopping itself,
     /// or being stopped before it started. Written under `vm_lock`.
     terminated_by_parent: AtomicBool,
@@ -146,6 +146,13 @@ unsafe extern "C" {
         message: &mut BunString,
         err: JSValue,
     );
+    // WorkerMessagingProxy.cpp; the observer passes `worker_thread` back to `request_termination`.
+    safe fn WebWorker__installHeapLimitObserver(
+        proxy: *mut c_void,
+        global: &JSGlobalObject,
+        worker_thread: *const c_void,
+    );
+    safe fn WebWorker__disarmHeapLimitObserver(proxy: *mut c_void);
     safe fn Bun__freeSharedHeaderBufferForThreadExit();
     // Raw FFI (no RAII guard) so `thread_main` can take the API lock and abandon
     // it with the VM — see the note there.
@@ -459,9 +466,9 @@ impl WebWorker {
 
     /// Ask the thread to stop: set `requested_terminate`, raise a
     /// TerminationException in its VM at the next safepoint, wake its loop.
-    /// Any thread that holds a ref (the proxy) may call this.
+    /// Any thread that holds a ref may call this; false if the thread was already stopping.
     #[unsafe(export_name = "WebWorker__requestTermination")]
-    pub(crate) extern "C" fn request_termination(this: *mut WebWorker) {
+    pub(crate) extern "C" fn request_termination(this: *mut WebWorker) -> bool {
         let this = bun_ptr::ParentRef::from(NonNull::new(this).expect("WebWorker FFI ptr"));
         // vm_lock serialises against shutdown() nulling `vm` and freeing the
         // arena it lives in — and is taken *before* the flag is published: a
@@ -471,7 +478,7 @@ impl WebWorker {
         this.vm_lock.lock();
         if this.set_requested_terminate() {
             this.vm_lock.unlock();
-            return;
+            return false;
         }
         log!("[{}] requestTermination", this.execution_context_id);
         // vm_lock held; `vm` is published/unpublished under vm_lock.
@@ -495,6 +502,7 @@ impl WebWorker {
             unsafe { (*(*vm_ptr).event_loop()).wakeup() };
         }
         this.vm_lock.unlock();
+        true
     }
 
     /// The parent is releasing this thread: drop the keep-alive on the parent's
@@ -718,6 +726,17 @@ impl WebWorker {
         // vm_lock held; this is the publish point.
         self.vm.set(vm);
         self.vm_lock.unlock();
+
+        // The observer is handed `self` from this thread because the proxy's
+        // `m_workerThread` is assigned on the parent thread, racing with us; it is
+        // installed after the publish so `request_termination` finds a live VM.
+        // SAFETY: `vm` is valid (checked above) and `global` is set by
+        // `init_worker` for the VM's lifetime; raw field read, no `&VirtualMachine`.
+        WebWorker__installHeapLimitObserver(
+            self.messaging_proxy,
+            JSGlobalObject::opaque_ref(unsafe { (*vm).global }),
+            core::ptr::from_ref(self).cast(),
+        );
 
         // Post-publish: do NOT re-form `&mut VirtualMachine`. Field/method
         // access goes through the raw `*mut` so any autoref is scoped to the
@@ -986,6 +1005,9 @@ impl WebWorker {
         self.set_status(Status::Terminated);
         bun_analytics::features::workers_terminated.fetch_add(1, Ordering::Relaxed);
         log!("[{}] shutdown", self.execution_context_id);
+
+        // The exit handlers' and teardown's collections must not report out of memory.
+        WebWorker__disarmHeapLimitObserver(self.messaging_proxy);
 
         // worker-thread only field; no other thread reads `arena`.
         let mut arena = self.arena.replace(None);

--- a/test/js/node/worker_threads/environmentdata-inherit-fixture.js
+++ b/test/js/node/worker_threads/environmentdata-inherit-fixture.js
@@ -7,7 +7,10 @@ if (isMainThread) {
 } else {
   console.log(getEnvironmentData("inherited"));
   const { depth } = workerData;
-  if (depth + 1 < 5) {
+  // Two levels prove the property (the value reaches a worker whose parent
+  // never called setEnvironmentData); each level is a full sequential JSC
+  // VM boot, so deeper chains only add debug-build time.
+  if (depth + 1 < 2) {
     new Worker(__filename, { workerData: { depth: depth + 1 } });
   }
 }

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -345,7 +345,10 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
-test("eval does not leak source code", async () => {
+// Skipped in debug: the fixture's 6 workers each lex a 100 MiB source, which
+// a debug build does at ~25 MiB/s (~30 s total), and a smaller source falls
+// below the fixture's RSS noise floor. Release + ASAN cover the regression.
+test.skipIf(isDebug)("eval does not leak source code", async () => {
   const proc = Bun.spawn({
     cmd: [bunExe(), "eval-source-leak-fixture.js"],
     env: bunEnv,
@@ -575,7 +578,7 @@ describe("environmentData", () => {
     if (errors.length > 0) throw new Error(errors);
     expect(proc.exitCode).toBe(0);
     const out = await proc.stdout.text();
-    expect(out).toBe("foo\n".repeat(5));
+    expect(out).toBe("foo\n".repeat(2));
   });
 
   test("can be used if parent thread had not imported worker_threads", async () => {
@@ -2584,4 +2587,340 @@ describe("worker stop ordering as seen by the worker's own handlers", () => {
     expect(tags).toEqual([TAG.ready, TAG.exitHandler]);
     expect(code).toBe(7);
   });
+});
+
+describe("resourceLimits", () => {
+  test("worker.resourceLimits echoes the normalized object", () => {
+    const w = new Worker(`process.exit(0)`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 32, maxYoungGenerationSizeMb: 8 },
+    });
+    expect(w.resourceLimits).toEqual({
+      maxYoungGenerationSizeMb: 8,
+      maxOldGenerationSizeMb: 32,
+      codeRangeSizeMb: -1,
+      stackSizeMb: 4,
+    });
+    return w.terminate();
+  });
+
+  test("maxOldGenerationSizeMb is floored at 2 like Node; the other keys are stored raw", () => {
+    // Node's parseResourceLimits: MathMax(obj.maxOldGenerationSizeMb, 2), for that key only.
+    const cases = [
+      { in: 0, out: 2 },
+      { in: -5, out: 2 },
+      { in: 0.5, out: 2 },
+      { in: 1, out: 2 },
+      { in: 1.99, out: 2 },
+      { in: 2, out: 2 },
+      { in: 3, out: 3 },
+    ];
+    const seen = cases.map(({ in: v }) => {
+      const w = new Worker("process.exit(0)", { eval: true, resourceLimits: { maxOldGenerationSizeMb: v } });
+      const { maxOldGenerationSizeMb } = w.resourceLimits;
+      w.terminate();
+      return { in: v, out: maxOldGenerationSizeMb };
+    });
+    expect(seen).toEqual(cases);
+
+    // The other three keys are stored unclamped in Node.
+    const w = new Worker("process.exit(0)", {
+      eval: true,
+      resourceLimits: { maxYoungGenerationSizeMb: 0, codeRangeSizeMb: -5, stackSizeMb: 0.5 },
+    });
+    expect(w.resourceLimits).toEqual({
+      maxYoungGenerationSizeMb: 0,
+      maxOldGenerationSizeMb: -1,
+      codeRangeSizeMb: -5,
+      stackSizeMb: 0.5,
+    });
+    return w.terminate();
+  });
+
+  test("worker.resourceLimits defaults when option is omitted", () => {
+    const w = new Worker(`process.exit(0)`, { eval: true });
+    expect(w.resourceLimits).toEqual({
+      maxYoungGenerationSizeMb: -1,
+      maxOldGenerationSizeMb: -1,
+      codeRangeSizeMb: -1,
+      stackSizeMb: 4,
+    });
+    return w.terminate();
+  });
+
+  test("options.resourceLimits is read once and worker.resourceLimits returns a fresh object", async () => {
+    // Like Node, the option (and each key) is parsed once, so the reported
+    // limits cannot diverge from the enforced ones, and the getter does not
+    // hand out a shared mutable object.
+    let optionReads = 0;
+    let keyReads = 0;
+    const limits = new Proxy({ maxOldGenerationSizeMb: 32 } as Record<string, unknown>, {
+      get(target, key) {
+        if (key === "maxOldGenerationSizeMb") keyReads++;
+        return target[key as string];
+      },
+    });
+    const w = new Worker(`process.exit(0)`, {
+      eval: true,
+      get resourceLimits() {
+        optionReads++;
+        return limits;
+      },
+    } as any);
+    const first = w.resourceLimits;
+    (first as any).maxOldGenerationSizeMb = 999;
+    expect({ optionReads, keyReads, second: w.resourceLimits, sameObject: first === w.resourceLimits }).toEqual({
+      optionReads: 1,
+      keyReads: 1,
+      second: { maxYoungGenerationSizeMb: -1, maxOldGenerationSizeMb: 32, codeRangeSizeMb: -1, stackSizeMb: 4 },
+      sameObject: false,
+    });
+    await w.terminate();
+  });
+
+  test("worker.resourceLimits stays {} after terminate() on a worker that exited with code 0", async () => {
+    const w = new Worker(`process.exit(0)`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 32 },
+    });
+    const [code] = await once(w, "exit");
+    // terminate() on an already-exited worker must not reset the exited
+    // state, must not hang, and resolves to undefined (not the exit code),
+    // like Node.
+    const terminated = w.terminate();
+    expect({ code, resourceLimits: w.resourceLimits }).toEqual({ code: 0, resourceLimits: {} });
+    expect(await terminated).toBeUndefined();
+  });
+
+  test("non-number resourceLimits values are ignored on both sides, like Node", async () => {
+    // Node's parseResourceLimits only accepts `typeof === 'number'`. Coercing
+    // "32"/true/null would silently enforce a limit the parent-side getter
+    // reports as unset.
+    const w = new Worker(`const wt = require("node:worker_threads"); wt.parentPort.postMessage(wt.resourceLimits);`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: "32", maxYoungGenerationSizeMb: true, stackSizeMb: null },
+    } as any);
+    const defaults = { maxYoungGenerationSizeMb: -1, maxOldGenerationSizeMb: -1, codeRangeSizeMb: -1, stackSizeMb: 4 };
+    const [inWorker] = await once(w, "message");
+    expect({ parent: w.resourceLimits, inWorker }).toEqual({ parent: defaults, inWorker: defaults });
+    await w.terminate();
+  });
+
+  test("a non-object resourceLimits is ignored, like Node", () => {
+    // Node's parseResourceLimits accepts only `typeof === 'object'`:
+    // primitives, arrays, and callables (even ones carrying a limit as an
+    // own property) all yield the defaults without throwing.
+    const defaults = { maxYoungGenerationSizeMb: -1, maxOldGenerationSizeMb: -1, codeRangeSizeMb: -1, stackSizeMb: 4 };
+    const workers = [5, [], "x", () => {}, Object.assign(() => {}, { maxOldGenerationSizeMb: 32 })].map(
+      bad => new Worker(`process.exit(0)`, { eval: true, resourceLimits: bad } as any),
+    );
+    expect(workers.map(w => w.resourceLimits)).toEqual(workers.map(() => defaults));
+    return Promise.all(workers.map(w => w.terminate()));
+  });
+
+  test("a stackSizeMb that is not positive reads back as Node's 4 MB default", () => {
+    // node_worker.cc falls back to the default stack size for stackSizeMb <= 0
+    // and writes that back into the limits the parent can read.
+    const cases = [
+      { in: 0, out: 4 },
+      { in: -1, out: 4 },
+      { in: 0.5, out: 0.5 },
+      { in: 8, out: 8 },
+    ];
+    const seen = cases.map(({ in: v }) => {
+      const w = new Worker("process.exit(0)", { eval: true, resourceLimits: { stackSizeMb: v } });
+      const { stackSizeMb } = w.resourceLimits;
+      w.terminate();
+      return { in: v, out: stackSizeMb };
+    });
+    expect(seen).toEqual(cases);
+  });
+
+  test("all four limits are reported on the parent side and inside the worker", async () => {
+    const limits = { maxYoungGenerationSizeMb: 8, maxOldGenerationSizeMb: 64, codeRangeSizeMb: 16, stackSizeMb: 2 };
+    const w = new Worker(`const wt = require("node:worker_threads"); wt.parentPort.postMessage(wt.resourceLimits);`, {
+      eval: true,
+      resourceLimits: limits,
+    });
+    const [inWorker] = await once(w, "message");
+    expect({ parent: w.resourceLimits, inWorker }).toEqual({ parent: limits, inWorker: limits });
+    await w.terminate();
+  });
+
+  test("the module-level export is {} on the main thread", () => {
+    expect(resourceLimits).toEqual({});
+  });
+
+  test("worker.resourceLimits is {} once terminate() has stopped the worker", async () => {
+    const w = new Worker(`setInterval(() => {}, 1000)`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 32 },
+    });
+    await once(w, "online");
+    const before = w.resourceLimits;
+    await w.terminate();
+    expect({ before: before.maxOldGenerationSizeMb, after: w.resourceLimits }).toEqual({ before: 32, after: {} });
+  });
+
+  test("maxYoungGenerationSizeMb alone does not cap the heap", async () => {
+    // Node sizes the nursery with it; it is not a limit on how much the worker
+    // may retain, so retaining far more than it must not be reported as OOM.
+    const w = new Worker(
+      `
+        // ~50 MB of live JS values, then a full collection while they are all still reachable.
+        const a = [];
+        for (let i = 0; i < 64; i++) a.push(new Array(100_000).fill(i));
+        Bun.gc(true);
+        require("node:worker_threads").parentPort.postMessage(a.length);
+      `,
+      { eval: true, resourceLimits: { maxYoungGenerationSizeMb: 1 } },
+    );
+    const errors: unknown[] = [];
+    w.on("error", e => errors.push(e));
+    const exited = once(w, "exit");
+    const [retained] = await once(w, "message");
+    const [code] = await exited;
+    expect({ retained, errors, code }).toEqual({ retained: 64, errors: [], code: 0 });
+  });
+
+  test("maxOldGenerationSizeMb terminates a runaway worker with ERR_WORKER_OUT_OF_MEMORY", async () => {
+    using dir = tempDir("worker-resource-limits", {
+      "main.mjs": `
+        import { Worker } from "node:worker_threads";
+        const w = new Worker(new URL("./child.mjs", import.meta.url), {
+          resourceLimits: { maxOldGenerationSizeMb: 64 },
+        });
+        console.log("parentLimits", JSON.stringify(w.resourceLimits));
+        w.on("message", m => console.log("message", JSON.stringify(m)));
+        // Node's worker.resourceLimits already reports {} inside the OOM
+        // 'error' handler (the worker has stopped by then).
+        w.on("error", e => console.log("error", e.code, e.message, JSON.stringify(w.resourceLimits)));
+        w.on("exit", c => console.log("exit", c));
+      `,
+      "child.mjs": `
+        import { resourceLimits, parentPort } from "node:worker_threads";
+        parentPort.postMessage({ resourceLimits });
+        const a = [];
+        let i = 0;
+        for (;;) {
+          a.push(new Array(10000).fill(i++));
+          // Fail the test if we blew well past the limit without being stopped.
+          if ((i & 4095) === 0) {
+            const mb = (process.memoryUsage().heapUsed / 1048576) | 0;
+            if (mb > 512) {
+              parentPort.postMessage("NOT_ENFORCED_" + mb + "MB");
+              process.exit(99);
+            }
+          }
+        }
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // One stdout line per event, in order: parent-side limits, worker-side
+    // limits, the ERR_WORKER_OUT_OF_MEMORY error, then exit code 1. A worker
+    // that outgrows the limit unchecked reports NOT_ENFORCED_<n>MB and exits 99.
+    const lines = stdout.trim().split("\n");
+    const jsonAfter = (line: string | undefined, prefix: string) => {
+      if (line === undefined || !line.startsWith(prefix)) return line;
+      try {
+        return JSON.parse(line.slice(prefix.length));
+      } catch {
+        return line;
+      }
+    };
+    const limits = { maxYoungGenerationSizeMb: -1, maxOldGenerationSizeMb: 64, codeRangeSizeMb: -1, stackSizeMb: 4 };
+    expect({
+      parentLimits: jsonAfter(lines[0], "parentLimits "),
+      workerLimits: jsonAfter(lines[1], "message "),
+      error: lines[2],
+      exit: lines[3],
+      stderr,
+      exitCode,
+    }).toEqual({
+      // worker.resourceLimits on the parent side
+      parentLimits: limits,
+      // require('worker_threads').resourceLimits inside the worker
+      workerLimits: { resourceLimits: limits },
+      error: "error ERR_WORKER_OUT_OF_MEMORY Worker terminated due to reaching memory limit: JS heap out of memory {}",
+      exit: "exit 1",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  });
+
+  test("maxOldGenerationSizeMb terminates a worker that OOMs inside vm.runInContext", async () => {
+    using dir = tempDir("worker-rl-vm-oom", {
+      "main.mjs": `
+        import { Worker } from "node:worker_threads";
+        const w = new Worker(new URL("./child.mjs", import.meta.url), {
+          resourceLimits: { maxOldGenerationSizeMb: 48 },
+        });
+        w.on("error", e => console.log("error", e.code ?? e.message));
+        w.on("exit", c => console.log("exit", c));
+      `,
+      "child.mjs": `
+        import vm from "node:vm";
+        // over() bounds the script so the test fails fast (by throwing a plain
+        // NOT_ENFORCED error) instead of hanging if the limit is unenforced.
+        // 512MB is >10x the 48MB cap, so enforcement always trips first.
+        const over = () => process.memoryUsage().heapUsed / 1048576 > 512;
+        const ctx = vm.createContext({ a: [], Array, over });
+        vm.runInContext(
+          "for (let i = 0;; i++) { a.push(new Array(10000).fill(i)); if ((i & 4095) === 0 && over()) throw new Error('NOT_ENFORCED'); }",
+          ctx,
+        );
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+      stdout: ["error ERR_WORKER_OUT_OF_MEMORY", "exit 1"],
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  });
+});
+
+// node:vm must treat the TerminationException that worker.terminate() raises
+// inside a no-timeout vm.runInContext as a worker-level termination, not a
+// script timeout or SIGINT.
+test("worker.terminate() while the worker is inside a no-timeout vm.runInContext", async () => {
+  using dir = tempDir("worker-terminate-vm", {
+    "main.mjs": `
+      import { Worker } from "node:worker_threads";
+      const w = new Worker(new URL("./child.mjs", import.meta.url));
+      w.on("message", () => w.terminate());
+      w.on("error", e => console.log("error", e.code ?? e.name));
+      w.on("exit", c => console.log("exit", c));
+    `,
+    "child.mjs": `
+      import vm from "node:vm";
+      import { parentPort } from "node:worker_threads";
+      const ctx = vm.createContext({ ping: () => parentPort.postMessage("in-vm") });
+      // Signals the parent from inside the script, then spins with no timeout.
+      vm.runInContext("ping(); for(;;);", ctx);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "exit 1\n", stderr: expect.any(String), exitCode: 0 });
 });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -282,13 +282,7 @@ describe("web worker", () => {
       stdio: ["inherit", "pipe", "inherit"],
     });
 
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
     x.exited.then(async code => {
-      clearTimeout(timer);
       if (code !== 0) {
         done(new Error("exited with non-zero code"));
       } else {
@@ -310,13 +304,7 @@ describe("web worker", () => {
       stdio: ["inherit", "pipe", "inherit"],
     });
 
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
     x.exited.then(async code => {
-      clearTimeout(timer);
       if (code !== 0) {
         done(new Error("exited with non-zero code"));
       } else {
@@ -612,8 +600,10 @@ describe("worker_threads", () => {
     // after 10 ms) — a fixed sleep races with worker startup, which under
     // debug/ASAN can exceed 200 ms.
     const [code] = await once(worker, "exit");
-    await worker.terminate();
     expect(code).toBe(2);
+    // terminate() on an already-exited worker resolves to undefined in
+    // Node, not the exit code (test-worker-terminate-null-handler.js).
+    expect(await worker.terminate()).toBeUndefined();
   });
 
   test("worker terminating forcefully properly interrupts", async () => {


### PR DESCRIPTION
Fixes #31411

### Problem

- `new Worker(file, { resourceLimits: { maxOldGenerationSizeMb: 32 } })` silently drops the option: the worker grows until the whole process runs out of memory, `worker.resourceLimits` is `undefined`, and `require("node:worker_threads").resourceLimits` inside the worker is `{}`. Node terminates the worker, emits an `'error'` whose `code` is `ERR_WORKER_OUT_OF_MEMORY`, exits it with code 1, and reports the limits through both properties.
- Cause: nothing read the option. `WorkerOptions` had no field for it, `src/js/node/worker_threads.ts` exported a placeholder `{}`, and the worker VM had no heap limit of any kind.

### Fix

- The constructor (`JSWorker.cpp`) parses the option once into `WorkerOptions::resourceLimits`, following node's `parseResourceLimits`: a non-object or callable value and non-number fields are ignored, `maxOldGenerationSizeMb` is floored at 2, and a `stackSizeMb` that is not positive reads back as node's 4 MB default. `worker.resourceLimits` (a getter on the prototype), the in-worker export (index 12 of the `createNodeWorkerThreadsBinding` array) and enforcement all read that one parse, so a getter- or Proxy-backed option is observed exactly once and the reported limits cannot differ from the enforced ones. The getter returns `{}` once the thread has exited, as node does, which includes the out-of-memory `'error'` handler.
- Enforcement (`WorkerMessagingProxy.cpp`): when `maxOldGenerationSizeMb` is set, `start_vm()` (`web_worker.rs`) registers a `JSC::HeapObserver` on the worker's heap. After each full collection it compares `sizeAfterLastFullCollection()` with the limit (plus `maxYoungGenerationSizeMb`, if given, as headroom, since JSC keeps young objects in the same heap) and, if exceeded, stops the thread through `WebWorker__requestTermination`, the same path `worker.terminate()` uses. That is why the exit looks exactly like node's: exit handlers do not run, the exit code is 1, and the proxy's existing exit task dispatches the `ERR_WORKER_OUT_OF_MEMORY` error event before the close event, so `'error'` precedes `'exit'`.
- Only a full collection measures the live set, so a worker can overshoot the limit between two of them; JSC schedules full collections in proportion to heap growth, so a runaway worker is caught within a small factor of the limit (the tests allocate until stopped and fail if they get anywhere near 512 MB). JSC's watchdog is not used because `node:vm`'s `timeout` option owns the VM's single watchdog.
- Two things keep the report honest: `WebWorker__requestTermination` now returns whether it initiated the stop, so a collection that runs while the worker is already being terminated or exiting does not relabel that exit as out-of-memory; and the thread disarms the observer when it begins shutting down, so the collections run by exit handlers and teardown cannot either. The observer's flag is set before JSC resumes the mutator (`Heap::runEndPhase` notifies observers first), so the exit task on the parent always sees it.
- A young generation size on its own configures nothing: in node it sizes the nursery and is not a limit on what the worker may retain, so capping the heap with it would fail workers that node runs fine. `codeRangeSizeMb` and `stackSizeMb` are reported back but not enforced; an unset field reads back as `-1` (node fills in V8's computed defaults there, which JSC has no equivalent of).
- Tests, in `test/js/node/worker_threads/worker_threads.test.ts` (`describe("resourceLimits")`): reporting of all four fields on both sides, the floor, the stack-size default, defaults when omitted, option read once and a fresh object per read, non-number and non-object values ignored, `{}` after a natural exit and after `terminate()`, `{}` on the main thread, a young-only limit not terminating a worker that retains ~50 MB, a runaway worker terminated with the exact node error code, message, exit code and `{}` inside the handler, the same from inside a no-timeout `vm.runInContext`, and `worker.terminate()` during a no-timeout `vm.runInContext`. All of the reporting and enforcement cases fail on main (`worker.resourceLimits` is `undefined`, the runaway workers are never stopped).
- Verified on top of main @ 04148c881c with a debug+ASAN build: `bun bd test test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts` runs all 15 resourceLimits tests green and 167 of 174 tests overall; the remaining failures were 5 s timeouts in the #37075 `terminate() races and lifecycle edges` block of `worker.test.ts`, which this change does not touch (the set of timing-out tests changed from run to run on a machine with a load average above 100 and the same file passes on main's own CI).
- Consolidates #31413 (now closed), which reported the limits without enforcing them; its stack-size rule and reporting tests are carried here.

### Background

- A `Worker` is three objects: the script-visible `WebCore::Worker` on the parent thread, the `WorkerMessagingProxy` shared between the parent and the worker thread (it owns `WorkerOptions` and outlives both the thread and the script object, which is why the observer and the out-of-memory flag live there), and the native thread object in `src/jsc/web_worker.rs`, which owns the thread's VM and is the only thing that can stop it (`request_termination`: raise a JSC termination exception at the next safepoint and wake the loop, from any thread).
- `JSC::HeapObserver::didGarbageCollect` is called at the end of every collection on whichever thread finished it, which for concurrent full collections is JSC's collector thread; that thread has none of bun's per-thread state, so the observer only uses what it captured when it was installed (the proxy, the VM and the thread object) and an any-thread entry point.
- `sizeAfterLastFullCollection()` is the heap size JSC computes for its own allocation limits at the end of a full collection, immediately before the observers are notified; it is the live set, whereas the size between collections includes garbage.
- Exit reporting runs on the parent thread in `WorkerMessagingProxy::workerGlobalScopeDestroyedInternal` after the thread has torn down its VM; it already sets the proxy to `Closing` (which is what makes `threadId` read `-1` and, now, `resourceLimits` read `{}`) before dispatching the close event that `worker_threads.ts` turns into `'exit'`. `worker_threads.ts` emits an error event's `error` object unchanged when the event has no message, which is how the `code` property reaches the `'error'` listener.
- Since #37075, `node:vm` checks the thread's `VmHandle` when a script is interrupted, and `request_termination` stops that handle; that is why a worker stopped for exceeding its limit inside `vm.runInContext` exits cleanly without the `node:vm` changes an earlier revision of this PR carried.

<details>
<summary>Branch history</summary>

For about two hours on 2026-08-13 the branch head was a merge commit (24d62c3710) whose parent order made GitHub diff the PR against a stale merge base and show ~3000 changed files; the comment-cop threads on files outside this change came from that. The branch is now a single commit on top of main with the same content (the only difference from the merge head is shorter comments), and those threads are resolved.

</details>
