### PR TITLE
semver: treat '-' inside build metadata as an identifier character

### DIFF
--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -1173,7 +1173,10 @@ impl Tag {
                     }
                 }
                 b'-' => {
-                    if state != State::Pre {
+                    // '-' only begins a prerelease before the '+'. Inside prerelease or
+                    // build metadata it is an ordinary identifier character (semver 2.0
+                    // items 9 and 10), so "1.0.0+sha-abc" is a release with build "sha-abc".
+                    if state == State::None {
                         state = State::Pre;
                         start = i + 1;
                     }
@@ -1193,12 +1196,6 @@ impl Tag {
                         }
                         State::Build => {
                             result.tag.build = sliced_string.sub(&input[start..i]).external();
-                            if cfg!(debug_assertions) {
-                                debug_assert!(!strings::contains_char(
-                                    result.tag.build.slice(sliced_string.buf),
-                                    b'-'
-                                ));
-                            }
                             state = State::None;
                         }
                     }

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -1153,7 +1153,13 @@ impl Tag {
         }
         let mut result = TagResult::default();
         // Common case: no allocation is necessary.
-        let mut state = State::None;
+        // A non-zero initial_pre_count means the caller already consumed the start of
+        // an implicit prerelease ("1.0.0rc.1" style), so we are already inside it.
+        let mut state = if initial_pre_count > 0 {
+            State::Pre
+        } else {
+            State::None
+        };
         let mut start: usize = 0;
 
         let mut i: usize = 0;
@@ -1163,7 +1169,7 @@ impl Tag {
             match c {
                 b'+' => {
                     // qualifier  ::= ( '-' pre )? ( '+' build )?
-                    if state == State::Pre || state == State::None && initial_pre_count > 0 {
+                    if state == State::Pre {
                         result.tag.pre = sliced_string.sub(&input[start..i]).external();
                     }
 
@@ -1204,11 +1210,6 @@ impl Tag {
                 }
             }
             i += 1;
-        }
-
-        if state == State::None && initial_pre_count > 0 {
-            state = State::Pre;
-            start = 0;
         }
 
         match state {

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -194,6 +194,21 @@ describe("Bun.semver.order()", () => {
       expect(order(right, left)).toBe(0);
     }
   });
+
+  test("a '-' inside an implicit prerelease stays in the prerelease", () => {
+    // "1.0.0rc-1" is the loose spelling of "1.0.0-rc-1"; node-semver's loose
+    // parser keeps "rc-1" as the whole prerelease identifier.
+    const tests = [
+      ["1.0.0rc-1", "1.0.0-rc-1"],
+      ["1.0.0alpha-2", "1.0.0-alpha-2"],
+      ["1.0.0rc.1", "1.0.0-rc.1"],
+    ];
+
+    for (const [left, right] of tests) {
+      expect(order(left, right)).toBe(0);
+      expect(order(right, left)).toBe(0);
+    }
+  });
 });
 
 describe("Bun.semver.satisfies()", () => {
@@ -781,6 +796,13 @@ describe("Bun.semver.satisfies()", () => {
     for (const [range, version] of failing) {
       expect(satisfies(version, range)).toBeFalse();
     }
+  });
+
+  test("a '-' inside an implicit prerelease stays in the prerelease", () => {
+    expect(satisfies("1.0.0rc-1", "1.0.0-rc-1")).toBeTrue();
+    expect(satisfies("1.0.0alpha-2", "1.0.0-alpha-2")).toBeTrue();
+    // A different prerelease still does not satisfy.
+    expect(satisfies("1.0.0rc-2", "1.0.0-rc-1")).toBeFalse();
   });
 
   test("pre-release snapshot", () => {

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -178,6 +178,22 @@ describe("Bun.semver.order()", () => {
       expect(order(right, left)).toBe(0);
     }
   });
+
+  test("build metadata containing '-' is ignored", () => {
+    // '-' is a plain identifier character inside build metadata (semver 2.0 item 10),
+    // it must not start a prerelease once the '+' has been seen.
+    const tests = [
+      ["1.0.0+sha-abc", "1.0.0"],
+      ["1.0.0+sha-abc", "1.0.0+other"],
+      ["1.0.0-beta+sha-abc", "1.0.0-beta"],
+      ["1.2.3+build-2024.01.05", "1.2.3"],
+    ];
+
+    for (const [left, right] of tests) {
+      expect(order(left, right)).toBe(0);
+      expect(order(right, left)).toBe(0);
+    }
+  });
 });
 
 describe("Bun.semver.satisfies()", () => {
@@ -731,6 +747,38 @@ describe("Bun.semver.satisfies()", () => {
     ];
 
     for (const [range, version] of tests) {
+      expect(satisfies(version, range)).toBeFalse();
+    }
+  });
+
+  test("build metadata containing '-' is ignored", () => {
+    // Expected values verified against node-semver. Build metadata never affects
+    // range matching; '-' after the '+' must not be read as a prerelease marker.
+    const passing = [
+      ["*", "1.0.0+sha-abc"],
+      ["1.0.0", "1.0.0+sha-abc"],
+      [">=1.0.0", "1.0.0+sha-abc"],
+      ["^2.0.0", "2.1.0+build-2024"],
+      ["1.0.0-beta", "1.0.0-beta+sha-abc"],
+      ["1.0.0", "1.0.0+a-b-c.d-e"],
+      ["1.2.3+sha-abc", "1.2.3"],
+      ["^1.2.3+sha-abc", "1.3.0"],
+      ["1.2.3+sha-a - 2.4.3+sha-b", "1.5.0"],
+    ];
+
+    for (const [range, version] of passing) {
+      expect(satisfies(version, range)).toBeTrue();
+    }
+
+    // '-' before any '+' still starts a prerelease.
+    const failing = [
+      ["1.0.1", "1.0.0+sha-abc"],
+      ["^1.2.3+sha-abc", "1.2.0"],
+      ["^2.0.0", "2.1.0-build-2024"],
+      ["1.2.3+sha-a - 2.4.3+sha-b", "1.2.3-pre.2"],
+    ];
+
+    for (const [range, version] of failing) {
       expect(satisfies(version, range)).toBeFalse();
     }
   });


### PR DESCRIPTION
### What does this PR do?

The semver tag tokenizer (`Tag::parse_with_pre_count` in `src/semver/Version.rs`) restarts the prerelease state on every `-` it sees, even when it is already inside a prerelease or build identifier. Per semver 2.0 (items 9 and 10), `-` is an ordinary identifier character there; it only introduces a prerelease before the `+`. node-semver agrees on every case.

Two paths reach the bad transition:

**1. Build metadata containing a `-`.** `1.0.0+sha-abc` is read as the prerelease `1.0.0-abc` and its build metadata is dropped. Build suffixes with dashes are common (`+sha-<git>`, `+build-2024...`), so `satisfies` checks against them silently return false and `order` sorts them before the release they label.

```js
Bun.semver.satisfies("1.0.0+sha-abc", "*")     // false   node-semver: true
Bun.semver.satisfies("1.0.0+sha-abc", "1.0.0") // false   node-semver: true
Bun.semver.order("1.0.0+sha-abc", "1.0.0")     // -1      node-semver: 0
Bun.semver.satisfies("1.0.0+abc", "1.0.0")     // true    (no dash, so it works)
```

**2. An implicit (loose) prerelease containing a `-`.** On the `1.0.0rc.1`-style loose path, the tokenizer is already inside the prerelease but its state still says `None`, so a `-` restarts the prerelease and drops the prefix. `1.0.0rc-1` is parsed with prerelease `1` instead of `rc-1`. (Found by review; same root defect, same match arm.)

```js
Bun.semver.order("1.0.0rc-1", "1.0.0-rc-1")     // -1      node-semver loose: 0
Bun.semver.satisfies("1.0.0rc-1", "1.0.0-rc-1") // false   node-semver loose: true
```

### Fix

Two small changes in `Tag::parse_with_pre_count`:

- The `-` arm only enters the prerelease state from `State::None`. Once in `Pre` or `Build`, a `-` stays part of the current identifier.
- When `initial_pre_count > 0`, the state machine now starts in `State::Pre` instead of `State::None`. That makes the two `state == State::None && initial_pre_count > 0` special cases (in the `+` arm and after the loop) dead, so they are removed.

The `debug_assert` that build metadata never contains a `-` asserted the consequence of the old transition, so it goes too.

The length consumed by `Tag::parse` is identical in every case (only which field gets populated changes), so the hyphen-range detection in `SemverQuery.rs`, which runs on the bytes after the tag, is unaffected.

### Verification

Added four tests to `test/cli/install/semver.test.ts` (one `build metadata containing '-' is ignored` and one `a '-' inside an implicit prerelease stays in the prerelease` in each of the `order()` and `satisfies()` blocks). Every expected value was checked against node-semver 7.7.1, and all four fail on an unfixed bun. The file's 25 existing tests still pass.

Differential sweeps against node-semver 7.7.1, before and after:

| corpus | pairs | mismatches before | after |
| --- | --- | --- | --- |
| strict: satisfies | 2,520 | 227 | 0 |
| strict: order | 28,224 | 2,976 | 0 |
| loose (`1.0.0rc-1` style): satisfies | 1,344 | 24 | 0 |
| loose: order | 28,224 | 4,944 | 0 |

The version corpora are prerelease x build cross products with `-` on both sides of the `+`; the loose corpus additionally pairs each implicit spelling with its explicit `-` spelling.
