### PR TITLE
fs.watch: report the watched directory's own name when it is removed or renamed

### DIFF
--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -1017,13 +1017,19 @@ impl Linux {
                     // the lock is held on this thread.
                     let watcher = unsafe { &mut *owner_watcher };
 
-                    // Build the path relative to this owner's root.
-                    let rel: &[u8] = if watcher_is_file {
-                        path::basename(watcher_path)
+                    // Build the path relative to this owner's root. inotify only
+                    // names directory *children*; events on the watched object
+                    // itself carry no name, so report the watched path's basename
+                    // (libuv does the same). For a wd added by the recursive
+                    // walk, `owner_subpath` already is that relative name.
+                    let rel: &[u8] = if name.is_empty() {
+                        if owner_subpath.is_empty() {
+                            path::basename(watcher_path)
+                        } else {
+                            owner_subpath
+                        }
                     } else if owner_subpath.is_empty() {
                         name
-                    } else if name.is_empty() {
-                        owner_subpath
                     } else {
                         join_string_buf::<platform::Posix>(
                             path_buf.as_mut_slice(),

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "bun";
-import { bunEnv, bunExe, bunRun, bunRunAsScript, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, bunRunAsScript, isLinux, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { EventEmitter } from "node:events";
 import fs, { FSWatcher } from "node:fs";
 import path from "path";
@@ -198,6 +198,38 @@ describe("fs.watch", () => {
       const fd = fs.openSync(filepath, "w");
       fs.closeSync(fd);
     });
+  });
+
+  // inotify gives no name for events on the watched object itself; node (libuv)
+  // substitutes the watched path's basename. Linux-only: the macOS FSEvents
+  // backend deliberately drops the watched directory's own removal, and the
+  // FreeBSD kqueue backend has no filename to report (same as libuv there).
+  test.skipIf(!isLinux)("should report the watched directory's own basename when it is removed", async () => {
+    using root = tempDir("fs-watch-self-rm", { mydir: {} });
+    const target = path.join(String(root), "mydir");
+    const { promise, resolve, reject } = Promise.withResolvers<[string, string | null]>();
+    const watcher = fs.watch(target, (event, filename) => resolve([event, filename]));
+    watcher.on("error", reject);
+    try {
+      fs.rmdirSync(target);
+      expect(await promise).toEqual(["rename", "mydir"]);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test.skipIf(!isLinux)("should report the watched directory's own basename when it is renamed", async () => {
+    using root = tempDir("fs-watch-self-mv", { mydir: {} });
+    const target = path.join(String(root), "mydir");
+    const { promise, resolve, reject } = Promise.withResolvers<[string, string | null]>();
+    const watcher = fs.watch(target, (event, filename) => resolve([event, filename]));
+    watcher.on("error", reject);
+    try {
+      fs.renameSync(target, path.join(String(root), "moved"));
+      expect(await promise).toEqual(["rename", "mydir"]);
+    } finally {
+      watcher.close();
+    }
   });
 
   // https://github.com/oven-sh/bun/issues/5442

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -210,6 +210,7 @@ describe("fs.watch", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/23306
   // inotify gives no name for events on the watched object itself; node (libuv)
   // substitutes the watched path's basename. Linux-only: the macOS FSEvents
   // backend deliberately drops the watched directory's own removal, and the

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1,5 +1,15 @@
 import { pathToFileURL } from "bun";
-import { bunEnv, bunExe, bunRun, bunRunAsScript, isLinux, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  bunRun,
+  bunRunAsScript,
+  isLinux,
+  isMacOS,
+  isWindows,
+  tempDir,
+  tempDirWithFiles,
+} from "harness";
 import { EventEmitter } from "node:events";
 import fs, { FSWatcher } from "node:fs";
 import path from "path";


### PR DESCRIPTION
Fixes #23306

### Repro

On Linux, `fs.watch` on a directory that then gets `rmdir`'d delivers the deletion event with `filename: undefined`. Node delivers the directory's own name. Renaming the watched directory has the same problem.

```js
import fs from "node:fs";
const dir = fs.mkdtempSync("/tmp/watched-"), sub = dir + "/mydir";
fs.mkdirSync(sub);
const evs = []; const w = fs.watch(sub, (ev, fn) => evs.push(ev + ":" + String(fn)));
setTimeout(() => fs.rmdirSync(sub), 100);
setTimeout(() => { w.close(); console.log(evs.join(" | ")); }, 500);
// node v26: rename:mydir | rename:mydir
// bun:      rename:undefined
```

"The thing I'm watching was deleted" is the one event a watcher has to be able to identify. `undefined` is also what Bun reports for the platform's legitimate "filename unavailable" case, so the deletion is indistinguishable from it.

### Cause

inotify only populates an event's `name` field for events on a directory's *children*. Events on the watched object itself (`IN_DELETE_SELF`, `IN_MOVE_SELF`, `IN_ATTRIB` on the watched directory) arrive with `name_len == 0`. The Linux backend in `src/runtime/node/path_watcher.rs` passed that empty name straight through, and `node_fs_watcher.rs` turns an empty path into `undefined`.

libuv substitutes the watched path's basename in exactly this case (`src/unix/linux.c`: `path = e->len ? (const char*) (e + 1) : uv__basename_r(w->path)`), which is where Node's `mydir` comes from. Bun's plain-file branch already did the same; the directory root wd did not.

### Fix

When inotify gives no name and the event is on the watcher's own root wd, report `basename(watched path)`. A wd added by the recursive walk keeps reporting its owner subpath, as before.

The fix is Linux (inotify) only:

- macOS: the FSEvents backend explicitly drops the watched directory's own removal (`fs_events.rs`, "Ignore events with path equal to directory itself"). That is a separate, pre-existing choice in a different backend and is not changed here.
- FreeBSD: kqueue has no filename to report at all, matching libuv on that platform.
- Windows: goes through libuv's `uv_fs_event` directly and is unaffected.

Two remaining Linux divergences are out of scope and left alone:

- Node emits the `rmdir` rename *twice* (libuv also reports the trailing `IN_IGNORED` as a rename). Bun coalesces same-path same-type events within 1ms, and forwarding `IN_IGNORED` would also double-emit in the recursive cases where Node emits once.
- `chmod` on the watched directory is `rename` in Node because libuv lets `IN_ISDIR` flip the event type; Bun reports `change`. The filename is fixed for that case too.

### On #23306

That issue describes three problems. This PR fixes bug1 (delete the watched folder -> `rename` with the folder's name). Bugs 2 and 3 (no `change` after create+modify, and no events after re-creating and re-watching the folder) already behave correctly on current main; I verified all three with the issue's attached `test.js`, whose output now matches Node's apart from the `IN_IGNORED` count difference described above.

### Verification

New tests in `test/js/node/watch/fs.watch.test.ts` ("should report the watched directory's own basename when it is removed" / "... when it is renamed"), gated to Linux. Both fail with `filename: undefined` on an unfixed build and pass with this change.

<details>
<summary>Before/after across the self-event matrix (Linux)</summary>

```
                                node v26                                            bun (before)                       bun (after)
dir: rmdir self                 rename:mydir | rename:mydir                         rename:undefined                   rename:mydir
dir: rename self                rename:mydir                                        rename:undefined                   rename:mydir
file: unlink self               change:myfile.txt | rename:myfile.txt | rename:...  change:myfile.txt | rename:my...   change:myfile.txt | rename:myfile.txt
file: rename self               rename:myfile.txt                                   rename:myfile.txt                  rename:myfile.txt
dir recursive: rmdir self       rename:                                             rename:undefined                   rename:mydir
dir: rmdir child                rename:kid                                          rename:kid                         rename:kid
dir recursive: rmdir child      rename:kid                                          rename:kid                         rename:kid
dir: chmod self                 rename:mydir                                        change:undefined                   change:mydir
```

</details>
