### PR TITLE
webcore: pin the FileReader across re-entrant cancel in on_read_chunk and on_reader_error

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -785,8 +785,19 @@ impl FileReader {
             self.pending_value
                 .with_mut(|p| p.clear_without_deallocation());
             self.pending_view.set(&mut []);
+            // Pin across `p.run()`: a re-entrant cancel() reaches
+            // on_reader_done, which drops the across-read ref and lets a GC
+            // free this box while the io caller still holds `&mut` into it.
+            let parent = self.parent();
+            // SAFETY: see `parent()`.
+            unsafe { (*parent).increment_count() };
             self.pending.with_mut(|p| p.run());
             close_if_needed!();
+            // Re-entrant cancel closed the reader; tell the io caller to stop.
+            let ret = if self.done.get() { false } else { ret };
+            // SAFETY: see `parent()`; the pin keeps the count >= 1, so this
+            // never frees. `self` is not accessed after.
+            let _ = unsafe { Source::decrement_count(parent) };
             return ret;
         } else if !is_slice_in_vec_capacity(buf, self.buffered.get()) {
             self.buffered.with_mut(|b| b.extend_from_slice(buf));
@@ -1033,14 +1044,22 @@ impl FileReader {
         self.pending.with_mut(|p| {
             p.result = streams::Result::Err(streams::StreamError::Error(err));
         });
+        // Pin across `p.run()`: a re-entrant cancel() reaches on_reader_done,
+        // which drops the across-read ref and lets a GC free this box before
+        // the `waiting_for_on_reader_done` read below.
+        let parent = self.parent();
+        // SAFETY: see `parent()`.
+        unsafe { (*parent).increment_count() };
         self.pending.with_mut(|p| p.run());
 
         if self.waiting_for_on_reader_done.get() && !self.done.get() {
             self.waiting_for_on_reader_done.set(false);
-            let parent = self.parent();
-            // SAFETY: see `parent()`; tail call, `self` is not accessed after.
+            // SAFETY: see `parent()`; the pin above keeps the count > 0.
             let _ = unsafe { Source::decrement_count(parent) };
         }
+        // SAFETY: see `parent()`; the pin keeps the count >= 1, so this never
+        // frees. Tail call, `self` is not accessed after.
+        let _ = unsafe { Source::decrement_count(parent) };
     }
 
     pub fn set_raw_mode(&self, _flag: bool) -> sys::Result<()> {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -1044,9 +1044,9 @@ impl FileReader {
         self.pending.with_mut(|p| {
             p.result = streams::Result::Err(streams::StreamError::Error(err));
         });
-        // Pin across `p.run()`: a re-entrant cancel() reaches on_reader_done,
-        // which drops the across-read ref and lets a GC free this box before
-        // the `waiting_for_on_reader_done` read below.
+        // Pin across `p.run()`: it runs user JS, and anything there that
+        // reaches on_reader_done would drop the across-read ref and let a GC
+        // free this box before the `waiting_for_on_reader_done` read below.
         let parent = self.parent();
         // SAFETY: see `parent()`.
         unsafe { (*parent).increment_count() };

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -242,8 +242,8 @@ test.skipIf(isWindows)(
       );
 
       // Release the grandchild, then block without ticking the event loop so
-      // it fills the socketpair buffer past the 128 KiB flush threshold
-      // before the readable poll can dispatch.
+      // it saturates the socketpair buffer before the readable poll can
+      // dispatch, delivering one large chunk in a single read_with_fn call.
       fs.writeFileSync(FLAG, "");
       Bun.sleepSync(800);
 
@@ -280,10 +280,13 @@ test.skipIf(isWindows)(
     } catch {
       throw new Error(`fixture did not emit JSON (exit ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`);
     }
-    // Precondition: the delivered chunk exceeded read_with_fn's mid-loop
-    // flush threshold (stack_buffer_len/2 = 128 KiB), so on_read_chunk's
-    // p.run() ran with more of read_with_fn's loop still ahead of it.
-    expect(result.chunkLen).toBeGreaterThan(128 * 1024);
+    // Precondition: a non-empty chunk was flushed, so on_read_chunk's p.run()
+    // ran with read_with_fn still on the stack. The kernel socketpair buffer
+    // decides which of read_with_fn's two flush sites fires (the 128 KiB
+    // mid-loop flush on Linux; the retry flush on macOS, whose default is a
+    // few KiB), and the pin under test guards both identically, so the chunk
+    // size is deliberately not pinned to a platform-specific buffer size.
+    expect(result.chunkLen).toBeGreaterThan(0);
     // Precondition: the from_pipe pin made the wrapper Strong before cancel.
     expect(result.protectedBefore).toBeGreaterThanOrEqual(1);
     // Invariant: the re-entrant cancel must not downgrade the wrapper while

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -173,31 +173,11 @@ test.skipIf(isWindows)(
   60_000,
 );
 
-// FileReader::on_read_chunk resolves the pending read promise from inside
-// PosixBufferedReader::read_with_fn, while that function still holds `&mut`
-// into the NewSource<FileReader> box. Resolving it drains microtasks, so user
-// JS runs mid-dispatch; if it calls reader.cancel() there, on_reader_done
-// releases the across-read ref (taken in from_pipe) and the box's count drops
-// to the JS wrapper's own ref, downgrading the wrapper's native Strong to
-// Weak. A GC in that same microtask drain then sweeps the wrapper, whose
-// finalizer frees the box, and the io caller's next access to it
-// (register_poll / on_error / _offset) is a heap-use-after-free.
-//
-// This asserts the lifetime invariant directly rather than racing for the
-// crash (which needs a GC to land in the short window before read_with_fn
-// returns, and conservative stack scanning makes that non-deterministic):
-// the source wrapper must still be Strong-protected immediately after the
-// re-entrant cancel, because on_read_chunk holds its own ref across p.run()
-// so the re-entrant release never reaches the downgrade-at-one threshold.
-// The from_pipe pin from the test above is what makes it Strong to begin
-// with; protectedBefore proves that precondition held.
-//
-// The chunk must exceed the 128 KiB mid-loop flush threshold in read_with_fn,
-// otherwise the flush happens on the tail retry path and nothing touches the
-// reader afterwards. A detached grandchild fills the stdout socketpair buffer
-// while the fixture is blocked in sleepSync so the whole payload arrives in
-// one poll dispatch, and keeps the write end open so received_hup stays false.
-//
+// Asserts the lifetime invariant rather than racing for the crash: the actual
+// free needs a GC to land inside the microtask drain, which conservative stack
+// scanning makes non-deterministic. Instead, the source wrapper must still be
+// Strong-protected right after a re-entrant reader.cancel(), because
+// on_read_chunk's own pin keeps it above the downgrade-at-one threshold.
 // Windows uses libuv for pipe I/O; the read_with_fn path under test is POSIX.
 test.skipIf(isWindows)(
   "re-entrant cancel inside a subprocess stdout read keeps the FileReader pinned for the rest of the dispatch",
@@ -248,7 +228,18 @@ test.skipIf(isWindows)(
       globalThis.__s = proc.stdout;
       await proc.exited; // sh has exited; only the grandchild holds the pipe
       globalThis.__r = globalThis.__s.getReader();
-      globalThis.__r.read().then(globalThis.__onchunk);
+      // Wire every failure into __done so a rejected read or a throwing
+      // handler fails the fixture with the real error instead of hanging.
+      globalThis.__r.read().then(
+        chunk => {
+          try {
+            globalThis.__onchunk(chunk);
+          } catch (err) {
+            globalThis.__done.reject(err);
+          }
+        },
+        err => globalThis.__done.reject(err),
+      );
 
       // Release the grandchild, then block without ticking the event loop so
       // it fills the socketpair buffer past the 128 KiB flush threshold

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 // Accessing `proc.stdout` on a piped subprocess moves the already-registered
@@ -171,4 +171,135 @@ test.skipIf(isWindows)(
     expect(exitCode).toBe(0);
   },
   60_000,
+);
+
+// FileReader::on_read_chunk resolves the pending read promise from inside
+// PosixBufferedReader::read_with_fn, while that function still holds `&mut`
+// into the NewSource<FileReader> box. Resolving it drains microtasks, so user
+// JS runs mid-dispatch; if it calls reader.cancel() there, on_reader_done
+// releases the across-read ref (taken in from_pipe) and the box's count drops
+// to the JS wrapper's own ref, downgrading the wrapper's native Strong to
+// Weak. A GC in that same microtask drain then sweeps the wrapper, whose
+// finalizer frees the box, and the io caller's next access to it
+// (register_poll / on_error / _offset) is a heap-use-after-free.
+//
+// This asserts the lifetime invariant directly rather than racing for the
+// crash (which needs a GC to land in the short window before read_with_fn
+// returns, and conservative stack scanning makes that non-deterministic):
+// the source wrapper must still be Strong-protected immediately after the
+// re-entrant cancel, because on_read_chunk holds its own ref across p.run()
+// so the re-entrant release never reaches the downgrade-at-one threshold.
+// The from_pipe pin from the test above is what makes it Strong to begin
+// with; protectedBefore proves that precondition held.
+//
+// The chunk must exceed the 128 KiB mid-loop flush threshold in read_with_fn,
+// otherwise the flush happens on the tail retry path and nothing touches the
+// reader afterwards. A detached grandchild fills the stdout socketpair buffer
+// while the fixture is blocked in sleepSync so the whole payload arrives in
+// one poll dispatch, and keeps the write end open so received_hup stays false.
+//
+// Windows uses libuv for pipe I/O; the read_with_fn path under test is POSIX.
+test.skipIf(isWindows)(
+  "re-entrant cancel inside a subprocess stdout read keeps the FileReader pinned for the rest of the dispatch",
+  async () => {
+    using dir = tempDir("fr-cancel-uaf", {});
+    const flag = join(String(dir), "go");
+    const pidFile = join(String(dir), "gcpid");
+
+    const script = /* js */ `
+      const { heapStats } = require("bun:jsc");
+      const fs = require("node:fs");
+      const FLAG = ${JSON.stringify(flag)};
+      const PIDFILE = ${JSON.stringify(pidFile)};
+
+      const protectedSrc = () =>
+        heapStats().protectedObjectTypeCounts.FileInternalReadableStreamSource ?? 0;
+
+      globalThis.__done = Promise.withResolvers();
+
+      globalThis.__onchunk = function __onchunk({ value, done }) {
+        const chunkLen = done ? 0 : value.byteLength;
+        const protectedBefore = protectedSrc();
+        // cancel() synchronously reaches FileReader::on_reader_done, which
+        // drops the across-read ref while read_with_fn is still on the stack.
+        globalThis.__r.cancel().catch(() => {});
+        const protectedAfter = protectedSrc();
+        fs.writeSync(1, JSON.stringify({ chunkLen, protectedBefore, protectedAfter }) + "\\n");
+        globalThis.__done.resolve();
+      };
+
+      // sh backgrounds a subshell that inherits stdout, writes its pid, and
+      // exits immediately; the grandchild waits for FLAG, blasts 512 KiB at
+      // the socketpair, then idles holding fd 1 so received_hup stays false.
+      const proc = Bun.spawn({
+        cmd: [
+          "/bin/sh",
+          "-c",
+          '( while [ ! -e "$0" ]; do sleep 0.02; done; ' +
+            'dd if=/dev/zero bs=65536 count=8 2>/dev/null; exec sleep 15 ) & ' +
+            'echo $! > "$1"',
+          FLAG,
+          PIDFILE,
+        ],
+        stdin: "ignore",
+        stdout: "pipe", // from_pipe: FileReader created, across-read ref taken
+        stderr: "ignore",
+      });
+      globalThis.__s = proc.stdout;
+      await proc.exited; // sh has exited; only the grandchild holds the pipe
+      globalThis.__r = globalThis.__s.getReader();
+      globalThis.__r.read().then(globalThis.__onchunk);
+
+      // Release the grandchild, then block without ticking the event loop so
+      // it fills the socketpair buffer past the 128 KiB flush threshold
+      // before the readable poll can dispatch.
+      fs.writeFileSync(FLAG, "");
+      Bun.sleepSync(800);
+
+      await globalThis.__done.promise;
+      try { process.kill(Number(fs.readFileSync(PIDFILE, "utf8").trim()), "SIGKILL"); } catch {}
+    `;
+
+    let stdout = "",
+      stderr = "",
+      exitCode: number | null = null;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "-e", script],
+        // The CI runner sets BUN_FEATURE_FLAG_NO_ORPHANS on ASAN lanes, which
+        // kills a detached grandchild the moment its intermediate parent
+        // exits. This test needs it to outlive sh and keep the pipe's write
+        // end open; cleanup is explicit (the fixture and the finally below).
+        env: { ...bunEnv, BUN_FEATURE_FLAG_NO_ORPHANS: undefined },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    } finally {
+      // Always reap the detached grandchild; the fixture's own kill is
+      // skipped if it crashes first.
+      try {
+        process.kill(Number(readFileSync(pidFile, "utf8").trim()), "SIGKILL");
+      } catch {}
+    }
+
+    let result: { chunkLen: number; protectedBefore: number; protectedAfter: number };
+    try {
+      result = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`fixture did not emit JSON (exit ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`);
+    }
+    // Precondition: the delivered chunk exceeded read_with_fn's mid-loop
+    // flush threshold (stack_buffer_len/2 = 128 KiB), so on_read_chunk's
+    // p.run() ran with more of read_with_fn's loop still ahead of it.
+    expect(result.chunkLen).toBeGreaterThan(128 * 1024);
+    // Precondition: the from_pipe pin made the wrapper Strong before cancel.
+    expect(result.protectedBefore).toBeGreaterThanOrEqual(1);
+    // Invariant: the re-entrant cancel must not downgrade the wrapper while
+    // read_with_fn is still on the stack. Before the fix, protectedAfter is 0
+    // here, and a GC in this window frees the box read_with_fn is using.
+    expect(result.protectedAfter).toBeGreaterThanOrEqual(1);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
 );


### PR DESCRIPTION
### What

`Bun.spawn` stdout/stderr pipe readers still hit a heap-use-after-free on current main under fault injection, with the faulting pc symbolizing to `PosixBufferedReader::on_error` and `PosixBufferedReader::register_poll`. #32743 fixed the read-completion path of this class (`on_reader_done` reached from `read_socket`) but the error and poll-registration completion paths have the same lifetime defect.

### Cause

`PosixBufferedReader::read_with_fn` holds `&mut` into the `NewSource<FileReader>` box for the whole epoll dispatch. Mid-loop, `FileReader::on_read_chunk` resolves the pending `read()` promise via `p.run()`, which enters JS and drains microtasks. If user JS calls `reader.cancel()` there, the chain

```
cancel -> on_cancel -> reader.close() -> done() -> on_reader_done()
```

runs synchronously and releases the across-read ref that #32743 added. That drops the box's count to the JS wrapper's own ref and downgrades the wrapper from Strong to Weak. A GC inside that same microtask drain sweeps the wrapper, and its finalizer frees the box out from under `read_with_fn`. On the next inner-loop iteration the (now closed) fd returns `EBADF` and read_with_fn calls `parent.on_error(err)` on the freed reader, or `parent.register_poll()` on the retry arm, reproducing the reported frames. `FileReader::on_reader_error` has the identical shape via its own `p.run()` followed by reads of `self`.

Both callbacks are reachable from `Bun.spawn` and from `Bun.file(fd).stream()`, so the blast radius is any app that streams a subprocess pipe.

### Fix

Hold one additional ref on the `NewSource` box across `p.run()` at both call sites (`on_read_chunk` and `on_reader_error`), released at true tail. The re-entrant release from `on_reader_done` then lands at a count of two instead of one, so it never crosses the downgrade threshold and the wrapper stays Strong-rooted for the remainder of the dispatch. The box is collected normally on a later, off-stack GC.

`on_read_chunk` also now returns `false` when the re-entrant cancel marked the reader done. `read_with_fn`'s two flush sites consult that return only when `received_hup` is false, so this stops the non-HUP path from issuing another `recv` on the cancelled reader's closed fd (the source of the spurious `EBADF` that previously reached `on_error`). The HUP-path flushes intentionally ignore it (`&& !received_hup` is a documented hang fix for shell blocking pipes), so they still loop to EOF; that is pre-existing, benign, and left alone, because the pin and not the return value is what makes both branches memory safe, and tightening it means changing `PipeReader.rs` infrastructure shared by every buffered-reader parent.

The sibling Posix site at `PipeReader::start` (SubprocessPipeReader.rs) already holds a `ScopedRef` across the same re-entrancy and is unaffected.

### Verification

`test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts` gains a second test next to the #32743 one. A detached grandchild saturates the stdout socketpair while the parent is blocked in `sleepSync`, so the payload arrives in one poll dispatch and `p.run()` fires with `read_with_fn` still on the stack. Which of `read_with_fn`'s two flush sites delivers it depends on the kernel socketpair buffer (the 128 KiB mid-loop flush on Linux, the retry flush on macOS, whose default is a few KiB); the pin guards both identically, so the test does not depend on a platform-specific buffer size. The `.then` callback cancels the reader and samples `heapStats().protectedObjectTypeCounts.FileInternalReadableStreamSource` immediately after.

That counter observes the `JsRef` Strong directly, so the test asserts the lifetime invariant rather than racing a GC into the vulnerable window, and is deterministic in both directions (no ASan or `collectContinuously` dependence):

- without the `src/` change: `protectedAfter` is `0` (Strong dropped mid-dispatch, the UAF precondition) and the test fails on that assertion with both preconditions green
- with it: `protectedAfter` is `1` and both tests in the file pass

The `on_reader_error` pin is the same bracket at the sibling site named by the reported `register_poll` frame, whose failure path calls it. It is not separately tested, and that is a proven limit rather than an untried one. Through the only live `Pending` consumer (the pull promise), the window cannot be reached from JS: the native pull promise's rejection arm in `#pull` errors the stream before any user reaction runs, and `readableStreamCancel` is a no-op on an errored stream, so a `reader.cancel()` inside a rejection handler never re-enters `on_reader_done`. I verified this empirically with the same dup2 fd swap `spawn-pipe-read-error-leak.test.ts` uses to force a non-retry `recv` error: `on_reader_error` fires, the in-handler `cancel()` produces no `onReaderDone` and no change in the protected count on either build, so no assertion through that route distinguishes fixed from unfixed. The `PendingFuture::Handler` consumer, the only other route to `p.run()` there, has no installers. The pin stays because `on_reader_error` reads `self` after a call that runs user JS; that contract holds today only through the non-local ordering inside `#pull`'s JS, which nothing enforces, and the bracket is balanced and free.

Also re-ran `spawn-pipe-read-error-leak`, `spawn-streaming-stdout`, `spawn-unread-stdout-gc`, `spawn-stdout-iterate-leak`, `readablestream-helpers`, `spawn-ipc-gc`, and `native-source-onclose-leak`: all green.

