### PR TITLE
HTMLRewriter: reject the transformed body when the upstream body fails

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -383,6 +383,7 @@ declare function $code(): TODO;
 declare function $controlledReadableStream(): TODO;
 declare function $controller(): TODO;
 declare function $createEmptyReadableStream(): TODO;
+declare function $createErroredReadableStream(reason: unknown): TODO;
 declare function $createFIFO(): TODO;
 declare function $createNativeReadableStream(): TODO;
 declare function $createUninitializedArrayBuffer(size: number): ArrayBuffer;

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -72,6 +72,7 @@ using namespace JSC;
     macro(controller) \
     macro(createCommonJSModule) \
     macro(createEmptyReadableStream) \
+    macro(createErroredReadableStream) \
     macro(createFIFO) \
     macro(createInternalModuleById) \
     macro(createNativeReadableStream) \

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -360,6 +360,15 @@ export function createUsedReadableStream() {
 }
 
 $linkTimeConstant;
+export function createErroredReadableStream(reason) {
+  var stream = new ReadableStream({
+    pull() {},
+  } as any);
+  $readableStreamError(stream, reason);
+  return stream;
+}
+
+$linkTimeConstant;
 export function createNativeReadableStream(nativePtr, autoAllocateChunkSize) {
   $assert(nativePtr, "nativePtr must be a valid pointer");
   return new ReadableStream({

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2982,6 +2982,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     putDirectBuiltinFunction(vm, this, builtinNames.createFIFOPrivateName(), streamInternalsCreateFIFOCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.createEmptyReadableStreamPrivateName(), readableStreamCreateEmptyReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.createUsedReadableStreamPrivateName(), readableStreamCreateUsedReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.createErroredReadableStreamPrivateName(), readableStreamCreateErroredReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.createNativeReadableStreamPrivateName(), readableStreamCreateNativeReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     // These three are CommonJS-only and never reached on an ESM startup path; install
     // lazy getters so their source isn't parsed during global object construction.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3189,6 +3189,20 @@ JSC::EncodedJSValue JSC__JSModuleLoader__evaluate(JSC::JSGlobalObject* globalObj
     return JSValue::encode(usedStream);
 }
 
+[[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue ReadableStream__errored(Zig::GlobalObject* globalObject, JSC::EncodedJSValue encodedReason)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto clientData = WebCore::clientData(vm);
+    auto* function = globalObject->getDirect(vm, clientData->builtinNames().createErroredReadableStreamPrivateName()).getObject();
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(JSC::JSValue::decode(encodedReason));
+    ASSERT(!arguments.hasOverflowed());
+    JSValue erroredStream = JSC::call(globalObject, function, arguments, "ReadableStream.create"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(erroredStream);
+}
+
 JSC::EncodedJSValue JSC__JSValue__createRangeError(const ZigString* message, const ZigString* arg1,
     JSC::JSGlobalObject* globalObject)
 {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -943,7 +943,10 @@ impl BufferOutputSink {
         if !captured.is_empty() {
             captured.ensure_still_alive();
             captured.unprotect();
-            return Ok(captured);
+            // Throw directly: the callers gate on `JSValue::to_error()`, which
+            // only recognises `ErrorInstance`/`Exception`, so an abort reason
+            // (a DOMException or any user value) would be returned instead.
+            return Err(global.throw_value(captured));
         }
 
         response_js_value.ensure_still_alive();

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -986,7 +986,7 @@ impl BufferOutputSink {
         // refcount > 0 so the allocation is live.
         let global = unsafe { (*sink).global };
 
-        if let Some(err) = js_err {
+        if let Some(mut err) = js_err {
             // SAFETY: (*sink).response is the heap Response allocated in init()
             // and kept alive by (*sink).response_value (Strong root).
             let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
@@ -1012,17 +1012,14 @@ impl BufferOutputSink {
                 let _ = sink_body_value.to_error_instance(err.dupe(&global), &global);
                 // TODO: properly propagate exception upwards
             } else {
-                let ret_err = create_lolhtml_error(&global);
+                let ret_err = err.to_js(&global);
                 ret_err.ensure_still_alive();
                 ret_err.protect();
                 Self::write_tmp_sync_error(sink, ret_err);
             }
-            // SAFETY: rewriter set by init(). Read into a local before the
-            // call — `end()` re-enters `OutputSink::done(&mut *sink)`.
-            let rewriter = unsafe { (*sink).rewriter };
-            // SAFETY: `rewriter` was created via `builder.build()` in `init()`
-            // and is not yet freed (destroyed only in `Drop` at refcount zero).
-            let _ = unsafe { lolhtml::HTMLRewriter::end(rewriter) };
+            // Do not `end()` the rewriter: that would run `done()`, replacing
+            // the error just stored on the body with the truncated output.
+            // `Drop` destroys the rewriter once the sink's refcount hits zero.
             return;
         }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -994,15 +994,21 @@ impl BufferOutputSink {
             // and kept alive by (*sink).response_value (Strong root).
             let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
             let sink_ptr_usize = sink as usize;
-            if matches!(sink_body_value, webcore::body::Value::Locked(l)
-                if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_none())
+            // If a `.body` readable is already attached, the body must stay
+            // `Locked` so `to_error_instance` below delivers the error to its
+            // `ByteStream`; clearing to `Empty` here would strand any pending
+            // `reader.read()` forever.
+            let has_readable = match sink_body_value {
+                webcore::body::Value::Locked(l) => l.readable.has(),
+                _ => false,
+            };
+            if !has_readable
+                && matches!(sink_body_value, webcore::body::Value::Locked(l)
+                    if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_none())
             {
-                if let webcore::body::Value::Locked(l) = sink_body_value {
-                    l.readable.deinit();
-                }
+                // No reader and no pending read: normalize to `Empty` so
+                // `to_error_instance` takes the simple (non-`Locked`) path.
                 *sink_body_value = webcore::body::Value::Empty;
-                // is there a pending promise?
-                // we will need to reject it
             } else if matches!(sink_body_value, webcore::body::Value::Locked(l)
                 if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_some())
             {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -994,10 +994,9 @@ impl BufferOutputSink {
             // and kept alive by (*sink).response_value (Strong root).
             let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
             let sink_ptr_usize = sink as usize;
-            // If a `.body` readable is already attached, the body must stay
-            // `Locked` so `to_error_instance` below delivers the error to its
-            // `ByteStream`; clearing to `Empty` here would strand any pending
-            // `reader.read()` forever.
+            // If a `.body` readable is already attached, stay `Locked` so
+            // `to_error_instance` delivers the error to its ByteStream; clearing
+            // to `Empty` here would strand any pending `reader.read()` forever.
             let has_readable = match sink_body_value {
                 webcore::body::Value::Locked(l) => l.readable.has(),
                 _ => false,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -926,9 +926,11 @@ impl Value {
 
                 Ok(locked.readable.get(global_this).unwrap().value)
             }
-            Value::Error(_) => {
-                // TODO: handle error properly
-                ReadableStream::empty(global_this)
+            Value::Error(err) => {
+                // Leave `self` as `Error` so the promise-returning readers
+                // (`handle_body_error`) still reject too.
+                let reason = err.to_js(global_this);
+                ReadableStream::errored(global_this, reason)
             }
         }
     }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1782,6 +1782,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         if matches!(value, Value::Used) {
             return Ok(handle_body_already_used(global_object));
         }
+        if let Some(rejected) = handle_body_error(value, global_object) {
+            return Ok(rejected);
+        }
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream(global_object) {
@@ -1852,6 +1855,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         if matches!(value, Value::Used) {
             return Ok(handle_body_already_used(global_object));
         }
+        if let Some(rejected) = handle_body_error(value, global_object) {
+            return Ok(rejected);
+        }
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream(global_object) {
@@ -1898,6 +1904,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         if matches!(value, Value::Used) {
             return Ok(handle_body_already_used(global_object));
+        }
+        if let Some(rejected) = handle_body_error(value, global_object) {
+            return Ok(rejected);
         }
 
         if matches!(value, Value::Locked(_)) {
@@ -1951,6 +1960,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         if matches!(value, Value::Used) {
             return Ok(handle_body_already_used(global_object));
         }
+        if let Some(rejected) = handle_body_error(value, global_object) {
+            return Ok(rejected);
+        }
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream(global_object) {
@@ -1998,6 +2010,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         if matches!(value, Value::Used) {
             return Ok(handle_body_already_used(global_object));
+        }
+        if let Some(rejected) = handle_body_error(value, global_object) {
+            return Ok(rejected);
         }
 
         if matches!(value, Value::Locked(_)) {
@@ -2092,6 +2107,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         if matches!(value, Value::Used) {
             return Ok(handle_body_already_used(global_object));
         }
+        if let Some(rejected) = handle_body_error(value, global_object) {
+            return Ok(rejected);
+        }
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream(global_object) {
@@ -2175,6 +2193,16 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
             format_args!("Body already used"),
         )
         .reject()
+}
+
+/// If the body already failed, reject the read with that error. Every body
+/// reader must call this before its `Locked` handling: `Value::Error` would
+/// otherwise fall through to `use_as_any_blob_*` and resolve empty.
+fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Option<JSValue> {
+    let Value::Error(err) = value else {
+        return None;
+    };
+    Some(JSPromise::rejected_promise(global_object, err.to_js(global_object)).to_js())
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -2328,6 +2356,13 @@ impl<'a> ValueBufferer<'a> {
     }
 
     fn on_stream_pipe(&mut self, stream: &streams::Result) {
+        if let streams::Result::Err(err) = stream {
+            bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe error");
+            let js_err = err.to_js(self.global);
+            let ref_ = jsc::strong::Optional::create(js_err, self.global);
+            (self.on_finished_buffering)(self.ctx, b"", Some(ValueError::JSValue(ref_)), true);
+            return;
+        }
         let chunk = stream.slice();
         bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe chunk {}", chunk.len());
         let _ = self.stream_buffer.write(chunk);
@@ -2461,6 +2496,22 @@ impl<'a> ValueBufferer<'a> {
                     // If we've received the complete body by the time this function is called
                     // we can avoid streaming it and just send it all at once.
                     if byte_stream.has_received_last_chunk.get() {
+                        if let streams::Result::Err(err) = &byte_stream.pending.get().result {
+                            bun_core::scoped_log!(
+                                BodyValueBufferer,
+                                "byte stream has_received_last_chunk error"
+                            );
+                            let js_err = err.to_js(self.global);
+                            let ref_ = jsc::strong::Optional::create(js_err, self.global);
+                            (self.on_finished_buffering)(
+                                self.ctx,
+                                b"",
+                                Some(ValueError::JSValue(ref_)),
+                                false,
+                            );
+                            stream.done(self.global);
+                            return Ok(());
+                        }
                         bun_core::scoped_log!(
                             BodyValueBufferer,
                             "byte stream has_received_last_chunk {}",

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1640,6 +1640,13 @@ impl Value {
             return Ok(Value::Null);
         }
 
+        // A failed body clones as failed, so the clone's readers reject via
+        // `handle_body_error` instead of falling through to `Empty` below and
+        // resolving as an empty "successful" body.
+        if let Value::Error(err) = self {
+            return Ok(Value::Error(err.dupe(global_this)));
+        }
+
         Ok(Value::Empty)
     }
 }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -108,6 +108,7 @@ unsafe extern "C" {
     ) -> bool;
     safe fn ReadableStream__empty(global: &JSGlobalObject) -> JSValue;
     safe fn ReadableStream__used(global: &JSGlobalObject) -> JSValue;
+    safe fn ReadableStream__errored(global: &JSGlobalObject, reason: JSValue) -> JSValue;
     safe fn ReadableStream__cancel(stream: JSValue, global: &JSGlobalObject);
     safe fn ReadableStream__cancelWithReason(
         stream: JSValue,
@@ -457,6 +458,15 @@ impl ReadableStream {
         bun_jsc::from_js_host_call(global_this, || {
             // SAFETY: FFI call into JSC bindings; global_this is a valid &JSGlobalObject.
             ReadableStream__used(global_this)
+        })
+    }
+
+    /// A stream already in the `errored` state, so every read rejects with
+    /// `reason` instead of closing cleanly.
+    pub fn errored(global_this: &JSGlobalObject, reason: JSValue) -> JsResult<JSValue> {
+        bun_jsc::from_js_host_call(global_this, || {
+            // SAFETY: FFI call into JSC bindings; global_this is a valid &JSGlobalObject.
+            ReadableStream__errored(global_this, reason)
         })
     }
 }

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -237,6 +237,29 @@ describe("HTMLRewriter", () => {
         expect(() => rewriter().transform(res)).toThrow(connectionError);
       });
     });
+
+    it("transform() of an aborted body throws the abort reason", async () => {
+      // An abort reason is a DOMException, not a JSC ErrorInstance. transform()
+      // must still throw it rather than returning it in place of the Response.
+      await withPartialBodyServer(async url => {
+        const controller = new AbortController();
+        const res = await fetch(url, { signal: controller.signal });
+        // The body is mid-stream (the server is stalled until release()).
+        const text = res.text();
+        controller.abort();
+        await expect(text).rejects.toThrow();
+        let thrown;
+        try {
+          rewriter().transform(res);
+        } catch (e) {
+          thrown = e;
+        }
+        expect({ name: thrown?.name, threw: thrown !== undefined }).toEqual({
+          name: "AbortError",
+          threw: true,
+        });
+      });
+    });
   });
 
   it("HTMLRewriter: async replacement using fetch + Bun.serve", async () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { once } from "events";
 import fs from "fs";
 import { gcTick, tls, tmpdirSync } from "harness";
+import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
 var setTimeoutAsync = (fn, delay) => {
@@ -103,6 +105,140 @@ describe("HTMLRewriter", () => {
   it("HTMLRewriter handles Symbol invalid type error", async () => {
     expect(() => new HTMLRewriter().transform(new Response(Symbol("ok")))).toThrow();
     expect(() => new HTMLRewriter().transform(Symbol("ok"))).toThrow();
+  });
+
+  describe("transform rejects when the upstream body fails", () => {
+    // An HTTP server that sends response headers plus a partial HTML body
+    // and then resets the connection once the test calls `release()`.
+    // The transformed body must surface this as an error instead of
+    // resolving with a silently truncated document presented as complete.
+    const fullBody = "<div id=a><p>hello <b>world</b></p></div>";
+    // Ties the rejection to the connection failure so an unrelated future
+    // rejection ("Body already used", an internal rewriter error, ...) cannot
+    // keep these tests green. The exact RST message varies by platform, so
+    // match loosely rather than on the whole string.
+    const connectionError = /socket|connection|ECONNRESET/i;
+
+    async function withPartialBodyServer(fn) {
+      let release;
+      const released = new Promise(r => (release = r));
+      const server = createTcpServer(socket => {
+        socket.on("error", () => {});
+        socket.write(
+          "HTTP/1.1 200 OK\r\n" +
+            "Content-Type: text/html\r\n" +
+            `Content-Length: ${fullBody.length}\r\n` +
+            "\r\n" +
+            fullBody.slice(0, 30),
+        );
+        released.then(() => socket.resetAndDestroy());
+      });
+      server.listen(0);
+      await once(server, "listening");
+      try {
+        await fn(`http://127.0.0.1:${server.address().port}/`, release);
+      } finally {
+        release();
+        await new Promise(r => server.close(r));
+      }
+    }
+
+    function rewriter() {
+      return new HTMLRewriter().on("p", {
+        element(e) {
+          e.setAttribute("seen", "1");
+        },
+      });
+    }
+
+    // Reports either settlement so a failing test shows the truncated
+    // document that was wrongly produced instead of just "did not reject".
+    function settle(promise) {
+      return promise.then(
+        value => ({ rejected: false, value }),
+        error => ({ rejected: true, message: String(error?.message) }),
+      );
+    }
+    const rejectedWithConnectionError = {
+      rejected: true,
+      message: expect.stringMatching(connectionError),
+    };
+
+    it("control: .text() on the untransformed response rejects", async () => {
+      await withPartialBodyServer(async (url, release) => {
+        const res = await fetch(url);
+        const text = res.text();
+        release();
+        await expect(text).rejects.toThrow(connectionError);
+      });
+    });
+
+    it(".text() on the transformed response rejects", async () => {
+      await withPartialBodyServer(async (url, release) => {
+        const res = await fetch(url);
+        const transformed = rewriter().transform(res);
+        const text = settle(transformed.text());
+        release();
+        // Must reject with the upstream connection error, and must never
+        // resolve with the truncated document.
+        expect(await text).toEqual(rejectedWithConnectionError);
+        // The body is now in its error state. A second read must report the
+        // same failure, not resolve as an empty "successful" document.
+        expect(await settle(transformed.text())).toEqual(rejectedWithConnectionError);
+      });
+    });
+
+    it(".arrayBuffer() on the transformed response rejects", async () => {
+      await withPartialBodyServer(async (url, release) => {
+        const res = await fetch(url);
+        const buf = rewriter().transform(res).arrayBuffer();
+        release();
+        await expect(buf).rejects.toThrow(connectionError);
+      });
+    });
+
+    it("does not invoke onDocument end for a document that never completed", async () => {
+      // Sanity: end() fires exactly once on a complete document.
+      {
+        let endCalls = 0;
+        new HTMLRewriter()
+          .onDocument({
+            end() {
+              endCalls++;
+            },
+          })
+          .transform(fullBody);
+        expect(endCalls).toBe(1);
+      }
+
+      await withPartialBodyServer(async (url, release) => {
+        let endCalls = 0;
+        const rw = rewriter().onDocument({
+          end() {
+            endCalls++;
+          },
+        });
+        const res = await fetch(url);
+        const text = rw.transform(res).text();
+        release();
+        await expect(text).rejects.toThrow(connectionError);
+        expect(endCalls).toBe(0);
+      });
+    });
+
+    it("transform() of a body that already failed throws the upstream error", async () => {
+      // Same failure class, synchronous path: once the body is already in its
+      // error state, transform() must throw the upstream connection error,
+      // not an unrelated (and usually empty) HTMLRewriter internal error.
+      await withPartialBodyServer(async (url, release) => {
+        const res = await fetch(url);
+        const text = res.text();
+        release();
+        // Awaiting the rejection is the barrier: the body is now Value::Error.
+        await expect(text).rejects.toThrow(connectionError);
+        expect(() => rewriter().transform(res)).toThrow(connectionError);
+      });
+    });
   });
 
   it("HTMLRewriter: async replacement using fetch + Bun.serve", async () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -195,6 +195,20 @@ describe("HTMLRewriter", () => {
       });
     });
 
+    it(".body on the transformed response is an errored stream", async () => {
+      await withPartialBodyServer(async (url, release) => {
+        const res = await fetch(url);
+        const transformed = rewriter().transform(res);
+        const text = settle(transformed.text());
+        release();
+        // Barrier: once this has rejected, the body is in its error state.
+        expect(await text).toEqual(rejectedWithConnectionError);
+        // Reading `.body` must reject with the same upstream error instead of
+        // closing cleanly as an empty "successful" document.
+        expect(await settle(transformed.body.getReader().read())).toEqual(rejectedWithConnectionError);
+      });
+    });
+
     it("does not invoke onDocument end for a document that never completed", async () => {
       // Sanity: end() fires exactly once on a complete document.
       {
@@ -247,7 +261,7 @@ describe("HTMLRewriter", () => {
         // The body is mid-stream (the server is stalled until release()).
         const text = res.text();
         controller.abort();
-        await expect(text).rejects.toThrow();
+        await expect(text).rejects.toThrow(/abort/i);
         let thrown;
         try {
           rewriter().transform(res);

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -108,15 +108,13 @@ describe("HTMLRewriter", () => {
   });
 
   describe("transform rejects when the upstream body fails", () => {
-    // An HTTP server that sends response headers plus a partial HTML body
-    // and then resets the connection once the test calls `release()`.
-    // The transformed body must surface this as an error instead of
-    // resolving with a silently truncated document presented as complete.
+    // Sends response headers plus a partial HTML body, then resets the
+    // connection once the test calls `release()`. The transformed body must
+    // reject instead of resolving with a truncated document.
     const fullBody = "<div id=a><p>hello <b>world</b></p></div>";
-    // Ties the rejection to the connection failure so an unrelated future
-    // rejection ("Body already used", an internal rewriter error, ...) cannot
-    // keep these tests green. The exact RST message varies by platform, so
-    // match loosely rather than on the whole string.
+    // Ties the rejection to the connection failure so an unrelated rejection
+    // ("Body already used", an internal rewriter error) can't keep this green.
+    // The exact RST message varies by platform, so match loosely.
     const connectionError = /socket|connection|ECONNRESET/i;
 
     async function withPartialBodyServer(fn) {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -209,6 +209,34 @@ describe("HTMLRewriter", () => {
       });
     });
 
+    it("a read already pending on .body when the upstream fails rejects", async () => {
+      await withPartialBodyServer(async (url, release) => {
+        const res = await fetch(url);
+        const transformed = rewriter().transform(res);
+        // Acquire the reader and start the read BEFORE the upstream fails.
+        // This is the one shape (readable attached, no pending promise) where
+        // the error handler must deliver the failure to the attached stream:
+        // discarding the readable here would leave this read pending forever.
+        const read = settle(transformed.body.getReader().read());
+        release();
+        expect(await read).toEqual(rejectedWithConnectionError);
+      });
+    });
+
+    it(".clone() of a failed transformed body is also failed", async () => {
+      await withPartialBodyServer(async (url, release) => {
+        const res = await fetch(url);
+        const transformed = rewriter().transform(res);
+        const text = settle(transformed.text());
+        release();
+        // Barrier: the body is now in its error state.
+        expect(await text).toEqual(rejectedWithConnectionError);
+        // Cloning a failed body must produce a failed body, not an empty one
+        // that reads back as a complete (and empty) document.
+        expect(await settle(transformed.clone().text())).toEqual(rejectedWithConnectionError);
+      });
+    });
+
     it("does not invoke onDocument end for a document that never completed", async () => {
       // Sanity: end() fires exactly once on a complete document.
       {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -213,10 +213,9 @@ describe("HTMLRewriter", () => {
       await withPartialBodyServer(async (url, release) => {
         const res = await fetch(url);
         const transformed = rewriter().transform(res);
-        // Acquire the reader and start the read BEFORE the upstream fails.
-        // This is the one shape (readable attached, no pending promise) where
-        // the error handler must deliver the failure to the attached stream:
-        // discarding the readable here would leave this read pending forever.
+        // Start the read BEFORE the upstream fails. This is the one shape
+        // (readable attached, no pending promise) where the error must reach
+        // the attached stream; discarding it would strand this read forever.
         const read = settle(transformed.body.getReader().read());
         release();
         expect(await read).toEqual(rejectedWithConnectionError);


### PR DESCRIPTION
### Problem

When the `Response` passed to `HTMLRewriter.transform()` has a streaming body that fails mid-document, the transformed body resolves successfully with a silently truncated document. Reading the same body directly rejects.

```js
// a server that sends the first 30 bytes of an HTML document, then resets the connection
const rw = () => new HTMLRewriter().on("p", { element(e) { e.setAttribute("seen", "1"); } });

await fetch(url).then(r => r.text());                 // rejects: "The socket connection was closed unexpectedly"
await rw().transform(await fetch(url)).text();        // resolves: '<div id=a><p seen="1">hello <b>world</b'
```

Cloudflare Workers (same lol-html engine, same API) rejects here. Truncation on error should be an error, not a shorter success: a rewriter is often used to enforce something (inject a tag, sanitize, strip scripts), and "the document ended early and that was fine" is never what the caller meant.

### Cause

`ValueBufferer::on_stream_pipe` in `src/runtime/webcore/Body.rs` only checked `StreamResult::is_done()`, which is also `true` for the `Err` variant. So on an upstream failure it handed the partial buffer to `on_finished_buffering` with `err: None`, and the rewriter finished "successfully" on whatever bytes happened to arrive. The sibling pump in `ResumableSink::on_stream_pipe` already distinguishes `Err` from `Done`.

Six more sites in the same path compounded it:

- `BufferOutputSink::on_finished_buffering`'s input-error branch called `lolhtml::HTMLRewriter::end()` after recording the error. Nothing has been written to the rewriter on that branch, so `end()` (a) re-entered `done()` and replaced the error body with an empty successful one, and (b) spuriously fired the user's `onDocument.end` handler for a document that never completed.
- The `has_received_last_chunk` short-circuit in `buffer_locked_body_value` (the synchronous sibling of the piped path above) never checked `pending.result` for an `Err`, so a body whose failure had already been delivered before `transform()` ran was still handed over as a complete buffer.
- The synchronous branch of `on_finished_buffering` built the value it throws from `create_lolhtml_error()`, which reads lol-html's threadlocal last-error. For an upstream body failure that error is unrelated and usually empty, so `transform()` of an already-failed body threw `Error: ""`.
- `transform()` decided whether to throw its synchronous error via `JSValue::to_error()`, which only recognises JSC `ErrorInstance`/`Exception` cells. A body error that is a `DOMException` (the abort reason) or any user-supplied abort reason value is neither, so once the synchronous branch produced the real body error, those values were returned from `transform()` in place of the Response instead of being thrown. The old code masked this by always fabricating an `ErrorInstance`.
- None of the body reader methods (`text`, `json`, `arrayBuffer`, `bytes`, `blob`, `formData`) handled `Value::Error`. They check `Used`, handle `Locked`, and fall through to the empty-blob path, so once a body reached its error state a later read resolved with an empty result instead of rejecting. Only reads whose promise was already pending when the failure arrived got the rejection. This was previously near-unreachable (errored bodies stayed `Locked` with the error parked on their `ByteStream`); propagating the error makes it the normal state of a failed transformed body.
- The seventh body reader, the `.body` getter, is not promise-returning so the guard above cannot cover it. For a `Value::Error` body it fell through to a `to_readable_stream` arm (a pre-existing `TODO`) that returned a cleanly closed, empty `ReadableStream`, so `transformed.body` after a failure read as an empty successful document.

### Fix

- `ValueBufferer::on_stream_pipe`: on `StreamResult::Err`, propagate the error to `on_finished_buffering` instead of treating it as a clean end of stream.
- `ValueBufferer::buffer_locked_body_value`: the `has_received_last_chunk` short-circuit now surfaces a parked `Err` the same way instead of handing over the partial buffer.
- `BufferOutputSink::on_finished_buffering`: don't `end()` the rewriter on the input-error path (it is still destroyed in `Drop` at refcount zero), and on the synchronous branch throw the actual body error rather than lol-html's last-error.
- `BufferOutputSink::init`: throw the captured synchronous error directly rather than returning it to the `to_error()` gate, which is what lets the previous point work for every error shape rather than only `ErrorInstance`s.
- `BodyMixin`: a new `handle_body_error` guard, called by every reader right after the existing `handle_body_already_used` check, rejects the read with the stored error when the body value is already `Error`.
- `Value::to_readable_stream`: the `Error` arm now returns a stream already in the errored state instead of an empty closed one, so reading `.body` rejects with the stored error. This adds a `createErroredReadableStream(reason)` builtin mirroring the existing `createEmptyReadableStream`, plus its `ReadableStream__errored` binding.
- `BufferOutputSink::on_finished_buffering` (review round): if a `.body` readable is already attached and no read promise is pending, leave the body `Locked` instead of clearing it to `Empty`. Clearing it discarded the readable before `to_error_instance` could notify its `ByteStream`, so a `reader.read()` that was already pending when the upstream failed never settled. With the `end()` removal above that ordering became a hang (previously it settled `{done: true}`, which was wrong but terminating); it now rejects with the upstream error.
- `Value::clone_with_readable_stream` (review round): a failed body clones as failed (an `Error` arm duping the stored error) instead of falling through to the `Empty` catch-all, so the clone's readers also reject via the `handle_body_error` guard above rather than resolving as an empty document.

### Sibling sites, intentionally not changed here

The same pattern (trusting `has_received_last_chunk` as "clean completion" when it is also set on `Err`, with the error parked on `pending.result`) exists at three more sites outside the HTMLRewriter path:

- `RequestContext.rs` (the `has_received_last_chunk` short-circuit and `on_pipe`): a `Bun.serve` handler streaming a failed upstream body serves a truncated response as a clean 200. This is the other half of #31964, and fixing it is a different kind of change: an in-flight HTTP response cannot reject, it has to abort the connection, which is the semantics decision that issue calls out.
- `ByteStream::to_any_blob` and `on_start`/`on_pull`: the raw `response.body` `ReadableStream` surface closes cleanly instead of erroring. Not reachable from `transform()`: `Value::to_error_instance` turns the body value into `Value::Error` in the same step that delivers the `Err` to the `ByteStream`, so `transform()` of a failed response whose `.body` was materialized already takes the `Value::Error` branch fixed above (verified against this branch, not assumed).

- `Response.clone()` / `Request.clone()` do not implement the Fetch spec's `TypeError` on a disturbed body (`do_clone` has no disturbed/`Used` check), which is what makes a post-failure `clone()` observable at all. That check predates this PR, applies to every already-consumed body (not only errored ones), and is a user-visible behavior change, so it stays separate; the clone arm here only keeps the failure from being downgraded to an empty success.

This PR is the `ValueBufferer` half of #31964; the `RequestContext` half stays open on that issue.

### Tests

`test/js/workerd/html-rewriter.test.js`, new `describe("transform rejects when the upstream body fails")`: a local TCP server sends headers plus a partial HTML body and then resets the connection once the test calls `release()`, so every read is registered before the failure can reach the client.

- control: `.text()` on the untransformed response rejects
- `.text()` and `.arrayBuffer()` on the transformed response reject
- reading `.body` on the transformed response after the failure rejects with the same error instead of completing as an empty stream
- a `reader.read()` that is already pending on `.body` when the upstream fails rejects with the same error (the readable is attached before the failure, the ordering the bullet above does not cover); the unfixed behavior is a read that never settles
- `.clone()` of a failed transformed body is also failed: its `.text()` rejects with the same error instead of resolving as an empty document
- a second `.text()` after the first rejection reports the same error rather than resolving as an empty document (this is the deterministic witness for the body-reader guard: after the first rejection the body is provably `Value::Error`)
- `onDocument.end` is not invoked for a document that never completed
- `transform()` of a body that has already failed throws the upstream error
- `transform()` of an aborted body throws the abort reason (a `DOMException`, not an `ErrorInstance`; this pins the error's identity, and it catches the case where the value would be returned instead of thrown)

The connection-error assertions require the rejection to match `/socket|connection|ECONNRESET/i` so an unrelated future rejection cannot keep them green; the message varies by platform so the match is a loose pattern rather than the whole string. The abort assertion requires `name === "AbortError"`.

Before the fix: 1 pass (control), 8 fail. The synchronous-path test fails with `Error: ""` on the unfixed build, which is the `create_lolhtml_error()` bug observed directly; the abort test fails with `HTMLRewriterError: ""` for the same reason. After: 9 pass. The two review-round tests were also each run against the commit immediately preceding their fix: the pending-read test fails by never settling (test timeout) and the clone test fails by resolving an empty document. Also re-ran the rest of the HTMLRewriter suite (51 tests across `test/js/workerd/`) and the body/fetch surface the reader changes touch (`body.test.ts`, `body-mixin-errors.test.ts`, `body-stream.test.ts`, `body-clone.test.ts`, `body-async-iterator.test.ts`, `request.test.ts`, `response.test.ts`, the abort suites): 9477 tests, no regressions.

Fixes #3861


