### PR TITLE
test: require an Error for .rejects.toThrow() and .resolves.toThrow()

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -364,13 +364,13 @@ impl JSValue {
     }
     /// Jest's `isError` from `@jest/expect-utils`: `Object.prototype.toString.call(v)`
     /// is `[object Error|Exception|DOMException]`, or `v instanceof Error`.
-    /// Exceptions raised by user traps during the check are swallowed.
-    #[inline]
-    pub fn is_jest_error(self, global: &JSGlobalObject) -> bool {
+    /// Can throw: reads `Symbol.toStringTag` and walks `getPrototypeOf`, both of
+    /// which may run user traps.
+    pub fn is_jest_error(self, global: &JSGlobalObject) -> JsResult<bool> {
         if !self.is_cell() {
-            return false;
+            return Ok(false);
         }
-        JSC__JSValue__isJestError(self, global)
+        host_fn::from_js_host_call_generic(global, || JSC__JSValue__isJestError(self, global))
     }
     /// `JSValue.isError()` — true iff this is an
     /// `ErrorInstance` cell (does NOT match `Exception`).

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -362,6 +362,16 @@ impl JSValue {
         }
         JSC__JSValue__isAnyError(self)
     }
+    /// Jest's `isError` from `@jest/expect-utils`: `Object.prototype.toString.call(v)`
+    /// is `[object Error|Exception|DOMException]`, or `v instanceof Error`.
+    /// Exceptions raised by user traps during the check are swallowed.
+    #[inline]
+    pub fn is_jest_error(self, global: &JSGlobalObject) -> bool {
+        if !self.is_cell() {
+            return false;
+        }
+        JSC__JSValue__isJestError(self, global)
+    }
     /// `JSValue.isError()` — true iff this is an
     /// `ErrorInstance` cell (does NOT match `Exception`).
     #[inline]
@@ -2083,6 +2093,7 @@ unsafe extern "C" {
         promise: &JSPromise,
     );
     safe fn JSC__JSValue__isAnyError(this: JSValue) -> bool;
+    safe fn JSC__JSValue__isJestError(this: JSValue, global: &JSGlobalObject) -> bool;
     // safe: `JSValue` is a by-value scalar; `&mut *const u8` / `&mut usize` are
     // ABI-identical to non-null `*mut` out-params the C++ side fills on success.
     safe fn JSC__JSValue__getClassInfoName(

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -362,10 +362,9 @@ impl JSValue {
         }
         JSC__JSValue__isAnyError(self)
     }
-    /// Jest's `isError` from `@jest/expect-utils`: `Object.prototype.toString.call(v)`
-    /// is `[object Error|Exception|DOMException]`, or `v instanceof Error`.
-    /// Can throw: reads `Symbol.toStringTag` and walks `getPrototypeOf`, both of
-    /// which may run user traps.
+    /// Jest's `isError` from `@jest/expect-utils`: `Object.prototype.toString.call(v)` is
+    /// `[object Error|Exception|DOMException]`, or `v instanceof Error`. Can throw: it reads
+    /// `Symbol.toStringTag` and walks `getPrototypeOf`, both of which may run user traps.
     pub fn is_jest_error(self, global: &JSGlobalObject) -> JsResult<bool> {
         if !self.is_cell() {
             return Ok(false);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3834,11 +3834,11 @@ bool JSC__JSValue__isJestError(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject
     }
 
     // `value instanceof Error`: does the prototype chain reach Error.prototype?
-    // A throwing Proxy trap makes getPrototype() return an empty JSValue, so
-    // `proto &&` must be checked before isObject().
+    // A throwing Proxy getPrototypeOf trap yields an empty JSValue (hence `proto &&`),
+    // and a trap returning a cycle would otherwise spin forever (hence the depth bound).
     JSC::JSValue proto = object->getPrototype(globalObject);
     CLEAR_IF_EXCEPTION(scope);
-    while (proto && proto.isObject()) {
+    for (unsigned depth = 0; proto && proto.isObject() && depth < 64; depth++) {
         JSC::JSCell* protoCell = proto.asCell();
         if (protoCell->inherits<JSC::ErrorPrototype>() || protoCell->type() == JSC::ErrorInstanceType)
             return true;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3819,31 +3819,33 @@ bool JSC__JSValue__isJestError(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject
     if (!value.isObject())
         return false;
 
+    // Called from Rust through from_js_host_call_generic, which turns a pending
+    // exception into an Err; a ThrowScope's destructor would simulate a throw
+    // that no C++ caller is around to check. Same idiom as isInstanceOf below.
     auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSObject* object = value.getObject();
 
     // A string Symbol.toStringTag overrides the builtin tag.
     JSC::JSValue tagValue = object->get(globalObject, vm.propertyNames->toStringTagSymbol);
-    CLEAR_IF_EXCEPTION(scope);
-    if (tagValue && tagValue.isString()) {
+    RETURN_IF_EXCEPTION(scope, {});
+    if (tagValue.isString()) {
         String tag = asString(tagValue)->value(globalObject);
-        CLEAR_IF_EXCEPTION(scope);
+        RETURN_IF_EXCEPTION(scope, {});
         if (tag == "Error"_s || tag == "Exception"_s || tag == "DOMException"_s)
             return true;
     }
 
     // `value instanceof Error`: does the prototype chain reach Error.prototype?
-    // A throwing Proxy getPrototypeOf trap yields an empty JSValue (hence `proto &&`),
-    // and a trap returning a cycle would otherwise spin forever (hence the depth bound).
+    // A Proxy getPrototypeOf trap returning a cycle would otherwise spin forever.
     JSC::JSValue proto = object->getPrototype(globalObject);
-    CLEAR_IF_EXCEPTION(scope);
-    for (unsigned depth = 0; proto && proto.isObject() && depth < 64; depth++) {
+    RETURN_IF_EXCEPTION(scope, {});
+    for (unsigned depth = 0; proto.isObject() && depth < 64; depth++) {
         JSC::JSCell* protoCell = proto.asCell();
         if (protoCell->inherits<JSC::ErrorPrototype>() || protoCell->type() == JSC::ErrorInstanceType)
             return true;
         proto = proto.getObject()->getPrototype(globalObject);
-        CLEAR_IF_EXCEPTION(scope);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     return false;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -37,6 +37,7 @@
 #include "JavaScriptCore/CodeBlock.h"
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/ErrorInstance.h"
+#include "JavaScriptCore/ErrorPrototype.h"
 #include "JavaScriptCore/ExceptionHelpers.h"
 #include "JavaScriptCore/ExceptionScope.h"
 #include "JavaScriptCore/FunctionConstructor.h"
@@ -3788,6 +3789,64 @@ bool JSC__JSValue__isAnyError(JSC::EncodedJSValue JSValue0)
     }
 
     return type == JSC::ErrorInstanceType;
+}
+
+// Jest's `isError` from @jest/expect-utils: Object.prototype.toString.call(v) is
+// "[object Error|Exception|DOMException]", or `v instanceof Error`. Used to decide
+// whether a `.rejects` / `.resolves` settled value counts as "thrown".
+bool JSC__JSValue__isJestError(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* globalObject)
+{
+    JSC::JSValue value = JSC::JSValue::decode(JSValue0);
+    if (!value.isCell())
+        return false;
+
+    JSC::JSCell* cell = value.asCell();
+    JSC::JSType type = cell->type();
+
+    // [[ErrorData]] internal slot -> builtin tag "Error"
+    if (type == JSC::ErrorInstanceType)
+        return true;
+
+    if (type == JSC::CellType && cell->inherits<JSC::Exception>())
+        return true;
+
+    // ResolveMessage / BuildMessage are error-like but do not extend Error
+    // (https://github.com/oven-sh/bun/issues/11780); util.types.isNativeError
+    // grants them the same exception so `import()` rejections count as thrown.
+    if (cell->inherits<WebCore::JSResolveMessage>() || cell->inherits<WebCore::JSBuildMessage>())
+        return true;
+
+    if (!value.isObject())
+        return false;
+
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSObject* object = value.getObject();
+
+    // A string Symbol.toStringTag overrides the builtin tag.
+    JSC::JSValue tagValue = object->get(globalObject, vm.propertyNames->toStringTagSymbol);
+    CLEAR_IF_EXCEPTION(scope);
+    if (tagValue && tagValue.isString()) {
+        String tag = asString(tagValue)->value(globalObject);
+        CLEAR_IF_EXCEPTION(scope);
+        if (tag == "Error"_s || tag == "Exception"_s || tag == "DOMException"_s)
+            return true;
+    }
+
+    // `value instanceof Error`: does the prototype chain reach Error.prototype?
+    // A throwing Proxy trap makes getPrototype() return an empty JSValue, so
+    // `proto &&` must be checked before isObject().
+    JSC::JSValue proto = object->getPrototype(globalObject);
+    CLEAR_IF_EXCEPTION(scope);
+    while (proto && proto.isObject()) {
+        JSC::JSCell* protoCell = proto.asCell();
+        if (protoCell->inherits<JSC::ErrorPrototype>() || protoCell->type() == JSC::ErrorInstanceType)
+            return true;
+        proto = proto.getObject()->getPrototype(globalObject);
+        CLEAR_IF_EXCEPTION(scope);
+    }
+
+    return false;
 }
 
 // This implementation closely mimics the one in JSC::JSPromise::reject

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -241,6 +241,7 @@ CPP_DECL double JSC__JSValue__getUnixTimestamp(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__hasOwnProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString arg2);
 CPP_DECL bool JSC__JSValue__isAggregateError(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL bool JSC__JSValue__isAnyError(JSC::EncodedJSValue JSValue0);
+CPP_DECL bool JSC__JSValue__isJestError(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL bool JSC__JSValue__isAnyInt(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isBigInt(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isBigInt32(JSC::EncodedJSValue JSValue0);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -824,7 +824,7 @@ impl Expect {
             if self.flags.get().promise() != Promise::None {
                 // Jest only counts a `.rejects`/`.resolves` settled value as "thrown"
                 // when it is an Error; any other value fails with "did not throw".
-                if value.is_jest_error(global_this) {
+                if value.is_jest_error(global_this)? {
                     return Ok((Some(value), return_value_from_function));
                 }
                 return Ok((None, value));
@@ -892,7 +892,7 @@ impl Expect {
         let Some(mut err_value_res) = err_value else { return Ok(None) };
         // Same predicate as get_value_as_to_throw: anything Jest counts as thrown
         // (e.g. DOMException, ResolveMessage) has its message read, not `undefined`.
-        if err_value_res.is_jest_error(global_this) {
+        if err_value_res.is_jest_error(global_this)? {
             let message: JSValue = err_value_res
                 .get_truthy(global_this, "message")?
                 .unwrap_or(JSValue::UNDEFINED);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -890,7 +890,9 @@ impl Expect {
         let (err_value, _) = self.get_value_as_to_throw(global_this, value)?;
 
         let Some(mut err_value_res) = err_value else { return Ok(None) };
-        if err_value_res.is_any_error() {
+        // Same predicate as get_value_as_to_throw: anything Jest counts as thrown
+        // (e.g. DOMException, ResolveMessage) has its message read, not `undefined`.
+        if err_value_res.is_jest_error(global_this) {
             let message: JSValue = err_value_res
                 .get_truthy(global_this, "message")?
                 .unwrap_or(JSValue::UNDEFINED);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -822,7 +822,12 @@ impl Expect {
 
         if !value.js_type().is_function() {
             if self.flags.get().promise() != Promise::None {
-                return Ok((Some(value), return_value_from_function));
+                // Jest only counts a `.rejects`/`.resolves` settled value as "thrown"
+                // when it is an Error; any other value fails with "did not throw".
+                if value.is_jest_error(global_this) {
+                    return Ok((Some(value), return_value_from_function));
+                }
+                return Ok((None, value));
             }
             return Err(global_this.throw(format_args!("Expected value must be a function")));
         }

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1023,6 +1023,19 @@ describe("expect()", () => {
       expect(await failureMessage(() => expect(Promise.reject(hostileProxy)).rejects.toThrow())).toContain(
         "did not throw",
       );
+
+      // ...and a cyclic getPrototypeOf trap must not spin the prototype walk forever.
+      const cyclicProxy = new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            return cyclicProxy;
+          },
+        },
+      );
+      expect(await failureMessage(() => expect(Promise.reject(cyclicProxy)).rejects.toThrow())).toContain(
+        "did not throw",
+      );
     }
   });
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1003,6 +1003,18 @@ describe("expect()", () => {
     await expect(Promise.reject(inheritsErrorPrototype)).rejects.toThrow("proto");
     await expect(Promise.resolve(new Error("res"))).resolves.toThrow("res");
 
+    // The check runs user traps. `value instanceof Error` on a Proxy whose
+    // getPrototypeOf throws propagates that error, same as Jest.
+    const hostileProxy = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("trap");
+        },
+      },
+    );
+    expect(await failureMessage(() => expect(Promise.reject(hostileProxy)).rejects.toThrow())).toBe("trap");
+
     if (isBun) {
       // ResolveMessage and BuildMessage are error-like but do not extend Error
       // (https://github.com/oven-sh/bun/issues/11780); they still count as thrown,
@@ -1011,20 +1023,8 @@ describe("expect()", () => {
       await expect(import(missingModule)).rejects.toThrow("Cannot find module");
       await expect(new Bun.Transpiler().transform("}")).rejects.toThrow();
 
-      // A throwing getPrototypeOf trap must not crash the error check.
-      const hostileProxy = new Proxy(
-        {},
-        {
-          getPrototypeOf() {
-            throw new Error("trap");
-          },
-        },
-      );
-      expect(await failureMessage(() => expect(Promise.reject(hostileProxy)).rejects.toThrow())).toContain(
-        "did not throw",
-      );
-
-      // ...and a cyclic getPrototypeOf trap must not spin the prototype walk forever.
+      // A cyclic getPrototypeOf trap must not spin the prototype walk forever.
+      // (Jest's `instanceof Error` genuinely hangs on this, so it is bun-only.)
       const cyclicProxy = new Proxy(
         {},
         {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -981,6 +981,10 @@ describe("expect()", () => {
     // ...and therefore they do satisfy .not.toThrow().
     await expect(Promise.reject("r")).rejects.not.toThrow();
     await expect(Promise.reject({ message: "r" })).rejects.not.toThrow("r");
+    // https://github.com/oven-sh/bun/issues/9687
+    await expect((async () => {})()).resolves.not.toThrow();
+    // https://github.com/oven-sh/bun/issues/14076
+    await expect(Promise.resolve("hello world")).resolves.not.toThrow();
 
     // Error-like settled values still count as thrown.
     await expect(Promise.reject(new Error("r"))).rejects.toThrow("r");
@@ -989,6 +993,11 @@ describe("expect()", () => {
     await expect(Promise.reject(new AggregateError([], "agg"))).rejects.toThrow("agg");
     await expect(Promise.reject(new DOMException("dom"))).rejects.toThrow("dom");
     await expect(Promise.reject({ [Symbol.toStringTag]: "Error", message: "tagged" })).rejects.toThrow("tagged");
+    // The snapshot matchers use the same gate, so a value that counts as thrown
+    // without being an ErrorInstance snapshots its message, not `undefined`.
+    await expect(
+      Promise.reject({ [Symbol.toStringTag]: "Error", message: "tagged snapshot" }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"tagged snapshot"`);
     const inheritsErrorPrototype = Object.create(Error.prototype);
     inheritsErrorPrototype.message = "proto";
     await expect(Promise.reject(inheritsErrorPrototype)).rejects.toThrow("proto");

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -949,6 +949,74 @@ describe("expect()", () => {
     }
   });
 
+  // Jest's .rejects.toThrow / .resolves.toThrow only treat the settled value as
+  // "thrown" when it is an Error (isError from @jest/expect-utils); any other
+  // value fails with "Received function did not throw".
+  test("rejects.toThrow requires an Error rejection value", async () => {
+    /** Run a matcher expected to fail and return its failure message.
+     * (bun throws synchronously; jest returns a rejecting promise.)
+     * @param {() => unknown} fn */
+    const failureMessage = async fn => {
+      try {
+        await fn();
+      } catch (e) {
+        return /** @type {any} */ (e).message;
+      }
+      throw new Error("expected the assertion to fail, but it passed");
+    };
+
+    // Non-Error settled values must not satisfy toThrow().
+    expect(await failureMessage(() => expect(Promise.reject("r")).rejects.toThrow("r"))).toContain("did not throw");
+    expect(await failureMessage(() => expect(Promise.reject("r")).rejects.toThrow())).toContain("did not throw");
+    expect(await failureMessage(() => expect(Promise.reject(42)).rejects.toThrow())).toContain("did not throw");
+    expect(await failureMessage(() => expect(Promise.reject(null)).rejects.toThrow())).toContain("did not throw");
+    expect(await failureMessage(() => expect(Promise.reject({ message: "r" })).rejects.toThrow("r"))).toContain(
+      "did not throw",
+    );
+    expect(
+      await failureMessage(() => expect(Promise.reject({ name: "X", message: "r", stack: "" })).rejects.toThrow("r")),
+    ).toContain("did not throw");
+    expect(await failureMessage(() => expect(Promise.resolve("r")).resolves.toThrow())).toContain("did not throw");
+
+    // ...and therefore they do satisfy .not.toThrow().
+    await expect(Promise.reject("r")).rejects.not.toThrow();
+    await expect(Promise.reject({ message: "r" })).rejects.not.toThrow("r");
+
+    // Error-like settled values still count as thrown.
+    await expect(Promise.reject(new Error("r"))).rejects.toThrow("r");
+    class ExpectRejectsCustomError extends Error {}
+    await expect(Promise.reject(new ExpectRejectsCustomError("x"))).rejects.toThrow("x");
+    await expect(Promise.reject(new AggregateError([], "agg"))).rejects.toThrow("agg");
+    await expect(Promise.reject(new DOMException("dom"))).rejects.toThrow("dom");
+    await expect(Promise.reject({ [Symbol.toStringTag]: "Error", message: "tagged" })).rejects.toThrow("tagged");
+    const inheritsErrorPrototype = Object.create(Error.prototype);
+    inheritsErrorPrototype.message = "proto";
+    await expect(Promise.reject(inheritsErrorPrototype)).rejects.toThrow("proto");
+    await expect(Promise.resolve(new Error("res"))).resolves.toThrow("res");
+
+    if (isBun) {
+      // ResolveMessage and BuildMessage are error-like but do not extend Error
+      // (https://github.com/oven-sh/bun/issues/11780); they still count as thrown,
+      // matching the exception util.types.isNativeError already grants them.
+      const missingModule = "/definitely-does-not-exist/" + "expect-rejects-to-throw.ts";
+      await expect(import(missingModule)).rejects.toThrow("Cannot find module");
+      await expect(new Bun.Transpiler().transform("}")).rejects.toThrow();
+
+      // A throwing getPrototypeOf trap must not crash the error check.
+      const hostileProxy = new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("trap");
+          },
+        },
+      );
+      expect(await failureMessage(() => expect(Promise.reject(hostileProxy)).rejects.toThrow())).toContain(
+        "did not throw",
+      );
+    }
+  });
+
   test("deepEquals derived strings and strings", () => {
     let a = new String("hello");
     let b = "hello";


### PR DESCRIPTION
## What does this PR do?

`bun:test`'s `.rejects.toThrow()` passed when the rejection value was not an Error. Jest fails it.

```js
test('A5 rejects.toThrow on non-Error rejection', async () => {
  await expect(Promise.reject('r')).rejects.toThrow('r');
});
```

- bun 1.4.0 and `main`: `(pass)`
- Jest 30.4.1 / Node 26: `Received function did not throw`

A suite asserting "this API rejects with a proper Error" via `rejects.toThrow(...)` kept passing under bun even after the implementation regressed to rejecting with a bare string or plain object. Same code, opposite verdict across runners.

Fixes #9687
Fixes #14076

Those two are the `.resolves.not.toThrow()` side of the same root cause (a non-Error resolution wrongly counted as "thrown", so `.not.toThrow()` failed). Their exact reproductions are included in the test.

### Cause

`Expect::get_value_as_to_throw` in `src/runtime/test_runner/expect.rs` returns the `.rejects`/`.resolves` settled value as "the thrown value" unconditionally. Jest gates it on `isError(received)` from `@jest/expect-utils` first:

```js
const isError = value => {
  switch (Object.prototype.toString.call(value)) {
    case '[object Error]':
    case '[object Exception]':
    case '[object DOMException]':
      return true;
    default:
      return value instanceof Error;
  }
};
```

and otherwise leaves `thrown` null, producing "Received function did not throw".

### Fix

Add a `JSC__JSValue__isJestError` binding in `src/jsc/bindings/bindings.cpp` mirroring the above (`ErrorInstanceType`, JSC `Exception`, a string `Symbol.toStringTag` of `Error`/`Exception`/`DOMException`, or `Error.prototype` anywhere in the prototype chain), and gate `get_value_as_to_throw` on it.

The check runs user code (a `Symbol.toStringTag` getter, a Proxy `getPrototypeOf` trap). An exception it raises propagates to the matcher, which is what `value instanceof Error` does in Jest. The binding uses the same `DECLARE_TOP_EXCEPTION_SCOPE` + `RETURN_IF_EXCEPTION` shape as the neighbouring `JSC__JSValue__isInstanceOf`, with the Rust wrapper going through `from_js_host_call_generic` so the pending exception surfaces as an `Err`. A `ThrowScope` would be wrong here: its destructor always simulates a throw for the benefit of a C++ caller, but this is an FFI boundary called from Rust and no C++ caller ever checks, so the simulated throw leaks and trips `exception check validation failed` in the next unrelated scope (the asan lane in build 66081 caught exactly that). The prototype walk is depth-bounded so a `getPrototypeOf` trap that returns a cycle cannot spin it; Jest's `instanceof Error` genuinely hangs on that input.

`ResolveMessage` and `BuildMessage` do not extend `Error` (#11780) but are granted the same exception `util.types.isNativeError` already gives them, so `expect(import(x)).rejects.toThrow()` and `Transpiler.transform()` rejections still count as thrown. `test/js/bun/resolve/resolve.test.ts` relies on this on Windows.

`toThrowErrorMatchingSnapshot` and `toThrowErrorMatchingInlineSnapshot` extract the message through the same helper but re-checked the narrower `is_any_error()`, which rejects every category the new gate admits that is not an `ErrorInstance` (`DOMException`, `ResolveMessage`, a `Symbol.toStringTag` of `"Error"`, anything inheriting `Error.prototype`), so those snapshotted the literal string `undefined`. They now use the same `is_jest_error` gate.

This also corrects, from the same root:
- `.rejects.not.toThrow()` on a non-Error rejection (wrongly failed)
- `.resolves.not.toThrow()` on a non-Error resolution (wrongly failed; #9687, #14076)
- `.resolves.toThrow()` on a non-Error, non-function resolution (wrongly passed)
- `.rejects.toThrowErrorMatchingSnapshot()` / `...InlineSnapshot()` on a non-Error rejection (wrote `undefined` into the snapshot and passed instead of failing)

### How did you verify your code works?

Added `test("rejects.toThrow requires an Error rejection value")` to `test/js/bun/test/expect.test.js`. Every assertion in it was first verified green against Jest 30.4.1 on Node 26, and the two issue reproductions plus the snapshot-message assertion were each confirmed to fail individually on unfixed bun. It fails on unfixed bun (`USE_SYSTEM_BUN=1`) and passes with this change.

```
bun bd test test/js/bun/test/expect.test.js -t toThrow

(pass) expect() > toThrow asymmetric matchers
(pass) expect() > toThrow
(pass) expect() > rejects.toThrow requires an Error rejection value
(pass) expect() > toThrow to return undefined
(pass) expect() > toThrowErrorMatchingInlineSnapshot to return undefined
(pass) expect() > toThrowErrorMatchingSnapshot to return undefined

 6 pass
 0 fail
 3 snapshots, 73 expect() calls
```

The full `test/js/bun/test/expect.test.js` run under the debug+ASAN build with `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1` (the configuration the asan CI lane uses) is 407 pass, 10 todo, 0 fail, with no exception-check assertions. Every case with a Jest counterpart (everything outside the `isBun` block) was also run against Jest 30.4.1 on Node 26 and passes there, including the `hostileProxy` trap-propagation assertion. Also ran `expect-extend.test.js`, `resolve.test.ts`, `timers.promises.test.ts`, and the ReadableStream `releaseLock` rejection test.

### Related

#14936 (2024) changed the same function toward Jest's behavior but only gated `.resolves`; it left `.rejects` returning the settled value unconditionally, which is the case reported here. It also targets `src/bun.js/test/expect.zig`, which was removed in the Zig to Rust migration. All of its `.resolves` test cases pass with this change.

