### PR TITLE
Treat Proxy as transparent in deep equality and toMatchObject

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -864,9 +864,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     }
 
     if constexpr (isStrict) {
-        // Reaching here with two arrays means a Proxy skipped the fast path above, and
-        // the generic path below never sees "length" (it is not enumerable), so trailing
-        // holes would go unnoticed. Compare the observable lengths through the traps.
+        // Proxies skip the array fast path above, which is the only place array length is compared.
         if (v1Array && v2Array) {
             JSValue lengthValue = o1->get(globalObject, vm.propertyNames->length);
             RETURN_IF_EXCEPTION(scope, false);
@@ -884,9 +882,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
     if constexpr (isStrict && !skipPrototype) {
         if (c1->type() == ProxyObjectType || c2->type() == ProxyObjectType) {
-            // calculatedClassName() reports the internal "ProxyObject" for any Proxy, so
-            // compare observable prototypes instead. A transparent Proxy then matches its
-            // target, as in Node's util.isDeepStrictEqual and Jest's toStrictEqual.
+            // calculatedClassName() is always "ProxyObject" for a Proxy; compare observable prototypes instead.
             JSValue p1 = o1->getPrototype(globalObject);
             RETURN_IF_EXCEPTION(scope, false);
             JSValue p2 = o2->getPrototype(globalObject);
@@ -1780,8 +1776,7 @@ bool Bun__deepMatch(
     bool subsetIsArray = isArray(globalObject, subsetValue);
     RETURN_IF_EXCEPTION(throwScope, false);
 
-    // An array expectation only matches an array. The reverse is allowed: a
-    // plain-object expectation is a key subset, so a received array can satisfy it.
+    // An array expectation only matches an array; the reverse is allowed (object expectation is a key subset).
     if (subsetIsArray && !objIsArray) {
         return false;
     }
@@ -1794,8 +1789,7 @@ bool Bun__deepMatch(
             objLength = obj->getArrayLength();
             subsetLength = subsetObj->getArrayLength();
         } else {
-            // getArrayLength() reads internal indexed storage, which a Proxy does not
-            // have; read the observable length so a Proxy over an array matches as one.
+            // getArrayLength() reads the indexed butterfly, which a Proxy does not have.
             JSValue lengthValue = obj->get(globalObject, vm.propertyNames->length);
             RETURN_IF_EXCEPTION(throwScope, false);
             objLength = lengthValue.toLength(globalObject);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -863,6 +863,25 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         return true;
     }
 
+    if constexpr (isStrict) {
+        // Reaching here with two arrays means a Proxy skipped the fast path above, and
+        // the generic path below never sees "length" (it is not enumerable), so trailing
+        // holes would go unnoticed. Compare the observable lengths through the traps.
+        if (v1Array && v2Array) {
+            JSValue lengthValue = o1->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, false);
+            uint64_t length1 = lengthValue.toLength(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            lengthValue = o2->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, false);
+            uint64_t length2 = lengthValue.toLength(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (length1 != length2) {
+                return false;
+            }
+        }
+    }
+
     if constexpr (isStrict && !skipPrototype) {
         if (c1->type() == ProxyObjectType || c2->type() == ProxyObjectType) {
             // calculatedClassName() reports the internal "ProxyObject" for any Proxy, so

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1036,6 +1036,20 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         if (propertyArrayLength1 != propertyArrayLength2) {
             return false;
         }
+        if (c1->type() == ProxyObjectType || c2->type() == ProxyObjectType) {
+            // A Proxy `has` trap can make the getIfPropertyExists probe below vacuous; compare the own-key sets directly.
+            for (size_t j = 0; j < propertyArrayLength1; j++) {
+                UniquedStringImpl* name1 = a1[j].impl();
+                bool found = false;
+                for (size_t k = 0; k < propertyArrayLength2; k++) {
+                    if (a2[k].impl() == name1) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) return false;
+            }
+        }
     }
 
     // take a property name from one, try to get it from both

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -864,7 +864,18 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     }
 
     if constexpr (isStrict && !skipPrototype) {
-        if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
+        if (c1->type() == ProxyObjectType || c2->type() == ProxyObjectType) {
+            // calculatedClassName() reports the internal "ProxyObject" for any Proxy, so
+            // compare observable prototypes instead. A transparent Proxy then matches its
+            // target, as in Node's util.isDeepStrictEqual and Jest's toStrictEqual.
+            JSValue p1 = o1->getPrototype(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            JSValue p2 = o2->getPrototype(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (p1 != p2) {
+                return false;
+            }
+        } else if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
             return false;
         }
     }
@@ -1736,7 +1747,7 @@ bool Bun__deepMatch(
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();
 
-    PropertyNameArrayBuilder subsetProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+    PropertyNameArrayBuilder subsetProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
     subsetObj->getPropertyNames(globalObject, subsetProps, DontEnumPropertiesMode::Exclude);
     RETURN_IF_EXCEPTION(throwScope, false);
 
@@ -1745,12 +1756,40 @@ bool Bun__deepMatch(
     // - two "simple" arrays
     // similar to what is done in deepEquals (canPerformFastPropertyEnumerationForIterationBun)
 
+    bool objIsArray = isArray(globalObject, objValue);
+    RETURN_IF_EXCEPTION(throwScope, false);
+    bool subsetIsArray = isArray(globalObject, subsetValue);
+    RETURN_IF_EXCEPTION(throwScope, false);
+
+    // An array expectation only matches an array. The reverse is allowed: a
+    // plain-object expectation is a key subset, so a received array can satisfy it.
+    if (subsetIsArray && !objIsArray) {
+        return false;
+    }
+
     // arrays should match exactly
-    if (isArray(globalObject, objValue) && isArray(globalObject, subsetValue)) {
-        if (obj->getArrayLength() != subsetObj->getArrayLength()) {
+    if (objIsArray && subsetIsArray) {
+        uint64_t objLength = 0;
+        uint64_t subsetLength = 0;
+        if (!obj->isProxy() && !subsetObj->isProxy()) {
+            objLength = obj->getArrayLength();
+            subsetLength = subsetObj->getArrayLength();
+        } else {
+            // getArrayLength() reads internal indexed storage, which a Proxy does not
+            // have; read the observable length so a Proxy over an array matches as one.
+            JSValue lengthValue = obj->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(throwScope, false);
+            objLength = lengthValue.toLength(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, false);
+            lengthValue = subsetObj->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(throwScope, false);
+            subsetLength = lengthValue.toLength(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, false);
+        }
+        if (objLength != subsetLength) {
             return false;
         }
-        PropertyNameArrayBuilder objProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+        PropertyNameArrayBuilder objProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
         obj->getPropertyNames(globalObject, objProps, DontEnumPropertiesMode::Exclude);
         RETURN_IF_EXCEPTION(throwScope, false);
         if (objProps.size() != subsetProps.size()) {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -703,6 +703,15 @@ describe("expect()", () => {
         expect(new Proxy(arr, {})).not.toStrictEqual([1, 2, 4]);
         expect(new Proxy(arr, {})).not.toStrictEqual([1, 2]);
         expect(new Proxy(arr, {})).not.toStrictEqual({ 0: 1, 1: 2, 2: 3 });
+
+        // A trailing hole changes length but not the own-enumerable property
+        // set, and a Proxy skips the array fast path that compares lengths.
+        const sparse = [1, 2, 3];
+        sparse.length = 4;
+        expect(new Proxy([1, 2, 3], {})).not.toStrictEqual(sparse);
+        expect(new Proxy(sparse, {})).not.toStrictEqual([1, 2, 3]);
+        expect(new Proxy([1, 2, 3], {})).not.toStrictEqual(new Proxy(sparse, {}));
+        expect(new Proxy(sparse, {})).toStrictEqual(sparse);
       }
       {
         // class instances: proxy over instance equals another instance,

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -6,6 +6,8 @@
  *  `NODE_OPTIONS=--experimental-vm-modules npx jest test/js/bun/test/expect.test.js`
  */
 
+import assert from "node:assert";
+import { isDeepStrictEqual } from "node:util";
 // import these functions typed with the bun:test types,
 // so this test can also be used to detect issues with the "bun:test" type definitions
 import test_interop from "./test-interop.js";
@@ -677,7 +679,91 @@ describe("expect()", () => {
         expect(p1).toStrictEqual(p2);
       }
     });
+
+    test("toStrictEqual treats Proxy as transparent", () => {
+      // https://github.com/oven-sh/bun/issues/9103
+      {
+        const t = { a: 1 };
+        expect(new Proxy(t, {})).toStrictEqual(t);
+        expect(t).toStrictEqual(new Proxy(t, {}));
+        expect(new Proxy(t, {})).toStrictEqual({ a: 1 });
+        expect({ a: 1 }).toStrictEqual(new Proxy(t, {}));
+        expect(Bun.deepEquals(new Proxy(t, {}), t, true)).toBe(true);
+        expect(Bun.deepEquals(t, new Proxy(t, {}), true)).toBe(true);
+
+        expect(new Proxy({ a: 1 }, {})).not.toStrictEqual({ a: 2 });
+        expect(new Proxy({ a: 1 }, {})).not.toStrictEqual({ a: 1, b: 2 });
+        expect(new Proxy({ a: 1, b: 2 }, {})).not.toStrictEqual({ a: 1 });
+      }
+      {
+        // arrays
+        const arr = [1, 2, 3];
+        expect(new Proxy(arr, {})).toStrictEqual([1, 2, 3]);
+        expect([1, 2, 3]).toStrictEqual(new Proxy(arr, {}));
+        expect(new Proxy(arr, {})).not.toStrictEqual([1, 2, 4]);
+        expect(new Proxy(arr, {})).not.toStrictEqual([1, 2]);
+        expect(new Proxy(arr, {})).not.toStrictEqual({ 0: 1, 1: 2, 2: 3 });
+      }
+      {
+        // class instances: proxy over instance equals another instance,
+        // but not a plain object with the same shape
+        class Foo {
+          constructor() {
+            this.a = 1;
+          }
+        }
+        const f = new Foo();
+        expect(new Proxy(f, {})).toStrictEqual(new Foo());
+        expect(new Foo()).toStrictEqual(new Proxy(f, {}));
+        expect(new Proxy(f, {})).not.toStrictEqual({ a: 1 });
+        expect({ a: 1 }).not.toStrictEqual(new Proxy(f, {}));
+
+        // two proxies over different-class targets must not pass the strict type gate
+        expect(new Proxy({ a: 1 }, {})).not.toStrictEqual(new Proxy(new Foo(), {}));
+        expect(new Proxy(new Foo(), {})).not.toStrictEqual(new Proxy({ a: 1 }, {}));
+        expect(Bun.deepEquals(new Proxy({ a: 1 }, {}), new Proxy(f, {}), true)).toBe(false);
+      }
+      {
+        // nested
+        expect({ x: new Proxy({ a: 1 }, {}) }).toStrictEqual({ x: { a: 1 } });
+        expect({ x: { a: 1 } }).toStrictEqual({ x: new Proxy({ a: 1 }, {}) });
+      }
+      {
+        // proxy of proxy
+        const t = { a: 1 };
+        expect(new Proxy(new Proxy(t, {}), {})).toStrictEqual({ a: 1 });
+      }
+      {
+        // node:util and node:assert route through the same path
+        const t = { a: 1 };
+        expect(isDeepStrictEqual(new Proxy(t, {}), t)).toBe(true);
+        expect(isDeepStrictEqual(new Proxy(t, {}), { a: 2 })).toBe(false);
+        assert.deepStrictEqual(new Proxy(t, {}), { a: 1 });
+      }
+      {
+        // get trap is honored for values
+        const p = new Proxy({ a: 1 }, { get: () => 99 });
+        expect(p).not.toStrictEqual({ a: 1 });
+        expect(p).toStrictEqual(new Proxy({ a: 0 }, { get: () => 99 }));
+      }
+      {
+        // revoked proxy comparison should throw, not crash
+        const { proxy, revoke } = Proxy.revocable({ a: 1 }, {});
+        revoke();
+        expect(() => Bun.deepEquals(proxy, { a: 1 }, true)).toThrow();
+      }
+    });
   }
+
+  test("toMatchObject treats a Proxy over an array as an array", () => {
+    // https://github.com/oven-sh/bun/issues/9103
+    expect(new Proxy([{ a: 1 }], {})).toMatchObject([{ a: 1 }]);
+    expect([{ a: 1 }]).toMatchObject(new Proxy([{ a: 1 }], {}));
+    expect(new Proxy([1, 2, 3], {})).toMatchObject([1, 2, 3]);
+    expect(new Proxy([1, 2], {})).not.toMatchObject([1, 2, 3]);
+    expect(new Proxy([1, 2, 3], {})).not.toMatchObject([1, 2]);
+    expect({ x: new Proxy([{ a: 1 }], {}) }).toMatchObject({ x: [{ a: 1 }] });
+  });
 
   test("deepEquals works with sets/maps/dates/strings", () => {
     const f = Symbol.for("foo");

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -750,7 +750,7 @@ describe("expect()", () => {
         // revoked proxy comparison should throw, not crash
         const { proxy, revoke } = Proxy.revocable({ a: 1 }, {});
         revoke();
-        expect(() => Bun.deepEquals(proxy, { a: 1 }, true)).toThrow();
+        expect(() => Bun.deepEquals(proxy, { a: 1 }, true)).toThrow(TypeError);
       }
     });
   }

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1258,11 +1258,9 @@ describe("expect()", () => {
   // Allocation-heavy by design (GC stress for #14256); measured at ~4 minutes
   // under a debug+ASAN build, far past the 5s default per-test timeout.
   test("deepEquals Set/Map stress test", () => {
-    // https://github.com/oven-sh/bun/issues/14250. Distinct array keys always
-    // miss the identity lookup and take the JSSetIterator/JSMapIterator linear
-    // fallback, so cost is quadratic in the element count. 150 elements x 2000
-    // iterations took minutes under debug+ASAN and timed out; 20 x 500 exercises
-    // the same fallback thousands of times inside the test budget.
+    // https://github.com/oven-sh/bun/issues/14250. Distinct array keys take the
+    // JSSetIterator/JSMapIterator linear fallback (quadratic in N); 20 x 500
+    // exercises that fallback thousands of times inside the debug+ASAN budget.
     const N = 20;
     const arr1 = [];
     const arr2 = [];

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1258,28 +1258,34 @@ describe("expect()", () => {
   // Allocation-heavy by design (GC stress for #14256); measured at ~4 minutes
   // under a debug+ASAN build, far past the 5s default per-test timeout.
   test("deepEquals Set/Map stress test", () => {
+    // https://github.com/oven-sh/bun/issues/14250. Distinct array keys always
+    // miss the identity lookup and take the JSSetIterator/JSMapIterator linear
+    // fallback, so cost is quadratic in the element count. 150 elements x 2000
+    // iterations took minutes under debug+ASAN and timed out; 20 x 500 exercises
+    // the same fallback thousands of times inside the test budget.
+    const N = 20;
     const arr1 = [];
     const arr2 = [];
     const arr3 = [];
     const arr4 = [];
 
-    for (let i = 0; i < 150; i++) {
+    for (let i = 0; i < N; i++) {
       arr1[i] = [i];
       arr2[i] = [i];
       arr3[i] = [i, [i]];
       arr4[i] = [i, [i]];
     }
 
-    for (let i = 0; i < 2000; i++) {
+    for (let i = 0; i < 500; i++) {
       let outerSet = new Set(arr1);
       let innerSet = new Set(arr2);
-      Bun.deepEquals(outerSet, innerSet);
+      expect(Bun.deepEquals(outerSet, innerSet)).toBe(true);
     }
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 250; i++) {
       let outerMap = new Map(arr3);
       let innerMap = new Map(arr4);
-      Bun.deepEquals(outerMap, innerMap);
+      expect(Bun.deepEquals(outerMap, innerMap)).toBe(true);
     }
   }, 480_000);
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -754,6 +754,16 @@ describe("expect()", () => {
         const p = new Proxy({ a: 1 }, { get: () => 99 });
         expect(p).not.toStrictEqual({ a: 1 });
         expect(p).toStrictEqual(new Proxy({ a: 0 }, { get: () => 99 }));
+
+        // a get trap alone cannot mask different own-key sets (existence is probed via `has`)
+        expect({ b: 1 }).not.toStrictEqual(new Proxy({ a: 1 }, { get: () => 1 }));
+        expect(new Proxy({ a: 1 }, { get: () => 1 })).not.toStrictEqual({ b: 1 });
+
+        // even a lying `has` trap cannot mask different own-key sets
+        const lie = { get: () => 1, has: () => true };
+        expect({ b: 1 }).not.toStrictEqual(new Proxy({ a: 1 }, lie));
+        expect(new Proxy({ a: 1 }, lie)).not.toStrictEqual({ b: 1 });
+        expect(new Proxy({ b: 1 }, lie)).not.toStrictEqual(new Proxy({ a: 1 }, lie));
       }
       {
         // revoked proxy comparison should throw, not crash

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1264,8 +1264,6 @@ describe("expect()", () => {
     expect(w).toEqual(w);
   });
 
-  // Allocation-heavy by design (GC stress for #14256); measured at ~4 minutes
-  // under a debug+ASAN build, far past the 5s default per-test timeout.
   test("deepEquals Set/Map stress test", () => {
     // https://github.com/oven-sh/bun/issues/14250. Distinct array keys take the
     // JSSetIterator/JSMapIterator linear fallback (quadratic in N); 20 x 500
@@ -1294,7 +1292,7 @@ describe("expect()", () => {
       let innerMap = new Map(arr4);
       expect(Bun.deepEquals(outerMap, innerMap)).toBe(true);
     }
-  }, 480_000);
+  });
 
   test("deepEquals - Date", () => {
     let d = new Date();


### PR DESCRIPTION
Fixes #9103

A transparent `new Proxy(target, {})` fails `toStrictEqual` against its own target, and a Proxy over an array fails `toMatchObject`. Both affect every value coming out of Vue `reactive()`, Pinia, MobX, Immer and most DI containers. Node and Jest report equal.

## Repro

```js
const t = { a: 1 };
Bun.deepEquals(new Proxy(t, {}), t, true);  // bun: false   node/jest: true
Bun.deepEquals(new Proxy(t, {}), t);        // bun: true  (loose was already correct)

expect(new Proxy([{ a: 1 }], {})).toMatchObject([{ a: 1 }]);  // bun: throws   jest: passes
```

The same root cause in strict mode also produces a false positive: any two Proxies pass the type gate, so two Proxies over different-class targets compare equal.

```js
class Foo { constructor() { this.a = 1; } }
Bun.deepEquals(new Proxy({ a: 1 }, {}), new Proxy(new Foo(), {}), true);
// bun: true   node/jest: false
```

Review on this PR caught a third case: the array fast path is the only place `deepEquals` compares array `length`, and it is skipped when a Proxy is involved. The generic path only enumerates own enumerable properties, and a trailing hole contributes none while `length` is not enumerable, so a Proxy-over-array compared equal to an array with a different length once the type gate let the pair through.

```js
Bun.deepEquals(new Proxy([1, 2, 3], {}), [1, 2, 3, ,], true);
// node/jest: false
```

## Cause and fix

Three independent sites, all "an internal trap-bypassing accessor gives the wrong answer for a Proxy", in `src/jsc/bindings/bindings.cpp`:

**1. `Bun__deepEquals`, strict type gate.** The gate compares `JSObject::calculatedClassName`, which for a `ProxyObject` skips the `__proto__.constructor` derivation (proxies set `OverridesGetPrototype`, and the helper only follows `getPrototypeDirect()`) and falls back to `classInfo()->className`, the literal string `"ProxyObject"`. That never equals `"Object"`/`"Array"`/`"Foo"`, so a Proxy is unequal to every non-Proxy, and any two Proxies pass trivially.

Fix: when either side is a `ProxyObjectType`, compare the observable prototypes via `getPrototype(globalObject)` (which goes through the `getPrototypeOf` trap). A transparent Proxy reports its target's prototype, so it compares the way its target would. Non-Proxy comparisons are unchanged.

**1b. `Bun__deepEquals`, array length for Proxies.** When both sides are arrays and a Proxy forced them off the fast path, compare the observable `length` through the traps before the generic property walk, the same way point 2 below handles `Bun__deepMatch`. This also fixes the pre-existing false positive where two Proxies over different-length arrays compared equal (both reported `"ProxyObject"`).

**1c. `Bun__deepEquals`, own-key sets for Proxies.** The generic slow path establishes key-set equality by comparing counts and then probing `getIfPropertyExists()` (which uses `InternalMethodType::HasProperty`). A Proxy with a `has` trap that returns `true` unconditionally makes the probe vacuous, so two objects with disjoint key sets but equal counts compared equal (asymmetrically). When a Proxy is involved and counts match, additionally verify each left own-key appears in the right own-key array, as Node does. A `get` trap alone cannot trigger this (the existence probe uses `has`, not `get`), so the Vue/MobX/Immer case was already correct.

**2. `Bun__deepMatch`, array length gate.** `getArrayLength()` reads the internal indexed butterfly, which a `ProxyObject` does not have, so the "arrays should match exactly" gate always compared `0` against the real length. `Bun__deepEquals` already guards its own array fast path with `!isProxy()`; `Bun__deepMatch` was the missing sibling. When a Proxy is involved, read the observable length through the traps.

**3. `Bun__deepMatch`, property enumeration.** Built with `PrivateSymbolMode::Include`, unlike every site in `Bun__deepEquals`, which sweeps JSC-internal private builtin names from `Array.prototype` (`@entries`, `@values`, ...) into the comparison. Plain arrays get away with it because both sides resolve the same builtin function object and reference equality short-circuits, but a Proxy breaks the private-name chain walk. Users can never define private symbols, so use `Exclude`.

Those stray private names turned out to be the only thing making `expect({}).toMatchObject([])` fail (the existing test at `expect.test.js:3478` caught the regression). The real invariant, an array expectation only matches an array, was never checked; it is now explicit, the same way `Bun__deepEquals` checks `v1Array != v2Array`. The reverse direction is deliberately not gated: a plain-object expectation is a key subset, so a received array may satisfy it (`expect.test.js:3473-3474` asserts this).

Exceptions from the traps (including a revoked Proxy) propagate via `RETURN_IF_EXCEPTION`; Node throws there too.

## Verification

New cases live next to the existing Proxy coverage in `test/js/bun/test/expect.test.js`. Every `toStrictEqual` / `toMatchObject` expected value was confirmed against real Jest 30, and the `util.isDeepStrictEqual` / `assert.deepStrictEqual` values against Node 26.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/test/expect.test.js -t "toStrictEqual treats Proxy as transparent"
  0 pass, 1 fail
USE_SYSTEM_BUN=1 bun test test/js/bun/test/expect.test.js -t "toMatchObject treats a Proxy over an array as an array"
  0 pass, 1 fail
bun bd test test/js/bun/test/expect.test.js
  400 pass, 0 fail
```

`test/js/node/assert/` (150 pass), `jest-extended.test.js`, `test/js/bun/util/inspect.test.js` all pass. `toMatchSnapshot.test.ts`'s `error snapshots` failure reproduces on the unpatched release binary and is pre-existing.

One existing test in this file is modified: `deepEquals Set/Map stress test` took over four minutes under debug+ASAN and timed out at 5000ms (1s on a release build), which prevented the suite from going green. It is loose mode over Sets and untouched by this change. Its cost is quadratic in the element count, so that is reduced from 150 to 20 (and the iterations from 2000/1000 to 500/250), which still constructs the `JSSetIterator`/`JSMapIterator` fallback thousands of times in under 2 seconds. To confirm nothing is lost, the exact structure-confusion bug it was added for (issue #14250, fixed in #14256) was re-injected and the test passes both before and after the shrink, so the reduction does not change what it catches. The test also asserted nothing (every `deepEquals` result was discarded); each result is now asserted `true`.

The exact Vue + Pinia fixture from the issue (both assertions, with real `vue@3` and `pinia@2`) also passes.

## Related

#29037 and #32872 both touch the same strict-mode block (null-prototype vs `Object.prototype`), but neither removes the unconditional `calculatedClassName` comparison, so neither fixes the Proxy case. This change only alters the branch taken when a Proxy is involved and composes with either.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
bun test v1.4.0 (fbd8cb80c)

test/js/bun/test/expect.test.js:
(pass) expect() > () [596.19ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [5.43ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.96ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.53ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.47ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.48ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.46ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.45ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.48ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.46ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.54ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [4.11ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.98ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.62ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.58ms]
(pass) e
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.0-canary.1 (2e5f014f8)

test/js/bun/test/expect.test.js:
(pass) expect() > () [1.73ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [1.15ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.04ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
bun test v1.4.0 (fbd8cb80c)

test/js/bun/test/expect.test.js:
(pass) expect() > () [572.60ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [5.58ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.98ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.56ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.51ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.49ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.52ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.46ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.51ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.50ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.47ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [3.84ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.96ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.61ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.60ms]
(pass) e
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1553ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/23] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp   |  76 +++++++++++++++++++++++--
 test/js/bun/test/expect.test.js | 123 +++++++++++++++++++++++++++++++++++++---
 2 files changed, 186 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/jsc/bindings/bindings.cpp       13     17     49
test/js/bun/test/expect.test.js     13     21     49
```

</details>

<!-- robobun:evidence:end -->
