### PR TITLE
node:fs: route fs.promises.realpath to the native realpath binding

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -282,7 +282,9 @@ const exports = {
     return _writeFile(fileHandleOrFdOrPath, ...args);
   },
   readlink: asyncWrap(fs.readlink, "readlink"),
-  realpath: asyncWrap(fs.realpath, "realpath"),
+  // Node routes fsPromises.realpath to the native realpath(3) binding, so its
+  // errors carry syscall "realpath" and a trailing slash on a file is ENOTDIR.
+  realpath: asyncWrap(fs.realpathNative, "realpath"),
   rename: asyncWrap(fs.rename, "rename"),
   stat: asyncWrap(fs.stat, "stat"),
   symlink: asyncWrap(fs.symlink, "symlink"),

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1894,6 +1894,31 @@ it("realpath async", async () => {
   expect(await promise).toBe(realpathSync(import.meta.path));
 }, 30_000);
 
+it("promises.realpath uses the native binding (Node syscall tag)", async () => {
+  // https://github.com/oven-sh/bun/issues/32963
+  const dir = tmpdirSync();
+  const file = join(dir, "f");
+  writeFileSync(file, "x");
+
+  // Node routes fsPromises.realpath to native realpath(3), so a missing path
+  // rejects with syscall "realpath", not the JS-walking variant's "lstat".
+  const enoent = await promises.realpath(join(dir, "nope")).then(
+    () => null,
+    e => ({ code: e.code, syscall: e.syscall }),
+  );
+  expect(enoent).toEqual({ code: "ENOENT", syscall: "realpath" });
+
+  if (isPosix) {
+    // A trailing separator on a regular file is ENOTDIR under native realpath,
+    // unlike the slash-ignoring fs.realpath/realpathSync JS walk.
+    const notdir = await promises.realpath(file + "/").then(
+      () => null,
+      e => ({ code: e.code, syscall: e.syscall }),
+    );
+    expect(notdir).toEqual({ code: "ENOTDIR", syscall: "realpath" });
+  }
+});
+
 describe("stat", () => {
   it("file metadata is correct", () => {
     const fileStats = statSync(join(import.meta.dir, "fs-stream.js"));

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1896,13 +1896,12 @@ it("realpath async", async () => {
 
 it("promises.realpath uses the native binding (Node syscall tag)", async () => {
   // https://github.com/oven-sh/bun/issues/32963
-  const dir = tmpdirSync();
-  const file = join(dir, "f");
-  writeFileSync(file, "x");
+  using dir = tempDir("realpath-native", { f: "x" });
+  const file = join(String(dir), "f");
 
   // Node routes fsPromises.realpath to native realpath(3), so a missing path
   // rejects with syscall "realpath", not the JS-walking variant's "lstat".
-  const enoent = await promises.realpath(join(dir, "nope")).then(
+  const enoent = await promises.realpath(join(String(dir), "nope")).then(
     () => null,
     e => ({ code: e.code, syscall: e.syscall }),
   );


### PR DESCRIPTION
Fixes #32963

## Problem

Node's `fsPromises.realpath` resolves paths via the native `realpath(3)` binding (the same path as `fs.realpath.native`/`fs.realpathSync.native`). Only the callback `fs.realpath` and sync `fs.realpathSync` use the JS-walking variant. As a result, rejections from `fsPromises.realpath` carry `syscall: "realpath"`, and a trailing separator on a regular file is rejected with `ENOTDIR`.

Bun wired `fs.promises.realpath` to the non-native (emulated, `lstat`-based) binding, so every error was tagged `syscall: "lstat"`.

```js
import * as fs from "node:fs";
import * as os from "node:os";
const d = fs.mkdtempSync(os.tmpdir() + "/prp-");
fs.writeFileSync(d + "/f", "x");
const E = async p => { try { return { ok: await p }; } catch (e) { return { code: e.code, syscall: e.syscall }; } };
console.log(JSON.stringify(await E(fs.promises.realpath(d + "/nope"))));
console.log(JSON.stringify(await E(fs.promises.realpath(d + "/f/"))));
```

| | Bun (before) | Node v26 / Bun (after) |
| --- | --- | --- |
| missing path | `{"code":"ENOENT","syscall":"lstat"}` | `{"code":"ENOENT","syscall":"realpath"}` |
| `<file>/` | `{"code":"ENOTDIR","syscall":"lstat"}` | `{"code":"ENOTDIR","syscall":"realpath"}` |

## Cause

`src/js/node/fs.promises.ts` wrapped the binding's non-native `realpath`, which `src/runtime/node/node_fs_binding.rs` maps to `RealpathNonNative` (it overrides the error's syscall tag to `lstat`). The native binding method `realpathNative` maps to `Realpath`, which keeps `syscall: "realpath"`.

## Fix

Route `fs.promises.realpath` to `fs.realpathNative`, matching Node. The `asyncWrap` call already forwards `(path, options)`, which is exactly the native binding's signature, and `args::Realpath` parses the encoding option identically for both variants.

This is why the change was kept out of #32920 (a POSIX-only fix teaching the non-native variant to ignore trailing separators): routing to native also selects the native Windows arm of `realpath_inner` and the variant used by `src/js/internal/fs/glob.ts`'s async path. On POSIX the two variants share one implementation (`realpath_inner` ignores the variant there) and differ only by error tag, so no resolution behavior changes for existing paths.

## Verification

New test in `test/js/node/fs/fs.test.ts` asserts the Node-matching `syscall: "realpath"` tag (and the `ENOTDIR` trailing-separator case on POSIX).

- Without the fix: `expect(received).toEqual(expected)` fails with `syscall: "lstat"`.
- With the fix: passes.
- `test/js/bun/glob/scan.test.ts` (symlink-following via the glob realpath path): 172 pass, 0 fail.