### PR TITLE
bun:sqlite: throw when a Statement is reused while its iterate() cursor is live

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -403,6 +403,16 @@ for (const row of query) {
 }
 ```
 
+While the iterator is running, the statement's cursor belongs to it. Calling `.get()`, `.all()`, `.values()`, `.raw()`, `.run()`, or `.iterate()` on the same `Statement` before the loop finishes (or reading its `.columnTypes`) throws `TypeError: This statement is busy executing a query`. To run another query inside the loop body, prepare a second statement:
+
+```ts db.ts icon="/icons/typescript.svg" highlight={2, 4}
+const outer = db.prepare("SELECT * FROM foo");
+const inner = db.prepare("SELECT * FROM bar WHERE foo_id = ?");
+for (const row of outer.iterate()) {
+  console.log(inner.all(row.id));
+}
+```
+
 ### `.values()`
 
 Use `values()` to run a query and get back all results as an array of arrays.

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -674,6 +674,12 @@ declare module "bun:sqlite" {
     /**
      * Execute the prepared statement and return an iterator over the results.
      *
+     * While the iterator is running, the statement's cursor belongs to it: calling
+     * `get`, `all`, `values`, `raw`, `run`, or `iterate` on the same `Statement`, or
+     * reading `columnTypes`, throws `TypeError: This statement is busy executing a
+     * query`. Exhaust the iterator or break out of the loop first, or prepare a
+     * second statement with {@link Database.prepare}.
+     *
      * @param params optional values to bind to the statement. If omitted, the statement is run with the last bound values or no parameters if there are none.
      */
     iterate(...params: ParamsType): IterableIterator<ReturnType>;
@@ -833,6 +839,7 @@ declare module "bun:sqlite" {
      * ```
      *
      * @throws Error if statement is not read-only (INSERT, UPDATE, DELETE, etc.)
+     * @throws TypeError if an iterator returned by {@link iterate} on this statement is still running
      * @since Bun v1.2.13
      */
     readonly columnTypes: Array<"INTEGER" | "FLOAT" | "TEXT" | "BLOB" | "NULL" | null>;

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -102,6 +102,9 @@ interface CppSQLStatement {
   get: (...args: TODO[]) => TODO;
   all: (...args: TODO[]) => TODO;
   iterate: (...args: TODO[]) => TODO;
+  // One row object, or null once the cursor is exhausted.
+  iterateNext: () => unknown;
+  iterateEnd: () => void;
   as: (...args: TODO[]) => TODO;
   values: (...args: TODO[]) => TODO;
   raw: (...args: TODO[]) => TODO;
@@ -197,10 +200,22 @@ class Statement {
     return this.#raw.all();
   }
 
-  *#iterateNoArgs() {
-    for (let res = this.#raw.iterate(); res; res = this.#raw.iterate()) {
-      yield res;
+  // `firstRow` comes from a native iterate() call that just began a cursor and marked the
+  // statement busy. The finally runs even when the loop is abandoned early (break, throw,
+  // return), so the statement is always released and reset for whatever comes next.
+  *#drainIterator(firstRow) {
+    const raw = this.#raw;
+    try {
+      for (let res = firstRow; res; res = raw.iterateNext()) {
+        yield res;
+      }
+    } finally {
+      raw.iterateEnd();
     }
+  }
+
+  *#iterateNoArgs() {
+    yield* this.#drainIterator(this.#raw.iterate());
   }
 
   #valuesNoArgs() {
@@ -263,13 +278,11 @@ class Statement {
     // ("foo") => ["foo"]
     // (Uint8Array(1024)) => [Uint8Array]
     // (123) => [123]
-    let res =
+    yield* this.#drainIterator(
       !isArray(arg0) && (!arg0 || typeof arg0 !== "object" || isTypedArray(arg0))
         ? this.#raw.iterate(args)
-        : this.#raw.iterate(...args);
-    for (; res; res = this.#raw.iterate()) {
-      yield res;
-    }
+        : this.#raw.iterate(...args),
+    );
   }
 
   #values(...args) {

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -200,9 +200,7 @@ class Statement {
     return this.#raw.all();
   }
 
-  // `firstRow` comes from a native iterate() call that just began a cursor and marked the
-  // statement busy. The finally runs even when the loop is abandoned early (break, throw,
-  // return), so the statement is always released and reset for whatever comes next.
+  // `firstRow` is the result of the native iterate() call that opened the cursor.
   *#drainIterator(firstRow) {
     const raw = this.#raw;
     try {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -190,9 +190,7 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
         return {};                                                                                                  \
     }
 
-// An iterator returned by Statement.prototype.iterate() owns the statement's cursor until
-// it is exhausted or returned from. Anything else that resets or steps the cursor would
-// restart or corrupt that iteration, so it is an error (matching better-sqlite3).
+// A live iterate() owns the cursor; resetting or stepping it from anywhere else is an error, as in better-sqlite3.
 #define CHECK_NOT_ITERATING                                                                                                             \
     if (castedThis->isIterating) [[unlikely]] {                                                                                         \
         throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "This statement is busy executing a query"_s)); \
@@ -2203,9 +2201,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSetPrototypeFunction, (JSGlobalObject * l
     return JSValue::encode(jsUndefined());
 }
 
-// Steps the iterate() cursor once and materializes the row (or jsNull when exhausted).
-// isIterating ends up true only when a row was successfully produced; every other exit
-// (done, SQLite error, JS exception) leaves it false so the statement is usable again.
+// Leaves isIterating set only when a row was produced, so done, SQLite errors, and JS exceptions all release the statement.
 static JSC::EncodedJSValue stepIterator(JSC::JSGlobalObject* lexicalGlobalObject, JSSQLStatement* castedThis, sqlite3_stmt* stmt)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -2289,12 +2285,9 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionIterateEnd, (JSC::JSGlobalObject 
 
     CHECK_THIS
 
-    // Releases the cursor even when the iteration was abandoned early (break, throw,
-    // .return()), so a later get()/all()/iterate() starts from the first row again.
     castedThis->isIterating = false;
     if (castedThis->stmt) {
-        // For a write statement abandoned after SQLITE_ROW (INSERT ... RETURNING with an
-        // early break), this reset is what commits the change, and it can fail.
+        // For INSERT ... RETURNING abandoned after SQLITE_ROW, this reset is the commit, and it can fail.
         int statusCode = sqlite3_reset(castedThis->stmt);
         if (statusCode != SQLITE_OK) [[unlikely]] {
             throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(castedThis->stmt)));

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -190,6 +190,15 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
         return {};                                                                                                  \
     }
 
+// An iterator returned by Statement.prototype.iterate() owns the statement's cursor until
+// it is exhausted or returned from. Anything else that resets or steps the cursor would
+// restart or corrupt that iteration, so it is an error (matching better-sqlite3).
+#define CHECK_NOT_ITERATING                                                                                                             \
+    if (castedThis->isIterating) [[unlikely]] {                                                                                         \
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "This statement is busy executing a query"_s)); \
+        return {};                                                                                                                      \
+    }
+
 namespace WebCore {
 class JSSQLStatement;
 static ASCIILiteral finalizedMessage(const JSSQLStatement* statement);
@@ -331,6 +340,8 @@ JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionGet);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionIterate);
+JSC_DECLARE_HOST_FUNCTION(jsSQLStatementFunctionIterateNext);
+JSC_DECLARE_HOST_FUNCTION(jsSQLStatementFunctionIterateEnd);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows);
 
@@ -529,6 +540,8 @@ public:
     // Created by db.query(); close(false) finalizes these but leaves db.prepare() statements usable.
     bool ownedByDatabase : 1 = false;
     bool finalizedByClose : 1 = false;
+    // True while an iterator from Statement.prototype.iterate() is mid-flight.
+    bool isIterating : 1 = false;
 
 protected:
     JSSQLStatement(JSC::Structure* structure, JSDOMGlobalObject& globalObject, sqlite3_stmt* stmt, VersionSqlite3* version_db, int64_t memorySizeChange = 0)
@@ -667,6 +680,8 @@ static const HashTableValue JSSQLStatementPrototypeTableValues[] = {
     { "get"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementExecuteStatementFunctionGet, 1 } },
     { "all"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementExecuteStatementFunctionAll, 1 } },
     { "iterate"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementExecuteStatementFunctionIterate, 1 } },
+    { "iterateNext"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementFunctionIterateNext, 0 } },
+    { "iterateEnd"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementFunctionIterateEnd, 0 } },
     { "as"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementSetPrototypeFunction, 1 } },
     { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementExecuteStatementFunctionRows, 1 } },
     { "raw"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementExecuteStatementFunctionRawRows, 1 } },
@@ -2188,30 +2203,15 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSetPrototypeFunction, (JSGlobalObject * l
     return JSValue::encode(jsUndefined());
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionIterate, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+// Steps the iterate() cursor once and materializes the row (or jsNull when exhausted).
+// isIterating ends up true only when a row was successfully produced; every other exit
+// (done, SQLite error, JS exception) leaves it false so the statement is usable again.
+static JSC::EncodedJSValue stepIterator(JSC::JSGlobalObject* lexicalGlobalObject, JSSQLStatement* castedThis, sqlite3_stmt* stmt)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto castedThis = dynamicDowncast<JSSQLStatement>(callFrame->thisValue());
 
-    CHECK_THIS
-
-    auto* stmt = castedThis->stmt;
-    CHECK_PREPARED
-
-    int busy = sqlite3_stmt_busy(stmt);
-    if (!busy) {
-        int statusCode = sqlite3_reset(stmt);
-        if (statusCode != SQLITE_OK) [[unlikely]] {
-            throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
-            return {};
-        }
-    }
-
-    if (callFrame->argumentCount() > 0) {
-        auto arg0 = callFrame->argument(0);
-        DO_REBIND(arg0);
-    }
+    castedThis->isIterating = false;
 
     int status = sqlite3_step(stmt);
     if (!sqlite3_stmt_readonly(stmt)) {
@@ -2223,22 +2223,86 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionIterate, (JSC::JS
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    JSValue result = jsNull();
     if (status == SQLITE_ROW) {
-        bool useBigInt64 = castedThis->useBigInt64;
-
-        result = useBigInt64 ? constructResultObject<true>(lexicalGlobalObject, castedThis)
-                             : constructResultObject<false>(lexicalGlobalObject, castedThis);
+        JSValue result = castedThis->useBigInt64
+            ? constructResultObject<true>(lexicalGlobalObject, castedThis)
+            : constructResultObject<false>(lexicalGlobalObject, castedThis);
         RETURN_IF_EXCEPTION(scope, {});
+        castedThis->isIterating = true;
+        RELEASE_AND_RETURN(scope, JSValue::encode(result));
     }
 
-    if (status == SQLITE_DONE || status == SQLITE_OK || status == SQLITE_ROW) {
-        RELEASE_AND_RETURN(scope, JSValue::encode(result));
-    } else {
+    if (status == SQLITE_DONE || status == SQLITE_OK) {
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsNull()));
+    }
+
+    throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
+    sqlite3_reset(stmt);
+    return {};
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionIterate, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto castedThis = dynamicDowncast<JSSQLStatement>(callFrame->thisValue());
+
+    CHECK_THIS
+
+    auto* stmt = castedThis->stmt;
+    CHECK_PREPARED
+    CHECK_NOT_ITERATING
+
+    int statusCode = sqlite3_reset(stmt);
+    if (statusCode != SQLITE_OK) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(stmt)));
-        sqlite3_reset(stmt);
         return {};
     }
+
+    if (callFrame->argumentCount() > 0) {
+        auto arg0 = callFrame->argument(0);
+        DO_REBIND(arg0);
+    }
+
+    RELEASE_AND_RETURN(scope, stepIterator(lexicalGlobalObject, castedThis, stmt));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionIterateNext, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto castedThis = dynamicDowncast<JSSQLStatement>(callFrame->thisValue());
+
+    CHECK_THIS
+
+    auto* stmt = castedThis->stmt;
+    CHECK_PREPARED
+
+    RELEASE_AND_RETURN(scope, stepIterator(lexicalGlobalObject, castedThis, stmt));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionIterateEnd, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto castedThis = dynamicDowncast<JSSQLStatement>(callFrame->thisValue());
+
+    CHECK_THIS
+
+    // Releases the cursor even when the iteration was abandoned early (break, throw,
+    // .return()), so a later get()/all()/iterate() starts from the first row again.
+    castedThis->isIterating = false;
+    if (castedThis->stmt) {
+        // For a write statement abandoned after SQLITE_ROW (INSERT ... RETURNING with an
+        // early break), this reset is what commits the change, and it can fail.
+        int statusCode = sqlite3_reset(castedThis->stmt);
+        if (statusCode != SQLITE_OK) [[unlikely]] {
+            throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, sqlite3_db_handle(castedThis->stmt)));
+            return {};
+        }
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -2251,6 +2315,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
 
     auto* stmt = castedThis->stmt;
     CHECK_PREPARED
+    CHECK_NOT_ITERATING
     int statusCode = sqlite3_reset(stmt);
 
     if (statusCode != SQLITE_OK) [[unlikely]] {
@@ -2346,6 +2411,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionGet, (JSC::JSGlob
 
     auto* stmt = castedThis->stmt;
     CHECK_PREPARED
+    CHECK_NOT_ITERATING
 
     int statusCode = sqlite3_reset(stmt);
     if (statusCode != SQLITE_OK) [[unlikely]] {
@@ -2400,6 +2466,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
 
     auto* stmt = castedThis->stmt;
     CHECK_PREPARED
+    CHECK_NOT_ITERATING
 
     int statusCode = sqlite3_reset(stmt);
     if (statusCode != SQLITE_OK) [[unlikely]] {
@@ -2489,6 +2556,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
 
     auto* stmt = castedThis->stmt;
     CHECK_PREPARED
+    CHECK_NOT_ITERATING
 
     int statusCode = sqlite3_reset(stmt);
     if (statusCode != SQLITE_OK) [[unlikely]] {
@@ -2580,6 +2648,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
 
     auto* stmt = castedThis->stmt;
     CHECK_PREPARED
+    CHECK_NOT_ITERATING
 
     int statusCode = sqlite3_reset(stmt);
     if (statusCode != SQLITE_OK) [[unlikely]] {
@@ -2716,6 +2785,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexical
     auto scope = DECLARE_THROW_SCOPE(vm);
     CHECK_THIS
     CHECK_PREPARED
+    CHECK_NOT_ITERATING
 
     int count = sqlite3_column_count(castedThis->stmt);
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1138,6 +1138,30 @@ describe("Statement.iterate() busy guard", () => {
     expect(db.prepare("SELECT id, pid FROM child").all()).toEqual([{ id: 1, pid: 999 }]);
     db.close();
   });
+
+  it("an exception from the loop body is not masked by a commit failure while releasing the cursor", () => {
+    const db = new Database(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+    db.exec("CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    db.exec(
+      "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED)",
+    );
+    const s = db.prepare("INSERT INTO child (id, pid) VALUES (1, 999) RETURNING id");
+
+    // Both fail here: the body throws, and releasing the cursor fails the deferred FK check.
+    // for..of closes the iterator with a throw completion, which keeps the body's exception.
+    expect(() => {
+      for (const _row of s.iterate()) {
+        throw new Error("boom");
+      }
+    }).toThrow("boom");
+
+    // The statement was still released.
+    expect(db.prepare("SELECT * FROM child").all()).toEqual([]);
+    db.exec("INSERT INTO parent (id) VALUES (999)");
+    expect(s.get()).toEqual({ id: 1 });
+    db.close();
+  });
 });
 
 it("db.run()", () => {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -916,6 +916,230 @@ it("db.query()", () => {
   db.close();
 });
 
+describe("Statement.iterate() busy guard", () => {
+  const busy = "This statement is busy executing a query";
+
+  function makeDb() {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (a INTEGER)");
+    for (let i = 0; i < 3; i++) db.exec(`INSERT INTO t VALUES (${i})`);
+    return db;
+  }
+
+  it("using the same statement inside its own iterate() loop throws instead of restarting the cursor", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+
+    const seen = [];
+    let throws = 0;
+    for (const row of s.iterate()) {
+      seen.push(row.a);
+      expect(() => s.get()).toThrow(TypeError);
+      expect(() => s.get()).toThrow(busy);
+      throws++;
+    }
+
+    // The rejected get() calls did not disturb the iteration.
+    expect(seen).toEqual([0, 1, 2]);
+    expect(throws).toBe(3);
+    db.close();
+  });
+
+  it("every operation that touches the cursor throws while the statement is being iterated", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+
+    for (const _row of s.iterate()) {
+      expect(() => s.get()).toThrow(busy);
+      expect(() => s.all()).toThrow(busy);
+      expect(() => s.values()).toThrow(busy);
+      expect(() => s.raw()).toThrow(busy);
+      expect(() => s.run()).toThrow(busy);
+      expect(() => s.columnTypes).toThrow(busy);
+      expect(() => s.iterate().next()).toThrow(busy);
+      // Operations that do not touch the cursor stay usable.
+      expect(s.toString()).toBe("SELECT a FROM t ORDER BY a");
+      expect(s.columnNames).toEqual(["a"]);
+      break;
+    }
+
+    // Once the loop exits, the statement is fully usable again.
+    expect(s.all()).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    db.close();
+  });
+
+  it("a second iterate() on the same statement throws instead of interleaving rows", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+
+    const a = s.iterate()[Symbol.iterator]();
+    expect(a.next().value).toEqual({ a: 0 });
+
+    const b = s.iterate()[Symbol.iterator]();
+    expect(() => b.next()).toThrow(busy);
+
+    // The rejected iterator did not disturb the live one.
+    expect(a.next().value).toEqual({ a: 1 });
+    expect(a.next().value).toEqual({ a: 2 });
+    expect(a.next().done).toBe(true);
+    db.close();
+  });
+
+  it("breaking out of iterate() resets the cursor for the next iteration", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+
+    for (const row of s.iterate()) {
+      expect(row).toEqual({ a: 0 });
+      break;
+    }
+
+    // A leaked cursor would resume at the second row here.
+    expect(Array.from(s.iterate())).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    db.close();
+  });
+
+  it("an exception thrown from the loop body releases the statement", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+
+    expect(() => {
+      for (const _row of s.iterate()) {
+        throw new Error("boom");
+      }
+    }).toThrow("boom");
+
+    // A leaked cursor would resume at the second row here.
+    expect(Array.from(s.iterate())).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    expect(s.all()).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    db.close();
+  });
+
+  it("a separately prepared statement for the same SQL is independent", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+    const other = db.prepare("SELECT a FROM t ORDER BY a");
+
+    const pairs = [];
+    for (const row of s.iterate()) {
+      pairs.push([row.a, other.get().a]);
+    }
+
+    expect(pairs).toEqual([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+    ]);
+    db.close();
+  });
+
+  it("iterate() with bound parameters enforces the same guard and releases on break", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t WHERE a >= $min ORDER BY a");
+
+    const seen = [];
+    for (const row of s.iterate({ $min: 1 })) {
+      seen.push(row.a);
+      expect(() => s.get({ $min: 0 })).toThrow(busy);
+      break;
+    }
+    expect(seen).toEqual([1]);
+
+    expect(s.all({ $min: 0 })).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    expect(Array.from(s.iterate({ $min: 0 }))).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    db.close();
+  });
+
+  it("array destructuring of iterate() (which calls .return()) releases the statement", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+
+    // Destructuring pulls one row then calls .return() on the unfinished iterator.
+    const [first] = s.iterate();
+    expect(first).toEqual({ a: 0 });
+
+    // A leaked cursor would resume at the second row here.
+    expect(Array.from(s.iterate())).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    expect(s.all()).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    db.close();
+  });
+
+  it("iterating the Statement directly via Symbol.iterator enforces the same guard and releases on break", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+
+    for (const row of s) {
+      expect(row).toEqual({ a: 0 });
+      expect(() => s.get()).toThrow(busy);
+      break;
+    }
+
+    // A leaked cursor would resume at the second row here.
+    expect(Array.from(s)).toEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    db.close();
+  });
+
+  it("finalize() inside the loop body ends the iteration without crashing", () => {
+    const db = makeDb();
+    const s = db.prepare("SELECT a FROM t ORDER BY a");
+
+    const seen = [];
+    expect(() => {
+      for (const row of s.iterate()) {
+        seen.push(row.a);
+        s.finalize();
+      }
+    }).toThrow("Statement has finalized");
+
+    // The one row stepped before the statement went away was still yielded.
+    expect(seen).toEqual([0]);
+    db.close();
+  });
+
+  // For a write statement abandoned after SQLITE_ROW, the sqlite3_reset() that releases the
+  // iterator is what commits the implicit transaction, and SQLite documents that it can fail
+  // even though every prior sqlite3_step() succeeded: https://www.sqlite.org/c3ref/reset.html
+  it("breaking out of an iterated INSERT ... RETURNING surfaces the commit failure", () => {
+    const db = new Database(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+    db.exec("CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    db.exec(
+      "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED)",
+    );
+
+    // No parent 999 exists, but the FK is deferred, so the first step still yields the row.
+    const s = db.prepare("INSERT INTO child (id, pid) VALUES (1, 999) RETURNING id");
+
+    const seen = [];
+    let err = null;
+    try {
+      for (const row of s.iterate()) {
+        seen.push(row);
+        break;
+      }
+    } catch (e) {
+      err = e;
+    }
+
+    // iterate() already handed back the "inserted" row...
+    expect(seen).toEqual([{ id: 1 }]);
+    // ...but the commit failed and must be reported, not swallowed: the row is not there.
+    expect(err).toBeInstanceOf(SQLiteError);
+    expect({ code: err?.code, message: err?.message }).toEqual({
+      code: "SQLITE_CONSTRAINT_FOREIGNKEY",
+      message: "FOREIGN KEY constraint failed",
+    });
+    expect(db.prepare("SELECT * FROM child").all()).toEqual([]);
+
+    // The failed commit released the cursor rather than bricking the statement: once the
+    // parent row exists, the same statement runs to completion.
+    db.exec("INSERT INTO parent (id) VALUES (999)");
+    expect(s.get()).toEqual({ id: 1 });
+    expect(db.prepare("SELECT id, pid FROM child").all()).toEqual([{ id: 1, pid: 999 }]);
+    db.close();
+  });
+});
+
 it("db.run()", () => {
   const db = Database.open(":memory:");
 


### PR DESCRIPTION
### What

`Statement.prototype.iterate()` now tracks its cursor explicitly. Any other use of the same `Statement` while an iterator from it is mid-flight throws:

```
TypeError: This statement is busy executing a query
```

which is what both `better-sqlite3` and `node:sqlite` do. Previously it silently restarted the cursor, turning a 3-row loop into an infinite one and letting two iterators on the same statement steal each other's rows.

### Reproduction

```js
import { Database } from "bun:sqlite";
const db = new Database(":memory:");
db.exec("create table t(a)");
for (let i = 0; i < 3; i++) db.exec(`insert into t values (${i})`);

const s = db.prepare("select * from t");
let n = 0;
for (const _row of s.iterate()) {
  n++;
  s.get(); // any other use of the SAME statement resets the shared cursor
  if (n > 50) break;
}
console.log(n);
```

On Bun before this change the loop never terminates (`n` is `51` only because of the manual `break`); `better-sqlite3` and `node:sqlite` both throw on the `s.get()`. A second `s.iterate()` started while the first is running interleaves the two cursors (`[0, 1, 2, done, 0, done]`) instead of throwing.

### Cause

`jsSQLStatementExecuteStatementFunctionIterate` used `sqlite3_stmt_busy(stmt)` to decide between "start a new query" (reset) and "continue the one in progress" (don't reset). That heuristic only asks whether the shared `sqlite3_stmt` is mid result set, so any other call on the same statement between iterations flips it:

- `get()` / `all()` / `run()` unconditionally `sqlite3_reset` + step the statement to `SQLITE_DONE`, so the stmt reads as not-busy and the next `iterate()` call resets back to row 0. With more rows in the table than the loop body produces, the cursor never reaches the end: an infinite loop.
- A second `iterate()` on the same statement reads as busy, so it *continues* the first cursor instead of starting its own, and the two iterators silently interleave and drop rows.

### Fix

- Add an explicit `isIterating : 1` bit to `JSSQLStatement` and a `CHECK_NOT_ITERATING` guard that throws the `better-sqlite3` error message. It's applied to every operation that resets or steps the cursor: `get`, `all`, `values`, `raw`, `run`, `iterate`, and the `columnTypes` getter (which also resets and steps). `toString()`, `columnNames`, `paramsCount`, `safeIntegers`, and `as()` don't touch the cursor and stay usable mid-iteration.
- Split the native `iterate()` into begin (`iterate`, which resets + binds + steps once) / `iterateNext` (step once) / `iterateEnd` (clear the flag and reset). `isIterating` is set only when a step produced a row, and cleared on every other exit (done, SQLite error, JS exception), so an error never wedges the statement.
- The JS generator in `sqlite.ts` drives those through a `try`/`finally`, so `break`, `throw`, and `.return()` from the loop body all release and reset the cursor. Previously an early `break` left the statement mid result set, and the next `for..of` over the same statement resumed where the abandoned one stopped instead of starting from the first row (covered by a new test).
- `iterateEnd` checks `sqlite3_reset()`'s return and throws a `SQLiteError` on failure, like the other reset sites in this file. For a write statement abandoned after `SQLITE_ROW` (an `INSERT ... RETURNING` with an early `break`), that reset is what commits the implicit transaction, and SQLite documents that it can fail even though every prior `sqlite3_step()` succeeded. Discarding it would mean the iterator returns the inserted row, the commit silently rolls back, and no error is raised (covered by a new test using a deferred foreign key).

One behavior note: code that nests two iterations of the *same* statement object, e.g. iterating `db.query(sql)` inside a loop over `db.query(sql)` (which returns the cached statement), now throws instead of silently interleaving. The fix is to `db.prepare()` a second statement; this matches both reference bindings and is called out in the docs and the `.d.ts`.

### Tests

`test/js/bun/sqlite/sqlite.test.js` gains a `Statement.iterate() busy guard` describe block covering: reuse inside the loop body, every guarded operation (and the unguarded ones as a negative contract), a concurrent second iterator, cursor release on `break` and on an exception from the loop body, independence of a separately prepared statement, and the bound-parameter `iterate(params)` path.

Without the fix, 6 of the 7 fail (the 7th is the two-independent-statements negative contract):

```
(fail) using the same statement inside its own iterate() loop throws instead of restarting the cursor
(fail) every operation that touches the cursor throws while the statement is being iterated
(fail) a second iterate() on the same statement throws instead of interleaving rows
(fail) breaking out of iterate() resets the cursor for the next iteration
(fail) an exception thrown from the loop body releases the statement
(pass) a separately prepared statement for the same SQL is independent
(fail) iterate() with bound parameters enforces the same guard and releases on break
```

With the fix, all 7 pass and the full `test/js/bun/sqlite/` suite is green (98 pass / 0 fail).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->