### PR TITLE
bun:test: accept thenables and functions in expect .resolves/.rejects

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -575,6 +575,9 @@ AsymmetricMatcherResult matchAsymmetricMatcher(JSGlobalObject* globalObject, JSV
 {
     ExpectFlags flags = ExpectFlags();
     AsymmetricMatcherResult result = matchAsymmetricMatcherAndGetFlags(globalObject, matcherProp, otherProp, throwScope, flags);
+    // readFlagsAndProcessPromise / the custom matcher can run user JS (a `.rejects`
+    // function, a `then` getter). Propagate instead of flipping FAIL to PASS on `.not`.
+    RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
     if (result != AsymmetricMatcherResult::NOT_MATCHER && (flags & FLAG_NOT)) {
         result = (result == AsymmetricMatcherResult::PASS) ? AsymmetricMatcherResult::FAIL : AsymmetricMatcherResult::PASS;
     }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -401,7 +401,29 @@ impl Expect {
     ) -> JsResult<JSValue> {
         match flags.promise() {
             resolution @ (Promise::Resolves | Promise::Rejects) => {
-                if let Some(promise) = value.as_any_promise() {
+                // Jest's `.rejects` accepts a function returning a promise or thenable;
+                // call it first. `value` stays the original received for error messages.
+                let received = if resolution == Promise::Rejects && value.is_callable() {
+                    value.call(global_this, JSValue::UNDEFINED, &[])?
+                } else {
+                    value
+                };
+                // Jest accepts any thenable, not only Promise instances. Wrap one in a
+                // real promise via the spec resolve algorithm so it can be awaited below.
+                // `awaited` stays on the stack to root the promise across `wait_for_promise`.
+                let awaited = if received.as_any_promise().is_none()
+                    && received.is_object()
+                    && received
+                        .get(global_this, b"then")?
+                        .is_some_and(|then| then.is_callable())
+                {
+                    let wrapper = js_promise::JSPromise::create(global_this);
+                    wrapper.resolve(global_this, received)?;
+                    wrapper.to_js()
+                } else {
+                    received
+                };
+                if let Some(promise) = awaited.as_any_promise() {
                     let vm = global_this.vm();
                     promise.set_handled(vm);
 
@@ -460,6 +482,10 @@ impl Expect {
                 } else {
                     if !silent {
                         let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
+                        let expected = match resolution {
+                            Promise::Rejects => "Expected promise or a function returning a promise",
+                            _ => "Expected promise",
+                        };
                         return Err(Self::throw_pretty_matcher_error(
                             global_this,
                             custom_label,
@@ -467,7 +493,7 @@ impl Expect {
                             matcher_params,
                             flags,
                             format_args!(
-                                "Expected promise<r>\nReceived: <red>{}<r>\n",
+                                "{expected}<r>\nReceived: <red>{}<r>\n",
                                 value.to_fmt(&mut formatter),
                             ),
                         ));

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -402,7 +402,7 @@ impl Expect {
         match flags.promise() {
             resolution @ (Promise::Resolves | Promise::Rejects) => {
                 // Jest's `.rejects` accepts a function returning a promise or thenable;
-                // call it first. `value` stays the original received for error messages.
+                // call it first. The usage error below reports the original `value`.
                 let received = if resolution == Promise::Rejects && value.is_callable() {
                     value.call(global_this, JSValue::UNDEFINED, &[])?
                 } else {
@@ -445,7 +445,7 @@ impl Expect {
                                         flags,
                                         format_args!(
                                             "Expected promise that rejects<r>\nReceived promise that resolved: <red>{}<r>\n",
-                                            value.to_fmt(&mut formatter),
+                                            new_value.to_fmt(&mut formatter),
                                         ),
                                     ));
                                 }
@@ -466,7 +466,7 @@ impl Expect {
                                         flags,
                                         format_args!(
                                             "Expected promise that resolves<r>\nReceived promise that rejected: <red>{}<r>\n",
-                                            value.to_fmt(&mut formatter),
+                                            new_value.to_fmt(&mut formatter),
                                         ),
                                     ));
                                 }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -401,9 +401,10 @@ impl Expect {
     ) -> JsResult<JSValue> {
         match flags.promise() {
             resolution @ (Promise::Resolves | Promise::Rejects) => {
-                // Jest's `.rejects` accepts a function returning a promise or thenable;
-                // call it first. The usage error below reports the original `value`.
-                let received = if resolution == Promise::Rejects && value.is_callable() {
+                // Jest's `.resolves` and `.rejects` both accept a function returning a
+                // promise or thenable; call it first and await what it returns. The usage
+                // error below still reports the original `value`.
+                let received = if value.is_callable() {
                     value.call(global_this, JSValue::UNDEFINED, &[])?
                 } else {
                     value
@@ -482,10 +483,6 @@ impl Expect {
                 } else {
                     if !silent {
                         let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-                        let expected = match resolution {
-                            Promise::Rejects => "Expected promise or a function returning a promise",
-                            _ => "Expected promise",
-                        };
                         return Err(Self::throw_pretty_matcher_error(
                             global_this,
                             custom_label,
@@ -493,7 +490,7 @@ impl Expect {
                             matcher_params,
                             flags,
                             format_args!(
-                                "{expected}<r>\nReceived: <red>{}<r>\n",
+                                "Expected a promise or a function returning a promise<r>\nReceived: <red>{}<r>\n",
                                 value.to_fmt(&mut formatter),
                             ),
                         ));

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -141,6 +141,71 @@ describe("expect()", () => {
     ).resolves.toBe(1);
   });
 
+  // `.resolves` / `.rejects` accept any thenable (duck-typed `.then`), not only
+  // Promise instances. `.rejects` also accepts a function returning a promise.
+  test("resolves accepts a thenable", async () => {
+    await expect({ then: (/** @type {any} */ onFulfilled) => void onFulfilled(42) }).resolves.toBe(42);
+    await expect({ then: (/** @type {any} */ onFulfilled) => void onFulfilled(42) }).resolves.not.toBe(43);
+
+    // settles on a later microtask
+    await expect({
+      then: (/** @type {any} */ onFulfilled) => void queueMicrotask(() => onFulfilled("later")),
+    }).resolves.toBe("later");
+
+    // thenable that delegates to a real promise (the ORM / query-builder shape)
+    await expect({
+      then: (/** @type {any} */ onFulfilled, /** @type {any} */ onRejected) =>
+        Promise.resolve({ rows: [1, 2] }).then(onFulfilled, onRejected),
+    }).resolves.toEqual({ rows: [1, 2] });
+
+    if (isBun) {
+      // a thenable that rejects is still a `.resolves` failure
+      await expectFailure(() =>
+        expect({
+          then: (/** @type {any} */ _f, /** @type {any} */ onRejected) => void onRejected(new Error("nope")),
+        }).resolves.toBe(1),
+      ).toThrow();
+      // `.resolves` does not call functions (only `.rejects` does)
+      await expectFailure(() => expect(ANY(() => Promise.resolve(1))).resolves.toBe(1)).toThrow();
+      // a plain object without a callable `.then` is still rejected
+      await expectFailure(() => expect(ANY({ then: 1 })).resolves.toBe(1)).toThrow();
+    }
+  });
+
+  test("rejects accepts a thenable and a function returning a promise", async () => {
+    await expect({
+      then: (/** @type {any} */ _f, /** @type {any} */ onRejected) => void onRejected(new Error("boom")),
+    }).rejects.toThrow("boom");
+
+    // rejects on a later microtask
+    await expect({
+      then: (/** @type {any} */ _f, /** @type {any} */ onRejected) =>
+        void queueMicrotask(() => onRejected(new Error("later"))),
+    }).rejects.toThrow("later");
+
+    // a function returning a rejected promise
+    await expect(() => Promise.reject(new Error("from fn"))).rejects.toThrow("from fn");
+
+    // an async function that throws
+    await expect(async () => {
+      throw new Error("from async fn");
+    }).rejects.toThrow("from async fn");
+
+    // a function returning a thenable that rejects
+    await expect(() => ({
+      then: (/** @type {any} */ _f, /** @type {any} */ onRejected) => void onRejected(new Error("fn thenable")),
+    })).rejects.toThrow("fn thenable");
+
+    if (isBun) {
+      // a function returning a non-promise is still a usage error
+      await expectFailure(() => expect(ANY(() => 42)).rejects.toBe(42)).toThrow();
+      // a thenable that fulfills is still a `.rejects` failure
+      await expectFailure(() =>
+        expect({ then: (/** @type {any} */ onFulfilled) => void onFulfilled(1) }).rejects.toBe(1),
+      ).toThrow();
+    }
+  });
+
   test("can call without an argument", () => {
     expect().toBe(undefined);
   });
@@ -1172,25 +1237,30 @@ describe("expect()", () => {
   // Allocation-heavy by design (GC stress for #14256); measured at ~4 minutes
   // under a debug+ASAN build, far past the 5s default per-test timeout.
   test("deepEquals Set/Map stress test", () => {
+    // Exercises the Set/Map iterator-allocation path in deepEquals (see #14256):
+    // the elements are distinct-identity arrays, so every comparison falls back
+    // to a linear search that allocates a fresh iterator per element. The counts
+    // below keep thousands of those allocations while staying within the default
+    // test timeout under a debug + ASAN build.
     const arr1 = [];
     const arr2 = [];
     const arr3 = [];
     const arr4 = [];
 
-    for (let i = 0; i < 150; i++) {
+    for (let i = 0; i < 25; i++) {
       arr1[i] = [i];
       arr2[i] = [i];
       arr3[i] = [i, [i]];
       arr4[i] = [i, [i]];
     }
 
-    for (let i = 0; i < 2000; i++) {
+    for (let i = 0; i < 500; i++) {
       let outerSet = new Set(arr1);
       let innerSet = new Set(arr2);
       Bun.deepEquals(outerSet, innerSet);
     }
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 250; i++) {
       let outerMap = new Map(arr3);
       let innerMap = new Map(arr4);
       Bun.deepEquals(outerMap, innerMap);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4642,6 +4642,14 @@ describe("expect()", () => {
         await expect({ a: Promise.reject("1") }).toEqual({ a: expect.not.rejectsTo.stringContaining("2") });
         await expect(Promise.reject(new Error("rejectMessage"))).rejects.toMatchObject({ message: "rejectMessage" });
 
+        // a non-Promise thenable should match too
+        await expect({ then: (/** @type {any} */ _f, /** @type {any} */ onRejected) => void onRejected("1") }).toEqual(
+          expect.rejectsTo.stringContaining("1"),
+        );
+        await expect({
+          a: { then: (/** @type {any} */ _f, /** @type {any} */ onRejected) => void onRejected("1") },
+        }).toEqual({ a: expect.rejectsTo.stringContaining("1") });
+
         // a resolved promise should not match
         await expect(Promise.resolve("a")).not.toEqual(expect.rejectsTo.stringContaining("a"));
 
@@ -4666,6 +4674,14 @@ describe("expect()", () => {
             throw new Error();
           }),
         ).resolves.toThrow();
+
+        // a non-Promise thenable should match too
+        await expect({ then: (/** @type {any} */ onFulfilled) => void onFulfilled("1") }).toEqual(
+          expect.resolvesTo.stringContaining("1"),
+        );
+        await expect({ a: { then: (/** @type {any} */ onFulfilled) => void onFulfilled("1") } }).toEqual({
+          a: expect.resolvesTo.stringContaining("1"),
+        });
 
         // a rejected promise should not match
         await expect(Promise.reject("a")).not.toEqual(expect.resolvesTo.stringContaining("a"));

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -203,7 +203,28 @@ describe("expect()", () => {
       await expectFailure(() =>
         expect({ then: (/** @type {any} */ onFulfilled) => void onFulfilled(1) }).rejects.toBe(1),
       ).toThrow();
+      // a function that throws synchronously propagates its error (it is not a rejection)
+      await expectFailure(() =>
+        expect(
+          ANY(() => {
+            throw new Error("sync throw");
+          }),
+        ).rejects.toThrow("anything"),
+      ).toThrow("sync throw");
     }
+  });
+
+  // The wrong-settlement error reports the settled value, not the received
+  // function / thenable that produced the promise.
+  test_skipIf(!isBun)("resolves/rejects settlement errors show the settled value", async () => {
+    await expectFailure(() => expect(ANY(() => Promise.resolve("rejectsSettledTo"))).rejects.toBe(1)).toThrow(
+      "rejectsSettledTo",
+    );
+    await expectFailure(() =>
+      expect({
+        then: (/** @type {any} */ _f, /** @type {any} */ onRejected) => void onRejected("resolvesSettledTo"),
+      }).resolves.toBe(1),
+    ).toThrow("resolvesSettledTo");
   });
 
   test("can call without an argument", () => {
@@ -1237,11 +1258,9 @@ describe("expect()", () => {
   // Allocation-heavy by design (GC stress for #14256); measured at ~4 minutes
   // under a debug+ASAN build, far past the 5s default per-test timeout.
   test("deepEquals Set/Map stress test", () => {
-    // Exercises the Set/Map iterator-allocation path in deepEquals (see #14256):
-    // the elements are distinct-identity arrays, so every comparison falls back
-    // to a linear search that allocates a fresh iterator per element. The counts
-    // below keep thousands of those allocations while staying within the default
-    // test timeout under a debug + ASAN build.
+    // Exercises Set/Map iterator allocation in deepEquals (#14256): distinct-identity
+    // array elements force the linear-search fallback that allocates an iterator per
+    // element. Counts sized to stay within the default timeout under debug + ASAN.
     const arr1 = [];
     const arr2 = [];
     const arr3 = [];
@@ -4695,6 +4714,16 @@ describe("expect()", () => {
             setTimeout(() => resolve("a"), 0);
           }),
         ).toEqual(expect.resolvesTo.stringContaining("a"));
+      });
+
+      // `rejectsTo` calls a received function like `.rejects` does; a synchronous
+      // throw must propagate as the test error, never be flipped to a pass by `.not`.
+      test("expect.rejectsTo calls a received function and propagates a sync throw", () => {
+        const boom = () => {
+          throw new Error("asymmetric sync boom");
+        };
+        expect(() => expect(boom).toEqual(expect.rejectsTo.anything())).toThrow("asymmetric sync boom");
+        expect(() => expect(boom).toEqual(expect.not.rejectsTo.anything())).toThrow("asymmetric sync boom");
       });
     }
   });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1258,28 +1258,25 @@ describe("expect()", () => {
   // Allocation-heavy by design (GC stress for #14256); measured at ~4 minutes
   // under a debug+ASAN build, far past the 5s default per-test timeout.
   test("deepEquals Set/Map stress test", () => {
-    // Exercises Set/Map iterator allocation in deepEquals (#14256): distinct-identity
-    // array elements force the linear-search fallback that allocates an iterator per
-    // element. Counts sized to stay within the default timeout under debug + ASAN.
     const arr1 = [];
     const arr2 = [];
     const arr3 = [];
     const arr4 = [];
 
-    for (let i = 0; i < 25; i++) {
+    for (let i = 0; i < 150; i++) {
       arr1[i] = [i];
       arr2[i] = [i];
       arr3[i] = [i, [i]];
       arr4[i] = [i, [i]];
     }
 
-    for (let i = 0; i < 500; i++) {
+    for (let i = 0; i < 2000; i++) {
       let outerSet = new Set(arr1);
       let innerSet = new Set(arr2);
       Bun.deepEquals(outerSet, innerSet);
     }
 
-    for (let i = 0; i < 250; i++) {
+    for (let i = 0; i < 1000; i++) {
       let outerMap = new Map(arr3);
       let innerMap = new Map(arr4);
       Bun.deepEquals(outerMap, innerMap);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -142,8 +142,8 @@ describe("expect()", () => {
   });
 
   // `.resolves` / `.rejects` accept any thenable (duck-typed `.then`), not only
-  // Promise instances. `.rejects` also accepts a function returning a promise.
-  test("resolves accepts a thenable", async () => {
+  // Promise instances. Both also accept a function returning a promise or thenable.
+  test("resolves accepts a thenable and a function returning a promise", async () => {
     await expect({ then: (/** @type {any} */ onFulfilled) => void onFulfilled(42) }).resolves.toBe(42);
     await expect({ then: (/** @type {any} */ onFulfilled) => void onFulfilled(42) }).resolves.not.toBe(43);
 
@@ -158,6 +158,11 @@ describe("expect()", () => {
         Promise.resolve({ rows: [1, 2] }).then(onFulfilled, onRejected),
     }).resolves.toEqual({ rows: [1, 2] });
 
+    // a function returning a promise or thenable
+    await expect(() => Promise.resolve(1)).resolves.toBe(1);
+    await expect(async () => "from async fn").resolves.toBe("from async fn");
+    await expect(() => ({ then: (/** @type {any} */ onFulfilled) => void onFulfilled(1) })).resolves.toBe(1);
+
     if (isBun) {
       // a thenable that rejects is still a `.resolves` failure
       await expectFailure(() =>
@@ -165,10 +170,18 @@ describe("expect()", () => {
           then: (/** @type {any} */ _f, /** @type {any} */ onRejected) => void onRejected(new Error("nope")),
         }).resolves.toBe(1),
       ).toThrow();
-      // `.resolves` does not call functions (only `.rejects` does)
-      await expectFailure(() => expect(ANY(() => Promise.resolve(1))).resolves.toBe(1)).toThrow();
+      // a function returning a non-promise is still a usage error
+      await expectFailure(() => expect(ANY(() => 42)).resolves.toBe(42)).toThrow();
       // a plain object without a callable `.then` is still rejected
       await expectFailure(() => expect(ANY({ then: 1 })).resolves.toBe(1)).toThrow();
+      // a function that throws synchronously propagates its error (it is not a resolution)
+      await expectFailure(() =>
+        expect(
+          ANY(() => {
+            throw new Error("sync throw");
+          }),
+        ).resolves.toBe(1),
+      ).toThrow("sync throw");
     }
   });
 


### PR DESCRIPTION
Fixes #18857
Fixes #16144

### Reproduction

```js
import { test, expect } from "bun:test";

test("resolves accepts a thenable", async () => {
  await expect({ then(r) { r(1); } }).resolves.toBe(1);
});
test("resolves accepts a function returning a promise", async () => {
  await expect(async () => true).resolves.toBe(true);
});
test("rejects accepts a function returning a promise", async () => {
  await expect(() => Promise.reject(new Error("boom"))).rejects.toThrow("boom");
});
```

All three fail on current bun:

```
error: expect(received).resolves.toBe(expected)

Expected promise
Received: {
  then: [Function: then],
}
```

All three pass on jest 30.4.1.

### Cause

`Expect::process_promise` in `src/runtime/test_runner/expect.rs` only accepted values for which `as_any_promise()` returns a real `JSPromise`/`JSInternalPromise`. Jest's contract for `.resolves`/`.rejects` is any thenable (an object with a callable `then`), and both matchers first call the received value when it is a function and await what it returns. Thenables are common in practice: knex and mongoose query builders, and many ORM and lazy-client APIs, return then-able objects rather than `Promise` instances.

The function-calling behavior was checked against real jest 30.4.1 rather than read from its source: jest's older implementation was `.rejects`-only, but jest 30 calls a callable receiver for `.resolves` as well, and uses the same "a promise or a function returning a promise" usage error for both. An earlier revision of this PR gated the call on `.rejects`.

### Fix

In `process_promise`:

- If the received value is callable, call it and use the result, for both `.resolves` and `.rejects`.
- If the value is not a native promise but is an object with a callable `then`, wrap it via `JSPromise::create` plus the spec `resolve()` algorithm (the same semantics as `await thenable`) so the existing `wait_for_promise` path can await it. The wrong-settlement errors report the settled value rather than the promise object.
- The usage error for both matchers now reads "Expected a promise or a function returning a promise", matching jest's wording. No test asserted on the old string.

One line in `src/jsc/bindings/bindings.cpp`: `matchAsymmetricMatcher` now checks for a pending exception after `matchAsymmetricMatcherAndGetFlags`. The widened `process_promise` can run user JS (a `then` getter, a received function) from inside asymmetric matching, and without the check a thrown exception was flipped into a pass/fail result by the `.not` handling instead of propagating.

All four entry points that share this helper pick up the change: `.resolves`, `.rejects`, the custom-matcher path, and the `expect.resolvesTo` / `expect.rejectsTo` asymmetric matchers.

### Tests

`resolves accepts a thenable and a function returning a promise` and `rejects accepts a thenable and a function returning a promise` in `test/js/bun/test/expect.test.js`. They cover: sync and async-settling thenables, a thenable delegating to a real promise, `.not`, functions returning a promise / a thenable, an async function that resolves, an async function that throws, and the negative cases (a non-thenable object, an object with a non-callable `then`, a function returning a non-promise, a synchronously throwing function propagating its own error, and a thenable settled the wrong way still failing). A third test asserts the wrong-settlement errors show the settled value.

The existing `expect.resolvesTo` and `expect.rejectsTo` asymmetric-matcher tests gain thenable cases (top-level and nested in `toEqual`), since those matchers share the same helper and were failing on thenables the same way.

`expect.test.js` also runs under jest and vitest, so the positive assertions double as a parity check. Every assertion outside an `isBun` guard was additionally run under jest 30.4.1 directly and passes there.

All of the new assertions fail on bun without the `src/` change and pass with it; the full `expect.test.js` suite (420 tests) is green with the change.
