### PR TITLE
structuredClone: share SharedArrayBuffers and clone WebAssembly.Module/Memory

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -570,13 +570,17 @@ const uint8_t cryptoKeyOKPOpNameTagMaximumValue = 1;
  * Version 11. added support for Blob's memory cost.
  * Version 12. added support for agent cluster ID.
  * Version 13. added support for ErrorInstance objects.
- * Version 14. Date, RegExp, Error, DOMException, CryptoKey, KeyObject, X509Certificate,
+ * Versions 14 and 15 are RESERVED. Upstream WebKit uses 14 (boolean values are
+ * encoded as uint8_t instead of int32_t) and 15 (changed the terminator of the
+ * indexed property section in arrays). Bun has adopted neither, but skips those
+ * numbers so a future sync never has to disambiguate the same version number.
+ * Version 16. Date, RegExp, Error, DOMException, CryptoKey, KeyObject, X509Certificate,
  * and Bun cloneable types are recorded in the object reference pool on both sides.
  */
-[[maybe_unused]] static constexpr unsigned CurrentVersion = 14;
-// Deserializers must not pool the version 14 terminal types for older payloads,
+[[maybe_unused]] static constexpr unsigned CurrentVersion = 16;
+// Deserializers must not pool the version 16 terminal types for older payloads,
 // whose writers never counted them, or the pool indices stop matching the writer's.
-[[maybe_unused]] static constexpr unsigned FirstVersionWithPooledTerminals = 14;
+[[maybe_unused]] static constexpr unsigned FirstVersionWithPooledTerminals = 16;
 [[maybe_unused]] static constexpr unsigned TerminatorTag = 0xFFFFFFFF;
 [[maybe_unused]] static constexpr unsigned StringPoolTag = 0xFFFFFFFE;
 [[maybe_unused]] static constexpr unsigned NonIndexPropertiesTag = 0xFFFFFFFD;
@@ -1399,7 +1403,48 @@ private:
             return true;
         }
 
+        // A view over a SharedArrayBuffer in a payload reduced to bytes (forStorage,
+        // cross-process IPC) carries a byte copy of the backing store, matching Node.js.
+        // Only a directly referenced SharedArrayBuffer is rejected (in dumpIfTerminal).
+        if (arrayBuffer->isShared()
+            && (m_forStorage == SerializationForStorage::Yes
+                || m_forTransfer == SerializationForCrossProcessTransfer::Yes)) {
+            JSValue bufferValue = toJSArrayBuffer(*arrayBuffer);
+            if (!startObjectInternal(asObject(bufferValue))) // handle duplicates
+                return true;
+            return writeArrayBufferAsCopy(*arrayBuffer, code);
+        }
+
         return dumpIfTerminal(toJSArrayBuffer(*arrayBuffer), code);
+    }
+
+    // Writes a byte copy of the buffer: ResizableArrayBufferTag when it is resizable or
+    // growable so an auto-length view over it still deserializes, ArrayBufferTag otherwise.
+    // The caller must have registered the buffer's wrapper via startObjectInternal so the
+    // deserializer's object pool stays in sync (it appends one entry per buffer it reads).
+    bool writeArrayBufferAsCopy(ArrayBuffer& arrayBuffer, SerializationReturnCode& code)
+    {
+        uint64_t byteLength = arrayBuffer.byteLength();
+        if (arrayBuffer.isResizableOrGrowableShared()) {
+            if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) * 2 + byteLength)) [[unlikely]] {
+                code = SerializationReturnCode::DataCloneError;
+                return true;
+            }
+            write(ResizableArrayBufferTag);
+            write(byteLength);
+            uint64_t maxByteLength = arrayBuffer.maxByteLength().value_or(0);
+            write(maxByteLength);
+            write(static_cast<const uint8_t*>(arrayBuffer.data()), byteLength);
+            return true;
+        }
+        if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) + byteLength)) [[unlikely]] {
+            code = SerializationReturnCode::DataCloneError;
+            return true;
+        }
+        write(ArrayBufferTag);
+        write(byteLength);
+        write(static_cast<const uint8_t*>(arrayBuffer.data()), byteLength);
+        return true;
     }
 
     // void dumpDOMPoint(const DOMPointReadOnly& point)
@@ -1838,6 +1883,17 @@ private:
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
+                // A SharedArrayBuffer's Data Block only exists in this process. Payloads
+                // reduced to bytes (forStorage, cross-process IPC) cannot carry it, so a
+                // directly referenced SharedArrayBuffer is rejected, matching Node.js. A
+                // view over one is byte-copied instead (see dumpArrayBufferView). Checked
+                // before the duplicate lookup so a buffer a view already copied still errors.
+                if (arrayBuffer->isShared()
+                    && (m_forStorage == SerializationForStorage::Yes
+                        || m_forTransfer == SerializationForCrossProcessTransfer::Yes)) {
+                    code = SerializationReturnCode::DataCloneError;
+                    return true;
+                }
                 auto index = m_transferredArrayBuffers.find(obj);
                 if (index != m_transferredArrayBuffers.end()) {
                     write(ArrayBufferTransferTag);
@@ -1847,45 +1903,26 @@ private:
                 if (!startObjectInternal(obj)) // handle duplicates
                     return true;
 
-                if (arrayBuffer->isShared() && m_context == SerializationContext::WorkerPostMessage) {
+                if (arrayBuffer->isShared()) {
                     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+                    // StructuredSerializeInternal re-shares the Data Block; it never copies it.
                     if (!JSC::Options::useSharedArrayBuffer()) {
                         code = SerializationReturnCode::DataCloneError;
                         return true;
                     }
                     uint32_t index = m_sharedBuffers.size();
                     ArrayBufferContents contents;
-                    if (arrayBuffer->shareWith(contents)) {
-                        write(SharedArrayBufferTag);
-                        m_sharedBuffers.append(WTF::move(contents));
-                        write(index);
-                        return true;
-                    }
-                }
-
-                if (arrayBuffer->isResizableOrGrowableShared()) {
-                    uint64_t byteLength = arrayBuffer->byteLength();
-                    if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) * 2 + byteLength)) [[unlikely]] {
+                    if (!arrayBuffer->shareWith(contents)) {
                         code = SerializationReturnCode::DataCloneError;
                         return true;
                     }
-                    write(ResizableArrayBufferTag);
-                    write(byteLength);
-                    uint64_t maxByteLength = arrayBuffer->maxByteLength().value_or(0);
-                    write(maxByteLength);
-                    write(static_cast<const uint8_t*>(arrayBuffer->data()), byteLength);
+                    write(SharedArrayBufferTag);
+                    m_sharedBuffers.append(WTF::move(contents));
+                    write(index);
                     return true;
                 }
 
-                uint64_t byteLength = arrayBuffer->byteLength();
-                if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) + byteLength)) [[unlikely]] {
-                    code = SerializationReturnCode::DataCloneError;
-                    return true;
-                }
-                write(ArrayBufferTag);
-                write(byteLength);
-                write(static_cast<const uint8_t*>(arrayBuffer->data()), byteLength);
-                return true;
+                return writeArrayBufferAsCopy(*arrayBuffer, code);
             }
             if (obj->inherits<JSArrayBufferView>()) {
                 if (checkForDuplicate(obj))
@@ -1983,8 +2020,14 @@ private:
 #endif
 #if ENABLE(WEBASSEMBLY)
             if (JSWebAssemblyModule* module = dynamicDowncast<JSWebAssemblyModule>(obj)) {
-                if (m_context != SerializationContext::WorkerPostMessage && m_context != SerializationContext::WindowPostMessage)
-                    return false;
+                // https://webassembly.github.io/spec/web-api/index.html#serialization
+                // A cloned Module re-shares the in-process JSC::Wasm::Module; payloads
+                // reduced to bytes (forStorage, cross-process IPC) cannot carry it.
+                if (m_forStorage == SerializationForStorage::Yes
+                    || m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
+                    code = SerializationReturnCode::DataCloneError;
+                    return true;
+                }
 
                 uint32_t index = m_wasmModules.size();
                 m_wasmModules.append(&module->module());
@@ -1998,7 +2041,8 @@ private:
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
-                if (m_context != SerializationContext::WorkerPostMessage) {
+                if (m_forStorage == SerializationForStorage::Yes
+                    || m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
@@ -6575,9 +6619,9 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     // #endif
     //             ));
     scope.releaseAssertNoException();
-    auto result = adoptRef(*new SerializedScriptValue(WTF::move(buffer), arrayBufferContentsArray.releaseReturnValue(), context == SerializationContext::WorkerPostMessage ? WTF::move(sharedBuffers) : nullptr
+    auto result = adoptRef(*new SerializedScriptValue(WTF::move(buffer), arrayBufferContentsArray.releaseReturnValue(), WTF::move(sharedBuffers)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-        ,
+                                                                                                                            ,
         WTF::move(detachedCanvases)
 #endif
 #if ENABLE(WEB_RTC)
@@ -6586,10 +6630,10 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 #endif
 #if ENABLE(WEBASSEMBLY)
             ,
-        makeUnique<WasmModuleArray>(wasmModules), context == SerializationContext::WorkerPostMessage ? makeUnique<WasmMemoryHandleArray>(wasmMemoryHandles) : nullptr
+        makeUnique<WasmModuleArray>(wasmModules), makeUnique<WasmMemoryHandleArray>(WTF::move(wasmMemoryHandles))
 #endif
 #if ENABLE(WEB_CODECS)
-        ,
+                                                      ,
         WTF::move(serializedVideoChunks), WTF::move(serializedVideoFrameData)
 #endif
             ));

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1403,12 +1403,11 @@ private:
             return true;
         }
 
-        // A view over a SharedArrayBuffer in a payload reduced to bytes (forStorage,
-        // cross-process IPC) carries a byte copy of the backing store, matching Node.js.
-        // Only a directly referenced SharedArrayBuffer is rejected (in dumpIfTerminal).
-        if (arrayBuffer->isShared()
-            && (m_forStorage == SerializationForStorage::Yes
-                || m_forTransfer == SerializationForCrossProcessTransfer::Yes)) {
+        // A view over a SharedArrayBuffer crosses a process boundary as a byte copy of
+        // the backing store, matching Node.js advanced IPC; only a SharedArrayBuffer
+        // referenced directly is rejected, in dumpIfTerminal. The forStorage paths do
+        // not need this escape: they byte-copy through dumpIfTerminal's fallthrough.
+        if (arrayBuffer->isShared() && m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
             JSValue bufferValue = toJSArrayBuffer(*arrayBuffer);
             if (!startObjectInternal(asObject(bufferValue))) // handle duplicates
                 return true;
@@ -1883,14 +1882,12 @@ private:
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
-                // A SharedArrayBuffer's Data Block only exists in this process. Payloads
-                // reduced to bytes (forStorage, cross-process IPC) cannot carry it, so a
-                // directly referenced SharedArrayBuffer is rejected, matching Node.js. A
-                // view over one is byte-copied instead (see dumpArrayBufferView). Checked
-                // before the duplicate lookup so a buffer a view already copied still errors.
-                if (arrayBuffer->isShared()
-                    && (m_forStorage == SerializationForStorage::Yes
-                        || m_forTransfer == SerializationForCrossProcessTransfer::Yes)) {
+                // A SharedArrayBuffer's Data Block only exists in this process, so a
+                // directly referenced one cannot cross a process boundary. Reject it for
+                // cross-process IPC, matching Node.js; a view over one is byte-copied
+                // instead (see dumpArrayBufferView). Checked before the duplicate lookup
+                // so a buffer a view already copied still errors when referenced directly.
+                if (arrayBuffer->isShared() && m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
@@ -1903,7 +1900,11 @@ private:
                 if (!startObjectInternal(obj)) // handle duplicates
                     return true;
 
-                if (arrayBuffer->isShared()) {
+                // Payloads reduced to self-contained bytes (bun:jsc / node:v8 serialize)
+                // cannot carry the out-of-band shared Data Block, so they byte-copy the
+                // SharedArrayBuffer below. serialize(serialize(x)) depends on this:
+                // bun:jsc serialize returns a SharedArrayBuffer by design.
+                if (arrayBuffer->isShared() && m_forStorage == SerializationForStorage::No) {
                     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
                     // StructuredSerializeInternal re-shares the Data Block; it never copies it.
                     if (!JSC::Options::useSharedArrayBuffer()) {

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3539,8 +3539,9 @@ private:
         m_objectPool.appendWithCrashOnOverflow(value);
     }
 
-    // Date, RegExp, Error, and the other version 14 terminal types are only counted by
-    // the serializer's pool from version 14 on, so older payloads must not pool them here.
+    // Date, RegExp, Error, and the other pooled terminal types are only counted by the
+    // serializer's pool from FirstVersionWithPooledTerminals on, so older payloads must
+    // not pool them here or the pool indices stop matching what the writer counted.
     void addTerminalToObjectPool(JSValue value)
     {
         if (m_version >= FirstVersionWithPooledTerminals)

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5962,8 +5962,12 @@ size_t SerializedScriptValue::computeMemoryCost() const
 #if ENABLE(WEBASSEMBLY)
     // We are not supporting WebAssembly Module memory estimation yet.
     if (m_wasmMemoryHandlesArray) {
-        for (auto& content : *m_wasmMemoryHandlesArray)
-            cost += content->sizeInBytes(std::memory_order_relaxed);
+        // A zero-sized shared WebAssembly.Memory serializes as a null handle, which the
+        // deserializer turns back into a zero-sized shared memory. Never dereference it.
+        for (auto& content : *m_wasmMemoryHandlesArray) {
+            if (content)
+                cost += content->sizeInBytes(std::memory_order_relaxed);
+        }
     }
 #endif
 #if ENABLE(WEB_CODECS)

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -575,7 +575,8 @@ const uint8_t cryptoKeyOKPOpNameTagMaximumValue = 1;
  * indexed property section in arrays). Bun has adopted neither, but skips those
  * numbers so a future sync never has to disambiguate the same version number.
  * Version 16. Date, RegExp, Error, DOMException, CryptoKey, KeyObject, X509Certificate,
- * and Bun cloneable types are recorded in the object reference pool on both sides.
+ * WebAssembly.Module, shared WebAssembly.Memory, and Bun cloneable types are recorded
+ * in the object reference pool on both sides.
  */
 [[maybe_unused]] static constexpr unsigned CurrentVersion = 16;
 // Deserializers must not pool the version 16 terminal types for older payloads,
@@ -2029,6 +2030,8 @@ private:
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
+                if (!startObjectInternal(obj)) // handle duplicates
+                    return true;
 
                 uint32_t index = m_wasmModules.size();
                 m_wasmModules.append(&module->module());
@@ -2047,6 +2050,8 @@ private:
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
+                if (!startObjectInternal(obj)) // handle duplicates
+                    return true;
                 uint32_t index = m_wasmMemoryHandles.size();
                 m_wasmMemoryHandles.append(memory->memory().shared());
                 write(WasmMemoryTag);
@@ -5279,7 +5284,9 @@ private:
                 fail();
                 return JSValue();
             }
-            return JSC::JSWebAssemblyModule::create(m_lexicalGlobalObject->vm(), m_globalObject->webAssemblyModuleStructure(), Ref { *m_wasmModules->at(index) });
+            JSValue result = JSC::JSWebAssemblyModule::create(m_lexicalGlobalObject->vm(), m_globalObject->webAssemblyModuleStructure(), Ref { *m_wasmModules->at(index) });
+            addTerminalToObjectPool(result);
+            return result;
         }
         case WasmMemoryTag: {
             if (m_version >= 12) {
@@ -5325,6 +5332,7 @@ private:
 
             result->adopt(memory.releaseNonNull());
             m_gcBuffer.appendWithCrashOnOverflow(result);
+            addTerminalToObjectPool(result);
             return result;
         }
 #endif

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -579,6 +579,9 @@ const uint8_t cryptoKeyOKPOpNameTagMaximumValue = 1;
  * in the object reference pool on both sides.
  */
 [[maybe_unused]] static constexpr unsigned CurrentVersion = 16;
+// Upstream WebKit's versions 14 and 15, which Bun never adopted or wrote (see above).
+// isValid() rejects [FirstReservedVersion, FirstVersionWithPooledTerminals).
+[[maybe_unused]] static constexpr unsigned FirstReservedVersion = 14;
 // Deserializers must not pool the version 16 terminal types for older payloads,
 // whose writers never counted them, or the pool indices stop matching the writer's.
 [[maybe_unused]] static constexpr unsigned FirstVersionWithPooledTerminals = 16;
@@ -3421,7 +3424,15 @@ private:
 
     DeserializationResult deserialize();
 
-    bool isValid() const { return m_version <= CurrentVersion; }
+    // The reserved upstream-WebKit versions have no reader here; a version 14 payload in
+    // particular would have its object-reference pool silently desynced instead of failing
+    // (its writer pooled the terminal types, this reader would not). Reject them loudly.
+    bool isValid() const
+    {
+        if (m_version >= FirstReservedVersion && m_version < FirstVersionWithPooledTerminals)
+            return false;
+        return m_version <= CurrentVersion;
+    }
 
     template<typename T> bool readLittleEndian(T& value)
     {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1028,6 +1028,31 @@ function thrownName(fn: () => unknown): string | undefined {
   }
 }
 
+// Versions 14 and 15 are reserved for upstream WebKit format changes Bun never adopted,
+// so the deserializer has no reader for either; a version 14 payload in particular would
+// have its object-reference pool silently desynced instead of failing, because its writer
+// pooled the terminal types and this reader would not. Both must reject, not misparse.
+describe("the serialization format version", () => {
+  const withVersion = (version: number) => {
+    // `serialize` returns a SharedArrayBuffer; Buffer.from views it, so the
+    // version patch lands in the same bytes that `deserialize` reads.
+    const bytes = Buffer.from(serialize({ a: 1 }));
+    bytes.writeUint32LE(version, 0);
+    return bytes;
+  };
+
+  test("serialize() stamps the current version", () => {
+    expect(Buffer.from(serialize({ a: 1 })).readUint32LE(0)).toBe(16);
+  });
+
+  // 14 and 15 are the reserved gap; 99 is the pre-existing newer-than-current rejection.
+  test.each([14, 15, 99])("a version %i payload is rejected instead of misparsed", version => {
+    expect(thrownName(() => deserialize(withVersion(version)))).toBe("TypeError");
+    // A well-formed payload through the same helper still round-trips.
+    expect(deserialize(withVersion(16))).toEqual({ a: 1 });
+  });
+});
+
 // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
 // StructuredSerializeInternal of a SharedArrayBuffer re-shares the Data Block; it never
 // copies it. That Data Block only exists in this process, so paths that reduce the clone

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -776,8 +776,9 @@ describe("reference pool survives a process boundary", () => {
 });
 
 // Version 13 payloads were written before Date, RegExp, Error, and the other terminal
-// types were entered into the object reference pool. The deserializer must not pool
-// them for version < 14 or its indices stop matching what the writer counted.
+// types were entered into the object reference pool (FirstVersionWithPooledTerminals).
+// The deserializer must not pool them for older versions or its indices stop matching
+// what the writer counted.
 describe("deserializing a version 13 payload", () => {
   const version13 = (base64: string) => {
     const bytes = Buffer.from(base64, "base64");

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,6 +1,6 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { bunEnv, bunExe, tls } from "harness";
+import { bunEnv, bunExe, isASAN, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
 import { join } from "path";
@@ -623,6 +623,12 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
   // buffer to its reserved capacity; the subsequent terminator write then triggers vector
   // growth. The default 1.5x growth exceeds the 2GiB cap and would crash. These cases must
   // succeed and round-trip correctly since the total serialized size still fits under 2GiB.
+  //
+  // Skipped under ASAN: each case is a 1.5 GiB allocation plus ~3 GiB of serialize +
+  // deserialize memcpy, which sits right on the 5000ms test budget once ASAN's shadow
+  // memory and per-byte poisoning are added (observed: "resizable ArrayBuffer in
+  // object" at 5000.3-5000.5ms, over and under the limit across runs). The 2GiB
+  // Vector-cap property is independent of ASAN and stays covered by every other lane.
   for (const [label, expr, check] of [
     ["ArrayBuffer in object", "{ h: new ArrayBuffer(size) }", "r.h.byteLength === size"],
     ["ArrayBuffer in array", "[new ArrayBuffer(size)]", "r[0].byteLength === size"],
@@ -634,7 +640,7 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
       "r.h.byteLength === size",
     ],
   ] as const) {
-    test(`${label} under 2GiB clones without crashing`, async () => {
+    test.skipIf(isASAN)(`${label} under 2GiB clones without crashing`, async () => {
       const script = `
         const size = 1600000000;
         let v;

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1097,6 +1097,20 @@ describe("structuredClone of a SharedArrayBuffer", () => {
     expect(clone[0]).toBe(9);
   });
 
+  // A SharedArrayBuffer and a genuinely transferred ArrayBuffer in one graph: the
+  // transfer lookup runs immediately before the SharedArrayBuffer sharing gate, so
+  // this exercises both branches on adjacent objects in one serialization.
+  test("a SharedArrayBuffer and a transferred ArrayBuffer in the same graph", () => {
+    const sab = new SharedArrayBuffer(4);
+    const ab = new ArrayBuffer(4);
+    const clone = structuredClone({ sab, ab }, { transfer: [ab] });
+    expect(clone.sab).toBeInstanceOf(SharedArrayBuffer);
+    expect(clone.ab).toBeInstanceOf(ArrayBuffer);
+    expect(ab.byteLength).toBe(0);
+    new Uint8Array(sab)[0] = 9;
+    expect(new Uint8Array(clone.sab)[0]).toBe(9);
+  });
+
   // bun:jsc serialize (which node:v8 serialize wraps) produces self-contained bytes,
   // so the Data Block cannot travel: a SharedArrayBuffer becomes a byte copy. This is
   // the pre-existing contract: bun:jsc serialize itself returns a SharedArrayBuffer,
@@ -1212,6 +1226,11 @@ describe("structuredClone of WebAssembly objects", () => {
 
   test("non-shared WebAssembly.Memory still rejects", () => {
     expect(thrownName(() => structuredClone(new WebAssembly.Memory({ initial: 1 })))).toBe("DataCloneError");
+  });
+
+  test("WebAssembly.Instance still rejects", () => {
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(emptyModuleBytes));
+    expect(thrownName(() => structuredClone(instance))).toBe("DataCloneError");
   });
 
   test("serialize() to bytes rejects WebAssembly.Module and shared Memory", () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1131,6 +1131,21 @@ describe("structuredClone of WebAssembly objects", () => {
     expect(new Uint8Array(clone.buffer)[0]).toBe(99);
   });
 
+  // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+  // The memory map runs before any type dispatch, so a repeated reference must
+  // come back as one clone.
+  test("preserves identity within one payload", () => {
+    const mod = new WebAssembly.Module(emptyModuleBytes);
+    const [a, b] = structuredClone([mod, mod]);
+    expect(a).toBeInstanceOf(WebAssembly.Module);
+    expect(a).toBe(b);
+
+    const mem = new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true });
+    const [c, d] = structuredClone([mem, mem]);
+    expect(c).toBeInstanceOf(WebAssembly.Memory);
+    expect(c).toBe(d);
+  });
+
   test("non-shared WebAssembly.Memory still rejects", () => {
     expect(thrownName(() => structuredClone(new WebAssembly.Memory({ initial: 1 })))).toBe("DataCloneError");
   });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1120,23 +1120,46 @@ describe("structuredClone of a SharedArrayBuffer", () => {
 
   // IPC crosses a process boundary, so the Data Block cannot be re-shared. Node's
   // advanced serialization rejects a directly referenced SharedArrayBuffer but
-  // byte-copies the backing store of a view over one. Match both halves.
+  // byte-copies the backing store of a view over one. Match both halves, and have
+  // the child echo back what it deserialized so the byte-copy is actually proven.
   test("subprocess.send() rejects a SharedArrayBuffer but copies a view over one", async () => {
+    // The child describes each payload it receives: constructor name, backing
+    // buffer's constructor name (null for a bare ArrayBuffer), and the first byte.
+    const echo =
+      "process.on('message', m => process.send([m.constructor.name, m.buffer?.constructor.name ?? null, m[0] ?? null]));";
+    const received: unknown[] = [];
+    const { promise: gotBoth, resolve, reject } = Promise.withResolvers<void>();
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "process.on('message', () => {});"],
+      cmd: [bunExe(), "-e", echo],
       env: bunEnv,
-      ipc() {},
+      ipc(message) {
+        received.push(message);
+        if (received.length === 2) resolve();
+      },
       stdout: "inherit",
       stderr: "inherit",
     });
+    proc.exited.then(() => reject(new Error("the child exited before echoing both payloads")));
+
+    // A directly referenced SharedArrayBuffer rejects before anything reaches the child.
     expect(thrownName(() => proc.send(new SharedArrayBuffer(8)))).toBe("DataCloneError");
-    expect(thrownName(() => proc.send(new Uint8Array(new SharedArrayBuffer(8))))).toBeUndefined();
-    // A direct reference to the same buffer anywhere in the payload still rejects,
-    // even after a view over it was already byte-copied earlier in that payload.
+    // It still rejects even after a view over the same buffer was already byte-copied
+    // earlier in that payload (the check runs before the object-pool duplicate lookup).
     const sab = new SharedArrayBuffer(8);
     expect(thrownName(() => proc.send([new Uint8Array(sab), sab]))).toBe("DataCloneError");
-    // A plain ArrayBuffer over the same channel is fine; only the direct SAB is rejected.
-    expect(thrownName(() => proc.send(new ArrayBuffer(8)))).toBeUndefined();
+
+    // A view over a SharedArrayBuffer, and a plain ArrayBuffer, both go through.
+    const view = new Uint8Array(new SharedArrayBuffer(8));
+    view[0] = 11;
+    expect(thrownName(() => proc.send(view))).toBeUndefined();
+    expect(thrownName(() => proc.send(new ArrayBuffer(4)))).toBeUndefined();
+
+    await gotBoth;
+    expect(received).toEqual([
+      // The child got a Uint8Array over a plain, non-shared, byte-copied ArrayBuffer.
+      ["Uint8Array", "ArrayBuffer", 11],
+      ["ArrayBuffer", null, null],
+    ]);
   });
 });
 
@@ -1162,6 +1185,16 @@ describe("structuredClone of WebAssembly objects", () => {
     expect(new Uint8Array(clone.buffer)[0]).toBe(99);
   });
 
+  // A zero-sized shared Memory has no backing-store handle at all: the serializer
+  // records a null and the deserializer re-creates it zero-sized. computeMemoryCost()
+  // must not dereference that null handle.
+  test("zero-sized shared WebAssembly.Memory clones", () => {
+    const mem = new WebAssembly.Memory({ initial: 0, maximum: 0, shared: true });
+    const clone = structuredClone(mem);
+    expect(clone).toBeInstanceOf(WebAssembly.Memory);
+    expect(clone.buffer.byteLength).toBe(0);
+  });
+
   // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
   // The memory map runs before any type dispatch, so a repeated reference must
   // come back as one clone.
@@ -1184,6 +1217,22 @@ describe("structuredClone of WebAssembly objects", () => {
   test("serialize() to bytes rejects WebAssembly.Module and shared Memory", () => {
     expect(thrownName(() => serialize(new WebAssembly.Module(emptyModuleBytes)))).toBe("DataCloneError");
     expect(thrownName(() => serialize(new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true })))).toBe(
+      "DataCloneError",
+    );
+  });
+
+  // Cross-process IPC reduces the payload to bytes, so the in-process Module and
+  // Memory side channels cannot follow. Node's advanced serialization rejects both.
+  test("subprocess.send() rejects WebAssembly.Module and shared Memory", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.on('message', () => {});"],
+      env: bunEnv,
+      ipc() {},
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    expect(thrownName(() => proc.send(new WebAssembly.Module(emptyModuleBytes)))).toBe("DataCloneError");
+    expect(thrownName(() => proc.send(new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true })))).toBe(
       "DataCloneError",
     );
   });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -555,8 +555,6 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
   for (const [label, expr] of [
     ["ArrayBuffer", "new ArrayBuffer(2 ** 31)"],
     ["resizable ArrayBuffer", "new ArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
-    ["SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31)"],
-    ["growable SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
     ["Uint8Array", "new Uint8Array(2 ** 31)"],
   ] as const) {
     test(label, async () => {
@@ -583,6 +581,40 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
       });
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
       expect(["DataCloneError", "SKIP"]).toContain(stdout.trim());
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  // SharedArrayBuffers never enter the serialization buffer: structuredClone re-shares
+  // the existing Data Block. A >=2GiB SAB therefore clones without copying or aborting.
+  for (const [label, expr] of [
+    ["SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31)"],
+    ["growable SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
+  ] as const) {
+    test(`${label} clones by sharing without copying`, async () => {
+      const script = `
+        let buf;
+        try {
+          buf = ${expr};
+        } catch {
+          console.log("SKIP");
+          process.exit(0);
+        }
+        const clone = structuredClone(buf);
+        new Uint8Array(buf)[0] = 42;
+        const shared = clone instanceof SharedArrayBuffer
+          && clone.byteLength === buf.byteLength
+          && new Uint8Array(clone)[0] === 42;
+        console.log(shared ? "SHARED" : "NOT_SHARED");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(["SHARED", "SKIP"]).toContain(stdout.trim());
       expect(exitCode).toBe(0);
     });
   }
@@ -757,7 +789,7 @@ describe("deserializing a version 13 payload", () => {
   // serialize([new Date(5), { tag: "first" }, { tag: "second" }, <ref first>, <ref second>])
   // written by Bun 1.4.0. Pooling the Date unconditionally would shift the two
   // back-references onto the Date and `first`.
-  test("back-references after a Date are not shifted by the version 14 behavior", () => {
+  test("back-references after a Date are not shifted by the pooled-terminal behavior", () => {
     const cloned = version13(
       "DQAAAAEFAAAAAAAAAAsAAAAAAAAUQAEAAAACAwAAgHRhZxAFAACAZmlyc3T/////AgAAAAL+////ABAGAACAc2Vjb25k/////wMAAAATAQQAAAATAv////8=",
     );
@@ -976,5 +1008,131 @@ describe("truncated Set/Map payloads are rejected without hanging", () => {
   test("valid Set and Map payloads still round-trip", () => {
     expect(deserialize(serialize(new Set([1, 0])))).toEqual(new Set([1, 0]));
     expect(deserialize(serialize(new Map([[1, 1]])))).toEqual(new Map([[1, 1]]));
+  });
+});
+
+/** Returns the `.name` of the error `fn` throws, or `undefined` if it does not throw. */
+function thrownName(fn: () => unknown): string | undefined {
+  try {
+    fn();
+    return undefined;
+  } catch (e) {
+    return (e as Error).name;
+  }
+}
+
+// https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+// StructuredSerializeInternal of a SharedArrayBuffer re-shares the Data Block; it never
+// copies it. That Data Block only exists in this process, so paths that reduce the clone
+// to bytes for another process or for storage must reject it instead.
+describe("structuredClone of a SharedArrayBuffer", () => {
+  test("shares the backing Data Block", () => {
+    const sab = new SharedArrayBuffer(8);
+    const clone = structuredClone(sab);
+    expect(clone).toBeInstanceOf(SharedArrayBuffer);
+    expect(clone).not.toBe(sab);
+    expect(clone.byteLength).toBe(8);
+    // Writes through either object are visible through the other.
+    new Uint8Array(sab)[0] = 42;
+    new Uint8Array(clone)[1] = 7;
+    expect(Array.from(new Uint8Array(clone))).toEqual([42, 7, 0, 0, 0, 0, 0, 0]);
+    expect(Array.from(new Uint8Array(sab))).toEqual([42, 7, 0, 0, 0, 0, 0, 0]);
+  });
+
+  test("preserves growability and propagates growth", () => {
+    const sab = new SharedArrayBuffer(1, { maxByteLength: 16 });
+    const clone = structuredClone(sab);
+    expect(clone).toBeInstanceOf(SharedArrayBuffer);
+    expect(clone.growable).toBe(true);
+    expect(clone.maxByteLength).toBe(16);
+    sab.grow(4);
+    expect(clone.byteLength).toBe(4);
+  });
+
+  test("preserves identity within one payload", () => {
+    const sab = new SharedArrayBuffer(4);
+    const [a, b] = structuredClone([sab, sab]);
+    expect(a).toBeInstanceOf(SharedArrayBuffer);
+    expect(a).toBe(b);
+  });
+
+  test("a view over a SharedArrayBuffer clones to a view over the shared block", () => {
+    const sab = new SharedArrayBuffer(8);
+    const clone = structuredClone(new Uint8Array(sab));
+    expect(clone).toBeInstanceOf(Uint8Array);
+    expect(clone.buffer).toBeInstanceOf(SharedArrayBuffer);
+    new Uint8Array(sab)[0] = 9;
+    expect(clone[0]).toBe(9);
+  });
+
+  // bun:jsc serialize (which node:v8 serialize wraps) produces bytes meant to be
+  // stored or deserialized elsewhere; a Data Block cannot travel that way. Node's
+  // v8.serialize throws for a directly referenced SharedArrayBuffer but byte-copies
+  // the backing store of a view over one. Match both halves.
+  test("serialize() to bytes rejects a directly referenced SharedArrayBuffer", () => {
+    expect(thrownName(() => serialize(new SharedArrayBuffer(8)))).toBe("DataCloneError");
+    expect(thrownName(() => serialize({ nested: new SharedArrayBuffer(8) }))).toBe("DataCloneError");
+  });
+
+  test("serialize() to bytes copies a view over a SharedArrayBuffer", () => {
+    const sab = new SharedArrayBuffer(8);
+    new Uint8Array(sab)[0] = 5;
+    const roundTripped = deserialize(serialize(new Uint8Array(sab)));
+    expect(roundTripped).toBeInstanceOf(Uint8Array);
+    expect(roundTripped.buffer).toBeInstanceOf(ArrayBuffer);
+    expect(roundTripped[0]).toBe(5);
+    // A direct reference to the same buffer anywhere in the payload still rejects,
+    // even after a view over it was already byte-copied.
+    expect(thrownName(() => serialize([new Uint8Array(sab), sab]))).toBe("DataCloneError");
+  });
+
+  // IPC crosses a process boundary, so the Data Block cannot be re-shared either.
+  // Node's advanced serialization makes the same direct-reference vs. view split.
+  test("subprocess.send() rejects a SharedArrayBuffer but copies a view over one", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.on('message', () => {});"],
+      env: bunEnv,
+      ipc() {},
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    expect(thrownName(() => proc.send(new SharedArrayBuffer(8)))).toBe("DataCloneError");
+    expect(thrownName(() => proc.send(new Uint8Array(new SharedArrayBuffer(8))))).toBeUndefined();
+    // A plain ArrayBuffer over the same channel is fine; only the direct SAB is rejected.
+    expect(thrownName(() => proc.send(new ArrayBuffer(8)))).toBeUndefined();
+  });
+});
+
+// https://webassembly.github.io/spec/web-api/index.html#serialization
+// A cloned WebAssembly.Module re-shares the compiled module, and a cloned shared
+// WebAssembly.Memory re-shares the memory. Both are in-process only.
+describe("structuredClone of WebAssembly objects", () => {
+  // The 8-byte empty module: `(module)`.
+  const emptyModuleBytes = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+
+  test("WebAssembly.Module clones to an instantiable Module", () => {
+    const mod = new WebAssembly.Module(emptyModuleBytes);
+    const clone = structuredClone(mod);
+    expect(clone).toBeInstanceOf(WebAssembly.Module);
+    expect(new WebAssembly.Instance(clone)).toBeInstanceOf(WebAssembly.Instance);
+  });
+
+  test("shared WebAssembly.Memory clones to a Memory sharing the same buffer", () => {
+    const mem = new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true });
+    const clone = structuredClone(mem);
+    expect(clone).toBeInstanceOf(WebAssembly.Memory);
+    new Uint8Array(mem.buffer)[0] = 99;
+    expect(new Uint8Array(clone.buffer)[0]).toBe(99);
+  });
+
+  test("non-shared WebAssembly.Memory still rejects", () => {
+    expect(thrownName(() => structuredClone(new WebAssembly.Memory({ initial: 1 })))).toBe("DataCloneError");
+  });
+
+  test("serialize() to bytes rejects WebAssembly.Module and shared Memory", () => {
+    expect(thrownName(() => serialize(new WebAssembly.Module(emptyModuleBytes)))).toBe("DataCloneError");
+    expect(thrownName(() => serialize(new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true })))).toBe(
+      "DataCloneError",
+    );
   });
 });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1066,29 +1066,30 @@ describe("structuredClone of a SharedArrayBuffer", () => {
     expect(clone[0]).toBe(9);
   });
 
-  // bun:jsc serialize (which node:v8 serialize wraps) produces bytes meant to be
-  // stored or deserialized elsewhere; a Data Block cannot travel that way. Node's
-  // v8.serialize throws for a directly referenced SharedArrayBuffer but byte-copies
-  // the backing store of a view over one. Match both halves.
-  test("serialize() to bytes rejects a directly referenced SharedArrayBuffer", () => {
-    expect(thrownName(() => serialize(new SharedArrayBuffer(8)))).toBe("DataCloneError");
-    expect(thrownName(() => serialize({ nested: new SharedArrayBuffer(8) }))).toBe("DataCloneError");
-  });
-
-  test("serialize() to bytes copies a view over a SharedArrayBuffer", () => {
+  // bun:jsc serialize (which node:v8 serialize wraps) produces self-contained bytes,
+  // so the Data Block cannot travel: a SharedArrayBuffer becomes a byte copy. This is
+  // the pre-existing contract: bun:jsc serialize itself returns a SharedArrayBuffer,
+  // so serialize(serialize(x)) depends on it (see test/js/bun/jsc/bun-jsc.test.ts).
+  test("serialize() to bytes copies a SharedArrayBuffer and a view over one", () => {
     const sab = new SharedArrayBuffer(8);
     new Uint8Array(sab)[0] = 5;
-    const roundTripped = deserialize(serialize(new Uint8Array(sab)));
-    expect(roundTripped).toBeInstanceOf(Uint8Array);
-    expect(roundTripped.buffer).toBeInstanceOf(ArrayBuffer);
-    expect(roundTripped[0]).toBe(5);
-    // A direct reference to the same buffer anywhere in the payload still rejects,
-    // even after a view over it was already byte-copied.
-    expect(thrownName(() => serialize([new Uint8Array(sab), sab]))).toBe("DataCloneError");
+
+    const direct = deserialize(serialize(sab));
+    expect(direct).toBeInstanceOf(ArrayBuffer);
+    expect(new Uint8Array(direct)[0]).toBe(5);
+    // The copy does not share: mutating the source is not visible through it.
+    new Uint8Array(sab)[0] = 6;
+    expect(new Uint8Array(direct)[0]).toBe(5);
+
+    const viaView = deserialize(serialize(new Uint8Array(sab)));
+    expect(viaView).toBeInstanceOf(Uint8Array);
+    expect(viaView.buffer).toBeInstanceOf(ArrayBuffer);
+    expect(viaView[0]).toBe(6);
   });
 
-  // IPC crosses a process boundary, so the Data Block cannot be re-shared either.
-  // Node's advanced serialization makes the same direct-reference vs. view split.
+  // IPC crosses a process boundary, so the Data Block cannot be re-shared. Node's
+  // advanced serialization rejects a directly referenced SharedArrayBuffer but
+  // byte-copies the backing store of a view over one. Match both halves.
   test("subprocess.send() rejects a SharedArrayBuffer but copies a view over one", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", "process.on('message', () => {});"],
@@ -1099,6 +1100,10 @@ describe("structuredClone of a SharedArrayBuffer", () => {
     });
     expect(thrownName(() => proc.send(new SharedArrayBuffer(8)))).toBe("DataCloneError");
     expect(thrownName(() => proc.send(new Uint8Array(new SharedArrayBuffer(8))))).toBeUndefined();
+    // A direct reference to the same buffer anywhere in the payload still rejects,
+    // even after a view over it was already byte-copied earlier in that payload.
+    const sab = new SharedArrayBuffer(8);
+    expect(thrownName(() => proc.send([new Uint8Array(sab), sab]))).toBe("DataCloneError");
     // A plain ArrayBuffer over the same channel is fine; only the direct SAB is rejected.
     expect(thrownName(() => proc.send(new ArrayBuffer(8)))).toBeUndefined();
   });


### PR DESCRIPTION
Several user-visible gaps in `SerializedScriptValue.cpp` relative to Node and upstream WebKit, all stemming from serialization gates keyed on `SerializationContext` instead of the `forStorage` / `forCrossProcessTransfer` flags.

### Repro

```console
$ bun -e 'const s = new SharedArrayBuffer(8); const c = structuredClone(s); new Uint8Array(s)[0] = 1; console.log(c.constructor.name, new Uint8Array(c)[0])'
ArrayBuffer 0    # should be: SharedArrayBuffer 1

$ bun -e 'WebAssembly.compile(new Uint8Array([0,0x61,0x73,0x6d,1,0,0,0])).then(m => console.log(structuredClone(m).constructor.name))'
DataCloneError: The object can not be cloned.    # should be: Module
```

Node handles both. For the first, `structuredClone(sab)` returned a **byte copy that is not even a `SharedArrayBuffer`**, so code relying on the sharing semantics silently desynchronizes.

### Cause

The serializer only took the `SharedArrayBufferTag` (re-share the Data Block) path when `m_context == SerializationContext::WorkerPostMessage`. `structuredClone`, `bun:jsc serialize`, `node:v8 serialize`, and IPC all use `SerializationContext::Default`, so a `SharedArrayBuffer` fell through to the plain byte-copy branch with no error. `WebAssembly.Module` and shared `WebAssembly.Memory` sat behind the same gate and threw `DataCloneError` outside of `postMessage`. The `SerializedScriptValue` constructor also dropped the shared-buffer and Wasm side channels for every non-`WorkerPostMessage` context.

### Fix

Replace the context gate on the `SharedArrayBuffer` and Wasm paths with the `forStorage` / `forCrossProcessTransfer` flags, which already distinguish the cases correctly:

| | before | after | Node |
| --- | --- | --- | --- |
| `structuredClone(sab)` | silent copy, plain `ArrayBuffer` | shared `SharedArrayBuffer` | shared |
| `structuredClone(new Uint8Array(sab))` | view over a copy | view over the shared block | same |
| `postMessage(sab)` to a `Worker` | shared | shared (unchanged) | shared |
| IPC `send(sab)` (advanced) | silent copy | `DataCloneError` | throws |
| IPC `send(new Uint8Array(sab))` | byte copy | byte copy (unchanged) | byte copy |
| `bun:jsc` / `node:v8` `serialize(sab)` | byte copy | byte copy (unchanged) | n/a / throws |
| `structuredClone(wasmModule)` | `DataCloneError` | works | works |
| `structuredClone(sharedWasmMemory)` | `DataCloneError` | works | works |

Two deliberate decisions worth calling out:

- **IPC rejects a directly referenced `SharedArrayBuffer`.** The Data Block cannot follow the bytes across a process boundary, so the previous behavior silently handed the child a non-shared copy while the sender believed it had shared memory. Node's advanced serialization throws here too. A **view over** one is byte-copied instead of rejected, which is also Node's behavior; the direct-reference check sits before the object-pool duplicate lookup so a buffer a view already copied still errors when referenced directly later in the same payload. This direct-vs-view split comes from #32955.
- **`bun:jsc serialize(sab)` keeps byte-copying, it is not a Node-parity change.** `bun:jsc serialize` is documented and typed to return a `SharedArrayBuffer` so that `serialize(serialize(x))` round-trips, and `test/js/bun/jsc/bun-jsc.test.ts` asserts that contract. That is a deliberate Bun API, separate from `node:v8`'s stricter behavior, so this PR leaves it alone. (An earlier revision rejected it; CI caught the contract break.)

The two byte-copy branches in `dumpIfTerminal` are factored into one `writeArrayBufferAsCopy` helper, also used by the new view path.

Both WebAssembly types also join the pooled-terminal set on the serializer and deserializer, so `structuredClone([mod, mod])` preserves identity (`a === b`). [StructuredSerializeInternal](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal) consults the memory map before any type dispatch, so this is a spec requirement and Node matches it; upstream WebKit has the same gap. It was unobservable here until this PR made `structuredClone` of these types possible, and it rides the same unshipped version bump. Making `WebAssembly.Memory` cloneable also exposed a latent null dereference: a zero-sized shared `Memory` has no backing-store handle (the deserializer already branches on the null), but `computeMemoryCost()` was the one loop in that function without the null guard its neighbors have, so `structuredClone(new WebAssembly.Memory({ initial: 0, maximum: 0, shared: true }))` crashed. The guard is added and the zero-sized shape now round-trips, matching Node. One same-class sibling is deliberately excluded: the Bun `perf_hooks.Histogram` branch also never enters the pool, but it is only reachable through a `WorkerPostMessage`-only gate this PR does not change, so its identity loss is pre-existing `postMessage`-only behavior and belongs in a follow-up.

The serialization format version is renumbered from 14 to 16. Upstream WebKit uses 14 and 15 for format changes Bun has not adopted; reserving those numbers keeps a future sync from having to disambiguate the same version number with two meanings. No released Bun has ever emitted a version 14 payload (the 13 to 14 bump merged a day earlier in #32796), so no existing payload is affected. Versions 13 and below continue to deserialize with the pre-pooling behavior. The deserializer also rejects the two reserved versions outright (`isValid()` checks the gap through a named `FirstReservedVersion` constant), so a payload stamped 14 or 15 fails with a clean `ValidationError` instead of having its object-reference pool silently desynced by a reader that has no format for it.

### Relationship to other open PRs

This consolidates three in-flight PRs into one change, per maintainer request (a "sync SerializedScriptValue" pass):

- #32804 made `structuredClone(sab)` share, but left the silent IPC copy in place.
- #32955 found the direct-reference vs. view split for IPC; this PR adopts that design and its `writeArrayBufferAsCopy` extraction verbatim.
- #32983 is the `Object.prototype` fix. It was merged to `main` separately while this PR was in review, so this PR has been rebased on top of it and no longer carries that change or its tests.

### Rebase

After #32983 merged, this branch was rebased onto `main`. The only conflicts were #32983's `Object.prototype` change landing on the same lines as this PR's copy of it; they were resolved by taking `main`'s version and dropping this PR's now-duplicate code, include, and test suite. Everything else applied cleanly. A later rebase onto `main` after #31216, #33072, #33622, #33919, and #33944 landed had a single trivial keep-both conflict (both branches appended independent `describe()` blocks to the end of `structured-clone.test.ts`); `SerializedScriptValue.cpp` auto-merged cleanly.

### Verification

18 new tests in `test/js/web/workers/structured-clone.test.ts`, every one of which fails on `main`, plus a preserved-contract test pinning the `serialize()` byte-copy. The two pre-existing "2 GiB SharedArrayBuffer" cases are updated: they previously asserted `DataCloneError` (the 2 GiB copy overflowed the serialization buffer), and now assert the clone succeeds by sharing, since a `SharedArrayBuffer` no longer enters the serialization buffer at all.

```
bun bd test test/js/web/workers/structured-clone.test.ts test/js/bun/jsc/bun-jsc.test.ts
 246 pass (the previously failing bun:jsc > serialize included)
```

Also verified against Node v26 for every row in the table above.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 10 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 failed, 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (40719f14a)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.39ms]
(pass) structuredClone > primitive null [0.63ms]
(pass) structuredClone > primitive true [0.51ms]
(pass) structuredClone > primitive false [0.45ms]
(pass) structuredClone > primitive string, empty string [0.40ms]
(pass) structuredClone > primitive string, lone high surrogate [0.38ms]
(pass) structuredClone > primitive string, lone low surrogate [0.39ms]
(pass) structuredClone > primitive string, NUL [0.38ms]
(pass) structuredClone > primitive string, astral character [0.58ms]
(pass) structuredClone > primitive number, 0.2 [0.40ms]
(pass) structuredClone > primitive number, 0 [0.41ms]
(pass) structuredClone > pri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (72db73156)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [0.08ms]
(pass) structuredClone > primitive null
(pass) structuredClone > primitive true
(pass) structuredClone > primitive false
(pass) structuredClone > primitive string, empty string
(pass) structuredClone > primitive string, lone high surrogate
(pass) structuredClone > primitive string, lone low surrogate
(pass) structuredClone > primitive string, NUL
(pass) structuredClone > primitive string, astral character
(pass) structuredClone > primitive number, 0.2
(pass) structuredClone > primitive number, 0
(pass) structuredClone > primitive number, -0
(pass) structuredClone > primitive number, NaN
(pass) structuredClone > primitive number, Infinity
(pass) structuredClone > primitive number, -Infinity
(pass) structuredClone > primitive number, 9007199254740992
(pass) structuredClone > primitive number, -9007199254740992 [0.02ms]
(pass) structuredClone > primitive number, 9007199254740994
(pass) structuredClone > primitive number, -9007199254740994
(pass) structuredClone > primitive BigInt, 0n
(pass) structuredClone > primitive BigInt, -0n
(pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (40719f14a)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.21ms]
(pass) structuredClone > primitive null [0.59ms]
(pass) structuredClone > primitive true [0.50ms]
(pass) structuredClone > primitive false [0.42ms]
(pass) structuredClone > primitive string, empty string [0.39ms]
(pass) structuredClone > primitive string, lone high surrogate [0.37ms]
(pass) structuredClone > primitive string, lone low surrogate [0.38ms]
(pass) structuredClone > primitive string, NUL [0.37ms]
(pass) structuredClone > primitive string, astral character [0.57ms]
(pass) structuredClone > primitive number, 0.2 [0.40ms]
(pass) structuredClone > primitive number, 0 [0.41ms]
(pass) structuredClone > pri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 720ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/webcore/SerializedScriptValue.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/SerializedScriptValue.cpp | 157 +++++++----
 test/js/web/workers/structured-clone.test.ts       | 292 ++++++++++++++++++++-
 2 files changed, 398 insertions(+), 51 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/SerializedScriptValue.cpp     18     22     42
test/js/web/workers/structured-clone.test.ts           14     22     42
```

</details>

<!-- robobun:evidence:end -->