### PR TITLE
fs.watch: emit only 'close' when the AbortSignal aborts, not 'error'

### DIFF
--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -15,9 +15,8 @@ use bun_jsc::abort_signal::AbortListener;
 use bun_jsc::event_loop::EventLoop;
 use bun_jsc::node::PathLike;
 use bun_jsc::{
-    self as jsc, AbortSignal, AbortSignalRef, ArgumentsSlice, CallFrame, GlobalRef,
-    JSGlobalObject, JSValue, JsRef, JsResult, SysErrorJsc,
-    VirtualMachineRef as VirtualMachine, ZigStringJsc as _,
+    self as jsc, AbortSignal, AbortSignalRef, ArgumentsSlice, CallFrame, GlobalRef, JSGlobalObject,
+    JSValue, JsRef, JsResult, SysErrorJsc, VirtualMachineRef as VirtualMachine, ZigStringJsc as _,
 };
 use bun_paths::resolve_path::{self as Path, platform};
 use bun_sys::{self, SystemErrno};

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -15,8 +15,8 @@ use bun_jsc::abort_signal::AbortListener;
 use bun_jsc::event_loop::EventLoop;
 use bun_jsc::node::PathLike;
 use bun_jsc::{
-    self as jsc, AbortSignal, AbortSignalRef, ArgumentsSlice, CallFrame, CommonAbortReason,
-    CommonAbortReasonExt as _, GlobalRef, JSGlobalObject, JSValue, JsRef, JsResult, SysErrorJsc,
+    self as jsc, AbortSignal, AbortSignalRef, ArgumentsSlice, CallFrame, GlobalRef,
+    JSGlobalObject, JSValue, JsRef, JsResult, SysErrorJsc,
     VirtualMachineRef as VirtualMachine, ZigStringJsc as _,
 };
 use bun_paths::resolve_path::{self as Path, platform};
@@ -38,7 +38,7 @@ use super::win_watcher as path_watcher;
 // interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). `&mut Self`
 // carried LLVM `noalias`, so a host-fn that re-entered JS while holding it let
 // the optimiser cache `self.closed` etc. across the FFI call — the `*mut Self`
-// dance in the old `emit_abort`/`emit_error` was a manual workaround for
+// dance in the old `emit_error` was a manual workaround for
 // exactly that. With `Cell`/`JsCell` (UnsafeCell-backed) the miscompile is
 // structurally impossible and those methods are now plain `&self`.
 #[bun_jsc::JsClass(no_constructor)]
@@ -708,10 +708,12 @@ impl<'a> Arguments<'a> {
 }
 
 impl AbortListener for FSWatcher {
+    // Node only closes the watcher when the signal aborts ('close' event, no
+    // 'error'), so the abort reason is unused.
     // R-2: trait sig is fixed at `&mut self`; body just reborrows as `&self`
-    // (auto-deref) and calls the interior-mutable `emit_abort`.
-    fn on_abort(&mut self, reason: JSValue) {
-        (*self).emit_abort(reason);
+    // (auto-deref) and calls the interior-mutable `close`.
+    fn on_abort(&mut self, _reason: JSValue) {
+        (*self).close();
     }
 }
 
@@ -764,58 +766,20 @@ impl FSWatcher {
         }
     }
 
+    /// Deferred handler for a signal that was already aborted when the watcher
+    /// was created: Node parity is `'close'` only, so just close.
     pub fn emit_if_aborted(&self) {
-        let reason = match self.signal.get() {
-            Some(s) if s.aborted() => Some(s.abort_reason()),
-            _ => None,
-        };
-        if let Some(err) = reason {
-            self.emit_abort(err);
+        // Scope the `&AbortSignalRef` borrow before `close()` -> `detach()`
+        // replaces `self.signal` with `None`.
+        let aborted = matches!(self.signal.get(), Some(s) if s.aborted());
+        if aborted {
+            self.close();
         }
     }
 
-    /// R-2: `&self` + `Cell<bool>` for `closed` makes the old `*mut Self`
-    /// re-derive dance unnecessary. `listener.call_with_global_this(...)`
-    /// re-enters JS, which can call `watcher.close()` on this same object via
-    /// the wrapper's `m_ptr` — setting `closed = true` and `detach()`-ing.
-    /// `Cell::get()` after the callback observes that write because
-    /// `UnsafeCell` suppresses `noalias` on `&Self`; the trailing
-    /// `self.close()` then no-ops.
-    pub fn emit_abort(&self, err: JSValue) {
-        if self.closed.get() {
-            return;
-        }
-        self.pending_activity_count.fetch_add(1, Ordering::Relaxed);
-        // unref_task() must execute before close(). No early returns below,
-        // so both calls are inlined at the end of this function.
-
-        err.ensure_still_alive();
-        let js_this = self.js_this.try_get();
-        if let Some(js_this) = js_this {
-            js_this.ensure_still_alive();
-            if let Some(listener) = js::listener_get_cached(js_this) {
-                listener.ensure_still_alive();
-                let global_this = self.global_this;
-                let args = [
-                    EventType::Error.to_js(&global_this),
-                    if err.is_empty_or_undefined_or_null() {
-                        CommonAbortReason::UserAbort.to_js(&global_this)
-                    } else {
-                        err
-                    },
-                ];
-                if listener.call_with_global_this(&global_this, &args).is_err() {
-                    global_this.clear_exception();
-                }
-            }
-        }
-
-        self.unref_task();
-        self.close();
-    }
-
-    /// R-2: see `emit_abort` — `&self` + `Cell` so the trailing `close()`
-    /// observes a re-entrant `watcher.close()` from inside the listener.
+    /// R-2: the listener call re-enters JS and can `watcher.close()` this same
+    /// object (`closed = true` + `detach()`); `&self` + `Cell` lets the
+    /// trailing `self.close()` observe that write and no-op.
     pub fn emit_error(&self, err: &bun_sys::Error) {
         if self.closed.get() {
             return;

--- a/test/js/node/watch/fixtures/persistent.js
+++ b/test/js/node/watch/fixtures/persistent.js
@@ -1,5 +1,12 @@
 import fs from "fs";
-fs.watch(import.meta.path, { persistent: false, signal: AbortSignal.timeout(4000) }).on("error", err => {
-  console.error(err.message);
-  process.exit(1);
-});
+// The process must exit on its own; the 4s abort (which only emits 'close')
+// fires only if the non-persistent watcher wrongly kept the event loop alive.
+fs.watch(import.meta.path, { persistent: false, signal: AbortSignal.timeout(4000) })
+  .on("error", err => {
+    console.error(err.message);
+    process.exit(1);
+  })
+  .on("close", () => {
+    console.error("process did not exit before the abort timeout");
+    process.exit(1);
+  });

--- a/test/js/node/watch/fixtures/relative.js
+++ b/test/js/node/watch/fixtures/relative.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 try {
+  let sawChange = false;
   const watcher = fs.watch("relative.txt", { signal: AbortSignal.timeout(2000) });
 
   watcher.on("change", function (event, filename) {
@@ -9,6 +10,7 @@ try {
       watcher.close();
       process.exit(1);
     } else {
+      sawChange = true;
       clearInterval(interval);
       watcher.close();
     }
@@ -17,6 +19,15 @@ try {
     clearInterval(interval);
     console.error(err.message);
     process.exit(1);
+  });
+  // The abort timeout only emits 'close', so a watcher that never delivered a
+  // change event has to be failed here (and the interval cleared so we exit).
+  watcher.on("close", () => {
+    clearInterval(interval);
+    if (!sawChange) {
+      console.error("timed out without a change event");
+      process.exit(1);
+    }
   });
 
   const interval = setInterval(() => {

--- a/test/js/node/watch/fixtures/relative_dir.js
+++ b/test/js/node/watch/fixtures/relative_dir.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 try {
+  let sawChange = false;
   const watcher = fs.watch("./myrelativedir/", { signal: AbortSignal.timeout(2000) });
 
   watcher.on("change", function (event, filename) {
@@ -9,6 +10,7 @@ try {
       watcher.close();
       process.exit(1);
     } else {
+      sawChange = true;
       clearInterval(interval);
       watcher.close();
     }
@@ -17,6 +19,15 @@ try {
     clearInterval(interval);
     console.error(err.message);
     process.exit(1);
+  });
+  // The abort timeout only emits 'close', so a watcher that never delivered a
+  // change event has to be failed here (and the interval cleared so we exit).
+  watcher.on("close", () => {
+    clearInterval(interval);
+    if (!sawChange) {
+      console.error("timed out without a change event");
+      process.exit(1);
+    }
   });
 
   const interval = setInterval(() => {

--- a/test/js/node/watch/fixtures/unref.js
+++ b/test/js/node/watch/fixtures/unref.js
@@ -1,7 +1,13 @@
 import fs from "fs";
+// The process must exit on its own; the 4s abort (which only emits 'close')
+// fires only if the unref'd watcher wrongly kept the event loop alive.
 fs.watch(import.meta.path, { signal: AbortSignal.timeout(4000) })
   .on("error", err => {
     console.error(err.message);
+    process.exit(1);
+  })
+  .on("close", () => {
+    console.error("process did not exit before the abort timeout");
     process.exit(1);
   })
   .unref();

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -112,9 +112,11 @@ describe("fs.watch", () => {
     });
 
     watcher.on("error", e => (err = e));
+    // The AbortSignal.timeout(3000) hang guard only emits 'close'; reaching it
+    // with fewer than 2 change events means no events were ever delivered.
     watcher.on("close", () => {
       clearInterval(interval);
-      done(err);
+      done(err ?? (count < 2 ? new Error(`timed out after ${count} change events`) : undefined));
     });
 
     const interval = repeat(() => {
@@ -167,9 +169,10 @@ describe("fs.watch", () => {
       }
     });
     watcher.on("error", e => (err = e));
+    // Same hang guard as "add file/folder to folder" above.
     watcher.on("close", () => {
       clearInterval(interval);
-      done(err);
+      done(err ?? (count < 2 ? new Error(`timed out after ${count} change events`) : undefined));
     });
 
     const interval = repeat(() => {

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -14,7 +14,7 @@ import { EventEmitter } from "node:events";
 import fs, { FSWatcher } from "node:fs";
 import path from "path";
 
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 // Because macOS (and possibly other operating systems) can return a watcher
 // before it is actually watching, we need to repeat the operation to avoid
 // a race condition.
@@ -131,15 +131,13 @@ describe("fs.watch", () => {
     } catch {}
     const controller = new AbortController();
     const watcher = fs.watch(root, { recursive: true, signal: controller.signal });
-    let err: Error | undefined = undefined;
-    const fn = mock();
-    watcher.on("error", fn);
-    watcher.on("close", fn);
+    // Node only emits 'close' when the signal aborts. The abort reason never
+    // surfaces as an 'error' event, even when it is a custom Error.
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    watcher.on("error", err => reject(new Error(`unexpected 'error' event: ${err}`)));
+    watcher.on("close", () => resolve());
     controller.abort(new Error("potato"));
-
-    await Bun.sleep(10);
-    expect(fn).toHaveBeenCalledTimes(2);
-    expect(fn.mock.calls[0][0].message).toBe("potato");
+    await promise;
   });
 
   test("add file/folder to subfolder", done => {
@@ -412,23 +410,19 @@ describe("fs.watch", () => {
     }
   });
 
-  test("calling close from error event should not throw", done => {
+  // Node routes an AbortSignal abort straight to close(): only 'close' is
+  // emitted, never a spurious 'error' (AbortError). The re-entrant-close
+  // coverage this test used to provide via the 'error' event is kept by
+  // "calling close from close event should not throw" below.
+  test("aborting the signal emits only 'close', never 'error'", async () => {
     const filepath = path.join(testDir, "close.txt");
-    try {
-      const ac = new AbortController();
-      const watcher = fs.watch(pathToFileURL(filepath), { signal: ac.signal });
-      watcher.once("error", err => {
-        try {
-          watcher.close();
-          done();
-        } catch (e: any) {
-          done("Should not error when calling close from error event");
-        }
-      });
-      ac.abort();
-    } catch (e: any) {
-      done(e);
-    }
+    const ac = new AbortController();
+    const watcher = fs.watch(pathToFileURL(filepath), { signal: ac.signal });
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    watcher.on("error", err => reject(new Error(`unexpected 'error' event: ${err}`)));
+    watcher.on("close", () => resolve());
+    ac.abort();
+    await promise;
   });
 
   test("calling close from close event should not throw", done => {
@@ -456,11 +450,10 @@ describe("fs.watch", () => {
     const filepath = path.join(testDir, "abort.txt");
 
     const ac = new AbortController();
-    const promise = new Promise((resolve, reject) => {
-      const watcher = fs.watch(filepath, { signal: ac.signal });
-      watcher.once("error", err => (err.message === "The operation was aborted." ? resolve(undefined) : reject(err)));
-      watcher.once("close", () => reject());
-    });
+    const watcher = fs.watch(filepath, { signal: ac.signal });
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    watcher.once("error", err => reject(new Error(`unexpected 'error' event: ${err}`)));
+    watcher.once("close", () => resolve());
     await Bun.sleep(10);
     ac.abort();
     await promise;
@@ -470,11 +463,11 @@ describe("fs.watch", () => {
     const filepath = path.join(testDir, "abort.txt");
 
     const signal = AbortSignal.abort();
-    await new Promise((resolve, reject) => {
-      const watcher = fs.watch(filepath, { signal });
-      watcher.once("error", err => (err.message === "The operation was aborted." ? resolve(undefined) : reject(err)));
-      watcher.once("close", () => reject());
-    });
+    const watcher = fs.watch(filepath, { signal });
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    watcher.once("error", err => reject(new Error(`unexpected 'error' event: ${err}`)));
+    watcher.once("close", () => resolve());
+    await promise;
   });
 
   test("should work with symlink", async () => {
@@ -1413,19 +1406,19 @@ test("fs.watch wrapper reference survives GC across event, abort and close paths
         await gotClose;
       }
 
-      // Phase 2: abort path under GC pressure.
+      // Phase 2: abort path under GC pressure. Aborting the signal must emit
+      // only 'close' (Node never emits 'error' for an abort).
       for (let i = 0; i < 3; i++) {
         const ac = new AbortController();
         const watcher = fs.watch(dir, { signal: ac.signal }, () => {});
-        const gotAbort = new Promise((resolve, reject) => {
-          watcher.once("error", err =>
-            err.message === "The operation was aborted." ? resolve() : reject(err),
-          );
+        const gotClose = new Promise((resolve, reject) => {
+          watcher.once("error", err => reject(err));
+          watcher.once("close", resolve);
         });
         Bun.gc(true);
         ac.abort();
         Bun.gc(true);
-        await gotAbort;
+        await gotClose;
       }
 
       // Phase 3: double-close and close-from-inside-listener under GC.


### PR DESCRIPTION
### Repro

```js
import fs from "node:fs";
const ac = new AbortController();
const w = fs.watch(fs.mkdtempSync("/tmp/watched-"), { signal: ac.signal }, () => {});
w.on("error", e => console.log("error event:", e.name));
w.on("close", () => console.log("close event"));
setTimeout(() => ac.abort(), 100);
```

Bun 1.4.0 and current main:

```
error event: AbortError
close event
```

Node (v20 through v26):

```
close event
```

Passing a signal is the documented way to tear a watcher down, and the standard pattern is `watcher.on("error", e => log/alert/restart)`. With the spurious `AbortError`, an intentional shutdown looks like a failure.

### Cause

`FSWatcher::emit_abort` in `src/runtime/node/node_fs_watcher.rs` synthesized an `'error'` event from the abort reason (falling back to a `UserAbort` DOMException) before closing the watcher. Node's `fs.watch` registers `() => watcher.close()` on the signal and never emits `'error'` for an abort, for both the live-abort and already-aborted cases (`lib/fs.js`).

### Fix

Route both abort paths (the live `abort` listener, and the deferred task for a signal that was already aborted when the watcher was created) straight to `FSWatcher::close()`, which emits only `'close'`. `emit_abort` and its error-event synthesis are deleted.

`fs.promises.watch` is unaffected: its async iterator handles the signal in JS and still rejects with an `AbortError` (`code: 'ABORT_ERR'`), matching Node.

### Tests

- New test in `test/js/node/watch/fs.watch.test.ts`: `aborting the signal emits only 'close', never 'error'`.
- Four existing tests in that file asserted the old behavior and are updated to Node's contract; each now rejects if `'error'` fires, so they fail without the fix (`unexpected 'error' event: Error: ...`).
- `calling close from error event should not throw` relied on the abort producing an `'error'` event, which no longer happens; it is replaced by the new test. Its re-entrant-close coverage is kept by the adjacent `calling close from close event should not throw`, which uses the same abort trigger.
- Several watch tests and fixtures used `AbortSignal.timeout` plus the `'error'` event as a hang detector rather than as the thing under test. That guard is rewired through `'close'`: the two `add file/folder to ...` tests now fail their `done` callback when fewer than 2 events arrived, and `fixtures/relative.js`, `relative_dir.js`, `unref.js`, and `persistent.js` exit 1 from a `'close'` handler when the abort timeout fires. Without this, a dead watcher would pass those tests silently (or hang the `spawnSync` callers). `fixtures/close.js` does not need it: `.close()` detaches the signal listener before the timeout can fire.

### Verification

- `bun bd test test/js/node/watch/fs.watch.test.ts`: 41 pass, 0 fail on the rebased branch. Without the fix, the updated abort assertions fail with `unexpected 'error' event`.
- Ported Node tests `test-fs-watch-abort-signal.js`, `test-fs-promises-watch.js`, and `test-fs-watch-recursive-promise.js` all exit 0.
- The restored hang guards were exercised directly: the unref/persistent shape without `.unref()` and the relative shape with the writer removed both exit 1 with the new message.
- The repro above prints only `close event`, matching Node.

### Rebase note

Rebased onto main after #32962 and #33110 landed. The only conflict was a `test.skipIf` this PR originally added for the two root-only `EACCES` tests; main landed the same guard in #32962, so this PR now takes main's version and no longer touches those tests.
