### PR TITLE
install: make `bun update <name>` re-resolve every dependency on `<name>`

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2010,11 +2010,9 @@ fn get_or_put_resolved_package_with_find_result(
             unsafe { &*(*this_ptr).lockfile }
                 .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id)
         } else {
-            // `bun update <name>`: every dependency on `<name>` is an update
-            // target, whichever workspace or parent package it belongs to.
-            // Matching only the current workspace's direct entry leaves every
-            // other resolution of `<name>` pinned to the lockfile-loaded
-            // version via `get_package_id`'s satisfies fallback, forever.
+            // `bun update <name>`: every dependency on `<name>` is an update target,
+            // whichever workspace or parent package it belongs to. Otherwise other
+            // resolutions stay pinned via `get_package_id`'s satisfies fallback.
             UpdateRequest::contains_name_hash(&this.update_requests, dependency.name_hash)
         };
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -20,9 +20,9 @@ use crate::lockfile::PackageIndexEntry;
 use crate::lockfile::package::Package;
 use crate::lockfile_real as Lockfile;
 use crate::package_manager_real::{
-    self, FailFn, PackageManager, SuccessFn, TaskCallbackList, determine_preinstall_state,
-    get_cache_directory, get_preinstall_state, get_temporary_directory, run_tasks,
-    set_preinstall_state,
+    self, FailFn, PackageManager, SuccessFn, TaskCallbackList, UpdateRequest,
+    determine_preinstall_state, get_cache_directory, get_preinstall_state, get_temporary_directory,
+    run_tasks, set_preinstall_state,
 };
 use crate::package_manager_task as Task;
 use crate::patch_install::EnqueueAfterState;
@@ -1999,21 +1999,24 @@ fn get_or_put_resolved_package_with_find_result(
 ) -> Result<Option<ResolvedPackageResult>, bun_core::Error> {
     // reshaped for borrowck — `is_root_dependency(&self, &mut PackageManager, …)`
     // borrows `this.lockfile` and `this` at once. Split via raw root.
-    let should_update = {
-        let this_ptr: *mut PackageManager = this;
-        // SAFETY: `is_root_dependency` reads `manager.root_dependency_list` /
-        // `manager.workspace_package_json_cache` only — disjoint from
-        // `manager.lockfile`.
-        this.to_update
-            // If updating, only update packages in the current workspace
-            && unsafe { &*(*this_ptr).lockfile }
+    let should_update = this.to_update
+        && if this.update_requests.is_empty() {
+            // Bare `bun update`: refresh only the current workspace's direct
+            // dependencies.
+            let this_ptr: *mut PackageManager = this;
+            // SAFETY: `is_root_dependency` reads `manager.root_dependency_list` /
+            // `manager.workspace_package_json_cache` only — disjoint from
+            // `manager.lockfile`.
+            unsafe { &*(*this_ptr).lockfile }
                 .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id)
-            // no need to do a look up if update requests are empty (`bun update` with no args)
-            && (this.update_requests.is_empty()
-                || this.updating_packages.contains(
-                    dependency.name.slice(this.lockfile.buffers.string_bytes.as_slice()),
-                ))
-    };
+        } else {
+            // `bun update <name>`: every dependency on `<name>` is an update
+            // target, whichever workspace or parent package it belongs to.
+            // Matching only the current workspace's direct entry leaves every
+            // other resolution of `<name>` pinned to the lockfile-loaded
+            // version via `get_package_id`'s satisfies fallback, forever.
+            UpdateRequest::contains_name_hash(&this.update_requests, dependency.name_hash)
+        };
 
     // Was this package already allocated? Let's reuse the existing one.
     //

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -70,6 +70,13 @@ fn anchor_cli_bytes(b: Box<[u8]>) -> &'static [u8] {
 }
 
 impl UpdateRequest {
+    /// `bun update <name>`: is `name_hash` one of the packages named on the
+    /// command line? `false` for a bare `bun update` (empty `requests`).
+    #[inline]
+    pub fn contains_name_hash(requests: &[UpdateRequest], name_hash: PackageNameHash) -> bool {
+        requests.iter().any(|r| r.name_hash == name_hash)
+    }
+
     /// Borrow the backing string buffer.
     ///
     /// SAFETY for callers: the buffer this points into (leaked CLI input, or

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -527,14 +527,9 @@ pub fn install_with_manager(
                         }
                     }
 
-                    // `bun update <name>` must re-resolve every dependency on
-                    // `<name>`, not only the current workspace's direct entry.
-                    // `Diff::generate` only invalidates root-level slots (and
-                    // workspaces whose own diff changed), so a `<name>` owned
-                    // by a preserved parent package never re-enters the queue
-                    // and its resolution stays pinned to the lockfile-loaded
-                    // version. Drop and re-enqueue every matching slot, like
-                    // the `overrides_changed` pass above.
+                    // `bun update <name>` must re-resolve every dependency on `<name>`,
+                    // not only the root-level slots `Diff::generate` invalidates. Drop and
+                    // re-enqueue every matching slot, like the `overrides_changed` pass above.
                     if manager.to_update && !manager.update_requests.is_empty() {
                         let dependencies_len = manager.lockfile.buffers.dependencies.len();
                         for dependency_i in 0..dependencies_len {

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -36,8 +36,8 @@ use bun_install_types::NodeLinker::NodeLinker;
 // to avoid one giant `impl PackageManager` block.
 use crate::package_manager_real::run_tasks::{RunTasksCallbacks, run_tasks};
 use crate::package_manager_real::{
-    enqueue_dependency_list, enqueue_dependency_with_main, enqueue_patch_task_pre, save_lockfile,
-    setup_global_dir, update_lockfile_if_needed, write_yarn_lock,
+    UpdateRequest, enqueue_dependency_list, enqueue_dependency_with_main, enqueue_patch_task_pre,
+    save_lockfile, setup_global_dir, update_lockfile_if_needed, write_yarn_lock,
 };
 
 use super::security_scanner;
@@ -523,6 +523,38 @@ pub fn install_with_manager(
                                 false,
                             ) {
                                 add_dependency_error(manager, &dep, err);
+                            }
+                        }
+                    }
+
+                    // `bun update <name>` must re-resolve every dependency on
+                    // `<name>`, not only the current workspace's direct entry.
+                    // `Diff::generate` only invalidates root-level slots (and
+                    // workspaces whose own diff changed), so a `<name>` owned
+                    // by a preserved parent package never re-enters the queue
+                    // and its resolution stays pinned to the lockfile-loaded
+                    // version. Drop and re-enqueue every matching slot, like
+                    // the `overrides_changed` pass above.
+                    if manager.to_update && !manager.update_requests.is_empty() {
+                        let dependencies_len = manager.lockfile.buffers.dependencies.len();
+                        for dependency_i in 0..dependencies_len {
+                            let dependency =
+                                manager.lockfile.buffers.dependencies[dependency_i].clone();
+                            if UpdateRequest::contains_name_hash(
+                                &manager.update_requests,
+                                dependency.name_hash,
+                            ) {
+                                manager.lockfile.buffers.resolutions[dependency_i] =
+                                    invalid_package_id;
+                                if let Err(err) = enqueue_dependency_with_main(
+                                    manager,
+                                    dependency_i as u32,
+                                    &dependency,
+                                    invalid_package_id,
+                                    false,
+                                ) {
+                                    add_dependency_error(manager, &dependency, err);
+                                }
                             }
                         }
                     }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1400,14 +1400,7 @@ impl Diff {
             ) {
                 if let Some(updates) = update_requests {
                     if updates.is_empty()
-                        || 'brk: {
-                            for request in updates {
-                                if from_dep.name_hash == request.name_hash {
-                                    break 'brk true;
-                                }
-                            }
-                            false
-                        }
+                        || UpdateRequest::contains_name_hash(updates, from_dep.name_hash)
                     {
                         // Listed as to be updated
                         summary.update += 1;
@@ -1541,7 +1534,7 @@ impl Diff {
             // above.
             let is_explicit_update_target = matches!(update_requests, Some(updates)
                 if updates.is_empty()
-                    || updates.iter().any(|r| r.name_hash == from_dep.name_hash));
+                    || UpdateRequest::contains_name_hash(updates, from_dep.name_hash));
             if !is_explicit_update_target {
                 if let Some(mapping) = id_mapping.as_deref_mut() {
                     let from_res_id = from_resolutions[i];

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -1,8 +1,8 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
 import { access, mkdir, readFile, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, toBeValidBin, toHaveBins } from "harness";
-import { join } from "path";
+import { bunExe, bunEnv as env, pack, readdirSorted, toBeValidBin, toHaveBins } from "harness";
+import { basename, join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -526,4 +526,129 @@ it("should print UTF-8 arrows correctly with colors enabled", async () => {
   // double-encoded UTF-8 (each byte of the arrow re-encoded as Latin-1)
   expect(out).not.toContain("â");
   expect(await exited2).toBe(0);
+});
+
+// Unlike `dummyRegistry`, this serves a distinct manifest per package name,
+// packing a real tarball for each version into `tgzDir`.
+async function perNameRegistry(
+  tgzDir: string,
+  manifests: Record<string, { versions: Record<string, { dependencies?: Record<string, string> }>; latest: string }>,
+) {
+  for (const [name, { versions }] of Object.entries(manifests)) {
+    for (const [version, extra] of Object.entries(versions)) {
+      const staging = join(tgzDir, ".staging", `${name}-${version}`);
+      await mkdir(staging, { recursive: true });
+      await writeFile(join(staging, "package.json"), JSON.stringify({ name, version, ...extra }));
+      await pack(staging, env, "--destination", tgzDir);
+    }
+  }
+  return (request: Request) => {
+    const url = request.url;
+    if (url.endsWith(".tgz")) return new Response(file(join(tgzDir, basename(url))));
+    const name = url.slice(url.indexOf("/", root_url.length) + 1);
+    const entry = manifests[name];
+    if (!entry) return new Response("not found", { status: 404 });
+    const versions: Record<string, object> = {};
+    for (const [version, extra] of Object.entries(entry.versions)) {
+      versions[version] = { name, version, dist: { tarball: `${url}-${version}.tgz` }, ...extra };
+    }
+    return new Response(JSON.stringify({ name, versions, "dist-tags": { latest: entry.latest } }));
+  };
+}
+
+async function runInPackageDir(...args: string[]) {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), ...args],
+    cwd: package_dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(exitCode).toBe(0);
+  return out;
+}
+
+// The set of `shared@<version>` resolutions in the text lockfile.
+async function lockedSharedResolutions() {
+  const lock = await file(join(package_dir, "bun.lock")).text();
+  return [...new Set(lock.match(/"shared@[\d.]+"/g))].sort();
+}
+
+async function writePerNameBunfig() {
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = "${root_url}/"\nsaveTextLockfile = true\nlinker = "hoisted"\n`,
+  );
+}
+
+// `bun update <name>` must re-resolve every dependency on `<name>` in the
+// lockfile, each within its own version range. A workspace whose range
+// resolves to a different version than the current workspace's used to be
+// left pinned to the lockfile-loaded entry forever: `bun outdated -r` kept
+// reporting it, but `bun update <name>` could never apply it.
+it("should update every resolution of a named package across workspaces", async () => {
+  setHandler(
+    await perNameRegistry(join(package_dir, ".tarballs"), {
+      shared: { versions: { "1.0.0": {}, "1.1.0": {}, "2.0.0": {} }, latest: "2.0.0" },
+    }),
+  );
+  await writePerNameBunfig();
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: { shared: "^2.0.0" } }),
+  );
+  const pkgOneJson = join(package_dir, "packages", "pkg-one", "package.json");
+  await mkdir(join(package_dir, "packages", "pkg-one"), { recursive: true });
+  await writeFile(pkgOneJson, JSON.stringify({ name: "pkg-one", version: "1.0.0", dependencies: { shared: "1.0.0" } }));
+  await runInPackageDir("install");
+
+  // Widen pkg-one's range. A plain install keeps its stale 1.0.0 because the
+  // previously resolved package still satisfies the new range.
+  await writeFile(
+    pkgOneJson,
+    JSON.stringify({ name: "pkg-one", version: "1.0.0", dependencies: { shared: "^1.0.0" } }),
+  );
+  await runInPackageDir("install");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.0.0"', '"shared@2.0.0"']);
+
+  // root's ^2.0.0 is already at 2.0.0; pkg-one's ^1.0.0 must move to 1.1.0.
+  await runInPackageDir("update", "shared");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.1.0"', '"shared@2.0.0"']);
+  expect(
+    await file(join(package_dir, "packages", "pkg-one", "node_modules", "shared", "package.json")).json(),
+  ).toMatchObject({ version: "1.1.0" });
+
+  // The update reached a fixpoint: running it again is a no-op.
+  await runInPackageDir("update", "shared");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.1.0"', '"shared@2.0.0"']);
+});
+
+// Same bug one level deeper: a dependency on `<name>` owned by a preserved
+// parent package never re-entered the resolve queue, so `bun update <name>`
+// left it on the lockfile-loaded version.
+it("should update transitive resolutions of a named package", async () => {
+  setHandler(
+    await perNameRegistry(join(package_dir, ".tarballs"), {
+      shared: { versions: { "1.0.0": {}, "1.1.0": {} }, latest: "1.1.0" },
+      "dep-x": { versions: { "1.0.0": { dependencies: { shared: "^1.0.0" } } }, latest: "1.0.0" },
+    }),
+  );
+  await writePerNameBunfig();
+  // dep-x@1.0.0 depends on shared@^1.0.0, which dedupes onto the root's
+  // exact shared@1.0.0 at install time.
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", dependencies: { shared: "1.0.0", "dep-x": "^1.0.0" } }),
+  );
+  await runInPackageDir("install");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.0.0"']);
+
+  // The root's exact `1.0.0` cannot move; dep-x's `^1.0.0` must move to 1.1.0.
+  await runInPackageDir("update", "shared");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.0.0"', '"shared@1.1.0"']);
+  expect(
+    await file(join(package_dir, "node_modules", "dep-x", "node_modules", "shared", "package.json")).json(),
+  ).toMatchObject({ version: "1.1.0" });
 });

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -649,3 +649,33 @@ it("should update transitive resolutions of a named package", async () => {
     await file(join(package_dir, "node_modules", "dep-x", "node_modules", "shared", "package.json")).json(),
   ).toMatchObject({ version: "1.1.0" });
 });
+
+// `<name>` appears only transitively: nothing in any package.json depends on
+// it directly. `bun update <name>` promotes it to a direct dependency of the
+// invoking package.json, and the transitive slot must re-resolve too.
+it("should update a resolution reachable only through a transitive dependency", async () => {
+  const tgzDir = join(package_dir, ".tarballs");
+  const depX = { "dep-x": { versions: { "1.0.0": { dependencies: { shared: "^1.0.0" } } }, latest: "1.0.0" } };
+  // Only shared@1.0.0 exists when the lockfile is created.
+  setHandler(await perNameRegistry(tgzDir, { ...depX, shared: { versions: { "1.0.0": {} }, latest: "1.0.0" } }));
+  await writePerNameBunfig();
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", dependencies: { "dep-x": "^1.0.0" } }),
+  );
+  await runInPackageDir("install");
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.0.0"']);
+
+  // shared@1.1.0 is published after the lockfile pinned 1.0.0.
+  setHandler(
+    await perNameRegistry(tgzDir, { ...depX, shared: { versions: { "1.0.0": {}, "1.1.0": {} }, latest: "1.1.0" } }),
+  );
+
+  // Both the new root entry and dep-x's `^1.0.0` must land on 1.1.0. Before
+  // the fix the root entry resolved to 1.1.0 while dep-x's stayed on 1.0.0.
+  await runInPackageDir("update", "shared");
+  expect(await file(join(package_dir, "package.json")).json()).toMatchObject({
+    dependencies: { "dep-x": "^1.0.0", shared: "^1.1.0" },
+  });
+  expect(await lockedSharedResolutions()).toEqual(['"shared@1.1.0"']);
+});

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -671,8 +671,7 @@ it("should update a resolution reachable only through a transitive dependency", 
     await perNameRegistry(tgzDir, { ...depX, shared: { versions: { "1.0.0": {}, "1.1.0": {} }, latest: "1.1.0" } }),
   );
 
-  // Both the new root entry and dep-x's `^1.0.0` must land on 1.1.0. Before
-  // the fix the root entry resolved to 1.1.0 while dep-x's stayed on 1.0.0.
+  // Both the new root entry and dep-x's `^1.0.0` must land on 1.1.0.
   await runInPackageDir("update", "shared");
   expect(await file(join(package_dir, "package.json")).json()).toMatchObject({
     dependencies: { "dep-x": "^1.0.0", shared: "^1.1.0" },

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -584,10 +584,8 @@ async function writePerNameBunfig() {
 }
 
 // `bun update <name>` must re-resolve every dependency on `<name>` in the
-// lockfile, each within its own version range. A workspace whose range
-// resolves to a different version than the current workspace's used to be
-// left pinned to the lockfile-loaded entry forever: `bun outdated -r` kept
-// reporting it, but `bun update <name>` could never apply it.
+// lockfile, each within its own version range, including a workspace whose
+// range resolves to a different version than the current workspace's.
 it("should update every resolution of a named package across workspaces", async () => {
   setHandler(
     await perNameRegistry(join(package_dir, ".tarballs"), {
@@ -625,9 +623,8 @@ it("should update every resolution of a named package across workspaces", async 
   expect(await lockedSharedResolutions()).toEqual(['"shared@1.1.0"', '"shared@2.0.0"']);
 });
 
-// Same bug one level deeper: a dependency on `<name>` owned by a preserved
-// parent package never re-entered the resolve queue, so `bun update <name>`
-// left it on the lockfile-loaded version.
+// The same invariant one level deeper: a dependency on `<name>` owned by a
+// preserved parent package must also re-enter the resolve queue.
 it("should update transitive resolutions of a named package", async () => {
   setHandler(
     await perNameRegistry(join(package_dir, ".tarballs"), {


### PR DESCRIPTION
### What does this PR do?

`bun update <name>` only treats `<name>` as an update target when it is a direct dependency of the workspace the command is run from. Every other resolution of `<name>` in the lockfile (another workspace's, a transitive parent's) is silently left on its current version. `bun outdated -r` keeps reporting those entries as outdated on every run, but no number of `bun update <name>` (or `-r` / `--filter`) invocations can move them: the command has an unreachable fixpoint, and a workspace whose range resolves to a different version than the current workspace's never gets bugfix or security releases.

#### Reproduction

Workspace `wa` depends on `shared@^1.0.0`, `wb` on `shared@^2.0.0`; the lockfile has `1.0.0` and `2.0.0`; then `1.5.0` and `2.5.0` are published.

```
$ bun outdated -r
| shared | 1.0.0 | 1.5.0 | 2.5.0 | wa |
| shared | 2.0.0 | 2.5.0 | 2.5.0 | wb |

$ bun update shared --recursive   # from the monorepo root (npm updates both here)
installed shared@2.5.0

# bun.lock: shared@2.5.0, wa/shared: shared@1.0.0   <- wa never moves

$ bun update shared --recursive   # again: fixpoint
# bun.lock unchanged

$ bun outdated -r
| shared | 1.0.0 | 1.5.0 | 2.5.0 | wa |   <- reported forever, never applicable
```

The same shape reproduces with no workspaces at all: a root `shared@1.0.0` plus a transitive `dep-x -> shared@^1.0.0` that deduped onto it. `bun update shared` leaves the transitive `^1.0.0` pinned.

(`wb` only looks updated above because `bun update <name>` adds `shared` to the root `package.json` when the root did not already depend on it, and the resulting `shared@2.5.0` happens to satisfy `wb`'s `^2.0.0`. Neither workspace's resolution was actually re-resolved.)

#### Cause

Two things, both in the resolution layer:

1. The `should_update` gate in `get_or_put_resolved_package_with_find_result` requires `lockfile.is_root_dependency(dependency_id)`, which is only true for direct dependencies of the workspace the command was run from. For every other `<name>` slot the gate is false, so `Lockfile::get_package_id` is called with the version range and its satisfies fallback dedupes straight back onto the lockfile-loaded package (the floor guard is skipped for lockfile-loaded entries by design).

2. `install_with_manager` only re-enqueues root-level dependency slots whose diff mapping was invalidated. A `<name>` slot owned by a preserved parent package (a non-workspace transitive parent, or a workspace whose own diff is empty) never re-enters the resolve queue at all, so even a correct `should_update` would not see it.

#### Fix

Both changes mirror mechanisms that already exist in the file they touch:

- `should_update`: when `update_requests` is non-empty, treat every dependency whose `name_hash` matches a request as an update target, instead of requiring `is_root_dependency`. This is the same name-hash match `Diff::generate` already uses to decide what counts as "listed as to be updated". A bare `bun update` (no names) keeps the current-workspace scope, so `bun update` in one workspace still does not touch another.
- `install_with_manager`: when `update_requests` is non-empty, walk the loaded dependency buffer, drop the resolution of every slot whose `name_hash` matches a request, and re-enqueue it. This is the same shape as the `overrides_changed` pass ten lines above it.

The two new sites and the two equivalent inline loops already in `Diff::generate` now share one helper, `UpdateRequest::contains_name_hash`.

After the fix:

```
$ bun update shared --recursive
# bun.lock: shared@2.5.0, wa/shared -> shared@1.5.0, wb/shared -> shared@2.5.0
# second run is a no-op; bun outdated -r reports nothing
```

#### Note on the previous revision of this PR

An earlier revision fixed the workspace symptom one layer up, by routing the non-interactive `--recursive` / `--filter` flags through the interactive command's workspace iteration. That left `bun update <name>` with no flag and the single-project transitive case unchanged, because the resolution layer still only recognized the current workspace's direct entry as an update target. This revision replaces it with the root-cause fix, which covers every spelling. Implementing `--recursive` / `--filter` as real workspace selectors for non-interactive `bun update` (#23507) is a separate feature and is not part of this PR.

#32810 special-cases the same `should_update` gate for catalog dependencies, which are another instance of "not a direct dependency of the current workspace". The name-hash match here subsumes that part of it; that PR's other half (not adding a spurious root dependency for a catalog name) is independent.

### How did you verify your code works?

Three tests in `test/cli/install/bun-update.test.ts`, against an in-process per-name registry:

- `should update every resolution of a named package across workspaces`: root on `shared@^2.0.0` and workspace `pkg-one` on `shared@^1.0.0` with a stale `1.0.0` resolution. `bun update shared` moves pkg-one to `1.1.0` and leaves root on `2.0.0`, the lockfile holds exactly `shared@1.1.0` and `shared@2.0.0`, and a second run changes nothing.
- `should update transitive resolutions of a named package`: root on an exact `shared@1.0.0` plus `dep-x@^1.0.0` whose `shared@^1.0.0` deduped onto it. `bun update shared` leaves the root's exact pin at `1.0.0` and moves `dep-x`'s transitive resolution to `1.1.0`.
- `should update a resolution reachable only through a transitive dependency`: nothing depends on `shared` directly, only `dep-x@^1.0.0 -> shared@^1.0.0`. `bun update shared` promotes `shared` to a direct root dependency and must also move the transitive slot; before the fix the promoted root entry resolved to `1.1.0` while `dep-x`'s stayed on `1.0.0`, leaving both in the lockfile.

All three fail on the released binary and pass with the fix. Each half of the fix is load-bearing: without the `should_update` change the first two fail; without the re-enqueue walk the transitive tests fail.

No regressions in `test/cli/install/{bun-update,bun-add,bun-remove,bun-install,bun-install-registry,bun-workspaces,catalogs,overrides,minimum-release-age}.test.ts` and `test/regression/issue/update-interactive-formatting.test.ts` (the only red tests in those suites are pre-existing external-network git/GitHub/Bitbucket cases that also fail on the unmodified released binary in this environment).

