### PR TITLE
bun:test: make toBeInstanceOf, expect.any, and toThrow honor Symbol.hasInstance

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2787,10 +2787,8 @@ impl JSValue {
 
     // ── instanceof / constructor. ─────────────────
     /// `JSValue.isInstanceOf` — `self instanceof constructor`.
+    /// Dispatches through `constructor[Symbol.hasInstance]`, so a primitive LHS can still match.
     pub fn is_instance_of(self, global: &JSGlobalObject, constructor: JSValue) -> JsResult<bool> {
-        if !self.is_cell() {
-            return Ok(false);
-        }
         host_fn::from_js_host_call_generic(global, || {
             JSC__JSValue__isInstanceOf(self, global, constructor)
         })

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2481,7 +2481,7 @@ impl ExpectAny {
 
         let constructor = arguments[0];
         constructor.ensure_still_alive();
-        if !constructor.is_constructor() {
+        if !constructor.is_callable() {
             const FMT: &str = "<d>expect.<r>any<d>(<r>constructor<d>)<r>\n\nExpected a constructor\n";
             return Err(global_this.throw_pretty(format_args!("{FMT}")));
         }

--- a/src/runtime/test_runner/expect/toBeInstanceOf.rs
+++ b/src/runtime/test_runner/expect/toBeInstanceOf.rs
@@ -29,7 +29,7 @@ pub(crate) fn to_be_instance_of(
     // `defer formatter.deinit()` → handled by Drop.
 
     let expected_value = arguments[0];
-    if !expected_value.is_constructor() {
+    if !expected_value.is_callable() {
         return Err(global.throw(format_args!(
             "Expected value must be a function: {}",
             expected_value.to_fmt(&mut formatter),

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -197,9 +197,12 @@ pub(crate) fn to_throw(
 
         let mut expected_class = ZigString::EMPTY;
         expected_value.get_class_name(global, &mut expected_class)?;
-        let received_message: JSValue = result
-            .fast_get(global, bun_jsc::BuiltinName::Message)?
-            .unwrap_or(JSValue::UNDEFINED);
+        let received_message: JSValue = (if result.is_object() {
+            result.fast_get(global, bun_jsc::BuiltinName::Message)?
+        } else {
+            Some(JSValue::from_cell(result.to_js_string(global)?))
+        })
+        .unwrap_or(JSValue::UNDEFINED);
         return this.throw(
             global,
             signature,

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -875,6 +875,21 @@ describe("expect()", () => {
     }).toThrow(expect.objectContaining({ code: "ERR_BAZ", name: "TypeError" }));
   });
 
+  test("toThrow honors Symbol.hasInstance with a primitive thrown value", () => {
+    class H {
+      static [Symbol.hasInstance]() {
+        return true;
+      }
+    }
+    expect(1 instanceof H).toBe(true);
+    expect(() => {
+      throw 1;
+    }).toThrow(H);
+    expect(() => {
+      throw 1;
+    }).not.toThrow(Error);
+  });
+
   test("toThrow", () => {
     expect(() => {
       throw new Error("hello");
@@ -4108,6 +4123,28 @@ describe("expect()", () => {
       expect(expect.any(Boolean)).toEqual(new Boolean(true));
       expect(expect.any(BigInt)).toEqual(Object(1n));
       expect(expect.any(Symbol)).toEqual(Object(Symbol()));
+    });
+
+    test("expect.any honors Symbol.hasInstance", () => {
+      class H {
+        static [Symbol.hasInstance](v) {
+          return typeof v === "number";
+        }
+      }
+      expect(1 instanceof H).toBe(true);
+      expect(1).toEqual(expect.any(H));
+      expect("x").not.toEqual(expect.any(H));
+
+      // Non-constructor callable, matching Jest's `typeof expected === "function"` check.
+      const F = () => {};
+      Object.defineProperty(F, Symbol.hasInstance, { value: v => typeof v === "number" });
+      expect(1 instanceof F).toBe(true);
+      expect(1).toEqual(expect.any(F));
+      expect("x").not.toEqual(expect.any(F));
+
+      // Non-callables are still rejected.
+      expect(() => expect.any(1)).toThrow("Expected a constructor");
+      expect(() => expect.any({})).toThrow("Expected a constructor");
     });
 
     //test('Any.toAsymmetricMatcher()', () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4111,13 +4111,15 @@ describe("expect()", () => {
     });
 
     test("rejects non-function expected", () => {
-      expect(() => expect({}).toBeInstanceOf({})).toThrow("Expected value must be a function");
-      expect(() => expect({}).toBeInstanceOf(1)).toThrow("Expected value must be a function");
+      // Jest's matcher error spells it "expected value must be a function".
+      const message = isBun ? "Expected value must be a function" : "value must be a function";
+      expect(() => expect({}).toBeInstanceOf({})).toThrow(message);
+      expect(() => expect({}).toBeInstanceOf(1)).toThrow(message);
       // Jest requires `typeof expected === "function"`, so a plain object with
       // Symbol.hasInstance (a valid `instanceof` RHS) is still rejected.
       const nonCallable = { [Symbol.hasInstance]: () => true };
       expect(1 instanceof nonCallable).toBe(true);
-      expect(() => expect(1).toBeInstanceOf(nonCallable)).toThrow("Expected value must be a function");
+      expect(() => expect(1).toBeInstanceOf(nonCallable)).toThrow(message);
     });
   });
 
@@ -4163,9 +4165,11 @@ describe("expect()", () => {
       expect(1).toEqual(expect.any(F));
       expect("x").not.toEqual(expect.any(F));
 
-      // Bun validates eagerly; Jest's expect.any only rejects undefined.
-      expect(() => expect.any(1)).toThrow("Expected a constructor");
-      expect(() => expect.any({})).toThrow("Expected a constructor");
+      if (isBun) {
+        // Bun validates eagerly; Jest's expect.any only rejects undefined.
+        expect(() => expect.any(1)).toThrow("Expected a constructor");
+        expect(() => expect.any({})).toThrow("Expected a constructor");
+      }
     });
 
     //test('Any.toAsymmetricMatcher()', () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4020,6 +4020,71 @@ describe("expect()", () => {
     expect("bob").not.toEndWith("alice");
   });
 
+  describe("toBeInstanceOf()", () => {
+    test("prototype chain", () => {
+      class A {}
+      class B extends A {}
+      expect(new B()).toBeInstanceOf(B);
+      expect(new B()).toBeInstanceOf(A);
+      expect(new B()).toBeInstanceOf(Object);
+      expect(new A()).not.toBeInstanceOf(B);
+      expect({}).not.toBeInstanceOf(A);
+    });
+
+    test("honors Symbol.hasInstance on class with primitive received", () => {
+      class H {
+        static [Symbol.hasInstance]() {
+          return true;
+        }
+      }
+      expect(1 instanceof H).toBe(true);
+      expect(1).toBeInstanceOf(H);
+      expect("x").toBeInstanceOf(H);
+      expect(null).toBeInstanceOf(H);
+      expect(true).toBeInstanceOf(H);
+    });
+
+    test("honors Symbol.hasInstance on class with object received", () => {
+      class H {
+        static [Symbol.hasInstance](v) {
+          return v && v.tag === "ok";
+        }
+      }
+      expect({ tag: "ok" }).toBeInstanceOf(H);
+      expect({ tag: "no" }).not.toBeInstanceOf(H);
+      expect(new H()).not.toBeInstanceOf(H);
+    });
+
+    test("honors Symbol.hasInstance returning false for default instance", () => {
+      class H {
+        static [Symbol.hasInstance]() {
+          return false;
+        }
+      }
+      expect(new H() instanceof H).toBe(false);
+      expect(new H()).not.toBeInstanceOf(H);
+    });
+
+    test("accepts non-constructor function with Symbol.hasInstance", () => {
+      const H = () => {};
+      Object.defineProperty(H, Symbol.hasInstance, { value: v => typeof v === "number" });
+      expect(typeof H).toBe("function");
+      expect(1 instanceof H).toBe(true);
+      expect(1).toBeInstanceOf(H);
+      expect("x").not.toBeInstanceOf(H);
+    });
+
+    test("rejects non-function expected", () => {
+      expect(() => expect({}).toBeInstanceOf({})).toThrow("Expected value must be a function");
+      expect(() => expect({}).toBeInstanceOf(1)).toThrow("Expected value must be a function");
+      // Jest requires `typeof expected === "function"`, so a plain object with
+      // Symbol.hasInstance (a valid `instanceof` RHS) is still rejected.
+      const nonCallable = { [Symbol.hasInstance]: () => true };
+      expect(1 instanceof nonCallable).toBe(true);
+      expect(() => expect(1).toBeInstanceOf(nonCallable)).toThrow("Expected value must be a function");
+    });
+  });
+
   describe("asymmetric matchers", () => {
     test("expect.any", () => {
       class Thing {}

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1197,25 +1197,32 @@ describe("expect()", () => {
   });
 
   test("deepEquals Set/Map stress test", () => {
+    // Each deepEquals call on object elements is quadratic in `elements`. Debug
+    // builds run it roughly 100x slower and exceed the test timeout, so only
+    // scale the volume down there; release keeps the full workload.
+    const isDebugBuild = isBun && Bun.version.includes("debug");
+    const elements = isDebugBuild ? 20 : 150;
+    const iterations = isDebugBuild ? 50 : 2000;
+
     const arr1 = [];
     const arr2 = [];
     const arr3 = [];
     const arr4 = [];
 
-    for (let i = 0; i < 150; i++) {
+    for (let i = 0; i < elements; i++) {
       arr1[i] = [i];
       arr2[i] = [i];
       arr3[i] = [i, [i]];
       arr4[i] = [i, [i]];
     }
 
-    for (let i = 0; i < 2000; i++) {
+    for (let i = 0; i < iterations; i++) {
       let outerSet = new Set(arr1);
       let innerSet = new Set(arr2);
       Bun.deepEquals(outerSet, innerSet);
     }
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < iterations / 2; i++) {
       let outerMap = new Map(arr3);
       let innerMap = new Map(arr4);
       Bun.deepEquals(outerMap, innerMap);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -888,6 +888,18 @@ describe("expect()", () => {
     expect(() => {
       throw 1;
     }).not.toThrow(Error);
+    // The .not failure path reads .message off the thrown value; it must
+    // produce a matcher error for a primitive thrown value.
+    expect(() =>
+      expect(() => {
+        throw 1;
+      }).not.toThrow(H),
+    ).toThrow(/Expected constructor: not/);
+    expect(() =>
+      expect(() => {
+        throw "boom";
+      }).not.toThrow(H),
+    ).toThrow(/Expected constructor: not/);
   });
 
   test("toThrow", () => {
@@ -4057,6 +4069,8 @@ describe("expect()", () => {
       expect("x").toBeInstanceOf(H);
       expect(null).toBeInstanceOf(H);
       expect(true).toBeInstanceOf(H);
+      // The .not failure path formats the primitive received value.
+      expect(() => expect(1).not.toBeInstanceOf(H)).toThrow(/Expected constructor: not/);
     });
 
     test("honors Symbol.hasInstance on class with object received", () => {
@@ -4142,7 +4156,7 @@ describe("expect()", () => {
       expect(1).toEqual(expect.any(F));
       expect("x").not.toEqual(expect.any(F));
 
-      // Non-callables are still rejected.
+      // Bun validates eagerly; Jest's expect.any only rejects undefined.
       expect(() => expect.any(1)).toThrow("Expected a constructor");
       expect(() => expect.any({})).toThrow("Expected a constructor");
     });


### PR DESCRIPTION
### What does this PR do?

Fixes `expect(x).toBeInstanceOf(C)` (and `expect.any(C)`) disagreeing with `x instanceof C` when `C` defines `Symbol.hasInstance`, and a pre-existing segfault in `.not.toThrow(C)` on the same code path.

### Repro

```js
import { test, expect } from "bun:test";

test("C3 toBeInstanceOf Symbol.hasInstance", () => {
  class H { static [Symbol.hasInstance]() { return true; } }
  expect(1 instanceof H).toBe(true); // passes: the operator is correct
  expect(1).toBeInstanceOf(H);       // fails on bun, passes on jest 30.4.1
});
```

```
error: expect(received).toBeInstanceOf(expected)

Expected constructor: [class H]
Received value: 1
```

`Symbol.hasInstance` is how cross-realm, branded, and interface-style classes (graphql-js, some ORM entity bases, ts-pattern style guards) define membership, so the matchers have to agree with the operator.

### Cause

Two independent gaps, both in the matcher path (the `instanceof` operator itself is handled by JSC and was always correct):

1. `JSValue::is_instance_of` in `src/jsc/JSValue.rs` returned `false` early when the received value is not a heap cell. A primitive LHS never reached `JSC__JSValue__isInstanceOf`, which is what dispatches through `JSObject::hasInstance` and therefore `C[Symbol.hasInstance]`.

2. `toBeInstanceOf` and `expect.any` validated the expected value with `is_constructor()`, which rejects arrow functions, methods, and generators. Jest checks `typeof expected === "function"`, so a non-constructor callable that defines `Symbol.hasInstance` threw `Expected value must be a function` (or `Expected a constructor`) instead of matching.

Review turned up a third problem on the same path: the `instanceof` arm of `.not.toThrow`'s failure message reads `.message` off the thrown value without the `is_object()` guard its three sibling arms have. Any non-object thrown value that satisfies `expected[Symbol.hasInstance]` reaches it and null-derefs the object pointer. This already segfaults on released builds with a thrown string or symbol, because those are cells and pass the old `is_cell` check:

```js
class H { static [Symbol.hasInstance]() { return true; } }
expect(() => { throw "boom"; }).not.toThrow(H);
// bun 1.3.14: panic(main thread): Segmentation fault at address 0x0
```

Removing the `is_cell` check widened that exposure to all primitives.

### Fix

- Drop the `is_cell` early return from `JSValue::is_instance_of` so every LHS reaches JSC's `hasInstance` dispatch.
- Validate `toBeInstanceOf`'s expected value with `is_callable()` instead of `is_constructor()`, matching Jest's `typeof` check.
- Same change for `expect.any`'s gate in `src/runtime/test_runner/expect.rs`; the asymmetric match path already goes through `JSObject::hasInstance`.
- Guard the `.not.toThrow` failure path's `.message` read the same way its three sibling arms already do, stringifying a non-object thrown value for the `Received message` line.

`toThrow` is the only other caller of `is_instance_of` and is affected the same way: a primitive thrown value now reaches the `Symbol.hasInstance` dispatch, so `expect(() => { throw 1 }).toThrow(H)` passes when `H[Symbol.hasInstance]` returns `true`. That matches Jest, which implements `toThrow(Class)` as `thrown instanceof Class`. The default `hasInstance` path is unchanged because `JSObject::defaultHasInstance` already returns `false` for a non-object LHS. One limitation carried over from the sibling arms: a thrown symbol on this `.not` path raises `TypeError: Cannot convert a symbol to a string` from the received-message stringification, instead of segfaulting as before. The released build behaves the same way today for `expect(() => { throw Symbol() }).not.toThrow("...")`, so making that extraction symbol-safe across all of the arms is left for a follow-up.

A plain (non-callable) object that defines `Symbol.hasInstance` is a valid `instanceof` RHS but is still rejected by both matchers, because Jest's `typeof` check comes first. A test pins that boundary.

### Tests

Added to `test/js/bun/test/expect.test.js`:

- A `toBeInstanceOf()` block: prototype chain baseline, `Symbol.hasInstance` with primitive and object LHS, `Symbol.hasInstance` returning `false` for a real instance, a non-constructor callable, the non-function rejection cases, and the `.not` failure message for a primitive received value.
- `expect.any honors Symbol.hasInstance`: a class, a non-constructor callable, and the still-rejected non-callables.
- `toThrow honors Symbol.hasInstance with a primitive thrown value`, including the `.not` failure path for a thrown number and a thrown string.

Before the fix (stock `bun`), 4 of the new tests fail, and the thrown-string `.not.toThrow` case segfaults released bun 1.3.14:

- `toBeInstanceOf > honors Symbol.hasInstance on class with primitive received`
- `toBeInstanceOf > accepts non-constructor function with Symbol.hasInstance`
- `expect.any honors Symbol.hasInstance`
- `toThrow honors Symbol.hasInstance with a primitive thrown value`

After the fix (`bun bd test`), the full `expect.test.js` and `jest-extended.test.js` suites pass.

One unrelated pre-existing problem in the same file is also addressed so the whole file is runnable under a debug build: `deepEquals Set/Map stress test` (from #14256) is 2000 iterations of `Bun.deepEquals` over two 150 element Sets plus 1000 Map iterations, with no assertions. Each call is quadratic in the element count, which is about a second on release but around 170 seconds under a debug ASAN build, so it always timed out and `bun bd test test/js/bun/test/expect.test.js` could never pass. It now scales its volume down on debug builds only (detected the same way `isDebug` in `test/harness.ts` is), and the release workload is unchanged.