### PR TITLE
File.name: return "" instead of undefined when the filename is empty

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2074,6 +2074,8 @@ impl BlobExt for Blob {
     fn get_name(&self, _: JSValue, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         Ok(match self.get_name_string() {
             Some(name) => name.to_js(global_this)?,
+            // File.name is always a string per the File API spec.
+            None if self.is_jsdom_file.get() => JSValue::js_empty_string(global_this),
             None => JSValue::UNDEFINED,
         })
     }

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -136,7 +136,8 @@ describe("multipart serialization (new Response(formData))", () => {
       ["dup", "first"],
       ["dup", "second"],
       ["unicode name ☺", "ünïcode välue 😊"],
-      ["blob", { file: true, name: undefined, type: "", text: "blob-bytes" }],
+      // Parsed entries are Files, so .name is a string even for an unnamed Blob.
+      ["blob", { file: true, name: expect.any(String), type: "", text: "blob-bytes" }],
       ["file", { file: true, name: "日本語ファイル名.html", type: "text/html;charset=utf-8", text: "<p>hi</p>" }],
     ]);
   });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -37,11 +37,30 @@ describe("FormData", () => {
     const blob = new Blob(["bar"]);
     const formData = new FormData();
     formData.append("foo", blob);
-    // @ts-expect-error
-    expect(formData.get("foo").name).toBeUndefined();
+    // FormData entries are always File instances, so .name is always a string.
+    expect((formData.get("foo") as File).name).toBeString();
     formData.append("foo2", new File([blob], "foo.txt"));
     // @ts-expect-error
     expect(formData.get("foo2").name).toBe("foo.txt");
+    // An explicit empty filename is a File named "" per spec.
+    formData.append("foo3", blob, "");
+    expect((formData.get("foo3") as File).name).toBe("");
+  });
+
+  it('multipart part with filename="" yields a File whose .name is the empty string', async () => {
+    // Browsers send filename="" for an unfilled <input type="file">.
+    const B = "X";
+    const body = `--${B}\r\nContent-Disposition: form-data; name="f"; filename=""\r\n\r\nDATA\r\n--${B}--\r\n`;
+    const fd = await new Response(body, {
+      headers: { "content-type": `multipart/form-data; boundary=${B}` },
+    }).formData();
+    const f = fd.get("f") as File;
+    expect(f instanceof File).toBe(true);
+    expect(typeof f.name).toBe("string");
+    expect(f.name).toBe("");
+    // The universal extension-check pattern must not throw.
+    expect(f.name.endsWith(".png")).toBe(false);
+    expect(await f.text()).toBe("DATA");
   });
 
   it("should use the correct filenames", async () => {
@@ -52,11 +71,11 @@ describe("FormData", () => {
 
     let b1 = form.get("foo") as any;
     expect(blob.name).toBeUndefined();
-    expect(b1.name).toBeUndefined();
+    expect(b1.name).toBeString();
 
     form.set("foo", b1, "foo.txt");
     expect(blob.name).toBeUndefined();
-    expect(b1.name).toBeUndefined();
+    expect(b1.name).toBeString();
 
     b1 = form.get("foo") as Blob;
     expect(blob.name).toBeUndefined();


### PR DESCRIPTION
## Repro

A multipart part with `filename=""` is what every browser sends for an empty `<input type="file">`. Bun parses it into a `File` whose `.name` is `undefined`, so the universal `file.name.endsWith(...)` pattern throws in upload handlers:

```js
const B = "X";
const body = `--${B}\r\nContent-Disposition: form-data; name="f"; filename=""\r\n\r\nDATA\r\n--${B}--\r\n`;
const fd = await new Response(body, { headers: { "content-type": `multipart/form-data; boundary=${B}` } }).formData();
const f = fd.get("f");
f instanceof File; // true
f.name;            // node: ""   bun: undefined
f.name.endsWith(".png");
// node: false
// bun:  TypeError: undefined is not an object (evaluating 'f.name.endsWith')
```

In the released 1.4.0 the same getter also made `new File([], "").name` return `undefined`. `main` has since changed the `File` constructor to store its name argument directly, so that path already returns `""` there. On `main` the remaining way to reach the bug is a `File` that `FormData` produced with an empty filename.

## Cause

`Blob::get_name` returned `JSValue::UNDEFINED` whenever `get_name_string()` found no stored name. That is correct for a plain `Blob` (which has no spec'd `name`), but a `File`'s `name` is a [USVString attribute](https://www.w3.org/TR/FileAPI/#dfn-name) and can never be `undefined`. On `main`, the only producer of such a `File` is `Blob__setAsFile` (`src/runtime/webcore/Blob.rs:4150`), which sets `is_jsdom_file` but leaves the name unset when the `FormData` filename is empty. That covers a multipart part with `filename=""`, `formData.append(name, blob)` with the filename omitted, and `formData.append(name, blob, "")`.

## Fix

When `get_name_string()` has nothing and the blob is a `File` (`is_jsdom_file`), return the empty string instead of `undefined`. Plain `Blob`s keep returning `undefined`, matching Node.

Three existing assertions asserted the old `undefined` behavior for `File`s retrieved from `FormData`. They now assert only that `.name` is a string (`toBeString()` / `expect.any(String)`), which is the invariant this PR introduces. A new case, `formData.append("foo3", blob, "")`, asserts that an explicit empty filename yields `.name === ""`.

Related: #32431 independently fixes the separate append-time default (a `Blob` appended to `FormData` with no filename should become a `File` named `"blob"`). This PR does not pin that value: the omitted-filename assertions here only require a string, so they stay correct when #32431 lands. The two PRs still edit the same test lines, so whichever merges second needs a trivial textual rebase.

## Verification

```sh
bun bd test test/js/web/html/FormData.test.ts
bun bd test test/js/web/html/FormData-multipart-serialization.test.ts
```

Checked the way the gate does: with `src/` at `main` and these tests in place, 4 tests fail (`Expected: "string" Received: "undefined"` and the round-trip `name` mismatch). With the fix, all 156 tests in the two files pass.

Rebased onto `main` once. The rebase required one source change: `main` removed `String::empty()`, which the first revision used. The match arm now returns `JSValue::js_empty_string(global_this)`, the same helper `get_type` uses a few lines above. The behavior is unchanged. An earlier revision also added a `new File([], "")` test in `blob.test.ts`. It was removed because that case already passes on `main`, so it did not exercise this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/html/FormData-multipart-serialization.test.ts

<!-- robobun:evidence:end -->



