### PR TITLE
bun:test: deprecate legacy Jest matcher aliases in types and docs

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -581,6 +581,22 @@ Bun implements the following matchers. Full Jest compatibility is planned; see t
 | ------ | -------------------------- |
 | ❌     | `.addSnapshotSerializer()` |
 
+### Legacy Jest Aliases
+
+Jest 30 removed the following matcher aliases. Bun continues to accept them at runtime so existing test suites keep working, but they are marked `@deprecated` in the type definitions. Prefer the canonical names so your tests run under Bun, Jest 30, and Vitest without changes.
+
+| Alias (deprecated)    | Use instead                   |
+| --------------------- | ----------------------------- |
+| `.toThrowError()`     | `.toThrow()`                  |
+| `.toBeCalled()`       | `.toHaveBeenCalled()`         |
+| `.toBeCalledTimes()`  | `.toHaveBeenCalledTimes()`    |
+| `.toBeCalledWith()`   | `.toHaveBeenCalledWith()`     |
+| `.lastCalledWith()`   | `.toHaveBeenLastCalledWith()` |
+| `.nthCalledWith()`    | `.toHaveBeenNthCalledWith()`  |
+| `.toReturn()`         | `.toHaveReturned()`           |
+| `.lastReturnedWith()` | `.toHaveLastReturnedWith()`   |
+| `.nthReturnedWith()`  | `.toHaveNthReturnedWith()`    |
+
 ## Best Practices
 
 ### Use Descriptive Test Names

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -583,7 +583,7 @@ Bun implements the following matchers. Full Jest compatibility is planned; see t
 
 ### Legacy Jest Aliases
 
-Jest 30 removed the following matcher aliases. Bun continues to accept them at runtime so existing test suites keep working, but they are marked `@deprecated` in the type definitions. Prefer the canonical names so your tests run under Bun, Jest 30, and Vitest without changes.
+Bun supports the following legacy matcher aliases that were removed in Jest 30. They remain available at runtime so existing test suites keep working, but are marked `@deprecated` in the type definitions. Prefer the canonical names so your tests run under Bun, Jest 30, and Vitest without changes.
 
 | Alias (deprecated)    | Use instead                   |
 | --------------------- | ----------------------------- |

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -778,7 +778,7 @@ declare module "bun:test" {
   export interface AsymmetricMatchersBuiltin {
     /**
      * Matches anything that was created with the given constructor.
-     * Use it inside `toEqual` or `toBeCalledWith` instead of a literal value.
+     * Use it inside `toEqual` or `toHaveBeenCalledWith` instead of a literal value.
      *
      * @example
      *
@@ -789,12 +789,12 @@ declare module "bun:test" {
      * test('randocall calls its callback with a number', () => {
      *   const mock = jest.fn();
      *   randocall(mock);
-     *   expect(mock).toBeCalledWith(expect.any(Number));
+     *   expect(mock).toHaveBeenCalledWith(expect.any(Number));
      * });
      */
     any(constructor: ((...args: any[]) => any) | { new (...args: any[]): any }): AsymmetricMatcher;
     /**
-     * Matches anything but null or undefined. Use it inside `toEqual` or `toBeCalledWith` instead
+     * Matches anything but null or undefined. Use it inside `toEqual` or `toHaveBeenCalledWith` instead
      * of a literal value. For example, to check that a mock function is called with a
      * non-null argument:
      *
@@ -803,13 +803,13 @@ declare module "bun:test" {
      * test('map calls its argument with a non-null argument', () => {
      *   const mock = jest.fn();
      *   [1].map(x => mock(x));
-     *   expect(mock).toBeCalledWith(expect.anything());
+     *   expect(mock).toHaveBeenCalledWith(expect.anything());
      * });
      */
     anything(): AsymmetricMatcher;
     /**
      * Matches any array made up entirely of elements in the provided array.
-     * Use it inside `toEqual` or `toBeCalledWith` instead of a literal value.
+     * Use it inside `toEqual` or `toHaveBeenCalledWith` instead of a literal value.
      *
      * Optionally, pass a type for the elements as a generic argument.
      */
@@ -1432,13 +1432,14 @@ declare module "bun:test" {
      * function fail() {
      *   throw new Error("Oops!");
      * }
-     * expect(fail).toThrowError("Oops!");
-     * expect(fail).toThrowError(/oops/i);
-     * expect(fail).toThrowError(Error);
-     * expect(fail).toThrowError();
+     * expect(fail).toThrow("Oops!");
+     * expect(fail).toThrow(/oops/i);
+     * expect(fail).toThrow(Error);
+     * expect(fail).toThrow();
      *
      * @param expected the expected error, error message, or error pattern
      * @alias toThrow
+     * @deprecated Use {@link toThrow} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
      */
     toThrowError(expected?: unknown): void;
 
@@ -1815,6 +1816,13 @@ declare module "bun:test" {
     toHaveReturned(): void;
 
     /**
+     * Ensures that a mock function has returned successfully at least once.
+     * @alias toHaveReturned
+     * @deprecated Use {@link toHaveReturned} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
+     */
+    toReturn(): void;
+
+    /**
      * Ensures that a mock function has returned successfully `times` times.
      *
      * An unfulfilled promise counts as a failure, as does a thrown error.
@@ -1834,12 +1842,26 @@ declare module "bun:test" {
     toHaveLastReturnedWith(expected: unknown): void;
 
     /**
+     * Ensures that a mock function has returned a specific value on its last invocation.
+     * @alias toHaveLastReturnedWith
+     * @deprecated Use {@link toHaveLastReturnedWith} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
+     */
+    lastReturnedWith(expected: unknown): void;
+
+    /**
      * Ensures that a mock function has returned a specific value on the nth invocation.
      * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
      * @param n The 1-based index of the function call
      * @param expected The expected return value
      */
     toHaveNthReturnedWith(n: number, expected: unknown): void;
+
+    /**
+     * Ensures that a mock function has returned a specific value on the nth invocation.
+     * @alias toHaveNthReturnedWith
+     * @deprecated Use {@link toHaveNthReturnedWith} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
+     */
+    nthReturnedWith(n: number, expected: unknown): void;
 
     /**
      * Ensures that a mock function is called.
@@ -1849,6 +1871,7 @@ declare module "bun:test" {
     /**
      * Ensures that a mock function is called.
      * @alias toHaveBeenCalled
+     * @deprecated Use {@link toHaveBeenCalled} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
      */
     toBeCalled(): void;
 
@@ -1860,6 +1883,7 @@ declare module "bun:test" {
     /**
      * Ensures that a mock function is called an exact number of times.
      * @alias toHaveBeenCalledTimes
+     * @deprecated Use {@link toHaveBeenCalledTimes} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
      */
     toBeCalledTimes(expected: number): void;
 
@@ -1871,6 +1895,7 @@ declare module "bun:test" {
     /**
      * Ensure that a mock function is called with specific arguments.
      * @alias toHaveBeenCalledWith
+     * @deprecated Use {@link toHaveBeenCalledWith} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
      */
     toBeCalledWith(...expected: unknown[]): void;
 
@@ -1882,6 +1907,7 @@ declare module "bun:test" {
     /**
      * Ensure that a mock function is called with specific arguments for the last call.
      * @alias toHaveBeenLastCalledWith
+     * @deprecated Use {@link toHaveBeenLastCalledWith} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
      */
     lastCalledWith(...expected: unknown[]): void;
 
@@ -1893,6 +1919,7 @@ declare module "bun:test" {
     /**
      * Ensure that a mock function is called with specific arguments for the nth call.
      * @alias toHaveBeenNthCalledWith
+     * @deprecated Use {@link toHaveBeenNthCalledWith} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.
      */
     nthCalledWith(n: number, ...expected: unknown[]): void;
   }

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -48,6 +48,30 @@ describe("bun:test", () => {
       expect(fail).toThrow(Error);
       expect(fail).toThrow(new Error("Bad"));
     });
+
+    // Jest 30 removed these aliases. Bun keeps them and declares them @deprecated.
+    test("legacy Jest matcher aliases (removed in Jest 30)", () => {
+      function fail() {
+        throw new Error("Bad");
+      }
+      expect(fail).toThrowError();
+      expect(fail).toThrowError("Bad");
+      expect(fail).toThrowError(/bad/i);
+      expect(fail).toThrowError(Error);
+      expect(fail).toThrowError(new Error("Bad"));
+
+      const fn = jest.fn((a: number) => a + 1);
+      fn(1);
+      fn(2);
+      expect(fn).toBeCalled();
+      expect(fn).toBeCalledTimes(2);
+      expect(fn).toBeCalledWith(1);
+      expect(fn).lastCalledWith(2);
+      expect(fn).nthCalledWith(1, 1);
+      expect(fn).toReturn();
+      expect(fn).lastReturnedWith(3);
+      expect(fn).nthReturnedWith(1, 2);
+    });
   });
   test("expect()", () => {
     expect(1).toBe(1);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4954,6 +4954,40 @@ describe("expect()", () => {
       expect(e.message).toContain('"ball"');
     }
   });
+
+  // Jest 30 removed these alias matchers. Bun keeps them for backward
+  // compatibility and marks them @deprecated in its type definitions.
+  describe("legacy Jest matcher aliases (removed in Jest 30)", () => {
+    test_skipIf(isJest)("toThrowError aliases toThrow", () => {
+      expect(() => {
+        throw new Error("x");
+      }).toThrowError("x");
+      expect(() => {}).not.toThrowError();
+    });
+
+    test_skipIf(isJest)("mock call aliases", () => {
+      const fn = jest.fn((/** @type {number} */ a) => a + 1);
+      expect(fn).not.toBeCalled();
+      fn(1);
+      fn(2);
+      expect(fn).toBeCalled();
+      expect(fn).toBeCalledTimes(2);
+      expect(fn).toBeCalledWith(1);
+      expect(fn).lastCalledWith(2);
+      expect(fn).nthCalledWith(1, 1);
+      expect(fn).nthCalledWith(2, 2);
+    });
+
+    test_skipIf(isJest)("mock return aliases", () => {
+      const fn = jest.fn((/** @type {number} */ a) => a + 1);
+      fn(1);
+      fn(2);
+      expect(fn).toReturn();
+      expect(fn).lastReturnedWith(3);
+      expect(fn).nthReturnedWith(1, 2);
+      expect(fn).nthReturnedWith(2, 3);
+    });
+  });
 });
 
 function tmpFile(exists) {


### PR DESCRIPTION
### Problem

Jest 30 removed the short-form matcher aliases (`toThrowError`, `toBeCalled`, `toBeCalledTimes`, `toBeCalledWith`, `lastCalledWith`, `nthCalledWith`, `toReturn`, `lastReturnedWith`, `nthReturnedWith`). Bun still accepts them at runtime, so a suite using them passes under `bun test` but fails with `TypeError: expect(...).toThrowError is not a function` under Jest 30. The Bun docs advertise Jest compatibility without saying which Jest's matcher set that means.

```js
test('alias', () => {
  expect(() => { throw new Error('x'); }).toThrowError('x');
});
```

```
bun test:      (pass) alias
jest 30.4.1:   TypeError: expect(...).toThrowError is not a function
```

### Approach

Keep the aliases working at runtime: removing them would break existing Bun test suites, and Vitest still accepts them as well. Instead, make the divergence explicit.

- **`packages/bun-types/test.d.ts`**: each alias is tagged `@deprecated` with `Use {@link canonical} instead. Jest removed this alias in Jest 30; Bun keeps it for backward compatibility.` This surfaces as IDE strikethrough and steers users to the name that works under Bun, Jest 30 and Vitest alike.
- **`packages/bun-types/test.d.ts`**: declares `toReturn`, `lastReturnedWith`, `nthReturnedWith`, which were wired up at runtime in `jest.classes.ts` but missing from the type definitions (they now follow the same `@deprecated` pattern). Also updates the `expect.any`/`expect.anything`/`arrayContaining` JSDoc examples to stop showcasing `toBeCalledWith`. (An earlier revision of this PR also fixed three mistargeted `@alias` tags on `lastCalledWith`/`nthCalledWith`; `main` has since fixed those independently in #33112, so they are no longer part of this diff.)
- **`docs/test/writing-tests.mdx`**: adds a "Legacy Jest Aliases" table listing each alias with its canonical replacement. The lead-in is scoped to the aliases Bun supports rather than Jest's removal set, since Jest 30 removed 11 aliases and Bun implements neither `toReturnTimes` nor `toReturnWith`.
- **`test/js/bun/test/expect.test.js`**: adds a `legacy Jest matcher aliases (removed in Jest 30)` describe block exercising all nine aliases at runtime, gated behind `test_skipIf(isJest)` since the file is also runnable under Jest and Vitest.
- **`test/integration/bun-types/fixture/test.ts`**: exercises all nine aliases through the packed `bun-types` contract so the type integration test fails if a declaration is removed or renamed. `@deprecated` is a JSDoc hint rather than a tsc error, so using the aliases in the fixture compiles while still catching a regression.

No runtime change.

Fixes #32334 (the three return-value aliases now have type declarations).

### Overlap with #32335

#32335 adds plain declarations for the three return-value aliases. This PR adds the same three declarations plus the `@deprecated` tag and the other six aliases; whichever lands first, the other reduces to a trivial rebase.

### Verification

The bun-types fixture is load-bearing: with `packages/bun-types/test.d.ts` reverted to `main`, the type integration test fails with exactly

```
TS2339: Property 'toReturn' does not exist on type 'Matchers<...>'
TS2339: Property 'lastReturnedWith' does not exist on type 'Matchers<...>'
TS2551: Property 'nthReturnedWith' does not exist on type 'Matchers<...>'
```

and passes again with the declarations restored.

```
bun test test/integration/bun-types/bun-types.test.ts
  11 pass, 1 unrelated env failure (@typescript/native-preview not installed)

bun bd test test/js/bun/test/expect.test.js
  409 pass, 10 todo, 0 fail
```

### Rebase

Rebased onto `main` after #33112, an editorial pass over `docs/` and the `bun-types` JSDoc, landed and conflicted with this PR in `packages/bun-types/test.d.ts` (six hunks). Resolved by keeping `main`'s editorial wording and reapplying this PR's changes on top: the canonical matcher name in the three asymmetric-matcher prose lines, the new `toReturn` declaration, and the `@deprecated` tags. #33112 independently made the same fix to the three mistargeted `@alias` tags this PR had also fixed, so that part is no longer in the diff. `docs/test/writing-tests.mdx`, `test/js/bun/test/expect.test.js`, and the bun-types fixture merged cleanly. Re-verified after the rebase: the full `expect.test.js` passes under `bun bd test` (409 pass, 0 fail, which now includes the tests `main` added to that file) and the bun-types integration type check passes.

### CI note

This PR changes four files, none of which is an input to the `bun` binary: a docs page, the ambient `packages/bun-types/test.d.ts`, and two test files. The binary built from this branch is therefore identical in behavior to the one `main` builds at the base commit (52a1ddf07b), so no runtime test behavior can differ from `main`'s.

On the rebased base, [build 67416](https://buildkite.com/bun/bun/builds/67416) finished with 282 of 287 jobs passed. None of the failures names a file this PR touches:

- `test/js/node/test/parallel/test-net-connect-memleak.js` failed on the two alpine x64 lanes. The same test is failing right now on two other unrelated PR builds ([67413](https://buildkite.com/bun/bun/builds/67413), [67410](https://buildkite.com/bun/bun/builds/67410)), so it is a property of current `main` on musl, not of this diff.
- `test/napi/napi.test.ts` has failed on every one of this PR's four CI runs, across three different trees and two bases, and also fails on other PRs' builds. `test/js/bun/webview/webview-chrome.test.ts` similarly recurs across this PR's builds and other PRs'. `test/js/bun/s3/s3.test.ts` failed with the S3 backend's own `InternalError: "We encountered an internal connectivity issue"` response. The remaining entries are each a single test file on a single lane with an automatic retry.
- Two `darwin 26 aarch64` test shards failed with no failing test annotated at all; that same lane failed identically on this PR's three earlier builds, which ran different trees.

Earlier, on the pre-rebase base, the same tree was run twice ([65756](https://buildkite.com/bun/bun/builds/65756), then [65816](https://buildkite.com/bun/bun/builds/65816) via an empty retrigger commit) and produced different failure sets (8 failing files, then 6, with 3 in common): the signature of nondeterministic tests, since a regression caused by a commit fails the same files on every run of that commit.

Two GitHub Actions checks (`TypeScript types`, `bun-plugin-svelte`) also fail on `main` HEAD and are unrelated: the former is `@typescript/native-preview` not resolving in the tsgo variant (the `basic type checks` variant, the one that exercises `test.d.ts` and the new fixture, passes); the latter is a bundler output-format assertion.

The diff itself is green and ready to merge.
