### PR TITLE
node:fs: report node's operation name in error.syscall, not the raw syscall

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -472,7 +472,7 @@ function asyncWrap(fn: any, name: string) {
 
     async read(bufferOrParams, offset, length, position) {
       const fd = this[kFd];
-      throwEBADFIfNecessary("fsync", fd);
+      throwEBADFIfNecessary("read", fd);
 
       let buffer = bufferOrParams;
       if (!types.isArrayBufferView(buffer)) {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5629,7 +5629,11 @@ impl NodeFS {
             to_sys_time_like(args.atime),
             to_sys_time_like(args.mtime),
         ) {
-            Err(err) => Err(err),
+            // `err.syscall` must be node's operation name, not `futimens(2)`.
+            Err(mut err) => {
+                err.syscall = sys::Tag::futime;
+                Err(err)
+            }
             Ok(_) => Ok(()),
         }
     }
@@ -8121,7 +8125,8 @@ impl NodeFS {
             to_sys_time_like(args.atime),
             to_sys_time_like(args.mtime),
         ) {
-            Err(err) => Err(err.with_path(args.path.slice())),
+            // `err.syscall` must be node's operation name, not `utimensat(2)`.
+            Err(err) => Err(err.with_path_and_syscall(args.path.slice(), sys::Tag::utime)),
             Ok(_) => Ok(()),
         }
     }
@@ -8143,7 +8148,7 @@ impl NodeFS {
             return if let Some(errno) = rc.errno() {
                 Err(sys::Error {
                     errno,
-                    syscall: sys::Tag::utime,
+                    syscall: sys::Tag::lutime,
                     path: args.path.slice().into(),
                     ..Default::default()
                 })
@@ -8157,7 +8162,8 @@ impl NodeFS {
             to_sys_time_like(args.atime),
             to_sys_time_like(args.mtime),
         ) {
-            Err(err) => Err(err.with_path(args.path.slice())),
+            // `err.syscall` must be node's operation name, not `utimensat(2)`.
+            Err(err) => Err(err.with_path_and_syscall(args.path.slice(), sys::Tag::lutime)),
             Ok(_) => Ok(()),
         }
     }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2314,8 +2314,17 @@ mod posix_impl {
         }
     }
 
+    // `syscall` is the JS-facing `err.syscall` tag (`stat`/`lstat`/`fstat`):
+    // node reports the operation name, never the `statx(2)` implementation
+    // detail, and the non-statx fallback below already uses those same tags.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn statx_impl(fd: Fd, path: Option<&ZStr>, flags: c_int, mask: u32) -> Maybe<PosixStat> {
+    fn statx_impl(
+        fd: Fd,
+        path: Option<&ZStr>,
+        flags: c_int,
+        mask: u32,
+        syscall: Tag,
+    ) -> Maybe<PosixStat> {
         use core::sync::atomic::Ordering;
         let mut buf = core::mem::MaybeUninit::<lx::statx>::uninit();
         let pathname: *const c_char = match path {
@@ -2356,7 +2365,7 @@ mod posix_impl {
                 }
                 return Err(Error {
                     errno: raw_errno as _,
-                    syscall: Tag::statx,
+                    syscall,
                     ..Default::default()
                 });
             }
@@ -2400,11 +2409,11 @@ mod posix_impl {
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn fstatx(fd: Fd, mask: u32) -> Maybe<PosixStat> {
-        statx_impl(fd, None, libc::AT_EMPTY_PATH, mask)
+        statx_impl(fd, None, libc::AT_EMPTY_PATH, mask, Tag::fstat)
     }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn statx(path: &ZStr, mask: u32) -> Maybe<PosixStat> {
-        statx_impl(Fd::from_native(libc::AT_FDCWD), Some(path), 0, mask)
+        statx_impl(Fd::from_native(libc::AT_FDCWD), Some(path), 0, mask, Tag::stat)
     }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn lstatx(path: &ZStr, mask: u32) -> Maybe<PosixStat> {
@@ -2413,6 +2422,7 @@ mod posix_impl {
             Some(path),
             libc::AT_SYMLINK_NOFOLLOW,
             mask,
+            Tag::lstat,
         )
     }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2413,7 +2413,13 @@ mod posix_impl {
     }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn statx(path: &ZStr, mask: u32) -> Maybe<PosixStat> {
-        statx_impl(Fd::from_native(libc::AT_FDCWD), Some(path), 0, mask, Tag::stat)
+        statx_impl(
+            Fd::from_native(libc::AT_FDCWD),
+            Some(path),
+            0,
+            mask,
+            Tag::stat,
+        )
     }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn lstatx(path: &ZStr, mask: u32) -> Maybe<PosixStat> {

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -15,11 +15,7 @@ test("delete() and stat() should work with unicode paths", async () => {
 
   expect(async () => {
     await Bun.file(filename).stat();
-  }).toThrow(
-    process.platform === "linux"
-      ? `ENOENT: no such file or directory, statx '${filename}'`
-      : `ENOENT: no such file or directory, stat '${filename}'`,
-  );
+  }).toThrow(`ENOENT: no such file or directory, stat '${filename}'`);
 
   await Bun.write(filename, "HI");
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3741,6 +3741,99 @@ it("test syscall errno, issue#4198", () => {
   rmdirSync(path);
 });
 
+describe("error.syscall is node's operation name, not the raw kernel syscall", () => {
+  // Node documents err.syscall as a stable, platform-independent operation
+  // name ("stat", "lstat", "utime", ...). On Linux, Bun implements stat via
+  // statx(2) and utimes via utimensat(2); the implementation detail must not
+  // leak into err.syscall.
+  const missing = join(tmpdir(), "fs-syscall-" + Date.now(), "nope");
+  const badfd = 2147483640;
+  const syscallOf = (fn: () => unknown) => {
+    try {
+      fn();
+    } catch (e: any) {
+      return e.syscall;
+    }
+    throw new Error("expected to throw");
+  };
+  const syscallOfAsync = async (fn: () => Promise<unknown>) => {
+    try {
+      await fn();
+    } catch (e: any) {
+      return e.syscall;
+    }
+    throw new Error("expected to reject");
+  };
+
+  it("sync", () => {
+    expect({
+      stat: syscallOf(() => statSync(missing)),
+      lstat: syscallOf(() => lstatSync(missing)),
+      fstat: syscallOf(() => fstatSync(badfd)),
+      utimes: syscallOf(() => fs.utimesSync(missing, 1, 1)),
+      lutimes: syscallOf(() => fs.lutimesSync(missing, 1, 1)),
+      futimes: syscallOf(() => fs.futimesSync(badfd, 1, 1)),
+    }).toEqual({
+      stat: "stat",
+      lstat: "lstat",
+      fstat: "fstat",
+      utimes: "utime",
+      lutimes: "lutime",
+      futimes: "futime",
+    });
+  });
+
+  it("syscall appears in the error message", () => {
+    expect(() => statSync(missing)).toThrow(/, stat '/);
+    expect(() => lstatSync(missing)).toThrow(/, lstat '/);
+    expect(() => fs.utimesSync(missing, 1, 1)).toThrow(/, utime '/);
+    expect(() => fs.lutimesSync(missing, 1, 1)).toThrow(/, lutime '/);
+  });
+
+  it("async (fs/promises)", async () => {
+    expect({
+      stat: await syscallOfAsync(() => promises.stat(missing)),
+      lstat: await syscallOfAsync(() => promises.lstat(missing)),
+      utimes: await syscallOfAsync(() => promises.utimes(missing, 1, 1)),
+      lutimes: await syscallOfAsync(() => promises.lutimes(missing, 1, 1)),
+    }).toEqual({
+      stat: "stat",
+      lstat: "lstat",
+      utimes: "utime",
+      lutimes: "lutime",
+    });
+  });
+
+  it("async (callback)", async () => {
+    const cb = (fn: (cb: (err: any) => void) => void) =>
+      new Promise<string>(resolve => fn(err => resolve(err?.syscall)));
+    expect({
+      stat: await cb(done => fs.stat(missing, done)),
+      lstat: await cb(done => fs.lstat(missing, done)),
+      utimes: await cb(done => fs.utimes(missing, 1, 1, done)),
+      lutimes: await cb(done => fs.lutimes(missing, 1, 1, done)),
+    }).toEqual({
+      stat: "stat",
+      lstat: "lstat",
+      utimes: "utime",
+      lutimes: "lutime",
+    });
+  });
+
+  it("FileHandle.read after close reports 'read', not 'fsync'", async () => {
+    using dir = tempDir("fs-syscall-fh", { "f.txt": "hello" });
+    const handle = await promises.open(join(String(dir), "f.txt"), "r");
+    await handle.close();
+    let err: any;
+    try {
+      await handle.read(Buffer.alloc(1), 0, 1, 0);
+    } catch (e) {
+      err = e;
+    }
+    expect({ code: err?.code, syscall: err?.syscall }).toEqual({ code: "EBADF", syscall: "read" });
+  });
+});
+
 it.if(isWindows)("writing to windows hidden file is possible", () => {
   const temp = tmpdir();
   writeFileSync(join(temp, "file.txt"), "FAIL");


### PR DESCRIPTION
Fixes the `error.syscall` value on `node:fs` errors to use Node's documented, platform-independent operation name instead of the raw syscall Bun happened to issue.

Node's `err.syscall` is a stable contract (`"stat"`, `"lstat"`, `"utime"`, ...) that a lot of npm code branches on. Bun leaked the implementing syscall, so those branches never matched.

### Repro

```js
import * as fs from "node:fs";
import * as fsp from "node:fs/promises";
import * as os from "node:os";
const R = fs.mkdtempSync(os.tmpdir() + "/fssc-");
fs.writeFileSync(R + "/f", "hello");
const E = (f) => { try { f(); } catch (e) { return e.syscall; } };
for (const [t, fn] of Object.entries({
  stat: () => fs.statSync(R + "/zz/zz"), lstat: () => fs.lstatSync(R + "/zz/zz"),
  utimes: () => fs.utimesSync(R + "/zz", 1, 1),
})) console.log(t + ":", E(fn));
console.log("fh-read-after-close:", await fsp.open(R + "/f", "r")
  .then(async h => { await h.close(); try { await h.read(Buffer.alloc(1), 0, 1, 0); }
  catch (e) { return e.code + "/" + e.syscall; } }));
```

Node prints `stat`, `lstat`, `utime`, `EBADF/read`. Bun printed `statx`, `statx`, `utimensat`, `EBADF/fsync`. The same wrong name also appears in the error message text (`ENOENT: no such file or directory, statx '...'`).

### Causes and fixes

- **`stat` / `lstat` / `fstat` all reported `statx` on Linux.** `statx_impl` in `src/sys/lib.rs` hardcoded `Tag::statx` on its error path. It now takes the JS-facing tag as a parameter, and `statx` / `lstatx` / `fstatx` pass `stat` / `lstat` / `fstat`. This also matches what the non-statx fallback path (seccomp / kernel < 4.11) already reported, so the value is no longer kernel-dependent.
- **`utimes` / `lutimes` reported `utimensat`, `futimes` reported `futimens`.** The `node_fs.rs` implementations now rewrite the tag to Node's `utime` / `lutime` / `futime`.
- **The Windows `lutimes` path tagged errors as `utime`** instead of `lutime`.
- **`FileHandle.read()` on a closed handle reported `syscall: "fsync"`**, copy-pasted from the `sync()` method directly above it in `fs.promises.ts`. Now `"read"`.

Audited the remaining ~25 `node:fs` operations against Node v26.3.0; every other `err.syscall` already matched.

### Tests

Added `describe("error.syscall is node's operation name, ...")` to `test/js/node/fs/fs.test.ts` covering the sync, callback, and `fs/promises` variants plus the `FileHandle.read` case. All five fail on the released build and pass with the fix.

Also removed the Linux-only `statx` special case in `test/js/bun/util/bun-file.test.ts`, which was encoding the old behavior.
