### PR TITLE
bun:test: make expect.arrayContaining([]) match any received value

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -473,15 +473,16 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
 
         // Note: isArray() accepts Proxy->Array, but jsDynamicCast returns null for Proxy.
         JSArray* expectedArray = dynamicDowncast<JSArray>(expectedArrayValue);
+
+        // Jest: an empty sample matches any received value, including non-arrays.
+        if (expectedArray && expectedArray->length() == 0) {
+            return AsymmetricMatcherResult::PASS;
+        }
+
         JSArray* otherArray = dynamicDowncast<JSArray>(otherProp);
         if (expectedArray && otherArray) {
             unsigned expectedLength = expectedArray->length();
             unsigned otherLength = otherArray->length();
-
-            // A empty array is all array's subset
-            if (expectedLength == 0) {
-                return AsymmetricMatcherResult::PASS;
-            }
 
             // O(m*n) but works for now
             for (unsigned m = 0; m < expectedLength; m++) {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4176,16 +4176,18 @@ describe("expect()", () => {
       expect(expect.arrayContaining([])).toEqual(["foo", "bar"]);
       expect(expect.arrayContaining(["foo"])).toEqual(["foo"]);
       expect(expect.arrayContaining(["foo"])).toEqual(["foo", "bar"]);
+      // Jest: an empty sample matches any received value, including non-arrays.
+      expect(expect.arrayContaining([])).toEqual(42);
+      expect(expect.arrayContaining([])).toEqual("jest");
+      expect(expect.arrayContaining([])).toEqual({});
+      expect(expect.arrayContaining([])).toEqual(null);
+      expect(expect.arrayContaining([])).toEqual(undefined);
+      expect(42).toEqual(expect.arrayContaining([]));
+      expect({ a: 5 }).toMatchObject({ a: expect.arrayContaining([]) });
     });
 
     test("ArrayContaining does not match", () => {
-      // we differ in jest on these cases: bun will fail matching non-array expected values, while jest doesn't
-      if (isBun) {
-        expect(expect.arrayContaining([])).not.toEqual(42);
-        expect(expect.arrayContaining([])).not.toEqual("jest");
-        expect(expect.arrayContaining([])).not.toEqual({});
-        expect(expect.arrayContaining(["foo"])).not.toEqual(42);
-      }
+      expect(expect.arrayContaining(["foo"])).not.toEqual(42);
       expect(expect.arrayContaining(["foo"])).not.toEqual("foo");
       expect(expect.arrayContaining(["foo"])).not.toEqual(["bar"]);
     });
@@ -4198,12 +4200,7 @@ describe("expect()", () => {
     });
 
     test("ArrayNotContaining matches", () => {
-      if (isBun) {
-        expect(expect.not.arrayContaining([])).toEqual(42);
-        expect(expect.not.arrayContaining([])).toEqual("jest");
-        expect(expect.not.arrayContaining([])).toEqual({});
-        expect(expect.not.arrayContaining(["foo"])).toEqual(42);
-      }
+      expect(expect.not.arrayContaining(["foo"])).toEqual(42);
       expect(expect.not.arrayContaining(["foo"])).toEqual("foo");
       expect(expect.not.arrayContaining(["foo"])).toEqual(["bar"]);
     });
@@ -4212,6 +4209,10 @@ describe("expect()", () => {
       expect(expect.not.arrayContaining([])).not.toEqual(["foo"]);
       expect(expect.not.arrayContaining(["foo"])).not.toEqual(["foo"]);
       expect(expect.not.arrayContaining(["foo"])).not.toEqual(["foo", "bar"]);
+      // Jest: an empty sample matches any received value, so the negated matcher never matches.
+      expect(expect.not.arrayContaining([])).not.toEqual(42);
+      expect(expect.not.arrayContaining([])).not.toEqual("jest");
+      expect(expect.not.arrayContaining([])).not.toEqual({});
     });
 
     test("ArrayNotContaining throws for non-arrays", () => {


### PR DESCRIPTION
## Reproduction

```ts
test("arrayContaining([]) vs non-array", () => {
  expect(5).toEqual(expect.arrayContaining([]));
});
```

Before this change:

```
error: expect(received).toEqual(expected)

Expected: ExpectArrayContaining {}
Received: 5
```

Jest 30 passes this test. The pattern `expect.arrayContaining(maybeEmpty)` shows up in parameterized suites where the expected list can be empty for some rows; those rows went red only under bun.

## Cause

Jest's `ArrayContaining.asymmetricMatch` is:

```js
const result =
  this.sample.length === 0 ||
  (Array.isArray(other) &&
    this.sample.every(item => other.some(another => equals(item, another, ...))));
```

The empty-sample short-circuit runs before the `Array.isArray(other)` check, so an empty sample matches anything. Bun's `matchAsymmetricMatcherAndGetFlags` in `src/jsc/bindings/bindings.cpp` required both the sample and the received value to downcast to `JSArray` before it reached the `expectedLength == 0` check, so a non-array received value fell through to `FAIL`.

## Fix

Move the empty-sample check ahead of the received-is-array check. `FLAG_NOT` inversion in the caller then makes `expect.not.arrayContaining([])` never match anything, which is also what Jest does.

## Tests

The existing `ArrayContaining` / `ArrayNotContaining` asymmetric-matcher tests in `test/js/bun/test/expect.test.js` previously asserted the divergence behind an `if (isBun)` guard; those are updated to assert Jest semantics, covering numbers, strings, objects, `null`, and `undefined` as received values, plus the negated form.

```
$ bun bd test test/js/bun/test/expect.test.js -t ArrayContaining
(pass) asymmetric matchers > ArrayContaining matches
(pass) asymmetric matchers > ArrayContaining does not match
(pass) asymmetric matchers > ArrayContaining throws for non-arrays
$ bun bd test test/js/bun/test/expect.test.js -t ArrayNotContaining
(pass) asymmetric matchers > ArrayNotContaining matches
(pass) asymmetric matchers > ArrayNotContaining does not match
(pass) asymmetric matchers > ArrayNotContaining throws for non-arrays
```

`ArrayContaining matches` and `ArrayNotContaining does not match` fail on the unfixed binary.