### PR TITLE
bun:test: stop reading and mutating lastIndex in regex matchers

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -456,8 +456,13 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
                 }
             } else if (expectedTestValue.isCell() and expectedTestValue.asCell()->type() == RegExpObjectType) {
                 if (auto* regex = dynamicDowncast<RegExpObject>(expectedTestValue)) {
-                    JSString* otherString = otherProp.toString(globalObject);
-                    if (regex->match(globalObject, otherString)) {
+                    auto otherView = JSC::asString(otherProp)->view(globalObject);
+                    RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
+                    // Match the underlying RegExp from offset 0 so /g and /y regexes neither
+                    // consume nor mutate the user's lastIndex across matcher invocations.
+                    bool matched = !!regex->regExp()->match(globalObject, otherView, 0);
+                    RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
+                    if (matched) {
                         return AsymmetricMatcherResult::PASS;
                     }
                 }
@@ -4715,7 +4720,13 @@ JSC::JSObject* JSC__JSValue__toObject(JSC::EncodedJSValue JSValue0, JSC::JSGloba
     }
     JSC::RegExpObject* regexObject = dynamicDowncast<JSC::RegExpObject>(regex);
 
-    return !!regexObject->match(global, JSC::asString(str));
+    JSC::VM& vm = global->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto input = JSC::asString(str)->view(global);
+    RETURN_IF_EXCEPTION(scope, false);
+    // Match the underlying RegExp from offset 0 so /g and /y regexes neither
+    // consume nor mutate the user's lastIndex across matcher invocations.
+    RELEASE_AND_RETURN(scope, !!regexObject->regExp()->match(global, input, 0));
 }
 
 bool JSC__JSValue__stringIncludes(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue other)

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -143,14 +143,9 @@ pub(crate) fn to_throw(
             if global.has_exception() {
                 return Ok(JSValue::ZERO);
             }
-            // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
-            if let Some(test_fn) = expected_value.get(global, "test")? {
-                let matches = test_fn
-                    .call(global, expected_value, &[received_message])
-                    .unwrap_or_else(|err| global.take_exception(err));
-                if !matches.to_boolean() {
-                    return Ok(JSValue::UNDEFINED);
-                }
+            let received_message_str = JSValue::from_cell(received_message.to_js_string(global)?);
+            if !expected_value.to_match(global, received_message_str)? {
+                return Ok(JSValue::UNDEFINED);
             }
 
             let mut formatter2 = super::make_formatter(global);
@@ -270,14 +265,9 @@ pub(crate) fn to_throw(
 
         if expected_value.is_reg_exp() {
             if let Some(received_message) = received_message_opt {
-                // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
-                if let Some(test_fn) = expected_value.get(global, "test")? {
-                    let matches = test_fn
-                        .call(global, expected_value, &[received_message])
-                        .unwrap_or_else(|err| global.take_exception(err));
-                    if matches.to_boolean() {
-                        return Ok(JSValue::UNDEFINED);
-                    }
+                let received_message_str = JSValue::from_cell(received_message.to_js_string(global)?);
+                if expected_value.to_match(global, received_message_str)? {
+                    return Ok(JSValue::UNDEFINED);
                 }
             }
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -949,7 +949,7 @@ describe("expect()", () => {
     }
   });
 
-  // jest and vitest call RegExp#test here, which reads and advances lastIndex for /g
+  // jest and vitest call RegExp#test here, which reads and advances lastIndex for /g and /y
   test_skipIf(!isBun)("toThrow with global regex is stateless across calls", () => {
     const re = /oops/g;
     const fn = () => {
@@ -959,7 +959,25 @@ describe("expect()", () => {
     expect(fn).toThrow(re);
     expect(fn).toThrow(re);
     expect(re.lastIndex).toBe(0);
-    expect(fn).not.toThrow(/nope/g);
+  });
+
+  test_skipIf(!isBun)("toThrow with sticky regex is stateless across calls", () => {
+    const re = /oops/y;
+    const fn = () => {
+      throw new Error("oops");
+    };
+    expect(fn).toThrow(re);
+    expect(fn).toThrow(re);
+  });
+
+  test_skipIf(!isBun)("not.toThrow with global regex is stateless across calls", () => {
+    const re = /oops/g;
+    const fn = () => {
+      throw new Error("oops");
+    };
+    // The message matches, so not.toThrow must reject every time, not just the first.
+    expect(() => expect(fn).not.toThrow(re)).toThrow();
+    expect(() => expect(fn).not.toThrow(re)).toThrow();
   });
 
   test("deepEquals derived strings and strings", () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -949,6 +949,19 @@ describe("expect()", () => {
     }
   });
 
+  // jest and vitest call RegExp#test here, which reads and advances lastIndex for /g
+  test_skipIf(!isBun)("toThrow with global regex is stateless across calls", () => {
+    const re = /oops/g;
+    const fn = () => {
+      throw new Error("oops");
+    };
+    expect(fn).toThrow(re);
+    expect(fn).toThrow(re);
+    expect(fn).toThrow(re);
+    expect(re.lastIndex).toBe(0);
+    expect(fn).not.toThrow(/nope/g);
+  });
+
   test("deepEquals derived strings and strings", () => {
     let a = new String("hello");
     let b = "hello";
@@ -3579,6 +3592,28 @@ describe("expect()", () => {
     for (const { label, value, matched } of tests) {
       test(label, () => expect(value).toMatch(matched));
     }
+
+    test("global regex is stateless across calls", () => {
+      const re = /a/g;
+      expect("a").toMatch(re);
+      expect("a").toMatch(re);
+      expect("a").toMatch(re);
+    });
+
+    // vitest's toMatch goes through String#match, which is stateful for /y
+    test_skipIf(isVitest)("sticky regex is stateless across calls", () => {
+      const re = /a/y;
+      expect("a").toMatch(re);
+      expect("a").toMatch(re);
+    });
+
+    // vitest's toMatch goes through String#match, which resets lastIndex for /g
+    test_skipIf(isVitest)("does not read or mutate lastIndex", () => {
+      const re = /a/g;
+      re.lastIndex = 100;
+      expect("aaaa").toMatch(re);
+      expect(re.lastIndex).toBe(100);
+    });
   });
 
   test_skipIf(isJest)("toBeNaN()", () => {
@@ -4417,6 +4452,28 @@ describe("expect()", () => {
     test("StringMatching matches string against regexp", () => {
       expect(expect.stringMatching(/en/)).toEqual("queen");
       expect(expect.stringMatching(/en/)).not.toEqual("queue");
+    });
+
+    test("StringMatching with global regex is stateless across calls", () => {
+      const re = /en/g;
+      expect("queen").toEqual(expect.stringMatching(re));
+      expect("queen").toEqual(expect.stringMatching(re));
+      expect("queen").toEqual(expect.stringMatching(re));
+      expect(re.lastIndex).toBe(0);
+    });
+
+    test("StringMatching with sticky regex is stateless across calls", () => {
+      const re = /qu/y;
+      expect("queen").toEqual(expect.stringMatching(re));
+      expect("queen").toEqual(expect.stringMatching(re));
+    });
+
+    // jest and vitest hold a live RegExp on the matcher, so reusing one instance is stateful there
+    test_skipIf(!isBun)("StringMatching instance with global regex is stateless across calls", () => {
+      const matcher = expect.stringMatching(/en/g);
+      expect("queen").toEqual(matcher);
+      expect("queen").toEqual(matcher);
+      expect("queen").toEqual(matcher);
     });
 
     test("StringMatching matches string against string", () => {


### PR DESCRIPTION
### Problem

`toMatch`, `toThrow`, and `expect.stringMatching` are stateful when given a `/g` or `/y` regex: the second use of the same RegExp object against the same string fails.

```ts
test("toMatch /g regex reused", () => {
  const r = /a/g;
  expect("a").toMatch(r);
  expect("a").toMatch(r); // fails in bun, passes in jest
});
```

```
error: expect(received).toMatch(expected)

Expected substring or pattern: /a/g
Received: "a"
```

This makes assertion results depend on how many times a regex was used before, so a module-level `const RE = /.../g` shared across tests passes or fails based on test ordering and `--filter`. Jest 30.4.1 passes the above.

### Cause

`toMatch` and `expect.stringMatching` went through `RegExpObject::match()`, which reads the object's `lastIndex` as the start offset and writes the match end back into it for global and sticky regexes. `toThrow` called `RegExp.prototype.test` through a property lookup, which does the same thing (and is also user-tamperable, and swallowed any exception it threw).

### Fix

Match the underlying `RegExp` from offset 0 instead of going through `RegExpObject::match`. Matchers now neither consume nor mutate the user's `lastIndex`. `toThrow` is rewired onto the same binding, which also resolves the `TODO: REMOVE THIS GETTER!` comments there.

A note on reference behavior, since the three sites end up stricter than upstream in places:

| case | jest 30.4.1 | vitest 4.1.9 | bun before | bun after |
|---|---|---|---|---|
| `toMatch` reusing a `/g` regex | pass | pass | fail | pass |
| `toMatch` reusing a `/y` regex | pass | fail | fail | pass |
| `expect.stringMatching(re)` called twice with the same `/g` regex | pass | pass | fail | pass |
| reusing one `expect.stringMatching(/x/g)` matcher instance | fail | fail | fail | pass |
| `toThrow` reusing a `/g` regex | fail | fail | fail | pass |

Jest and vitest still have the statefulness in the last two rows because they call `RegExp#test` there. Being stateless everywhere is strictly safer (a stale `lastIndex` can only ever turn a true match into a false failure), so the tests for those rows are gated to bun in the shared `expect.test.js`.

### Verification

Added tests to `test/js/bun/test/expect.test.js` covering `/g` and `/y` reuse for all three matchers, plus an assertion that `lastIndex` is neither read nor written. This includes a dedicated `not.toThrow` case, where the symptom has the opposite polarity: the first assertion correctly rejects because the message matches, but the second silently passes once `lastIndex` has advanced past the match, so it is a false green rather than a false red. All nine fail on bun 1.4.0 and pass with this change. The jest/vitest-divergent ones are gated with the file's existing `test_skipIf` helpers so the file stays runnable under all three runners (verified the gating against real jest 30.4.1 and vitest 4.1.9).

