### PR TITLE
S3: derive the error code from the HTTP status when the error response has no body

### DIFF
--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -10,7 +10,7 @@ use bun_http::{AsyncHTTP, HTTPClientResult, Headers, Signals};
 use bun_io::KeepAlive;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_s3_signing::credentials::SignResult;
-use bun_s3_signing::error::S3Error;
+use bun_s3_signing::error::{S3Error, get_error_code_and_message_for_status};
 use bun_threading::Mutex;
 
 bun_core::declare_scope!(S3, hidden);
@@ -107,8 +107,7 @@ impl S3HttpDownloadStreamingTask {
         let chunk: MutableString = 'brk: {
             if failed {
                 if !has_more {
-                    let mut _has_body_code = false;
-                    let mut _has_body_message = false;
+                    let mut has_error_code = false;
 
                     let mut code: &[u8] = b"UnknownError";
                     let mut message: &[u8] = b"an unexpected error has occurred";
@@ -116,7 +115,7 @@ impl S3HttpDownloadStreamingTask {
                         // SAFETY: request_error != 0 checked above; value originated from @intFromError.
                         let req_err = Error::from_raw(state.request_error());
                         code = req_err.name().as_bytes();
-                        _has_body_code = true;
+                        has_error_code = true;
                     } else {
                         let bytes = self.reported_response_buffer.list.as_slice();
                         if !bytes.is_empty() {
@@ -128,7 +127,7 @@ impl S3HttpDownloadStreamingTask {
                                     strings::index_of(&bytes[value_start..], b"</Code>")
                                 {
                                     code = &bytes[value_start..value_start + end];
-                                    _has_body_code = true;
+                                    has_error_code = true;
                                 }
                             }
                             if let Some(start) = strings::index_of(bytes, b"<Message>") {
@@ -137,9 +136,20 @@ impl S3HttpDownloadStreamingTask {
                                     strings::index_of(&bytes[value_start..], b"</Message>")
                                 {
                                     message = &bytes[value_start..value_start + end];
-                                    _has_body_message = true;
                                 }
                             }
+                        }
+                    }
+
+                    // No <Code> in the body: derive the S3 error code from the
+                    // HTTP status (body-less error responses have no XML error
+                    // document, e.g. a failed HEAD).
+                    if !has_error_code {
+                        if let Some(status_err) =
+                            get_error_code_and_message_for_status(state.status_code())
+                        {
+                            code = status_err.code;
+                            message = status_err.message;
                         }
                     }
 

--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -107,16 +107,22 @@ impl S3HttpDownloadStreamingTask {
         let chunk: MutableString = 'brk: {
             if failed {
                 if !has_more {
-                    let mut has_error_code = false;
-
                     let mut code: &[u8] = b"UnknownError";
                     let mut message: &[u8] = b"an unexpected error has occurred";
                     if state.request_error() != 0 {
                         // SAFETY: request_error != 0 checked above; value originated from @intFromError.
                         let req_err = Error::from_raw(state.request_error());
                         code = req_err.name().as_bytes();
-                        has_error_code = true;
                     } else {
+                        // Seed code/message from the HTTP status (a body-less
+                        // error response carries no XML error document). The
+                        // body, when present, wins below.
+                        if let Some(status_err) =
+                            get_error_code_and_message_for_status(state.status_code())
+                        {
+                            code = status_err.code;
+                            message = status_err.message;
+                        }
                         let bytes = self.reported_response_buffer.list.as_slice();
                         if !bytes.is_empty() {
                             message = bytes;
@@ -127,7 +133,6 @@ impl S3HttpDownloadStreamingTask {
                                     strings::index_of(&bytes[value_start..], b"</Code>")
                                 {
                                     code = &bytes[value_start..value_start + end];
-                                    has_error_code = true;
                                 }
                             }
                             if let Some(start) = strings::index_of(bytes, b"<Message>") {
@@ -138,18 +143,6 @@ impl S3HttpDownloadStreamingTask {
                                     message = &bytes[value_start..value_start + end];
                                 }
                             }
-                        }
-                    }
-
-                    // No <Code> in the body: derive the S3 error code from the
-                    // HTTP status (body-less error responses have no XML error
-                    // document, e.g. a failed HEAD).
-                    if !has_error_code {
-                        if let Some(status_err) =
-                            get_error_code_and_message_for_status(state.status_code())
-                        {
-                            code = status_err.code;
-                            message = status_err.message;
                         }
                     }
 

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -245,10 +245,8 @@ impl S3HttpSimpleTask {
     fn error_with_body(&self, error_type: ErrorType) -> JsTerminatedResult<()> {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
-        let mut has_error_code = false;
         if let Some(err) = self.result.fail {
             code = err.name().as_bytes();
-            has_error_code = true;
         } else {
             // HEAD responses never carry an XML error document (HTTP forbids a
             // body on HEAD), so seed code/message from the status. The body,
@@ -259,7 +257,6 @@ impl S3HttpSimpleTask {
                 {
                     code = status_err.code;
                     message = status_err.message;
-                    has_error_code = true;
                 }
             }
             if let Some(body) = &self.result.body {
@@ -271,7 +268,6 @@ impl S3HttpSimpleTask {
                         if let Some(end) = strings::index_of(bytes, b"</Code>") {
                             if end >= value_start {
                                 code = &bytes[value_start..end];
-                                has_error_code = true;
                             }
                         }
                     }
@@ -288,10 +284,6 @@ impl S3HttpSimpleTask {
         }
 
         if error_type == ErrorType::NotFound {
-            if !has_error_code {
-                code = b"NoSuchKey";
-                message = b"The specified key does not exist.";
-            }
             self.callback
                 .not_found(code, message, self.callback_context)?;
         } else {

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -14,7 +14,9 @@ use bun_jsc::virtual_machine::VirtualMachine;
 use bun_picohttp as picohttp;
 use bun_s3_signing::acl::ACL;
 use bun_s3_signing::credentials::{S3Credentials, SignOptions, SignResult};
-use bun_s3_signing::error::{S3Error, get_sign_error_code_and_message};
+use bun_s3_signing::error::{
+    S3Error, get_error_code_and_message_for_status, get_sign_error_code_and_message,
+};
 use bun_s3_signing::storage_class::StorageClass;
 use bun_threading::thread_pool;
 use bun_url::URL;
@@ -271,6 +273,21 @@ impl S3HttpSimpleTask {
             }
         }
 
+        // HEAD responses never carry an XML error document (HTTP forbids a
+        // body on HEAD), so the status code is the only error signal S3 gives
+        // us. Map it to the canonical S3 error code when the body had none.
+        if !has_error_code {
+            if let Some(metadata) = &self.result.metadata {
+                if let Some(status_err) =
+                    get_error_code_and_message_for_status(metadata.response.status_code)
+                {
+                    code = status_err.code;
+                    message = status_err.message;
+                    has_error_code = true;
+                }
+            }
+        }
+
         if error_type == ErrorType::NotFound {
             if !has_error_code {
                 code = b"NoSuchKey";
@@ -287,9 +304,11 @@ impl S3HttpSimpleTask {
     fn fail_if_contains_error(&mut self, status: u32) -> JsTerminatedResult<bool> {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
+        let mut has_error_code = false;
 
         if let Some(err) = self.result.fail {
             code = err.name().as_bytes();
+            has_error_code = true;
         } else if let Some(body) = &self.result.body {
             let bytes = body.list.as_slice();
             let mut has_error = false;
@@ -302,6 +321,7 @@ impl S3HttpSimpleTask {
                         if let Some(end) = strings::index_of(bytes, b"</Code>") {
                             if end >= value_start {
                                 code = &bytes[value_start..end];
+                                has_error_code = true;
                             }
                         }
                     }
@@ -320,6 +340,14 @@ impl S3HttpSimpleTask {
             }
         } else if status == 200 || status == 206 {
             return Ok(false);
+        }
+        // No <Code> in the body: derive the S3 error code from the HTTP status
+        // (a body-less error response has no XML error document to parse).
+        if !has_error_code {
+            if let Some(status_err) = get_error_code_and_message_for_status(status) {
+                code = status_err.code;
+                message = status_err.message;
+            }
         }
         self.callback.fail(code, message, self.callback_context)?;
         Ok(true)

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -249,34 +249,10 @@ impl S3HttpSimpleTask {
         if let Some(err) = self.result.fail {
             code = err.name().as_bytes();
             has_error_code = true;
-        } else if let Some(body) = &self.result.body {
-            let bytes = body.list.as_slice();
-            if !bytes.is_empty() {
-                message = bytes;
-                if let Some(start) = strings::index_of(bytes, b"<Code>") {
-                    let value_start = start + b"<Code>".len();
-                    if let Some(end) = strings::index_of(bytes, b"</Code>") {
-                        if end >= value_start {
-                            code = &bytes[value_start..end];
-                            has_error_code = true;
-                        }
-                    }
-                }
-                if let Some(start) = strings::index_of(bytes, b"<Message>") {
-                    let value_start = start + b"<Message>".len();
-                    if let Some(end) = strings::index_of(bytes, b"</Message>") {
-                        if end >= value_start {
-                            message = &bytes[value_start..end];
-                        }
-                    }
-                }
-            }
-        }
-
-        // HEAD responses never carry an XML error document (HTTP forbids a
-        // body on HEAD), so the status code is the only error signal S3 gives
-        // us. Map it to the canonical S3 error code when the body had none.
-        if !has_error_code {
+        } else {
+            // HEAD responses never carry an XML error document (HTTP forbids a
+            // body on HEAD), so seed code/message from the status. The body,
+            // when present, wins below: it is the server's own diagnostic.
             if let Some(metadata) = &self.result.metadata {
                 if let Some(status_err) =
                     get_error_code_and_message_for_status(metadata.response.status_code)
@@ -284,6 +260,29 @@ impl S3HttpSimpleTask {
                     code = status_err.code;
                     message = status_err.message;
                     has_error_code = true;
+                }
+            }
+            if let Some(body) = &self.result.body {
+                let bytes = body.list.as_slice();
+                if !bytes.is_empty() {
+                    message = bytes;
+                    if let Some(start) = strings::index_of(bytes, b"<Code>") {
+                        let value_start = start + b"<Code>".len();
+                        if let Some(end) = strings::index_of(bytes, b"</Code>") {
+                            if end >= value_start {
+                                code = &bytes[value_start..end];
+                                has_error_code = true;
+                            }
+                        }
+                    }
+                    if let Some(start) = strings::index_of(bytes, b"<Message>") {
+                        let value_start = start + b"<Message>".len();
+                        if let Some(end) = strings::index_of(bytes, b"</Message>") {
+                            if end >= value_start {
+                                message = &bytes[value_start..end];
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -304,49 +303,47 @@ impl S3HttpSimpleTask {
     fn fail_if_contains_error(&mut self, status: u32) -> JsTerminatedResult<bool> {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
-        let mut has_error_code = false;
 
         if let Some(err) = self.result.fail {
             code = err.name().as_bytes();
-            has_error_code = true;
-        } else if let Some(body) = &self.result.body {
-            let bytes = body.list.as_slice();
-            let mut has_error = false;
-            if !bytes.is_empty() {
-                message = bytes;
-                if strings::index_of(bytes, b"<Error>").is_some() {
-                    has_error = true;
-                    if let Some(start) = strings::index_of(bytes, b"<Code>") {
-                        let value_start = start + b"<Code>".len();
-                        if let Some(end) = strings::index_of(bytes, b"</Code>") {
-                            if end >= value_start {
-                                code = &bytes[value_start..end];
-                                has_error_code = true;
+        } else {
+            // Seed code/message from the HTTP status (a body-less error
+            // response carries no XML error document to parse). The body,
+            // when present, wins below: it is the server's own diagnostic.
+            if let Some(status_err) = get_error_code_and_message_for_status(status) {
+                code = status_err.code;
+                message = status_err.message;
+            }
+            if let Some(body) = &self.result.body {
+                let bytes = body.list.as_slice();
+                let mut has_error = false;
+                if !bytes.is_empty() {
+                    message = bytes;
+                    if strings::index_of(bytes, b"<Error>").is_some() {
+                        has_error = true;
+                        if let Some(start) = strings::index_of(bytes, b"<Code>") {
+                            let value_start = start + b"<Code>".len();
+                            if let Some(end) = strings::index_of(bytes, b"</Code>") {
+                                if end >= value_start {
+                                    code = &bytes[value_start..end];
+                                }
                             }
                         }
-                    }
-                    if let Some(start) = strings::index_of(bytes, b"<Message>") {
-                        let value_start = start + b"<Message>".len();
-                        if let Some(end) = strings::index_of(bytes, b"</Message>") {
-                            if end >= value_start {
-                                message = &bytes[value_start..end];
+                        if let Some(start) = strings::index_of(bytes, b"<Message>") {
+                            let value_start = start + b"<Message>".len();
+                            if let Some(end) = strings::index_of(bytes, b"</Message>") {
+                                if end >= value_start {
+                                    message = &bytes[value_start..end];
+                                }
                             }
                         }
                     }
                 }
-            }
-            if (!has_error && status == 200) || status == 206 {
+                if (!has_error && status == 200) || status == 206 {
+                    return Ok(false);
+                }
+            } else if status == 200 || status == 206 {
                 return Ok(false);
-            }
-        } else if status == 200 || status == 206 {
-            return Ok(false);
-        }
-        // No <Code> in the body: derive the S3 error code from the HTTP status
-        // (a body-less error response has no XML error document to parse).
-        if !has_error_code {
-            if let Some(status_err) = get_error_code_and_message_for_status(status) {
-                code = status_err.code;
-                message = status_err.message;
             }
         }
         self.callback.fail(code, message, self.callback_context)?;

--- a/src/s3_signing/error.rs
+++ b/src/s3_signing/error.rs
@@ -46,9 +46,9 @@ pub fn get_sign_error_code_and_message(e: Error) -> ErrorCodeAndMessage {
     }
 }
 
-/// Canonical S3 error code + message for an HTTP status. Used when the
-/// response carries no XML error document (HEAD responses never have a body),
-/// covering the statuses with exactly one canonical code in the S3 error table.
+/// S3's most representative error code + message for an HTTP status. Used
+/// when the response carries no XML error document to take the real code
+/// from (HEAD responses never have a body). `None` when there is no clear one.
 pub fn get_error_code_and_message_for_status(status: u32) -> Option<ErrorCodeAndMessage> {
     // https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
     Some(match status {

--- a/src/s3_signing/error.rs
+++ b/src/s3_signing/error.rs
@@ -46,6 +46,52 @@ pub fn get_sign_error_code_and_message(e: Error) -> ErrorCodeAndMessage {
     }
 }
 
+/// Canonical S3 error code + message for an HTTP status. Used when the
+/// response carries no XML error document (HEAD responses never have a body),
+/// covering the statuses with exactly one canonical code in the S3 error table.
+pub fn get_error_code_and_message_for_status(status: u32) -> Option<ErrorCodeAndMessage> {
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+    Some(match status {
+        403 => ErrorCodeAndMessage {
+            code: b"AccessDenied",
+            message: b"Access Denied",
+        },
+        404 => ErrorCodeAndMessage {
+            code: b"NoSuchKey",
+            message: b"The specified key does not exist.",
+        },
+        405 => ErrorCodeAndMessage {
+            code: b"MethodNotAllowed",
+            message: b"The specified method is not allowed against this resource.",
+        },
+        411 => ErrorCodeAndMessage {
+            code: b"MissingContentLength",
+            message: b"You must provide the Content-Length HTTP header.",
+        },
+        412 => ErrorCodeAndMessage {
+            code: b"PreconditionFailed",
+            message: b"At least one of the preconditions you specified did not hold.",
+        },
+        416 => ErrorCodeAndMessage {
+            code: b"InvalidRange",
+            message: b"The requested range is not satisfiable.",
+        },
+        500 => ErrorCodeAndMessage {
+            code: b"InternalError",
+            message: b"We encountered an internal error. Please try again.",
+        },
+        501 => ErrorCodeAndMessage {
+            code: b"NotImplemented",
+            message: b"A header you provided implies functionality that is not implemented.",
+        },
+        503 => ErrorCodeAndMessage {
+            code: b"ServiceUnavailable",
+            message: b"Service is unable to handle request.",
+        },
+        _ => return None,
+    })
+}
+
 // `getJSSignError` / `throwSignError` live as extension-trait methods in the
 // `*_jsc` crate (see PORTING.md §Idiom map).
 

--- a/test/js/bun/s3/s3-error-codes-fixture.ts
+++ b/test/js/bun/s3/s3-error-codes-fixture.ts
@@ -41,7 +41,7 @@ async function errorOf(promise: Promise<unknown>): Promise<unknown> {
 const results: Record<string, unknown> = {};
 
 // A failed HEAD response has no body (HTTP forbids a body on HEAD), so both the
-// code and the message can only come from the status. 418 has no canonical code.
+// code and the message can only come from the status. 418 has no S3 mapping.
 for (const status of [403, 404, 405, 411, 412, 416, 418, 500, 501, 503]) {
   using server = serve(() => new Response(null, { status }));
   results[`stat ${status}`] = await errorOf(S3Client.file("key", options(server.url.href)).stat());

--- a/test/js/bun/s3/s3-error-codes-fixture.ts
+++ b/test/js/bun/s3/s3-error-codes-fixture.ts
@@ -1,0 +1,70 @@
+// Spawned by s3-error-codes.test.ts. Runs every S3 operation against local
+// mock servers that answer with error statuses, and prints the observed error
+// codes as a single JSON object on stdout.
+import { S3Client, type S3Options } from "bun";
+
+const baseOptions = {
+  accessKeyId: "test",
+  secretAccessKey: "test",
+  region: "eu-west-3",
+  bucket: "my_bucket",
+} satisfies Omit<S3Options, "endpoint">;
+
+function options(endpoint: string): S3Options {
+  return { ...baseOptions, endpoint };
+}
+
+function serve(fetch: (req: Request) => Response) {
+  return Bun.serve({ port: 0, fetch });
+}
+
+/** Resolve to the rejection's `code`, or a sentinel if the promise resolved. */
+async function codeOf(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+    return "<resolved>";
+  } catch (error: any) {
+    return error?.code;
+  }
+}
+
+const results: Record<string, unknown> = {};
+
+// A failed HEAD response has no body (HTTP forbids a body on HEAD), so the S3
+// error code can only come from the HTTP status. 418 has no canonical S3 code.
+for (const status of [403, 404, 405, 411, 412, 416, 418, 500, 501, 503]) {
+  using server = serve(() => new Response(null, { status }));
+  results[`stat ${status}`] = await codeOf(S3Client.file("key", options(server.url.href)).stat());
+}
+
+// Every operation routes its errors through the same status fallback.
+{
+  using server = serve(() => new Response(null, { status: 403 }));
+  const opts = options(server.url.href);
+  results["exists 403"] = await codeOf(S3Client.file("key", opts).exists());
+  results["text 403"] = await codeOf(S3Client.file("key", opts).text());
+  results["stream 403"] = await codeOf(new Response(S3Client.file("key", opts).stream()).text());
+  results["write 403"] = await codeOf(S3Client.file("key", opts).write("data"));
+  results["delete 403"] = await codeOf(S3Client.file("key", opts).delete());
+  results["list 403"] = await codeOf(new S3Client(opts).list());
+}
+
+// An XML <Code> in the response body takes precedence over the status mapping.
+{
+  using server = serve(
+    () =>
+      new Response(
+        `<?xml version="1.0" encoding="UTF-8"?><Error><Code>SignatureDoesNotMatch</Code><Message>bad signature</Message></Error>`,
+        { status: 403 },
+      ),
+  );
+  results["text 403 with xml body"] = await codeOf(S3Client.file("key", options(server.url.href)).text());
+}
+
+// exists() must keep distinguishing "not there" (false) from "not allowed" (reject).
+{
+  using server = serve(() => new Response(null, { status: 404 }));
+  results["exists 404"] = await S3Client.file("key", options(server.url.href)).exists();
+}
+
+console.log(JSON.stringify(results));

--- a/test/js/bun/s3/s3-error-codes-fixture.ts
+++ b/test/js/bun/s3/s3-error-codes-fixture.ts
@@ -1,6 +1,6 @@
 // Spawned by s3-error-codes.test.ts. Runs every S3 operation against local
 // mock servers that answer with error statuses, and prints the observed error
-// codes as a single JSON object on stdout.
+// codes/messages as a single JSON object on stdout.
 import { S3Client, type S3Options } from "bun";
 
 const baseOptions = {
@@ -28,13 +28,23 @@ async function codeOf(promise: Promise<unknown>): Promise<unknown> {
   }
 }
 
+/** Resolve to the rejection's `{ code, message }`, or a sentinel if it resolved. */
+async function errorOf(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+    return "<resolved>";
+  } catch (error: any) {
+    return { code: error?.code, message: error?.message };
+  }
+}
+
 const results: Record<string, unknown> = {};
 
-// A failed HEAD response has no body (HTTP forbids a body on HEAD), so the S3
-// error code can only come from the HTTP status. 418 has no canonical S3 code.
+// A failed HEAD response has no body (HTTP forbids a body on HEAD), so both the
+// code and the message can only come from the status. 418 has no canonical code.
 for (const status of [403, 404, 405, 411, 412, 416, 418, 500, 501, 503]) {
   using server = serve(() => new Response(null, { status }));
-  results[`stat ${status}`] = await codeOf(S3Client.file("key", options(server.url.href)).stat());
+  results[`stat ${status}`] = await errorOf(S3Client.file("key", options(server.url.href)).stat());
 }
 
 // Every operation routes its errors through the same status fallback.
@@ -58,7 +68,16 @@ for (const status of [403, 404, 405, 411, 412, 416, 418, 500, 501, 503]) {
         { status: 403 },
       ),
   );
-  results["text 403 with xml body"] = await codeOf(S3Client.file("key", options(server.url.href)).text());
+  results["text 403 with xml body"] = await errorOf(S3Client.file("key", options(server.url.href)).text());
+}
+
+// A non-XML error body (e.g. a load balancer's plain-text error page) is the
+// only diagnostic the server sent: keep it as the message, and take only the
+// code from the status.
+{
+  const body = "upstream connect error or disconnect/reset before headers";
+  using server = serve(() => new Response(body, { status: 503 }));
+  results["text 503 with text body"] = await errorOf(S3Client.file("key", options(server.url.href)).text());
 }
 
 // exists() must keep distinguishing "not there" (false) from "not allowed" (reject).

--- a/test/js/bun/s3/s3-error-codes.test.ts
+++ b/test/js/bun/s3/s3-error-codes.test.ts
@@ -28,18 +28,25 @@ test("S3 error code is derived from the HTTP status when the error response has 
   // If the fixture crashed before printing, surface its output in the diff.
   const results = stdout.trim() ? JSON.parse(stdout) : { stdout, stderr, exitCode };
   expect(results).toEqual({
-    // Statuses with exactly one canonical S3 error code map to it.
-    "stat 403": "AccessDenied",
-    "stat 404": "NoSuchKey",
-    "stat 405": "MethodNotAllowed",
-    "stat 411": "MissingContentLength",
-    "stat 412": "PreconditionFailed",
-    "stat 416": "InvalidRange",
-    "stat 500": "InternalError",
-    "stat 501": "NotImplemented",
-    "stat 503": "ServiceUnavailable",
+    // A body-less response with a status that has exactly one canonical S3
+    // error code maps to that code and to S3's canonical message for it.
+    "stat 403": { code: "AccessDenied", message: "Access Denied" },
+    "stat 404": { code: "NoSuchKey", message: "The specified key does not exist." },
+    "stat 405": { code: "MethodNotAllowed", message: "The specified method is not allowed against this resource." },
+    "stat 411": { code: "MissingContentLength", message: "You must provide the Content-Length HTTP header." },
+    "stat 412": {
+      code: "PreconditionFailed",
+      message: "At least one of the preconditions you specified did not hold.",
+    },
+    "stat 416": { code: "InvalidRange", message: "The requested range is not satisfiable." },
+    "stat 500": { code: "InternalError", message: "We encountered an internal error. Please try again." },
+    "stat 501": {
+      code: "NotImplemented",
+      message: "A header you provided implies functionality that is not implemented.",
+    },
+    "stat 503": { code: "ServiceUnavailable", message: "Service is unable to handle request." },
     // A status with no single canonical S3 code keeps the generic code.
-    "stat 418": "UnknownError",
+    "stat 418": { code: "UnknownError", message: "an unexpected error has occurred" },
     // Every operation goes through the same status fallback.
     "exists 403": "AccessDenied",
     "text 403": "AccessDenied",
@@ -47,8 +54,14 @@ test("S3 error code is derived from the HTTP status when the error response has 
     "write 403": "AccessDenied",
     "delete 403": "AccessDenied",
     "list 403": "AccessDenied",
-    // An XML <Code> in the body still takes precedence over the status.
-    "text 403 with xml body": "SignatureDoesNotMatch",
+    // An XML <Code>/<Message> in the body still takes precedence over the status.
+    "text 403 with xml body": { code: "SignatureDoesNotMatch", message: "bad signature" },
+    // A non-XML error body is the server's own diagnostic: it stays as the
+    // message, and only the code comes from the status.
+    "text 503 with text body": {
+      code: "ServiceUnavailable",
+      message: "upstream connect error or disconnect/reset before headers",
+    },
     // A body-less 404 HEAD still reports "does not exist" instead of rejecting.
     "exists 404": false,
   });

--- a/test/js/bun/s3/s3-error-codes.test.ts
+++ b/test/js/bun/s3/s3-error-codes.test.ts
@@ -28,8 +28,8 @@ test("S3 error code is derived from the HTTP status when the error response has 
   // If the fixture crashed before printing, surface its output in the diff.
   const results = stdout.trim() ? JSON.parse(stdout) : { stdout, stderr, exitCode };
   expect(results).toEqual({
-    // A body-less response with a status that has exactly one canonical S3
-    // error code maps to that code and to S3's canonical message for it.
+    // A body-less error response has no XML <Code> to parse, so both the code
+    // and the message come from S3's most representative pair for the status.
     "stat 403": { code: "AccessDenied", message: "Access Denied" },
     "stat 404": { code: "NoSuchKey", message: "The specified key does not exist." },
     "stat 405": { code: "MethodNotAllowed", message: "The specified method is not allowed against this resource." },
@@ -45,7 +45,7 @@ test("S3 error code is derived from the HTTP status when the error response has 
       message: "A header you provided implies functionality that is not implemented.",
     },
     "stat 503": { code: "ServiceUnavailable", message: "Service is unable to handle request." },
-    // A status with no single canonical S3 code keeps the generic code.
+    // A status with no representative S3 code keeps the generic fallback.
     "stat 418": { code: "UnknownError", message: "an unexpected error has occurred" },
     // Every operation goes through the same status fallback.
     "exists 403": "AccessDenied",

--- a/test/js/bun/s3/s3-error-codes.test.ts
+++ b/test/js/bun/s3/s3-error-codes.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// S3 cannot include an XML error document in a HEAD response (HTTP forbids a
+// body on HEAD), so the error code for a failed stat()/exists() has to come
+// from the HTTP status. It previously always collapsed into "UnknownError".
+// The status -> code table follows
+// https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+test("S3 error code is derived from the HTTP status when the error response has no body", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "s3-error-codes-fixture.ts")],
+    // The fixture talks to its own local mock servers. Strip the proxy env so
+    // an egress proxy on the host cannot intercept those requests.
+    env: {
+      ...bunEnv,
+      HTTP_PROXY: undefined,
+      HTTPS_PROXY: undefined,
+      http_proxy: undefined,
+      https_proxy: undefined,
+      ALL_PROXY: undefined,
+      all_proxy: undefined,
+    },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // If the fixture crashed before printing, surface its output in the diff.
+  const results = stdout.trim() ? JSON.parse(stdout) : { stdout, stderr, exitCode };
+  expect(results).toEqual({
+    // Statuses with exactly one canonical S3 error code map to it.
+    "stat 403": "AccessDenied",
+    "stat 404": "NoSuchKey",
+    "stat 405": "MethodNotAllowed",
+    "stat 411": "MissingContentLength",
+    "stat 412": "PreconditionFailed",
+    "stat 416": "InvalidRange",
+    "stat 500": "InternalError",
+    "stat 501": "NotImplemented",
+    "stat 503": "ServiceUnavailable",
+    // A status with no single canonical S3 code keeps the generic code.
+    "stat 418": "UnknownError",
+    // Every operation goes through the same status fallback.
+    "exists 403": "AccessDenied",
+    "text 403": "AccessDenied",
+    "stream 403": "AccessDenied",
+    "write 403": "AccessDenied",
+    "delete 403": "AccessDenied",
+    "list 403": "AccessDenied",
+    // An XML <Code> in the body still takes precedence over the status.
+    "text 403 with xml body": "SignatureDoesNotMatch",
+    // A body-less 404 HEAD still reports "does not exist" instead of rejecting.
+    "exists 404": false,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem

`stat()` / `exists()` / `size()` on an `S3File` report every non-404 failure as:

```js
S3Error { name: "S3Error", code: "UnknownError", message: "an unexpected error has occurred" }
```

S3 cannot put an XML error document in a `HEAD` response (HTTP forbids a body on `HEAD`), and the error-code derivation only looked at the response body's `<Code>` element. With no body there is nothing to parse, so 403, 503, and everything else collapse into the same `UnknownError`, which makes "does this key exist / am I authorized / is this transient?" branching impossible. The same happens for GET/PUT/DELETE/LIST errors whose response has no XML body, for example a 5xx from a load balancer in front of the bucket.

```js
// a body-less 403, exactly what real S3 returns for HEAD on a forbidden object
using server = Bun.serve({ port: 0, fetch: () => new Response(null, { status: 403 }) });
await S3Client.file("k", { accessKeyId: "a", secretAccessKey: "b", bucket: "c", endpoint: server.url.href }).stat();
// before: S3Error { code: "UnknownError", message: "an unexpected error has occurred" }
// after:  S3Error { code: "AccessDenied", message: "Access Denied" }
```

### Fix

`get_error_code_and_message_for_status` in `src/s3_signing/error.rs` maps each HTTP status to S3's most representative error code and message for it, taken from the [S3 error table](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html):

| status | 403 | 404 | 405 | 411 | 412 | 416 | 500 | 501 | 503 |
|---|---|---|---|---|---|---|---|---|---|
| code | `AccessDenied` | `NoSuchKey` | `MethodNotAllowed` | `MissingContentLength` | `PreconditionFailed` | `InvalidRange` | `InternalError` | `NotImplemented` | `ServiceUnavailable` |

The table is used as a seed before the body parsing in the three places that build an `S3Error` from an HTTP response, so anything the body does provide (its raw text, a `<Message>`, a `<Code>`) still takes precedence. In particular a non-XML error body (a load balancer's plain-text error page, an nginx/Envoy 5xx page) stays as the error's `message`, because it is the only diagnostic the server sent; only the `code` falls back to the status in that case.

- `simple_request.rs` `error_with_body`: stat, exists, delete, upload, buffered download, listObjects
- `simple_request.rs` `fail_if_contains_error`: multipart complete and upload-part
- `download_stream.rs` `report_progress`: `.stream()`

Statuses with no clear representative S3 code (400, 409, 429, 502, ...) keep the existing `UnknownError` fallback so nothing gets misreported; the existing `s3-insecure.test.ts` (a 400 with a non-XML body) still sees `UnknownError`.

The 404 arm was already handled for stat/delete/list/download through the `NotFound` routing. The table's 404 entry supplies the identical `NoSuchKey` / `"The specified key does not exist."`, so that path is unchanged, and the now-redundant hard-coded `NoSuchKey` fallback inside the `NotFound` branch is deleted. `exists()` still resolves to `false` on a body-less 404 instead of rejecting.

Not included here: attaching the numeric HTTP status as a property on the error object (the AWS SDK exposes it as `$metadata.httpStatusCode`). That is new API surface on `S3Error` and a larger change, so it is better done separately if wanted.

### Test

`test/js/bun/s3/s3-error-codes.test.ts` spawns a fixture that runs the whole matrix against local mock servers and asserts all 19 outcomes with a single `toEqual`. The fixture runs in a child process with the proxy env stripped so an egress proxy on the CI host cannot intercept the mock. On bun 1.4.0 without the fix, 16 of the 19 cases come back wrong (14 operations report `UnknownError`, and the body-less HEAD cases also lose the canonical message); the cases that already behaved correctly (body-less 404, unmapped 418, XML body precedence, and `exists()` on 404) are asserted unchanged, as is the non-XML body text staying as the `message`.

<details>
<summary>test diff on bun 1.4.0 without the fix</summary>

```
-   "delete 403": "AccessDenied",
-   "exists 403": "AccessDenied",
+   "delete 403": "UnknownError",
+   "exists 403": "UnknownError",
    "exists 404": false,
-   "list 403": "AccessDenied",
+   "list 403": "UnknownError",
    "stat 403": {
-     "code": "AccessDenied",
-     "message": "Access Denied",
+     "code": "UnknownError",
+     "message": "an unexpected error has occurred",
    },
    "stat 404": {
      "code": "NoSuchKey",
      "message": "The specified key does not exist.",
    },
    "stat 405": {
-     "code": "MethodNotAllowed",
-     "message": "The specified method is not allowed against this resource.",
+     "code": "UnknownError",
+     "message": "an unexpected error has occurred",
    },
    "stat 411": {
-     "code": "MissingContentLength",
-     "message": "You must provide the Content-Length HTTP header.",
+     "code": "UnknownError",
+     "message": "an unexpected error has occurred",
    },
    "stat 412": {
-     "code": "PreconditionFailed",
-     "message": "At least one of the preconditions you specified did not hold.",
+     "code": "UnknownError",
+     "message": "an unexpected error has occurred",
    },
    "stat 416": {
-     "code": "InvalidRange",
-     "message": "The requested range is not satisfiable.",
+     "code": "UnknownError",
+     "message": "an unexpected error has occurred",
    },
    "stat 418": {
      "code": "UnknownError",
      "message": "an unexpected error has occurred",
    },
    "stat 500": {
-     "code": "InternalError",
-     "message": "We encountered an internal error. Please try again.",
+     "code": "UnknownError",
+     "message": "an unexpected error has occurred",
    },
    "stat 501": {
-     "code": "NotImplemented",
-     "message": "A header you provided implies functionality that is not implemented.",
+     "code": "UnknownError",
+     "message": "an unexpected error has occurred",
    },
    "stat 503": {
-     "code": "ServiceUnavailable",
-     "message": "Service is unable to handle request.",
+     "code": "UnknownError",
+     "message": "an unexpected error has occurred",
    },
-   "stream 403": "AccessDenied",
-   "text 403": "AccessDenied",
+   "stream 403": "UnknownError",
+   "text 403": "UnknownError",
    "text 403 with xml body": {
      "code": "SignatureDoesNotMatch",
      "message": "bad signature",
    },
    "text 503 with text body": {
-     "code": "ServiceUnavailable",
+     "code": "UnknownError",
      "message": "upstream connect error or disconnect/reset before headers",
    },
-   "write 403": "AccessDenied",
+   "write 403": "UnknownError",
  }
```
</details>

The rest of `test/js/bun/s3/` still passes (77 pass, 0 fail), and `cargo clippy -p bun_s3_signing -p bun_runtime` is clean.

### Related

#19461 reports the same symptom: `s3file.write()` behind Coolify's reverse proxy fails with exactly `an unexpected error has occurred` and nothing else to go on, which is the `UnknownError` default this PR replaces whenever the error response has no XML body and the status has a canonical S3 code. The report never logs `error.code`, so it could also be a connection-level failure where the error already carried a descriptive code and this PR changes nothing, so I am not auto-closing it.


