### PR TITLE
node:fs: reject aborted operations with node's AbortError, not the raw signal.reason

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1409,7 +1409,7 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: Abort
   try {
     for await (let chunk of iterable) {
       if (signal?.aborted) {
-        throw signal.reason;
+        throw $makeAbortError(undefined, { cause: signal.reason });
       }
 
       if (mustRencode && typeof chunk === "string") {
@@ -1442,7 +1442,7 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
     mode = optionsOrEncoding?.mode ?? (mode || 0o666);
     signal = optionsOrEncoding?.signal ?? null;
     if (signal?.aborted) {
-      throw signal.reason;
+      throw $makeAbortError(undefined, { cause: signal.reason });
     }
   } else if (typeof optionsOrEncoding === "string" || optionsOrEncoding == null) {
     encoding = optionsOrEncoding || "utf8";
@@ -1463,7 +1463,7 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
 
   if (signal?.aborted) {
     if (mustClose) await fs.close(fdOrPath);
-    throw signal.reason;
+    throw $makeAbortError(undefined, { cause: signal.reason });
   }
 
   let totalBytesWritten = 0;
@@ -1489,7 +1489,7 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
 
   // Abort signal shadows other errors
   if (signal?.aborted) {
-    error = signal.reason;
+    error = $makeAbortError(undefined, { cause: signal.reason });
   }
 
   if (error) {

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -67,6 +67,7 @@ unsafe extern "C" {
         arg2: &mut u8,
     ) -> JSValue;
     safe fn WebCore__AbortSignal__new(arg0: &JSGlobalObject) -> *mut AbortSignal;
+    safe fn Bun__wrapAbortError(global_object: &JSGlobalObject, cause: JSValue) -> JSValue;
 }
 
 /// Abort-callback monomorphization for `listen`. Implement on your context type.
@@ -250,6 +251,13 @@ impl AbortReason {
             AbortReason::Common(reason) => reason.to_js(global),
             AbortReason::Js(value) => value,
         }
+    }
+
+    /// Node.js APIs reject with an `AbortError` (`Error` subclass,
+    /// `code === "ABORT_ERR"`) whose `.cause` is `signal.reason`, not with
+    /// the Web `DOMException` held in `signal.reason` itself.
+    pub fn to_node_abort_error(self, global: &JSGlobalObject) -> JSValue {
+        Bun__wrapAbortError(global, self.to_js(global))
     }
 }
 

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -67,6 +67,7 @@ unsafe extern "C" {
         arg2: &mut u8,
     ) -> JSValue;
     safe fn WebCore__AbortSignal__new(arg0: &JSGlobalObject) -> *mut AbortSignal;
+    safe fn WebCore__AbortSignal__jsReason(arg0: &AbortSignal, arg1: &JSGlobalObject) -> JSValue;
     safe fn Bun__wrapAbortError(global_object: &JSGlobalObject, cause: JSValue) -> JSValue;
 }
 
@@ -141,6 +142,22 @@ impl AbortSignal {
             return None; // not aborted
         }
         Some(AbortReason::Js(js_reason))
+    }
+
+    /// Node.js APIs reject aborted operations with an `AbortError` (`Error`
+    /// subclass, `code === "ABORT_ERR"`) whose `cause` is `signal.reason`,
+    /// rather than the Web `DOMException` held in `signal.reason` itself.
+    /// Returns `None` if the signal is not aborted. JS thread only.
+    pub fn node_abort_error_if_aborted(&self, global: &JSGlobalObject) -> Option<JSValue> {
+        if !self.aborted() {
+            return None;
+        }
+        // `jsReason` returns the same (cached) object the JS `.reason` getter
+        // does, so `err.cause === signal.reason` holds, matching Node.
+        Some(Bun__wrapAbortError(
+            global,
+            WebCore__AbortSignal__jsReason(self, global),
+        ))
     }
 
     pub fn ref_(&self) -> *mut AbortSignal {
@@ -251,13 +268,6 @@ impl AbortReason {
             AbortReason::Common(reason) => reason.to_js(global),
             AbortReason::Js(value) => value,
         }
-    }
-
-    /// Node.js APIs reject with an `AbortError` (`Error` subclass,
-    /// `code === "ABORT_ERR"`) whose `.cause` is `signal.reason`, not with
-    /// the Web `DOMException` held in `signal.reason` itself.
-    pub fn to_node_abort_error(self, global: &JSGlobalObject) -> JSValue {
-        Bun__wrapAbortError(global, self.to_js(global))
     }
 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5801,6 +5801,14 @@ extern "C" JSC::EncodedJSValue WebCore__AbortSignal__abortReason(WebCore::AbortS
     return JSC::JSValue::encode(abortSignal->reason().getValue(jsNull()));
 }
 
+// Same value the JS `signal.reason` getter returns: lazily materializes the
+// `DOMException` for a common abort reason and caches it, so repeated reads
+// (native or JS) observe the identical object.
+extern "C" JSC::EncodedJSValue WebCore__AbortSignal__jsReason(WebCore::AbortSignal* signal, JSC::JSGlobalObject* globalObject)
+{
+    return JSC::JSValue::encode(signal->jsReason(*globalObject));
+}
+
 extern "C" WebCore::AbortSignalTimeout WebCore__AbortSignal__getTimeout(WebCore::AbortSignal* arg0)
 {
     WebCore::AbortSignal* abortSignal = reinterpret_cast<WebCore::AbortSignal*>(arg0);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1359,7 +1359,8 @@ mod _async_tasks {
             if Self::HAVE_ABORT_SIGNAL {
                 if let Some(signal) = self.args.signal() {
                     if let Some(reason) = signal.reason_if_aborted(global_object) {
-                        return promise.reject(global_object, Ok(reason.to_js(global_object)));
+                        return promise
+                            .reject(global_object, Ok(reason.to_node_abort_error(global_object)));
                     }
                 }
             }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1358,9 +1358,8 @@ mod _async_tasks {
 
             if Self::HAVE_ABORT_SIGNAL {
                 if let Some(signal) = self.args.signal() {
-                    if let Some(reason) = signal.reason_if_aborted(global_object) {
-                        return promise
-                            .reject(global_object, Ok(reason.to_node_abort_error(global_object)));
+                    if let Some(abort_error) = signal.node_abort_error_if_aborted(global_object) {
+                        return promise.reject(global_object, Ok(abort_error));
                     }
                 }
             }

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -106,7 +106,7 @@ fn run_async<A: FsArgument>(
                 let promise =
                     JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                         global,
-                        reason.to_js(global),
+                        reason.to_node_abort_error(global),
                     );
                 args.unprotect();
                 drop(args);

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -102,11 +102,11 @@ fn run_async<A: FsArgument>(
 
     if A::HAVE_ABORT_SIGNAL {
         if let Some(signal) = args.signal() {
-            if let Some(reason) = signal.reason_if_aborted(global) {
+            if let Some(abort_error) = signal.node_abort_error_if_aborted(global) {
                 let promise =
                     JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                         global,
-                        reason.to_node_abort_error(global),
+                        abort_error,
                     );
                 args.unprotect();
                 drop(args);

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -402,3 +402,110 @@ it("teardown waits for every concurrent in-flight write", async () => {
   expect(fs.statSync(join(dir, "a.bin")).size).toBe(big.byteLength * 2);
   expect(fh.fd).toBe(-1);
 });
+
+// node rejects abortable fs APIs with an AbortError (an Error whose code is the
+// string "ABORT_ERR" and whose cause is signal.reason), never with the raw
+// DOMException held in signal.reason (whose .code is the number 20).
+describe("AbortSignal rejections use node's AbortError shape", () => {
+  function expectNodeAbortError(err, reason) {
+    expect(err).toBeInstanceOf(Error);
+    expect({ name: err.name, code: err.code, message: err.message }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      message: "The operation was aborted.",
+    });
+    expect(err.cause).toBe(reason);
+  }
+
+  test("readFile with a pre-aborted signal", async () => {
+    const dir = tempDirWithFiles("fs-abort-readfile", { "f.txt": "hello" });
+    const signal = AbortSignal.abort();
+    expect.assertions(3);
+    try {
+      await fsPromises.readFile(join(dir, "f.txt"), { signal });
+    } catch (err) {
+      expectNodeAbortError(err, signal.reason);
+    }
+  });
+
+  test("readFile with a custom abort reason", async () => {
+    const dir = tempDirWithFiles("fs-abort-readfile-reason", { "f.txt": "hello" });
+    const reason = new Error("my reason");
+    expect.assertions(3);
+    try {
+      await fsPromises.readFile(join(dir, "f.txt"), { signal: AbortSignal.abort(reason) });
+    } catch (err) {
+      expectNodeAbortError(err, reason);
+    }
+  });
+
+  test("readFile aborted while in flight", async () => {
+    const dir = tempDirWithFiles("fs-abort-readfile-inflight", { "f.txt": "hello" });
+    const ac = new AbortController();
+    const reason = new Error("stop");
+    const promise = fsPromises.readFile(join(dir, "f.txt"), { signal: ac.signal });
+    ac.abort(reason);
+    expect.assertions(3);
+    try {
+      await promise;
+    } catch (err) {
+      expectNodeAbortError(err, reason);
+    }
+  });
+
+  test("writeFile with a pre-aborted signal", async () => {
+    const dir = tempDirWithFiles("fs-abort-writefile", {});
+    const signal = AbortSignal.abort();
+    expect.assertions(3);
+    try {
+      await fsPromises.writeFile(join(dir, "f.txt"), "data", { signal });
+    } catch (err) {
+      expectNodeAbortError(err, signal.reason);
+    }
+  });
+
+  test("writeFile of an async iterable with a pre-aborted signal", async () => {
+    const dir = tempDirWithFiles("fs-abort-writefile-iter", {});
+    const signal = AbortSignal.abort();
+    expect.assertions(3);
+    try {
+      await fsPromises.writeFile(
+        join(dir, "f.txt"),
+        (async function* () {
+          yield "a";
+        })(),
+        { signal },
+      );
+    } catch (err) {
+      expectNodeAbortError(err, signal.reason);
+    }
+  });
+
+  test("writeFile of an async iterable aborted between chunks", async () => {
+    const dir = tempDirWithFiles("fs-abort-writefile-iter-inflight", {});
+    const ac = new AbortController();
+    expect.assertions(3);
+    try {
+      await fsPromises.writeFile(
+        join(dir, "f.txt"),
+        (async function* () {
+          yield "a";
+          ac.abort();
+          yield "b";
+        })(),
+        { signal: ac.signal },
+      );
+    } catch (err) {
+      expectNodeAbortError(err, ac.signal.reason);
+    }
+  });
+
+  test("callback readFile and writeFile with a pre-aborted signal", async () => {
+    const dir = tempDirWithFiles("fs-abort-callback", { "f.txt": "hello" });
+    const signal = AbortSignal.abort();
+    const readErr = await new Promise(resolve => fs.readFile(join(dir, "f.txt"), { signal }, resolve));
+    expectNodeAbortError(readErr, signal.reason);
+    const writeErr = await new Promise(resolve => fs.writeFile(join(dir, "o.txt"), "x", { signal }, resolve));
+    expectNodeAbortError(writeErr, signal.reason);
+  });
+});

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -409,6 +409,7 @@ it("teardown waits for every concurrent in-flight write", async () => {
 describe("AbortSignal rejections use node's AbortError shape", () => {
   function expectNodeAbortError(err, reason) {
     expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(DOMException);
     expect({ name: err.name, code: err.code, message: err.message }).toEqual({
       name: "AbortError",
       code: "ABORT_ERR",
@@ -420,7 +421,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   test("readFile with a pre-aborted signal", async () => {
     const dir = tempDirWithFiles("fs-abort-readfile", { "f.txt": "hello" });
     const signal = AbortSignal.abort();
-    expect.assertions(3);
+    expect.assertions(4);
     try {
       await fsPromises.readFile(join(dir, "f.txt"), { signal });
     } catch (err) {
@@ -431,7 +432,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   test("readFile with a custom abort reason", async () => {
     const dir = tempDirWithFiles("fs-abort-readfile-reason", { "f.txt": "hello" });
     const reason = new Error("my reason");
-    expect.assertions(3);
+    expect.assertions(4);
     try {
       await fsPromises.readFile(join(dir, "f.txt"), { signal: AbortSignal.abort(reason) });
     } catch (err) {
@@ -445,7 +446,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     const reason = new Error("stop");
     const promise = fsPromises.readFile(join(dir, "f.txt"), { signal: ac.signal });
     ac.abort(reason);
-    expect.assertions(3);
+    expect.assertions(4);
     try {
       await promise;
     } catch (err) {
@@ -453,10 +454,36 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     }
   });
 
+  // abort() with no reason stores the signal's lazily-created DOMException in a
+  // common-reason slot; the cause must still be that exact object, not a copy.
+  test("readFile aborted while in flight with the default abort reason", async () => {
+    const dir = tempDirWithFiles("fs-abort-readfile-inflight-default", { "f.txt": "hello" });
+    const ac = new AbortController();
+    const promise = fsPromises.readFile(join(dir, "f.txt"), { signal: ac.signal });
+    ac.abort();
+    expect.assertions(4);
+    try {
+      await promise;
+    } catch (err) {
+      expectNodeAbortError(err, ac.signal.reason);
+    }
+  });
+
+  test("appendFile with a pre-aborted signal", async () => {
+    const dir = tempDirWithFiles("fs-abort-appendfile", {});
+    const signal = AbortSignal.abort();
+    expect.assertions(4);
+    try {
+      await fsPromises.appendFile(join(dir, "f.txt"), "data", { signal });
+    } catch (err) {
+      expectNodeAbortError(err, signal.reason);
+    }
+  });
+
   test("writeFile with a pre-aborted signal", async () => {
     const dir = tempDirWithFiles("fs-abort-writefile", {});
     const signal = AbortSignal.abort();
-    expect.assertions(3);
+    expect.assertions(4);
     try {
       await fsPromises.writeFile(join(dir, "f.txt"), "data", { signal });
     } catch (err) {
@@ -467,7 +494,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   test("writeFile of an async iterable with a pre-aborted signal", async () => {
     const dir = tempDirWithFiles("fs-abort-writefile-iter", {});
     const signal = AbortSignal.abort();
-    expect.assertions(3);
+    expect.assertions(4);
     try {
       await fsPromises.writeFile(
         join(dir, "f.txt"),
@@ -484,7 +511,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   test("writeFile of an async iterable aborted between chunks", async () => {
     const dir = tempDirWithFiles("fs-abort-writefile-iter-inflight", {});
     const ac = new AbortController();
-    expect.assertions(3);
+    expect.assertions(4);
     try {
       await fsPromises.writeFile(
         join(dir, "f.txt"),


### PR DESCRIPTION
## What

`node:fs` / `node:fs/promises` operations aborted through an `AbortSignal` rejected with the raw `signal.reason`, which for an `AbortSignal` aborted with no explicit reason is a Web `DOMException` whose `.code` is the legacy numeric constant `20` (`DOMException.ABORT_ERR`).

Node.js rejects every abortable `fs` API with an `AbortError`: an `Error` whose `code` is the string `"ABORT_ERR"` and whose `cause` is `signal.reason`. The documented `err.code === "ABORT_ERR"` check, the canonical way to tell a deliberate cancellation from a real I/O failure, therefore never matched on Bun (`20 !== "ABORT_ERR"`), so cancellations got treated as real errors.

## Repro

```js
import * as fsp from "node:fs/promises";
import * as fs from "node:fs";
import * as os from "node:os";
const R = fs.mkdtempSync(os.tmpdir() + "/fsab-");
fs.writeFileSync(R + "/f", "hello");
try { await fsp.readFile(R + "/f", { signal: AbortSignal.abort() }); }
catch (e) { console.log(e.constructor.name, JSON.stringify(e.name), JSON.stringify(e.code)); }
```

Node v26.3.0: `AbortError "AbortError" "ABORT_ERR"`
Bun 1.4.0: `DOMException "AbortError" 20`

## Cause

The native async fs path rejected with `signal.reason_if_aborted(...).to_js(global)` directly, i.e. with `signal.reason` itself, at both rejection sites: the pre-aborted fast path (`node_fs_binding.rs`) and the post-completion check (`node_fs.rs`, `run_from_js_thread`). The `writeFile` async-iterator slow path in `fs.promises.ts` had four parallel `throw signal.reason` sites.

A second, adjacent problem: for a no-argument `AbortController#abort()`, `reasonIfAborted` in `bindings.cpp` short-circuits on the sticky `m_commonReason` and mints a fresh `DOMException` instead of returning the one already cached in `m_reason`. So even once wrapped, the error's `cause` was a different object than `signal.reason`; Node keeps them identical.

Bun's other node-compat modules (timers/promises, events, readline, the callback `fs.stat`) already build the correct shape via `$makeAbortError`, which calls the same underlying `Bun__wrapAbortError`, so only fs was affected. This also went unnoticed because the ported Node tests for `readFile`/`writeFile` abort only assert `name: 'AbortError'`, which the `DOMException` also satisfies.

## Fix

Added `AbortSignal::node_abort_error_if_aborted`, used at both native rejection sites. It wraps the reason through the existing `Bun__wrapAbortError`, and it reads the reason via a new `WebCore__AbortSignal__jsReason` shim over `AbortSignal::jsReason`, the same lazily-materializing, caching getter the JS `.reason` property uses. That makes the wrapped error's `cause` the exact object JS observes, covering both the explicit-reason and the no-argument `abort()` cases.

The four `throw signal.reason` sites in the async-iterator path now use `$makeAbortError(undefined, { cause: signal.reason })`. `readFile`, `writeFile`, `appendFile` (a type alias of the `WriteFile` args natively), the `FileHandle` methods, and the callback APIs all go through these paths.

`fetch()` is unchanged: aborting a Web API is a `DOMException` by spec, and `FetchTasklet` needs `reason_if_aborted`'s enum discriminant to carry the reason across threads, so that shared helper is not modified.

The `FileHandle.writer()` / `.pull()` rejection sites are not touched; those APIs do not exist in any released Node (`fh.writer is not a function` on v26.3.0), so there is no reference behavior to match, and their in-tree ported Node tests pass as-is.

## Not in scope, noted for reviewers

`Bun__wrapAbortError`'s message is `"The operation was aborted."` where Node's has no trailing period. This predates the change, is shared by every `$makeAbortError` caller (timers, events, streams, watch), and is asserted by several existing tests, so changing it is a separate PR.

## Verification

Added a describe block (9 tests) to `test/js/node/fs/promises.test.js` covering the promise, async-iterator, and callback variants, asserting the exact `{ name, code, message }` triple, `cause` identity, and that the rejection is not a `DOMException`. All 9 fail on `bun@1.4.0` and pass with this change. The "aborted while in flight with the default abort reason" test specifically fails without the `jsReason` change (the `cause` comes back as a distinct `DOMException`).

The full file, the ported Node tests (`test-fs-promises-readfile.js`, `test-fs-promises-writefile.js`, `test-fs-readfile.js`, `test-fs-write-file.js`, `test-fs-writefile-with-fd.js`, `test-fs-promises-file-handle-readFile.js`, `test-fs-promises-file-handle-writeFile.js`, `test-fs-stat-abort-test.js`, `test-fs-watch-recursive-promise.js`), and `abort-signal-leak-read-write-file.test.ts` were also run. The last of those times out on a local debug+ASAN build regardless of this change (100k real `writeFile` round-trips vs a 5s timeout) and is already quarantined for ASAN in `test/expectations.txt`.
