### PR TITLE
shell: support the suffix operand in the basename builtin

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -180,7 +180,7 @@ shell_builtins! {
     inline: {
         Pwd      => (pwd::Pwd,          "pwd",      b""),
         Exit     => (exit::Exit,        "exit",     b"usage: exit [n]\n"),
-        Basename => (basename::Basename,"basename", b"usage: basename string\n"),
+        Basename => (basename::Basename,"basename", b"usage: basename string [suffix]\n"),
         Dirname  => (dirname::Dirname,  "dirname",  b"usage: dirname string\n"),
         Cd       => (cd::Cd,            "cd",       b""),
         Echo     => (echo::Echo,        "echo",     b""),

--- a/src/runtime/shell/builtin/basename.rs
+++ b/src/runtime/shell/builtin/basename.rs
@@ -22,14 +22,21 @@ impl Basename {
         let buf = {
             let bltn = Builtin::of(interp, cmd);
             let argc = bltn.args_slice().len();
-            if argc == 0 {
+            // POSIX: `basename string [suffix]`.
+            if argc == 0 || argc > 2 {
                 return Self::fail(interp, cmd, Kind::Basename.usage_string());
             }
-            let mut buf = Vec::new();
-            for i in 0..argc {
-                buf.extend_from_slice(bun_paths::resolve_path::basename(bltn.arg_bytes(i)));
-                buf.push(b'\n');
+            let mut name = bun_paths::resolve_path::basename(bltn.arg_bytes(0));
+            if argc == 2 {
+                let suffix = bltn.arg_bytes(1);
+                // Strip only a proper suffix: `basename .txt .txt` stays `.txt`.
+                if name.len() > suffix.len() && bun_core::strings::ends_with(name, suffix) {
+                    name = &name[..name.len() - suffix.len()];
+                }
             }
+            let mut buf = Vec::with_capacity(name.len() + 1);
+            buf.extend_from_slice(name);
+            buf.push(b'\n');
             buf
         };
 

--- a/test/js/bun/shell/commands/basename.test.ts
+++ b/test/js/bun/shell/commands/basename.test.ts
@@ -3,7 +3,11 @@ import { createTestBuilder } from "../test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
 describe("basename", async () => {
-  TestBuilder.command`basename`.exitCode(1).stdout("").stderr("usage: basename string\n").runAsTest("shows usage");
+  TestBuilder.command`basename`
+    .exitCode(1)
+    .stdout("")
+    .stderr("usage: basename string [suffix]\n")
+    .runAsTest("shows usage");
 
   TestBuilder.command`basename js/bun/shell/commands/basename.test.ts`
     .exitCode(0)
@@ -17,12 +21,6 @@ describe("basename", async () => {
     .stderr("")
     .runAsTest("works absolute");
 
-  TestBuilder.command`basename /usr/share/aclocal/pkg.m4 /var/log/bar/file.txt`
-    .exitCode(0)
-    .stdout("pkg.m4\nfile.txt\n")
-    .stderr("")
-    .runAsTest("works multiple");
-
   TestBuilder.command`basename C:/Documents/Newsletters/Summer2018.pdf`
     .exitCode(0)
     .stdout("Summer2018.pdf\n")
@@ -34,6 +32,46 @@ describe("basename", async () => {
   TestBuilder.command`basename /catalog`.exitCode(0).stdout("catalog\n").stderr("").runAsTest("at root");
 
   TestBuilder.command`basename /`.exitCode(0).stdout("/\n").stderr("").runAsTest("root is idempotent");
+
+  // POSIX: `basename string [suffix]`. The second operand is a suffix to
+  // strip, not a second name.
+  TestBuilder.command`basename /home/tux/example.txt .txt`
+    .exitCode(0)
+    .stdout("example\n")
+    .stderr("")
+    .runAsTest("strips suffix");
+
+  TestBuilder.command`basename a.txt/ .txt`
+    .exitCode(0)
+    .stdout("a\n")
+    .stderr("")
+    .runAsTest("strips suffix after trailing slash");
+
+  TestBuilder.command`basename foo.txt txt`.exitCode(0).stdout("foo.\n").stderr("").runAsTest("suffix without a dot");
+
+  TestBuilder.command`basename /a/b/.txt .txt`
+    .exitCode(0)
+    .stdout(".txt\n")
+    .stderr("")
+    .runAsTest("suffix identical to the name is not stripped");
+
+  TestBuilder.command`basename /home/tux/example.txt .md`
+    .exitCode(0)
+    .stdout("example.txt\n")
+    .stderr("")
+    .runAsTest("non-matching suffix is not stripped");
+
+  TestBuilder.command`basename /usr/share/aclocal/pkg.m4 /var/log/bar/file.txt`
+    .exitCode(0)
+    .stdout("pkg.m4\n")
+    .stderr("")
+    .runAsTest("second operand is a suffix, not a second name");
+
+  TestBuilder.command`basename a b c`
+    .exitCode(1)
+    .stdout("")
+    .stderr("usage: basename string [suffix]\n")
+    .runAsTest("extra operand is an error");
 });
 
 describe("basename without stdout", async () => {

--- a/test/js/bun/shell/pipeline_stack.test.ts
+++ b/test/js/bun/shell/pipeline_stack.test.ts
@@ -213,7 +213,7 @@ describe("pipeline stack edge cases", () => {
 
     TestBuilder.command`basename | echo after 2>/dev/null`
       .stdout("after\n")
-      .stderr("usage: basename string\n")
+      .stderr("usage: basename string [suffix]\n")
       .runAsTest("basename (no args) | echo");
   });
 


### PR DESCRIPTION
Bun Shell's `basename` builtin treated every operand as a separate name, so the standard two-operand form silently produced the wrong result:

```js
await Bun.$`basename foo.txt .txt`.text();
// Bun:       "foo.txt\n.txt\n"
// coreutils: "foo\n"
```

Every real `basename` (POSIX, GNU coreutils, busybox) takes `basename string [suffix]`: the second operand is a suffix to strip, not a second name. Scripts using the common `basename "$f" .ext` idiom got the full filename back, plus a stray `.ext` line.

### Fix

`src/runtime/shell/builtin/basename.rs` now implements `basename string [suffix]`:

- one operand: unchanged
- two operands: the second is stripped from the end of the basename of the first, but only when it is a proper suffix, so `basename .txt .txt` stays `.txt`, matching coreutils
- more than two operands: usage error (coreutils reports `extra operand`)

The usage string becomes `usage: basename string [suffix]`.

This replaces the previous non-standard multi-name behavior, where `basename A B` printed two lines. The two readings of `basename A B` are mutually exclusive, and no real `basename` uses the multi-name one without an explicit `-a`/`--multiple` flag. The `works multiple` test that asserted it is replaced by `second operand is a suffix, not a second name`, which asserts the coreutils result for the same invocation.

### Verification

The new cases in `test/js/bun/shell/commands/basename.test.ts` (suffix strip, suffix after a trailing slash, suffix without a dot, identical suffix not stripped, non-matching suffix not stripped, extra operand) were each cross-checked against GNU coreutils `basename`. 8 of the 16 tests in that file fail against the unchanged builtin and all 16 pass with the fix, as do the 63 in `test/js/bun/shell/pipeline_stack.test.ts`, which asserts the updated usage string.