### PR TITLE
napi: return napi_pending_exception from napi_throw_*error when an exception is already pending

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1049,8 +1049,14 @@ static JSC::ErrorInstance* createErrorWithCode(JSC::VM& vm, JSC::JSGlobalObject*
 // used to implement napi_throw_*_error
 static napi_status throwErrorWithCStrings(napi_env env, const char* code_utf8, const char* msg_utf8, JSC::ErrorType type)
 {
+    NAPI_CHECK_ENV_NOT_IN_GC(env);
     auto* globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
+    if (env->isFinishingFinalizers()) {
+        return napi_set_last_error(env, env->napiModule().nm_version >= 10 ? napi_cannot_run_js : napi_pending_exception);
+    }
 
     if (!msg_utf8) {
         return napi_set_last_error(env, napi_invalid_arg);
@@ -1060,6 +1066,7 @@ static napi_status throwErrorWithCStrings(napi_env env, const char* code_utf8, c
     WTF::String message = WTF::String::fromUTF8(msg_utf8);
 
     JSC::ErrorInstance* error = createErrorWithCode(vm, globalObject, code, message, type);
+    RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));
     env->scheduleException(error);
     return napi_set_last_error(env, napi_ok);
 }
@@ -1344,11 +1351,11 @@ extern "C" napi_status napi_get_and_clear_last_exception(napi_env env,
         *result = toNapi(JSValue(scope.exception()->value()), globalObject);
     } else if (std::optional<JSValue> pending = env->pendingException()) {
         *result = toNapi(pending.value(), globalObject);
-        env->clearPendingException();
     } else {
         *result = toNapi(JSC::jsUndefined(), globalObject);
     }
     (void)scope.tryClearException();
+    env->clearPendingException();
 
     return napi_set_last_error(env, napi_ok);
 }

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -390,6 +390,111 @@ static napi_value test_napi_throw_with_nullptr(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+static const char *throw_pending_status_name(napi_status s) {
+  switch (s) {
+  case napi_ok:
+    return "ok";
+  case napi_pending_exception:
+    return "pending_exception";
+  case napi_invalid_arg:
+    return "invalid_arg";
+  default:
+    return "other";
+  }
+}
+
+static void throw_pending_report(napi_env env, const char *label,
+                                  napi_status s1, napi_status s2) {
+  bool pending_before = false;
+  napi_is_exception_pending(env, &pending_before);
+
+  napi_value exc = nullptr;
+  napi_status get_status = napi_get_and_clear_last_exception(env, &exc);
+
+  bool pending_after = false;
+  napi_is_exception_pending(env, &pending_after);
+
+  char kept[64] = {0};
+  if (exc != nullptr) {
+    napi_value msg = nullptr;
+    if (napi_get_named_property(env, exc, "message", &msg) == napi_ok) {
+      size_t got = 0;
+      napi_get_value_string_utf8(env, msg, kept, sizeof(kept), &got);
+    }
+  }
+
+  printf("%s: throw1=%s throw2=%s pending=%d get_and_clear=%s "
+         "pending_after_clear=%d kept=%s\n",
+         label, throw_pending_status_name(s1), throw_pending_status_name(s2),
+         (int)pending_before, throw_pending_status_name(get_status),
+         (int)pending_after, kept);
+}
+
+// napi_throw_error (and the _type_error / _range_error / syntax_error
+// variants) called while an exception is already pending must return
+// napi_pending_exception and preserve the first exception. Returning napi_ok
+// and overwriting the pending exception would make the original (root cause)
+// error disappear when cleanup code throws on top of it.
+static napi_value
+test_napi_throw_with_pending_exception(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+#ifndef _WIN32
+  BlockingStdoutScope stdout_scope;
+#endif
+
+  using ThrowFunction =
+      napi_status (*)(napi_env, const char *code, const char *msg);
+  struct {
+    const char *name;
+    ThrowFunction fn;
+  } variants[] = {
+      {"napi_throw_error", napi_throw_error},
+      {"napi_throw_type_error", napi_throw_type_error},
+      {"napi_throw_range_error", napi_throw_range_error},
+      {"node_api_throw_syntax_error", node_api_throw_syntax_error},
+  };
+
+  for (const auto &variant : variants) {
+    napi_status s1 = variant.fn(env, "E1", "first");
+    napi_status s2 = variant.fn(env, "E2", "second");
+    throw_pending_report(env, variant.name, s1, s2);
+  }
+
+  // napi_throw with an already-created error value
+  {
+    napi_value err1 = nullptr, err2 = nullptr;
+    napi_value msg1 = nullptr, msg2 = nullptr;
+    napi_create_string_utf8(env, "first", NAPI_AUTO_LENGTH, &msg1);
+    napi_create_string_utf8(env, "second", NAPI_AUTO_LENGTH, &msg2);
+    napi_create_error(env, nullptr, msg1, &err1);
+    napi_create_error(env, nullptr, msg2, &err2);
+    napi_status s1 = napi_throw(env, err1);
+    napi_status s2 = napi_throw(env, err2);
+    throw_pending_report(env, "napi_throw", s1, s2);
+  }
+
+  // Second throw attempted after another call has observed the first
+  // pending exception: the second throw must still fail with
+  // napi_pending_exception and a single napi_get_and_clear_last_exception
+  // must leave the env clean so nothing escapes back to JavaScript.
+  {
+    napi_status s1 = napi_throw_error(env, "E1", "first");
+    napi_value undef = nullptr;
+    napi_get_undefined(env, &undef);
+    napi_value unused = nullptr;
+    napi_call_function(env, undef, info[0], 0, nullptr, &unused);
+    napi_status s2 = napi_throw_error(env, "E2", "second");
+    throw_pending_report(env, "throw_call_throw", s1, s2);
+  }
+
+  bool final_pending = false;
+  napi_is_exception_pending(env, &final_pending);
+  printf("final_pending=%d\n", (int)final_pending);
+
+  return ok(env);
+}
+
 // Call Node-API functions in ways that result in different error handling
 // (erroneous call, valid call, or valid call while an exception is pending) and
 // log information from napi_get_last_error_info
@@ -2403,6 +2508,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_ref);
   REGISTER_FUNCTION(env, exports, test_napi_run_script);
   REGISTER_FUNCTION(env, exports, test_napi_throw_with_nullptr);
+  REGISTER_FUNCTION(env, exports, test_napi_throw_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_extended_error_messages);
   REGISTER_FUNCTION(env, exports, bigint_to_i64);
   REGISTER_FUNCTION(env, exports, bigint_to_u64);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -455,6 +455,22 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it("does not throw with nullptr", async () => {
       await checkSameOutput("test_napi_throw_with_nullptr", []);
     });
+
+    it("returns napi_pending_exception and preserves the first exception when one is already pending", async () => {
+      const result = await checkSameOutput("test_napi_throw_with_pending_exception", []);
+      // the first throw wins for every variant; nothing escapes the native call
+      expect(result).toContain("napi_throw_error: throw1=ok throw2=pending_exception");
+      expect(result).toContain("napi_throw_type_error: throw1=ok throw2=pending_exception");
+      expect(result).toContain("napi_throw_range_error: throw1=ok throw2=pending_exception");
+      expect(result).toContain("node_api_throw_syntax_error: throw1=ok throw2=pending_exception");
+      expect(result).toContain("napi_throw: throw1=ok throw2=pending_exception");
+      expect(result).toContain("throw_call_throw: throw1=ok throw2=pending_exception");
+      expect(result).toContain("kept=first");
+      expect(result).toContain("pending_after_clear=0");
+      expect(result).toContain("final_pending=0");
+      expect(result).not.toContain("kept=second");
+      expect(result).not.toContain("synchronously threw");
+    });
   });
   describe("napi_create_error functions", () => {
     it("has the right code and message", async () => {


### PR DESCRIPTION
### What

`napi_throw_error`, `napi_throw_type_error`, `napi_throw_range_error`, and `node_api_throw_syntax_error` called while an exception is already pending returned `napi_ok` and silently replaced the pending exception. Node returns `napi_pending_exception` and preserves the first exception.

### Repro

Native addon:

```c
napi_status s1 = napi_throw_error(env, "E1", "first");
napi_status s2 = napi_throw_error(env, "E2", "second");
```

Node v26.3.0:

```
throwTwice    : throw1=ok throw2=pending_exception pending=1 get_and_clear=ok pending_after_clear=0 kept=first
throwCallThrow: throw1=ok throw2=pending_exception pending=1 get_and_clear=ok pending_after_clear=0 kept=first
```

Bun (before):

```
throwTwice    : throw1=ok throw2=ok pending=1 get_and_clear=ok pending_after_clear=0 kept=second
throwCallThrow: THREW OUT E2 second
```

In the second probe (a `napi_call_function` between the two throws), the second throw overwrote the env's stashed exception after the first one had already been promoted into the VM. `napi_get_and_clear_last_exception` then cleared only the VM slot, left the env slot populated, and the second exception escaped the native call even though the addon had cleared the exception state.

This matters because the documented Node-API contract is that a second throw while an exception is pending fails with `napi_pending_exception` and the first exception wins. Addon error-path code written against that contract loses the root-cause exception on Bun.

### Cause

`throwErrorWithCStrings` (the shared implementation of all four `napi_throw_*error` variants) called `env->scheduleException()` unconditionally. It never checked the VM exception slot or the env's pending-exception slot, unlike `napi_throw` which already does both.

`napi_get_and_clear_last_exception` reads the two exception slots in priority order (VM, then env) but only cleared the one it read, so a populated env slot survived a clear of the VM slot.

### Fix

- `throwErrorWithCStrings` now performs the same preflight as `napi_throw`: GC check, return `napi_pending_exception` if either the VM or the env slot already holds an exception, and the `isFinishingFinalizers` check. The first exception is never overwritten.
- `napi_get_and_clear_last_exception` now clears the env pending-exception slot unconditionally at the end, so a single call always leaves the env with no pending exception regardless of which slot held the value.

### Verification

Added `test_napi_throw_with_pending_exception` to the napi-app fixture, covering all four `napi_throw_*error` variants, `napi_throw`, and the throw / `napi_call_function` / throw sequence. It asserts identical output between Bun and Node (`checkSameOutput`), plus that the second throw returns `pending_exception`, the first message is kept, a single `napi_get_and_clear_last_exception` leaves the state clean, and nothing escapes the native call.

Before the fix (`USE_SYSTEM_BUN=1 bun test test/napi/napi.test.ts -t "returns napi_pending_exception"`):

```
- "napi_throw_error: throw1=ok throw2=pending_exception ... kept=first
+ "napi_throw_error: throw1=ok throw2=ok ... kept=second
...
- throw_call_throw: throw1=ok throw2=pending_exception ... pending_after_clear=0 kept=first
- final_pending=0"
+ throw_call_throw: throw1=ok throw2=ok ... pending_after_clear=1 kept=
+ final_pending=1
+ synchronously threw Error: message "second", code "E2""
```

After the fix (`bun bd test test/napi/napi.test.ts`): 100 pass. The upstream Node-API suites `test_error`, `test_exception`, and `test_general` also pass.
