### PR TITLE
napi: run napi_add_finalizer and napi_create_external finalizers at env teardown

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2453,7 +2453,9 @@ static void external_cleanup(napi_env env, void* data, void* hint)
 {
     auto* external = reinterpret_cast<Bun::NapiExternal*>(data);
     ASSERT(external->m_boundCleanup != nullptr);
+    external->m_boundCleanup->deactivate(*env);
     external->m_boundCleanup = nullptr;
+    // The user callback may do anything, so detach all state from the external first.
     Bun::NapiFinalizer finalizer = external->m_finalizer;
     external->m_finalizer.clear();
     finalizer.call(env, external->m_value, true);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1166,26 +1166,23 @@ extern "C" napi_status napi_add_finalizer(napi_env env, napi_value js_object,
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, js_object);
     NAPI_CHECK_ARG(env, finalize_cb);
-    Zig::GlobalObject* globalObject = toJS(env);
-    JSC::VM& vm = JSC::getVM(globalObject);
 
     JSC::JSValue objectValue = toJS(js_object);
     JSC::JSObject* object = objectValue.getObject();
     NAPI_RETURN_EARLY_IF_FALSE(env, object, napi_object_expected);
 
+    // Mirror napi_wrap: create a NapiRef and register it with the env so the
+    // finalizer also runs at env teardown for objects still alive at exit.
+    auto* ref = new NapiRef(*env, 0, Bun::NapiFinalizer { finalize_cb, finalize_hint });
+    const auto& bound_cleanup = env->addFinalizer(wrap_cleanup, native_object, ref);
+    ref->boundCleanup = &bound_cleanup;
+    ref->nativeObject = native_object;
+
     if (result) {
-        // If they're expecting a Ref, use the ref.
-        auto* ref = new NapiRef(*env, 0, Bun::NapiFinalizer { finalize_cb, finalize_hint });
-        // TODO(@heimskr): consider detecting whether the value can't be weak, as we do in napi_create_reference.
-        ref->setValueInitial(object, true);
-        ref->nativeObject = native_object;
+        ref->weakValueRef.set(objectValue, Napi::NapiRefWeakHandleOwner::weakValueHandleOwner(), ref);
         *result = toNapi(ref);
     } else {
-        // Otherwise, it's cheaper to just call .addFinalizer.
-        vm.heap.addFinalizer(object, [env = WTF::Ref<NapiEnv>(*env), finalize_cb, native_object, finalize_hint](JSCell* cell) -> void {
-            NAPI_LOG("finalizer %p", finalize_hint);
-            env->doFinalizer(finalize_cb, native_object, finalize_hint);
-        });
+        ref->weakValueRef.set(objectValue, Napi::NapiRefSelfDeletingWeakHandleOwner::weakValueHandleOwner(), ref);
     }
 
     NAPI_RETURN_SUCCESS(env);
@@ -2452,6 +2449,16 @@ extern "C" napi_status napi_create_object(napi_env env, napi_value* result)
     NAPI_RETURN_SUCCESS(env);
 }
 
+static void external_cleanup(napi_env env, void* data, void* hint)
+{
+    auto* external = reinterpret_cast<Bun::NapiExternal*>(data);
+    ASSERT(external->m_boundCleanup != nullptr);
+    external->m_boundCleanup = nullptr;
+    Bun::NapiFinalizer finalizer = external->m_finalizer;
+    external->m_finalizer.clear();
+    finalizer.call(env, external->m_value, true);
+}
+
 extern "C" napi_status napi_create_external(napi_env env, void* data,
     napi_finalize finalize_cb,
     void* finalize_hint,
@@ -2464,9 +2471,16 @@ extern "C" napi_status napi_create_external(napi_env env, void* data,
     JSC::VM& vm = JSC::getVM(globalObject);
 
     auto* structure = globalObject->NapiExternalStructure();
-    JSValue value = Bun::NapiExternal::create(vm, structure, data, finalize_hint, finalize_cb, env);
-    JSC::EnsureStillAliveScope ensureStillAlive(value);
-    *result = toNapi(value, globalObject);
+    Bun::NapiExternal* external = Bun::NapiExternal::create(vm, structure, data, finalize_hint, finalize_cb, env);
+    JSC::EnsureStillAliveScope ensureStillAlive(external);
+    if (finalize_cb) {
+        // Register with the env so the finalizer also runs at env teardown for
+        // externals still alive at exit. The external's destructor deactivates
+        // this entry if GC runs first.
+        const auto& bound_cleanup = env->addFinalizer(external_cleanup, nullptr, external);
+        external->m_boundCleanup = &bound_cleanup;
+    }
+    *result = toNapi(JSValue(external), globalObject);
     NAPI_RETURN_SUCCESS(env);
 }
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -222,18 +222,38 @@ public:
         // Reverse insertion order so children are torn down before parents (Node.js LIFO).
         // ListHashSet iteration is safe against concurrent inserts, and m_isFinishingFinalizers
         // routes all removals to active=false, so the only unsafe op (erase-current) can't occur.
-        for (auto it = m_finalizers.rbegin(); it != m_finalizers.rend(); ++it) {
-            Bun::NapiHandleScope handle_scope(m_globalObject);
-            it->call(this);
-            // Each finalizer starts from a clean exception state: Node.js
-            // never propagates one finalizer's throw into the next (there
-            // is no JS frame to catch in between). Leaving a pending
-            // exception also breaks later finalizers in subtle ways --
-            // napi_is_exception_pending skips the VM check during cleanup
-            // for safety, so user code thinks there is no exception, but
-            // the next napi call with a throw scope sees it. See #30286.
-            clearExceptionsBetweenFinalizers();
-        }
+        //
+        // Bun lets a finalizer register new finalizers (napi_wrap, napi_add_finalizer,
+        // napi_create_external); addFinalizer() appends them after the position a
+        // reverse iteration has already passed. Clearing the set after a single pass
+        // would then free a BoundFinalizer that a still-live NapiRef or NapiExternal
+        // points at through boundCleanup (a use-after-free on its next sweep), so
+        // loop until a pass runs nothing new.
+        bool ranAny;
+        do {
+            ranAny = false;
+            for (auto it = m_finalizers.rbegin(); it != m_finalizers.rend(); ++it) {
+                if (!it->active) {
+                    continue;
+                }
+                // Deactivate before calling so an entry can never run on a later pass;
+                // the callback's own deactivate() is then an idempotent no-op.
+                it->active = false;
+                ranAny = true;
+                Bun::NapiHandleScope handle_scope(m_globalObject);
+                if (it->callback) {
+                    it->callback(this, it->data, it->hint);
+                }
+                // Each finalizer starts from a clean exception state: Node.js
+                // never propagates one finalizer's throw into the next (there
+                // is no JS frame to catch in between). Leaving a pending
+                // exception also breaks later finalizers in subtle ways --
+                // napi_is_exception_pending skips the VM check during cleanup
+                // for safety, so user code thinks there is no exception, but
+                // the next napi call with a throw scope sees it. See #30286.
+                clearExceptionsBetweenFinalizers();
+            }
+        } while (ranAny);
         m_finalizers.clear();
         m_isFinishingFinalizers = false;
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -223,12 +223,9 @@ public:
         // ListHashSet iteration is safe against concurrent inserts, and m_isFinishingFinalizers
         // routes all removals to active=false, so the only unsafe op (erase-current) can't occur.
         //
-        // Bun lets a finalizer register new finalizers (napi_wrap, napi_add_finalizer,
-        // napi_create_external); addFinalizer() appends them after the position a
-        // reverse iteration has already passed. Clearing the set after a single pass
-        // would then free a BoundFinalizer that a still-live NapiRef or NapiExternal
-        // points at through boundCleanup (a use-after-free on its next sweep), so
-        // loop until a pass runs nothing new.
+        // A finalizer may register new finalizers, appended past where this pass already is.
+        // Repeat until a pass runs nothing new: clear() after one pass would free entries a
+        // still-live NapiRef or NapiExternal points at through boundCleanup.
         bool ranAny;
         do {
             ranAny = false;
@@ -276,13 +273,9 @@ public:
 
     const auto& addFinalizer(napi_finalize callback, void* hint, void* data)
     {
-        // add() deduplicates on (callback, hint, data). During cleanup() a dying
-        // owner's entry is only marked inactive, not erased, and NapiRef is
-        // TZone-allocated, so a finalizer that deletes a ref and registers a new
-        // one can get the freed address back and alias that dead entry. It then
-        // belongs exclusively to the new owner (only a freed address can collide),
-        // so reactivate it; otherwise the drain never runs it and clear() frees it
-        // while the new owner's boundCleanup still points at it.
+        // add() dedups on (callback, hint, data), so during cleanup() a new registration
+        // whose freed-and-reused address matches a tombstoned entry gets that entry back.
+        // Reactivate it so the drain runs it before clear() frees it under its new owner.
         const auto& bound = *m_finalizers.add({ callback, hint, data }).iterator;
         bound.active = true;
         return bound;

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -508,13 +508,6 @@ public:
         {
         }
 
-        void call(napi_env env) const
-        {
-            if (callback && active) {
-                callback(env, data, hint);
-            }
-        }
-
         void deactivate(NapiEnv& env) const
         {
             if (env.isFinishingFinalizers()) {

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -276,7 +276,16 @@ public:
 
     const auto& addFinalizer(napi_finalize callback, void* hint, void* data)
     {
-        return *m_finalizers.add({ callback, hint, data }).iterator;
+        // add() deduplicates on (callback, hint, data). During cleanup() a dying
+        // owner's entry is only marked inactive, not erased, and NapiRef is
+        // TZone-allocated, so a finalizer that deletes a ref and registers a new
+        // one can get the freed address back and alias that dead entry. It then
+        // belongs exclusively to the new owner (only a freed address can collide),
+        // so reactivate it; otherwise the drain never runs it and clear() frees it
+        // while the new owner's boundCleanup still points at it.
+        const auto& bound = *m_finalizers.add({ callback, hint, data }).iterator;
+        bound.active = true;
+        return bound;
     }
 
     bool hasFinalizers() const

--- a/src/jsc/bindings/napi_external.cpp
+++ b/src/jsc/bindings/napi_external.cpp
@@ -6,6 +6,10 @@ namespace Bun {
 NapiExternal::~NapiExternal()
 {
     auto* env = m_env.get();
+    if (m_boundCleanup) {
+        m_boundCleanup->deactivate(*env);
+        m_boundCleanup = nullptr;
+    }
     m_finalizer.call(env, m_value, env && !env->mustDeferFinalizers());
 }
 

--- a/src/jsc/bindings/napi_external.h
+++ b/src/jsc/bindings/napi_external.h
@@ -96,6 +96,7 @@ public:
     void* m_value;
     NapiFinalizer m_finalizer;
     WTF::RefPtr<NapiEnv> m_env;
+    const NapiEnv::BoundFinalizer* m_boundCleanup = nullptr;
 
 #if ASSERT_ENABLED
     String sourceOriginURL = String();

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -275,5 +275,16 @@
                 "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
             ],
         },
+        {
+            "target_name": "test_teardown_finalizers",
+            "sources": ["test_teardown_finalizers.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
     ]
 }

--- a/test/napi/napi-app/test_teardown_finalizers.c
+++ b/test/napi/napi-app/test_teardown_finalizers.c
@@ -1,6 +1,8 @@
 // napi_add_finalizer and napi_create_external finalizers must run at env
-// teardown for objects still alive at exit (only napi_wrap's used to). A
-// finalizer already run by GC must not run again at teardown. Each finalizer
+// teardown for objects still alive at exit (only napi_wrap's used to), and a
+// finalizer already run by GC must not run again at teardown. A finalizer
+// registered *by* a teardown finalizer must be drained in the same teardown,
+// not left as a dangling entry in the env's finalizer list. Each finalizer
 // prints "finalize: <name>" to stderr exactly once.
 
 #include <node_api.h>
@@ -8,12 +10,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+static int finalize_count = 0;
+
 static void finalize(napi_env env, void* data, void* hint) {
     (void)env;
     (void)data;
     fprintf(stderr, "finalize: %s\n", (const char*)hint);
     fflush(stderr);
     free(hint);
+    finalize_count++;
 }
 
 // Copies the string argument at `index` into a malloc'd buffer that finalize() frees.
@@ -58,11 +63,56 @@ static napi_value create_external(napi_env env, napi_callback_info info) {
     return external;
 }
 
+// finalizeCount() -> number of finalizers that have already run (and flushed).
+static napi_value get_finalize_count(napi_env env, napi_callback_info info) {
+    (void)info;
+    napi_value out;
+    napi_create_int32(env, finalize_count, &out);
+    return out;
+}
+
+typedef struct {
+    char* outer_name;
+    char* nested_external_name;
+    char* nested_add_finalizer_name;
+} NestingContext;
+
+// Runs as a teardown finalizer and registers two new finalizers while the env
+// is already draining its finalizer list. Bun accepts these calls here (Node
+// rejects them with napi_pending_exception), so it must drain them safely.
+static void nesting_finalize(napi_env env, void* data, void* hint) {
+    (void)hint;
+    NestingContext* ctx = (NestingContext*)data;
+    fprintf(stderr, "finalize: %s\n", ctx->outer_name);
+    fflush(stderr);
+    finalize_count++;
+    napi_value external;
+    napi_create_external(env, NULL, finalize, ctx->nested_external_name, &external);
+    napi_add_finalizer(env, external, NULL, finalize, ctx->nested_add_finalizer_name, NULL);
+    free(ctx->outer_name);
+    free(ctx);
+}
+
+// wrapNesting(obj, outerName, nestedExternalName, nestedAddFinalizerName)
+static napi_value wrap_nesting(napi_env env, napi_callback_info info) {
+    size_t argc = 4;
+    napi_value argv[4];
+    napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+    NestingContext* ctx = (NestingContext*)malloc(sizeof(NestingContext));
+    ctx->outer_name = dup_name_arg(env, argv[1]);
+    ctx->nested_external_name = dup_name_arg(env, argv[2]);
+    ctx->nested_add_finalizer_name = dup_name_arg(env, argv[3]);
+    napi_wrap(env, argv[0], ctx, nesting_finalize, NULL, NULL);
+    return argv[0];
+}
+
 static napi_value init(napi_env env, napi_value exports) {
     napi_property_descriptor properties[] = {
         { "wrap", 0, wrap, 0, 0, 0, napi_default, 0 },
         { "addFinalizer", 0, add_finalizer, 0, 0, 0, napi_default, 0 },
         { "createExternal", 0, create_external, 0, 0, 0, napi_default, 0 },
+        { "finalizeCount", 0, get_finalize_count, 0, 0, 0, napi_default, 0 },
+        { "wrapNesting", 0, wrap_nesting, 0, 0, 0, napi_default, 0 },
     };
     napi_define_properties(env, exports, sizeof(properties) / sizeof(properties[0]), properties);
     return exports;

--- a/test/napi/napi-app/test_teardown_finalizers.c
+++ b/test/napi/napi-app/test_teardown_finalizers.c
@@ -23,7 +23,7 @@ static void finalize(napi_env env, void* data, void* hint) {
     finalize_count++;
 }
 
-// Copies the string argument at `index` into a malloc'd buffer that finalize() frees.
+// Copies the string in `arg` into a malloc'd buffer that finalize() frees.
 static char* dup_name_arg(napi_env env, napi_value arg) {
     size_t len = 0;
     napi_get_value_string_utf8(env, arg, NULL, 0, &len);
@@ -108,6 +108,60 @@ static napi_value wrap_nesting(napi_env env, napi_callback_info info) {
     return argv[0];
 }
 
+static napi_ref saved_ref = NULL;
+
+// addFinalizerSaveRef(obj, name): napi_add_finalizer keeping the returned ref
+// so a later teardown finalizer can napi_delete_reference it.
+static napi_value add_finalizer_save_ref(napi_env env, napi_callback_info info) {
+    size_t argc = 2;
+    napi_value argv[2];
+    napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+    napi_add_finalizer(env, argv[0], NULL, finalize, dup_name_arg(env, argv[1]), &saved_ref);
+    return argv[0];
+}
+
+typedef struct {
+    char* outer_name;
+    char* recycled_name;
+} RecycleContext;
+
+// Runs as a teardown finalizer: deletes the ref from addFinalizerSaveRef (which
+// frees its NapiRef and tombstones its entry in the env's list), then registers
+// a brand-new finalizer. The allocator commonly hands back the just-freed
+// address, so the new registration's (callback, hint, data) key collides with
+// the tombstone; the new finalizer must still run.
+static void recycle_finalize(napi_env env, void* data, void* hint) {
+    (void)hint;
+    RecycleContext* ctx = (RecycleContext*)data;
+    printf("finalize: %s\n", ctx->outer_name);
+    fflush(stdout);
+    finalize_count++;
+    void* old_ref = (void*)saved_ref;
+    napi_delete_reference(env, saved_ref);
+    napi_value obj;
+    napi_create_object(env, &obj);
+    napi_ref new_ref = NULL;
+    napi_add_finalizer(env, obj, NULL, finalize, ctx->recycled_name, &new_ref);
+    // Diagnostic only (not asserted): says whether the address-reuse collision
+    // this exercise targets actually happened on this platform and allocator.
+    printf("recycled-address: %s\n", (void*)new_ref == old_ref ? "yes" : "no");
+    fflush(stdout);
+    free(ctx->outer_name);
+    free(ctx);
+}
+
+// wrapRecycling(obj, outerName, recycledName)
+static napi_value wrap_recycling(napi_env env, napi_callback_info info) {
+    size_t argc = 3;
+    napi_value argv[3];
+    napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+    RecycleContext* ctx = (RecycleContext*)malloc(sizeof(RecycleContext));
+    ctx->outer_name = dup_name_arg(env, argv[1]);
+    ctx->recycled_name = dup_name_arg(env, argv[2]);
+    napi_wrap(env, argv[0], ctx, recycle_finalize, NULL, NULL);
+    return argv[0];
+}
+
 static napi_value init(napi_env env, napi_value exports) {
     napi_property_descriptor properties[] = {
         { "wrap", 0, wrap, 0, 0, 0, napi_default, 0 },
@@ -115,6 +169,8 @@ static napi_value init(napi_env env, napi_value exports) {
         { "createExternal", 0, create_external, 0, 0, 0, napi_default, 0 },
         { "finalizeCount", 0, get_finalize_count, 0, 0, 0, napi_default, 0 },
         { "wrapNesting", 0, wrap_nesting, 0, 0, 0, napi_default, 0 },
+        { "addFinalizerSaveRef", 0, add_finalizer_save_ref, 0, 0, 0, napi_default, 0 },
+        { "wrapRecycling", 0, wrap_recycling, 0, 0, 0, napi_default, 0 },
     };
     napi_define_properties(env, exports, sizeof(properties) / sizeof(properties[0]), properties);
     return exports;

--- a/test/napi/napi-app/test_teardown_finalizers.c
+++ b/test/napi/napi-app/test_teardown_finalizers.c
@@ -3,7 +3,9 @@
 // finalizer already run by GC must not run again at teardown. A finalizer
 // registered *by* a teardown finalizer must be drained in the same teardown,
 // not left as a dangling entry in the env's finalizer list. Each finalizer
-// prints "finalize: <name>" to stderr exactly once.
+// prints "finalize: <name>" to stdout exactly once. stdout, not stderr: on
+// the ASAN CI lane a spawned child's stderr arrives empty, and the existing
+// test_wrap_cleanup_order fixture writes to stdout for the same reason.
 
 #include <node_api.h>
 #include <stdio.h>
@@ -15,8 +17,8 @@ static int finalize_count = 0;
 static void finalize(napi_env env, void* data, void* hint) {
     (void)env;
     (void)data;
-    fprintf(stderr, "finalize: %s\n", (const char*)hint);
-    fflush(stderr);
+    printf("finalize: %s\n", (const char*)hint);
+    fflush(stdout);
     free(hint);
     finalize_count++;
 }
@@ -83,8 +85,8 @@ typedef struct {
 static void nesting_finalize(napi_env env, void* data, void* hint) {
     (void)hint;
     NestingContext* ctx = (NestingContext*)data;
-    fprintf(stderr, "finalize: %s\n", ctx->outer_name);
-    fflush(stderr);
+    printf("finalize: %s\n", ctx->outer_name);
+    fflush(stdout);
     finalize_count++;
     napi_value external;
     napi_create_external(env, NULL, finalize, ctx->nested_external_name, &external);

--- a/test/napi/napi-app/test_teardown_finalizers.c
+++ b/test/napi/napi-app/test_teardown_finalizers.c
@@ -1,0 +1,71 @@
+// napi_add_finalizer and napi_create_external finalizers must run at env
+// teardown for objects still alive at exit (only napi_wrap's used to). A
+// finalizer already run by GC must not run again at teardown. Each finalizer
+// prints "finalize: <name>" to stderr exactly once.
+
+#include <node_api.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void finalize(napi_env env, void* data, void* hint) {
+    (void)env;
+    (void)data;
+    fprintf(stderr, "finalize: %s\n", (const char*)hint);
+    fflush(stderr);
+    free(hint);
+}
+
+// Copies the string argument at `index` into a malloc'd buffer that finalize() frees.
+static char* dup_name_arg(napi_env env, napi_value arg) {
+    size_t len = 0;
+    napi_get_value_string_utf8(env, arg, NULL, 0, &len);
+    char* name = (char*)malloc(len + 1);
+    napi_get_value_string_utf8(env, arg, name, len + 1, &len);
+    return name;
+}
+
+// wrap(obj, name)
+static napi_value wrap(napi_env env, napi_callback_info info) {
+    size_t argc = 2;
+    napi_value argv[2];
+    napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+    napi_wrap(env, argv[0], NULL, finalize, dup_name_arg(env, argv[1]), NULL);
+    return argv[0];
+}
+
+// addFinalizer(obj, name, wantRef): wantRef=true exercises the napi_ref-returning overload.
+static napi_value add_finalizer(napi_env env, napi_callback_info info) {
+    size_t argc = 3;
+    napi_value argv[3];
+    napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+    bool want_ref = false;
+    napi_get_value_bool(env, argv[2], &want_ref);
+    // Leaked on purpose: this test never releases the ref, matching addons
+    // that hold a weak ref for the object's whole lifetime.
+    napi_ref* ref = want_ref ? (napi_ref*)malloc(sizeof(napi_ref)) : NULL;
+    napi_add_finalizer(env, argv[0], NULL, finalize, dup_name_arg(env, argv[1]), ref);
+    return argv[0];
+}
+
+// createExternal(name) -> external value
+static napi_value create_external(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value argv[1];
+    napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+    napi_value external;
+    napi_create_external(env, NULL, finalize, dup_name_arg(env, argv[0]), &external);
+    return external;
+}
+
+static napi_value init(napi_env env, napi_value exports) {
+    napi_property_descriptor properties[] = {
+        { "wrap", 0, wrap, 0, 0, 0, napi_default, 0 },
+        { "addFinalizer", 0, add_finalizer, 0, 0, 0, napi_default, 0 },
+        { "createExternal", 0, create_external, 0, 0, 0, napi_default, 0 },
+    };
+    napi_define_properties(env, exports, sizeof(properties) / sizeof(properties[0]), properties);
+    return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/napi/napi-app/test_teardown_finalizers.c
+++ b/test/napi/napi-app/test_teardown_finalizers.c
@@ -1,11 +1,6 @@
-// napi_add_finalizer and napi_create_external finalizers must run at env
-// teardown for objects still alive at exit (only napi_wrap's used to), and a
-// finalizer already run by GC must not run again at teardown. A finalizer
-// registered *by* a teardown finalizer must be drained in the same teardown,
-// not left as a dangling entry in the env's finalizer list. Each finalizer
-// prints "finalize: <name>" to stdout exactly once. stdout, not stderr: on
-// the ASAN CI lane a spawned child's stderr arrives empty, and the existing
-// test_wrap_cleanup_order fixture writes to stdout for the same reason.
+// Every finalizer registration API must run its finalizer at env teardown,
+// exactly once, including finalizers registered by another teardown finalizer.
+// Each prints "finalize: <name>" to stdout (a child's stderr is unreliable on CI).
 
 #include <node_api.h>
 #include <stdio.h>
@@ -125,11 +120,9 @@ typedef struct {
     char* recycled_name;
 } RecycleContext;
 
-// Runs as a teardown finalizer: deletes the ref from addFinalizerSaveRef (which
-// frees its NapiRef and tombstones its entry in the env's list), then registers
-// a brand-new finalizer. The allocator commonly hands back the just-freed
-// address, so the new registration's (callback, hint, data) key collides with
-// the tombstone; the new finalizer must still run.
+// Runs as a teardown finalizer: deletes the ref from addFinalizerSaveRef, then
+// registers a new finalizer. The allocator commonly hands back the just-freed
+// NapiRef address; the new finalizer must still run.
 static void recycle_finalize(napi_env env, void* data, void* hint) {
     (void)hint;
     RecycleContext* ctx = (RecycleContext*)data;

--- a/test/napi/napi-teardown-finalizers.test.ts
+++ b/test/napi/napi-teardown-finalizers.test.ts
@@ -9,7 +9,9 @@ const addonSource = join(addonDir, "test_teardown_finalizers.c");
 const addonPath = join(addonDir, "build/Debug/test_teardown_finalizers.node");
 
 // Printed by the fixture after the gc_* finalizers have been observed, so the
-// test can prove they ran during Bun.gc(), not only at env teardown.
+// test can prove they ran during Bun.gc(), not only at env teardown. The
+// addon writes to stdout (not stderr) because on bun's ASAN CI lane a spawned
+// child's stderr arrives empty, so the barrier goes to stdout too.
 const GC_BARRIER = "--gc-barrier--";
 
 beforeAll(() => {
@@ -54,9 +56,14 @@ async function runFixture(code: string) {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // On Windows the C runtime writes \r\n, so split on either line ending.
-  const lines = stderr.split(/\r?\n/).filter(l => l.startsWith("finalize: ") || l === GC_BARRIER);
+  const lines = stdout.split(/\r?\n/).filter(l => l.startsWith("finalize: ") || l === GC_BARRIER);
   const names = (ls: string[]) => ls.map(l => l.slice("finalize: ".length)).sort();
-  return { stdout, stderr, exitCode, lines, names, finalized: names(lines.filter(l => l !== GC_BARRIER)) };
+  const finalized = names(lines.filter(l => l !== GC_BARRIER));
+  // If nothing fired, the child never got that far (crashed, require failed,
+  // or the finalizers regressed). Surface its raw output in the failure diff
+  // instead of an unreadable empty array.
+  const childOutputIfNothingFinalized = finalized.length === 0 ? { stdout, stderr } : null;
+  return { stdout, stderr, exitCode, lines, names, finalized, childOutputIfNothingFinalized };
 }
 
 it.skipIf(!canBuildNodeAddons())(
@@ -66,16 +73,18 @@ it.skipIf(!canBuildNodeAddons())(
     // any of them; env teardown is the finalizers' only chance to run. Node.js
     // runs all four. Bun used to drain only napi_wrap's finalizers at teardown
     // and silently drop the rest, leaking whatever native state they owned.
-    const { stdout, exitCode, finalized } = await runFixture(`
+    const { exitCode, finalized, childOutputIfNothingFinalized } = await runFixture(`
       const o1 = {}, o2 = {}, o3 = {};
       addon.wrap(o1, "wrap");
       addon.addFinalizer(o2, "add_finalizer", false);
       addon.addFinalizer(o3, "add_finalizer_ref", true);
       globalThis.__keep = [o1, o2, o3, addon.createExternal("external")];
     `);
-    expect(stdout).toBe("");
-    expect(finalized).toEqual(["add_finalizer", "add_finalizer_ref", "external", "wrap"]);
-    expect(exitCode).toBe(0);
+    expect({ exitCode, finalized, childOutputIfNothingFinalized }).toEqual({
+      exitCode: 0,
+      finalized: ["add_finalizer", "add_finalizer_ref", "external", "wrap"],
+      childOutputIfNothingFinalized: null,
+    });
   },
   30_000,
 );
@@ -90,7 +99,7 @@ it.skipIf(!canBuildNodeAddons())(
     // rooted until teardown. Asserting the two groups land on opposite sides of
     // the barrier, each exactly once, proves both that GC-time finalization
     // still works and that teardown does not re-run a finalizer GC already ran.
-    const { stdout, exitCode, lines, names } = await runFixture(`
+    const { exitCode, lines, names, childOutputIfNothingFinalized } = await runFixture(`
       function makeGarbage() {
         addon.addFinalizer({}, "gc_add_finalizer", false);
         addon.createExternal("gc_external");
@@ -101,22 +110,23 @@ it.skipIf(!canBuildNodeAddons())(
         Bun.gc(true);
         await new Promise(resolve => setImmediate(resolve));
       }
-      console.error(${JSON.stringify(GC_BARRIER)});
+      console.log(${JSON.stringify(GC_BARRIER)});
       const kept = {};
       addon.addFinalizer(kept, "exit_add_finalizer", false);
       globalThis.__keep = [kept, addon.createExternal("exit_external")];
     `);
-    expect(stdout).toBe("");
     const barrier = lines.indexOf(GC_BARRIER);
-    expect(barrier).not.toBe(-1);
     expect({
-      beforeGcBarrier: names(lines.slice(0, barrier)),
-      afterGcBarrier: names(lines.slice(barrier + 1)),
+      exitCode,
+      beforeGcBarrier: barrier === -1 ? "missing barrier" : names(lines.slice(0, barrier)),
+      afterGcBarrier: barrier === -1 ? "missing barrier" : names(lines.slice(barrier + 1)),
+      childOutputIfNothingFinalized,
     }).toEqual({
+      exitCode: 0,
       beforeGcBarrier: ["gc_add_finalizer", "gc_external"],
       afterGcBarrier: ["exit_add_finalizer", "exit_external"],
+      childOutputIfNothingFinalized: null,
     });
-    expect(exitCode).toBe(0);
   },
   30_000,
 );
@@ -131,14 +141,16 @@ it.skipIf(!canBuildNodeAddons())(
     // a bulk free of the list never ran them, and freeing them left the
     // still-live NapiExternal / NapiRef holding a dangling pointer to its list
     // entry (a use-after-free on the next sweep).
-    const { stdout, exitCode, finalized } = await runFixture(`
+    const { exitCode, finalized, childOutputIfNothingFinalized } = await runFixture(`
       const o = {};
       addon.wrapNesting(o, "outer", "nested_external", "nested_add_finalizer");
       globalThis.__keep = [o];
     `);
-    expect(stdout).toBe("");
-    expect(finalized).toEqual(["nested_add_finalizer", "nested_external", "outer"]);
-    expect(exitCode).toBe(0);
+    expect({ exitCode, finalized, childOutputIfNothingFinalized }).toEqual({
+      exitCode: 0,
+      finalized: ["nested_add_finalizer", "nested_external", "outer"],
+      childOutputIfNothingFinalized: null,
+    });
   },
   30_000,
 );

--- a/test/napi/napi-teardown-finalizers.test.ts
+++ b/test/napi/napi-teardown-finalizers.test.ts
@@ -50,7 +50,12 @@ beforeAll(() => {
 async function runFixture(code: string) {
   await using proc = spawn({
     cmd: [bunExe(), "-e", `const addon = require(${JSON.stringify(addonPath)});\n${code}`],
-    env: bunEnv,
+    // Strip JSC exception-scope validation if a CI agent has it set (like the
+    // JSC_useJIT strip in harness.ts). Every napi_* call opens a ThrowScope that
+    // simulates a throw on return into the addon's C frame, and Node-API has no
+    // place for an exception check between two napi calls, so any addon callback
+    // making two of them aborts under the validator regardless of this fix.
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: undefined, BUN_JSC_dumpSimulatedThrows: undefined },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/napi/napi-teardown-finalizers.test.ts
+++ b/test/napi/napi-teardown-finalizers.test.ts
@@ -1,25 +1,36 @@
 import { spawn, spawnSync } from "bun";
 import { beforeAll, expect, it } from "bun:test";
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { bunEnv, bunExe, canBuildNodeAddons } from "harness";
 import { join } from "path";
 
-const addonPath = join(__dirname, "napi-app/build/Debug/test_teardown_finalizers.node");
+const addonDir = join(__dirname, "napi-app");
+const addonSource = join(addonDir, "test_teardown_finalizers.c");
+const addonPath = join(addonDir, "build/Debug/test_teardown_finalizers.node");
+
+// Printed by the fixture after the gc_* finalizers have been observed, so the
+// test can prove they ran during Bun.gc(), not only at env teardown.
+const GC_BARRIER = "--gc-barrier--";
 
 beforeAll(() => {
   if (!canBuildNodeAddons()) return;
   // Build the native addons in napi-app, but only if the one this test needs
-  // is missing (napi.test.ts or a previous run usually has built it already).
-  // The addon doesn't link against bun, so an existing binary stays valid
-  // across bun builds; skipping the install avoids re-running the node-gyp
-  // rebuild, which is slow and occasionally flaky under resource pressure.
+  // is missing or older than its inputs (napi.test.ts or a previous run
+  // usually has built it already). The addon doesn't link against bun, so an
+  // existing binary stays valid across bun builds; skipping the install avoids
+  // re-running the node-gyp rebuild, which is slow and occasionally flaky
+  // under resource pressure.
   if (existsSync(addonPath)) {
-    return;
+    const built = statSync(addonPath).mtimeMs;
+    const inputs = [addonSource, join(addonDir, "binding.gyp")];
+    if (inputs.every(f => statSync(f).mtimeMs <= built)) {
+      return;
+    }
   }
   for (let attempt = 0; ; attempt++) {
     const install = spawnSync({
       cmd: [bunExe(), "install", "--verbose"],
-      cwd: join(__dirname, "napi-app"),
+      cwd: addonDir,
       stderr: "inherit",
       env: bunEnv,
       stdout: "inherit",
@@ -42,12 +53,10 @@ async function runFixture(code: string) {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const finalized = stderr
-    .split("\n")
-    .filter(l => l.startsWith("finalize: "))
-    .map(l => l.slice("finalize: ".length))
-    .sort();
-  return { stdout, stderr, exitCode, finalized };
+  // On Windows the C runtime writes \r\n, so split on either line ending.
+  const lines = stderr.split(/\r?\n/).filter(l => l.startsWith("finalize: ") || l === GC_BARRIER);
+  const names = (ls: string[]) => ls.map(l => l.slice("finalize: ".length)).sort();
+  return { stdout, stderr, exitCode, lines, names, finalized: names(lines.filter(l => l !== GC_BARRIER)) };
 }
 
 it.skipIf(!canBuildNodeAddons())(
@@ -74,24 +83,61 @@ it.skipIf(!canBuildNodeAddons())(
 it.skipIf(!canBuildNodeAddons())(
   "a finalizer already run by GC does not run again at env teardown",
   async () => {
-    // "gc_*" objects become garbage and are finalized by Bun.gc(); "exit_*"
-    // objects stay rooted until teardown. Each name must appear exactly once:
-    // a duplicate would be a double-invocation (double free in a real addon),
-    // a missing "gc_*" would mean GC-time finalization regressed.
-    const { stdout, exitCode, finalized } = await runFixture(`
+    // The gc_* objects become garbage; the fixture forces GC until their
+    // finalizers have observably run (the addon defers them to the event loop,
+    // so it polls a native counter rather than assuming Bun.gc is synchronous),
+    // then prints the barrier and registers the exit_* objects, which stay
+    // rooted until teardown. Asserting the two groups land on opposite sides of
+    // the barrier, each exactly once, proves both that GC-time finalization
+    // still works and that teardown does not re-run a finalizer GC already ran.
+    const { stdout, exitCode, lines, names } = await runFixture(`
       function makeGarbage() {
         addon.addFinalizer({}, "gc_add_finalizer", false);
         addon.createExternal("gc_external");
       }
       makeGarbage();
-      Bun.gc(true);
-      Bun.gc(true);
+      for (let i = 0; addon.finalizeCount() < 2; i++) {
+        if (i > 500) throw new Error("gc-time finalizers never ran; count=" + addon.finalizeCount());
+        Bun.gc(true);
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      console.error(${JSON.stringify(GC_BARRIER)});
       const kept = {};
       addon.addFinalizer(kept, "exit_add_finalizer", false);
       globalThis.__keep = [kept, addon.createExternal("exit_external")];
     `);
     expect(stdout).toBe("");
-    expect(finalized).toEqual(["exit_add_finalizer", "exit_external", "gc_add_finalizer", "gc_external"]);
+    const barrier = lines.indexOf(GC_BARRIER);
+    expect(barrier).not.toBe(-1);
+    expect({
+      beforeGcBarrier: names(lines.slice(0, barrier)),
+      afterGcBarrier: names(lines.slice(barrier + 1)),
+    }).toEqual({
+      beforeGcBarrier: ["gc_add_finalizer", "gc_external"],
+      afterGcBarrier: ["exit_add_finalizer", "exit_external"],
+    });
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+it.skipIf(!canBuildNodeAddons())(
+  "finalizers registered by a teardown finalizer also run in the same teardown",
+  async () => {
+    // nesting_finalize runs during env teardown and registers two more
+    // finalizers (napi_create_external + napi_add_finalizer) while the env is
+    // already draining its finalizer list. Bun accepts those calls there, so
+    // it must drain the entries they append: a single reverse pass followed by
+    // a bulk free of the list never ran them, and freeing them left the
+    // still-live NapiExternal / NapiRef holding a dangling pointer to its list
+    // entry (a use-after-free on the next sweep).
+    const { stdout, exitCode, finalized } = await runFixture(`
+      const o = {};
+      addon.wrapNesting(o, "outer", "nested_external", "nested_add_finalizer");
+      globalThis.__keep = [o];
+    `);
+    expect(stdout).toBe("");
+    expect(finalized).toEqual(["nested_add_finalizer", "nested_external", "outer"]);
     expect(exitCode).toBe(0);
   },
   30_000,

--- a/test/napi/napi-teardown-finalizers.test.ts
+++ b/test/napi/napi-teardown-finalizers.test.ts
@@ -1,0 +1,98 @@
+import { spawn, spawnSync } from "bun";
+import { beforeAll, expect, it } from "bun:test";
+import { existsSync } from "fs";
+import { bunEnv, bunExe, canBuildNodeAddons } from "harness";
+import { join } from "path";
+
+const addonPath = join(__dirname, "napi-app/build/Debug/test_teardown_finalizers.node");
+
+beforeAll(() => {
+  if (!canBuildNodeAddons()) return;
+  // Build the native addons in napi-app, but only if the one this test needs
+  // is missing (napi.test.ts or a previous run usually has built it already).
+  // The addon doesn't link against bun, so an existing binary stays valid
+  // across bun builds; skipping the install avoids re-running the node-gyp
+  // rebuild, which is slow and occasionally flaky under resource pressure.
+  if (existsSync(addonPath)) {
+    return;
+  }
+  for (let attempt = 0; ; attempt++) {
+    const install = spawnSync({
+      cmd: [bunExe(), "install", "--verbose"],
+      cwd: join(__dirname, "napi-app"),
+      stderr: "inherit",
+      env: bunEnv,
+      stdout: "inherit",
+      stdin: "inherit",
+    });
+    if (install.success && existsSync(addonPath)) {
+      return;
+    }
+    if (attempt >= 1) {
+      throw new Error("building napi-app addons failed");
+    }
+  }
+}, 300_000);
+
+async function runFixture(code: string) {
+  await using proc = spawn({
+    cmd: [bunExe(), "-e", `const addon = require(${JSON.stringify(addonPath)});\n${code}`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const finalized = stderr
+    .split("\n")
+    .filter(l => l.startsWith("finalize: "))
+    .map(l => l.slice("finalize: ".length))
+    .sort();
+  return { stdout, stderr, exitCode, finalized };
+}
+
+it.skipIf(!canBuildNodeAddons())(
+  "finalizers from every registration API run at env teardown",
+  async () => {
+    // Every object is kept strongly reachable until exit so GC never collects
+    // any of them; env teardown is the finalizers' only chance to run. Node.js
+    // runs all four. Bun used to drain only napi_wrap's finalizers at teardown
+    // and silently drop the rest, leaking whatever native state they owned.
+    const { stdout, exitCode, finalized } = await runFixture(`
+      const o1 = {}, o2 = {}, o3 = {};
+      addon.wrap(o1, "wrap");
+      addon.addFinalizer(o2, "add_finalizer", false);
+      addon.addFinalizer(o3, "add_finalizer_ref", true);
+      globalThis.__keep = [o1, o2, o3, addon.createExternal("external")];
+    `);
+    expect(stdout).toBe("");
+    expect(finalized).toEqual(["add_finalizer", "add_finalizer_ref", "external", "wrap"]);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+it.skipIf(!canBuildNodeAddons())(
+  "a finalizer already run by GC does not run again at env teardown",
+  async () => {
+    // "gc_*" objects become garbage and are finalized by Bun.gc(); "exit_*"
+    // objects stay rooted until teardown. Each name must appear exactly once:
+    // a duplicate would be a double-invocation (double free in a real addon),
+    // a missing "gc_*" would mean GC-time finalization regressed.
+    const { stdout, exitCode, finalized } = await runFixture(`
+      function makeGarbage() {
+        addon.addFinalizer({}, "gc_add_finalizer", false);
+        addon.createExternal("gc_external");
+      }
+      makeGarbage();
+      Bun.gc(true);
+      Bun.gc(true);
+      const kept = {};
+      addon.addFinalizer(kept, "exit_add_finalizer", false);
+      globalThis.__keep = [kept, addon.createExternal("exit_external")];
+    `);
+    expect(stdout).toBe("");
+    expect(finalized).toEqual(["exit_add_finalizer", "exit_external", "gc_add_finalizer", "gc_external"]);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);

--- a/test/napi/napi-teardown-finalizers.test.ts
+++ b/test/napi/napi-teardown-finalizers.test.ts
@@ -8,20 +8,16 @@ const addonDir = join(__dirname, "napi-app");
 const addonSource = join(addonDir, "test_teardown_finalizers.c");
 const addonPath = join(addonDir, "build/Debug/test_teardown_finalizers.node");
 
-// Printed by the fixture after the gc_* finalizers have been observed, so the
-// test can prove they ran during Bun.gc(), not only at env teardown. The
-// addon writes to stdout (not stderr) because on bun's ASAN CI lane a spawned
-// child's stderr arrives empty, so the barrier goes to stdout too.
+// Printed by the fixture after the gc_* finalizers are observed so the test can
+// prove they ran during Bun.gc(), not only at env teardown. The addon writes to
+// stdout (a spawned child's stderr is unreliable on some CI lanes), so this does too.
 const GC_BARRIER = "--gc-barrier--";
 
 beforeAll(() => {
   if (!canBuildNodeAddons()) return;
-  // Build the native addons in napi-app, but only if the one this test needs
-  // is missing or older than its inputs (napi.test.ts or a previous run
-  // usually has built it already). The addon doesn't link against bun, so an
-  // existing binary stays valid across bun builds; skipping the install avoids
-  // re-running the node-gyp rebuild, which is slow and occasionally flaky
-  // under resource pressure.
+  // Build the napi-app addons only if the one this test needs is missing or older
+  // than its inputs. It doesn't link against bun, so an existing binary stays valid
+  // across bun builds, and skipping the slow node-gyp rebuild avoids flakes.
   if (existsSync(addonPath)) {
     const built = statSync(addonPath).mtimeMs;
     const inputs = [addonSource, join(addonDir, "binding.gyp")];
@@ -51,10 +47,8 @@ async function runFixture(code: string) {
   await using proc = spawn({
     cmd: [bunExe(), "-e", `const addon = require(${JSON.stringify(addonPath)});\n${code}`],
     // Strip JSC exception-scope validation if a CI agent has it set (like the
-    // JSC_useJIT strip in harness.ts). Every napi_* call opens a ThrowScope that
-    // simulates a throw on return into the addon's C frame, and Node-API has no
-    // place for an exception check between two napi calls, so any addon callback
-    // making two of them aborts under the validator regardless of this fix.
+    // JSC_useJIT strip in harness.ts): Node-API has no place for an exception check
+    // between two napi calls, so any addon callback making two aborts under it.
     env: { ...bunEnv, BUN_JSC_validateExceptionChecks: undefined, BUN_JSC_dumpSimulatedThrows: undefined },
     stdout: "pipe",
     stderr: "pipe",
@@ -64,47 +58,34 @@ async function runFixture(code: string) {
   const lines = stdout.split(/\r?\n/).filter(l => l.startsWith("finalize: ") || l === GC_BARRIER);
   const names = (ls: string[]) => ls.map(l => l.slice("finalize: ".length)).sort();
   const finalized = names(lines.filter(l => l !== GC_BARRIER));
-  // If nothing fired, the child never got that far (crashed, require failed,
-  // or the finalizers regressed). Surface its raw output in the failure diff
-  // instead of an unreadable empty array.
+  // If nothing fired, the child never got that far (crashed, require failed, or
+  // the finalizers regressed); surface its raw output in the failure diff.
   const childOutputIfNothingFinalized = finalized.length === 0 ? { stdout, stderr } : null;
   return { stdout, stderr, exitCode, lines, names, finalized, childOutputIfNothingFinalized };
 }
 
-it.skipIf(!canBuildNodeAddons())(
-  "finalizers from every registration API run at env teardown",
-  async () => {
-    // Every object is kept strongly reachable until exit so GC never collects
-    // any of them; env teardown is the finalizers' only chance to run. Node.js
-    // runs all four. Bun used to drain only napi_wrap's finalizers at teardown
-    // and silently drop the rest, leaking whatever native state they owned.
-    const { exitCode, finalized, childOutputIfNothingFinalized } = await runFixture(`
+it.skipIf(!canBuildNodeAddons())("finalizers from every registration API run at env teardown", async () => {
+  // Every object is kept strongly reachable until exit so GC never collects any
+  // of them: env teardown is the finalizers' only chance to run. Node runs all four.
+  const { exitCode, finalized, childOutputIfNothingFinalized } = await runFixture(`
       const o1 = {}, o2 = {}, o3 = {};
       addon.wrap(o1, "wrap");
       addon.addFinalizer(o2, "add_finalizer", false);
       addon.addFinalizer(o3, "add_finalizer_ref", true);
       globalThis.__keep = [o1, o2, o3, addon.createExternal("external")];
     `);
-    expect({ exitCode, finalized, childOutputIfNothingFinalized }).toEqual({
-      exitCode: 0,
-      finalized: ["add_finalizer", "add_finalizer_ref", "external", "wrap"],
-      childOutputIfNothingFinalized: null,
-    });
-  },
-  30_000,
-);
+  expect({ exitCode, finalized, childOutputIfNothingFinalized }).toEqual({
+    exitCode: 0,
+    finalized: ["add_finalizer", "add_finalizer_ref", "external", "wrap"],
+    childOutputIfNothingFinalized: null,
+  });
+});
 
-it.skipIf(!canBuildNodeAddons())(
-  "a finalizer already run by GC does not run again at env teardown",
-  async () => {
-    // The gc_* objects become garbage; the fixture forces GC until their
-    // finalizers have observably run (the addon defers them to the event loop,
-    // so it polls a native counter rather than assuming Bun.gc is synchronous),
-    // then prints the barrier and registers the exit_* objects, which stay
-    // rooted until teardown. Asserting the two groups land on opposite sides of
-    // the barrier, each exactly once, proves both that GC-time finalization
-    // still works and that teardown does not re-run a finalizer GC already ran.
-    const { exitCode, lines, names, childOutputIfNothingFinalized } = await runFixture(`
+it.skipIf(!canBuildNodeAddons())("a finalizer already run by GC does not run again at env teardown", async () => {
+  // The fixture forces GC until the gc_* finalizers have observably run, prints
+  // the barrier, then roots the exit_* objects until teardown. Each group landing
+  // on its own side of the barrier exactly once proves no finalizer runs twice.
+  const { exitCode, lines, names, childOutputIfNothingFinalized } = await runFixture(`
       function makeGarbage() {
         addon.addFinalizer({}, "gc_add_finalizer", false);
         addon.createExternal("gc_external");
@@ -120,32 +101,26 @@ it.skipIf(!canBuildNodeAddons())(
       addon.addFinalizer(kept, "exit_add_finalizer", false);
       globalThis.__keep = [kept, addon.createExternal("exit_external")];
     `);
-    const barrier = lines.indexOf(GC_BARRIER);
-    expect({
-      exitCode,
-      beforeGcBarrier: barrier === -1 ? "missing barrier" : names(lines.slice(0, barrier)),
-      afterGcBarrier: barrier === -1 ? "missing barrier" : names(lines.slice(barrier + 1)),
-      childOutputIfNothingFinalized,
-    }).toEqual({
-      exitCode: 0,
-      beforeGcBarrier: ["gc_add_finalizer", "gc_external"],
-      afterGcBarrier: ["exit_add_finalizer", "exit_external"],
-      childOutputIfNothingFinalized: null,
-    });
-  },
-  30_000,
-);
+  const barrier = lines.indexOf(GC_BARRIER);
+  expect({
+    exitCode,
+    beforeGcBarrier: barrier === -1 ? "missing barrier" : names(lines.slice(0, barrier)),
+    afterGcBarrier: barrier === -1 ? "missing barrier" : names(lines.slice(barrier + 1)),
+    childOutputIfNothingFinalized,
+  }).toEqual({
+    exitCode: 0,
+    beforeGcBarrier: ["gc_add_finalizer", "gc_external"],
+    afterGcBarrier: ["exit_add_finalizer", "exit_external"],
+    childOutputIfNothingFinalized: null,
+  });
+});
 
 it.skipIf(!canBuildNodeAddons())(
   "finalizers registered by a teardown finalizer also run in the same teardown",
   async () => {
-    // nesting_finalize runs during env teardown and registers two more
-    // finalizers (napi_create_external + napi_add_finalizer) while the env is
-    // already draining its finalizer list. Bun accepts those calls there, so
-    // it must drain the entries they append: a single reverse pass followed by
-    // a bulk free of the list never ran them, and freeing them left the
-    // still-live NapiExternal / NapiRef holding a dangling pointer to its list
-    // entry (a use-after-free on the next sweep).
+    // nesting_finalize registers two more finalizers (napi_create_external and
+    // napi_add_finalizer) while the env is already draining its finalizer list.
+    // Both must still run before the list is freed out from under their owners.
     const { exitCode, finalized, childOutputIfNothingFinalized } = await runFixture(`
       const o = {};
       addon.wrapNesting(o, "outer", "nested_external", "nested_add_finalizer");
@@ -157,30 +132,21 @@ it.skipIf(!canBuildNodeAddons())(
       childOutputIfNothingFinalized: null,
     });
   },
-  30_000,
 );
 
-it.skipIf(!canBuildNodeAddons())(
-  "a finalizer registered after deleting a ref during teardown still runs",
-  async () => {
-    // recycle_finalize runs at teardown, napi_delete_references the "saved" ref
-    // (freeing its NapiRef, whose entry in the env's finalizer list is only
-    // tombstoned while that list is being drained), then registers a new
-    // finalizer. The allocator commonly returns the just-freed NapiRef address,
-    // so the new entry's identity collides with the tombstone; it must be
-    // revived, or "recycled" never runs and the new ref is left pointing at a
-    // freed list node. Deleting the ref also cancels "saved", which must not run.
-    const { exitCode, finalized, childOutputIfNothingFinalized } = await runFixture(`
+it.skipIf(!canBuildNodeAddons())("a finalizer registered after deleting a ref during teardown still runs", async () => {
+  // recycle_finalize deletes the "saved" ref during teardown, then registers a
+  // new finalizer; the allocator commonly hands back the just-freed NapiRef
+  // address. "recycled" must still run, and the deleted "saved" must not.
+  const { exitCode, finalized, childOutputIfNothingFinalized } = await runFixture(`
       const o1 = {}, o2 = {};
       addon.addFinalizerSaveRef(o2, "saved");
       addon.wrapRecycling(o1, "outer", "recycled");
       globalThis.__keep = [o1, o2];
     `);
-    expect({ exitCode, finalized, childOutputIfNothingFinalized }).toEqual({
-      exitCode: 0,
-      finalized: ["outer", "recycled"],
-      childOutputIfNothingFinalized: null,
-    });
-  },
-  30_000,
-);
+  expect({ exitCode, finalized, childOutputIfNothingFinalized }).toEqual({
+    exitCode: 0,
+    finalized: ["outer", "recycled"],
+    childOutputIfNothingFinalized: null,
+  });
+});

--- a/test/napi/napi-teardown-finalizers.test.ts
+++ b/test/napi/napi-teardown-finalizers.test.ts
@@ -159,3 +159,28 @@ it.skipIf(!canBuildNodeAddons())(
   },
   30_000,
 );
+
+it.skipIf(!canBuildNodeAddons())(
+  "a finalizer registered after deleting a ref during teardown still runs",
+  async () => {
+    // recycle_finalize runs at teardown, napi_delete_references the "saved" ref
+    // (freeing its NapiRef, whose entry in the env's finalizer list is only
+    // tombstoned while that list is being drained), then registers a new
+    // finalizer. The allocator commonly returns the just-freed NapiRef address,
+    // so the new entry's identity collides with the tombstone; it must be
+    // revived, or "recycled" never runs and the new ref is left pointing at a
+    // freed list node. Deleting the ref also cancels "saved", which must not run.
+    const { exitCode, finalized, childOutputIfNothingFinalized } = await runFixture(`
+      const o1 = {}, o2 = {};
+      addon.addFinalizerSaveRef(o2, "saved");
+      addon.wrapRecycling(o1, "outer", "recycled");
+      globalThis.__keep = [o1, o2];
+    `);
+    expect({ exitCode, finalized, childOutputIfNothingFinalized }).toEqual({
+      exitCode: 0,
+      finalized: ["outer", "recycled"],
+      childOutputIfNothingFinalized: null,
+    });
+  },
+  30_000,
+);


### PR DESCRIPTION
### Problem

Node-API guarantees that every registered finalizer runs at environment teardown, even for objects that are still strongly reachable at exit (the `RefTracker::FinalizeAll` pass in `napi_env__::DeleteMe()`). Addons rely on this to flush and close native resources held by externals: DB handles, mmap'd files, thread pools.

Bun only honored that contract for `napi_wrap`. Its finalizer is registered on the `NapiEnv` teardown list (`m_finalizers`) that `NapiEnv::cleanup()` drains. `napi_add_finalizer` and `napi_create_external` registered their finalizers only as GC callbacks (`vm.heap.addFinalizer` and the `NapiExternal` destructor respectively), so for anything still alive at exit they never ran.

At process exit that means buffers are never flushed. In a long-lived process that creates and destroys envs (workers), it is an unbounded native leak.

### Reproduction

An addon that registers all three kinds of finalizer (each prints `finalize: <name>` to stderr), with every JS object kept strongly reachable until exit so env teardown is their only chance to run:

```c
napi_wrap(env, o1, NULL, fin, "wrap", NULL);
napi_add_finalizer(env, o2, NULL, fin, "add_finalizer", NULL);
napi_add_finalizer(env, o3, NULL, fin, "add_finalizer_ref", &ref);
napi_create_external(env, NULL, fin, "external", &ext);
```

Node v26.3.0 prints all four. Bun prints only:

```
finalize: wrap
```

### Fix

- `napi_add_finalizer` now always creates a `NapiRef` and registers the same `wrap_cleanup` teardown entry `napi_wrap` uses, for both the `napi_ref`-returning and `result == NULL` variants. The GC-time deferral semantics are unchanged: `NapiRef::callFinalizer` applies the same `mustDeferFinalizers() && inGC()` rule the old `doFinalizer` lambda did.
- `napi_create_external` registers an `external_cleanup` entry on the same list. `NapiExternal` gets an `m_boundCleanup` field; its destructor deactivates the entry when GC collects the external first, and `external_cleanup` clears `m_finalizer` before calling it, so a finalizer never runs twice on either ordering.

Existing behavior that protected against double-invocation is preserved: `callFinalizer()` copies and clears the finalizer before calling it, and `BoundFinalizer::deactivate` removes the entry (or marks it inactive if teardown is mid-iteration).

Review also found a second, narrower instance of the same class in the drain loop itself. A dying owner's entry is only tombstoned during the drain (erasing the current node would invalidate the iterator), and `NapiRef` is TZone allocated, so a teardown finalizer that deletes a ref and registers a new one can get the freed address back; the new entry's `(callback, hint, data)` key then aliases the tombstone, `ListHashSet::add` deduplicates to the dead node, and `clear()` frees it while the new ref still points at it. `addFinalizer` now reactivates the entry it returns, which is a no-op for genuinely new nodes and is the only way a key can alias a dead one (two live owners can never collide because the key includes the owner pointer).

### Intentionally excluded sibling

`napi_create_external_arraybuffer` / `napi_create_external_buffer` have the same gap (Node runs their finalizers at teardown, Bun does not). Their finalizer is the `ArrayBuffer::Contents` deleter, and invoking it at env teardown while the `JSArrayBuffer` is still a reachable cell would free memory that later env cleanup hooks can still read through the buffer. Doing it safely requires detaching the buffer first, which needs per-env tracking of live external buffers. That is a larger, separate change.

### Verification

`test/napi/napi-teardown-finalizers.test.ts` (new addon `test_teardown_finalizers.c`):

1. All four registration kinds fire at teardown when every object is rooted until exit.
2. A finalizer already run by GC does not run again at teardown, and teardown-time ones still do: each name appears exactly once.

Both tests fail on the unfixed build (only `wrap` fires) and pass with the fix. With the fix, all 7 `test_wrap_lifetime_* / test_ref_deleted_*` sub-tests produce output identical to node v26.3.0, and the `napi_create_external_buffer` / `napi_create_external_arraybuffer` suites still pass.

### Rebase conflicts

Rebased onto main after it landed the #30286 fix, which added `clearExceptionsBetweenFinalizers()` after each finalizer in the same `cleanup()` loop this PR rewrites into a drain-until-idle. Resolved by calling `clearExceptionsBetweenFinalizers()` after each callback inside the new drain loop, preserving both the #30286 semantics (each finalizer starts from a clean exception state) and this PR's (entries appended mid-drain are reached before `clear()` frees them). Both of main's #30286 tests pass with the merged loop, as do this PR's four tests and the existing LIFO-order test.

The other conflict was `binding.gyp`: both sides appended a target at the end of the list; kept both.
