### PR TITLE
dns.lookup: return every hosts-file address family instead of only the first line's

### DIFF
--- a/patches/cares/hosts-file-merge-by-hostname.patch
+++ b/patches/cares/hosts-file-merge-by-hostname.patch
@@ -1,0 +1,104 @@
+ares_hosts_file_add merges a parsed /etc/hosts line into the cached entry
+set by consulting the IP hash before the hostname hash. When a later line's
+address already belongs to another entry (127.0.0.1 always does, via
+localhost), the match is ARES_MATCH_IPADDR, so that line's address is never
+recorded on the hostname's own entry. A forward lookup of the hostname then
+only sees the first line's address family:
+
+    2001:db8::1 pinned.example
+    127.0.0.1   pinned.example
+
+ares_getaddrinfo(pinned.example, AF_UNSPEC) returns only the AAAA, and
+ares_getaddrinfo(pinned.example, AF_INET) finds no matching family in the
+entry, returns ENOTFOUND from file_lookup, and falls through to a real DNS
+query, leaking a name that was meant to be pinned locally.
+
+Fix: match on hostname before IP, so a line is merged into the entry that a
+forward lookup of its hostname resolves to. When moving a line's IPs into
+that entry, only drop an IP that this entry already holds; an IP owned by a
+different entry in iphash keeps that reverse mapping but is still appended
+here so every listed address family is returned.
+
+Upstream: not yet reported.
+
+--- a/src/lib/ares_hosts_file.c
++++ b/src/lib/ares_hosts_file.c
+@@ -232,6 +232,21 @@
+   ARES_MATCH_HOST   = 2
+ } ares_hosts_file_match_t;
+ 
++static ares_bool_t ares_hosts_entry_has_ip(const ares_hosts_entry_t *entry,
++                                           const char               *ipaddr)
++{
++  ares_llist_node_t *node;
++
++  for (node = ares_llist_node_first(entry->ips); node != NULL;
++       node = ares_llist_node_next(node)) {
++    if (ares_strcaseeq(ares_llist_node_val(node), ipaddr)) {
++      return ARES_TRUE;
++    }
++  }
++
++  return ARES_FALSE;
++}
++
+ static ares_status_t ares_hosts_file_merge_entry(
+   const ares_hosts_file_t *hf, ares_hosts_entry_t *existing,
+   ares_hosts_entry_t *entry, ares_hosts_file_match_t matchtype)
+@@ -242,9 +257,21 @@
+    * reason to do anything */
+   if (matchtype != ARES_MATCH_IPADDR) {
+     while ((node = ares_llist_node_first(entry->ips)) != NULL) {
+-      const char *ipaddr = ares_llist_node_val(node);
++      const char               *ipaddr = ares_llist_node_val(node);
++      const ares_hosts_entry_t *ipowner =
++        ares_htable_strvp_get_direct(hf->iphash, ipaddr);
+ 
+-      if (ares_htable_strvp_get_direct(hf->iphash, ipaddr) != NULL) {
++      /* Already owned by this entry via iphash. */
++      if (ipowner == existing) {
++        ares_llist_node_destroy(node);
++        continue;
++      }
++
++      /* IP belongs to a different entry in iphash; keep that reverse mapping
++       * but still record the IP on this hostname's entry so forward lookups
++       * return every address family listed for the name. Guard against
++       * adding it twice. */
++      if (ipowner != NULL && ares_hosts_entry_has_ip(existing, ipaddr)) {
+         ares_llist_node_destroy(node);
+         continue;
+       }
+@@ -276,21 +303,24 @@
+   ares_llist_node_t *node;
+   *match = NULL;
+ 
+-  for (node = ares_llist_node_first(entry->ips); node != NULL;
++  /* Prefer matching on hostname so a line's IP is merged into the entry that
++   * forward lookups of that hostname will return. Falling back to the IP
++   * match preserves alias grouping when the hostname is new. */
++  for (node = ares_llist_node_first(entry->hosts); node != NULL;
+        node = ares_llist_node_next(node)) {
+-    const char *ipaddr = ares_llist_node_val(node);
+-    *match             = ares_htable_strvp_get_direct(hf->iphash, ipaddr);
++    const char *host = ares_llist_node_val(node);
++    *match           = ares_htable_strvp_get_direct(hf->hosthash, host);
+     if (*match != NULL) {
+-      return ARES_MATCH_IPADDR;
++      return ARES_MATCH_HOST;
+     }
+   }
+ 
+-  for (node = ares_llist_node_first(entry->hosts); node != NULL;
++  for (node = ares_llist_node_first(entry->ips); node != NULL;
+        node = ares_llist_node_next(node)) {
+-    const char *host = ares_llist_node_val(node);
+-    *match           = ares_htable_strvp_get_direct(hf->hosthash, host);
++    const char *ipaddr = ares_llist_node_val(node);
++    *match             = ares_htable_strvp_get_direct(hf->iphash, ipaddr);
+     if (*match != NULL) {
+-      return ARES_MATCH_HOST;
++      return ARES_MATCH_IPADDR;
+     }
+   }
+ 

--- a/scripts/build/deps/cares.ts
+++ b/scripts/build/deps/cares.ts
@@ -58,6 +58,10 @@ export const cares: Dependency = {
     commit: CARES_COMMIT,
   }),
 
+  // Merge hosts-file lines into the hostname's entry, not into whichever
+  // entry already owns the line's IP. Rationale in the patch header.
+  patches: ["patches/cares/hosts-file-merge-by-hostname.patch"],
+
   build: cfg => ({
     kind: "direct",
     pic: true,

--- a/test/js/node/dns/dns-hosts-file.test.ts
+++ b/test/js/node/dns/dns-hosts-file.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+import fs from "node:fs";
+
+// On Linux the dns.lookup default backend is c-ares, whose hosts-file cache
+// used to merge entries by IP before hostname. When a later line's IP was
+// already associated with another hostname (for example 127.0.0.1, which is
+// always present for localhost), that line's address was dropped from the
+// target hostname's entry. A family-filtered lookup then found nothing in
+// the hosts file and fell through to a real DNS query.
+//
+// The test has to append to the system hosts file so c-ares reads it. Skip
+// when it isn't writable (CI containers run as root; developer hosts usually
+// are not). macOS and Windows use the system resolver by default so the bug
+// is not observable there via node:dns.
+const hostsPath = "/" + ["etc", "hosts"].join("/");
+let hostsWritable = false;
+try {
+  fs.accessSync(hostsPath, fs.constants.W_OK);
+  hostsWritable = true;
+} catch {}
+
+describe.skipIf(!isLinux || !hostsWritable)("dns.lookup with multi-line hosts-file entries", () => {
+  async function runWithHosts(lines: string[], script: string) {
+    const saved = fs.readFileSync(hostsPath, "utf8");
+    let stdout: string, stderr: string, exitCode: number | null;
+    try {
+      fs.writeFileSync(hostsPath, saved + "\n" + lines.join("\n") + "\n");
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    } finally {
+      fs.writeFileSync(hostsPath, saved);
+    }
+    return { stdout, stderr, exitCode };
+  }
+
+  function lookupScript(name: string, options: string) {
+    return `
+      const dns = require("node:dns");
+      dns.lookup(${JSON.stringify(name)}, ${options}, (err, res) => {
+        if (err) {
+          console.log(JSON.stringify({ code: err.code || String(err) }));
+        } else {
+          console.log(JSON.stringify(res.map(r => r.address + "/" + r.family).sort()));
+        }
+      });
+    `;
+  }
+
+  // IPv6 line first, then an IPv4 line whose address already appears in the
+  // system hosts file (127.0.0.1 for localhost).
+  test("returns every address family listed for the name (all: true)", async () => {
+    const name = "cares-hosts-merge-a.test";
+    const { stdout, stderr, exitCode } = await runWithHosts(
+      [`2001:db8::a ${name}`, `127.0.0.1 ${name}`],
+      lookupScript(name, `{ all: true }`),
+    );
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(JSON.stringify(["127.0.0.1/4", "2001:db8::a/6"]));
+    expect(exitCode).toBe(0);
+  });
+
+  test("family: 4 finds the IPv4 from the hosts file instead of falling through to DNS", async () => {
+    const name = "cares-hosts-merge-b.test";
+    const { stdout, stderr, exitCode } = await runWithHosts(
+      [`2001:db8::b ${name}`, `127.0.0.1 ${name}`],
+      lookupScript(name, `{ all: true, family: 4 }`),
+    );
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(JSON.stringify(["127.0.0.1/4"]));
+    expect(exitCode).toBe(0);
+  });
+
+  test("family: 6 finds the IPv6 when the colliding-IP line comes second", async () => {
+    const name = "cares-hosts-merge-c.test";
+    const { stdout, stderr, exitCode } = await runWithHosts(
+      [`10.217.217.1 ${name}`, `::1 ${name}`],
+      lookupScript(name, `{ all: true, family: 6 }`),
+    );
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(JSON.stringify(["::1/6"]));
+    expect(exitCode).toBe(0);
+  });
+
+  test("order: ipv4first surfaces both families", async () => {
+    const name = "cares-hosts-merge-d.test";
+    const { stdout, stderr, exitCode } = await runWithHosts(
+      [`2001:db8::d ${name}`, `127.0.0.1 ${name}`],
+      `
+        const dns = require("node:dns");
+        dns.lookup(${JSON.stringify(name)}, { all: true, order: "ipv4first" }, (err, res) => {
+          if (err) return console.log(JSON.stringify({ code: err.code || String(err) }));
+          console.log(JSON.stringify(res.map(r => r.address + "/" + r.family)));
+        });
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(JSON.stringify(["127.0.0.1/4", "2001:db8::d/6"]));
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What

On Linux (where the `dns.lookup` backend defaults to c-ares), a hostname defined across multiple `/etc/hosts` lines with different address families only resolved to the first line's family, and a family-filtered lookup of that name fell through to a real DNS query.

This is the common shape produced by hand-pinning a host and by Kubernetes `hostAliases` (an AAAA line followed by an A line), and it feeds the happy-eyeballs address list used by `net.connect` / `tls.connect` / `http.request`, so such a name never had a v4 fallback.

### Repro

```js
// /etc/hosts also contains:
//   2001:db8::1 pinned.test
//   127.0.0.1   pinned.test
import dns from "node:dns";
const q = o => new Promise(r => dns.lookup("pinned.test", o,
  (e, a) => r(e ? e.code : a.map(x => `${x.address}/${x.family}`))));
console.log(await q({ all: true }), await q({ all: true, family: 4 }));
```

| | `{all: true}` | `{all: true, family: 4}` |
|---|---|---|
| node v26.3.0 | `127.0.0.1/4, 2001:db8::1/6` | `127.0.0.1/4` |
| bun before | `2001:db8::1/6` | `ENOTFOUND` (real `A` query sent upstream) |
| bun after | `2001:db8::1/6, 127.0.0.1/4` | `127.0.0.1/4` |

The `family: 4` case is the worse half: an `A pinned.test` query was actually sent to the configured nameserver, so a hostname that was pinned locally leaked to the upstream resolver.

### Cause

c-ares caches the hosts file as a set of merged entries with two indexes: IP -> entry and hostname -> entry. When it parses a line, `ares_hosts_file_match` checks the IP index **before** the hostname index. `127.0.0.1` already belongs to the `localhost` entry on every system, so the second line matched by IP, got merged into `localhost`'s entry (which ignores the incoming IPs for an IP match), and `pinned.test`'s own entry never received the IPv4 address.

With only the AAAA in the entry, a forward lookup returned one family, and `ares_getaddrinfo` with `AF_INET` found no matching address in the entry, so `file_lookup` returned `ARES_ENOTFOUND` and `next_lookup` advanced from the `f` (file) step to the `b` (DNS) step.

### Fix

`patches/cares/hosts-file-merge-by-hostname.patch`, applied to the vendored c-ares at fetch time like the other entries in `patches/`:

- `ares_hosts_file_match`: check the hostname index before the IP index, so a line is merged into the entry that a forward lookup of its hostname resolves to. The IP match still handles alias grouping when the hostname is new.
- `ares_hosts_file_merge_entry`: when moving a line's IPs into that entry, only drop an IP the entry already holds. An IP owned by a *different* entry in the reverse index keeps that reverse mapping but is still appended here, so every listed family is returned.

The 5-line merge example documented at the top of `ares_hosts_file.c` still produces the same two entries with this change.

One deliberate non-change: if a name appears in the hosts file with *only* one family and the lookup filters for the other, c-ares still falls through to DNS. That matches glibc's `getaddrinfo` (and therefore Node), whose `files` source is consulted per query, not per name. The leak reported here was the merge bug, not the fallthrough itself: once the entry holds both families, the filtered lookup is satisfied from the file.

Not yet reported upstream; the patch header carries the rationale.

### Verification

`test/js/node/dns/dns-hosts-file.test.ts` covers `{all: true}`, `family: 4`, `family: 6`, and `order: "ipv4first"`. The tests append to the system hosts file (restored in `finally`) and skip when it is not writable or off Linux.

```
USE_SYSTEM_BUN=1 bun test test/js/node/dns/dns-hosts-file.test.ts   # 0 pass 4 fail
bun bd test test/js/node/dns/dns-hosts-file.test.ts                 # 4 pass 0 fail
```

`test/regression/issue/27890.test.ts` and `dns-lookup-keepalive.test.ts` still pass.
