### PR TITLE
CookieMap: percent-decode each value independently and preserve non-ASCII characters

### DIFF
--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -12,27 +12,25 @@
 #include <wtf/HashSet.h>
 namespace WebCore {
 
-// decodeURIComponentSIMD requires ASCII input. For values that mix non-ASCII
-// characters with percent escapes, decode over the UTF-8 representation so
-// the original characters round-trip instead of being treated as Latin-1.
+// decodeURIComponentSIMD requires ASCII input. Percent-encode the non-ASCII
+// bytes of the value's UTF-8 form first so both paths share the same decoder
+// and non-ASCII characters round-trip instead of being misread as Latin-1.
 static String percentDecodeUTF8CookieValue(StringView value)
 {
     Bun::UTF8View utf8View(value);
     auto bytes = utf8View.bytes();
-    Vector<uint8_t, 256> decoded;
-    decoded.reserveInitialCapacity(bytes.size());
-    size_t i = 0;
-    while (i < bytes.size()) {
-        uint8_t byte = bytes[i];
-        if (byte == '%' && i + 2 < bytes.size() && isASCIIHexDigit(bytes[i + 1]) && isASCIIHexDigit(bytes[i + 2])) {
-            decoded.append(static_cast<uint8_t>((toASCIIHexValue(bytes[i + 1]) << 4) | toASCIIHexValue(bytes[i + 2])));
-            i += 3;
+    Vector<uint8_t, 256> ascii;
+    ascii.reserveInitialCapacity(bytes.size());
+    for (uint8_t byte : bytes) {
+        if (isASCII(byte)) {
+            ascii.append(byte);
         } else {
-            decoded.append(byte);
-            i += 1;
+            ascii.append('%');
+            ascii.append(upperNibbleToASCIIHexDigit(byte));
+            ascii.append(lowerNibbleToASCIIHexDigit(byte));
         }
     }
-    return String::fromUTF8ReplacingInvalidSequences(decoded.span());
+    return Bun::decodeURIComponentSIMD(ascii.span());
 }
 
 template<typename Res>

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -8,8 +8,32 @@
 #include "HTTPParsers.h"
 #include "decodeURIComponentSIMD.h"
 #include "BunString.h"
+#include <wtf/ASCIICType.h>
 #include <wtf/HashSet.h>
 namespace WebCore {
+
+// decodeURIComponentSIMD requires ASCII input. For values that mix non-ASCII
+// characters with percent escapes, decode over the UTF-8 representation so
+// the original characters round-trip instead of being treated as Latin-1.
+static String percentDecodeUTF8CookieValue(StringView value)
+{
+    Bun::UTF8View utf8View(value);
+    auto bytes = utf8View.bytes();
+    Vector<uint8_t, 256> decoded;
+    decoded.reserveInitialCapacity(bytes.size());
+    size_t i = 0;
+    while (i < bytes.size()) {
+        uint8_t byte = bytes[i];
+        if (byte == '%' && i + 2 < bytes.size() && isASCIIHexDigit(bytes[i + 1]) && isASCIIHexDigit(bytes[i + 2])) {
+            decoded.append(static_cast<uint8_t>((toASCIIHexValue(bytes[i + 1]) << 4) | toASCIIHexValue(bytes[i + 2])));
+            i += 3;
+        } else {
+            decoded.append(byte);
+            i += 1;
+        }
+    }
+    return String::fromUTF8ReplacingInvalidSequences(decoded.span());
+}
 
 template<typename Res>
 static void CookieMap__writeFetchHeadersToUWSResponse(CookieMap* cookie_map, JSC::JSGlobalObject* global_this, Res* res)
@@ -95,7 +119,6 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
             auto pairs = forCookieHeader.split(';');
             Vector<KeyValuePair<String, String>> cookies;
 
-            bool hasAnyPercentEncoded = forCookieHeader.find('%') != notFound;
             for (auto pair : pairs) {
                 String name = ""_s;
                 String value = ""_s;
@@ -114,11 +137,17 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
 
                 name = nameView.toString();
 
-                if (hasAnyPercentEncoded) {
-                    Bun::UTF8View utf8View(valueView);
-                    value = Bun::decodeURIComponentSIMD(utf8View.bytes());
-                } else {
+                if (valueView.find('%') == notFound) {
                     value = valueView.toString();
+                } else if (valueView.containsOnlyASCII()) {
+                    if (valueView.is8Bit()) {
+                        value = Bun::decodeURIComponentSIMD(valueView.span8());
+                    } else {
+                        Bun::UTF8View utf8View(valueView);
+                        value = Bun::decodeURIComponentSIMD(utf8View.bytes());
+                    }
+                } else {
+                    value = percentDecodeUTF8CookieValue(valueView);
                 }
 
                 cookies.append(KeyValuePair<String, String>(name, value));

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -402,6 +402,14 @@ describe("CookieMap percent-decoding with non-ASCII values", () => {
     expect(map.get("mix")).toBe("🍪 cookie");
   });
 
+  test("malformed percent escapes decode the same with and without non-ASCII characters", () => {
+    // Both branches route through the same decoder, so an invalid escape must
+    // produce the same result whether or not the value also has non-ASCII characters.
+    const ascii = new Bun.CookieMap("a=%ZZ").get("a")!;
+    expect(new Bun.CookieMap("a=é%ZZ").get("a")).toBe("é" + ascii);
+    expect(new Bun.CookieMap("a=%ZZé").get("a")).toBe(ascii + "é");
+  });
+
   test("percent-encoded UTF-8 still decodes via the fast path when the value is ASCII", () => {
     const map = new Bun.CookieMap("k=%C3%A9");
     expect(map.get("k")).toBe("é");
@@ -419,9 +427,10 @@ describe("CookieMap percent-decoding with non-ASCII values", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe('["é","A"]');
-    expect(exitCode).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr is included so its contents surface in the diff if the child
+    // crashes, without asserting it is empty (ASAN/debug builds emit warnings).
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: '["é","A"]', stderr, exitCode: 0 });
   });
 });
 

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 describe("Bun.Cookie and Bun.CookieMap", () => {
   // Basic Cookie tests
@@ -347,6 +348,80 @@ describe("iterator", () => {
     a=b
     c=d"
   `);
+  });
+});
+
+describe("CookieMap percent-decoding with non-ASCII values", () => {
+  test("percent-decoding one value does not affect a sibling non-ASCII value", () => {
+    // Each value is decoded independently: the presence of a '%' in one
+    // cookie's value must not change how another cookie's value is parsed.
+    const map = new Bun.CookieMap("a=é; z=%41");
+    expect([...map]).toEqual([
+      ["a", "é"],
+      ["z", "A"],
+    ]);
+  });
+
+  test("reversing the order does not change results", () => {
+    const map = new Bun.CookieMap("z=%41; a=é");
+    expect([...map]).toEqual([
+      ["z", "A"],
+      ["a", "é"],
+    ]);
+  });
+
+  test("non-ASCII value with no percent escapes is preserved exactly", () => {
+    const map = new Bun.CookieMap("name=读写汉字学中文; plain=hello");
+    expect(map.get("name")).toBe("读写汉字学中文");
+    expect(map.get("plain")).toBe("hello");
+  });
+
+  test("non-ASCII value alongside a percent-encoded sibling is preserved exactly", () => {
+    const map = new Bun.CookieMap("name=读写汉字学中文; token=abc%3Ddef");
+    expect([...map]).toEqual([
+      ["name", "读写汉字学中文"],
+      ["token", "abc=def"],
+    ]);
+  });
+
+  test("a single value containing both non-ASCII characters and percent escapes decodes correctly", () => {
+    const map = new Bun.CookieMap("greeting=café%20au%20lait");
+    expect(map.get("greeting")).toBe("café au lait");
+  });
+
+  test("astral-plane characters are preserved when another cookie has percent escapes", () => {
+    const map = new Bun.CookieMap("emoji=🍪; other=%20");
+    expect([...map]).toEqual([
+      ["emoji", "🍪"],
+      ["other", " "],
+    ]);
+  });
+
+  test("a single value containing both astral-plane characters and percent escapes decodes correctly", () => {
+    const map = new Bun.CookieMap("mix=🍪%20cookie");
+    expect(map.get("mix")).toBe("🍪 cookie");
+  });
+
+  test("percent-encoded UTF-8 still decodes via the fast path when the value is ASCII", () => {
+    const map = new Bun.CookieMap("k=%C3%A9");
+    expect(map.get("k")).toBe("é");
+  });
+
+  test("parsing a Cookie header with non-ASCII and percent escapes does not crash", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const m = new Bun.CookieMap("a=é; z=%41");` +
+          `process.stdout.write(JSON.stringify([m.get("a"), m.get("z")]));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe('["é","A"]');
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
`CookieMap::create` decided whether to percent-decode cookie values by scanning the whole Cookie header for `%`, then fed every value through `decodeURIComponentSIMD` via `UTF8View`. `decodeURIComponentSIMD` appends literal (non-`%`) bytes as Latin-1, so when a value containing non-ASCII characters was converted to UTF-8 bytes first, those bytes were then misread as Latin-1 on the way out.

### Repro

```js
[...new Bun.CookieMap("a=é")]
// [["a", "é"]]

[...new Bun.CookieMap("a=é; z=%41")]
// [["a", "Ã©"], ["z", "A"]]   <- "é" changed because "z" has a %
```

One cookie's percent escape changed how an unrelated cookie's value was decoded.

### Fix

In `src/jsc/bindings/CookieMap.cpp`:

- Check for `%` per value instead of once across the whole header, so a percent escape in one value no longer affects siblings.
- Only hand ASCII values to `decodeURIComponentSIMD` (its documented precondition). Values that mix non-ASCII characters with percent escapes go through a small UTF-8-aware fallback that decodes `%XX` over the UTF-8 byte representation and reconstructs the string with `String::fromUTF8ReplacingInvalidSequences`, so the original characters round-trip.

The SIMD fast path is unchanged for the common case (ASCII value containing `%`).

### Tests

Added a `CookieMap percent-decoding with non-ASCII values` describe block in `test/js/bun/cookie/cookie-map.test.ts` covering:

- non-ASCII value alongside a percent-encoded sibling (both orders)
- a single value containing both non-ASCII characters and percent escapes
- astral-plane characters in both positions
- percent-encoded UTF-8 still decoding via the fast path
- a subprocess run exercising the same header

Seven of the nine new tests fail on the unmodified build; the other two are regression guards for behavior that was already correct. The rest of `test/js/bun/cookie/` (158 tests) and `test/js/bun/http/bun-serve-cookies.test.ts` (25 tests) continue to pass.

Related to #32823, which fixes handling of invalid `%XX` escapes in the same decoder; the two changes are independent.
