### PR TITLE
transpiler: expose reactFastRefresh on Bun.Transpiler

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2452,6 +2452,14 @@ declare module "bun" {
     macro?: MacroMap;
 
     autoImportJSX?: boolean;
+    /**
+     * Inject React Fast Refresh transforms (`$RefreshReg$` / `$RefreshSig$`) for JSX/TSX.
+     * The consumer must provide the refresh runtime globals (e.g. `react-refresh/runtime`).
+     * No-op on non-JSX loaders.
+     *
+     * @default false
+     */
+    reactFastRefresh?: boolean;
     allowBunRuntime?: boolean;
     exports?: {
       eliminate?: string[];

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2453,9 +2453,15 @@ declare module "bun" {
 
     autoImportJSX?: boolean;
     /**
-     * Inject React Fast Refresh transforms (`$RefreshReg$` / `$RefreshSig$`) for JSX/TSX.
-     * The consumer must provide the refresh runtime globals (e.g. `react-refresh/runtime`).
-     * No-op on non-JSX loaders.
+     * Inject React Fast Refresh transforms for JSX/TSX: `$RefreshReg$` registration
+     * calls for top-level components and `$RefreshSig$` hook signatures, plus an import
+     * of `register` / `createSignatureFunctionForTransform` from `react-refresh/runtime`.
+     * No-op on non-JSX loaders and on files that declare no components.
+     *
+     * Components are keyed by the transpiler's synthetic source name, so every file
+     * registers as `"input.tsx:Name"`. When transpiling multiple files (e.g. a per-file
+     * HMR dev server) rewrite that prefix to the real module path, otherwise same-named
+     * components in different files share one refresh identity.
      *
      * @default false
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2458,10 +2458,11 @@ declare module "bun" {
      * of `register` / `createSignatureFunctionForTransform` from `react-refresh/runtime`.
      * No-op on non-JSX loaders and on files that declare no components or hooks.
      *
-     * Components are keyed by the transpiler's synthetic source name, so every file
-     * registers as `"input.tsx:Name"`. When transpiling multiple files (e.g. a per-file
-     * HMR dev server) rewrite that prefix to the real module path, otherwise same-named
-     * components in different files share one refresh identity.
+     * Components are keyed by the transpiler's synthetic source name (`input.tsx` or
+     * `input.jsx`, by loader), so they register as e.g. `"input.tsx:Name"`. These keys
+     * are not unique across files: when transpiling multiple files (e.g. a per-file HMR
+     * dev server), rewrite the synthetic prefix to each file's real path so same-named
+     * components in different files don't share one refresh identity.
      *
      * @default false
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2456,7 +2456,7 @@ declare module "bun" {
      * Inject React Fast Refresh transforms for JSX/TSX: `$RefreshReg$` registration
      * calls for top-level components and `$RefreshSig$` hook signatures, plus an import
      * of `register` / `createSignatureFunctionForTransform` from `react-refresh/runtime`.
-     * No-op on non-JSX loaders and on files that declare no components.
+     * No-op on non-JSX loaders and on files that declare no components or hooks.
      *
      * Components are keyed by the transpiler's synthetic source name, so every file
      * registers as `"input.tsx:Name"`. When transpiling multiple files (e.g. a per-file

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1634,6 +1634,8 @@ impl<'a> Transpiler<'a> {
 
                 opts.features.inlining = self.options.inlining;
                 opts.features.auto_import_jsx = self.options.auto_import_jsx;
+                opts.features.react_fast_refresh =
+                    self.options.react_fast_refresh && loader.is_jsx();
                 // JavaScriptCore implements `using` / `await using` natively, so
                 // when targeting Bun there is no need to lower them.
                 opts.features.lower_using = !target.is_bun();

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -390,6 +390,10 @@ impl Config {
             self.runtime.auto_import_jsx = flag;
         }
 
+        if let Some(flag) = object.get_boolean_loose(global, "reactFastRefresh")? {
+            self.runtime.react_fast_refresh = flag;
+        }
+
         if let Some(flag) = object.get_boolean_loose(global, "allowBunRuntime")? {
             self.runtime.allow_runtime = flag;
         }
@@ -1093,7 +1097,7 @@ impl JSTranspiler {
         transpiler.options.auto_import_jsx = config.runtime.auto_import_jsx;
         transpiler.options.inlining = config.runtime.inlining;
         transpiler.options.hot_module_reloading = config.runtime.hot_module_reloading;
-        transpiler.options.react_fast_refresh = false;
+        transpiler.options.react_fast_refresh = config.runtime.react_fast_refresh;
         transpiler.options.repl_mode = config.repl_mode;
 
         Ok(bun_core::heap::into_raw(this))

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4896,4 +4896,55 @@ describe("multi-line comment scanning", () => {
     expectParseError(`/*${Buffer.alloc(600, "*").toString()}`, message);
     expectParseError(`/*${pad600}🦊`, message);
   });
+
+  describe("reactFastRefresh", () => {
+    const reactComponent = `
+import { useState } from "react";
+export function App() {
+  const [n, setN] = useState(0);
+  return <h1>{n}</h1>;
+}
+`;
+
+    it("is not applied by default", () => {
+      const out = new Bun.Transpiler({ loader: "tsx" }).transformSync(reactComponent);
+      expect(out).not.toContain("$RefreshReg$");
+      expect(out).not.toContain("$RefreshSig$");
+    });
+
+    it("injects $RefreshReg$/$RefreshSig$ for tsx when enabled", () => {
+      const out = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transformSync(reactComponent);
+      expect(out).toContain("$RefreshReg$");
+      expect(out).toContain("$RefreshSig$");
+    });
+
+    it("injects for jsx when enabled", () => {
+      const out = new Bun.Transpiler({ loader: "jsx", reactFastRefresh: true }).transformSync(reactComponent);
+      expect(out).toContain("$RefreshReg$");
+    });
+
+    it("also works on the async transform()", async () => {
+      const out = await new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transform(reactComponent);
+      expect(out).toContain("$RefreshReg$");
+    });
+
+    it("respects a per-call loader override on transformSync", () => {
+      // Default loader is tsx, but the call overrides it to a non-JSX loader.
+      const t = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true });
+      const out = t.transformSync(`export function foo() { return 42; }\n`, "ts");
+      expect(out).not.toContain("$RefreshReg$");
+    });
+
+    it("is a no-op on non-JSX loaders even when enabled", () => {
+      const out = new Bun.Transpiler({ loader: "ts", reactFastRefresh: true }).transformSync(
+        `export function foo() { return 42; }\n`,
+      );
+      expect(out).not.toContain("$RefreshReg$");
+    });
+
+    it("does not inject for JSX files without components", () => {
+      const out = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transformSync(`export const x = 42;\n`);
+      expect(out).not.toContain("$RefreshReg$");
+    });
+  });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4896,9 +4896,10 @@ describe("multi-line comment scanning", () => {
     expectParseError(`/*${Buffer.alloc(600, "*").toString()}`, message);
     expectParseError(`/*${pad600}🦊`, message);
   });
+});
 
-  describe("reactFastRefresh", () => {
-    const reactComponent = `
+describe("Bun.Transpiler reactFastRefresh", () => {
+  const reactComponent = `
 import { useState } from "react";
 export function App() {
   const [n, setN] = useState(0);
@@ -4906,45 +4907,48 @@ export function App() {
 }
 `;
 
-    it("is not applied by default", () => {
-      const out = new Bun.Transpiler({ loader: "tsx" }).transformSync(reactComponent);
-      expect(out).not.toContain("$RefreshReg$");
-      expect(out).not.toContain("$RefreshSig$");
-    });
+  it("is not applied by default", () => {
+    const out = new Bun.Transpiler({ loader: "tsx" }).transformSync(reactComponent);
+    expect(out).not.toContain("$RefreshReg$");
+    expect(out).not.toContain("$RefreshSig$");
+  });
 
-    it("injects $RefreshReg$/$RefreshSig$ for tsx when enabled", () => {
-      const out = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transformSync(reactComponent);
-      expect(out).toContain("$RefreshReg$");
-      expect(out).toContain("$RefreshSig$");
-    });
+  it("injects $RefreshReg$/$RefreshSig$ for tsx when enabled", () => {
+    const out = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transformSync(reactComponent);
+    expect(out).toContain("$RefreshReg$");
+    expect(out).toContain("$RefreshSig$");
+  });
 
-    it("injects for jsx when enabled", () => {
-      const out = new Bun.Transpiler({ loader: "jsx", reactFastRefresh: true }).transformSync(reactComponent);
-      expect(out).toContain("$RefreshReg$");
-    });
+  it("injects for jsx when enabled", () => {
+    const out = new Bun.Transpiler({ loader: "jsx", reactFastRefresh: true }).transformSync(reactComponent);
+    expect(out).toContain("$RefreshReg$");
+  });
 
-    it("also works on the async transform()", async () => {
-      const out = await new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transform(reactComponent);
-      expect(out).toContain("$RefreshReg$");
-    });
+  it("also works on the async transform()", async () => {
+    const out = await new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transform(reactComponent);
+    expect(out).toContain("$RefreshReg$");
+  });
 
-    it("respects a per-call loader override on transformSync", () => {
-      // Default loader is tsx, but the call overrides it to a non-JSX loader.
-      const t = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true });
-      const out = t.transformSync(`export function foo() { return 42; }\n`, "ts");
-      expect(out).not.toContain("$RefreshReg$");
-    });
+  it("respects a per-call loader override on transformSync", () => {
+    // Same source and transpiler; only the per-call loader differs, isolating the JSX-loader gate.
+    // `Foo` is componentish, so it registers under the tsx default but must not under a ts override.
+    const src = `export function Foo() { return 42; }\n`;
+    const t = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true });
+    expect(t.transformSync(src)).toContain("$RefreshReg$");
+    expect(t.transformSync(src, "ts")).not.toContain("$RefreshReg$");
+  });
 
-    it("is a no-op on non-JSX loaders even when enabled", () => {
-      const out = new Bun.Transpiler({ loader: "ts", reactFastRefresh: true }).transformSync(
-        `export function foo() { return 42; }\n`,
-      );
-      expect(out).not.toContain("$RefreshReg$");
-    });
+  it("is a no-op on non-JSX loaders even when enabled", () => {
+    // `Foo` would register under a JSX loader (see the per-call override test), so asserting it
+    // does not register here actually exercises the `loader.is_jsx()` gate rather than the name.
+    const out = new Bun.Transpiler({ loader: "ts", reactFastRefresh: true }).transformSync(
+      `export function Foo() { return 42; }\n`,
+    );
+    expect(out).not.toContain("$RefreshReg$");
+  });
 
-    it("does not inject for JSX files without components", () => {
-      const out = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transformSync(`export const x = 42;\n`);
-      expect(out).not.toContain("$RefreshReg$");
-    });
+  it("does not inject for JSX files without components", () => {
+    const out = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true }).transformSync(`export const x = 42;\n`);
+    expect(out).not.toContain("$RefreshReg$");
   });
 });


### PR DESCRIPTION
Closes #32919

## What

Exposes the existing `reactFastRefresh` option on `new Bun.Transpiler()`, matching the `Bun.build()` API. Per-file HMR dev servers (the Vite pattern: transpile one `.tsx` on change instead of a full `Bun.build()`) can now ask the transpiler to inject the `$RefreshReg$` / `$RefreshSig$` registration calls directly.

```ts
const out = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true })
  .transformSync(`import { useState } from "react";
export function App() { const [n] = useState(0); return <h1>{n}</h1>; }`);
// out now contains $RefreshReg$ / $RefreshSig$ and an import of "react-refresh/runtime"
```

## Cause

`Bun.build()` threads `reactFastRefresh` into the parser via the bundler's `ParseTask` (`src/bundler/ParseTask.rs:2469`). The `Bun.Transpiler` path never did:

- `from_js` parsed `autoImportJSX`, `minify`, etc. but had no `reactFastRefresh` branch.
- the constructor hardcoded `transpiler.options.react_fast_refresh = false` (`JSTranspiler.rs:1096`).
- the single-file transpile path, `Transpiler::parse` in `src/bundler/transpiler.rs`, is separate from `ParseTask` and built parser features without ever reading `self.options.react_fast_refresh`, so setting that field alone was a no-op.

## Fix

Three spots, mirroring how `auto_import_jsx` is already handled:

1. Parse the option in `from_js` into the runtime features.
2. Thread it onto `TransformOptions` in the constructor (replacing the `= false` hardcode).
3. Have `Transpiler::parse` set `opts.features.react_fast_refresh = self.options.react_fast_refresh && loader.is_jsx()`.

The JSX-loader gate lives in `Transpiler::parse` (not the constructor) because the loader is resolved per transform call there (`this_parse.loader`); `transpiler.options.loader` at construction time is not the loader passed to `new Bun.Transpiler({ loader })`. Non-JSX loaders stay a no-op even when the flag is set. When no framework is configured the parser already defaults the refresh import to `react-refresh/runtime` (`parse_entry.rs:2244`), and the import is only emitted when a component/hook is actually found, so a JSX file with no components is also a no-op.

The parser `framework: None` / `bun build --no-bundle --react-fast-refresh` CLI path now also honors the flag (it previously dropped it silently); the bundler, `Bun.build()`, and bake dev server are unaffected since they bundle via `ParseTask`, a separate path.

Added the `reactFastRefresh?: boolean` field to `TranspilerOptions` in `packages/bun-types/bun.d.ts`.

## Verification

```
bun bd test test/bundler/transpiler/transpiler.test.js
# 178 pass, 0 fail (includes 7 new reactFastRefresh tests)
```

Fail-before on the released binary (feature absent, so the "injects" cases fail):

```
USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t reactFastRefresh
# 4 pass, 3 fail
```

`bun run` of a `.tsx` still does not inject refresh, and `test/regression/issue/25716.test.ts` (`Bun.build` reactFastRefresh) still passes.