### PR TITLE
sqlite: reset the statement when iterate() ends early

### DIFF
--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -103,6 +103,7 @@ interface CppSQLStatement {
   as: (...args: TODO[]) => TODO;
   values: (...args: TODO[]) => TODO;
   raw: (...args: TODO[]) => TODO;
+  reset: (...args: TODO[]) => TODO;
   finalize: (...args: TODO[]) => TODO;
   toString: (...args: TODO[]) => TODO;
   columns: string[];
@@ -193,8 +194,14 @@ class Statement {
   }
 
   *#iterateNoArgs() {
-    for (let res = this.#raw.iterate(); res; res = this.#raw.iterate()) {
-      yield res;
+    try {
+      for (let res = this.#raw.iterate(); res; res = this.#raw.iterate()) {
+        yield res;
+      }
+    } finally {
+      // Ending iteration early (break, return(), throw) leaves the statement's
+      // cursor open; reset it so the next execution starts from the first row.
+      this.#raw.reset();
     }
   }
 
@@ -254,16 +261,22 @@ class Statement {
   *#iterate(...args) {
     if (args.length === 0) return yield* this.#iterateNoArgs();
     var arg0 = args[0];
-    // ["foo"] => ["foo"]
-    // ("foo") => ["foo"]
-    // (Uint8Array(1024)) => [Uint8Array]
-    // (123) => [123]
-    let res =
-      !isArray(arg0) && (!arg0 || typeof arg0 !== "object" || isTypedArray(arg0))
-        ? this.#raw.iterate(args)
-        : this.#raw.iterate(...args);
-    for (; res; res = this.#raw.iterate()) {
-      yield res;
+    try {
+      // ["foo"] => ["foo"]
+      // ("foo") => ["foo"]
+      // (Uint8Array(1024)) => [Uint8Array]
+      // (123) => [123]
+      let res =
+        !isArray(arg0) && (!arg0 || typeof arg0 !== "object" || isTypedArray(arg0))
+          ? this.#raw.iterate(args)
+          : this.#raw.iterate(...args);
+      for (; res; res = this.#raw.iterate()) {
+        yield res;
+      }
+    } finally {
+      // Ending iteration early (break, return(), throw) leaves the statement's
+      // cursor open; reset it so the next execution starts from the first row.
+      this.#raw.reset();
     }
   }
 

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -310,6 +310,7 @@ JSC_DECLARE_HOST_FUNCTION(jsSQLStatementDeserialize);
 
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementSetPrototypeFunction);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementFunctionFinalize);
+JSC_DECLARE_HOST_FUNCTION(jsSQLStatementFunctionReset);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementToStringFunction);
 
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnNames);
@@ -635,6 +636,7 @@ static const HashTableValue JSSQLStatementPrototypeTableValues[] = {
     { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementExecuteStatementFunctionRows, 1 } },
     { "raw"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementExecuteStatementFunctionRawRows, 1 } },
     { "finalize"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementFunctionFinalize, 0 } },
+    { "reset"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementFunctionReset, 0 } },
     { "toString"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsSQLStatementToStringFunction, 0 } },
     { "columns"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnNames, 0 } },
     { "columnsCount"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnCount, 0 } },
@@ -2810,6 +2812,23 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionFinalize, (JSC::JSGlobalObject * 
     if (castedThis->stmt) {
         sqlite3_finalize(castedThis->stmt);
         castedThis->stmt = nullptr;
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
+}
+
+// Releases the cursor of a statement whose iteration ended early, so the next
+// execution starts from the first row instead of resuming (or failing to bind).
+// A finalized statement has nothing to reset; step errors were already thrown.
+JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionReset, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    JSSQLStatement* castedThis = dynamicDowncast<JSSQLStatement>(callFrame->thisValue());
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    CHECK_THIS
+
+    if (castedThis->stmt) {
+        sqlite3_reset(castedThis->stmt);
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -731,6 +731,106 @@ it("db.query()", () => {
   db.close();
 });
 
+describe("Statement.iterate() ended early", () => {
+  const allRows = Array.from({ length: 10 }, (_, a) => ({ a }));
+
+  function openDB() {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (a INTEGER)");
+    for (let i = 0; i < 10; i++) db.exec(`INSERT INTO t VALUES (${i})`);
+    return db;
+  }
+
+  it("break resets the statement so the next iterate() returns every row", () => {
+    using db = openDB();
+    using stmt = db.prepare("SELECT a FROM t ORDER BY a");
+
+    for (const row of stmt.iterate()) break;
+
+    expect([...stmt.iterate()]).toEqual(allRows);
+  });
+
+  it("break resets a statement with bound parameters instead of failing to rebind", () => {
+    using db = openDB();
+    using stmt = db.prepare("SELECT a FROM t WHERE a >= ? ORDER BY a");
+
+    for (const row of stmt.iterate(0)) break;
+
+    // Without the reset, rebinding a busy statement fails with
+    // "bad parameter or other API misuse" (SQLITE_MISUSE).
+    expect([...stmt.iterate(0)]).toEqual(allRows);
+    expect([...stmt.iterate(5)]).toEqual(allRows.slice(5));
+  });
+
+  it("a throw from the loop body resets the statement", () => {
+    using db = openDB();
+    using stmt = db.prepare("SELECT a FROM t ORDER BY a");
+
+    expect(() => {
+      for (const row of stmt.iterate()) {
+        throw new Error("stop");
+      }
+    }).toThrow("stop");
+
+    expect([...stmt.iterate()]).toEqual(allRows);
+  });
+
+  it("destructuring the iterator resets the statement", () => {
+    using db = openDB();
+    using stmt = db.prepare("SELECT a FROM t ORDER BY a");
+
+    const [first] = stmt.iterate();
+    expect(first).toEqual({ a: 0 });
+
+    expect([...stmt.iterate()]).toEqual(allRows);
+  });
+
+  it("break out of for..of over the Statement itself resets it", () => {
+    using db = openDB();
+    using stmt = db.prepare("SELECT a FROM t ORDER BY a");
+
+    for (const row of stmt) break;
+
+    expect([...stmt]).toEqual(allRows);
+  });
+
+  it("stopping partway through resets the statement", () => {
+    using db = openDB();
+    using stmt = db.prepare("SELECT a FROM t ORDER BY a");
+
+    const seen = [];
+    for (const row of stmt.iterate()) {
+      seen.push(row);
+      if (seen.length === 3) break;
+    }
+    expect(seen).toEqual(allRows.slice(0, 3));
+
+    expect([...stmt.iterate()]).toEqual(allRows);
+    expect(stmt.all()).toEqual(allRows);
+    expect(stmt.get()).toEqual(allRows[0]);
+  });
+
+  it("completing the iteration still allows the statement to be reused", () => {
+    using db = openDB();
+    using stmt = db.prepare("SELECT a FROM t ORDER BY a");
+
+    expect([...stmt.iterate()]).toEqual(allRows);
+    expect([...stmt.iterate()]).toEqual(allRows);
+  });
+
+  it("finalizing the statement inside the loop does not throw on break", () => {
+    using db = openDB();
+    using stmt = db.prepare("SELECT a FROM t ORDER BY a");
+
+    for (const row of stmt.iterate()) {
+      stmt.finalize();
+      break;
+    }
+
+    expect(() => stmt.all()).toThrow("Statement has finalized");
+  });
+});
+
 it("db.run()", () => {
   const db = Database.open(":memory:");
 


### PR DESCRIPTION
### What

`bun:sqlite` left a prepared statement in an undefined state after a `Statement.iterate()` loop ended early. The next use of the same statement either threw `SQLiteError: bad parameter or other API misuse` (when it had parameters to rebind) or silently returned a truncated result set (the un-reset cursor resumed past the first row).

```js
import { Database } from "bun:sqlite";
const db = new Database(":memory:");
db.exec("create table t(a)");
for (let i = 0; i < 10; i++) db.exec(`insert into t values (${i})`);
const s = db.prepare("select a from t order by a");

for (const row of s.iterate()) break; // any early exit: break, return, throw, destructuring

[...s.iterate()].length; // 9 instead of 10; with bound parameters it throws instead
```

`better-sqlite3` and `node:sqlite` both return all 10 rows here.

### Why

The native `iterate()` uses `sqlite3_stmt_busy()` to decide whether a call is starting a new iteration (reset first) or continuing one (do not reset). Breaking out of the loop abandons the JS generator, so nothing ever resets the statement and it stays "busy":

- the next no-argument `iterate()` is misread as a continuation and resumes the stale cursor, so the first row is silently dropped,
- the next parameterized `iterate()` calls `sqlite3_bind_*` on a busy statement, which fails with `SQLITE_MISUSE`.

The same thing happens when the loop body throws, when the iterator is closed by destructuring, and when iterating the `Statement` itself via `Symbol.iterator`.

### How

- `JSSQLStatement.cpp`: add an internal `reset` method on the native statement handle that calls `sqlite3_reset` (a no-op once the statement is finalized).
- `src/js/bun/sqlite.ts`: wrap both `iterate` generator bodies in `try`/`finally` and reset the statement in the `finally`, so closing the iterator for any reason (completion, `break`, `return()`, `throw()`) releases the cursor.

This is the same approach both reference implementations take: they reset the statement when the row iterator is disposed early. `Statement.all()`/`get()`/`run()` were already unaffected because they reset unconditionally.

### Tests

Added `Statement.iterate() ended early` to `test/js/bun/sqlite/sqlite.test.js`, covering `break`, a throw from the loop body, destructuring the iterator, `for..of` over the `Statement` itself, bound parameters, stopping partway through, and finalizing inside the loop. 6 of the 8 cases fail on `bun test` without the fix (9 rows instead of 10, or `bad parameter or other API misuse`) and all pass with it; the full `test/js/bun/sqlite/` suite still passes (99 tests).
