### PR TITLE
node:tls: report the fatal TLS alert when a handshake over a Duplex fails

### DIFF
--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -970,6 +970,7 @@ unsafe extern "C" {
     // Thread-local error queue — no pointer args, no preconditions.
     pub safe fn ERR_clear_error();
     pub safe fn ERR_get_error() -> u32;
+    pub safe fn ERR_peek_error() -> u32;
     pub safe fn ERR_peek_last_error() -> u32;
     pub fn ERR_error_string(packed_error: u32, buf: *mut c_char) -> *mut c_char;
     // `ERR_error_string_n` declared once in the crypto/err block above.

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -914,8 +914,7 @@ pub mod ssl_wrapper {
                 return true;
             }
 
-            // Per-thread queue: drop entries left by other sockets so a reason
-            // peeked below belongs to this handshake (as ssl_update_handshake does).
+            // Stale entries would be misattributed by peek_fatal_ssl_error below.
             boring_sys::ERR_clear_error();
             // SAFETY: ssl is a live SSL*.
             let result = unsafe { boring_sys::SSL_do_handshake(ssl.as_ptr()) };

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -156,15 +156,15 @@ pub mod ssl_wrapper {
     mod boring_sys {
         pub(super) use bun_boringssl::c::{
             BIO_ctrl_pending, BIO_free, BIO_new, BIO_read, BIO_s_mem, BIO_set_mem_eof_return,
-            BIO_write, ERR_clear_error, OwnedSslCtx, SSL, SSL_CTX_get_verify_mode, SSL_ERROR_SSL,
-            SSL_ERROR_SYSCALL, SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE,
-            SSL_ERROR_WANT_WRITE, SSL_ERROR_ZERO_RETURN, SSL_RECEIVED_SHUTDOWN,
-            SSL_VERIFY_FAIL_IF_NO_PEER_CERT, SSL_VERIFY_NONE, SSL_VERIFY_PEER, SSL_do_handshake,
-            SSL_free, SSL_get_error, SSL_get_rbio, SSL_get_shutdown, SSL_get_wbio,
-            SSL_is_init_finished, SSL_new, SSL_pending, SSL_read, SSL_renegotiate,
-            SSL_set_accept_state, SSL_set_bio, SSL_set_connect_state, SSL_set_renegotiate_mode,
-            SSL_set_verify, SSL_set0_verify_cert_store, SSL_shutdown, SSL_write, X509_STORE,
-            X509_STORE_CTX, ssl_renegotiate_explicit, ssl_renegotiate_never,
+            BIO_write, ERR_clear_error, ERR_error_string_n, ERR_peek_error, OwnedSslCtx, SSL,
+            SSL_CTX_get_verify_mode, SSL_ERROR_SSL, SSL_ERROR_SYSCALL, SSL_ERROR_WANT_READ,
+            SSL_ERROR_WANT_RENEGOTIATE, SSL_ERROR_WANT_WRITE, SSL_ERROR_ZERO_RETURN,
+            SSL_RECEIVED_SHUTDOWN, SSL_VERIFY_FAIL_IF_NO_PEER_CERT, SSL_VERIFY_NONE,
+            SSL_VERIFY_PEER, SSL_do_handshake, SSL_free, SSL_get_error, SSL_get_rbio,
+            SSL_get_shutdown, SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_pending, SSL_read,
+            SSL_renegotiate, SSL_set_accept_state, SSL_set_bio, SSL_set_connect_state,
+            SSL_set_renegotiate_mode, SSL_set_verify, SSL_set0_verify_cert_store, SSL_shutdown,
+            SSL_write, X509_STORE, X509_STORE_CTX, ssl_renegotiate_explicit, ssl_renegotiate_never,
         };
     }
 
@@ -864,6 +864,23 @@ pub mod ssl_wrapper {
             unsafe { us_ssl_socket_verify_error_from_ssl(ssl.as_ptr()) }
         }
 
+        /// Mirrors `ssl_park_fatal_reason` in openssl.c.
+        fn peek_fatal_ssl_error(buf: &mut [u8; 256]) -> Option<us_bun_verify_error_t> {
+            let packed = boring_sys::ERR_peek_error();
+            if packed == 0 {
+                return None;
+            }
+            // SAFETY: buf is a valid mutable buffer for `buf.len()` bytes.
+            unsafe {
+                boring_sys::ERR_error_string_n(packed, buf.as_mut_ptr().cast(), buf.len());
+            }
+            Some(us_bun_verify_error_t {
+                error_no: -71,
+                code: c"EPROTO".as_ptr(),
+                reason: buf.as_ptr().cast(),
+            })
+        }
+
         /// Update the handshake state. Returns true if we can call handle_reading.
         fn update_handshake_state(&self) -> bool {
             if self.flags.closed_notified() {
@@ -903,6 +920,14 @@ pub mod ssl_wrapper {
             if result <= 0 {
                 // SAFETY: ssl is still valid.
                 let err = unsafe { boring_sys::SSL_get_error(ssl.as_ptr(), result) };
+                let is_fatal =
+                    err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL;
+                let mut reason_buf = [0u8; 256];
+                let fatal_reason = if is_fatal {
+                    Self::peek_fatal_ssl_error(&mut reason_buf)
+                } else {
+                    None
+                };
                 boring_sys::ERR_clear_error();
                 if err == boring_sys::SSL_ERROR_ZERO_RETURN {
                     // Remotely-Initiated Shutdown
@@ -916,14 +941,11 @@ pub mod ssl_wrapper {
                 // as far as I know these are the only errors we want to handle
                 if err != boring_sys::SSL_ERROR_WANT_READ && err != boring_sys::SSL_ERROR_WANT_WRITE
                 {
-                    // clear per thread error queue if it may contain something
-                    self.flags.set_fatal_error(
-                        err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL,
-                    );
+                    self.flags.set_fatal_error(is_fatal);
 
                     self.flags
                         .set_handshake_state(HandshakeState::HandshakeCompleted);
-                    let verify = self.get_verify_error();
+                    let verify = fatal_reason.unwrap_or_else(|| self.get_verify_error());
                     self.trigger_handshake_callback(false, verify);
 
                     if self.flags.fatal_error() {

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -914,6 +914,9 @@ pub mod ssl_wrapper {
                 return true;
             }
 
+            // Per-thread queue: drop entries left by other sockets so a reason
+            // peeked below belongs to this handshake (as ssl_update_handshake does).
+            boring_sys::ERR_clear_error();
             // SAFETY: ssl is a live SSL*.
             let result = unsafe { boring_sys::SSL_do_handshake(ssl.as_ptr()) };
 

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -236,6 +236,83 @@ for (const { name, connect } of tests) {
     });
     const COMMON_CERT = { ...COMMON_CERT_ };
 
+    it("surfaces the fatal TLS alert when ALPN has no overlap", async () => {
+      // The server only speaks h2 and the client only offers xyz, so the
+      // server rejects the handshake with a fatal no_application_protocol
+      // alert. No TLS session (and no peer certificate) ever exists: the
+      // error must carry the OpenSSL alert, not a certificate-verification
+      // code, and checkServerIdentity must never run.
+      await using server = tls.createServer({
+        key: COMMON_CERT.key,
+        cert: COMMON_CERT.cert,
+        ALPNProtocols: ["h2"],
+      });
+      server.on("tlsClientError", () => {});
+      server.on("secureConnection", s => {
+        s.on("error", () => {});
+        s.end();
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const port = (server.address() as AddressInfo).port;
+
+      let checkServerIdentityCalled = false;
+      const result = await new Promise<{ kind: string; code?: string; library?: string }>(resolve => {
+        const socket = connect({
+          host: "127.0.0.1",
+          port,
+          servername: "localhost",
+          ca: COMMON_CERT.cert,
+          ALPNProtocols: ["xyz"],
+          checkServerIdentity(hostname, cert) {
+            checkServerIdentityCalled = true;
+            return tls.checkServerIdentity(hostname, cert);
+          },
+        });
+        socket.on("secureConnect", () => {
+          resolve({ kind: "secureConnect" });
+          socket.destroy();
+        });
+        socket.on("error", (err: NodeJS.ErrnoException & { library?: string }) => {
+          resolve({ kind: "error", code: err.code, library: err.library });
+        });
+      });
+
+      expect({ ...result, checkServerIdentityCalled }).toEqual({
+        kind: "error",
+        code: "ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL",
+        library: "SSL routines",
+        checkServerIdentityCalled: false,
+      });
+    });
+
+    it("emits error (not secureConnect) on a handshake_failure alert with rejectUnauthorized: false", async () => {
+      // Peer answers the ClientHello with a fatal handshake_failure alert: the
+      // TLS layer was never established, so the socket must error. It cannot
+      // fall through to secureConnect even with verification disabled.
+      await using server = net.createServer(s => {
+        s.resume();
+        s.end(Buffer.from([0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x28]));
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const port = (server.address() as AddressInfo).port;
+
+      const result = await new Promise<{ kind: string; code?: string }>(resolve => {
+        const socket = connect({ host: "127.0.0.1", port, servername: "localhost", rejectUnauthorized: false });
+        socket.on("secureConnect", () => {
+          resolve({ kind: "secureConnect" });
+          socket.destroy();
+        });
+        socket.on("error", (err: NodeJS.ErrnoException) => {
+          resolve({ kind: "error", code: err.code });
+        });
+      });
+
+      expect(result).toEqual({
+        kind: "error",
+        code: "ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE",
+      });
+    });
+
     it("Bun.serve() should work with tls and Bun.file()", async () => {
       using server = Bun.serve({
         port: 0,

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -237,11 +237,6 @@ for (const { name, connect } of tests) {
     const COMMON_CERT = { ...COMMON_CERT_ };
 
     it("surfaces the fatal TLS alert when ALPN has no overlap", async () => {
-      // The server only speaks h2 and the client only offers xyz, so the
-      // server rejects the handshake with a fatal no_application_protocol
-      // alert. No TLS session (and no peer certificate) ever exists: the
-      // error must carry the OpenSSL alert, not a certificate-verification
-      // code, and checkServerIdentity must never run.
       await using server = tls.createServer({
         key: COMMON_CERT.key,
         cert: COMMON_CERT.cert,
@@ -286,11 +281,9 @@ for (const { name, connect } of tests) {
     });
 
     it("emits error (not secureConnect) on a handshake_failure alert with rejectUnauthorized: false", async () => {
-      // Peer answers the ClientHello with a fatal handshake_failure alert: the
-      // TLS layer was never established, so the socket must error. It cannot
-      // fall through to secureConnect even with verification disabled.
       await using server = net.createServer(s => {
         s.resume();
+        // TLS alert record: level fatal (2), description handshake_failure (40).
         s.end(Buffer.from([0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x28]));
       });
       await once(server.listen(0, "127.0.0.1"), "listening");


### PR DESCRIPTION
### Problem
- `tls.connect({ socket: <Duplex> })` reports a phantom certificate error when the server rejects the handshake with a fatal alert. An ALPN mismatch surfaces as `UNABLE_TO_GET_ISSUER_CERT` instead of `ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL`. A `handshake_failure` alert with `rejectUnauthorized: false` even emits `secureConnect` on a session that never existed.
- The cause is `SSLWrapper::update_handshake_state` (`src/uws/lib.rs`). It called `ERR_clear_error()` right after `SSL_get_error()`, which discarded the queued alert reason. It then built the error from `SSL_get_verify_result()` of a certificate the peer never sent.

### Fix
- When `SSL_get_error` reports `SSL_ERROR_SSL` or `SSL_ERROR_SYSCALL`, read `ERR_peek_error()` into a stack buffer before the clear. Pass it to the handshake callback as `{ error_no: -71, code: "EPROTO", reason }`.
- This is the shape the native TCP path already produces (`ssl_park_fatal_reason` and `ssl_dispatch_parked_reason` in `openssl.c`). `net.ts` already treats `EPROTO` as a protocol failure, derives the `ERR_SSL_*` code, and skips `checkServerIdentity`. Both engines now report the same code as each other, and the same queue entry as Node.
- `ERR_peek_error` is restored to the BoringSSL bindings. #39585 pruned it as unused. This is its first Rust caller.
- Verified: `test/js/node/tls/node-tls-connect.test.ts`, two new tests in the existing direct / duplex-proxy matrix. Stock bun fails both duplex variants. The full file passes (53 pass, 0 fail).

### Background
- Bun has two TLS engines. A socket on a real fd uses the uSockets C path (`openssl.c`). A TLS session over a generic `Duplex` or a Windows named pipe uses `SSLWrapper`, a Rust memory-BIO wrapper. Both report the handshake result through the same `(success, us_bun_verify_error_t)` callback into `net.ts`.
- BoringSSL keeps a per-thread error queue. A fatal alert pushes the alert reason first. Later entries wrap it. `ERR_peek_error()` reads the oldest entry (the root cause, what Node reports). `ERR_peek_last_error()` reads the newest.
- The `reason` pointer refers to a stack buffer. Every consumer of the callback clones it synchronously, the same contract as the C path's stack-local `reason[]`.

<details><summary>Notes</summary>

**Repro** (any cert/key; server speaks only `h2`, client offers only `xyz`, over a Duplex):

```js
import tls from "node:tls";
import net from "node:net";
import { Duplex } from "node:stream";

const srv = tls.createServer({ key, cert, ALPNProtocols: ["h2"] });
srv.on("tlsClientError", () => {});
srv.listen(0, "127.0.0.1", () => {
  const raw = net.connect(srv.address().port, "127.0.0.1", () => {
    const dup = new Duplex({
      read() {},
      write(c, e, cb) { raw.write(c, e, cb); },
      final(cb) { raw.end(); cb(); },
    });
    raw.on("data", d => dup.push(d));
    raw.on("end", () => dup.push(null));
    tls.connect({ socket: dup, servername: "localhost", ca: cert, ALPNProtocols: ["xyz"] })
      .on("error", e => console.log(e.code));
  });
});
```

| | ALPN mismatch | raw `handshake_failure` alert, `rejectUnauthorized: false` |
|---|---|---|
| Node v26.3.0 | `ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL` | `ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE` (error) |
| Bun before | `UNABLE_TO_GET_ISSUER_CERT` | `secureConnect` fires |
| Bun after | `ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL` | `ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE` (error) |

The Node / Bun spelling difference in the second column is OpenSSL 3 vs BoringSSL reason strings for the same queue entry, not a queue-position difference.

**Why the direct path was already correct:** `ssl_update_handshake` in `openssl.c` parks the queued reason via `ssl_park_fatal_reason` (which reads `ERR_peek_error()`) and `ssl_dispatch_parked_reason` emits it as `EPROTO` before anything reads the verify result. `SSLWrapper` had no equivalent.

**`UNABLE_TO_GET_ISSUER_CERT` vs `ERR_TLS_CERT_ALTNAME_INVALID`:** the former is the `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT` default that `us_internal_verify_peer_certificate` returns when there is no peer certificate. When that fallback yields `X509_V_OK` instead (PSK, resumed TLS 1.3), the callback gets `verifyError = null` and `net.ts` falls through into `checkServerIdentity()` against an empty `{}` cert, which produces `ERR_TLS_CERT_ALTNAME_INVALID: Cert does not contain a DNS name`. Same lost-reason bug, different surface.

**Review history:** an earlier revision read `ERR_peek_last_error()`. Review pointed out that `ssl_park_fatal_reason` deliberately reads the oldest entry; for `handshake_failure` BoringSSL pushes `SSLV3_ALERT_HANDSHAKE_FAILURE` then `HANDSHAKE_FAILURE_ON_CLIENT_HELLO`, so the two engines disagreed and the test needed a regex. Switched to `ERR_peek_error()`; the test now asserts the exact code.

**Rebase:** `main` refactored `SSLWrapper` from the laundered `Self::r(this)` pattern to plain `&self` with interior mutability (#36571, #40516) and reworked the surrounding read path (#37467, #37673). The change was re-applied by hand on top of that; the logic is unchanged. #39585 had meanwhile removed the `ERR_peek_error` extern as dead, so the one-line `pub safe fn ERR_peek_error() -> u32;` declaration is re-added next to its `ERR_peek_last_error` sibling.

**Not fixed here:** #9365 (`success: true` with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`, a real verdict on a cert that was sent) and #20727 (a hang on the native path plus SNI-for-IP) are different bugs; see the earlier comment on this PR.

</details>
