### PR TITLE
webcrypto: set alg: "Ed25519" on exported Ed25519 JWKs

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -200,6 +200,7 @@ ExceptionOr<JsonWebKey> CryptoKeyOKP::exportJwk() const
         break;
     case NamedCurve::Ed25519:
         result.crv = Ed25519;
+        result.alg = Ed25519;
         break;
     }
 

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -333,6 +333,52 @@ describe("Ed25519", () => {
       expect(privateKey.algorithm!.namedCurve).toBe(undefined);
     });
   });
+
+  // https://wicg.github.io/webcrypto-secure-curves/#ed25519-operations step 6.2:
+  // exported Ed25519 JWKs carry `alg: "Ed25519"` (X25519 JWKs do not).
+  it('exportKey("jwk") sets alg to "Ed25519"', async () => {
+    const { publicKey, privateKey } = (await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+      "sign",
+      "verify",
+    ])) as CryptoKeyPair;
+
+    const pub = (await crypto.subtle.exportKey("jwk", publicKey)) as JsonWebKey;
+    expect(pub).toEqual({
+      kty: "OKP",
+      crv: "Ed25519",
+      alg: "Ed25519",
+      x: expect.any(String),
+      key_ops: ["verify"],
+      ext: true,
+    });
+    expect(Object.keys(pub).sort()).toEqual(["alg", "crv", "ext", "key_ops", "kty", "x"]);
+
+    const priv = (await crypto.subtle.exportKey("jwk", privateKey)) as JsonWebKey;
+    expect(priv).toEqual({
+      kty: "OKP",
+      crv: "Ed25519",
+      alg: "Ed25519",
+      x: expect.any(String),
+      d: expect.any(String),
+      key_ops: ["sign"],
+      ext: true,
+    });
+
+    // The exported JWK must round-trip back through importKey.
+    const reimported = await crypto.subtle.importKey("jwk", pub, { name: "Ed25519" }, true, ["verify"]);
+    expect(((await crypto.subtle.exportKey("jwk", reimported)) as JsonWebKey).alg).toBe("Ed25519");
+  });
+
+  it('X25519 exportKey("jwk") omits alg (spec does not define one)', async () => {
+    const { publicKey, privateKey } = (await crypto.subtle.generateKey({ name: "X25519" }, true, [
+      "deriveBits",
+    ])) as CryptoKeyPair;
+    const pub = (await crypto.subtle.exportKey("jwk", publicKey)) as JsonWebKey;
+    const priv = (await crypto.subtle.exportKey("jwk", privateKey)) as JsonWebKey;
+    expect("alg" in pub).toBe(false);
+    expect("alg" in priv).toBe(false);
+    expect(pub.crv).toBe("X25519");
+  });
 });
 
 // https://github.com/oven-sh/bun/issues/32613


### PR DESCRIPTION
### Problem

`crypto.subtle.exportKey("jwk", ed25519Key)` omits the `alg` member:

```js
const k = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
const j = await crypto.subtle.exportKey("jwk", k.publicKey);
console.log("alg:", JSON.stringify(j.alg), "keys:", Object.keys(j).sort().join(","));
```

| | `alg` | keys |
|---|---|---|
| Node v26.3.0 | `"Ed25519"` | `alg,crv,ext,key_ops,kty,x` |
| Bun before | `undefined` | `crv,ext,key_ops,kty,x` |
| Bun after | `"Ed25519"` | `alg,crv,ext,key_ops,kty,x` |

The [Secure Curves in WebCrypto](https://wicg.github.io/webcrypto-secure-curves/#ed25519-operations) spec sets `alg = "Ed25519"` in the Ed25519 export-key-as-JWK steps. A JWKS consumer that selects keys by `alg` never matches a Bun-exported Ed25519 key, and round-tripping such a key through Bun silently drops a member so JWK fingerprints change.

### Cause

`CryptoKeyOKP::exportJwk()` populates `kty`, `crv`, `key_ops`, `ext`, `x`, and `d`, but never sets `alg`. Other WebCrypto algorithms (AES, HMAC, RSA) set `jwk.alg` during export; the OKP path was missing the assignment.

### Fix

Set `result.alg = "Ed25519"` in the `NamedCurve::Ed25519` arm of `CryptoKeyOKP::exportJwk()`. The `X25519` arm is left unchanged: the spec does not define an `alg` for X25519, and Node does not emit one either.

The import-side `alg` validation (rejecting a JWK whose `alg` is neither `"Ed25519"` nor `"EdDSA"`) is handled separately in #32827.

### Verification

```
USE_SYSTEM_BUN=1 bun test test/js/web/crypto/web-crypto.test.ts -t Ed25519  # fails (alg missing)
bun bd test test/js/web/crypto/web-crypto.test.ts -t Ed25519                # passes
```

Also checked that `test-webcrypto-wrap-unwrap.js` (which JWK-wraps Ed25519 keys and deep-compares the round-trip) and the `node:crypto` KeyObject JWK export path (which does not go through `CryptoKeyOKP::exportJwk` and already matched Node) are unaffected.