### PR TITLE
node:http: emit 'end'/'error'/'close' on server sockets when the client disconnects

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -199,7 +199,7 @@ private:
         return s;
     }
 
-    static us_socket_t *onClose(us_socket_t *s, int /*code*/, void * /*reason*/) {
+    static us_socket_t *onClose(us_socket_t *s, int code, void * /*reason*/) {
         ((AsyncSocket<SSL> *)s)->uncorkWithoutSending();
 
         /* Get socket ext */
@@ -225,7 +225,7 @@ private:
         }
 
         if (httpResponseData->socketData && httpContextData->onSocketClosed) {
-            httpContextData->onSocketClosed(httpResponseData->socketData, SSL, s);
+            httpContextData->onSocketClosed(httpResponseData->socketData, SSL, s, code);
         }
         /* Signal broken HTTP request only if we have a pending request */
         if (httpResponseData->onAborted != nullptr && httpResponseData->userData != nullptr) {

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -47,7 +47,7 @@ private:
     using OnSocketDrainCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
     using OnSocketUpgradedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
     using OnClientErrorCallback = MoveOnlyFunction<void(int is_ssl, struct us_socket_t *rawSocket, uWS::HttpParserError errorCode, char *rawPacket, int rawPacketLength)>;
-    using OnSocketClosedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
+    using OnSocketClosedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket, int code);
 
     MoveOnlyFunction<void(const char *hostname)> missingServerNameHandler;
 

--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -281,7 +281,7 @@ private:
         /* For whatever reason, if we already have emitted close event, do not emit it again */
         WebSocketData *webSocketData = (WebSocketData *) (us_socket_ext(s));
         if (webSocketData->socketData && webSocketData->onSocketClosed) {
-            webSocketData->onSocketClosed(webSocketData->socketData, SSL, (us_socket_t *) s);
+            webSocketData->onSocketClosed(webSocketData->socketData, SSL, (us_socket_t *) s, code);
         }
         if (!webSocketData->isShuttingDown) {
             /* Emit close event */

--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -281,7 +281,9 @@ private:
         /* For whatever reason, if we already have emitted close event, do not emit it again */
         WebSocketData *webSocketData = (WebSocketData *) (us_socket_ext(s));
         if (webSocketData->socketData && webSocketData->onSocketClosed) {
-            webSocketData->onSocketClosed(webSocketData->socketData, SSL, (us_socket_t *) s, code);
+            /* code here is the WebSocket close-reason length (see forceClose),
+             * not a recv errno; the node:http shim expects 0 for non-error. */
+            webSocketData->onSocketClosed(webSocketData->socketData, SSL, (us_socket_t *) s, 0);
         }
         if (!webSocketData->isShuttingDown) {
             /* Emit close event */

--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -281,9 +281,10 @@ private:
         /* For whatever reason, if we already have emitted close event, do not emit it again */
         WebSocketData *webSocketData = (WebSocketData *) (us_socket_ext(s));
         if (webSocketData->socketData && webSocketData->onSocketClosed) {
-            /* code here is the WebSocket close-reason length (see forceClose),
-             * not a recv errno; the node:http shim expects 0 for non-error. */
-            webSocketData->onSocketClosed(webSocketData->socketData, SSL, (us_socket_t *) s, 0);
+            /* code is dual-purpose (see closeHandler below): on the forceClose()
+             * path it is the close-reason length (reason != NULL), on a recv()
+             * failure it is the errno (reason == NULL). Only forward the errno. */
+            webSocketData->onSocketClosed(webSocketData->socketData, SSL, (us_socket_t *) s, reason == NULL ? code : 0);
         }
         if (!webSocketData->isShuttingDown) {
             /* Emit close event */

--- a/packages/bun-uws/src/WebSocketData.h
+++ b/packages/bun-uws/src/WebSocketData.h
@@ -53,7 +53,7 @@ private:
     /* We could be a subscriber */
     Subscriber *subscriber = nullptr;
 public:
-    using OnSocketClosedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
+    using OnSocketClosedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket, int code);
     void *socketData = nullptr;
     /* node http compatibility callbacks */
     OnSocketClosedCallback onSocketClosed = nullptr;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1018,7 +1018,6 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
 
 const kBytesWritten = Symbol("kBytesWritten");
 const kEnableStreaming = Symbol("kEnableStreaming");
-const kIsTunnel = Symbol("kIsTunnel");
 function onServerSocketError(this: any, _err) {
   // Default 'error' listener so socket-level errors (e.g. res.destroy(err)
   // forwarding the error to the socket) do not crash the process as
@@ -1036,7 +1035,6 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   connecting = false;
   timeout = 0;
   [kBytesWritten] = 0;
-  [kIsTunnel] = false;
   [kHandle];
   server: Server;
   _httpMessage;
@@ -1070,10 +1068,6 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
 
   [kEnableStreaming](enable: boolean) {
-    // kIsTunnel latches: once a socket is detached into CONNECT/upgrade tunnel
-    // mode it never returns to normal request handling, and #onClose relies on
-    // it to emit 'close' on native close.
-    if (enable) this[kIsTunnel] = true;
     const handle = this[kHandle];
     if (handle) {
       if (enable) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1162,17 +1162,19 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
       process.nextTick(emitCloseNT, message);
     }
 
-    // Surface the peer disconnect on the Duplex itself. libus close codes
-    // 0/1/2 are clean/self-initiated; anything above is a recv errno (RST).
-    // `destroyed` guards the path where onServerRequestEvent already ran.
+    // Surface the disconnect on the Duplex itself. libus close codes 0/1/2
+    // cover clean FIN and self-initiated close; anything above is a recv
+    // errno (RST). `destroyed` guards the onServerRequestEvent path; `ended`
+    // guards CONNECT/upgrade tunnels whose readable side was already EOF'd
+    // via onSocketData(last=true) before this ran.
     if (!this.destroyed) {
-      if (code > 2) {
-        const err = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };
-        err.errno = -(code | 0);
+      const ended = this._readableState?.ended;
+      if (code > 2 && !ended) {
+        const err = new ConnResetException("read ECONNRESET") as Error & { syscall?: string };
         err.syscall = "read";
         this.destroy(err);
       } else {
-        if (this.readable) {
+        if (!ended) {
           this.push(null);
           this.read(0);
         }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1162,11 +1162,9 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
       process.nextTick(emitCloseNT, message);
     }
 
-    // Surface the disconnect on the Duplex itself. libus close codes 0/1/2
-    // cover clean FIN and self-initiated close; anything above is a recv
-    // errno (RST). `destroyed` guards the onServerRequestEvent path; `ended`
-    // guards CONNECT/upgrade tunnels whose readable side was already EOF'd
-    // via onSocketData(last=true) before this ran.
+    // Surface the disconnect on the Duplex itself. libus close codes >2
+    // are recv errnos (RST); 0/1/2 cover clean FIN and self-initiated close.
+    // `ended` preserves tunnels already EOF'd by onSocketData(last=true).
     if (!this.destroyed) {
       const ended = this._readableState?.ended;
       if (code > 2 && !ended) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1120,7 +1120,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
       req.destroy();
     }
   }
-  #onClose() {
+  #onClose(code) {
     this[kHandle] = null;
     this.server?.[kTrackedConnections]?.delete(this);
 
@@ -1162,11 +1162,22 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
       process.nextTick(emitCloseNT, message);
     }
 
-    // A tunneled/upgraded connection (CONNECT or WebSocket upgrade) is detached
-    // from the request/response lifecycle, so end the Duplex on native close to
-    // emit 'close' for the upgrade handler and user listeners, like Node.js.
-    if (this[kIsTunnel] && !this.destroyed) {
-      this.destroy();
+    // Surface the peer disconnect on the Duplex itself. libus close codes
+    // 0/1/2 are clean/self-initiated; anything above is a recv errno (RST).
+    // `destroyed` guards the path where onServerRequestEvent already ran.
+    if (!this.destroyed) {
+      if (code > 2) {
+        const err = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };
+        err.errno = -(code | 0);
+        err.syscall = "read";
+        this.destroy(err);
+      } else {
+        if (this.readable) {
+          this.push(null);
+          this.read(0);
+        }
+        this.destroy();
+      }
     }
   }
   #onCloseForDestroy(closeCallback, err?: Error) {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -455,10 +455,10 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
 template<bool isSSL>
 static void assignOnNodeJSCompat(uWS::TemplatedApp<isSSL>* app)
 {
-    app->setOnSocketClosed([](void* socketData, int is_ssl, struct us_socket_t* rawSocket) -> void {
+    app->setOnSocketClosed([](void* socketData, int is_ssl, struct us_socket_t* rawSocket, int code) -> void {
         auto* socket = reinterpret_cast<JSNodeHTTPServerSocket*>(socketData);
         ASSERT(rawSocket == socket->socket || socket->socket == nullptr);
-        socket->onClose();
+        socket->onClose(code);
     });
     app->setOnSocketDrain([](void* socketData, int is_ssl, struct us_socket_t* rawSocket) -> void {
         auto* socket = reinterpret_cast<JSNodeHTTPServerSocket*>(socketData);

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -142,7 +142,7 @@ void JSNodeHTTPServerSocket::detach()
     this->strongThis.clear();
 }
 
-void JSNodeHTTPServerSocket::onClose()
+void JSNodeHTTPServerSocket::onClose(int code)
 {
     this->socket = nullptr;
     if (auto* res = this->currentResponseObject.get(); res != nullptr && res->m_ctx != nullptr) {
@@ -169,7 +169,7 @@ void JSNodeHTTPServerSocket::onClose()
         return;
     }
 
-    scriptExecutionContext->postTask([self = this](ScriptExecutionContext& context) {
+    scriptExecutionContext->postTask([self = this, code](ScriptExecutionContext& context) {
         WTF::NakedPtr<JSC::Exception> exception;
         auto* globalObject = defaultGlobalObject(context.globalObject());
         auto* thisObject = self;
@@ -183,6 +183,7 @@ void JSNodeHTTPServerSocket::onClose()
         }
         auto callData = JSC::getCallData(callbackObject);
         MarkedArgumentBuffer args;
+        args.append(JSC::jsNumber(code));
         EnsureStillAliveScope ensureStillAlive(self);
 
         if (globalObject->scriptExecutionStatus(globalObject, thisObject) == ScriptExecutionStatus::Running) {

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -102,7 +102,7 @@ public:
     }
 
     void detach();
-    void onClose();
+    void onClose(int code = 0);
     void onDrain();
     void onData(const char* data, int length, bool last);
 

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -61,12 +61,28 @@ test.concurrent("WebSocket upgrade should unref poll_ref from response", async (
   expect(exitCode).toBe(0);
 });
 
-test.concurrent("RST on a ws-upgraded connection emits 'error' ECONNRESET then 'close' on the socket", async () => {
+// Not test.concurrent: the "unref poll_ref" test above spawns a debug
+// subprocess that already runs close to the per-test budget, and an extra
+// concurrent sibling starves it past the timeout.
+test("RST on a ws-upgraded connection emits 'error' ECONNRESET then 'close' on the socket", async () => {
   const events: string[] = [];
   const closed = Promise.withResolvers<void>();
   const upgraded = Promise.withResolvers<void>();
+  const handshake = Promise.withResolvers<void>();
+  // Before `disconnecting` flips, a client/wss error or early client close is
+  // a setup failure, not the behaviour under test: reject instead of letting
+  // the awaits below time out.
+  let disconnecting = false;
+  const fail = (why: string) => (e?: unknown) => {
+    if (disconnecting) return;
+    const err = new Error(why + (e instanceof Error ? ": " + e.message : ""));
+    handshake.reject(err);
+    upgraded.reject(err);
+    closed.reject(err);
+  };
   const server = http.createServer();
   const wss = new WebSocketServer({ server });
+  wss.on("error", fail("ws server errored during setup"));
   wss.on("connection", ws => {
     ws.on("error", () => {});
     upgraded.resolve();
@@ -87,7 +103,8 @@ test.concurrent("RST on a ws-upgraded connection emits 'error' ECONNRESET then '
 
     const client = net.connect(port, "127.0.0.1");
     client.setNoDelay(true);
-    client.on("error", () => {});
+    client.on("error", fail("client errored during setup"));
+    client.on("close", fail("client closed before the upgrade completed"));
     client.on("connect", () => {
       client.write(
         `GET / HTTP/1.1\r\nHost: localhost:${port}\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
@@ -95,7 +112,6 @@ test.concurrent("RST on a ws-upgraded connection emits 'error' ECONNRESET then '
       );
     });
     let buf = "";
-    const handshake = Promise.withResolvers<void>();
     client.on("data", chunk => {
       buf += chunk.toString("latin1");
       if (buf.includes("\r\n\r\n")) handshake.resolve();
@@ -105,6 +121,7 @@ test.concurrent("RST on a ws-upgraded connection emits 'error' ECONNRESET then '
     // The ws server has adopted the socket: the RST below exercises the
     // WebSocketContext onClose path, not the plain HTTP one.
     await upgraded.promise;
+    disconnecting = true;
     client.resetAndDestroy();
     await closed.promise;
     expect(events).toEqual(["connection", "socket-error ECONNRESET", "socket-close"]);

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as options } from "harness";
+import http from "http";
 import https from "https";
+import net from "node:net";
 import type { AddressInfo } from "node:net";
 import tls from "tls";
 import { WebSocketServer } from "ws";
@@ -57,6 +59,50 @@ test.concurrent("WebSocket upgrade should unref poll_ref from response", async (
   expect(stderr).not.toContain("BUG_DETECTED");
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
+});
+
+test.concurrent("RST on a ws-upgraded connection emits 'error' ECONNRESET then 'close' on the socket", async () => {
+  const events: string[] = [];
+  const closed = Promise.withResolvers<void>();
+  const server = http.createServer();
+  const wss = new WebSocketServer({ server });
+  wss.on("connection", ws => ws.on("error", () => {}));
+  server.on("connection", socket => {
+    events.push("connection");
+    socket.on("end", () => events.push("socket-end"));
+    socket.on("error", (e: any) => events.push("socket-error " + e.code));
+    socket.on("close", () => {
+      events.push("socket-close");
+      closed.resolve();
+    });
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await new Promise<void>(resolve => server.once("listening", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const client = net.connect(port, "127.0.0.1");
+    client.setNoDelay(true);
+    client.on("error", () => {});
+    client.on("connect", () => {
+      client.write(
+        `GET / HTTP/1.1\r\nHost: localhost:${port}\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
+          "Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n",
+      );
+    });
+    let buf = "";
+    client.on("data", chunk => {
+      buf += chunk.toString("latin1");
+      // Reset once the 101 handshake is complete so the server-side close is
+      // driven by a recv() error, not a FIN.
+      if (buf.includes("\r\n\r\n")) client.resetAndDestroy();
+    });
+    await closed.promise;
+    expect(events).toEqual(["connection", "socket-error ECONNRESET", "socket-close"]);
+  } finally {
+    wss.close();
+    server.close();
+  }
 });
 
 test.concurrent("should not crash when closing sockets after upgrade", async () => {

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -64,9 +64,13 @@ test.concurrent("WebSocket upgrade should unref poll_ref from response", async (
 test.concurrent("RST on a ws-upgraded connection emits 'error' ECONNRESET then 'close' on the socket", async () => {
   const events: string[] = [];
   const closed = Promise.withResolvers<void>();
+  const upgraded = Promise.withResolvers<void>();
   const server = http.createServer();
   const wss = new WebSocketServer({ server });
-  wss.on("connection", ws => ws.on("error", () => {}));
+  wss.on("connection", ws => {
+    ws.on("error", () => {});
+    upgraded.resolve();
+  });
   server.on("connection", socket => {
     events.push("connection");
     socket.on("end", () => events.push("socket-end"));
@@ -91,12 +95,17 @@ test.concurrent("RST on a ws-upgraded connection emits 'error' ECONNRESET then '
       );
     });
     let buf = "";
+    const handshake = Promise.withResolvers<void>();
     client.on("data", chunk => {
       buf += chunk.toString("latin1");
-      // Reset once the 101 handshake is complete so the server-side close is
-      // driven by a recv() error, not a FIN.
-      if (buf.includes("\r\n\r\n")) client.resetAndDestroy();
+      if (buf.includes("\r\n\r\n")) handshake.resolve();
     });
+    await handshake.promise;
+    expect(buf.slice(0, "HTTP/1.1 101".length)).toBe("HTTP/1.1 101");
+    // The ws server has adopted the socket: the RST below exercises the
+    // WebSocketContext onClose path, not the plain HTTP one.
+    await upgraded.promise;
+    client.resetAndDestroy();
     await closed.promise;
     expect(events).toEqual(["connection", "socket-error ECONNRESET", "socket-close"]);
   } finally {

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as options } from "harness";
 import http from "http";
 import https from "https";
-import net from "node:net";
 import type { AddressInfo } from "node:net";
+import net from "node:net";
 import tls from "tls";
 import { WebSocketServer } from "ws";
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2995,6 +2995,7 @@ describe("'connection' socket emits disconnect events", () => {
     const ev: string[] = [];
     const closed = Promise.withResolvers<void>();
     const requestServed = Promise.withResolvers<void>();
+    const responseReceived = Promise.withResolvers<void>();
     const server = createServer((req, res) => {
       req.resume();
       res.on("finish", requestServed.resolve);
@@ -3014,10 +3015,21 @@ describe("'connection' socket emits disconnect events", () => {
       await once(server, "listening");
       const { port } = server.address() as AddressInfo;
 
-      const responseReceived = Promise.withResolvers<void>();
+      // Before `disconnecting` flips, a client error or early close is a
+      // setup failure, not the behaviour under test: reject instead of
+      // letting the awaits below time out.
+      let disconnecting = false;
+      const fail = (why: string) => (e?: unknown) => {
+        if (disconnecting) return;
+        const err = new Error(why + (e instanceof Error ? ": " + e.message : ""));
+        requestServed.reject(err);
+        responseReceived.reject(err);
+        closed.reject(err);
+      };
       const client = connect(port, "127.0.0.1");
       client.setNoDelay(true);
-      client.on("error", () => {});
+      client.on("error", fail("client errored during setup"));
+      client.on("close", fail("client closed before the response was read"));
       client.on("connect", () => client.write("GET / HTTP/1.1\r\nHost: a\r\n\r\n"));
       let buf = "";
       client.on("data", chunk => {
@@ -3027,6 +3039,7 @@ describe("'connection' socket emits disconnect events", () => {
       // Wait for the response to be fully sent and received so the server
       // socket is in keep-alive idle state when the client disconnects.
       await Promise.all([requestServed.promise, responseReceived.promise]);
+      disconnecting = true;
       if (rst) {
         client.resetAndDestroy();
       } else {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2990,6 +2990,64 @@ it("clientError after a kept-alive request reuses the connection's socket and un
   }
 });
 
+describe("'connection' socket emits disconnect events", () => {
+  async function probe(rst: boolean) {
+    const ev: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    const requestServed = Promise.withResolvers<void>();
+    const server = createServer((req, res) => {
+      req.resume();
+      res.end("ok");
+      res.on("finish", requestServed.resolve);
+    });
+    server.on("connection", s => {
+      ev.push("connection");
+      s.on("end", () => ev.push("socket-end"));
+      s.on("error", (e: any) => ev.push("socket-error " + e.code));
+      s.on("close", () => {
+        ev.push("socket-close");
+        closed.resolve();
+      });
+    });
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+
+      const responseReceived = Promise.withResolvers<void>();
+      const client = connect(port, "127.0.0.1");
+      client.setNoDelay(true);
+      client.on("error", () => {});
+      client.on("connect", () => client.write("GET / HTTP/1.1\r\nHost: a\r\n\r\n"));
+      let buf = "";
+      client.on("data", chunk => {
+        buf += chunk.toString("latin1");
+        if (buf.includes("\r\n\r\nok")) responseReceived.resolve();
+      });
+      // Wait for the response to be fully sent and received so the server
+      // socket is in keep-alive idle state when the client disconnects.
+      await Promise.all([requestServed.promise, responseReceived.promise]);
+      if (rst) {
+        client.resetAndDestroy();
+      } else {
+        client.end();
+      }
+      await closed.promise;
+    } finally {
+      server.close();
+    }
+    return ev;
+  }
+
+  it("on FIN: 'end' then 'close'", async () => {
+    expect(await probe(false)).toEqual(["connection", "socket-end", "socket-close"]);
+  });
+
+  it("on RST: 'error' ECONNRESET then 'close'", async () => {
+    expect(await probe(true)).toEqual(["connection", "socket-error ECONNRESET", "socket-close"]);
+  });
+});
+
 it("req.upgrade reflects the upgrade dispatch decision like Node.js", async () => {
   // true inside the 'upgrade' listener; false for an Upgrade-carrying request
   // that falls through to 'request' (no Connection: upgrade token here).

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2997,8 +2997,8 @@ describe("'connection' socket emits disconnect events", () => {
     const requestServed = Promise.withResolvers<void>();
     const server = createServer((req, res) => {
       req.resume();
-      res.end("ok");
       res.on("finish", requestServed.resolve);
+      res.end("ok");
     });
     server.on("connection", s => {
       ev.push("connection");

--- a/test/regression/issue/32734.test.ts
+++ b/test/regression/issue/32734.test.ts
@@ -17,7 +17,10 @@ test("node:http upgrade socket emits 'close' when the WebSocket peer closes", as
   const rawSocketClosed = Promise.withResolvers<void>();
 
   server.on("upgrade", (req, socket, head) => {
-    socket.once("error", err => rawSocketClosed.reject(err));
+    // TCP teardown after a graceful WebSocket close can surface as
+    // ECONNRESET on Windows; the behaviour under test is that 'close'
+    // fires, so swallow a preceding 'error'.
+    socket.once("error", () => {});
     socket.once("close", () => rawSocketClosed.resolve());
     // `ws` is load-bearing, not incidental: only its graceful bidirectional
     // close handshake (close frame -> reply -> both FIN) reaches the native


### PR DESCRIPTION
## What does this PR do?

The per-connection `net.Socket` passed to a `node:http` server's `'connection'` event (and exposed as `req.socket`) never emitted `'end'`, `'error'`, or `'close'` when the client closed the connection while it was sitting idle in keep-alive. Everything that keys per-connection cleanup off those events (on-finished, `ws` upgrade bookkeeping, connection counters, graceful-shutdown drain loops) saw every connection as permanently alive from the application's point of view.

## Reproduction

```js
import http from 'node:http';
import net from 'node:net';
async function probe(mode) {
  return new Promise(res => {
    const ev = []; const srv = http.createServer((q, r) => { q.resume(); r.end('ok'); });
    srv.on('connection', s => { ev.push('connection');
      s.on('end', () => ev.push('socket-end')); s.on('error', e => ev.push('socket-error ' + e.code)); s.on('close', () => ev.push('socket-close')); });
    srv.listen(0, '127.0.0.1', () => {
      const s = net.connect(srv.address().port); s.setNoDelay(true); s.on('error', () => {});
      s.on('connect', () => s.write('GET / HTTP/1.1\r\nHost:a\r\n\r\n')); s.resume();
      setTimeout(() => { mode === 'fin' ? s.end() : s.resetAndDestroy(); }, 200);
      setTimeout(() => { srv.close(); res({ mode, serverSocketEvents: ev }); }, 2000);
    });
  });
}
console.log(JSON.stringify(await probe('fin')));
console.log(JSON.stringify(await probe('rst')));
```

Bun before:
```
{"mode":"fin","serverSocketEvents":["connection"]}
{"mode":"rst","serverSocketEvents":["connection"]}
```

Node.js v26.3.0 / Bun after:
```
{"mode":"fin","serverSocketEvents":["connection","socket-end","socket-close"]}
{"mode":"rst","serverSocketEvents":["connection","socket-error ECONNRESET","socket-close"]}
```

## Cause

Two gaps:

1. `uWS::HttpContext::onClose` received the usockets close code (0 for FIN, errno for RST) but dropped it; the `onSocketClosed` node-compat callback had no way to tell a clean close from a reset.
2. `NodeHTTPServerSocket.#onClose` (the JS `handle.onclose`) only tore down the in-flight `req`/`res`; it never destroyed the Duplex itself. When the last request on the connection had already completed, the per-request abort path was skipped (`REQUEST_HAS_COMPLETED` short-circuits `handle_abort_or_timeout`), so nothing destroyed the socket at all.

## Fix

Thread the close code through `OnSocketClosedCallback` -> `JSNodeHTTPServerSocket::onClose(code)` -> the JS `handle.onclose(code)` callback. In `#onClose`, when the Duplex has not already been destroyed by the mid-request abort path:

- clean close (code 0/1/2): `push(null)` + `read(0)` so `'end'` fires, then `destroy()` for `'close'`
- recv error (code > 2, e.g. ECONNRESET from RST): `destroy(ConnResetException)` so `'error'` fires before `'close'`

This matches Node's `onStreamRead` behaviour for server sockets.

Related: #28979 fixes an overlapping mid-request-abort scenario with a JS-only change; this PR additionally distinguishes FIN from RST so RST surfaces as `'error' ECONNRESET` rather than `'end'`.

## How did you verify your code works?

New tests in `test/js/node/http/node-http.test.ts` cover both FIN and RST on a keep-alive-idle connection and assert the exact event sequence Node.js produces. Verified against Node v26.3.0. Existing `test/js/node/http/`, `test/js/third_party/express/res.sendFile.test.ts`, and related `test/js/node/test/parallel/test-http-*` pass.


Fixes #28976

## Rebase note

Rebased onto main after #32737 landed. That PR added a tunnel-only `this.destroy()` at the end of `#onClose` gated on a new `kIsTunnel` flag. The `#onClose` block in this PR destroys the Duplex for every socket (not only tunnels) with FIN-vs-RST classification, which subsumes the tunnel-only path, so the conflict was resolved by keeping this PR's block and removing the now-unused `kIsTunnel` symbol/field. The #32734 regression tests (both the upgrade and CONNECT cases) continue to pass.