### PR TITLE
glob: treat a brace group with no comma as literal in match()

### DIFF
--- a/src/glob/lib.rs
+++ b/src/glob/lib.rs
@@ -6,7 +6,7 @@ pub mod matcher;
 
 // `match` is a Rust keyword; re-export with raw identifier.
 pub use crate::glob_walker as walk;
-pub use crate::matcher::{MatchResult, r#match};
+pub use crate::matcher::{MatchResult, escape_literal_braces, match_preprocessed, r#match};
 pub use walk::GlobWalker;
 
 // `ignore_filter_fn` is a runtime fn-pointer field supplied at `init()` rather than a type

--- a/src/glob/lib.rs
+++ b/src/glob/lib.rs
@@ -6,7 +6,7 @@ pub mod matcher;
 
 // `match` is a Rust keyword; re-export with raw identifier.
 pub use crate::glob_walker as walk;
-pub use crate::matcher::{MatchResult, escape_literal_braces, match_preprocessed, r#match};
+pub use crate::matcher::{MatchResult, escape_literal_braces, r#match, match_preprocessed};
 pub use walk::GlobWalker;
 
 // `ignore_filter_fn` is a runtime fn-pointer field supplied at `init()` rather than a type

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -111,11 +111,15 @@ struct Wildcard {
 /// Brace groups only expand when they contain at least one unescaped top-level
 /// comma; `{a}`, `{}`, and unclosed `{...` are taken literally, matching bash,
 /// picomatch, and minimatch. Returns a rewritten pattern with each such `{`/`}`
-/// escaped, or `None` if every brace group already has a comma.
+/// escaped, or `None` if no brace needs rewriting.
+///
+/// The rewritten bytes are for the matcher only: they must never be handed to
+/// `GlobWalker::build_pattern_components`, which treats `\` as a path
+/// separator on Windows and would split the pattern at the inserted escapes.
+/// `r#match` applies this itself, so walker components and every other caller
+/// of `r#match` get the behavior without seeing the rewritten form.
 pub fn escape_literal_braces(glob: &[u8]) -> Option<Vec<u8>> {
-    if strings::index_of_char(glob, b'{').is_none() {
-        return None;
-    }
+    strings::index_of_char(glob, b'{')?;
 
     let mut stack: SmallVec<[(u32, bool); 8]> = SmallVec::new();
     let mut literal: SmallVec<[u32; 8]> = SmallVec::new();
@@ -201,10 +205,10 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
     }
 }
 
-/// Like `r#match`, but assumes every `{...}` in `glob` is a valid brace
-/// expansion (contains a top-level comma). Callers that retain a pattern
-/// across many matches should call `escape_literal_braces` once up front
-/// and pass the result here to avoid rescanning on every call.
+/// `r#match` without the `escape_literal_braces` pass. Only for callers that
+/// hold a pattern already returned by `escape_literal_braces` (or for which it
+/// returned `None`) and match it many times; everything else should use
+/// `r#match`.
 pub fn match_preprocessed(glob: &[u8], path: &[u8]) -> MatchResult {
     let mut state = State::default();
 

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -108,6 +108,23 @@ struct Wildcard {
     brace_depth: u8,
 }
 
+/// Whether the `[` at `glob[open]` has an unescaped `]` later in the pattern.
+/// An unclosed `[` is a literal byte, not the start of a bracket class, so it
+/// must not hide a following `}` or `,` from `escape_literal_braces`'s scan:
+/// bash, picomatch, and minimatch all expand `{a,[}` to `a` and `[`.
+fn bracket_has_closing(glob: &[u8], open: usize) -> bool {
+    let mut j = open + 1;
+    while j < glob.len() {
+        match glob[j] {
+            b']' => return true,
+            b'\\' => j += 1,
+            _ => {}
+        }
+        j += 1;
+    }
+    false
+}
+
 /// Brace groups only expand when they contain at least one unescaped top-level
 /// comma; `{a}`, `{}`, and unclosed `{...` are taken literally, matching bash,
 /// picomatch, and minimatch. Returns a rewritten pattern with each such `{`/`}`
@@ -141,7 +158,7 @@ pub fn escape_literal_braces(glob: &[u8]) -> Option<Vec<u8>> {
                     top.1 = true;
                 }
             }
-            b'[' if !in_brackets => in_brackets = true,
+            b'[' if !in_brackets && bracket_has_closing(glob, i) => in_brackets = true,
             b']' => in_brackets = false,
             b'\\' => i += 1,
             _ => {}

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -110,8 +110,10 @@ struct Wildcard {
 
 /// Whether the `[` at `glob[open]` has an unescaped `]` later in the pattern.
 /// An unclosed `[` is a literal byte, not the start of a bracket class, so it
-/// must not hide a following `}` or `,` from `escape_literal_braces`'s scan:
-/// bash, picomatch, and minimatch all expand `{a,[}` to `a` and `[`.
+/// must not hide a following `}` or `,` from `escape_literal_braces`'s scan;
+/// bash, picomatch, and minimatch all keep `{a,[}` an expansion. This only
+/// decides the escaping: whether the `[` branch itself can match is up to
+/// `match_brace`, whose own unclosed-`[` handling is unchanged.
 fn bracket_has_closing(glob: &[u8], open: usize) -> bool {
     let mut j = open + 1;
     while j < glob.len() {
@@ -141,6 +143,10 @@ pub fn escape_literal_braces(glob: &[u8]) -> Option<Vec<u8>> {
     let mut stack: SmallVec<[(u32, bool); 8]> = SmallVec::new();
     let mut literal: SmallVec<[u32; 8]> = SmallVec::new();
     let mut in_brackets = false;
+    // `bracket_has_closing` walks the same escape-aware path this loop does,
+    // so once it finds no `]` after one `[` there is none after any later `[`
+    // either; remembering that keeps a long run of unclosed `[` linear.
+    let mut no_closing_bracket = false;
     let mut i: usize = 0;
     while i < glob.len() {
         match glob[i] {
@@ -158,7 +164,13 @@ pub fn escape_literal_braces(glob: &[u8]) -> Option<Vec<u8>> {
                     top.1 = true;
                 }
             }
-            b'[' if !in_brackets && bracket_has_closing(glob, i) => in_brackets = true,
+            b'[' if !in_brackets && !no_closing_bracket => {
+                if bracket_has_closing(glob, i) {
+                    in_brackets = true;
+                } else {
+                    no_closing_bracket = true;
+                }
+            }
             b']' => in_brackets = false,
             b'\\' => i += 1,
             _ => {}

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -23,6 +23,7 @@
 // THE SOFTWARE.
 
 use bun_collections::BoundedArray;
+use bun_collections::smallvec::SmallVec;
 use bun_core::strings;
 
 /// used in matchBrace to determine the size of the stack buffer used in the stack fallback allocator
@@ -107,6 +108,63 @@ struct Wildcard {
     brace_depth: u8,
 }
 
+/// Brace groups only expand when they contain at least one unescaped top-level
+/// comma; `{a}`, `{}`, and unclosed `{...` are taken literally, matching bash,
+/// picomatch, and minimatch. Returns a rewritten pattern with each such `{`/`}`
+/// escaped, or `None` if every brace group already has a comma.
+pub fn escape_literal_braces(glob: &[u8]) -> Option<Vec<u8>> {
+    if strings::index_of_char(glob, b'{').is_none() {
+        return None;
+    }
+
+    let mut stack: SmallVec<[(u32, bool); 8]> = SmallVec::new();
+    let mut literal: SmallVec<[u32; 8]> = SmallVec::new();
+    let mut in_brackets = false;
+    let mut i: usize = 0;
+    while i < glob.len() {
+        match glob[i] {
+            b'{' if !in_brackets => stack.push((i as u32, false)),
+            b'}' if !in_brackets => {
+                if let Some((open, has_comma)) = stack.pop() {
+                    if !has_comma {
+                        literal.push(open);
+                        literal.push(i as u32);
+                    }
+                }
+            }
+            b',' if !in_brackets => {
+                if let Some(top) = stack.last_mut() {
+                    top.1 = true;
+                }
+            }
+            b'[' if !in_brackets => in_brackets = true,
+            b']' => in_brackets = false,
+            b'\\' => i += 1,
+            _ => {}
+        }
+        i += 1;
+    }
+    for (open, _) in stack.drain(..) {
+        literal.push(open);
+    }
+
+    if literal.is_empty() {
+        return None;
+    }
+
+    literal.sort_unstable();
+    let mut out = Vec::with_capacity(glob.len() + literal.len());
+    let mut prev: usize = 0;
+    for &pos in literal.iter() {
+        let pos = pos as usize;
+        out.extend_from_slice(&glob[prev..pos]);
+        out.push(b'\\');
+        prev = pos;
+    }
+    out.extend_from_slice(&glob[prev..]);
+    Some(out)
+}
+
 /// This function checks returns a boolean value if the pathname `path` matches
 /// the pattern `glob`.
 ///
@@ -137,6 +195,17 @@ struct Wildcard {
 // TODO: consider just taking arena and resetting to initial state,
 // all usages of this function pass in Arena.arena()
 pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
+    match escape_literal_braces(glob) {
+        Some(escaped) => match_preprocessed(&escaped, path),
+        None => match_preprocessed(glob, path),
+    }
+}
+
+/// Like `r#match`, but assumes every `{...}` in `glob` is a valid brace
+/// expansion (contains a top-level comma). Callers that retain a pattern
+/// across many matches should call `escape_literal_braces` once up front
+/// and pass the result here to avoid rescanning on every call.
+pub fn match_preprocessed(glob: &[u8], path: &[u8]) -> MatchResult {
     let mut state = State::default();
 
     let mut negated = false;

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -18,6 +18,14 @@ use bun_sys as syscall;
 #[bun_jsc::JsClass]
 pub struct Glob {
     pattern: Box<[u8]>,
+    /// `pattern` with its literal (comma-less or unclosed) brace groups
+    /// escaped, precomputed once so `match()` does not rescan the pattern on
+    /// every call. `None` when `pattern` needs no rewriting. The walker keeps
+    /// using the raw `pattern`: `build_pattern_components` treats `\` as a
+    /// path separator on Windows, so the escaped form must never reach it
+    /// (the walker's per-component `bun_glob::r#match` applies the escaping
+    /// itself).
+    match_pattern: Option<Box<[u8]>>,
     has_pending_activity: AtomicUsize,
 }
 
@@ -370,14 +378,15 @@ impl Glob {
             )));
         }
 
-        let pat_str = pat_arg.to_slice_clone(global_this)?.into_vec();
-        let pat_str: Box<[u8]> = match bun_glob::escape_literal_braces(&pat_str) {
-            Some(escaped) => escaped.into_boxed_slice(),
-            None => pat_str.into_boxed_slice(),
-        };
+        let pat_str: Box<[u8]> = pat_arg
+            .to_slice_clone(global_this)?
+            .into_vec()
+            .into_boxed_slice();
+        let match_pattern = bun_glob::escape_literal_braces(&pat_str).map(Vec::into_boxed_slice);
 
         Ok(Box::new(Glob {
             pattern: pat_str,
+            match_pattern,
             has_pending_activity: AtomicUsize::new(0),
         }))
     }
@@ -501,8 +510,9 @@ impl Glob {
         let str = str_arg.to_slice(global_this)?;
         // `str` drops at scope exit.
 
+        let pattern = self.match_pattern.as_deref().unwrap_or(&self.pattern);
         Ok(JSValue::from(
-            bun_glob::match_preprocessed(&self.pattern, str.slice()).matches(),
+            bun_glob::match_preprocessed(pattern, str.slice()).matches(),
         ))
     }
 }

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -370,10 +370,11 @@ impl Glob {
             )));
         }
 
-        let pat_str: Box<[u8]> = pat_arg
-            .to_slice_clone(global_this)?
-            .into_vec()
-            .into_boxed_slice();
+        let pat_str = pat_arg.to_slice_clone(global_this)?.into_vec();
+        let pat_str: Box<[u8]> = match bun_glob::escape_literal_braces(&pat_str) {
+            Some(escaped) => escaped.into_boxed_slice(),
+            None => pat_str.into_boxed_slice(),
+        };
 
         Ok(Box::new(Glob {
             pattern: pat_str,
@@ -501,7 +502,7 @@ impl Glob {
         // `str` drops at scope exit.
 
         Ok(JSValue::from(
-            bun_glob::r#match(&self.pattern, str.slice()).matches(),
+            bun_glob::match_preprocessed(&self.pattern, str.slice()).matches(),
         ))
     }
 }

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -368,7 +368,7 @@ impl Expansion {
     /// able to broaden the match. Mirrors `do_brace_expand`'s escaping loop,
     /// but the glob matcher has no general backslash-escape that survives
     /// `build_pattern_components` on every platform, so each byte is wrapped
-    /// in a single-character class (`[c]`) — or a one-branch brace group for
+    /// in a single-character class (`[c]`) — or a two-branch brace group for
     /// a component-leading `!` — which the matcher provably treats as that
     /// literal character.
     /// `current_out` itself is not mutated: the no-match error message and the
@@ -391,18 +391,21 @@ impl Expansion {
                 // class wrapper. Only a `!` at the start of a path component
                 // (the same split `build_pattern_components` performs) can act
                 // as pattern syntax — the matcher's negation loop — so wrap
-                // that one in a one-branch brace group whose sole branch is
-                // the literal `!`. Every other `!` already matches literally
-                // and is emitted bare: wrapping each one costs a brace-stack
-                // slot per byte, and a run of more than 10 interpolated `!`
-                // would overflow the matcher's bounded brace stack and turn
-                // the whole word into a spurious no-match.
+                // that one in a brace group whose branches are both the
+                // literal `!`. The group needs a top-level comma: the matcher
+                // only expands a `{...}` that contains one and treats a
+                // comma-less group as the literal braces (same as bash).
+                // Every other `!` already matches literally and is emitted
+                // bare: wrapping each one costs a brace-stack slot per byte,
+                // and a run of more than 10 interpolated `!` would overflow
+                // the matcher's bounded brace stack and turn the whole word
+                // into a spurious no-match.
                 b'!' => {
                     let starts_component = pattern
                         .last()
                         .is_none_or(|&prev| bun_core::path_sep::is_sep_native(prev));
                     if starts_component {
-                        pattern.extend_from_slice(b"{!}");
+                        pattern.extend_from_slice(b"{!,!}");
                     } else {
                         pattern.push(b'!');
                     }

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -120,7 +120,7 @@ describe("Glob.match", () => {
     expect(glob.match("foobuzz")).toBeTrue();
     expect(glob.match("foobarz")).toBeTrue();
 
-    glob = new Glob("{a}/{b}/");
+    glob = new Glob("{a,}/{b,}/");
     expect(glob.match("a/b/")).toBeTrue();
 
     glob = new Glob("{a,b}/c/{d,e}/**/*est.ts");
@@ -306,15 +306,18 @@ describe("Glob.match", () => {
     expect(glob.match("b")).toBeTrue();
     expect(glob.match("c")).toBeTrue();
 
-    // Empty nested group
+    // Inner group with no comma is literal (bash/picomatch/minimatch)
     glob = new Glob("{a,b{}}");
     expect(glob.match("a")).toBeTrue();
-    expect(glob.match("b")).toBeTrue();
+    expect(glob.match("b")).toBeFalse();
+    expect(glob.match("b{}")).toBeTrue();
 
     // Empty nested group with tail
     glob = new Glob("{a,b{,c{{}}}}d");
     expect(glob.match("ad")).toBeTrue();
-    expect(glob.match("bcd")).toBeTrue();
+    expect(glob.match("bd")).toBeTrue();
+    expect(glob.match("bcd")).toBeFalse();
+    expect(glob.match("bc{{}}d")).toBeTrue();
 
     // Leading nested group
     glob = new Glob("{{a,b},c}");
@@ -322,11 +325,113 @@ describe("Glob.match", () => {
     expect(glob.match("b")).toBeTrue();
     expect(glob.match("c")).toBeTrue();
 
-    // Empty nested group in middle
+    // Inner group with no comma is literal
     glob = new Glob("{a,b{c,d{}}}e");
     expect(glob.match("ae")).toBeTrue();
     expect(glob.match("bce")).toBeTrue();
-    expect(glob.match("bde")).toBeTrue();
+    expect(glob.match("bde")).toBeFalse();
+    expect(glob.match("bd{}e")).toBeTrue();
+  });
+
+  test("brace groups without a comma are literal", () => {
+    let glob: Glob;
+
+    // A `{...}` group with no top-level comma is not an expansion; the braces
+    // are matched literally. bash, picomatch, and minimatch all agree.
+    glob = new Glob("{a}");
+    expect(glob.match("{a}")).toBeTrue();
+    expect(glob.match("a")).toBeFalse();
+
+    glob = new Glob("{a}.ts");
+    expect(glob.match("{a}.ts")).toBeTrue();
+    expect(glob.match("a.ts")).toBeFalse();
+
+    glob = new Glob("{}");
+    expect(glob.match("{}")).toBeTrue();
+    expect(glob.match("")).toBeFalse();
+
+    glob = new Glob("x{}y");
+    expect(glob.match("x{}y")).toBeTrue();
+    expect(glob.match("xy")).toBeFalse();
+
+    // `{1..3}` has no comma and Bun does not implement range expansion, so
+    // it is literal.
+    glob = new Glob("{1..3}");
+    expect(glob.match("{1..3}")).toBeTrue();
+    expect(glob.match("1..3")).toBeFalse();
+    expect(glob.match("2")).toBeFalse();
+
+    // Unclosed `{` is literal.
+    glob = new Glob("{abc");
+    expect(glob.match("{abc")).toBeTrue();
+    expect(glob.match("abc")).toBeFalse();
+
+    glob = new Glob("{a,b");
+    expect(glob.match("{a,b")).toBeTrue();
+    expect(glob.match("a")).toBeFalse();
+
+    // Escaped comma does not make the group an expansion.
+    glob = new Glob("{a\\,b}");
+    expect(glob.match("{a,b}")).toBeTrue();
+    expect(glob.match("a")).toBeFalse();
+    expect(glob.match("b")).toBeFalse();
+
+    // A comma inside a `[...]` class does not make the group an expansion.
+    glob = new Glob("{[,]}");
+    expect(glob.match("{,}")).toBeTrue();
+    expect(glob.match(",")).toBeFalse();
+
+    // Outer group has no top-level comma (literal), inner group does (expands).
+    glob = new Glob("{a{b,c}}");
+    expect(glob.match("{ab}")).toBeTrue();
+    expect(glob.match("{ac}")).toBeTrue();
+    expect(glob.match("ab")).toBeFalse();
+    expect(glob.match("ac")).toBeFalse();
+
+    glob = new Glob("{{a,b}}");
+    expect(glob.match("{a}")).toBeTrue();
+    expect(glob.match("{b}")).toBeTrue();
+    expect(glob.match("a")).toBeFalse();
+
+    // Literal group nested between two expanding groups.
+    glob = new Glob("{x,{a{b,c}}}");
+    expect(glob.match("x")).toBeTrue();
+    expect(glob.match("{ab}")).toBeTrue();
+    expect(glob.match("{ac}")).toBeTrue();
+    expect(glob.match("ab")).toBeFalse();
+
+    // Literal group followed by a valid expansion.
+    glob = new Glob("{a}.{ts,js}");
+    expect(glob.match("{a}.ts")).toBeTrue();
+    expect(glob.match("{a}.js")).toBeTrue();
+    expect(glob.match("a.ts")).toBeFalse();
+
+    // Wildcard interacting with a literal group.
+    glob = new Glob("*{a}");
+    expect(glob.match("x{a}")).toBeTrue();
+    expect(glob.match("{a}")).toBeTrue();
+    expect(glob.match("xa")).toBeFalse();
+
+    // Negation with a literal group.
+    glob = new Glob("!{a}");
+    expect(glob.match("{a}")).toBeFalse();
+    expect(glob.match("a")).toBeTrue();
+
+    // Groups with a comma still expand as before.
+    glob = new Glob("{a,b}");
+    expect(glob.match("a")).toBeTrue();
+    expect(glob.match("b")).toBeTrue();
+    expect(glob.match("{a,b}")).toBeFalse();
+
+    glob = new Glob("{,a}");
+    expect(glob.match("")).toBeTrue();
+    expect(glob.match("a")).toBeTrue();
+    expect(glob.match("{,a}")).toBeFalse();
+
+    // Already-escaped braces still work.
+    glob = new Glob("\\{a\\}");
+    expect(glob.match("{a}")).toBeTrue();
+    expect(glob.match("a")).toBeFalse();
   });
 
   test("deeply nested braces do not overflow depth counters", () => {
@@ -353,11 +458,11 @@ describe("Glob.match", () => {
     glob = new Glob("*{a," + opens + closes + "}");
     expect(glob.match("za")).toBeTrue();
 
-    // >32767 consecutive `{` overflows match_brace's group pre-scan counter.
-    // The group never closes, so nothing matches.
+    // >32767 consecutive `{` with no closing brace: every `{` is literal.
     glob = new Glob(Buffer.alloc(40_000, "{").toString());
     expect(glob.match("a")).toBeFalse();
     expect(glob.match("{")).toBeFalse();
+    expect(glob.match(Buffer.alloc(40_000, "{").toString())).toBeTrue();
   });
 
   // Most of the potential bugs when dealing with non-ASCII patterns is when the

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -105,7 +105,7 @@ describe("Glob.match", () => {
     expect(new Glob("**/*/c.js").match("a/b/c.js")).toBeTrue();
   });
 
-  test("braces", async () => {
+  test("braces", () => {
     let glob: Glob;
 
     glob = new Glob("index.{ts,tsx,js,jsx}");
@@ -131,66 +131,56 @@ describe("Glob.match", () => {
 
     glob = new Glob("{**/a,**/b}");
     expect(glob.match("b")).toBeTrue();
+  });
 
-    const fixtures = [
-      {
-        pattern: "{src,extensions}/**/test/**/{fixtures,browser,common}/**/*.{ts,js}",
-        expectedMatches: "matched-0.txt",
-      },
-      { pattern: "{extensions,src}/**/{media,images,icons}/**/*.{svg,png,gif,jpg}", expectedMatches: "matched-1.txt" },
-      {
-        pattern: "{.github,build,test}/**/{workflows,azure-pipelines,integration,smoke}/**/*.{yml,yaml,json}",
-        expectedMatches: "matched-2.txt",
-      },
-      {
-        pattern: "src/vs/{base,editor,platform,workbench}/test/{browser,common,node}/**/[a-z]*[tT]est.ts",
-        expectedMatches: "matched-3.txt",
-      },
-      {
-        pattern: "src/vs/workbench/{contrib,services}/**/*{Editor,Workspace,Terminal}*.ts",
-        expectedMatches: "matched-4.txt",
-      },
-      {
-        pattern: "{extensions,src}/**/{markdown,json,javascript,typescript}/**/*.{ts,json}",
-        expectedMatches: "matched-5.txt",
-      },
-      {
-        pattern: "**/{electron-sandbox,electron-main,browser,node}/**/{*[sS]ervice*,*[cC]ontroller*}.ts",
-        expectedMatches: "matched-6.txt",
-      },
-      {
-        pattern: "{src,extensions}/**/{common,browser,electron-sandbox}/**/*{[cC]ontribution,[sS]ervice}.ts",
-        expectedMatches: "matched-7.txt",
-      },
-      {
-        pattern: "src/vs/{base,platform,workbench}/**/{test,browser}/**/*{[mM]odel,[cC]ontroller}*.ts",
-        expectedMatches: "matched-8.txt",
-      },
-      {
-        pattern: "extensions/**/{browser,common,node}/{**/*[sS]ervice*,**/*[pP]rovider*}.ts",
-        expectedMatches: "matched-9.txt",
-      },
-    ];
+  // One test per pattern: the full matrix is ~79k match() calls against the
+  // 7894-entry vscode file list, which sits right at the 5s per-test budget
+  // under a debug+ASAN build when run as a single test.
+  test.each([
+    {
+      pattern: "{src,extensions}/**/test/**/{fixtures,browser,common}/**/*.{ts,js}",
+      expectedMatches: "matched-0.txt",
+    },
+    { pattern: "{extensions,src}/**/{media,images,icons}/**/*.{svg,png,gif,jpg}", expectedMatches: "matched-1.txt" },
+    {
+      pattern: "{.github,build,test}/**/{workflows,azure-pipelines,integration,smoke}/**/*.{yml,yaml,json}",
+      expectedMatches: "matched-2.txt",
+    },
+    {
+      pattern: "src/vs/{base,editor,platform,workbench}/test/{browser,common,node}/**/[a-z]*[tT]est.ts",
+      expectedMatches: "matched-3.txt",
+    },
+    {
+      pattern: "src/vs/workbench/{contrib,services}/**/*{Editor,Workspace,Terminal}*.ts",
+      expectedMatches: "matched-4.txt",
+    },
+    {
+      pattern: "{extensions,src}/**/{markdown,json,javascript,typescript}/**/*.{ts,json}",
+      expectedMatches: "matched-5.txt",
+    },
+    {
+      pattern: "**/{electron-sandbox,electron-main,browser,node}/**/{*[sS]ervice*,*[cC]ontroller*}.ts",
+      expectedMatches: "matched-6.txt",
+    },
+    {
+      pattern: "{src,extensions}/**/{common,browser,electron-sandbox}/**/*{[cC]ontribution,[sS]ervice}.ts",
+      expectedMatches: "matched-7.txt",
+    },
+    {
+      pattern: "src/vs/{base,platform,workbench}/**/{test,browser}/**/*{[mM]odel,[cC]ontroller}*.ts",
+      expectedMatches: "matched-8.txt",
+    },
+    {
+      pattern: "extensions/**/{browser,common,node}/{**/*[sS]ervice*,**/*[pP]rovider*}.ts",
+      expectedMatches: "matched-9.txt",
+    },
+  ])("braces match the vscode filelist: $pattern", async ({ pattern, expectedMatches }) => {
+    const fixtureDir = join(import.meta.dir, "..", "..", "..", "fixtures", "glob");
+    const allFilePaths = (await Bun.file(join(fixtureDir, "filelist.txt")).text()).split("\n");
+    const shouldMatch = (await Bun.file(join(fixtureDir, expectedMatches)).text()).split("\n");
 
-    const allFilePaths = (
-      await Bun.file(join(import.meta.dir, "..", "..", "..", "fixtures", "glob", "filelist.txt")).text()
-    ).split("\n");
-
-    for (const { pattern, expectedMatches } of fixtures) {
-      const shouldMatch = (
-        await Bun.file(join(import.meta.dir, "..", "..", "..", "fixtures", "glob", `${expectedMatches}`)).text()
-      ).split("\n");
-
-      glob = new Glob(pattern);
-      let matched: string[] = [];
-      for (const filepath of allFilePaths) {
-        if (glob.match(filepath)) {
-          matched.push(filepath);
-        }
-      }
-
-      expect(matched).toEqual(shouldMatch);
-    }
+    const glob = new Glob(pattern);
+    expect(allFilePaths.filter(filepath => glob.match(filepath))).toEqual(shouldMatch);
   });
 
   test("nested braces", () => {
@@ -482,6 +472,16 @@ describe("Glob.match", () => {
     // Same shape inside a wildcard backtrack.
     glob = new Glob("*{a," + opens + "x" + closes + "}");
     expect(glob.match("za")).toBeTrue();
+
+    // >32767 nested comma-bearing groups: match_brace's forward pre-scan
+    // counter must be wider than i16. The unclosed variant below no longer
+    // reaches match_brace, so this one carries a comma at every level.
+    const deepOpens = Buffer.alloc(120_000, "{a,").toString(); // 40_000 x "{a,"
+    const deepCloses = Buffer.alloc(40_000, "}").toString();
+    glob = new Glob("{" + deepOpens + "x" + deepCloses + ",z}");
+    expect(glob.match("a")).toBeTrue();
+    expect(glob.match("z")).toBeTrue();
+    expect(glob.match("b")).toBeFalse();
 
     // >32767 consecutive `{` with no closing brace: every `{` is literal.
     glob = new Glob(Buffer.alloc(40_000, "{").toString());

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -393,9 +393,9 @@ describe("Glob.match", () => {
     expect(glob.match("{,}")).toBeTrue();
     expect(glob.match(",")).toBeFalse();
 
-    // An unclosed `[` is a literal `[`, not the start of a bracket class, so
-    // it does not hide the group's `}`: the group still has a top-level comma
-    // and still expands (bash, picomatch, and minimatch agree).
+    // An unclosed `[` is a literal `[`, not a bracket class, so it cannot hide
+    // the group's `}` and the first branch still matches. The `[` branch is a
+    // separate pre-existing gap in match_brace's own unclosed-`[` handling.
     glob = new Glob("{a,[}");
     expect(glob.match("a")).toBeTrue();
 

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -393,6 +393,15 @@ describe("Glob.match", () => {
     expect(glob.match("{,}")).toBeTrue();
     expect(glob.match(",")).toBeFalse();
 
+    // An unclosed `[` is a literal `[`, not the start of a bracket class, so
+    // it does not hide the group's `}`: the group still has a top-level comma
+    // and still expands (bash, picomatch, and minimatch agree).
+    glob = new Glob("{a,[}");
+    expect(glob.match("a")).toBeTrue();
+
+    glob = new Glob("{foo,[bar}");
+    expect(glob.match("foo")).toBeTrue();
+
     // Outer group has no top-level comma (literal), inner group does (expands).
     glob = new Glob("{a{b,c}}");
     expect(glob.match("{ab}")).toBeTrue();

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -346,6 +346,28 @@ describe("Glob.match", () => {
     expect(glob.match("{a}.ts")).toBeTrue();
     expect(glob.match("a.ts")).toBeFalse();
 
+    // Only the braces become literal; glob syntax inside the group still
+    // applies. bash's `{*}` is a literal `{`, a wildcard, and a literal `}`;
+    // picomatch and minimatch agree.
+    glob = new Glob("{*}");
+    expect(glob.match("{*}")).toBeTrue();
+    expect(glob.match("{abc}")).toBeTrue();
+    expect(glob.match("abc")).toBeFalse();
+
+    glob = new Glob("{?}");
+    expect(glob.match("{x}")).toBeTrue();
+    expect(glob.match("x")).toBeFalse();
+
+    glob = new Glob("{[ab]}");
+    expect(glob.match("{a}")).toBeTrue();
+    expect(glob.match("{b}")).toBeTrue();
+    expect(glob.match("{c}")).toBeFalse();
+    expect(glob.match("a")).toBeFalse();
+
+    glob = new Glob("x{*}y");
+    expect(glob.match("x{abc}y")).toBeTrue();
+    expect(glob.match("xabcy")).toBeFalse();
+
     glob = new Glob("{}");
     expect(glob.match("{}")).toBeTrue();
     expect(glob.match("")).toBeFalse();
@@ -435,27 +457,30 @@ describe("Glob.match", () => {
   });
 
   test("deeply nested braces do not overflow depth counters", () => {
-    const opens = Buffer.alloc(300, "{").toString();
+    // Every level carries a top-level comma so the groups stay expansions;
+    // a comma-less group is a literal and would never reach the counters.
+    const opens = Buffer.alloc(900, "{a,").toString(); // 300 x "{a,"
     const closes = Buffer.alloc(300, "}").toString();
 
     // First branch matches; skip_branch must scan past >255 nested braces to
     // find the closing brace of the outer group.
-    let glob = new Glob("{a," + opens + closes + "}");
+    let glob = new Glob("{a," + opens + "x" + closes + "}");
     expect(glob.match("a")).toBeTrue();
     expect(glob.match("b")).toBeFalse();
 
-    // Deeply nested braces in the first (non-matching) branch, second branch matches.
-    glob = new Glob("{" + opens + closes + ",a}");
+    // Deeply nested braces in the first branch, second branch matches.
+    glob = new Glob("{" + opens + "x" + closes + ",z}");
     expect(glob.match("a")).toBeTrue();
+    expect(glob.match("z")).toBeTrue();
 
     // Deep nest with content, surrounded by matching branches on both sides.
-    glob = new Glob("{a," + opens + "x" + closes + ",b}");
-    expect(glob.match("a")).toBeTrue();
-    expect(glob.match("b")).toBeTrue();
+    glob = new Glob("{q," + opens + "x" + closes + ",r}");
+    expect(glob.match("q")).toBeTrue();
+    expect(glob.match("r")).toBeTrue();
     expect(glob.match("y")).toBeFalse();
 
     // Same shape inside a wildcard backtrack.
-    glob = new Glob("*{a," + opens + closes + "}");
+    glob = new Glob("*{a," + opens + "x" + closes + "}");
     expect(glob.match("za")).toBeTrue();
 
     // >32767 consecutive `{` with no closing brace: every `{` is literal.


### PR DESCRIPTION
## Problem

`Bun.Glob.match()` expands every `{...}` as a brace group, including groups that contain no comma:

```js
new Bun.Glob("{a}").match("{a}")       // false, should be true
new Bun.Glob("{a}").match("a")         // true,  should be false
new Bun.Glob("{a}.ts").match("a.ts")   // true,  should be false
new Bun.Glob("{}").match("{}")         // false, should be true
new Bun.Glob("x{}y").match("xy")       // true,  should be false
```

bash only performs brace expansion when the group contains at least one unescaped comma (or a `..` sequence expression): `touch '{a}.ts'; echo {a}.ts` prints `{a}.ts`. picomatch and minimatch agree:

```js
require('picomatch')('{a}.ts')('{a}.ts')  // true
require('picomatch')('{a}.ts')('a.ts')    // false
require('minimatch')('{a}.ts', '{a}.ts')  // true
```

This bites framework filename conventions that use literal braces in paths, and means `{1..3}` (which Bun does not implement as a range) matches the wrong thing.

## Cause

`match_brace` in `src/glob/matcher.rs` tries each comma-separated segment of a `{...}` group as a branch; when there is no comma it still tries the single segment between `{` and `}`, so `{a}` becomes a one-branch expansion matching `a` and `{}` matches the empty string.

## Fix

Scan the pattern once up front and, for every `{...}` group that has no unescaped top-level comma (or no closing `}` at all), escape the braces to `\{` / `\}`. The matching loop then sees them as ordinary literal bytes with no changes to its state machine. The scan uses the same depth / `[...]` / `\` rules as `match_brace`, so a comma nested inside an inner group or inside a bracket class does not count, and only the braces themselves become literal: glob syntax inside the group still applies (`{*}` matches `{abc}`, `{a{b,c}}` matches `{ab}` or `{ac}`, same as bash and picomatch).

One deliberate divergence from `match_brace`: the scan only enters bracket mode at a `[` when an unescaped `]` follows, so an unclosed `[` is a literal byte and cannot hide the group's `}` or `,`. Without this, `{a,[}` would be misclassified as an unclosed group and go literal, but bash, picomatch, and minimatch all keep it an expansion, and `match_brace` already matched the `a` branch (it fires each branch at its comma and does not need the structural close). This only decides whether the group survives escaping; the `[` branch itself is still unreachable because `match_brace`'s own unclosed-`[` handling is unchanged, which is the separate pre-existing gap #32895 addresses. The first `false` from the lookahead is sticky (no `]` after one `[` means none after any later `[`), so a long run of unclosed `[` stays linear.

The escaped bytes stay inside `r#match` and never reach `GlobWalker::build_pattern_components` (which treats `\` as a path separator on Windows and would split the pattern at the inserted escapes). `Bun.Glob` still caches the escaped form in a dedicated field so `match()` does not rescan on every call, but the walker keeps reading the raw pattern and its per-component `r#match` applies the escaping itself. Every other caller of `bun_glob::r#match` (test scanner, `pm pack`, `--filter`, `path.matchesGlob`, etc.) gets the scan inline.

The shell neutralized a component-leading interpolated `!` by emitting the one-branch group `{!}`, which this change correctly turns into a literal. It now emits `{!,!}`, a real two-branch expansion whose branches are both the literal `!`, so interpolated `!` stays inert.

## Verification

New `brace groups without a comma are literal` block in `test/js/bun/glob/match.test.ts` covers the reported cases plus `{1..3}`, unclosed `{`, escaped `\,`, comma inside `[...]`, glob syntax inside a literal group (`{*}`, `{?}`, `{[ab]}`), an unclosed `[` inside a comma-bearing group (`{a,[}` still expands), literal-outer/expanding-inner nesting, wildcard and negation interaction, and already-escaped `\{`. A few existing assertions in the `nested braces` block were asserting the expansion behaviour for comma-less inner groups and are updated to the bash/picomatch result.

The deeply-nested-brace fixtures from 8c8787161e were written against patterns that this change now treats as literals, so they no longer reached the depth counters they guard. The 300-level fixtures now carry a comma at every level so `skip_branch` still scans past the >255 boundary, and a comma-bearing 40,000-level fixture sits alongside the original unclosed one so `match_brace`'s pre-scan still climbs past `i16::MAX`. Verified by temporarily narrowing that counter back to `i16`: the new fixture aborts with a checked-overflow panic and passes again at `i32`.

The `braces` test ran its 10-pattern x 7894-path vscode fixture matrix as a single test, which takes 4 to 5.3 seconds under `bun bd` (debug + ASAN) against the 5 second per-test budget and was timing out about one run in four, before and after this change. It is split into one test per pattern with identical assertions so each has its own budget.

```
bun bd test test/js/bun/glob/match.test.ts
# 37 pass, 0 fail

bun bd test test/js/bun/glob/scan.test.ts
# 172 pass, 0 fail

bun bd test test/js/bun/shell/bunshell.test.ts -t "glob"
# 14 pass, 0 fail
```

`scan()` / `scanSync()` pick up the fix via the walker's per-component `r#match` (`new Bun.Glob("{a}.ts").scanSync()` now yields `{a}.ts`, not `a.ts`), and `path.matchesGlob` inherits it through `Bun.Glob`.

Related: #32894 handles the unclosed-`{` case specifically; this PR's preprocessing covers that case as well (an unclosed `{` has no top-level comma before a matching `}`, so it is escaped), so whichever lands second will need a small rebase in `matcher.rs`.



