### PR TITLE
DOMException: inherit from ErrorInstance for [[ErrorData]] and .stack

### DIFF
--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -27,6 +27,7 @@
 #include "napi_handle_scope.h"
 #include "NativePromiseContext.h"
 #include "StrongRootBlock.h"
+#include "JSDOMException.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -39,6 +40,7 @@ JSHeapData::JSHeapData(Heap& heap)
     , m_heapCellTypeForBakeGlobalObject(JSC::IsoHeapCellType::Args<Bake::GlobalObject>())
     , m_heapCellTypeForNapiHandleScopeImpl(JSC::IsoHeapCellType::Args<Bun::NapiHandleScopeImpl>())
     , m_heapCellTypeForNativePromiseContext(JSC::IsoHeapCellType::Args<Bun::NativePromiseContext>())
+    , m_heapCellTypeForJSDOMException(JSC::IsoHeapCellType::Args<WebCore::JSDOMException>())
     , m_domConstructorSpace ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, JSDOMConstructorBase)
     , m_domNamespaceObjectSpace ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, JSDOMObject)
     , m_subspaces(makeUnique<ExtendedDOMIsoSubspaces>())

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -97,6 +97,7 @@ public:
     JSC::IsoHeapCellType m_heapCellTypeForNapiHandleScopeImpl;
     JSC::IsoHeapCellType m_heapCellTypeForBakeGlobalObject;
     JSC::IsoHeapCellType m_heapCellTypeForNativePromiseContext;
+    JSC::IsoHeapCellType m_heapCellTypeForJSDOMException;
     // JSC::IsoHeapCellType m_heapCellTypeForGeneratedClass;
 
 private:

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -416,8 +416,8 @@ static String computeErrorInfoWithoutPrepareStackTrace(
                 lexicalGlobalObject = errorInstance->globalObject();
             }
             if (auto* domException = dynamicDowncast<WebCore::JSDOMException>(instance)) {
-                name = domException->wrapped().name();
-                message = domException->wrapped().message();
+                name = domException->displayName(vm);
+                message = domException->displayMessage(vm);
             } else {
                 name = instance->sanitizedNameString(lexicalGlobalObject);
                 RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -22,6 +22,7 @@
 #include "BunClientData.h"
 #include "CallSite.h"
 #include "ErrorStackTrace.h"
+#include "JSDOMException.h"
 #include "headers-handwritten.h"
 
 #include <wtf/Scope.h>
@@ -414,10 +415,15 @@ static String computeErrorInfoWithoutPrepareStackTrace(
             if (!lexicalGlobalObject) {
                 lexicalGlobalObject = errorInstance->globalObject();
             }
-            name = instance->sanitizedNameString(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, {});
-            message = instance->sanitizedMessageString(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, {});
+            if (auto* domException = dynamicDowncast<WebCore::JSDOMException>(instance)) {
+                name = domException->wrapped().name();
+                message = domException->wrapped().message();
+            } else {
+                name = instance->sanitizedNameString(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                message = instance->sanitizedMessageString(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
         }
     }
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -679,8 +679,13 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
     }
 
     if (source->stackTrace()) {
-        destination->stackTrace()->appendVector(*source->stackTrace());
-        source->stackTrace()->clear();
+        // Mutate m_stackTrace only through setStackFrames: its cellLock pairs with
+        // concurrent readers (JSDOMException::visitChildren on the GC marker thread).
+        WTF::Vector<JSC::StackFrame> combined;
+        combined.appendVector(*destination->stackTrace());
+        combined.appendVector(*source->stackTrace());
+        destination->setStackFrames(vm, WTF::move(combined));
+        source->setStackFrames(vm, {});
     }
 
     return JSC::JSValue::encode(jsUndefined());
@@ -730,7 +735,9 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
         WTF::Vector<JSC::StackFrame> emptyTrace;
         result = computeErrorInfoToJSValue(vm, emptyTrace, line, column, sourceURL, errorObject, nullptr);
     } else {
-        auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
+        // Copy, don't move: stealing the live buffer out of m_stackTrace outside the
+        // cellLock races with a concurrent visitChildren iterating it (JSDOMException).
+        auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(*stackTrace);
         JSC::MarkedArgumentBuffer protectedFrameCells;
         protectedFrameCells.ensureCapacity(ownedStackTrace->size() * 2);
         for (auto& frame : *ownedStackTrace) {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -679,8 +679,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
     }
 
     if (source->stackTrace()) {
-        // Mutate m_stackTrace only through setStackFrames: its cellLock pairs with
-        // concurrent readers (JSDOMException::visitChildren on the GC marker thread).
+        // setStackFrames takes the cellLock that JSDOMException::visitChildren reads under.
         WTF::Vector<JSC::StackFrame> combined;
         combined.appendVector(*destination->stackTrace());
         combined.appendVector(*source->stackTrace());
@@ -735,8 +734,7 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
         WTF::Vector<JSC::StackFrame> emptyTrace;
         result = computeErrorInfoToJSValue(vm, emptyTrace, line, column, sourceURL, errorObject, nullptr);
     } else {
-        // Copy, don't move: stealing the live buffer out of m_stackTrace outside the
-        // cellLock races with a concurrent visitChildren iterating it (JSDOMException).
+        // Copy: a move here races JSDOMException::visitChildren reading under the cellLock.
         auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(*stackTrace);
         JSC::MarkedArgumentBuffer protectedFrameCells;
         protectedFrameCells.ensureCapacity(ownedStackTrace->size() * 2);

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -103,7 +103,9 @@ String retrieveErrorMessage(JSGlobalObject& lexicalGlobalObject, VM& vm, JSValue
     // FIXME: <http://webkit.org/b/115087> Web Inspector: WebCore::reportException should not evaluate JavaScript handling exceptions
     // If this is a custom exception object, call toString on it to try and get a nice string representation for the exception.
     String errorMessage;
-    if (auto* error = dynamicDowncast<ErrorInstance>(exception))
+    if (auto* error = dynamicDowncast<JSDOMException>(exception))
+        errorMessage = makeString(error->wrapped().name(), ": "_s, error->wrapped().message());
+    else if (auto* error = dynamicDowncast<ErrorInstance>(exception))
         errorMessage = error->sanitizedToString(&lexicalGlobalObject);
     else
         errorMessage = exception.toWTFString(&lexicalGlobalObject);
@@ -184,7 +186,6 @@ JSValue createDOMException(JSGlobalObject* lexicalGlobalObject, ExceptionCode ec
         JSValue errorObject = toJS(lexicalGlobalObject, globalObject, DOMException::create(ec, message));
 
         ASSERT(errorObject);
-        addErrorInfo(lexicalGlobalObject, asObject(errorObject), true);
         return errorObject;
     }
     }

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -103,11 +103,9 @@ String retrieveErrorMessage(JSGlobalObject& lexicalGlobalObject, VM& vm, JSValue
     // FIXME: <http://webkit.org/b/115087> Web Inspector: WebCore::reportException should not evaluate JavaScript handling exceptions
     // If this is a custom exception object, call toString on it to try and get a nice string representation for the exception.
     String errorMessage;
-    if (auto* error = dynamicDowncast<JSDOMException>(exception)) {
-        auto name = error->displayName(vm);
-        auto message = error->displayMessage(vm);
-        errorMessage = message.isEmpty() ? name : makeString(name, ": "_s, message);
-    } else if (auto* error = dynamicDowncast<ErrorInstance>(exception))
+    if (auto* error = dynamicDowncast<JSDOMException>(exception))
+        errorMessage = error->displayHeader(vm);
+    else if (auto* error = dynamicDowncast<ErrorInstance>(exception))
         errorMessage = error->sanitizedToString(&lexicalGlobalObject);
     else
         errorMessage = exception.toWTFString(&lexicalGlobalObject);

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -104,8 +104,9 @@ String retrieveErrorMessage(JSGlobalObject& lexicalGlobalObject, VM& vm, JSValue
     // If this is a custom exception object, call toString on it to try and get a nice string representation for the exception.
     String errorMessage;
     if (auto* error = dynamicDowncast<JSDOMException>(exception)) {
-        auto& impl = error->wrapped();
-        errorMessage = impl.message().isEmpty() ? impl.name() : makeString(impl.name(), ": "_s, impl.message());
+        auto name = error->displayName(vm);
+        auto message = error->displayMessage(vm);
+        errorMessage = message.isEmpty() ? name : makeString(name, ": "_s, message);
     } else if (auto* error = dynamicDowncast<ErrorInstance>(exception))
         errorMessage = error->sanitizedToString(&lexicalGlobalObject);
     else

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -103,9 +103,10 @@ String retrieveErrorMessage(JSGlobalObject& lexicalGlobalObject, VM& vm, JSValue
     // FIXME: <http://webkit.org/b/115087> Web Inspector: WebCore::reportException should not evaluate JavaScript handling exceptions
     // If this is a custom exception object, call toString on it to try and get a nice string representation for the exception.
     String errorMessage;
-    if (auto* error = dynamicDowncast<JSDOMException>(exception))
-        errorMessage = makeString(error->wrapped().name(), ": "_s, error->wrapped().message());
-    else if (auto* error = dynamicDowncast<ErrorInstance>(exception))
+    if (auto* error = dynamicDowncast<JSDOMException>(exception)) {
+        auto& impl = error->wrapped();
+        errorMessage = impl.message().isEmpty() ? impl.name() : makeString(impl.name(), ": "_s, impl.message());
+    } else if (auto* error = dynamicDowncast<ErrorInstance>(exception))
         errorMessage = error->sanitizedToString(&lexicalGlobalObject);
     else
         errorMessage = exception.toWTFString(&lexicalGlobalObject);

--- a/src/jsc/bindings/JSDOMWrapperCache.h
+++ b/src/jsc/bindings/JSDOMWrapperCache.h
@@ -45,15 +45,15 @@ template<typename WrapperClass> JSC::JSObject* getDOMPrototype(JSC::VM&, JSDOMGl
 JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, JSC::ArrayBuffer*);
 void* wrapperKey(JSC::ArrayBuffer*);
 
-std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, void*);
+std::optional<JSC::JSObject*> getInlineCachedWrapper(DOMWrapperWorld&, void*);
 std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*);
 std::optional<JSC::JSArrayBuffer*> getInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*);
 
-bool setInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*, JSC::WeakHandleOwner*);
+bool setInlineCachedWrapper(DOMWrapperWorld&, void*, JSC::JSObject*, JSC::WeakHandleOwner*);
 bool setInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*, JSDOMObject* wrapper, JSC::WeakHandleOwner* wrapperOwner);
 bool setInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*, JSC::JSArrayBuffer* wrapper, JSC::WeakHandleOwner* wrapperOwner);
 
-bool clearInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*);
+bool clearInlineCachedWrapper(DOMWrapperWorld&, void*, JSC::JSObject*);
 bool clearInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*, JSDOMObject* wrapper);
 bool clearInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*, JSC::JSArrayBuffer* wrapper);
 
@@ -98,9 +98,9 @@ inline void* wrapperKey(JSC::ArrayBuffer* domObject)
     return domObject;
 }
 
-inline std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, void*) { return std::nullopt; }
-inline bool setInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*, JSC::WeakHandleOwner*) { return false; }
-inline bool clearInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*) { return false; }
+inline std::optional<JSC::JSObject*> getInlineCachedWrapper(DOMWrapperWorld&, void*) { return std::nullopt; }
+inline bool setInlineCachedWrapper(DOMWrapperWorld&, void*, JSC::JSObject*, JSC::WeakHandleOwner*) { return false; }
+inline bool clearInlineCachedWrapper(DOMWrapperWorld&, void*, JSC::JSObject*) { return false; }
 
 inline std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject)
 {

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -461,8 +461,7 @@ static JSC::JSValue getNonObservable(JSC::VM& vm, JSC::JSGlobalObject* global, J
     PropertySlot slot = PropertySlot(obj, PropertySlot::InternalMethodType::VMInquiry, &vm);
     bool found = obj->getNonIndexPropertySlot(global, propertyName, slot);
     RETURN_IF_EXCEPTION(scope, {});
-    // Only plain data properties: accessors AND native custom getters
-    // (e.g. DOMException.prototype.code) are observable and must not run here.
+    // isValue() also rejects custom getters (DOMException.prototype.code), which isAccessor() does not.
     if (!found || !slot.isValue())
         return {};
     JSValue value = slot.getValue(global, propertyName);

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -512,7 +512,7 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
     }
 
     if (auto* domException = dynamicDowncast<WebCore::JSDOMException>(err))
-        except.name = Bun::toStringRef(domException->wrapped().name());
+        except.name = Bun::toStringRef(domException->displayName(vm));
     else
         except.name = Bun::toStringRef(err->sanitizedNameString(global));
     if (!scope.clearExceptionExceptTermination()) [[unlikely]] {

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -457,19 +457,18 @@ static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& 
 
 static JSC::JSValue getNonObservable(JSC::VM& vm, JSC::JSGlobalObject* global, JSC::JSObject* obj, const JSC::PropertyName& propertyName)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     PropertySlot slot = PropertySlot(obj, PropertySlot::InternalMethodType::VMInquiry, &vm);
-    if (obj->getNonIndexPropertySlot(global, propertyName, slot)) {
-        if (slot.isAccessor()) {
-            return {};
-        }
-
-        JSValue value = slot.getValue(global, propertyName);
-        if (!value || value.isUndefinedOrNull()) {
-            return {};
-        }
-        return value;
-    }
-    return {};
+    bool found = obj->getNonIndexPropertySlot(global, propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, {});
+    // Only plain data properties: accessors AND native custom getters
+    // (e.g. DOMException.prototype.code) are observable and must not run here.
+    if (!found || !slot.isValue())
+        return {};
+    JSValue value = slot.getValue(global, propertyName);
+    if (!value || value.isUndefinedOrNull())
+        return {};
+    return value;
 }
 
 static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -34,6 +34,7 @@
 #include "ZigGlobalObject.h"
 #include "helpers.h"
 #include "JavaScriptCore/JSObjectInlines.h"
+#include "JSDOMException.h"
 
 #include "wtf/Assertions.h"
 #include "wtf/text/OrdinalNumber.h"
@@ -512,7 +513,10 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
         return;
     }
 
-    except.name = Bun::toStringRef(err->sanitizedNameString(global));
+    if (auto* domException = dynamicDowncast<WebCore::JSDOMException>(err))
+        except.name = Bun::toStringRef(domException->wrapped().name());
+    else
+        except.name = Bun::toStringRef(err->sanitizedNameString(global));
     if (!scope.clearExceptionExceptTermination()) [[unlikely]] {
         return;
     }

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -246,8 +246,7 @@ void JSDOMException::finishCreation(VM& vm)
     Base::finishCreation(vm, String(), JSValue(), nullptr, JSC::TypeNothing, true);
     ASSERT(inherits(info()));
 
-    // ErrorInstance leaves .stack unset for an empty trace (e.g. a native timer
-    // firing with no JS frames); other engines still give the name: message header.
+    // ErrorInstance leaves .stack unset on an empty trace; other engines still give the name: message header.
     auto* trace = stackTrace();
     if (!trace || trace->isEmpty()) {
         auto& impl = wrapped();
@@ -266,8 +265,7 @@ void JSDOMException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
-    // Heap only sweeps dead frames out of vm.errorInstanceSpace(); this class
-    // lives in its own subspace, so it must keep its frames alive itself.
+    // Heap sweeps dead frames only for vm.errorInstanceSpace(); this subspace must keep its own alive.
     Locker locker { thisObject->cellLock() };
     if (auto* stackTrace = thisObject->stackTrace()) {
         for (auto& frame : *stackTrace)

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -155,19 +155,14 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMExceptionDOMConstru
         RETURN_IF_EXCEPTION(throwScope, {});
     }
 
-    auto object = DOMException::create(WTF::move(message), WTF::move(name));
-    if constexpr (IsExceptionOr<decltype(object)>)
-        RETURN_IF_EXCEPTION(throwScope, {});
-    static_assert(TypeOrExceptionOrUnderlyingType<decltype(object)>::isRef);
-    auto jsValue = toJSNewlyCreated<IDLInterface<DOMException>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(object));
-    if constexpr (IsExceptionOr<decltype(object)>)
-        RETURN_IF_EXCEPTION(throwScope, {});
-    setSubclassStructureIfNeeded<DOMException>(lexicalGlobalObject, callFrame, asObject(jsValue));
+    // Not toJSNewlyCreated: own properties must wait until after the subclass structure swap.
+    auto* wrapper = createWrapper<DOMException>(castedThis->globalObject(), DOMException::create(WTF::move(message), WTF::move(name)));
+    setSubclassStructureIfNeeded<DOMException>(lexicalGlobalObject, callFrame, wrapper);
     RETURN_IF_EXCEPTION(throwScope, {});
-    if (!cause.isEmpty()) {
-        jsValue.getObject()->putDirect(vm, vm.propertyNames->cause, cause, JSC::PropertyAttribute::DontEnum | 0);
-    }
-    return JSValue::encode(jsValue);
+    wrapper->putHeaderStackIfNoFrames(vm);
+    if (!cause.isEmpty())
+        wrapper->putDirect(vm, vm.propertyNames->cause, cause, JSC::PropertyAttribute::DontEnum | 0);
+    return JSValue::encode(wrapper);
 }
 JSC_ANNOTATE_HOST_FUNCTION(JSDOMExceptionDOMConstructorConstruct, JSDOMExceptionDOMConstructor::construct);
 
@@ -245,17 +240,25 @@ void JSDOMException::finishCreation(VM& vm)
     // Null message/cause: those stay prototype accessors over the wrapped impl.
     Base::finishCreation(vm, String(), JSValue(), nullptr, JSC::TypeNothing, true);
     ASSERT(inherits(info()));
+    // No own properties here: the constructor may still swap in a subclass structure.
+}
 
-    // ErrorInstance leaves .stack unset on an empty trace; other engines still give the name: message header.
+void JSDOMException::setStackString(VM& vm, String&& stack)
+{
+    putDirect(vm, vm.propertyNames->stack, jsString(vm, WTF::move(stack)), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+    setStackPropertyAlreadyMaterialized();
+}
+
+// ErrorInstance leaves .stack unset on an empty trace; other engines still give the name: message header.
+void JSDOMException::putHeaderStackIfNoFrames(VM& vm)
+{
     auto* trace = stackTrace();
-    if (!trace || trace->isEmpty()) {
-        auto& impl = wrapped();
-        auto name = impl.name();
-        auto message = impl.message();
-        auto header = message.isEmpty() ? name : makeString(name, ": "_s, message);
-        putDirect(vm, vm.propertyNames->stack, jsString(vm, WTF::move(header)), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
-        setStackPropertyAlreadyMaterialized();
-    }
+    if (trace && !trace->isEmpty())
+        return;
+    auto& impl = wrapped();
+    auto name = impl.name();
+    auto message = impl.message();
+    setStackString(vm, message.isEmpty() ? name : makeString(name, ": "_s, message));
 }
 
 template<typename Visitor>
@@ -382,7 +385,9 @@ void JSDOMExceptionOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* conte
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<DOMException>&& impl)
 {
-    return createWrapper<DOMException>(globalObject, WTF::move(impl));
+    auto* wrapper = createWrapper<DOMException>(globalObject, WTF::move(impl));
+    wrapper->putHeaderStackIfNoFrames(globalObject->vm());
+    return wrapper;
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, DOMException& impl)

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -38,8 +38,10 @@
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
 
+#include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StackFrame.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -232,17 +234,37 @@ void JSDOMExceptionPrototype::finishCreation(VM& vm)
 const ClassInfo JSDOMException::s_info = { "DOMException"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMException) };
 
 JSDOMException::JSDOMException(Structure* structure, JSDOMGlobalObject& globalObject, Ref<DOMException>&& impl)
-    : JSDOMWrapper<DOMException>(structure, globalObject, WTF::move(impl))
+    : Base(globalObject.vm(), structure, JSC::ErrorType::Error)
+    , m_wrapped(WTF::move(impl))
 {
 }
 
 void JSDOMException::finishCreation(VM& vm)
 {
-    Base::finishCreation(vm);
+    // Capture a stack trace like a native Error. Pass a null message/cause so
+    // they stay as prototype accessors reading from the wrapped DOMException.
+    Base::finishCreation(vm, String(), JSValue(), nullptr, JSC::TypeNothing, true);
     ASSERT(inherits(info()));
-
-    // static_assert(!std::is_base_of<ActiveDOMObject, DOMException>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
 }
+
+template<typename Visitor>
+void JSDOMException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSDOMException>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+
+    // ErrorInstance drops dead stack frames via finalizeUnconditionally over
+    // vm.errorInstanceSpace(); our own subspace isn't swept there, so keep the
+    // frames alive explicitly until the stack is materialized.
+    Locker locker { thisObject->cellLock() };
+    if (auto* stackTrace = thisObject->stackTrace()) {
+        for (auto& frame : *stackTrace)
+            frame.visitAggregate(visitor);
+    }
+}
+
+DEFINE_VISIT_CHILDREN(JSDOMException);
 
 JSObject* JSDOMException::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {
@@ -316,12 +338,13 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMException_message, (JSGlobalObject * lexicalGlobal
 
 JSC::GCClient::IsoSubspace* JSDOMException::subspaceForImpl(JSC::VM& vm)
 {
-    return WebCore::subspaceForImpl<JSDOMException, UseCustomHeapCellType::No>(
+    return WebCore::subspaceForImpl<JSDOMException, UseCustomHeapCellType::Yes>(
         vm,
         [](auto& spaces) { return spaces.m_clientSubspaceForDOMException.get(); },
         [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMException = std::forward<decltype(space)>(space); },
         [](auto& spaces) { return spaces.m_subspaceForDOMException.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMException = std::forward<decltype(space)>(space); });
+        [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMException = std::forward<decltype(space)>(space); },
+        [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForJSDOMException; });
 }
 
 void JSDOMException::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -255,10 +255,30 @@ void JSDOMException::putHeaderStackIfNoFrames(VM& vm)
     auto* trace = stackTrace();
     if (trace && !trace->isEmpty())
         return;
-    auto& impl = wrapped();
-    auto name = impl.name();
-    auto message = impl.message();
+    auto name = displayName(vm);
+    auto message = displayMessage(vm);
     setStackString(vm, message.isEmpty() ? name : makeString(name, ": "_s, message));
+}
+
+String JSDOMException::ownStringOr(VM& vm, PropertyName propertyName, String&& fallback) const
+{
+    JSValue own = getDirect(vm, propertyName);
+    if (!own || !own.isString())
+        return WTF::move(fallback);
+    auto* string = asString(own);
+    if (string->isRope()) // Resolving would allocate; callers may be inside a finalizer.
+        return WTF::move(fallback);
+    return String(string->tryGetValue(false));
+}
+
+String JSDOMException::displayName(VM& vm) const
+{
+    return ownStringOr(vm, vm.propertyNames->name, wrapped().name());
+}
+
+String JSDOMException::displayMessage(VM& vm) const
+{
+    return ownStringOr(vm, vm.propertyNames->message, wrapped().message());
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -46,6 +46,7 @@
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
 using namespace JSC;
@@ -245,6 +246,20 @@ void JSDOMException::finishCreation(VM& vm)
     // they stay as prototype accessors reading from the wrapped DOMException.
     Base::finishCreation(vm, String(), JSValue(), nullptr, JSC::TypeNothing, true);
     ASSERT(inherits(info()));
+
+    // ErrorInstance never materializes a `stack` from an empty trace. That only
+    // happens when we are created with no JS frames on the stack (a native entry
+    // like AbortSignal.timeout). Give it the `name: message` header so `.stack`
+    // is always a string on a DOMException, like other engines.
+    auto* trace = stackTrace();
+    if (!trace || trace->isEmpty()) {
+        auto& impl = wrapped();
+        auto name = impl.name();
+        auto message = impl.message();
+        auto header = message.isEmpty() ? name : makeString(name, ": "_s, message);
+        putDirect(vm, vm.propertyNames->stack, jsString(vm, WTF::move(header)), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+        setStackPropertyAlreadyMaterialized();
+    }
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -247,10 +247,9 @@ void JSDOMException::finishCreation(VM& vm)
     Base::finishCreation(vm, String(), JSValue(), nullptr, JSC::TypeNothing, true);
     ASSERT(inherits(info()));
 
-    // ErrorInstance never materializes a `stack` from an empty trace. That only
-    // happens when we are created with no JS frames on the stack (a native entry
-    // like AbortSignal.timeout). Give it the `name: message` header so `.stack`
-    // is always a string on a DOMException, like other engines.
+    // ErrorInstance never materializes `stack` from an empty trace, which can
+    // happen for native entries like AbortSignal.timeout. Give `.stack` the
+    // `name: message` header so DOMException matches other engines.
     auto* trace = stackTrace();
     if (!trace || trace->isEmpty()) {
         auto& impl = wrapped();

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -246,18 +246,29 @@ void JSDOMException::finishCreation(VM& vm)
 void JSDOMException::setStackString(VM& vm, String&& stack)
 {
     putDirect(vm, vm.propertyNames->stack, jsString(vm, WTF::move(stack)), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+    setStackFrames(vm, {}); // Nothing will read the captured frames now; stop visitChildren from rooting them.
     setStackPropertyAlreadyMaterialized();
 }
 
-// ErrorInstance leaves .stack unset on an empty trace; other engines still give the name: message header.
+// ErrorInstance leaves .stack unset on an empty trace; other engines still give the header line.
 void JSDOMException::putHeaderStackIfNoFrames(VM& vm)
 {
     auto* trace = stackTrace();
     if (trace && !trace->isEmpty())
         return;
+    setStackString(vm, displayHeader(vm));
+}
+
+// Same joining rule as formatStackTrace: either side may be empty.
+String JSDOMException::displayHeader(VM& vm) const
+{
     auto name = displayName(vm);
     auto message = displayMessage(vm);
-    setStackString(vm, message.isEmpty() ? name : makeString(name, ": "_s, message));
+    if (name.isEmpty())
+        return message;
+    if (message.isEmpty())
+        return name;
+    return makeString(name, ": "_s, message);
 }
 
 String JSDOMException::ownStringOr(VM& vm, PropertyName propertyName, String&& fallback) const

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -242,14 +242,12 @@ JSDOMException::JSDOMException(Structure* structure, JSDOMGlobalObject& globalOb
 
 void JSDOMException::finishCreation(VM& vm)
 {
-    // Capture a stack trace like a native Error. Pass a null message/cause so
-    // they stay as prototype accessors reading from the wrapped DOMException.
+    // Null message/cause: those stay prototype accessors over the wrapped impl.
     Base::finishCreation(vm, String(), JSValue(), nullptr, JSC::TypeNothing, true);
     ASSERT(inherits(info()));
 
-    // ErrorInstance never materializes `stack` from an empty trace, which can
-    // happen for native entries like AbortSignal.timeout. Give `.stack` the
-    // `name: message` header so DOMException matches other engines.
+    // ErrorInstance leaves .stack unset for an empty trace (e.g. a native timer
+    // firing with no JS frames); other engines still give the name: message header.
     auto* trace = stackTrace();
     if (!trace || trace->isEmpty()) {
         auto& impl = wrapped();
@@ -268,9 +266,8 @@ void JSDOMException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
-    // ErrorInstance drops dead stack frames via finalizeUnconditionally over
-    // vm.errorInstanceSpace(); our own subspace isn't swept there, so keep the
-    // frames alive explicitly until the stack is materialized.
+    // Heap only sweeps dead frames out of vm.errorInstanceSpace(); this class
+    // lives in its own subspace, so it must keep its frames alive itself.
     Locker locker { thisObject->cellLock() };
     if (auto* stackTrace = thisObject->stackTrace()) {
         for (auto& frame : *stackTrace)

--- a/src/jsc/bindings/webcore/JSDOMException.h
+++ b/src/jsc/bindings/webcore/JSDOMException.h
@@ -24,14 +24,22 @@
 
 #include "DOMException.h"
 #include "JSDOMWrapper.h"
+#include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/ErrorPrototype.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
-class JSDOMException : public JSDOMWrapper<DOMException> {
+// JSDOMException inherits from ErrorInstance so that, per WebIDL, DOMException
+// objects carry [[ErrorData]] (Error.isError returns true) and a captured stack.
+class JSDOMException : public JSC::ErrorInstance {
 public:
-    using Base = JSDOMWrapper<DOMException>;
+    using Base = JSC::ErrorInstance;
+    using DOMWrapped = DOMException;
+
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
+
     static JSDOMException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<DOMException>&& impl)
     {
         JSDOMException* ptr = new (NotNull, JSC::allocateCell<JSDOMException>(globalObject->vm())) JSDOMException(structure, *globalObject, WTF::move(impl));
@@ -45,10 +53,11 @@ public:
     static void destroy(JSC::JSCell*);
 
     DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ErrorInstanceType, StructureFlags), info(), JSC::NonArray);
     }
 
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
@@ -61,10 +70,20 @@ public:
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm);
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
+    DOMException& wrapped() const { return m_wrapped; }
+    Ref<DOMException> protectedWrapped() const { return m_wrapped; }
+    static constexpr ptrdiff_t offsetOfWrapped() { return OBJECT_OFFSETOF(JSDOMException, m_wrapped); }
+    constexpr static bool hasCustomPtrTraits() { return false; }
+
+    JSDOMGlobalObject* globalObject() const { return uncheckedDowncast<JSDOMGlobalObject>(JSC::JSNonFinalObject::globalObject()); }
+
 protected:
     JSDOMException(JSC::Structure*, JSDOMGlobalObject&, Ref<DOMException>&&);
 
     void finishCreation(JSC::VM&);
+
+private:
+    Ref<DOMException> m_wrapped;
 };
 
 class JSDOMExceptionOwner final : public JSC::WeakHandleOwner {

--- a/src/jsc/bindings/webcore/JSDOMException.h
+++ b/src/jsc/bindings/webcore/JSDOMException.h
@@ -30,8 +30,7 @@
 
 namespace WebCore {
 
-// JSDOMException inherits from ErrorInstance so that, per WebIDL, DOMException
-// objects carry [[ErrorData]] (Error.isError returns true) and a captured stack.
+// An ErrorInstance so DOMException has [[ErrorData]] and a stack, as WebIDL requires.
 class JSDOMException : public JSC::ErrorInstance {
 public:
     using Base = JSC::ErrorInstance;

--- a/src/jsc/bindings/webcore/JSDOMException.h
+++ b/src/jsc/bindings/webcore/JSDOMException.h
@@ -83,6 +83,7 @@ public:
     // An own data property wins over the wrapped impl, as it does for a plain Error. Never allocates or runs JS.
     WTF::String displayName(JSC::VM&) const;
     WTF::String displayMessage(JSC::VM&) const;
+    WTF::String displayHeader(JSC::VM&) const;
 
 protected:
     JSDOMException(JSC::Structure*, JSDOMGlobalObject&, Ref<DOMException>&&);

--- a/src/jsc/bindings/webcore/JSDOMException.h
+++ b/src/jsc/bindings/webcore/JSDOMException.h
@@ -76,6 +76,10 @@ public:
 
     JSDOMGlobalObject* globalObject() const { return uncheckedDowncast<JSDOMGlobalObject>(JSC::JSNonFinalObject::globalObject()); }
 
+    // Installs `stack` as an own property and keeps the lazily captured trace from overwriting it.
+    void setStackString(JSC::VM&, WTF::String&&);
+    void putHeaderStackIfNoFrames(JSC::VM&);
+
 protected:
     JSDOMException(JSC::Structure*, JSDOMGlobalObject&, Ref<DOMException>&&);
 

--- a/src/jsc/bindings/webcore/JSDOMException.h
+++ b/src/jsc/bindings/webcore/JSDOMException.h
@@ -80,12 +80,18 @@ public:
     void setStackString(JSC::VM&, WTF::String&&);
     void putHeaderStackIfNoFrames(JSC::VM&);
 
+    // An own data property wins over the wrapped impl, as it does for a plain Error. Never allocates or runs JS.
+    WTF::String displayName(JSC::VM&) const;
+    WTF::String displayMessage(JSC::VM&) const;
+
 protected:
     JSDOMException(JSC::Structure*, JSDOMGlobalObject&, Ref<DOMException>&&);
 
     void finishCreation(JSC::VM&);
 
 private:
+    WTF::String ownStringOr(JSC::VM&, JSC::PropertyName, WTF::String&& fallback) const;
+
     Ref<DOMException> m_wrapped;
 };
 

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -416,8 +416,10 @@ const uint8_t cryptoKeyOKPOpNameTagMaximumValue = 1;
  * Version 13. added support for ErrorInstance objects.
  * Version 14. Date, RegExp, Error, DOMException, CryptoKey, KeyObject, X509Certificate,
  * and Bun cloneable types are recorded in the object reference pool on both sides.
+ * Version 15. DOMException records its stack.
  */
-[[maybe_unused]] static constexpr unsigned CurrentVersion = 14;
+[[maybe_unused]] static constexpr unsigned CurrentVersion = 15;
+[[maybe_unused]] static constexpr unsigned FirstVersionWithDOMExceptionStack = 15;
 // Deserializers must not pool the version 14 terminal types for older payloads,
 // whose writers never counted them, or the pool indices stop matching the writer's.
 [[maybe_unused]] static constexpr unsigned FirstVersionWithPooledTerminals = 14;
@@ -1077,20 +1079,6 @@ private:
         return dumpIfTerminal(toJSArrayBuffer(*arrayBuffer), code);
     }
 
-    void dumpDOMException(JSObject* obj, SerializationReturnCode& code)
-    {
-        if (auto* exception = JSDOMException::toWrapped(m_lexicalGlobalObject->vm(), obj)) {
-            if (!startObjectInternal(obj)) // handle duplicates
-                return;
-            write(DOMExceptionTag);
-            write(exception->message());
-            write(exception->name());
-            return;
-        }
-
-        code = SerializationReturnCode::DataCloneError;
-    }
-
     bool dumpIfTerminal(JSValue value, SerializationReturnCode& code)
     {
         if (!value.isCell()) {
@@ -1183,8 +1171,23 @@ private:
                 write(String::fromLatin1(JSC::Yarr::flagsString(regExp->regExp()->flags()).data()));
                 return true;
             }
-            if (obj->inherits<JSDOMException>()) {
-                dumpDOMException(obj, code);
+            if (auto* domException = dynamicDowncast<JSDOMException>(obj)) {
+                if (!startObjectInternal(domException)) // handle duplicates
+                    return true;
+                auto& vm = m_lexicalGlobalObject->vm();
+                // [[Get]] runs a user prepareStackTrace; the throw propagates out of the clone like Node.
+                JSValue stackValue = domException->get(m_lexicalGlobalObject, vm.propertyNames->stack);
+                RETURN_IF_EXCEPTION(scope, false);
+                String stack;
+                if (stackValue.isString()) {
+                    stack = stackValue.toWTFString(m_lexicalGlobalObject);
+                    RETURN_IF_EXCEPTION(scope, false);
+                }
+                auto& impl = domException->wrapped();
+                write(DOMExceptionTag);
+                write(impl.message());
+                write(impl.name());
+                writeNullableString(stack);
                 return true;
             }
             if (auto* errorInstance = dynamicDowncast<ErrorInstance>(obj)) {
@@ -3461,8 +3464,13 @@ private:
         CachedStringRef name;
         if (!readStringData(name))
             return JSValue();
+        String stack;
+        if (m_version >= FirstVersionWithDOMExceptionStack && !readNullableString(stack))
+            return JSValue();
         auto exception = DOMException::create(message->string(), name->string());
         JSValue wrapper = getJSValue(exception);
+        if (!stack.isNull())
+            uncheckedDowncast<JSDOMException>(asObject(wrapper))->setStackString(m_lexicalGlobalObject->vm(), WTF::move(stack));
         addTerminalToObjectPool(wrapper);
         return wrapper;
     }

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1183,6 +1183,10 @@ private:
                 write(String::fromLatin1(JSC::Yarr::flagsString(regExp->regExp()->flags()).data()));
                 return true;
             }
+            if (obj->inherits<JSDOMException>()) {
+                dumpDOMException(obj, code);
+                return true;
+            }
             if (auto* errorInstance = dynamicDowncast<ErrorInstance>(obj)) {
                 if (!startObjectInternal(errorInstance)) // handle duplicates
                     return true;
@@ -1391,10 +1395,6 @@ private:
                 return true;
             }
 #endif
-            if (obj->inherits<JSDOMException>()) {
-                dumpDOMException(obj, code);
-                return true;
-            }
 
             // write bun types
             auto _cloneable = StructuredCloneableSerialize::fromJS(value);

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -56,11 +56,97 @@ describe("DOMException in Node.js environment", () => {
     expect(DOMException.DATA_CLONE_ERR).toBe(25);
   });
 
-  // TODO: missing stack trace on DOMException
-  it.failing("inherits prototype properties from Error", () => {
+  it("inherits prototype properties from Error", () => {
     const error = new DOMException("Test error");
     expect(error.toString()).toBe("Error: Test error");
     expect(error.stack).toBeDefined();
+  });
+
+  it("has [[ErrorData]] internal slot", () => {
+    const error = new DOMException("boom", "AbortError");
+    expect(Error.isError(error)).toBe(true);
+    expect(Object.prototype.toString.call(error)).toBe("[object DOMException]");
+  });
+
+  it("captures a stack trace", () => {
+    function inner() {
+      return new DOMException("boom", "AbortError");
+    }
+    const error = inner();
+    expect(typeof error.stack).toBe("string");
+    expect(error.stack).toStartWith("AbortError: boom");
+    expect(error.stack).toContain("inner");
+    expect(Object.getOwnPropertyNames(error)).toContain("stack");
+  });
+
+  it("keeps name/message/code as prototype accessors", () => {
+    const error = new DOMException("boom", "AbortError");
+    const own = Object.getOwnPropertyNames(error);
+    expect(own).not.toContain("name");
+    expect(own).not.toContain("message");
+    expect(own).not.toContain("code");
+
+    const proto = Object.getPrototypeOf(error);
+    expect(Object.getOwnPropertyDescriptor(proto, "name").get).toBeFunction();
+    expect(Object.getOwnPropertyDescriptor(proto, "message").get).toBeFunction();
+    expect(Object.getOwnPropertyDescriptor(proto, "code").get).toBeFunction();
+  });
+
+  it("AbortSignal.abort().reason is a DOMException with a stack", () => {
+    const reason = AbortSignal.abort().reason;
+    expect(reason).toBeInstanceOf(DOMException);
+    expect(Error.isError(reason)).toBe(true);
+    expect(reason.name).toBe("AbortError");
+    expect(typeof reason.stack).toBe("string");
+    expect(reason.stack).toStartWith("AbortError");
+  });
+
+  it("AbortController.abort() reason is a DOMException with a stack", () => {
+    const c = new AbortController();
+    c.abort();
+    const reason = c.signal.reason;
+    expect(reason).toBeInstanceOf(DOMException);
+    expect(Error.isError(reason)).toBe(true);
+    expect(reason.name).toBe("AbortError");
+    expect(typeof reason.stack).toBe("string");
+    expect(reason.stack).toStartWith("AbortError");
+  });
+
+  it("structuredClone preserves DOMException and captures a stack", () => {
+    const original = new DOMException("boom", "QuotaExceededError");
+    const clone = structuredClone(original);
+    expect(clone).toBeInstanceOf(DOMException);
+    expect(Error.isError(clone)).toBe(true);
+    expect(clone.name).toBe("QuotaExceededError");
+    expect(clone.message).toBe("boom");
+    expect(clone.code).toBe(22);
+    expect(typeof clone.stack).toBe("string");
+  });
+
+  it("util.inspect shows the error name and message", () => {
+    const { inspect } = require("node:util");
+    const error = new DOMException("boom", "AbortError");
+    const inspected = inspect(error);
+    expect(inspected).toStartWith("DOMException [AbortError]: boom");
+  });
+
+  it("survives GC with intact stack traces", () => {
+    function makeError() {
+      return new DOMException("gc test", "AbortError");
+    }
+    const errors = [];
+    for (let i = 0; i < 100; i++) errors.push(makeError());
+    Bun.gc(true);
+    for (const e of errors) {
+      expect(Error.isError(e)).toBe(true);
+      expect(typeof e.stack).toBe("string");
+      expect(e.stack).toContain("makeError");
+    }
+    Bun.gc(true);
+    for (const e of errors) {
+      expect(e.name).toBe("AbortError");
+      expect(e.message).toBe("gc test");
+    }
   });
 
   it("has proper instance properties", () => {

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { inspect } from "node:util";
 
 describe("DOMException in Node.js environment", () => {
   it("exists globally", () => {
@@ -101,6 +102,19 @@ describe("DOMException in Node.js environment", () => {
     expect(reason.stack).toStartWith("AbortError");
   });
 
+  it("AbortSignal.timeout() reason gets a stack even with no JS frames", async () => {
+    // The timeout fires from a native timer with no JS on the stack, so there
+    // are no frames to capture; the stack must still be the error header.
+    const signal = AbortSignal.timeout(1);
+    const { promise, resolve } = Promise.withResolvers();
+    signal.addEventListener("abort", resolve);
+    await promise;
+    const reason = signal.reason;
+    expect(reason).toBeInstanceOf(DOMException);
+    expect(Error.isError(reason)).toBe(true);
+    expect(reason.stack).toBe("TimeoutError: The operation timed out.");
+  });
+
   it("AbortController.abort() reason is a DOMException with a stack", () => {
     const c = new AbortController();
     c.abort();
@@ -124,7 +138,6 @@ describe("DOMException in Node.js environment", () => {
   });
 
   it("util.inspect shows the error name and message", () => {
-    const { inspect } = require("node:util");
     const error = new DOMException("boom", "AbortError");
     const inspected = inspect(error);
     expect(inspected).toStartWith("DOMException [AbortError]: boom");

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { inspect } from "node:util";
 
 describe("DOMException in Node.js environment", () => {
@@ -102,17 +103,42 @@ describe("DOMException in Node.js environment", () => {
     expect(reason.stack).toStartWith("AbortError");
   });
 
-  it("AbortSignal.timeout() reason gets a stack even with no JS frames", async () => {
-    // The timeout fires from a native timer with no JS on the stack, so there
-    // are no frames to capture; the stack must still be the error header.
-    const signal = AbortSignal.timeout(1);
-    const { promise, resolve } = Promise.withResolvers();
-    signal.addEventListener("abort", resolve);
-    await promise;
+  it("AbortSignal.timeout() reason is a DOMException with a stack", async () => {
+    // AbortSignal.timeout()'s timer is not ref'd and awaiting only its abort
+    // event hangs the Windows test runner, so drive the loop with a ref'd
+    // sleep and poll the aborted flag (same shape as web/abort/abort.test.ts).
+    const signal = AbortSignal.timeout(0);
+    for (let i = 0; i < 200 && !signal.aborted; i++) await Bun.sleep(10);
+    expect(signal.aborted).toBe(true);
     const reason = signal.reason;
     expect(reason).toBeInstanceOf(DOMException);
     expect(Error.isError(reason)).toBe(true);
-    expect(reason.stack).toBe("TimeoutError: The operation timed out.");
+    expect(reason.name).toBe("TimeoutError");
+    expect(typeof reason.stack).toBe("string");
+    expect(reason.stack).toStartWith("TimeoutError: The operation timed out.");
+  });
+
+  it("gets a header-only stack when no frames are captured", async () => {
+    // Error.stackTraceLimit is process-global, so mutate it in a subprocess.
+    // `undefined` makes getStackTrace return no trace; `0` returns an empty one.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `Error.stackTraceLimit = undefined;
+         console.log(JSON.stringify(new DOMException("boom", "AbortError").stack));
+         Error.stackTraceLimit = 0;
+         console.log(JSON.stringify(new DOMException("boom", "AbortError").stack));
+         console.log(JSON.stringify(new DOMException("", "AbortError").stack));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({
+      stdout: '"AbortError: boom"\n"AbortError: boom"\n"AbortError"\n',
+      exitCode: 0,
+    });
   });
 
   it("AbortController.abort() reason is a DOMException with a stack", () => {

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -137,6 +137,23 @@ describe("DOMException in Node.js environment", () => {
     expect(typeof clone.stack).toBe("string");
   });
 
+  it("works with Error.captureStackTrace", () => {
+    function frameName() {
+      const error = new DOMException("boom", "NetworkError");
+      Error.captureStackTrace(error);
+      return error;
+    }
+    const error = frameName();
+    expect(typeof error.stack).toBe("string");
+    expect(error.stack).toStartWith("NetworkError: boom");
+    expect(error.stack).toContain("frameName");
+  });
+
+  it("stack header omits the separator when the message is empty", () => {
+    expect(new DOMException().stack.split("\n")[0]).toBe("Error");
+    expect(new DOMException("", "AbortError").stack.split("\n")[0]).toBe("AbortError");
+  });
+
   it("util.inspect shows the error name and message", () => {
     const error = new DOMException("boom", "AbortError");
     const inspected = inspect(error);

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -186,6 +186,34 @@ describe("DOMException in Node.js environment", () => {
     expect(new DOMException("", "AbortError").stack.split("\n")[0]).toBe("AbortError");
   });
 
+  it("own name/message properties win in the stack header, like a plain Error", () => {
+    const define = error => {
+      Object.defineProperty(error, "name", { value: "CustomError", configurable: true });
+      Object.defineProperty(error, "message", { value: "custom message", configurable: true });
+      return error.stack.split("\n")[0];
+    };
+    expect(define(new DOMException("boom", "AbortError"))).toBe(define(new Error("boom")));
+  });
+
+  it("own name property wins in the uncaught exception report", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const error = new DOMException("boom", "AbortError");
+         Object.defineProperty(error, "name", { value: "CustomError" });
+         throw error;`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    // The source line echoed above the report still says AbortError; only the report line must not.
+    expect(stderr).toContain("\nCustomError: boom\n");
+    expect(stderr).not.toContain("\nAbortError: boom\n");
+    expect(exitCode).toBe(1);
+  });
+
   it("util.inspect shows the error name and message", () => {
     const error = new DOMException("boom", "AbortError");
     const inspected = inspect(error);

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -135,8 +135,9 @@ describe("DOMException in Node.js environment", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({
+    expect({ stdout, stderr, exitCode }).toEqual({
       stdout: '"AbortError: boom"\n"AbortError: boom"\n"AbortError"\n',
+      stderr: "",
       exitCode: 0,
     });
   });

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -125,18 +125,20 @@ describe("DOMException in Node.js environment", () => {
       cmd: [
         bunExe(),
         "-e",
-        `Error.stackTraceLimit = undefined;
+        `class Sub extends DOMException {}
+         Error.stackTraceLimit = undefined;
          console.log(JSON.stringify(new DOMException("boom", "AbortError").stack));
          Error.stackTraceLimit = 0;
          console.log(JSON.stringify(new DOMException("boom", "AbortError").stack));
-         console.log(JSON.stringify(new DOMException("", "AbortError").stack));`,
+         console.log(JSON.stringify(new DOMException("", "AbortError").stack));
+         console.log(JSON.stringify(new Sub("boom", "AbortError").stack));`,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: '"AbortError: boom"\n"AbortError: boom"\n"AbortError"\n',
+      stdout: '"AbortError: boom"\n"AbortError: boom"\n"AbortError"\n"AbortError: boom"\n',
       stderr: "",
       exitCode: 0,
     });
@@ -153,15 +155,18 @@ describe("DOMException in Node.js environment", () => {
     expect(reason.stack).toStartWith("AbortError");
   });
 
-  it("structuredClone preserves DOMException and captures a stack", () => {
+  it("structuredClone preserves a DOMException including its stack", () => {
     const original = new DOMException("boom", "QuotaExceededError");
-    const clone = structuredClone(original);
+    const clone = structuredClone(structuredClone(original));
     expect(clone).toBeInstanceOf(DOMException);
     expect(Error.isError(clone)).toBe(true);
-    expect(clone.name).toBe("QuotaExceededError");
-    expect(clone.message).toBe("boom");
-    expect(clone.code).toBe(22);
-    expect(typeof clone.stack).toBe("string");
+    expect(clone.stack).toContain("domexception-node.test.js");
+    expect({ name: clone.name, message: clone.message, code: clone.code, stack: clone.stack }).toEqual({
+      name: "QuotaExceededError",
+      message: "boom",
+      code: 22,
+      stack: original.stack,
+    });
   });
 
   it("works with Error.captureStackTrace", () => {

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -170,7 +170,7 @@ describe("DOMException in Node.js environment", () => {
     });
     // The clone's own capture at the structuredClone call site is discarded: reading the
     // position properties must not materialize the clone site's line/column over the copy.
-    void clone.line, clone.column, clone.sourceURL;
+    (void clone.line, clone.column, clone.sourceURL);
     expect(Object.getOwnPropertyNames(clone)).toEqual(["stack"]);
   });
 

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -207,11 +207,14 @@ describe("DOMException in Node.js environment", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // The source line echoed above the report still says AbortError; only the report line must not.
-    expect(stderr).toContain("\nCustomError: boom\n");
     expect(stderr).not.toContain("\nAbortError: boom\n");
-    expect(exitCode).toBe(1);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining("\nCustomError: boom\n"),
+      exitCode: 1,
+    });
   });
 
   it("util.inspect shows the error name and message", () => {

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -131,6 +131,7 @@ describe("DOMException in Node.js environment", () => {
          Error.stackTraceLimit = 0;
          console.log(JSON.stringify(new DOMException("boom", "AbortError").stack));
          console.log(JSON.stringify(new DOMException("", "AbortError").stack));
+         console.log(JSON.stringify(new DOMException("boom", "").stack));
          console.log(JSON.stringify(new Sub("boom", "AbortError").stack));`,
       ],
       env: bunEnv,
@@ -138,7 +139,7 @@ describe("DOMException in Node.js environment", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: '"AbortError: boom"\n"AbortError: boom"\n"AbortError"\n"AbortError: boom"\n',
+      stdout: '"AbortError: boom"\n"AbortError: boom"\n"AbortError"\n"boom"\n"AbortError: boom"\n',
       stderr: "",
       exitCode: 0,
     });
@@ -167,6 +168,10 @@ describe("DOMException in Node.js environment", () => {
       code: 22,
       stack: original.stack,
     });
+    // The clone's own capture at the structuredClone call site is discarded: reading the
+    // position properties must not materialize the clone site's line/column over the copy.
+    void clone.line, clone.column, clone.sourceURL;
+    expect(Object.getOwnPropertyNames(clone)).toEqual(["stack"]);
   });
 
   it("works with Error.captureStackTrace", () => {


### PR DESCRIPTION
## What

`DOMException` now derives from `JSC::ErrorInstance`, so it carries the `[[ErrorData]]` internal slot and a captured stack trace like native Error types. WebIDL §3.14.1 specifies this, and Node.js, Chrome and Firefox all do it.

## Repro

```js
const d = new DOMException("boom", "AbortError");
console.log(Error.isError(d));                        // was false, now true
console.log(typeof d.stack);                          // was undefined, now string
console.log(typeof AbortSignal.abort().reason.stack); // was undefined, now string
console.log(typeof structuredClone(d).stack);         // was undefined, now string
console.log(d);  // was a 25-line legacy-constant object dump, now formats as an error
```

Bun was also internally inconsistent: `AbortController#abort()` produced a reason with a `.stack` (because `createDOMException` called `addErrorInfo` afterwards), while `AbortSignal.abort()` and user-constructed DOMExceptions had none.

## Cause

`JSDOMException` was a plain `JSDOMWrapper<DOMException>` with `JSType::ObjectType`. `Error.isError` checks `type() == ErrorInstanceType`, and nothing on the wrapper-creation path captured a stack.

## Fix

`JSDOMException` now inherits from `JSC::ErrorInstance` while keeping its `Ref<DOMException>` wrapped impl and the existing prototype (accessor-based `name`/`message`/`code`, legacy constants):

- `createStructure` uses `ErrorInstanceType`.
- `finishCreation` calls `ErrorInstance::finishCreation` with a null message/cause so a stack trace is captured but `name`/`message` stay as prototype accessors backed by the wrapped DOMException.
- `visitChildren` keeps the captured stack frames' callee/codeBlock alive. `ErrorInstance` normally relies on Heap's `finalizeUnconditionally` sweep over `errorInstanceSpace`, which our DOM subspace is not part of, so without this a lazy `.stack` read after GC would touch freed `CodeBlock`s.
- New `IsoHeapCellType` in `JSHeapData` so the larger cell destructs its `Ref<DOMException>` and `ErrorInstance` state correctly.
- When the captured trace is empty (a native entry with no JS frames, e.g. `AbortSignal.timeout()` firing from a native timer), `ErrorInstance` never materializes a `stack`, so `finishCreation` eagerly puts the `name: message` header. A DOMException `.stack` is now always a string. This improves #25182 and #21900 (no longer `undefined` / `""`) but does not close them: Node shows real async frames there and Bun's native timer has none to capture.

Callers that branched on `ErrorInstance` before `JSDOMException` now check the DOMException case first: the `.stack` header in `FormatStackTraceForJS`, the `except.name` in `ZigException`, and the terminal-dump path in `SerializedScriptValue`, so `structuredClone` keeps emitting `DOMExceptionTag` instead of falling through to `ErrorInstanceTag`. The redundant `addErrorInfo` in `createDOMException` is removed now that the wrapper captures a Bun-formatted stack on construction; internally-thrown DOMExceptions now have the same stack format as regular errors instead of JSC's native `foo@file` format.

### Latent exception-check bug this exposed

The `BUN_JSC_validateExceptionChecks` CI lane caught an unchecked exception in `getNonObservable` (ZigException.cpp):

```
This scope can throw a JS exception: getNonIndexPropertySlot @ JSObjectInlines.h:251
But the exception was unchecked as of this scope: get @ JSDOMAttribute.h:83
```

`getNonObservable` called a throwable `getNonIndexPropertySlot` with no exception check, and its `slot.isAccessor()` guard only filters JS getter/setter pairs, not native custom accessors, so `slot.getValue()` would invoke them. That was unreachable while `fromErrorInstance` only saw plain `ErrorInstance`s, whose prototypes have no custom accessors. With `JSDOMException` now an `ErrorInstance`, the lookup for `code` lands on `DOMException.prototype.code` and invokes the getter. Fixed by adding a `ThrowScope` with `RETURN_IF_EXCEPTION` (the caller already clears after each call) and restricting the helper to plain data properties, which is what its name promises. This also stops the DOM legacy code (`20`) from being misread as a node `system_code`.

### structuredClone round-trips the stack (wire format version 15)

`test/js/node/test/parallel/test-structuredClone-domexception.js` asserts `clone.stack === e.stack`. That passed vacuously before (both `undefined`); once DOMExceptions had stacks, the clone captured a fresh one at the `structuredClone` call site. Node serializes the stack, so `DOMExceptionTag` now carries it: the serializer reads it through `[[Get]]` (a throwing `prepareStackTrace` propagates out of the clone, as in the `ErrorInstanceTag` branch) and the deserializer installs it on the new wrapper, drops the frames the wrapper captured at the clone site (so GC does not keep rooting them and `.line` cannot materialize the clone site's position over the copy), and pins the stack property. `CurrentVersion` is bumped to 15 and the read is gated on it; older payloads still deserialize.

### Header stack is put after the subclass structure swap

The header-only `.stack` fallback (empty trace, e.g. `Error.stackTraceLimit = 0` or a native timer firing with no JS frames) was put from `finishCreation`. `JSDOMException` has no inline slots, so that allocated a butterfly, and `setSubclassStructureIfNeeded` then swapped `class Sub extends DOMException` instances onto a capacity-0 structure, tripping the `setStructure` butterfly assertion on debug builds. `finishCreation` now puts nothing; the `toJSNewlyCreated` free function (every internal creation path) puts the header after `createWrapper`, and the constructor builds the wrapper directly so the swap happens before the header and `cause` are put.

## Verification

`test/js/node/domexception-node.test.js` adds coverage for `Error.isError`, `.stack` capture (including the `AbortSignal.abort()`, `AbortSignal.timeout()`, and `structuredClone` paths), stack equality through two `structuredClone`s, the subclass + `stackTraceLimit = 0` case, prototype-accessor invariants, `util.inspect` formatting, and a GC stress loop over lazy stack materialization. `test-structuredClone-domexception.js`, `structured-clone.test.ts` (including its version 13 payload and cross-process cases) and `bun-jsc.test.ts` pass. The existing `.failing` test for `.stack` is un-failed. `fetch.test.ts` and `abort.test.ts` pass under `BUN_JSC_validateExceptionChecks=1`.


Fixes #15821
Fixes #17877
Fixes #37419
Refs #25182
Refs #21900

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/domexception-node.test.js
bun test v1.4.0 (d8661f2c1)

test/js/node/domexception-node.test.js:
(pass) DOMException in Node.js environment > exists globally [5.14ms]
(pass) DOMException in Node.js environment > creates instance with message and name [2.99ms]
(pass) DOMException in Node.js environment > uses default name when only message is provided [1.97ms]
(pass) DOMException in Node.js environment > creates instance with options object [2.48ms]
(pass) DOMException in Node.js environment > has standard error constants [12.29ms]
59 |   });
60 | 
61 |   it("inherits prototype properties from Error", () => {
62 |     const error = new DOMException("Test error");
63 |     expect(error.toString()).toBe("Error: Test error");
64 |     expect(error.stack).toBeDefined();
                             ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/node/domexception-node.test.js:64:25)
(fail) DOMException in Node.js environment > inherits prototype properties from Error [6.2
... (truncated)

release without fix: 14 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/node/domexception-node.test.js:
(pass) DOMException in Node.js environment > exists globally [0.05ms]
(pass) DOMException in Node.js environment > creates instance with message and name [0.04ms]
(pass) DOMException in Node.js environment > uses default name when only message is provided [0.02ms]
(pass) DOMException in Node.js environment > creates instance with options object [0.03ms]
(pass) DOMException in Node.js environment > has standard error constants [0.09ms]
59 |   });
60 | 
61 |   it("inherits prototype properties from Error", () => {
62 |     const error = new DOMException("Test error");
63 |     expect(error.toString()).toBe("Error: Test error");
64 |     expect(error.stack).toBeDefined();
                             ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/node/domexception-node.test.js:64:25)
(fail) DOMException in Node.js environment > inherits prototype properties from Error [0.22ms]
64 |     expect(error.stack).toBeDefined();
65 |   });
66 | 
67 |   it("has [[ErrorData]] internal slot", () => {
68 |     const error = new DOMException("boom
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/domexception-node.test.js
bun test v1.4.0 (d8661f2c1)

test/js/node/domexception-node.test.js:
(pass) DOMException in Node.js environment > exists globally [5.89ms]
(pass) DOMException in Node.js environment > creates instance with message and name [5.23ms]
(pass) DOMException in Node.js environment > uses default name when only message is provided [3.14ms]
(pass) DOMException in Node.js environment > creates instance with options object [5.01ms]
(pass) DOMException in Node.js environment > has standard error constants [15.38ms]
(pass) DOMException in Node.js environment > inherits prototype properties from Error [5.43ms]
(pass) DOMException in Node.js environment > has [[ErrorData]] internal slot [4.84ms]
(pass) DOMException in Node.js environment > captures a stack trace [7.83ms]
(pass) DOMException in Node.js environment > keeps name/message/code as prototype accessors [8.57ms]
(pass) DOMException in Node.js environment > AbortSignal.abort().reason is a DOMException with a stack [7.24ms]
(pass) DOMException in Node.js e
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 740ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/127] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/127] gen cpp.rs (cppbind)
[3/127] gen JS modules (bundle-modules)
Preprocess modules (9568ms)
Bundle modules (69ms)
Postprocesss modules (26ms)
Bundle Functions (637ms)
Generate Code (31ms)

[10.35s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/126] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunClientData.cpp                 |   2 +
 src/jsc/bindings/BunClientData.h                   |   1 +
 src/jsc/bindings/FormatStackTraceForJS.cpp         |  25 ++-
 src/jsc/bindings/JSDOMExceptionHandling.cpp        |   5 +-
 src/jsc/bindings/JSDOMWrapperCache.h               |  12 +-
 src/jsc/bindings/ZigException.cpp                  |  28 +--
 src/jsc/bindings/webcore/JSDOMException.cpp        | 104 ++++++++++--
 src/jsc/bindings/webcore/JSDOMException.h          |  35 +++-
 src/jsc/bindings/webcore/SerializedScriptValue.cpp |  46 ++---
 test/js/node/domexception-node.test.js             | 188 ++++++++++++++++++++-
 10 files changed, 376 insertions(+), 70 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/BunClientData.cpp                      1      2     18
src/jsc/bindings/BunClientData.h                        1      1     18
src/jsc/bindings/FormatStackTraceForJS.cpp              4      8     18
src/jsc/bindings/JSDOMExceptionHandling.cpp             5      7     18
src/jsc/bindings/JSDOMWrapperCache.h                    1      2     18
src/jsc/bindings/ZigException.cpp                       4      6     18
src/jsc/bindings/webcore/JSDOMException.cpp            10     18     18
src/jsc/bindings/webcore/JSDOMException.h               5      5     18
src/jsc/bindings/webcore/SerializedScriptValue.cpp      5      7     18
test/js/node/domexception-node.test.js                 13     18     18
```

</details>

<!-- robobun:evidence:end -->
