### PR TITLE
shell: stop enqueuing to an IOWriter after a fatal write error

### DIFF
--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -214,6 +214,13 @@ struct State {
     winbuf: Vec<u8>,
     writer_idx: usize,
     total_bytes_written: usize,
+    /// Set (and never cleared) by `fail_pending_writers`. A writer with a
+    /// stored error is dead: `enqueue`/`enqueue_fmt_bltn` must reject new
+    /// chunks with this error instead of queueing them (see
+    /// `handle_dead_writer`). The syscall error is kept (not the derived
+    /// `SystemError`) so each rejected chunk gets its own freshly-derived
+    /// `SystemError`.
+    err: Option<sys::Error>,
     evtloop: EventLoopHandle,
     is_writing: bool,
     started: bool,
@@ -290,6 +297,7 @@ impl IOWriter {
                 winbuf: Vec::new(),
                 writer_idx: 0,
                 total_bytes_written: 0,
+                err: None,
                 evtloop,
                 is_writing: false,
                 started: false,
@@ -841,6 +849,11 @@ impl IOWriter {
         if err.get_errno() == E::EPIPE {
             s.flags.broken_pipe = true;
         }
+        // Mark the writer dead before any completion below runs: a child that
+        // enqueues from its callback (the next statement, the RHS of `&&`, ...)
+        // must be rejected by `handle_dead_writer`, not queued onto a writer
+        // whose handle the error path is tearing down.
+        s.err = Some(err.clone());
         // Writers before writer_idx have already had their callback fired and
         // may have been freed; only notify the still-pending ones, dedup'd.
         let mut pending: Vec<ChildPtr> = Vec::new();
@@ -933,13 +946,31 @@ impl IOWriter {
 
     // ── enqueue ─────────────────────────────────────────────────────────
 
-    fn handle_broken_pipe(&self, ptr: ChildPtr) -> Option<Yield> {
-        if self.state().flags.broken_pipe {
+    /// A writer that already reported a fatal error must not accept new
+    /// chunks: `PosixBufferedWriter::_on_error` closes the handle after
+    /// `on_error` returns, so a chunk queued from inside the completion
+    /// callbacks (or any later one) would wait on a poll that is being torn
+    /// down, and a later `write()` would run with `handle == Closed` (the
+    /// pollable path asserts `handle == Poll`). Broken pipes are the EPIPE
+    /// flavor of the same thing. Report the error to the child instead of
+    /// queueing the chunk.
+    fn handle_dead_writer(&self, ptr: ChildPtr) -> Option<Yield> {
+        let s = self.state();
+        if s.flags.broken_pipe {
             let err = sys::Error::from_code(E::EPIPE, sys::Tag::write).to_system_error();
             return Some(Yield::OnIoWriterChunk {
                 child: ptr,
                 written: 0,
                 err: Some(err),
+            });
+        }
+        if let Some(err) = &s.err {
+            return Some(Yield::OnIoWriterChunk {
+                child: ptr,
+                written: 0,
+                // `SystemError` owns its `bun_core::String`s by value, so
+                // derive a fresh one per rejected chunk (see `on_error`).
+                err: Some(err.to_shell_system_error()),
             });
         }
         None
@@ -962,6 +993,7 @@ impl IOWriter {
     /// `child` is the writer that was just pushed (see `on_sync_error`).
     fn enqueue_internal(&self, child: ChildPtr) -> Yield {
         debug_assert!(!self.state().flags.broken_pipe);
+        debug_assert!(self.state().err.is_none());
         #[cfg(not(windows))]
         if !self.state().flags.pollable {
             return self.enqueue_file(child);
@@ -977,7 +1009,7 @@ impl IOWriter {
     /// Queue `buf` for writing; when the chunk completes (or errors),
     /// `child`'s `on_io_writer_chunk` fires.
     pub fn enqueue(&self, child: ChildPtr, bytelist: Option<*mut Vec<u8>>, buf: &[u8]) -> Yield {
-        if let Some(y) = self.handle_broken_pipe(child) {
+        if let Some(y) = self.handle_dead_writer(child) {
             return y;
         }
         if buf.is_empty() {
@@ -1013,9 +1045,10 @@ impl IOWriter {
             let _ = write!(&mut s.buf, "{}: ", k.as_str());
         }
         let _ = s.buf.write_fmt(args);
-        // `buf` is written *before* checking broken_pipe (the bytes are dead
-        // on the error path but the buffer will be cleared there anyway).
-        // NOTE: inline `handle_broken_pipe` instead of calling the helper —
+        // `buf` is written *before* the dead-writer checks (the bytes are dead
+        // on the error path but no `Writer` references them, and an errored
+        // writer never drains again).
+        // NOTE: inline `handle_dead_writer` instead of calling the helper —
         // the helper re-derives `state()` while `s` is still live, which is two
         // simultaneous `&mut State` (UB under Stacked Borrows).
         if s.flags.broken_pipe {
@@ -1024,6 +1057,13 @@ impl IOWriter {
                 child,
                 written: 0,
                 err: Some(err),
+            };
+        }
+        if let Some(err) = &s.err {
+            return Yield::OnIoWriterChunk {
+                child,
+                written: 0,
+                err: Some(err.to_shell_system_error()),
             };
         }
         let end = s.buf.len();

--- a/test/js/bun/shell/shell-write-fault.test.ts
+++ b/test/js/bun/shell/shell-write-fault.test.ts
@@ -1,21 +1,15 @@
 // An LD_PRELOAD shim makes send() on the shell pipeline's socketpair fail with
-// ENOMEM, so the subshell's stdout IOWriter hits a fatal (non-EPIPE) write
-// error after its first chunk. The IOWriter must then refuse the chunks the
-// remaining statements enqueue: before the fix it queued them, cleared them
-// inside on_error, and closed its poll handle, so the second `echo` waited
-// forever on a callback that could never fire (and in a build with debug
-// assertions, a later write() asserted `matches!(handle, PollOrFd::Poll(_))`
-// on the closed handle).
+// ENOMEM (a fatal, non-EPIPE write error). The IOWriter must report that error
+// to every chunk enqueued afterwards instead of queueing onto the dead writer.
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
-// SHELL_FAIL_SEND=1: every send() on an AF_UNIX socket that is not
-// stdin/stdout/stderr fails with ENOMEM. The shell's pipeline "pipes" are
-// AF_UNIX socketpairs and its IOWriter uses send(MSG_DONTWAIT|MSG_NOSIGNAL)
-// on them, so this faults exactly the pipeline write path and nothing else.
+// SHELL_FAIL_SEND=1: every send() on a non-stdio AF_UNIX socket fails with
+// ENOMEM. The shell's pipeline pipes are AF_UNIX socketpairs written with
+// send(), so this faults exactly the pipeline write path and nothing else.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -50,11 +44,9 @@ ssize_t send(int fd, const void *buf, size_t len, int flags) {
 }
 `;
 
-// The subshell runs three statements that all write to the same stdout
-// IOWriter (the socketpair feeding \`cat\`). The first chunk's send() fails;
-// the second and third enqueues land on the already-errored writer. The
-// whole command must still finish: cat (last in the pipeline) sees EOF and
-// exits 0, and nothing made it through the pipe.
+// All three statements write to the same stdout IOWriter (the socketpair
+// feeding \`cat\`). The first chunk's send() fails; the later enqueues must
+// fail fast so the pipeline still finishes (cat sees EOF and exits 0).
 const FIXTURE = /* js */ `
 import { $ } from "bun";
 const r = await $\`(echo one; echo two; echo three) | cat\`.quiet().nothrow();

--- a/test/js/bun/shell/shell-write-fault.test.ts
+++ b/test/js/bun/shell/shell-write-fault.test.ts
@@ -1,0 +1,125 @@
+// An LD_PRELOAD shim makes send() on the shell pipeline's socketpair fail with
+// ENOMEM, so the subshell's stdout IOWriter hits a fatal (non-EPIPE) write
+// error after its first chunk. The IOWriter must then refuse the chunks the
+// remaining statements enqueue: before the fix it queued them, cleared them
+// inside on_error, and closed its poll handle, so the second `echo` waited
+// forever on a callback that could never fire (and in a build with debug
+// assertions, a later write() asserted `matches!(handle, PollOrFd::Poll(_))`
+// on the closed handle).
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+// SHELL_FAIL_SEND=1: every send() on an AF_UNIX socket that is not
+// stdin/stdout/stderr fails with ENOMEM. The shell's pipeline "pipes" are
+// AF_UNIX socketpairs and its IOWriter uses send(MSG_DONTWAIT|MSG_NOSIGNAL)
+// on them, so this faults exactly the pipeline write path and nothing else.
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static ssize_t (*real_send)(int, const void *, size_t, int);
+static int fail_send = -1;
+
+static int is_unix_sock(int fd) {
+  struct stat st;
+  if (fstat(fd, &st) != 0 || !S_ISSOCK(st.st_mode)) return 0;
+  int domain = 0;
+  socklen_t len = sizeof(domain);
+  return getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &domain, &len) == 0 && domain == AF_UNIX;
+}
+
+ssize_t send(int fd, const void *buf, size_t len, int flags) {
+  if (!real_send) {
+    real_send = (ssize_t (*)(int, const void *, size_t, int))dlsym(RTLD_NEXT, "send");
+    fail_send = getenv("SHELL_FAIL_SEND") != NULL;
+  }
+  if (fail_send && fd > 2 && is_unix_sock(fd)) {
+    errno = ENOMEM;
+    return -1;
+  }
+  return real_send(fd, buf, len, flags);
+}
+`;
+
+// The subshell runs three statements that all write to the same stdout
+// IOWriter (the socketpair feeding \`cat\`). The first chunk's send() fails;
+// the second and third enqueues land on the already-errored writer. The
+// whole command must still finish: cat (last in the pipeline) sees EOF and
+// exits 0, and nothing made it through the pipe.
+const FIXTURE = /* js */ `
+import { $ } from "bun";
+const r = await $\`(echo one; echo two; echo three) | cat\`.quiet().nothrow();
+console.log(JSON.stringify({ exitCode: r.exitCode, stdout: r.stdout.toString() }));
+`;
+
+let shimPath: string;
+let dir: ReturnType<typeof tempDir> | undefined;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  dir = tempDir("shell-write-fault", {
+    "shim.c": SHIM_C,
+    "fixture.js": FIXTURE,
+  });
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell finishes when send() on a pipeline pipe fails after the writer started",
+  async () => {
+    const existing = bunEnv.LD_PRELOAD;
+    await using proc = Bun.spawn({
+      // If the fixture does crash, skip the debug build's slow symbolized
+      // backtrace so the failure surfaces as the panic message, not a test
+      // timeout. The fixture ignores the extra argv entry.
+      cmd: [bunExe(), "fixture.js", "--debug-crash-handler-use-trace-string"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+        SHELL_FAIL_SEND: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const line = stdout.trim().split("\n").pop() ?? "";
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      parsed = line;
+    }
+    // One combined assertion so a crash surfaces stderr and the exit code in
+    // the diff. `cat` is last in the pipeline, so the expression's exit code
+    // is 0; the failed writer means nothing reached it.
+    expect({ parsed, stderr, exitCode }).toEqual({
+      parsed: { exitCode: 0, stdout: "" },
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+);


### PR DESCRIPTION
### What does this PR do?

Fixes a Bun Shell IOWriter state machine hole: after a fatal (non-EPIPE) write error, the writer still accepted new chunks.

Fuzzing the shell's pipe syscalls (`epoll_ctl(EPOLL_CTL_MOD)` and `send` on the `$` pipeline's socketpair returning `ENOMEM`) hits this in a debug build:

```
panic: assertion failed: matches!(s.writer.handle, PollOrFd::Poll(_))
  IOWriter::write            src/runtime/shell/IOWriter.rs
  <- IOWriter::enqueue_internal
  <- IOWriter::enqueue
```

### Cause

When a write on a pollable fd fails with anything other than a retryable errno, `PosixBufferedWriter::_on_error` reports the error to the `IOWriter` (`IOWriter::on_error`) and then calls `close()`, which tears down the poll and leaves `handle == PollOrFd::Closed`.

`IOWriter` keeps `started = true` and `flags.pollable = true`, and nothing records that the writer is dead. EPIPE is the only error with a guard (`flags.broken_pipe`). So the statements that run after the failure keep writing to the same fd, and go down one of two bad paths:

- The completion callbacks that `on_error` fires drive the trampoline, so the next statement's `enqueue` runs while `on_error` is still on the stack, before `_on_error`'s `close()`. It sees `handle == Poll`, re-registers the poll, and suspends; `close()` then tears that poll down, so the chunk can never complete and that child waits forever. `(echo one; echo two; echo three) | cat` hangs the shell.
- An enqueue that instead lands after the close (a later event loop turn) reaches `write()` with `handle == Closed` and trips the `PollOrFd::Poll(_)` assertion above. In a release build that `debug_assert` compiles out and `write()` restarts a writer it already tore down.

### Fix

Record the error on the `IOWriter` in `fail_pending_writers` (shared by the async `on_error` path and the sync `on_sync_error` path, and set before any completion callback runs), and treat a writer with a stored error exactly like one with a broken pipe: `enqueue` / `enqueue_fmt_bltn` report the stored error to the child immediately instead of queueing a chunk (`handle_broken_pipe` generalized to `handle_dead_writer`). The state stores the `sys::Error` itself rather than a derived `SystemError`, so each rejected chunk gets its own freshly derived `SystemError` (same as what `on_error` hands to the children that were already pending).

### Test

`test/js/bun/shell/shell-write-fault.test.ts`: an `LD_PRELOAD` shim makes `send()` on AF_UNIX sockets fail with `ENOMEM`, so the subshell's first chunk errors and the second and third `echo` enqueue onto the dead writer.

```
# without the fix (src/ reverted to main)
(fail) shell finishes when send() on a pipeline pipe fails after the writer started [5000.56ms]
  ^ this test timed out after 5000ms.        # child hung, killed 1 dangling process

# with the fix
(pass) shell finishes when send() on a pipeline pipe fails after the writer started [764.46ms]
```

The `handle == Closed` assertion itself needs the enqueue to arrive on a later event loop turn than the error, which requires the fuzzer's recorded fault ordering; the hang above is the deterministic form of the same broken invariant and the same fix removes both.

Shell suites (`bunshell`, `yield`, `epipe`, `file-io`, `shell-pipe-read-fault`) pass on a debug ASAN build with the change.

### Notes

- Rebased over #33008, which restructured the same error path (it stopped `on_error` from re-entering the trampoline on synchronous write errors and removed the then-unused `State::err` field). The mechanism described above is current main. Before #33008 the missing guard additionally showed up as the re-entrant chunk being wiped by `on_error`'s trailing queue clear; #33008 removed that clear but not the underlying hole, which this PR closes by re-introducing `State::err` as the dead-writer marker, now set in the shared `fail_pending_writers`.

### Related

- #29996 (open, conflicting with main) contains the same enqueue-side guard inside a larger `on_error` change; see [the comparison](https://github.com/oven-sh/bun/pull/32946#issuecomment-4823325510). They should not both land.
- #26580 reports an intermittent Bun Shell hang with large piped output. This PR produces that symptom only after a failed write syscall, which that report does not show, so it is not marked as fixed by this PR.
