### PR TITLE
expect: objectContaining never matches an array received value

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -513,6 +513,15 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
         if (!readFlagsAndProcessPromise(matcherProp, flags, globalObject, otherProp, constructorType))
             return AsymmetricMatcherResult::FAIL;
 
+        bool receivedIsArray = JSC::isArray(globalObject, otherProp);
+        RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
+        if (receivedIsArray) {
+            // Jest rejects an array receiver before the "not" flag is applied, so
+            // an array satisfies neither objectContaining nor not.objectContaining.
+            flags = flags & ~FLAG_NOT;
+            return AsymmetricMatcherResult::FAIL;
+        }
+
         JSValue patternObject = expectObjectContaining->m_objectValue.get();
         if (patternObject.isObject()) {
             if (otherProp.isObject()) {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4271,6 +4271,8 @@ describe("expect()", () => {
     // adopted this yet. https://github.com/jestjs/jest/pull/15463
     test_skipIf(isVitest)("ObjectContaining never matches an array received value", () => {
       expect([1, 2]).not.toEqual(expect.objectContaining({ 0: 1 }));
+      expect([1, 2]).not.toEqual(expect.not.objectContaining({ 0: 1 }));
+      expect([1, 2]).not.toEqual(expect.not.objectContaining({ foo: "bar" }));
       expect(expect.objectContaining({ 0: 1 })).not.toEqual([1, 2]);
       expect(expect.objectContaining({ length: 2 })).not.toEqual([1, 2]);
       expect(expect.objectContaining({})).not.toEqual([1, 2]);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4266,6 +4266,26 @@ describe("expect()", () => {
         expect(expect.objectContaining({ [foo]: "foo" })).not.toEqual({ [bar]: "bar" }));
     });
 
+    // Jest 30 rejects an array received value before the "not" flag is applied, so an
+    // array satisfies neither objectContaining nor not.objectContaining. Vitest has not
+    // adopted this yet. https://github.com/jestjs/jest/pull/15463
+    test_skipIf(isVitest)("ObjectContaining never matches an array received value", () => {
+      expect([1, 2]).not.toEqual(expect.objectContaining({ 0: 1 }));
+      expect(expect.objectContaining({ 0: 1 })).not.toEqual([1, 2]);
+      expect(expect.objectContaining({ length: 2 })).not.toEqual([1, 2]);
+      expect(expect.objectContaining({})).not.toEqual([1, 2]);
+      expect(expect.not.objectContaining({ 0: 1 })).not.toEqual([1, 2]);
+      expect(expect.not.objectContaining({ foo: "bar" })).not.toEqual([1, 2]);
+      expect({ data: [1, 2] }).not.toEqual({ data: expect.objectContaining({ 0: 1 }) });
+      class ArraySubclass extends Array {}
+      expect(expect.objectContaining({ 0: 1 })).not.toEqual(ArraySubclass.from([1, 2]));
+      expect(expect.objectContaining({ 0: 1 })).not.toEqual(new Proxy([1, 2], {}));
+
+      // array-like objects that are not arrays still qualify as received values
+      expect(expect.objectContaining({ 0: 1, length: 2 })).toEqual({ 0: 1, 1: 2, length: 2 });
+      expect(expect.objectContaining({ 0: 1 })).toEqual(new Uint8Array([1, 2]));
+    });
+
     test("ObjectContaining matches defined properties", () => {
       const definedPropertyObject = {};
       Object.defineProperty(definedPropertyObject, "foo", { get: () => "bar" });


### PR DESCRIPTION
### Repro

```js
test("objectContaining vs array", () => {
  expect([1, 2]).toEqual(expect.objectContaining({ 0: 1 }));
});
```

`bun test` (1.4.0 and main): passes. Jest 30.4.1: fails with `Expected: ObjectContaining {"0": 1}` / `Received: [1, 2]`.

This is a false green: a value that regresses from `{ items, total }` to a bare array still satisfies an `objectContaining` assertion.

### Cause

In `matchAsymmetricMatcherAndGetFlags` the `JSExpectObjectContaining` branch only checked `otherProp.isObject()`. Arrays are objects in JSC, so `Bun__deepMatch` happily matched an array received value by index (`0`, `1`) or `length`.

Jest's `ObjectContaining.asymmetricMatch` rejects arrays, and does so before applying `inverse`:

```js
if (typeof other !== 'object' || Array.isArray(other)) {
  return false;
}
```

so `expect.not.objectContaining(...)` never matches an array either. That half was also wrong in Bun: `expect([1, 2]).toEqual(expect.not.objectContaining({ foo: 1 }))` was another false green, because the failed inner match got inverted into a pass.

For context, this guard is new in Jest 30 (jestjs/jest#15463, refined by jestjs/jest#16196 to keep accepting class instances). Jest 29 and current Vitest have no receiver guard at all, so Bun's old behavior matched those. Aligning to current Jest is still the right call, and the array case is the one where the old behavior reads as a plain false green.

### Fix

In the `objectContaining` branch, bail on `JSC::isArray(globalObject, otherProp)` (`Array.isArray` semantics, so Array subclasses and Proxy-wrapped arrays are covered) and clear `FLAG_NOT` before returning FAIL. Clearing the flag is the same idiom the `closeTo` branch a few lines below already uses for non-number received values, for the same reason.

The deliberate Bun/Jest divergence for primitive and `null` received values (documented in `expect.test.js` as "on purpose") is untouched. Jest also rejects callable received values via `typeof`; Bun keeps `isObject()` there, which is pre-existing and out of scope here.

### Verification

New `ObjectContaining never matches an array received value` test in `test/js/bun/test/expect.test.js`. Every assertion in it was verified against Jest 30.4.1. On the unfixed build, seven of them fail; all pass with the fix. The test is `test_skipIf(isVitest)` because Vitest has not adopted Jest 30's guard.

Covers: plain arrays, an empty sample, `length` in the sample, both `not.objectContaining` shapes, a matcher nested inside an expected object, an `Array` subclass, a `Proxy` over an array, and the negative contract (array-like plain objects and `Uint8Array` still match, since `Array.isArray` is false for them).

Audited every other `expect.objectContaining` use in `test/` (they are all `toThrow(objectContaining({code}))` or plain-object receivers), and re-ran the full `expect.test.js` against the fixed build: 407 pass, 0 fail.
