### PR TITLE
Validate Bun.Cookie maxAge as a safe integer

### DIFF
--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -20,6 +20,7 @@
 #include "JSDOMWrapperCache.h"
 #include <JavaScriptCore/HeapAnalyzer.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/MathCommon.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
@@ -83,6 +84,22 @@ static int64_t getExpiresValue(JSGlobalObject* lexicalGlobalObject, JSC::ThrowSc
     }
 
     return Bun::ERR::INVALID_ARG_VALUE(throwScope, lexicalGlobalObject, "expires"_s, expiresValue, "Invalid expires value. Must be a Date or a number"_s);
+}
+
+// Max-Age is serialized as RFC 6265 delta-seconds (["-"] *DIGIT), so only integers the
+// double represents exactly are accepted. NaN is the internal "no Max-Age" sentinel.
+static double getMaxAgeValue(JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& throwScope, JSValue maxAgeValue)
+{
+    if (maxAgeValue.isUndefinedOrNull())
+        return std::numeric_limits<double>::quiet_NaN();
+
+    double maxAge = maxAgeValue.toNumber(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, std::numeric_limits<double>::quiet_NaN());
+    if (!JSC::isSafeInteger(maxAge)) [[unlikely]] {
+        throwScope.throwException(lexicalGlobalObject, createRangeError(lexicalGlobalObject, "maxAge must be a safe integer"_s));
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return maxAge;
 }
 
 template<bool checkName>
@@ -160,9 +177,8 @@ static std::optional<CookieInit> cookieInitFromJS(JSC::VM& vm, JSGlobalObject* l
             auto maxAgeValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.maxAgePublicName());
             RETURN_IF_EXCEPTION(throwScope, std::nullopt);
             if (maxAgeValue) {
-                if (!maxAgeValue.isUndefined() && !maxAgeValue.isNull() && maxAgeValue.isNumber()) {
-                    maxAge = maxAgeValue.asNumber();
-                }
+                maxAge = getMaxAgeValue(lexicalGlobalObject, throwScope, maxAgeValue);
+                RETURN_IF_EXCEPTION(throwScope, std::nullopt);
             }
 
             // secure
@@ -869,14 +885,9 @@ JSC_DEFINE_CUSTOM_SETTER(jsCookiePrototypeSetter_maxAge, (JSGlobalObject * lexic
     if (!thisObject) [[unlikely]]
         return throwThisTypeError(*lexicalGlobalObject, throwScope, "Cookie"_s, "maxAge"_s);
     auto& impl = thisObject->wrapped();
-    if (JSValue::decode(encodedValue).isUndefinedOrNull()) {
-        impl.setMaxAge(std::numeric_limits<double>::quiet_NaN());
-        return true;
-    }
-    auto value = convert<IDLDouble>(*lexicalGlobalObject, JSValue::decode(encodedValue));
+    double maxAge = getMaxAgeValue(lexicalGlobalObject, throwScope, JSValue::decode(encodedValue));
     RETURN_IF_EXCEPTION(throwScope, false);
-    impl.setMaxAge(value);
-
+    impl.setMaxAge(maxAge);
     return true;
 }
 

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -55,6 +55,71 @@ describe("Bun.Cookie validation tests", () => {
     });
   });
 
+  describe("maxAge validation", () => {
+    // RFC 6265 Max-Age is delta-seconds (["-"] *DIGIT), so anything that can't be
+    // serialized as a plain integer must be rejected instead of put on the wire.
+    test.each([Infinity, -Infinity, NaN, 1.5, -1.5, -1.5e21, 1e300, 2 ** 53, -(2 ** 53)])(
+      "throws for maxAge: %p in every entry point",
+      bad => {
+        expect(() => new Bun.Cookie("name", "value", { maxAge: bad })).toThrow("maxAge must be a safe integer");
+        expect(() => new Bun.Cookie({ name: "name", value: "value", maxAge: bad })).toThrow(
+          "maxAge must be a safe integer",
+        );
+        expect(() => Bun.Cookie.from("name", "value", { maxAge: bad })).toThrow("maxAge must be a safe integer");
+        expect(() => new Bun.CookieMap().set("name", "value", { maxAge: bad })).toThrow(
+          "maxAge must be a safe integer",
+        );
+
+        const cookie = new Bun.Cookie("name", "value");
+        expect(() => {
+          cookie.maxAge = bad;
+        }).toThrow("maxAge must be a safe integer");
+        expect(cookie.maxAge).toBeUndefined();
+        expect(cookie.toString()).toBe("name=value; Path=/; SameSite=Lax");
+      },
+    );
+
+    test("throws a RangeError", () => {
+      expect(() => new Bun.Cookie("name", "value", { maxAge: Infinity })).toThrow(RangeError);
+    });
+
+    test.each([
+      [0, "Max-Age=0"],
+      [-1, "Max-Age=-1"],
+      [3600, "Max-Age=3600"],
+      [Number.MAX_SAFE_INTEGER, "Max-Age=9007199254740991"],
+      [Number.MIN_SAFE_INTEGER, "Max-Age=-9007199254740991"],
+    ])("serializes maxAge: %p as plain digits", (maxAge, expected) => {
+      const cookie = new Bun.Cookie("name", "value", { maxAge });
+      expect(cookie.maxAge).toBe(maxAge);
+      expect(cookie.toString()).toBe(`name=value; Path=/; ${expected}; SameSite=Lax`);
+    });
+
+    test("undefined and null mean no Max-Age", () => {
+      expect(new Bun.Cookie("name", "value", { maxAge: undefined }).maxAge).toBeUndefined();
+      // @ts-expect-error null is accepted at runtime
+      expect(new Bun.Cookie("name", "value", { maxAge: null }).maxAge).toBeUndefined();
+
+      const cookie = new Bun.Cookie("name", "value", { maxAge: 5 });
+      cookie.maxAge = undefined;
+      expect(cookie.maxAge).toBeUndefined();
+      expect(cookie.toString()).toBe("name=value; Path=/; SameSite=Lax");
+    });
+
+    test("coerces non-numbers with ToNumber, same as the maxAge setter", () => {
+      // @ts-expect-error the setter has always coerced strings; the constructor now matches it
+      expect(new Bun.Cookie("name", "value", { maxAge: "60" }).maxAge).toBe(60);
+      const cookie = new Bun.Cookie("name", "value");
+      // @ts-expect-error
+      cookie.maxAge = "60";
+      expect(cookie.maxAge).toBe(60);
+      // @ts-expect-error
+      expect(() => new Bun.Cookie("name", "value", { maxAge: "not a number" })).toThrow(
+        "maxAge must be a safe integer",
+      );
+    });
+  });
+
   describe("Cookie.from validation", () => {
     test("throws for NaN Date in Cookie.from", () => {
       const invalidDate = new Date("invalid date");

--- a/test/js/bun/util/cookie.test.js
+++ b/test/js/bun/util/cookie.test.js
@@ -522,22 +522,22 @@ describe("cookie.serialize(name, value, options)", function () {
   });
 
   describe('with "maxAge" option', function () {
-    it.failing("should throw when not a number", function () {
+    it("should throw when not a number", function () {
       expect(function () {
         cookie.serialize("foo", "bar", { maxAge: "buzz" });
-      }).toThrow(/option maxAge is invalid/);
+      }).toThrow(/maxAge must be a safe integer/);
     });
 
-    it.failing("should throw when Infinity", function () {
+    it("should throw when Infinity", function () {
       expect(function () {
         cookie.serialize("foo", "bar", { maxAge: Infinity });
-      }).toThrow(/option maxAge is invalid/);
+      }).toThrow(/maxAge must be a safe integer/);
     });
 
-    it.failing("should throw when max-age is not an integer", function () {
+    it("should throw when max-age is not an integer", function () {
       expect(function () {
         cookie.serialize("foo", "bar", { maxAge: 3.14 });
-      }).toThrow(/option maxAge is invalid/);
+      }).toThrow(/maxAge must be a safe integer/);
     });
 
     it("should set max-age to value", function () {


### PR DESCRIPTION
### What

`Bun.Cookie` serializes any numeric `maxAge` verbatim, so all of these emit a malformed `Set-Cookie` with no error:

```js
new Bun.Cookie("a", "b", { maxAge: Infinity }).toString(); // a=b; Path=/; Max-Age=Infinity; SameSite=Lax
new Bun.Cookie("a", "b", { maxAge: 1.5 }).toString();      // a=b; Path=/; Max-Age=1.5; SameSite=Lax
new Bun.Cookie("a", "b", { maxAge: -1.5e21 }).toString();  // a=b; Path=/; Max-Age=-1.5e+21; SameSite=Lax
```

RFC 6265 defines `Max-Age` as delta-seconds (`["-"] *DIGIT`) and recipients drop the attribute when it does not parse, so a cookie the caller believes is long lived silently becomes a session cookie. `request.cookies.set(name, value, { maxAge })` in `Bun.serve` goes through the same path, so this reaches real response headers. Inputs like these are easy to produce by accident (`ttlMs / 1000`, a missing config value read as `Infinity`).

### Cause

`cookieInitFromJS` stores `maxAgeValue.asNumber()` with no validation, and `Cookie::appendTo` prints the double with `String::number`, which uses JS `ToString` semantics (`"Infinity"`, `"1.5"`, exponent form from `1e21`). The `maxAge` setter was already stricter than the constructor: WebIDL `double` conversion rejects `Infinity`/`NaN` there, so `new Bun.Cookie("a", "b", { maxAge: Infinity })` succeeded while `cookie.maxAge = Infinity` threw.

### Fix

Add a `getMaxAgeValue()` helper next to `getExpiresValue()` and use it from the constructor/options path (which also covers `Bun.Cookie.from`, `new Bun.Cookie({...})`, and `CookieMap.set`) and from the `maxAge` setter:

- `undefined` and `null` still mean "no Max-Age".
- Anything else is converted with `ToNumber` (what the setter already did) and must be a safe integer, otherwise `RangeError: maxAge must be a safe integer`.

Safe integers are exactly the doubles `String::number` always prints as plain digits, and `cookie` on npm rejects non-finite `maxAge` the same way. Behavior changes beyond the repro: an explicit `maxAge: NaN` used to be silently treated as unset and now throws, a non-numeric `maxAge` in the options object used to be silently ignored and is now coerced exactly like the setter (`"60"` works, `"buzz"` throws), and the setter's error for non-finite input is now the same `RangeError` as the constructor instead of a WebIDL `TypeError`.

Cookie parsing (`Bun.Cookie.parse`, `Set-Cookie` headers) is intentionally unchanged: the lenient parser already produces integers there and must not throw on weird attributes.

The `expires` half of the same report (`expires: 1e15` serializing an impossible date, `expires: 1e300` disappearing) is already fixed by the open #32267, so this PR leaves `getExpiresValue` alone rather than conflict with it.

### Tests

New `maxAge validation` suite in `test/js/bun/cookie/cookie.test.ts`: every invalid input (`Infinity`, `-Infinity`, `NaN`, `1.5`, `-1.5`, `-1.5e21`, `1e300`, `2**53`, `-(2**53)`) is asserted to throw from every entry point, plus the valid boundary values (`0`, `-1`, `Number.MAX_SAFE_INTEGER`, `Number.MIN_SAFE_INTEGER`) and the unset/coercion cases. Three `it.failing` tests in `test/js/bun/util/cookie.test.js` (ported from the `cookie` package suite, demanding exactly this) now pass and are un-marked.

```
USE_SYSTEM_BUN=1 bun test cookie.test.ts util/cookie.test.js   # 14 fail
bun bd test test/js/bun/cookie/ test/js/bun/util/cookie.test.js \
  test/js/bun/http/bun-serve-cookies.test.ts test/js/web/fetch/cookies.test.ts
# 295 pass, 0 fail
```
