### PR TITLE
webcore: fix Content-Type lost when Request/Response body is read before headers

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3806,10 +3806,10 @@ where
         if let Some(mut headers_) = response.swap_init_headers() {
             has_content_disposition = headers_.fast_has(jsc::HTTPHeaderName::ContentDisposition);
             has_content_range = headers_.fast_has(jsc::HTTPHeaderName::ContentRange);
-            // For .slice()-driven ranges, only promote to 206 if the user
-            // also set Content-Range (preserves the old contract). For an
-            // incoming Range: header (sendfile.total > 0) we always 206.
-            needs_content_range = needs_content_range && (sendfile.total > 0 || has_content_range);
+            // A caller who passed headers without a Content-Range is managing
+            // the range themselves; an incoming Range: (sendfile.total > 0) always 206s.
+            needs_content_range = needs_content_range
+                && (sendfile.total > 0 || has_content_range || !response.headers_from_init());
             if needs_content_range {
                 status = 206;
             }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1666,7 +1666,26 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     /// (FFI signature is `*mut`). Returning `NonNull` instead of `&FetchHeaders`
     /// avoids deriving `&mut T` from `&T` at the call sites (UB).
     fn get_fetch_headers(&self) -> Option<NonNull<FetchHeaders>>;
+    /// Create the lazily-built headers now, copying the body Blob's Content-Type in.
+    fn materialize_headers(&self, global_object: &JSGlobalObject) -> JsResult<()>;
     fn get_form_data_encoding(&self) -> JsResult<Option<Box<bun_core::form_data::AsyncFormData>>>;
+
+    /// Called by every body consumer before it takes the Blob: the Blob is the
+    /// only place a body-derived Content-Type (a multipart boundary) lives.
+    fn preserve_body_content_type(&self, global_object: &JSGlobalObject) -> JsResult<()> {
+        if self.get_fetch_headers().is_some() {
+            return Ok(());
+        }
+        // reshaped for borrowck
+        let blob_has_content_type = matches!(
+            self.get_body_value(),
+            Value::Blob(blob) if !blob.content_type_slice().is_empty()
+        );
+        if blob_has_content_type {
+            self.materialize_headers(global_object)?;
+        }
+        Ok(())
+    }
 
     // ────────────────────────────────────────────────────────────────────
     // Twin methods (identical for Request/Response). These were previously
@@ -1804,6 +1823,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             }
         }
 
+        self.preserve_body_content_type(global_object)?;
         let value = self.get_body_value();
         let mut blob = value.use_as_any_blob_allow_non_utf8_string();
         let result = JSPromise::wrap(global_object, |g| blob.to_string(g, Lifetime::Transfer));
@@ -1822,6 +1842,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 return Ok(readable.value);
             }
         }
+        self.preserve_body_content_type(global_this)?;
         let stream = self.get_body_value().to_readable_stream(global_this)?;
         // The wrapper's traced `m_stream` slot owns the stream from here;
         // release the `Strong` `to_readable_stream` parked in `Locked.readable`.
@@ -1852,6 +1873,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         // Step 2: null body → a new empty closed ReadableStream.
         // Steps 3-6: decode directly from the body's backing bytes.
+        self.preserve_body_content_type(global_this)?;
         let stream = self.get_body_value().to_text_readable_stream(global_this)?;
         if stream.is_null() {
             return ReadableStream::empty(global_this);
@@ -1945,6 +1967,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             }
         }
 
+        self.preserve_body_content_type(global_object)?;
         let value = self.get_body_value();
         let mut blob = value.use_as_any_blob_allow_non_utf8_string();
         let result = JSPromise::wrap(global_object, |g| blob.to_json(g, Lifetime::Share));
@@ -1999,6 +2022,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         }
 
         // toArrayBuffer in AnyBlob checks for non-UTF8 strings
+        self.preserve_body_content_type(global_object)?;
         let value = self.get_body_value();
         let mut blob: AnyBlob = value.use_as_any_blob_allow_non_utf8_string();
         let result = JSPromise::wrap(global_object, |g| {
@@ -2050,6 +2074,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         }
 
         // toArrayBuffer in AnyBlob checks for non-UTF8 strings
+        self.preserve_body_content_type(global_object)?;
         let value = self.get_body_value();
         let mut blob: AnyBlob = value.use_as_any_blob_allow_non_utf8_string();
         let result = JSPromise::wrap(global_object, |g| {
@@ -2107,6 +2132,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 .reject());
         };
 
+        self.preserve_body_content_type(global_object)?;
         let value = self.get_body_value();
         if let Value::Locked(_locked) = value {
             let owned_readable = self.get_body_readable_stream(global_object);
@@ -2204,6 +2230,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             }
         }
 
+        self.preserve_body_content_type(global_object)?;
         let value = self.get_body_value();
         let blob_ptr = Blob::new(value.use_());
         // SAFETY: `Blob::new` returns a freshly heap-allocated, ref-counted Blob.

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -188,6 +188,11 @@ impl BodyMixin for Request {
         })
     }
     #[inline]
+    fn materialize_headers(&self, global_object: &JSGlobalObject) -> JsResult<()> {
+        self.ensure_fetch_headers(global_object)?;
+        Ok(())
+    }
+    #[inline]
     fn get_form_data_encoding(
         &self,
     ) -> bun_jsc::JsResult<Option<Box<bun_core::form_data::AsyncFormData>>> {
@@ -1491,19 +1496,19 @@ impl Request {
 
         req.url.set(href);
 
-        if matches!(req.body_value(), BodyValue::Blob(_)) && req.headers.get().is_some() {
-            if let BodyValue::Blob(blob) = req.body_value() {
-                let ct: &[u8] = blob.content_type_slice();
-                if !ct.is_empty()
-                    && !req
-                        .headers_mut()
-                        .as_mut()
-                        .unwrap()
-                        .fast_has(HTTPHeaderName::ContentType)
-                {
-                    // Reshaped for borrowck — split borrow of req.body and req.headers
-                    let ct_ptr: *const [u8] = ct;
-                    match req.headers_mut().as_mut().unwrap().put(
+        if let BodyValue::Blob(blob) = req.body_value() {
+            let ct: &[u8] = blob.content_type_slice();
+            if !ct.is_empty() {
+                // Reshaped for borrowck — split borrow of req.body and req.headers
+                let ct_ptr: *const [u8] = ct;
+                // Per Fetch the header list is fixed at construction, so it must
+                // not depend on whether the body or `.headers` is read first.
+                if req.headers.get().is_none() {
+                    req.headers.set(Some(HeadersRef::create_empty()));
+                }
+                let headers = req.headers_mut().as_mut().unwrap();
+                if !headers.fast_has(HTTPHeaderName::ContentType) {
+                    match headers.put(
                         HTTPHeaderName::ContentType,
                         // SAFETY: ct_ptr borrows req.body which is not mutated here.
                         &BunString::ascii(unsafe { &*ct_ptr }),

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -302,6 +302,11 @@ impl BodyMixin for Response {
         })
     }
     #[inline]
+    fn materialize_headers(&self, global_object: &JSGlobalObject) -> JsResult<()> {
+        self.get_or_create_headers(global_object)?;
+        Ok(())
+    }
+    #[inline]
     fn get_form_data_encoding(
         &self,
     ) -> bun_jsc::JsResult<Option<Box<bun_core::form_data::AsyncFormData>>> {
@@ -424,6 +429,10 @@ impl Response {
     #[inline]
     pub(crate) fn swap_init_headers(&self) -> Option<HeadersRef> {
         self.init.with_mut(|init| init.headers.take())
+    }
+
+    pub fn headers_from_init(&self) -> bool {
+        self.init.get().headers_from_init
     }
 
     #[inline]
@@ -1378,6 +1387,9 @@ impl Response {
 // the remaining `status_text` is still dropped at scope end via field drop glue.
 pub struct Init {
     pub(crate) headers: Option<HeadersRef>,
+    /// Set from the caller's `ResponseInit`. `headers` alone can't tell: the
+    /// lazy `.headers` getter and body consumers also populate it.
+    pub(crate) headers_from_init: bool,
     pub(crate) status_code: u16,
     pub(crate) status_text: OwnedString,
     pub method: Method,
@@ -1387,6 +1399,7 @@ impl Default for Init {
     fn default() -> Self {
         Self {
             headers: None,
+            headers_from_init: false,
             status_code: 0,
             status_text: OwnedString::new(BunString::empty()),
             method: Method::GET,
@@ -1405,6 +1418,7 @@ impl Init {
         };
         Ok(Init {
             headers,
+            headers_from_init: self.headers_from_init,
             status_code: self.status_code,
             status_text: self.status_text.clone(),
             method: self.method,
@@ -1446,6 +1460,7 @@ impl Init {
                 }
 
                 result.method = req.method;
+                result.headers_from_init = result.headers.is_some();
                 return Ok(Some(result));
             }
 
@@ -1453,7 +1468,10 @@ impl Init {
                 // SAFETY: `as_direct` returned a live `*mut Response` owned by the
                 // JS wrapper cell; rooted by `response_init` for this call.
                 let resp = unsafe { &*resp };
-                return Ok(Some(resp.init.get().clone(global_this)?));
+                let mut result = resp.init.get().clone(global_this)?;
+                // Decided for this init, not inherited from how the donor got its headers.
+                result.headers_from_init = result.headers.is_some();
+                return Ok(Some(result));
             }
         }
 
@@ -1519,6 +1537,7 @@ impl Init {
             }
         }
 
+        result.headers_from_init = result.headers.is_some();
         Ok(Some(result))
     }
 }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2132,6 +2132,68 @@ describe("should support Content-Range with Bun.file()", () => {
       });
     });
   }
+
+  // The auto-206 for `.slice()` must key on the caller having supplied a
+  // `headers` init, not on whether a FetchHeaders object happens to exist:
+  // the lazy `headers` getter and the body-derived Content-Type also
+  // materialize one.
+  it("206 for a slice is not defeated by reading response.headers", async () => {
+    await runTest(
+      {
+        fetch() {
+          const response = new Response(Bun.file(fixture).slice(0, 10));
+          response.headers.get("x-not-set");
+          return response;
+        },
+      },
+      async server => {
+        const response = await fetch(server.url.origin);
+        expect(await response.arrayBuffer()).toEqual(full.buffer.slice(0, 10));
+        // A `.slice()` has no resolved total, so the range is reported as `*`.
+        expect(response.headers.get("content-range")).toBe("bytes 0-9/*");
+        expect(response.status).toBe(206);
+      },
+    );
+  });
+
+  it("slice with a headers init and no Content-Range stays 200", async () => {
+    await runTest(
+      {
+        fetch() {
+          return new Response(Bun.file(fixture).slice(0, 10), { headers: { "x-custom": "1" } });
+        },
+      },
+      async server => {
+        const response = await fetch(server.url.origin);
+        expect(response.headers.get("x-custom")).toBe("1");
+        expect(await response.arrayBuffer()).toEqual(full.buffer.slice(0, 10));
+        expect(response.headers.get("content-range")).toBeNull();
+        expect(response.status).toBe(200);
+      },
+    );
+  });
+
+  // `new Response(body, existingResponse)` is a headers-carrying init exactly
+  // like a plain `{ headers }`; it must not inherit the donor's own
+  // headers_from_init (the donor may have materialized its headers lazily).
+  it("slice with a Response as the headers-carrying init stays 200", async () => {
+    await runTest(
+      {
+        fetch() {
+          const donor = new Response("x");
+          donor.headers.set("x-custom", "1");
+          return new Response(Bun.file(fixture).slice(0, 10), donor);
+        },
+      },
+      async server => {
+        const response = await fetch(server.url.origin);
+        expect(response.headers.get("x-custom")).toBe("1");
+        expect(await response.arrayBuffer()).toEqual(full.buffer.slice(0, 10));
+        expect(response.headers.get("content-range")).toBeNull();
+        expect(response.status).toBe(200);
+      },
+    );
+  });
 });
 
 it("formats error responses correctly", async () => {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,7 +1,8 @@
 import { file, spawn, version } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, exampleSite } from "harness";
+import { bunEnv, bunExe, exampleSite, tempDir } from "harness";
 import net from "net";
+import { join } from "node:path";
 
 const exampleServer = exampleSite("http");
 
@@ -66,6 +67,22 @@ const utf8 = [
     string: "⁉️",
     buffer: new Uint8Array([0xe2, 0x81, 0x89, 0xef, 0xb8, 0x8f]),
   },
+];
+
+// Body types whose extracted Blob carries a Content-Type that the
+// Request/Response headers must reflect.
+const bodyContentTypeCases: Array<[label: string, makeBody: () => BodyInit, pattern: RegExp]> = [
+  [
+    "FormData",
+    () => {
+      const f = new FormData();
+      f.append("n", "V");
+      return f;
+    },
+    /^multipart\/form-data; boundary=/,
+  ],
+  ["URLSearchParams", () => new URLSearchParams({ a: "b" }), /^application\/x-www-form-urlencoded/],
+  ["Blob with type", () => new Blob(["x"], { type: "application/json" }), /^application\/json/],
 ];
 
 for (const { body, fn } of bodyTypes) {
@@ -1160,8 +1177,148 @@ for (const { body, fn } of bodyTypes) {
         });
       });
     });
+
+    // Per Fetch, the header list is fixed at construction: the body-derived
+    // Content-Type (multipart boundary, urlencoded, blob type) must be the
+    // same whether the body or the headers is read first.
+    describe("content-type survives reading the body before the headers", () => {
+      for (const [label, makeBody, pattern] of bodyContentTypeCases) {
+        for (const consume of ["arrayBuffer", "bytes", "text", "blob"] as const) {
+          test(`${label} via .${consume}()`, async () => {
+            const obj = fn(makeBody());
+            const payload = await obj[consume]();
+            const ct = obj.headers.get("content-type");
+            expect(ct).toMatch(pattern);
+            if (label === "FormData") {
+              const boundary = ct!.slice("multipart/form-data; boundary=".length);
+              expect(boundary.length).toBeGreaterThan(0);
+              const text =
+                typeof payload === "string"
+                  ? payload
+                  : payload instanceof Blob
+                    ? await payload.text()
+                    : new TextDecoder().decode(payload as ArrayBuffer | Uint8Array);
+              // The boundary in the header must match the one used in the body.
+              expect(text).toContain("--" + boundary);
+            }
+          });
+        }
+
+        // json() rejects for these non-JSON bodies but still consumes them;
+        // the header must be intact regardless of how the call settled.
+        test(`${label} via .json()`, async () => {
+          const obj = fn(makeBody());
+          await obj.json().catch(() => {});
+          expect(obj.headers.get("content-type")).toMatch(pattern);
+        });
+
+        // formData() must actually parse the multipart / urlencoded body. The
+        // typed Blob is excluded: its formData() rejects on the MIME check
+        // before consuming the body, so nothing new would be observed.
+        if (label !== "Blob with type") {
+          test(`${label} via .formData()`, async () => {
+            const obj = fn(makeBody());
+            const parsed = await obj.formData();
+            expect(Array.from(parsed.keys())).toHaveLength(1);
+            expect(obj.headers.get("content-type")).toMatch(pattern);
+          });
+        }
+
+        test(`${label} via draining .body`, async () => {
+          const obj = fn(makeBody());
+          for await (const _ of obj.body!) {
+          }
+          expect(obj.headers.get("content-type")).toMatch(pattern);
+        });
+
+        test(`${label} via draining .textStream()`, async () => {
+          const obj = fn(makeBody());
+          for await (const _ of (obj as any).textStream() as ReadableStream<string>) {
+          }
+          expect(obj.headers.get("content-type")).toMatch(pattern);
+        });
+
+        test(`${label} matches headers-first order`, async () => {
+          const a = fn(makeBody());
+          const ctBefore = a.headers.get("content-type");
+          await a.arrayBuffer();
+          expect(a.headers.get("content-type")).toBe(ctBefore);
+
+          const b = fn(makeBody());
+          await b.arrayBuffer();
+          expect(b.headers.get("content-type")).toMatch(pattern);
+        });
+
+        test(`${label} explicit Content-Type header is not overridden`, async () => {
+          const obj = fn(makeBody(), { "content-type": "text/plain" });
+          await obj.arrayBuffer();
+          expect(obj.headers.get("content-type")).toBe("text/plain");
+        });
+      }
+    });
   });
 }
+
+// fetch(request) extracts the body Blob directly, without going through the
+// BodyMixin body-consuming methods. The user-held Request's headers must still
+// carry the body-derived Content-Type afterwards (it is what a proxy or
+// middleware forwards), and it must match what was actually sent on the wire.
+describe("Request content-type survives fetch(request) and matches the wire", () => {
+  for (const [label, makeBody, pattern] of bodyContentTypeCases) {
+    test(label, async () => {
+      const { promise, resolve } = Promise.withResolvers<{ contentType: string | null; body: string }>();
+      await using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          resolve({ contentType: req.headers.get("content-type"), body: await req.text() });
+          return new Response("ok");
+        },
+      });
+
+      const req = new Request(server.url, { method: "POST", body: makeBody() });
+      const res = await fetch(req);
+      expect(await res.text()).toBe("ok");
+
+      const received = await promise;
+      const ct = req.headers.get("content-type");
+      expect(ct).toMatch(pattern);
+      expect(received.contentType).toBe(ct);
+      if (label === "FormData") {
+        const boundary = ct!.slice("multipart/form-data; boundary=".length);
+        expect(boundary.length).toBeGreaterThan(0);
+        expect(received.body).toContain("--" + boundary);
+      }
+    });
+  }
+});
+
+// Responses fetched from data:, file:, and blob: URLs derive their Content-Type
+// from the body Blob too, so it must also survive the body being read first.
+describe("fetch() non-remote response content-type survives body consumption", () => {
+  test("data: URL", async () => {
+    const res = await fetch("data:application/json,{}");
+    expect(await res.text()).toBe("{}");
+    expect(res.headers.get("content-type")).toBe("application/json;charset=utf-8");
+  });
+
+  test("blob: URL", async () => {
+    const url = URL.createObjectURL(new Blob(["body"], { type: "text/css" }));
+    try {
+      const res = await fetch(url);
+      expect(await res.text()).toBe("body");
+      expect(res.headers.get("content-type")).toBe("text/css;charset=utf-8");
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  });
+
+  test("file: URL", async () => {
+    using dir = tempDir("body-file-url-ct", { "a.json": "{}" });
+    const res = await fetch(Bun.pathToFileURL(join(String(dir), "a.json")));
+    expect(await res.text()).toBe("{}");
+    expect(res.headers.get("content-type")).toBe("application/json;charset=utf-8");
+  });
+});
 
 function arrayBuffer(buffer: BufferSource) {
   if (buffer instanceof ArrayBuffer) {


### PR DESCRIPTION
## Problem

The Content-Type header that Bun derives from a `FormData`, `URLSearchParams`, or typed `Blob` body is only copied into the Request/Response headers lazily, on the first access of `.headers`. Consuming the body first replaces the internal Blob with `Value::Used`, after which the lazy path finds no Blob and synthesizes empty headers.

For a multipart body the boundary lives only in that header, so it became unrecoverable:

```js
const fd = new FormData();
fd.append("n", "V");
const req = new Request("http://x/", { method: "POST", body: fd });
const body = await req.arrayBuffer(); // read the body first, as a proxy/middleware does

req.headers.get("content-type");
// bun:  null  (the boundary is now unknowable)
// node: "multipart/form-data; boundary=----formdata-undici-0416..."
// ...while `body` already starts with "------WebKitFormBoundaryc00e33..."
```

Reading `.headers` before the body returned the correct value, so the result depended on access order. This breaks the standard proxy/signing/middleware shape (consume or hash the body, then forward the headers plus bytes): the forwarded multipart body has no boundary the upstream can parse. Per Fetch, the header list is fixed at construction, so it must not depend on which of the two is read first.

`URLSearchParams` and `Blob` bodies with a type lost their Content-Type the same way, `Response` had the identical bug, and `Response.body` lost it too. `fetch(request)` was also affected: it extracts the body Blob directly, so afterwards the user-held Request's `headers.get("content-type")` was `null` even though the correct boundary went out on the wire.

## Cause

`Request::construct_into` only copied the Blob's content type into the headers when a `headers` init was supplied; otherwise it deferred to `ensure_fetch_headers`, which reads the content type off `BodyValue::Blob(blob)`. Once the body is consumed that match arm no longer hits and nothing is written. `Response::constructor` / `get_or_create_headers` had the same guard.

## Fix

The two classes need different treatment.

**Request: write the Content-Type into the headers at construction** (`construct_into`). When the extracted body is a Blob with a non-empty content type, the headers object is created (if it does not already exist) and the Content-Type written, unless the headers already have one. Nothing depends on a user-constructed Request's headers being unmaterialized, and fixing it at construction closes every path that takes the body Blob afterwards at once: the `BodyMixin` consumers, `fetch(request)` (`fetch.rs:1249`), `Bun.write`, the shell, `new Blob([req])`, and anything added later. `fetch()` already skips the body's content type when the headers contain one (`from_fetch_headers`), so nothing is sent twice.

**Response: preserve the Content-Type at consumption time.** Construction-time materialization regressed 25 Content-Range tests in `serve.test.ts` plus 1 in `bun-serve-file.test.ts` in an earlier revision of this PR, because `Bun.serve` read `Response.init.headers` being unset as "the user passed no headers init" when deciding whether a sliced `Bun.file()` response gets an automatic 206 (`RequestContext::render_metadata`). The last commit replaces that overloaded signal (see the second fix below), but preservation at consumption time is still the right shape for Response: it is the only approach that also covers the Responses `fetch()` builds internally for `data:`, `file:`, and `blob:` URLs (which never pass through the JS constructor), and it keeps `new Response(body)` on the `Bun.serve` path from allocating a `FetchHeaders` nothing reads. So `BodyMixin` gains `preserve_body_content_type`, a gated default that materializes the lazy headers only when they do not exist yet and the body is a `Value::Blob` with a non-empty content type; every body-consuming method (`get_text`, `get_json`, `get_array_buffer`, `get_bytes`, `get_form_data`, `get_blob_with_this_value`, and `get_text_stream`, which main added while this PR was open) and the `.body` getter call it right before the Blob is taken. `Request` and `Response` each supply a one-line `materialize_headers` that routes to their existing lazy materializer. For a Request this hook is now a no-op (the headers are already materialized), which its doc comment states.

Response external consumers that bypass `BodyMixin` (`Bun.write(dest, response)`, `HTMLRewriter.transform`, the shell, `WebAssembly.compileStreaming`, `new Blob([response])`, and the `Bun.serve` send path) are intentionally not hooked: they consume the Response as an input rather than as the headers-then-body proxy shape this fixes. The internal `jsFunctionGetCompleteRequestOrResponseBodyValueAsArrayBuffer` is also not hooked; it has no JS call site.

## Verification

`test/js/web/fetch/body.test.ts`, under `"content-type survives reading the body before the headers"`, covers Request and Response x {FormData, URLSearchParams, typed Blob} x {arrayBuffer, bytes, text, blob, json, formData, draining `.body`, draining `.textStream()`}, asserts the header matches the headers-first order, asserts the multipart boundary in the header is the one actually used in the body bytes, and asserts an explicit `content-type` from the init is not overridden. A separate test, `"Request content-type survives fetch(request) and matches the wire"`, fetches the Request to a local `Bun.serve` and asserts the user-held Request's boundary is non-null and identical to the Content-Type the server received and to the boundary in the body bytes.

A third block, `"fetch() non-remote response content-type survives body consumption"`, covers the three `fetch()` URL schemes that build a Response whose Content-Type lives only on the body Blob and so had the identical bug: `data:`, `file:`, and `blob:` URLs each had `headers.get("content-type")` return `null` if the body was read first. The `BodyMixin` hook fixes them; these tests pin that down.

Against unmodified `main` plus only the tests:
- `bun bd test test/js/web/fetch/body.test.ts -t "content-type survives"`: 52 fail, 8 pass (the 8 are the explicit-header cases and Request's `.body` path, which already worked)
- `bun bd test test/js/web/fetch/body.test.ts -t "via draining .textStream"`: 6 fail, 0 pass
- `bun bd test test/js/web/fetch/body.test.ts -t "survives fetch"`: 1 fail

With the fix (numbers as of the rebase onto current main):
- `bun bd test test/js/web/fetch/body.test.ts`: 512 pass, 0 fail
- `bun bd test test/js/bun/http/serve.test.ts -t "Content-Range"`: 42 pass, 0 fail
- `bun bd test test/js/bun/http/bun-serve-file.test.ts`: 105 pass, 0 fail
- `bun bd test test/js/bun/http/fetch-file-upload.test.ts`: 11 pass, 0 fail

### Rebase notes

Rebased onto current main as a single commit. Three source conflicts, all resolved in favor of keeping both sides:
- `RequestContext.rs`: main moved `sendfile` into a `Cell<SendfileContext>` read once into a local, so the 206 condition now uses that local instead of `self.sendfile.total`.
- `Body.rs`: main added stream-ownership bookkeeping (`check_body_stream_ref`) to the `.body` getter; the `preserve_body_content_type` call sits before it. Main also added a new consumer, `get_text_stream` (`.textStream()`), which takes the Blob the same way, so it gets the same call and a row in the test matrix (fails 6/6 without the fix).
- `Response.rs`: main narrowed the `Init` fields to `pub(crate)`; the new `headers_from_init` field follows suit.

Also verified that `fetch()` with a FormData body (both the options-object and the `fetch(new Request(...))` shapes) still sends a single `multipart/form-data; boundary=...` header whose boundary matches the body bytes, that `request.clone()` and the original keep the same boundary, and that typeless bodies (plain string, Blob without a type) still correctly get no Content-Type.

## Second fix: `Bun.serve` auto-206 for a sliced blob keyed on the wrong signal

Found while landing the above. `Bun.serve` decides whether a `.slice()`-driven `Bun.file()` response should auto-promote to 206 with a `Content-Range` by checking whether `Response.init.headers` exists. That signal is overloaded: `init.headers` is also created by the lazy `headers` getter, and (with this PR) by the Content-Type preservation above, neither of which means the caller supplied a `headers` init.

The lazy-getter case is a pre-existing bug, reproducible on unmodified bun:

```js
Bun.serve({
  fetch() {
    const response = new Response(Bun.file(path).slice(0, 10));
    response.headers.get("x-not-set"); // any read of .headers
    return response;                   // 200, should be 206
  },
});
```

`Response::Init` gains a `headers_from_init` flag, set inside `Init::init` (the one place a user `ResponseInit` is parsed, so `new Response(body, init)`, `Response.json(data, init)`, and `Response.redirect(url, init)` are all covered, not just the constructor). `Bun.serve` keys the auto-206 decision on it instead of on `init.headers` being present.

`Init::init` has three paths (a Request as the init, a Response as the init, and a plain object). Each computes `headers_from_init` as `result.headers.is_some()` for itself. The Response-as-init path clones the donor's `Init` for the other fields but must not inherit the donor's `headers_from_init`: the donor may have materialized its own headers lazily, but `new Response(slice, donor)` is still a headers-carrying init from this caller's point of view. An earlier revision did inherit it via `Init::clone`, which would have regressed that shape from 200 to 206; `Init::clone` is otherwise unchanged since its other caller is `response.clone()`, where the verbatim copy is correct.

This is also what makes it safe for anything other than a user init to create `init.headers` at all, and it removes the one consumer that depended on a Response's headers staying unmaterialized.

New tests in `test/js/bun/http/serve.test.ts` under `"should support Content-Range with Bun.file()"`:
- `"206 for a slice is not defeated by reading response.headers"`: fails on unmodified bun (200), passes with the fix.
- `"slice with a headers init and no Content-Range stays 200"`: guards the preserved contract, that a caller who supplies a `headers` init without a `Content-Range` is managing the response themselves. Passes before and after.
- `"slice with a Response as the headers-carrying init stays 200"`: the Response-as-init shape above. Passes on unmodified bun and with the fix, and would have failed on the revision that inherited `headers_from_init` from the donor.

With the fix, `bun bd test test/js/bun/http/serve.test.ts -t "Content-Range"`: 42 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts test/js/web/fetch/body.test.ts

<!-- robobun:evidence:end -->