### PR TITLE
test: use strict equality in toContain to match Jest

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2237,6 +2237,16 @@ impl JSValue {
             JSC__JSValue__isSameValue(self, other, global)
         })
     }
+    /// `JSValue.isStrictEqual` (`===` / IsStrictlyEqual semantics).
+    ///
+    /// Differs from SameValue: `NaN !== NaN` and `-0 === +0`.
+    /// Can throw (rope-string resolution).
+    pub fn is_strict_equal(self, other: JSValue, global: &JSGlobalObject) -> JsResult<bool> {
+        // No encoded-bits fast path: two NaNs share an encoding but NaN !== NaN.
+        host_fn::from_js_host_call_generic(global, || {
+            JSC__JSValue__isStrictEqual(self, other, global)
+        })
+    }
 
     // ── Numeric coercion. ────────────────────
     /// `JSValue.toNumber` — full ECMA `ToNumber` (`+value`); may throw.
@@ -2652,6 +2662,11 @@ impl JSValue {
 unsafe extern "C" {
     safe fn JSC__JSValue__eqlValue(this: JSValue, other: JSValue) -> bool;
     safe fn JSC__JSValue__isSameValue(
+        this: JSValue,
+        other: JSValue,
+        global: &JSGlobalObject,
+    ) -> bool;
+    safe fn JSC__JSValue__isStrictEqual(
         this: JSValue,
         other: JSValue,
         global: &JSGlobalObject,

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -25,27 +25,14 @@ use bun_threading::work_pool::{IntrusiveWorkTask as _, Task as WorkPoolTask, Wor
 /// Local extension shims for `JSValue` methods not yet surfaced on the
 /// `bun_jsc::JSValue` type.
 trait JSValueNapiExt {
-    fn is_strict_equal(self, other: JSValue, global: &JSGlobalObject) -> jsc::JsResult<bool>;
     fn is_async_context_frame(self) -> bool;
 }
 
 unsafe extern "C" {
-    fn JSC__JSValue__isStrictEqual(
-        this: JSValue,
-        other: JSValue,
-        global: *mut JSGlobalObject,
-    ) -> bool;
     fn Bun__JSValue__isAsyncContextFrame(value: JSValue) -> bool;
 }
 
 impl JSValueNapiExt for JSValue {
-    fn is_strict_equal(self, other: JSValue, global: &JSGlobalObject) -> jsc::JsResult<bool> {
-        // SAFETY: FFI; may run JS (getters on Proxy etc.); `call_check_slow!` opens the
-        // exception scope before the call and propagates any pending exception.
-        bun_jsc::call_check_slow!(global, || unsafe {
-            JSC__JSValue__isStrictEqual(self, other, global.as_mut_ptr())
-        })
-    }
     #[inline]
     fn is_async_context_frame(self) -> bool {
         // SAFETY: trivial FFI.

--- a/src/runtime/test_runner/expect/toContain.rs
+++ b/src/runtime/test_runner/expect/toContain.rs
@@ -35,10 +35,12 @@ impl Expect {
             pass: *mut bool,
         }
 
+        // Jest's toContain uses `===` (Array.prototype.indexOf), not Object.is:
+        // `[-0]` contains `0`, `[NaN]` does not contain `NaN`.
         if value.js_type_loose().is_array_like() {
             let mut itr = value.array_iterator(global)?;
             while let Some(item) = itr.next()? {
-                if item.is_same_value(expected, global)? {
+                if item.is_strict_equal(expected, global)? {
                     pass = true;
                     break;
                 }
@@ -63,7 +65,7 @@ impl Expect {
                 pass: &raw mut pass,
             };
 
-            extern "C" fn same_value_iterator(
+            extern "C" fn strict_equal_iterator(
                 _: *mut VM,
                 _: &JSGlobalObject,
                 entry_: *mut c_void,
@@ -76,7 +78,7 @@ impl Expect {
                 // SAFETY: entry.global was set from `std::ptr::from_ref(global)` on the caller's
                 // stack frame, which outlives the synchronous for_each this callback runs inside.
                 let global = unsafe { &*entry.global };
-                let Ok(same) = item.is_same_value(entry.expected, global) else {
+                let Ok(same) = item.is_strict_equal(entry.expected, global) else {
                     return;
                 };
                 if same {
@@ -90,7 +92,7 @@ impl Expect {
             value.for_each(
                 global,
                 (&raw mut expected_entry).cast::<c_void>(),
-                same_value_iterator,
+                strict_equal_iterator,
             )?;
         } else {
             return Err(global.throw(format_args!(

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1169,6 +1169,8 @@ describe("expect()", () => {
     expect(w).toEqual(w);
   });
 
+  // Allocation-heavy by design (GC stress for #14256); measured at ~4 minutes
+  // under a debug+ASAN build, far past the 5s default per-test timeout.
   test("deepEquals Set/Map stress test", () => {
     const arr1 = [];
     const arr2 = [];
@@ -1193,7 +1195,7 @@ describe("expect()", () => {
       let innerMap = new Map(arr4);
       Bun.deepEquals(outerMap, innerMap);
     }
-  });
+  }, 480_000);
 
   test("deepEquals - Date", () => {
     let d = new Date();
@@ -2387,6 +2389,18 @@ describe("expect()", () => {
     ["😄", "😄"],
     ["", ""],
     [[1, 2, 3], 1],
+    // toContain uses === like Jest (Array.prototype.indexOf), so -0 and +0 match.
+    [[-0], 0],
+    [[0], -0],
+    [new Float64Array([-0]), 0],
+    [
+      {
+        *[Symbol.iterator]() {
+          yield -0;
+        },
+      },
+      0,
+    ],
     [["a", "b", "c"], "c"],
     [[null, undefined], undefined],
     [[1n, "abc", null, -1n, undefined], -1n],
@@ -2419,6 +2433,10 @@ describe("expect()", () => {
     [new String("hello"), ""],
     ["emoji: 😃", "😄"],
     [[1, 2, 3], -1],
+    // toContain uses === like Jest (Array.prototype.indexOf), so NaN never matches.
+    [[NaN], NaN],
+    [new Float64Array([NaN]), NaN],
+    [new Set([NaN]), NaN],
     [[1, 2, 3], 1n],
     [["a", "b", "c"], "d"],
     [[Symbol.for("a")], Symbol("a")],


### PR DESCRIPTION
### Problem

`expect().toContain()` compares array and iterable elements with SameValue (`Object.is`), but Jest uses `Array.prototype.indexOf`, which is strict equality. The two only differ on `NaN` and signed zero, and both directions diverge today:

```js
test("a", () => expect([-0]).toContain(0));    // bun: fail, jest 30.4.1: pass
test("b", () => expect([NaN]).toContain(NaN)); // bun: pass, jest 30.4.1: fail
```

```
error: expect(received).toContain(expected)

Expected to contain: 0
Received: [ -0 ]
```

The first direction is the painful one: any numeric result that happens to be `-0` breaks an otherwise valid `toContain(0)` only under `bun test`. Jest's own failure output names the comparison it uses (`expect(received).toContain(expected) // indexOf`), and the docs say `toContain` "uses ===, a strict equality check".

### Fix

`toContain.rs` now uses `JSC::JSValue::strictEqual` instead of `sameValue` on both the array-like and iterable paths. `toBe`, which Jest documents as `Object.is`, is unchanged, and `toContainEqual` still does deep equality.

The existing `JSC__JSValue__isStrictEqual` binding is surfaced as `JSValue::is_strict_equal`, and the napi-local shim that duplicated it is removed. The new helper deliberately has no encoded-bits fast path: two NaNs share an encoding but are not strictly equal.

### Tests

Added `-0` / `NaN` variants to the existing `toContain` and `not.toContain` `test.each` lists in `test/js/bun/test/expect.test.js`, covering both the array-like path (`Array`, `Float64Array`) and the iterable path (`Set`, generator). All 7 fail on current bun and match Jest 30.4.1 on Node 26.

That file also contains a pre-existing `deepEquals Set/Map stress test` that takes about 4 minutes under a debug+ASAN build, far past the default 5s per-test timeout, so `bun bd test test/js/bun/test/expect.test.js` was already red on main. It is the GC stress regression test for #14256 and its iteration count is load-bearing, so it now carries an explicit timeout rather than a smaller workload. CI's ASAN lane already gives it a 270s budget through the runner's 3x multiplier, so only plain `bun bd test` was affected.

`test/napi/napi.test.ts -t napi_strict_equals` still matches Node after the shim removal.