### PR TITLE
bun:test: fix toHaveProperty throwing on null/undefined intermediate in path

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4505,6 +4505,9 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
                 if (i == length) {
 
                     if (ic == '.') {
+                        if (currProp.isUndefinedOrNull()) {
+                            return {};
+                        }
                         auto* currPropObject = currProp.toObject(globalObject);
                         RETURN_IF_EXCEPTION(scope, {});
                         currProp = currPropObject->getIfPropertyExists(globalObject, vm.propertyNames->emptyIdentifier);
@@ -4523,6 +4526,9 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
                 char16_t previous = ic;
                 ic = pathString.codeUnitAt(i);
                 if (previous == '.' && ic == '.') {
+                    if (currProp.isUndefinedOrNull()) {
+                        return {};
+                    }
                     auto* currPropObject = currProp.toObject(globalObject);
                     RETURN_IF_EXCEPTION(scope, {});
                     currProp = currPropObject->getIfPropertyExists(globalObject, vm.propertyNames->emptyIdentifier);
@@ -4548,6 +4554,9 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
             String propNameStr = pathString.substring(i, j - i);
             PropertyName propName = PropertyName(Identifier::fromString(vm, propNameStr));
 
+            if (currProp.isUndefinedOrNull()) {
+                return {};
+            }
             auto* currPropObject = currProp.toObject(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             currProp = currPropObject->getIfPropertyExists(globalObject, propName);
@@ -4578,6 +4587,10 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
             PropertyName propName = PropertyName(propNameString->toIdentifier(globalObject));
             RETURN_IF_EXCEPTION(scope, {});
 
+            if (currProp.isUndefinedOrNull()) {
+                currProp = {};
+                return false;
+            }
             auto* currPropObject = currProp.toObject(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             currProp = currPropObject->getIfPropertyExists(globalObject, propName);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2078,6 +2078,33 @@ describe("expect()", () => {
     expect({ "[[[": 0 }).not.toHaveProperty("[[[", 0);
   });
 
+  test("toHaveProperty() - null/undefined intermediate in path", () => {
+    // Jest treats a null/undefined intermediate as "property not found" rather than throwing.
+    expect({ a: null }).not.toHaveProperty("a.b");
+    expect({ a: undefined }).not.toHaveProperty("a.b");
+    expect({ a: null }).not.toHaveProperty(["a", "b"]);
+    expect({ a: undefined }).not.toHaveProperty(["a", "b"]);
+    expect({ a: { b: null } }).not.toHaveProperty("a.b.c");
+    expect({ a: { b: undefined } }).not.toHaveProperty(["a", "b", "c"]);
+    expect({ a: null }).not.toHaveProperty("a.b", 1);
+    expect({ a: null }).not.toHaveProperty(["a", "b"], 1);
+    expect({ "": null }).not.toHaveProperty("..");
+    expect({ "": null }).not.toHaveProperty(".a");
+    expect({ a: null }).not.toHaveProperty("a.");
+    expect({ a: null }).not.toHaveProperty("a..b");
+
+    expect(() => expect({ a: null }).toHaveProperty("a.b")).toThrow("Unable to find property");
+    expect(() => expect({ a: null }).toHaveProperty(["a", "b"])).toThrow("Unable to find property");
+
+    // null/undefined as the final value is still "found"
+    expect({ a: null }).toHaveProperty("a");
+    expect({ a: null }).toHaveProperty("a", null);
+    expect({ a: null }).toHaveProperty(["a"], null);
+    expect({ a: { b: undefined } }).toHaveProperty("a.b");
+    expect({ a: { b: undefined } }).toHaveProperty("a.b", undefined);
+    expect({ a: { b: undefined } }).toHaveProperty(["a", "b"], undefined);
+  });
+
   test("toHaveProperty() - with string or array", () => {
     const a = new Array(["a", "b", "c"]);
     expect(a).toHaveProperty("0.1", "b");


### PR DESCRIPTION
## Problem

`expect().toHaveProperty(path)` throws a `TypeError` instead of evaluating to "not found" when the path traverses through a `null` or `undefined` intermediate value.

```js
expect({ a: null }).not.toHaveProperty('a.b');
```

```
TypeError: null is not an object (evaluating 'expect({ a: null }).not.toHaveProperty("a.b")')
```

Jest 30 passes this assertion: when an intermediate value in the path is `null` or `undefined`, Jest's `getPath` stops traversal and reports `hasEndProp: false` (property not found).

## Cause

`JSC__JSValue__getIfPropertyExistsFromPath` in `src/jsc/bindings/bindings.cpp` walks the path by repeatedly calling `currProp.toObject(globalObject)` on the current value before looking up the next segment. After the first lookup, `currProp` can be `null` or `undefined`, and `toObject()` on those throws.

## Fix

Before each `toObject()` call on `currProp` that can be reached after a prior property lookup, check `currProp.isUndefinedOrNull()` and return empty (not found) if so. This applies to the main segment lookup, the trailing `.` case, the `..` case, and the array-path iteration.

A `null`/`undefined` value at the *final* segment is still reported as found (unchanged).

## Verification

Added `toHaveProperty() - null/undefined intermediate in path` to `test/js/bun/test/expect.test.js` covering string paths, array paths, nested intermediates, trailing/double-dot edge cases, the positive `.toHaveProperty` failure message, and the final-segment-null case.

Fails on `main`:
```
TypeError: null is not an object (evaluating 'expect({ a: null }).not.toHaveProperty("a.b")')
(fail) expect() > toHaveProperty() - null/undefined intermediate in path
```

Passes with this change; existing `toHaveProperty` tests still pass.