### PR TITLE
node:fs: add frsize to statfs() / statfsSync() results

### DIFF
--- a/src/jsc/bindings/NodeFSStatFSBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatFSBinding.cpp
@@ -216,12 +216,13 @@ private:
 JSC::Structure* createJSStatFSObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     auto* prototype = JSStatFSPrototype::create(vm, globalObject, JSStatFSPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
-    auto structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray, 7);
+    auto structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray, 8);
 
     // Add property transitions for all statfs fields
     PropertyOffset offset = 0;
     structure = structure->addPropertyTransition(vm, structure, vm.propertyNames->type, 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bsize"_s), 0, offset);
+    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "frsize"_s), 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "blocks"_s), 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bfree"_s), 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bavail"_s), 0, offset);
@@ -234,12 +235,13 @@ JSC::Structure* createJSStatFSObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* 
 JSC::Structure* createJSBigIntStatFSObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     auto prototype = JSBigIntStatFSPrototype::create(vm, globalObject, JSBigIntStatFSPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
-    auto structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray, 7);
+    auto structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray, 8);
 
     // Add property transitions for all bigint statfs fields
     PropertyOffset offset = 0;
     structure = structure->addPropertyTransition(vm, structure, vm.propertyNames->type, 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bsize"_s), 0, offset);
+    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "frsize"_s), 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "blocks"_s), 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bfree"_s), 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bavail"_s), 0, offset);
@@ -252,6 +254,7 @@ JSC::Structure* createJSBigIntStatFSObjectStructure(JSC::VM& vm, JSC::JSGlobalOb
 extern "C" JSC::EncodedJSValue Bun__createJSStatFSObject(Zig::GlobalObject* globalObject,
     int64_t fstype,
     int64_t bsize,
+    int64_t frsize,
     int64_t blocks,
     int64_t bfree,
     int64_t bavail,
@@ -262,6 +265,7 @@ extern "C" JSC::EncodedJSValue Bun__createJSStatFSObject(Zig::GlobalObject* glob
 
     JSC::JSValue js_fstype = JSC::jsNumber(fstype);
     JSC::JSValue js_bsize = JSC::jsNumber(bsize);
+    JSC::JSValue js_frsize = JSC::jsNumber(frsize);
     JSC::JSValue js_blocks = JSC::jsNumber(blocks);
     JSC::JSValue js_bfree = JSC::jsNumber(bfree);
     JSC::JSValue js_bavail = JSC::jsNumber(bavail);
@@ -273,11 +277,12 @@ extern "C" JSC::EncodedJSValue Bun__createJSStatFSObject(Zig::GlobalObject* glob
 
     object->putDirectOffset(vm, 0, js_fstype);
     object->putDirectOffset(vm, 1, js_bsize);
-    object->putDirectOffset(vm, 2, js_blocks);
-    object->putDirectOffset(vm, 3, js_bfree);
-    object->putDirectOffset(vm, 4, js_bavail);
-    object->putDirectOffset(vm, 5, js_files);
-    object->putDirectOffset(vm, 6, js_ffree);
+    object->putDirectOffset(vm, 2, js_frsize);
+    object->putDirectOffset(vm, 3, js_blocks);
+    object->putDirectOffset(vm, 4, js_bfree);
+    object->putDirectOffset(vm, 5, js_bavail);
+    object->putDirectOffset(vm, 6, js_files);
+    object->putDirectOffset(vm, 7, js_ffree);
 
     return JSC::JSValue::encode(object);
 }
@@ -285,6 +290,7 @@ extern "C" JSC::EncodedJSValue Bun__createJSStatFSObject(Zig::GlobalObject* glob
 extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatFSObject(Zig::GlobalObject* globalObject,
     int64_t fstype,
     int64_t bsize,
+    int64_t frsize,
     int64_t blocks,
     int64_t bfree,
     int64_t bavail,
@@ -298,6 +304,8 @@ extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatFSObject(Zig::GlobalObject
     JSC::JSValue js_fstype = JSC::JSBigInt::createFrom(globalObject, fstype);
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSValue js_bsize = JSC::JSBigInt::createFrom(globalObject, bsize);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSC::JSValue js_frsize = JSC::JSBigInt::createFrom(globalObject, frsize);
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSValue js_blocks = JSC::JSBigInt::createFrom(globalObject, blocks);
     RETURN_IF_EXCEPTION(scope, {});
@@ -314,11 +322,12 @@ extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatFSObject(Zig::GlobalObject
 
     object->putDirectOffset(vm, 0, js_fstype);
     object->putDirectOffset(vm, 1, js_bsize);
-    object->putDirectOffset(vm, 2, js_blocks);
-    object->putDirectOffset(vm, 3, js_bfree);
-    object->putDirectOffset(vm, 4, js_bavail);
-    object->putDirectOffset(vm, 5, js_files);
-    object->putDirectOffset(vm, 6, js_ffree);
+    object->putDirectOffset(vm, 2, js_frsize);
+    object->putDirectOffset(vm, 3, js_blocks);
+    object->putDirectOffset(vm, 4, js_bfree);
+    object->putDirectOffset(vm, 5, js_bavail);
+    object->putDirectOffset(vm, 6, js_files);
+    object->putDirectOffset(vm, 7, js_ffree);
 
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(object));
 }
@@ -337,21 +346,23 @@ inline JSValue callJSStatFSFunction(JSC::JSGlobalObject* globalObject, JSC::Call
 
     JSValue type = callFrame->argument(0);
     JSValue bsize = callFrame->argument(1);
-    JSValue blocks = callFrame->argument(2);
-    JSValue bfree = callFrame->argument(3);
-    JSValue bavail = callFrame->argument(4);
-    JSValue files = callFrame->argument(5);
-    JSValue ffree = callFrame->argument(6);
+    JSValue frsize = callFrame->argument(2);
+    JSValue blocks = callFrame->argument(3);
+    JSValue bfree = callFrame->argument(4);
+    JSValue bavail = callFrame->argument(5);
+    JSValue files = callFrame->argument(6);
+    JSValue ffree = callFrame->argument(7);
 
     auto* object = JSC::JSFinalObject::create(vm, structure);
 
     object->putDirectOffset(vm, 0, type);
     object->putDirectOffset(vm, 1, bsize);
-    object->putDirectOffset(vm, 2, blocks);
-    object->putDirectOffset(vm, 3, bfree);
-    object->putDirectOffset(vm, 4, bavail);
-    object->putDirectOffset(vm, 5, files);
-    object->putDirectOffset(vm, 6, ffree);
+    object->putDirectOffset(vm, 2, frsize);
+    object->putDirectOffset(vm, 3, blocks);
+    object->putDirectOffset(vm, 4, bfree);
+    object->putDirectOffset(vm, 5, bavail);
+    object->putDirectOffset(vm, 6, files);
+    object->putDirectOffset(vm, 7, ffree);
 
     return object;
 }
@@ -379,15 +390,17 @@ inline JSValue constructJSStatFSObject(JSC::JSGlobalObject* lexicalGlobalObject,
 
     JSValue type = callFrame->argument(0);
     JSValue bsize = callFrame->argument(1);
-    JSValue blocks = callFrame->argument(2);
-    JSValue bfree = callFrame->argument(3);
-    JSValue bavail = callFrame->argument(4);
-    JSValue files = callFrame->argument(5);
-    JSValue ffree = callFrame->argument(6);
+    JSValue frsize = callFrame->argument(2);
+    JSValue blocks = callFrame->argument(3);
+    JSValue bfree = callFrame->argument(4);
+    JSValue bavail = callFrame->argument(5);
+    JSValue files = callFrame->argument(6);
+    JSValue ffree = callFrame->argument(7);
 
     JSFinalObject* object = JSC::JSFinalObject::create(vm, structure);
     object->putDirect(vm, vm.propertyNames->type, type, 0);
     object->putDirect(vm, Identifier::fromString(vm, "bsize"_s), bsize, 0);
+    object->putDirect(vm, Identifier::fromString(vm, "frsize"_s), frsize, 0);
     object->putDirect(vm, Identifier::fromString(vm, "blocks"_s), blocks, 0);
     object->putDirect(vm, Identifier::fromString(vm, "bfree"_s), bfree, 0);
     object->putDirect(vm, Identifier::fromString(vm, "bavail"_s), bavail, 0);

--- a/src/runtime/node/StatFS.rs
+++ b/src/runtime/node/StatFS.rs
@@ -21,6 +21,7 @@ macro_rules! define_statfs_type {
             // Common fields between Linux and macOS
             pub _fstype: $Int,
             pub _bsize: $Int,
+            pub _frsize: $Int,
             pub _blocks: $Int,
             pub _bfree: $Int,
             pub _bavail: $Int,
@@ -40,6 +41,7 @@ macro_rules! define_statfs_type {
                             global,
                             self._fstype as i64,
                             self._bsize as i64,
+                            self._frsize as i64,
                             self._blocks as i64,
                             self._bfree as i64,
                             self._bavail as i64,
@@ -53,6 +55,7 @@ macro_rules! define_statfs_type {
                     global,
                     self._fstype as i64,
                     self._bsize as i64,
+                    self._frsize as i64,
                     self._blocks as i64,
                     self._bfree as i64,
                     self._bavail as i64,
@@ -78,6 +81,12 @@ macro_rules! define_statfs_type {
                     statfs_.f_files,
                     statfs_.f_ffree,
                 );
+                // Only Linux's `struct statfs` has a distinct `f_frsize`; on other
+                // platforms libuv (and Node) report `f_bsize` for this field.
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                let frsize_ = statfs_.f_frsize;
+                #[cfg(not(any(target_os = "linux", target_os = "android")))]
+                let frsize_ = bsize_;
                 #[cfg(target_arch = "wasm32")]
                 compile_error!("Unsupported OS");
 
@@ -87,6 +96,7 @@ macro_rules! define_statfs_type {
                 Self {
                     _fstype: (fstype_ as i64) as $Int,
                     _bsize: (bsize_ as i64) as $Int,
+                    _frsize: (frsize_ as i64) as $Int,
                     _blocks: (blocks_ as i64) as $Int,
                     _bfree: (bfree_ as i64) as $Int,
                     _bavail: (bavail_ as i64) as $Int,
@@ -106,6 +116,7 @@ unsafe extern "C" {
         global: &JSGlobalObject,
         fstype: i64,
         bsize: i64,
+        frsize: i64,
         blocks: i64,
         bfree: i64,
         bavail: i64,
@@ -117,6 +128,7 @@ unsafe extern "C" {
         global: &JSGlobalObject,
         fstype: i64,
         bsize: i64,
+        frsize: i64,
         blocks: i64,
         bfree: i64,
         bavail: i64,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3931,7 +3931,7 @@ it("fs.mkdirSync recursive: false should error when the directory already exists
 
 it("fs.statfsSync should work", () => {
   const stats = statfsSync(import.meta.path);
-  ["type", "bsize", "blocks", "bfree", "bavail", "files", "ffree"].forEach(k => {
+  ["type", "bsize", "frsize", "blocks", "bfree", "bavail", "files", "ffree"].forEach(k => {
     expect(stats).toHaveProperty(k);
     expect(stats[k]).toBeNumber();
   });
@@ -3947,7 +3947,7 @@ it("fs.statfsSync should work", () => {
   }
 
   const bigIntStats = statfsSync(import.meta.path, { bigint: true });
-  ["type", "bsize", "blocks", "bfree", "bavail", "files", "ffree"].forEach(k => {
+  ["type", "bsize", "frsize", "blocks", "bfree", "bavail", "files", "ffree"].forEach(k => {
     expect(bigIntStats).toHaveProperty(k);
     expect(bigIntStats[k]).toBeTypeOf("bigint");
   });
@@ -3955,6 +3955,27 @@ it("fs.statfsSync should work", () => {
     expect(bigIntStats.bsize > 0n).toBe(true);
     expect(bigIntStats.blocks > 0n).toBe(true);
   }
+});
+
+it("fs.statfsSync .frsize is populated", () => {
+  const stats = statfsSync(import.meta.path);
+  expect(stats.frsize).toBeNumber();
+  expect(stats.frsize).toBeGreaterThan(0);
+  // POSIX says block counts are in units of f_frsize; this must be finite.
+  expect(Number.isFinite(Number(stats.bavail) * Number(stats.frsize))).toBe(true);
+  if (!isLinux) {
+    expect(stats.frsize).toBe(stats.bsize);
+  }
+
+  const big = statfsSync(import.meta.path, { bigint: true });
+  expect(big.frsize).toBeTypeOf("bigint");
+  expect(big.frsize > 0n).toBe(true);
+  if (!isLinux) {
+    expect(big.frsize).toBe(big.bsize);
+  }
+
+  expect(Object.keys(stats)).toEqual(["type", "bsize", "frsize", "blocks", "bfree", "bavail", "files", "ffree"]);
+  expect(Object.keys(big)).toEqual(["type", "bsize", "frsize", "blocks", "bfree", "bavail", "files", "ffree"]);
 });
 
 it("fs.promises.statfs should work", async () => {
@@ -3984,7 +4005,7 @@ it("fs.statfs (callback) should work with bigint", async () => {
   });
   const stats = await promise;
   expect(stats).toBeDefined();
-  for (const k of ["type", "bsize", "blocks", "bfree", "bavail", "files", "ffree"]) {
+  for (const k of ["type", "bsize", "frsize", "blocks", "bfree", "bavail", "files", "ffree"]) {
     expect(stats).toHaveProperty(k);
     expect(stats[k]).toBeTypeOf("bigint");
   }


### PR DESCRIPTION
### What

`fs.statfsSync()` / `fs.statfs()` / `fs.promises.statfs()` were missing the `frsize` field that Node documents on `fs.StatFs`. It came back `undefined`, so the documented free-space formula `bavail * frsize` silently evaluated to `NaN`.

### Repro

```js
import * as fs from "node:fs";
import * as os from "node:os";
const R = fs.mkdtempSync(os.tmpdir() + "/fssf-");
const s = fs.statfsSync(R);
console.log("frsize" in s, s.frsize, Number(s.bavail) * Number(s.frsize));
```

Node v26.3.0: `true 4096 922748223488`
Bun 1.4.0: `false undefined NaN`

### Cause

`StatFS.rs` and `NodeFSStatFSBinding.cpp` never read or exposed a fragment size. Node gets `frsize` from libuv's `uv_statfs_t.f_frsize` (added in libuv 1.52, carved out of `f_spare[0]`), which libuv fills from `struct statfs.f_frsize` on Linux and falls back to `f_bsize` everywhere else (`uv__fs_statfs` in `src/unix/fs.c`, `fs__statfs` in `src/win/fs.c`).

### Fix

- `src/runtime/node/StatFS.rs`: add `_frsize`, populated from `statfs.f_frsize` on Linux/Android and from `f_bsize` on macOS / FreeBSD / Windows (those platforms have no distinct fragment size; this matches libuv and Node).
- `src/jsc/bindings/NodeFSStatFSBinding.cpp`: add the `frsize` property to both the number and bigint object structures (inserted between `bsize` and `blocks` to match Node's property order) and to both `Bun__createJS*StatFSObject` entry points.

### Verification

```
bun bd test test/js/node/fs/fs.test.ts -t statfs   # 5 pass, 0 fail
./build/debug/bun-debug test/js/node/test/parallel/test-fs-statfs.js   # exit 0
```

The repro now prints the same keys and values as Node (`type,bsize,frsize,blocks,bfree,bavail,files,ffree`, `frsize: 4096`). Cross-checked that `cargo check -p bun_runtime` passes on `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, `x86_64-unknown-linux-musl`, and `aarch64-unknown-linux-gnu` (the last two exercise the `f_frsize` branch, the first two the `f_bsize` fallback).