### PR TITLE
node:http: honour HTTP/1.0 Connection: keep-alive when the response has a Content-Length

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -301,12 +301,17 @@ private:
             httpResponseData->state = HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
 
 
-            /* Mark this response as connectionClose if ancient or connection: close */
-            if (httpRequest->isAncient() || httpRequest->getHeader("connection").length() == 5) {
+            /* Mark this response as connectionClose: HTTP/1.1 persists unless
+             * Connection: close is sent; HTTP/1.0 closes unless the client sent
+             * a Connection: keep-alive token (llhttp_should_keep_alive semantics). */
+            bool isAncient = httpRequest->isAncient();
+            if (isAncient
+                    ? !httpRequest->hasConnectionToken("keep-alive")
+                    : httpRequest->hasConnectionToken("close")) {
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
             }
 
-            httpResponseData->fromAncientRequest = httpRequest->isAncient();
+            httpResponseData->fromAncientRequest = isAncient;
 
             /* Per-request framing flags; writeHead only ever sets them, so a
              * stale true from a previous 204/304 (or close-delimited) response

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -237,6 +237,44 @@ namespace uWS
             return std::string_view(nullptr, 0);
         }
 
+        /* Token-match any Connection header's comma-separated value list
+         * (case-insensitive, OWS trimmed), like llhttp: a whole-value compare
+         * would miss compound values such as "keep-alive, TE". */
+        bool hasConnectionToken(std::string_view token)
+        {
+            if (!bf.mightHave("connection")) {
+                return false;
+            }
+            for (Header *h = headers; (++h)->key.length();) {
+                if (h->key.length() != 10 || strncasecmp(h->key.data(), "connection", 10)) {
+                    continue;
+                }
+                const auto value = h->value;
+                size_t pos = 0;
+                while (pos < value.length()) {
+                    while (pos < value.length() && (value[pos] == ' ' || value[pos] == '\t')) {
+                        pos++;
+                    }
+                    size_t tokenStart = pos;
+                    while (pos < value.length() && value[pos] != ',') {
+                        pos++;
+                    }
+                    size_t tokenEnd = pos;
+                    while (tokenEnd > tokenStart && (value[tokenEnd - 1] == ' ' || value[tokenEnd - 1] == '\t')) {
+                        tokenEnd--;
+                    }
+                    if (tokenEnd - tokenStart == token.length()
+                        && !strncasecmp(value.data() + tokenStart, token.data(), token.length())) {
+                        return true;
+                    }
+                    if (pos < value.length() && value[pos] == ',') {
+                        pos++;
+                    }
+                }
+            }
+            return false;
+        }
+
         struct TransferEncoding {
             bool has: 1 = false;
             bool chunked: 1 = false;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -179,15 +179,20 @@ public:
                 /* Write mark, this propagates to WebSockets too */
                 writeMark();
 
-                /* WebSocket upgrades does not allow content-length */
-                if (allowContentLength) {
-                    /* Even zero is a valid content-length */
-                    Super::write("Content-Length: ", 16);
-                    writeUnsigned64(totalSize);
-                    Super::write("\r\n\r\n", 4);
-                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
-                } else if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED))) {
-                    Super::write("\r\n", 2);
+                /* The header block can only be terminated once. write() already
+                 * terminated it when HTTP_WRITE_CALLED is set, so anything
+                 * written here would land inside the body. */
+                if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
+                    /* WebSocket upgrades does not allow content-length */
+                    if (allowContentLength) {
+                        /* Even zero is a valid content-length */
+                        Super::write("Content-Length: ", 16);
+                        writeUnsigned64(totalSize);
+                        Super::write("\r\n\r\n", 4);
+                        httpResponseData->state |= HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+                    } else {
+                        Super::write("\r\n", 2);
+                    }
                 }
 
                 /* Mark end called */
@@ -535,6 +540,12 @@ public:
         writeStatus(HTTP_200_OK);
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
         if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED | HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER))) {
+            /* HTTP/1.0 cannot chunk-frame the body; without a Content-Length
+             * the body is close-delimited, so the socket must close even when
+             * the client asked for keep-alive. */
+            if (httpResponseData->fromAncientRequest) {
+                httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+            }
             /* Write mark on first call to write */
             writeMark();
 
@@ -572,6 +583,12 @@ public:
             }
 
          } else if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
+            /* HTTP/1.0 cannot chunk-frame the body; without a Content-Length
+             * the body is close-delimited, so the socket must close even when
+             * the client asked for keep-alive. */
+            if (httpResponseData->fromAncientRequest && !(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+                httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+            }
             writeMark();
             Super::write("\r\n", 2);
             httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
@@ -647,6 +664,12 @@ public:
             writeUnsignedHex((unsigned int) data.length());
             Super::write("\r\n", 2);
         } else if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
+            /* HTTP/1.0 cannot chunk-frame the body; without a Content-Length
+             * the body is close-delimited, so the socket must close even when
+             * the client asked for keep-alive. */
+            if (httpResponseData->fromAncientRequest && !(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+                httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+            }
             writeMark();
             Super::write("\r\n", 2);
             httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -651,14 +651,21 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         });
         http_res._keepAliveTimeout = server.keepAliveTimeout;
 
-        // The request itself forbids connection reuse (HTTP/1.0, or the
-        // client sent Connection: close): end the server's writable side as
-        // soon as the response has been written, like Node.js's resOnFinish.
-        // Registered before the 'request' event so the socket is already
-        // ended inside user 'finish' listeners. (Not done for the
-        // maxRequestsPerSocket limit - pipelined requests past the limit
-        // still need to be answered with 503.)
-        if (!requestShouldKeepAlive(http_req)) {
+        // Node.js's parserOnIncoming: `res.shouldKeepAlive = keepAlive` (the
+        // parser's llhttp_should_keep_alive value), overwriting the ctor's
+        // HTTP/1.0 `shouldKeepAlive = false` when the client explicitly sent
+        // Connection: keep-alive.
+        const reqShouldKeepAlive = requestShouldKeepAlive(http_req);
+        http_res.shouldKeepAlive = reqShouldKeepAlive;
+
+        // The request itself forbids connection reuse (HTTP/1.0 without
+        // keep-alive, or the client sent Connection: close): end the server's
+        // writable side as soon as the response has been written, like
+        // Node.js's resOnFinish. Registered before the 'request' event so the
+        // socket is already ended inside user 'finish' listeners. (Not done
+        // for the maxRequestsPerSocket limit - pipelined requests past the
+        // limit still need to be answered with 503.)
+        if (!reqShouldKeepAlive) {
           http_res[kMustCloseConnection] = true;
         }
         http_res.once("finish", endSocketOnFinishIfNeeded.bind(undefined, socket, http_res));
@@ -1600,6 +1607,13 @@ function renderNativeHeaders(res) {
       // HEAD / 204 / 304 / 1xx: there is no body to delimit, so removing the
       // framing headers must not close the connection (Node's _storeHeader
       // checks !_hasBody before its close-delimited else-branch).
+    } else if (!res.useChunkedEncodingByDefault) {
+      // Node's _storeHeader: `else if (!this.useChunkedEncodingByDefault)
+      // this._last = true` - chunked encoding is unavailable (HTTP/1.0
+      // without a `TE: chunked` request header) and the user wrote no
+      // framing headers, so the socket must close after the response,
+      // even when the user set an explicit Connection: keep-alive header.
+      res[kMustCloseConnection] = true;
     } else if (res._removedTE) {
       closeDelimited = true;
       res[kMustCloseConnection] = true;
@@ -1616,13 +1630,19 @@ function renderNativeHeaders(res) {
       res[kMustCloseConnection] = true;
     }
   } else if (!hasConnection) {
-    if (
+    // Node's _storeHeader shouldSendKeepAlive: persist only when the
+    // response can be framed without closing (an explicit Content-Length,
+    // or chunked encoding is available). HTTP/1.0 has no chunked encoding,
+    // so keep-alive there requires a Content-Length. res.shouldKeepAlive is
+    // the one-time parser snapshot taken at dispatch (like Node's
+    // parserOnIncoming); never re-read req.headers here - userland mutates it.
+    const hasContentLength = res[kOutHeaders]?.["content-length"] !== undefined;
+    const shouldSendKeepAlive =
       !defectiveNoBodyResponse &&
       !closeDelimited &&
-      !res.maxRequestsOnConnectionReached &&
       res.shouldKeepAlive !== false &&
-      requestShouldKeepAlive(res.req)
-    ) {
+      (hasContentLength || res.useChunkedEncodingByDefault);
+    if (shouldSendKeepAlive && !res.maxRequestsOnConnectionReached) {
       flat.push("Connection", "keep-alive");
       const keepAliveTimeout = res._keepAliveTimeout;
       if (keepAliveTimeout && !hasKeepAlive) {
@@ -1634,10 +1654,11 @@ function renderNativeHeaders(res) {
         flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}${max}`);
       }
     } else {
-      // Like Node's shouldSendKeepAlive/_last handling: a user-cleared
-      // shouldKeepAlive (graceful-shutdown helpers set it on in-flight
-      // responses) must also end the socket after 'finish'.
-      if (res.shouldKeepAlive === false) {
+      // Node's _storeHeader else-branch sets `this._last = true` whenever
+      // shouldSendKeepAlive is false, so the socket ends after 'finish'.
+      // The maxRequestsPerSocket limit only advertises close - pipelined
+      // requests past the limit still need to be answered with 503.
+      if (!shouldSendKeepAlive) {
         res[kMustCloseConnection] = true;
       }
       flat.push("Connection", "close");
@@ -1692,17 +1713,16 @@ function endSocketOnFinishIfNeeded(socket, res) {
 
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 const RE_CONN_UPGRADE = /(?:^|\W)upgrade(?:$|\W)/i;
-// Whether the response should advertise a persistent connection.
+const RE_CONN_KEEP_ALIVE = /(?:^|\W)keep-alive(?:$|\W)/i;
+// Whether the request asked for a persistent connection (Node.js passes this
+// as the parser's shouldKeepAlive to parserOnIncoming, computed by
+// llhttp_should_keep_alive).
 function requestShouldKeepAlive(req) {
   if (!req) return true;
   const connection = req.headers.connection;
   if (req.httpVersionMajor === 1 && req.httpVersionMinor === 0) {
-    // The native server always closes HTTP/1.0 connections after the
-    // response, even when the request asked for keep-alive, so the response
-    // must advertise Connection: close to stay consistent with the transport.
-    // (Node.js answers Connection: close here too whenever it cannot frame
-    // the response without closing, which is the common case for HTTP/1.0.)
-    return false;
+    // HTTP/1.0 defaults to close; persist only on an explicit keep-alive.
+    return typeof connection === "string" && RE_CONN_KEEP_ALIVE.test(connection);
   }
   return !(typeof connection === "string" && RE_CONN_CLOSE.test(connection));
 }

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1346,6 +1346,13 @@ extern "C"
         }
         data->state |= uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE;
       }
+      /* HTTP/1.0 cannot chunk-frame the body; without a Content-Length the
+       * (empty) body is close-delimited, so the socket must close even when
+       * the client asked for keep-alive. */
+      if (data->fromAncientRequest && !(data->state & uWS::HttpResponseData<true>::HTTP_WROTE_CONTENT_LENGTH_HEADER))
+      {
+        data->state |= uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE;
+      }
       if (!(data->state & uWS::HttpResponseData<true>::HTTP_END_CALLED))
       {
         uwsRes->AsyncSocket<true>::write("\r\n", 2);
@@ -1364,6 +1371,13 @@ extern "C"
         {
           uwsRes->writeHeader("Connection", "close");
         }
+        data->state |= uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE;
+      }
+      /* HTTP/1.0 cannot chunk-frame the body; without a Content-Length the
+       * (empty) body is close-delimited, so the socket must close even when
+       * the client asked for keep-alive. */
+      if (data->fromAncientRequest && !(data->state & uWS::HttpResponseData<false>::HTTP_WROTE_CONTENT_LENGTH_HEADER))
+      {
         data->state |= uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE;
       }
       if (!(data->state & uWS::HttpResponseData<false>::HTTP_END_CALLED))

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3246,3 +3246,105 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
     signalCode: null,
   });
 });
+
+// An HTTP/1.0 keep-alive request whose streamed Response errors before any
+// write ends on the chunk-terminator path with no Content-Length; HTTP/1.0
+// cannot chunk-frame, so the body is close-delimited and the socket must
+// still close or the client hangs waiting for FIN. (An empty stream that
+// close()s instead renders as Content-Length: 0 and may legitimately persist.)
+it("Bun.serve closes an HTTP/1.0 keep-alive socket after a ReadableStream body errors before any write", async () => {
+  await using server = serve({
+    port: 0,
+    // The erroring stream surfaces here; the response is already committed.
+    error() {},
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          start(c) {
+            c.error(new Error("boom"));
+          },
+        }),
+      );
+    },
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: closed, resolve: onClose } = Promise.withResolvers<string>();
+  const chunks: Buffer[] = [];
+  socket.on("data", c => chunks.push(c));
+  socket.on("error", () => {});
+  socket.on("close", () => onClose(Buffer.concat(chunks).toString()));
+  socket.on("connect", () => socket.write("GET / HTTP/1.0\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"));
+
+  const out = await closed;
+  expect(out).toStartWith("HTTP/1.1 ");
+});
+
+// A static-route If-None-Match hit answers 304 via end_without_body with no
+// Content-Length (do_write_headers strips it): the response has no body
+// framing, so HTTP/1.0 keep-alive must still close the socket or the client
+// hangs waiting for FIN.
+it("Bun.serve closes an HTTP/1.0 keep-alive socket after an unframed end_without_body response", async () => {
+  await using server = serve({
+    port: 0,
+    routes: { "/s": new Response("static") },
+    fetch() {
+      return new Response("fallback");
+    },
+  });
+
+  // Learn the static route's ETag, then revalidate it over HTTP/1.0.
+  const first = await fetch(`${server.url}s`);
+  const etag = first.headers.get("etag")!;
+  await first.arrayBuffer();
+  expect(etag).toBeTruthy();
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: closed, resolve: onClose } = Promise.withResolvers<string>();
+  const chunks: Buffer[] = [];
+  socket.on("data", c => chunks.push(c));
+  socket.on("error", () => {});
+  socket.on("close", () => onClose(Buffer.concat(chunks).toString()));
+  socket.on("connect", () =>
+    socket.write(`GET /s HTTP/1.0\r\nHost: x\r\nConnection: keep-alive\r\nIf-None-Match: ${etag}\r\n\r\n`),
+  );
+
+  const out = await closed;
+  expect(out).toStartWith("HTTP/1.1 304 ");
+  expect(out).not.toContain("Content-Length");
+});
+
+// "close" must be matched as a token inside the comma-separated Connection
+// value list, not as the whole header value: a compound value such as
+// "Connection: close, TE" must still close the socket after the response.
+it("Bun.serve closes the socket on a compound HTTP/1.1 'Connection: close, TE' header", async () => {
+  let served = 0;
+  await using server = serve({
+    port: 0,
+    fetch() {
+      served++;
+      return new Response("ok");
+    },
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: closed, resolve: onClose } = Promise.withResolvers<string>();
+  let data = "";
+  let sentSecond = false;
+  socket.on("data", c => {
+    data += c;
+    // After the first response, reuse the socket: if "close" inside a
+    // compound value is missed, the socket persists and serves this too.
+    if (!sentSecond && data.includes("\r\n\r\nok")) {
+      sentSecond = true;
+      socket.write("GET /second HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+    }
+  });
+  socket.on("error", () => {});
+  socket.on("close", () => onClose(data));
+  socket.on("connect", () => socket.write("GET /first HTTP/1.1\r\nHost: x\r\nConnection: close, TE\r\n\r\n"));
+
+  const out = await closed;
+  expect(served).toBe(1);
+  expect(out.match(/HTTP\/1\.1 200 OK/g)).toHaveLength(1);
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2646,6 +2646,191 @@ it("close-delimited streaming writes carry raw bytes with no chunk framing artif
   }
 });
 
+it("node:http honours HTTP/1.0 Connection: keep-alive when the response has a Content-Length", async () => {
+  // Node.js (llhttp_should_keep_alive) treats HTTP/1.0 + Connection: keep-alive
+  // as persistent; the second request on the same socket must reach the
+  // server and get a response.
+  const seen: { url: string; shouldKeepAlive: boolean }[] = [];
+  const server = createServer((req, res) => {
+    seen.push({ url: req.url!, shouldKeepAlive: res.shouldKeepAlive });
+    res.writeHead(200, { "content-length": "2" });
+    res.end("hi");
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const out = await new Promise<string>(resolve => {
+      const socket = connect(port, "127.0.0.1");
+      let data = "";
+      let sentSecond = false;
+      socket.on("data", chunk => {
+        data += chunk;
+        // After the first response body arrived, reuse the socket for a
+        // second HTTP/1.0 request without keep-alive so the server closes
+        // the connection after it (deterministic 'close').
+        if (!sentSecond && data.includes("\r\n\r\nhi")) {
+          sentSecond = true;
+          socket.write("GET /second HTTP/1.0\r\nHost: a\r\n\r\n");
+        }
+      });
+      // If the server wrongly closed after /first the second write may
+      // EPIPE/ECONNRESET; the assertions below surface that.
+      socket.on("error", () => {});
+      socket.on("close", () => resolve(data));
+      // A compound, mixed-case Connection value: llhttp (and Node) match the
+      // keep-alive token within the comma-separated list, not the whole value.
+      socket.write("GET /first HTTP/1.0\r\nHost: a\r\nConnection: Keep-Alive, TE\r\n\r\n");
+    });
+
+    // Both requests reached the server over the one connection, and
+    // res.shouldKeepAlive mirrors the parser decision like Node.js's
+    // parserOnIncoming.
+    expect(seen).toEqual([
+      { url: "/first", shouldKeepAlive: true },
+      { url: "/second", shouldKeepAlive: false },
+    ]);
+    const responses = out.split(/(?=HTTP\/1\.1 200 OK\r\n)/);
+    expect(responses).toHaveLength(2);
+    expect(responses[0]).toContain("Connection: keep-alive");
+    expect(responses[0]).toContain("Keep-Alive: timeout=");
+    expect(responses[1]).toContain("Connection: close");
+    expect(responses[0].slice(responses[0].indexOf("\r\n\r\n") + 4)).toBe("hi");
+    expect(responses[1].slice(responses[1].indexOf("\r\n\r\n") + 4)).toBe("hi");
+  } finally {
+    server.close();
+  }
+});
+
+it("node:http refuses HTTP/1.0 keep-alive when the response has no explicit Content-Length", async () => {
+  // Node.js's shouldSendKeepAlive requires contLen || useChunkedEncodingByDefault;
+  // for HTTP/1.0 chunked is off, so without a user-set Content-Length the
+  // server answers Connection: close and ends the socket even though the
+  // client asked for keep-alive.
+  const server = createServer((req, res) => {
+    res.end("hello world");
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const out = await new Promise<string>(resolve => {
+      const socket = connect(port, "127.0.0.1");
+      let data = "";
+      socket.on("data", chunk => (data += chunk));
+      socket.on("error", () => {});
+      socket.on("close", () => resolve(data));
+      socket.write("GET / HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n");
+    });
+
+    expect(out).toContain("Connection: close");
+    expect(out).not.toContain("Transfer-Encoding");
+    expect(out).not.toContain("Connection: keep-alive");
+    const body = out.slice(out.indexOf("\r\n\r\n") + 4);
+    expect(body).toBe("hello world");
+  } finally {
+    server.close();
+  }
+});
+
+it("node:http closes after an HTTP/1.0 request without Connection: keep-alive", async () => {
+  // Default HTTP/1.0 behaviour: no keep-alive means the server closes after
+  // one response.
+  let seen = 0;
+  const server = createServer((req, res) => {
+    seen++;
+    res.writeHead(200, { "content-length": "2" });
+    res.end("ok");
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const out = await new Promise<string>(resolve => {
+      const socket = connect(port, "127.0.0.1");
+      let data = "";
+      socket.on("data", chunk => (data += chunk));
+      socket.on("error", () => {});
+      socket.on("close", () => resolve(data));
+      socket.write("GET / HTTP/1.0\r\nHost: a\r\n\r\n");
+    });
+
+    expect(seen).toBe(1);
+    expect(out).toContain("Connection: close");
+    expect(out.slice(out.indexOf("\r\n\r\n") + 4)).toBe("ok");
+  } finally {
+    server.close();
+  }
+});
+
+it("node:http closes after an HTTP/1.0 keep-alive response with an explicit unframeable Connection: keep-alive header", async () => {
+  // Node's _storeHeader: the user's Connection: keep-alive header is sent
+  // verbatim, but with no Content-Length and chunked unavailable the body is
+  // close-delimited, so _last = true still closes the socket (vendored
+  // test-http-1.0-keep-alive.js, case "keep-alive, no TE header").
+  const server = createServer((req, res) => {
+    res.writeHead(200, { Connection: "keep-alive" });
+    res.end("OK");
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const out = await new Promise<string>(resolve => {
+      const socket = connect(port, "127.0.0.1");
+      let data = "";
+      socket.on("data", chunk => (data += chunk));
+      socket.on("error", () => {});
+      // The server must send FIN on its own; the client never half-closes.
+      socket.on("close", () => resolve(data));
+      socket.write("POST / HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n");
+    });
+
+    expect(out).toContain("Connection: keep-alive");
+    expect(out.slice(out.indexOf("\r\n\r\n") + 4)).toBe("OK");
+  } finally {
+    server.close();
+  }
+});
+
+it("node:http does not inject a Content-Length header into an HTTP/1.0 streamed body", async () => {
+  // write() terminates the header block and emits the raw (close-delimited)
+  // body; end(chunk) must not append internalEnd()'s auto Content-Length
+  // into the byte stream after it. Node.js sends the body close-delimited
+  // with no Content-Length at all for an HTTP/1.0 response with streaming
+  // writes and no explicit framing headers.
+  const server = createServer((req, res) => {
+    res.write("hello");
+    res.end(" world");
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const out = await new Promise<string>(resolve => {
+      const socket = connect(port, "127.0.0.1");
+      let data = "";
+      socket.on("data", chunk => (data += chunk));
+      socket.on("error", () => {});
+      // The body is close-delimited; the server must send FIN on its own.
+      socket.on("close", () => resolve(data));
+      socket.write("GET / HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n");
+    });
+
+    expect(out.slice(out.indexOf("\r\n\r\n") + 4)).toBe("hello world");
+    expect(out).not.toContain("Content-Length");
+    expect(out).not.toContain("Transfer-Encoding");
+    expect(out).toContain("Connection: close");
+  } finally {
+    server.close();
+  }
+});
+
 // A bare `new IncomingMessage(null)` has httpVersionMajor/Minor === null;
 // `null < 1` is true, so the ServerResponse constructor's HTTP/1.0 branch
 // (matching node v26.3.0 lib/_http_server.js L214) sets shouldKeepAlive=false


### PR DESCRIPTION
### Problem

The HTTP server never honours `Connection: keep-alive` on an HTTP/1.0 request. The response is always answered with `Connection: close` and the socket is closed, so a second request pipelined on the same connection is never served. Node.js keeps the connection open when the client explicitly asks for keep-alive and the response can be framed without closing (an explicit `Content-Length`).

This affects both `node:http` and `Bun.serve`. Legacy proxies and load-balancer health checkers that speak HTTP/1.0 with keep-alive re-handshake on every request.

```js
import http from 'node:http';
import net from 'node:net';
const reqs = [];
const srv = http.createServer((q, r) => { q.resume(); reqs.push(q.url); r.writeHead(200, { 'content-length': '2' }); r.end('hi'); });
srv.listen(0, '127.0.0.1', () => {
  const s = net.connect(srv.address().port); s.setNoDelay(true); let wire = ''; s.on('error', () => {});
  s.on('connect', () => s.write('GET /1 HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n'));
  setTimeout(() => { try { s.write('GET /2 HTTP/1.0\r\nHost: a\r\n\r\n'); } catch (e) {} }, 300);
  s.on('data', d => wire += d);
  setTimeout(() => { console.log(JSON.stringify({ requestsServed: reqs, wire: wire.replace(/Date:[^\r]*/g, 'Date:X') })); process.exit(0); }, 1200);
});
```

Before (bun 1.4.0 and `main`):

```
{"requestsServed":["/1"],"wire":"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nDate:X\r\nConnection: close\r\n\r\nhi"}
```

Node v26.3.0 and after this change:

```
{"requestsServed":["/1","/2"],"wire":"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nDate:X\r\nConnection: keep-alive\r\nKeep-Alive: timeout=5\r\n\r\nhiHTTP/1.1 200 OK\r\ncontent-length: 2\r\nDate:X\r\nConnection: close\r\n\r\nhi"}
```

### Cause

Two layers each force the close independently:

- `packages/bun-uws/src/HttpContext.h`: `HTTP_CONNECTION_CLOSE` is set at parse time for every ancient (HTTP/1.0) request, regardless of the `Connection` header.
- `src/js/node/_http_server.ts`: `requestShouldKeepAlive()` hardcodes `false` for HTTP/1.0 because the native socket always closed, so the response header was made to match the transport.

### Fix

Match Node.js's `llhttp_should_keep_alive` / `_storeHeader` semantics:

- `HttpContext.h` / `HttpParser.h`: HTTP/1.0 sets `HTTP_CONNECTION_CLOSE` unless the client's `Connection` header carries a `keep-alive` token. The check is the new `HttpRequest::hasConnectionToken()`, which tokenizes the comma-separated value(s) case-insensitively with OWS trimming (like llhttp), so a compound value such as `Connection: keep-alive, TE` agrees with the `node:http` layer's token match. HTTP/1.1 behaviour is unchanged.
- `_http_server.ts`:
  - `requestShouldKeepAlive()` returns true for HTTP/1.0 only on an explicit `Connection: keep-alive`.
  - `res.shouldKeepAlive` is set from that parser decision like Node's `parserOnIncoming`, overwriting the constructor's HTTP/1.0 `shouldKeepAlive = false`.
  - `renderNativeHeaders()` mirrors `_storeHeader`'s `shouldSendKeepAlive` (`contLen || useChunkedEncodingByDefault`) and its `!useChunkedEncodingByDefault -> _last = true` framing rule, so an HTTP/1.0 response with no `Content-Length` still closes (chunked encoding is unavailable for 1.0), even when the user wrote their own `Connection: keep-alive` header.
- `HttpResponse.h`: when an ancient request's response starts a streaming body with no `Content-Length`, set `HTTP_CONNECTION_CLOSE` so the body stays close-delimited. All three sites that terminate the header block this way (`write()`, `flushHeaders()`, `sendTerminatingChunk()`) get the guard. This keeps `Bun.serve` correct for `new Response(readableStream)` on an HTTP/1.0 keep-alive connection (including one that errors before the first write), which would otherwise emit an unframed body on a socket that never closes.
- `HttpResponse.h` (`internalEnd()`): fixes an adjacent, pre-existing body corruption on the same path that review surfaced. Once `write()` has terminated the header block, the first `end(chunk)` still appended the auto `Content-Length: N\r\n\r\n` header into the byte stream, so `res.write("hello"); res.end(" world")` on an HTTP/1.0 request produced a close-delimited body of

  ```
  helloContent-Length: 6\r\n\r\n world
  ```

  The `!HTTP_WRITE_CALLED` guard that was already on the bare `\r\n` header-terminator arm is hoisted over both arms, so nothing is appended as a header once the body has started. Node.js sends this body close-delimited with no `Content-Length` at all, which is what Bun now does. Every other cell of the `(allowContentLength, HTTP_WRITE_CALLED)` truth table is unchanged.

`Bun.serve` gets the fix from the native change: `should_close_connection()` just reads the uWS `HTTP_CONNECTION_CLOSE` flag.

### Verification

- New tests in `test/js/node/http/node-http.test.ts`: keep-alive honoured with `Content-Length` (two requests served over one socket), refused without a `Content-Length`, plain HTTP/1.0 still closes, a user-set unframeable `Connection: keep-alive` header still closes the socket, and an HTTP/1.0 streamed `write()` + `end(chunk)` body has no injected `Content-Length`. The first and last fail on `main`.
- A regression test in `test/js/bun/http/serve.test.ts`: an HTTP/1.0 keep-alive request whose streamed Response body errors before the first write still gets a closed socket.
- The vendored Node tests `test-http-1.0-keep-alive.js`, `test-http-1.0.js`, `test-http-should-keep-alive.js` and `test-http-keep-alive-close-on-header.js` pass. `test-http-1.0-keep-alive.js` exercises all four HTTP/1.0 keep-alive framing combinations, including the user-set `Connection: keep-alive` header without a `Content-Length`, which must still close.
- `test/js/node/http/node-http.test.ts` and `test/js/bun/http/hspec.test.ts` pass (the one pre-existing `node-http.test.ts` failure, `issue#4295`, fails identically on `main`; it ECONNREFUSEDs reaching the `exampleSite` helper).


