### PR TITLE
shell: fix $.escape corrupting Latin-1 characters and dropping empty strings

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -470,9 +470,7 @@ pub(crate) fn shell_escape(
 
     let mut outbuf: Vec<u8> = Vec::new();
 
-    // An empty string still has to become a shell word (`""`): returning it
-    // unchanged would contribute no argument at all when used with `{ raw: }`.
-    if bunstr.is_empty() || bun_shell_parser::needs_escape_bunstr(*bunstr) {
+    if bun_shell_parser::needs_escape_bunstr(*bunstr) {
         let result = bun_shell_parser::escape_bun_str::<true>(*bunstr, &mut outbuf)?;
         if !result {
             return Err(global_this.throw(format_args!(

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -470,7 +470,9 @@ pub(crate) fn shell_escape(
 
     let mut outbuf: Vec<u8> = Vec::new();
 
-    if bun_shell_parser::needs_escape_bunstr(*bunstr) {
+    // An empty string still has to become a shell word (`""`): returning it
+    // unchanged would contribute no argument at all when used with `{ raw: }`.
+    if bunstr.is_empty() || bun_shell_parser::needs_escape_bunstr(*bunstr) {
         let result = bun_shell_parser::escape_bun_str::<true>(*bunstr, &mut outbuf)?;
         if !result {
             return Err(global_this.throw(format_args!(

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -817,7 +817,7 @@ pub(crate) fn run_scripts_with_filter(
             for part in &ctx.passthrough {
                 copy_script.push(b' ');
                 if crate::shell::needs_escape_utf8_ascii_latin1(part) {
-                    crate::shell::escape_8bit::<true>(part, &mut copy_script)?;
+                    crate::shell::escape_8bit::<true, false>(part, &mut copy_script)?;
                 } else {
                     copy_script.extend_from_slice(part);
                 }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -291,7 +291,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         for part in passthrough {
             copy_script.push(b' ');
             if needs_escape_utf8_ascii_latin1(part) {
-                escape_8bit::<true>(part, &mut copy_script).unwrap_or_oom();
+                escape_8bit::<true, false>(part, &mut copy_script).unwrap_or_oom();
                 continue;
             }
             copy_script.extend_from_slice(part);

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -1045,13 +1045,8 @@ impl<'a> ShellSrcBuilder<'a> {
     }
 
     pub fn append_latin1_impl(&mut self, latin1: &[u8]) -> Result<(), bun_alloc::AllocError> {
-        let non_ascii_idx = strings::first_non_ascii(latin1).unwrap_or(0);
-
-        if non_ascii_idx > 0 {
-            self.append_utf8_impl(&latin1[..non_ascii_idx as usize])?;
-        }
-
-        // Move the Vec out, transform it, and store it back.
+        // `allocate_latin1_into_utf8_with_list` appends ALL of `latin1` after `len`,
+        // including its leading ASCII run; pre-appending any of it would duplicate it.
         let len = self.outbuf.len();
         let buf = core::mem::take(self.outbuf);
         *self.outbuf = strings::allocate_latin1_into_utf8_with_list(buf, len, latin1);

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -988,14 +988,10 @@ impl<'a> ShellSrcBuilder<'a> {
         if invalid {
             return Ok(false);
         }
-        // Empty interpolated values must still produce an argument (e.g. `${''}` should
-        // pass "" as an arg). Route through appendJSStrRef so the \x08 marker is recognized
-        // by the lexer regardless of quote context (e.g. inside single quotes).
-        if ALLOW_ESCAPE && bunstr.length() == 0 {
-            self.append_js_str_ref(bunstr)?;
-            return Ok(true);
-        }
         if ALLOW_ESCAPE {
+            // `needs_escape_bunstr` is true for empty strings: `${''}` must still
+            // produce an argument. Routing through appendJSStrRef makes the \x08
+            // marker recognized regardless of quote context (e.g. inside single quotes).
             if needs_escape_bunstr(bunstr) || is_if_clause_keyword_bunstr(bunstr) {
                 self.append_js_str_ref(bunstr)?;
                 return Ok(true);

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -4222,13 +4222,20 @@ pub fn escape_bun_str<const ADD_QUOTES: bool>(
         let res = escape_utf16::<ADD_QUOTES>(bunstr.utf16(), outbuf)?;
         return Ok(!res.is_invalid);
     }
-    // otherwise should be utf-8, latin-1, or ascii
-    escape_8bit::<ADD_QUOTES>(bunstr.byte_slice(), outbuf)?;
+    if bunstr.is_utf8() {
+        escape_8bit::<ADD_QUOTES, false>(bunstr.byte_slice(), outbuf)?;
+        return Ok(true);
+    }
+    // Otherwise 8-bit (Latin-1/ASCII). `outbuf` is consumed as UTF-8, so
+    // Latin-1 code units 0x80..=0xFF must be re-encoded, not copied verbatim.
+    escape_8bit::<ADD_QUOTES, true>(bunstr.byte_slice(), outbuf)?;
     Ok(true)
 }
 
-/// works for utf-8, latin-1, and ascii
-pub fn escape_8bit<const ADD_QUOTES: bool>(
+/// Escapes an 8-bit byte string into UTF-8 output. `LATIN1` selects how bytes
+/// >= 0x80 are interpreted: Latin-1 code units (re-encoded as 2-byte UTF-8) or
+/// bytes of an already-UTF-8 string (copied verbatim).
+pub fn escape_8bit<const ADD_QUOTES: bool, const LATIN1: bool>(
     str: &[u8],
     outbuf: &mut Vec<u8>,
 ) -> Result<(), bun_alloc::AllocError> {
@@ -4247,6 +4254,10 @@ pub fn escape_8bit<const ADD_QUOTES: bool>(
         }
         if c == SPECIAL_JS_CHAR {
             outbuf.extend_from_slice(&[SPECIAL_JS_CHAR, b'"', b'"']);
+            continue;
+        }
+        if LATIN1 && c >= 0x80 {
+            outbuf.extend_from_slice(&[0xC0 | (c >> 6), 0x80 | (c & 0x3F)]);
             continue;
         }
         outbuf.push(c);

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -4329,6 +4329,9 @@ pub fn needs_escape_bunstr(bunstr: BunString) -> bool {
 }
 
 pub fn needs_escape_utf16(str: &[u16]) -> bool {
+    if str.is_empty() {
+        return true;
+    }
     for &codeunit in str {
         if codeunit < 0xff && SPECIAL_CHARS_TABLE.is_set(codeunit as usize) {
             return true;
@@ -4340,8 +4343,12 @@ pub fn needs_escape_utf16(str: &[u16]) -> bool {
 /// Checks for the presence of any char from `SPECIAL_CHARS` in `str`. This
 /// indicates the *possibility* that the string must be escaped, so it can have
 /// false positives, but it is faster than running the shell lexer through the
-/// input string for a more correct implementation.
+/// input string for a more correct implementation. An empty string always
+/// needs escaping: quoting is the only way it becomes a shell word at all.
 pub fn needs_escape_utf8_ascii_latin1(str: &[u8]) -> bool {
+    if str.is_empty() {
+        return true;
+    }
     for &c in str {
         if SPECIAL_CHARS_TABLE.is_set(c as usize) {
             return true;

--- a/test/cli/run/run-quote.test.ts
+++ b/test/cli/run/run-quote.test.ts
@@ -58,7 +58,9 @@ it.each([
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ argv: JSON.parse(stdout), exitCode }).toEqual({ argv: ["a", "", "b"], exitCode: 0 });
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(stdout.trim()).toBe('["a","","b"]');
+  expect(exitCode).toBe(0);
 });
 
 it("preserves empty passthrough arguments (bun --filter)", async () => {
@@ -70,6 +72,7 @@ it("preserves empty passthrough arguments (bun --filter)", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) expect(stderr).toBe("");
   // `--filter` prefixes each output line with "<package> <script>: ".
   expect(stdout).toContain('["a","","b"]');
   expect(exitCode).toBe(0);

--- a/test/cli/run/run-quote.test.ts
+++ b/test/cli/run/run-quote.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "bun:test";
-import { bunEnv, bunExe, bunRunAsScript, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRunAsScript, tempDir, tempDirWithFiles } from "harness";
 
 it("should handle quote escapes", () => {
   const package_json = JSON.stringify({
@@ -34,5 +34,43 @@ it("keeps pass-through arguments containing tabs and question marks as single wo
   });
   const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe(JSON.stringify(passthrough) + "\n");
+  expect(exitCode).toBe(0);
+});
+
+// Positional arguments appended to a package.json script are joined into the
+// script string, so an empty one must be emitted as a quoted empty word (`""`).
+// Dropping it shifts every following positional left by one.
+const argvEchoFixture = {
+  "package.json": JSON.stringify({ name: "run-empty-arg", version: "1.0.0", scripts: { p: "bun args.js" } }),
+  "args.js": "console.log(JSON.stringify(process.argv.slice(2)));",
+};
+
+it.each([
+  ["bun run <script>", ["run", "p"]],
+  ["bun run <script> --", ["run", "p", "--"]],
+  ["bun <script>", ["p"]],
+])("preserves empty passthrough arguments (%s)", async (_label, prefix) => {
+  using dir = tempDir("run-empty-arg", argvEchoFixture);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...prefix, "a", "", "b"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ argv: JSON.parse(stdout), exitCode }).toEqual({ argv: ["a", "", "b"], exitCode: 0 });
+});
+
+it("preserves empty passthrough arguments (bun --filter)", async () => {
+  using dir = tempDir("run-empty-arg-filter", argvEchoFixture);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--filter", "*", "p", "a", "", "b"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // `--filter` prefixes each output line with "<package> <script>: ".
+  expect(stdout).toContain('["a","","b"]');
   expect(exitCode).toBe(0);
 });

--- a/test/cli/run/run-quote.test.ts
+++ b/test/cli/run/run-quote.test.ts
@@ -45,7 +45,7 @@ const argvEchoFixture = {
   "args.js": "console.log(JSON.stringify(process.argv.slice(2)));",
 };
 
-it.each([
+it.concurrent.each([
   ["bun run <script>", ["run", "p"]],
   ["bun run <script> --", ["run", "p", "--"]],
   ["bun <script>", ["p"]],
@@ -63,7 +63,7 @@ it.each([
   expect(exitCode).toBe(0);
 });
 
-it("preserves empty passthrough arguments (bun --filter)", async () => {
+it.concurrent("preserves empty passthrough arguments (bun --filter)", async () => {
   using dir = tempDir("run-empty-arg-filter", argvEchoFixture);
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--filter", "*", "p", "a", "", "b"],

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -441,6 +441,14 @@ describe("bunshell", () => {
       TestBuilder.command`echo ${" à"}`.stdout(" à\n").runAsTest("latin-1 character preceded by space");
       TestBuilder.command`echo ${"à¿"}`.stdout("à¿\n").runAsTest("multiple latin-1 characters");
       TestBuilder.command`echo ${'"à¿"'}`.stdout('"à¿"\n').runAsTest("latin-1 characters in quotes");
+      // An ASCII run before the first non-ASCII code unit must not be emitted
+      // twice. This shape (ASCII prefix + Latin-1 + no shell metacharacters)
+      // takes the no-escape append_latin1_impl path, unlike every case above.
+      TestBuilder.command`echo ${"café"}`.stdout("café\n").runAsTest("ascii prefix before a latin-1 character");
+      TestBuilder.command`echo ${"résumé"}`.stdout("résumé\n").runAsTest("interleaved ascii and latin-1 runs");
+      TestBuilder.command`echo ${{ raw: "café" }}`
+        .stdout("café\n")
+        .runAsTest("ascii prefix before a latin-1 character via raw");
     });
   });
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -155,6 +155,30 @@ describe("bunshell", () => {
     escapeTest("lmao=✔", '"lmao=✔"');
     escapeTest("元気かい、兄弟", "元気かい、兄弟");
     escapeTest("d元気かい、兄弟", "d元気かい、兄弟");
+    // Strings made only of U+0000-U+00FF code points use JSC's 8-bit (Latin-1)
+    // storage; quoting must re-encode those code units to UTF-8, not copy the
+    // raw bytes, or every one of them becomes U+FFFD.
+    escapeTest("é");
+    escapeTest("é;", '"é;"');
+    escapeTest("ü;id", '"ü;id"');
+    escapeTest("café && ok", '"café && ok"');
+    escapeTest("\u0080;\u00ff", '"\u0080;\u00ff"');
+
+    test("latin-1 values survive $.escape + {raw:} round trip", async () => {
+      for (const value of ["é;", "ü;id", "café && ok", "\u0080;\u00ff"]) {
+        const escaped = $.escape(value);
+        expect(escaped).not.toInclude("\uFFFD");
+        const { stdout } = await $`echo ${{ raw: escaped }}`;
+        expect(stdout.toString()).toEqual(`${value}\n`);
+      }
+    });
+
+    test("$.escape of an empty string is an empty shell word", async () => {
+      expect($.escape("")).toBe('""');
+      // `{ raw: $.escape(v) }` must contribute exactly one argv entry, even for "".
+      const { stdout } = await $`echo a ${{ raw: $.escape("") }} b`;
+      expect(stdout.toString()).toEqual("a  b\n");
+    });
 
     test("quotes values containing a tab, carriage return, or question mark", async () => {
       expect($.escape("a\tb")).toEqual('"a\tb"');

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -164,14 +164,15 @@ describe("bunshell", () => {
     escapeTest("café && ok", '"café && ok"');
     escapeTest("\u0080;\u00ff", '"\u0080;\u00ff"');
 
-    test("latin-1 values survive $.escape + {raw:} round trip", async () => {
-      for (const value of ["é;", "ü;id", "café && ok", "\u0080;\u00ff"]) {
+    test.each(["é;", "ü;id", "café && ok", "\u0080;\u00ff"])(
+      "latin-1 value %p survives $.escape + {raw:} round trip",
+      async value => {
         const escaped = $.escape(value);
         expect(escaped).not.toInclude("\uFFFD");
         const { stdout } = await $`echo ${{ raw: escaped }}`;
         expect(stdout.toString()).toEqual(`${value}\n`);
-      }
-    });
+      },
+    );
 
     test("$.escape of an empty string is an empty shell word", async () => {
       expect($.escape("")).toBe('""');


### PR DESCRIPTION
### What does this PR do?

Fixes three Bun Shell bugs in how Latin-1 strings and empty values are turned into shell words.

```js
import { $ } from "bun";

// 1. $.escape destroys Latin-1 code units as soon as quoting kicks in
$.escape("é")   // "é"          (no quoting needed, untouched)
$.escape("é;")  // "\"\uFFFD;\""   the é becomes U+FFFD
$.escape("Ā;")  // "\"Ā;\""     (U+0100+ forces UTF-16 storage and is fine)

// 2. An empty value produces no shell word, shifting every following positional
$.escape("")                                       // ""
await $`echo a ${{ raw: $.escape("") }} b`.text()  // "a b\n", should be "a  b\n"

// 3. Interpolating a Latin-1 string duplicates its leading ASCII run
await $`echo ${"café"}`.text()    // "cafcafé\n"
await $`echo ${"résumé"}`.text()  // "rrésumé\n"
```

Bug 2 also drops empty passthrough arguments in `bun run` / `bun <script>` / `bun --filter`:

```
# args.js: console.log(JSON.stringify(process.argv.slice(2)))
$ bun run p a "" b      # script "p" is "bun args.js"
$ bun args.js a  b
["a","b"]               # should be ["a","","b"]
```

All of this reproduces on 1.4.0 and on main before this change.

**Cause.** JSC stores strings made only of U+0000..U+00FF code points as 8-bit Latin-1. Those bytes are not UTF-8; U+0080..U+00FF must be re-encoded as two bytes.

1. `$.escape` Latin-1 corruption: `escape_bun_str` routes 8-bit strings through `escape_8bit`, which copies the raw Latin-1 bytes into a buffer that `shell_escape` then hands to `BunString::clone_utf8`. A lone 0x80..0xFF byte is invalid UTF-8, so every non-ASCII Latin-1 code unit decodes to U+FFFD.
2. Dropped empty words: the `needs_escape_*` predicates return false for an empty input, so every call site that uses them to decide whether to emit a quoted word emits nothing instead: `$.escape("")`, and the `bun run` / `bun --filter` passthrough loops that append positional args to the script string. Two other call sites (`${""}` interpolation and `append_bun_str`) each carried their own empty special case to work around this.
3. Duplicated ASCII prefix (found in review): `append_latin1_impl` appends `latin1[..non_ascii_idx]` to the script buffer and then passes the full `latin1` slice to `allocate_latin1_into_utf8_with_list`, which appends the whole slice again because it handles the leading ASCII run itself. This is the default (no metacharacters) interpolation path, so `echo ${"café"}` prints `cafcafé`. It survived because every existing Latin-1 test either starts with a non-ASCII character (so the duplicated prefix is empty) or contains a metacharacter (which routes through the separate, correct, escape path).

**Fix.**

- `escape_8bit` gains a `LATIN1` const generic. When set, bytes >= 0x80 are emitted as their two-byte UTF-8 encoding instead of copied verbatim, and `escape_bun_str` routes 8-bit non-UTF-8 strings through it. The existing callers in `run_command.rs` and `filter_run.rs` pass argv bytes and keep the verbatim behavior.
- `needs_escape_utf8_ascii_latin1` and `needs_escape_utf16` now return true for empty input: quoting is the only way an empty value becomes a shell word at all. This fixes `$.escape("")` and the two `bun run` passthrough sites at the shared predicate, and lets me delete the per-call-site empty special case in `append_bun_str` it made redundant.
- `append_latin1_impl` drops its redundant prefix pre-append. All other callers of `allocate_latin1_into_utf8_with_list` were already passing the full slice without pre-appending.

### How did you verify your code works?

New tests in the existing `escape` and `latin-1` blocks of `test/js/bun/shell/bunshell.test.ts` and in `test/cli/run/run-quote.test.ts`:

- Exact `$.escape` output for `"é;"`, `"ü;id"`, `"café && ok"`, and the `"\u0080"`/`"\u00ff"` boundary code points, plus a `$.escape` + `{raw:}` round trip for each, plus `$.escape("")`.
- The previously-untested interpolation shape (ASCII prefix + Latin-1 + no metacharacters) as `"café"`, `"résumé"`, and the `{raw:}` variant.
- `a "" b` passthrough preserved for `bun run <script>`, `bun run <script> --`, `bun <script>`, and `bun --filter`.

All 16 new tests fail on the released binary with the U+FFFD / dropped-argument / `cafcafé` output above and pass with this change. The full `bunshell.test.ts`, `exec.test.ts`, `lex.test.ts`, `parse.test.ts`, `env.positionals.test.ts`, and `run-quote.test.ts` suites pass on a debug+ASAN build.
