### PR TITLE
S3: validate presign expiresIn against the SigV4 7 day cap

### DIFF
--- a/docs/runtime/s3.mdx
+++ b/docs/runtime/s3.mdx
@@ -243,7 +243,7 @@ You can pass any of the following ACLs:
 
 ### Expiring URLs
 
-To set an expiration time for a presigned URL, pass the `expiresIn` option.
+To set an expiration time for a presigned URL, pass the `expiresIn` option. AWS Signature v4 limits presigned URLs to 7 days, so the value must be between 1 and 604800 seconds; anything else throws a `RangeError`.
 
 ```ts s3.ts icon="/icons/typescript.svg"
 const url = s3file.presign({

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -377,6 +377,10 @@ declare module "bun" {
     /**
      * Number of seconds until the presigned URL expires.
      * - Default: 86400 (1 day)
+     * - Minimum: 1
+     * - Maximum: 604800 (7 days), the limit AWS Signature v4 allows
+     *
+     * Values outside that range throw a `RangeError` at presign time.
      *
      * @example
      *     // Short-lived URL

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -753,15 +753,15 @@ pub(crate) fn get_presign_url_from(
                     }
                 };
             }
-            if let Some(expires_) = options.get_optional_int::<i32>(global, "expiresIn")? {
-                const MAX_EXPIRES: i32 =
-                    bun_s3_signing::SignQueryOptions::MAX_EXPIRES_SECONDS as i32;
+            if let Some(expires_) = options.get_optional_int::<i64>(global, "expiresIn")? {
+                const MAX_EXPIRES: i64 =
+                    bun_s3_signing::SignQueryOptions::MAX_EXPIRES_SECONDS as i64;
                 if !(1..=MAX_EXPIRES).contains(&expires_) {
                     return Err(global.throw_range_error(
-                        i64::from(expires_),
+                        expires_,
                         RangeErrorOptions {
                             min: 1,
-                            max: i64::from(MAX_EXPIRES),
+                            max: MAX_EXPIRES,
                             field_name: b"expiresIn",
                             ..Default::default()
                         },

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -7,7 +7,9 @@ use crate::webcore::s3::client::error_jsc::s3_error_to_js_with_async_stack;
 use crate::webcore::s3_client::S3CredentialsExt as _;
 use bun_core::strings;
 use bun_http::Method;
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass as _, JsError, JsResult};
+use bun_jsc::{
+    CallFrame, JSGlobalObject, JSValue, JsClass as _, JsError, JsResult, RangeErrorOptions,
+};
 
 // Local front for `bun_core::pretty_fmt!` that accepts a runtime / const-
 // generic bool. The proc-macro only matches `true`/`false` literals, so
@@ -752,10 +754,18 @@ pub(crate) fn get_presign_url_from(
                 };
             }
             if let Some(expires_) = options.get_optional_int::<i32>(global, "expiresIn")? {
-                if expires_ <= 0 {
-                    return Err(global.throw_invalid_arguments(format_args!(
-                        "expiresIn must be greather than 0"
-                    )));
+                const MAX_EXPIRES: i32 =
+                    bun_s3_signing::SignQueryOptions::MAX_EXPIRES_SECONDS as i32;
+                if !(1..=MAX_EXPIRES).contains(&expires_) {
+                    return Err(global.throw_range_error(
+                        i64::from(expires_),
+                        RangeErrorOptions {
+                            min: 1,
+                            max: i64::from(MAX_EXPIRES),
+                            field_name: b"expiresIn",
+                            ..Default::default()
+                        },
+                    ));
                 }
                 expires = expires_ as usize;
             }

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -1076,6 +1076,13 @@ pub struct SignQueryOptions {
     pub expires: usize,
 }
 
+impl SignQueryOptions {
+    /// SigV4 caps `X-Amz-Expires` at 7 days; S3 rejects every use of a URL
+    /// signed with a larger value (`AuthorizationQueryParametersError`).
+    /// See <https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html>.
+    pub const MAX_EXPIRES_SECONDS: usize = 7 * 24 * 60 * 60;
+}
+
 impl Default for SignQueryOptions {
     fn default() -> Self {
         Self { expires: 86400 }

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1589,6 +1589,50 @@ describe.concurrent("s3 missing credentials", () => {
   });
 });
 
+// Presigning is local signing math, so these run without any S3 service.
+describe.concurrent("presign expiresIn validation", () => {
+  // AWS Signature v4 rejects X-Amz-Expires above 7 days.
+  const MAX_EXPIRES_IN = 7 * 24 * 60 * 60;
+  const localOptions: S3Options = {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    bucket: "bucket",
+    region: "us-east-1",
+  };
+  const entryPoints: [string, (expiresIn: unknown) => string][] = [
+    ["client.presign()", expiresIn => S3(localOptions).presign("key.txt", { expiresIn } as any)],
+    ["S3Client.presign()", expiresIn => S3Client.presign("key.txt", { ...localOptions, expiresIn } as any)],
+    [
+      "file.presign()",
+      expiresIn =>
+        S3(localOptions)
+          .file("key.txt")
+          .presign({ expiresIn } as any),
+    ],
+  ];
+
+  for (const [name, presign] of entryPoints) {
+    describe(name, () => {
+      it("accepts the 7 day maximum", () => {
+        expect(new URL(presign(MAX_EXPIRES_IN)).searchParams.get("X-Amz-Expires")).toBe(String(MAX_EXPIRES_IN));
+      });
+      it("rejects expiresIn above 7 days", () => {
+        expect(() => presign(MAX_EXPIRES_IN + 1)).toThrowWithCode(RangeError, "ERR_OUT_OF_RANGE");
+        expect(() => presign(8 * 24 * 60 * 60)).toThrow(
+          `The value of "expiresIn" is out of range. It must be >= 1 and <= 604800. Received 691200`,
+        );
+      });
+      it("rejects expiresIn below 1", () => {
+        expect(() => presign(0)).toThrowWithCode(RangeError, "ERR_OUT_OF_RANGE");
+        expect(() => presign(-1)).toThrowWithCode(RangeError, "ERR_OUT_OF_RANGE");
+      });
+      it("rejects a non-integer expiresIn", () => {
+        expect(() => presign(1.5)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+      });
+    });
+  }
+});
+
 // Archive + S3 integration tests
 describe.skipIf(!minioCredentials)("Archive with S3", () => {
   const credentials = minioCredentials!;

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1830,7 +1830,14 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The fixture only talks to its own localhost mock: an ambient proxy must not capture that traffic.
+      env: {
+        ...bunEnv,
+        http_proxy: undefined,
+        HTTP_PROXY: undefined,
+        https_proxy: undefined,
+        HTTPS_PROXY: undefined,
+      },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1621,6 +1621,10 @@ describe.concurrent("presign expiresIn validation", () => {
         expect(() => presign(8 * 24 * 60 * 60)).toThrow(
           `The value of "expiresIn" is out of range. It must be >= 1 and <= 604800. Received 691200`,
         );
+        // Values past i32 still report the SigV4 bound, not an integer-width bound.
+        expect(() => presign(2 ** 31)).toThrow(
+          `The value of "expiresIn" is out of range. It must be >= 1 and <= 604800. Received 2147483648`,
+        );
       });
       it("rejects expiresIn below 1", () => {
         expect(() => presign(0)).toThrowWithCode(RangeError, "ERR_OUT_OF_RANGE");


### PR DESCRIPTION
### Problem

```js
const url = s3.presign("key.txt", { expiresIn: 8 * 24 * 3600 }); // 8 days
// returns a URL with X-Amz-Expires=691200
```

SigV4 limits presigned URLs to 7 days (604800 seconds). `presign()` only validated `expiresIn > 0`, so anything larger was signed into `X-Amz-Expires` and S3/R2/MinIO reject every request made with the resulting URL: `AuthorizationQueryParametersError: X-Amz-Expires must be less than a week`. Since presigned URLs are typically generated in one place and consumed later somewhere else, the failure surfaces as dead links after they have been distributed. The AWS SDK rejects the same input synchronously at presign time.

### Fix

`get_presign_url_from` in `src/runtime/webcore/S3File.rs` is the single site behind `client.presign()`, `S3Client.presign()`, and `file.presign()`. It now range-checks `expiresIn` to `1..=604800` and throws `ERR_OUT_OF_RANGE`, the same shape the other numeric S3 options (`partSize`, `queueSize`, `retry`) already use:

```
RangeError: The value of "expiresIn" is out of range. It must be >= 1 and <= 604800. Received 691200
```

The cap is defined once as `SignQueryOptions::MAX_EXPIRES_SECONDS` in `bun_s3_signing`. As part of this, `expiresIn: 0` and negative values also report `ERR_OUT_OF_RANGE` now instead of the previous `ERR_INVALID_ARG_TYPE` with the typo'd message "expiresIn must be greather than 0". Non-integer and non-number values were already rejected and are unchanged. The `expiresIn` docs in `packages/bun-types/s3.d.ts` and `docs/runtime/s3.mdx` mention the limit.

### Test

`test/js/bun/s3/s3.test.ts` gets a `presign expiresIn validation` block that needs no S3 service and covers all three entry points: exactly 604800 is accepted, 604801 and 691200 throw `ERR_OUT_OF_RANGE` with the exact message, 0 and -1 throw, and 1.5 still throws `ERR_INVALID_ARG_TYPE`. The new assertions fail on the released bun and pass with this change.

The multipart upload id fixture in the same file now strips `HTTP_PROXY`/`HTTPS_PROXY` from its child env. It only talks to its own localhost mock, but S3 requests read the proxy env without consulting `NO_PROXY` (unlike fetch, which uses `get_http_proxy_for(url)`), so any environment that forces a proxy captured that traffic and failed the test before it asserted anything. The missing `NO_PROXY` handling on the S3 path is a separate issue and is not changed here.
