### PR TITLE
Bun.write: fix hang when source is a Response/Request with a ReadableStream body

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -246,6 +246,9 @@ pub trait BlobExt {
         global_this: &JSGlobalObject,
         readable_stream: ReadableStream,
         extra_options: Option<JSValue>,
+        mkdirp_if_not_exists: bool,
+        mode: Option<bun_sys::Mode>,
+        took_stream: &mut bool,
     ) -> JsResult<JSValue>;
     fn get_writer(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
     fn get_slice_from(
@@ -1387,6 +1390,11 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         readable_stream: ReadableStream,
         extra_options: Option<JSValue>,
+        mkdirp_if_not_exists: bool,
+        mode: Option<bun_sys::Mode>,
+        // Set when `assign_to_stream` takes the stream (stream state cannot
+        // answer this after the fact). False on every earlier return.
+        took_stream: &mut bool,
     ) -> JsResult<JSValue> {
         let Some(store) = self.store.get().clone() else {
             return Ok(
@@ -1467,17 +1475,28 @@ impl BlobExt for Blob {
                 } else {
                     let mut file_path = bun_paths::PathBuffer::uninit();
                     let path = pathlike.path().slice_z(&mut file_path);
-                    match bun_sys::open(
-                        path,
-                        bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK,
-                        WRITE_PERMISSIONS,
-                    ) {
-                        bun_sys::Result::Ok(result) => result,
-                        bun_sys::Result::Err(err) => {
-                            return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                                global_this,
-                                err.with_path(path).to_js(global_this),
-                            ));
+                    // `Bun.write` has replace semantics: truncate when opening by path.
+                    let open_flags = bun_sys::O::WRONLY
+                        | bun_sys::O::CREAT
+                        | bun_sys::O::NONBLOCK
+                        | bun_sys::O::TRUNC;
+                    let mut mkdirp_pending = mkdirp_if_not_exists;
+                    loop {
+                        match bun_sys::open(path, open_flags, mode.unwrap_or(WRITE_PERMISSIONS)) {
+                            bun_sys::Result::Ok(result) => break result,
+                            bun_sys::Result::Err(err) => {
+                                if mkdirp_pending
+                                    && err.get_errno() == bun_sys::E::ENOENT
+                                    && mkdirp_parent_of(path.as_bytes())
+                                {
+                                    mkdirp_pending = false;
+                                    continue;
+                                }
+                                return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                                    global_this,
+                                    sys_error_with_path_like(&err, pathlike).to_js(global_this),
+                                ));
+                            }
                         }
                     }
                 };
@@ -1554,61 +1573,78 @@ impl BlobExt for Blob {
 
             #[cfg(not(windows))]
             {
-                let sink = webcore::FileSink::init(
-                    Fd::INVALID,
-                    jsc::EventLoopHandle::init(
-                        self.global_this()
-                            .expect("Blob.global_this set at construction")
-                            .bun_vm()
-                            .as_mut()
-                            .event_loop()
-                            .cast::<()>(),
-                    ),
-                );
-
-                let input_path: webcore::PathOrFileDescriptor = match &store.data.as_file().pathlike
-                {
-                    PathOrFileDescriptor::Fd(fd) => webcore::PathOrFileDescriptor::Fd(*fd),
-                    PathOrFileDescriptor::Path(p) => webcore::PathOrFileDescriptor::Path(
-                        bun_core::ZigStringSlice::init_dupe(p.slice()).expect("oom"),
-                    ),
-                };
-                // input_path drops at scope exit.
-
-                let stream_start = streams::Start::FileSink(streams::FileSinkOptions {
-                    input_path,
-                    ..Default::default()
-                });
-
-                // SAFETY: `init` returns a freshly-allocated +1 *mut FileSink.
-                if let bun_sys::Result::Err(err) = unsafe { (*sink).start(&stream_start) } {
-                    // SAFETY: release the +1 strong ref taken by `init` on the error path.
-                    unsafe { webcore::FileSink::deref(sink) };
-                    return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err.to_js(global_this),
+                let pathlike = &store.data.as_file().pathlike;
+                // Truncate path destinations (replace semantics); never truncate an fd.
+                let is_path = matches!(pathlike, PathOrFileDescriptor::Path(_));
+                let mut mkdirp_pending = mkdirp_if_not_exists && is_path;
+                loop {
+                    let sink = webcore::FileSink::init(
+                        Fd::INVALID,
+                        jsc::EventLoopHandle::init(
+                            self.global_this()
+                                .expect("Blob.global_this set at construction")
+                                .bun_vm()
+                                .as_mut()
+                                .event_loop()
+                                .cast::<()>(),
                         ),
                     );
+
+                    let input_path: webcore::PathOrFileDescriptor = match pathlike {
+                        PathOrFileDescriptor::Fd(fd) => webcore::PathOrFileDescriptor::Fd(*fd),
+                        PathOrFileDescriptor::Path(p) => webcore::PathOrFileDescriptor::Path(
+                            bun_core::ZigStringSlice::init_dupe(p.slice()).expect("oom"),
+                        ),
+                    };
+                    // input_path drops at scope exit.
+
+                    let stream_start = streams::Start::FileSink(streams::FileSinkOptions {
+                        input_path,
+                        truncate: is_path,
+                        mode: mode.unwrap_or(WRITE_PERMISSIONS),
+                        ..Default::default()
+                    });
+
+                    // SAFETY: `init` returns a freshly-allocated +1 *mut FileSink.
+                    if let bun_sys::Result::Err(err) = unsafe { (*sink).start(&stream_start) } {
+                        // SAFETY: release the +1 strong ref taken by `init` on the error path.
+                        unsafe { webcore::FileSink::deref(sink) };
+                        if mkdirp_pending
+                            && err.get_errno() == bun_sys::E::ENOENT
+                            && mkdirp_parent_of(pathlike.path().slice())
+                        {
+                            mkdirp_pending = false;
+                            continue;
+                        }
+                        return Ok(
+                            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                                global_this,
+                                sys_error_with_path_like(&err, pathlike).to_js(global_this),
+                            ),
+                        );
+                    }
+                    break 'brk_sink sink;
                 }
-                break 'brk_sink sink;
             }
         };
 
+        // SAFETY: `file_sink` is the +1 ref taken by `FileSink::init` above; the
+        // guard now owns it (the Pending arm moves it into `FileStreamWrapper`).
+        let sink = unsafe { webcore::file_sink::FileSinkRef::adopt(file_sink) };
+        sink.start_counting_received();
+
+        *took_stream = true;
         // Stay on the JS pump here: the native ByteStream path returns UNDEFINED before
         // completion, which would resolve-0 early.
         let assignment_result: JSValue = webcore::file_sink::JSSink::assign_to_stream(
             global_this,
             readable_stream.value,
-            // SAFETY: file_sink is a live +1 *mut FileSink.
-            unsafe { NonNull::new_unchecked(file_sink) },
+            sink.as_ptr(),
         );
 
         assignment_result.ensure_still_alive();
 
         if let Some(err) = assignment_result.to_error() {
-            // SAFETY: release our +1 ref on the sink.
-            unsafe { webcore::FileSink::deref(file_sink) };
             return Ok(
                 JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                     global_this,
@@ -1632,7 +1668,7 @@ impl BlobExt for Blob {
                                     readable_stream,
                                     global_this,
                                 ),
-                            sink: file_sink,
+                            sink,
                         }));
                         // SAFETY: wrapper was just produced by heap::alloc; sole owner here.
                         let promise_value = unsafe { (*wrapper).promise.value() };
@@ -1645,27 +1681,24 @@ impl BlobExt for Blob {
                         return Ok(promise_value);
                     }
                     jsc::js_promise::Status::Fulfilled => {
-                        // SAFETY: release our +1 ref on the sink.
-                        unsafe { webcore::FileSink::deref(file_sink) };
+                        let written = sink.received_count() as f64;
                         readable_stream.done(global_this);
                         return Ok(JSPromise::resolved_promise_value(
                             global_this,
-                            JSValue::js_number(0.0),
+                            JSValue::js_number(written),
                         ));
                     }
                     jsc::js_promise::Status::Rejected => {
-                        // SAFETY: release our +1 ref on the sink.
-                        unsafe { webcore::FileSink::deref(file_sink) };
+                        let err = promise.result(global_this.vm());
+                        promise.set_handled(global_this.vm());
                         readable_stream.cancel(global_this);
                         return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
-                            promise.result(global_this.vm()),
+                            err,
                         ));
                     }
                 }
             } else {
-                // SAFETY: release our +1 ref on the sink.
-                unsafe { webcore::FileSink::deref(file_sink) };
                 readable_stream.cancel(global_this);
                 return Ok(
                     JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
@@ -1675,12 +1708,11 @@ impl BlobExt for Blob {
                 );
             }
         }
-        // SAFETY: release our +1 ref on the sink.
-        unsafe { webcore::FileSink::deref(file_sink) };
+        let written = sink.received_count() as f64;
 
         Ok(JSPromise::resolved_promise_value(
             global_this,
-            JSValue::js_number(0.0),
+            JSValue::js_number(written),
         ))
     }
 
@@ -4342,6 +4374,25 @@ pub(crate) fn mkdir_if_not_exists<T: MkdirpTarget>(
     Retry::No
 }
 
+/// `createPath` ENOENT retry for `pipe_readable_stream_to_blob` (opens via
+/// `FileSink`, not the `FileOpener` tasks that use [`mkdir_if_not_exists`]).
+fn mkdirp_parent_of(dest_path: &[u8]) -> bool {
+    let Some(dirname) = bun_core::dirname(dest_path) else {
+        return false;
+    };
+    let mut node_fs = node::fs::NodeFS::default();
+    node_fs
+        .mkdir_recursive(&node::fs::args::Mkdir {
+            path: node::PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(
+                dirname, false,
+            )),
+            recursive: true,
+            always_return_none: true,
+            ..Default::default()
+        })
+        .is_ok()
+}
+
 /// `bun_sys::Error` only
 /// exposes `with_path(&[u8])`, so route through the
 /// `PathOrFileDescriptor`'s slice when it's a path and leave the error
@@ -4694,10 +4745,15 @@ pub(crate) fn write_file_with_source_destination(
             )?,
             ctx,
         )? {
+            // An S3 source has no Body to mark used, so the taken signal is unused.
+            let mut _took_stream = false;
             return destination_blob.pipe_readable_stream_to_blob(
                 ctx,
                 stream,
                 options.extra_options,
+                options.mkdirp_if_not_exists.unwrap_or(true),
+                options.mode,
+                &mut _took_stream,
             );
         } else {
             return Ok(
@@ -5049,20 +5105,27 @@ pub(crate) fn write_file_internal(
         // `Response` and `Request` both expose `get_body_value()` /
         // `get_body_readable_stream()`; one helper takes the
         // body-value pointer and a `get_stream` closure.
-        let mut body_dispatch =
-            |body_value: *mut webcore::body::Value,
-             get_stream: &mut dyn FnMut(&JSGlobalObject) -> Option<ReadableStream>|
-             -> JsResult<core::ops::ControlFlow<JSValue, Blob>> {
-                use core::ops::ControlFlow;
-                use webcore::body::Value as BodyValue;
-                enum BodyTag {
-                    Use,
-                    Error,
-                    Locked,
-                }
-                // `body_value` is `&mut Body::Value` from a live JS heap
-                // Response/Request `m_ctx`, held raw so every borrow below is
-                // scoped and none spans the JS-running calls in the arms.
+        let mut body_dispatch = |body_value: *mut webcore::body::Value,
+                                 get_stream: &mut dyn FnMut(
+            &JSGlobalObject,
+        ) -> Option<ReadableStream>|
+         -> JsResult<core::ops::ControlFlow<JSValue, Blob>> {
+            use core::ops::ControlFlow;
+            use webcore::body::Value as BodyValue;
+            enum BodyTag {
+                Use,
+                Error,
+                Locked,
+            }
+            // `body_value` is `&mut Body::Value` from a live JS heap
+            // Response/Request `m_ctx`, held raw so every borrow below is
+            // scoped and none spans the JS-running calls in the arms.
+            // SAFETY: exclusive borrow scoped to the call; runs no JS. As in the
+            // other native consumers, a blob- or file-backed stream folds back
+            // into a Blob here so the Use arm takes the copy engines. A
+            // disturbed stream stays Locked and hits the used check below.
+            unsafe { (*body_value).to_blob_if_possible() };
+            {
                 // SAFETY: scoped shared read of the variant tag.
                 let tag = match unsafe { &*body_value } {
                     BodyValue::Error(_) => BodyTag::Error,
@@ -5072,7 +5135,7 @@ pub(crate) fn write_file_internal(
                 match tag {
                     BodyTag::Use => {
                         // SAFETY: exclusive borrow scoped to the call; `use_()` runs no JS.
-                        Ok(ControlFlow::Continue(unsafe { (*body_value).use_() }))
+                        return Ok(ControlFlow::Continue(unsafe { (*body_value).use_() }));
                     }
                     BodyTag::Error => {
                         let err_js = {
@@ -5083,14 +5146,14 @@ pub(crate) fn write_file_internal(
                             err_ref.to_js(global_this)
                         };
                         destination_blob.detach();
-                        // SAFETY: exclusive borrow scoped to the call; no other
-                        // borrow of the body value is live.
+                        // SAFETY: exclusive borrow scoped to the call; no other borrow live.
                         let _ = unsafe { (*body_value).use_() };
-                        Ok(ControlFlow::Break(
+                        return Ok(ControlFlow::Break(
                         JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this, err_js,
+                            global_this,
+                            err_js,
                         ),
-                    ))
+                    ));
                     }
                     BodyTag::Locked => {
                         if destination_blob.is_s3() {
@@ -5112,7 +5175,9 @@ pub(crate) fn write_file_internal(
                                 locked.readable.get(global_this)
                             });
                             if let Some(readable) = readable_opt {
-                                if readable.is_disturbed(global_this) {
+                                if readable.is_locked(global_this)
+                                    || readable.is_disturbed(global_this)
+                                {
                                     destination_blob.detach();
                                     return Err(global_this.throw_invalid_arguments(format_args!(
                                         "ReadableStream has already been used"
@@ -5149,6 +5214,37 @@ pub(crate) fn write_file_internal(
                                 "ReadableStream has already been used"
                             )));
                         }
+
+                        // A Locked body carrying a ReadableStream has no native driver to
+                        // fire on_receive_value below, so pump it into the file here.
+                        // (`get_stream` falls back to the native `locked.readable` slot.)
+                        if let Some(readable) = get_stream(global_this) {
+                            // Reject an unusable source before the pipe truncates the destination.
+                            if readable.is_locked(global_this) || readable.is_disturbed(global_this)
+                            {
+                                destination_blob.detach();
+                                return Err(global_this.throw_invalid_arguments(format_args!(
+                                    "ReadableStream has already been used"
+                                )));
+                            }
+                            let mut took_stream = false;
+                            let result = destination_blob.pipe_readable_stream_to_blob(
+                                global_this,
+                                readable,
+                                options.extra_options,
+                                options.mkdirp_if_not_exists.unwrap_or(true),
+                                options.mode,
+                                &mut took_stream,
+                            );
+                            // An early rejection (open failure) left the body untouched.
+                            if took_stream {
+                                // SAFETY: re-borrow `body_value` (a live JS-heap Body);
+                                // the `readable` borrow ended above.
+                                unsafe { *body_value = BodyValue::Used };
+                            }
+                            return result.map(ControlFlow::Break);
+                        }
+
                         let task =
                             bun_core::heap::into_raw(Box::new(WriteFileWaitFromLockedValueTask {
                                 global_this: bun_ptr::BackRef::new(global_this),
@@ -5159,6 +5255,7 @@ pub(crate) fn write_file_internal(
                                 ),
                                 promise: jsc::JSPromiseStrong::init(global_this),
                                 mkdirp_if_not_exists: options.mkdirp_if_not_exists.unwrap_or(true),
+                                mode: options.mode,
                             }));
                         // SAFETY: re-borrow after the early-return paths.
                         let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
@@ -5174,10 +5271,11 @@ pub(crate) fn write_file_internal(
                         if let Some((on_start_buffering, producer_task)) = producer_hook {
                             on_start_buffering(producer_task);
                         }
-                        Ok(ControlFlow::Break(promise))
+                        return Ok(ControlFlow::Break(promise));
                     }
                 }
-            };
+            }
+        };
 
         // `as_class_ref` is the safe shared-borrow downcast (one audited unsafe
         // in `JSValue`); `get_body_value` / `get_body_readable_stream` both
@@ -5876,17 +5974,8 @@ impl Drop for S3BlobDownloadTask {
 struct FileStreamWrapper {
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) readable_stream_ref: webcore::readable_stream::ReadableStreamStrong,
-    // LIFETIMES.tsv: SHARED — but FileSink uses an intrusive single-thread refcount
-    // (`ref_`/`deref`) and crosses FFI as a raw pointer, so this stays `*mut`
-    // rather than `Arc<T>`.
-    pub sink: *mut webcore::FileSink,
-}
-
-impl Drop for FileStreamWrapper {
-    fn drop(&mut self) {
-        // SAFETY: `sink` is the +1 ref handed over by `pipe_readable_stream_to_blob`.
-        unsafe { webcore::FileSink::deref(self.sink) };
-    }
+    /// Owns the sink ref; released when the wrapper drops.
+    pub(crate) sink: webcore::file_sink::FileSinkRef,
 }
 
 pub(crate) fn on_file_stream_resolve_request_stream(
@@ -5902,7 +5991,9 @@ pub(crate) fn on_file_stream_resolve_request_stream(
     if let Some(stream) = strong.get(global_this) {
         stream.done(global_this);
     }
-    this.promise.resolve(global_this, JSValue::js_number(0.0))?;
+    let written = this.sink.received_count() as f64;
+    this.promise
+        .resolve(global_this, JSValue::js_number(written))?;
     Ok(JSValue::UNDEFINED)
 }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1,10 +1,12 @@
 use core::cell::Cell;
+use core::ptr::NonNull;
 use core::sync::atomic::{AtomicI32, Ordering};
 
 #[cfg(windows)]
 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use bun_io::{self, WriteResult, WriteStatus};
 use bun_jsc::JsCell;
+use bun_simdutf_sys::simdutf;
 use bun_sys::{self as sys, Fd, FdExt as _};
 
 use crate::api::bun::process::Status as SpawnStatus;
@@ -34,6 +36,10 @@ pub struct FileSink {
     pub(crate) writer: JsCell<IOWriter>,
     pub(crate) event_loop_handle: EventLoopHandle,
     pub(crate) written: Cell<usize>,
+    /// `Some(n)` only while a `Bun.write` pipe is counting the UTF-8 bytes the
+    /// write fns accept (each chunk once; `written` can double-count). `None`
+    /// for every other sink, which skips the per-chunk length passes.
+    received_bytes: Cell<Option<u64>>,
     pub(crate) pending: JsCell<streams::WritablePending>,
     pub(crate) source: JsCell<streams::SourceHandle>,
     pub(crate) done: Cell<bool>,
@@ -70,9 +76,26 @@ pub struct FileSink {
 
 /// RAII owner of one intrusive ref on a `FileSink`. Drops the ref (and frees
 /// the allocation if it was the last) on scope exit, without borrowing `self`.
-struct FileSinkRef(*mut FileSink);
+pub(crate) struct FileSinkRef(*mut FileSink);
+
+impl core::ops::Deref for FileSinkRef {
+    type Target = FileSink;
+    #[inline]
+    fn deref(&self) -> &FileSink {
+        // SAFETY: constructor contract — the guard owns a ref, so `self.0` is
+        // live for as long as the guard is.
+        unsafe { &*self.0 }
+    }
+}
 
 impl FileSinkRef {
+    /// The pointer for FFI calls; the guard keeps ownership of the ref.
+    #[inline]
+    pub(crate) fn as_ptr(&self) -> NonNull<FileSink> {
+        // SAFETY: constructor contract — `self.0` is non-null.
+        unsafe { NonNull::new_unchecked(self.0) }
+    }
+
     /// Take a fresh ref on `this` for the guard's lifetime.
     ///
     /// # Safety
@@ -94,7 +117,7 @@ impl FileSinkRef {
     /// `this` must point to a live `FileSink` and the caller must own one
     /// outstanding ref that is being transferred to this guard.
     #[inline]
-    unsafe fn adopt(this: *mut FileSink) -> Self {
+    pub(crate) unsafe fn adopt(this: *mut FileSink) -> Self {
         Self(this)
     }
 }
@@ -191,6 +214,8 @@ bun_io::impl_streaming_writer_parent! {
 
 pub struct Options {
     pub(crate) input_path: PathOrFileDescriptor,
+    /// `O_TRUNC` on open. Default `false` (in-place overwrite); `Bun.write` opts in.
+    pub(crate) truncate: bool,
     pub close: bool,
     pub(crate) mode: bun_sys::Mode,
 }
@@ -199,6 +224,7 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             input_path: PathOrFileDescriptor::Fd(Fd::INVALID),
+            truncate: false,
             close: false,
             mode: 0o664,
         }
@@ -207,8 +233,11 @@ impl Default for Options {
 
 impl Options {
     pub(crate) fn flags(&self) -> i32 {
-        let _ = self;
-        bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC | bun_sys::O::CREAT | bun_sys::O::WRONLY
+        bun_sys::O::NONBLOCK
+            | bun_sys::O::CLOEXEC
+            | bun_sys::O::CREAT
+            | bun_sys::O::WRONLY
+            | if self.truncate { bun_sys::O::TRUNC } else { 0 }
     }
 }
 
@@ -1015,6 +1044,27 @@ impl FileSink {
         this
     }
 
+    /// Opt this sink into `received_bytes` accounting (`Bun.write` pipes only).
+    pub(crate) fn start_counting_received(&self) {
+        self.received_bytes.set(Some(0));
+    }
+
+    /// Bytes credited so far; 0 for a sink that never opted in.
+    pub(crate) fn received_count(&self) -> u64 {
+        self.received_bytes.get().unwrap_or(0)
+    }
+
+    /// Credit one accepted chunk. `emitted_len` only runs while counting, so
+    /// sinks that never opted in skip the string length passes entirely.
+    /// `Done(n)` credits nothing: its `n` can include already-credited bytes.
+    fn count_received(&self, rc: &WriteResult, emitted_len: impl FnOnce() -> usize) {
+        if let Some(total) = self.received_bytes.get() {
+            if matches!(rc, WriteResult::Wrote(_) | WriteResult::Pending(_)) {
+                self.received_bytes.set(Some(total + emitted_len() as u64));
+            }
+        }
+    }
+
     pub fn write(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
             return streams::Writable::Done;
@@ -1022,6 +1072,7 @@ impl FileSink {
         let buffered_before = self.writer.get().buffered_len();
         // SAFETY(JsCell): `IOWriter::write` buffers/writes to fd; does not call JS.
         let rc = self.writer.with_mut(|w| w.write(data.slice()));
+        self.count_received(&rc, || data.slice().len());
         let accepted = self.bytes_accepted(buffered_before, &rc);
         self.to_result(rc, accepted)
     }
@@ -1033,6 +1084,7 @@ impl FileSink {
         let buffered_before = self.writer.get().buffered_len();
         // SAFETY(JsCell): `IOWriter::write_latin1` buffers/writes; no JS.
         let rc = self.writer.with_mut(|w| w.write_latin1(data.slice()));
+        self.count_received(&rc, || simdutf::length::utf8::from::latin1(data.slice()));
         let accepted = self.bytes_accepted(buffered_before, &rc);
         self.to_result(rc, accepted)
     }
@@ -1044,6 +1096,10 @@ impl FileSink {
         let buffered_before = self.writer.get().buffered_len();
         // SAFETY(JsCell): `IOWriter::write_utf16` buffers/writes; no JS.
         let rc = self.writer.with_mut(|w| w.write_utf16(data.slice16()));
+        // `le_with_replacement`: lone surrogates emit U+FFFD (3 bytes), not 2.
+        self.count_received(&rc, || {
+            simdutf::length::utf8::from::utf16::le_with_replacement(data.slice16())
+        });
         let accepted = self.bytes_accepted(buffered_before, &rc);
         self.to_result(rc, accepted)
     }
@@ -1413,6 +1469,7 @@ impl FileSink {
             // SAFETY: sentinel only; never dispatched (overwritten before use).
             event_loop_handle: EventLoopHandle::init(core::ptr::null_mut()),
             written: Cell::new(0),
+            received_bytes: Cell::new(None),
             pending: JsCell::new(streams::WritablePending {
                 result: streams::Writable::Done,
                 ..Default::default()

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1306,6 +1306,7 @@ pub struct WriteFileWaitFromLockedValueTask {
     pub global_this: bun_ptr::BackRef<JSGlobalObject>,
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) mkdirp_if_not_exists: bool,
+    pub(crate) mode: Option<bun_sys::Mode>,
 }
 
 impl WriteFileWaitFromLockedValueTask {
@@ -1361,6 +1362,7 @@ impl WriteFileWaitFromLockedValueTask {
                     &mut file_blob,
                     &blob::WriteFileOptions {
                         mkdirp_if_not_exists: Some(this.mkdirp_if_not_exists),
+                        mode: this.mode,
                         ..Default::default()
                     },
                 ) {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2642,6 +2642,11 @@ impl FetchTasklet {
             }
 
             if let BodyValue::Locked(locked) = body {
+                if locked.on_receive_value.is_some() {
+                    // Scenario 2b: a consumer (e.g. `Bun.write`) is waiting on
+                    // `resolve()`, so keep `native_response` reachable.
+                    return;
+                }
                 if let Some(promise) = locked.promise {
                     if promise.is_empty_or_undefined_or_null() {
                         // Scenario 2b.

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -391,6 +391,331 @@ const IS_UV_FS_COPYFILE_DISABLED =
     await gcTick();
   });
 
+  describe("Bun.write(path, new Response(readableStream))", () => {
+    it("JS ReadableStream (start/close)", async () => {
+      using dir = tempDir("bun-write-response-rs-start", {});
+      const dest = path.join(String(dir), "out.txt");
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("hello-js-stream"));
+          c.close();
+        },
+      });
+      const n = await Bun.write(dest, new Response(rs));
+      expect(await Bun.file(dest).text()).toBe("hello-js-stream");
+      expect(n).toBe(15);
+      await gcTick();
+    });
+
+    it("JS ReadableStream (pull, multiple chunks)", async () => {
+      using dir = tempDir("bun-write-response-rs-pull", {});
+      const dest = path.join(String(dir), "out.txt");
+      const chunks = ["one-", "two-", "three"];
+      let i = 0;
+      const rs = new ReadableStream({
+        pull(c) {
+          if (i < chunks.length) {
+            c.enqueue(new TextEncoder().encode(chunks[i++]));
+          } else {
+            c.close();
+          }
+        },
+      });
+      const n = await Bun.write(dest, new Response(rs));
+      expect(await Bun.file(dest).text()).toBe("one-two-three");
+      expect(n).toBe(13);
+      await gcTick();
+    });
+
+    it("Bun.file().stream() wrapped in Response", async () => {
+      using dir = tempDir("bun-write-response-file-stream", {
+        "src.txt": "hello-file-stream",
+      });
+      const src = path.join(String(dir), "src.txt");
+      const dest = path.join(String(dir), "out.txt");
+      const n = await Bun.write(dest, new Response(Bun.file(src).stream()));
+      expect(await Bun.file(dest).text()).toBe("hello-file-stream");
+      // This source folds back into a file Blob and takes the file copy engine,
+      // which on Windows (uv_fs_copyfile) resolves with 0 today, as the
+      // "Bun.file -> Bun.file" test above also tolerates.
+      if (!isWindows) expect(n).toBe(17);
+      await gcTick();
+    });
+
+    it("Request with ReadableStream body", async () => {
+      using dir = tempDir("bun-write-request-rs", {});
+      const dest = path.join(String(dir), "out.txt");
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("hello-request"));
+          c.close();
+        },
+      });
+      const req = new Request("http://example.com", { method: "POST", body: rs });
+      const n = await Bun.write(dest, req);
+      expect(await Bun.file(dest).text()).toBe("hello-request");
+      expect(n).toBe(13);
+      await gcTick();
+    });
+
+    it("rejects when the stream errors", async () => {
+      using dir = tempDir("bun-write-response-rs-error", {});
+      const dest = path.join(String(dir), "out.txt");
+      const rs = new ReadableStream({
+        pull(c) {
+          c.error(new Error("boom"));
+        },
+      });
+      let caught;
+      await Bun.write(dest, new Response(rs)).then(
+        () => {},
+        e => (caught = e),
+      );
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught.message).toBe("boom");
+    });
+
+    it("marks the Response body as used", async () => {
+      using dir = tempDir("bun-write-response-rs-used", {});
+      const dest = path.join(String(dir), "out.txt");
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("hello"));
+          c.close();
+        },
+      });
+      const resp = new Response(rs);
+      await Bun.write(dest, resp);
+      expect(resp.bodyUsed).toBe(true);
+    });
+
+    it("truncates a longer pre-existing destination", async () => {
+      using dir = tempDir("bun-write-response-rs-trunc", {
+        "out.txt": Buffer.alloc(64, "X").toString(),
+      });
+      const dest = path.join(String(dir), "out.txt");
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("hello"));
+          c.close();
+        },
+      });
+      expect(await Bun.write(dest, new Response(rs))).toBe(5);
+      expect(await Bun.file(dest).text()).toBe("hello");
+    });
+
+    it("creates missing parent directories by default", async () => {
+      using dir = tempDir("bun-write-response-rs-mkdirp", {});
+      const dest = path.join(String(dir), "a", "b", "out.txt");
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("nested"));
+          c.close();
+        },
+      });
+      expect(await Bun.write(dest, new Response(rs))).toBe(6);
+      expect(await Bun.file(dest).text()).toBe("nested");
+    });
+
+    it("with { createPath: false }, rejects and leaves the body unused", async () => {
+      using dir = tempDir("bun-write-response-rs-noent", {});
+      const dest = path.join(String(dir), "missing", "out.txt");
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("keep"));
+          c.close();
+        },
+      });
+      const resp = new Response(rs);
+      let caught;
+      await Bun.write(dest, resp, { createPath: false }).then(
+        () => {},
+        e => (caught = e),
+      );
+      expect({ code: caught?.code, path: caught?.path }).toEqual({ code: "ENOENT", path: dest });
+      // The open failed before the stream was read, so the body is still intact.
+      expect(resp.bodyUsed).toBe(false);
+      expect(await resp.text()).toBe("keep");
+    });
+
+    it("supports a type: 'direct' stream, counting each chunk once", async () => {
+      using dir = tempDir("bun-write-response-rs-direct", {});
+      const dest = path.join(String(dir), "out.txt");
+      const rs = new ReadableStream({
+        type: "direct",
+        pull(c) {
+          c.write(new TextEncoder().encode("ab"));
+          c.write("héllo"); // latin1 JSString: 5 chars, 6 UTF-8 bytes
+          c.write("日本\uD800"); // utf16 JSString; the lone surrogate encodes as U+FFFD (3 bytes)
+          c.close();
+        },
+      });
+      const resp = new Response(rs);
+      const n = await Bun.write(dest, resp);
+      expect({ n, text: await Bun.file(dest).text(), bodyUsed: resp.bodyUsed }).toEqual({
+        n: 17,
+        text: "abhéllo日本\uFFFD",
+        bodyUsed: true,
+      });
+    });
+
+    it.skipIf(isWindows)("honours { mode }", async () => {
+      using dir = tempDir("bun-write-response-rs-mode", {});
+      const dest = path.join(String(dir), "out.txt");
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("m"));
+          c.close();
+        },
+      });
+      await Bun.write(dest, new Response(rs), { mode: 0o600 });
+      expect(fs.statSync(dest).mode & 0o777).toBe(0o600);
+    });
+
+    it("fetch Response whose wrapper is collected while the write waits on the body", async () => {
+      using dir = tempDir("bun-write-response-fetch-finalized", {});
+      const dest = path.join(String(dir), "out.bin");
+      const { promise: release, resolve: doRelease } = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new Response(
+            new ReadableStream({
+              async start(c) {
+                c.enqueue(Buffer.alloc(1024, "a"));
+                await release;
+                c.enqueue(Buffer.alloc(1024, "b"));
+                c.close();
+              },
+            }),
+          ),
+      });
+      // The Response stays reachable only inside this helper, so its wrapper
+      // can be finalized while Bun.write is parked on the producer. Returning
+      // the write inside an object keeps the promise from being flattened.
+      async function start() {
+        const res = await fetch(server.url);
+        return { write: Bun.write(dest, res) };
+      }
+      const { write } = await start();
+      for (let i = 0; i < 3; i++) {
+        Bun.gc(true);
+        await gcTick();
+      }
+      doRelease();
+      expect(await write).toBe(2048);
+      const out = await Bun.file(dest).text();
+      expect([out.slice(0, 1024), out.slice(1024)]).toEqual([
+        Buffer.alloc(1024, "a").toString(),
+        Buffer.alloc(1024, "b").toString(),
+      ]);
+    });
+
+    it("fetch Response after its .body getter was touched", async () => {
+      using dir = tempDir("bun-write-response-fetch-body-touched", {});
+      const dest = path.join(String(dir), "out.txt");
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new Response(
+            new ReadableStream({
+              start(c) {
+                c.enqueue(new TextEncoder().encode("fetch-body-content"));
+                c.close();
+              },
+            }),
+          ),
+      });
+      const res = await fetch(server.url);
+      // Materialises a ByteStream-backed readable on `locked.readable`
+      // without consuming it.
+      void res.body;
+      const n = await Bun.write(dest, res);
+      expect({ n, text: await Bun.file(dest).text() }).toEqual({
+        n: 18,
+        text: "fetch-body-content",
+      });
+    });
+
+    it("server Request after its .body getter was touched", async () => {
+      using dir = tempDir("bun-write-server-req-body-touched", {});
+      const dest = path.join(String(dir), "out.txt");
+      const { promise, resolve, reject } = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          if (!req.body) return new Response("no-body");
+          try {
+            resolve(await Bun.write(dest, req));
+          } catch (e) {
+            reject(e);
+          }
+          return new Response("ok");
+        },
+      });
+      const res = await fetch(server.url, { method: "POST", body: "server-request-payload" });
+      expect(await res.text()).toBe("ok");
+      expect({ n: await promise, text: await Bun.file(dest).text() }).toEqual({
+        n: 22,
+        text: "server-request-payload",
+      });
+    });
+
+    it("new Response(req.body) inside a server handler", async () => {
+      // The original #13237 reproduction.
+      using dir = tempDir("bun-write-server-req-body-wrapped", {});
+      const dest = path.join(String(dir), "out.txt");
+      const { promise, resolve, reject } = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          try {
+            resolve(await Bun.write(dest, new Response(req.body)));
+          } catch (e) {
+            reject(e);
+          }
+          return new Response("ok");
+        },
+      });
+      const res = await fetch(server.url, { method: "POST", body: "wrapped-request-payload" });
+      expect(await res.text()).toBe("ok");
+      expect({ n: await promise, text: await Bun.file(dest).text() }).toEqual({
+        n: 23,
+        text: "wrapped-request-payload",
+      });
+    });
+
+    it("rejects a locked source without truncating the destination", async () => {
+      using dir = tempDir("bun-write-response-rs-locked", {
+        "out.txt": "PRECIOUS-EXISTING-CONTENTS",
+      });
+      const dest = path.join(String(dir), "out.txt");
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("hi"));
+          c.close();
+        },
+      });
+      const resp = new Response(rs);
+      rs.getReader(); // locks the body's stream without disturbing it
+      let caught;
+      try {
+        await Bun.write(dest, resp);
+      } catch (e) {
+        caught = e;
+      }
+      expect({
+        message: caught?.message,
+        text: await Bun.file(dest).text(),
+        bodyUsed: resp.bodyUsed,
+      }).toEqual({
+        message: "ReadableStream has already been used",
+        text: "PRECIOUS-EXISTING-CONTENTS",
+        bodyUsed: false,
+      });
+    });
+  });
+
   it("Bun.write('output.html', '')", async () => {
     using tmpbase = tempDir("bun-write-output-html", {});
     await Bun.write(tmpbase + "output.html", "lalalala");
@@ -852,7 +1177,9 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
           const resp = await fetch(\`http://127.0.0.1:\${server.port}/\`);
           ${expose}
           await Bun.sleep(5);
-          await Promise.race([Bun.write(${out}, resp).catch(() => {}), Bun.sleep(100)]);
+          // A disturbed body throws synchronously now; this test is about the
+          // heap-use-after-free only, not the rejection, so swallow both paths.
+          try { await Promise.race([Bun.write(${out}, resp), Bun.sleep(100)]); } catch {}
         }
         console.log("done");
         server.stop(true);
@@ -860,9 +1187,6 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       `;
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture],
-        // detect_leaks=0: the write promise never settles on a stream-backed
-        // body (#13237), so WriteFileWaitFromLockedValueTask is still live at
-        // process.exit; this test is about the heap-use-after-free only.
         env: {
           ...bunEnv,
           ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":"),

--- a/test/js/bun/s3/s3-source-to-file.test.ts
+++ b/test/js/bun/s3/s3-source-to-file.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import path from "node:path";
+
+function client(endpoint: string) {
+  return new Bun.S3Client({
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    region: "us-east-1",
+    bucket: "bucket",
+    endpoint,
+  });
+}
+
+test("Bun.write(path, s3file) replaces a longer destination and resolves with the byte count", async () => {
+  const body = Buffer.alloc(100, "S").toString();
+  using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response(body, { headers: { "content-length": String(body.length) } }),
+  });
+  using dir = tempDir("s3-source-to-file", {
+    "out.bin": Buffer.alloc(500, "X").toString(),
+  });
+  const dest = path.join(String(dir), "out.bin");
+
+  const n = await Bun.write(dest, client(server.url.href).file("obj.bin"));
+
+  expect({ n, contents: await Bun.file(dest).text() }).toEqual({ n: 100, contents: body });
+});
+
+test("Bun.write(missing/dir/file, s3file) creates the parent directories", async () => {
+  const body = "nested";
+  using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response(body, { headers: { "content-length": String(body.length) } }),
+  });
+  using dir = tempDir("s3-source-to-file-mkdirp", {});
+  const dest = path.join(String(dir), "a", "b", "out.txt");
+
+  const n = await Bun.write(dest, client(server.url.href).file("obj.txt"));
+
+  expect({ n, contents: await Bun.file(dest).text() }).toEqual({ n: body.length, contents: body });
+});

--- a/test/js/bun/s3/s3-write-to-file-sync-close.test.ts
+++ b/test/js/bun/s3/s3-write-to-file-sync-close.test.ts
@@ -13,7 +13,7 @@ import path from "node:path";
 // Accept either outcome here so a future fix that surfaces the error does not
 // trip this test.
 test("Bun.file().write(S3 file) when the S3 stream closes synchronously", async () => {
-  using dir = tempDir("s3-write-sync-close", {});
+  using dir = tempDir("s3-write-sync-close", { "out.bin": "stale" });
   const dest = path.join(String(dir), "out.bin");
 
   const fixture = `
@@ -53,10 +53,15 @@ test("Bun.file().write(S3 file) when the S3 stream closes synchronously", async 
     stdout: normalizeBunSnapshot(stdout),
     stderr: normalizeBunSnapshot(stderr),
     signalCode: proc.signalCode,
+    // Bun.write replaces the destination: it is opened with truncation before
+    // the source stream is started, so a source that fails up front still
+    // leaves an empty file rather than the previous contents.
+    destination: await Bun.file(dest).text(),
   }).toEqual({
     stdout: expect.stringMatching(/^(resolved|rejected:ERR_S3_MISSING_CREDENTIALS)$/),
     stderr: "",
     signalCode: null,
+    destination: "",
   });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Repro

```js
const rs = new ReadableStream({
  start(c) {
    c.enqueue(new TextEncoder().encode("hello-js-stream"));
    c.close();
  },
});
await Bun.write("/tmp/out.txt", new Response(rs)); // never settles
```

`Bun.write(dest, new Response(readableStream))` never resolved or rejected when the Response body is a JS-constructed ReadableStream (any `new ReadableStream(...)`, a `type: "direct"` stream, or `Bun.file(x).stream()`). The same applied to `Request` bodies, and to a `fetch()` Response after its `.body` getter had been touched. The docs list `Response` as a supported source, and `new Response(rs).text()` on the very same object resolves immediately.

### Cause

In `write_file_internal`'s `body_dispatch`, the non-S3 `BodyValue::Locked` arm registers `on_receive_value` on the locked body and returns the task promise. That callback only fires when a native producer calls `resolve()` on the body (the fetch path). A body constructed from a user ReadableStream has no native producer, so nothing ever fires the callback and the promise hangs. The S3 destination arm already handled this by extracting the readable and streaming it; the file destination arm did not.

### Fix

When the locked body already has a readable stream (via `get_body_readable_stream` or `locked.readable`), hand it to `pipe_readable_stream_to_blob`, which drives the stream into a `FileSink` through `assignToStream` and chains on the existing `FileStreamWrapper` promise handlers. Fetch responses whose body has not been materialised continue to use `WriteFileWaitFromLockedValueTask` unchanged.

The entry guard rejects an unusable source, locked or disturbed (the Fetch spec's predicate), before any side effect. Disturbed alone is not enough: `getReader()` locks a stream without disturbing it, and since the pipe now opens the destination with `O_TRUNC` before it touches the stream, a locked-only source would have truncated the destination to 0 bytes and then rejected when `readStreamIntoSink`'s own `getReader()` threw.

The body is marked `Used` only when the pipe actually handed the stream to `assignToStream`, reported through a `took_stream` out-param set at that single point. Stream state cannot answer this after the fact: an open failure never touches the stream, and a synchronously completing `type: "direct"` stream has its `$reader` lock sentinel cleared by its own close handler before control returns to Rust, so it is neither locked nor disturbed despite being fully consumed. An open that fails before the stream is reached (for example ENOENT with `createPath: false`) therefore rejects without consuming the body.

Review caught that `pipe_readable_stream_to_blob` did not carry `Bun.write`'s file-open semantics, which would have surfaced on this newly working path, so this PR also fixes the helper itself:

- **Truncate the destination.** `FileSink::Options.truncate` was a dead field (`flags()` discarded `self` and never read it), so no FileSink open ever applied `O_TRUNC` and a shorter stream over a longer existing file left stale trailing bytes. `truncate` is now wired into `flags()` with the default flipped to `false`: that flip is unobservable to existing callers because the field was never read and every existing construction uses `..Default::default()`, so `Bun.file(path).writer()` keeps its in-place overwrite behavior (verified directly). The two `Bun.write` pipe sites opt in, and only for a path destination, never an fd.
- **Honour `createPath` and `mode`.** Both are threaded into `pipe_readable_stream_to_blob` at this arm and at the existing S3-to-file arm, which shared the gap. ENOENT on open retries once after creating the parent directory chain, matching `WriteFile`/`CopyFile`.
- **Resolve with the byte count.** This path always resolved with `0`. `FileSink.written` cannot be used for it: it mixes the writer's buffered and flushed progress reports and double-counts on the direct-stream protocol (a 12 byte body reported 24), though it is exact for `writer()` and the default stream path. A new `FileSink.received_bytes` counts each accepted chunk exactly once at the three write entry points. It is opt-in (`Option<u64>`, enabled only by the `Bun.write` pipe, with the length computed in a closure), so `writer()`, stdout, subprocess stdin and the stream pumps do not pay a length pass per string chunk. While counting, a chunk is credited as its emitted UTF-8 length: `utf8_length_from_latin1` for Latin-1 strings (exact unconditionally) and `utf16::le_with_replacement` for UTF-16 strings, which is documented as the exact byte count of the replacement encoder. The non-validating `le` is not usable here: it only sizes the fast-path reservation, and on a lone surrogate the simdutf conversion commits nothing and an U+FFFD fallback emits 3 bytes. `written` is untouched since it backs the public `writer().end()` and `flush()` return values.
- Mark the `assignToStream` promise as handled when it is already rejected synchronously (an errored or locked stream), so callers see one rejection instead of a rejection plus a stray unhandled-rejection event.

### Fetch Response collected while the write waits on it

When no readable is cached on the locked body (a `fetch()` Response before its `.body` getter has been touched), `body_dispatch` falls through to `WriteFileWaitFromLockedValueTask`, which waits for the producer to `resolve()` the body. (The producer's `on_start_buffering` is already fired before `locked.task` is replaced; that landed in #36006 and this PR keeps that ordering unchanged.)

The remaining defect is in `FetchTasklet::on_response_finalize`, the Response JS wrapper's weak finalizer: it decided "no one is waiting" by checking only `locked.promise`. A consumer that registered `on_receive_value` instead was missed, so if the wrapper was collected while the write was parked, the finalizer dropped `native_response` and the later `on_body_received` had no Response to resolve, and the write never settled. The fix treats `on_receive_value.is_some()` as Scenario 2b (a consumer is waiting) and keeps `native_response` alive. `WriteFileWaitFromLockedValueTask` also now carries `mode` through to the deferred write.

Two smaller points raised in review are also in: `body_dispatch` calls `to_blob_if_possible()` before dispatching, like the other native Body consumers, so a blob- or file-backed stream (`new Response(Bun.file(p).stream())`) takes the existing copy engines rather than the JS pump; and the S3-source-to-file arm, which shares `pipe_readable_stream_to_blob`, now has tests for what it picked up.

### Verification

New tests in `test/js/bun/io/bun-write.test.js` under `Bun.write(path, new Response(readableStream))`: synchronous `start`/`close` stream, multi-chunk `pull` stream, `Bun.file().stream()` wrapped in a Response, `Request` with a ReadableStream body, a stream that errors (single rejection, no unhandled event), `bodyUsed` after the write, truncation of a longer pre-existing destination, `createPath` creating missing parent directories by default, `createPath: false` rejecting with ENOENT while leaving the body unused and still readable, `mode` (POSIX), a `type: "direct"` stream writing a byte chunk, a Latin-1 string, and a UTF-16 string containing a lone surrogate through one sink and asserting the exact emitted byte count (including the 3 byte U+FFFD replacement), the contents, and `bodyUsed`, a source locked by the caller's own reader rejecting upfront while leaving the destination contents and `bodyUsed` untouched, a `fetch()` Response whose wrapper is dropped and collected (`Bun.gc`) while the write is parked on a server that is holding back the last chunk (this one pins the `on_response_finalize` change and times out without it), a `fetch()` Response after its `.body` getter was touched, a server `Request` after its `.body` getter was touched, and the original `new Response(req.body)` reproduction from the issue. All 16 fail on a build without this change (the earlier streaming-fetch test, which passed on main once #36006 landed, is the one replaced by the finalizer test above) and all pass with it.

`test/js/bun/s3/s3-source-to-file.test.ts` (new) writes an S3 source served by `Bun.serve` over a longer pre-existing destination and into a missing directory, asserting the resolved byte count and the contents both times, and `s3-write-to-file-sync-close.test.ts` now also asserts the destination is emptied when the source fails up front (the destination is opened for replacement before the source starts). Both files fail on main.

```
bun bd test test/js/bun/io/bun-write.test.js -t "new Response\(readableStream\)"
 16 pass
 0 fail
```

`test/js/bun/util/filesink.test.ts`, `test/js/web/fetch/body.test.ts`, `test/js/web/fetch/body-stream.test.ts`, and `test/js/web/fetch/fetch-response-finalizer-sweep.test.ts` still pass, `Bun.file(path).writer()` still overwrites in place on a longer pre-existing file, a 16 MB backpressured stream resolves with the exact byte count, and `test/js/web/fetch/fetch-leak.test.ts` shows no new failures versus the branch without this change.

### Rebase note

Rebased onto 39fb3c10 as a single commit. The one conflict was the tail of the wait-task arm in `body_dispatch`: main now fires the producer's `on_start_buffering` after the wait task is installed and its promise read out, since the hook may synchronously run `then_wrap`; main's version was taken unchanged. Earlier rebases: onto fc865b39 (no conflicts) and onto 3f5d8163, where the one conflict was with #33538's independent instrumentation of the same three `FileSink` write entry points, resolved additively.

### Related

#31689 and #31739 also route stream sources through `pipe_readable_stream_to_blob`, but for different inputs: #31689 fixes a *raw* `ReadableStream` source being stringified to `"[object ReadableStream]"`, and #31739 streams a fetch `ByteStream`-backed body (it explicitly gates on `readable.ptr.bytes().is_some()`). Neither touches the JS-stream-backed Response/Request case, so none of the three is a duplicate.

Fixes #13237

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 13 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->

