### PR TITLE
ipc: signal backpressure from send() when the write queue exceeds Node's threshold

### DIFF
--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -1215,6 +1215,16 @@ impl SendQueue {
         false // error state.
     }
 
+    /// Bytes serialized into the send queue that have not yet reached the
+    /// kernel. Equivalent to libuv's `writeQueueSize` on the IPC stream.
+    fn pending_bytes(&self) -> usize {
+        let mut total: usize = 0;
+        for item in &self.queue {
+            total = total.saturating_add(item.data.size());
+        }
+        total
+    }
+
     pub fn update_ref(&mut self, global: &JSGlobalObject) {
         let _ = global;
         // Note: KeepAlive::{ref_,unref} take an `EventLoopCtx` (aio cycle-
@@ -1379,7 +1389,10 @@ impl SendQueue {
         log!("IPC call continueSend() from serializeAndSend");
         self.continue_send(global, ContinueSendReason::NewMessageAppended);
 
-        if indicate_backoff {
+        // Node: `return channel.writeQueueSize < (65536 * 2)`. Check after the
+        // synchronous write attempt so sends that fit in the kernel socket
+        // buffer still return `true`.
+        if indicate_backoff || self.pending_bytes() >= SEND_BACKPRESSURE_THRESHOLD {
             return SerializeAndSendResult::Backoff;
         }
         SerializeAndSendResult::Success
@@ -1741,6 +1754,11 @@ impl Drop for SendQueue {
 }
 
 const MAX_HANDLE_RETRANSMISSIONS: u32 = 3;
+
+/// Node returns `false` from `send()` once `channel.writeQueueSize` reaches
+/// this many bytes (see Node's lib/internal/child_process.js). This is the
+/// only backpressure signal IPC exposes, so the threshold must match.
+const SEND_BACKPRESSURE_THRESHOLD: usize = 65536 * 2;
 
 enum IPCCommand {
     Handle(JSValue),

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -92,14 +92,25 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
     // is never drained. Parent floods ~64 KiB messages; send() must flip to
     // false once queued bytes exceed the 128 KiB threshold instead of
     // buffering without bound.
-    const { promise: ready, resolve } = Promise.withResolvers<void>();
+    //
+    // The child only enters the busy-loop from the send() callback (which
+    // fires once "ready" has actually been written): the first send() lazily
+    // opens the IPC socket and, in advanced mode on Windows, queues a version
+    // packet behind an async uv_write, so "ready" would otherwise sit unsent
+    // forever once the event loop stops running.
+    const { promise: ready, resolve, reject } = Promise.withResolvers<void>();
     await using child = spawn({
-      cmd: [bunExe(), "-e", `process.send("ready"); const end = Date.now() + 120000; while (Date.now() < end) {}`],
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.send("ready", () => { const end = Date.now() + 10000; while (Date.now() < end) {} })`,
+      ],
       env: bunEnv,
       stdio: ["ignore", "ignore", "ignore"],
       serialization: mode,
       ipc: () => resolve(),
     });
+    child.exited.then(code => reject(new Error(`exited ${code} before ready`)));
     await ready;
     const payload = { s: Buffer.alloc(65536, "z").toString() };
     let trueCount = 0;
@@ -112,11 +123,10 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
       trueCount++;
     }
     child.kill("SIGKILL");
-    expect({ falseCount, total: trueCount + falseCount }).toEqual({
-      falseCount: 1,
-      total: trueCount + 1,
-    });
-    expect(trueCount).toBeLessThan(500);
+    // Exactly one send() must have returned false (the loop breaks on it).
+    // trueCount is included so a regression's failure output shows how many
+    // sends went through before the loop gave up.
+    expect(`true=${trueCount} false=${falseCount}`).toMatch(/^true=\d+ false=1$/);
   });
 });
 

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -85,6 +85,43 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
         .sort((a, b) => a - b),
     ).toEqual(Array.from({ length: 32 }, (_, i) => i));
   });
+
+  // https://github.com/oven-sh/bun/issues/30569
+  it("send() returns false once the IPC write queue backs up", async () => {
+    // Child acknowledges, then busy-loops so the parent end of the IPC pipe
+    // is never drained. Parent floods ~64 KiB messages; send() must flip to
+    // false once queued bytes exceed the 128 KiB threshold instead of
+    // buffering without bound.
+    const { promise: ready, resolve } = Promise.withResolvers<void>();
+    await using child = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.send("ready"); const end = Date.now() + 120000; while (Date.now() < end) {}`,
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "ignore", "ignore"],
+      serialization: mode,
+      ipc: () => resolve(),
+    });
+    await ready;
+    const payload = { s: Buffer.alloc(65536, "z").toString() };
+    let trueCount = 0;
+    let falseCount = 0;
+    for (let i = 0; i < 500; i++) {
+      if (child.send(payload) === false) {
+        falseCount++;
+        break;
+      }
+      trueCount++;
+    }
+    child.kill("SIGKILL");
+    expect({ falseCount, total: trueCount + falseCount }).toEqual({
+      falseCount: 1,
+      total: trueCount + 1,
+    });
+    expect(trueCount).toBeLessThan(500);
+  });
 });
 
 describe("ipc mode advanced", () => {

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -94,11 +94,7 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
     // buffering without bound.
     const { promise: ready, resolve } = Promise.withResolvers<void>();
     await using child = spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `process.send("ready"); const end = Date.now() + 120000; while (Date.now() < end) {}`,
-      ],
+      cmd: [bunExe(), "-e", `process.send("ready"); const end = Date.now() + 120000; while (Date.now() < end) {}`],
       env: bunEnv,
       stdio: ["ignore", "ignore", "ignore"],
       serialization: mode,

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -64,12 +64,16 @@ describe("send() returns false when the IPC write queue backs up", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
     // Exactly one send() must have returned false (the loop breaks on it).
     // The count of true returns before that depends on the kernel socket
-    // buffer size, so only the false count is fixed.
-    expect(stdout.trim()).toMatch(/^true=\d+ false=1$/);
-    expect(exitCode).toBe(0);
+    // buffer size, so only the false count is fixed. stderr is not asserted
+    // (debug/ASAN builds can emit benign noise) but is included so a fixture
+    // failure shows up in the same diff as the counts and exit code.
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: expect.stringMatching(/^true=\d+ false=1$/),
+      stderr,
+      exitCode: 0,
+    });
   });
 
   // Child-side process.send(): parent blocks its event loop so nothing
@@ -122,8 +126,11 @@ describe("send() returns false when the IPC write queue backs up", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toMatch(/^true=\d+ false=1$/);
-    expect(exitCode).toBe(0);
+    // See above: stderr is surfaced in the diff but not asserted empty.
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: expect.stringMatching(/^true=\d+ false=1$/),
+      stderr,
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -23,13 +23,21 @@ describe("send() returns false when the IPC write queue backs up", () => {
   // The parent floods ~64 KiB messages until send() returns false (or gives
   // up after 500 sends, ~32 MiB). Printed as "true=N false=M" so the
   // assertion shows the actual split on failure.
+  //
+  // The child only enters the busy-loop from the send() callback (which fires
+  // once "ready" has actually been written), not immediately after the call:
+  // the first send() lazily opens the IPC socket and, in advanced mode on
+  // Windows, queues a version packet behind an async uv_write, so "ready"
+  // would otherwise sit unsent forever once the event loop stops running.
   const fixture = `
     const cp = require("child_process");
     if (process.argv[2] === "--child") {
-      process.send("ready");
-      const end = Date.now() + 120000;
-      while (Date.now() < end) {}
-      process.exit(0);
+      process.send("ready", () => {
+        const end = Date.now() + 10000;
+        while (Date.now() < end) {}
+        process.exit(0);
+      });
+      return;
     }
     const child = cp.fork(__filename, ["--child"], { serialization: process.argv[2] });
     child.on("message", () => {
@@ -61,7 +69,6 @@ describe("send() returns false when the IPC write queue backs up", () => {
     // The count of true returns before that depends on the kernel socket
     // buffer size, so only the false count is fixed.
     expect(stdout.trim()).toMatch(/^true=\d+ false=1$/);
-    expect(stdout.trim()).not.toBe("true=500 false=0");
     expect(exitCode).toBe(0);
   });
 
@@ -76,15 +83,17 @@ describe("send() returns false when the IPC write queue backs up", () => {
         const path = require("path");
         const resultPath = path.join(__dirname, "result.txt");
         const child = cp.fork(path.join(__dirname, "child.js"), [resultPath]);
-        child.send("go");
-        // Spin synchronously until the child has written its result. The
-        // event loop does not run during sync fs calls, so the IPC socket is
-        // never read here.
-        const deadline = Date.now() + 30000;
-        while (!fs.existsSync(resultPath) && Date.now() < deadline) {}
-        process.stdout.write(fs.readFileSync(resultPath, "utf8"));
-        child.kill("SIGKILL");
-        child.on("close", () => process.exit(0));
+        // Enter the busy-spin only once "go" has actually been written (the
+        // send callback fires on write completion), then never yield again.
+        // The event loop does not run during sync fs calls, so the IPC
+        // socket is never read here.
+        child.send("go", () => {
+          const deadline = Date.now() + 15000;
+          while (!fs.existsSync(resultPath) && Date.now() < deadline) {}
+          process.stdout.write(fs.existsSync(resultPath) ? fs.readFileSync(resultPath, "utf8") : "");
+          child.kill("SIGKILL");
+          child.on("close", () => process.exit(0));
+        });
       `,
       "child.js": `
         const fs = require("fs");
@@ -96,7 +105,11 @@ describe("send() returns false when the IPC write queue backs up", () => {
             if (process.send(payload) === false) { f++; break; }
             t++;
           }
-          fs.writeFileSync(resultPath, "true=" + t + " false=" + f + "\\n");
+          // writeFileSync is open(O_CREAT) + write + close, so the parent's
+          // existsSync spin could observe the name before the bytes land.
+          // Publish atomically with a rename instead.
+          fs.writeFileSync(resultPath + ".tmp", "true=" + t + " false=" + f + "\\n");
+          fs.renameSync(resultPath + ".tmp", resultPath);
           process.exit(0);
         });
       `,

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("child_process ipc", async () => {
   const output = await $`${bunExe()} ${import.meta.dir}/fixtures/ipc_fixture.js`.text();
@@ -12,4 +12,105 @@ test("child_process ipc", async () => {
     cb ERR_IPC_CHANNEL_CLOSED
     "
   `);
+});
+
+// https://github.com/oven-sh/bun/issues/30569
+// Node: `send()` returns false once `channel.writeQueueSize >= 65536 * 2`.
+// This boolean is the only backpressure signal IPC exposes, so a producer
+// that follows the documented contract never throttles if it stays true.
+describe("send() returns false when the IPC write queue backs up", () => {
+  // The child sends "ready" then busy-loops so it never drains the IPC pipe.
+  // The parent floods ~64 KiB messages until send() returns false (or gives
+  // up after 500 sends, ~32 MiB). Printed as "true=N false=M" so the
+  // assertion shows the actual split on failure.
+  const fixture = `
+    const cp = require("child_process");
+    if (process.argv[2] === "--child") {
+      process.send("ready");
+      const end = Date.now() + 120000;
+      while (Date.now() < end) {}
+      process.exit(0);
+    }
+    const child = cp.fork(__filename, ["--child"], { serialization: process.argv[2] });
+    child.on("message", () => {
+      const payload = { s: Buffer.alloc(65536, "z").toString() };
+      let t = 0, f = 0;
+      for (let i = 0; i < 500; i++) {
+        if (child.send(payload) === false) { f++; break; }
+        t++;
+      }
+      console.log("true=" + t + " false=" + f);
+      child.kill("SIGKILL");
+      child.on("close", () => process.exit(0));
+    });
+    child.on("error", err => { console.error(String(err)); process.exit(1); });
+  `;
+
+  test.each(["json", "advanced"])("child_process fork (%s)", async serialization => {
+    using dir = tempDir("ipc-backpressure", { "index.js": fixture });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js", serialization],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Exactly one send() must have returned false (the loop breaks on it).
+    // The count of true returns before that depends on the kernel socket
+    // buffer size, so only the false count is fixed.
+    expect(stdout.trim()).toMatch(/^true=\d+ false=1$/);
+    expect(stdout.trim()).not.toBe("true=500 false=0");
+    expect(exitCode).toBe(0);
+  });
+
+  // Child-side process.send(): parent blocks its event loop so nothing
+  // drains the parent end of the IPC pipe; child floods upward and writes
+  // its result to a file (stdout would not be drained either).
+  test("process.send from child", async () => {
+    using dir = tempDir("ipc-backpressure-child", {
+      "index.js": `
+        const cp = require("child_process");
+        const fs = require("fs");
+        const path = require("path");
+        const resultPath = path.join(__dirname, "result.txt");
+        const child = cp.fork(path.join(__dirname, "child.js"), [resultPath]);
+        child.send("go");
+        // Spin synchronously until the child has written its result. The
+        // event loop does not run during sync fs calls, so the IPC socket is
+        // never read here.
+        const deadline = Date.now() + 30000;
+        while (!fs.existsSync(resultPath) && Date.now() < deadline) {}
+        process.stdout.write(fs.readFileSync(resultPath, "utf8"));
+        child.kill("SIGKILL");
+        child.on("close", () => process.exit(0));
+      `,
+      "child.js": `
+        const fs = require("fs");
+        const resultPath = process.argv[2];
+        process.on("message", () => {
+          const payload = { s: Buffer.alloc(65536, "z").toString() };
+          let t = 0, f = 0;
+          for (let i = 0; i < 500; i++) {
+            if (process.send(payload) === false) { f++; break; }
+            t++;
+          }
+          fs.writeFileSync(resultPath, "true=" + t + " false=" + f + "\\n");
+          process.exit(0);
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toMatch(/^true=\d+ false=1$/);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
Fixes #30569. Replaces #30572, which had the same fix against the old Zig source tree and was closed when those files were removed in the Rust migration.

## Problem

`ChildProcess#send()`, child-side `process.send()`, and `Bun.spawn({ipc}).send()` always return `true`, no matter how much unsent data is queued behind a peer that never reads. Node returns `false` once the channel's `writeQueueSize` reaches `65536 * 2` (lib/internal/child_process.js), and the docs say it is "unwise to send further messages" past that point. That boolean is the only backpressure mechanism IPC has, so a producer following the documented contract (`if (!send(m)) waitForDrain()`) never throttles on Bun: the parent buffers without bound and OOMs under a slow consumer.

Reproduction (parent floods a child that busy-loops instead of reading):

```js
const cp = require("child_process");
if (process.argv[2] === "--child") {
  process.send("ready");
  setTimeout(() => { const e = Date.now() + 60000; while (Date.now() < e) {} }, 50);
  return;
}
const child = cp.fork(__filename, ["--child"]);
child.on("message", () => setTimeout(() => {
  const payload = { s: "z".repeat(65536) };
  let t = 0, f = 0;
  for (let i = 0; i < 2000; i++) (child.send(payload) === false) ? f++ : t++;
  console.log(`send() -> true=${t} false=${f}`);
  child.kill("SIGKILL");
}, 300));
```

| runtime | output |
| --- | --- |
| node v26.3.0 | `send() -> true=3 false=1997` |
| bun (before) | `send() -> true=2000 false=0` (~130 MB queued) |
| bun (after) | `send() -> true=5 false=1995` |

## Root cause

`SendQueue.serialize_and_send` in `src/jsc/ipc.rs` only returned `Backoff` while waiting for a handle ACK with a non-empty queue. It never looked at how many bytes were actually sitting unsent in the queue, so an arbitrarily large backlog still reported `Success`.

## Fix

Add `SendQueue::pending_bytes()`, which sums the unsent portion (`list.len() - cursor`) of every queued message. This is the same quantity libuv exposes as `writeQueueSize`. `serialize_and_send` checks it after `continue_send` runs the synchronous write attempt (matching Node, which reads `writeQueueSize` after the write), and returns `Backoff` once it reaches `65536 * 2`. The existing handle-ACK backoff condition is kept.

Messages that have already been handed to the kernel, and the message parked in `waiting_for_ack`, are not counted, since neither is "queued and unsent".

`node:cluster` shares `serialize_and_send` through `node_cluster_binding.rs`. Its callers either discard the return value or forward it out of `Worker.send()`, which in Node is `process.send()` and has the same threshold, so the behavior there is Node parity too. Its internal control messages are far too small to reach 128 KiB on their own.

## Tests

- `test/js/node/child_process/child_process_ipc.test.js`: `child_process.fork` parent-side `send()` in both `json` and `advanced` serialization modes, plus child-side `process.send()`. Each floods a peer that never reads and asserts exactly one `false` was observed.
- `test/js/bun/spawn/spawn.ipc.test.ts`: `Bun.spawn({ipc}).send()` in both modes.

All five fail before the fix with `true=N false=0` and pass after. The existing IPC suites (`spawn.ipc.*`, `child_process_ipc_large_disconnect`, `child_process_send_cb`, `bun-ipc-inherit`, `spawn-ipc-gc`, `test-cluster-send-deadlock`) still pass.
