### PR TITLE
bun:sqlite: throw TypeError for async transaction callbacks

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -578,7 +578,10 @@ console.log(`Inserted ${count} cats`);
 The driver will automatically [`begin`](https://www.sqlite.org/lang_transaction.html) a transaction when `insertCats` is called and `commit` it when the wrapped function returns. If an exception is thrown, the transaction will be rolled back. The exception will propagate as usual; it is not caught.
 
 <Note>
-**Async callbacks are not supported.** `BEGIN` and `COMMIT` bracket the synchronous callback, so an `async` callback would escape the transaction at its first `await` and nothing after that point would be atomic. `db.transaction()` throws a `TypeError` if the callback is an async function, and invoking a transaction whose callback returns a `Promise` rolls it back and throws. Do any asynchronous work before starting the transaction.
+  **Async callbacks are not supported.** `BEGIN` and `COMMIT` bracket the synchronous callback, so an `async` callback
+  would escape the transaction at its first `await` and nothing after that point would be atomic. `db.transaction()`
+  throws a `TypeError` if the callback is an async function, and invoking a transaction whose callback returns a
+  `Promise` rolls it back and throws. Do any asynchronous work before starting the transaction.
 </Note>
 
 <Note>

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -578,6 +578,10 @@ console.log(`Inserted ${count} cats`);
 The driver will automatically [`begin`](https://www.sqlite.org/lang_transaction.html) a transaction when `insertCats` is called and `commit` it when the wrapped function returns. If an exception is thrown, the transaction will be rolled back. The exception will propagate as usual; it is not caught.
 
 <Note>
+**Async callbacks are not supported.** `BEGIN` and `COMMIT` bracket the synchronous callback, so an `async` callback would escape the transaction at its first `await` and nothing after that point would be atomic. `db.transaction()` throws a `TypeError` if the callback is an async function, and invoking a transaction whose callback returns a `Promise` rolls it back and throws. Do any asynchronous work before starting the transaction.
+</Note>
+
+<Note>
 **Nested transactions** — Transaction functions can be called from inside other transaction functions. When doing so, the inner transaction becomes a [savepoint](https://www.sqlite.org/lang_savepoint.html).
 
 <Accordion title="View nested transaction example">

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -354,7 +354,14 @@ declare module "bun:sqlite" {
      * the transaction will be rolled back (and the exception will propagate as
      * usual).
      *
-     * @param insideTransaction The callback which runs inside a transaction
+     * The callback must be synchronous: the transaction is committed when the
+     * callback returns, so an `async` callback would escape it at its first
+     * `await`. Passing an async function throws a `TypeError`, as does invoking
+     * the transaction with a callback that returns a `Promise` (after rolling
+     * back anything the callback already ran). Run awaited work before starting
+     * the transaction.
+     *
+     * @param insideTransaction The synchronous callback which runs inside a transaction
      *
      * @example
      * ```ts

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -681,9 +681,11 @@ const wrapTransaction = (fn, db, { begin, commit, rollback, savepoint, release, 
     try {
       before.run();
       const result = fn.$apply(this, args);
-      // Catches non-async callbacks that still return a promise. Throwing here lands
-      // in the catch below, which rolls back everything the callback ran so far.
+      // Catches non-async callbacks that still return a promise; the catch below rolls
+      // back. `result` is never handed to the caller, so mark it handled: nothing else
+      // can attach a rejection handler to it, and an unhandled rejection is fatal.
       if ($isPromise(result) || typeof result?.then === "function") {
+        if ($isPromise(result)) $markPromiseAsHandled(result);
         throw new TypeError(
           "db.transaction() callback cannot return a Promise. Run any awaited work before starting the transaction.",
         );

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -8,6 +8,8 @@ const defineProperties = Object.defineProperties;
 const toStringTag = Symbol.toStringTag;
 const isArray = Array.isArray;
 const isTypedArray = ArrayBuffer.isView;
+const getPrototypeOf = Object.getPrototypeOf;
+const AsyncFunctionPrototype = getPrototypeOf(async function () {});
 
 let internalFieldTuple;
 
@@ -600,6 +602,14 @@ class Database implements SqliteTypes.Database {
   // thank you @JoshuaWise!
   transaction(fn, self) {
     if (typeof fn !== "function") throw new TypeError("Expected first argument to be a function");
+    // SQLite transactions are bound to the synchronous call: an async callback would
+    // COMMIT at its first await, leaving every later statement (and the rollback on
+    // throw) outside the transaction. https://github.com/oven-sh/bun/issues/24662
+    if (getPrototypeOf(fn) === AsyncFunctionPrototype) {
+      throw new TypeError(
+        "db.transaction() callback cannot be an async function. Run any awaited work before starting the transaction.",
+      );
+    }
 
     const db = this;
     const controller = getController(db, self);
@@ -671,6 +681,13 @@ const wrapTransaction = (fn, db, { begin, commit, rollback, savepoint, release, 
     try {
       before.run();
       const result = fn.$apply(this, args);
+      // Catches non-async callbacks that still return a promise. Throwing here lands
+      // in the catch below, which rolls back everything the callback ran so far.
+      if ($isPromise(result) || typeof result?.then === "function") {
+        throw new TypeError(
+          "db.transaction() callback cannot return a Promise. Run any awaited work before starting the transaction.",
+        );
+      }
       after.run();
       return result;
     } catch (ex) {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -844,6 +844,59 @@ it("db.transaction()", () => {
   expect(db.inTransaction).toBe(false);
 });
 
+// An async callback is never transactional: the implicit transaction would end at
+// the first await, so later statements and the rollback would run outside of it.
+// https://github.com/oven-sh/bun/issues/24662
+it("db.transaction() rejects an async callback up front", () => {
+  const db = Database.open(":memory:");
+  const message =
+    "db.transaction() callback cannot be an async function. Run any awaited work before starting the transaction.";
+  expect(() => db.transaction(async () => {})).toThrow(TypeError);
+  expect(() => db.transaction(async () => {})).toThrow(message);
+  expect(() => db.transaction(async function () {})).toThrow(message);
+});
+
+it("db.transaction() rolls back and throws when the callback returns a Promise", () => {
+  const db = Database.open(":memory:");
+  db.exec("CREATE TABLE accounts (id INTEGER PRIMARY KEY, balance INTEGER)");
+  db.exec("INSERT INTO accounts VALUES (1, 100), (2, 0)");
+
+  // Not an async function, so it gets past db.transaction(), but it returns a
+  // Promise: the debit it already ran must be rolled back, not committed.
+  const transfer = db.transaction(amount => {
+    db.exec(`UPDATE accounts SET balance = balance - ${amount} WHERE id = 1`);
+    return Promise.resolve(amount);
+  });
+
+  const message =
+    "db.transaction() callback cannot return a Promise. Run any awaited work before starting the transaction.";
+  expect(() => transfer(60)).toThrow(TypeError);
+  expect(() => transfer(60)).toThrow(message);
+  expect(() => transfer.immediate(60)).toThrow(message);
+  expect(db.inTransaction).toBe(false);
+  expect(db.prepare("SELECT balance FROM accounts ORDER BY id").values()).toEqual([[100], [0]]);
+});
+
+it("db.transaction() rolls a nested Promise-returning callback back to its savepoint", () => {
+  const db = Database.open(":memory:");
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+
+  const inner = db.transaction(() => {
+    db.exec("INSERT INTO t VALUES (2)");
+    return Promise.resolve();
+  });
+  const outer = db.transaction(() => {
+    db.exec("INSERT INTO t VALUES (1)");
+    expect(() => inner()).toThrow(TypeError);
+    // Only the inner savepoint was undone; the outer transaction is still open.
+    expect(db.inTransaction).toBe(true);
+  });
+
+  outer();
+  expect(db.inTransaction).toBe(false);
+  expect(db.prepare("SELECT id FROM t ORDER BY id").values()).toEqual([[1]]);
+});
+
 // this bug was fixed by ensuring FinalObject has no more than 64 properties
 it("inlineCapacity #987", async () => {
   const db = new Database(":memory:");

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -897,6 +897,31 @@ it("db.transaction() rolls a nested Promise-returning callback back to its savep
   expect(db.prepare("SELECT id FROM t ORDER BY id").values()).toEqual([[1]]);
 });
 
+it("db.transaction() marks a discarded rejected Promise as handled", async () => {
+  // The Promise is never handed to the caller, so they cannot attach a rejection
+  // handler to it; left unmarked, its rejection would take down the process.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { Database } from "bun:sqlite";
+const db = new Database(":memory:");
+const tx = db.transaction(() => Promise.reject(new Error("boom")));
+try { tx(); } catch (e) { console.log("caught", e.constructor.name); }`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, unhandledBoom: stderr.includes("boom"), exitCode }).toEqual({
+    stdout: "caught TypeError\n",
+    unhandledBoom: false,
+    exitCode: 0,
+  });
+});
+
 // this bug was fixed by ensuring FinalObject has no more than 64 properties
 it("inlineCapacity #987", async () => {
   const db = new Database(":memory:");


### PR DESCRIPTION
`db.transaction()` silently accepted an async callback and produced a non-atomic "transaction": the implicit transaction committed at the callback's first `await`, so every statement after that point, and the rollback when the callback eventually threw, ran outside any transaction. Partial writes were committed while the caller believed they had been rolled back.

### Repro (Bun 1.4.0)

```ts
import { Database } from "bun:sqlite";
const db = new Database(":memory:");
db.exec("create table accounts(id integer primary key, balance integer)");
db.exec("insert into accounts values (1, 100), (2, 0)");

const transfer = db.transaction(async amt => {
  db.exec(`update accounts set balance = balance - ${amt} where id = 1`); // debit
  await Bun.sleep(5); // <- the implicit transaction ends here
  throw new Error("abort! roll the whole transfer back"); // "rollback" is a no-op
});
try { await transfer(60); } catch {}
console.log(db.prepare("select * from accounts").all());
// expected: [{id:1, balance:100}, {id:2, balance:0}]   nothing committed
// actual:   [{id:1, balance:40},  {id:2, balance:0}]   the debit committed
```

### Cause

`wrapTransaction` in `src/js/bun/sqlite.ts` runs `BEGIN`, calls `fn`, then `COMMIT`, all synchronously. An async `fn` returns a pending `Promise` at its first `await`, so `COMMIT` fires immediately. The rest of the callback, and the rollback when it later throws, runs after the transaction is already gone, and `db.inTransaction` is already `false` by the time the caller catches.

### Fix

Match better-sqlite3, which bun's transaction helper is already ported from and which refuses this for the same reason:

- `db.transaction(fn)` throws a `TypeError` if `fn` is an async function, before anything runs:
  `db.transaction() callback cannot be an async function. Run any awaited work before starting the transaction.`
- Invoking a transaction whose callback returns a `Promise` (a non-async function can still do that) throws a `TypeError`, and the existing `catch` rolls back whatever the callback already ran:
  `db.transaction() callback cannot return a Promise. Run any awaited work before starting the transaction.`

The second check lives in `wrapTransaction`, so `.deferred`/`.immediate`/`.exclusive` and the nested savepoint path are covered by the same code.

The discarded `Promise` is marked as handled (`$markPromiseAsHandled`) before the throw: it is never handed back to the caller, so nothing can attach a rejection handler to it, and a later rejection would otherwise be reported as unhandled even though the caller caught the `TypeError`.

Actually supporting async transactions is a separate feature with its own hazards (unrelated statements on the same connection would interleave into the open transaction across an `await`); that is tracked in #24662 and not attempted here. This PR only turns the silent data corruption into a loud error.

Also documents the constraint in `packages/bun-types/sqlite.d.ts` and `docs/runtime/sqlite.mdx`.

### Verification

The four new tests in `test/js/bun/sqlite/sqlite.test.js` fail on Bun 1.4.0 and pass with this change. The rest of the `bun:sqlite` suite is unaffected.

