### PR TITLE
structuredClone: clone Object.prototype to an empty object

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -91,6 +91,7 @@
 #include <JavaScriptCore/JSWebAssemblyModule.h>
 #include <JavaScriptCore/NumberObject.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <JavaScriptCore/ObjectPrototype.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/RegExp.h>
 #include <JavaScriptCore/RegExpObject.h>
@@ -2774,7 +2775,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
             // a DataCloneError.
             // NapiPrototype is allowed because napi_create_object should behave
             // like a plain object from JS's perspective (matches Node.js).
-            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info())
+            // ObjectPrototype is allowed because %Object.prototype% is an immutable
+            // prototype exotic object that the spec carves out of this rejection.
+            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info())
                 return SerializationReturnCode::DataCloneError;
             inputObjectStack.append(inObject);
             indexStack.append(0);

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -650,3 +650,28 @@ describe("deserializing a version 13 payload", () => {
     expect(cloned[0]).not.toBe(cloned[1]);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/32981
+// %Object.prototype% is an immutable prototype exotic object that the structured
+// serialization spec carves out of the exotic-object rejection, so it clones to
+// an empty plain object instead of throwing a DataCloneError.
+describe("structuredClone(Object.prototype)", () => {
+  test("clones to an empty plain object", () => {
+    const cloned = structuredClone(Object.prototype);
+    expect(cloned).toEqual({});
+    expect(Object.keys(cloned)).toEqual([]);
+    expect(cloned).not.toBe(Object.prototype);
+    expect(Object.getPrototypeOf(cloned)).toBe(Object.prototype);
+  });
+
+  test("clones when nested inside another object", () => {
+    const cloned = structuredClone({ a: Object.prototype, b: 1 });
+    expect(cloned).toEqual({ a: {}, b: 1 });
+    expect(cloned.a).not.toBe(Object.prototype);
+  });
+
+  test("bun:jsc serialize/deserialize round-trips it too", () => {
+    const cloned = deserialize(serialize(Object.prototype));
+    expect(cloned).toEqual({});
+  });
+});


### PR DESCRIPTION
Fixes #32981

### Repro

```console
$ bun -e 'console.log(structuredClone(Object.prototype))'
DataCloneError: The object can not be cloned.
```

Node returns `{}`:

```console
$ node -e 'console.log(structuredClone(Object.prototype))'
{}
```

### Cause

[StructuredSerializeInternal](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal) excludes `%Object.prototype%` from its exotic-object rejection step:

> Otherwise, if value is an exotic object and value is not the %Object.prototype% intrinsic object associated with any Realm, then throw a "DataCloneError" DOMException.
>
> Note: %Object.prototype% is an immutable prototype exotic object; that is why it is excluded from this step. It will be handled in the default case, and end up being deserialized as an empty object.

Bun's `CloneSerializer` in `src/jsc/bindings/webcore/SerializedScriptValue.cpp` kept the exotic-object rejection but only allowed `JSFinalObject` and `NapiPrototype`:

```cpp
if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info())
    return SerializationReturnCode::DataCloneError;
```

`Object.prototype` is a `JSC::ObjectPrototype`, not a `JSFinalObject`, so it hit the reject branch. Upstream WebCore allows `ObjectPrototype::info()` here; the fork dropped that allowance.

### Fix

Allow `JSC::ObjectPrototype::info()` in the same condition, matching upstream WebCore. The value then falls through to normal object serialization. `Object.prototype`'s own properties are all non-enumerable and `getOwnPropertyNames(..., DontEnumPropertiesMode::Exclude)` skips them, so it serializes and deserializes as `{}`, matching the spec note and Node.

### Verification

```console
$ bun -e 'console.log(structuredClone(Object.prototype))'
{}
$ bun -e 'console.log(structuredClone({a: Object.prototype}))'
{ a: {} }
```

Tests added to `test/js/web/workers/structured-clone.test.ts` cover the top-level value, the nested case, and the `bun:jsc` serialize/deserialize round-trip. They fail on `main` with `DataCloneError` and pass with this change.