### PR TITLE
napi: don't require addon code to satisfy JSC's exception-check discipline

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -389,10 +389,14 @@ napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_pro
         if (property.getter) {
             auto name = makeString("get "_s, propertyName.isSymbol() ? String() : propertyName.string());
             descriptor.setGetter(NapiClass::create(vm, env, name, property.getter, dataPtr, 0, nullptr));
+            // Each NapiClass::create opens and closes a throw scope; the check between
+            // them is required for JSC's exception-check discipline.
+            RETURN_IF_EXCEPTION(scope, napi_pending_exception);
         }
         if (property.setter) {
             auto name = makeString("set "_s, propertyName.isSymbol() ? String() : propertyName.string());
             descriptor.setSetter(NapiClass::create(vm, env, name, property.setter, dataPtr, 0, nullptr));
+            RETURN_IF_EXCEPTION(scope, napi_pending_exception);
         }
     } else if (property.method != nullptr) {
         WTF::String name;

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -131,9 +131,9 @@ public:
 // Only use this for functions that need their own throw or catch scope. Functions that call into
 // JS code that might throw should use NAPI_RETURN_IF_EXCEPTION.
 // No do..while is used as this declares a variable that must outlive any inner ThrowScope.
-#define NAPI_PREAMBLE_NO_THROW_SCOPE(_env)                                             \
-    NAPI_LOG_CURRENT_FUNCTION;                                                         \
-    NAPI_CHECK_ARG(_env, _env);                                                        \
+#define NAPI_PREAMBLE_NO_THROW_SCOPE(_env)                                           \
+    NAPI_LOG_CURRENT_FUNCTION;                                                       \
+    NAPI_CHECK_ARG(_env, _env);                                                      \
     auto napi_preamble_boundary_scope__ = DECLARE_NAPI_BOUNDARY_SCOPE((_env)->vm()); \
     (void)napi_preamble_boundary_scope__
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -80,36 +80,72 @@
 using namespace JSC;
 using namespace Zig;
 
+// Exception scope for the N-API C ABI boundary. The caller is addon C code, so it
+// cannot satisfy JSC's exception-check discipline: a ThrowScope's simulated throw
+// would make the next napi_* call's scope abort under validateExceptionChecks.
+// Instead this scope reads vm.exception() on entry (acknowledging a sibling napi_*
+// call's simulated throw) and on exit (acknowledging inner scopes'), and never
+// simulates a throw of its own. Real exceptions still surface as napi_pending_exception.
+class NapiBoundaryScope : public JSC::ExceptionScope {
+public:
+#if ENABLE(EXCEPTION_SCOPE_VERIFICATION)
+    NapiBoundaryScope(JSC::VM& vm, JSC::ExceptionEventLocation location)
+        : JSC::ExceptionScope(vm, location)
+    {
+        (void)exception();
+    }
+    ~NapiBoundaryScope()
+    {
+        (void)exception();
+    }
+#else
+    ALWAYS_INLINE NapiBoundaryScope(JSC::VM& vm)
+        : JSC::ExceptionScope(vm)
+    {
+    }
+#endif
+    NapiBoundaryScope(const NapiBoundaryScope&) = delete;
+    NapiBoundaryScope(NapiBoundaryScope&&) = default;
+};
+
+#if ENABLE(EXCEPTION_SCOPE_VERIFICATION)
+#define DECLARE_NAPI_BOUNDARY_SCOPE(vm__) \
+    NapiBoundaryScope((vm__), JSC::ExceptionEventLocation(EXCEPTION_SCOPE_POSITION_FOR_ASAN(vm__), __FUNCTION__, __FILE__, __LINE__))
+#else
+#define DECLARE_NAPI_BOUNDARY_SCOPE(vm__) NapiBoundaryScope((vm__))
+#endif
+
 // Every NAPI function should use this at the start. It does the following:
 // - if NAPI_VERBOSE is 1, log that the function was called
 // - if env is nullptr, return napi_invalid_arg
 // - if there is a pending exception, return napi_pending_exception
 // No do..while is used as this declares a variable that other macros need to use
-#define NAPI_PREAMBLE(_env)                                             \
-    NAPI_LOG_CURRENT_FUNCTION;                                          \
-    NAPI_CHECK_ARG(_env, _env);                                         \
-    /* You should not use this throw scope directly -- if you need */   \
-    /* to throw or clear exceptions, make your own scope */             \
-    auto napi_preamble_throw_scope__ = DECLARE_THROW_SCOPE(_env->vm()); \
+#define NAPI_PREAMBLE(_env)                                                       \
+    NAPI_LOG_CURRENT_FUNCTION;                                                    \
+    NAPI_CHECK_ARG(_env, _env);                                                   \
+    /* You should not use this scope directly -- if you need */                   \
+    /* to throw or clear exceptions, make your own scope */                       \
+    auto napi_preamble_throw_scope__ = DECLARE_NAPI_BOUNDARY_SCOPE((_env)->vm()); \
     NAPI_RETURN_IF_EXCEPTION(_env)
 
 // Only use this for functions that need their own throw or catch scope. Functions that call into
 // JS code that might throw should use NAPI_RETURN_IF_EXCEPTION.
-#define NAPI_PREAMBLE_NO_THROW_SCOPE(_env) \
-    do {                                   \
-        NAPI_LOG_CURRENT_FUNCTION;         \
-        NAPI_CHECK_ARG(_env, _env);        \
-    } while (0)
+// No do..while is used as this declares a variable that must outlive any inner ThrowScope.
+#define NAPI_PREAMBLE_NO_THROW_SCOPE(_env)                                             \
+    NAPI_LOG_CURRENT_FUNCTION;                                                         \
+    NAPI_CHECK_ARG(_env, _env);                                                        \
+    auto napi_preamble_boundary_scope__ = DECLARE_NAPI_BOUNDARY_SCOPE((_env)->vm()); \
+    (void)napi_preamble_boundary_scope__
 
 // Like NAPI_PREAMBLE but does NOT return napi_pending_exception when the env
 // has a stashed napi_throw* exception. Mirrors Node.js's CHECK_ENV_NOT_IN_GC
 // for pure value constructors/accessors that are safe to call while an
-// exception is pending. Still declares a throw scope so NAPI_RETURN_SUCCESS
-// can assert and VM-level exceptions from JSC internals are caught.
-#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                            \
-    NAPI_LOG_CURRENT_FUNCTION;                                          \
-    NAPI_CHECK_ARG(_env, _env);                                         \
-    auto napi_preamble_throw_scope__ = DECLARE_THROW_SCOPE(_env->vm()); \
+// exception is pending. Still declares a scope so NAPI_RETURN_SUCCESS can
+// assert and VM-level exceptions from JSC internals are caught.
+#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                      \
+    NAPI_LOG_CURRENT_FUNCTION;                                                    \
+    NAPI_CHECK_ARG(_env, _env);                                                   \
+    auto napi_preamble_throw_scope__ = DECLARE_NAPI_BOUNDARY_SCOPE((_env)->vm()); \
     NAPI_RETURN_IF_VM_EXCEPTION(_env)
 
 // Return an error code if arg is null. Only use for input validation.

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -80,12 +80,9 @@
 using namespace JSC;
 using namespace Zig;
 
-// Exception scope for the N-API C ABI boundary. The caller is addon C code, so it
-// cannot satisfy JSC's exception-check discipline: a ThrowScope's simulated throw
-// would make the next napi_* call's scope abort under validateExceptionChecks.
-// Instead this scope reads vm.exception() on entry (acknowledging a sibling napi_*
-// call's simulated throw) and on exit (acknowledging inner scopes'), and never
-// simulates a throw of its own. Real exceptions still surface as napi_pending_exception.
+// Exception scope for the N-API C ABI boundary: addon C callers can't satisfy JSC's
+// exception-check discipline, so acknowledge pending checks on entry and exit instead
+// of simulating a throw. A real exception still surfaces as napi_pending_exception.
 class NapiBoundaryScope : public JSC::ExceptionScope {
 public:
 #if ENABLE(EXCEPTION_SCOPE_VERIFICATION)

--- a/test/napi/napi-exception-check.test.ts
+++ b/test/napi/napi-exception-check.test.ts
@@ -63,7 +63,7 @@ NAPI_MODULE_INIT() {
 async function loadAddonWithValidator(name: string, addonSource: string, loadJs: string, expectedStdout: string) {
   using dir = tempDir(name, { "addon.c": addonSource, "load.js": loadJs });
 
-  const compile = Bun.spawnSync({
+  await using compile = Bun.spawn({
     cmd: [
       cc!,
       "-shared",
@@ -79,11 +79,12 @@ async function loadAddonWithValidator(name: string, addonSource: string, loadJs:
     ],
     cwd: String(dir),
     env: bunEnv,
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "pipe",
   });
+  const [compileStderr, compileExitCode] = await Promise.all([compile.stderr.text(), compile.exited]);
   // Don't require an empty stderr: ld64 may warn about dynamic_lookup.
-  expect({ exitCode: compile.exitCode, stderr: compile.stderr.toString() }).toMatchObject({ exitCode: 0 });
+  expect({ exitCode: compileExitCode, stderr: compileStderr }).toMatchObject({ exitCode: 0 });
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "load.js"],

--- a/test/napi/napi-exception-check.test.ts
+++ b/test/napi/napi-exception-check.test.ts
@@ -69,6 +69,8 @@ test.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExce
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ stdout, exitCode }).toEqual({ stdout: "loaded 42\n", exitCode: 0 });
+  // stderr is in the received object so the abort report shows up in the
+  // failure diff, but its contents are not asserted (debug builds write noise).
+  expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "loaded 42\n", exitCode: 0 });
   expect(stderr).not.toContain("Unchecked JS exception");
 });

--- a/test/napi/napi-exception-check.test.ts
+++ b/test/napi/napi-exception-check.test.ts
@@ -8,13 +8,9 @@ const napiHeaderDir = join(import.meta.dir, "..", "..", "src", "runtime", "napi"
 // A plain C compiler is enough: the addon below only needs the N-API C ABI.
 const cc = Bun.which("cc") ?? Bun.which("clang") ?? Bun.which("gcc");
 
-// The canonical two-line module Init that every N-API tutorial and the
-// node-addon-api template emit. Each napi_* call opens a JSC exception scope;
-// the scope opened by napi_create_function must not require the addon's C code
-// (which cannot participate in JSC's exception-check discipline) to have
-// "checked" it before napi_set_named_property opens the next one. Under
-// BUN_JSC_validateExceptionChecks=1 on an assert-enabled build, getting this
-// wrong aborts the process at module load with "ERROR: Unchecked JS exception".
+// The canonical two-call Init that every N-API template emits. Addon C code cannot
+// satisfy JSC's exception-check discipline between the two napi_* calls; on an
+// assert-enabled build with the validator on, getting that wrong aborts at module load.
 const addonSource = /* c */ `
 #include <node_api.h>
 

--- a/test/napi/napi-exception-check.test.ts
+++ b/test/napi/napi-exception-check.test.ts
@@ -32,38 +32,31 @@ NAPI_MODULE_INIT() {
 }
 `;
 
-test.skipIf(isWindows || !cc)(
-  "N-API module Init runs under BUN_JSC_validateExceptionChecks",
-  async () => {
-    using dir = tempDir("napi-exception-check", {
-      "addon.c": addonSource,
-      "load.js": `const addon = require("./addon.node");\nconsole.log("loaded", addon.hello());\n`,
-    });
+test.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExceptionChecks", async () => {
+  using dir = tempDir("napi-exception-check", {
+    "addon.c": addonSource,
+    "load.js": `const addon = require("./addon.node");\nconsole.log("loaded", addon.hello());\n`,
+  });
 
-    const compile = Bun.spawnSync({
-      cmd: [cc!, "-shared", "-fPIC", `-I${napiHeaderDir}`, "-o", "addon.node", "addon.c"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(compile.stderr.toString()).toBe("");
-    expect(compile.exitCode).toBe(0);
+  const compile = Bun.spawnSync({
+    cmd: [cc!, "-shared", "-fPIC", `-I${napiHeaderDir}`, "-o", "addon.node", "addon.c"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(compile.stderr.toString()).toBe("");
+  expect(compile.exitCode).toBe(0);
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "load.js"],
-      cwd: String(dir),
-      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "load.js"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stdout, exitCode }).toEqual({ stdout: "loaded 42\n", exitCode: 0 });
-    expect(stderr).not.toContain("Unchecked JS exception");
-  },
-);
+  expect({ stdout, exitCode }).toEqual({ stdout: "loaded 42\n", exitCode: 0 });
+  expect(stderr).not.toContain("Unchecked JS exception");
+});

--- a/test/napi/napi-exception-check.test.ts
+++ b/test/napi/napi-exception-check.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// Path to the in-repo copies of node_api.h / js_native_api.h.
+const napiHeaderDir = join(import.meta.dir, "..", "..", "src", "runtime", "napi");
+
+// A plain C compiler is enough: the addon below only needs the N-API C ABI.
+const cc = Bun.which("cc") ?? Bun.which("clang") ?? Bun.which("gcc");
+
+// The canonical two-line module Init that every N-API tutorial and the
+// node-addon-api template emit. Each napi_* call opens a JSC exception scope;
+// the scope opened by napi_create_function must not require the addon's C code
+// (which cannot participate in JSC's exception-check discipline) to have
+// "checked" it before napi_set_named_property opens the next one. Under
+// BUN_JSC_validateExceptionChecks=1 on an assert-enabled build, getting this
+// wrong aborts the process at module load with "ERROR: Unchecked JS exception".
+const addonSource = /* c */ `
+#include <node_api.h>
+
+static napi_value Method(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_create_int32(env, 42, &result);
+  return result;
+}
+
+NAPI_MODULE_INIT() {
+  napi_value fn;
+  napi_create_function(env, NULL, 0, Method, NULL, &fn);
+  napi_set_named_property(env, exports, "hello", fn);
+  return exports;
+}
+`;
+
+test.skipIf(isWindows || !cc)(
+  "N-API module Init runs under BUN_JSC_validateExceptionChecks",
+  async () => {
+    using dir = tempDir("napi-exception-check", {
+      "addon.c": addonSource,
+      "load.js": `const addon = require("./addon.node");\nconsole.log("loaded", addon.hello());\n`,
+    });
+
+    const compile = Bun.spawnSync({
+      cmd: [cc!, "-shared", "-fPIC", `-I${napiHeaderDir}`, "-o", "addon.node", "addon.c"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(compile.stderr.toString()).toBe("");
+    expect(compile.exitCode).toBe(0);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "load.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ stdout, exitCode }).toEqual({ stdout: "loaded 42\n", exitCode: 0 });
+    expect(stderr).not.toContain("Unchecked JS exception");
+  },
+);

--- a/test/napi/napi-exception-check.test.ts
+++ b/test/napi/napi-exception-check.test.ts
@@ -100,7 +100,7 @@ async function loadAddonWithValidator(name: string, addonSource: string, loadJs:
   expect(stderr).not.toContain("Unchecked JS exception");
 }
 
-test.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExceptionChecks", async () => {
+test.concurrent.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExceptionChecks", async () => {
   await loadAddonWithValidator(
     "napi-exception-check",
     twoCallInitSource,
@@ -109,11 +109,14 @@ test.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExce
   );
 });
 
-test.skipIf(isWindows || !cc)("napi_define_class accessors run under BUN_JSC_validateExceptionChecks", async () => {
-  await loadAddonWithValidator(
-    "napi-exception-check-class",
-    accessorClassSource,
-    `const { Thing } = require("./addon.node");\nconsole.log("value", new Thing().value);\n`,
-    "value 42\n",
-  );
-});
+test.concurrent.skipIf(isWindows || !cc)(
+  "napi_define_class accessors run under BUN_JSC_validateExceptionChecks",
+  async () => {
+    await loadAddonWithValidator(
+      "napi-exception-check-class",
+      accessorClassSource,
+      `const { Thing } = require("./addon.node");\nconsole.log("value", new Thing().value);\n`,
+      "value 42\n",
+    );
+  },
+);

--- a/test/napi/napi-exception-check.test.ts
+++ b/test/napi/napi-exception-check.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // Path to the in-repo copies of node_api.h / js_native_api.h.
@@ -39,14 +39,26 @@ test.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExce
   });
 
   const compile = Bun.spawnSync({
-    cmd: [cc!, "-shared", "-fPIC", `-I${napiHeaderDir}`, "-o", "addon.node", "addon.c"],
+    cmd: [
+      cc!,
+      "-shared",
+      "-fPIC",
+      // The napi_* symbols are resolved from the host process at dlopen time.
+      // Linux ld allows undefined symbols in shared objects by default; macOS
+      // ld64 errors on them unless told to defer, which is what node-gyp does.
+      ...(isMacOS ? ["-undefined", "dynamic_lookup"] : []),
+      `-I${napiHeaderDir}`,
+      "-o",
+      "addon.node",
+      "addon.c",
+    ],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(compile.stderr.toString()).toBe("");
-  expect(compile.exitCode).toBe(0);
+  // Don't require an empty stderr: ld64 may warn about dynamic_lookup.
+  expect({ exitCode: compile.exitCode, stderr: compile.stderr.toString() }).toMatchObject({ exitCode: 0 });
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "load.js"],

--- a/test/napi/napi-exception-check.test.ts
+++ b/test/napi/napi-exception-check.test.ts
@@ -5,13 +5,13 @@ import { join } from "path";
 // Path to the in-repo copies of node_api.h / js_native_api.h.
 const napiHeaderDir = join(import.meta.dir, "..", "..", "src", "runtime", "napi");
 
-// A plain C compiler is enough: the addon below only needs the N-API C ABI.
+// A plain C compiler is enough: the addons below only need the N-API C ABI.
 const cc = Bun.which("cc") ?? Bun.which("clang") ?? Bun.which("gcc");
 
 // The canonical two-call Init that every N-API template emits. Addon C code cannot
 // satisfy JSC's exception-check discipline between the two napi_* calls; on an
 // assert-enabled build with the validator on, getting that wrong aborts at module load.
-const addonSource = /* c */ `
+const twoCallInitSource = /* c */ `
 #include <node_api.h>
 
 static napi_value Method(napi_env env, napi_callback_info info) {
@@ -28,11 +28,40 @@ NAPI_MODULE_INIT() {
 }
 `;
 
-test.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExceptionChecks", async () => {
-  using dir = tempDir("napi-exception-check", {
-    "addon.c": addonSource,
-    "load.js": `const addon = require("./addon.node");\nconsole.log("loaded", addon.hello());\n`,
-  });
+// A class with a getter+setter property creates two NapiClass objects back to back
+// inside Napi::defineProperty, which is a second place the exception-check discipline
+// has to be satisfied (this is the shape every node-addon-api ObjectWrap accessor has).
+const accessorClassSource = /* c */ `
+#include <node_api.h>
+#include <stddef.h>
+
+static napi_value Ctor(napi_env env, napi_callback_info info) {
+  napi_value this_arg;
+  napi_get_cb_info(env, info, NULL, NULL, &this_arg, NULL);
+  return this_arg;
+}
+
+static napi_value Getter(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_create_int32(env, 42, &result);
+  return result;
+}
+
+static napi_value Setter(napi_env env, napi_callback_info info) {
+  return NULL;
+}
+
+NAPI_MODULE_INIT() {
+  napi_property_descriptor prop = {"value", NULL, NULL, Getter, Setter, NULL, napi_default, NULL};
+  napi_value cls;
+  napi_define_class(env, "Thing", NAPI_AUTO_LENGTH, Ctor, NULL, 1, &prop, &cls);
+  napi_set_named_property(env, exports, "Thing", cls);
+  return exports;
+}
+`;
+
+async function loadAddonWithValidator(name: string, addonSource: string, loadJs: string, expectedStdout: string) {
+  using dir = tempDir(name, { "addon.c": addonSource, "load.js": loadJs });
 
   const compile = Bun.spawnSync({
     cmd: [
@@ -67,6 +96,24 @@ test.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExce
 
   // stderr is in the received object so the abort report shows up in the
   // failure diff, but its contents are not asserted (debug builds write noise).
-  expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "loaded 42\n", exitCode: 0 });
+  expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: expectedStdout, exitCode: 0 });
   expect(stderr).not.toContain("Unchecked JS exception");
+}
+
+test.skipIf(isWindows || !cc)("N-API module Init runs under BUN_JSC_validateExceptionChecks", async () => {
+  await loadAddonWithValidator(
+    "napi-exception-check",
+    twoCallInitSource,
+    `const addon = require("./addon.node");\nconsole.log("loaded", addon.hello());\n`,
+    "loaded 42\n",
+  );
+});
+
+test.skipIf(isWindows || !cc)("napi_define_class accessors run under BUN_JSC_validateExceptionChecks", async () => {
+  await loadAddonWithValidator(
+    "napi-exception-check-class",
+    accessorClassSource,
+    `const { Thing } = require("./addon.node");\nconsole.log("value", new Thing().value);\n`,
+    "value 42\n",
+  );
 });


### PR DESCRIPTION
### Repro

The canonical two-line `Init` that every N-API tutorial and the node-addon-api template emit is enough:

```c
NAPI_MODULE_INIT() {
  napi_value fn;
  napi_create_function(env, NULL, 0, Method, NULL, &fn);
  napi_set_named_property(env, exports, "hello", fn);
  return exports;
}
```

On an assert-enabled build with `BUN_JSC_validateExceptionChecks=1`, `require()`ing that addon aborts at module load:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: napi_create_function @ src/jsc/bindings/napi.cpp:968
        (ExceptionScope::m_recursionDepth was 10)
    But the exception was unchecked as of this scope: napi_set_named_property @ src/jsc/bindings/napi.cpp:607
        (ExceptionScope::m_recursionDepth was 10)
ASSERTION FAILED: exception check validation failed
vendor/WebKit/Source/JavaScriptCore/runtime/VM.cpp(1561) : void JSC::VM::verifyExceptionCheckNeedIsSatisfied(...)
```

This means no native addon can load at all under exception-scope validation. Bun's CI already runs the validator on the linux x64 ASAN test shard (`scripts/runner.node.mjs` sets `BUN_JSC_validateExceptionChecks=1` for every test file not listed in `test/no-validate-exceptions.txt`), and the entire N-API section of that list (`node-napi-tests/`, `uv.test.ts`, `napi-finalizer-delete-ref.test.ts`, ...) is a casualty of this: those tests cannot currently run with the validator on. Release builds compile `ENABLE(EXCEPTION_SCOPE_VERIFICATION)` out, so they do not abort, but the underlying discipline violation is real: a pending exception raised inside `Init` (for example by a getter on `exports`) can be dropped or surface at an unrelated later point.

### Cause

Two instances of the same mistake: calling two scope-opening JSC operations on the N-API path with nothing observing the exception state in between.

1. `NAPI_PREAMBLE` declared a `JSC::ThrowScope`. A `ThrowScope` destructor always calls `simulateThrow()` toward its caller unless the caller is LLInt/JIT, which sets `VM::m_needExceptionCheck`. JSC's discipline then requires the caller to observe `exception()` before the next scope is constructed. But the caller of a N-API entry point is the addon's C code, which cannot participate in that discipline, so the very next `napi_*` call's scope constructor finds the unsatisfied check and `RELEASE_ASSERT`s. Any two back-to-back `napi_*` calls from native code trigger it; module `Init` is just the most universal instance.

2. `Napi::defineProperty` creates two `NapiClass` objects back to back for a property descriptor with both a getter and a setter (`NapiClass::create` for the getter, then again for the setter). Each `NapiClass::finishCreation` opens and closes its own `ThrowScope`, so the second one's constructor aborts on the first one's simulated throw:

```
    This scope can throw a JS exception: finishCreation @ src/jsc/bindings/NapiClass.cpp:116
    But the exception was unchecked as of this scope: finishCreation @ src/jsc/bindings/NapiClass.cpp:116
```

That is the shape of every node-addon-api `ObjectWrap` accessor, and it is what was aborting Node's upstream `js-native-api/6_object_wrap` conformance test even with fix 1 applied.

### Fix

For 1, replace the preamble's `ThrowScope` with a `NapiBoundaryScope`, a minimal `JSC::ExceptionScope` subclass for the C ABI boundary. It reads `vm.exception()` on entry (acknowledging the simulated throw left by a sibling `napi_*` call) and on exit (acknowledging inner scopes'), and never simulates a throw toward its native caller. `NAPI_PREAMBLE_NO_THROW_SCOPE` now declares the same boundary scope, covering entry points such as `napi_get_and_clear_last_exception` that construct an inner `TopExceptionScope` (whose constructor verifies) and would otherwise hit the identical abort.

This does not weaken validation inside Bun's own code: every `DECLARE_THROW_SCOPE` inside a N-API function body still verifies and simulates normally against its own nesting, `NAPI_RETURN_SUCCESS` still `RELEASE_ASSERT`s that no real exception is pending, and a real pending exception is still reported to the addon as `napi_pending_exception`. JSC's own C API makes the same choice at its boundary (`DECLARE_TOP_EXCEPTION_SCOPE` in `JSObjectRef.cpp`); `TopExceptionScope` itself is not usable here because it verifies the pending-check bit in its constructor. In release builds the class collapses to the trivial non-verification `ExceptionScope`, so there is no behavior or codegen change.

For 2, add the missing `RETURN_IF_EXCEPTION` checks in `Napi::defineProperty`: after the property-name lookup (which can genuinely throw via `toPropertyKey`) and after each `NapiClass` creation in the accessor branch.

### Verification

`test/napi/napi-exception-check.test.ts` compiles two addons with the system C compiler against the in-repo N-API headers (no node-gyp, so it is a separate file from `napi.test.ts` and does not depend on that suite's toolchain setup) and `require()`s each in a child process with `BUN_JSC_validateExceptionChecks=1`:

- the canonical two-call `Init` (fix 1), and
- a `napi_define_class` with a getter+setter property (fix 2).

Without the `src/` changes both abort (SIGABRT, exit 134) with the `Unchecked JS exception` reports above; with them, both load and run. With only fix 1 applied, the second test still aborted with the `finishCreation` pair, so each test is pinned to its own fix. On release builds the validator is compiled out, so the option is a no-op and the tests still pass.

Also ran, with `BUN_JSC_validateExceptionChecks=1` against the fixed debug build: `test/napi/napi-finalizer-delete-ref.test.ts` and Node's upstream `js-native-api/2_function_arguments`, `3_callbacks`, and `6_object_wrap` suites (`6_object_wrap` aborted before fix 2), plus `test/napi/napi.test.ts` and the `napi_get_value_string_utf8` / `napi_define_class` / `napi_wrap` groups without the validator.

### Not addressed here

Some `node-napi-tests` entries still abort under the validator on a separate, pre-existing unchecked scope in the module-load path, before any `napi_*` call runs (for example `js-native-api/4_object_factory`):

```
    This scope can throw a JS exception: putInlineSlow @ JavaScriptCore/runtime/JSObject.cpp:836
    But the exception was unchecked as of this scope: Process_functionDlopen @ src/jsc/bindings/BunProcess.cpp:393
```

That is in the `require`/`process.dlopen` path, not in the N-API entry points, so it is left for a separate change, and the N-API entries in `test/no-validate-exceptions.txt` are intentionally not removed yet.


### Rebase note

This branch was rebased over two upstream refactors of the same code and the fix was re-applied into their new shapes:

- `NAPI_PREAMBLE` on main now ends with `NAPI_RETURN_IF_EXCEPTION` (also checks the env-stashed `napi_throw*` exception); the rebased preamble keeps that behavior and declares a `NapiBoundaryScope`. The new third preamble macro, `NAPI_PREAMBLE_NO_PENDING_CHECK`, received the same boundary-scope conversion since it has the identical `ThrowScope` pattern.
- `Napi::defineProperty` was rewritten on main (now returns `napi_status` and uses a `PropertyDescriptor`). The upstream rewrite already checks after `toPropertyKey`, so that part of the original change is subsumed; the remaining back-to-back `NapiClass::create` calls in the accessor branch still lacked a check between them, which is re-applied with the new return value.

After the rebase, both tests still fail on main's `napi.cpp` (with the same `napi_create_function`/`napi_set_named_property` and `finishCreation`/`finishCreation` pairs at updated line numbers) and pass with the fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi-exception-check.test.ts

<!-- robobun:evidence:end -->