### PR TITLE
Fix Bun.Cookie Expires to emit an IMF-fixdate

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -5,6 +5,7 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/StringToIntegerConversion.h>
+#include <JavaScriptCore/DateConversion.h>
 #include <JavaScriptCore/DateInstance.h>
 #include "HTTPParsers.h"
 namespace WebCore {
@@ -267,11 +268,11 @@ void Cookie::appendTo(JSC::VM& vm, StringBuilder& builder) const
     // Add expires if present
     if (hasExpiry()) {
         builder.append("; Expires="_s);
-        // In a real implementation, this would convert the timestamp to a proper date string
-        // For now, just use a numeric timestamp
+        // RFC 6265 wants an IMF-fixdate ("Thu, 01 Jan 1970 00:00:00 GMT"). Reuse the
+        // Date.prototype.toUTCString() formatter, which emits exactly that.
         WTF::GregorianDateTime dateTime;
         vm.dateCache.msToGregorianDateTime(m_expires, WTF::TimeType::UTCTime, dateTime);
-        builder.append(WTF::makeRFC2822DateString(dateTime.weekDay(), dateTime.monthDay(), dateTime.month(), dateTime.year(), dateTime.hour(), dateTime.minute(), dateTime.second(), dateTime.utcOffsetInMinute()));
+        builder.append(JSC::formatDateTime(dateTime, JSC::DateTimeFormat::DateAndTime, /* asUTCVariant */ true, vm.dateCache));
     }
 
     // Add Max-Age if present

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -198,7 +198,7 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`
       [
         "foo=bar; Path=/; Secure; HttpOnly; Partitioned; SameSite=Lax",
-        "name=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+        "name=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
       ]
     `);
   });

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -99,6 +99,30 @@ describe("Bun.Cookie validation tests", () => {
   });
 });
 
+describe("Expires serialization", () => {
+  // RFC 6265 expects an IMF-fixdate: "Wdy, DD Mon YYYY HH:MM:SS GMT".
+  // Date.prototype.toUTCString() produces exactly that, so the two must agree.
+  test("Expires is an IMF-fixdate matching Date.toUTCString() for every weekday", () => {
+    // 7 consecutive UTC days covers every weekday; the 9th keeps the day zero-padded.
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(Date.UTC(2031, 5, 9 + i, 4, 5, 6));
+      const cookie = new Bun.Cookie("a", "b", { expires: date });
+      expect(cookie.toString()).toBe(`a=b; Path=/; Expires=${date.toUTCString()}; SameSite=Lax`);
+    }
+  });
+
+  test("Expires=0 serializes the epoch, not the day after", () => {
+    const cookie = new Bun.Cookie("a", "b", { expires: new Date(0) });
+    expect(cookie.toString()).toBe("a=b; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax");
+  });
+
+  test("CookieMap.delete emits an IMF-fixdate epoch", () => {
+    const map = new Bun.CookieMap();
+    map.delete("gone");
+    expect(map.toSetCookieHeaders()).toEqual(["gone=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"]);
+  });
+});
+
 console.log("describe Bun.serve() cookies");
 describe("Bun.serve() cookies", () => {
   const server = Bun.serve({
@@ -181,7 +205,7 @@ describe("Bun.serve() cookies", () => {
     expect(body).toMatchInlineSnapshot(`{}`);
     expect(res.headers.getAll("Set-Cookie")).toMatchInlineSnapshot(`
       [
-        "test=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+        "test=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
       ]
     `);
   });
@@ -238,7 +262,7 @@ describe("Bun.serve() cookies", () => {
     map.set("do_modify", "FIVE");
     expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`
       [
-        "do_delete=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+        "do_delete=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
         "do_modify=FIVE; Path=/; SameSite=Lax",
       ]
     `);
@@ -352,10 +376,10 @@ test("delete cookie path option", () => {
   map.delete("d", { path: "/" });
   expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`
     [
-      "a=; Path=/b; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
-      "b=; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
-      "c=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
-      "d=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+      "a=; Path=/b; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+      "b=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+      "c=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+      "d=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
     ]
   `);
 });

--- a/test/js/bun/util/cookie.test.js
+++ b/test/js/bun/util/cookie.test.js
@@ -178,7 +178,7 @@ describe("Bun.CookieMap", () => {
 
     expect(cookieMap.toSetCookieHeaders()).toMatchInlineSnapshot(`
       [
-        "name=; Domain=example.com; Path=/foo; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+        "name=; Domain=example.com; Path=/foo; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
       ]
     `);
 
@@ -507,7 +507,7 @@ describe("cookie.serialize(name, value, options)", function () {
         cookie.serialize("foo", "bar", {
           expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
         }),
-      ).toEqual("foo=bar; Expires=Mon, 24 Dec 2000 10:30:59 -0000; SameSite=Lax");
+      ).toEqual("foo=bar; Expires=Sun, 24 Dec 2000 10:30:59 GMT; SameSite=Lax");
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

`Bun.Cookie` serializes `Expires` with the wrong weekday on every date, an unpadded day, and a `-0000` zone instead of `GMT`. The result is not an IMF-fixdate (RFC 9110) / cookie-date (RFC 6265), which is what `Expires` is supposed to be.

```js
for (const t of [0, 1700000000_000, 1445412480_000]) {
  const d = new Date(t);
  console.log("real:", d.toUTCString(), "| bun:", new Bun.Cookie("a", "b", { expires: d }).toString());
}
// real: Thu, 01 Jan 1970 00:00:00 GMT | bun: a=b; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax
// real: Tue, 14 Nov 2023 22:13:20 GMT | bun: a=b; Path=/; Expires=Wed, 14 Nov 2023 22:13:20 -0000; SameSite=Lax
// real: Wed, 21 Oct 2015 07:28:00 GMT | bun: a=b; Path=/; Expires=Thu, 21 Oct 2015 07:28:00 -0000; SameSite=Lax
```

Thursday is rendered as Friday, Tuesday as Wednesday, and so on. This affects every `Set-Cookie` header Bun emits with an expiry, including the epoch date used by `CookieMap.delete()`.

## Cause

`Cookie::appendTo` passes `GregorianDateTime::weekDay()` (which is `tm_wday`-style, 0 = Sunday) into `WTF::makeRFC2822DateString`, whose `weekdayName` table is Monday-first (`{Mon, Tue, Wed, Thu, Fri, Sat, Sun}`). Indexing a Monday-first table with a Sunday-based index is a constant +1. JSC's own `toUTCString()` path (`DateConversion.cpp`) compensates with `(weekDay() + 6) % 7`; Cookie.cpp did not. `makeRFC2822DateString` also emits an unpadded day and a numeric `-0000` offset, neither of which is valid in a cookie-date.

## Fix

Call `JSC::formatDateTime(dateTime, DateTimeFormat::DateAndTime, /* asUTCVariant */ true, vm.dateCache)` instead. That is the exact formatter behind `Date.prototype.toUTCString()`, and it produces `Thu, 01 Jan 1970 00:00:00 GMT` verbatim. `Bun.Cookie.parse` already accepts IMF-fixdate (it uses `WTF::parseDate`), so round-tripping is unaffected.

Several existing tests asserted the broken output; those inline snapshots are updated in the same commit.

## How did you verify your code works?

Added tests in `test/js/bun/cookie/cookie.test.ts` covering all seven weekdays against `Date.toUTCString()`, the epoch, and the `CookieMap.delete()` header, and corrected the stale assertions in `cookie.test.ts`, `cookie-map.test.ts`, and `util/cookie.test.js`.

- `USE_SYSTEM_BUN=1 bun test` on the three files: 9 tests fail, all on the `Expires` format
- `bun bd test test/js/bun/cookie/ test/js/bun/util/cookie.test.js test/regression/issue/22475.test.ts`: 255 pass, 0 fail
