### PR TITLE
HTMLRewriter: deliver the transformed output to consumers of the response's body stream

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -17,6 +17,7 @@ use bun_jsc::{
 use bun_jsc::virtual_machine::VirtualMachine;
 
 use crate::webcore::response::HeadersRef;
+use crate::webcore::streams::StreamResult;
 use crate::webcore::{self, Response};
 use bun_core::String as BunString;
 // `ZigString` re-exports `bun_core::ZigString`; JSC-side methods
@@ -555,6 +556,10 @@ pub struct BufferOutputSink {
     pub context: Rc<RefCell<LOLHTMLContext>>,
     pub response: *mut Response, // BORROW_FIELD: kept alive by response_value Strong
     pub response_value: StrongOptional,
+    /// Set by [`Self::on_readable_stream_available`] when a consumer
+    /// (`Bun.serve`, `response.body`) converts the pending output body into a
+    /// ByteStream. `done`/the error paths must terminally settle that stream.
+    pub readable_stream_ref: webcore::readable_stream::Strong,
     pub body_value_bufferer: Option<webcore::body::ValueBufferer<'static>>,
     // Points at the `sink_error` stack local in `init()`;
     // only written while `init()` is on the stack.
@@ -596,6 +601,7 @@ impl BufferOutputSink {
             context,
             response: core::ptr::null_mut(),
             response_value: StrongOptional::empty(),
+            readable_stream_ref: webcore::readable_stream::Strong::default(),
             body_value_bufferer: None,
             tmp_sync_error: None,
         }));
@@ -614,6 +620,10 @@ impl BufferOutputSink {
             webcore::Body::new({
                 let mut pv = webcore::body::PendingValue::new(global);
                 pv.task = Some(sink.cast::<core::ffi::c_void>());
+                // A consumer can turn this pending body into a ByteStream via
+                // `Value::to_readable_stream` before the input is buffered;
+                // without this hook the sink never learns and it never ends.
+                pv.on_readable_stream_available = Some(Self::on_readable_stream_available);
                 webcore::body::Value::Locked(pv)
             }),
             BunString::empty(),
@@ -658,6 +668,11 @@ impl BufferOutputSink {
             scope.apply(vm);
         }
 
+        // lol-html asserts the preallocation is below `max_allowed_memory_usage`,
+        // and `get_body_len` reports an unknown size as either `blob::MAX_SIZE`
+        // or `u64::MAX` (non-seekable/missing file), both past that bound.
+        let max_allowed_memory_usage = u32::MAX as usize;
+
         // The handler closures point into `Box`es owned by `(*sink).context`,
         // which `sink` keeps alive for the rewriter's whole lifetime.
         // SAFETY: sink is a live heap allocation (refcount >= 1); the `RefMut`
@@ -674,13 +689,13 @@ impl BufferOutputSink {
                 encoding: lol_html::AsciiCompatibleEncoding::utf_8(),
                 memory_settings: lol_html::MemorySettings {
                     preallocated_parsing_buffer_size: if input_size as u64
-                        == webcore::blob::MAX_SIZE
+                        >= max_allowed_memory_usage as u64
                     {
                         1024
                     } else {
                         input_size.max(1024) as usize
                     },
-                    max_allowed_memory_usage: u32::MAX as usize,
+                    max_allowed_memory_usage,
                 },
                 strict: false,
                 enable_esi_tags: false,
@@ -785,6 +800,74 @@ impl BufferOutputSink {
         Ok(response_js_value)
     }
 
+    /// `PendingValue::on_readable_stream_available` hook registered on the
+    /// output Response's pending body in [`Self::init`]. Runs inside
+    /// `Value::to_readable_stream` on the JS thread.
+    fn on_readable_stream_available(
+        ctx: *mut core::ffi::c_void,
+        global_this: &JSGlobalObject,
+        readable: webcore::ReadableStream,
+    ) {
+        let sink = ctx.cast::<BufferOutputSink>();
+        // SAFETY: `ctx` is the `PendingValue::task` pointer registered in
+        // `init()`. The output body is still `Locked` (this hook only fires
+        // from `to_readable_stream` on that variant), which means
+        // `on_finished_buffering` has not run yet and the in-flight bufferer
+        // still holds its +1 on the sink.
+        unsafe {
+            (*sink).readable_stream_ref =
+                webcore::readable_stream::Strong::init(readable, global_this);
+        }
+    }
+
+    /// Deliver the terminal `result` into the consumer-attached output
+    /// ByteStream (set by [`Self::on_readable_stream_available`]) and release
+    /// the sink's reference to it. No-op if no stream is attached.
+    ///
+    /// Takes `*mut Self`, not `&mut self`, per the module-wide aliasing rule
+    /// (see [`Self::run_output_sink`]): `ByteStream::on_data` re-enters the
+    /// consumer (pipe handler / promise resolution).
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation (refcount > 0).
+    unsafe fn finish_output_stream(sink: *mut Self, result: StreamResult) {
+        // SAFETY: sink is live (caller invariant); `global` is a Copy back-ref.
+        let global = unsafe { (*sink).global };
+        // Take the Strong out before `on_data`; `stream_ref` drops at function
+        // exit, so the ByteStream stays rooted across the re-entrant call.
+        // SAFETY: sink is live (caller invariant).
+        let stream_ref = unsafe { core::mem::take(&mut (*sink).readable_stream_ref) };
+        let Some(readable) = stream_ref.get(&global) else {
+            return;
+        };
+        // `to_readable_stream` only ever hands a `Source::Bytes` stream to
+        // `on_readable_stream_available`.
+        let Some(byte_stream) = readable.ptr.bytes() else {
+            return;
+        };
+        let _ = byte_stream.on_data(result);
+    }
+
+    /// Fail an asynchronous rewrite with `err`, delivering it through both
+    /// output channels: the consumer-attached ByteStream (if any, see
+    /// [`Self::finish_output_stream`]) and the output body value.
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation with
+    /// refcount > 0 and `(*sink).response` set.
+    unsafe fn fail_async(sink: *mut Self, mut err: webcore::body::ValueError) {
+        // SAFETY: sink is live (caller invariant); both fields are Copy reads.
+        let (global, response) = unsafe { ((*sink).global, (*sink).response) };
+        // SAFETY: `sink` is live (caller invariant).
+        if unsafe { (*sink).readable_stream_ref.has() } {
+            let stream_error = err.to_stream_error(&global);
+            // SAFETY: `sink` is live (caller invariant).
+            unsafe { Self::finish_output_stream(sink, StreamResult::Err(stream_error)) };
+        }
+        // SAFETY: response kept alive by response_value Strong.
+        let _ = unsafe { (*response).get_body_value() }.to_error_instance(err, &global);
+    }
+
     fn on_finished_buffering_trampoline(
         ctx: *mut core::ffi::c_void,
         bytes: &[u8],
@@ -822,17 +905,29 @@ impl BufferOutputSink {
         let global = unsafe { (*sink).global };
 
         if let Some(mut err) = js_err {
-            // SAFETY: (*sink).response is the heap Response allocated in init()
-            // and kept alive by (*sink).response_value (Strong root).
-            let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
-            let sink_ptr_usize = sink as usize;
             // If a `.body` readable is already attached, stay `Locked` so
             // `to_error_instance` delivers the error to its ByteStream; clearing
             // to `Empty` here would strand any pending `reader.read()` forever.
-            let has_readable = match sink_body_value {
+            // SAFETY: (*sink).response is the heap Response allocated in init()
+            // and kept alive by (*sink).response_value (Strong root).
+            let has_readable = match unsafe { (*(*sink).response).get_body_value() } {
                 webcore::body::Value::Locked(l) => l.readable.has(),
                 _ => false,
             };
+            // A consumer can instead take the readable out of the lock entirely
+            // (Bun.serve does, marking the body `Used`); `to_error_instance`
+            // never reaches it then, so fail it through the sink's own ref.
+            // SAFETY: `sink` is live (refcount > 0, see fn safety contract).
+            if !has_readable && unsafe { (*sink).readable_stream_ref.has() } {
+                let stream_error = err.to_stream_error(&global);
+                // SAFETY: `sink` is live (refcount > 0, see fn safety contract).
+                unsafe { Self::finish_output_stream(sink, StreamResult::Err(stream_error)) };
+            }
+            // Fetched after `finish_output_stream`: `get_body_value`'s borrow
+            // must not be held across a call that can re-enter JS.
+            // SAFETY: see the `get_body_value` SAFETY note above.
+            let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
+            let sink_ptr_usize = sink as usize;
             if !has_readable
                 && matches!(sink_body_value, webcore::body::Value::Locked(l)
                     if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_none())
@@ -884,9 +979,9 @@ impl BufferOutputSink {
         // SAFETY: sink is a live heap allocation (refcount > 0, caller
         // invariant). Read fields into locals before the rewriter calls so no
         // borrow of `*sink` is live across the re-entrant output sink.
-        let (global, response, rewriter) = unsafe {
+        let (global, rewriter) = unsafe {
             let _ = (*sink).bytes.grow_by(bytes.len()); // OOM/capacity: fire-and-forget
-            ((*sink).global, (*sink).response, (*sink).rewriter)
+            ((*sink).global, (*sink).rewriter)
         };
 
         // SAFETY: rewriter heap-allocated by init(), not yet freed.
@@ -894,12 +989,10 @@ impl BufferOutputSink {
             // Poisoned: never call `end()` after a failed `write()`. The
             // field stays non-null so `Drop` frees the rewriter.
             if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
+                // SAFETY: `sink` is live (refcount > 0, caller invariant).
+                unsafe {
+                    Self::fail_async(sink, webcore::body::ValueError::Message(lol_err_string(&e)))
+                };
                 return None;
             } else {
                 return Some(create_lolhtml_error(&global, &e));
@@ -913,12 +1006,10 @@ impl BufferOutputSink {
         // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
         if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
             if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
+                // SAFETY: `sink` is live (refcount > 0, caller invariant).
+                unsafe {
+                    Self::fail_async(sink, webcore::body::ValueError::Message(lol_err_string(&e)))
+                };
                 return None;
             } else {
                 return Some(create_lolhtml_error(&global, &e));
@@ -932,6 +1023,31 @@ impl BufferOutputSink {
         // SAFETY: self.response is kept alive by self.response_value (Strong
         // root) for the lifetime of this sink.
         let body_value = unsafe { (*self.response).get_body_value() };
+
+        // A consumer (Bun.serve, `.body`) may already hold the output body as
+        // a ByteStream (`on_readable_stream_available`). `Value::resolve`
+        // below only settles promises, so deliver the rewritten bytes into
+        // that stream here or it never produces any data.
+        if self.readable_stream_ref.has() {
+            // Detach the lock first: `PendingValue::task` points at this
+            // sink, which is freed once `on_finished_buffering` returns, and
+            // the consumer already owns the stream.
+            *body_value = webcore::body::Value::Used;
+            let sink: *mut Self = self;
+            // SAFETY: `sink` is this live allocation; the `Temporary*` slice
+            // borrows `self.bytes`, which outlives the synchronous `on_data`
+            // call inside `finish_output_stream`.
+            unsafe {
+                Self::finish_output_stream(
+                    sink,
+                    StreamResult::TemporaryAndDone(bun_ptr::RawSlice::new(
+                        (*sink).bytes.list.as_slice(),
+                    )),
+                );
+            }
+            return;
+        }
+
         let mut prev_value = core::mem::replace(
             body_value,
             webcore::body::Value::InternalBlob(webcore::InternalBlob {
@@ -978,7 +1094,8 @@ pub enum BufferOutputSinkSync {
 
 impl Drop for BufferOutputSink {
     fn drop(&mut self) {
-        // bytes, body_value_bufferer, context (Rc), response_value (Strong) drop automatically.
+        // bytes, body_value_bufferer, context (Rc), response_value (Strong),
+        // and readable_stream_ref (Strong) drop automatically.
         if !self.rewriter.is_null() {
             // SAFETY: rewriter heap-allocated by init() and not yet freed
             // (`run_output_sink` nulls the field before consuming it in `end`).

--- a/test/js/workerd/html-rewriter-streaming-fixture.ts
+++ b/test/js/workerd/html-rewriter-streaming-fixture.ts
@@ -1,15 +1,6 @@
-// Fixture for html-rewriter.test.js. Exercises one consumer of the Response
-// returned by `HTMLRewriter.transform(<streaming body>)` and prints a single
-// JSON line describing what that consumer observed. On a runtime with the
-// output-streaming bug the consumer never completes, so this process never
-// prints and/or never exits, which the parent test observes as a failure (the
-// spawned child is killed when the test ends).
-//
-// argv[2] = "serve"          Bun.serve returning transform(Bun.file(argv[3]))
-//         | "serve-throw"    same, but the element handler throws
-//         | "serve-upstream" Bun.serve returning transform(fetch(<streaming server>))
-//         | "body"           transform(Bun.file(argv[3])).body.text()
-// argv[3] = path to the HTML file ("serve" also uses it for a missing path)
+// Runs one consumer of `HTMLRewriter.transform(<streaming body>)` and prints
+// what it observed as one JSON line; on a buggy runtime it never completes.
+// argv[2]: "serve" | "serve-throw" | "serve-upstream" | "body". argv[3]: HTML path.
 const mode = process.argv[2];
 const htmlFile = process.argv[3];
 
@@ -32,10 +23,11 @@ if (mode === "body") {
   console.log(JSON.stringify(result));
 } else {
   let upstream: Bun.Server | undefined;
+  // Holds the upstream's second chunk until transform() has run, so the
+  // proxied Response is provably still streaming at that point.
+  const releaseRest = Promise.withResolvers<void>();
   if (mode === "serve-upstream") {
     const inputHTML = await Bun.file(htmlFile).text();
-    // A ReadableStream body that yields between chunks guarantees the proxied
-    // Response is still streaming when transform() runs on it.
     upstream = Bun.serve({
       port: 0,
       fetch() {
@@ -44,7 +36,7 @@ if (mode === "body") {
           new ReadableStream({
             async pull(controller) {
               controller.enqueue(encoder.encode(inputHTML.slice(0, 24)));
-              await Bun.sleep(10);
+              await releaseRest.promise;
               controller.enqueue(encoder.encode(inputHTML.slice(24)));
               controller.close();
             },
@@ -59,7 +51,11 @@ if (mode === "body") {
     port: 0,
     fetch:
       mode === "serve-upstream"
-        ? async () => rewrite().transform(await fetch(upstream!.url))
+        ? async () => {
+            const transformed = rewrite().transform(await fetch(upstream!.url));
+            releaseRest.resolve();
+            return transformed;
+          }
         : () => rewrite().transform(new Response(Bun.file(htmlFile))),
   });
 

--- a/test/js/workerd/html-rewriter-streaming-fixture.ts
+++ b/test/js/workerd/html-rewriter-streaming-fixture.ts
@@ -1,0 +1,71 @@
+// Fixture for html-rewriter.test.js. Exercises one consumer of the Response
+// returned by `HTMLRewriter.transform(<streaming body>)` and prints a single
+// JSON line describing what that consumer observed. On a runtime with the
+// output-streaming bug the consumer never completes, so this process never
+// prints and/or never exits, which the parent test observes as a failure (the
+// spawned child is killed when the test ends).
+//
+// argv[2] = "serve"          Bun.serve returning transform(Bun.file(argv[3]))
+//         | "serve-throw"    same, but the element handler throws
+//         | "serve-upstream" Bun.serve returning transform(fetch(<streaming server>))
+//         | "body"           transform(Bun.file(argv[3])).body.text()
+// argv[3] = path to the HTML file ("serve" also uses it for a missing path)
+const mode = process.argv[2];
+const htmlFile = process.argv[3];
+
+const rewrite = () =>
+  new HTMLRewriter().on("title", {
+    element(element) {
+      if (mode === "serve-throw") {
+        throw new Error("handler boom");
+      }
+      element.setInnerContent("rewritten");
+    },
+  });
+
+if (mode === "body") {
+  const transformed = rewrite().transform(new Response(Bun.file(htmlFile)));
+  const result = await transformed.body!.text().then(
+    text => ({ text }),
+    (error: any) => ({ error: error?.code }),
+  );
+  console.log(JSON.stringify(result));
+} else {
+  let upstream: Bun.Server | undefined;
+  if (mode === "serve-upstream") {
+    const inputHTML = await Bun.file(htmlFile).text();
+    // A ReadableStream body that yields between chunks guarantees the proxied
+    // Response is still streaming when transform() runs on it.
+    upstream = Bun.serve({
+      port: 0,
+      fetch() {
+        const encoder = new TextEncoder();
+        return new Response(
+          new ReadableStream({
+            async pull(controller) {
+              controller.enqueue(encoder.encode(inputHTML.slice(0, 24)));
+              await Bun.sleep(10);
+              controller.enqueue(encoder.encode(inputHTML.slice(24)));
+              controller.close();
+            },
+          }),
+          { headers: { "content-type": "text/html" } },
+        );
+      },
+    });
+  }
+
+  const server = Bun.serve({
+    port: 0,
+    fetch:
+      mode === "serve-upstream"
+        ? async () => rewrite().transform(await fetch(upstream!.url))
+        : () => rewrite().transform(new Response(Bun.file(htmlFile))),
+  });
+
+  const res = await fetch(server.url);
+  console.log(JSON.stringify({ status: res.status, text: await res.text() }));
+  server.stop(true);
+  upstream?.stop(true);
+}
+// No process.exit(): a clean natural exit is part of what the parent asserts.

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, tempDirWithFiles, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -1259,5 +1259,57 @@ describe("tagName, endTag.name, and comment.text setters", () => {
     expect(savedElement.tagName).toBeUndefined();
     expect(savedEndTag.name).toBeUndefined();
     expect(savedComment.text).toBeNull();
+  });
+});
+
+// `transform()` returns a Response whose body stays pending until the input
+// finishes buffering. Consumers that convert that pending body into a
+// ReadableStream before then (Bun.serve returning the transformed response,
+// `response.body`) previously never received the rewritten bytes, so the
+// request / read hung forever. Pre-buffered inputs (strings, buffers) resolve
+// synchronously inside transform() and never hit this path.
+// https://github.com/oven-sh/bun/issues/6068
+// https://github.com/oven-sh/bun/issues/19305
+describe("HTMLRewriter output of a streaming input body", () => {
+  const inputHTML = "<!doctype html><html><head><title>a</title></head><body><h1>hi</h1></body></html>";
+  const expectedHTML = inputHTML.replace("<title>a</title>", "<title>rewritten</title>");
+  const dir = tempDirWithFiles("html-rewriter-stream", { "streaming-input.html": inputHTML });
+  const htmlFile = join(dir, "streaming-input.html");
+  const missingFile = join(dir, "does-not-exist.html");
+
+  // Every case runs in a child process (see the fixture): the broken behavior
+  // is a fetch / body read that never completes, and a never-settling
+  // in-process await would wedge this test process. On a timeout the test
+  // runner reaps the dangling child; `await using` never runs for a
+  // timed-out test, which is also why this is not `it.concurrent.each`.
+  it.each([
+    ["Bun.serve a transform of a Bun.file() body", "serve", htmlFile, { status: 200, text: expectedHTML }],
+    [
+      "Bun.serve a transform of a proxied streaming fetch() body",
+      "serve-upstream",
+      htmlFile,
+      { status: 200, text: expectedHTML },
+    ],
+    // The 200 and headers are committed before the body starts streaming, so
+    // an error after that can only surface as an ended/empty body; the bug
+    // was the request never completing at all.
+    ["Bun.serve a transform of a missing Bun.file() body", "serve", missingFile, { status: 200, text: "" }],
+    [
+      "Bun.serve a transform whose element handler throws on a streaming input",
+      "serve-throw",
+      htmlFile,
+      { status: 200, text: "" },
+    ],
+    [".body of a transformed Bun.file() response", "body", htmlFile, { text: expectedHTML }],
+    [".body of a transformed missing Bun.file() response rejects", "body", missingFile, { error: "ENOENT" }],
+  ])("%s", async (_name, mode, path, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "html-rewriter-streaming-fixture.ts"), mode, path],
+      env: bunEnv,
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual(expected);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1262,14 +1262,10 @@ describe("tagName, endTag.name, and comment.text setters", () => {
   });
 });
 
-// `transform()` returns a Response whose body stays pending until the input
-// finishes buffering. Consumers that convert that pending body into a
-// ReadableStream before then (Bun.serve returning the transformed response,
-// `response.body`) previously never received the rewritten bytes, so the
-// request / read hung forever. Pre-buffered inputs (strings, buffers) resolve
-// synchronously inside transform() and never hit this path.
+// Consumers that convert transform()'s pending output body into a
+// ReadableStream before the input finishes buffering (Bun.serve, `.body`)
+// used to never receive the rewritten bytes, so the request hung forever.
 // https://github.com/oven-sh/bun/issues/6068
-// https://github.com/oven-sh/bun/issues/19305
 describe("HTMLRewriter output of a streaming input body", () => {
   const inputHTML = "<!doctype html><html><head><title>a</title></head><body><h1>hi</h1></body></html>";
   const expectedHTML = inputHTML.replace("<title>a</title>", "<title>rewritten</title>");
@@ -1277,11 +1273,9 @@ describe("HTMLRewriter output of a streaming input body", () => {
   const htmlFile = join(dir, "streaming-input.html");
   const missingFile = join(dir, "does-not-exist.html");
 
-  // Every case runs in a child process (see the fixture): the broken behavior
-  // is a fetch / body read that never completes, and a never-settling
-  // in-process await would wedge this test process. On a timeout the test
-  // runner reaps the dangling child; `await using` never runs for a
-  // timed-out test, which is also why this is not `it.concurrent.each`.
+  // Each case spawns the fixture: the broken behavior is a read that never
+  // completes, and a never-settling in-process await wedges bun test. Only a
+  // sequential test's timeout reaps the dangling child, so no `.concurrent`.
   it.each([
     ["Bun.serve a transform of a Bun.file() body", "serve", htmlFile, { status: 200, text: expectedHTML }],
     [


### PR DESCRIPTION
Fixes #6068.

### Problem

Returning `rewriter.transform(response)` from `Bun.serve` hangs forever when the input body is streaming (a `Bun.file()` response, a proxied `fetch()` response). Only fully pre-buffered bodies work.

```js
const rw = () => new HTMLRewriter().on("title", { element(e) { e.setInnerContent("X"); } });
using srv = Bun.serve({ port: 0, fetch(req) {
  const u = new URL(req.url);
  if (u.pathname === "/buffered") return rw().transform(new Response("<title>a</title>"));      // responds
  if (u.pathname === "/file")     return rw().transform(new Response(Bun.file("./page.html"))); // hangs forever
  if (u.pathname === "/upstream") return fetch(origin).then(r => rw().transform(r));            // hangs forever
}});
```

The same root cause produces two more symptoms:

- `transform(streamingResponse).body` (a reader, `.text()`, `new Response(body)`, S3 `write`, ...) produces an empty result instead of the rewritten document. Likely also #19305.
- If the streaming input fails (ENOENT, socket error), neither consumer is ever notified: the `Bun.serve` request still hangs and a `.body` read pends forever.

On a debug build the error repro crashes instead, which is a fourth bug in the same function (details below):

```
panic: Total preallocated memory size should be less than `MemorySettings::max_allowed_memory_usage`.
```

### Cause

`transform()` returns a Response whose body is a pending `Value::Locked` that `BufferOutputSink` settles once the whole input has been buffered. `BufferOutputSink::done()` settled it with `Value::resolve`, which only handles a pending *promise* (`.text()`, `.arrayBuffer()`, ...).

A consumer that converts the pending body into a `ReadableStream` first gets nothing:

- `Bun.serve` calls `Value::to_readable_stream`, takes the resulting ByteStream, and marks the body `Used`. `done()` then had nothing to resolve and nothing fed the stream the server was piping from, so the request never completed.
- `response.body` leaves the body `Locked` with the stream attached, and `Value::resolve` *cancels* that stream (it assumes the real bytes are being installed in its place), so the read completes empty.
- The input-error branch of `on_finished_buffering` resets the body to `Empty` (or finds it already `Used`) before calling `to_error_instance`, so the error never reached the stream either.

`PendingValue` already has a hook for exactly this, `on_readable_stream_available`; `FetchTasklet` uses it to learn about the ByteStream a consumer attached to a still-downloading fetch response and then pipes the final chunk (or the error) into it. The HTMLRewriter sink never registered it.

The debug panic is a separate pre-existing bug in the same `init()`: `get_body_len()` reports a non-seekable or missing file as `u64::MAX` (see `Blob::get_size_for_bindings`), but the "unknown size" check only matched `blob::MAX_SIZE` (`(1<<52)-1`), so lol-html was asked to preallocate a `u64::MAX`-byte arena. Release builds silently failed the reservation; debug builds hit lol-html's `debug_assert!`. It has to be fixed here for the error-path tests to run at all on a debug build.

### Fix

In `src/runtime/api/html_rewriter.rs`:

- Register `PendingValue::on_readable_stream_available` on the output Response's pending body. It stores a `readable_stream::Strong` on the sink, exactly like `FetchTasklet::on_readable_stream_available`.
- `done()` delivers the rewritten bytes into that ByteStream as a terminal `TemporaryAndDone` chunk when one is attached, instead of running `Value::resolve`.
- The input-error branch of `on_finished_buffering` and the lol-html `write()`/`end()` failure paths deliver the error into the stream the same way (the latter two were byte-identical, so they now share a `fail_async` helper).
- Change the size-sentinel comparison from `==` to `>=` so `u64::MAX` is also treated as "size unknown".

No change when no consumer attached a stream: `done()` and the error paths behave exactly as before, so pre-buffered inputs and the `.text()`/`.json()` promise consumers are untouched.

The lol-html `write()`/`end()` failure arms are also JS-reachable: a content handler that throws on a streaming input makes `write()` return an error through the Stop directive, and returning that transform from `Bun.serve` hung forever too (the body is already `Used`, so `to_error_instance` never reaches the consumer's stream). That path goes through the same `fail_async` helper and has its own fixture case. #32927 (an upstream stream error being swallowed as a truncated success) has since landed and is composed with this change; see the rebase note.

### Verification

Six new cases in `test/js/workerd/html-rewriter.test.js`, each spawning `test/js/workerd/html-rewriter-streaming-fixture.ts` in a child process (the broken behavior is a request or body read that never completes, and a never-settling in-process await leaves the test runner unable to exit): `Bun.serve` with a `Bun.file()` input, `Bun.serve` with a proxied streaming `fetch()` input, `Bun.serve` with a throwing element handler on a streaming input, `.body.text()` of a transformed `Bun.file()` response, and the two input-error variants.

Against `bun-v1.4.0` / current `main` the file exits with `44 pass, 5 fail` in ~20s (the three `Bun.serve` cases and the `.body` error case time out waiting for the child; the `.body` success case reads `""`). With the fix:

```
bun bd test test/js/workerd/html-rewriter.test.js
 49 pass
 2 todo
 0 fail
Ran 51 tests across 1 file.
```

`test/js/workerd/html-rewriter-end-error.test.ts` and `test/js/workerd/html-rewriter-leak.test.ts` also pass.


### Rebase notes

Rebased three times while open, onto #32840, then #32927, then #33048.

The #32840 rebase was trivial (both PRs appended `describe` blocks to the end of `test/js/workerd/html-rewriter.test.js`; the `src` changes are in disjoint functions).

The #32927 rebase was not, because that PR rewrote the input-error branch of `on_finished_buffering` that this PR also adds to. The two compose rather than conflict, and the merged branch makes the split explicit:

- #32927 stops clearing the body lock's readable and no longer `end()`s the rewriter, so for a `.body` consumer whose stream is still attached to the lock, the existing `to_error_instance(Locked)` now delivers the error to that stream.
- This PR covers the case `to_error_instance` can never reach: a consumer that took the readable *out* of the lock entirely (`Bun.serve` does, marking the body `Used`). That is the `finish_output_stream(StreamResult::Err(..))` call, now gated on #32927's `!has_readable` so exactly one of the two mechanisms fires per state and nothing is delivered twice.

#33048 rewrote the HTMLRewriter binding layer to use the lol_html Rust crate directly instead of its C API. `BufferOutputSink` and every function this PR touches survived with the same structure, so this PR's additions were re-expressed onto the new code rather than merged textually. The only semantic adaptation: the rewriter `write()`/`end()` failure arms now carry the real `lol_html` error (`lol_err_string(&e)`) instead of the old take-once thread-local, so the `fail_async` helper this PR extracts from those two (previously duplicated) arms takes that error as a parameter.

On the rebased tree the whole file (this PR's 6 cases plus the tests added by #32840, #32927 and #33048, plus the pre-existing suite) is 75 pass, 0 fail under `bun bd`, and the unfixed release fails 14 of them and exits in 25s. The branch is a single commit.



