### PR TITLE
CookieMap: keep cookie values raw when they do not percent-decode cleanly

### DIFF
--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -6,10 +6,36 @@
 #include <wtf/text/ParsingUtilities.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include "HTTPParsers.h"
-#include "decodeURIComponentSIMD.h"
 #include "BunString.h"
+#include <wtf/ASCIICType.h>
 #include <wtf/HashSet.h>
 namespace WebCore {
+
+// Percent-decodes a Cookie header value only if the whole value decodes
+// cleanly, matching node's `cookie` package. Returns a null String on any
+// malformed escape or invalid UTF-8 so the caller keeps the raw value.
+static String percentDecodeCookieValue(StringView valueView)
+{
+    Bun::UTF8View utf8View(valueView);
+    auto input = utf8View.bytes();
+    Vector<uint8_t, 64> decoded;
+    decoded.reserveInitialCapacity(input.size());
+    for (size_t i = 0; i < input.size();) {
+        if (input[i] != '%') {
+            decoded.append(input[i]);
+            i++;
+            continue;
+        }
+        // RFC 6265 allows a literal '%' in a cookie-octet, so a '%' that is
+        // not followed by two hex digits is data, not a truncated escape.
+        if (i + 2 >= input.size() || !isASCIIHexDigit(input[i + 1]) || !isASCIIHexDigit(input[i + 2]))
+            return String();
+        decoded.append(toASCIIHexValue(input[i + 1], input[i + 2]));
+        i += 3;
+    }
+    // String::fromUTF8 returns a null String if the bytes are not valid UTF-8.
+    return String::fromUTF8(decoded.span());
+}
 
 template<typename Res>
 static void CookieMap__writeFetchHeadersToUWSResponse(CookieMap* cookie_map, JSC::JSGlobalObject* global_this, Res* res)
@@ -95,7 +121,6 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
             auto pairs = forCookieHeader.split(';');
             Vector<KeyValuePair<String, String>> cookies;
 
-            bool hasAnyPercentEncoded = forCookieHeader.find('%') != notFound;
             for (auto pair : pairs) {
                 String name = ""_s;
                 String value = ""_s;
@@ -114,11 +139,13 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
 
                 name = nameView.toString();
 
-                if (hasAnyPercentEncoded) {
-                    Bun::UTF8View utf8View(valueView);
-                    value = Bun::decodeURIComponentSIMD(utf8View.bytes());
-                } else {
+                if (valueView.find('%') == notFound) {
                     value = valueView.toString();
+                } else {
+                    value = percentDecodeCookieValue(valueView);
+                    if (value.isNull()) {
+                        value = valueView.toString();
+                    }
                 }
 
                 cookies.append(KeyValuePair<String, String>(name, value));

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 describe("Bun.Cookie and Bun.CookieMap", () => {
   // Basic Cookie tests
@@ -359,5 +360,87 @@ describe("invalid delete usage", () => {
       // @ts-ignore
       v2.delete(v2);
     }).toThrow("Cookie name is required");
+  });
+});
+
+// A Cookie header value is percent-decoded only if the whole value decodes
+// cleanly, matching node's `cookie` package. RFC 6265 allows a literal "%"
+// in a cookie value, so a value that was never percent-encoded must come
+// through verbatim instead of being corrupted with U+FFFD.
+describe("Bun.CookieMap percent-decoding", () => {
+  test("values that do not decode cleanly are kept raw", () => {
+    const cases: Record<string, string> = {
+      // a "%" that never forms a %XX escape
+      "50%": "50%",
+      "%zz": "%zz",
+      "x%": "x%",
+      "%": "%",
+      "%1": "%1",
+      "50%-off": "50%-off",
+      "a%%b": "a%%b",
+      // a syntactically valid %XX whose decoded bytes are not valid UTF-8
+      "a%C3b": "a%C3b",
+      "a%b2c": "a%b2c",
+      "%ED%A0%80": "%ED%A0%80",
+      "%C0%80": "%C0%80",
+      // all-or-nothing: one bad escape keeps the whole value raw
+      "a%25b%zz": "a%25b%zz",
+      "ok%20but%": "ok%20but%",
+    };
+    const parsed = Object.fromEntries(Object.keys(cases).map(raw => [raw, new Bun.CookieMap(`v=${raw}`).get("v")]));
+    expect(parsed).toEqual(cases);
+  });
+
+  test("values that decode cleanly are percent-decoded", () => {
+    const cases: Record<string, string> = {
+      "%41": "A",
+      "100%25": "100%",
+      "a%20b": "a b",
+      "%E8%AF%BB": "读",
+      "caf%C3%A9": "café",
+      "%F0%9F%8D%AA": "🍪",
+    };
+    const parsed = Object.fromEntries(Object.keys(cases).map(raw => [raw, new Bun.CookieMap(`v=${raw}`).get("v")]));
+    expect(parsed).toEqual(cases);
+  });
+
+  test("literal % values in a Cookie header are preserved verbatim", () => {
+    const map = new Bun.CookieMap("a=50%; b=%zz; c=x%");
+    expect(Object.fromEntries(map)).toEqual({ a: "50%", b: "%zz", c: "x%" });
+  });
+
+  // The old parser routed every value through an ASCII-only decoder as soon
+  // as any value in the header contained a "%", which misread non-ASCII
+  // values as Latin-1. Run in a subprocess: the unfixed debug build asserts.
+  test("non-ASCII values are preserved alongside percent-encoded siblings", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const m = new Bun.CookieMap("a=é; b=读%E5%86%99; c=🍪; d=%41");
+         process.stdout.write(JSON.stringify(Object.fromEntries(m)));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({
+      stdout: JSON.stringify({ a: "é", b: "读写", c: "🍪", d: "A" }),
+      exitCode: 0,
+    });
+  });
+
+  test("req.cookies preserves a literal % in values", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/": req => Response.json(req.cookies),
+      },
+    });
+    const res = await fetch(server.url, {
+      headers: { Cookie: "a=50%; b=%zz; c=x%; d=a%20b" },
+    });
+    expect(await res.json()).toEqual({ a: "50%", b: "%zz", c: "x%", d: "a b" });
+    expect(res.status).toBe(200);
   });
 });

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -408,9 +408,8 @@ describe("Bun.CookieMap percent-decoding", () => {
     expect(Object.fromEntries(map)).toEqual({ a: "50%", b: "%zz", c: "x%" });
   });
 
-  // The old parser routed every value through an ASCII-only decoder as soon
-  // as any value in the header contained a "%", which misread non-ASCII
-  // values as Latin-1. Run in a subprocess: the unfixed debug build asserts.
+  // Run in a subprocess so a native assertion surfaces as an isolated
+  // child-process failure instead of aborting the whole test runner.
   test("non-ASCII values are preserved alongside percent-encoded siblings", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -364,9 +364,8 @@ describe("invalid delete usage", () => {
 });
 
 // A Cookie header value is percent-decoded only if the whole value decodes
-// cleanly, matching node's `cookie` package. RFC 6265 allows a literal "%"
-// in a cookie value, so a value that was never percent-encoded must come
-// through verbatim instead of being corrupted with U+FFFD.
+// cleanly (node `cookie` semantics). RFC 6265 allows a literal "%" in a
+// cookie value, so a value that was never percent-encoded must round-trip.
 describe("Bun.CookieMap percent-decoding", () => {
   test("values that do not decode cleanly are kept raw", () => {
     const cases: Record<string, string> = {

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -424,8 +424,9 @@ describe("Bun.CookieMap percent-decoding", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, exitCode }).toEqual({
+    expect({ stdout, stderr, exitCode }).toEqual({
       stdout: JSON.stringify({ a: "é", b: "读写", c: "🍪", d: "A" }),
+      stderr: "",
       exitCode: 0,
     });
   });

--- a/test/js/bun/util/cookie.test.js
+++ b/test/js/bun/util/cookie.test.js
@@ -342,7 +342,7 @@ describe("cookie.parse(str)", function () {
     expect(cookie.parse("\tfoo\t=\tbar\t")).toEqual({ foo: "bar" });
   });
 
-  it.failing("should return original value on escape error", function () {
+  it("should return original value on escape error", function () {
     expect(cookie.parse("foo=%1;bar=bar")).toEqual({ foo: "%1", bar: "bar" });
   });
 


### PR DESCRIPTION
`Bun.CookieMap` and `req.cookies` silently corrupt any incoming cookie value that contains a literal `%` not forming a valid percent escape. The value is rewritten with U+FFFD, so the application receives a different string than the client sent and there is no error to catch.

### Repro

```js
const m = new Bun.CookieMap("a=50%; b=%zz; c=x%");
JSON.stringify({ a: m.get("a"), b: m.get("b"), c: m.get("c") })
// expected (node cookie / browsers / RFC 6265):  {"a":"50%","b":"%zz","c":"x%"}
// bun:                                           {"a":"50\uFFFD","b":"\uFFFD","c":"x\uFFFD"}
```

A `%` in a cookie value is legal (RFC 6265 `cookie-octet` includes `%`) and common: un-encoded percentages, base64url-like tokens, values written by other stacks that never percent-encode. node's `cookie` package, browsers, and other servers pass it through verbatim, so session, CSRF, and bucketing cookies that happen to contain a `%` stop matching only on Bun. This is `test/js/bun/util/cookie.test.js` "should return original value on escape error", which was marked `it.failing` as a known compatibility gap.

### Cause

Two problems in `CookieMap::create` (`src/jsc/bindings/CookieMap.cpp`):

1. It decided whether to decode by scanning the whole Cookie header for `%`, so one cookie containing an escape routed every sibling value through the decoder. A non-ASCII sibling value was then misread as Latin-1 on the way out (`a=é; z=%41` turned `é` into `Ã©`).
2. The decoder it used, `decodeURIComponentSIMD`, substitutes U+FFFD on any failure instead of reporting one, so the caller had no way to keep the original value.

### Fix

Percent-decode each value independently, and only if the entire value decodes cleanly: every `%` must form a `%XX` escape and the decoded bytes must be valid UTF-8. Otherwise the value is kept verbatim. This is what node's `cookie` package does (`decodeURIComponent` in a try/catch, returning the original string on `URIError`), and it is the first option suggested by the reporter.

The all-or-nothing rule also covers the escape that is syntactically valid hex but decodes to invalid UTF-8, such as a lone continuation byte: `a%C3b` and `%ED%A0%80` now round-trip instead of becoming U+FFFD.

`CookieMap` no longer uses `decodeURIComponentSIMD` at all. Its remaining callers are `ServerRouteList` (route params, a separate surface with the analogous bug fixed in #32823) and the `bun:internal-for-testing` export used by its unit test.

### Verification

New `Bun.CookieMap percent-decoding` describe block in `test/js/bun/cookie/cookie-map.test.ts`:

- values that do not decode cleanly are kept raw (bad escape, truncated escape, valid hex that is invalid UTF-8, one bad escape poisoning an otherwise valid value)
- values that do decode cleanly still decode (`%41`, `%E8%AF%BB`, an astral-plane code point)
- the exact reported header, plus the same header end to end through `req.cookies`
- a subprocess case with non-ASCII values alongside percent-encoded siblings, which the old header-wide `%` scan corrupted into mojibake

Four of the five new tests fail on the unmodified build with the exact reported output. `test/js/bun/util/cookie.test.js` "should return original value on escape error" loses its `it.failing` marker and passes.

All of `test/js/bun/cookie/`, `test/js/bun/util/cookie.test.js`, `test/js/bun/http/bun-serve-cookies.test.ts`, `test/js/bun/http/decodeURIComponentSIMD.test.ts`, `test/js/bun/http/bun-serve-routes.test.ts`, `test/js/web/fetch/cookies.test.ts`, and `test/bake/dev/request-cookies.test.ts` pass (550 tests).

Supersedes #32909, which fixed the per-value scoping and the non-ASCII mojibake but still substituted U+FFFD for invalid escapes. Independent of #32823, which fixes the same invalid-escape handling for route params.
