### PR TITLE
webcrypto: reject HMAC importKey with length 0

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
@@ -107,6 +107,11 @@ void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, cons
         return;
     }
 
+    if (hmacParameters.length && !hmacParameters.length.value()) {
+        exceptionCallback(DataError, ""_s);
+        return;
+    }
+
     RefPtr<CryptoKeyHMAC> result;
     switch (format) {
     case CryptoKeyFormat::Raw:

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
@@ -107,17 +107,20 @@ void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, cons
         return;
     }
 
-    if (hmacParameters.length && !hmacParameters.length.value()) {
-        exceptionCallback(DataError, ""_s);
-        return;
-    }
-
     RefPtr<CryptoKeyHMAC> result;
     switch (format) {
     case CryptoKeyFormat::Raw:
+        if (hmacParameters.length && !hmacParameters.length.value()) {
+            exceptionCallback(DataError, ""_s);
+            return;
+        }
         result = CryptoKeyHMAC::importRaw(hmacParameters.length.value_or(0), hmacParameters.hashIdentifier, WTF::move(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Jwk: {
+        if (hmacParameters.length && !hmacParameters.length.value()) {
+            exceptionCallback(DataError, ""_s);
+            return;
+        }
         auto checkAlgCallback = [](CryptoAlgorithmIdentifier hash, const String& alg) -> bool {
             switch (hash) {
             case CryptoAlgorithmIdentifier::SHA_1:

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -105,6 +105,45 @@ describe("Web Crypto", () => {
     expect(isSigValid).toBe(true);
   });
 
+  // https://w3c.github.io/webcrypto/#hmac-operations
+  describe("HMAC importKey length", () => {
+    const outcome = (p: Promise<CryptoKey>) =>
+      p.then(
+        k => ({ length: (k.algorithm as HmacKeyAlgorithm).length }),
+        e => ({ error: e.name }),
+      );
+
+    it("rejects length:0 with DataError and accepts an absent length (raw)", async () => {
+      const data = new Uint8Array(20);
+      const algo = { name: "HMAC", hash: "SHA-256" } as const;
+      expect({
+        absent: await outcome(crypto.subtle.importKey("raw", data, algo, true, ["sign"])),
+        zero: await outcome(crypto.subtle.importKey("raw", data, { ...algo, length: 0 }, true, ["sign"])),
+        one: await outcome(crypto.subtle.importKey("raw", data, { ...algo, length: 1 }, true, ["sign"])),
+        short: await outcome(crypto.subtle.importKey("raw", data, { ...algo, length: 159 }, true, ["sign"])),
+        exact: await outcome(crypto.subtle.importKey("raw", data, { ...algo, length: 160 }, true, ["sign"])),
+      }).toEqual({
+        absent: { length: 160 },
+        zero: { error: "DataError" },
+        one: { error: "DataError" },
+        short: { error: "DataError" },
+        exact: { length: 160 },
+      });
+    });
+
+    it("rejects length:0 with DataError and accepts an absent length (jwk)", async () => {
+      const jwk = { kty: "oct", k: "AAAAAAAAAAAAAAAAAAAAAAAAAAA" };
+      const algo = { name: "HMAC", hash: "SHA-256" } as const;
+      expect({
+        absent: await outcome(crypto.subtle.importKey("jwk", jwk, algo, true, ["sign"])),
+        zero: await outcome(crypto.subtle.importKey("jwk", jwk, { ...algo, length: 0 }, true, ["sign"])),
+      }).toEqual({
+        absent: { length: 160 },
+        zero: { error: "DataError" },
+      });
+    });
+  });
+
   describe("unwrapKey JWK error handling", () => {
     // Setup: AES-GCM key that can encrypt arbitrary bytes and also unwrap keys.
     // We encrypt payloads that decrypt to invalid JWK data so the JWK parse path

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -142,6 +142,22 @@ describe("Web Crypto", () => {
         zero: { error: "DataError" },
       });
     });
+
+    // An unsupported format must reject with NotSupportedError before the
+    // length member is even considered.
+    it.each(["pkcs8", "spki"] as const)("rejects the %s format with NotSupportedError regardless of length", async format => {
+      const data = new Uint8Array(20);
+      const algo = { name: "HMAC", hash: "SHA-256" } as const;
+      expect({
+        absent: await outcome(crypto.subtle.importKey(format, data, algo, true, ["sign"])),
+        zero: await outcome(crypto.subtle.importKey(format, data, { ...algo, length: 0 }, true, ["sign"])),
+        one: await outcome(crypto.subtle.importKey(format, data, { ...algo, length: 1 }, true, ["sign"])),
+      }).toEqual({
+        absent: { error: "NotSupportedError" },
+        zero: { error: "NotSupportedError" },
+        one: { error: "NotSupportedError" },
+      });
+    });
   });
 
   describe("unwrapKey JWK error handling", () => {

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -145,19 +145,22 @@ describe("Web Crypto", () => {
 
     // An unsupported format must reject with NotSupportedError before the
     // length member is even considered.
-    it.each(["pkcs8", "spki"] as const)("rejects the %s format with NotSupportedError regardless of length", async format => {
-      const data = new Uint8Array(20);
-      const algo = { name: "HMAC", hash: "SHA-256" } as const;
-      expect({
-        absent: await outcome(crypto.subtle.importKey(format, data, algo, true, ["sign"])),
-        zero: await outcome(crypto.subtle.importKey(format, data, { ...algo, length: 0 }, true, ["sign"])),
-        one: await outcome(crypto.subtle.importKey(format, data, { ...algo, length: 1 }, true, ["sign"])),
-      }).toEqual({
-        absent: { error: "NotSupportedError" },
-        zero: { error: "NotSupportedError" },
-        one: { error: "NotSupportedError" },
-      });
-    });
+    it.each(["pkcs8", "spki"] as const)(
+      "rejects the %s format with NotSupportedError regardless of length",
+      async format => {
+        const data = new Uint8Array(20);
+        const algo = { name: "HMAC", hash: "SHA-256" } as const;
+        expect({
+          absent: await outcome(crypto.subtle.importKey(format, data, algo, true, ["sign"])),
+          zero: await outcome(crypto.subtle.importKey(format, data, { ...algo, length: 0 }, true, ["sign"])),
+          one: await outcome(crypto.subtle.importKey(format, data, { ...algo, length: 1 }, true, ["sign"])),
+        }).toEqual({
+          absent: { error: "NotSupportedError" },
+          zero: { error: "NotSupportedError" },
+          one: { error: "NotSupportedError" },
+        });
+      },
+    );
   });
 
   describe("unwrapKey JWK error handling", () => {


### PR DESCRIPTION
## Problem

`crypto.subtle.importKey` with HMAC and an explicit `length: 0` in `HmacImportParams` returns a usable key whose `algorithm.length` is derived from the key data, instead of rejecting. The [spec](https://w3c.github.io/webcrypto/#hmac-operations) requires `DataError` when the `length` member is present and zero.

```js
const k = await crypto.subtle.importKey(
  "raw", new Uint8Array(20),
  { name: "HMAC", hash: "SHA-256", length: 0 },
  true, ["sign"],
);
// before: resolves, k.algorithm.length === 160
// after:  rejects with DataError
```

Node v26.3.0, Deno, and browsers all reject with `DataError` here.

## Cause

`CryptoAlgorithmHMAC::importKey` passes `hmacParameters.length.value_or(0)` to `CryptoKeyHMAC::importRaw` / `importJwk`, collapsing "length is absent" and "length is 0" into the same value. `importRaw` then treats `0` as "unspecified" via a falsy check and falls back to the key-data length.

## Fix

Reject a present-and-zero `length` inside the `raw` and `jwk` branches of `CryptoAlgorithmHMAC::importKey`, after the format dispatch. That placement keeps the spec's error precedence: an unsupported format (`pkcs8`, `spki`) still rejects with `NotSupportedError` regardless of `length`.

The check has to live here rather than in `CryptoKeyHMAC::importRaw`: `SerializedScriptValue.cpp` calls `importRaw(0, ...)` for structured-clone deserialization, where `0` must keep meaning "unspecified".

The `length: 1..159` cases already throw `DataError`, which is what the spec says; Node's `NotSupportedError` there is Node deviating, so those rows are left as-is.

## Verification

```
$ bun bd test test/js/web/crypto/web-crypto.test.ts -t "HMAC importKey length"
(pass) Web Crypto > HMAC importKey length > rejects length:0 with DataError and accepts an absent length (raw)
(pass) Web Crypto > HMAC importKey length > rejects length:0 with DataError and accepts an absent length (jwk)
(pass) Web Crypto > HMAC importKey length > rejects the pkcs8 format with NotSupportedError regardless of length
(pass) Web Crypto > HMAC importKey length > rejects the spki format with NotSupportedError regardless of length
```

The two `length:0` tests fail on `main` with `zero: { length: 160 }` instead of `zero: { error: "DataError" }`. The format-precedence tests pass on `main` and guard against a guard placed before the format switch.
