### PR TITLE
Fix panic when require.resolve options.paths entries are not absolute

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -372,6 +372,12 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                 WTF::Vector<BunString> paths;
                 for (size_t i = 0; i < userPathListArray->length(); ++i) {
                     JSValue path = userPathListArray->getIndex(globalObject, i);
+                    if (scope.exception()) [[unlikely]]
+                        goto cleanup;
+                    if (!path.isString()) {
+                        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, makeString("paths["_s, i, ']'), "string"_s, path);
+                        goto cleanup;
+                    }
                     WTF::String pathStr = path.toWTFString(globalObject);
                     if (scope.exception()) [[unlikely]]
                         goto cleanup;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -379,6 +379,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
                 if (scope.exception())
                     return;
 
+                if (!item.isString()) {
+                    Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, makeString("paths["_s, paths.size(), ']'), "string"_s, item);
+                    return;
+                }
+
                 WTF::String pathStr = item.toWTFString(lexicalGlobalObject);
                 if (scope.exception())
                     return;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -380,6 +380,7 @@ pub struct Bufs {
     pub dir_info_uncached_path: PathBuffer,
     pub tsconfig_base_url: PathBuffer,
     pub relative_abs_path: PathBuffer,
+    pub custom_dir_path: PathBuffer,
     pub load_as_file_or_directory_via_tsconfig_base_path: PathBuffer,
     pub node_modules_check: PathBuffer,
     pub field_abs_path: PathBuffer,
@@ -2091,12 +2092,16 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8_without_ref();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    let mut custom_dir = custom_utf8.slice();
+                    // Node.js resolves relative `paths` entries against the cwd.
+                    if !bun_paths::is_absolute(custom_dir) {
+                        let buf = bufs!(custom_dir_path);
+                        let Some(abs) = self.fs_ref().abs_buf_checked(&[custom_dir], buf) else {
+                            continue;
+                        };
+                        custom_dir = abs;
+                    }
+                    match self.check_package_path(custom_dir, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -183,6 +183,40 @@ test("require.resolve with relative path and options.paths (Next.js use case)", 
   }
 });
 
+test("require.resolve throws ERR_INVALID_ARG_TYPE for non-string entries in options.paths", () => {
+  for (const bad of [{}, 123, null]) {
+    let err;
+    try {
+      require.resolve("some-package-that-does-not-exist", { paths: [bad] });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.message.includes('"paths[0]"')).toBe(true);
+  }
+});
+
+test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE for non-string entries in options.paths", () => {
+  let err;
+  try {
+    Module._resolveFilename("some-package-that-does-not-exist", null, false, { paths: [{}] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+  expect(err.message.includes('"paths[0]"')).toBe(true);
+});
+
+test("require.resolve with a relative options.paths entry reports MODULE_NOT_FOUND", () => {
+  let err;
+  try {
+    require.resolve("some-package-that-does-not-exist", { paths: ["some-dir-that-does-not-exist"] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("MODULE_NOT_FOUND");
+});
+
 test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array", () => {
   // Test with string (which is iterable but not an array)
   expect(() => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -267,6 +267,42 @@ describe.concurrent("node-module-module", () => {
     expect(stdout.trim()).toBe("pass");
     expect(await proc.exited).toBe(0);
   });
+  test("require.resolve options.paths entries that are not absolute paths", async () => {
+    using dir = tempDir("resolve-paths-relative", {
+      "sub/node_modules/relative-paths-pkg/package.json": JSON.stringify({
+        name: "relative-paths-pkg",
+        main: "index.js",
+      }),
+      "sub/node_modules/relative-paths-pkg/index.js": "module.exports = 42;",
+      "main.js": `
+        const assert = require("assert");
+        const path = require("path");
+        const Module = require("module");
+        const expected = path.join(process.cwd(), "sub", "node_modules", "relative-paths-pkg", "index.js");
+        assert.strictEqual(require.resolve("relative-paths-pkg", { paths: ["sub"] }), expected);
+        assert.strictEqual(Module._resolveFilename("relative-paths-pkg", module, false, { paths: ["sub"] }), expected);
+        for (const bad of [{}, 123, null]) {
+          assert.throws(() => require.resolve("relative-paths-pkg", { paths: [bad] }), { code: "ERR_INVALID_ARG_TYPE" });
+          assert.throws(() => Module._resolveFilename("relative-paths-pkg", module, false, { paths: [bad] }), { code: "ERR_INVALID_ARG_TYPE" });
+        }
+        assert.throws(() => require.resolve("package-that-does-not-exist", { paths: ["dir-that-does-not-exist"] }), { code: "MODULE_NOT_FOUND" });
+        console.log("pass");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "inherit",
+      stdout: "pipe",
+    });
+
+    const stdout = await proc.stdout.text();
+    expect(stdout.trim()).toBe("pass");
+    expect(await proc.exited).toBe(0);
+  });
+
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "children-fixture/a.cjs"), arg],


### PR DESCRIPTION
### What does this PR do?

Fuzzing found that any non-absolute entry in the `paths` option of `require.resolve()` or `Module._resolveFilename()` crashes the process:

```js
require.resolve("lodash", { paths: [{}] });
// panic: cannot resolve DirInfo for non-absolute path: [object Object]
require.resolve("lodash", { paths: ["foo"] });
// panic: cannot resolve DirInfo for non-absolute path: foo
```

The resolver uses each `paths` entry verbatim as a source directory for package resolution, and `dir_info_cached()` asserts that its input is absolute. The regular `source_dir` is normalized before that point (non-absolute falls back to the top level directory), but the `paths` loop skipped that step, so any relative entry (including the `"[object Object]"` produced by stringifying a non-string element) tripped the assert and aborted. This reproduces on the release build too, so it is a trivial DoS for anything that forwards user input into `paths`.

Two changes:

- `src/resolver/resolver.rs`: resolve non-absolute `paths` entries against the cwd before using them, which is what Node does (each entry goes through `path.resolve`). `require.resolve("pkg", { paths: ["sub"] })` now finds `./sub/node_modules/pkg` like Node instead of panicking.
- `ImportMetaObject.cpp` / `NodeModuleModule.cpp`: reject non-string `paths` elements with `ERR_INVALID_ARG_TYPE` instead of stringifying them, matching Node's message exactly:

```
node: The "paths[0]" argument must be of type string. Received an instance of Object
bun:  The "paths[0]" argument must be of type string. Received an instance of Object
```

The relative-specifier branch (`require.resolve("./x", { paths: [...] })`) already absolutized inside `check_relative_path()`, so only the package-path loop needed the resolver change.

### How did you verify your code works?

- `bun bd test test/js/node/module/module-resolve-filename-paths.test.js`: 3 new tests (non-string entries throw `ERR_INVALID_ARG_TYPE`, a relative entry reports `MODULE_NOT_FOUND`). This file also runs under Node, and all 9 tests pass there (`node module-resolve-filename-paths.test.js`).
- `bun bd test test/js/node/module/node-module-module.test.js`: new spawned test covering cwd-relative resolution of a relative `paths` entry, the TypeError cases, and the not-found case.
- Without the fix, the first file aborts the test runner with `panic: cannot resolve DirInfo for non-absolute path: [object Object]` and the second fails with the child panicking on `non-absolute path: sub`.
