### PR TITLE
fs.watch(Linux): deliver both rename self-events and the basename when the watched path is deleted

### DIFF
--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -305,6 +305,18 @@ impl PathWatcher {
         }
     }
 
+    /// Like [`emit`](Self::emit), but without per-handler duplicate suppression.
+    /// The `IN_IGNORED` retiring a deleted inode's wd lands in the same
+    /// millisecond as its `IN_DELETE_SELF`, with the same path and type, so
+    /// `should_emit` would fold the two into one; node (libuv) delivers both.
+    /// Caller holds `manager.mutex`.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn emit_unsuppressed(&mut self, event_type: EventType, rel_path: &[u8], is_file: bool) {
+        for &ctx in self.handlers.keys() {
+            (FSWatcher::ON_PATH_UPDATE)(Some(ctx), event_type.to_event(rel_path.into()), is_file);
+        }
+    }
+
     #[cfg(not(any(windows, target_os = "freebsd")))]
     fn emit_error(&mut self, err: &sys::Error) {
         for &ctx in self.handlers.keys() {
@@ -922,14 +934,38 @@ impl Linux {
                 i += core::mem::size_of::<InotifyEvent>() + ev.name_len as usize;
                 let wd = ev.watch_descriptor;
 
-                // Kernel retired this wd (rm_watch, or the watched inode is gone).
+                // Kernel retired this wd: `remove_watch` issued an explicit
+                // `inotify_rm_watch` (it deletes the `wd_map` entry first, so no
+                // owners remain to notify) or the watched inode is gone. libuv
+                // turns the latter into one more "rename" after IN_DELETE_SELF,
+                // so a deleted watch root reports two. Recursive sub-wds stay
+                // silent; their parent directory's IN_DELETE already reported it.
                 if ev.mask & IN::IGNORED != 0 {
                     // SAFETY: holding manager.mutex; exclusive access to `wd_map`.
                     let wd_map = unsafe { &mut (*plat).wd_map };
                     if let Some(owners) = wd_map.get_mut(&wd) {
                         for o in owners.drain(..) {
+                            // SAFETY: o.watcher live under manager.mutex. `path` is
+                            // read through the raw pointer (a separate ZBox heap
+                            // allocation) so the slice is not derived from the
+                            // `&mut` formed below, as in the dispatch loop.
+                            let (w_is_file, w_recursive, w_path): (bool, bool, &[u8]) = unsafe {
+                                (
+                                    (*o.watcher).is_file,
+                                    (*o.watcher).recursive,
+                                    &*std::ptr::from_ref::<[u8]>((*o.watcher).path.as_bytes()),
+                                )
+                            };
                             // SAFETY: o.watcher live under manager.mutex.
                             let w = unsafe { &mut *o.watcher };
+                            if o.subpath.as_bytes().is_empty() && (w_is_file || !w_recursive) {
+                                w.emit_unsuppressed(
+                                    EventType::Rename,
+                                    path::basename(w_path),
+                                    w_is_file,
+                                );
+                                let _ = handle_oom(touched.get_or_put(o.watcher));
+                            }
                             if let Some(idx) = w.platform.wds.iter().position(|&x| x == wd) {
                                 w.platform.wds.swap_remove(idx);
                             }
@@ -1021,7 +1057,16 @@ impl Linux {
                     let rel: &[u8] = if watcher_is_file {
                         path::basename(watcher_path)
                     } else if owner_subpath.is_empty() {
-                        name
+                        if name.is_empty() && !watcher_recursive {
+                            // A nameless event on the root wd is about the watched
+                            // directory itself (IN_DELETE_SELF, IN_MOVE_SELF,
+                            // IN_ATTRIB); libuv reports basename(watched path),
+                            // same as for a file. node's recursive watcher uses
+                            // root-relative paths instead, so those keep "".
+                            path::basename(watcher_path)
+                        } else {
+                            name
+                        }
                     } else if name.is_empty() {
                         owner_subpath
                     } else {

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1,5 +1,15 @@
 import { pathToFileURL } from "bun";
-import { bunEnv, bunExe, bunRun, bunRunAsScript, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  bunRun,
+  bunRunAsScript,
+  isLinux,
+  isMacOS,
+  isWindows,
+  tempDir,
+  tempDirWithFiles,
+} from "harness";
 import { EventEmitter } from "node:events";
 import fs, { FSWatcher } from "node:fs";
 import path from "path";
@@ -529,6 +539,54 @@ describe("fs.watch", () => {
       expect(err.code).toBe("EACCES");
       expect(err.syscall).toBe("watch");
     }
+  });
+
+  // Deleting the watched path retires its inotify watch: the kernel queues
+  // IN_DELETE_SELF followed by IN_IGNORED, and node (libuv) reports both as
+  // "rename". The exact sequence is inotify-specific, so Linux only.
+  test.skipIf(!isLinux)("unlinking the watched file delivers both rename self-events", async () => {
+    using dir = tempDir("fs-watch-unlink-self", { "f.txt": "x" });
+    const target = path.join(String(dir), "f.txt");
+    const events: [string, string | null][] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const watcher = fs.watch(target, (eventType, filename) => {
+      events.push([eventType, filename]);
+      if (events.filter(([type]) => type === "rename").length === 2) resolve();
+    });
+    try {
+      fs.unlinkSync(target);
+      await promise;
+    } finally {
+      watcher.close();
+    }
+    // unlink(2) emits IN_ATTRIB (link count drop), IN_DELETE_SELF, IN_IGNORED.
+    expect(events).toEqual([
+      ["change", "f.txt"],
+      ["rename", "f.txt"],
+      ["rename", "f.txt"],
+    ]);
+  });
+
+  test.skipIf(!isLinux)("removing the watched directory delivers both rename self-events named after it", async () => {
+    using dir = tempDir("fs-watch-rmdir-self", { "sub": {} });
+    const target = path.join(String(dir), "sub");
+    const events: [string, string | null][] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const watcher = fs.watch(target, (eventType, filename) => {
+      events.push([eventType, filename]);
+      if (events.filter(([type]) => type === "rename").length === 2) resolve();
+    });
+    try {
+      fs.rmdirSync(target);
+      await promise;
+    } finally {
+      watcher.close();
+    }
+    // The self-events carry no name; node reports basename(watched path).
+    expect(events).toEqual([
+      ["rename", "sub"],
+      ["rename", "sub"],
+    ]);
   });
 });
 

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -541,26 +541,34 @@ describe("fs.watch", () => {
     }
   });
 
-  // Deleting the watched path retires its inotify watch: the kernel queues
-  // IN_DELETE_SELF followed by IN_IGNORED, and node (libuv) reports both as
-  // "rename". The exact sequence is inotify-specific, so Linux only.
-  test.skipIf(!isLinux)("unlinking the watched file delivers both rename self-events", async () => {
-    using dir = tempDir("fs-watch-unlink-self", { "f.txt": "x" });
-    const target = path.join(String(dir), "f.txt");
+  // Self-events (the watched path itself is deleted or renamed) carry no name,
+  // and node (libuv) reports basename(watched path) for them. Deleting the
+  // watched path also retires its inotify watch: the kernel queues
+  // IN_DELETE_SELF followed by IN_IGNORED and node reports both as "rename".
+  // The exact sequences are inotify-specific, so Linux only.
+  // https://github.com/oven-sh/bun/issues/23306
+  async function collectWatchEvents(target: string, renames: number, act: () => void) {
     const events: [string, string | null][] = [];
-    const { promise, resolve } = Promise.withResolvers<void>();
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
     const watcher = fs.watch(target, (eventType, filename) => {
       events.push([eventType, filename]);
-      if (events.filter(([type]) => type === "rename").length === 2) resolve();
+      if (events.filter(([type]) => type === "rename").length === renames) resolve();
     });
+    watcher.once("error", reject);
     try {
-      fs.unlinkSync(target);
+      act();
       await promise;
     } finally {
       watcher.close();
     }
+    return events;
+  }
+
+  test.skipIf(!isLinux)("unlinking the watched file delivers both rename self-events", async () => {
+    using dir = tempDir("fs-watch-unlink-self", { "f.txt": "x" });
+    const target = path.join(String(dir), "f.txt");
     // unlink(2) emits IN_ATTRIB (link count drop), IN_DELETE_SELF, IN_IGNORED.
-    expect(events).toEqual([
+    expect(await collectWatchEvents(target, 2, () => fs.unlinkSync(target))).toEqual([
       ["change", "f.txt"],
       ["rename", "f.txt"],
       ["rename", "f.txt"],
@@ -570,21 +578,16 @@ describe("fs.watch", () => {
   test.skipIf(!isLinux)("removing the watched directory delivers both rename self-events named after it", async () => {
     using dir = tempDir("fs-watch-rmdir-self", { "sub": {} });
     const target = path.join(String(dir), "sub");
-    const events: [string, string | null][] = [];
-    const { promise, resolve } = Promise.withResolvers<void>();
-    const watcher = fs.watch(target, (eventType, filename) => {
-      events.push([eventType, filename]);
-      if (events.filter(([type]) => type === "rename").length === 2) resolve();
-    });
-    try {
-      fs.rmdirSync(target);
-      await promise;
-    } finally {
-      watcher.close();
-    }
-    // The self-events carry no name; node reports basename(watched path).
-    expect(events).toEqual([
+    expect(await collectWatchEvents(target, 2, () => fs.rmdirSync(target))).toEqual([
       ["rename", "sub"],
+      ["rename", "sub"],
+    ]);
+  });
+
+  test.skipIf(!isLinux)("renaming the watched directory away reports its basename", async () => {
+    using dir = tempDir("fs-watch-mv-self", { "sub": {} });
+    const target = path.join(String(dir), "sub");
+    expect(await collectWatchEvents(target, 1, () => fs.renameSync(target, path.join(String(dir), "moved")))).toEqual([
       ["rename", "sub"],
     ]);
   });


### PR DESCRIPTION
### Problem

On Linux, `fs.watch` under-reports the transition watchers care about most: the watched path itself going away.

```js
import fs from "node:fs";
const dir = fs.mkdtempSync("/tmp/watched-"), f = dir + "/f.txt";
fs.writeFileSync(f, "x");
const evs = [];
const w = fs.watch(f, (ev, fn) => evs.push(ev + ":" + fn));
setTimeout(() => fs.unlinkSync(f), 100);
setTimeout(() => { w.close(); console.log(evs.join(" | ")); }, 600);
```

node reports `change:f.txt | rename:f.txt | rename:f.txt`, bun reports `change:f.txt | rename:f.txt`. For a watched directory it is worse: `rmdir` of the watched directory produces a single `rename` whose `filename` is `undefined`.

| scenario | node v26 | bun before | bun after |
|---|---|---|---|
| unlink the watched file | change, rename, rename | change, rename | change, rename, rename |
| rmdir the watched dir | rename:sub, rename:sub | rename:undefined | rename:sub, rename:sub |
| rename the watched dir away | rename:sub | rename:undefined | rename:sub |
| rename the watched file away | rename:f.txt | rename:f.txt | rename:f.txt |
| unlink a file inside a watched dir | rename:f.txt | rename:f.txt | rename:f.txt |
| recursive: rm -rf of a subdir | rename:sub/a.txt, rename:sub | unchanged | unchanged |

Fixes #23306 (bug 1: deleting a watched folder must emit `rename` with the folder's name; bugs 2 and 3 in that issue already behave like node on current main, and the missing deletion report in bug 3's first watcher is this fix).

### Cause

Deleting a watched inode queues `IN_DELETE_SELF` followed by `IN_IGNORED` on its watch descriptor. libuv maps every mask bit outside `IN_ATTRIB|IN_MODIFY` to `UV_RENAME`, so node's callback fires twice. Bun's inotify reader consumed `IN_IGNORED` purely as wd bookkeeping and never emitted it.

Separately, self-events (`IN_DELETE_SELF`, `IN_MOVE_SELF`, `IN_ATTRIB` on the watched inode) carry no `name`. libuv substitutes `basename(watched path)`; bun only did that for file watches, so a watched directory's self-events surfaced with `filename: undefined`.

### Fix

In `src/runtime/node/path_watcher.rs` (the Linux backend):

- When `IN_IGNORED` retires a wd that still has owners (the inode is gone, as opposed to an explicit `watcher.close()`), emit a `rename` to each root owner before dropping them. This bypasses the per-handler duplicate suppression, which would otherwise fold it into the `IN_DELETE_SELF` rename delivered in the same millisecond.
- Nameless events on a non-recursive directory root now report `basename(watched path)`, matching the existing file-watch behavior.

Explicit `inotify_rm_watch` is unaffected: `remove_watch` deletes the `wd_map` entry before issuing it, so no owners remain by the time its `IN_IGNORED` arrives. Recursive sub-wds stay silent, because node's recursive watcher reports a removed subtree once (via the parent directory's `IN_DELETE`), which bun already matches.

### Verification

Three Linux-gated tests in `test/js/node/watch/fs.watch.test.ts`. All fail without the fix (the first two time out waiting for the second rename, the third gets `undefined` instead of the basename) and pass with it:

```
bun test v1.4.0-canary.1 (df92f8fd6)                    # without the fix
(fail) fs.watch > unlinking the watched file delivers both rename self-events [5000.82ms]
(fail) fs.watch > removing the watched directory delivers both rename self-events named after it [5001.05ms]
(fail) fs.watch > renaming the watched directory away reports its basename [4.78ms]

bun test v1.4.0 (debug build with the fix)
(pass) fs.watch > unlinking the watched file delivers both rename self-events [145.21ms]
(pass) fs.watch > removing the watched directory delivers both rename self-events named after it [36.00ms]
(pass) fs.watch > renaming the watched directory away reports its basename [25.84ms]
```

`test/js/node/watch/` and the vendored `test-fs-watch*` / `test-fs-promises-watch*` Node.js parallel tests still pass.

Supersedes #32959, which contains the basename half of this change (its two scenarios are covered by the tests here).
