### PR TITLE
webcrypto: reject importKey("jwk") with a missing or wrong kty with DataError

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -124,6 +124,9 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwkInternal(CryptoAlgorithmIdentifier i
     if (!isPlatformSupportedCurve(namedCurve))
         return nullptr;
 
+    if (keyData.kty != "OKP"_s)
+        return nullptr;
+
     switch (namedCurve) {
     case NamedCurve::Ed25519:
         if (!keyData.d.isEmpty() && !onlyPublic) {
@@ -133,8 +136,6 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwkInternal(CryptoAlgorithmIdentifier i
             if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageSign | CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey))
                 return nullptr;
         }
-        if (keyData.kty != "OKP"_s)
-            return nullptr;
         if (keyData.crv != "Ed25519"_s)
             return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "sig"_s)

--- a/src/jsc/bindings/webcrypto/JSJsonWebKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSJsonWebKey.cpp
@@ -160,9 +160,6 @@ template<> JsonWebKey convertDictionary<JsonWebKey>(JSGlobalObject& lexicalGloba
     if (!ktyValue.isUndefined()) {
         result.kty = convert<IDLDOMString>(lexicalGlobalObject, ktyValue);
         RETURN_IF_EXCEPTION(throwScope, {});
-    } else {
-        throwRequiredMemberTypeError(lexicalGlobalObject, throwScope, "kty"_s, "JsonWebKey"_s, "DOMString"_s);
-        return {};
     }
     JSValue nValue;
     if (isNullOrUndefined)

--- a/src/jsc/bindings/webcrypto/JsonWebKey.idl
+++ b/src/jsc/bindings/webcrypto/JsonWebKey.idl
@@ -28,7 +28,7 @@
     JSGenerateToJSObject,
 ] dictionary JsonWebKey {
     // The following fields are defined in Section 3.1 of JSON Web Key
-    required DOMString kty;
+    DOMString kty;
     DOMString use;
     sequence<CryptoKeyUsage> key_ops;
     DOMString alg;

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -106,20 +106,35 @@ describe("Web Crypto", () => {
   });
 
   // W3C WebCrypto: JsonWebKey.kty is not a required dictionary member; each
-  // algorithm's import key operation rejects a missing/wrong kty with DataError.
-  describe("importKey jwk with missing kty rejects with DataError", () => {
+  // algorithm's import key operation rejects a missing or wrong kty with DataError.
+  describe("importKey jwk kty validation rejects with DataError", () => {
+    // Well-formed 32-byte x coordinate so the kty is the only invalid member.
+    const x32 = Buffer.alloc(32).toString("base64url");
     const cases: Array<[string, object, object, KeyUsage[]]> = [
       ["AES-GCM", { k: "AAECAwQFBgcICQoLDA0ODw" }, { name: "AES-GCM" }, ["encrypt"]],
       ["HMAC", { k: "AAECAwQFBgcICQoLDA0ODw" }, { name: "HMAC", hash: "SHA-256" }, ["sign"]],
       ["RSA-OAEP", { n: "AQAB", e: "AQAB" }, { name: "RSA-OAEP", hash: "SHA-256" }, ["encrypt"]],
       ["ECDSA", { crv: "P-256", x: "", y: "" }, { name: "ECDSA", namedCurve: "P-256" }, ["verify"]],
-      ["Ed25519", { crv: "Ed25519", x: "" }, { name: "Ed25519" }, ["verify"]],
+      ["Ed25519", { crv: "Ed25519", x: x32 }, { name: "Ed25519" }, ["verify"]],
+      ["X25519", { crv: "X25519", x: x32 }, { name: "X25519" }, []],
     ];
-    it.each(cases)("%s", async (_name, jwk, alg, usages) => {
+    it.each(cases)("missing kty: %s", async (_name, jwk, alg, usages) => {
       const err = await crypto.subtle.importKey("jwk", jwk as JsonWebKey, alg, true, usages).then(
         () => null,
         e => e,
       );
+      expect(err).toBeInstanceOf(DOMException);
+      expect(err.name).toBe("DataError");
+    });
+
+    // X25519 import key, step 2.2: if the kty field of jwk is not "OKP", throw a DataError.
+    it("wrong kty: X25519", async () => {
+      const err = await crypto.subtle
+        .importKey("jwk", { kty: "EC", crv: "X25519", x: x32 }, { name: "X25519" }, true, [])
+        .then(
+          () => null,
+          e => e,
+        );
       expect(err).toBeInstanceOf(DOMException);
       expect(err.name).toBe("DataError");
     });
@@ -154,9 +169,8 @@ describe("Web Crypto", () => {
       expect(err.name).toBe("DataError");
     });
 
-    // Previously this promise never settled: the exception from JsonWebKey
-    // dictionary conversion escaped as an uncaught exception and the
-    // DeferredPromise was left in m_pendingPromises forever.
+    // An object with no recognized members (including no kty) is a valid
+    // JsonWebKey dictionary; the per-algorithm import key operation rejects it.
     it("rejects when wrapped bytes are valid JSON but not a valid JWK", async () => {
       const { key, iv, wrapped } = await setup(new TextEncoder().encode(JSON.stringify({ foo: "bar" })));
       const err = await crypto.subtle
@@ -169,12 +183,29 @@ describe("Web Crypto", () => {
       expect(err.name).toBe("DataError");
     });
 
+    // Previously this promise never settled: the exception from JsonWebKey
+    // dictionary conversion escaped as an uncaught exception and the
+    // DeferredPromise was left in m_pendingPromises forever.
+    it("rejects when the JWK dictionary conversion throws", async () => {
+      const { key, iv, wrapped } = await setup(
+        new TextEncoder().encode(JSON.stringify({ kty: "oct", key_ops: ["bogus"] })),
+      );
+      const err = await crypto.subtle
+        .unwrapKey("jwk", wrapped, key, { name: "AES-GCM", iv }, { name: "AES-GCM" }, true, ["encrypt", "decrypt"])
+        .then(
+          () => null,
+          e => e,
+        );
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.message).toContain("enumeration");
+    });
+
     it("does not leak DeferredPromise in m_pendingPromises on JWK parse errors", async () => {
       // Each leaked entry in m_pendingPromises holds a Ref<DeferredPromise>. On
-      // the dictionary-conversion error path the promise was never rejected, so
-      // DeferredPromise never removed itself from JSDOMGlobalObject's
-      // guardedObjects set and the JSPromise stayed alive. Count live Promise
-      // cells in the JSC heap to detect the leak.
+      // the dictionary-conversion error path (here, an invalid key_ops enum
+      // value) the promise was never rejected, so DeferredPromise never removed
+      // itself from JSDOMGlobalObject's guardedObjects set and the JSPromise
+      // stayed alive. Count live Promise cells in the JSC heap to detect the leak.
       const fixture = /* js */ `
         const { heapStats } = require("bun:jsc");
         const keyData = new Uint8Array(32).fill(1);
@@ -185,7 +216,7 @@ describe("Web Crypto", () => {
         const wrapped = await crypto.subtle.encrypt(
           { name: "AES-GCM", iv },
           key,
-          new TextEncoder().encode(JSON.stringify({ foo: "bar" })),
+          new TextEncoder().encode(JSON.stringify({ kty: "oct", key_ops: ["bogus"] })),
         );
         async function once() {
           await crypto.subtle

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -105,6 +105,31 @@ describe("Web Crypto", () => {
     expect(isSigValid).toBe(true);
   });
 
+  // W3C WebCrypto: JsonWebKey.kty is not a required dictionary member; each
+  // algorithm's import key operation rejects a missing/wrong kty with DataError.
+  describe("importKey jwk with missing kty rejects with DataError", () => {
+    const cases: Array<[string, object, object, KeyUsage[]]> = [
+      ["AES-GCM", { k: "AAECAwQFBgcICQoLDA0ODw" }, { name: "AES-GCM" }, ["encrypt"]],
+      ["HMAC", { k: "AAECAwQFBgcICQoLDA0ODw" }, { name: "HMAC", hash: "SHA-256" }, ["sign"]],
+      [
+        "RSA-OAEP",
+        { n: "AQAB", e: "AQAB" },
+        { name: "RSA-OAEP", hash: "SHA-256" },
+        ["encrypt"],
+      ],
+      ["ECDSA", { crv: "P-256", x: "", y: "" }, { name: "ECDSA", namedCurve: "P-256" }, ["verify"]],
+      ["Ed25519", { crv: "Ed25519", x: "" }, { name: "Ed25519" }, ["verify"]],
+    ];
+    it.each(cases)("%s", async (_name, jwk, alg, usages) => {
+      const err = await crypto.subtle.importKey("jwk", jwk as JsonWebKey, alg, true, usages).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBeInstanceOf(DOMException);
+      expect(err.name).toBe("DataError");
+    });
+  });
+
   describe("unwrapKey JWK error handling", () => {
     // Setup: AES-GCM key that can encrypt arbitrary bytes and also unwrap keys.
     // We encrypt payloads that decrypt to invalid JWK data so the JWK parse path
@@ -134,7 +159,7 @@ describe("Web Crypto", () => {
       expect(err.name).toBe("DataError");
     });
 
-    // Previously this promise never settled: the TypeError from JsonWebKey
+    // Previously this promise never settled: the exception from JsonWebKey
     // dictionary conversion escaped as an uncaught exception and the
     // DeferredPromise was left in m_pendingPromises forever.
     it("rejects when wrapped bytes are valid JSON but not a valid JWK", async () => {
@@ -145,8 +170,8 @@ describe("Web Crypto", () => {
           () => null,
           e => e,
         );
-      expect(err).toBeInstanceOf(TypeError);
-      expect(err.message).toContain("kty");
+      expect(err).toBeInstanceOf(DOMException);
+      expect(err.name).toBe("DataError");
     });
 
     it("does not leak DeferredPromise in m_pendingPromises on JWK parse errors", async () => {

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -111,12 +111,7 @@ describe("Web Crypto", () => {
     const cases: Array<[string, object, object, KeyUsage[]]> = [
       ["AES-GCM", { k: "AAECAwQFBgcICQoLDA0ODw" }, { name: "AES-GCM" }, ["encrypt"]],
       ["HMAC", { k: "AAECAwQFBgcICQoLDA0ODw" }, { name: "HMAC", hash: "SHA-256" }, ["sign"]],
-      [
-        "RSA-OAEP",
-        { n: "AQAB", e: "AQAB" },
-        { name: "RSA-OAEP", hash: "SHA-256" },
-        ["encrypt"],
-      ],
+      ["RSA-OAEP", { n: "AQAB", e: "AQAB" }, { name: "RSA-OAEP", hash: "SHA-256" }, ["encrypt"]],
       ["ECDSA", { crv: "P-256", x: "", y: "" }, { name: "ECDSA", namedCurve: "P-256" }, ["verify"]],
       ["Ed25519", { crv: "Ed25519", x: "" }, { name: "Ed25519" }, ["verify"]],
     ];


### PR DESCRIPTION
## What does this PR do?

`crypto.subtle.importKey("jwk", ...)` with a JWK object missing the `kty` member threw `TypeError` instead of `DataError`.

```js
try {
  await crypto.subtle.importKey("jwk", { k: "AAECAwQFBgcICQoLDA0ODw" }, { name: "AES-GCM" }, true, ["encrypt"]);
} catch (e) { console.log(e.name); }
```

| | before | after / Node.js / Chrome |
| --- | --- | --- |
| output | `TypeError` | `DataError` |

The [W3C WebCrypto spec](https://w3c.github.io/webcrypto/#JsonWebKey-dictionary) defines `JsonWebKey.kty` as an optional `DOMString`. Each algorithm's Import Key operation is then responsible for "If the `kty` field of jwk is not `<expected>`, then throw a `DataError`."

Bun inherited WebKit's IDL which marks `kty` as `required`, so the generated WebIDL dictionary conversion threw `TypeError: Member JsonWebKey.kty is required and must be an instance of DOMString` before the per-algorithm check ever ran. `DataError` is a `DOMException` and `TypeError` is a JS `Error`, so code that distinguishes "bad key material" (`DataError`: reject the key, try the next one in the JWKS) from "programmer error" (`TypeError`: crash) takes the wrong branch on every malformed JWK from an untrusted source.

Two changes:

1. `JSJsonWebKey.cpp`: drop the required-member `TypeError` for `kty`. A missing `kty` leaves `result.kty` as a null `String`, which fails each algorithm's `keyData.kty != "<expected>"` check and surfaces `DataError` via the normal `exceptionCallback(DataError, ...)` path. `JsonWebKey.idl` loses `required` to stay in sync.
2. `CryptoKeyOKP.cpp`: hoist the `keyData.kty != "OKP"` check above the curve switch in `importJwkInternal`. It previously lived only in the `Ed25519` arm; the `X25519` arm checked only `crv`, so with the WebIDL guard gone an X25519 JWK with a missing `kty` would have imported successfully instead of rejecting. This also fixes the pre-existing case where a wrong `kty` (for example `"EC"`) was silently accepted for X25519.

## How did you verify your code works?

In `test/js/web/crypto/web-crypto.test.ts`:

- `it.each` over AES-GCM, HMAC, RSA-OAEP, ECDSA, Ed25519, X25519: missing `kty` rejects with `DataError`. The OKP rows use a well-formed 32-byte `x` so the missing `kty` is the only reason the import is rejected.
- `wrong kty: X25519`: `{ kty: "EC", crv: "X25519", x }` rejects with `DataError`. On current Bun this imports successfully, so this test fails without the `CryptoKeyOKP.cpp` change on its own.
- The `unwrapKey` tests that used `{foo:"bar"}` to exercise the JWK dictionary-conversion exception path no longer do (that object converts cleanly now that `kty` is optional), so those fixtures switch to an invalid `key_ops` enum value. The `{foo:"bar"}` case is kept as coverage for the kty-less `DataError` path.

```
bun bd test test/js/web/crypto/web-crypto.test.ts    # 23 pass
USE_SYSTEM_BUN=1 bun test <same file>                # 8 fail (the new and changed assertions)
```

No regressions in the existing OKP JWK import coverage: `test/js/deno/crypto/webcrypto.test.ts`, `test/js/bun/crypto/x25519-derive-bits.test.ts`, and Node's `test-webcrypto-derivebits-cfrg.js`, `test-webcrypto-derivekey-cfrg.js`, `test-webcrypto-sign-verify.js`, and `test-webcrypto-wrap-unwrap.js` all pass.
