### PR TITLE
FormData: normalize lone CR and lone LF to CRLF in serialized multipart names and string values

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3957,22 +3957,52 @@ struct FormDataContext<'a> {
     global_this: &'a JSGlobalObject,
 }
 
-/// WHATWG HTML "multipart/form-data encoding algorithm": percent-encode `"`,
-/// CR and LF in field names and filenames so they cannot terminate the
-/// quoted-string or inject part headers. Returns `None` when nothing needs
-/// escaping so the caller can keep using the original bytes without a copy.
-fn escape_form_data_name(bytes: &[u8]) -> Option<Box<[u8]>> {
-    if !bytes.iter().any(|&b| matches!(b, b'"' | b'\r' | b'\n')) {
+/// Which piece of a `multipart/form-data` entry a string is, selecting the
+/// transforms the WHATWG "multipart/form-data encoding algorithm" applies to
+/// it: <https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data>
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FormDataComponent {
+    /// Entry name: newlines normalized to CRLF, then `"`/CR/LF percent-encoded.
+    Name,
+    /// Non-File entry value: newlines normalized to CRLF, emitted unescaped.
+    StringValue,
+    /// Filename: `"`/CR/LF percent-encoded only; the spec does not normalize it.
+    Filename,
+}
+
+/// WHATWG HTML "multipart/form-data encoding algorithm". Names and non-File
+/// values first have every CR, LF, and CRLF replaced with CRLF; names and
+/// filenames are then percent-encoded (`"` -> `%22`, CR -> `%0D`, LF -> `%0A`)
+/// so they cannot terminate the quoted-string or inject part headers. Returns
+/// `None` when no byte needs either transform so the caller can keep using the
+/// original bytes without a copy.
+fn encode_form_data_component(bytes: &[u8], component: FormDataComponent) -> Option<Box<[u8]>> {
+    let escape = component != FormDataComponent::StringValue;
+    let normalize = component != FormDataComponent::Filename;
+    if !bytes
+        .iter()
+        .any(|&b| matches!(b, b'\r' | b'\n') || (escape && b == b'"'))
+    {
         return None;
     }
-    let mut out = Vec::with_capacity(bytes.len() + 6);
-    for &b in bytes {
+    let mut out = Vec::with_capacity(bytes.len() + 8);
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
         match b {
-            b'"' => out.extend_from_slice(b"%22"),
+            b'"' if escape => out.extend_from_slice(b"%22"),
+            b'\r' | b'\n' if normalize => {
+                out.extend_from_slice(if escape { b"%0D%0A" } else { b"\r\n" });
+                // A CRLF pair is already one normalized newline: consume both.
+                if b == b'\r' && bytes.get(i + 1) == Some(&b'\n') {
+                    i += 1;
+                }
+            }
             b'\r' => out.extend_from_slice(b"%0D"),
             b'\n' => out.extend_from_slice(b"%0A"),
             _ => out.push(b),
         }
+        i += 1;
     }
     Some(out.into_boxed_slice())
 }
@@ -3982,13 +4012,16 @@ impl FormDataContext<'_> {
     /// borrowed case points into a WTF string owned by the `DOMFormData` being
     /// serialized, which outlives `joiner.done()` in `from_dom_form_data`; an owned slice
     /// (UTF-16 / non-ASCII Latin-1 conversion) transfers its allocation to the
-    /// joiner. When `escape` is set, `"`/CR/LF are percent-encoded into a copy.
-    fn push_string_slice(joiner: &mut StringJoiner<'_>, slice: ZigStringSlice, escape: bool) {
-        if escape {
-            if let Some(escaped) = escape_form_data_name(slice.slice()) {
-                joiner.push_owned(escaped);
-                return;
-            }
+    /// joiner. `component` selects the spec's newline-normalization and
+    /// percent-encoding transforms, which copy when they apply.
+    fn push_string_slice(
+        joiner: &mut StringJoiner<'_>,
+        slice: ZigStringSlice,
+        component: FormDataComponent,
+    ) {
+        if let Some(encoded) = encode_form_data_component(slice.slice(), component) {
+            joiner.push_owned(encoded);
+            return;
         }
         if matches!(slice, ZigStringSlice::Owned(_)) {
             // `into_vec` moves the buffer out of an `Owned` slice without copying.
@@ -4019,16 +4052,16 @@ impl FormDataContext<'_> {
         joiner.push_static(b"\r\n");
 
         joiner.push_static(b"Content-Disposition: form-data; name=\"");
-        Self::push_string_slice(joiner, name.to_slice(), true);
+        Self::push_string_slice(joiner, name.to_slice(), FormDataComponent::Name);
 
         match entry {
             FormDataEntry::String(value) => {
                 joiner.push_static(b"\"\r\n\r\n");
-                Self::push_string_slice(joiner, value.to_slice(), false);
+                Self::push_string_slice(joiner, value.to_slice(), FormDataComponent::StringValue);
             }
             FormDataEntry::File { blob, filename } => {
                 joiner.push_static(b"\"; filename=\"");
-                Self::push_string_slice(joiner, filename.to_slice(), true);
+                Self::push_string_slice(joiner, filename.to_slice(), FormDataComponent::Filename);
                 joiner.push_static(b"\"\r\n");
 
                 // Borrowed from the blob, which the `DOMFormData` keeps alive

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3979,31 +3979,39 @@ enum FormDataComponent {
 fn encode_form_data_component(bytes: &[u8], component: FormDataComponent) -> Option<Box<[u8]>> {
     let escape = component != FormDataComponent::StringValue;
     let normalize = component != FormDataComponent::Filename;
-    if !bytes
-        .iter()
-        .any(|&b| matches!(b, b'\r' | b'\n') || (escape && b == b'"'))
-    {
-        return None;
-    }
+    // Only the bytes a transform rewrites are needles; for a string value a
+    // `"` stays literal and must not force a copy. With >= 2 needles
+    // `index_of_any` dispatches to the highway SIMD scan.
+    let needles: &'static [u8] = if escape { b"\"\r\n" } else { b"\r\n" };
+
+    // The first scan doubles as the "needs a copy at all?" fast path.
+    let mut i = strings::index_of_any(bytes, needles)? as usize;
+    let mut remain = bytes;
     let mut out = Vec::with_capacity(bytes.len() + 8);
-    let mut i = 0;
-    while i < bytes.len() {
-        let b = bytes[i];
+    loop {
+        out.extend_from_slice(&remain[..i]);
+        let b = remain[i];
+        let mut consumed = 1;
         match b {
-            b'"' if escape => out.extend_from_slice(b"%22"),
-            b'\r' | b'\n' if normalize => {
+            // `"` is a needle only when `escape` is set.
+            b'"' => out.extend_from_slice(b"%22"),
+            _ if normalize => {
+                // CR, LF, and CRLF all normalize to one CRLF before escaping.
                 out.extend_from_slice(if escape { b"%0D%0A" } else { b"\r\n" });
-                // A CRLF pair is already one normalized newline: consume both.
-                if b == b'\r' && bytes.get(i + 1) == Some(&b'\n') {
-                    i += 1;
+                if b == b'\r' && remain.get(i + 1) == Some(&b'\n') {
+                    consumed = 2;
                 }
             }
             b'\r' => out.extend_from_slice(b"%0D"),
-            b'\n' => out.extend_from_slice(b"%0A"),
-            _ => out.push(b),
+            _ => out.extend_from_slice(b"%0A"),
         }
-        i += 1;
+        remain = &remain[i + consumed..];
+        match strings::index_of_any(remain, needles) {
+            Some(next) => i = next as usize,
+            None => break,
+        }
     }
+    out.extend_from_slice(remain);
     Some(out.into_boxed_slice())
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3981,11 +3981,11 @@ fn encode_form_data_component(bytes: &[u8], component: FormDataComponent) -> Opt
     let normalize = component != FormDataComponent::Filename;
     // Only the bytes a transform rewrites are needles; for a string value a
     // `"` stays literal and must not force a copy. With >= 2 needles
-    // `index_of_any` dispatches to the highway SIMD scan.
+    // `bun_core::immutable::index_of_any` uses the highway SIMD scan.
     let needles: &'static [u8] = if escape { b"\"\r\n" } else { b"\r\n" };
 
     // The first scan doubles as the "needs a copy at all?" fast path.
-    let mut i = strings::index_of_any(bytes, needles)? as usize;
+    let mut i = bun_core::immutable::index_of_any(bytes, needles)? as usize;
     let mut remain = bytes;
     let mut out = Vec::with_capacity(bytes.len() + 8);
     loop {
@@ -4006,7 +4006,7 @@ fn encode_form_data_component(bytes: &[u8], component: FormDataComponent) -> Opt
             _ => out.extend_from_slice(b"%0A"),
         }
         remain = &remain[i + consumed..];
-        match strings::index_of_any(remain, needles) {
+        match bun_core::immutable::index_of_any(remain, needles) {
             Some(next) => i = next as usize,
             None => break,
         }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3980,12 +3980,13 @@ fn encode_form_data_component(bytes: &[u8], component: FormDataComponent) -> Opt
     let escape = component != FormDataComponent::StringValue;
     let normalize = component != FormDataComponent::Filename;
     // Only the bytes a transform rewrites are needles; for a string value a
-    // `"` stays literal and must not force a copy. With >= 2 needles
-    // `bun_core::immutable::index_of_any` uses the highway SIMD scan.
+    // `"` stays literal and must not force a copy.
     let needles: &'static [u8] = if escape { b"\"\r\n" } else { b"\r\n" };
 
-    // The first scan doubles as the "needs a copy at all?" fast path.
-    let mut i = bun_core::immutable::index_of_any(bytes, needles)? as usize;
+    // SIMD scan; the first hit doubles as the "needs a copy at all?" fast
+    // path. `highway` directly: `bun_core::immutable::index_of_any` narrows
+    // the index to `u32`, which a multi-GiB string value can overflow.
+    let mut i = bun_highway::index_of_any_char(bytes, needles)?;
     let mut remain = bytes;
     let mut out = Vec::with_capacity(bytes.len() + 8);
     loop {
@@ -4006,8 +4007,8 @@ fn encode_form_data_component(bytes: &[u8], component: FormDataComponent) -> Opt
             _ => out.extend_from_slice(b"%0A"),
         }
         remain = &remain[i + consumed..];
-        match bun_core::immutable::index_of_any(remain, needles) {
-            Some(next) => i = next as usize,
+        match bun_highway::index_of_any_char(remain, needles) {
+            Some(next) => i = next,
             None => break,
         }
     }

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -54,6 +54,44 @@ describe("multipart serialization (new Response(formData))", () => {
     );
   });
 
+  // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data
+  // Step 1 of the encoding algorithm replaces every lone CR, lone LF, and CRLF
+  // in an entry's name (and in its value when it is not a File) with CRLF,
+  // before names/filenames are percent-encoded. Filenames are escaped but not
+  // normalized, so lone CR / lone LF stay distinct there.
+  test("normalizes lone CR and lone LF to CRLF in names and string values", async () => {
+    const formData = new FormData();
+    // All three newline spellings in a name must serialize identically.
+    formData.append("a\rb", "1");
+    formData.append("a\nb", "2");
+    formData.append("a\r\nb", "3");
+    // Non-File string value: newlines normalized to CRLF, never percent-encoded.
+    formData.append("value", "x\ry\nz\r\nw");
+    // Filename: percent-encoded only.
+    formData.append("file", new Blob(["hi"]), "q\rw\ne");
+
+    const response = new Response(formData);
+    const contentType = response.headers.get("Content-Type")!;
+    const boundary = contentType.slice(contentType.indexOf("boundary=") + "boundary=".length);
+
+    expect(await response.text()).toBe(
+      [
+        `--${boundary}\r\n`,
+        `Content-Disposition: form-data; name="a%0D%0Ab"\r\n\r\n1\r\n`,
+        `--${boundary}\r\n`,
+        `Content-Disposition: form-data; name="a%0D%0Ab"\r\n\r\n2\r\n`,
+        `--${boundary}\r\n`,
+        `Content-Disposition: form-data; name="a%0D%0Ab"\r\n\r\n3\r\n`,
+        `--${boundary}\r\n`,
+        `Content-Disposition: form-data; name="value"\r\n\r\nx\r\ny\r\nz\r\nw\r\n`,
+        `--${boundary}\r\n`,
+        `Content-Disposition: form-data; name="file"; filename="q%0Dw%0Ae"\r\n`,
+        `Content-Type: application/octet-stream\r\n\r\nhi\r\n`,
+        `--${boundary}--\r\n`,
+      ].join(""),
+    );
+  });
+
   test("round-trips every entry kind through Response.formData()", async () => {
     const formData = new FormData();
     formData.append("simple", "value");

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -92,6 +92,24 @@ describe("multipart serialization (new Response(formData))", () => {
     );
   });
 
+  test("normalizes newlines in a large string value", async () => {
+    // 4 KiB runs of ordinary bytes between the newlines exercise the bulk-copy
+    // path of the serializer's scan, not just the per-byte rewrites.
+    const run = Buffer.alloc(4096, "a").toString();
+    const formData = new FormData();
+    formData.append("big", `${run}\r${run}\n${run}\r\n${run}`);
+
+    const response = new Response(formData);
+    const contentType = response.headers.get("Content-Type")!;
+    const boundary = contentType.slice(contentType.indexOf("boundary=") + "boundary=".length);
+
+    expect(await response.text()).toBe(
+      `--${boundary}\r\nContent-Disposition: form-data; name="big"\r\n\r\n` +
+        `${run}\r\n${run}\r\n${run}\r\n${run}\r\n` +
+        `--${boundary}--\r\n`,
+    );
+  });
+
   test("round-trips every entry kind through Response.formData()", async () => {
     const formData = new FormData();
     formData.append("simple", "value");


### PR DESCRIPTION
### What

The WHATWG [multipart/form-data encoding algorithm](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data) starts by replacing every lone CR, lone LF, and CRLF in an entry's name (and in its value, when the value is not a File) with CRLF, and only then percent-encodes `"`/CR/LF in names and filenames. Bun's serializer skipped the normalization step, so lone CR and lone LF survived into the escaped output and the same logical field name left Bun looking different than it does from Node, undici, or any browser.

```js
const fd = new FormData();
fd.append("a\rb", "1");
fd.append("a\nb", "2");
fd.append("a\r\nb", "3");
await fetch(url, { method: "POST", body: fd });
```

Raw bytes on the wire (recorded by a plain `net` server):

```
node:  name="a%0D%0Ab"   name="a%0D%0Ab"   name="a%0D%0Ab"
bun:   name="a%0Db"      name="a%0Ab"      name="a%0D%0Ab"
```

Non-File string values have the same missing step: `fd.append("v", "x\ry\nz")` serialized the value as the literal bytes `x\ry\nz` where Node emits `x\r\ny\r\nz`.

Servers that key on the decoded field name see a different name from Bun than from every other client, and the lone CR / lone LF vs CRLF distinction is exactly the ambiguity that parsers which re-normalize disagree on.

### Fix

`src/runtime/webcore/Blob.rs`: replace `escape_form_data_name` with `encode_form_data_component`, which takes which piece of the entry it is encoding and applies the spec's transforms for it:

| component | normalize newlines to CRLF | percent-encode `"`/CR/LF |
|---|---|---|
| name | yes | yes |
| string value | yes | no |
| filename | no | yes |

Filenames are deliberately left unnormalized: the spec's normalization step applies only to names and non-File values, and Node and browsers agree (a filename of `q\rw\ne` serializes as `q%0Dw%0Ae` in both Node and Bun, before and after this change). File contents are untouched.

After the fix Bun's output for the repro above is byte-identical to Node's.

This is the serializer half of the pair; #32958 fixes the inverse bug in the parser (the `%0D`/`%0A`/`%22` escapes were never decoded back). The two are independent.

### Test

Added `normalizes lone CR and lone LF to CRLF in names and string values` to `test/js/web/html/FormData-multipart-serialization.test.ts`, alongside the existing test that already covered the (previously correct) CRLF-in-name case. It locks in the exact serialized bytes for all three newline spellings of a name, a string value containing all three, and a filename containing lone CR / lone LF.

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/html/FormData-multipart-serialization.test.ts   # bun 1.4.0
 4 pass, 1 fail   (name="a%0Db", name="a%0Ab")
$ bun bd test test/js/web/html/FormData-multipart-serialization.test.ts
 5 pass, 0 fail
```

Also re-ran the adjacent FormData/body suites (`FormData.test.ts`, `FormData-file-error-leak.test.ts`, `form-data-boundary-crash.test.ts`, `form-data-set-append.test.js`, `body.test.ts`, `content-length.test.js`): 486 pass, 0 fail.
