### PR TITLE
bun:test: populate customTesters, utils.diff, iterableEquality, and subsetEquality on the expect.extend matcher context

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1958,7 +1958,7 @@ declare module "bun:test" {
   type MatcherHintColor = (arg: string) => string; // subset of Chalk type
 
   interface MatcherUtils {
-    //customTesters: Array<Tester>;
+    customTesters: Array<Tester>;
     //dontThrow(): void; // (internally used by jest snapshot)
     equals: EqualsFunction;
     utils: Readonly<{
@@ -1980,8 +1980,9 @@ declare module "bun:test" {
           secondArgumentColor?: MatcherHintColor;
         },
       ): string;
-      //iterableEquality: Tester;
-      //subsetEquality: Tester;
+      diff(a: unknown, b: unknown, options?: unknown): string | null;
+      iterableEquality: Tester;
+      subsetEquality: Tester;
       // ...
     }>;
   }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2883,15 +2883,27 @@ impl ExpectMatcherUtils {
         bun_jsc::bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
     }
 
+    /// Jest's `iterableEquality` "out of domain" guard: not an object,
+    /// an Array, an `ArrayBuffer.isView`, or not iterable.
+    fn is_iterable_equality_operand(value: JSValue, global_this: &JSGlobalObject) -> JsResult<bool> {
+        if !value.is_cell() {
+            return Ok(false);
+        }
+        let ty = value.js_type();
+        Ok(ty.is_object()
+            && !ty.is_array()
+            && !ty.is_typed_array_or_array_buffer()
+            && value.is_iterable(global_this)?)
+    }
+
     #[bun_jsc::host_fn(method)]
     pub fn iterable_equality(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arguments = callframe.arguments_old::<2>();
         let args = arguments.slice();
         let a = if args.is_empty() { JSValue::UNDEFINED } else { args[0] };
         let b = if args.len() > 1 { args[1] } else { JSValue::UNDEFINED };
-        if !a.is_cell() || !a.js_type().is_object() || a.is_array()
-            || !b.is_cell() || !b.js_type().is_object() || b.is_array()
-            || !a.is_iterable(global_this)? || !b.is_iterable(global_this)?
+        if !Self::is_iterable_equality_operand(a, global_this)?
+            || !Self::is_iterable_equality_operand(b, global_this)?
         {
             return Ok(JSValue::UNDEFINED);
         }
@@ -2904,8 +2916,18 @@ impl ExpectMatcherUtils {
         let args = arguments.slice();
         let object = if args.is_empty() { JSValue::UNDEFINED } else { args[0] };
         let subset = if args.len() > 1 { args[1] } else { JSValue::UNDEFINED };
-        if !subset.is_cell() || !subset.js_type().is_object()
-            || subset.is_array() || subset.is_error() || subset.is_date()
+        // Jest's `isObjectWithKeys`: a plain-ish object, so not an Array,
+        // Error, Date, Set, or Map.
+        if !subset.is_cell() {
+            return Ok(JSValue::UNDEFINED);
+        }
+        let subset_ty = subset.js_type();
+        if !subset_ty.is_object()
+            || subset_ty.is_array()
+            || subset_ty.is_set()
+            || subset_ty.is_map()
+            || subset.is_error()
+            || subset.is_date()
         {
             return Ok(JSValue::UNDEFINED);
         }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -4,7 +4,7 @@ use core::fmt;
 
 use bun_core::Output;
 use bun_jsc::{
-    CallFrame, JSGlobalObject, JSValue, JsError, JsResult,
+    CallFrame, JSGlobalObject, JSType, JSValue, JsError, JsResult,
     ConsoleObject, JSFunction, JSPropertyIterator, JSString,
 };
 use bun_jsc::{JsClass as _, StringJsc as _};
@@ -2770,7 +2770,8 @@ impl ExpectMatcherContext {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_custom_testers(_this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        // TODO: populate from expect.addEqualityTesters once supported
+        // `expect.addEqualityTesters` is not implemented, so there is never a
+        // registered tester to surface; Jest also returns [] when there are none.
         JSValue::create_empty_array(global_this, 0)
     }
 
@@ -2916,16 +2917,16 @@ impl ExpectMatcherUtils {
         let args = arguments.slice();
         let object = if args.is_empty() { JSValue::UNDEFINED } else { args[0] };
         let subset = if args.len() > 1 { args[1] } else { JSValue::UNDEFINED };
-        // Jest's `isObjectWithKeys`: a plain-ish object, so not an Array,
-        // Error, Date, Set, or Map.
+        // Jest's `isObjectWithKeys`: not an Array, Error, Date, Set, or Map.
+        // Its `instanceof Set`/`Map` does not match WeakSet/WeakMap, so only the
+        // strong variants are out of domain (`is_set`/`is_map` include the weak ones).
         if !subset.is_cell() {
             return Ok(JSValue::UNDEFINED);
         }
         let subset_ty = subset.js_type();
         if !subset_ty.is_object()
             || subset_ty.is_array()
-            || subset_ty.is_set()
-            || subset_ty.is_map()
+            || matches!(subset_ty, JSType::Set | JSType::Map)
             || subset.is_error()
             || subset.is_date()
         {

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2935,13 +2935,14 @@ impl ExpectMatcherUtils {
         {
             return Ok(JSValue::UNDEFINED);
         }
-        // Jest never gates `object`: every subset key is checked against it, so
-        // a subset with no own enumerable keys matches anything vacuously.
-        if !Self::is_typeof_object(object) {
-            return Ok(JSValue::from(
-                subset.keys(global_this)?.get_length(global_this)? == 0,
-            ));
-        }
+        // Jest never gates `object`: each subset key (string or symbol) is
+        // checked against it, and none can match a non-object, so an empty
+        // object stands in for one and both branches share one engine.
+        let object = if Self::is_typeof_object(object) {
+            object
+        } else {
+            JSValue::create_empty_object(global_this, 0)
+        };
         Ok(JSValue::from(object.jest_deep_match(subset, global_this, false)?))
     }
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2884,17 +2884,21 @@ impl ExpectMatcherUtils {
         bun_jsc::bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
     }
 
-    /// Jest's `iterableEquality` "out of domain" guard: not an object,
+    /// `typeof value === "object"` for a non-null value. JSC's `is_object()`
+    /// is `type >= ObjectType`, which also admits callables; Jest's domain
+    /// guards are written in terms of `typeof`, which reports them as "function".
+    fn is_typeof_object(value: JSValue) -> bool {
+        value.is_cell() && value.js_type().is_object() && !value.is_callable()
+    }
+
+    /// Jest's `iterableEquality` "out of domain" guard: not `typeof "object"`,
     /// an Array, an `ArrayBuffer.isView`, or not iterable.
     fn is_iterable_equality_operand(value: JSValue, global_this: &JSGlobalObject) -> JsResult<bool> {
-        if !value.is_cell() {
+        if !Self::is_typeof_object(value) {
             return Ok(false);
         }
         let ty = value.js_type();
-        Ok(ty.is_object()
-            && !ty.is_array()
-            && !ty.is_typed_array_or_array_buffer()
-            && value.is_iterable(global_this)?)
+        Ok(!ty.is_array() && !ty.is_typed_array_or_array_buffer() && value.is_iterable(global_this)?)
     }
 
     #[bun_jsc::host_fn(method)]
@@ -2917,23 +2921,26 @@ impl ExpectMatcherUtils {
         let args = arguments.slice();
         let object = if args.is_empty() { JSValue::UNDEFINED } else { args[0] };
         let subset = if args.len() > 1 { args[1] } else { JSValue::UNDEFINED };
-        // Jest's `isObjectWithKeys`: not an Array, Error, Date, Set, or Map.
-        // Its `instanceof Set`/`Map` does not match WeakSet/WeakMap, so only the
-        // strong variants are out of domain (`is_set`/`is_map` include the weak ones).
-        if !subset.is_cell() {
+        // Jest's `isObjectWithKeys`: `typeof "object"`, and not an Array, Error,
+        // Date, Set, or Map. Its `instanceof Set`/`Map` does not match
+        // WeakSet/WeakMap, so only the strong variants are out of domain.
+        if !Self::is_typeof_object(subset) {
             return Ok(JSValue::UNDEFINED);
         }
         let subset_ty = subset.js_type();
-        if !subset_ty.is_object()
-            || subset_ty.is_array()
+        if subset_ty.is_array()
             || matches!(subset_ty, JSType::Set | JSType::Map)
             || subset.is_error()
             || subset.is_date()
         {
             return Ok(JSValue::UNDEFINED);
         }
-        if !object.is_cell() || !object.js_type().is_object() {
-            return Ok(JSValue::FALSE);
+        // Jest never gates `object`: every subset key is checked against it, so
+        // a subset with no own enumerable keys matches anything vacuously.
+        if !Self::is_typeof_object(object) {
+            return Ok(JSValue::from(
+                subset.keys(global_this)?.get_length(global_this)? == 0,
+            ));
         }
         Ok(JSValue::from(object.jest_deep_match(subset, global_this, false)?))
     }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2768,6 +2768,12 @@ impl ExpectMatcherContext {
         JSValue::FALSE
     }
 
+    #[bun_jsc::host_fn(getter)]
+    pub fn get_custom_testers(_this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+        // TODO: populate from expect.addEqualityTesters once supported
+        JSValue::create_empty_array(global_this, 0)
+    }
+
     #[bun_jsc::host_fn(method)]
     pub fn equals(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arguments = callframe.arguments_old::<3>();
@@ -2857,6 +2863,56 @@ impl ExpectMatcherUtils {
         let arguments = arguments.slice();
         let value = if arguments.is_empty() { JSValue::UNDEFINED } else { arguments[0] };
         Ok(Self::print_value_catched(global_this, value, Some("<red>")))
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn diff(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let arguments = callframe.arguments_old::<2>();
+        let args = arguments.slice();
+        let a = if args.is_empty() { JSValue::UNDEFINED } else { args[0] };
+        let b = if args.len() > 1 { args[1] } else { JSValue::UNDEFINED };
+        let formatter = DiffFormatter {
+            received_string: None,
+            expected_string: None,
+            received: Some(b),
+            expected: Some(a),
+            global_this: Some(global_this),
+            not: false,
+        };
+        let buf = format!("{}", formatter);
+        bun_jsc::bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn iterable_equality(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let arguments = callframe.arguments_old::<2>();
+        let args = arguments.slice();
+        let a = if args.is_empty() { JSValue::UNDEFINED } else { args[0] };
+        let b = if args.len() > 1 { args[1] } else { JSValue::UNDEFINED };
+        if !a.is_cell() || !a.js_type().is_object() || a.is_array()
+            || !b.is_cell() || !b.js_type().is_object() || b.is_array()
+            || !a.is_iterable(global_this)? || !b.is_iterable(global_this)?
+        {
+            return Ok(JSValue::UNDEFINED);
+        }
+        Ok(JSValue::from(a.jest_deep_equals(b, global_this)?))
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn subset_equality(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let arguments = callframe.arguments_old::<2>();
+        let args = arguments.slice();
+        let object = if args.is_empty() { JSValue::UNDEFINED } else { args[0] };
+        let subset = if args.len() > 1 { args[1] } else { JSValue::UNDEFINED };
+        if !subset.is_cell() || !subset.js_type().is_object()
+            || subset.is_array() || subset.is_error() || subset.is_date()
+        {
+            return Ok(JSValue::UNDEFINED);
+        }
+        if !object.is_cell() || !object.js_type().is_object() {
+            return Ok(JSValue::FALSE);
+        }
+        Ok(JSValue::from(object.jest_deep_match(subset, global_this, false)?))
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2935,13 +2935,13 @@ impl ExpectMatcherUtils {
         {
             return Ok(JSValue::UNDEFINED);
         }
-        // Jest never gates `object`: each subset key (string or symbol) is
-        // checked against it, and none can match a non-object, so an empty
-        // object stands in for one and both branches share one engine.
+        // Jest never gates `object`: no subset key can match a non-object, so a
+        // stand-in with a null prototype (the engine's key lookup walks the
+        // prototype chain) reproduces that and both branches share one engine.
         let object = if Self::is_typeof_object(object) {
             object
         } else {
-            JSValue::create_empty_object(global_this, 0)
+            JSValue::create_empty_object_with_null_prototype(global_this)
         };
         Ok(JSValue::from(object.jest_deep_match(subset, global_this, false)?))
     }

--- a/src/runtime/test_runner/jest.classes.ts
+++ b/src/runtime/test_runner/jest.classes.ts
@@ -123,6 +123,9 @@ export default [
       expand: {
         getter: "getExpand",
       },
+      customTesters: {
+        getter: "getCustomTesters",
+      },
       equals: {
         fn: "equals",
         length: 3,
@@ -162,6 +165,18 @@ export default [
       matcherHint: {
         fn: "matcherHint",
         length: 1,
+      },
+      diff: {
+        fn: "diff",
+        length: 2,
+      },
+      iterableEquality: {
+        fn: "iterableEquality",
+        length: 2,
+      },
+      subsetEquality: {
+        fn: "subsetEquality",
+        length: 2,
       },
     },
   }),

--- a/src/runtime/test_runner/jest.classes.ts
+++ b/src/runtime/test_runner/jest.classes.ts
@@ -125,6 +125,7 @@ export default [
       },
       customTesters: {
         getter: "getCustomTesters",
+        cache: true,
       },
       equals: {
         fn: "equals",

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -126,12 +126,15 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
         iterEqSetsNe: this.utils.iterableEquality(new Set([1]), new Set([2])),
         iterEqArrays: this.utils.iterableEquality([1], [1]),
         iterEqTypedArrays: this.utils.iterableEquality(new Uint8Array([1]), new Uint8Array([1])),
+        iterEqWeakSets: this.utils.iterableEquality(new WeakSet(), new WeakSet()),
         iterEqNonIter: this.utils.iterableEquality({}, {}),
         subsetEqMatch: this.utils.subsetEquality({ a: 1, b: 2 }, { a: 1 }),
         subsetEqMiss: this.utils.subsetEquality({ a: 1 }, { b: 2 }),
         subsetEqArray: this.utils.subsetEquality({ a: 1 }, [1]),
         subsetEqSet: this.utils.subsetEquality({ a: 1 }, new Set([1])),
         subsetEqMap: this.utils.subsetEquality({ a: 1 }, new Map([[1, 2]])),
+        subsetEqWeakSet: this.utils.subsetEquality({ a: 1 }, new WeakSet()),
+        subsetEqWeakMap: this.utils.subsetEquality({ a: 1 }, new WeakMap()),
         subsetEqPrimitive: this.utils.subsetEquality(1, 1),
       };
       return { pass: true, message: () => "" };
@@ -150,9 +153,11 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
 
   expect(captured.iterEqSets).toBe(true);
   expect(captured.iterEqSetsNe).toBe(false);
-  // Arrays and ArrayBuffer views are out of iterableEquality's domain in jest.
+  // Arrays and ArrayBuffer views are out of iterableEquality's domain in jest,
+  // and so are weak collections (no Symbol.iterator).
   expect(captured.iterEqArrays).toBe(undefined);
   expect(captured.iterEqTypedArrays).toBe(undefined);
+  expect(captured.iterEqWeakSets).toBe(undefined);
   expect(captured.iterEqNonIter).toBe(undefined);
 
   expect(captured.subsetEqMatch).toBe(true);
@@ -161,6 +166,10 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
   expect(captured.subsetEqArray).toBe(undefined);
   expect(captured.subsetEqSet).toBe(undefined);
   expect(captured.subsetEqMap).toBe(undefined);
+  // WeakSet/WeakMap are NOT instanceof Set/Map, so jest keeps them in the
+  // domain; they have no enumerable keys, so the subset match is vacuously true.
+  expect(captured.subsetEqWeakSet).toBe(true);
+  expect(captured.subsetEqWeakMap).toBe(true);
   expect(captured.subsetEqPrimitive).toBe(undefined);
 });
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -151,6 +151,8 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
         subsetEqUndefObjWeakMap: this.utils.subsetEquality(undefined, new WeakMap()),
         subsetEqNullObjNonEmpty: this.utils.subsetEquality(null, { a: 1 }),
         subsetEqNullObjSymbol: this.utils.subsetEquality(null, { [Symbol("s")]: 1 }),
+        subsetEqFnObj: this.utils.subsetEquality(fnWithProp, { a: 2 }),
+        subsetEqFnObjEmpty: this.utils.subsetEquality(fnWithProp, {}),
       };
       return { pass: true, message: () => "" };
     },
@@ -189,12 +191,15 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
   // domain; they have no enumerable keys, so the subset match is vacuously true.
   expect(captured.subsetEqWeakSet).toBe(true);
   expect(captured.subsetEqWeakMap).toBe(true);
-  // jest only gates the subset arg: every subset key (string or symbol) is
-  // checked against `object`, so only an empty subset matches a null object.
+  // jest only gates the subset arg. Its hasPropertyInObject rejects any
+  // receiver that is not typeof "object" (null, primitives, callables), so
+  // against such a receiver only an empty subset matches, whatever its own keys.
   expect(captured.subsetEqNullObjEmpty).toBe(true);
   expect(captured.subsetEqUndefObjWeakMap).toBe(true);
   expect(captured.subsetEqNullObjNonEmpty).toBe(false);
   expect(captured.subsetEqNullObjSymbol).toBe(false);
+  expect(captured.subsetEqFnObj).toBe(false);
+  expect(captured.subsetEqFnObjEmpty).toBe(true);
 });
 
 it("is ok if there is no message specified", () => {

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -151,6 +151,7 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
         subsetEqUndefObjWeakMap: this.utils.subsetEquality(undefined, new WeakMap()),
         subsetEqNullObjNonEmpty: this.utils.subsetEquality(null, { a: 1 }),
         subsetEqNullObjSymbol: this.utils.subsetEquality(null, { [Symbol("s")]: 1 }),
+        subsetEqNullObjProtoKey: this.utils.subsetEquality(null, { constructor: Object }),
         subsetEqFnObj: this.utils.subsetEquality(fnWithProp, { a: 2 }),
         subsetEqFnObjEmpty: this.utils.subsetEquality(fnWithProp, {}),
       };
@@ -198,6 +199,8 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
   expect(captured.subsetEqUndefObjWeakMap).toBe(true);
   expect(captured.subsetEqNullObjNonEmpty).toBe(false);
   expect(captured.subsetEqNullObjSymbol).toBe(false);
+  // Even a subset key that exists on Object.prototype cannot match a null object.
+  expect(captured.subsetEqNullObjProtoKey).toBe(false);
   expect(captured.subsetEqFnObj).toBe(false);
   expect(captured.subsetEqFnObjEmpty).toBe(true);
 });

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -111,6 +111,14 @@ it("exposes matcherUtils in context", () => {
 });
 
 it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with jest semantics", () => {
+  // `typeof` reports these as "function", which puts them outside both testers'
+  // domains in jest even when they are objects that happen to be iterable.
+  const callableIterable = Object.assign(() => {}, {
+    *[Symbol.iterator]() {
+      yield 1;
+    },
+  });
+  const fnWithProp = Object.assign(function f() {}, { a: 2 });
   /** @type {any} */
   let captured;
   expect.extend({
@@ -127,6 +135,7 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
         iterEqArrays: this.utils.iterableEquality([1], [1]),
         iterEqTypedArrays: this.utils.iterableEquality(new Uint8Array([1]), new Uint8Array([1])),
         iterEqWeakSets: this.utils.iterableEquality(new WeakSet(), new WeakSet()),
+        iterEqCallable: this.utils.iterableEquality(callableIterable, callableIterable),
         iterEqNonIter: this.utils.iterableEquality({}, {}),
         subsetEqMatch: this.utils.subsetEquality({ a: 1, b: 2 }, { a: 1 }),
         subsetEqMiss: this.utils.subsetEquality({ a: 1 }, { b: 2 }),
@@ -135,7 +144,12 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
         subsetEqMap: this.utils.subsetEquality({ a: 1 }, new Map([[1, 2]])),
         subsetEqWeakSet: this.utils.subsetEquality({ a: 1 }, new WeakSet()),
         subsetEqWeakMap: this.utils.subsetEquality({ a: 1 }, new WeakMap()),
+        subsetEqFn: this.utils.subsetEquality({ a: 1 }, () => {}),
+        subsetEqFnWithProp: this.utils.subsetEquality({ a: 1 }, fnWithProp),
         subsetEqPrimitive: this.utils.subsetEquality(1, 1),
+        subsetEqNullObjEmpty: this.utils.subsetEquality(null, {}),
+        subsetEqUndefObjWeakMap: this.utils.subsetEquality(undefined, new WeakMap()),
+        subsetEqNullObjNonEmpty: this.utils.subsetEquality(null, { a: 1 }),
       };
       return { pass: true, message: () => "" };
     },
@@ -153,24 +167,32 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
 
   expect(captured.iterEqSets).toBe(true);
   expect(captured.iterEqSetsNe).toBe(false);
-  // Arrays and ArrayBuffer views are out of iterableEquality's domain in jest,
-  // and so are weak collections (no Symbol.iterator).
+  // Arrays, ArrayBuffer views, callables (typeof "function"), and weak
+  // collections (no Symbol.iterator) are out of iterableEquality's domain in jest.
   expect(captured.iterEqArrays).toBe(undefined);
   expect(captured.iterEqTypedArrays).toBe(undefined);
   expect(captured.iterEqWeakSets).toBe(undefined);
+  expect(captured.iterEqCallable).toBe(undefined);
   expect(captured.iterEqNonIter).toBe(undefined);
 
   expect(captured.subsetEqMatch).toBe(true);
   expect(captured.subsetEqMiss).toBe(false);
-  // Only a plain-ish object subset is in subsetEquality's domain in jest.
+  // Only a `typeof "object"` plain-ish subset is in subsetEquality's domain in jest.
   expect(captured.subsetEqArray).toBe(undefined);
   expect(captured.subsetEqSet).toBe(undefined);
   expect(captured.subsetEqMap).toBe(undefined);
+  expect(captured.subsetEqFn).toBe(undefined);
+  expect(captured.subsetEqFnWithProp).toBe(undefined);
+  expect(captured.subsetEqPrimitive).toBe(undefined);
   // WeakSet/WeakMap are NOT instanceof Set/Map, so jest keeps them in the
   // domain; they have no enumerable keys, so the subset match is vacuously true.
   expect(captured.subsetEqWeakSet).toBe(true);
   expect(captured.subsetEqWeakMap).toBe(true);
-  expect(captured.subsetEqPrimitive).toBe(undefined);
+  // jest only gates the subset arg: every subset key is checked against
+  // `object`, so an empty-key subset matches even a null or undefined object.
+  expect(captured.subsetEqNullObjEmpty).toBe(true);
+  expect(captured.subsetEqUndefObjWeakMap).toBe(true);
+  expect(captured.subsetEqNullObjNonEmpty).toBe(false);
 });
 
 it("is ok if there is no message specified", () => {

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -95,14 +95,10 @@ it("is available globally when matcher is variadic", () => {
 it("exposes matcherUtils in context", () => {
   expect.extend({
     _shouldNotError(_actual) {
-      const pass = "equals" in this;
-      //const pass = this.equals(
-      //  this.utils,
-      //  Object.assign(matcherUtils, {
-      //    iterableEquality,
-      //    subsetEquality,
-      //  }),
-      //);
+      const pass =
+        typeof this.equals === "function" &&
+        typeof this.utils.iterableEquality === "function" &&
+        typeof this.utils.subsetEquality === "function";
       const message = pass
         ? () => "expected this.utils to be defined in an extend call"
         : () => "expected this.utils not to be defined in an extend call";
@@ -112,6 +108,50 @@ it("exposes matcherUtils in context", () => {
   });
 
   expect("test")._shouldNotError();
+});
+
+it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with jest semantics", () => {
+  /** @type {any} */
+  let captured;
+  expect.extend({
+    _captureMatcherContext() {
+      captured = {
+        customTesters: this.customTesters,
+        diff: this.utils.diff,
+        iterableEquality: this.utils.iterableEquality,
+        subsetEquality: this.utils.subsetEquality,
+        diffOutput: this.utils.diff({ a: 1 }, { a: 2 }),
+        iterEqSets: this.utils.iterableEquality(new Set([1, 2]), new Set([2, 1])),
+        iterEqSetsNe: this.utils.iterableEquality(new Set([1]), new Set([2])),
+        iterEqArrays: this.utils.iterableEquality([1], [1]),
+        iterEqNonIter: this.utils.iterableEquality({}, {}),
+        subsetEqMatch: this.utils.subsetEquality({ a: 1, b: 2 }, { a: 1 }),
+        subsetEqMiss: this.utils.subsetEquality({ a: 1 }, { b: 2 }),
+        subsetEqArray: this.utils.subsetEquality({ a: 1 }, [1]),
+        subsetEqPrimitive: this.utils.subsetEquality(1, 1),
+      };
+      return { pass: true, message: () => "" };
+    },
+  });
+  expect(null)._captureMatcherContext();
+
+  expect(Array.isArray(captured.customTesters)).toBe(true);
+  expect(typeof captured.diff).toBe("function");
+  expect(typeof captured.iterableEquality).toBe("function");
+  expect(typeof captured.subsetEquality).toBe("function");
+
+  expect(typeof captured.diffOutput).toBe("string");
+  expect(captured.diffOutput.length).toBeGreaterThan(0);
+
+  expect(captured.iterEqSets).toBe(true);
+  expect(captured.iterEqSetsNe).toBe(false);
+  expect(captured.iterEqArrays).toBe(undefined);
+  expect(captured.iterEqNonIter).toBe(undefined);
+
+  expect(captured.subsetEqMatch).toBe(true);
+  expect(captured.subsetEqMiss).toBe(false);
+  expect(captured.subsetEqArray).toBe(undefined);
+  expect(captured.subsetEqPrimitive).toBe(undefined);
 });
 
 it("is ok if there is no message specified", () => {

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -117,6 +117,7 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
     _captureMatcherContext() {
       captured = {
         customTesters: this.customTesters,
+        customTestersStable: this.customTesters === this.customTesters,
         diff: this.utils.diff,
         iterableEquality: this.utils.iterableEquality,
         subsetEquality: this.utils.subsetEquality,
@@ -124,10 +125,13 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
         iterEqSets: this.utils.iterableEquality(new Set([1, 2]), new Set([2, 1])),
         iterEqSetsNe: this.utils.iterableEquality(new Set([1]), new Set([2])),
         iterEqArrays: this.utils.iterableEquality([1], [1]),
+        iterEqTypedArrays: this.utils.iterableEquality(new Uint8Array([1]), new Uint8Array([1])),
         iterEqNonIter: this.utils.iterableEquality({}, {}),
         subsetEqMatch: this.utils.subsetEquality({ a: 1, b: 2 }, { a: 1 }),
         subsetEqMiss: this.utils.subsetEquality({ a: 1 }, { b: 2 }),
         subsetEqArray: this.utils.subsetEquality({ a: 1 }, [1]),
+        subsetEqSet: this.utils.subsetEquality({ a: 1 }, new Set([1])),
+        subsetEqMap: this.utils.subsetEquality({ a: 1 }, new Map([[1, 2]])),
         subsetEqPrimitive: this.utils.subsetEquality(1, 1),
       };
       return { pass: true, message: () => "" };
@@ -136,6 +140,7 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
   expect(null)._captureMatcherContext();
 
   expect(Array.isArray(captured.customTesters)).toBe(true);
+  expect(captured.customTestersStable).toBe(true);
   expect(typeof captured.diff).toBe("function");
   expect(typeof captured.iterableEquality).toBe("function");
   expect(typeof captured.subsetEquality).toBe("function");
@@ -145,12 +150,17 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
 
   expect(captured.iterEqSets).toBe(true);
   expect(captured.iterEqSetsNe).toBe(false);
+  // Arrays and ArrayBuffer views are out of iterableEquality's domain in jest.
   expect(captured.iterEqArrays).toBe(undefined);
+  expect(captured.iterEqTypedArrays).toBe(undefined);
   expect(captured.iterEqNonIter).toBe(undefined);
 
   expect(captured.subsetEqMatch).toBe(true);
   expect(captured.subsetEqMiss).toBe(false);
+  // Only a plain-ish object subset is in subsetEquality's domain in jest.
   expect(captured.subsetEqArray).toBe(undefined);
+  expect(captured.subsetEqSet).toBe(undefined);
+  expect(captured.subsetEqMap).toBe(undefined);
   expect(captured.subsetEqPrimitive).toBe(undefined);
 });
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -420,8 +420,11 @@ describe("async support", () => {
 });
 
 it("should not crash under intensive usage", () => {
+  // GC-churn crash check. 1,000 iterations keeps it well inside the default 5s
+  // per-test timeout on debug+ASAN builds, where each iteration runs about
+  // 100x slower than it does in a release build.
   withoutAggressiveGC(() => {
-    for (let i = 0; i < 10000; ++i) {
+    for (let i = 0; i < 1000; ++i) {
       expect(i)._toBeDivisibleBy(1);
       expect(i).toEqual(expect._toBeDivisibleBy(1));
     }

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -150,6 +150,7 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
         subsetEqNullObjEmpty: this.utils.subsetEquality(null, {}),
         subsetEqUndefObjWeakMap: this.utils.subsetEquality(undefined, new WeakMap()),
         subsetEqNullObjNonEmpty: this.utils.subsetEquality(null, { a: 1 }),
+        subsetEqNullObjSymbol: this.utils.subsetEquality(null, { [Symbol("s")]: 1 }),
       };
       return { pass: true, message: () => "" };
     },
@@ -188,11 +189,12 @@ it("exposes customTesters and utils.diff/iterableEquality/subsetEquality with je
   // domain; they have no enumerable keys, so the subset match is vacuously true.
   expect(captured.subsetEqWeakSet).toBe(true);
   expect(captured.subsetEqWeakMap).toBe(true);
-  // jest only gates the subset arg: every subset key is checked against
-  // `object`, so an empty-key subset matches even a null or undefined object.
+  // jest only gates the subset arg: every subset key (string or symbol) is
+  // checked against `object`, so only an empty subset matches a null object.
   expect(captured.subsetEqNullObjEmpty).toBe(true);
   expect(captured.subsetEqUndefObjWeakMap).toBe(true);
   expect(captured.subsetEqNullObjNonEmpty).toBe(false);
+  expect(captured.subsetEqNullObjSymbol).toBe(false);
 });
 
 it("is ok if there is no message specified", () => {


### PR DESCRIPTION
Custom matchers registered with `expect.extend` receive a matcher context (`this`) that, in Jest, carries `customTesters` and a `this.utils` including `diff`, `iterableEquality`, and `subsetEquality`. Bun left all four `undefined`, so community matcher packages that reach for them (`jest-extended`, `@testing-library/jest-dom`, most published custom matchers) throw or silently degrade under `bun test`.

### Repro

```js
import { expect, test } from "bun:test";
expect.extend({ ctxComplete() {
  const ok = Array.isArray(this.customTesters) && typeof this.utils.diff === "function"
          && typeof this.utils.subsetEquality === "function";
  return { pass: ok, message: () => "customTesters=" + typeof this.customTesters
      + " utils.diff=" + typeof this.utils.diff + " utils.subsetEquality=" + typeof this.utils.subsetEquality };
}});
test("C5 expect.extend context complete", () => { expect(1).ctxComplete(); });
```

Before (bun 1.4.0 and main), the test fails:

```
error: expect(received).ctxComplete()
customTesters=undefined utils.diff=undefined utils.subsetEquality=undefined
```

Jest 30 passes it.

### Cause

`ExpectMatcherContext` and `ExpectMatcherUtils` in `src/runtime/test_runner/jest.classes.ts` never declared these properties, so the generated prototypes simply did not have them. The upstream Jest test in `test/js/bun/test/expect-extend.test.js` that exercised `this.utils.iterableEquality` / `this.utils.subsetEquality` had been neutered (reduced to `"equals" in this`), which is why this never surfaced.

### Fix

- `ExpectMatcherContext.customTesters`: getter returning an empty array. `expect.addEqualityTesters` is not implemented in Bun yet, so there is no registry to read from; Jest returns `[]` in that case too.
- `ExpectMatcherUtils.diff(a, b)`: renders via the existing `DiffFormatter` (the same code path `matcherHint` already uses), and always returns a string. `jest-diff` returns `null` instead of a string for some inputs (same-type primitives, some asymmetric matchers); reproducing that requires its `getType`/`getExpectedType`/per-type comparator tree, so it is out of scope with the rest of the `jest-diff` surface, and the declaration stays `string | null` so Jest-targeted matcher code typechecks.
- `ExpectMatcherUtils.iterableEquality(a, b)`: returns `undefined` when either argument is outside Jest's domain (not a non-callable `typeof "object"` value, an Array, an `ArrayBuffer` view, or not iterable), otherwise defers to Bun's `jestDeepEquals`. That is exact for `Set` and `Map`, which `jestDeepEquals` special-cases, including order insensitivity. For other in-domain iterables (generator objects, classes implementing `Symbol.iterator`) `jestDeepEquals` compares own properties rather than the iteration sequence the way Jest does; that is the comparison Bun's `toEqual` already applies to those values, so it is a pre-existing gap surfaced under a new name and is scoped out here, like the `addEqualityTesters` plumbing below.
- `ExpectMatcherUtils.subsetEquality(object, subset)`: returns `undefined` when `subset` is outside Jest's `isObjectWithKeys` domain (not `typeof "object"`, or an Array, Error, Date, `Set`, or `Map`), otherwise defers to `jestDeepMatch` (the `toMatchObject` implementation). As in Jest, the `object` argument is not gated: a subset with no own enumerable keys matches any `object` vacuously. The builtin exclusions are brand checks on the engine cell type, so real subclasses are classified like their parent, while an object faking a builtin via `Object.create(X.prototype)` is treated as a plain object.
- Restored the neutered assertions in the upstream Jest test and added a test covering the new surface, including the `undefined` returns for out-of-domain inputs.
- Uncommented the corresponding declarations in `packages/bun-types/test.d.ts`.

`this.equals` still ignores a 3rd `customTesters` argument (pre-existing; it needs `addEqualityTesters` plumbing in `Bun__deepEquals`). Since nothing can register a custom tester yet, passing the standard testers to it, as these packages do, is behaviorally a no-op, which is what this PR unblocks.

### Verification

`bun bd test test/js/bun/test/expect-extend.test.js -t "matcherUtils|customTesters"`: the two tests fail without the `src/` change and pass with it, and the whole file passes.

The pre-existing `"should not crash under intensive usage"` GC stress test in this file ran 10,000 custom-matcher plus asymmetric-matcher iterations. On a debug+ASAN build, where each iteration is roughly 100x slower than release, that took about 6s and failed the default 5000ms per-test timeout with and without this change, so a bare `bun bd test` of this file could never pass (CI only passes because the runner grants ASAN lanes a 90s `--timeout`). Following the repo guideline to shrink a slow test's workload rather than raise its timeout, the loop is now 1,000 iterations; the property it guards, no crash from matcher-context and asymmetric-matcher churn followed by `Bun.gc(true)`, is unchanged.

Every `iterableEquality` / `subsetEquality` case the new test asserts was also run through the real functions from `@jest/expect-utils` 30.4.1; Bun returns the identical value for all of them.

The `TypeScript types` and `bun-plugin-svelte` GitHub Actions checks fail identically on the base commit this branch is cut from (8706328b, with none of these changes), so they are pre-existing on main and not introduced here. In the two Buildkite runs of the final revision, the only failing jobs were a macOS shard that never ran a test (artifact download timed out) and Docker-backed SQL integration suites on two other runners; `expect-extend.test.js` passed on every shard of both runs.








