### PR TITLE
bun:test: compare Error cause in toThrow(errorInstance)

### DIFF
--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -18,16 +18,10 @@ fn get_truthy_cause(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<
     Ok(value.get(global, "cause")?.filter(|v| v.to_boolean()))
 }
 
-fn get_object_message(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<JSValue>> {
-    if !value.is_object() {
-        return Ok(None);
-    }
-    value.fast_get(global, bun_jsc::BuiltinName::Message)
-}
-
 // Jest 30 compares `cause` in addition to `message` for `toThrow(errorInstance)`.
-// Error-like causes (objects with a `message`) are compared by message, then the
-// walk descends into their own causes; anything else is compared by deep equality.
+// Error-instance causes are compared by message and the walk descends into their
+// own causes (Jest's serializer sees only own properties, so it cannot tell
+// `Error` subclasses apart either). Non-Error causes are compared structurally.
 fn error_causes_equal(
     expected: JSValue,
     received: JSValue,
@@ -45,16 +39,18 @@ fn error_causes_equal(
             (None, None) => return Ok(true),
             (Some(_), None) | (None, Some(_)) => return Ok(false),
             (Some(ec), Some(rc)) => {
-                if let (Some(em), Some(rm)) = (
-                    get_object_message(ec, global)?,
-                    get_object_message(rc, global)?,
-                ) {
-                    if !em.is_same_value(rm, global)? {
-                        return Ok(false);
+                if ec.is_error() && rc.is_error() {
+                    if let (Some(em), Some(rm)) = (
+                        ec.fast_get(global, bun_jsc::BuiltinName::Message)?,
+                        rc.fast_get(global, bun_jsc::BuiltinName::Message)?,
+                    ) {
+                        if !em.is_same_value(rm, global)? {
+                            return Ok(false);
+                        }
+                        expected = ec;
+                        received = rc;
+                        continue;
                     }
-                    expected = ec;
-                    received = rc;
-                    continue;
                 }
                 return ec.jest_deep_equals(rc, global);
             }

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -11,11 +11,12 @@ use super::expect_any_js;
 use super::get_signature;
 
 // Jest treats falsy causes (`undefined`, `null`, `0`, `false`, `""`) as absent.
+// `Error` installs `cause` as an own data property; inherited values are not consulted.
 fn get_truthy_cause(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<JSValue>> {
     if !value.is_object() {
         return Ok(None);
     }
-    Ok(value.get(global, "cause")?.filter(|v| v.to_boolean()))
+    Ok(value.get_own_truthy(global, "cause")?.filter(|v| v.to_boolean()))
 }
 
 // Jest 30 compares `cause` in addition to `message` for `toThrow(errorInstance)`.

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -10,6 +10,59 @@ use super::ExpectAny;
 use super::expect_any_js;
 use super::get_signature;
 
+// Jest treats falsy causes (`undefined`, `null`, `0`, `false`, `""`) as absent.
+fn get_truthy_cause(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<JSValue>> {
+    if !value.is_object() {
+        return Ok(None);
+    }
+    Ok(value.get(global, "cause")?.filter(|v| v.to_boolean()))
+}
+
+fn get_object_message(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<JSValue>> {
+    if !value.is_object() {
+        return Ok(None);
+    }
+    value.fast_get(global, bun_jsc::BuiltinName::Message)
+}
+
+// Jest 30 compares `cause` in addition to `message` for `toThrow(errorInstance)`.
+// Error-like causes (objects with a `message`) are compared by message, then the
+// walk descends into their own causes; anything else is compared by deep equality.
+fn error_causes_equal(
+    expected: JSValue,
+    received: JSValue,
+    global: &JSGlobalObject,
+) -> JsResult<bool> {
+    let mut expected = expected;
+    let mut received = received;
+    // Bounded so a self-referential cause chain (`err.cause === err`) terminates.
+    // A chain that matches at every level through the cap is treated as equal,
+    // which is what Jest's cycle-detecting serializer produces for that shape.
+    for _ in 0..1000 {
+        let expected_cause = get_truthy_cause(expected, global)?;
+        let received_cause = get_truthy_cause(received, global)?;
+        match (expected_cause, received_cause) {
+            (None, None) => return Ok(true),
+            (Some(_), None) | (None, Some(_)) => return Ok(false),
+            (Some(ec), Some(rc)) => {
+                if let (Some(em), Some(rm)) = (
+                    get_object_message(ec, global)?,
+                    get_object_message(rc, global)?,
+                ) {
+                    if !em.is_same_value(rm, global)? {
+                        return Ok(false);
+                    }
+                    expected = ec;
+                    received = rc;
+                    continue;
+                }
+                return ec.jest_deep_equals(rc, global);
+            }
+        }
+    }
+    Ok(true)
+}
+
 pub(crate) fn to_throw(
     this: &Expect,
     global: &JSGlobalObject,
@@ -181,6 +234,24 @@ pub(crate) fn to_throw(
                 return Ok(JSValue::UNDEFINED);
             }
 
+            // A matching message with a mismatched cause is not a match.
+            if !error_causes_equal(expected_value, result, global)? {
+                return Ok(JSValue::UNDEFINED);
+            }
+
+            if let Some(expected_cause) = get_truthy_cause(expected_value, global)? {
+                let mut formatter2 = super::make_formatter(global);
+                return this.throw(
+                    global,
+                    signature,
+                    format_args!(
+                        "\n\nExpected message: not <green>{}<r>\nExpected cause: not <green>{}<r>\n",
+                        expected_message.to_fmt(&mut formatter),
+                        expected_cause.to_fmt(&mut formatter2),
+                    ),
+                );
+            }
+
             return this.throw(
                 global,
                 signature,
@@ -341,10 +412,14 @@ pub(crate) fn to_throw(
         if let Some(expected_message) = expected_value.fast_get(global, bun_jsc::BuiltinName::Message)? {
             let signature: &'static str = get_signature("toThrow", "<green>expected<r>", false);
 
-            if let Some(received_message) = received_message_opt {
-                if received_message.is_same_value(expected_message, global)? {
-                    return Ok(JSValue::UNDEFINED);
-                }
+            let message_matches = if let Some(received_message) = received_message_opt {
+                received_message.is_same_value(expected_message, global)?
+            } else {
+                false
+            };
+
+            if message_matches && error_causes_equal(expected_value, result, global)? {
+                return Ok(JSValue::UNDEFINED);
             }
 
             // error: message from received error does not match expected error message.
@@ -352,6 +427,25 @@ pub(crate) fn to_throw(
             let mut formatter2 = super::make_formatter(global);
 
             if let Some(received_message) = received_message_opt {
+                if message_matches {
+                    let expected_cause =
+                        get_truthy_cause(expected_value, global)?.unwrap_or(JSValue::UNDEFINED);
+                    let received_cause =
+                        get_truthy_cause(result, global)?.unwrap_or(JSValue::UNDEFINED);
+                    let mut formatter3 = super::make_formatter(global);
+                    let mut formatter4 = super::make_formatter(global);
+                    return this.throw(
+                        global,
+                        signature,
+                        format_args!(
+                            "\n\nExpected message: <green>{}<r>\nReceived message: <red>{}<r>\n\nExpected cause: <green>{}<r>\nReceived cause: <red>{}<r>\n",
+                            expected_message.to_fmt(&mut formatter),
+                            received_message.to_fmt(&mut formatter2),
+                            expected_cause.to_fmt(&mut formatter3),
+                            received_cause.to_fmt(&mut formatter4),
+                        ),
+                    );
+                }
                 return this.throw(
                     global,
                     signature,

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -19,10 +19,9 @@ fn get_truthy_cause(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<
     Ok(value.get_own_truthy(global, "cause")?.filter(|v| v.to_boolean()))
 }
 
-// Jest 30 compares `cause` in addition to `message` for `toThrow(errorInstance)`.
-// Error-instance causes are compared by message and the walk descends into their
-// own causes (Jest's serializer sees only own properties, so it cannot tell
-// `Error` subclasses apart either). Non-Error causes are compared structurally.
+// Jest 30 compares `cause` alongside `message` for `toThrow(errorInstance)`.
+// Error-instance causes use the message walk (not deep equality) because Jest's
+// own-property serializer cannot tell `Error` subclasses apart either.
 fn error_causes_equal(
     expected: JSValue,
     received: JSValue,

--- a/test/js/bun/test/expect/toThrow.test.ts
+++ b/test/js/bun/test/expect/toThrow.test.ts
@@ -7,10 +7,27 @@ describe("toThrow compares Error cause", () => {
     throw err;
   };
 
+  // Runs `fn`, asserts that it threw, and checks the failure message for each
+  // `snippet` so an unrelated exception cannot satisfy a negative case.
+  const expectAssertionFailure = (fn: () => void, ...snippets: string[]) => {
+    let caught: Error | undefined;
+    try {
+      fn();
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    for (const snippet of snippets) {
+      expect(caught!.message).toContain(snippet);
+    }
+  };
+
   test("same message, different primitive cause fails", () => {
-    expect(() => {
-      expect(thrower(new Error("m", { cause: "a" }))).toThrow(new Error("m", { cause: "b" }));
-    }).toThrow();
+    expectAssertionFailure(
+      () => expect(thrower(new Error("m", { cause: "a" }))).toThrow(new Error("m", { cause: "b" })),
+      "Expected cause:",
+      "Received cause:",
+    );
   });
 
   test("same message, same primitive cause passes", () => {
@@ -18,9 +35,12 @@ describe("toThrow compares Error cause", () => {
   });
 
   test("same message, different Error cause fails", () => {
-    expect(() => {
-      expect(thrower(new Error("m", { cause: new Error("a") }))).toThrow(new Error("m", { cause: new Error("b") }));
-    }).toThrow();
+    expectAssertionFailure(
+      () =>
+        expect(thrower(new Error("m", { cause: new Error("a") }))).toThrow(new Error("m", { cause: new Error("b") })),
+      "Expected cause:",
+      "Received cause:",
+    );
   });
 
   test("same message, same Error cause passes", () => {
@@ -28,18 +48,24 @@ describe("toThrow compares Error cause", () => {
   });
 
   test("received has truthy cause but expected has none fails", () => {
-    expect(() => {
-      expect(thrower(new Error("m", { cause: new Error("a") }))).toThrow(new Error("m"));
-    }).toThrow();
-    expect(() => {
-      expect(thrower(new Error("m", { cause: "x" }))).toThrow(new Error("m"));
-    }).toThrow();
+    expectAssertionFailure(
+      () => expect(thrower(new Error("m", { cause: new Error("a") }))).toThrow(new Error("m")),
+      "Expected cause:",
+      "Received cause:",
+    );
+    expectAssertionFailure(
+      () => expect(thrower(new Error("m", { cause: "x" }))).toThrow(new Error("m")),
+      "Expected cause:",
+      "Received cause:",
+    );
   });
 
   test("received has no cause but expected has truthy cause fails", () => {
-    expect(() => {
-      expect(thrower(new Error("m"))).toThrow(new Error("m", { cause: new Error("a") }));
-    }).toThrow();
+    expectAssertionFailure(
+      () => expect(thrower(new Error("m"))).toThrow(new Error("m", { cause: new Error("a") })),
+      "Expected cause:",
+      "Received cause:",
+    );
   });
 
   // Jest gates `cause` comparison on truthiness, so these are all no-cause.
@@ -49,11 +75,14 @@ describe("toThrow compares Error cause", () => {
   });
 
   test("nested causes differing at depth 2 fail", () => {
-    expect(() => {
-      expect(thrower(new Error("m", { cause: new Error("a", { cause: new Error("x") }) }))).toThrow(
-        new Error("m", { cause: new Error("a", { cause: new Error("y") }) }),
-      );
-    }).toThrow();
+    expectAssertionFailure(
+      () =>
+        expect(thrower(new Error("m", { cause: new Error("a", { cause: new Error("x") }) }))).toThrow(
+          new Error("m", { cause: new Error("a", { cause: new Error("y") }) }),
+        ),
+      "Expected cause:",
+      "Received cause:",
+    );
   });
 
   test("nested causes matching at all depths pass", () => {
@@ -70,9 +99,11 @@ describe("toThrow compares Error cause", () => {
 
   test("object causes compare structurally", () => {
     expect(thrower(new Error("m", { cause: { x: 1 } }))).toThrow(new Error("m", { cause: { x: 1 } }));
-    expect(() => {
-      expect(thrower(new Error("m", { cause: { x: 1 } }))).toThrow(new Error("m", { cause: { x: 2 } }));
-    }).toThrow();
+    expectAssertionFailure(
+      () => expect(thrower(new Error("m", { cause: { x: 1 } }))).toThrow(new Error("m", { cause: { x: 2 } })),
+      "Expected cause:",
+      "Received cause:",
+    );
   });
 
   // A plain object with a `message` is not an Error instance, so it is compared
@@ -81,25 +112,34 @@ describe("toThrow compares Error cause", () => {
     expect(thrower(new Error("m", { cause: { message: "x", code: 1 } }))).toThrow(
       new Error("m", { cause: { message: "x", code: 1 } }),
     );
-    expect(() => {
-      expect(thrower(new Error("m", { cause: { message: "x", code: 1 } }))).toThrow(
-        new Error("m", { cause: { message: "x", code: 2 } }),
-      );
-    }).toThrow();
+    expectAssertionFailure(
+      () =>
+        expect(thrower(new Error("m", { cause: { message: "x", code: 1 } }))).toThrow(
+          new Error("m", { cause: { message: "x", code: 2 } }),
+        ),
+      "Expected cause:",
+      "Received cause:",
+    );
   });
 
   test(".not inverts the cause check", () => {
     expect(thrower(new Error("m", { cause: "a" }))).not.toThrow(new Error("m", { cause: "b" }));
-    expect(() => {
-      expect(thrower(new Error("m", { cause: "a" }))).not.toThrow(new Error("m", { cause: "a" }));
-    }).toThrow();
+    expectAssertionFailure(
+      () => expect(thrower(new Error("m", { cause: "a" }))).not.toThrow(new Error("m", { cause: "a" })),
+      "Expected message: not",
+      "Expected cause: not",
+    );
     expect(thrower(new Error("m", { cause: new Error("a") }))).not.toThrow(new Error("m"));
   });
 
   test("a different message still fails regardless of cause", () => {
-    expect(() => {
-      expect(thrower(new Error("m1", { cause: "a" }))).toThrow(new Error("m2", { cause: "a" }));
-    }).toThrow();
+    expectAssertionFailure(
+      () => expect(thrower(new Error("m1", { cause: "a" }))).toThrow(new Error("m2", { cause: "a" })),
+      "Expected message:",
+      "Received message:",
+      "m2",
+      "m1",
+    );
   });
 
   test("no cause on either side still matches by message only", () => {
@@ -108,19 +148,13 @@ describe("toThrow compares Error cause", () => {
   });
 
   test("cause mismatch reports both causes", () => {
-    let caught: Error | undefined;
-    try {
-      expect(() => {
-        throw new Error("m", { cause: "received-cause" });
-      }).toThrow(new Error("m", { cause: "expected-cause" }));
-    } catch (e) {
-      caught = e as Error;
-    }
-    expect(caught).toBeDefined();
-    expect(caught!.message).toContain("Expected cause:");
-    expect(caught!.message).toContain("Received cause:");
-    expect(caught!.message).toContain("expected-cause");
-    expect(caught!.message).toContain("received-cause");
+    expectAssertionFailure(
+      () => expect(thrower(new Error("m", { cause: "received-cause" }))).toThrow(new Error("m", { cause: "expected-cause" })),
+      "Expected cause:",
+      "Received cause:",
+      "expected-cause",
+      "received-cause",
+    );
   });
 
   test("circular causes do not hang", () => {
@@ -134,13 +168,15 @@ describe("toThrow compares Error cause", () => {
   });
 
   test("rejects.toThrow compares cause", async () => {
-    let caught: unknown;
+    let caught: Error | undefined;
     try {
       await expect(Promise.reject(new Error("m", { cause: "a" }))).rejects.toThrow(new Error("m", { cause: "b" }));
     } catch (e) {
-      caught = e;
+      caught = e as Error;
     }
     expect(caught).toBeDefined();
+    expect(caught!.message).toContain("Expected cause:");
+    expect(caught!.message).toContain("Received cause:");
     await expect(Promise.reject(new Error("m", { cause: "a" }))).rejects.toThrow(new Error("m", { cause: "a" }));
   });
 });

--- a/test/js/bun/test/expect/toThrow.test.ts
+++ b/test/js/bun/test/expect/toThrow.test.ts
@@ -63,13 +63,28 @@ describe("toThrow compares Error cause", () => {
   });
 
   test("error subclass causes compare by message", () => {
+    class Wrapped extends Error {}
     expect(thrower(new Error("m", { cause: new TypeError("x") }))).toThrow(new Error("m", { cause: new Error("x") }));
+    expect(thrower(new Error("m", { cause: new Wrapped("x") }))).toThrow(new Error("m", { cause: new Error("x") }));
   });
 
   test("object causes compare structurally", () => {
     expect(thrower(new Error("m", { cause: { x: 1 } }))).toThrow(new Error("m", { cause: { x: 1 } }));
     expect(() => {
       expect(thrower(new Error("m", { cause: { x: 1 } }))).toThrow(new Error("m", { cause: { x: 2 } }));
+    }).toThrow();
+  });
+
+  // A plain object with a `message` is not an Error instance, so it is compared
+  // structurally and every differing property is a mismatch, as in Jest 30.
+  test("non-Error causes with a message still compare all properties", () => {
+    expect(thrower(new Error("m", { cause: { message: "x", code: 1 } }))).toThrow(
+      new Error("m", { cause: { message: "x", code: 1 } }),
+    );
+    expect(() => {
+      expect(thrower(new Error("m", { cause: { message: "x", code: 1 } }))).toThrow(
+        new Error("m", { cause: { message: "x", code: 2 } }),
+      );
     }).toThrow();
   });
 

--- a/test/js/bun/test/expect/toThrow.test.ts
+++ b/test/js/bun/test/expect/toThrow.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+
+// Jest 30 compares `cause` recursively in addition to `message` when the
+// expected value passed to `toThrow` is an error object.
+describe("toThrow compares Error cause", () => {
+  const thrower = (err: unknown) => () => {
+    throw err;
+  };
+
+  test("same message, different primitive cause fails", () => {
+    expect(() => {
+      expect(thrower(new Error("m", { cause: "a" }))).toThrow(new Error("m", { cause: "b" }));
+    }).toThrow();
+  });
+
+  test("same message, same primitive cause passes", () => {
+    expect(thrower(new Error("m", { cause: "a" }))).toThrow(new Error("m", { cause: "a" }));
+  });
+
+  test("same message, different Error cause fails", () => {
+    expect(() => {
+      expect(thrower(new Error("m", { cause: new Error("a") }))).toThrow(new Error("m", { cause: new Error("b") }));
+    }).toThrow();
+  });
+
+  test("same message, same Error cause passes", () => {
+    expect(thrower(new Error("m", { cause: new Error("a") }))).toThrow(new Error("m", { cause: new Error("a") }));
+  });
+
+  test("received has truthy cause but expected has none fails", () => {
+    expect(() => {
+      expect(thrower(new Error("m", { cause: new Error("a") }))).toThrow(new Error("m"));
+    }).toThrow();
+    expect(() => {
+      expect(thrower(new Error("m", { cause: "x" }))).toThrow(new Error("m"));
+    }).toThrow();
+  });
+
+  test("received has no cause but expected has truthy cause fails", () => {
+    expect(() => {
+      expect(thrower(new Error("m"))).toThrow(new Error("m", { cause: new Error("a") }));
+    }).toThrow();
+  });
+
+  // Jest gates `cause` comparison on truthiness, so these are all no-cause.
+  test.each([undefined, null, 0, false, ""])("falsy cause %p is treated as absent", falsy => {
+    expect(thrower(new Error("m", { cause: falsy }))).toThrow(new Error("m"));
+    expect(thrower(new Error("m"))).toThrow(new Error("m", { cause: falsy }));
+  });
+
+  test("nested causes differing at depth 2 fail", () => {
+    expect(() => {
+      expect(thrower(new Error("m", { cause: new Error("a", { cause: new Error("x") }) }))).toThrow(
+        new Error("m", { cause: new Error("a", { cause: new Error("y") }) }),
+      );
+    }).toThrow();
+  });
+
+  test("nested causes matching at all depths pass", () => {
+    expect(thrower(new Error("m", { cause: new Error("a", { cause: new Error("x") }) }))).toThrow(
+      new Error("m", { cause: new Error("a", { cause: new Error("x") }) }),
+    );
+  });
+
+  test("error subclass causes compare by message", () => {
+    expect(thrower(new Error("m", { cause: new TypeError("x") }))).toThrow(new Error("m", { cause: new Error("x") }));
+  });
+
+  test("object causes compare structurally", () => {
+    expect(thrower(new Error("m", { cause: { x: 1 } }))).toThrow(new Error("m", { cause: { x: 1 } }));
+    expect(() => {
+      expect(thrower(new Error("m", { cause: { x: 1 } }))).toThrow(new Error("m", { cause: { x: 2 } }));
+    }).toThrow();
+  });
+
+  test(".not inverts the cause check", () => {
+    expect(thrower(new Error("m", { cause: "a" }))).not.toThrow(new Error("m", { cause: "b" }));
+    expect(() => {
+      expect(thrower(new Error("m", { cause: "a" }))).not.toThrow(new Error("m", { cause: "a" }));
+    }).toThrow();
+    expect(thrower(new Error("m", { cause: new Error("a") }))).not.toThrow(new Error("m"));
+  });
+
+  test("a different message still fails regardless of cause", () => {
+    expect(() => {
+      expect(thrower(new Error("m1", { cause: "a" }))).toThrow(new Error("m2", { cause: "a" }));
+    }).toThrow();
+  });
+
+  test("no cause on either side still matches by message only", () => {
+    expect(thrower(new Error("m"))).toThrow(new Error("m"));
+    expect(thrower(new Error("m"))).not.toThrow(new Error("other"));
+  });
+
+  test("cause mismatch reports both causes", () => {
+    let caught: Error | undefined;
+    try {
+      expect(() => {
+        throw new Error("m", { cause: "received-cause" });
+      }).toThrow(new Error("m", { cause: "expected-cause" }));
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain("Expected cause:");
+    expect(caught!.message).toContain("Received cause:");
+    expect(caught!.message).toContain("expected-cause");
+    expect(caught!.message).toContain("received-cause");
+  });
+
+  test("circular causes do not hang", () => {
+    const a: Error = new Error("m");
+    a.cause = a;
+    const b: Error = new Error("m");
+    b.cause = b;
+    expect(() => {
+      throw a;
+    }).toThrow(b);
+  });
+
+  test("rejects.toThrow compares cause", async () => {
+    let caught: unknown;
+    try {
+      await expect(Promise.reject(new Error("m", { cause: "a" }))).rejects.toThrow(new Error("m", { cause: "b" }));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    await expect(Promise.reject(new Error("m", { cause: "a" }))).rejects.toThrow(new Error("m", { cause: "a" }));
+  });
+});

--- a/test/js/bun/test/expect/toThrow.test.ts
+++ b/test/js/bun/test/expect/toThrow.test.ts
@@ -149,7 +149,10 @@ describe("toThrow compares Error cause", () => {
 
   test("cause mismatch reports both causes", () => {
     expectAssertionFailure(
-      () => expect(thrower(new Error("m", { cause: "received-cause" }))).toThrow(new Error("m", { cause: "expected-cause" })),
+      () =>
+        expect(thrower(new Error("m", { cause: "received-cause" }))).toThrow(
+          new Error("m", { cause: "expected-cause" }),
+        ),
       "Expected cause:",
       "Received cause:",
       "expected-cause",


### PR DESCRIPTION
### Problem

`expect(fn).toThrow(errorInstance)` only compared `message`, so a thrown error with the wrong `cause` still passed:

```ts
test("toThrow(errorInstance) ignores cause", () => {
  expect(() => {
    throw new Error("m", { cause: "a" });
  }).toThrow(new Error("m", { cause: "b" }));
});
```

Observed with `bun test` (1.4.0 and main): **pass**. Jest 30 fails it. Jest 30 added recursive `cause` comparison to `toThrow(error)` (`toThrowExpectedObject` in `expect/src/toThrowMatchers.ts`), and `cause` is how wrapped/re-thrown errors carry the real failure, so suites migrating to bun silently lose that check.

### Fix

`src/runtime/test_runner/expect/toThrow.rs` now compares `cause` once the messages match. Semantics derived from running the cases against `expect@30.4.1`:

- Falsy causes (`undefined`, `null`, `0`, `false`, `""`) are treated as absent, matching Jest's `if (error.cause)` truthiness gate.
- If exactly one side has a truthy cause, no match.
- If both do: error-like causes (objects with a `message`) are compared by message and the walk descends into their own causes; anything else falls back to deep equality.
- The walk is iterative with a bound so a self-referential cause chain (`err.cause === err`) terminates and compares equal, which matches Jest's cycle-detecting serializer for that shape.

The `.not` branch gets the same rule, and a cause mismatch now reports `Expected cause:` / `Received cause:` in the failure message.

### Tests

`test/js/bun/test/expect/toThrow.test.ts` covers primitive / Error / nested / object causes, the one-sided cases, the falsy-cause matrix, `.not`, circular causes, `.rejects.toThrow`, and the failure-message contents. Without the `src/` change, 9 of the 21 tests fail; with it, all 21 pass. The existing `toThrow` tests in `expect.test.js` and the four `toThrow(new Error(...))` call sites elsewhere in the suite (zlib, fetch, napi, headers) are unaffected since none of them involve a truthy `cause`.
