### PR TITLE
test runner: don't throw synchronously on an invalid expect.assertions(n) count

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -843,14 +843,14 @@ impl CommandLineReporter {
                         if let bun_test::ExpectAssertions::Exact(n) = sequence.expect_assertions {
                             n
                         } else {
-                            12345
+                            12345.0
                         };
                     Output::err(
                         bun_core::err!("AssertionError"),
                         "expected <green>{} assertion{}<r>, but test ended with <red>{} assertion{}<r>\n",
                         (
-                            expected_count,
-                            if expected_count == 1 { "" } else { "s" },
+                            bun_fmt::double(expected_count),
+                            if expected_count == 1.0 { "" } else { "s" },
                             sequence.expect_call_count,
                             if sequence.expect_call_count == 1 {
                                 ""

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -134,11 +134,13 @@ impl ConcurrentGroup {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum ExpectAssertions {
     NotSet,
     AtLeastOne,
-    Exact(u32),
+    /// The raw numeric argument to `expect.assertions(n)`, recorded without
+    /// validation. A value no `expect_call_count` can equal always fails.
+    Exact(f64),
 }
 
 pub struct ExecutionSequence {
@@ -653,7 +655,7 @@ impl Execution {
                 }
             }
             ExpectAssertions::Exact(expected) => {
-                if sequence.expect_call_count != expected
+                if (sequence.expect_call_count as f64) != expected
                     && sequence.result.is_pass(PendingIs::PendingIsPass)
                 {
                     sequence.result = Result::FailBecauseExpectedAssertionCount;

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1651,7 +1651,7 @@ impl Expect {
         if !expected.is_number() {
             let mut fmt = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
             return Err(global_this.throw(format_args!(
-                "Expected value must be a non-negative integer: {}",
+                "Expected value must be a number: {}",
                 expected.to_fmt(&mut fmt),
             )));
         }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1656,21 +1656,10 @@ impl Expect {
             )));
         }
 
-        let expected_assertions: f64 = expected.to_number(global_this)?;
-        if expected_assertions.round() != expected_assertions
-            || expected_assertions.is_infinite()
-            || expected_assertions.is_nan()
-            || expected_assertions < 0.0
-            || expected_assertions > u32::MAX as f64
-        {
-            let mut fmt = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-            return Err(global_this.throw(format_args!(
-                "Expected value must be a non-negative integer: {}",
-                expected.to_fmt(&mut fmt),
-            )));
-        }
-
-        let unsigned_expected_assertions: u32 = expected_assertions as u32;
+        // Jest records any numeric argument verbatim and compares it at end-of-test, so a
+        // bogus count (negative, non-integer, NaN, Infinity) fails the test there instead
+        // of throwing here, where a try/catch in the test body would swallow it.
+        let expected_assertions: f64 = expected.as_number();
 
         let Some(buntest_strong) = bun_test::clone_active_strong() else {
             return Err(global_this.throw(format_args!("expect.assertions() must be called within a test")));
@@ -1680,7 +1669,7 @@ impl Expect {
         let Some(execution) = state_data.sequence(buntest) else {
             return Err(global_this.throw(format_args!("expect.assertions() is not supported in the describe phase, in concurrent tests, between tests, or after test execution has completed")));
         };
-        execution.expect_assertions = ExpectAssertions::Exact(unsigned_expected_assertions);
+        execution.expect_assertions = ExpectAssertions::Exact(expected_assertions);
 
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1642,25 +1642,6 @@ impl Expect {
         let arguments_ = call_frame.arguments_old::<1>();
         let arguments = arguments_.slice();
 
-        if arguments.is_empty() {
-            return Err(global_this.throw_invalid_arguments(format_args!("expect.assertions() takes 1 argument")));
-        }
-
-        let expected: JSValue = arguments[0];
-
-        if !expected.is_number() {
-            let mut fmt = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-            return Err(global_this.throw(format_args!(
-                "Expected value must be a number: {}",
-                expected.to_fmt(&mut fmt),
-            )));
-        }
-
-        // Jest records any numeric argument verbatim and compares it at end-of-test, so a
-        // bogus count (negative, non-integer, NaN, Infinity) fails the test there instead
-        // of throwing here, where a try/catch in the test body would swallow it.
-        let expected_assertions: f64 = expected.as_number();
-
         let Some(buntest_strong) = bun_test::clone_active_strong() else {
             return Err(global_this.throw(format_args!("expect.assertions() must be called within a test")));
         };
@@ -1669,9 +1650,27 @@ impl Expect {
         let Some(execution) = state_data.sequence(buntest) else {
             return Err(global_this.throw(format_args!("expect.assertions() is not supported in the describe phase, in concurrent tests, between tests, or after test execution has completed")));
         };
-        execution.expect_assertions = ExpectAssertions::Exact(expected_assertions);
 
-        Ok(JSValue::UNDEFINED)
+        // Jest records any numeric argument verbatim and compares it at end-of-test, so a
+        // bogus count (negative, non-integer, NaN, Infinity) fails the test there instead
+        // of throwing here, where a try/catch in the test body would swallow it.
+        let expected = arguments.first().copied().unwrap_or(JSValue::UNDEFINED);
+        if expected.is_number() {
+            execution.expect_assertions = ExpectAssertions::Exact(expected.as_number());
+            return Ok(JSValue::UNDEFINED);
+        }
+
+        // A non-number is recorded as NaN (which no assertion count can equal) before the
+        // TypeError, so the test still fails at the end even when the throw is caught.
+        execution.expect_assertions = ExpectAssertions::Exact(f64::NAN);
+        if arguments.is_empty() {
+            return Err(global_this.throw_invalid_arguments(format_args!("expect.assertions() takes 1 argument")));
+        }
+        let mut fmt = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
+        Err(global_this.throw(format_args!(
+            "Expected value must be a number: {}",
+            expected.to_fmt(&mut fmt),
+        )))
     }
 
     #[bun_jsc::host_fn(method)]

--- a/test/js/bun/test/expect-assertions.test.ts
+++ b/test/js/bun/test/expect-assertions.test.ts
@@ -90,7 +90,7 @@ test("expect.assertions with an invalid numeric argument fails the test instead 
       });
 
       test("non-number argument still throws synchronously", () => {
-        expect(() => expect.assertions("2" as any)).toThrow("Expected value must be a non-negative integer");
+        expect(() => expect.assertions("2" as any)).toThrow("Expected value must be a number");
       });
 
       test("missing argument still throws synchronously", () => {

--- a/test/js/bun/test/expect-assertions.test.ts
+++ b/test/js/bun/test/expect-assertions.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
 test("expect.assertions causes the test to fail when it should", async () => {
@@ -27,4 +27,120 @@ test("expect.assertions causes the test to fail when it should", async () => {
   expect(result.exitCode).toBe(1);
   expect(result.stderr.toString()).toContain("5 fail\n");
   expect(result.stderr.toString()).toContain("0 pass\n");
+});
+
+// Jest records any numeric argument to expect.assertions(n) as-is and compares it at
+// end-of-test. It never throws synchronously for a bogus number, so a try/catch in the
+// test body cannot swallow the failure and turn it into a false pass. Non-number and
+// missing arguments keep throwing a TypeError (Jest silently ignores those, which is a
+// worse false pass, so we intentionally stay stricter there).
+test("expect.assertions with an invalid numeric argument fails the test instead of throwing", async () => {
+  using dir = tempDir("expect-assertions-arg", {
+    "assertions-arg.test.ts": `
+      import { test, expect } from "bun:test";
+
+      test("negative count swallowed by try/catch still fails", () => {
+        try {
+          expect.assertions(-1);
+        } catch {}
+        expect(1).toBe(1);
+      });
+
+      test("non-integer count swallowed by try/catch still fails", () => {
+        try {
+          expect.assertions(1.5);
+        } catch {}
+        expect(1).toBe(1);
+      });
+
+      test("NaN count swallowed by try/catch still fails", () => {
+        try {
+          expect.assertions(NaN);
+        } catch {}
+        expect(1).toBe(1);
+      });
+
+      test("Infinity count swallowed by try/catch still fails", () => {
+        try {
+          expect.assertions(Infinity);
+        } catch {}
+        expect(1).toBe(1);
+      });
+
+      test("count above u32 range swallowed by try/catch still fails", () => {
+        try {
+          expect.assertions(1e100);
+        } catch {}
+        expect(1).toBe(1);
+      });
+
+      test("negative count without a try/catch still fails", () => {
+        expect.assertions(-1);
+        expect(1).toBe(1);
+      });
+
+      test("matching count still passes", () => {
+        expect.assertions(2);
+        expect(1).toBe(1);
+        expect(2).toBe(2);
+      });
+
+      test("negative zero with no assertions still passes", () => {
+        expect.assertions(-0);
+      });
+
+      test("non-number argument still throws synchronously", () => {
+        expect(() => expect.assertions("2" as any)).toThrow("Expected value must be a non-negative integer");
+      });
+
+      test("missing argument still throws synchronously", () => {
+        expect(() => (expect.assertions as any)()).toThrow("expect.assertions() takes 1 argument");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "assertions-arg.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({
+    stdout: normalizeBunSnapshot(stdout, String(dir)),
+    stderr: normalizeBunSnapshot(stderr, String(dir)),
+    exitCode,
+  }).toMatchInlineSnapshot(`
+    {
+      "exitCode": 1,
+      "stderr": 
+    "assertions-arg.test.ts:
+    AssertionError: expected -1 assertions, but test ended with 1 assertion
+    (fail) negative count swallowed by try/catch still fails
+    AssertionError: expected 1.5 assertions, but test ended with 1 assertion
+    (fail) non-integer count swallowed by try/catch still fails
+    AssertionError: expected NaN assertions, but test ended with 1 assertion
+    (fail) NaN count swallowed by try/catch still fails
+    AssertionError: expected Infinity assertions, but test ended with 1 assertion
+    (fail) Infinity count swallowed by try/catch still fails
+    AssertionError: expected 1e+100 assertions, but test ended with 1 assertion
+    (fail) count above u32 range swallowed by try/catch still fails
+    AssertionError: expected -1 assertions, but test ended with 1 assertion
+    (fail) negative count without a try/catch still fails
+    (pass) matching count still passes
+    (pass) negative zero with no assertions still passes
+    (pass) non-number argument still throws synchronously
+    (pass) missing argument still throws synchronously
+
+     4 pass
+     6 fail
+     10 expect() calls
+    Ran 10 tests across 1 file."
+    ,
+      "stdout": "bun test <version> (<revision>)",
+    }
+  `);
 });

--- a/test/js/bun/test/expect-assertions.test.ts
+++ b/test/js/bun/test/expect-assertions.test.ts
@@ -29,12 +29,12 @@ test("expect.assertions causes the test to fail when it should", async () => {
   expect(result.stderr.toString()).toContain("0 pass\n");
 });
 
-// Jest records any numeric argument to expect.assertions(n) as-is and compares it at
-// end-of-test. It never throws synchronously for a bogus number, so a try/catch in the
-// test body cannot swallow the failure and turn it into a false pass. Non-number and
-// missing arguments keep throwing a TypeError (Jest silently ignores those, which is a
-// worse false pass, so we intentionally stay stricter there).
-test("expect.assertions with an invalid numeric argument fails the test instead of throwing", async () => {
+// Jest records the argument to expect.assertions(n) as-is and compares it at end-of-test,
+// so an invalid count always fails the test: a try/catch in the test body cannot swallow
+// it and turn it into a false pass. Non-number and missing arguments still get an eager
+// TypeError (unlike Jest, which silently ignores them), but they are recorded as NaN
+// first so catching that throw does not turn the test green either.
+test("expect.assertions with an invalid argument fails the test even when the call is wrapped in try/catch", async () => {
   using dir = tempDir("expect-assertions-arg", {
     "assertions-arg.test.ts": `
       import { test, expect } from "bun:test";
@@ -89,11 +89,18 @@ test("expect.assertions with an invalid numeric argument fails the test instead 
         expect.assertions(-0);
       });
 
-      test("non-number argument still throws synchronously", () => {
+      test("non-number argument throws and still fails the test", () => {
         expect(() => expect.assertions("2" as any)).toThrow("Expected value must be a number");
       });
 
-      test("missing argument still throws synchronously", () => {
+      test("undefined count swallowed by try/catch still fails", () => {
+        try {
+          expect.assertions(undefined as any);
+        } catch {}
+        expect(1).toBe(1);
+      });
+
+      test("missing argument throws and still fails the test", () => {
         expect(() => (expect.assertions as any)()).toThrow("expect.assertions() takes 1 argument");
       });
     `,
@@ -132,13 +139,17 @@ test("expect.assertions with an invalid numeric argument fails the test instead 
     (fail) negative count without a try/catch still fails
     (pass) matching count still passes
     (pass) negative zero with no assertions still passes
-    (pass) non-number argument still throws synchronously
-    (pass) missing argument still throws synchronously
+    AssertionError: expected NaN assertions, but test ended with 1 assertion
+    (fail) non-number argument throws and still fails the test
+    AssertionError: expected NaN assertions, but test ended with 1 assertion
+    (fail) undefined count swallowed by try/catch still fails
+    AssertionError: expected NaN assertions, but test ended with 1 assertion
+    (fail) missing argument throws and still fails the test
 
-     4 pass
-     6 fail
-     10 expect() calls
-    Ran 10 tests across 1 file."
+     2 pass
+     9 fail
+     11 expect() calls
+    Ran 11 tests across 1 file."
     ,
       "stdout": "bun test <version> (<revision>)",
     }


### PR DESCRIPTION
### Repro

```ts
import { test, expect } from "bun:test";

test("expect.assertions(-1) validation", () => {
  try { expect.assertions(-1); } catch (e) {}
  expect(1).toBe(1);
});
```

`bun test` reports `(pass)`. Jest 30 fails the test.

### Cause

Bun validated the argument and threw synchronously at the call site:

```
error: Expected value must be a non-negative integer: -1
```

A `try/catch` in the test body (or any wrapper that tolerates throws) swallows that error, turning an invalid-usage signal into a green test.

Jest records any numeric argument verbatim and compares it to the assertion count at the end of the test, precisely so the failure can never be swallowed. Verified against jest 30.4.2: `-1`, `1.5`, `NaN`, `Infinity`, and `1e100` all produce a deferred test failure and never throw.

### Fix

`ExpectAssertions::Exact` now stores the raw `f64` argument instead of a validated `u32`, and the existing end-of-test comparison does the rest: a count that no `expect_call_count` can equal always fails. This covers the whole numeric class (negative, non-integer, `NaN`, `Infinity`, above `u32::MAX`) and removes the validation block and the `u32` truncation that required it.

```
AssertionError: expected -1 assertions, but test ended with 1 assertion
```

A non-number or missing argument is the same swallowable shape, so it is recorded as `NaN` (which no assertion count can equal) before the `TypeError` is thrown. The uncaught case still gets the immediate, specific `TypeError`, and the deferred check never overwrites a test that already failed; but catching that throw no longer turns the test green either. Jest silently ignores non-numbers, which is a worse false pass, so Bun stays stricter here while still closing the swallow hole.

### Verification

`test/js/bun/test/expect-assertions.test.ts` spawns `bun test` on a fixture covering the matrix (5 swallowed bogus numbers, a swallowed `undefined`, the uncaught case, a matching count, `-0`, and the two still-throwing arg shapes) and inline-snapshots the output. On an unfixed build the 7 swallowed cases report `(pass)` instead of `(fail)`, so the snapshot diverges (9 pass / 2 fail vs 2 pass / 9 fail) and the test fails.
