### PR TITLE
expect: match Jest's typeof semantics for expect.any(Object)

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -394,10 +394,11 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
         }
 
         case AsymmetricMatcherConstructorType::Object: {
-            if (otherProp.isObject()) {
+            // Jest: `typeof other === 'object'` (null matches, functions do not; no instanceof fallback)
+            if (otherProp.isNull() || (otherProp.isObject() && !otherProp.isCallable())) {
                 return AsymmetricMatcherResult::PASS;
             }
-            break;
+            return AsymmetricMatcherResult::FAIL;
         }
 
         case AsymmetricMatcherConstructorType::InstanceOf: {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4031,9 +4031,48 @@ describe("expect()", () => {
       expect(expect.any(BigInt)).toEqual(1n);
       expect(expect.any(Symbol)).toEqual(Symbol());
       expect(expect.any(Object)).toEqual({});
-      //expect(expect.any(Object)).toEqual(null); // TODO: succeeds on jest, fails on bun
       expect(expect.any(Array)).toEqual([]);
       expect(expect.any(Thing)).toEqual(new Thing());
+    });
+
+    test("expect.any(Object) matches typeof === 'object'", () => {
+      // https://github.com/jestjs/jest/blob/main/packages/expect/src/asymmetricMatchers.ts
+      // Jest: `if (this.sample == Object) return typeof other == 'object';`
+      class Thing {}
+
+      // typeof x === 'object'
+      expect(null).toEqual(expect.any(Object));
+      expect({}).toEqual(expect.any(Object));
+      expect([]).toEqual(expect.any(Object));
+      expect(new Thing()).toEqual(expect.any(Object));
+      expect(new Date()).toEqual(expect.any(Object));
+      expect(new Map()).toEqual(expect.any(Object));
+      expect(/re/).toEqual(expect.any(Object));
+
+      // typeof x !== 'object'
+      expect(undefined).not.toEqual(expect.any(Object));
+      expect(1).not.toEqual(expect.any(Object));
+      expect("s").not.toEqual(expect.any(Object));
+      expect(true).not.toEqual(expect.any(Object));
+      expect(1n).not.toEqual(expect.any(Object));
+      expect(Symbol()).not.toEqual(expect.any(Object));
+      expect(() => {}).not.toEqual(expect.any(Object));
+      expect(function f() {}).not.toEqual(expect.any(Object));
+      expect(async () => {}).not.toEqual(expect.any(Object));
+      expect(Thing).not.toEqual(expect.any(Object));
+
+      // nested in toEqual / objectContaining
+      expect({ a: null }).toEqual({ a: expect.any(Object) });
+      expect({ a: () => {} }).not.toEqual({ a: expect.any(Object) });
+      expect({ a: () => {} }).not.toEqual(expect.objectContaining({ a: expect.any(Object) }));
+
+      // toHaveBeenCalledWith
+      const fn = jest.fn();
+      fn(null);
+      expect(fn).toHaveBeenCalledWith(expect.any(Object));
+      const fn2 = jest.fn();
+      fn2(() => {});
+      expect(fn2).not.toHaveBeenCalledWith(expect.any(Object));
     });
 
     test("expect.any on primitive wrapper classes", () => {


### PR DESCRIPTION
### What

`expect.any(Object)` implemented an inverted type predicate: `null` did not match, and functions did.

```js
test("null matches",          () => expect(null).toEqual(expect.any(Object)));           // bun: fail, jest: pass
test("function doesn't match", () => expect(() => {}).not.toEqual(expect.any(Object)));  // bun: fail, jest: pass
```

```
error: expect(received).toEqual(expected)

Expected: Any
Received: null
```

### Why

Jest's `Any.asymmetricMatch` is literally `typeof other === 'object'` for `Object` (see [asymmetricMatchers.ts](https://github.com/jestjs/jest/blob/main/packages/expect/src/asymmetricMatchers.ts)), so `null` matches and callables don't, with no `instanceof` fallback.

Bun's `matchAsymmetricMatcherAndGetFlags` used `JSValue::isObject()`, which is the reverse on both counts: it excludes `null` and includes functions. On a non-match it also fell through to the shared `constructorObject->hasInstance` check, so classes and arrow functions (all `instanceof Object`) matched anyway.

Both directions of the inversion bite real suites: `toHaveBeenCalledWith(expect.any(Object))` rejects a legitimate `null` argument, and a function slips through an assertion that meant "a plain options object".

### Fix

In the `AsymmetricMatcherConstructorType::Object` arm of `matchAsymmetricMatcherAndGetFlags` (`src/jsc/bindings/bindings.cpp`), match `typeof === 'object'` exactly (`isNull() || (isObject() && !isCallable())`) and return FAIL on a miss instead of falling through to `hasInstance`.

### Tests

Added a case to `test/js/bun/test/expect.test.js` covering both directions plus the rest of the `typeof` table (arrays, Dates, Maps, RegExps, class instances match; `undefined`, primitives, arrow/named/async functions, and classes don't), nested in `toEqual`/`objectContaining`, and through `toHaveBeenCalledWith`. Also un-commented the long-standing `// TODO: succeeds on jest, fails on bun` case this fixes.

Fails on main, passes with the fix:

```
$ bun bd test test/js/bun/test/expect.test.js -t "expect.any"
(pass) expect() > asymmetric matchers > expect.any
(pass) expect() > asymmetric matchers > expect.any(Object) matches typeof === 'object'
(pass) expect() > asymmetric matchers > expect.any on primitive wrapper classes
 3 pass
```

The full `expect.test.js` run is 398 pass; the single failure is `deepEquals Set/Map stress test`, a pre-existing debug+ASAN timeout (192s vs the 5s limit) that doesn't touch asymmetric matchers and passes on the release build.
