### PR TITLE
node:http2: treat frames on idle streams as connection errors (RFC 9113 5.1)

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -143,6 +143,14 @@ pub trait Sink {
     fn is_local_stream(&self, _stream_id: u32) -> bool {
         false
     }
+    /// Transition shim companion to `is_local_stream`: the highest stream id the embedder's legacy
+    /// layer has ever allocated or processed. The engine never sees outbound HEADERS, so once a
+    /// locally-opened stream is evicted after full close `is_local_stream` forgets it; this
+    /// high-water mark is what still distinguishes it (closed, §5.1) from an id neither peer ever
+    /// used (idle — where any frame but HEADERS/PRIORITY is a connection PROTOCOL_ERROR).
+    fn last_local_stream_id(&self) -> u32 {
+        0
+    }
 }
 
 pub struct Connection {
@@ -660,6 +668,15 @@ impl Connection {
     ) -> bool {
         let increment =
             u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]) & 0x7fff_ffff;
+        // §5.1: WINDOW_UPDATE on an idle stream is a connection error of type PROTOCOL_ERROR.
+        if self.is_idle_stream(sink, hdr.stream_id) {
+            self.send_go_away(
+                sink,
+                ErrorCode::ProtocolError,
+                b"WINDOW_UPDATE on idle stream",
+            );
+            return true;
+        }
         // §6.9.1: a 0 increment is an error (connection error on stream 0).
         if increment == 0 {
             if hdr.stream_id == 0 {
@@ -704,6 +721,21 @@ impl Connection {
     }
 
     // ---- Stream-level inbound ------------------------------------------
+
+    /// RFC 9113 §5.1: is `stream_id` idle, i.e. never opened by either peer? The engine is blind
+    /// to locally-initiated streams (the legacy encoder sends them — transition shim), so a stream
+    /// it has never seen is idle only if the embedder did not open it either and it is above both
+    /// sides' high-water marks; ids at or below them existed and were evicted after full close,
+    /// which makes them closed (a stream error), not idle (a connection error).
+    fn is_idle_stream(&self, sink: &impl Sink, stream_id: u32) -> bool {
+        if stream_id == 0 || sink.is_local_stream(stream_id) {
+            return false;
+        }
+        match self.streams.get(&stream_id) {
+            Some(s) => s.state == State::Idle,
+            None => stream_id > self.last_stream_id && stream_id > sink.last_local_stream_id(),
+        }
+    }
 
     /// RFC 9113 §6.2 HEADERS: strip padding/priority, then begin (or complete) the header block.
     fn handle_headers(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
@@ -756,6 +788,13 @@ impl Connection {
                 ErrorCode::ProtocolError,
                 b"invalid stream id for HEADERS",
             );
+            return true;
+        }
+        // §5.1 / §8.4: a server only creates streams with PUSH_PROMISE (which reserves the
+        // promised id before its HEADERS arrive), so a HEADERS frame a client receives on a
+        // stream it never opened is on an idle stream: a connection error of PROTOCOL_ERROR.
+        if !self.is_server && self.is_idle_stream(sink, hdr.stream_id) {
+            self.send_go_away(sink, ErrorCode::ProtocolError, b"HEADERS on idle stream");
             return true;
         }
         let refused = is_new && self.is_server && !sink.can_open_stream();
@@ -1084,6 +1123,13 @@ impl Connection {
             return StreamedDataStart::Fatal;
         }
 
+        // §5.1: DATA on an idle stream — one neither peer ever opened — is a connection error of
+        // type PROTOCOL_ERROR. Only a closed/evicted stream gets the STREAM_CLOSED reset below.
+        if self.is_idle_stream(sink, hdr.stream_id) {
+            self.send_go_away(sink, ErrorCode::ProtocolError, b"DATA on idle stream");
+            return StreamedDataStart::Fatal;
+        }
+
         if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
             let send_init = self.remote_settings.initial_window_size;
             let recv_init = self.local_settings.initial_window_size;
@@ -1206,6 +1252,13 @@ impl Connection {
             }
         }
 
+        // §5.1: DATA on an idle stream — one neither peer ever opened — is a connection error of
+        // type PROTOCOL_ERROR. Only a closed/evicted stream gets the STREAM_CLOSED reset below.
+        if self.is_idle_stream(sink, hdr.stream_id) {
+            self.send_go_away(sink, ErrorCode::ProtocolError, b"DATA on idle stream");
+            return true;
+        }
+
         // Per-stream flow control + state check, decided under a scoped borrow so the self.* calls
         // below don't alias the streams map.
         enum DataDecision {
@@ -1225,7 +1278,7 @@ impl Connection {
             .acked_local_initial_window
             .max(self.local_settings.initial_window_size) as i64;
         let decision = match self.streams.get_mut(&hdr.stream_id) {
-            // §5.1: DATA for an unknown/closed stream is a STREAM_CLOSED error.
+            // §5.1: DATA for a closed or evicted stream is a STREAM_CLOSED stream error.
             None => DataDecision::Rst(ErrorCode::StreamClosed),
             Some(s) => {
                 if !stream::can_receive_data(s.state) {
@@ -1309,17 +1362,16 @@ impl Connection {
     /// RFC 9113 §6.4 RST_STREAM.
     fn handle_rst_stream(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
         let code_raw = u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
-        // §5.1: RST_STREAM on an idle (or never-seen) stream is a connection PROTOCOL_ERROR.
-        let mut on_idle = match self.streams.get_mut(&hdr.stream_id) {
-            Some(s) if s.state != State::Idle => {
-                s.state = State::Closed;
-                false
-            }
-            _ => true,
-        };
-        // Transition shim: a stream the embedder opened locally (legacy outbound) is not idle even
-        // though this engine never saw its HEADERS go out.
-        if on_idle && sink.is_local_stream(hdr.stream_id) {
+        // §5.1: RST_STREAM on an idle stream is a connection PROTOCOL_ERROR.
+        if self.is_idle_stream(sink, hdr.stream_id) {
+            self.send_go_away(sink, ErrorCode::ProtocolError, b"RST_STREAM on idle stream");
+            return true;
+        }
+        if let Some(s) = self.streams.get_mut(&hdr.stream_id) {
+            s.state = State::Closed;
+        } else if sink.is_local_stream(hdr.stream_id) {
+            // Transition shim: a stream the embedder opened locally (legacy outbound) is not idle
+            // even though this engine never saw its HEADERS go out.
             let send_init = self.remote_settings.initial_window_size;
             let recv_init = self.local_settings.initial_window_size;
             let s = self
@@ -1327,17 +1379,10 @@ impl Connection {
                 .entry(hdr.stream_id)
                 .or_insert_with(|| Stream::new(send_init, recv_init));
             s.state = State::Closed;
-            on_idle = false;
-        }
-        // §5.1: a stream evicted after full close (per-request memory release) is
-        // closed, not idle — a late RST_STREAM on it MUST be tolerated. Anything at or
-        // below the highest stream id this connection has processed has existed.
-        if on_idle && hdr.stream_id <= self.last_stream_id {
+        } else {
+            // §5.1: a stream evicted after full close (per-request memory release) is closed,
+            // not idle — a late RST_STREAM on it MUST be tolerated.
             return false;
-        }
-        if on_idle {
-            self.send_go_away(sink, ErrorCode::ProtocolError, b"RST_STREAM on idle stream");
-            return true;
         }
         sink.on_stream_reset(hdr.stream_id, code_raw);
         false

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5695,6 +5695,13 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         self.streams.get().contains_key(&stream_id)
     }
 
+    fn last_local_stream_id(&self) -> u32 {
+        // The legacy layer's high-water mark: bumped for every locally allocated stream
+        // (get_next_stream) and every stream registered through handle_received_stream_id,
+        // so it also remembers locally-opened streams evicted after full close.
+        self.last_stream_id.get()
+    }
+
     fn on_push_promise(&self, _parent_id: u32, promised_id: u32) {
         // The promised request headers follow via on_header/on_headers_complete for promised_id;
         // remember it so that completion dispatches onStreamPush instead of onStreamHeaders.

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -306,6 +306,30 @@ describe("frame structure (checklist §2,§3)", () => {
     expect(goawayErrorCode(goaway)).toBe(ErrorCode.PROTOCOL_ERROR);
     c.destroy();
   });
+
+  // RFC 9113 §5.1: receiving any frame other than HEADERS or PRIORITY on a stream in the
+  // idle state MUST be treated as a connection error of type PROTOCOL_ERROR.
+  test("DATA on an idle stream is a PROTOCOL_ERROR (§5.1)", async () => {
+    const c = await RawH2.connect(port);
+    c.sendPreface();
+    c.sendEmptySettings();
+    c.sendFrame(FrameType.DATA, 0x1 /* END_STREAM */, 1, Buffer.from("x")); // stream 1 was never opened
+    const goaway = await c.waitForGoaway();
+    expect(goawayErrorCode(goaway)).toBe(ErrorCode.PROTOCOL_ERROR);
+    c.destroy();
+  });
+
+  test("WINDOW_UPDATE on an idle stream is a PROTOCOL_ERROR (§5.1)", async () => {
+    const c = await RawH2.connect(port);
+    c.sendPreface();
+    c.sendEmptySettings();
+    const inc = Buffer.alloc(4);
+    inc.writeUInt32BE(1, 0);
+    c.sendFrame(FrameType.WINDOW_UPDATE, 0, 1, inc); // stream 1 was never opened
+    const goaway = await c.waitForGoaway();
+    expect(goawayErrorCode(goaway)).toBe(ErrorCode.PROTOCOL_ERROR);
+    c.destroy();
+  });
 });
 
 describe("stream-id rules (checklist §3)", () => {
@@ -543,6 +567,97 @@ describe("push stream states (checklist §5.1, RFC 9113 §6.4/§8.4)", () => {
       raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
       await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
       expect(Buffer.concat(pushedData).length).toBe(0);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+});
+
+describe("frames on idle streams at the client (RFC 9113 §5.1)", () => {
+  // §5.1: receiving any frame other than HEADERS or PRIORITY on an idle stream MUST be treated
+  // as a connection error of type PROTOCOL_ERROR. A client's peer (a server) can only create
+  // streams with PUSH_PROMISE (§8.4), so for a client that has only opened stream 1:
+  //   - DATA/WINDOW_UPDATE on stream 5 (an odd id the client never allocated) is on an idle stream
+  //   - HEADERS on stream 2 (an even id that was never PUSH_PROMISEd) is on an idle stream
+  // The session must error and GOAWAY(PROTOCOL_ERROR) instead of staying "healthy" and letting
+  // later requests multiplex onto a connection whose peer is provably confused.
+  const windowUpdateInc = Buffer.alloc(4);
+  windowUpdateInc.writeUInt32BE(1, 0);
+  // A DATA frame header declaring a 4096-byte payload with only 10 bytes behind it: the
+  // client's incremental-DATA path (frame larger than the bytes available) must make the
+  // same idle-stream decision as a fully-buffered DATA frame.
+  const partialData = Buffer.alloc(9 + 10, 0x61);
+  partialData.writeUIntBE(4096, 0, 3);
+  partialData.writeUInt8(FrameType.DATA, 3);
+  partialData.writeUInt8(0, 4);
+  partialData.writeUInt32BE(5, 5);
+
+  const cases: [string, Buffer][] = [
+    ["DATA on an unopened client-numbered stream", encodeFrame(FrameType.DATA, 0x1, 5, Buffer.from("x"))],
+    ["a partially received DATA on an unopened stream", partialData],
+    // :status 200 (HPACK static table index 8), END_HEADERS | END_STREAM.
+    ["HEADERS on a never-promised even stream", encodeFrame(FrameType.HEADERS, 0x5, 2, Buffer.from([0x88]))],
+    ["WINDOW_UPDATE on an unopened stream", encodeFrame(FrameType.WINDOW_UPDATE, 0, 5, windowUpdateInc)],
+  ];
+
+  test.each(cases)("%s is a connection PROTOCOL_ERROR", async (_name, illegalFrame) => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    const sessionError = new Promise<NodeJS.ErrnoException>(resolve => client.once("error", resolve));
+    try {
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0); // server SETTINGS
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0); // ACK the client's
+      raw.socket!.write(illegalFrame);
+      // The client answers with a connection-level GOAWAY carrying PROTOCOL_ERROR...
+      const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
+      expect(goaway.payload.readUInt32BE(4)).toBe(ErrorCode.PROTOCOL_ERROR);
+      // ...and surfaces it as a session error, tearing the session down.
+      const err = await sessionError;
+      expect(err.code).toBe("ERR_HTTP2_SESSION_ERROR");
+      expect(err.message).toBe("Session closed with error code NGHTTP2_PROTOCOL_ERROR");
+      expect(client.destroyed).toBe(true);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  // The converse: a stream the client opened and then aborted before any response arrived is
+  // closed, not idle, once it is evicted. A stale server frame for it must stay a stream-level
+  // error; promoting it to a connection error would kill the whole session for a routine race.
+  test("a late frame on a locally aborted, already evicted stream is not a connection error", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    let sessionError: Error | null = null;
+    client.on("error", e => (sessionError = e));
+    try {
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      // Abort the request before the server ever responds, then let the stream fully close.
+      const closed = once(req, "close");
+      req.close();
+      await raw.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      await closed;
+      // One inbound round-trip so the client evicts the closed stream from its tables.
+      raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      // A stale server frame for the aborted stream lands in the next read.
+      raw.sendFrame(FrameType.DATA, 0x1 /* END_STREAM */, 1, Buffer.from("late"));
+      const opaque = Buffer.from("idlechk!");
+      raw.sendFrame(FrameType.PING, 0, 0, opaque);
+      // The connection is still alive and serviceable: the second PING is ACKed, no GOAWAY
+      // went out, and the session never errored.
+      await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0 && f.payload.equals(opaque));
+      expect(raw.frames.find(f => f.type === FrameType.GOAWAY)).toBeUndefined();
+      expect(sessionError).toBeNull();
+      expect(client.destroyed).toBe(false);
     } finally {
       client.destroy();
       raw.close();


### PR DESCRIPTION
### Problem

The `node:http2` client silently tolerates connection-fatal protocol violations. RFC 9113 section 5.1 says receiving any frame other than HEADERS or PRIORITY on an **idle** stream MUST be treated as a connection error of type PROTOCOL_ERROR. node's client (nghttp2) sends a GOAWAY and destroys the session; so did Bun's legacy inbound parser. The rewritten inbound engine (#31584) answers every unknown stream with a stream-level `RST_STREAM(STREAM_CLOSED)` instead, so the session stays "healthy":

| frame | node v26 | bun before | bun after |
|---|---|---|---|
| DATA on idle stream 5 (never opened by the client) | session error + GOAWAY | silently RSTs the stream | session error + GOAWAY(PROTOCOL_ERROR) |
| HEADERS on even stream 2 (never PUSH_PROMISEd) | session error + GOAWAY | opens a phantom stream | session error + GOAWAY(PROTOCOL_ERROR) |

A client that ignores frames on streams it never opened keeps multiplexing requests onto a connection whose peer is provably confused or malicious, which is exactly the situation connection errors exist to bail out of.

<details>
<summary>Repro (raw h2 server injects an illegal frame into a <code>http2.connect</code> client)</summary>

```js
const net = require("net"), http2 = require("http2");
const mode = process.argv[2] || "A";
function frame(t, fl, sid, p = Buffer.alloc(0)) {
  const h = Buffer.alloc(9);
  h.writeUIntBE(p.length, 0, 3); h.writeUInt8(t, 3); h.writeUInt8(fl, 4); h.writeUInt32BE(sid, 5);
  return Buffer.concat([h, p]);
}
const PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
const server = net.createServer(sock => {
  let buf = Buffer.alloc(0), preface = false, injected = false;
  sock.on("error", () => {});
  sock.on("data", d => {
    buf = Buffer.concat([buf, d]);
    if (!preface) { if (buf.length < 24) return; buf = buf.subarray(24); preface = true; sock.write(frame(4, 0, 0)); }
    while (buf.length >= 9) {
      const len = buf.readUIntBE(0, 3); if (buf.length < 9 + len) break;
      const t = buf.readUInt8(3), fl = buf.readUInt8(4); buf = buf.subarray(9 + len);
      if (t === 4 && !(fl & 1)) sock.write(frame(4, 1, 0));
      if (t === 1 && !injected) {
        injected = true;
        if (mode === "A") sock.write(frame(0, 1, 5, Buffer.from("boom"))); // DATA on idle stream 5
        else sock.write(frame(1, 5, 2, Buffer.from([0x88])));              // HEADERS on even stream 2
      }
    }
  });
});
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  let err = null;
  client.on("error", e => (err = e));
  const req = client.request({ ":path": "/" });
  req.on("error", () => {});
  req.end();
  setTimeout(() => { console.log({ err: err && err.code, destroyed: client.destroyed }); process.exit(0); }, 2500);
});
```

```
node  A: { err: 'ERR_HTTP2_ERROR',         destroyed: true }
node  B: { err: 'ERR_HTTP2_ERROR',         destroyed: true }
bun   A: { err: null,                      destroyed: false }   <-- before
bun   B: { err: null,                      destroyed: false }   <-- before
bun   A: { err: 'ERR_HTTP2_SESSION_ERROR', destroyed: true }    <-- after
bun   B: { err: 'ERR_HTTP2_SESSION_ERROR', destroyed: true }    <-- after
```
</details>

### Cause

In `src/runtime/api/bun/h2/connection.rs`, `handle_data` treats every stream not in the engine's map as closed (`DataDecision::Rst(ErrorCode::StreamClosed)`), `handle_headers` lets an inbound HEADERS open any new stream on a client, and `handle_window_update` ignores unknown streams entirely. Only `handle_rst_stream` kept the idle/closed distinction from RFC 9113 section 5.1. The legacy parser the engine replaced sent `GOAWAY(PROTOCOL_ERROR)` on these paths.

### Fix

`Connection::is_idle_stream(sink, id)` answers "is this stream in the idle state", consistent with nghttp2's `session_detect_idle_stream`: a stream is idle only if neither the engine nor the embedder knows it and it sits above both sides' high-water marks. DATA (both the whole-frame and the partial streamed path), client-side HEADERS, WINDOW_UPDATE, and RST_STREAM now route through it; a frame on an idle stream sends `GOAWAY(PROTOCOL_ERROR)` and errors the session.

The engine is blind to outbound HEADERS (the legacy encoder still sends them), and a fully closed stream is evicted from both the engine's and the legacy map, so without more the engine would mistake a locally opened, aborted, and evicted stream for an idle one when a stale server frame for it arrives. A new `Sink::last_local_stream_id()` shim (the sibling of the existing `is_local_stream` transition shim) exposes the legacy layer's stream high-water mark so such a stream stays closed (a stream error) rather than becoming a false connection error; `handle_rst_stream` inherits the same tolerance.

Known limit, unchanged from the existing `handle_rst_stream` design: both high-water marks mix the two stream parities, so an even never-promised stream id numerically below the client's own latest odd request id is still tolerated. That only under-detects (it can never produce a false connection error), and the first illegal frame on a fresh connection, which is the reported case, is always caught. Fixing it fully needs per-parity tracking across the transition shim, which is better done when the outbound half moves into the engine. `handle_push_promise` already validates its promised id and is deliberately untouched.

### Tests

`test/js/node/http2/h2-conformance.test.ts`:
* client direction (raw server, `http2.connect`): DATA on an unopened odd stream, a partially received DATA on an unopened stream, HEADERS on a never-promised even stream, and WINDOW_UPDATE on an unopened stream each produce `GOAWAY(PROTOCOL_ERROR)` on the wire plus an `ERR_HTTP2_SESSION_ERROR` session error, and the session is destroyed.
* server direction (raw client): DATA and WINDOW_UPDATE on an idle stream produce `GOAWAY(PROTOCOL_ERROR)`, next to the existing RST_STREAM sibling.
* negative: a stream the client opened, aborted with `close()`, and had evicted does not turn a stale server DATA frame into a connection error; the session stays alive and serviceable.

On the unfixed build all 6 positive tests fail (no GOAWAY ever arrives) and the negative passes; on the fixed build all 30 tests in the file pass. `test/js/node/http2/` is otherwise unchanged (286/287 in `node-http2.test.js`; the one timeout is the pre-existing 10,000-request `maxSessionMemory` test, which fails identically with this diff reverted).
