### PR TITLE
ipc: reject SharedArrayBuffer in advanced serialization instead of sending a copy

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1411,12 +1411,25 @@ private:
         return dumpIfTerminal(toJSArrayBuffer(*arrayBuffer), code);
     }
 
-    // Writes ArrayBufferTag + byteLength + contents. The caller must have registered
-    // the buffer's wrapper via startObjectInternal so the deserializer's object pool
-    // stays in sync (it appends one entry per ArrayBufferTag it reads).
+    // Writes a byte copy of the buffer: ResizableArrayBufferTag when it is resizable or
+    // growable so an auto-length view over it still deserializes, ArrayBufferTag otherwise.
+    // The caller must have registered the buffer's wrapper via startObjectInternal so the
+    // deserializer's object pool stays in sync (it appends one entry per buffer it reads).
     bool writeArrayBufferAsCopy(ArrayBuffer& arrayBuffer, SerializationReturnCode& code)
     {
         uint64_t byteLength = arrayBuffer.byteLength();
+        if (arrayBuffer.isResizableOrGrowableShared()) {
+            if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) * 2 + byteLength)) [[unlikely]] {
+                code = SerializationReturnCode::DataCloneError;
+                return true;
+            }
+            write(ResizableArrayBufferTag);
+            write(byteLength);
+            uint64_t maxByteLength = arrayBuffer.maxByteLength().value_or(0);
+            write(maxByteLength);
+            write(static_cast<const uint8_t*>(arrayBuffer.data()), byteLength);
+            return true;
+        }
         if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) + byteLength)) [[unlikely]] {
             code = SerializationReturnCode::DataCloneError;
             return true;
@@ -1861,20 +1874,6 @@ private:
                         write(index);
                         return true;
                     }
-                }
-
-                if (arrayBuffer->isResizableOrGrowableShared()) {
-                    uint64_t byteLength = arrayBuffer->byteLength();
-                    if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) * 2 + byteLength)) [[unlikely]] {
-                        code = SerializationReturnCode::DataCloneError;
-                        return true;
-                    }
-                    write(ResizableArrayBufferTag);
-                    write(byteLength);
-                    uint64_t maxByteLength = arrayBuffer->maxByteLength().value_or(0);
-                    write(maxByteLength);
-                    write(static_cast<const uint8_t*>(arrayBuffer->data()), byteLength);
-                    return true;
                 }
 
                 return writeArrayBufferAsCopy(*arrayBuffer, code);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1398,7 +1398,33 @@ private:
             return true;
         }
 
+        // A view over a SharedArrayBuffer crosses a process boundary as a copy of the
+        // bytes (matching Node.js advanced IPC); only a SharedArrayBuffer referenced
+        // directly is rejected, in dumpIfTerminal.
+        if (arrayBuffer->isShared() && m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
+            JSValue bufferValue = toJSArrayBuffer(*arrayBuffer);
+            if (!startObjectInternal(asObject(bufferValue))) // handle duplicates
+                return true;
+            return writeArrayBufferAsCopy(*arrayBuffer, code);
+        }
+
         return dumpIfTerminal(toJSArrayBuffer(*arrayBuffer), code);
+    }
+
+    // Writes ArrayBufferTag + byteLength + contents. The caller must have registered
+    // the buffer's wrapper via startObjectInternal so the deserializer's object pool
+    // stays in sync (it appends one entry per ArrayBufferTag it reads).
+    bool writeArrayBufferAsCopy(ArrayBuffer& arrayBuffer, SerializationReturnCode& code)
+    {
+        uint64_t byteLength = arrayBuffer.byteLength();
+        if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) + byteLength)) [[unlikely]] {
+            code = SerializationReturnCode::DataCloneError;
+            return true;
+        }
+        write(ArrayBufferTag);
+        write(byteLength);
+        write(static_cast<const uint8_t*>(arrayBuffer.data()), byteLength);
+        return true;
     }
 
     // void dumpDOMPoint(const DOMPointReadOnly& point)
@@ -1809,6 +1835,15 @@ private:
                     write(index->value);
                     return true;
                 }
+
+                // Memory cannot be shared with another process: reject a directly referenced
+                // SharedArrayBuffer like Node.js does, instead of delivering an ArrayBuffer copy.
+                // Checked before the duplicate lookup so a buffer a view already copied still errors.
+                if (arrayBuffer->isShared() && m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
+                    code = SerializationReturnCode::DataCloneError;
+                    return true;
+                }
+
                 if (!startObjectInternal(obj)) // handle duplicates
                     return true;
 
@@ -1842,15 +1877,7 @@ private:
                     return true;
                 }
 
-                uint64_t byteLength = arrayBuffer->byteLength();
-                if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) + byteLength)) [[unlikely]] {
-                    code = SerializationReturnCode::DataCloneError;
-                    return true;
-                }
-                write(ArrayBufferTag);
-                write(byteLength);
-                write(static_cast<const uint8_t*>(arrayBuffer->data()), byteLength);
-                return true;
+                return writeArrayBufferAsCopy(*arrayBuffer, code);
             }
             if (obj->inherits<JSArrayBufferView>()) {
                 if (checkForDuplicate(obj))

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1411,10 +1411,9 @@ private:
         return dumpIfTerminal(toJSArrayBuffer(*arrayBuffer), code);
     }
 
-    // Writes a byte copy of the buffer: ResizableArrayBufferTag when it is resizable or
-    // growable so an auto-length view over it still deserializes, ArrayBufferTag otherwise.
-    // The caller must have registered the buffer's wrapper via startObjectInternal so the
-    // deserializer's object pool stays in sync (it appends one entry per buffer it reads).
+    // Writes a byte copy: ResizableArrayBufferTag if resizable/growable (so an auto-length
+    // view still deserializes), ArrayBufferTag otherwise. The caller must have registered
+    // the wrapper via startObjectInternal; the deserializer adds one pool entry per buffer.
     bool writeArrayBufferAsCopy(ArrayBuffer& arrayBuffer, SerializationReturnCode& code)
     {
         uint64_t byteLength = arrayBuffer.byteLength();

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -874,8 +874,7 @@ console.log(JSON.stringify({ uid: process.getuid(), threwCode: thrown?.code, thr
 });
 
 // Memory cannot be shared across processes, so IPC in "advanced" serialization mode
-// must reject a SharedArrayBuffer at send() time like Node.js does, instead of
-// silently delivering a plain ArrayBuffer copy to the other process. A TypedArray
+// must reject a SharedArrayBuffer at send() time like Node.js does. A TypedArray
 // view over a SharedArrayBuffer is the one allowed form: Node copies the view's bytes.
 it("fork with advanced serialization rejects a SharedArrayBuffer at send()", async () => {
   using dir = tempDir("ipc-sab", {
@@ -904,8 +903,8 @@ it("fork with advanced serialization rejects a SharedArrayBuffer at send()", asy
             });
             return;
           }
-          // Before the fix the SharedArrayBuffer/object/array sends were delivered;
-          // report what arrived so the assertion diff shows it instead of timing out.
+          // Report unexpected message types so the assertion diff shows what was
+          // delivered instead of the test timing out waiting for replies.
           process.send("unexpected: " + Object.prototype.toString.call(m));
         });
         return;

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,7 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tempDir, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { promisify } from "node:util";
@@ -870,5 +870,87 @@ console.log(JSON.stringify({ uid: process.getuid(), threwCode: thrown?.code, thr
 
     const r = spawnSync("cmd.exe", ["/c", "exit 0"], { gid: 0 });
     expect(r.error?.code).toBe("ENOTSUP");
+  });
+});
+
+// Memory cannot be shared across processes, so IPC in "advanced" serialization mode
+// must reject a SharedArrayBuffer at send() time like Node.js does, instead of
+// silently delivering a plain ArrayBuffer copy to the other process. A TypedArray
+// view over a SharedArrayBuffer is the one allowed form: Node copies the view's bytes.
+it("fork with advanced serialization rejects a SharedArrayBuffer at send()", async () => {
+  using dir = tempDir("ipc-sab", {
+    "fixture.js": `
+      const cp = require("child_process");
+      if (process.argv[2] === "--child") {
+        process.on("message", m => {
+          if (m === "try-sab") {
+            let result;
+            try {
+              process.send(new SharedArrayBuffer(8));
+              result = "child-send: did not throw";
+            } catch (e) {
+              result = "child-send: " + e.name;
+            }
+            process.send(result);
+            return;
+          }
+          process.send({
+            tag: Object.prototype.toString.call(m),
+            buf: Object.prototype.toString.call(m.buffer),
+            bytes: Array.from(m),
+          });
+        });
+        return;
+      }
+      const child = cp.fork(__filename, ["--child"], { serialization: "advanced" });
+      const out = [];
+      function trySend(label, value) {
+        try {
+          child.send(value);
+          out.push(label + ": sent");
+        } catch (e) {
+          out.push(label + ": " + e.name);
+        }
+      }
+      const sab = new SharedArrayBuffer(8);
+      trySend("direct", sab);
+      trySend("nested", { x: new SharedArrayBuffer(8) });
+      trySend("mixed", [new Uint8Array(sab), sab]);
+      const view = new Uint8Array(new SharedArrayBuffer(4));
+      view.set([1, 2, 3, 4]);
+      trySend("view", view);
+      let replies = 0;
+      child.on("message", reply => {
+        replies++;
+        if (replies === 1) {
+          out.push("reply: " + JSON.stringify(reply));
+          child.send("try-sab");
+          return;
+        }
+        out.push(String(reply));
+        console.log(out.join("\\n"));
+        child.kill();
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lines: stdout.trim().split(/\r?\n/), stderr, exitCode }).toEqual({
+    lines: [
+      "direct: DataCloneError",
+      "nested: DataCloneError",
+      "mixed: DataCloneError",
+      "view: sent",
+      'reply: {"tag":"[object Uint8Array]","buf":"[object ArrayBuffer]","bytes":[1,2,3,4]}',
+      "child-send: DataCloneError",
+    ],
+    stderr: "",
+    exitCode: 0,
   });
 });

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -894,11 +894,19 @@ it("fork with advanced serialization rejects a SharedArrayBuffer at send()", asy
             process.send(result);
             return;
           }
-          process.send({
-            tag: Object.prototype.toString.call(m),
-            buf: Object.prototype.toString.call(m.buffer),
-            bytes: Array.from(m),
-          });
+          if (ArrayBuffer.isView(m)) {
+            process.send({
+              tag: Object.prototype.toString.call(m),
+              buf: Object.prototype.toString.call(m.buffer),
+              bufByteLength: m.buffer.byteLength,
+              bufMaxByteLength: m.buffer.maxByteLength,
+              bytes: Array.from(m),
+            });
+            return;
+          }
+          // Before the fix the SharedArrayBuffer/object/array sends were delivered;
+          // report what arrived so the assertion diff shows it instead of timing out.
+          process.send("unexpected: " + Object.prototype.toString.call(m));
         });
         return;
       }
@@ -919,17 +927,20 @@ it("fork with advanced serialization rejects a SharedArrayBuffer at send()", asy
       const view = new Uint8Array(new SharedArrayBuffer(4));
       view.set([1, 2, 3, 4]);
       trySend("view", view);
-      let replies = 0;
+      // An auto-length view over a growable SharedArrayBuffer serializes its length as
+      // the auto-length marker, which only deserializes over a resizable buffer; the
+      // copy must be written as ResizableArrayBufferTag or the message never arrives.
+      const growable = new Uint8Array(new SharedArrayBuffer(4, { maxByteLength: 16 }));
+      growable.set([9, 8, 7, 6]);
+      trySend("growable", growable);
+      // Sent last; IPC is ordered, so its reply marks the end of all child replies.
+      child.send("try-sab");
       child.on("message", reply => {
-        replies++;
-        if (replies === 1) {
-          out.push("reply: " + JSON.stringify(reply));
-          child.send("try-sab");
-          return;
+        out.push(typeof reply === "string" ? reply : "reply: " + JSON.stringify(reply));
+        if (typeof reply === "string" && reply.startsWith("child-send:")) {
+          console.log(out.join("\\n"));
+          child.kill();
         }
-        out.push(String(reply));
-        console.log(out.join("\\n"));
-        child.kill();
       });
     `,
   });
@@ -947,7 +958,9 @@ it("fork with advanced serialization rejects a SharedArrayBuffer at send()", asy
       "nested: DataCloneError",
       "mixed: DataCloneError",
       "view: sent",
-      'reply: {"tag":"[object Uint8Array]","buf":"[object ArrayBuffer]","bytes":[1,2,3,4]}',
+      "growable: sent",
+      'reply: {"tag":"[object Uint8Array]","buf":"[object ArrayBuffer]","bufByteLength":4,"bufMaxByteLength":4,"bytes":[1,2,3,4]}',
+      'reply: {"tag":"[object Uint8Array]","buf":"[object ArrayBuffer]","bufByteLength":4,"bufMaxByteLength":16,"bytes":[9,8,7,6]}',
       "child-send: DataCloneError",
     ],
     stderr: "",


### PR DESCRIPTION
### Problem

`child_process` IPC in advanced serialization mode silently delivers a `SharedArrayBuffer` to the other process as a plain `ArrayBuffer` deep copy. Memory cannot be shared across a process boundary, so Node.js refuses at `send()` time; Bun instead changed the type in transit and handed the child a private copy. `Atomics.wait`/`notify` coordination silently never wakes anyone and neither side sees the other's writes; nothing crashes, the data is just wrong.

```js
const cp = require("child_process");
if (process.argv[2] === "--child") {
  process.on("message", m => { process.send(Object.prototype.toString.call(m)); process.exit(0); });
  return;
}
const child = cp.fork(__filename, ["--child"], { serialization: "advanced" });
child.on("message", tag => { console.log("child received:", tag); process.exit(0); });
try { child.send(new SharedArrayBuffer(8)); }
catch (e) { console.log("send() threw:", e.message); child.kill(); }
```

Node v26.3.0:

```
send() threw: #<SharedArrayBuffer> could not be cloned.
```

Bun 1.4.0 and main:

```
child received: [object ArrayBuffer]
```

### Cause

`CloneSerializer::dumpIfTerminal` only special-cases a shared buffer for `SerializationContext::WorkerPostMessage`. IPC serializes with `SerializationContext::Default` and `SerializationForCrossProcessTransfer::Yes`, so a `SharedArrayBuffer` fell through to the plain `ArrayBufferTag` byte-copy path and deserialized as a non-shared `ArrayBuffer` in the other process.

### Fix

In `SerializedScriptValue.cpp`:

- A directly referenced `SharedArrayBuffer` now fails with `DataCloneError` when `m_forTransfer == SerializationForCrossProcessTransfer::Yes`. The check sits before the duplicate lookup so `[new Uint8Array(sab), sab]` still errors regardless of order (Node rejects that too).
- A TypedArray or DataView over a `SharedArrayBuffer` is still allowed and sends a copy of the bytes, matching Node (its `DefaultSerializer` treats views as host objects and writes the raw bytes, never the backing `SharedArrayBuffer`). The copy goes through the same `startObjectInternal` registration as a plain buffer so the deserializer's back-reference pool stays index- and byte-width-synchronized.
- The copy is written by `writeArrayBufferAsCopy`, which now owns the existing `ResizableArrayBufferTag` handling (folded in from `dumpIfTerminal`, which calls the same helper) as well as the plain `ArrayBufferTag` path. This matters because `dumpArrayBufferView` writes the view header before the backing buffer: an auto-length view over a *growable* `SharedArrayBuffer` (`new Uint8Array(new SharedArrayBuffer(4, { maxByteLength: 16 }))`) records the auto-length marker as its byteLength, and the deserializer rejects that marker over a non-resizable buffer. Emitting `ArrayBufferTag` there would have made the message fail to deserialize; `ResizableArrayBufferTag` preserves the shape main already produces.

Nothing else sets `SerializationForCrossProcessTransfer::Yes`, so `structuredClone`, `Worker#postMessage` (which really shares the memory), `v8.serialize`, and JSON-mode IPC are unchanged.

Bun reports the failure as a `DataCloneError` `DOMException`, consistent with every other uncloneable value over advanced IPC (shared `WebAssembly.Memory`, functions). Node surfaces V8's plain `Error: #<SharedArrayBuffer> could not be cloned.`; both throw synchronously from `send()`.

Resulting behavior, verified against Node v26.3.0 for each case:

| value | Node | Bun before | Bun after |
| --- | --- | --- | --- |
| `sab` | throws | ArrayBuffer copy | throws |
| `{ x: sab }` | throws | copy | throws |
| `[new Uint8Array(sab), sab]` | throws | copy | throws |
| `new Uint8Array(sab)` | Uint8Array over a plain ArrayBuffer copy | same | same |
| `new Uint8Array(growableSab)` (auto-length) | Uint8Array copy | Uint8Array over a resizable ArrayBuffer copy | same as before |

### Tests

`test/js/node/child_process/child_process.test.ts`: "fork with advanced serialization rejects a SharedArrayBuffer at send()" forks a child with `serialization: "advanced"` and asserts all five cases above from the parent plus `process.send(sab)` from the child. The growable case additionally asserts `buffer.maxByteLength === 16` on the child side so the resizable shape is locked in. The child reports whatever unexpectedly arrives instead of assuming a typed array, so on the unfixed build the test fails with a readable diff rather than a timeout.

It fails on the unfixed build:

```diff
  "lines": [
-   "direct: DataCloneError",
-   "nested: DataCloneError",
-   "mixed: DataCloneError",
+   "direct: sent",
+   "nested: sent",
+   "mixed: sent",
    "view: sent",
    "growable: sent",
+   "unexpected: [object ArrayBuffer]",
+   "unexpected: [object Object]",
+   "unexpected: [object Array]",
    "reply: {\"tag\":\"[object Uint8Array]\",...,\"bufMaxByteLength\":4,\"bytes\":[1,2,3,4]}",
    "reply: {\"tag\":\"[object Uint8Array]\",...,\"bufMaxByteLength\":16,\"bytes\":[9,8,7,6]}",
-   "child-send: DataCloneError",
+   "reply: {}",
+   "child-send: did not throw",
  ],
```

Also ran `test/js/web/workers/structured-clone.test.ts` (which covers both fixed and growable `SharedArrayBuffer` through `structuredClone`, `bun:jsc` serialization, and the cross-process round-trip suites), `test/js/bun/spawn/spawn.ipc.test.ts`, the other `child_process` IPC suites, and `test/js/node/worker_threads/15787.test.ts` to confirm worker `postMessage` still truly shares.

### Note on #32804

#32804 (in-process `structuredClone(sab)` returning a shared clone) touches the same function and added a negative-contract test asserting IPC advanced mode still deep-copies a `SharedArrayBuffer`; this PR establishes that the deep copy is itself the bug. The two fixes compose (that PR gates sharing on `forTransfer == No`, this one errors on `forTransfer == Yes`), but whichever lands second needs that one test flipped to expect the error. I left a note there.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->