### PR TITLE
Quote the ETag header values in the HTML import manifest per RFC 9110

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -188,6 +188,7 @@ Bun.serve({
 - **Filesystem reads** on each request - checks file existence and reads content
 - **Built-in 404 handling** - Returns `404 Not Found` if file doesn't exist or becomes inaccessible
 - **Last-Modified support** - Uses file modification time for `If-Modified-Since` headers
+- **If-None-Match** - Returns `304 Not Modified` when the route carries an `ETag` header that matches the client's tag. File routes don't generate an `ETag` automatically, so supply one via response headers. When present, `If-None-Match` takes precedence over `If-Modified-Since`
 - **If-Modified-Since** - Returns `304 Not Modified` when file hasn't changed since client's cached version
 - **Range request support** - Automatically handles partial content requests with `Content-Range` headers
 - **Streaming transfers** - Uses buffered reader with backpressure handling for efficient memory usage

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -11,7 +11,7 @@
 //!
 //! ```javascript
 //! var src_default = __jsonParse(
-//!   '{"index":"./index.html","files":[{"input":"index.html","path":"./index-f2me3qnf.js","loader":"js","isEntry":true,"headers":{"etag": "eet6gn75","content-type": "text/javascript;charset=utf-8"}},{"input":"index.html","path":"./index.html","loader":"html","isEntry":true,"headers":{"etag": "r9njjakd","content-type": "text/html;charset=utf-8"}},{"input":"index.html","path":"./index-gysa5fmk.css","loader":"css","isEntry":true,"headers":{"etag": "50zb7x61","content-type": "text/css;charset=utf-8"}},{"input":"logo.svg","path":"./logo-kygw735p.svg","loader":"file","isEntry":false,"headers":{"etag": "kygw735p","content-type": "application/octet-stream"}},{"input":"react.svg","path":"./react-ck11dneg.svg","loader":"file","isEntry":false,"headers":{"etag": "ck11dneg","content-type": "application/octet-stream"}}]}'
+//!   '{"index":"./index.html","files":[{"input":"index.html","path":"./index-f2me3qnf.js","loader":"js","isEntry":true,"headers":{"etag":"\\"091b90ee07b0f279\\"","content-type":"text/javascript;charset=utf-8"}},{"input":"index.html","path":"./index.html","loader":"html","isEntry":true,"headers":{"etag":"\\"8233f19ae76692b0\\"","content-type":"text/html;charset=utf-8"}},{"input":"index.html","path":"./index-gysa5fmk.css","loader":"css","isEntry":true,"headers":{"etag":"\\"0544d399e8651fe0\\"","content-type":"text/css;charset=utf-8"}},{"input":"logo.svg","path":"./logo-kygw735p.svg","loader":"file","isEntry":false,"headers":{"etag":"\\"9711c3f356ce527c\\"","content-type":"application/octet-stream"}},{"input":"react.svg","path":"./react-ck11dneg.svg","loader":"file","isEntry":false,"headers":{"etag":"\\"54a5b1cd1fe03720\\"","content-type":"application/octet-stream"}}]}'
 //! );
 //! ```
 //!
@@ -106,14 +106,13 @@ fn write_entry_item<W: Write + ?Sized>(
     writer.write_all(b",\"headers\":{")?;
 
     if hash > 0 {
-        const BASE64_BUF_LEN: usize =
-            bun_base64::encode_len_from_size(core::mem::size_of::<u64>()) + 2;
-        let mut base64_buf = [0u8; BASE64_BUF_LEN];
-        let n = bun_base64::encode_url_safe(&mut base64_buf, &hash.to_ne_bytes());
-        let base64 = &base64_buf[..n];
-        writer.write_all(b"\"etag\":\"")?;
-        writer.write_all(base64)?;
-        writer.write_all(b"\",")?;
+        // Same quoted RFC 9110 entity-tag the runtime HTML routes serve, so
+        // `bun build` output and in-process `Bun.serve` agree on one format.
+        let mut etag_buf: bun_http_types::ETag::FormatBuffer = [0; 40];
+        let etag = bun_http_types::ETag::format(hash, &mut etag_buf);
+        writer.write_all(b"\"etag\":")?;
+        bun_js_printer::write_json_string::<_, { Encoding::Utf8 }>(etag, writer)?;
+        writer.write_all(b",")?;
     }
 
     // Valid mime types are valid headers, which do not need to be escaped in JSON.

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, rmScope, tempDirWithFiles } from "harness";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
@@ -110,7 +110,7 @@ console.log(favicon);
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "efKwB-6QGwk",
+                  "etag": "\\"091b90ee07b0f279\\"",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -120,7 +120,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "sJJm55rxM4I",
+                  "etag": "\\"8233f19ae76692b0\\"",
                   "content-type": "text/html;charset=utf-8"
                 }
               },
@@ -130,7 +130,7 @@ console.log(favicon);
                 "loader": "css",
                 "isEntry": true,
                 "headers": {
-                  "etag": "4B9l6JnTRAU",
+                  "etag": "\\"0544d399e8651fe0\\"",
                   "content-type": "text/css;charset=utf-8"
                 }
               },
@@ -140,7 +140,7 @@ console.log(favicon);
                 "loader": "file",
                 "isEntry": false,
                 "headers": {
-                  "etag": "fFLOVvPDEZc",
+                  "etag": "\\"9711c3f356ce527c\\"",
                   "content-type": "image/png"
                 }
               }
@@ -290,7 +290,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "xAZoSOIIQJ8",
+                  "etag": ""9f4008e2486806c4"",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -300,7 +300,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "uIE6dXgvM-4",
+                  "etag": ""ee332f78753a81b8"",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -310,7 +310,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/css;charset=utf-8",
-                  "etag": "ZTZtbLd3364",
+                  "etag": ""aedf77b76c6d3665"",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -325,7 +325,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "INLwcb4oxw8",
+                  "etag": ""0fc728be71f0d220"",
                 },
                 "input": "about.html",
                 "isEntry": true,
@@ -335,7 +335,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "ZpqlG2wo2xo",
+                  "etag": ""1adb286c1ba59a66"",
                 },
                 "input": "about.html",
                 "isEntry": true,
@@ -345,7 +345,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/css;charset=utf-8",
-                  "etag": "x6pW8hAzxGI",
+                  "etag": ""62c43310f256aac7"",
                 },
                 "input": "about.html",
                 "isEntry": true,
@@ -393,6 +393,87 @@ console.log("About manifest:", aboutHtml);
     expect(jsA.path).not.toBe(jsB.path);
     expect(htmlA.path).toBe(htmlB.path);
     expect(htmlA.headers.etag).not.toBe(htmlB.headers.etag);
+  });
+
+  // RFC 9110 §8.8.3: an entity-tag is a quoted-string. The manifest's
+  // `headers` object carries the literal response header values that
+  // `Bun.serve` emits verbatim, so the ETag must already be quoted.
+  test("html-import/manifest-etag-is-a-quoted-entity-tag", async () => {
+    const dir = tempDirWithFiles("html-etag-quoted", {
+      "server.ts": /*js*/ `
+        import index from "./index.html";
+        const server = Bun.serve({ port: 0, development: false, routes: { "/": index } });
+        const base = server.url.href;
+        const htmlRes = await fetch(base);
+        const html = await htmlRes.text();
+        const jsPath = html.match(/src="([^"]+\\.js)"/)[1];
+        const jsRes = await fetch(new URL(jsPath, base));
+        const jsETag = jsRes.headers.get("etag");
+        const conditional = await fetch(new URL(jsPath, base), {
+          headers: { "If-None-Match": jsETag ?? "missing" },
+        });
+        const conditionalHead = await fetch(new URL(jsPath, base), {
+          method: "HEAD",
+          headers: { "If-None-Match": jsETag ?? "missing" },
+        });
+        const conditionalMiss = await fetch(new URL(jsPath, base), {
+          headers: { "If-None-Match": '"0000000000000000"' },
+        });
+        await conditionalMiss.text();
+        console.log(JSON.stringify({
+          manifestETags: index.files.map(f => f.headers.etag),
+          htmlETag: htmlRes.headers.get("etag"),
+          jsETag,
+          conditionalStatus: conditional.status,
+          conditionalHeadStatus: conditionalHead.status,
+          conditionalMissStatus: conditionalMiss.status,
+        }));
+        await server.stop(true);
+      `,
+      "index.html": `<!doctype html><html><body><script type="module" src="./app.ts"></script></body></html>`,
+      "app.ts": `console.log("app");`,
+    });
+    using cleanup = rmScope(dir);
+
+    const out = join(dir, "out");
+    const build = await Bun.build({ entrypoints: [join(dir, "server.ts")], outdir: out, target: "bun" });
+    expect(build.success).toBe(true);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(out, "server.js")],
+      env: bunEnv,
+      cwd: out,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      throw new Error("built server failed:\n" + stdout + "\n" + stderr);
+    }
+    const result = JSON.parse(stdout) as {
+      manifestETags: string[];
+      htmlETag: string | null;
+      jsETag: string | null;
+      conditionalStatus: number;
+      conditionalHeadStatus: number;
+      conditionalMissStatus: number;
+    };
+
+    const quotedEntityTag = /^"[0-9a-f]{16}"$/;
+    expect(result.manifestETags.length).toBeGreaterThan(0);
+    for (const etag of result.manifestETags) {
+      expect(etag).toMatch(quotedEntityTag);
+    }
+    // The on-the-wire response headers are the manifest values verbatim.
+    expect(result.htmlETag).toMatch(quotedEntityTag);
+    expect(result.jsETag).toMatch(quotedEntityTag);
+    expect(result.manifestETags).toContain(result.jsETag);
+    // Round-tripping the served ETag through If-None-Match revalidates.
+    expect({
+      get: result.conditionalStatus,
+      head: result.conditionalHeadStatus,
+      miss: result.conditionalMissStatus,
+    }).toEqual({ get: 304, head: 304, miss: 200 });
   });
 
   // Test that import with {type: 'file'} still works as a file import

--- a/test/js/bun/http/bun-serve-html-manifest.test.ts
+++ b/test/js/bun/http/bun-serve-html-manifest.test.ts
@@ -41,7 +41,7 @@ describe("Bun.serve HTML manifest", () => {
       "app.js": `console.log("Hello from app");`,
     });
 
-    using cleanup = { [Symbol.dispose]: () => rmScope(dir) };
+    using cleanup = rmScope(dir);
 
     const proc = Bun.spawn({
       cmd: [bunExe(), "run", join(dir, "server.ts")],
@@ -152,7 +152,7 @@ describe("Bun.serve HTML manifest", () => {
       "app.js": `console.log("App loaded");`,
     });
 
-    using cleanup = { [Symbol.dispose]: () => rmScope(dir) };
+    using cleanup = rmScope(dir);
 
     // Build first
     const buildProc = Bun.spawn({
@@ -220,6 +220,125 @@ describe("Bun.serve HTML manifest", () => {
     await serverProc.exited;
   });
 
+  // The manifest produced by `bun build --target=bun` carries the ETag header
+  // values that are written verbatim to the wire at serve time. RFC 9110
+  // 8.8.3 requires an entity-tag to be a quoted-string.
+  it("bundled manifest emits quoted ETags (RFC 9110)", async () => {
+    const dir = tempDirWithFiles("serve-html-etag", {
+      "build.ts": `
+        const result = await Bun.build({
+          entrypoints: ["./server.ts"],
+          target: "bun",
+          outdir: "./dist",
+        });
+        if (!result.success) {
+          console.error("Build failed");
+          process.exit(1);
+        }
+      `,
+      "server.ts": `
+        import index from "./index.html";
+
+        const server = Bun.serve({
+          port: 0,
+          development: false,
+          routes: {
+            "/": index,
+          },
+        });
+
+        console.log("PORT=" + server.port);
+      `,
+      "index.html": `<!DOCTYPE html>
+<html>
+<head>
+  <title>ETag</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <h1>ETag test</h1>
+  <script src="./app.js"></script>
+</body>
+</html>`,
+      "styles.css": `body { margin: 0; }`,
+      "app.js": `console.log("loaded");`,
+    });
+
+    using cleanup = rmScope(dir);
+
+    await using buildProc = Bun.spawn({
+      cmd: [bunExe(), "run", join(dir, "build.ts")],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [, buildStderr, buildExit] = await Promise.all([
+      buildProc.stdout.text(),
+      buildProc.stderr.text(),
+      buildProc.exited,
+    ]);
+    expect(buildStderr).not.toContain("Build failed");
+    expect(buildExit).toBe(0);
+
+    await using serverProc = Bun.spawn({
+      cmd: [bunExe(), "run", join(dir, "dist", "server.js")],
+      cwd: join(dir, "dist"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    // Drain stderr as it arrives so the child can never block on a full pipe.
+    const serverStderr = serverProc.stderr.text();
+
+    let port: number | undefined;
+    const reader = serverProc.stdout.getReader();
+    const decoder = new StringDecoder("utf8");
+    let buffer = "";
+
+    while (!port) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.write(value);
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        const portMatch = line.match(/PORT=(\d+)/);
+        if (portMatch) {
+          port = parseInt(portMatch[1]);
+          break;
+        }
+      }
+    }
+
+    reader.releaseLock();
+    if (port === undefined) {
+      // stdout closed without a PORT= line, so the server already exited and
+      // the stderr stream is complete.
+      throw new Error(`server exited before printing its port:\n${await serverStderr}`);
+    }
+
+    // entity-tag = [ weak ] opaque-tag ; opaque-tag = DQUOTE *etagc DQUOTE
+    const entityTag = /^(W\/)?"[!#-~\x80-\xff]*"$/;
+
+    const htmlRes = await fetch(`http://localhost:${port}/`);
+    expect(htmlRes.status).toBe(200);
+    const htmlEtag = htmlRes.headers.get("etag");
+    expect(htmlEtag).not.toBeNull();
+    expect(htmlEtag).toMatch(entityTag);
+
+    const html = await htmlRes.text();
+    const jsSrc = html.match(/<script[^>]+src="([^"]+)"/)?.[1]!;
+    expect(jsSrc).toBeDefined();
+    const jsRes = await fetch(new URL(jsSrc, `http://localhost:${port}/`));
+    expect(jsRes.status).toBe(200);
+    expect(jsRes.headers.get("etag")).toMatch(entityTag);
+  });
+
   it("validates manifest files exist", async () => {
     const dir = tempDirWithFiles("serve-html-validate", {
       "test.ts": `
@@ -255,7 +374,7 @@ describe("Bun.serve HTML manifest", () => {
       `,
     });
 
-    using cleanup = { [Symbol.dispose]: () => rmScope(dir) };
+    using cleanup = rmScope(dir);
 
     const proc = Bun.spawn({
       cmd: [bunExe(), "run", join(dir, "test.ts")],
@@ -310,7 +429,7 @@ describe("Bun.serve HTML manifest", () => {
       "test.css": `h1 { color: red; }`,
     });
 
-    using cleanup = { [Symbol.dispose]: () => rmScope(dir) };
+    using cleanup = rmScope(dir);
 
     // Build first to generate the manifest
     await using buildProc = Bun.spawn({


### PR DESCRIPTION
### Problem

The manifest that `bun build --target=bun` embeds for HTML imports carries the HTTP headers that `Bun.serve` later writes verbatim to the wire, and it emits the `ETag` value as a bare url-safe base64 token:

```
etag: kWgazS628Z0
```

RFC 9110 section 8.8.3 requires an entity-tag to be a quoted-string (`ETag: "..."`), so strict caches and proxies see a malformed field value and `If-None-Match` revalidation from conforming intermediaries can silently stop matching. The in-process HTML routes already emit the quoted hex form (since #32854), so built output and in-process serving also disagreed on the validator form for the same asset.

### Reproduction

```sh
bun build --target=bun --outdir=out ./server.ts   # server.ts imports ./index.html
cd out && bun server.js
```

```
ETag: VFFkLsNEKcA                        # bare token, no quotes
```

### Fix

`src/bundler/HTMLImportManifest.rs`: write the manifest `etag` with the shared quoted formatter `bun_http_types::ETag::format` (the same one the in-process HTML routes use since #32854), JSON-escaped via `write_json_string`, instead of the hand-rolled bare base64. Every HTML import path now produces the same quoted 16-hex entity-tag. The built manifest routes are served by `FileRoute`, whose `If-None-Match` handling (#33620) strips quotes from both sides, so revalidation against either the old or the new form keeps working.

The `FileRoute` `If-None-Match` work that was in earlier revisions of this PR was superseded on main by #33620 and has been dropped; `FileRoute.rs` is now untouched.

### Verification

- `test/bundler/html-import-manifest.test.ts`: new end-to-end test builds with `--target=bun`, runs the output, and asserts that the manifest and the on-the-wire `ETag` values are quoted 16-hex entity-tags, that `If-None-Match` round-trips to 304 on both GET and HEAD, and that a non-matching tag still returns 200. Inline snapshots regenerated; the new hex values decode to the same u64 hashes as the old base64 (`efKwB-6QGwk` is `0x091b90ee07b0f279`), so only the encoding changed.
- `test/js/bun/http/bun-serve-html-manifest.test.ts`: end-to-end build-then-serve test asserting the RFC 9110 entity-tag grammar on the served `ETag`, plus the `rmScope` cleanups from review.

Without the `src/` change both files fail (bare base64 tokens `goGACJqXTuY` and `kWgazS628Z0`); with it, both are green along with the untouched `bun-serve-file.test.ts` and `serve-if-none-match.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/html-import-manifest.test.ts test/js/bun/http/bun-serve-html-manifest.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f6839e2f8)

test/bundler/html-import-manifest.test.ts:
(pass) bundler > html-import/etag-changes-with-referenced-chunks [216.99ms]
281 |           expect(file.headers).toHaveProperty("etag");
282 |           expect(file.headers).toHaveProperty("content-type");
283 |         }
284 |       }
285 | 
286 |       expect(manifests).toMatchInlineSnapshot(`
                              ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  [
    {
      "files": [
        {
          "headers": {
            "content-type": "text/javascript;charset=utf-8",
-           "etag": ""9f4008e2486806c4"",
+           "etag": "xAZoSOIIQJ8",
          },
          "input": "home.html"
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/html-import-manifest.test.ts:
281 |           expect(file.headers).toHaveProperty("etag");
282 |           expect(file.headers).toHaveProperty("content-type");
283 |         }
284 |       }
285 | 
286 |       expect(manifests).toMatchInlineSnapshot(`
                              ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  [
    {
      "files": [
        {
          "headers": {
            "content-type": "text/javascript;charset=utf-8",
-           "etag": ""9f4008e2486806c4"",
+           "etag": "xAZoSOIIQJ8",
          },
          "input": "home.html",
          "isEntry": true,
          "loader": "js",
          "path": "./home-4688280z.js",
        },
        {
          "headers": {
            "content-type": "text/html;charset=utf-8",
-           "etag": ""ee332f78753a81b8"",
+           "etag": "uIE6dXgvM-4",
          },
          "input": "home.html",
          "isEntry": true,
          "loader": "html",
          "path": "./home.html",
        },
        {
          "headers": {
            "content-type": "text/css;charset=utf-8",
-           "etag": ""aedf77b76c6d3665"",
+    
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/html-import-manifest.test.ts test/js/bun/http/bun-serve-html-manifest.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f6839e2f8)

test/bundler/html-import-manifest.test.ts:
(pass) bundler > html-import/etag-changes-with-referenced-chunks [197.07ms]
(pass) bundler > html-import/multiple-manifests [349.06ms]
(pass) bundler > html-import/manifest-etag-is-a-quoted-entity-tag [647.43ms]
(pass) bundler > html-import/manifest-with-metadata [1223.00ms]
(pass) bundler > html-import/html-referenced-assets-in-manifest [845.34ms]
(pass) bundler > html-import/with-type-file-attribute [898.65ms]

test/js/bun/http/bun-serve-html-manifest.test.ts:
(pass) Bun.serve HTML manifest > serves HTML import with manifest [561.97ms]
(pass) Bun.serve HTML manifest > serves HTML with bundled assets [1087.35ms]
(pass) Bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f6839e2f85
  features     (none)

22 deps, 105 codegen, 1168 objects in 783ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen ErrorCode+*.h
[4/1231] gen bindgenv2
[5/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[6/1231] fetch zlib
[zlib] up to date
[7/1231] fetch tinycc
[tinycc] up to date
[8/1230] gen ProcessBindingConstant
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/http/routing.mdx                    |   1 +
 src/bundler/HTMLImportManifest.rs                |  17 ++-
 test/bundler/html-import-manifest.test.ts        | 103 ++++++++++++++++--
 test/js/bun/http/bun-serve-html-manifest.test.ts | 127 ++++++++++++++++++++++-
 4 files changed, 224 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
docs/runtime/http/routing.mdx                         1      1     49
src/bundler/HTMLImportManifest.rs                     4      4     50
test/bundler/html-import-manifest.test.ts             4      8     23
test/js/bun/http/bun-serve-html-manifest.test.ts      9      6     29
```

</details>

<!-- robobun:evidence:end -->