### PR TITLE
node:fs: add Symbol.dispose / Symbol.asyncDispose to fs.Dir

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1178,6 +1178,16 @@ class Dir {
     this.#handle = -1;
   }
 
+  [Symbol.dispose]() {
+    if (this.#handle < 0) return;
+    this.closeSync();
+  }
+
+  async [Symbol.asyncDispose]() {
+    if (this.#handle < 0) return;
+    await this.close();
+  }
+
   get path() {
     if (!(#path in this)) throw $ERR_INVALID_THIS("Dir");
     return this.#path;

--- a/test/js/node/fs/dir.test.ts
+++ b/test/js/node/fs/dir.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { tempDir } from "harness";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -136,21 +137,11 @@ describe("fs.Dir", () => {
   }); // </given an empty temp directory>
 
   describe("explicit resource management", () => {
-    let dirname: string;
-
-    beforeAll(() => {
-      const name = "dir-dispose.test." + String(Math.random() * 100).substring(0, 6);
-      dirname = path.join(os.tmpdir(), name);
-      fs.mkdirSync(dirname);
-      fs.writeFileSync(path.join(dirname, "entry.txt"), "x");
-    });
-
-    afterAll(() => {
-      fs.rmSync(dirname, { recursive: true, force: true });
-    });
+    const files = { "entry.txt": "x" };
 
     it("has Symbol.dispose and Symbol.asyncDispose on the prototype", () => {
-      const dir = fs.opendirSync(dirname);
+      using tmp = tempDir("fs-dir-dispose", files);
+      const dir = fs.opendirSync(String(tmp));
       try {
         const proto = Object.getPrototypeOf(dir);
         expect(Object.getOwnPropertyDescriptor(proto, Symbol.dispose)).toEqual({
@@ -171,39 +162,44 @@ describe("fs.Dir", () => {
     });
 
     it("`using` closes the directory at scope exit", () => {
+      using tmp = tempDir("fs-dir-dispose", files);
       let dir: fs.Dir;
       {
-        using d = fs.opendirSync(dirname);
+        using d = fs.opendirSync(String(tmp));
         dir = d;
-        expect(d.readSync()).not.toBeNull();
+        expect(d.readSync()?.name).toBe("entry.txt");
       }
       expect(() => dir.readSync()).toThrow(expect.objectContaining({ code: "ERR_DIR_CLOSED" }));
     });
 
     it("`await using` closes the directory at scope exit", async () => {
+      using tmp = tempDir("fs-dir-dispose", files);
       let dir: fs.Dir;
       {
-        await using d = fs.opendirSync(dirname);
+        await using d = fs.opendirSync(String(tmp));
         dir = d;
-        expect(await d.read()).not.toBeNull();
+        expect((await d.read())?.name).toBe("entry.txt");
       }
       expect(() => dir.readSync()).toThrow(expect.objectContaining({ code: "ERR_DIR_CLOSED" }));
     });
 
     it("Symbol.dispose is a no-op on an already-closed directory", () => {
-      const dir = fs.opendirSync(dirname);
+      using tmp = tempDir("fs-dir-dispose", files);
+      const dir = fs.opendirSync(String(tmp));
       dir.closeSync();
       expect(dir[Symbol.dispose]()).toBeUndefined();
     });
 
     it("Symbol.asyncDispose is a no-op on an already-closed directory", async () => {
-      const dir = fs.opendirSync(dirname);
+      using tmp = tempDir("fs-dir-dispose", files);
+      const dir = fs.opendirSync(String(tmp));
       dir.closeSync();
       await expect(dir[Symbol.asyncDispose]()).resolves.toBeUndefined();
     });
 
     it("Symbol.dispose throws ERR_DIR_CONCURRENT_OPERATION with an in-flight async op", async () => {
-      const dir = fs.opendirSync(dirname);
+      using tmp = tempDir("fs-dir-dispose", files);
+      const dir = fs.opendirSync(String(tmp));
       const pending = dir.read();
       try {
         expect(() => dir[Symbol.dispose]()).toThrow(expect.objectContaining({ code: "ERR_DIR_CONCURRENT_OPERATION" }));
@@ -214,11 +210,29 @@ describe("fs.Dir", () => {
     });
 
     it("Symbol.asyncDispose queues behind an in-flight async op", async () => {
-      const dir = fs.opendirSync(dirname);
+      using tmp = tempDir("fs-dir-dispose", files);
+      const dir = fs.opendirSync(String(tmp));
       const pending = dir.read();
       await expect(dir[Symbol.asyncDispose]()).resolves.toBeUndefined();
       await pending.catch(() => {});
       expect(() => dir.readSync()).toThrow(expect.objectContaining({ code: "ERR_DIR_CLOSED" }));
+    });
+
+    // Node parity: a close() queued behind a read does not make a later
+    // Symbol.asyncDispose a no-op; it queues its own close, which then rejects.
+    it("Symbol.asyncDispose after a queued close rejects ERR_DIR_CLOSED like Node", async () => {
+      using tmp = tempDir("fs-dir-dispose", files);
+      const dir = fs.opendirSync(String(tmp));
+      const pending = dir.read();
+      const closed = dir.close();
+      const disposed = dir[Symbol.asyncDispose]();
+      const settle = (p: Promise<unknown>) =>
+        p.then(
+          () => "resolved",
+          (e: any) => "rejected:" + e.code,
+        );
+      expect(await Promise.all([settle(closed), settle(disposed)])).toEqual(["resolved", "rejected:ERR_DIR_CLOSED"]);
+      await pending.catch(() => {});
     });
   }); // </explicit resource management>
 }); // </fs.Dir>

--- a/test/js/node/fs/dir.test.ts
+++ b/test/js/node/fs/dir.test.ts
@@ -134,6 +134,95 @@ describe("fs.Dir", () => {
       }); // </when closed>
     }); // </when an empty directory is opened>
   }); // </given an empty temp directory>
+
+  describe("explicit resource management", () => {
+    let dirname: string;
+
+    beforeAll(() => {
+      const name = "dir-dispose.test." + String(Math.random() * 100).substring(0, 6);
+      dirname = path.join(os.tmpdir(), name);
+      fs.mkdirSync(dirname);
+      fs.writeFileSync(path.join(dirname, "entry.txt"), "x");
+    });
+
+    afterAll(() => {
+      fs.rmSync(dirname, { recursive: true, force: true });
+    });
+
+    it("has Symbol.dispose and Symbol.asyncDispose on the prototype", () => {
+      const dir = fs.opendirSync(dirname);
+      try {
+        const proto = Object.getPrototypeOf(dir);
+        expect(Object.getOwnPropertyDescriptor(proto, Symbol.dispose)).toEqual({
+          value: expect.any(Function),
+          writable: true,
+          enumerable: false,
+          configurable: true,
+        });
+        expect(Object.getOwnPropertyDescriptor(proto, Symbol.asyncDispose)).toEqual({
+          value: expect.any(Function),
+          writable: true,
+          enumerable: false,
+          configurable: true,
+        });
+      } finally {
+        dir.closeSync();
+      }
+    });
+
+    it("`using` closes the directory at scope exit", () => {
+      let dir: fs.Dir;
+      {
+        using d = fs.opendirSync(dirname);
+        dir = d;
+        expect(d.readSync()).not.toBeNull();
+      }
+      expect(() => dir.readSync()).toThrow(expect.objectContaining({ code: "ERR_DIR_CLOSED" }));
+    });
+
+    it("`await using` closes the directory at scope exit", async () => {
+      let dir: fs.Dir;
+      {
+        await using d = fs.opendirSync(dirname);
+        dir = d;
+        expect(await d.read()).not.toBeNull();
+      }
+      expect(() => dir.readSync()).toThrow(expect.objectContaining({ code: "ERR_DIR_CLOSED" }));
+    });
+
+    it("Symbol.dispose is a no-op on an already-closed directory", () => {
+      const dir = fs.opendirSync(dirname);
+      dir.closeSync();
+      expect(dir[Symbol.dispose]()).toBeUndefined();
+    });
+
+    it("Symbol.asyncDispose is a no-op on an already-closed directory", async () => {
+      const dir = fs.opendirSync(dirname);
+      dir.closeSync();
+      await expect(dir[Symbol.asyncDispose]()).resolves.toBeUndefined();
+    });
+
+    it("Symbol.dispose throws ERR_DIR_CONCURRENT_OPERATION with an in-flight async op", async () => {
+      const dir = fs.opendirSync(dirname);
+      const pending = dir.read();
+      try {
+        expect(() => dir[Symbol.dispose]()).toThrow(
+          expect.objectContaining({ code: "ERR_DIR_CONCURRENT_OPERATION" }),
+        );
+      } finally {
+        await pending.catch(() => {});
+        await dir.close().catch(() => {});
+      }
+    });
+
+    it("Symbol.asyncDispose queues behind an in-flight async op", async () => {
+      const dir = fs.opendirSync(dirname);
+      const pending = dir.read();
+      await expect(dir[Symbol.asyncDispose]()).resolves.toBeUndefined();
+      await pending.catch(() => {});
+      expect(() => dir.readSync()).toThrow(expect.objectContaining({ code: "ERR_DIR_CLOSED" }));
+    });
+  }); // </explicit resource management>
 }); // </fs.Dir>
 
 describe("fs.opendir async validation", () => {

--- a/test/js/node/fs/dir.test.ts
+++ b/test/js/node/fs/dir.test.ts
@@ -206,9 +206,7 @@ describe("fs.Dir", () => {
       const dir = fs.opendirSync(dirname);
       const pending = dir.read();
       try {
-        expect(() => dir[Symbol.dispose]()).toThrow(
-          expect.objectContaining({ code: "ERR_DIR_CONCURRENT_OPERATION" }),
-        );
+        expect(() => dir[Symbol.dispose]()).toThrow(expect.objectContaining({ code: "ERR_DIR_CONCURRENT_OPERATION" }));
       } finally {
         await pending.catch(() => {});
         await dir.close().catch(() => {});


### PR DESCRIPTION
### What

`fs.Dir` had no `Symbol.dispose` or `Symbol.asyncDispose`, so the modern explicit resource management idiom threw instead of closing the handle:

```js
import * as fs from "node:fs";
{
  using d = fs.opendirSync(dir);   // TypeError: @@dispose must not be undefined or null
}
```

Node v26.3.0:
```
dir-dispose: function function
dir-using: ok
```

Bun before:
```
dir-dispose: undefined undefined
dir-using: TypeError
```

### Fix

Add both to the `Dir` prototype in `src/js/node/fs.ts`:

- `[Symbol.dispose]()` delegates to `closeSync()`
- `[Symbol.asyncDispose]()` delegates to `close()`

Both guard on `this.#handle < 0` so disposing an already-closed directory is a no-op (matching Node), which lets `using` compose with an explicit `close()` without throwing `ERR_DIR_CLOSED`. The guard is the same one the class's existing `Symbol.asyncIterator` teardown uses.

Verified against Node v26.3.0:
- dispose on already-closed: no-op (Node: no-op)
- asyncDispose on already-closed: no-op (Node: no-op)
- dispose with an in-flight async op: throws `ERR_DIR_CONCURRENT_OPERATION` (Node: same, via `closeSync()`)
- asyncDispose with an in-flight async op: queues behind it and resolves (Node: same, via `close()`)
- prototype descriptors: `{ writable: true, enumerable: false, configurable: true }` (class method syntax)

### Tests

Added to `test/js/node/fs/dir.test.ts` under `describe("explicit resource management")`: prototype descriptors, `using` / `await using` close at scope exit, idempotent dispose on a closed handle, the concurrent-operation behavior for both variants, and the queued-close interaction below. All eight fail on current main and pass with the fix. The vendored `test/js/node/test/parallel/test-fs-opendir.js` still passes.

One behavior worth calling out: Node's already-closed guard is a flag that is set when a close operation actually runs, not when one is merely queued. So a `Symbol.asyncDispose` issued while a `close()` is still queued behind an in-flight read enqueues a second close, which later rejects with `ERR_DIR_CLOSED` (verified on Node v26.3.0). The `#handle < 0` guard here reproduces that exactly, and a test pins it.

Overlaps with the `fs.Dir` portion of the batch in #32813; this PR carries only that fix standalone.
