### PR TITLE
Percent-decode values in Bun.Cookie.parse

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -1,9 +1,12 @@
 #include "Cookie.h"
+#include "BunString.h"
 #include "EncodeURIComponent.h"
 #include "JSCookie.h"
 #include "helpers.h"
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <wtf/ASCIICType.h>
 #include <wtf/WallTime.h>
+#include <wtf/text/StringCommon.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <JavaScriptCore/DateInstance.h>
 #include "HTTPParsers.h"
@@ -69,6 +72,39 @@ String Cookie::serialize(JSC::VM& vm, const std::span<const Ref<Cookie>> cookies
     return builder.toString();
 }
 
+// Inverse of the encodeURIComponent in appendTo(). A value is decoded only if
+// it decodes cleanly (every '%' a valid %XX escape, result valid UTF-8), else
+// returned verbatim: RFC 6265 allows a literal '%' (node `cookie` semantics).
+String Cookie::decodeCookieValue(StringView value)
+{
+    if (value.find('%') == notFound)
+        return value.toString();
+
+    Bun::UTF8View utf8View(value);
+    auto input = utf8View.bytes();
+    Vector<uint8_t, 64> decoded;
+    decoded.reserveInitialCapacity(input.size());
+    for (size_t i = 0; i < input.size();) {
+        if (input[i] != '%') {
+            // Copy the whole run up to the next '%' at once. find8() is memchr-backed.
+            const auto* next = WTF::find8(input.data() + i, '%', input.size() - i);
+            size_t runEnd = next ? static_cast<size_t>(next - input.data()) : input.size();
+            decoded.append(input.subspan(i, runEnd - i));
+            i = runEnd;
+            continue;
+        }
+        if (i + 2 >= input.size() || !isASCIIHexDigit(input[i + 1]) || !isASCIIHexDigit(input[i + 2]))
+            return value.toString();
+        decoded.append(toASCIIHexValue(input[i + 1], input[i + 2]));
+        i += 3;
+    }
+    // String::fromUTF8 returns a null String if the bytes are not valid UTF-8.
+    auto result = String::fromUTF8(decoded.span());
+    if (result.isNull())
+        return value.toString();
+    return result;
+}
+
 ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
 {
     // RFC 6265 sec 4.1.1, RFC 2616 2.2 defines a cookie name consists of one char minimum, plus '='.
@@ -90,7 +126,9 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
         return Exception { TypeError, "Invalid cookie string: name cannot be empty"_s };
 
     ASSERT(isValidHTTPHeaderValue(name));
-    String value = cookiePair.substring(firstEqualsPos + 1).trim(isASCIIWhitespace<char16_t>).toString();
+    auto rawValue = cookiePair.substring(firstEqualsPos + 1).trim(isASCIIWhitespace<char16_t>);
+    ASSERT(rawValue.isEmpty() || isValidHTTPHeaderValue(rawValue));
+    String value = decodeCookieValue(rawValue);
 
     // Default values
     String domain;
@@ -101,7 +139,6 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
     bool httpOnly = false;
     double maxAge = std::numeric_limits<double>::quiet_NaN();
     bool partitioned = false;
-    ASSERT(value.isEmpty() || isValidHTTPHeaderValue(value));
     // Parse attributes if there are any
     if (firstSemicolonPos != notFound) {
         auto attributesString = cookieString.substring(firstSemicolonPos + 1);

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -117,6 +117,8 @@ public:
     static bool isValidCookiePath(const String& path);
     static bool isValidCookieDomain(const String& domain);
 
+    static String decodeCookieValue(StringView value);
+
 private:
     Cookie(const String& name, const String& value,
         const String& domain, const String& path,

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -6,8 +6,6 @@
 #include <wtf/text/ParsingUtilities.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include "HTTPParsers.h"
-#include "decodeURIComponentSIMD.h"
-#include "BunString.h"
 #include <wtf/HashSet.h>
 namespace WebCore {
 
@@ -95,11 +93,7 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
             auto pairs = forCookieHeader.split(';');
             Vector<KeyValuePair<String, String>> cookies;
 
-            bool hasAnyPercentEncoded = forCookieHeader.find('%') != notFound;
             for (auto pair : pairs) {
-                String name = ""_s;
-                String value = ""_s;
-
                 auto equalsPos = pair.find('=');
                 if (equalsPos == notFound) {
                     continue;
@@ -112,16 +106,7 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
                     continue;
                 }
 
-                name = nameView.toString();
-
-                if (hasAnyPercentEncoded) {
-                    Bun::UTF8View utf8View(valueView);
-                    value = Bun::decodeURIComponentSIMD(utf8View.bytes());
-                } else {
-                    value = valueView.toString();
-                }
-
-                cookies.append(KeyValuePair<String, String>(name, value));
+                cookies.append(KeyValuePair<String, String>(nameView.toString(), Cookie::decodeCookieValue(valueView)));
             }
 
             return adoptRef(*new CookieMap(WTF::move(cookies)));

--- a/src/jsc/bindings/decodeURIComponentSIMD.cpp
+++ b/src/jsc/bindings/decodeURIComponentSIMD.cpp
@@ -294,7 +294,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDecodeURIComponentSIMD, (JSC::JSGlobalObject 
         auto string = input.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
 
-        // decodeURIComponentSIMD consumes UTF-8 bytes, like the ServerRouteList and CookieMap callers.
+        // decodeURIComponentSIMD consumes UTF-8 bytes, like the ServerRouteList caller.
         UTF8View utf8View(string);
         auto&& output = decodeURIComponentSIMD(utf8View.bytes());
         return JSC::JSValue::encode(JSC::jsString(vm, output));

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -466,3 +466,75 @@ describe("invalid delete usage", () => {
     }).toThrow("Cookie name is required");
   });
 });
+
+// A Cookie header value is percent-decoded only if the whole value decodes
+// cleanly (node `cookie` semantics). RFC 6265 allows a literal "%" in a
+// cookie value, so a value that was never percent-encoded must round-trip.
+describe("Bun.CookieMap percent-decoding", () => {
+  test("values that do not decode cleanly are kept raw", () => {
+    const cases: Record<string, string> = {
+      // a "%" that never forms a %XX escape
+      "50%": "50%",
+      "%zz": "%zz",
+      "x%": "x%",
+      "%": "%",
+      "%1": "%1",
+      "50%-off": "50%-off",
+      "a%%b": "a%%b",
+      // a syntactically valid %XX whose decoded bytes are not valid UTF-8
+      "a%C3b": "a%C3b",
+      "a%b2c": "a%b2c",
+      "%ED%A0%80": "%ED%A0%80",
+      "%C0%80": "%C0%80",
+      // all-or-nothing: one bad escape keeps the whole value raw
+      "a%25b%zz": "a%25b%zz",
+      "ok%20but%": "ok%20but%",
+      // a value already holding non-ASCII keeps its characters when it is kept raw
+      "café%zz": "café%zz",
+      "café%C3": "café%C3",
+    };
+    const parsed = Object.fromEntries(Object.keys(cases).map(raw => [raw, new Bun.CookieMap(`v=${raw}`).get("v")]));
+    expect(parsed).toEqual(cases);
+  });
+
+  test("values that decode cleanly are percent-decoded", () => {
+    const cases: Record<string, string> = {
+      "%41": "A",
+      "100%25": "100%",
+      "a%20b": "a b",
+      "%E8%AF%BB": "读",
+      "caf%C3%A9": "café",
+      "%F0%9F%8D%AA": "🍪",
+    };
+    const parsed = Object.fromEntries(Object.keys(cases).map(raw => [raw, new Bun.CookieMap(`v=${raw}`).get("v")]));
+    expect(parsed).toEqual(cases);
+  });
+
+  // The decoder copies the bytes between escapes in bulk, so a run longer than
+  // the scalar prefix of the underlying search needs its own coverage.
+  test("long literal runs between escapes are decoded correctly", () => {
+    const run = Buffer.alloc(100, "x").toString();
+    expect(new Bun.CookieMap(`v=${run}%20${run}`).get("v")).toBe(`${run} ${run}`);
+    // a malformed escape after a long run still keeps the whole value raw
+    expect(new Bun.CookieMap(`v=${run}%zz`).get("v")).toBe(`${run}%zz`);
+  });
+
+  test("literal % values in a Cookie header are preserved verbatim", () => {
+    const map = new Bun.CookieMap("a=50%; b=%zz; c=x%");
+    expect(Object.fromEntries(map)).toEqual({ a: "50%", b: "%zz", c: "x%" });
+  });
+
+  test("req.cookies preserves a literal % in values", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/": req => Response.json(req.cookies),
+      },
+    });
+    const res = await fetch(server.url, {
+      headers: { Cookie: "a=50%; b=%zz; c=x%; d=a%20b" },
+    });
+    expect(await res.json()).toEqual({ a: "50%", b: "%zz", c: "x%", d: "a b" });
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -450,3 +450,44 @@ describe("cookie name parsing from Cookie header", () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe("Bun.Cookie.parse percent-decoding", () => {
+  test("Cookie.parse decodes percent-encoded values", () => {
+    expect(Bun.Cookie.parse("a=x%20y").value).toBe("x y");
+    expect(Bun.Cookie.parse("a=100%25").value).toBe("100%");
+    expect(Bun.Cookie.parse("a=%E8%AF%BB%E5%86%99").value).toBe("读写");
+    expect(Bun.Cookie.parse("a=x%20y; Path=/p; Secure; SameSite=Strict").value).toBe("x y");
+    // A '%' that never forms a %XX escape is data, not a truncated escape.
+    expect(Bun.Cookie.parse("a=50%").value).toBe("50%");
+    expect(Bun.Cookie.parse("a=%zz").value).toBe("%zz");
+  });
+
+  test("parse(cookie.toString()) round-trips the value", () => {
+    for (const value of ["x y", "a;b=c", "100%", "读写汉字", "!@#$%^&*()", "🍪", "plain", ""]) {
+      const wire = new Bun.Cookie("name", value).toString();
+      const reparsed = Bun.Cookie.parse(wire);
+      expect({ value: reparsed.value, wire: reparsed.toString() }).toEqual({ value, wire });
+    }
+  });
+
+  test("Cookie.parse agrees with CookieMap on the same header", () => {
+    for (const header of ["a=x%20y", "a=100%25", "a=%E8%AF%BB%E5%86%99", "a=plain", "a=50%", "a=%zz", "a=%ED%A0%80"]) {
+      expect(Bun.Cookie.parse(header).value).toBe(new Bun.CookieMap(header).get("a")!);
+    }
+  });
+
+  test("cookie names are never decoded", () => {
+    // Decoding the name would let "__%48ost-a" alias "__Host-a".
+    const cookie = Bun.Cookie.parse("__%48ost-a=v%20x");
+    expect({ name: cookie.name, value: cookie.value }).toEqual({ name: "__%48ost-a", value: "v x" });
+  });
+
+  test("a value decoding to a control character is accepted, like CookieMap", () => {
+    // The decoded value is no longer a valid HTTP header value, so parse must
+    // validate the raw value rather than the decoded one.
+    expect(Bun.Cookie.parse("a=%00").value).toBe("\0");
+    expect(new Bun.CookieMap("a=%00").get("a")).toBe("\0");
+    // Serializing re-encodes it, so a control character never reaches the wire raw.
+    expect(Bun.Cookie.parse("a=%00").toString()).toBe("a=%00; Path=/; SameSite=Lax");
+  });
+});

--- a/test/js/bun/util/cookie.test.js
+++ b/test/js/bun/util/cookie.test.js
@@ -342,7 +342,7 @@ describe("cookie.parse(str)", function () {
     expect(cookie.parse("\tfoo\t=\tbar\t")).toEqual({ foo: "bar" });
   });
 
-  it.failing("should return original value on escape error", function () {
+  it("should return original value on escape error", function () {
     expect(cookie.parse("foo=%1;bar=bar")).toEqual({ foo: "%1", bar: "bar" });
   });
 


### PR DESCRIPTION
`Bun.Cookie.toString()` percent-encodes the value, but `Bun.Cookie.parse()` never decoded it. Every parse/serialize cycle added one more layer of encoding, and `Bun.Cookie.parse` disagreed with `Bun.CookieMap` (which does decode) about the same header.

### Repro

```js
const c = new Bun.Cookie("a", "x y");
const wire = c.toString();              // "a=x%20y; Path=/; SameSite=Lax"
const back = Bun.Cookie.parse(wire);
back.value                              // "x%20y"            expected "x y"
back.toString()                         // "a=x%2520y; ..."   double-encoded
new Bun.CookieMap("a=x%20y").get("a")   // "x y"              the other parser decodes
```

Any code that reads a cookie with `Bun.Cookie.parse` and writes it back (refreshing an expiry, re-issuing on a subdomain, middleware rewriting `Set-Cookie`) corrupts the value by one more encoding layer per hop.

### Cause

`Cookie::appendTo` in `src/jsc/bindings/Cookie.cpp` runs the value through `encodeURIComponent`, so `m_value` is meant to hold the decoded value (the comment on the never-defined `Cookie::isValidCookieValue` in `Cookie.h` says as much). `Cookie::parse` stored the raw substring instead. `CookieMap::create` had its own private decoding logic in `CookieMap.cpp`, so the two parsers could not agree.

### Fix

One shared decoder, `Cookie::decodeCookieValue(StringView)`, used by both `Cookie::parse` and `CookieMap::create`. A value is decoded only if the whole value decodes cleanly: every `%` forms a `%XX` escape and the decoded bytes are valid UTF-8. Otherwise it is returned verbatim, because RFC 6265 allows a literal `%` in a cookie-octet. This matches node's `cookie` package (`decodeURIComponent` in a try/catch that returns the original string on `URIError`).

`parse(cookie.toString())` is now the identity, and `Bun.Cookie.parse` returns the same value as `Bun.CookieMap` for the same header. Cookie names are still never decoded, so `__%48ost-` cannot alias `__Host-`.

Two consequences worth calling out:

- `new Bun.CookieMap("a=50%").get("a")` returned `"50\uFFFD"`: a `%` that never forms an escape was replaced with U+FFFD. It is now kept verbatim, which is the behavior `test/js/bun/util/cookie.test.js` already asserted under an `it.failing` marker (that marker is removed here). `CookieMap` no longer calls `decodeURIComponentSIMD`; the remaining caller is `ServerRouteList` (route params), which is unaffected.
- `Cookie::parse` now validates the raw value rather than the decoded one. A decoded value may legitimately hold bytes that are not a valid HTTP header value (`a=%00` decodes to a NUL), so asserting on the decoded string would fire in debug builds.

### Verification

New `Bun.Cookie.parse percent-decoding` describe in `test/js/bun/cookie/cookie.test.ts`:

- `Bun.Cookie.parse("a=x%20y").value` is `"x y"`, plus `%25`, multibyte UTF-8, and values that must stay raw (`50%`, `%zz`)
- `parse(new Bun.Cookie("name", v).toString())` round-trips the value and `toString()` is a fixed point, for spaces, semicolons, a literal `%`, CJK, an emoji, special characters, and the empty string
- `Bun.Cookie.parse(h).value === new Bun.CookieMap(h).get("a")` for well-formed, malformed, and invalid-UTF-8 headers
- cookie names are not decoded, and `a=%00` decodes to NUL in both parsers

Plus a `Bun.CookieMap percent-decoding` describe in `test/js/bun/cookie/cookie-map.test.ts` (raw on malformed escape, on invalid UTF-8, and on a malformed escape in an already non-ASCII value; decoded when clean; `req.cookies` end to end), and `test/js/bun/util/cookie.test.js` "should return original value on escape error" loses its `it.failing` marker.

Nine tests fail on the unmodified build with the reported output. All of `test/js/bun/cookie/`, `test/js/bun/util/cookie.test.js`, `test/js/bun/http/bun-serve-cookies.test.ts`, `test/js/bun/http/bun-serve-routes.test.ts`, `test/js/bun/http/decodeURIComponentSIMD.test.ts`, `test/js/web/fetch/cookies.test.ts`, `test/regression/issue/22475.test.ts`, and `test/bake/dev/request-cookies.test.ts` pass (581 tests).

### Performance

`CookieMap::create` used to scan the whole header for a `%` and, if it found one anywhere, run every value through `decodeURIComponentSIMD` plus a `UTF8View` that allocates for non-ASCII, so one percent-encoded cookie taxed all of its plain siblings. The decision is now per value, and the bytes between escapes are copied in bulk with `WTF::find8` (memchr-backed) so that long values with escapes keep the skip-ahead the SIMD decoder had.

`new Bun.CookieMap(header)`, 200k iterations, min of 3 runs, release builds from the same tree with and without this diff:

| case | baseline | this PR | delta |
| --- | ---: | ---: | ---: |
| 8 plain cookies | 1190.8 ns | 1026.5 ns | -13.8% |
| 1 encoded + 7 plain | 1297.3 ns | 1117.5 ns | -13.9% |
| 8 encoded cookies | 1581.1 ns | 1151.3 ns | -27.2% |
| single plain | 518.3 ns | 505.4 ns | -2.5% |
| single encoded | 677.4 ns | 624.5 ns | -7.8% |
| long value with escapes | 972.0 ns | 863.3 ns | -11.2% |
| long plain value | 683.6 ns | 629.7 ns | -7.9% |
| non-ASCII + encoded sibling | 529.9 ns | 426.4 ns | -19.5% |

No case regresses. An earlier revision of the decoder copied literal bytes one at a time and was 80% slower on the long-value-with-escapes case; the bulk copy fixed that.

### Rebase notes

Rebased onto current main, which changed what this PR needs to claim:

- #33072 fixed `decodeURIComponentSIMD` so it decodes non-ASCII input as UTF-8. An earlier revision of this PR also fixed two `CookieMap` bugs that followed from the old ASCII-only decoder (a debug assertion, and non-ASCII values being misread as Latin-1 when a sibling value in the header was percent-encoded). Both are now fixed upstream, so those claims and the test that covered them are dropped here; the tests #33072 added for that behavior pass against this PR's decoder.
- #33393 removed the `hasMaxAge` gate in `Cookie::parse`, which is the one line that conflicted. Its `Expires`/`Max-Age` fix and `isExpired()` precedence are preserved.
- Supersedes #32916 (closed), which introduced the all-or-nothing decoder for `CookieMap` as a file-local static. Moving it onto `Cookie` lets `Cookie::parse` share it.
- Independent of #32823 (open), which changes `decodeURIComponentSIMD` itself. After this PR, `CookieMap` no longer calls that function, so #32823's remaining surface is `req.params`. The two overlap only on test assertions in `cookie-map.test.ts` and `cookie.test.js`; whichever merges second needs a small rebase on those.

