### PR TITLE
worker_threads: emit 'online' before any event the worker produces

### DIFF
--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -452,14 +452,8 @@ void Worker::dispatchOnline(Zig::GlobalObject* workerGlobalObject)
     // Pending→Running under the same lock postTaskToWorkerGlobalScope uses, so
     // a message post racing this transition either queues (drained below by
     // fireEarlyMessages) or posts directly — never both, never neither.
-    //
-    // This MUST happen BEFORE the open event is posted to the parent: the
-    // parent's `online` handler may immediately call getHeapSnapshot() (or
-    // anything else gated on isOnline() / postTaskToWorkerGlobalScope()). If
-    // the state flip happens after the post, a fast parent thread can run the
-    // open task while m_state is still Pending and observe
-    // ERR_WORKER_NOT_RUNNING — flaky `await once(worker, "online");
-    // worker.getHeapSnapshot()` in worker_threads.test.ts.
+    // dispatchOpenIfNeeded() takes the same edge on the parent thread, so an
+    // 'online' handler always observes isOnline() whichever side flips first.
     {
         Locker lock(m_pendingTasksMutex);
         m_state.store(State::Running);

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -398,9 +398,11 @@ void Worker::dispatchEvent(Event& event)
     EventTargetWithInlineData::dispatchEvent(event);
 }
 
-// Dispatch 'open' (node's 'online') at most once, on the parent thread: from
-// dispatchOnline()'s posted task, or earlier from drainToParent() when the
-// worker posted a message during module evaluation (Node: 'online' precedes 'message').
+// Dispatch 'open' (node's 'online') at most once, on the parent thread. Node
+// emits 'online' before the entry point even loads, so it strictly precedes
+// every event the worker produces ('message', 'error', 'close'). Each
+// parent-side task that can be the first one delivered therefore calls this:
+// dispatchOnline()'s task, drainToParent(), the error tasks, and the close task.
 // Returns whether the event was dispatched by this call.
 bool Worker::dispatchOpenIfNeeded()
 {
@@ -511,7 +513,11 @@ void Worker::fireEarlyMessages(Zig::GlobalObject* workerGlobalObject)
 
 void Worker::dispatchErrorWithMessage(WTF::String message)
 {
-    postTaskToParent([protectedThis = Ref { *this }, message = message.isolatedCopy()](ScriptExecutionContext&) {
+    postTaskToParent([protectedThis = Ref { *this }, message = message.isolatedCopy()](ScriptExecutionContext& context) {
+        // A worker whose entry point fails to load or evaluate posts this
+        // before dispatchOnline() ever runs; Node still emits 'online' first.
+        if (protectedThis->dispatchOpenIfNeeded())
+            defaultGlobalObject(context.jsGlobalObject())->drainMicrotasks();
         ErrorEvent::Init init;
         init.message = message;
 
@@ -549,6 +555,9 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
     }
 
     return postTaskToParent([protectedThis = Ref { *this }, serialized, errorCode = WTF::move(errorCode).isolatedCopy()](ScriptExecutionContext& context) {
+        // See dispatchErrorWithMessage: 'online' precedes a module-load error.
+        if (protectedThis->dispatchOpenIfNeeded())
+            defaultGlobalObject(context.jsGlobalObject())->drainMicrotasks();
         auto* globalObject = context.globalObject();
         auto& vm = JSC::getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
@@ -594,7 +603,14 @@ bool Worker::dispatchExit(int32_t exitCode)
     return ScriptExecutionContext::postTaskTo(
         m_parentContextId,
         [this] { this->deref(); },
-        [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext&) {
+        [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
+            // A worker that never reached dispatchOnline (its entry point
+            // called process.exit() or failed to load) still started, so Node
+            // emits 'online' before 'exit'. No-op once 'open' has fired, and
+            // suppressed by dispatchEvent() after terminate().
+            if (protectedThis->dispatchOpenIfNeeded())
+                defaultGlobalObject(context.jsGlobalObject())->drainMicrotasks();
+
             // Closing → dispatch 'close' → Closed. The split lets 'close'/'exit'
             // handlers observe threadId == -1 and isOnline() == false while
             // postMessage() (gated only on Closed) still accepts and drops the

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -516,8 +516,11 @@ void Worker::dispatchErrorWithMessage(WTF::String message)
     postTaskToParent([protectedThis = Ref { *this }, message = message.isolatedCopy()](ScriptExecutionContext& context) {
         // A worker whose entry point fails to load or evaluate posts this
         // before dispatchOnline() ever runs; Node still emits 'online' first.
-        if (protectedThis->dispatchOpenIfNeeded())
-            defaultGlobalObject(context.jsGlobalObject())->drainMicrotasks();
+        if (protectedThis->dispatchOpenIfNeeded()) {
+            // Nullable for the same reason as in drainToParent().
+            if (auto* globalObject = defaultGlobalObject(context.jsGlobalObject()))
+                globalObject->drainMicrotasks();
+        }
         ErrorEvent::Init init;
         init.message = message;
 
@@ -556,8 +559,11 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
 
     return postTaskToParent([protectedThis = Ref { *this }, serialized, errorCode = WTF::move(errorCode).isolatedCopy()](ScriptExecutionContext& context) {
         // See dispatchErrorWithMessage: 'online' precedes a module-load error.
-        if (protectedThis->dispatchOpenIfNeeded())
-            defaultGlobalObject(context.jsGlobalObject())->drainMicrotasks();
+        if (protectedThis->dispatchOpenIfNeeded()) {
+            // Nullable for the same reason as in drainToParent().
+            if (auto* zigGlobalObject = defaultGlobalObject(context.jsGlobalObject()))
+                zigGlobalObject->drainMicrotasks();
+        }
         auto* globalObject = context.globalObject();
         auto& vm = JSC::getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
@@ -608,8 +614,11 @@ bool Worker::dispatchExit(int32_t exitCode)
             // called process.exit() or failed to load) still started, so Node
             // emits 'online' before 'exit'. No-op once 'open' has fired, and
             // suppressed by dispatchEvent() after terminate().
-            if (protectedThis->dispatchOpenIfNeeded())
-                defaultGlobalObject(context.jsGlobalObject())->drainMicrotasks();
+            if (protectedThis->dispatchOpenIfNeeded()) {
+                // Nullable for the same reason as in drainToParent().
+                if (auto* globalObject = defaultGlobalObject(context.jsGlobalObject()))
+                    globalObject->drainMicrotasks();
+            }
 
             // Closing → dispatch 'close' → Closed. The split lets 'close'/'exit'
             // handlers observe threadId == -1 and isOnline() == false while

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -354,6 +354,9 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         m_toParent.drainScheduled.store(false, std::memory_order_relaxed);
         return;
     }
+    // A worker that posts during module evaluation reaches here before
+    // dispatchOnline() has posted the 'open' task; emit 'open' first.
+    dispatchOpenIfNeeded();
     bool reschedule = drainInbox(m_toParent, globalObject, context, [&](Event& event) {
         dispatchEvent(event);
     });
@@ -390,6 +393,20 @@ void Worker::dispatchEvent(Event& event)
     if (m_terminateRequested.load() || m_state.load() == State::Closed)
         return;
     EventTargetWithInlineData::dispatchEvent(event);
+}
+
+// Dispatch 'open' (node's 'online') at most once, on the parent thread: from
+// dispatchOnline()'s posted task, or earlier from drainToParent() when the
+// worker posted a message during module evaluation (Node: 'online' precedes 'message').
+void Worker::dispatchOpenIfNeeded()
+{
+    if (m_openDispatched)
+        return;
+    m_openDispatched = true;
+    if (hasEventListeners(eventNames().openEvent)) {
+        auto event = Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No);
+        dispatchEvent(event);
+    }
 }
 
 bool Worker::postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&& task)
@@ -435,10 +452,7 @@ void Worker::dispatchOnline(Zig::GlobalObject* workerGlobalObject)
     }
 
     postTaskToParent([protectedThis = Ref { *this }](ScriptExecutionContext&) {
-        if (protectedThis->hasEventListeners(eventNames().openEvent)) {
-            auto event = Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No);
-            protectedThis->dispatchEvent(event);
-        }
+        protectedThis->dispatchOpenIfNeeded();
     });
 
     auto* thisContext = workerGlobalObject->scriptExecutionContext();

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -355,8 +355,11 @@ void Worker::drainToParent(ScriptExecutionContext& context)
         return;
     }
     // A worker that posts during module evaluation reaches here before
-    // dispatchOnline() has posted the 'open' task; emit 'open' first.
-    dispatchOpenIfNeeded();
+    // dispatchOnline() has posted the 'open' task: emit 'open' first, then run
+    // microtasks the 'online' handler queued, before the first message (as
+    // Node does between the two deliveries).
+    if (dispatchOpenIfNeeded())
+        globalObject->drainMicrotasks();
     bool reschedule = drainInbox(m_toParent, globalObject, context, [&](Event& event) {
         dispatchEvent(event);
     });
@@ -398,15 +401,26 @@ void Worker::dispatchEvent(Event& event)
 // Dispatch 'open' (node's 'online') at most once, on the parent thread: from
 // dispatchOnline()'s posted task, or earlier from drainToParent() when the
 // worker posted a message during module evaluation (Node: 'online' precedes 'message').
-void Worker::dispatchOpenIfNeeded()
+// Returns whether the event was dispatched by this call.
+bool Worker::dispatchOpenIfNeeded()
 {
     if (m_openDispatched)
-        return;
+        return false;
     m_openDispatched = true;
-    if (hasEventListeners(eventNames().openEvent)) {
-        auto event = Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No);
-        dispatchEvent(event);
+    // The 'online' handler may immediately call getHeapSnapshot(), or anything
+    // else gated on isOnline(), so Running must be visible before the event:
+    // the same ordering dispatchOnline() establishes on the worker thread.
+    {
+        Locker lock(m_pendingTasksMutex);
+        // Only Pending -> Running; never walk Closing/Closed back to Running.
+        auto expected = State::Pending;
+        m_state.compare_exchange_strong(expected, State::Running);
     }
+    if (!hasEventListeners(eventNames().openEvent))
+        return false;
+    auto event = Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No);
+    dispatchEvent(event);
+    return true;
 }
 
 bool Worker::postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&& task)

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -98,7 +98,7 @@ class Worker final : public ThreadSafeRefCounted<Worker>, public EventTargetWith
 public:
     enum class State : uint8_t {
         Pending, // created; worker thread starting up
-        Running, // dispatchOnline has fired; worker event loop is spinning
+        Running, // set by dispatchOnline (worker thread) or dispatchOpenIfNeeded (parent); isOnline() is true
         Closing, // worker thread has exited; close task is dispatching the 'close' event
         Closed, // close event dispatched on the parent; worker is fully done
     };

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -162,6 +162,7 @@ private:
 
     void enqueueToWorker(MessageWithMessagePorts&&);
     void drainToParent(ScriptExecutionContext&);
+    void dispatchOpenIfNeeded();
 
     WorkerOptions m_options;
 
@@ -176,6 +177,10 @@ private:
 
     std::atomic<State> m_state { State::Pending };
     std::atomic<bool> m_terminateRequested { false };
+
+    // Whether the 'open' event has been dispatched (dispatchOpenIfNeeded).
+    // Parent thread only, so it needs no synchronization.
+    bool m_openDispatched { false };
 
     // Stable for the process lifetime; used with ScriptExecutionContext::
     // postTaskTo() so the worker thread never dereferences the parent context

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -80,6 +80,10 @@ struct WorkerOptions;
 ///                 │Closing │ ───────────────► │ Closed │
 ///                 └────────┘  dispatched      └────────┘
 ///
+/// dispatchOpenIfNeeded() (parent thread) takes the same Pending -> Running
+/// edge, under the same lock, when the parent observes the worker's first
+/// output before the worker thread has reached dispatchOnline().
+///
 /// Closing exists so that inside the 'close'/'exit' handler threadId reads
 /// -1 and isOnline() is false (old ClosingFlag behaviour) while postMessage()
 /// — which only gates on Closed (old TerminatedFlag behaviour) — still
@@ -162,7 +166,7 @@ private:
 
     void enqueueToWorker(MessageWithMessagePorts&&);
     void drainToParent(ScriptExecutionContext&);
-    void dispatchOpenIfNeeded();
+    bool dispatchOpenIfNeeded();
 
     WorkerOptions m_options;
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1113,11 +1113,12 @@ impl WebWorker {
 
         self.flush_logs(vm);
         log!("[{}] event loop start", self.execution_context_id);
-        // dispatchOnline fires the parent-side 'open' event and flips the C++
-        // state to Running (which routes postMessage directly instead of
-        // queuing). It is placed after the entry point has loaded so the parent
-        // observes 'online' only once the worker's top-level code has completed;
-        // moving it earlier would change that observable ordering.
+        // dispatchOnline flips the C++ state to Running (so parent postMessage
+        // posts directly instead of queuing) and posts the parent-side 'open'
+        // task. The parent may already have observed 'open' and Running
+        // earlier, from Worker::drainToParent, if the worker posted a message
+        // during module evaluation (Node: 'online' precedes any 'message');
+        // Worker::dispatchOpenIfNeeded dedupes the two sites.
         // `cpp_worker` is the opaque C++-owned handle round-tripped via `safe fn`;
         // `vm.global()` yields the live `&JSGlobalObject` published in start_vm.
         WebWorker__dispatchOnline(self.cpp_worker, vm.global());

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1113,12 +1113,9 @@ impl WebWorker {
 
         self.flush_logs(vm);
         log!("[{}] event loop start", self.execution_context_id);
-        // dispatchOnline flips the C++ state to Running (so parent postMessage
-        // posts directly instead of queuing) and posts the parent-side 'open'
-        // task. The parent may already have observed 'open' and Running
-        // earlier, from Worker::drainToParent, if the worker posted a message
-        // during module evaluation (Node: 'online' precedes any 'message');
-        // Worker::dispatchOpenIfNeeded dedupes the two sites.
+        // dispatchOnline flips the C++ state to Running and posts the parent's
+        // 'open' task. The parent may have done both already (drainToParent, if
+        // the worker posted during module evaluation); dispatchOpenIfNeeded dedupes.
         // `cpp_worker` is the opaque C++-owned handle round-tripped via `safe fn`;
         // `vm.global()` yields the live `&JSGlobalObject` published in start_vm.
         WebWorker__dispatchOnline(self.cpp_worker, vm.global());

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -93,6 +93,44 @@ test("'online' precedes a message posted before a module evaluation error", asyn
   });
 });
 
+test("a 'message' handler attached from a microtask queued by 'online' sees the first message", async () => {
+  // 'online' and the first message can share one parent task; Node still
+  // runs a microtask checkpoint between the two deliveries.
+  const worker = new Worker(`require("node:worker_threads").parentPort.postMessage("first")`, { eval: true });
+  const received: string[] = [];
+  worker.on("online", () => {
+    queueMicrotask(() => worker.on("message", m => received.push("micro:" + m)));
+  });
+  const [code] = await once(worker, "exit");
+  expect(received).toEqual(["micro:first"]);
+  expect(code).toBe(0);
+});
+
+test("an 'online' handler that runs during module evaluation can call getHeapSnapshot()", async () => {
+  // 'online' can fire from the first message drain while the worker is still
+  // evaluating its module; isOnline() must already be true there or
+  // getHeapSnapshot() rejects with ERR_WORKER_NOT_RUNNING.
+  const sab = new SharedArrayBuffer(4);
+  const worker = new Worker(
+    `const { parentPort, workerData } = require("node:worker_threads");
+     parentPort.postMessage("evaluating");
+     Atomics.wait(new Int32Array(workerData), 0, 0);`,
+    { eval: true, workerData: sab },
+  );
+  const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+  worker.on("online", () => worker.getHeapSnapshot().then(resolve, reject));
+  // Release the worker from module evaluation only once the parent has
+  // observed its message (and therefore 'online', which precedes it).
+  worker.on("message", () => {
+    Atomics.store(new Int32Array(sab), 0, 1);
+    Atomics.notify(new Int32Array(sab), 0);
+  });
+  worker.on("error", reject);
+  const stream = (await promise) as Readable;
+  expect(stream.constructor.name).toBe("HeapSnapshotStream");
+  await worker.terminate();
+});
+
 test("all worker_threads module properties are present", () => {
   expect(wt).toHaveProperty("getEnvironmentData");
   expect(wt).toHaveProperty("isMainThread");

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -379,19 +379,27 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
-test("eval does not leak source code", async () => {
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "eval-source-leak-fixture.js"],
-    env: bunEnv,
-    cwd: __dirname,
-    stderr: "pipe",
-    stdout: "ignore",
-  });
-  await proc.exited;
-  const errors = await proc.stderr.text();
-  if (errors.length > 0) throw new Error(errors);
-  expect(proc.exitCode).toBe(0);
-});
+// The fixture cycles 6 workers holding 100 MiB of eval source each and forces
+// 3 full GCs after every one: ~2s under a release build, ~36s under a debug
+// ASAN build. The workload cannot be shrunk (smaller source sizes fall under
+// the process's RSS noise floor and false-positive the leak threshold).
+test(
+  "eval does not leak source code",
+  async () => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "eval-source-leak-fixture.js"],
+      env: bunEnv,
+      cwd: __dirname,
+      stderr: "pipe",
+      stdout: "ignore",
+    });
+    await proc.exited;
+    const errors = await proc.stderr.text();
+    if (errors.length > 0) throw new Error(errors);
+    expect(proc.exitCode).toBe(0);
+  },
+  120_000,
+);
 
 describe("worker event", () => {
   test("is emitted on the next tick with the right value", () => {
@@ -469,21 +477,27 @@ describe("environmentData", () => {
     expect(getEnvironmentData("does_not_exist")).toBeUndefined();
   });
 
-  test("is deeply inherited", async () => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "environmentdata-inherit-fixture.js"],
-      env: bunEnv,
-      cwd: __dirname,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    await proc.exited;
-    const errors = await proc.stderr.text();
-    if (errors.length > 0) throw new Error(errors);
-    expect(proc.exitCode).toBe(0);
-    const out = await proc.stdout.text();
-    expect(out).toBe("foo\n".repeat(5));
-  });
+  // 5 nested worker VMs at roughly 1s each under a debug ASAN build sits
+  // right at the 5s default, so this flakes there while taking 80ms released.
+  test(
+    "is deeply inherited",
+    async () => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "environmentdata-inherit-fixture.js"],
+        env: bunEnv,
+        cwd: __dirname,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      await proc.exited;
+      const errors = await proc.stderr.text();
+      if (errors.length > 0) throw new Error(errors);
+      expect(proc.exitCode).toBe(0);
+      const out = await proc.stdout.text();
+      expect(out).toBe("foo\n".repeat(5));
+    },
+    30_000,
+  );
 
   test("can be used if parent thread had not imported worker_threads", async () => {
     const proc = Bun.spawn({

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -383,23 +383,19 @@ describe("execArgv option", async () => {
 // 3 full GCs after every one: ~2s under a release build, ~36s under a debug
 // ASAN build. The workload cannot be shrunk (smaller source sizes fall under
 // the process's RSS noise floor and false-positive the leak threshold).
-test(
-  "eval does not leak source code",
-  async () => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "eval-source-leak-fixture.js"],
-      env: bunEnv,
-      cwd: __dirname,
-      stderr: "pipe",
-      stdout: "ignore",
-    });
-    await proc.exited;
-    const errors = await proc.stderr.text();
-    if (errors.length > 0) throw new Error(errors);
-    expect(proc.exitCode).toBe(0);
-  },
-  120_000,
-);
+test("eval does not leak source code", async () => {
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "eval-source-leak-fixture.js"],
+    env: bunEnv,
+    cwd: __dirname,
+    stderr: "pipe",
+    stdout: "ignore",
+  });
+  await proc.exited;
+  const errors = await proc.stderr.text();
+  if (errors.length > 0) throw new Error(errors);
+  expect(proc.exitCode).toBe(0);
+}, 120_000);
 
 describe("worker event", () => {
   test("is emitted on the next tick with the right value", () => {
@@ -479,25 +475,21 @@ describe("environmentData", () => {
 
   // 5 nested worker VMs at roughly 1s each under a debug ASAN build sits
   // right at the 5s default, so this flakes there while taking 80ms released.
-  test(
-    "is deeply inherited",
-    async () => {
-      const proc = Bun.spawn({
-        cmd: [bunExe(), "environmentdata-inherit-fixture.js"],
-        env: bunEnv,
-        cwd: __dirname,
-        stderr: "pipe",
-        stdout: "pipe",
-      });
-      await proc.exited;
-      const errors = await proc.stderr.text();
-      if (errors.length > 0) throw new Error(errors);
-      expect(proc.exitCode).toBe(0);
-      const out = await proc.stdout.text();
-      expect(out).toBe("foo\n".repeat(5));
-    },
-    30_000,
-  );
+  test("is deeply inherited", async () => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "environmentdata-inherit-fixture.js"],
+      env: bunEnv,
+      cwd: __dirname,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    await proc.exited;
+    const errors = await proc.stderr.text();
+    if (errors.length > 0) throw new Error(errors);
+    expect(proc.exitCode).toBe(0);
+    const out = await proc.stdout.text();
+    expect(out).toBe("foo\n".repeat(5));
+  }, 30_000);
 
   test("can be used if parent thread had not imported worker_threads", async () => {
     const proc = Bun.spawn({

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -57,13 +57,19 @@ test("'online' and a message posted before module evaluation completes are deliv
   const worker = new Worker(`require("node:worker_threads").parentPort.postMessage("ready"); for (;;);`, {
     eval: true,
   });
-  const events: string[] = [];
-  worker.on("online", () => events.push("online"));
-  worker.on("message", m => events.push("msg:" + m));
-  const [message] = await once(worker, "message");
-  expect(message).toBe("ready");
-  expect(events).toEqual(["online", "msg:ready"]);
-  await worker.terminate();
+  try {
+    const events: string[] = [];
+    worker.on("online", () => events.push("online"));
+    worker.on("message", m => events.push("msg:" + m));
+    const [message] = await once(worker, "message");
+    expect(message).toBe("ready");
+    expect(events).toEqual(["online", "msg:ready"]);
+  } finally {
+    // The for(;;) worker only stops on terminate(); register it before the
+    // assertions so a failure does not leave a thread spinning at 100% CPU
+    // for the rest of the test file.
+    await worker.terminate();
+  }
 });
 
 test("'online' precedes a message posted before a module evaluation error", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -99,6 +99,49 @@ test("'online' precedes a message posted before a module evaluation error", asyn
   });
 });
 
+test("'online' is emitted for a worker that fails before posting any message", async () => {
+  // Node emits 'online' before the entry point even loads, so it precedes
+  // 'error' and 'exit' for every failure mode, including ones where no user
+  // code ran. In a subprocess so the worker's uncaught-exception path is the
+  // runtime one, not the bun:test variant.
+  const src = /* js */ `
+    const { Worker } = require("node:worker_threads");
+    function run(arg, opts) {
+      return new Promise(resolve => {
+        const ev = [];
+        const w = new Worker(arg, opts);
+        w.on("online", () => ev.push("online"));
+        w.on("message", m => ev.push("msg:" + m));
+        w.on("error", () => ev.push("error"));
+        w.on("exit", c => { ev.push("exit:" + c); resolve(ev); });
+      });
+    }
+    Promise.all([
+      run('throw new Error("boom")', { eval: true }),
+      run("/nonexistent/worker-online-32908.js"),
+      run("process.exit(0)", { eval: true }),
+      run("process.exit(3)", { eval: true }),
+    ]).then(r => console.log(JSON.stringify(r)));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify([
+      ["online", "error", "exit:1"], // entry point throws
+      ["online", "error", "exit:1"], // entry point fails to resolve
+      ["online", "exit:0"], // process.exit(0) during module evaluation
+      ["online", "exit:3"], // process.exit(3) during module evaluation
+    ]),
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
+}, 30_000);
+
 test("a 'message' handler attached from a microtask queued by 'online' sees the first message", async () => {
   // 'online' and the first message can share one parent task; Node still
   // runs a microtask checkpoint between the two deliveries.

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -32,6 +32,67 @@ test("support eval in worker", async () => {
   await worker.terminate();
 });
 
+// Node documents 'online' as firing once the worker has started executing JS,
+// i.e. strictly before any 'message' the worker produces. Pool implementations
+// attach their real 'message' handler inside 'online'.
+test("'online' is emitted before any 'message' from the worker", async () => {
+  const worker = new Worker(
+    `const { parentPort } = require("node:worker_threads");
+     parentPort.postMessage("a");
+     parentPort.postMessage("b");`,
+    { eval: true },
+  );
+  const events: string[] = [];
+  worker.on("online", () => events.push("online"));
+  worker.on("message", m => events.push("msg:" + m));
+  worker.on("error", e => events.push("error:" + e?.message));
+  const [code] = await once(worker, "exit");
+  events.push("exit:" + code);
+  expect(events).toEqual(["online", "msg:a", "msg:b", "exit:0"]);
+});
+
+test("'online' and a message posted before module evaluation completes are delivered", async () => {
+  // The worker's module never finishes evaluating (same shape as Node's
+  // test-worker-message-port-terminate-transfer-list.js).
+  const worker = new Worker(`require("node:worker_threads").parentPort.postMessage("ready"); for (;;);`, {
+    eval: true,
+  });
+  const events: string[] = [];
+  worker.on("online", () => events.push("online"));
+  worker.on("message", m => events.push("msg:" + m));
+  const [message] = await once(worker, "message");
+  expect(message).toBe("ready");
+  expect(events).toEqual(["online", "msg:ready"]);
+  await worker.terminate();
+});
+
+test("'online' precedes a message posted before a module evaluation error", async () => {
+  // In a subprocess so the worker's uncaught-exception path is the runtime
+  // one, not the bun:test variant.
+  const src = /* js */ `
+    const { Worker } = require("node:worker_threads");
+    const body = 'require("node:worker_threads").parentPort.postMessage("before-throw"); throw new Error("boom");';
+    const w = new Worker(body, { eval: true });
+    const ev = [];
+    w.on("online", () => ev.push("online"));
+    w.on("message", m => ev.push("msg:" + m));
+    w.on("error", () => ev.push("error"));
+    w.on("exit", c => { ev.push("exit:" + c); console.log(JSON.stringify(ev)); });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify(["online", "msg:before-throw", "error", "exit:1"]),
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
+});
+
 test("all worker_threads module properties are present", () => {
   expect(wt).toHaveProperty("getEnvironmentData");
   expect(wt).toHaveProperty("isMainThread");

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -365,17 +365,32 @@ describe("execArgv option", async () => {
     expect(await proc.stdout.text()).toBe(expected);
   }
 
-  it("inherits the parent's execArgv when falsy or unspecified", async () => {
-    await run("null", '["--smol"]\n');
-    await run("0", '["--smol"]\n');
-  });
-  it("provides empty execArgv when passed an empty array", async () => {
-    // empty array should result in empty execArgv, not inherited from parent thread
-    await run("[]", "[]\n");
-  });
-  it("can specify an array of strings", async () => {
-    await run('["--no-warnings"]', '["--no-warnings"]\n');
-  });
+  // Each run() spawns a bun process that itself spawns a worker VM: ~100ms
+  // released, ~3s under a debug ASAN build. Two in sequence overrun the 5s
+  // default; the workload is the point of the test, so budget it instead.
+  it(
+    "inherits the parent's execArgv when falsy or unspecified",
+    async () => {
+      await run("null", '["--smol"]\n');
+      await run("0", '["--smol"]\n');
+    },
+    30_000,
+  );
+  it(
+    "provides empty execArgv when passed an empty array",
+    async () => {
+      // empty array should result in empty execArgv, not inherited from parent thread
+      await run("[]", "[]\n");
+    },
+    30_000,
+  );
+  it(
+    "can specify an array of strings",
+    async () => {
+      await run('["--no-warnings"]', '["--no-warnings"]\n');
+    },
+    30_000,
+  );
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -175,9 +175,14 @@ test("an 'online' handler that runs during module evaluation can call getHeapSna
     Atomics.notify(new Int32Array(sab), 0);
   });
   worker.on("error", reject);
-  const stream = (await promise) as Readable;
-  expect(stream.constructor.name).toBe("HeapSnapshotStream");
-  await worker.terminate();
+  try {
+    const stream = (await promise) as Readable;
+    expect(stream.constructor.name).toBe("HeapSnapshotStream");
+  } finally {
+    // The worker sits in Atomics.wait until terminated; terminate it even if
+    // the assertions fail so it cannot outlive this test.
+    await worker.terminate();
+  }
 });
 
 test("all worker_threads module properties are present", () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -368,29 +368,17 @@ describe("execArgv option", async () => {
   // Each run() spawns a bun process that itself spawns a worker VM: ~100ms
   // released, ~3s under a debug ASAN build. Two in sequence overrun the 5s
   // default; the workload is the point of the test, so budget it instead.
-  it(
-    "inherits the parent's execArgv when falsy or unspecified",
-    async () => {
-      await run("null", '["--smol"]\n');
-      await run("0", '["--smol"]\n');
-    },
-    30_000,
-  );
-  it(
-    "provides empty execArgv when passed an empty array",
-    async () => {
-      // empty array should result in empty execArgv, not inherited from parent thread
-      await run("[]", "[]\n");
-    },
-    30_000,
-  );
-  it(
-    "can specify an array of strings",
-    async () => {
-      await run('["--no-warnings"]', '["--no-warnings"]\n');
-    },
-    30_000,
-  );
+  it("inherits the parent's execArgv when falsy or unspecified", async () => {
+    await run("null", '["--smol"]\n');
+    await run("0", '["--smol"]\n');
+  }, 30_000);
+  it("provides empty execArgv when passed an empty array", async () => {
+    // empty array should result in empty execArgv, not inherited from parent thread
+    await run("[]", "[]\n");
+  }, 30_000);
+  it("can specify an array of strings", async () => {
+    await run('["--no-warnings"]', '["--no-warnings"]\n');
+  }, 30_000);
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 


### PR DESCRIPTION
## Problem

A worker that calls `parentPort.postMessage()` during its module evaluation delivers that message to the parent before the parent's `'online'` event fires.

```js
import { Worker } from "node:worker_threads";
const ev = [];
const w = new Worker(`require("node:worker_threads").parentPort.postMessage("body")`, { eval: true });
w.on("online", () => ev.push("online"));
w.on("message", m => ev.push("msg:" + m));
w.on("exit", c => { ev.push("exit:" + c); console.log(ev.join(" | ")); });
```

Bun before this change:
```
msg:body | online | exit:0
```

Node.js (and Bun after this change):
```
online | msg:body | exit:0
```

Node documents `'online'` as firing when the worker thread has started executing JavaScript, i.e. strictly before any message the worker produces can arrive. Worker pool implementations commonly attach their real `'message'` handler (or mark the worker ready) inside the `'online'` listener; with the inverted ordering the first messages land on a handler that isn't installed yet.

## Cause

`Worker::enqueueToParent` (the worker to parent `postMessage` path) posts a drain task to the parent immediately. `Worker::dispatchOnline` runs after module evaluation and posts the `'open'` event task. Both go through the same FIFO `ScriptExecutionContext::postTaskTo`, so the parent runs the drain first, then the open task.

More generally, Bun only ever emitted `'online'` once module evaluation succeeded (that is the only thing that reached `dispatchOnline`), while Node sends it as soon as the worker thread starts executing JS, before the entry point even loads. So `'online'` was not just reordered; it was skipped entirely for a worker whose entry point threw, failed to resolve, or called `process.exit()`.

## Fix

Dispatch `'open'` on the parent lazily and at most once, via a new `Worker::dispatchOpenIfNeeded()` called from every parent-side task that can be the first one the worker's execution produces:

- `drainToParent()`, just before delivering the first worker message
- the task `dispatchOnline()` posts (the existing, success-only site)
- the two error-dispatch lambdas (`dispatchErrorWithValue` / `dispatchErrorWithMessage`)
- the close task posted by `dispatchExit()`

It dedupes on a parent-thread-only flag, only dispatches when an `'open'`/`'online'` listener is attached, and the dispatch is still suppressed after `terminate()`. Messages are never held back, so a worker whose module never finishes evaluating still delivers what it posted, now after `'online'`.

Three details from review, each verified against node v26.3.0 first:

- Because `'open'` can now fire before the worker thread has reached `dispatchOnline()`, `dispatchOpenIfNeeded()` also performs the same `Pending -> Running` transition, idempotently and under the same lock. Without it, `worker.getHeapSnapshot()` called from an `'online'` handler rejected with `ERR_WORKER_NOT_RUNNING`, since it is gated on `isOnline()`; that is the invariant documented above `dispatchOnline()`.
- `drainToParent()` runs a microtask checkpoint between a freshly dispatched `'open'` and the first message, as Node does between those two deliveries, so a `'message'` handler attached from a microtask queued by the `'online'` handler does not miss the first message. The new call sites do the same.
- The error and close tasks also call `dispatchOpenIfNeeded()`, so a worker that fails or exits without ever posting a message (a throw during evaluation, an unresolvable entry path, `process.exit()`) emits `'online'` before `'error'` and `'exit'`. Those are the last four rows of the table below, and the fourth `online` test.

An earlier revision of this PR instead buffered worker-to-parent messages until `dispatchOnline`. That hangs any worker that posts a message and then never completes its module, which is exactly what `test/js/node/test/parallel/test-worker-message-port-terminate-transfer-list.js` does; it timed out on seven CI lanes. This revision replaces that approach entirely.

### Failure modes

Every case below already matched Node once the worker's module evaluation succeeded. The full matrix, compared against node v26.3.0:

| worker body | node | bun before | bun after |
|---|---|---|---|
| `postMessage("m")` | `online, msg:m, exit:0` | `msg:m, online, exit:0` | `online, msg:m, exit:0` |
| `postMessage("m"); throw` | `online, msg:m, error, exit:1` | `msg:m, error, exit:1` | `online, msg:m, error, exit:1` |
| `throw new Error(...)` | `online, error, exit:1` | `error, exit:1` | `online, error, exit:1` |
| nonexistent entry path | `online, error, exit:1` | `error, exit:1` | `online, error, exit:1` |
| `process.exit(0)` | `online, exit:0` | `exit:0` | `online, exit:0` |
| `process.exit(3)` | `online, exit:3` | `exit:3` | `online, exit:3` |

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/worker_threads/worker_threads.test.ts -t "online"   # 5 of 6 fail
bun bd test test/js/node/worker_threads/worker_threads.test.ts                             # 40 pass
```

The six `online` tests cover: normal module evaluation, a module that never finishes evaluating, a module that throws after posting, a worker that fails without posting anything (throw, unresolvable path, `process.exit(0)`, `process.exit(3)`), `getHeapSnapshot()` from an `'online'` handler that fired during module evaluation, and a `'message'` handler attached from a microtask queued by `'online'`.

The `getHeapSnapshot()` test is the one that passes on current main, where `'online'` can only ever fire once the worker is already `Running`, so the property holds there by construction. It fails with `ERR_WORKER_NOT_RUNNING` on the first commit of this branch and pins the regression that commit would otherwise have introduced.

Also verified unchanged: all 14 of node's own `test/js/node/test/parallel/test-worker-*.js` that touch `'online'` or a worker error path still pass. None of them attach an `'online'` listener to a worker they expect to fail, and `dispatchOpenIfNeeded()` only dispatches to an attached listener, so a worker with no such listener is byte-for-byte unaffected.

