### PR TITLE
hot: stop Bun.serve instances the new generation did not re-adopt

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -292,6 +292,10 @@ pub struct VirtualMachine {
     pub pending_internal_promise_is_protected: bool,
     pub pending_internal_promise_reported_at: u32,
     pub hot_reload_deferred: bool,
+    /// `hot_reload_counter` value at the last `--hot` orphan sweep. Gates
+    /// [`Self::report_exception_in_hot_reloaded_module_if_needed`] so each
+    /// generation sweeps at most once.
+    pub hot_reload_orphan_swept_at: u32,
     pub entry_point_result: EntryPointResult,
 
     pub auto_install_dependencies: bool,
@@ -1765,6 +1769,12 @@ pub struct RuntimeHooks {
     /// the `.reload` mode preserves the next-fire schedule across the new
     /// global so timers re-register instead of being torn down.
     pub cron_clear_all_reload: fn(vm: &mut VirtualMachine),
+    /// Stop every `Bun.serve` instance the current `--hot` generation did not
+    /// re-adopt. The server types live in `bun_runtime` (forward-dep), so the
+    /// body is hoisted to the high tier; the low-tier caller is
+    /// [`VirtualMachine::report_exception_in_hot_reloaded_module_if_needed`],
+    /// once the reloaded entry-point promise fulfills.
+    pub hot_stop_orphaned_servers: fn(vm: &mut VirtualMachine),
     /// Standalone-graph sourcemap load.
     /// The concrete `bun_standalone_graph::Graph` / `File` / `LazySourceMap`
     /// live above `bun_jsc`; the high tier reaches them via the graph's own
@@ -3385,7 +3395,19 @@ impl VirtualMachine {
                     crate::JSPromise::opaque_mut(promise).set_handled();
                 }
             }
-            crate::js_promise::Status::Fulfilled => {}
+            crate::js_promise::Status::Fulfilled => {
+                // The reloaded module finished evaluating: any `Bun.serve` a
+                // previous `--hot` generation registered but this one did not
+                // adopt is an orphan. Sweep at most once per generation.
+                if self.hot_reload == HOT_RELOAD_HOT
+                    && self.hot_reload_orphan_swept_at != self.hot_reload_counter
+                {
+                    self.hot_reload_orphan_swept_at = self.hot_reload_counter;
+                    if let Some(hooks) = runtime_hooks() {
+                        (hooks.hot_stop_orphaned_servers)(self);
+                    }
+                }
+            }
         }
 
         if self.hot_reload_deferred {

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -63,12 +63,17 @@ pub struct HotMap {
 pub struct HotMapEntry {
     pub tag: u8,
     pub ptr: *mut (),
+    /// `vm.hot_reload_counter` at the time this entry was last inserted or
+    /// adopted by `Bun.serve`. An entry whose generation is older than the
+    /// current counter was not re-adopted by the latest module generation.
+    pub generation: u32,
 }
 impl Default for HotMapEntry {
     fn default() -> Self {
         Self {
             tag: 0,
             ptr: core::ptr::null_mut(),
+            generation: 0,
         }
     }
 }
@@ -106,6 +111,25 @@ impl HotMap {
         let is_same_slice = stored.as_ptr() == key.as_ptr() && stored.len() == key.len();
         debug_assert!(!is_same_slice);
         self._map.swap_remove(key);
+    }
+
+    /// Stamp the entry at `key` (if any) with `generation`.
+    pub fn touch(&mut self, key: &[u8], generation: u32) {
+        if let Some(v) = self._map.get_mut(key) {
+            v.generation = generation;
+        }
+    }
+
+    /// Copy out every entry whose `generation` is older than `current`. The
+    /// entries themselves are left in place; callers remove them via the
+    /// object's own teardown path (which calls [`HotMap::remove`]).
+    pub fn collect_stale(&self, current: u32) -> Vec<HotMapEntry> {
+        self._map
+            .values()
+            .iter()
+            .filter(|v| v.generation < current)
+            .copied()
+            .collect()
     }
 }
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1601,12 +1601,16 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
     use bun_jsc::rare_data::HotMapEntry;
 
     if config.allow_hot {
+        let generation = vm.hot_reload_counter;
         if let Some(hot) = vm.hot_map() {
             if config.id.is_empty() {
                 config.id = config.compute_id().into();
             }
 
             if let Some(entry) = hot.get_entry(&config.id) {
+                // Mark the entry as adopted by the current module generation
+                // so the post-reload orphan sweep leaves it running.
+                hot.touch(&config.id, generation);
                 macro_rules! reload {
                     ($T:ty) => {{
                         // SAFETY: tag was matched; ptr was inserted as `*mut $T` below.
@@ -1670,12 +1674,15 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
             if server_ref.config.allow_hot {
                 // SAFETY: same VM pointer; re-borrow after the earlier `vm` mut
                 // borrow was released by the `hot_map()` arm above.
-                if let Some(hot) = global_object.bun_vm().as_mut().hot_map() {
+                let vm = global_object.bun_vm().as_mut();
+                let generation = vm.hot_reload_counter;
+                if let Some(hot) = vm.hot_map() {
                     hot.insert_raw(
                         &server_ref.config.id,
                         HotMapEntry {
                             tag: $tag as u8,
                             ptr: server.cast::<()>(),
+                            generation,
                         },
                     );
                 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1411,6 +1411,7 @@ pub(crate) static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     parse_worker_exec_argv_allow_addons,
     cron_clear_all_teardown,
     cron_clear_all_reload,
+    hot_stop_orphaned_servers,
     terminate_all_workers_and_wait,
     retroactively_report_discovered_tests,
     cancel_all_timers,
@@ -1503,6 +1504,38 @@ fn cron_clear_all_teardown(vm: &mut VirtualMachine) {
 fn cron_clear_all_reload(vm: &mut VirtualMachine) {
     use crate::api::cron::{ClearMode, CronJob};
     CronJob::clear_all_for_vm::<{ ClearMode::Reload }>(vm);
+}
+
+/// Stop every `Bun.serve` instance registered by a previous `--hot` generation
+/// that the current generation did not adopt (by calling `Bun.serve` again
+/// with the same computed id). Entries are stale when their stamped
+/// `generation` predates `vm.hot_reload_counter`; inserting and adopting both
+/// stamp the current counter (see `crate::api::bun_object::serve`).
+fn hot_stop_orphaned_servers(vm: &mut VirtualMachine) {
+    use crate::server::{AnyServer, AnyServerTag};
+    let current = vm.hot_reload_counter;
+    // Snapshot the stale entries first: `NewServer::stop` removes its own key
+    // from the hot map, which would invalidate an in-place iterator.
+    let stale = match vm.hot_map() {
+        Some(hot) => hot.collect_stale(current),
+        None => return,
+    };
+    for entry in stale {
+        let tag = match entry.tag {
+            t if t == AnyServerTag::HTTPServer as u8 => AnyServerTag::HTTPServer,
+            t if t == AnyServerTag::HTTPSServer as u8 => AnyServerTag::HTTPSServer,
+            t if t == AnyServerTag::DebugHTTPServer as u8 => AnyServerTag::DebugHTTPServer,
+            t if t == AnyServerTag::DebugHTTPSServer as u8 => AnyServerTag::DebugHTTPSServer,
+            _ => continue,
+        };
+        let mut server = AnyServer {
+            tag,
+            ptr: entry.ptr,
+        };
+        // Graceful stop: close the listener so in-flight requests on the old
+        // handler can drain, matching `server.stop()` from JS.
+        server.stop(false);
+    }
 }
 
 /// `webcore.WebWorker.terminateAllAndWait(timeout_ms)` —

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -925,7 +925,9 @@ describe("--hot Bun.serve orphaned server", () => {
         return msg.gen > 1 && msg.port !== oldPort;
       });
       const { port: newPort } = JSON.parse(second) as { port: number };
-      expect(await (await get(newPort)).text()).toMatch(/^gen [2-9]\d*$/);
+      // "gen N" for any integer N >= 2.
+      const genPast1 = /^gen ([2-9]|[1-9]\d+)$/;
+      expect(await (await get(newPort)).text()).toMatch(genPast1);
 
       const { refused: oldRefused, lastText: oldText } = await pollUntilRefused(oldPort);
       // The new server must still be up: proves the old listener was closed
@@ -934,7 +936,7 @@ describe("--hot Bun.serve orphaned server", () => {
       expect({ oldRefused, oldText, newStillUp }).toEqual({
         oldRefused: true,
         oldText: "",
-        newStillUp: expect.stringMatching(/^gen [2-9]\d*$/),
+        newStillUp: expect.stringMatching(genPast1),
       });
       runner.kill();
     },

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { beforeEach, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -766,3 +766,254 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   },
   longTimeout,
 );
+
+// On a `--hot` soft reload, a `Bun.serve` instance the new module generation
+// does not re-adopt (no `Bun.serve` call, or a different host/port) must stop
+// listening instead of serving the previous generation's handler forever.
+describe("--hot Bun.serve orphaned server", () => {
+  const gen1 = `
+    declare global { var n: number }
+    globalThis.n = (globalThis.n ?? 0) + 1;
+    const g = globalThis.n;
+    const server = Bun.serve({ port: 0, fetch() { return new Response("gen " + g); } });
+    console.log(JSON.stringify({ event: "listening", gen: g, port: server.port }));
+  `;
+
+  /**
+   * Incremental newline-delimited reader over a child stream. A plain
+   * `for await` would close the underlying ReadableStream when its loop
+   * exits, so a second `waitFor` on the same stream would see it drained.
+   */
+  function lineReader(stream: ReadableStream<Uint8Array>) {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    let done = false;
+    const queue: string[] = [];
+
+    async function fill() {
+      const { value, done: d } = await reader.read();
+      if (d) {
+        done = true;
+        if (buf) {
+          queue.push(buf);
+          buf = "";
+        }
+        return;
+      }
+      buf += decoder.decode(value);
+      let i;
+      while ((i = buf.indexOf("\n")) >= 0) {
+        queue.push(buf.slice(0, i));
+        buf = buf.slice(i + 1);
+      }
+    }
+
+    return {
+      async waitFor(predicate: (line: string) => boolean): Promise<string> {
+        const seen: string[] = [];
+        while (true) {
+          while (queue.length) {
+            const line = queue.shift()!;
+            seen.push(line);
+            if (predicate(line)) return line;
+          }
+          if (done) {
+            throw new Error("stream ended; saw: " + JSON.stringify(seen));
+          }
+          await fill();
+        }
+      },
+    };
+  }
+
+  /**
+   * GET with connection pooling disabled, so every probe opens a fresh TCP
+   * connection. The orphan sweep closes the *listener* (same semantics as
+   * `server.stop()`), not sockets that are already established; a pooled
+   * keep-alive socket from an earlier fetch would keep getting answers.
+   */
+  function get(port: number) {
+    return fetch(`http://127.0.0.1:${port}/`, { headers: { Connection: "close" } });
+  }
+
+  /** Poll `port` until nothing answers, or the bounded window expires. */
+  async function pollUntilRefused(port: number): Promise<{ refused: boolean; lastText: string }> {
+    let lastText = "";
+    for (let i = 0; i < 100; i++) {
+      try {
+        lastText = await (await get(port)).text();
+      } catch {
+        return { refused: true, lastText: "" };
+      }
+      await Bun.sleep(50);
+    }
+    return { refused: false, lastText };
+  }
+
+  it(
+    "stops the previous generation's server when the new generation has no Bun.serve",
+    async () => {
+      using dir = tempDir("hot-serve-orphan", { "s.ts": gen1 });
+      const src = join(String(dir), "s.ts");
+
+      await using runner = spawn({
+        cmd: [bunExe(), "--hot", "run", src],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "inherit",
+        stdin: "ignore",
+      });
+
+      const out = lineReader(runner.stdout);
+
+      const first = await out.waitFor(l => l.includes('"listening"'));
+      const { port } = JSON.parse(first) as { port: number };
+      expect(await (await get(port)).text()).toBe("gen 1");
+
+      // Reload to a version that never calls Bun.serve. The generation-1
+      // server was not adopted, so its listener must be closed.
+      writeFileSync(src, `console.log(JSON.stringify({ event: "no-server" }));\nsetInterval(() => {}, 1e9);\n`);
+      await out.waitFor(l => l.includes('"no-server"'));
+
+      const { refused, lastText } = await pollUntilRefused(port);
+      // `childAlive` guards against passing because the child crashed/exited
+      // (which would also make the port stop answering).
+      expect({ refused, lastText, childAlive: runner.exitCode === null }).toEqual({
+        refused: true,
+        lastText: "",
+        childAlive: true,
+      });
+      runner.kill();
+    },
+    timeout,
+  );
+
+  it(
+    "stops the previous generation's server when the new generation's server has a different id",
+    async () => {
+      using dir = tempDir("hot-serve-orphan-id", { "s.ts": gen1 });
+      const src = join(String(dir), "s.ts");
+
+      await using runner = spawn({
+        cmd: [bunExe(), "--hot", "run", src],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "inherit",
+        stdin: "ignore",
+      });
+
+      const out = lineReader(runner.stdout);
+
+      const first = await out.waitFor(l => l.includes('"listening"'));
+      const { port: oldPort } = JSON.parse(first) as { port: number };
+      expect(await (await get(oldPort)).text()).toBe("gen 1");
+
+      // The hot-reuse id is derived from hostname+port, so a different
+      // hostname is a different server: the old one is an orphan.
+      writeFileSync(src, gen1.replace("port: 0", `port: 0, hostname: "127.0.0.1"`));
+
+      // The watcher can fire more than once per save, so the generation the
+      // new port serves may be > 2. Accept any generation past 1 that bound a
+      // fresh port; later reloads of the same source re-adopt that server, so
+      // `newPort` is stable from here on.
+      const second = await out.waitFor(l => {
+        if (!l.includes('"listening"')) return false;
+        const msg = JSON.parse(l) as { gen: number; port: number };
+        return msg.gen > 1 && msg.port !== oldPort;
+      });
+      const { port: newPort } = JSON.parse(second) as { port: number };
+      expect(await (await get(newPort)).text()).toMatch(/^gen [2-9]\d*$/);
+
+      const { refused: oldRefused, lastText: oldText } = await pollUntilRefused(oldPort);
+      // The new server must still be up: proves the old listener was closed
+      // by the orphan sweep, not by the whole process dying.
+      const newStillUp = await (await get(newPort)).text();
+      expect({ oldRefused, oldText, newStillUp }).toEqual({
+        oldRefused: true,
+        oldText: "",
+        newStillUp: expect.stringMatching(/^gen [2-9]\d*$/),
+      });
+      runner.kill();
+    },
+    timeout,
+  );
+
+  it(
+    "keeps serving when the new generation adopts the same server",
+    async () => {
+      using dir = tempDir("hot-serve-adopted", { "s.ts": gen1 });
+      const src = join(String(dir), "s.ts");
+
+      await using runner = spawn({
+        cmd: [bunExe(), "--hot", "run", src],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "inherit",
+        stdin: "ignore",
+      });
+
+      const out = lineReader(runner.stdout);
+
+      const first = await out.waitFor(l => l.includes('"listening"'));
+      const { port } = JSON.parse(first) as { port: number };
+      expect(await (await get(port)).text()).toBe("gen 1");
+
+      // Same config on every reload => same hot id => the server is adopted,
+      // keeps its bound port, and the sweep must leave it alone.
+      let lastSeen = 1;
+      for (let round = 0; round < 3; round++) {
+        writeFileSync(src, gen1 + `\n// touch ${round}\n`);
+        const line = await out.waitFor(l => {
+          if (!l.includes('"listening"')) return false;
+          return (JSON.parse(l) as { gen: number }).gen > lastSeen;
+        });
+        lastSeen = (JSON.parse(line) as { gen: number }).gen;
+        // Still answering on the original port, with a handler from the
+        // current (or a later, if the watcher double-fired) generation.
+        const body = await (await get(port)).text();
+        expect(body).toMatch(/^gen \d+$/);
+        expect(Number(body.slice("gen ".length))).toBeGreaterThanOrEqual(lastSeen);
+      }
+      runner.kill();
+    },
+    timeout,
+  );
+
+  it(
+    "keeps the previous server running when the new generation throws during load",
+    async () => {
+      using dir = tempDir("hot-serve-throw", { "s.ts": gen1 });
+      const src = join(String(dir), "s.ts");
+
+      await using runner = spawn({
+        cmd: [bunExe(), "--hot", "run", src],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
+
+      const out = lineReader(runner.stdout);
+      const err = lineReader(runner.stderr);
+
+      const first = await out.waitFor(l => l.includes('"listening"'));
+      const { port } = JSON.parse(first) as { port: number };
+      expect(await (await get(port)).text()).toBe("gen 1");
+
+      // The new generation throws at top level: its entry-point promise
+      // rejects, so the orphan sweep does not run and the last good
+      // generation's server keeps answering.
+      writeFileSync(src, `throw new Error("boom-on-load");\n`);
+      await err.waitFor(l => l.includes("boom-on-load"));
+
+      expect(await (await get(port)).text()).toBe("gen 1");
+      runner.kill();
+    },
+    timeout,
+  );
+});


### PR DESCRIPTION
## What

Under `--hot`, a `Bun.serve()` from a previous module generation is never shut down when the reloaded code no longer calls `Bun.serve` (or moves to a different host/port). The orphaned listener keeps serving the old generation's `fetch` handler indefinitely, and nothing else can ever bind the port. There is also no handle to close it from the new generation.

This contradicts `docs/runtime/watch-mode.mdx` ("your HTTP server will be reloaded with the updated code without the process being restarted"): when the updated code has no server at all, one keeps running with the old handler.

## Reproduction

```bash
D=$(mktemp -d); cd "$D"
cat > s.ts <<'EOF'
declare global { var n: number }
globalThis.n = (globalThis.n ?? 0) + 1;
const g = globalThis.n;
const server = Bun.serve({ port: 0, fetch() { return new Response("gen " + g) } });
console.log("up gen", g, "port", server.port);
EOF
bun --hot s.ts & sleep 1
# note the port P printed above
curl -s localhost:$P        # => "gen 1"
cat > s.ts <<'EOF'
console.log("NO SERVER IN THIS VERSION OF THE SOURCE");
setInterval(() => {}, 1e9);
EOF
sleep 1
curl -s localhost:$P        # still "gen 1" -- nothing should be listening
```

After the reload the source on disk has no `Bun.serve`, but the port still answers with `gen 1`.

## Cause

Each `Bun.serve` under `--hot` registers in the per-VM `HotMap` keyed by its computed `host:port` id. When the next generation calls `Bun.serve` with a matching id, the entry is found and the existing server is adopted (handlers swapped in place). That is the only path that touches the entry. If the new generation never calls `Bun.serve` again, or binds a different address (a different id), nothing removes or stops the old server. `VirtualMachine::reload()` has no symmetric teardown for it.

## Fix

- `HotMapEntry` gains a `generation: u32` stamped from `vm.hot_reload_counter` whenever an entry is inserted or adopted by `Bun.serve`.
- Once the reloaded entry point's internal promise fulfills, sweep the map and gracefully stop (same semantics as `server.stop()`: close the listener, let in-flight requests drain) every server whose stamp predates the current counter.
- The sweep runs only under `--hot`, at most once per generation, and is skipped when the reloaded module throws, so the last good generation keeps serving. That matches the existing error-recovery behavior.

The sweep body lives in `bun_runtime` and is reached from `bun_jsc` through a new `RuntimeHooks::hot_stop_orphaned_servers` slot, the same forward-dep pattern `cron_clear_all_reload` already uses on this code path.

## Verification

Four new tests in `test/cli/hot/hot.test.ts` under `--hot Bun.serve orphaned server`:

- the new generation has no `Bun.serve`: the old port stops answering
- the new generation's server has a different id: the old port stops answering while the new one keeps serving
- the new generation adopts the same server: it keeps serving across repeated reloads (the sweep must leave it alone)
- the new generation throws during load: the previous server keeps running

The first two fail on the unfixed build (the old port keeps answering `gen 1`); all four pass with the fix. The last two also pass without the fix and guard against the sweep being over-eager.

The probes send `Connection: close` so each opens a fresh TCP connection. The sweep closes the listener, not sockets that are already established, and a pooled keep-alive socket from an earlier fetch would otherwise still get answers.

Note: this is specific to `Bun.serve`. `Bun.listen` never had `HotMap` wiring at all; that is #30906, which is the inverse problem (the old listener is never *found*, so the new one gets `EADDRINUSE`).


## Behavior notes for review

These are the deliberate semantic edges of the sweep, for the lifecycle sign-off:

- **"Finished evaluating" is the entry-point internal promise fulfilling.** Top-level `await` before `Bun.serve` is covered (the promise stays pending until it resolves). A `Bun.serve` deferred *past* module evaluation (for example inside a `setTimeout`) now gets a fresh server instead of adopting the previous generation's, because the sweep already stopped it. That matches the report's framing ("after the new generation finishes evaluating") and the server still ends up listening; I don't think anyone is relying on adopting a listener from a timer callback, but it is a behavior change for that pattern.
- **The stop is graceful, so it has exactly `server.stop()`'s semantics.** The listener closes (no new connections can reach the old handler), in-flight requests drain, and idle keep-alive sockets are reaped by the server's idle timeout. Full teardown happens once GC finalizes the now-unreferenced JS `Server` object, the same lifecycle as calling `server.stop()` and dropping the reference.
- **Only servers that opted into hot reuse are swept.** `allow_hot: false` servers never enter the `HotMap`, so they are invisible to both the existing adoption path and this sweep; their (pre-existing) behavior is unchanged. The sweep covers exactly the set of servers the adoption path covers.
