### PR TITLE
S3: accept session tokens longer than the fixed signing buffers

### DIFF
--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -559,7 +559,10 @@ impl S3Credentials {
             };
 
             if sign_query {
-                let mut token_encoded_buffer = [0u8; 2048]; // token is normaly like 600-700 but can be up to 2k
+                // AWS documents no maximum STS session token length (Cognito /
+                // role-chaining tokens routinely exceed 2 KB), and percent-encoding
+                // expands a byte to at most 3, so size each buffer to its input.
+                let mut token_encoded_buffer = vec![0u8; session_token.map_or(0, |t| t.len() * 3)];
                 let mut encoded_session_token: Option<&[u8]> = None;
                 if let Some(token) = session_token {
                     encoded_session_token = Some(
@@ -568,8 +571,8 @@ impl S3Credentials {
                     );
                 }
 
-                // MD5 as base64 (which is required for AWS SigV4) is always 44, when encoded its always 46 (44 + ==)
-                let mut content_md5_encoded_buffer = [0u8; 128];
+                let mut content_md5_encoded_buffer =
+                    vec![0u8; content_md5.as_deref().map_or(0, |v| v.len() * 3)];
                 let mut encoded_content_md5: Option<&[u8]> = None;
                 if let Some(content_md5_value) = content_md5.as_deref() {
                     encoded_content_md5 = Some(
@@ -582,7 +585,8 @@ impl S3Credentials {
                 }
 
                 // Encode response override parameters for presigned URLs
-                let mut content_disposition_encoded_buffer = [0u8; 512];
+                let mut content_disposition_encoded_buffer =
+                    vec![0u8; content_disposition.map_or(0, |v| v.len() * 3)];
                 let mut encoded_content_disposition: Option<&[u8]> = None;
                 if let Some(cd) = content_disposition {
                     encoded_content_disposition = Some(
@@ -591,7 +595,8 @@ impl S3Credentials {
                     );
                 }
 
-                let mut content_type_encoded_buffer = [0u8; 256];
+                let mut content_type_encoded_buffer =
+                    vec![0u8; content_type.map_or(0, |v| v.len() * 3)];
                 let mut encoded_content_type: Option<&[u8]> = None;
                 if let Some(ct) = content_type {
                     encoded_content_type = Some(
@@ -601,7 +606,7 @@ impl S3Credentials {
                 }
 
                 // Build query parameters in alphabetical order for AWS Signature V4 canonical request
-                let canonical: &[u8] = 'brk_canonical: {
+                let canonical: Vec<u8> = {
                     let mut query_parts: Vec<Vec<u8>> = Vec::with_capacity(13);
 
                     // Add parameters in alphabetical order: Content-MD5, X-Amz-Acl, X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date, X-Amz-Expires, X-Amz-Security-Token, X-Amz-SignedHeaders, response-content-disposition, response-content-type, x-amz-request-payer, x-amz-storage-class
@@ -651,24 +656,22 @@ impl S3Credentials {
                         query_string.extend_from_slice(part);
                     }
 
-                    break 'brk_canonical buf_print(
-                        &mut tmp_buffer,
-                        format_args!(
-                            "{}\n{}\n{}\nhost:{}\n\nhost\n{}",
-                            method_name,
-                            BStr::new(normalized_path),
-                            BStr::new(&query_string),
-                            BStr::new(&host),
-                            BStr::new(aws_content_hash)
-                        ),
+                    // The query string carries the (unbounded) encoded session
+                    // token, so the canonical request must live on the heap.
+                    alloc_print!(
+                        "{}\n{}\n{}\nhost:{}\n\nhost\n{}",
+                        method_name,
+                        BStr::new(normalized_path),
+                        BStr::new(&query_string),
+                        BStr::new(&host),
+                        BStr::new(aws_content_hash)
                     )
-                    .map_err(|_| SignError::NoSpaceLeft)?;
                 };
                 let mut sha_digest = [0u8; bun_sha_hmac::SHA256::DIGEST];
                 // was `bun_jsc::VirtualMachine::get().rare_data().boring_engine()`;
                 // BoringSSL ignores the ENGINE arg, so pass null (see `boring_engine()` doc).
                 // SAFETY: `boring_engine()` returns null (default engine).
-                unsafe { bun_sha_hmac::SHA256::hash(canonical, &mut sha_digest, boring_engine()) };
+                unsafe { bun_sha_hmac::SHA256::hash(&canonical, &mut sha_digest, boring_engine()) };
 
                 let sign_value = buf_print(
                     &mut tmp_buffer,
@@ -755,7 +758,6 @@ impl S3Credentials {
                 .into_boxed_slice();
             } else {
                 let canonical = CanonicalRequest::format(
-                    &mut tmp_buffer,
                     header_key,
                     method_name.as_bytes(),
                     normalized_path,
@@ -770,13 +772,12 @@ impl S3Credentials {
                     session_token,
                     storage_class,
                     signed_headers,
-                )
-                .map_err(|_| SignError::NoSpaceLeft)?;
+                );
                 let mut sha_digest = [0u8; bun_sha_hmac::SHA256::DIGEST];
                 // was `bun_jsc::VirtualMachine::get().rare_data().boring_engine()`;
                 // BoringSSL ignores the ENGINE arg, so pass null (see `boring_engine()` doc).
                 // SAFETY: `boring_engine()` returns null (default engine).
-                unsafe { bun_sha_hmac::SHA256::hash(canonical, &mut sha_digest, boring_engine()) };
+                unsafe { bun_sha_hmac::SHA256::hash(&canonical, &mut sha_digest, boring_engine()) };
 
                 let sign_value = buf_print(
                     &mut tmp_buffer,
@@ -1365,8 +1366,9 @@ struct CanonicalRequest;
 
 impl CanonicalRequest {
     // Builds the canonical request at runtime with conditional writes; profile if hot.
-    pub(crate) fn format<'b>(
-        buf: &'b mut [u8],
+    // Heap-allocated: several inputs (session token, host, content-disposition)
+    // have no bounded length.
+    pub(crate) fn format(
         key: SignedHeadersKey,
         method: &[u8],
         path: &[u8],
@@ -1381,10 +1383,10 @@ impl CanonicalRequest {
         session_token: Option<&[u8]>,
         storage_class: Option<&[u8]>,
         signed_headers: &[u8],
-    ) -> Result<&'b [u8], core::fmt::Error> {
-        let mut c = bun_core::fmt::SliceCursor::new(buf);
+    ) -> Vec<u8> {
+        let mut c: Vec<u8> = Vec::new();
         macro_rules! w {
-            ($($arg:tt)*) => { core::fmt::Write::write_fmt(&mut c, format_args!($($arg)*))? };
+            ($($arg:tt)*) => { write!(&mut c, $($arg)*).expect("write to Vec<u8> never fails") };
         }
         // method, path, query
         w!(
@@ -1435,8 +1437,7 @@ impl CanonicalRequest {
         // signed_headers, hash
         w!("\n{}\n{}", BStr::new(signed_headers), BStr::new(hash));
 
-        let len = c.at;
-        Ok(&c.buf[..len])
+        c
     }
 }
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -117,6 +117,21 @@ if (isDebug) {
   bunEnv.BUN_DEBUG_NO_DUMP = "1";
 }
 
+/**
+ * `bunEnv` with every ambient HTTP(S) proxy variable cleared. Use for spawned
+ * fixtures that must reach an in-process server directly instead of being
+ * rerouted through a proxy configured on the CI host.
+ */
+export const bunEnvNoProxy: NodeJS.Dict<string> = {
+  ...bunEnv,
+  NO_PROXY: undefined,
+  no_proxy: undefined,
+  HTTP_PROXY: undefined,
+  http_proxy: undefined,
+  HTTPS_PROXY: undefined,
+  https_proxy: undefined,
+};
+
 export function bunExe() {
   if (isWindows) return process.execPath.replaceAll("\\", "/");
   return process.execPath;

--- a/test/js/bun/s3/s3-list-encode-overflow.test.ts
+++ b/test/js/bun/s3/s3-list-encode-overflow.test.ts
@@ -1,6 +1,7 @@
 import { S3Client } from "bun";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { createHash, createHmac } from "node:crypto";
 
 describe("S3Client.list() option encoding", () => {
   it.each(["prefix", "delimiter", "continuationToken", "startAfter"])(
@@ -119,5 +120,175 @@ describe("S3 endpoints without a region component", () => {
     expect(lines[0]).toMatch(/^s3\.amazonaws\.com test\/\d{8}\/us-east-1\/s3\/aws4_request$/);
     expect(lines[1]).toMatch(/^mybucket\.s3\.amazonaws\.com test\/\d{8}\/us-east-1\/s3\/aws4_request$/);
     expect(exitCode).toBe(0);
+  });
+});
+
+// ── Independent, from-spec AWS Signature V4 reference ─────────────────────
+// Used to prove that the signatures Bun produces for oversized inputs are
+// not just present but correct.
+// https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+
+function sigv4Signature(
+  secretAccessKey: string,
+  day: string,
+  region: string,
+  service: string,
+  amzDate: string,
+  canonicalRequest: string,
+): string {
+  let key: string | Buffer = `AWS4${secretAccessKey}`;
+  for (const part of [day, region, service, "aws4_request"]) {
+    key = createHmac("sha256", key).update(part, "utf8").digest();
+  }
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    `${day}/${region}/${service}/aws4_request`,
+    createHash("sha256").update(canonicalRequest, "utf8").digest("hex"),
+  ].join("\n");
+  return createHmac("sha256", key).update(stringToSign, "utf8").digest("hex");
+}
+
+/** The X-Amz-Signature a compliant signer must produce for `presignedUrl`. */
+function expectedPresignSignature(presignedUrl: string, secretAccessKey: string, method = "GET"): string {
+  const url = new URL(presignedUrl);
+  // Canonical query string: every parameter except X-Amz-Signature, sorted,
+  // keeping the raw (already percent-encoded) key=value pairs.
+  const canonicalQuery = presignedUrl
+    .slice(presignedUrl.indexOf("?") + 1)
+    .split("&")
+    .filter(kv => !kv.startsWith("X-Amz-Signature="))
+    .sort()
+    .join("&");
+  const canonicalRequest = [
+    method,
+    url.pathname,
+    canonicalQuery,
+    `host:${url.host}`,
+    "",
+    "host",
+    "UNSIGNED-PAYLOAD",
+  ].join("\n");
+  const [, day, region, service] = url.searchParams.get("X-Amz-Credential")!.split("/");
+  return sigv4Signature(secretAccessKey, day, region, service, url.searchParams.get("X-Amz-Date")!, canonicalRequest);
+}
+
+/** The Authorization signature a compliant signer must produce for `request`. */
+function expectedHeaderSignature(
+  request: { method: string; url: string; headers: Record<string, string> },
+  secretAccessKey: string,
+): { got: string; want: string } {
+  const [, credential, signedHeaders, got] =
+    /^AWS4-HMAC-SHA256 Credential=([^,]+), SignedHeaders=([^,]+), Signature=([0-9a-f]{64})$/.exec(
+      request.headers["authorization"],
+    )!;
+  const [, day, region, service] = credential.split("/");
+  const url = new URL(request.url);
+  const canonicalRequest = [
+    request.method,
+    url.pathname,
+    url.search.slice(1),
+    ...signedHeaders.split(";").map(name => `${name}:${request.headers[name]}`),
+    "",
+    signedHeaders,
+    request.headers["x-amz-content-sha256"],
+  ].join("\n");
+  return {
+    got,
+    want: sigv4Signature(secretAccessKey, day, region, service, request.headers["x-amz-date"], canonicalRequest),
+  };
+}
+
+const secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRjfiCYEXAMPLEKEY";
+const signingCredentials = {
+  accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+  secretAccessKey,
+  bucket: "bucket",
+  region: "us-east-1",
+  endpoint: "https://s3.example.com",
+} as const;
+
+// Shaped like a real STS token: base64 alphabet including "+", "/" and "=",
+// each of which percent-encodes to 3 bytes.
+const STS_TOKEN_FILL = "FwoGZXIvYXdzEBEaDLongChainedToken+Chunk/Pad=";
+const sessionToken = (length: number) => Buffer.alloc(length, STS_TOKEN_FILL).toString();
+
+describe.concurrent("S3 presign with a long session token", () => {
+  // The reference implementation must agree with Bun on input that has
+  // always worked; this anchors the long-input assertions below.
+  it("reference SigV4 signature matches Bun for a short session token", () => {
+    const url = new S3Client({ ...signingCredentials, sessionToken: sessionToken(64) }).presign("some-object-key");
+    expect(new URL(url).searchParams.get("X-Amz-Signature")).toBe(expectedPresignSignature(url, secretAccessKey));
+  });
+
+  // AWS documents no maximum STS session token length, and Cognito /
+  // role-chaining routinely produce multi-KB tokens. These used to fail
+  // with ERR_S3_INVALID_SESSION_TOKEN once the percent-encoded token no
+  // longer fit in a fixed 2048-byte buffer.
+  it.each([2049, 4096, 16384])("presigns a %i-character session token with a valid signature", length => {
+    const token = sessionToken(length);
+    const url = new S3Client({ ...signingCredentials, sessionToken: token }).presign("some-object-key");
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("X-Amz-Security-Token")).toBe(token);
+    expect(parsed.searchParams.get("X-Amz-Signature")).toBe(expectedPresignSignature(url, secretAccessKey));
+  });
+
+  // Same bug class: response-content-disposition was percent-encoded into a
+  // fixed 512-byte buffer and failed with ERR_S3_INVALID_SIGNATURE.
+  it("presigns a contentDisposition longer than 512 bytes when encoded", () => {
+    const contentDisposition = `attachment; filename="${Buffer.alloc(600, "long file name ").toString()}.pdf"`;
+    const url = new S3Client(signingCredentials).presign("some-object-key", { contentDisposition });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("response-content-disposition")).toBe(contentDisposition);
+    expect(parsed.searchParams.get("X-Amz-Signature")).toBe(expectedPresignSignature(url, secretAccessKey));
+  });
+});
+
+describe.concurrent("S3 header auth with a long session token", () => {
+  // Header-signed operations built their canonical request in a fixed
+  // 4096-byte buffer, so tokens past ~3.9 KB failed with
+  // ERR_S3_INVALID_SIGNATURE before a request was even attempted.
+  it("signs and sends a PUT whose session token is 8 KB", async () => {
+    const length = 8192;
+    const token = sessionToken(length);
+    // The fixture rebuilds the same token so it never travels through argv.
+    const fixture = `
+      const captured = Promise.withResolvers();
+      using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          captured.resolve({
+            method: req.method,
+            url: req.url,
+            headers: Object.fromEntries(req.headers),
+            body: await req.text(),
+          });
+          return new Response("", { status: 200 });
+        },
+      });
+      const client = new Bun.S3Client({
+        ...${JSON.stringify(signingCredentials)},
+        endpoint: server.url.href,
+        sessionToken: Buffer.alloc(${length}, ${JSON.stringify(STS_TOKEN_FILL)}).toString(),
+      });
+      await client.file("some-object-key").write("hello s3");
+      console.log(JSON.stringify(await captured.promise));
+    `;
+    // Bun's S3 client routes through $HTTP_PROXY when it is set; the server
+    // is in-process, so drop proxy variables from the child environment.
+    const env: Record<string, string | undefined> = { ...bunEnv };
+    for (const name of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]) delete env[name];
+
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ exitCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({ exitCode: 0, stderr: "" });
+
+    const request = JSON.parse(stdout);
+    expect(request.method).toBe("PUT");
+    expect(request.body).toBe("hello s3");
+    expect(request.headers["x-amz-security-token"]).toBe(token);
+    expect(request.headers["authorization"]).toContain("x-amz-security-token");
+    const { got, want } = expectedHeaderSignature(request, secretAccessKey);
+    expect(got).toBe(want);
   });
 });

--- a/test/js/bun/s3/s3-list-encode-overflow.test.ts
+++ b/test/js/bun/s3/s3-list-encode-overflow.test.ts
@@ -274,12 +274,21 @@ describe.concurrent("S3 header auth with a long session token", () => {
       await client.file("some-object-key").write("hello s3");
       console.log(JSON.stringify(await captured.promise));
     `;
-    // Bun's S3 client routes through $HTTP_PROXY when it is set; the server
-    // is in-process, so drop proxy variables from the child environment.
-    const env: Record<string, string | undefined> = { ...bunEnv };
-    for (const name of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]) delete env[name];
-
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env, stderr: "pipe" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      // The fixture's S3 request targets an in-process server and must not
+      // be rerouted by ambient proxy configuration on CI hosts.
+      env: {
+        ...bunEnv,
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
+      stderr: "pipe",
+    });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ exitCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({ exitCode: 0, stderr: "" });
 

--- a/test/js/bun/s3/s3-list-encode-overflow.test.ts
+++ b/test/js/bun/s3/s3-list-encode-overflow.test.ts
@@ -1,6 +1,6 @@
 import { S3Client } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunEnvNoProxy, bunExe } from "harness";
 import { createHash, createHmac } from "node:crypto";
 
 describe("S3Client.list() option encoding", () => {
@@ -274,21 +274,9 @@ describe.concurrent("S3 header auth with a long session token", () => {
       await client.file("some-object-key").write("hello s3");
       console.log(JSON.stringify(await captured.promise));
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture],
-      // The fixture's S3 request targets an in-process server and must not
-      // be rerouted by ambient proxy configuration on CI hosts.
-      env: {
-        ...bunEnv,
-        NO_PROXY: undefined,
-        no_proxy: undefined,
-        HTTP_PROXY: undefined,
-        http_proxy: undefined,
-        HTTPS_PROXY: undefined,
-        https_proxy: undefined,
-      },
-      stderr: "pipe",
-    });
+    // The fixture's S3 request targets an in-process server and must not
+    // be rerouted by ambient proxy configuration on CI hosts.
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnvNoProxy, stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ exitCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({ exitCode: 0, stderr: "" });
 

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1785,7 +1785,17 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The fixture's S3 requests target an in-process server and must not
+      // be rerouted by ambient proxy configuration on CI hosts.
+      env: {
+        ...bunEnv,
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -3,7 +3,7 @@ import { S3Client, s3 as defaultS3, file, randomUUIDv7 } from "bun";
 import { describe, expect, it } from "bun:test";
 import child_process from "child_process";
 import { randomUUID } from "crypto";
-import { bunEnv, bunExe, dockerExe, getSecret, isCI, isDockerEnabled, tempDirWithFiles } from "harness";
+import { bunEnv, bunEnvNoProxy, bunExe, dockerExe, getSecret, isCI, isDockerEnabled, tempDirWithFiles } from "harness";
 import path from "path";
 const s3 = (...args) => defaultS3.file(...args);
 const S3 = (...args) => new S3Client(...args);
@@ -1787,15 +1787,7 @@ describe("s3 multipart upload id validation", () => {
       cmd: [bunExe(), "-e", fixture],
       // The fixture's S3 requests target an in-process server and must not
       // be rerouted by ambient proxy configuration on CI hosts.
-      env: {
-        ...bunEnv,
-        NO_PROXY: undefined,
-        no_proxy: undefined,
-        HTTP_PROXY: undefined,
-        http_proxy: undefined,
-        HTTPS_PROXY: undefined,
-        https_proxy: undefined,
-      },
+      env: bunEnvNoProxy,
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1273,19 +1273,18 @@ for (let credentials of allCredentials) {
             }),
           );
         });
-        it("should error when presign with invalid token", async () => {
+        it("should presign with a session token larger than 2 KB", async () => {
           await Promise.all(
             [s3, (path, ...args) => S3(...args).file(path)].map(async fn => {
               let options = { ...s3Options, bucket: S3Bucket };
+              // AWS documents no maximum session token length; Cognito and
+              // role chaining routinely produce multi-KB tokens. This used to
+              // throw ERR_S3_INVALID_SESSION_TOKEN.
               options.sessionToken = Buffer.alloc(4096, "a").toString();
 
-              try {
-                const s3file = fn(randomUUID(), options);
-                await s3file.presign();
-                expect.unreachable();
-              } catch (e: any) {
-                expect(e?.code).toBe("ERR_S3_INVALID_SESSION_TOKEN");
-              }
+              const s3file = fn(randomUUID(), options);
+              const url = await s3file.presign();
+              expect(new URL(url).searchParams.get("X-Amz-Security-Token")).toBe(options.sessionToken);
             }),
           );
         });


### PR DESCRIPTION
`Bun.S3Client.presign()` rejects valid STS session tokens once their percent-encoded form exceeds an internal 2048-byte stack buffer, while header-authenticated operations on the same client keep working:

```js
const s3 = new Bun.S3Client({ accessKeyId, secretAccessKey, sessionToken, endpoint });
await s3.file("k").write("data"); // ok: the token is sent as the X-Amz-Security-Token header
s3.presign("k");                  // ERR_S3_INVALID_SESSION_TOKEN: Invalid session token
```

On 1.4.0 this reproduces at 2049 characters for an all-alphanumeric token, and at about 1700 characters for a realistic base64 token, because `+`, `/` and `=` each expand to 3 bytes when percent-encoded. Cognito identity-pool and role-chaining credentials routinely produce 2 to 4 KB tokens, and AWS explicitly documents that callers should make no assumptions about the maximum token size, so affected setups can read and write objects but cannot mint presigned URLs at all. The error text also points users at their (valid) credentials rather than at a size limit.

### Cause

`S3Credentials::sign_request` in `src/s3_signing/credentials.rs` routed unbounded inputs through fixed-size stack buffers:

- The presign path percent-encoded the session token into `[u8; 2048]` and mapped the overflow to `SignError::InvalidSessionToken`.
- Both canonical requests (query presign and header auth) were formatted into a shared `[u8; 4096]` scratch buffer. Fixing only the first buffer would just move the presign failure to about 3.5 KB, and header auth already fails today at about 3.9 KB with `ERR_S3_INVALID_SIGNATURE` ("Failed to retrieve S3 content. Are the credentials correct?").
- The `contentMd5`, `contentDisposition` and `contentType` presign parameters used the same pattern with 128, 512 and 256-byte buffers. A `contentDisposition` longer than 512 bytes when encoded (a long quoted filename) fails the same way.

### Fix

Size each percent-encoding buffer to its input (3 bytes per input byte is the worst case, matching how `client.rs` already encodes the `list()` options), and build both canonical requests on the heap. `CanonicalRequest::format` now returns a `Vec<u8>` instead of writing into a caller slice. The remaining uses of the 4 KB scratch buffer (signing-key derivation and the string to sign) only hold fixed-size digests plus the region and secret, so they are unchanged.

Nothing produces `ERR_S3_INVALID_SESSION_TOKEN` after this change; the error code and its mappings are left in place since they are part of the documented public error surface.

### Tests

`test/js/bun/s3/s3-list-encode-overflow.test.ts` gains a self-contained, from-spec SigV4 reference implementation so the new tests assert the signatures are correct, not just that signing no longer throws:

- an anchor test proving the reference agrees with Bun for a short session token (passes before and after)
- presign with 2049, 4096 and 16384-character STS-shaped tokens: the token round-trips through `X-Amz-Security-Token` and `X-Amz-Signature` matches the reference
- presign with a 627-character `contentDisposition`
- header auth: a PUT with an 8 KB token against a local `Bun.serve`, spawned with proxy variables stripped so it stays hermetic; the received `x-amz-security-token` is intact and the `Authorization` signature matches the reference

The existing `s3.test.ts` case "should error when presign with invalid token" asserted that a 4096-character token must throw `ERR_S3_INVALID_SESSION_TOKEN`; it is rewritten to assert the presigned URL carries the full token. The existing multipart-upload-id fixture in the same file spawns the same kind of local-server child, so it gets the same proxy-free environment (it otherwise fails on any host that sets `HTTP_PROXY`, since the S3 client follows the proxy even for a loopback endpoint).

On `main`, the five new tests fail:

```
(pass) S3 presign with a long session token > reference SigV4 signature matches Bun for a short session token
(fail) S3 presign with a long session token > presigns a 2049-character session token with a valid signature
(fail) S3 presign with a long session token > presigns a 4096-character session token with a valid signature
(fail) S3 presign with a long session token > presigns a 16384-character session token with a valid signature
(fail) S3 presign with a long session token > presigns a contentDisposition longer than 512 bytes when encoded
(fail) S3 header auth with a long session token > signs and sends a PUT whose session token is 8 KB
```

With the fix, all 11 tests in the file pass.


### Rebase onto main

Rebased past #33072, which touched both files this PR changes. Resolved by keeping both sides:

- `src/s3_signing/credentials.rs` merged cleanly: that PR's region validation (`is_valid_host_component`) and `guess_bucket`/`guess_region` bounds fixes sit in different functions than the buffer changes here, and both are present.
- `test/js/bun/s3/s3-list-encode-overflow.test.ts` conflicted because both appended describe blocks to the end of the file. Both sets are kept, and the harness import is now `{ bunEnv, bunEnvNoProxy, bunExe }` since that PR's new test uses `bunEnv` while the header-auth test here uses `bunEnvNoProxy`.

The whole file passes after the rebase: 18 tests (6 pre-existing, 7 from #33072, 5 added here).
