### PR TITLE
shell: fix use-after-free when poll re-registration fails during a poll-driven read

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -397,7 +397,11 @@ impl PosixBufferedReader {
         self.vtable.on_reader_error(err);
     }
 
-    pub fn register_poll(&mut self) {
+    /// Returns `false` when registration failed and `on_reader_error` was
+    /// dispatched. That callback may drop the last reference to the struct
+    /// embedding `self` (the shell `PipeReader` does exactly that), so the
+    /// caller must not touch `self` again after a `false` return.
+    pub fn register_poll(&mut self) -> bool {
         // Hoist vtable-derived scalars and
         // normalize self.handle to Poll before taking the single &mut borrow,
         // so no raw-pointer escape is needed.
@@ -407,7 +411,7 @@ impl PosixBufferedReader {
 
         if let PollOrFd::Fd(fd) = self.handle {
             if !self.flags.contains(PosixFlags::POLLABLE) {
-                return;
+                return true;
             }
             self.handle = PollOrFd::Poll(FilePollRef::init(
                 ev,
@@ -416,7 +420,7 @@ impl PosixBufferedReader {
             ));
         }
         let Some(poll) = self.handle.get_poll_mut() else {
-            return;
+            return true;
         };
         poll.set_owner(Owner::new(PollTag::BufferedReader, owner_ptr.cast()));
 
@@ -427,8 +431,9 @@ impl PosixBufferedReader {
         match poll.register_with_fd(lp.cast(), FilePollKind::Readable, poll.fd()) {
             sys::Result::Err(err) => {
                 self.vtable.on_reader_error(err);
+                false
             }
-            sys::Result::Ok(()) => {}
+            sys::Result::Ok(()) => true,
         }
     }
 
@@ -808,8 +813,10 @@ impl PosixBufferedReader {
         // SAFETY: `this` aliases the live `&mut parent`; single JS thread.
         // Shadow-rebind so the local `parent` is no longer the `noalias` arg
         // but a raw-ptr-derived borrow (precedent: `JSMySQLQuery::resolve`).
-        // The reader struct is an inline field of its parent (never freed
-        // mid-call), so `*this` stays a valid place across re-entry.
+        // The reader struct is an inline field of its parent, which
+        // `on_read_chunk` re-entry never frees per `BufferedReaderParent`'s
+        // contract. `on_reader_error` MAY free it, so nothing below touches
+        // `parent` after dispatching an error (see the EAGAIN arm).
         let parent = unsafe { &mut *this };
         let streaming = parent.vtable.is_streaming_enabled();
 
@@ -882,8 +889,11 @@ impl PosixBufferedReader {
                                     bun_core::debug_warn!(
                                         "Received EAGAIN while reading from a file. This is a bug.",
                                     );
-                                } else {
-                                    parent.register_poll();
+                                } else if !parent.register_poll() {
+                                    // `on_reader_error` ran and may have freed
+                                    // the struct embedding `parent`; the
+                                    // drained head must not be delivered.
+                                    return;
                                 }
 
                                 if head_start > 0 {

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -624,9 +624,12 @@ impl PosixBufferedReader {
         // Shadow-rebind so the local `parent` is no longer the `noalias` arg
         // but a raw-ptr-derived borrow whose loads must reload after each
         // opaque vtable call (precedent: `JSMySQLQuery::resolve`'s guard
-        // re-borrow). The reader struct is an inline field of its parent
-        // (never freed mid-call), so `*this` stays a valid place even if
-        // re-entry calls `done()`/`close()`.
+        // re-borrow). The reader struct is an inline field of its parent;
+        // `on_read_chunk` re-entry never frees it per `BufferedReaderParent`'s
+        // contract, so `*this` stays a valid place even if re-entry calls
+        // `done()`/`close()`. `on_reader_error` MAY free it, and every
+        // `register_poll()`/`on_error()` below is in tail position, so nothing
+        // touches `parent` after one can have dispatched it.
         let parent = unsafe { &mut *this };
         let mut received_hup = received_hup_initially;
         loop {

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -3,7 +3,7 @@
 // surfaces synchronously from inside the spawn call. The command must finish
 // with the syscall errno as its exit code, not tear state down under the spawn.
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, tempDir } from "harness";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
@@ -21,6 +21,12 @@ const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 //                            a fixed chunk ("FAKE-CHUNK\\n"), every later one
 //                            returns EAGAIN. Pins the "child wrote some bytes,
 //                            then stalled" interleaving so it is deterministic.
+//   SHELL_RECV_EAGAIN_FIRST=1 the first recv() on each AF_UNIX socket returns
+//                            EAGAIN, every later recv() is real. Pushes the
+//                            first successful read out of the eager spawn-time
+//                            read_all() and into the epoll dispatch.
+//   SHELL_FAIL_EPOLL_FROM=N  the Nth and every later epoll_ctl ADD/MOD on each
+//                            AF_UNIX socket fails with ENOMEM (1-based).
 // FilePoll registers the socketpair through the raw syscall(SYS_epoll_ctl,
 // ...) wrapper, not the libc epoll_ctl symbol, so the epoll modes interpose
 // syscall(2).
@@ -49,6 +55,8 @@ static int fail_recv = -1;
 static int fail_epoll = -1;
 static int fail_epoll_after = -1;
 static int recv_one_chunk = -1;
+static int recv_eagain_first = -1;
+static int fail_epoll_from = -1; /* 0 = off, N >= 1 = 1-based index of the first failing call */
 static unsigned char recv_count[MAX_FD];
 static unsigned char epoll_count[MAX_FD];
 
@@ -57,6 +65,11 @@ static void init_modes(void) {
   if (fail_epoll < 0) fail_epoll = getenv("SHELL_FAIL_EPOLL") != NULL;
   if (fail_epoll_after < 0) fail_epoll_after = getenv("SHELL_FAIL_EPOLL_AFTER") != NULL;
   if (recv_one_chunk < 0) recv_one_chunk = getenv("SHELL_RECV_ONE_CHUNK") != NULL;
+  if (recv_eagain_first < 0) recv_eagain_first = getenv("SHELL_RECV_EAGAIN_FIRST") != NULL;
+  if (fail_epoll_from < 0) {
+    const char *s = getenv("SHELL_FAIL_EPOLL_FROM");
+    fail_epoll_from = s ? atoi(s) : 0;
+  }
 }
 
 static int is_unix_sock(int fd) {
@@ -92,6 +105,10 @@ ssize_t recv(int fd, void *buf, size_t len, int flags) {
     errno = EAGAIN;
     return -1;
   }
+  if (recv_eagain_first && fd >= 0 && fd < MAX_FD && is_unix_sock(fd) && recv_count[fd]++ == 0) {
+    errno = EAGAIN;
+    return -1;
+  }
   return real_recv(fd, buf, len, flags);
 }
 
@@ -120,6 +137,12 @@ long syscall(long number, ...) {
       }
       if (fail_epoll_after && target >= 0 && target < MAX_FD && is_unix_sock(target)) {
         if (epoll_count[target]++ >= 1) {
+          errno = ENOMEM;
+          return -1;
+        }
+      }
+      if (fail_epoll_from > 0 && target >= 0 && target < MAX_FD && is_unix_sock(target)) {
+        if (++epoll_count[target] >= fail_epoll_from) {
           errno = ENOMEM;
           return -1;
         }
@@ -171,6 +194,21 @@ const r = await $\`sleep 5\`.quiet().nothrow();
 console.log(JSON.stringify({ exitCode: r.exitCode }));
 `;
 
+// For SHELL_RECV_EAGAIN_FIRST + SHELL_FAIL_EPOLL_FROM=3: the eager spawn-time
+// read gets EAGAIN and re-registers the poll (epoll_ctl #2, succeeds), so the
+// spawn returns and drops its keepalive. The child's bytes then wake the poll;
+// that read drains the chunk, hits a real EAGAIN, and its re-registration
+// (epoll_ctl #3) fails, tearing the stream down from under the in-flight read
+// while it still has the drained chunk to deliver. `exec sleep` keeps stdout
+// open so the poll-driven read sees data-then-EAGAIN instead of EOF, and
+// `2> /dev/null` makes stdout the only captured stream so the Cmd finishes
+// as soon as it errors instead of waiting out the child.
+const POLL_CHUNK_FIXTURE = /* js */ `
+import { $ } from "bun";
+const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.quiet().nothrow();
+console.log(JSON.stringify({ exitCode: r.exitCode }));
+`;
+
 let shimPath: string;
 let dir: ReturnType<typeof tempDir> | undefined;
 
@@ -181,6 +219,7 @@ beforeAll(async () => {
     "stdout-only.js": STDOUT_ONLY_FIXTURE,
     "both-pipes.js": BOTH_PIPES_FIXTURE,
     "quiet-chunk.js": QUIET_CHUNK_FIXTURE,
+    "poll-chunk.js": POLL_CHUNK_FIXTURE,
   });
   shimPath = join(String(dir), "shim.so");
   await using ccProc = Bun.spawn({
@@ -202,16 +241,32 @@ afterAll(() => {
 // The shell surfaces the failed syscall's errno as the command's exit code.
 const ENOMEM = 12;
 
-const MODES = ["SHELL_FAIL_RECV", "SHELL_FAIL_EPOLL", "SHELL_FAIL_EPOLL_AFTER", "SHELL_RECV_ONE_CHUNK"] as const;
+const MODES = [
+  "SHELL_FAIL_RECV",
+  "SHELL_FAIL_EPOLL",
+  "SHELL_FAIL_EPOLL_AFTER",
+  "SHELL_RECV_ONE_CHUNK",
+  "SHELL_RECV_EAGAIN_FIRST",
+] as const;
+// Integer-valued fault knobs; cleared alongside MODES and set through `extraEnv`.
+const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM"] as const;
 
-async function expectShellFault(script: string, modes: (typeof MODES)[number][]) {
+async function expectShellFault(
+  script: string,
+  modes: (typeof MODES)[number][],
+  extraEnv: Partial<Record<(typeof VALUE_MODES)[number], string>> = {},
+) {
   const existing = bunEnv.LD_PRELOAD;
   const env: Record<string, string | undefined> = {
     ...bunEnv,
     LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+    // ASAN symbolizes the whole debug binary before exiting on an error, which
+    // alone blows the per-test budget. No assertion reads the symbolized frames.
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
   };
-  for (const m of MODES) env[m] = undefined;
+  for (const m of [...MODES, ...VALUE_MODES]) env[m] = undefined;
   for (const m of modes) env[m] = "1";
+  Object.assign(env, extraEnv);
   await using proc = Bun.spawn({
     // If the fixture does crash, skip the debug build's slow symbolized
     // backtrace so the failure surfaces as the panic message, not a test
@@ -275,5 +330,18 @@ test.concurrent.skipIf(!isLinux || !cc)(
   "shell survives a poll re-registration failure after the eager read drained a chunk",
   async () => {
     await expectShellFault("quiet-chunk.js", ["SHELL_FAIL_EPOLL_AFTER", "SHELL_RECV_ONE_CHUNK"]);
+  },
+);
+
+// Same re-registration failure, but raised from the poll-driven read instead
+// of the eager spawn-time one. `Readable::start_pipe_reader` holds an Arc
+// across the eager read, but the epoll dispatch holds nothing, so when the
+// failed register_poll's on_reader_error dropped the last reference to the
+// PipeReader, read_with_fn's EAGAIN arm delivered the drained chunk to the
+// freed reader. ASAN: heap-use-after-free in PipeReader::on_read_chunk.
+test.concurrent.skipIf(!isLinux || !cc || !isASAN)(
+  "shell survives a poll re-registration failure during a poll-driven read",
+  async () => {
+    await expectShellFault("poll-chunk.js", ["SHELL_RECV_EAGAIN_FIRST"], { SHELL_FAIL_EPOLL_FROM: "3" });
   },
 );

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
-// Four env-selected fault modes:
+// Env-selected fault modes:
 //   SHELL_FAIL_RECV=1        every recv() fails with ENOMEM.
 //   SHELL_FAIL_EPOLL=1       every epoll_ctl ADD/MOD on a pipe-like fd fails
 //                            with ENOMEM.


### PR DESCRIPTION
## Problem

Heap use-after-free in Bun Shell when `epoll_ctl` fails while re-registering a pipe's `FilePoll` from a poll-driven read. Found by syscall-fault-injection fuzzing against `origin/main`. Follow-up to #32754, which fixed the same failure on the eager spawn-time read path.

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 1, thread T0
  #0 <bun_io::pipe_reader::BufferedReaderVTable>::link            io/PipeReader.rs:105
  #1 <bun_io::pipe_reader::BufferedReaderVTable>::on_read_chunk   io/PipeReader.rs:125
  #2 <bun_io::pipe_reader::PosixBufferedReader>::read_with_fn     io/PipeReader.rs:890
  #3 <bun_io::pipe_reader::PosixBufferedReader>::read_socket      io/PipeReader.rs:576
  #4 <bun_io::pipe_reader::PosixBufferedReader>::on_poll          io/PipeReader.rs:529
  #5 __bun_run_file_poll                                          runtime/dispatch.rs:677
freed by:
  <alloc::sync::Arc<bun_runtime::shell::subproc::PipeReader>>::drop
```

## Repro

1. `PipeReader::start` registers the poll and the eager spawn-time `read_all()` hits `EAGAIN`, so `read_with_fn`'s `EAGAIN` arm re-registers the poll and the spawn returns.
2. The child writes to stdout and the poll fires. `__bun_run_file_poll`'s `BUFFERED_READER` arm dispatches straight into `PosixBufferedReader::on_poll` with a bare `&mut *h` and no keepalive.
3. `read_with_fn` drains the chunk, `recv()` returns a real `EAGAIN`, and `register_poll()` issues another `epoll_ctl`, which fails (`ENOMEM` in the repro).
4. `register_poll` dispatches `on_reader_error`. The shell `PipeReader::on_reader_error` signals the `Cmd`, the `Readable::Pipe` `Arc` is dropped, and the callback's own `guard_from_raw` keepalive becomes the last reference. The code already documents this: "Dropping `guard` is the matching `deref()`; may free `this`."
5. Back in `read_with_fn`, the `EAGAIN` arm still delivers the drained head: `parent.vtable.on_read_chunk(.., ReadState::Drained)` reads the freed vtable.

Traced with the test's `LD_PRELOAD` shim:

```
[shim] epoll_ctl(ADD fd=13) unix call#1 -> ok       PipeReader::start
[shim] recv(fd=13)          unix call#1 -> EAGAIN   eager read, inside spawn
[shim] epoll_ctl(MOD fd=13) unix call#2 -> ok       re-register; spawn returns
[shim] recv(fd=13)          unix call#2             poll fired: the child's bytes
[shim] recv(fd=13)          unix call#3             real EAGAIN
[shim] epoll_ctl(MOD fd=13) unix call#3 -> ENOMEM   register_poll fails
[shell_subproc] PipeReader(0x..250) onReaderError errno: 12
[shell_subproc] PipeReader(0x..250, stdout) detach()
[shell_subproc] PipeReader(0x..250, stdout) deinit()
==ERROR: AddressSanitizer: heap-use-after-free
```

## Cause

`register_poll()`'s failure path dispatches `on_reader_error`, which the `BufferedReaderParent` contract explicitly allows to free the parent, but `register_poll` gave the caller no way to know that happened. `read_with_fn`'s `EAGAIN` arm is the only call site that touches the reader afterwards; every other `register_poll()` is in tail position. The `SAFETY` comment above the `parent` rebind claimed the parent is "never freed mid-call", which holds for `on_read_chunk` re-entry but not for `on_reader_error`.

#32754 covered this exact sequence on the eager spawn-time entry by holding an `Arc<PipeReader>` across `start()` and `read_all()` in `Readable::start_pipe_reader`. The epoll dispatch has no equivalent keepalive, so the poll-driven entry was still exposed.

## Fix

`PosixBufferedReader::register_poll()` now returns whether registration succeeded. `false` means `on_reader_error` was dispatched and `self` must not be touched again, so `read_with_fn`'s `EAGAIN` arm returns there instead of delivering the drained head to a possibly freed parent. The stream has already been completed with the registration error at that point, so nothing is lost. All other `register_poll()` call sites are tail calls and discard the result.

## Test

Two new modes in `test/js/bun/shell/shell-pipe-read-fault.test.ts`'s `LD_PRELOAD` fault shim:

- `SHELL_RECV_EAGAIN_FIRST=1`: the first `recv()` on each `AF_UNIX` socket returns `EAGAIN`, pushing the first successful read off the eager spawn-time `read_all()` and onto the epoll dispatch.
- `SHELL_FAIL_EPOLL_FROM=N`: the Nth and later `epoll_ctl` `ADD`/`MOD` on each `AF_UNIX` socket fail with `ENOMEM`. `N=3` lets the initial registration and the eager read's re-registration succeed, then fails the first poll-driven one.

The new test is `skipIf(!isASAN)` because the use-after-free is only reliably observable under ASAN. With `src/io/PipeReader.rs` reverted to `main` it fails in ~1.1s with the `heap-use-after-free` above; with the fix all 6 tests in the file pass.

## Out of scope

Shell `PipeReader::on_read_chunk` also calls `self.reader.register_poll()` from a `&mut self` method whose stated contract is that it never frees `self`. If that inner registration fails, the same free can happen under `read_with_fn`'s mid-loop flush instead of its `EAGAIN` arm. Reaching it needs a large (>32 KB) burst in one poll wake; I have not reproduced it, so it is not changed here.
