### PR TITLE
Enable Temporal by default

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -324,10 +324,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             JSC::Options::useAsyncStackTrace() = true;
             JSC::Options::useExplicitResourceManagement() = true;
             JSC::Options::useImportDefer() = true;
-            // Upstream enabled Temporal by default; keep it off in Bun until
-            // the remaining integration work lands. BUN_JSC_useTemporal=1
-            // re-enables it for opt-in testing.
-            JSC::Options::useTemporal() = false;
+            JSC::Options::useTemporal() = true;
             // Upstream enabled Wasm Memory64 by default (0d0080ea539d); keep
             // it off in Bun while upstream stabilises it.
             // BUN_JSC_useWasmMemory64=1 re-enables it for opt-in testing.

--- a/test/js/bun/jsc/temporal-global.test.ts
+++ b/test/js/bun/jsc/temporal-global.test.ts
@@ -1,25 +1,25 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// Upstream WebKit enabled Temporal by default; Bun overrides useTemporal to
-// false in ZigGlobalObject.cpp until the remaining integration work lands.
-// BUN_JSC_useTemporal=1 re-enables it for opt-in testing.
-test("Temporal is not exposed by default", async () => {
+// Temporal ships enabled by default. BUN_JSC_useTemporal=0 is the opt-out;
+// the BUN_JSC_* environment overrides are applied after the defaults block
+// in ZigGlobalObject.cpp, so it can still turn the global back off.
+test.concurrent("Temporal is exposed by default", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `process.stdout.write(typeof Temporal)`],
+    cmd: [bunExe(), "-e", `process.stdout.write(typeof Temporal + " " + typeof Temporal.Now.instant)`],
     env: { ...bunEnv, BUN_JSC_useTemporal: undefined },
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "undefined", stderr: expect.any(String), exitCode: 0 });
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "object function", stderr: expect.any(String), exitCode: 0 });
 });
 
-test("Temporal is exposed when BUN_JSC_useTemporal=1", async () => {
+test.concurrent("BUN_JSC_useTemporal=0 disables Temporal", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `process.stdout.write(typeof Temporal + " " + typeof Temporal.Now.instant)`],
-    env: { ...bunEnv, BUN_JSC_useTemporal: "1" },
+    cmd: [bunExe(), "-e", `process.stdout.write(typeof Temporal)`],
+    env: { ...bunEnv, BUN_JSC_useTemporal: "0" },
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "object function", stderr: expect.any(String), exitCode: 0 });
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "undefined", stderr: expect.any(String), exitCode: 0 });
 });

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/15853
+// The default-on/opt-out subprocess tests live in
+// test/js/bun/jsc/temporal-global.test.ts next to the other JSC option tests.
+describe.concurrent("Temporal global", () => {
+  test("is installed with the spec property attributes", () => {
+    expect(Object.getOwnPropertyDescriptor(globalThis, "Temporal")).toMatchObject({
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
+  test("exposes all nine namespaces", () => {
+    expect(Object.getOwnPropertyNames(Temporal).sort()).toEqual([
+      "Duration",
+      "Instant",
+      "Now",
+      "PlainDate",
+      "PlainDateTime",
+      "PlainMonthDay",
+      "PlainTime",
+      "PlainYearMonth",
+      "ZonedDateTime",
+    ]);
+    expect(Temporal[Symbol.toStringTag]).toBe("Temporal");
+  });
+});
+
+describe("Temporal core operations", () => {
+  test("Temporal.Now", () => {
+    expect(Temporal.Now.instant()).toBeInstanceOf(Temporal.Instant);
+    expect(Temporal.Now.plainDateISO()).toBeInstanceOf(Temporal.PlainDate);
+    expect(Temporal.Now.plainDateTimeISO()).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(Temporal.Now.plainTimeISO()).toBeInstanceOf(Temporal.PlainTime);
+    expect(Temporal.Now.zonedDateTimeISO()).toBeInstanceOf(Temporal.ZonedDateTime);
+    expect(typeof Temporal.Now.timeZoneId()).toBe("string");
+  });
+
+  test("parsing, arithmetic, and formatting round-trip", () => {
+    const d = Temporal.PlainDate.from("2024-06-15");
+    expect(d.add({ months: 1, days: 20 }).toString()).toBe("2024-08-04");
+    expect(d.since("2023-01-01", { largestUnit: "month" }).toString()).toBe("P17M14D");
+
+    const i = Temporal.Instant.from("2024-06-15T12:34:56.789Z");
+    expect(i.epochMilliseconds).toBe(1718454896789);
+    expect(i.round({ smallestUnit: "minute" }).toString()).toBe("2024-06-15T12:35:00Z");
+
+    const z = Temporal.ZonedDateTime.from("2024-06-15T12:34:56-04:00[America/New_York]");
+    expect(z.toString()).toBe("2024-06-15T12:34:56-04:00[America/New_York]");
+    expect(z.withTimeZone("Asia/Tokyo").toString()).toBe("2024-06-16T01:34:56+09:00[Asia/Tokyo]");
+
+    expect(Temporal.Duration.from({ hours: 36, minutes: 30 }).round({ largestUnit: "day" }).toString()).toBe(
+      "P1DT12H30M",
+    );
+  });
+
+  test("DST disambiguation", () => {
+    // 2024-03-10 02:30 does not exist in America/New_York (spring-forward gap).
+    const gap = Temporal.PlainDateTime.from("2024-03-10T02:30:00");
+    expect(gap.toZonedDateTime("America/New_York", { disambiguation: "earlier" }).toString()).toBe(
+      "2024-03-10T01:30:00-05:00[America/New_York]",
+    );
+    expect(gap.toZonedDateTime("America/New_York", { disambiguation: "later" }).toString()).toBe(
+      "2024-03-10T03:30:00-04:00[America/New_York]",
+    );
+    expect(() => gap.toZonedDateTime("America/New_York", { disambiguation: "reject" })).toThrow(RangeError);
+  });
+
+  test("Date.prototype.toTemporalInstant", () => {
+    const date = new Date("2024-06-15T12:34:56.789Z");
+    const instant = date.toTemporalInstant();
+    expect(instant).toBeInstanceOf(Temporal.Instant);
+    expect(instant.epochMilliseconds).toBe(date.getTime());
+  });
+
+  test("Intl.DateTimeFormat formats Temporal objects", () => {
+    const d = Temporal.PlainDate.from("2024-06-15");
+    expect(new Intl.DateTimeFormat("en-US").format(d)).toBe("6/15/2024");
+    expect(d.toLocaleString("en-US")).toBe("6/15/2024");
+  });
+
+  test("structuredClone rejects Temporal objects", () => {
+    expect(() => structuredClone(Temporal.PlainDate.from("2024-06-15"))).toThrow(DOMException);
+    expect(() => structuredClone(Temporal.Instant.from("2024-06-15T00:00Z"))).toThrow(DOMException);
+  });
+});

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -85,7 +85,6 @@ leak:JSC::stringProtoFuncReplaceUsingRegExp
 leak:WebCore::parseTypeAndSubtype
 leak:runtime.node.util.parse_args.parseArgs
 leak:JSC::IntlDateTimeFormat::initializeDateTimeFormat
-leak:JSC::TemporalCore::withTimeZone
 leak:WebCore__DOMURL__fileSystemPath
 leak:runtime.node.node_fs_watcher.FSWatcher.Arguments.fromJS
 leak:jsc.web_worker.create

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -129,3 +129,11 @@ leak:bun_runtime::cli::multi_run::run
 # NAPI weak finalizers which enqueue Box<NapiFinalizerTask> into the event
 # loop; the loop is already exiting so they never drain.
 leak:napi_internal_enqueue_finalizer
+# test/js/web/temporal/temporal.test.ts
+# TemporalCore::withTimeZone keeps up to 8 open UCalendars in a process-
+# lifetime LazyNeverDestroyed TinyLRUCache, one per time zone ID; LRU
+# eviction ucal_closes them. The TimeZoneCacheEntry that owns each UCalendar
+# is WTF_MAKE_TZONE_ALLOCATED (bmalloc), which LSAN does not scan as a root
+# region, so the libc-allocated UCalendar it holds is reported as a direct
+# leak even though it is reachable and bounded.
+leak:TemporalCore::withTimeZone


### PR DESCRIPTION
### What does this PR do?

Enables JavaScriptCore's `Temporal` implementation by default by setting `JSC::Options::useTemporal() = true` alongside the other JSC option defaults in `ZigGlobalObject.cpp`. This exposes the `Temporal` global and `Date.prototype.toTemporalInstant`. `BUN_JSC_useTemporal=0` still turns it back off, because the `BUN_JSC_*` environment overrides are applied after the defaults block.

Fixes #15853.

### Why now

JSC's Temporal implementation has improved a lot since the 40% test262 pass rate reported on #15853 in early 2025. Measured with `temporal-test262-runner` 0.4.0 (the same tool that produced that 40% figure) against test262 `de8e621c`, with Node v26.3.0 (which ships Temporal on by default) for comparison:

| Suite | Tests | Bun | Node 26.3 |
|---|---|---|---|
| `built-ins/Temporal` (core spec) | 4603 | 100.0% | 98.7% |
| `built-ins/Date/prototype/toTemporalInstant` | 8 | 100% | 100% |
| `intl402/DateTimeFormat` + `DurationFormat` on Temporal objects | 259 | 99.2% | 91.9% |
| `intl402/Temporal` (non-ISO calendars) | 2029 | 56.2% | 38.3% |

Every one of the 136 tests where Bun is behind Node is in `intl402/Temporal`, which is non-ISO calendar behavior. Outside of that there is not a single test262 test where Bun is behind Node. I also byte-diffed the output of 20,500 deterministic Temporal operations (seeded identically in both engines): the iso8601, gregory, and roc calendars, 2000 DST-disambiguation cases, all offset-option handling, Instant rounding, and formatting options produced zero divergences.

The full test262 run was repeated on a debug + ASAN build of this branch's parent: zero crashes, zero ASAN reports, zero assertion failures, and a pass/fail set identical to release across all 6634 tests.

Chrome 144, Firefox, and Node 26 ship Temporal on by default. TypeScript 6.0 ships the type declarations and its `lib.esnext.d.ts` references `esnext.temporal`, so nothing is needed in `bun-types`.

### The Windows blocker is resolved

This PR was converted to a draft when CI showed `Temporal.PlainDate.prototype.since` throwing `RangeError: Duration is outside the representable range` on trivial input, on Windows x64 and Windows aarch64 only (the two platforms where WTF's `Int128` is the emulated `Int128Impl` rather than native `__int128`).

The WebKit upgrade in #34373 (`2603e9eb41f0`) brought in upstream's Temporal duration-arithmetic and spec-alignment fixes, and the bug no longer reproduces. Verified on current main's canary (`1.4.0-canary.1+6b6fb1a33`) on both Windows 2019 x64 and Windows 11 aarch64 with `BUN_JSC_useTemporal=1`: the previously failing expression returns `P17M14D`, and a 10-expression smoke covering `since`/`until`, `Duration.round`/`total`/`compare`, `Instant` arithmetic, epoch nanoseconds, and ZonedDateTime DST transitions produces byte-identical output to Linux on both.

### Cost

The `Temporal` namespace object is installed the same way `Intl` is (one line above it in `JSGlobalObject::init`): a single small object whose nine sub-constructors are `PropertyCallback` lookup-table entries created on first access, with their structures registered via `initLater`. Measured over 420 cold starts of `bun -e ''`: 1887 us/start with `useTemporal` off, 1875 us/start with it on (within measurement noise). RSS is 31.5 MB vs 31.4 MB. The implementation was already compiled into the binary behind the runtime flag, so there is no size change.

### Known gaps, all non-ISO calendars and all upstream JavaScriptCore

- `dayOfYear` ignores the calendar and returns the ISO day of year. Every other calendar-dependent field getter has a non-ISO branch through `TemporalCore`; this one does not, and `TemporalZonedDateTimePrototype.cpp` already has a source comment acknowledging it.
- The buddhist calendar's `year` returns the ISO year instead of BE, because `TemporalCore::calendarYear()` uses ICU's `UCAL_EXTENDED_YEAR`, which is the Gregorian year for the `GregorianCalendar`-derived calendars. The same function already special-cases `roc` for this exact quirk.
- Chinese/dangi leap-month placement disagrees with the reference on 2-3% of dates, and the `ad`/`bc` era aliases are not accepted (`ce`/`bce` are).
- Legacy IANA time zone IDs such as `CET` and `EST5EDT` are rejected. This is not Temporal-specific: `new Date()` and `Intl.DateTimeFormat().resolvedOptions().timeZone` already fall back to `UTC` for them today.

The first two are being filed upstream on bugs.webkit.org with one-line reproductions. None of these are regressions this PR can introduce; they are pre-existing in the JSC implementation, which is only reachable behind `BUN_JSC_useTemporal=1` today.

### Nothing else needed to change

- `test/js/node/test/common/globals.js` already handles the new global conditionally (`if (global.Temporal) intrinsics.add('Temporal')`).
- `test/js/bun/jsc/temporal-global.test.ts` (added by #34373 to pin the off-by-default state) is updated to assert the new default and the `BUN_JSC_useTemporal=0` opt-out; the subprocess flag tests live there, next to the other JSC option coverage, and the in-process functional coverage lives in `test/js/web/temporal/temporal.test.ts`.
- `structuredClone` and `postMessage` correctly reject Temporal objects with a `DataCloneError`, matching Node.
- Temporal string parsing uses its own strict ISO 8601 grammar in `ISO8601.cpp`. It never touches the date parser selected by `useV8DateParser`, which has exactly one call site (`DateCache::parseDate`), so there is no interaction with that override.

### LeakSanitizer

The x64-asan lane flags JSC's Temporal time zone bridge on any test that touches a named time zone. `JSC::TemporalCore::withTimeZone` keeps a process-lifetime `LazyNeverDestroyed` LRU of at most 8 open `UCalendar`s (evicted entries are `ucal_close`d), and the `TimeZoneCacheEntry` that owns each one lives in bmalloc memory, which LeakSanitizer does not scan as a root region, so the libc-allocated `UCalendar` is misreported as a direct leak. This PR adds the one `test/leaksan.supp` entry for it with a comment. It is bounded and intentional, not a real leak.

### How did you verify your code works?

`test/js/bun/jsc/temporal-global.test.ts` covers the global being present by default and the `BUN_JSC_useTemporal=0` escape hatch. `test/js/web/temporal/temporal.test.ts` covers the spec property attributes, all nine namespaces, `Temporal.Now`, parsing/arithmetic/DST-disambiguation round-trips, `Date.prototype.toTemporalInstant`, `Intl.DateTimeFormat` formatting of Temporal objects, and `structuredClone` rejection.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/temporal-global.test.ts test/js/web/temporal/temporal.test.ts
 1 pass
 9 fail

$ bun bd test test/js/bun/jsc/temporal-global.test.ts test/js/web/temporal/temporal.test.ts
 10 pass
 0 fail
```

`test/js/web/workers/structured-clone.test.ts` (231 tests) also passes with the flag on.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsc/temporal-global.test.ts test/js/web/temporal/temporal.test.ts
bun test v1.4.0 (f2e0cd5a1)

test/js/bun/jsc/temporal-global.test.ts:
 9 |     cmd: [bunExe(), "-e", `process.stdout.write(typeof Temporal + " " + typeof Temporal.Now.instant)`],
10 |     env: { ...bunEnv, BUN_JSC_useTemporal: undefined },
11 |     stderr: "pipe",
12 |   });
13 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
14 |   expect({ stdout, stderr, exitCode }).toEqual({ stdout: "object function", stderr: expect.any(String), exitCode: 0 });
                                            ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": Any<String>,
-   "stdout": "object function",
+   "exitCode": 1,
+   "stderr": 
+ "1 | process.stdout.write(typeof Temporal + " " + typeof Temporal.Now.instant)
+                                                         ^
+ ReferenceError: Temporal is not defined
+       at /workspace/bun/[eval]:1:53
+ 
+ Bun v1.4.0-debug+f2e0cd5
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2f503b5f2)

test/js/bun/jsc/temporal-global.test.ts:
(pass) Temporal is exposed by default [18.29ms]
(pass) BUN_JSC_useTemporal=0 disables Temporal [17.95ms]

test/js/web/temporal/temporal.test.ts:
(pass) Temporal global > is installed with the spec property attributes [0.03ms]
(pass) Temporal global > exposes all nine namespaces [0.05ms]
(pass) Temporal core operations > Temporal.Now [5.26ms]
(pass) Temporal core operations > parsing, arithmetic, and formatting round-trip [0.17ms]
(pass) Temporal core operations > DST disambiguation [0.09ms]
(pass) Temporal core operations > Date.prototype.toTemporalInstant [0.04ms]
(pass) Temporal core operations > Intl.DateTimeFormat formats Temporal objects [2.06ms]
(pass) Temporal core operations > structuredClone rejects Temporal objects [0.12ms]

 10 pass
 0 fail
 27 expect() calls
Ran 10 tests across 2 files. [175.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsc/temporal-global.test.ts test/js/web/temporal/temporal.test.ts
bun test v1.4.0 (f2e0cd5a1)

test/js/bun/jsc/temporal-global.test.ts:
(pass) Temporal is exposed by default [1284.32ms]
(pass) BUN_JSC_useTemporal=0 disables Temporal [1302.12ms]

test/js/web/temporal/temporal.test.ts:
(pass) Temporal global > is installed with the spec property attributes [2.15ms]
(pass) Temporal global > exposes all nine namespaces [3.39ms]
(pass) Temporal core operations > Temporal.Now [168.15ms]
(pass) Temporal core operations > parsing, arithmetic, and formatting round-trip [9.26ms]
(pass) Temporal core operations > DST disambiguation [6.56ms]
(pass) Temporal core operations > Date.prototype.toTemporalInstant [2.74ms]
(pass) Temporal core operations > Intl.DateTimeFormat formats Temporal objects [27.37ms]
(pass) Temporal core operations > structuredClone rejects Temporal objects [7.59ms]

 10 pass
 0 fail
 27 expect() calls
Ran 10 tests across 2 files. [3.65s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 711ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp    |  5 +-
 test/js/bun/jsc/temporal-global.test.ts | 20 ++++----
 test/js/web/temporal/temporal.test.ts   | 88 +++++++++++++++++++++++++++++++++
 test/leaksan.supp                       |  9 +++-
 4 files changed, 107 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp         2      1      8
test/js/bun/jsc/temporal-global.test.ts      0      0      0
test/js/web/temporal/temporal.test.ts        0      2      7
test/leaksan.supp                            0      0     10
```

</details>

<!-- robobun:evidence:end -->