### PR TITLE
node:crypto: validate OKP private JWK x matches d in createPrivateKey

### DIFF
--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -880,6 +880,17 @@ KeyObject KeyObject::getKeyObjectHandleFromJwk(JSGlobalObject* globalObject, Thr
             return {};
         }
 
+        if (keyType != CryptoKeyType::Public) {
+            auto* xBuf = decodeJwkString(globalObject, scope, xView, "key.x"_s);
+            RETURN_IF_EXCEPTION(scope, {});
+            auto xSpan = xBuf->span();
+            auto derivedPublic = key.rawPublicKey();
+            if (!derivedPublic || xSpan.size() != derivedPublic.size() || CRYPTO_memcmp(xSpan.data(), derivedPublic.get(), xSpan.size()) != 0) {
+                ERR::CRYPTO_INVALID_JWK(scope, globalObject);
+                return {};
+            }
+        }
+
         return create(keyType, WTF::move(key));
     }
     case Kty::Ec: {

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -414,6 +414,21 @@ describe("crypto.KeyObjects", () => {
       expect(jwt).toEqual(info.jwk);
     });
 
+    test(`${keyType} createPrivateKey from jwk with mismatched x should throw`, () => {
+      const xBytes = Buffer.from(info.jwk.x, "base64url");
+      const wrongX = Buffer.alloc(xBytes.length).toString("base64url");
+      expect(() => createPrivateKey({ key: { ...info.jwk, x: wrongX }, format: "jwk" })).toThrow(
+        expect.objectContaining({ code: "ERR_CRYPTO_INVALID_JWK" }),
+      );
+    });
+
+    test(`${keyType} createPrivateKey from jwk with wrong-length x should throw`, () => {
+      const wrongX = Buffer.alloc(8).toString("base64url");
+      expect(() => createPrivateKey({ key: { ...info.jwk, x: wrongX }, format: "jwk" })).toThrow(
+        expect.objectContaining({ code: "ERR_CRYPTO_INVALID_JWK" }),
+      );
+    });
+
     [
       ["public", info.public],
       ["private", info.private],


### PR DESCRIPTION
## Problem

`crypto.createPrivateKey({format: "jwk"})` accepts an OKP (Ed25519/X25519) private JWK whose `x` does not match the public key derived from `d`. The supplied `x` is silently replaced by one re-derived from `d`:

```js
const crypto = require("crypto");
const jwk = { kty: "OKP", crv: "Ed25519", d: "wVK6M3SMhQh3NK-7GRrSV-BVWQx1FO5pW8hhQeu_NdA", x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" };
const k = crypto.createPrivateKey({ key: jwk, format: "jwk" });
console.log(k.export({ format: "jwk" }).x);
```

| | Node v26.3.0 | Bun before | Bun after |
|---|---|---|---|
| `x` does not match `d` | throws `ERR_CRYPTO_INVALID_JWK` | accepted, `x` silently replaced | throws `ERR_CRYPTO_INVALID_JWK` |
| `x` is the wrong length | throws `ERR_CRYPTO_INVALID_JWK` | accepted | throws `ERR_CRYPTO_INVALID_JWK` |

RFC 8037 section 2 requires `x` to be the public key corresponding to `d`. A maliciously inconsistent private JWK is supposed to be rejected at the trust boundary; silently repairing it means a key whose `(d, x)` pair an application stored and later compares is no longer the key it imported, and validation code that relies on the import throwing never fires.

## Cause

`KeyObject::getKeyObjectHandleFromJwk` required `x` to be present on an OKP private JWK but built the `EVP_PKEY` from `d` alone and never compared the two. (`x` being required is why "d present, x missing" already threw, unlike the sibling WebCrypto path.)

## Fix

After constructing the private `EVP_PKEY` from `d`, decode `x` and compare it against the key's raw public key (`EVP_PKEY_get_raw_public_key` via `EVPKeyPointer::rawPublicKey()`), using `CRYPTO_memcmp`. Reject with `ERR_CRYPTO_INVALID_JWK` if it is absent, the wrong length, or differs. This matches Node's `getKeyObjectHandleFromJwk`.

## Verification

New tests in `test/js/node/crypto/crypto.key-objects.test.ts` cover mismatched and wrong-length `x` for both Ed25519 and X25519, alongside the existing correct-`x` round-trip tests. They fail on current `main` and pass with this change.

## Relationship to #32827

#32827 (open, from an earlier report) fixes the same bug class in the WebCrypto `crypto.subtle.importKey("jwk", ...)` path (`CryptoKeyOKP::importJwkInternal`), which had the additional problem of not requiring `x` at all. This PR originally covered both; it is now scoped to the `node:crypto` half only, which #32827 does not touch, so the two are complementary.
