### PR TITLE
Serialize the correct weekday in Bun.Cookie Expires attributes

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -267,11 +267,11 @@ void Cookie::appendTo(JSC::VM& vm, StringBuilder& builder) const
     // Add expires if present
     if (hasExpiry()) {
         builder.append("; Expires="_s);
-        // In a real implementation, this would convert the timestamp to a proper date string
-        // For now, just use a numeric timestamp
         WTF::GregorianDateTime dateTime;
         vm.dateCache.msToGregorianDateTime(m_expires, WTF::TimeType::UTCTime, dateTime);
-        builder.append(WTF::makeRFC2822DateString(dateTime.weekDay(), dateTime.monthDay(), dateTime.month(), dateTime.year(), dateTime.hour(), dateTime.minute(), dateTime.second(), dateTime.utcOffsetInMinute()));
+        // GregorianDateTime::weekDay() is 0 = Sunday, but makeRFC2822DateString's
+        // day-name table starts at Monday, so the index has to be rotated.
+        builder.append(WTF::makeRFC2822DateString((dateTime.weekDay() + 6) % 7, dateTime.monthDay(), dateTime.month(), dateTime.year(), dateTime.hour(), dateTime.minute(), dateTime.second(), dateTime.utcOffsetInMinute()));
     }
 
     // Add Max-Age if present

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -198,7 +198,7 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`
       [
         "foo=bar; Path=/; Secure; HttpOnly; Partitioned; SameSite=Lax",
-        "name=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+        "name=; Path=/; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
       ]
     `);
   });

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -99,6 +99,22 @@ describe("Bun.Cookie validation tests", () => {
   });
 });
 
+describe("Expires weekday", () => {
+  test("serializes the unix epoch with the correct weekday", () => {
+    expect(new Bun.Cookie("name", "value", { expires: 0 }).toString()).toBe(
+      "name=value; Path=/; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+    );
+  });
+
+  test("matches Date#toUTCString for every day of the week", () => {
+    for (let day = 7; day < 14; day++) {
+      const date = new Date(Date.UTC(2024, 0, day)); // 2024-01-07 is a Sunday
+      const cookie = new Bun.Cookie("name", "value", { expires: date });
+      expect(cookie.toString()).toContain(`; Expires=${date.toUTCString().slice(0, 3)}, ${day} Jan 2024`);
+    }
+  });
+});
+
 console.log("describe Bun.serve() cookies");
 describe("Bun.serve() cookies", () => {
   const server = Bun.serve({
@@ -181,7 +197,7 @@ describe("Bun.serve() cookies", () => {
     expect(body).toMatchInlineSnapshot(`{}`);
     expect(res.headers.getAll("Set-Cookie")).toMatchInlineSnapshot(`
       [
-        "test=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+        "test=; Path=/; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
       ]
     `);
   });
@@ -238,7 +254,7 @@ describe("Bun.serve() cookies", () => {
     map.set("do_modify", "FIVE");
     expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`
       [
-        "do_delete=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+        "do_delete=; Path=/; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
         "do_modify=FIVE; Path=/; SameSite=Lax",
       ]
     `);
@@ -352,10 +368,10 @@ test("delete cookie path option", () => {
   map.delete("d", { path: "/" });
   expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`
     [
-      "a=; Path=/b; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
-      "b=; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
-      "c=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
-      "d=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+      "a=; Path=/b; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+      "b=; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+      "c=; Path=/; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+      "d=; Path=/; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
     ]
   `);
 });

--- a/test/js/bun/util/cookie.test.js
+++ b/test/js/bun/util/cookie.test.js
@@ -178,7 +178,7 @@ describe("Bun.CookieMap", () => {
 
     expect(cookieMap.toSetCookieHeaders()).toMatchInlineSnapshot(`
       [
-        "name=; Domain=example.com; Path=/foo; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+        "name=; Domain=example.com; Path=/foo; Expires=Thu, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
       ]
     `);
 
@@ -507,7 +507,7 @@ describe("cookie.serialize(name, value, options)", function () {
         cookie.serialize("foo", "bar", {
           expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
         }),
-      ).toEqual("foo=bar; Expires=Mon, 24 Dec 2000 10:30:59 -0000; SameSite=Lax");
+      ).toEqual("foo=bar; Expires=Sun, 24 Dec 2000 10:30:59 -0000; SameSite=Lax");
     });
   });
 


### PR DESCRIPTION
### What

Every `Expires=` attribute serialized by `Bun.Cookie` / `Bun.CookieMap` names the wrong day of the week:

```js
new Bun.Cookie("a", "b", { expires: 0 }).toString();
// a=b; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax
//                      ^^^ January 1, 1970 is a Thursday
new Date(0).toUTCString();
// "Thu, 01 Jan 1970 00:00:00 GMT"
```

`CookieMap.delete()` works by setting `Expires` to the epoch, so every cookie deletion from a `Bun.serve` handler puts `Expires=Fri, 1 Jan 1970 ...` on the wire.

### Cause

`Cookie::appendTo` passes `GregorianDateTime::weekDay()` straight into `WTF::makeRFC2822DateString`. `weekDay()` uses the `tm_wday` convention (0 = Sunday), but `makeRFC2822DateString` indexes a day-name table that starts at Monday (`{"Mon", "Tue", ..., "Sun"}`), so every date is shifted forward one day name.

### Fix

Rotate the index at the call site: `(weekDay() + 6) % 7`. RFC 6265 recipients ignore the weekday when parsing a cookie-date, so this never broke expiry in practice, but the header should not contradict itself. Also drops a stale comment on those lines that claimed the code does not format a date string.

### Tests

New `Expires weekday` tests in `test/js/bun/cookie/cookie.test.ts`: the epoch serializes as `Thu`, and a cookie for each day of a known week must agree with `Date#toUTCString()`. Eight existing expectations that had captured the off-by-one output (`Expires=Fri, 1 Jan 1970 ...` from `CookieMap.delete`, `Expires=Mon, 24 Dec 2000 ...` for a Sunday) are corrected in the same commit.

```
USE_SYSTEM_BUN=1 bun test cookie.test.ts cookie-map.test.ts util/cookie.test.js   # 8 fail
bun bd test test/js/bun/cookie/ test/js/bun/util/cookie.test.js                   # 0 fail
```
