### PR TITLE
HTMLRewriter: stream the rewrite instead of buffering the whole document

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -6,8 +6,8 @@ use std::rc::Rc;
 
 use bun_core::MutableString;
 use bun_jsc::{
-    self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsResult, ProtectedJSValue,
-    StrongOptional, SystemError, bun_string_jsc,
+    self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsRef, JsResult,
+    ProtectedJSValue, SystemError, bun_string_jsc,
 };
 // Note: `bun_jsc::VirtualMachine` is a *module* re-export
 // (`pub use self::virtual_machine as VirtualMachine;`). The struct lives at
@@ -557,21 +557,22 @@ pub struct BufferOutputSink {
     // output sink re-enters `&mut *sink` while the rewriter runs.
     pub rewriter: *mut lol_html::HtmlRewriter<'static, SinkRef>, // null when unset
     pub context: Rc<RefCell<LOLHTMLContext>>,
-    pub response: *mut Response, // BORROW_FIELD: kept alive by response_value Strong
-    pub response_value: StrongOptional,
+    pub response: *mut Response, // BORROW_FIELD: wrapper held alive by `response_ref`
+    /// The output `Response`'s JS wrapper, held strong for this sink's
+    /// lifetime: the sink delivers into `response` from source callbacks
+    /// long after `transform()` returned, so the wrapper (whose
+    /// `visitChildrenImpl` in turn owns the body's stream and cached
+    /// values) must outlive it. This is the sink's only GC reference; the
+    /// stream a consumer attaches and any error are reached through, and
+    /// owned by, the `Response` object graph.
+    pub response_ref: JsRef,
     pub body_value_bufferer: Option<webcore::body::ValueBufferer<'static>>,
-    /// Set by `on_readable_stream_available` once a consumer streams the
-    /// output (`.body` / `Bun.serve`). While set, rewritten bytes are
-    /// pushed into its `ByteStream` instead of accumulating in `bytes`,
-    /// and `done()` closes that stream instead of swapping in a blob.
-    pub output_stream: webcore::readable_stream::Strong,
-    /// Set when a `write` on a source chunk fails (a parse error or a
-    /// thrown handler). The typed `RewritingError` exists only on the
-    /// failing call's frame, so the JS error is built there, once, and
-    /// shared by every later report. The rewriter is poisoned once this is
-    /// set: later chunks are dropped and completion reports this error
-    /// instead of calling `end()`.
-    pub write_error: StrongOptional,
+    /// `true` once lol-html fails (a `write` on a source chunk, or
+    /// `end()`). The rewriter is poisoned: later source chunks are
+    /// dropped, and `end()` must never run on it again. The JS error
+    /// itself is built and fully reported on the failing frame, never
+    /// stored here.
+    pub failed: bool,
     /// `true` while `drive_rewriter` is on the stack. `HtmlRewriter::write`
     /// runs user JS handlers, and an async handler blocks it by spinning
     /// the full event loop (`wait_for_promise`), during which the source
@@ -629,10 +630,9 @@ impl BufferOutputSink {
             rewriter: core::ptr::null_mut(),
             context,
             response: core::ptr::null_mut(),
-            response_value: StrongOptional::empty(),
+            response_ref: JsRef::empty(),
             body_value_bufferer: None,
-            output_stream: webcore::readable_stream::Strong::default(),
-            write_error: StrongOptional::empty(),
+            failed: false,
             writing: false,
             drain_scheduled: false,
             pending_input: MutableString::init_empty(),
@@ -759,8 +759,10 @@ impl BufferOutputSink {
         // Hold off on cloning until we're actually done.
         // SAFETY: (*sink).response == result (set above), live heap allocation.
         let response_js_value = unsafe { (*(*sink).response).to_js(&(*sink).global) };
+        // Strong for the sink's lifetime: source callbacks deliver into
+        // `response` long after `transform()` returned (see the field doc).
         // SAFETY: sink is a live heap allocation (refcount >= 1).
-        unsafe { (*sink).response_value.set(global, response_js_value) };
+        unsafe { (*sink).response_ref = JsRef::init_strong(response_js_value, global) };
 
         // SAFETY: result/original are live *Response (see SAFETY note above).
         // `url()` is +0 borrowed-bits; `set_url` takes +1 — `.clone()` to bump.
@@ -846,8 +848,8 @@ impl BufferOutputSink {
 
     /// `PendingValue::on_start_streaming`: seed the consumer's new
     /// `ByteStream` with whatever rewritten output already accumulated.
-    /// Always `Owned`: `Empty` would null the body and skip
-    /// `on_readable_stream_available`, orphaning the transform.
+    /// Always `Owned`: `Empty` would null the body and never build the
+    /// stream, orphaning the transform.
     fn on_start_streaming(ctx: *mut core::ffi::c_void) -> webcore::DrainResult {
         let sink = ctx.cast::<BufferOutputSink>();
         // SAFETY: `ctx` is a live sink (see block comment). The `&mut` is
@@ -858,23 +860,27 @@ impl BufferOutputSink {
         webcore::DrainResult::Owned { list, size_hint }
     }
 
-    /// `PendingValue::on_readable_stream_available`: remember the stream the
-    /// consumer will read so `SinkRef::handle_chunk` pushes into it. First
-    /// stream wins; a second materialization (the first consumer took
-    /// `locked.readable`, then `.body` ran again) is left empty rather than
-    /// swapping the active push target mid-transform.
+    /// `PendingValue::on_readable_stream_available`: stash the consumer's
+    /// new stream in the `Response` cell's `stream` WriteBarrier slot
+    /// (visited by its generated `visitChildrenImpl`), where
+    /// `consumer_stream` reads it back. `Bun.serve` moves the stream out
+    /// of the body `Value` and replaces it with `Used`
+    /// (`do_render_with_body`), so the body is not a stable path to it;
+    /// the JS cell's slot is. First stream wins. The sink itself holds no
+    /// reference.
     fn on_readable_stream_available(
         ctx: *mut core::ffi::c_void,
         global: &JSGlobalObject,
         readable: webcore::ReadableStream,
     ) {
         let sink = ctx.cast::<BufferOutputSink>();
-        // SAFETY: `ctx` is a live sink (see block comment).
-        unsafe {
-            if (*sink).output_stream.get(global).is_some() {
-                return;
-            }
-            (*sink).output_stream = webcore::readable_stream::Strong::init(readable, global);
+        // SAFETY: `ctx` is a live sink (see block comment); `response_ref`
+        // is set in `init()` before the source can deliver anything.
+        let Some(response_js) = (unsafe { &(*sink).response_ref }).try_get() else {
+            return;
+        };
+        if webcore::response::js::stream_get_cached(response_js).is_none() {
+            webcore::response::js::stream_set_cached(response_js, global, readable.value);
         }
     }
 
@@ -916,7 +922,7 @@ impl BufferOutputSink {
     /// refcount > 0 and `(*sink).rewriter` set.
     unsafe fn on_input_chunk(sink: *mut Self, bytes: &[u8], is_async: bool) {
         // SAFETY: sink is live (fn contract); raw field reads only.
-        let (failed, writing) = unsafe { ((*sink).write_error.has(), (*sink).writing) };
+        let (failed, writing) = unsafe { ((*sink).failed, (*sink).writing) };
         if failed || bytes.is_empty() {
             return;
         }
@@ -992,14 +998,16 @@ impl BufferOutputSink {
     /// so `writing` is set for the duration and the loop drains whatever
     /// accumulated once each `write` returns.
     ///
+    /// A fresh `write` failure is reported from this frame's tail, before
+    /// any deferred terminal signal is delivered. The error must not wait
+    /// for the source to end: on the asynchronous path every later chunk
+    /// is dropped and the terminal may be arbitrarily far away (or never
+    /// come), which would strand `.text()` / `.body` / `Bun.serve` for as
+    /// long as the upstream stays open.
+    ///
     /// `source_is_async` is whether the source is a still-open stream (the
-    /// microtask drain path) rather than the synchronous `init()` path. On
-    /// the stream path, a fresh `write` failure with no pending terminal is
-    /// reported to consumers immediately: every later chunk is dropped and
-    /// the terminal may be arbitrarily far away (or never come), so waiting
-    /// for it would strand `.text()` / `.body` / `Bun.serve` for as long as
-    /// the upstream stays open. The synchronous path needs no such report;
-    /// its `on_finished_buffering` runs on the same call chain.
+    /// microtask drain path) rather than the synchronous `init()` path; it
+    /// selects the error channel (the body vs. `transform()`'s throw slot).
     ///
     /// # Safety
     /// `sink` must be a live `BufferOutputSink` heap allocation with
@@ -1009,14 +1017,18 @@ impl BufferOutputSink {
         let (global, rewriter) = unsafe { ((*sink).global, (*sink).rewriter) };
         // SAFETY: sink live; caller guarantees `writing` is false.
         unsafe { (*sink).writing = true };
+        // The JS error from a failed `write`, built on that frame. It
+        // lives on this stack (conservatively scanned) until the tail
+        // reports it; it is never stored on the sink.
+        let mut failure: Option<JSValue> = None;
         // SAFETY: sink live (fn contract).
-        let was_already_failed = unsafe { (*sink).write_error.has() };
-        let mut failed = was_already_failed;
-        if !failed && !first.is_empty() {
+        let mut poisoned = unsafe { (*sink).failed };
+        if !poisoned && !first.is_empty() {
             // SAFETY: sink live; rewriter is (*sink).rewriter.
-            failed = unsafe { Self::write_chunk(sink, &global, rewriter, first) };
+            failure = unsafe { Self::write_chunk(sink, &global, rewriter, first) };
+            poisoned = failure.is_some();
         }
-        while !failed {
+        while !poisoned {
             // Each drained batch can itself suspend and queue more, so
             // loop until the queue stays empty.
             // SAFETY: sink live; the re-entrant call above has returned.
@@ -1028,10 +1040,18 @@ impl BufferOutputSink {
                 break;
             }
             // SAFETY: sink live; rewriter is (*sink).rewriter.
-            failed = unsafe { Self::write_chunk(sink, &global, rewriter, &queued) };
+            failure = unsafe { Self::write_chunk(sink, &global, rewriter, &queued) };
+            poisoned = failure.is_some();
         }
         // SAFETY: sink live.
         unsafe { (*sink).writing = false };
+        // Report a `write` failure from THIS frame before delivering any
+        // deferred terminal: the failure happened first, and `finish` on a
+        // poisoned sink has nothing left to report (see the fn doc).
+        if let Some(err) = failure {
+            // SAFETY: sink live (fn contract).
+            unsafe { Self::report_rewriter_failure(sink, &global, err, source_is_async) };
+        }
         // The source finished (or errored) on the asynchronous path; its
         // callback deferred here and kept its +1 ref, which `finish`
         // consumes.
@@ -1041,20 +1061,15 @@ impl BufferOutputSink {
             // consumes it). `is_async` is true because every deferral came
             // from the asynchronous path, whose error channel this is.
             unsafe { Self::finish(sink, terminal, true) };
-        } else if failed && !was_already_failed && source_is_async {
-            // A `write` failed on THIS frame and the source is still open:
-            // report to every consumer channel now instead of stranding
-            // them until the source ends (see the fn doc). The eventual
-            // source end re-enters `report_rewriter_failure`, which is
-            // idempotent (see its doc).
-            // SAFETY: sink live (fn contract).
-            unsafe { Self::report_rewriter_failure(sink, &global, true) };
         }
     }
 
-    /// One `HtmlRewriter::write`. On failure, capture the error on this
-    /// frame and poison the sink (see `write_error`). Returns whether the
-    /// write failed.
+    /// One `HtmlRewriter::write`. On failure, poison the sink and return
+    /// the JS error, built NOW on the failing frame: the typed
+    /// `RewritingError` exists only here, and a throwing handler's
+    /// captured JS exception (which it wraps) is consume-once. The caller
+    /// reports it before returning to JS. lol-html is poisoned after a
+    /// failed `write`, so `end()` must never run on this rewriter again.
     ///
     /// # Safety
     /// `sink` must be a live `BufferOutputSink` heap allocation with
@@ -1064,26 +1079,17 @@ impl BufferOutputSink {
         global: &JSGlobalObject,
         rewriter: *mut lol_html::HtmlRewriter<'static, SinkRef>,
         chunk: &[u8],
-    ) -> bool {
+    ) -> Option<JSValue> {
         // SAFETY: rewriter heap-allocated by init() and not yet freed: a
         // poisoned rewriter never reaches `end()` (which is what consumes
         // it), so it is still owned by the field until `Drop`.
         let Err(e) = (unsafe { (*rewriter).write(chunk) }) else {
-            return false;
+            return None;
         };
-        // Build the JS error NOW, on the same frame as the failing `write`:
-        // the typed `RewritingError` exists only here, and a throwing
-        // handler's captured JS exception (which it wraps) is consume-once.
-        // lol-html is poisoned after a failed `write`, so `end()` must
-        // never run on this rewriter again.
         // SAFETY: sink still live; the call above has returned so no other
         // `&mut *sink` exists.
-        unsafe {
-            (*sink)
-                .write_error
-                .set(global, create_lolhtml_error(global, &e))
-        };
-        true
+        unsafe { (*sink).failed = true };
+        Some(create_lolhtml_error(global, &e))
     }
 
     fn on_finished_buffering_trampoline(
@@ -1114,7 +1120,7 @@ impl BufferOutputSink {
         is_async: bool,
     ) {
         // Two situations must not drive the rewriter here, because both of
-        // its terminal paths (`end()` or reporting a `write_error`) can
+        // its terminal paths (`end()`, or reporting the source error) can
         // run user JS or must not run at all mid-write:
         // - `writing`: a `drive_rewriter` is suspended on this stack (an
         //   async handler is spinning the event loop); its own tail
@@ -1152,7 +1158,7 @@ impl BufferOutputSink {
     /// # Safety
     /// `sink` must be a live `BufferOutputSink` heap allocation with
     /// refcount > 0 and `(*sink).writing` false; `(*sink).response` must
-    /// be rooted by `response_value`.
+    /// be held alive by `response_ref`.
     unsafe fn finish(
         sink: *mut BufferOutputSink,
         js_err: Option<webcore::body::ValueError>,
@@ -1172,15 +1178,15 @@ impl BufferOutputSink {
         let global = unsafe { (*sink).global };
 
         if let Some(mut err) = js_err {
-            // A consumer already streaming the rewritten output must observe
-            // the failure: reject its stream before the body is rewritten
-            // below (which may have dropped `locked.readable` by then).
+            // Reject the stream a consumer is already reading. After
+            // `Bun.serve` takes it the body `Value` is `Used`, so the
+            // `to_error_instance` below never reaches that stream.
             // SAFETY: sink live (fn contract).
             unsafe {
-                Self::fail_output_stream(sink, &global, err.dupe(&global).to_stream_error(&global));
+                Self::fail_output_stream(sink, err.dupe(&global).to_stream_error(&global));
             }
             // SAFETY: (*sink).response is the heap Response allocated in init()
-            // and kept alive by (*sink).response_value (Strong root).
+            // and kept alive by (*sink).response_ref for the sink's lifetime.
             let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
             let sink_ptr_usize = sink as usize;
             // If a `.body` readable is already attached, stay `Locked` so
@@ -1220,12 +1226,12 @@ impl BufferOutputSink {
             return;
         }
 
-        // A `write` on some earlier source chunk failed. `end()` would
-        // panic on the poisoned rewriter; report the failure directly.
+        // A `write` on an earlier source chunk failed. `end()` would panic
+        // on the poisoned rewriter, and nothing is left to report: the
+        // failing `drive_rewriter` already delivered the error from its
+        // own tail (to the body, or to `transform()`'s throw slot).
         // SAFETY: sink live (fn contract).
-        if unsafe { (*sink).write_error.has() } {
-            // SAFETY: sink live (fn contract).
-            unsafe { Self::report_rewriter_failure(sink, &global, is_async) };
+        if unsafe { (*sink).failed } {
             return;
         }
 
@@ -1239,79 +1245,71 @@ impl BufferOutputSink {
         unsafe { (*sink).rewriter = core::ptr::null_mut() };
         // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
         if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
-            // Build the error once from the typed `RewritingError` and
-            // report it through every channel (the output stream, the body,
-            // and the synchronous `transform()` throw).
             // SAFETY: sink live; the call above has returned.
-            unsafe {
-                (*sink)
-                    .write_error
-                    .set(&global, create_lolhtml_error(&global, &e))
-            };
+            unsafe { (*sink).failed = true };
+            // Build the error from the typed `RewritingError`, which exists
+            // only on this frame, and report it now.
             // SAFETY: sink live (fn contract).
-            unsafe { Self::report_rewriter_failure(sink, &global, is_async) };
+            unsafe {
+                Self::report_rewriter_failure(
+                    sink,
+                    &global,
+                    create_lolhtml_error(&global, &e),
+                    is_async,
+                )
+            };
         }
     }
 
-    /// Reject a consumer streaming the rewritten output (if any) with `err`
-    /// and drop the sink's ref on that stream so a subsequent `done()`
-    /// takes the buffered path. `err` is consumed either way.
+    /// Reject a consumer streaming the rewritten output (if any) with
+    /// `err`. No-op once the stream is already closed or errored.
     ///
     /// # Safety
-    /// `sink` must be a live `BufferOutputSink` heap allocation
-    /// (refcount > 0).
-    unsafe fn fail_output_stream(
-        sink: *mut Self,
-        global: &JSGlobalObject,
-        err: streams::StreamError,
-    ) {
-        // SAFETY: sink live (fn contract); short shared reborrow of one
-        // field, nothing re-entrant runs while it is live.
-        let Some(out) = (unsafe { &(*sink).output_stream }).get(global) else {
+    /// `sink` must be a live `BufferOutputSink` heap allocation with
+    /// refcount > 0 and `(*sink).response` held alive by `response_ref`.
+    unsafe fn fail_output_stream(sink: *mut Self, err: streams::StreamError) {
+        // SAFETY: sink live (fn contract); `consumer_stream` forms a short
+        // `&Self` and nothing re-entrant runs while it is live.
+        let Some(out) = (unsafe { &*sink }).consumer_stream() else {
             return;
         };
         if let Some(byte_stream) = out.ptr.bytes() {
             let _ = byte_stream.on_data(StreamResult::Err(err));
         }
-        // SAFETY: sink live (fn contract).
-        unsafe { (*sink).output_stream.deinit() };
     }
 
     /// lol-html itself failed (a `write` on a source chunk, or `end()`):
-    /// surface the error through every channel a consumer may be waiting on.
+    /// deliver `err_value` to whoever is waiting. Called exactly once per
+    /// failure, on the failing frame, with the JS error built there.
     ///
-    /// `write_error` is set by the failing call (`write_chunk`, or the
-    /// `end()` arm in `finish`) from the typed error on that frame; the
-    /// fallback below is unreachable in practice and exists only so a
-    /// future caller cannot report an empty error.
-    ///
-    /// Idempotent. A fresh `write` failure is reported immediately from
-    /// `drive_rewriter`, and the real source end then reports again through
-    /// `finish`. Every channel tolerates the second delivery:
-    /// `fail_output_stream` no-ops once the stream is dropped,
-    /// `write_error.get()` is a peek (not a take), and `to_error_instance`
-    /// on an already-`Error` body is a same-`err` overwrite.
+    /// Asynchronous source: error the consumer's stream directly (after
+    /// `Bun.serve` takes it, the body `Value` is `Used` and no longer
+    /// reaches it), then put the body into `Error`, which also rejects a
+    /// pending `.text()` / `.json()` promise. Synchronous source:
+    /// `transform()` is still on the stack and the error becomes its
+    /// throw; nothing can be attached to a `Response` the caller has
+    /// never seen.
     ///
     /// # Safety
     /// `sink` must be a live `BufferOutputSink` heap allocation with
-    /// refcount > 0 and `(*sink).response` rooted by `response_value`.
-    unsafe fn report_rewriter_failure(sink: *mut Self, global: &JSGlobalObject, is_async: bool) {
-        // SAFETY: sink live (fn contract); short shared reborrow of one field.
-        let err_value = (unsafe { &(*sink).write_error })
-            .get()
-            .unwrap_or_else(|| create_lolhtml_error(global, &"The HTMLRewriter failed"));
-        // SAFETY: sink live (fn contract).
-        unsafe {
-            Self::fail_output_stream(
-                sink,
-                global,
-                streams::StreamError::JSValue(jsc::strong::Optional::create(err_value, global)),
-            );
-        }
+    /// refcount > 0 and `(*sink).response` held alive by `response_ref`.
+    unsafe fn report_rewriter_failure(
+        sink: *mut Self,
+        global: &JSGlobalObject,
+        err_value: JSValue,
+        is_async: bool,
+    ) {
         if is_async {
+            // SAFETY: sink live (fn contract).
+            unsafe {
+                Self::fail_output_stream(
+                    sink,
+                    streams::StreamError::JSValue(jsc::strong::Optional::create(err_value, global)),
+                );
+            }
             // `to_error_instance` only fails when the VM is terminating;
             // there is nowhere left to report to (same as `done()`).
-            // SAFETY: response kept alive by response_value Strong.
+            // SAFETY: response kept alive by `response_ref` (fn contract).
             let _ = unsafe { (*(*sink).response).get_body_value() }.to_error_instance(
                 webcore::body::ValueError::JSValue(jsc::strong::Optional::create(
                     err_value, global,
@@ -1333,13 +1331,13 @@ impl BufferOutputSink {
     /// completion path (done, rewriter failure, source error, early bail).
     fn detach_from_output_body(&mut self) {
         // The builder-failure path in `init()` frees `response` before
-        // `response_value` is ever set; only a rooted wrapper guarantees
+        // `response_ref` is ever set; only a held wrapper guarantees
         // `self.response` is still live.
-        if self.response_value.get().is_none() {
+        if self.response_ref.try_get().is_none() {
             return;
         }
-        // SAFETY: `response_value` (Strong) roots the JS Response wrapper,
-        // which owns `response` as its m_ctx; both outlive this call.
+        // SAFETY: `response_ref` holds the JS Response wrapper, which owns
+        // `response` as its m_ctx; both outlive this call.
         let body_value = unsafe { (*self.response).get_body_value() };
         let self_usize = std::ptr::from_mut(self) as usize;
         if let webcore::body::Value::Locked(l) = body_value {
@@ -1351,20 +1349,31 @@ impl BufferOutputSink {
         }
     }
 
+    /// The `ReadableStream` a consumer attached to the output `Response`,
+    /// if any. The `Response` owns it: `on_readable_stream_available`
+    /// put it in the cell's `stream` WriteBarrier slot, which the
+    /// generated `visitChildrenImpl` visits and which
+    /// `get_body_readable_stream` reads first. The sink never takes a
+    /// reference of its own.
+    fn consumer_stream(&self) -> Option<webcore::ReadableStream> {
+        // SAFETY: `self.response` is the live m_ctx of the `Response`
+        // wrapper `self.response_ref` holds for this sink's lifetime.
+        unsafe { (*self.response).get_body_readable_stream(&self.global) }
+    }
+
     pub fn done(&mut self) {
-        // A consumer is streaming the output: close its `ByteStream`. The
-        // body `Value` stays `Locked { readable }`; the data already went
-        // through the stream, exactly like a completed `fetch()` body.
-        if let Some(out) = self.output_stream.get(&self.global) {
+        // A consumer is streaming the output: close its `ByteStream`.
+        // Whoever took the stream (the reader, or `Bun.serve`) owns it;
+        // the data already went through it, like a completed `fetch()`.
+        if let Some(out) = self.consumer_stream() {
             if let Some(byte_stream) = out.ptr.bytes() {
                 let _ = byte_stream.on_data(StreamResult::Done);
             }
-            self.output_stream.deinit();
             return;
         }
 
-        // SAFETY: self.response is kept alive by self.response_value (Strong
-        // root) for the lifetime of this sink.
+        // SAFETY: self.response is kept alive by self.response_ref for the
+        // lifetime of this sink.
         let body_value = unsafe { (*self.response).get_body_value() };
         // An earlier source/handler error already put the body into the
         // `Error` state; the buffered output is incomplete, so don't
@@ -1388,7 +1397,7 @@ impl BufferOutputSink {
         // A consumer is streaming: hand the rewritten bytes straight to its
         // `ByteStream`. `on_data` copies `Temporary` slices synchronously
         // and runs no user JS, so the enclosing `&mut self` stays unique.
-        if let Some(out) = self.output_stream.get(&self.global) {
+        if let Some(out) = self.consumer_stream() {
             if let Some(byte_stream) = out.ptr.bytes() {
                 let _ = byte_stream.on_data(StreamResult::Temporary(bun_ptr::RawSlice::new(bytes)));
                 return;
@@ -1427,12 +1436,12 @@ pub enum BufferOutputSinkSync {
 
 impl Drop for BufferOutputSink {
     fn drop(&mut self) {
-        // Must run before `response_value` (a struct field) drops: after
-        // that, nothing roots the output Response and its `Locked` body's
+        // Must run before `response_ref` (a struct field) drops: after
+        // that, nothing holds the output Response and its `Locked` body's
         // callback pointers into this about-to-be-freed sink.
         self.detach_from_output_body();
-        // bytes, output_stream (Strong), body_value_bufferer, context (Rc),
-        // response_value (Strong) drop automatically.
+        // bytes, body_value_bufferer, context (Rc), response_ref drop
+        // automatically.
         if !self.rewriter.is_null() {
             // SAFETY: rewriter heap-allocated by init() and not yet freed
             // (`finish` nulls the field before consuming it in `end`).

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -544,21 +544,50 @@ impl HTMLRewriter {
 
 // ───────────────────────── BufferOutputSink ──────────────────────────────
 
-#[derive(bun_ptr::CellRefCounted)]
-pub struct BufferOutputSink {
-    // Intrusive RefCount; *Self is the `SinkRef` carried inside `rewriter`.
-    ref_count: Cell<u32>,
-    pub global: GlobalRef, // JSC_BORROW
+/// The driver's queueing state. Touched by the source's callbacks (a
+/// chunk, the terminal) and by the drain task, possibly while
+/// `drive_rewriter` is suspended on an async element handler spinning the
+/// event loop. Never touched from inside a lol-html `write()`/`end()`
+/// call itself, so `drive_rewriter` never holds a borrow of it across one.
+struct Driver {
+    /// `true` once lol-html fails (a `write` on a source chunk, or
+    /// `end()`). The rewriter is poisoned: later source chunks are
+    /// dropped, and `end()` must never run on it again. The JS error
+    /// itself is built and fully reported on the failing frame, never
+    /// stored here.
+    failed: bool,
+    /// `true` while `drive_rewriter` is on the stack. `HtmlRewriter::write`
+    /// runs user JS handlers, and an async handler blocks it by spinning
+    /// the full event loop (`wait_for_promise`), during which the source
+    /// can deliver more chunks or finish. lol-html is not re-entrant, so
+    /// those signals are queued in the fields below and drained by the
+    /// suspended `drive_rewriter` once its in-flight `write` returns.
+    writing: bool,
+    /// `true` while a drain task is enqueued and has not yet run.
+    drain_scheduled: bool,
+    /// Source bytes not yet fed to lol-html: either queued by the
+    /// asynchronous delivery paths for the next drain task, or
+    /// queued by a re-entrant arrival while `drive_rewriter` is suspended.
+    pending_input: MutableString,
+    /// Deferred terminal source signal: `Some(None)` is a clean end,
+    /// `Some(Some(e))` a source error. The deferring
+    /// `on_finished_buffering` keeps its +1 ref on the sink; `finish`
+    /// (invoked from `drive_rewriter`'s tail) consumes it.
+    pending_finish: Option<Option<webcore::body::ValueError>>,
+}
+
+/// The output half: what lol-html's `SinkRef::handle_chunk` and the output
+/// body's streaming hooks touch, always from INSIDE a `write()`/`end()`
+/// (as the re-entrant output callback, or as a user element handler that
+/// reached the output `Response`). A borrow of it is never held across a
+/// call that can run lol-html or user JS.
+struct Out {
     /// Rewritten output not yet handed to a consumer. Drained into the
     /// output stream's initial buffer by `on_start_streaming`, or resolved
     /// as the body's `InternalBlob` in `done()` if nothing streamed.
-    pub bytes: MutableString,
-    // Heap-allocated (never held by value): `drive_rewriter` must reach the
-    // rewriter through a raw pointer, never a `&mut` of `*sink`, because the
-    // output sink re-enters `&mut *sink` while the rewriter runs.
-    pub rewriter: *mut lol_html::HtmlRewriter<'static, SinkRef>, // null when unset
-    pub context: Rc<RefCell<LOLHTMLContext>>,
-    pub response: *mut Response, // BORROW_FIELD: wrapper held alive by `response_ref`
+    bytes: MutableString,
+    /// BORROW_FIELD: the wrapper is held alive by `response_ref`.
+    response: *mut Response,
     /// The output `Response`'s JS wrapper, held strong for this sink's
     /// lifetime: the sink delivers into `response` from source callbacks
     /// long after `transform()` returned, so the wrapper (whose
@@ -566,40 +595,48 @@ pub struct BufferOutputSink {
     /// values) must outlive it. This is the sink's only GC reference; the
     /// stream a consumer attaches and any error are reached through, and
     /// owned by, the `Response` object graph.
-    pub response_ref: JsRef,
-    pub body_value_bufferer: Option<webcore::body::ValueBufferer<'static>>,
-    /// `true` once lol-html fails (a `write` on a source chunk, or
-    /// `end()`). The rewriter is poisoned: later source chunks are
-    /// dropped, and `end()` must never run on it again. The JS error
-    /// itself is built and fully reported on the failing frame, never
-    /// stored here.
-    pub failed: bool,
-    /// `true` while `drive_rewriter` is on the stack. `HtmlRewriter::write`
-    /// runs user JS handlers, and an async handler blocks it by spinning
-    /// the full event loop (`wait_for_promise`), during which the source
-    /// can deliver more chunks or finish. lol-html is not re-entrant, so
-    /// those signals are queued in the fields below and drained by the
-    /// suspended `drive_rewriter` once its in-flight `write` returns.
-    pub writing: bool,
-    /// `true` while a drain task is enqueued and has not yet run.
-    pub drain_scheduled: bool,
-    /// The event-loop task `schedule_drain` enqueues. It lives on the
-    /// sink (a stable heap address) so the event loop holds a pointer to
-    /// it; `drain_scheduled` guarantees at most one is in flight.
-    drain_task: AnyTask,
-    /// Source bytes not yet fed to lol-html: either queued by the
-    /// asynchronous delivery paths for the next drain task, or
-    /// queued by a re-entrant arrival while `drive_rewriter` is suspended.
-    pub pending_input: MutableString,
-    /// Deferred terminal source signal: `Some(None)` is a clean end,
-    /// `Some(Some(e))` a source error. The deferring
-    /// `on_finished_buffering` keeps its +1 ref on the sink; `finish`
-    /// (invoked from `drive_rewriter`'s tail) consumes it.
-    pub pending_finish: Option<Option<webcore::body::ValueError>>,
+    response_ref: JsRef,
+}
+
+/// Re-entrancy: `HtmlRewriter::write()` calls back into
+/// `SinkRef::handle_chunk` (which carries a `*mut BufferOutputSink`) and
+/// runs user element handlers, which can synchronously reach the output
+/// `Response`'s streaming hooks and, for an async handler, spin the whole
+/// event loop. So every entry point here forms only a SHARED `&Self` from
+/// its `*mut Self` (never `&mut Self`, which would alias), and the three
+/// interior-mutability domains below are disjoint: nothing re-entered from
+/// inside a `write()`/`end()` borrows the cell the driver is holding.
+/// `RefCell` makes a violated domain a loud panic instead of aliasing UB.
+#[derive(bun_ptr::CellRefCounted)]
+pub struct BufferOutputSink {
+    // Intrusive RefCount; *Self is the `SinkRef` carried inside `rewriter`.
+    ref_count: Cell<u32>,
+    pub global: GlobalRef, // JSC_BORROW
+    pub context: Rc<RefCell<LOLHTMLContext>>,
+    /// Set once in `init()` and never touched again until `Drop`. Plain
+    /// (not celled): `Body.rs`'s stream machinery holds raw pointers into
+    /// the bufferer for the source's lifetime, which a `RefCell` borrow
+    /// could not cover.
+    body_value_bufferer: Option<webcore::body::ValueBufferer<'static>>,
     // Points at the `sink_error` stack local in `init()`;
     // only written while `init()` is on the stack.
     // See `write_tmp_sync_error` for the full liveness/provenance argument.
-    pub tmp_sync_error: Option<NonNull<JSValue>>,
+    tmp_sync_error: Option<NonNull<JSValue>>,
+    /// The event-loop task `schedule_drain` enqueues. `UnsafeCell`: the
+    /// event loop holds a raw pointer to it between enqueue and run, and
+    /// forms its own `&mut` through that pointer to run it, which must
+    /// not be invalidated by a `RefCell` borrow ending in between.
+    /// `drain_scheduled` guarantees at most one is outstanding, so the
+    /// write in `schedule_drain` never overlaps the event loop's read.
+    drain_task: core::cell::UnsafeCell<AnyTask>,
+    /// Borrowed mutably only by `drive_rewriter` (across `write()`) and
+    /// `finish` (which takes it out before `end()`). Nothing re-entered
+    /// from inside lol-html touches it: a chunk or terminal arriving
+    /// while `drive_rewriter` is suspended goes to `driver` instead, and
+    /// a stale drain task bails on `driver.writing` before reaching here.
+    rewriter: RefCell<Option<lol_html::HtmlRewriter<'static, SinkRef>>>,
+    driver: RefCell<Driver>,
+    out: RefCell<Out>,
 }
 
 impl BufferOutputSink {
@@ -613,11 +650,11 @@ impl BufferOutputSink {
     /// still on the stack, so the pointee is live and the `Cell`-derived
     /// pointer carries `SharedReadWrite` provenance.
     #[inline]
-    fn write_tmp_sync_error(sink: *mut Self, err: JSValue) {
-        // SAFETY: `sink` is a live heap allocation (refcount > 0, caller
-        // invariant); `tmp_sync_error` was set in `init()` and the synchronous
-        // caller is reached only while `init()` is still on the stack.
-        unsafe { *(*sink).tmp_sync_error.unwrap().as_ptr() = err };
+    fn write_tmp_sync_error(this: &Self, err: JSValue) {
+        // SAFETY: `tmp_sync_error` was set in `init()` and the synchronous
+        // caller is reached only while `init()` is still on the stack, so
+        // the pointee (`init`'s `sink_error` stack `Cell`) is live.
+        unsafe { *this.tmp_sync_error.unwrap().as_ptr() = err };
     }
 
     /// # Safety
@@ -631,19 +668,23 @@ impl BufferOutputSink {
         let sink = bun_core::heap::into_raw(Box::new(BufferOutputSink {
             ref_count: Cell::new(1),
             global: GlobalRef::from(global),
-            bytes: MutableString::init_empty(),
-            rewriter: core::ptr::null_mut(),
             context,
-            response: core::ptr::null_mut(),
-            response_ref: JsRef::empty(),
             body_value_bufferer: None,
-            failed: false,
-            writing: false,
-            drain_scheduled: false,
-            drain_task: AnyTask::default(),
-            pending_input: MutableString::init_empty(),
-            pending_finish: None,
             tmp_sync_error: None,
+            drain_task: core::cell::UnsafeCell::new(AnyTask::default()),
+            rewriter: RefCell::new(None),
+            driver: RefCell::new(Driver {
+                failed: false,
+                writing: false,
+                drain_scheduled: false,
+                pending_input: MutableString::init_empty(),
+                pending_finish: None,
+            }),
+            out: RefCell::new(Out {
+                bytes: MutableString::init_empty(),
+                response: core::ptr::null_mut(),
+                response_ref: JsRef::empty(),
+            }),
         }));
         // SAFETY: `sink` is the `heap::into_raw` allocation above; refcount >= 1.
         let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
@@ -673,7 +714,7 @@ impl BufferOutputSink {
         )));
 
         // SAFETY: sink was just allocated via heap::alloc above; refcount==1.
-        unsafe { (*sink).response = result };
+        unsafe { (*sink).out.borrow_mut().response = result };
         // Note (Stacked Borrows): `sink_error` is written via raw pointer
         // by the unhandled-rejection handler during `bufferer.run()` and via
         // `tmp_sync_error` from `on_finished_buffering`. Use a `Cell` so the
@@ -716,10 +757,10 @@ impl BufferOutputSink {
         // of `(*sink).context` is released at the end of this statement.
         let (element_content_handlers, document_content_handlers) =
             unsafe { build_settings(&mut (*sink).context.borrow_mut()) };
-        // `SinkRef` carries the raw `sink` (`heap::into_raw` root) so every
-        // `(*sink).field` access shares its provenance; `drive_rewriter` and
-        // `finish` reach the rewriter through a raw pointer, never `&mut *sink`.
-        let rewriter = bun_core::heap::into_raw(Box::new(lol_html::HtmlRewriter::new(
+        // `SinkRef` carries the raw `sink` (the `heap::into_raw` root) so
+        // every entry point it re-enters shares that pointer's provenance
+        // and forms only a shared `&BufferOutputSink` (see the struct doc).
+        let rewriter = lol_html::HtmlRewriter::new(
             lol_html::Settings {
                 element_content_handlers,
                 document_content_handlers,
@@ -739,9 +780,9 @@ impl BufferOutputSink {
                 adjust_charset_on_meta_tag: false,
             },
             SinkRef(sink),
-        )));
+        );
         // SAFETY: sink is a live heap allocation (refcount >= 1).
-        unsafe { (*sink).rewriter = rewriter };
+        *unsafe { (*sink).rewriter.borrow_mut() } = Some(rewriter);
 
         // SAFETY: result and original are both live *Response (result allocated
         // above, original kept alive by caller); no aliasing &mut exists.
@@ -763,12 +804,14 @@ impl BufferOutputSink {
         }
 
         // Hold off on cloning until we're actually done.
-        // SAFETY: (*sink).response == result (set above), live heap allocation.
-        let response_js_value = unsafe { (*(*sink).response).to_js(&(*sink).global) };
+        // SAFETY: `result` is the live heap `Response` allocated above.
+        let response_js_value = unsafe { (*result).to_js(global) };
         // Strong for the sink's lifetime: source callbacks deliver into
         // `response` long after `transform()` returned (see the field doc).
         // SAFETY: sink is a live heap allocation (refcount >= 1).
-        unsafe { (*sink).response_ref = JsRef::init_strong(response_js_value, global) };
+        unsafe {
+            (*sink).out.borrow_mut().response_ref = JsRef::init_strong(response_js_value, global)
+        };
 
         // SAFETY: result/original are live *Response (see SAFETY note above).
         // `url()` is +0 borrowed-bits; `set_url` takes +1 — `.clone()` to bump.
@@ -857,11 +900,13 @@ impl BufferOutputSink {
     /// Always `Owned`: `Empty` would null the body and never build the
     /// stream, orphaning the transform.
     fn on_start_streaming(ctx: *mut core::ffi::c_void) -> webcore::DrainResult {
-        let sink = ctx.cast::<BufferOutputSink>();
-        // SAFETY: `ctx` is a live sink (see block comment). The `&mut` is
-        // scoped to the single field for the duration of `replace`.
-        let list =
-            unsafe { core::mem::replace(&mut (*sink).bytes, MutableString::init_empty()) }.list;
+        // SAFETY: `ctx` is a live sink (see block comment).
+        let this = unsafe { &*ctx.cast::<BufferOutputSink>() };
+        let list = core::mem::replace(
+            &mut this.out.borrow_mut().bytes,
+            MutableString::init_empty(),
+        )
+        .list;
         let size_hint = list.len();
         webcore::DrainResult::Owned { list, size_hint }
     }
@@ -879,10 +924,10 @@ impl BufferOutputSink {
         global: &JSGlobalObject,
         readable: webcore::ReadableStream,
     ) {
-        let sink = ctx.cast::<BufferOutputSink>();
-        // SAFETY: `ctx` is a live sink (see block comment); `response_ref`
-        // is set in `init()` before the source can deliver anything.
-        let Some(response_js) = (unsafe { &(*sink).response_ref }).try_get() else {
+        // SAFETY: `ctx` is a live sink (see block comment).
+        let this = unsafe { &*ctx.cast::<BufferOutputSink>() };
+        // `response_ref` is set in `init()` before the source can deliver.
+        let Some(response_js) = this.out.borrow().response_ref.try_get() else {
             return;
         };
         if webcore::response::js::stream_get_cached(response_js).is_none() {
@@ -928,25 +973,31 @@ impl BufferOutputSink {
     /// `sink` must be a live `BufferOutputSink` heap allocation with
     /// refcount > 0 and `(*sink).rewriter` set.
     unsafe fn on_input_chunk(sink: *mut Self, bytes: &[u8], is_async: bool) {
-        // SAFETY: sink is live (fn contract); raw field reads only.
-        let (failed, writing) = unsafe { ((*sink).failed, (*sink).writing) };
-        if failed || bytes.is_empty() {
-            return;
-        }
+        // SAFETY: sink is live (fn contract).
+        let this = unsafe { &*sink };
+        let writing = {
+            let mut d = this.driver.borrow_mut();
+            if d.failed || bytes.is_empty() {
+                return;
+            }
+            if d.writing || is_async {
+                let _ = d.pending_input.append(bytes); // OOM: fire-and-forget
+            }
+            d.writing
+        };
         if writing {
-            // SAFETY: sink live; the suspended `drive_rewriter` holds no
-            // borrow of `pending_input` (it read its fields into locals).
-            let _ = unsafe { (*sink).pending_input.append(bytes) }; // OOM: fire-and-forget
+            // A `drive_rewriter` is suspended on this stack (an async
+            // handler is spinning the event loop inside a `write`); its own
+            // loop drains what was just queued once that write returns.
             return;
         }
         if is_async {
-            // SAFETY: sink live; no borrow of `pending_input` exists.
-            let _ = unsafe { (*sink).pending_input.append(bytes) }; // OOM: fire-and-forget
             // SAFETY: sink live (fn contract).
             unsafe { Self::schedule_drain(sink) };
             return;
         }
-        // SAFETY: sink live (fn contract); `writing` is false.
+        // The `driver` borrow above is released; `writing` is false.
+        // SAFETY: sink live (fn contract).
         unsafe { Self::drive_rewriter(sink, bytes, false) };
     }
 
@@ -965,21 +1016,26 @@ impl BufferOutputSink {
     /// `sink` must be a live `BufferOutputSink` heap allocation with
     /// refcount > 0.
     unsafe fn schedule_drain(sink: *mut Self) {
-        // SAFETY: sink live (fn contract); raw field accesses only.
-        // `drain_scheduled` guarantees at most one enqueued task points at
-        // `drain_task`, so overwriting it below is never a race with one.
-        unsafe {
-            if (*sink).drain_scheduled {
+        // SAFETY: sink live (fn contract).
+        let this = unsafe { &*sink };
+        {
+            let mut d = this.driver.borrow_mut();
+            if d.drain_scheduled {
                 return;
             }
-            (*sink).drain_scheduled = true;
-            (*sink).ref_();
-            (*sink).drain_task = AnyTask::from_typed(sink, Self::drain_pending_input);
+            d.drain_scheduled = true;
         }
-        // SAFETY: the sink is a heap allocation with a stable address, and
-        // the +1 taken above keeps it (and `drain_task` inside it) alive
-        // until the task runs.
-        let task = unsafe { (*sink).drain_task.task() };
+        this.ref_();
+        // `drain_scheduled` guarantees at most one enqueued task points at
+        // `drain_task`, so nothing reads it between the write below and the
+        // event loop running the task.
+        // SAFETY: `drain_task` is an `UnsafeCell` whose only other access is
+        // the event loop running the task; the +1 taken above keeps the sink
+        // (and the cell's stable heap address) alive until then.
+        let task = unsafe {
+            *this.drain_task.get() = AnyTask::from_typed(sink, Self::drain_pending_input);
+            (*this.drain_task.get()).task()
+        };
         // SAFETY: the per-thread VM singleton outlives this call.
         VirtualMachine::get().as_mut().enqueue_task(task);
     }
@@ -992,12 +1048,16 @@ impl BufferOutputSink {
         // `adopt` consumes it on drop.
         let _g = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
         // SAFETY: sink live (refcount > 0).
-        unsafe { (*sink).drain_scheduled = false };
+        let this = unsafe { &*sink };
+        let writing = {
+            let mut d = this.driver.borrow_mut();
+            d.drain_scheduled = false;
+            d.writing
+        };
         // A previously started `drive_rewriter` is suspended somewhere on
         // the stack; its own loop drains `pending_input` / `pending_finish`
         // once its in-flight `write` returns.
-        // SAFETY: sink live (refcount > 0).
-        if unsafe { (*sink).writing } {
+        if writing {
             return Ok(());
         }
         // SAFETY: sink live; `writing` is false.
@@ -1032,50 +1092,60 @@ impl BufferOutputSink {
     /// `sink` must be a live `BufferOutputSink` heap allocation with
     /// refcount > 0, `(*sink).rewriter` set, and `(*sink).writing` false.
     unsafe fn drive_rewriter(sink: *mut Self, first: &[u8], source_is_async: bool) {
-        // SAFETY: sink live (fn contract); raw field reads only.
-        let (global, rewriter) = unsafe { ((*sink).global, (*sink).rewriter) };
-        // SAFETY: sink live; caller guarantees `writing` is false.
-        unsafe { (*sink).writing = true };
+        // SAFETY: sink live (fn contract).
+        let this = unsafe { &*sink };
+        let global = this.global;
+        // Caller guarantees `writing` is false.
+        this.driver.borrow_mut().writing = true;
         // The JS error from a failed `write`, built on that frame. It
         // lives on this stack (conservatively scanned) until the tail
         // reports it; it is never stored on the sink.
         let mut failure: Option<JSValue> = None;
-        // SAFETY: sink live (fn contract).
-        let mut poisoned = unsafe { (*sink).failed };
-        if !poisoned && !first.is_empty() {
-            // SAFETY: sink live; rewriter is (*sink).rewriter.
-            failure = unsafe { Self::write_chunk(sink, &global, rewriter, first) };
-            poisoned = failure.is_some();
-        }
-        while !poisoned {
-            // Each drained batch can itself suspend and queue more, so
-            // loop until the queue stays empty.
-            // SAFETY: sink live; the re-entrant call above has returned.
-            let queued = unsafe {
-                core::mem::replace(&mut (*sink).pending_input, MutableString::init_empty())
+        let mut poisoned = this.driver.borrow().failed;
+        {
+            // Held across every `write()` below. The re-entrant
+            // `SinkRef::handle_chunk` borrows `out`, a handler reaching the
+            // output `Response` borrows `out`, and an async handler's
+            // event-loop spin reaches `driver`; nothing re-entered touches
+            // `rewriter`, because everything that could is turned away by
+            // `driver.writing` first.
+            let mut slot = this.rewriter.borrow_mut();
+            let rewriter = slot
+                .as_mut()
+                .expect("set by init(), taken only by finish()");
+            if !poisoned && !first.is_empty() {
+                failure = Self::write_chunk(this, rewriter, &global, first);
+                poisoned = failure.is_some();
             }
-            .list;
-            if queued.is_empty() {
-                break;
+            while !poisoned {
+                // Each drained batch can itself suspend and queue more, so
+                // loop until the queue stays empty.
+                let queued = core::mem::replace(
+                    &mut this.driver.borrow_mut().pending_input,
+                    MutableString::init_empty(),
+                )
+                .list;
+                if queued.is_empty() {
+                    break;
+                }
+                failure = Self::write_chunk(this, rewriter, &global, &queued);
+                poisoned = failure.is_some();
             }
-            // SAFETY: sink live; rewriter is (*sink).rewriter.
-            failure = unsafe { Self::write_chunk(sink, &global, rewriter, &queued) };
-            poisoned = failure.is_some();
         }
-        // SAFETY: sink live.
-        unsafe { (*sink).writing = false };
+        this.driver.borrow_mut().writing = false;
         // Report a `write` failure from THIS frame before delivering any
         // deferred terminal: the failure happened first, and `finish` on a
         // poisoned sink has nothing left to report (see the fn doc).
         if let Some(err) = failure {
-            // SAFETY: sink live (fn contract).
-            unsafe { Self::report_rewriter_failure(sink, &global, err, source_is_async) };
+            Self::report_rewriter_failure(this, &global, err, source_is_async);
         }
         // The source finished (or errored) on the asynchronous path; its
         // callback deferred here and kept its +1 ref, which `finish`
-        // consumes.
-        // SAFETY: sink live (refcount > 0: that deferred +1 is outstanding).
-        if let Some(terminal) = unsafe { (*sink).pending_finish.take() } {
+        // consumes. Bind the `take()` first: in `if let`, a temporary in
+        // the scrutinee lives to the end of the whole block, which would
+        // hold the `driver` borrow across `finish`.
+        let terminal = this.driver.borrow_mut().pending_finish.take();
+        if let Some(terminal) = terminal {
             // SAFETY: sink live (the deferred +1 is outstanding; `finish`
             // consumes it). `is_async` is true because every deferral came
             // from the asynchronous path, whose error channel this is.
@@ -1090,24 +1160,18 @@ impl BufferOutputSink {
     /// reports it before returning to JS. lol-html is poisoned after a
     /// failed `write`, so `end()` must never run on this rewriter again.
     ///
-    /// # Safety
-    /// `sink` must be a live `BufferOutputSink` heap allocation with
-    /// refcount > 0; `rewriter` must be `(*sink).rewriter`.
-    unsafe fn write_chunk(
-        sink: *mut Self,
+    /// `rewriter` is `drive_rewriter`'s live borrow of `this.rewriter`, so
+    /// only `driver` is touched here, and only after `write` has returned.
+    fn write_chunk(
+        this: &Self,
+        rewriter: &mut lol_html::HtmlRewriter<'static, SinkRef>,
         global: &JSGlobalObject,
-        rewriter: *mut lol_html::HtmlRewriter<'static, SinkRef>,
         chunk: &[u8],
     ) -> Option<JSValue> {
-        // SAFETY: rewriter heap-allocated by init() and not yet freed: a
-        // poisoned rewriter never reaches `end()` (which is what consumes
-        // it), so it is still owned by the field until `Drop`.
-        let Err(e) = (unsafe { (*rewriter).write(chunk) }) else {
+        let Err(e) = rewriter.write(chunk) else {
             return None;
         };
-        // SAFETY: sink still live; the call above has returned so no other
-        // `&mut *sink` exists.
-        unsafe { (*sink).failed = true };
+        this.driver.borrow_mut().failed = true;
         Some(create_lolhtml_error(global, &e))
     }
 
@@ -1150,23 +1214,23 @@ impl BufferOutputSink {
         //   fresh event-loop task.
         // The +1 ref this call holds is deliberately NOT consumed here;
         // `finish` (invoked from `drive_rewriter`'s tail) adopts it.
-        // SAFETY: sink live (fn contract); raw field accesses only.
-        if unsafe { (*sink).writing } || is_async {
-            // SAFETY: sink live; any suspended `drive_rewriter` holds no
-            // borrow of `pending_finish` (it read its fields into locals).
-            unsafe { (*sink).pending_finish = Some(js_err) };
+        // SAFETY: sink live (fn contract).
+        let this = unsafe { &*sink };
+        let writing = this.driver.borrow().writing;
+        if writing || is_async {
+            this.driver.borrow_mut().pending_finish = Some(js_err);
             // A suspended `drive_rewriter`'s own tail handles
             // `pending_finish`; otherwise schedule a drain (a no-op if the
             // final chunk already queued one a moment ago).
-            // SAFETY: sink live (fn contract); raw field read only.
-            if !unsafe { (*sink).writing } {
+            if !writing {
                 // SAFETY: sink live (fn contract).
                 unsafe { Self::schedule_drain(sink) };
             }
             return;
         }
-        // SAFETY: sink live; `writing` is false and this is the
-        // synchronous path, so the caller's +1 is consumed here.
+        // `writing` is false and this is the synchronous path, so the
+        // caller's +1 is consumed here.
+        // SAFETY: sink live (fn contract).
         unsafe { Self::finish(sink, js_err, false) };
     }
 
@@ -1186,27 +1250,20 @@ impl BufferOutputSink {
         // SAFETY: the caller holds a +1 ref (see fn doc); `adopt` consumes
         // it on Drop.
         let _g = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
-        // Note: do not materialise `&mut *sink` here. The rewriter `end()`
-        // call below re-enters `SinkRef::handle_chunk` through the stored
-        // raw pointer, which forms its own `&mut *sink`. Holding an outer
-        // `&mut` across that re-entry is aliased-&mut UB. Access fields via
-        // raw-pointer place expressions instead (mirroring `init()`).
-        //
         // SAFETY: sink was ref'd in init() before scheduling this callback;
         // refcount > 0 so the allocation is live.
-        let global = unsafe { (*sink).global };
+        let this = unsafe { &*sink };
+        let global = this.global;
 
         if let Some(mut err) = js_err {
             // Reject the stream a consumer is already reading. After
             // `Bun.serve` takes it the body `Value` is `Used`, so the
             // `to_error_instance` below never reaches that stream.
-            // SAFETY: sink live (fn contract).
-            unsafe {
-                Self::fail_output_stream(sink, err.dupe(&global).to_stream_error(&global));
-            }
-            // SAFETY: (*sink).response is the heap Response allocated in init()
-            // and kept alive by (*sink).response_ref for the sink's lifetime.
-            let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
+            Self::fail_output_stream(this, err.dupe(&global).to_stream_error(&global));
+            let out_response = this.out.borrow().response;
+            // SAFETY: `out_response` is the heap Response allocated in init()
+            // and kept alive by `out.response_ref` for the sink's lifetime.
+            let sink_body_value = unsafe { (*out_response).get_body_value() };
             let sink_ptr_usize = sink as usize;
             // If a `.body` readable is already attached, stay `Locked` so
             // `to_error_instance` delivers the error to its ByteStream; clearing
@@ -1237,7 +1294,7 @@ impl BufferOutputSink {
                 let ret_err = err.to_js(&global);
                 ret_err.ensure_still_alive();
                 ret_err.protect();
-                Self::write_tmp_sync_error(sink, ret_err);
+                Self::write_tmp_sync_error(this, ret_err);
             }
             // Do not `end()` the rewriter: that would run `done()`, replacing
             // the error just stored on the body with the truncated output.
@@ -1249,47 +1306,39 @@ impl BufferOutputSink {
         // on the poisoned rewriter, and nothing is left to report: the
         // failing `drive_rewriter` already delivered the error from its
         // own tail (to the body, or to `transform()`'s throw slot).
-        // SAFETY: sink live (fn contract).
-        if unsafe { (*sink).failed } {
+        let failed = this.driver.borrow().failed;
+        if failed {
             return;
         }
 
         // Flush lol-html. On success `end()` re-enters `SinkRef::handle_chunk`
         // with the empty terminal chunk, which runs `done()`.
-        // SAFETY: rewriter set by init(). Read into a local before the call.
-        let rewriter = unsafe { (*sink).rewriter };
-        // `HtmlRewriter::end(self)` consumes the rewriter: null the field
-        // first so `Drop` does not free it a second time.
-        // SAFETY: sink is a live heap allocation (refcount > 0).
-        unsafe { (*sink).rewriter = core::ptr::null_mut() };
-        // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
-        if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
-            // SAFETY: sink live; the call above has returned.
-            unsafe { (*sink).failed = true };
+        // `HtmlRewriter::end(self)` consumes the rewriter: take it out of the
+        // cell (the `RefMut` ends at the `;`) so nothing `end()` re-enters can
+        // see a half-consumed slot, and so `Drop` does not free it twice. No
+        // drain task can be outstanding here (the terminal only arrives after
+        // the last source chunk), so nothing touches `rewriter` during `end`.
+        let rewriter = this.rewriter.borrow_mut().take();
+        if let Err(e) = rewriter
+            .expect("set by init(), taken exactly once here")
+            .end()
+        {
+            this.driver.borrow_mut().failed = true;
             // Build the error from the typed `RewritingError`, which exists
             // only on this frame, and report it now.
-            // SAFETY: sink live (fn contract).
-            unsafe {
-                Self::report_rewriter_failure(
-                    sink,
-                    &global,
-                    create_lolhtml_error(&global, &e),
-                    is_async,
-                )
-            };
+            Self::report_rewriter_failure(
+                this,
+                &global,
+                create_lolhtml_error(&global, &e),
+                is_async,
+            );
         }
     }
 
     /// Reject a consumer streaming the rewritten output (if any) with
     /// `err`. No-op once the stream is already closed or errored.
-    ///
-    /// # Safety
-    /// `sink` must be a live `BufferOutputSink` heap allocation with
-    /// refcount > 0 and `(*sink).response` held alive by `response_ref`.
-    unsafe fn fail_output_stream(sink: *mut Self, err: streams::StreamError) {
-        // SAFETY: sink live (fn contract); `consumer_stream` forms a short
-        // `&Self` and nothing re-entrant runs while it is live.
-        let Some(out) = (unsafe { &*sink }).consumer_stream() else {
+    fn fail_output_stream(this: &Self, err: streams::StreamError) {
+        let Some(out) = this.consumer_stream() else {
             return;
         };
         if let Some(byte_stream) = out.ptr.bytes() {
@@ -1308,28 +1357,22 @@ impl BufferOutputSink {
     /// `transform()` is still on the stack and the error becomes its
     /// throw; nothing can be attached to a `Response` the caller has
     /// never seen.
-    ///
-    /// # Safety
-    /// `sink` must be a live `BufferOutputSink` heap allocation with
-    /// refcount > 0 and `(*sink).response` held alive by `response_ref`.
-    unsafe fn report_rewriter_failure(
-        sink: *mut Self,
+    fn report_rewriter_failure(
+        this: &Self,
         global: &JSGlobalObject,
         err_value: JSValue,
         is_async: bool,
     ) {
         if is_async {
-            // SAFETY: sink live (fn contract).
-            unsafe {
-                Self::fail_output_stream(
-                    sink,
-                    streams::StreamError::JSValue(jsc::strong::Optional::create(err_value, global)),
-                );
-            }
+            Self::fail_output_stream(
+                this,
+                streams::StreamError::JSValue(jsc::strong::Optional::create(err_value, global)),
+            );
+            let out_response = this.out.borrow().response;
             // `to_error_instance` only fails when the VM is terminating;
             // there is nowhere left to report to (same as `done()`).
-            // SAFETY: response kept alive by `response_ref` (fn contract).
-            let _ = unsafe { (*(*sink).response).get_body_value() }.to_error_instance(
+            // SAFETY: `out_response` is kept alive by `out.response_ref`.
+            let _ = unsafe { (*out_response).get_body_value() }.to_error_instance(
                 webcore::body::ValueError::JSValue(jsc::strong::Optional::create(
                     err_value, global,
                 )),
@@ -1338,7 +1381,7 @@ impl BufferOutputSink {
         } else {
             err_value.ensure_still_alive();
             err_value.protect();
-            Self::write_tmp_sync_error(sink, err_value);
+            Self::write_tmp_sync_error(this, err_value);
         }
     }
 
@@ -1348,17 +1391,18 @@ impl BufferOutputSink {
     /// invoke `on_start_streaming`/`on_readable_stream_available` with a
     /// freed `task`. Idempotent; called from `Drop` so it covers every
     /// completion path (done, rewriter failure, source error, early bail).
-    fn detach_from_output_body(&mut self) {
+    fn detach_from_output_body(&self) {
+        let out = self.out.borrow();
         // The builder-failure path in `init()` frees `response` before
-        // `response_ref` is ever set; only a held wrapper guarantees
-        // `self.response` is still live.
-        if self.response_ref.try_get().is_none() {
+        // `out.response_ref` is ever set; only a held wrapper guarantees
+        // `out.response` is still live.
+        if out.response_ref.try_get().is_none() {
             return;
         }
-        // SAFETY: `response_ref` holds the JS Response wrapper, which owns
-        // `response` as its m_ctx; both outlive this call.
-        let body_value = unsafe { (*self.response).get_body_value() };
-        let self_usize = std::ptr::from_mut(self) as usize;
+        // SAFETY: `out.response_ref` holds the JS Response wrapper, which
+        // owns `response` as its m_ctx; both outlive this call.
+        let body_value = unsafe { (*out.response).get_body_value() };
+        let self_usize = std::ptr::from_ref(self) as usize;
         if let webcore::body::Value::Locked(l) = body_value {
             if l.task.map_or(0, |p| p as usize) == self_usize {
                 l.task = None;
@@ -1375,12 +1419,13 @@ impl BufferOutputSink {
     /// `get_body_readable_stream` reads first. The sink never takes a
     /// reference of its own.
     fn consumer_stream(&self) -> Option<webcore::ReadableStream> {
-        // SAFETY: `self.response` is the live m_ctx of the `Response`
-        // wrapper `self.response_ref` holds for this sink's lifetime.
-        unsafe { (*self.response).get_body_readable_stream(&self.global) }
+        let response = self.out.borrow().response;
+        // SAFETY: `response` is the live m_ctx of the `Response` wrapper
+        // `out.response_ref` holds for this sink's lifetime.
+        unsafe { (*response).get_body_readable_stream(&self.global) }
     }
 
-    pub fn done(&mut self) {
+    pub fn done(&self) {
         // A consumer is streaming the output: close its `ByteStream`.
         // Whoever took the stream (the reader, or `Bun.serve`) owns it;
         // the data already went through it, like a completed `fetch()`.
@@ -1391,57 +1436,67 @@ impl BufferOutputSink {
             return;
         }
 
-        // SAFETY: self.response is kept alive by self.response_ref for the
+        let response = self.out.borrow().response;
+        // SAFETY: `response` is kept alive by `out.response_ref` for the
         // lifetime of this sink.
-        let body_value = unsafe { (*self.response).get_body_value() };
+        let body_value = unsafe { (*response).get_body_value() };
         // An earlier source/handler error already put the body into the
         // `Error` state; the buffered output is incomplete, so don't
         // overwrite the error with it.
         if matches!(body_value, webcore::body::Value::Error(_)) {
             return;
         }
+        let buffered = core::mem::replace(
+            &mut self.out.borrow_mut().bytes,
+            MutableString::init_empty(),
+        )
+        .list;
         let mut prev_value = core::mem::replace(
             body_value,
             webcore::body::Value::InternalBlob(webcore::InternalBlob {
-                bytes: core::mem::replace(&mut self.bytes, MutableString::init_empty()).list,
+                bytes: buffered,
                 was_string: false,
             }),
         );
 
+        // `resolve` settles the pending read as a microtask; no user JS
+        // runs synchronously here, so no borrow of `out` can be re-entered.
         let _ = webcore::body::Value::resolve(&mut prev_value, body_value, &self.global, None);
         // TODO: properly propagate exception upwards
     }
 
-    pub fn write(&mut self, bytes: &[u8]) {
+    pub fn write(&self, bytes: &[u8]) {
         // A consumer is streaming: hand the rewritten bytes straight to its
         // `ByteStream`. `on_data` copies `Temporary` slices synchronously
-        // and runs no user JS, so the enclosing `&mut self` stays unique.
+        // and runs no user JS, so no borrow of `out` can be re-entered.
         if let Some(out) = self.consumer_stream() {
             if let Some(byte_stream) = out.ptr.bytes() {
                 let _ = byte_stream.on_data(StreamResult::Temporary(bun_ptr::RawSlice::new(bytes)));
                 return;
             }
         }
-        let _ = self.bytes.append(bytes); // OOM/capacity: fire-and-forget
+        let _ = self.out.borrow_mut().bytes.append(bytes); // OOM/capacity: fire-and-forget
     }
 }
 
 /// `lol_html::OutputSink` for the rewriter built in [`BufferOutputSink::init`].
 /// Carries a raw `*mut BufferOutputSink` (never a reference) so the rewriter
-/// stored on the sink does not self-borrow.
+/// stored inside the sink's `rewriter` cell does not self-borrow.
 pub struct SinkRef(*mut BufferOutputSink);
 
 impl lol_html::OutputSink for SinkRef {
     fn handle_chunk(&mut self, chunk: &[u8]) {
         // SAFETY: `self.0` is the sink that owns this rewriter (refcount > 0
-        // per `write_chunk` / `finish`, lol-html's only drivers), and no
-        // other `&mut *sink` is live: both read the rewriter into a local first.
-        let sink = unsafe { &mut *self.0 };
+        // per `drive_rewriter` / `finish`, lol-html's only drivers). Only a
+        // shared `&BufferOutputSink` is formed, here and in every caller up
+        // the stack; the mutation below goes through the `out` cell, which
+        // neither of those drivers is borrowing across a lol-html call.
+        let this = unsafe { &*self.0 };
         // lol-html signals end-of-output with a zero-length final chunk.
         if chunk.is_empty() {
-            sink.done();
+            this.done();
         } else {
-            sink.write(chunk);
+            this.write(chunk);
         }
     }
 }
@@ -1455,17 +1510,12 @@ pub enum BufferOutputSinkSync {
 
 impl Drop for BufferOutputSink {
     fn drop(&mut self) {
-        // Must run before `response_ref` (a struct field) drops: after
+        // Must run before `out` (which holds `response_ref`) drops: after
         // that, nothing holds the output Response and its `Locked` body's
         // callback pointers into this about-to-be-freed sink.
         self.detach_from_output_body();
-        // bytes, body_value_bufferer, context (Rc), response_ref drop
-        // automatically.
-        if !self.rewriter.is_null() {
-            // SAFETY: rewriter heap-allocated by init() and not yet freed
-            // (`finish` nulls the field before consuming it in `end`).
-            unsafe { bun_core::heap::destroy(self.rewriter) };
-        }
+        // Everything else, including a `rewriter` that `finish` never
+        // consumed, drops automatically.
     }
 }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -711,8 +711,8 @@ impl BufferOutputSink {
         let (element_content_handlers, document_content_handlers) =
             unsafe { build_settings(&mut (*sink).context.borrow_mut()) };
         // `SinkRef` carries the raw `sink` (`heap::into_raw` root) so every
-        // `(*sink).field` access shares its provenance; `run_output_sink`
-        // reaches the rewriter through a raw pointer, never `&mut *sink`.
+        // `(*sink).field` access shares its provenance; `drive_rewriter` and
+        // `finish` reach the rewriter through a raw pointer, never `&mut *sink`.
         let rewriter = bun_core::heap::into_raw(Box::new(lol_html::HtmlRewriter::new(
             lol_html::Settings {
                 element_content_handlers,
@@ -846,7 +846,7 @@ impl BufferOutputSink {
 
     /// `PendingValue::on_start_streaming`: seed the consumer's new
     /// `ByteStream` with whatever rewritten output already accumulated.
-    /// Always `Owned` — `Empty` would null the body and skip
+    /// Always `Owned`: `Empty` would null the body and skip
     /// `on_readable_stream_available`, orphaning the transform.
     fn on_start_streaming(ctx: *mut core::ffi::c_void) -> webcore::DrainResult {
         let sink = ctx.cast::<BufferOutputSink>();
@@ -1161,7 +1161,7 @@ impl BufferOutputSink {
         // SAFETY: the caller holds a +1 ref (see fn doc); `adopt` consumes
         // it on Drop.
         let _g = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
-        // Note: do not materialise `&mut *sink` here — the rewriter `end()`
+        // Note: do not materialise `&mut *sink` here. The rewriter `end()`
         // call below re-enters `SinkRef::handle_chunk` through the stored
         // raw pointer, which forms its own `&mut *sink`. Holding an outer
         // `&mut` across that re-entry is aliased-&mut UB. Access fields via
@@ -1353,7 +1353,7 @@ impl BufferOutputSink {
 
     pub fn done(&mut self) {
         // A consumer is streaming the output: close its `ByteStream`. The
-        // body `Value` stays `Locked { readable }` — the data already went
+        // body `Value` stays `Locked { readable }`; the data already went
         // through the stream, exactly like a completed `fetch()` body.
         if let Some(out) = self.output_stream.get(&self.global) {
             if let Some(byte_stream) = out.ptr.bytes() {
@@ -1406,8 +1406,8 @@ pub struct SinkRef(*mut BufferOutputSink);
 impl lol_html::OutputSink for SinkRef {
     fn handle_chunk(&mut self, chunk: &[u8]) {
         // SAFETY: `self.0` is the sink that owns this rewriter (refcount > 0
-        // inside `run_output_sink`), and no other `&mut *sink` is live —
-        // `run_output_sink` reads its fields into locals before the call.
+        // per `write_chunk` / `finish`, lol-html's only drivers), and no
+        // other `&mut *sink` is live: both read the rewriter into a local first.
         let sink = unsafe { &mut *self.0 };
         // lol-html signals end-of-output with a zero-length final chunk.
         if chunk.is_empty() {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -5,6 +5,7 @@ use core::ptr::NonNull;
 use std::rc::Rc;
 
 use bun_core::MutableString;
+use bun_event_loop::AnyTask::AnyTask;
 use bun_jsc::{
     self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsRef, JsResult,
     ProtectedJSValue, SystemError, bun_string_jsc,
@@ -580,10 +581,14 @@ pub struct BufferOutputSink {
     /// those signals are queued in the fields below and drained by the
     /// suspended `drive_rewriter` once its in-flight `write` returns.
     pub writing: bool,
-    /// `true` while a `drain_microtask` is queued and has not yet run.
+    /// `true` while a drain task is enqueued and has not yet run.
     pub drain_scheduled: bool,
+    /// The event-loop task `schedule_drain` enqueues. It lives on the
+    /// sink (a stable heap address) so the event loop holds a pointer to
+    /// it; `drain_scheduled` guarantees at most one is in flight.
+    drain_task: AnyTask,
     /// Source bytes not yet fed to lol-html: either queued by the
-    /// asynchronous delivery paths for the next `drain_microtask`, or
+    /// asynchronous delivery paths for the next drain task, or
     /// queued by a re-entrant arrival while `drive_rewriter` is suspended.
     pub pending_input: MutableString,
     /// Deferred terminal source signal: `Some(None)` is a clean end,
@@ -635,6 +640,7 @@ impl BufferOutputSink {
             failed: false,
             writing: false,
             drain_scheduled: false,
+            drain_task: AnyTask::default(),
             pending_input: MutableString::init_empty(),
             pending_finish: None,
             tmp_sync_error: None,
@@ -906,9 +912,10 @@ impl BufferOutputSink {
     ///   spinning the full event loop, which would park the HTTP thread
     ///   (and every in-flight `fetch`) on that mutex for the duration, and
     ///   deadlock outright if the handler's own `await` needs it. Copy the
-    ///   bytes out and drive the rewriter from a fresh microtask frame,
-    ///   which runs in the same tick but strictly after the enqueuing task
-    ///   has returned and released its locks.
+    ///   bytes out and drive the rewriter from a fresh event-loop task,
+    ///   which runs strictly after the enqueuing task has returned and
+    ///   released its locks, and at the top of an event-loop turn (see
+    ///   `schedule_drain` for why that last part matters).
     /// - Synchronous delivery (a materialized blob / string, or a source
     ///   that is already complete): `init()` is on the stack and no
     ///   producer lock is held, so drive the rewriter directly. This
@@ -943,34 +950,45 @@ impl BufferOutputSink {
         unsafe { Self::drive_rewriter(sink, bytes, false) };
     }
 
-    /// If no `drain_microtask` is already queued, take a +1 ref on the
-    /// sink and queue one. The microtask consumes that ref.
+    /// If no drain task is already enqueued, take a +1 ref on the sink
+    /// and enqueue one on the event loop. The task consumes that ref.
+    ///
+    /// This must be an event-loop TASK, never a microtask. `write` runs
+    /// user element handlers, and an async handler blocks the `write` by
+    /// spinning the full event loop (`wait_for_promise`), which drains
+    /// the microtask queue. Doing that from inside a microtask callback
+    /// would re-enter the microtask drain. A task instead runs at the
+    /// top of an event-loop turn, the same kind of frame the synchronous
+    /// `transform()` path has always driven lol-html from.
     ///
     /// # Safety
     /// `sink` must be a live `BufferOutputSink` heap allocation with
     /// refcount > 0.
     unsafe fn schedule_drain(sink: *mut Self) {
         // SAFETY: sink live (fn contract); raw field accesses only.
+        // `drain_scheduled` guarantees at most one enqueued task points at
+        // `drain_task`, so overwriting it below is never a race with one.
         unsafe {
             if (*sink).drain_scheduled {
                 return;
             }
             (*sink).drain_scheduled = true;
             (*sink).ref_();
+            (*sink).drain_task = AnyTask::from_typed(sink, Self::drain_pending_input);
         }
-        // SAFETY: sink live; the +1 just taken keeps it alive until the
-        // microtask runs. The microtask is queued on the JS thread's own
-        // JSC microtask queue and drains after the current event-loop
-        // task returns (and releases any locks it holds).
-        unsafe { &(*sink).global }.queue_microtask_callback(sink, Self::drain_microtask);
+        // SAFETY: the sink is a heap allocation with a stable address, and
+        // the +1 taken above keeps it (and `drain_task` inside it) alive
+        // until the task runs.
+        let task = unsafe { (*sink).drain_task.task() };
+        // SAFETY: the per-thread VM singleton outlives this call.
+        VirtualMachine::get().as_mut().enqueue_task(task);
     }
 
-    /// Drain the queued source input on a fresh microtask frame, outside
+    /// Drain the queued source input on a fresh event-loop task, outside
     /// the producer's critical section. Consumes the +1 ref taken by
     /// `schedule_drain`.
-    unsafe extern "C" fn drain_microtask(ctx: *mut core::ffi::c_void) {
-        let sink = ctx.cast::<BufferOutputSink>();
-        // SAFETY: the microtask owns the +1 taken in `schedule_drain`;
+    fn drain_pending_input(sink: *mut Self) -> bun_event_loop::JsResult<()> {
+        // SAFETY: the task owns the +1 taken in `schedule_drain`;
         // `adopt` consumes it on drop.
         let _g = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
         // SAFETY: sink live (refcount > 0).
@@ -980,10 +998,11 @@ impl BufferOutputSink {
         // once its in-flight `write` returns.
         // SAFETY: sink live (refcount > 0).
         if unsafe { (*sink).writing } {
-            return;
+            return Ok(());
         }
         // SAFETY: sink live; `writing` is false.
         unsafe { Self::drive_rewriter(sink, b"", true) };
+        Ok(())
     }
 
     /// Feed `first`, then everything that accumulates in `pending_input`,
@@ -1006,7 +1025,7 @@ impl BufferOutputSink {
     /// long as the upstream stays open.
     ///
     /// `source_is_async` is whether the source is a still-open stream (the
-    /// microtask drain path) rather than the synchronous `init()` path; it
+    /// drain-task path) rather than the synchronous `init()` path; it
     /// selects the error channel (the body vs. `transform()`'s throw slot).
     ///
     /// # Safety
@@ -1128,7 +1147,7 @@ impl BufferOutputSink {
         // - `is_async`: the delivery may be running inside a producer's
         //   critical section (see `on_input_chunk`), and `end()` can also
         //   suspend on an async `onDocument.end` handler. Defer to a
-        //   fresh microtask frame.
+        //   fresh event-loop task.
         // The +1 ref this call holds is deliberately NOT consumed here;
         // `finish` (invoked from `drive_rewriter`'s tail) adopts it.
         // SAFETY: sink live (fn contract); raw field accesses only.

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -17,6 +17,7 @@ use bun_jsc::{
 use bun_jsc::virtual_machine::VirtualMachine;
 
 use crate::webcore::response::HeadersRef;
+use crate::webcore::streams::{self, StreamResult};
 use crate::webcore::{self, Response};
 use bun_core::String as BunString;
 // `ZigString` re-exports `bun_core::ZigString`; JSC-side methods
@@ -547,8 +548,11 @@ pub struct BufferOutputSink {
     // Intrusive RefCount; *Self is the `SinkRef` carried inside `rewriter`.
     ref_count: Cell<u32>,
     pub global: GlobalRef, // JSC_BORROW
+    /// Rewritten output not yet handed to a consumer. Drained into the
+    /// output stream's initial buffer by `on_start_streaming`, or resolved
+    /// as the body's `InternalBlob` in `done()` if nothing streamed.
     pub bytes: MutableString,
-    // Heap-allocated (never held by value): `run_output_sink` must reach the
+    // Heap-allocated (never held by value): `drive_rewriter` must reach the
     // rewriter through a raw pointer, never a `&mut` of `*sink`, because the
     // output sink re-enters `&mut *sink` while the rewriter runs.
     pub rewriter: *mut lol_html::HtmlRewriter<'static, SinkRef>, // null when unset
@@ -556,6 +560,36 @@ pub struct BufferOutputSink {
     pub response: *mut Response, // BORROW_FIELD: kept alive by response_value Strong
     pub response_value: StrongOptional,
     pub body_value_bufferer: Option<webcore::body::ValueBufferer<'static>>,
+    /// Set by `on_readable_stream_available` once a consumer streams the
+    /// output (`.body` / `Bun.serve`). While set, rewritten bytes are
+    /// pushed into its `ByteStream` instead of accumulating in `bytes`,
+    /// and `done()` closes that stream instead of swapping in a blob.
+    pub output_stream: webcore::readable_stream::Strong,
+    /// Set when a `write` on a source chunk fails (a parse error or a
+    /// thrown handler). The typed `RewritingError` exists only on the
+    /// failing call's frame, so the JS error is built there, once, and
+    /// shared by every later report. The rewriter is poisoned once this is
+    /// set: later chunks are dropped and completion reports this error
+    /// instead of calling `end()`.
+    pub write_error: StrongOptional,
+    /// `true` while `drive_rewriter` is on the stack. `HtmlRewriter::write`
+    /// runs user JS handlers, and an async handler blocks it by spinning
+    /// the full event loop (`wait_for_promise`), during which the source
+    /// can deliver more chunks or finish. lol-html is not re-entrant, so
+    /// those signals are queued in the fields below and drained by the
+    /// suspended `drive_rewriter` once its in-flight `write` returns.
+    pub writing: bool,
+    /// `true` while a `drain_microtask` is queued and has not yet run.
+    pub drain_scheduled: bool,
+    /// Source bytes not yet fed to lol-html: either queued by the
+    /// asynchronous delivery paths for the next `drain_microtask`, or
+    /// queued by a re-entrant arrival while `drive_rewriter` is suspended.
+    pub pending_input: MutableString,
+    /// Deferred terminal source signal: `Some(None)` is a clean end,
+    /// `Some(Some(e))` a source error. The deferring
+    /// `on_finished_buffering` keeps its +1 ref on the sink; `finish`
+    /// (invoked from `drive_rewriter`'s tail) consumes it.
+    pub pending_finish: Option<Option<webcore::body::ValueError>>,
     // Points at the `sink_error` stack local in `init()`;
     // only written while `init()` is on the stack.
     // See `write_tmp_sync_error` for the full liveness/provenance argument.
@@ -597,6 +631,12 @@ impl BufferOutputSink {
             response: core::ptr::null_mut(),
             response_value: StrongOptional::empty(),
             body_value_bufferer: None,
+            output_stream: webcore::readable_stream::Strong::default(),
+            write_error: StrongOptional::empty(),
+            writing: false,
+            drain_scheduled: false,
+            pending_input: MutableString::init_empty(),
+            pending_finish: None,
             tmp_sync_error: None,
         }));
         // SAFETY: `sink` is the `heap::into_raw` allocation above; refcount >= 1.
@@ -614,6 +654,12 @@ impl BufferOutputSink {
             webcore::Body::new({
                 let mut pv = webcore::body::PendingValue::new(global);
                 pv.task = Some(sink.cast::<core::ffi::c_void>());
+                // Output streaming hooks: the same lazy contract fetch bodies
+                // install, so a consumer that streams the transformed body
+                // (`.body`, `Bun.serve`) gets rewritten bytes as they are
+                // produced instead of an orphaned, never-written stream.
+                pv.on_start_streaming = Some(Self::on_start_streaming);
+                pv.on_readable_stream_available = Some(Self::on_readable_stream_available);
                 webcore::body::Value::Locked(pv)
             }),
             BunString::empty(),
@@ -734,6 +780,9 @@ impl BufferOutputSink {
                 // `on_finished_buffering` takes `*mut BufferOutputSink`. The
                 // wrapper trampoline restores the concrete type.
                 Self::on_finished_buffering_trampoline,
+                // Per-chunk delivery: drive lol-html's chunked `write` as
+                // source bytes arrive instead of buffering the whole input.
+                Some(Self::on_input_chunk_trampoline),
                 &(*sink).global,
             ));
         }
@@ -785,6 +834,258 @@ impl BufferOutputSink {
         Ok(response_js_value)
     }
 
+    // ── output body stream hooks (fetch-style lazy streaming) ───────────
+    //
+    // Both run when the output body is still `Locked { task: sink }` with
+    // these hooks installed, which implies the sink is live (its `Drop`
+    // nulls them via `detach_from_output_body` before the last ref drops).
+    // Neither materialises `&mut *sink`: they can be reached from a JS
+    // handler running inside `HtmlRewriter::write` (a handler that closed
+    // over the output `Response` and touched `.body`), and at that point
+    // only raw-pointer place expressions are sound.
+
+    /// `PendingValue::on_start_streaming`: seed the consumer's new
+    /// `ByteStream` with whatever rewritten output already accumulated.
+    /// Always `Owned` — `Empty` would null the body and skip
+    /// `on_readable_stream_available`, orphaning the transform.
+    fn on_start_streaming(ctx: *mut core::ffi::c_void) -> webcore::DrainResult {
+        let sink = ctx.cast::<BufferOutputSink>();
+        // SAFETY: `ctx` is a live sink (see block comment). The `&mut` is
+        // scoped to the single field for the duration of `replace`.
+        let list =
+            unsafe { core::mem::replace(&mut (*sink).bytes, MutableString::init_empty()) }.list;
+        let size_hint = list.len();
+        webcore::DrainResult::Owned { list, size_hint }
+    }
+
+    /// `PendingValue::on_readable_stream_available`: remember the stream the
+    /// consumer will read so `SinkRef::handle_chunk` pushes into it. First
+    /// stream wins; a second materialization (the first consumer took
+    /// `locked.readable`, then `.body` ran again) is left empty rather than
+    /// swapping the active push target mid-transform.
+    fn on_readable_stream_available(
+        ctx: *mut core::ffi::c_void,
+        global: &JSGlobalObject,
+        readable: webcore::ReadableStream,
+    ) {
+        let sink = ctx.cast::<BufferOutputSink>();
+        // SAFETY: `ctx` is a live sink (see block comment).
+        unsafe {
+            if (*sink).output_stream.get(global).is_some() {
+                return;
+            }
+            (*sink).output_stream = webcore::readable_stream::Strong::init(readable, global);
+        }
+    }
+
+    // ── input side: per-chunk lol-html writes ───────────────────────────
+
+    fn on_input_chunk_trampoline(ctx: *mut core::ffi::c_void, bytes: &[u8], is_async: bool) {
+        // SAFETY: `ctx` is the `sink` registered with the bufferer in
+        // `init()`; it was `ref_()`'d there so refcount > 0.
+        unsafe { Self::on_input_chunk(ctx.cast::<BufferOutputSink>(), bytes, is_async) };
+    }
+
+    /// Accept one source chunk. Three cases:
+    ///
+    /// - A `drive_rewriter` is already suspended on this stack (an async
+    ///   handler is spinning the event loop inside `HtmlRewriter::write`):
+    ///   queue the bytes; the suspended call drains them.
+    /// - `is_async`: the delivery came from a producer callback that may
+    ///   hold a lock across it. `ValueBufferer`'s pipe handler runs inside
+    ///   `FetchTasklet::on_progress_update`, which holds the tasklet's
+    ///   mutex until after `ByteStream::on_data` returns, and the singleton
+    ///   HTTP-client thread takes that same mutex before delivering the
+    ///   next chunk. `HtmlRewriter::write` can suspend on an async handler
+    ///   spinning the full event loop, which would park the HTTP thread
+    ///   (and every in-flight `fetch`) on that mutex for the duration, and
+    ///   deadlock outright if the handler's own `await` needs it. Copy the
+    ///   bytes out and drive the rewriter from a fresh microtask frame,
+    ///   which runs in the same tick but strictly after the enqueuing task
+    ///   has returned and released its locks.
+    /// - Synchronous delivery (a materialized blob / string, or a source
+    ///   that is already complete): `init()` is on the stack and no
+    ///   producer lock is held, so drive the rewriter directly. This
+    ///   preserves `transform()`'s synchronous contract for non-streaming
+    ///   inputs. The pre-buffered prefix of a still-streaming source is
+    ///   not this case: it is handed over with `is_async == true` and
+    ///   takes the deferred path above like every other pipe delivery.
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation with
+    /// refcount > 0 and `(*sink).rewriter` set.
+    unsafe fn on_input_chunk(sink: *mut Self, bytes: &[u8], is_async: bool) {
+        // SAFETY: sink is live (fn contract); raw field reads only.
+        let (failed, writing) = unsafe { ((*sink).write_error.has(), (*sink).writing) };
+        if failed || bytes.is_empty() {
+            return;
+        }
+        if writing {
+            // SAFETY: sink live; the suspended `drive_rewriter` holds no
+            // borrow of `pending_input` (it read its fields into locals).
+            let _ = unsafe { (*sink).pending_input.append(bytes) }; // OOM: fire-and-forget
+            return;
+        }
+        if is_async {
+            // SAFETY: sink live; no borrow of `pending_input` exists.
+            let _ = unsafe { (*sink).pending_input.append(bytes) }; // OOM: fire-and-forget
+            // SAFETY: sink live (fn contract).
+            unsafe { Self::schedule_drain(sink) };
+            return;
+        }
+        // SAFETY: sink live (fn contract); `writing` is false.
+        unsafe { Self::drive_rewriter(sink, bytes, false) };
+    }
+
+    /// If no `drain_microtask` is already queued, take a +1 ref on the
+    /// sink and queue one. The microtask consumes that ref.
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation with
+    /// refcount > 0.
+    unsafe fn schedule_drain(sink: *mut Self) {
+        // SAFETY: sink live (fn contract); raw field accesses only.
+        unsafe {
+            if (*sink).drain_scheduled {
+                return;
+            }
+            (*sink).drain_scheduled = true;
+            (*sink).ref_();
+        }
+        // SAFETY: sink live; the +1 just taken keeps it alive until the
+        // microtask runs. The microtask is queued on the JS thread's own
+        // JSC microtask queue and drains after the current event-loop
+        // task returns (and releases any locks it holds).
+        unsafe { &(*sink).global }.queue_microtask_callback(sink, Self::drain_microtask);
+    }
+
+    /// Drain the queued source input on a fresh microtask frame, outside
+    /// the producer's critical section. Consumes the +1 ref taken by
+    /// `schedule_drain`.
+    unsafe extern "C" fn drain_microtask(ctx: *mut core::ffi::c_void) {
+        let sink = ctx.cast::<BufferOutputSink>();
+        // SAFETY: the microtask owns the +1 taken in `schedule_drain`;
+        // `adopt` consumes it on drop.
+        let _g = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
+        // SAFETY: sink live (refcount > 0).
+        unsafe { (*sink).drain_scheduled = false };
+        // A previously started `drive_rewriter` is suspended somewhere on
+        // the stack; its own loop drains `pending_input` / `pending_finish`
+        // once its in-flight `write` returns.
+        // SAFETY: sink live (refcount > 0).
+        if unsafe { (*sink).writing } {
+            return;
+        }
+        // SAFETY: sink live; `writing` is false.
+        unsafe { Self::drive_rewriter(sink, b"", true) };
+    }
+
+    /// Feed `first`, then everything that accumulates in `pending_input`,
+    /// into lol-html, then deliver any deferred terminal signal.
+    ///
+    /// `HtmlRewriter::write` re-enters `SinkRef::handle_chunk` and runs
+    /// user JS handlers through the stored raw pointer, so no borrow of
+    /// `*sink` may be live across it. An **async** handler suspends the
+    /// `write` by spinning the full event loop, during which the source
+    /// can deliver more chunks (queued by `on_input_chunk`) or finish
+    /// (deferred by `on_finished_buffering`). lol-html is not re-entrant,
+    /// so `writing` is set for the duration and the loop drains whatever
+    /// accumulated once each `write` returns.
+    ///
+    /// `source_is_async` is whether the source is a still-open stream (the
+    /// microtask drain path) rather than the synchronous `init()` path. On
+    /// the stream path, a fresh `write` failure with no pending terminal is
+    /// reported to consumers immediately: every later chunk is dropped and
+    /// the terminal may be arbitrarily far away (or never come), so waiting
+    /// for it would strand `.text()` / `.body` / `Bun.serve` for as long as
+    /// the upstream stays open. The synchronous path needs no such report;
+    /// its `on_finished_buffering` runs on the same call chain.
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation with
+    /// refcount > 0, `(*sink).rewriter` set, and `(*sink).writing` false.
+    unsafe fn drive_rewriter(sink: *mut Self, first: &[u8], source_is_async: bool) {
+        // SAFETY: sink live (fn contract); raw field reads only.
+        let (global, rewriter) = unsafe { ((*sink).global, (*sink).rewriter) };
+        // SAFETY: sink live; caller guarantees `writing` is false.
+        unsafe { (*sink).writing = true };
+        // SAFETY: sink live (fn contract).
+        let was_already_failed = unsafe { (*sink).write_error.has() };
+        let mut failed = was_already_failed;
+        if !failed && !first.is_empty() {
+            // SAFETY: sink live; rewriter is (*sink).rewriter.
+            failed = unsafe { Self::write_chunk(sink, &global, rewriter, first) };
+        }
+        while !failed {
+            // Each drained batch can itself suspend and queue more, so
+            // loop until the queue stays empty.
+            // SAFETY: sink live; the re-entrant call above has returned.
+            let queued = unsafe {
+                core::mem::replace(&mut (*sink).pending_input, MutableString::init_empty())
+            }
+            .list;
+            if queued.is_empty() {
+                break;
+            }
+            // SAFETY: sink live; rewriter is (*sink).rewriter.
+            failed = unsafe { Self::write_chunk(sink, &global, rewriter, &queued) };
+        }
+        // SAFETY: sink live.
+        unsafe { (*sink).writing = false };
+        // The source finished (or errored) on the asynchronous path; its
+        // callback deferred here and kept its +1 ref, which `finish`
+        // consumes.
+        // SAFETY: sink live (refcount > 0: that deferred +1 is outstanding).
+        if let Some(terminal) = unsafe { (*sink).pending_finish.take() } {
+            // SAFETY: sink live (the deferred +1 is outstanding; `finish`
+            // consumes it). `is_async` is true because every deferral came
+            // from the asynchronous path, whose error channel this is.
+            unsafe { Self::finish(sink, terminal, true) };
+        } else if failed && !was_already_failed && source_is_async {
+            // A `write` failed on THIS frame and the source is still open:
+            // report to every consumer channel now instead of stranding
+            // them until the source ends (see the fn doc). The eventual
+            // source end re-enters `report_rewriter_failure`, which is
+            // idempotent (see its doc).
+            // SAFETY: sink live (fn contract).
+            unsafe { Self::report_rewriter_failure(sink, &global, true) };
+        }
+    }
+
+    /// One `HtmlRewriter::write`. On failure, capture the error on this
+    /// frame and poison the sink (see `write_error`). Returns whether the
+    /// write failed.
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation with
+    /// refcount > 0; `rewriter` must be `(*sink).rewriter`.
+    unsafe fn write_chunk(
+        sink: *mut Self,
+        global: &JSGlobalObject,
+        rewriter: *mut lol_html::HtmlRewriter<'static, SinkRef>,
+        chunk: &[u8],
+    ) -> bool {
+        // SAFETY: rewriter heap-allocated by init() and not yet freed: a
+        // poisoned rewriter never reaches `end()` (which is what consumes
+        // it), so it is still owned by the field until `Drop`.
+        let Err(e) = (unsafe { (*rewriter).write(chunk) }) else {
+            return false;
+        };
+        // Build the JS error NOW, on the same frame as the failing `write`:
+        // the typed `RewritingError` exists only here, and a throwing
+        // handler's captured JS exception (which it wraps) is consume-once.
+        // lol-html is poisoned after a failed `write`, so `end()` must
+        // never run on this rewriter again.
+        // SAFETY: sink still live; the call above has returned so no other
+        // `&mut *sink` exists.
+        unsafe {
+            (*sink)
+                .write_error
+                .set(global, create_lolhtml_error(global, &e))
+        };
+        true
+    }
+
     fn on_finished_buffering_trampoline(
         ctx: *mut core::ffi::c_void,
         bytes: &[u8],
@@ -798,30 +1099,86 @@ impl BufferOutputSink {
         }
     }
 
+    /// The source body is exhausted (or errored). All bytes already went
+    /// through `on_input_chunk`, so `_bytes` is always empty here.
+    ///
     /// # Safety
     /// `sink` must be a live `BufferOutputSink` heap allocation with
-    /// refcount > 0 (the +1 taken in `init()` is consumed here).
+    /// refcount > 0 (the +1 taken in `init()` is consumed here, except on
+    /// the deferred path below, which keeps it for `drive_rewriter`'s
+    /// tail to consume via `finish`).
     unsafe fn on_finished_buffering(
         sink: *mut BufferOutputSink,
-        bytes: &[u8],
+        _bytes: &[u8],
         js_err: Option<webcore::body::ValueError>,
         is_async: bool,
     ) {
-        // SAFETY: `sink` was ref'd in `init()` before scheduling this callback;
-        // refcount > 0 so the allocation is live. `adopt` consumes that +1 on Drop.
+        // Two situations must not drive the rewriter here, because both of
+        // its terminal paths (`end()` or reporting a `write_error`) can
+        // run user JS or must not run at all mid-write:
+        // - `writing`: a `drive_rewriter` is suspended on this stack (an
+        //   async handler is spinning the event loop); its own tail
+        //   delivers the terminal signal once its `write` returns.
+        // - `is_async`: the delivery may be running inside a producer's
+        //   critical section (see `on_input_chunk`), and `end()` can also
+        //   suspend on an async `onDocument.end` handler. Defer to a
+        //   fresh microtask frame.
+        // The +1 ref this call holds is deliberately NOT consumed here;
+        // `finish` (invoked from `drive_rewriter`'s tail) adopts it.
+        // SAFETY: sink live (fn contract); raw field accesses only.
+        if unsafe { (*sink).writing } || is_async {
+            // SAFETY: sink live; any suspended `drive_rewriter` holds no
+            // borrow of `pending_finish` (it read its fields into locals).
+            unsafe { (*sink).pending_finish = Some(js_err) };
+            // A suspended `drive_rewriter`'s own tail handles
+            // `pending_finish`; otherwise schedule a drain (a no-op if the
+            // final chunk already queued one a moment ago).
+            // SAFETY: sink live (fn contract); raw field read only.
+            if !unsafe { (*sink).writing } {
+                // SAFETY: sink live (fn contract).
+                unsafe { Self::schedule_drain(sink) };
+            }
+            return;
+        }
+        // SAFETY: sink live; `writing` is false and this is the
+        // synchronous path, so the caller's +1 is consumed here.
+        unsafe { Self::finish(sink, js_err, false) };
+    }
+
+    /// Deliver the terminal source signal: flush lol-html (`end()`), or
+    /// report the source / rewriter error through every channel a
+    /// consumer may be waiting on. Consumes one +1 ref on `sink`.
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation with
+    /// refcount > 0 and `(*sink).writing` false; `(*sink).response` must
+    /// be rooted by `response_value`.
+    unsafe fn finish(
+        sink: *mut BufferOutputSink,
+        js_err: Option<webcore::body::ValueError>,
+        is_async: bool,
+    ) {
+        // SAFETY: the caller holds a +1 ref (see fn doc); `adopt` consumes
+        // it on Drop.
         let _g = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
-        // Note: do not materialise `&mut *sink` here — the rewriter
-        // write/end calls below re-enter `SinkRef::handle_chunk`
-        // through the stored raw pointer, which forms
-        // its own `&mut *sink`. Holding an outer `&mut` across that re-entry
-        // is aliased-&mut UB. Access fields via raw-pointer place expressions
-        // instead (mirroring `init()`).
+        // Note: do not materialise `&mut *sink` here — the rewriter `end()`
+        // call below re-enters `SinkRef::handle_chunk` through the stored
+        // raw pointer, which forms its own `&mut *sink`. Holding an outer
+        // `&mut` across that re-entry is aliased-&mut UB. Access fields via
+        // raw-pointer place expressions instead (mirroring `init()`).
         //
         // SAFETY: sink was ref'd in init() before scheduling this callback;
         // refcount > 0 so the allocation is live.
         let global = unsafe { (*sink).global };
 
         if let Some(mut err) = js_err {
+            // A consumer already streaming the rewritten output must observe
+            // the failure: reject its stream before the body is rewritten
+            // below (which may have dropped `locked.readable` by then).
+            // SAFETY: sink live (fn contract).
+            unsafe {
+                Self::fail_output_stream(sink, &global, err.dupe(&global).to_stream_error(&global));
+            }
             // SAFETY: (*sink).response is the heap Response allocated in init()
             // and kept alive by (*sink).response_value (Strong root).
             let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
@@ -863,75 +1220,158 @@ impl BufferOutputSink {
             return;
         }
 
-        // SAFETY: `sink` is live (refcount > 0, see fn safety contract).
-        if let Some(ret_err) = unsafe { Self::run_output_sink(sink, bytes, is_async) } {
-            ret_err.ensure_still_alive();
-            ret_err.protect();
-            Self::write_tmp_sync_error(sink, ret_err);
-        }
-    }
-
-    /// Note: takes `*mut Self` (not `&mut self`) because
-    /// `HtmlRewriter::write/end` re-enter
-    /// `SinkRef::handle_chunk(&mut self)` through the
-    /// raw `*mut BufferOutputSink` captured at build time. A `&mut self`
-    /// receiver here would alias that inner `&mut` (Stacked Borrows UB).
-    ///
-    /// # Safety
-    /// `sink` must be a live `BufferOutputSink` heap allocation with
-    /// refcount > 0; `(*sink).rewriter` and `(*sink).response` must be set.
-    unsafe fn run_output_sink(sink: *mut Self, bytes: &[u8], is_async: bool) -> Option<JSValue> {
-        // SAFETY: sink is a live heap allocation (refcount > 0, caller
-        // invariant). Read fields into locals before the rewriter calls so no
-        // borrow of `*sink` is live across the re-entrant output sink.
-        let (global, response, rewriter) = unsafe {
-            let _ = (*sink).bytes.grow_by(bytes.len()); // OOM/capacity: fire-and-forget
-            ((*sink).global, (*sink).response, (*sink).rewriter)
-        };
-
-        // SAFETY: rewriter heap-allocated by init(), not yet freed.
-        if let Err(e) = unsafe { (*rewriter).write(bytes) } {
-            // Poisoned: never call `end()` after a failed `write()`. The
-            // field stays non-null so `Drop` frees the rewriter.
-            if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
-                return None;
-            } else {
-                return Some(create_lolhtml_error(&global, &e));
-            }
+        // A `write` on some earlier source chunk failed. `end()` would
+        // panic on the poisoned rewriter; report the failure directly.
+        // SAFETY: sink live (fn contract).
+        if unsafe { (*sink).write_error.has() } {
+            // SAFETY: sink live (fn contract).
+            unsafe { Self::report_rewriter_failure(sink, &global, is_async) };
+            return;
         }
 
+        // Flush lol-html. On success `end()` re-enters `SinkRef::handle_chunk`
+        // with the empty terminal chunk, which runs `done()`.
+        // SAFETY: rewriter set by init(). Read into a local before the call.
+        let rewriter = unsafe { (*sink).rewriter };
         // `HtmlRewriter::end(self)` consumes the rewriter: null the field
         // first so `Drop` does not free it a second time.
         // SAFETY: sink is a live heap allocation (refcount > 0).
         unsafe { (*sink).rewriter = core::ptr::null_mut() };
         // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
         if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
-            if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
-                return None;
-            } else {
-                return Some(create_lolhtml_error(&global, &e));
+            // Build the error once from the typed `RewritingError` and
+            // report it through every channel (the output stream, the body,
+            // and the synchronous `transform()` throw).
+            // SAFETY: sink live; the call above has returned.
+            unsafe {
+                (*sink)
+                    .write_error
+                    .set(&global, create_lolhtml_error(&global, &e))
+            };
+            // SAFETY: sink live (fn contract).
+            unsafe { Self::report_rewriter_failure(sink, &global, is_async) };
+        }
+    }
+
+    /// Reject a consumer streaming the rewritten output (if any) with `err`
+    /// and drop the sink's ref on that stream so a subsequent `done()`
+    /// takes the buffered path. `err` is consumed either way.
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation
+    /// (refcount > 0).
+    unsafe fn fail_output_stream(
+        sink: *mut Self,
+        global: &JSGlobalObject,
+        err: streams::StreamError,
+    ) {
+        // SAFETY: sink live (fn contract); short shared reborrow of one
+        // field, nothing re-entrant runs while it is live.
+        let Some(out) = (unsafe { &(*sink).output_stream }).get(global) else {
+            return;
+        };
+        if let Some(byte_stream) = out.ptr.bytes() {
+            let _ = byte_stream.on_data(StreamResult::Err(err));
+        }
+        // SAFETY: sink live (fn contract).
+        unsafe { (*sink).output_stream.deinit() };
+    }
+
+    /// lol-html itself failed (a `write` on a source chunk, or `end()`):
+    /// surface the error through every channel a consumer may be waiting on.
+    ///
+    /// `write_error` is set by the failing call (`write_chunk`, or the
+    /// `end()` arm in `finish`) from the typed error on that frame; the
+    /// fallback below is unreachable in practice and exists only so a
+    /// future caller cannot report an empty error.
+    ///
+    /// Idempotent. A fresh `write` failure is reported immediately from
+    /// `drive_rewriter`, and the real source end then reports again through
+    /// `finish`. Every channel tolerates the second delivery:
+    /// `fail_output_stream` no-ops once the stream is dropped,
+    /// `write_error.get()` is a peek (not a take), and `to_error_instance`
+    /// on an already-`Error` body is a same-`err` overwrite.
+    ///
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation with
+    /// refcount > 0 and `(*sink).response` rooted by `response_value`.
+    unsafe fn report_rewriter_failure(sink: *mut Self, global: &JSGlobalObject, is_async: bool) {
+        // SAFETY: sink live (fn contract); short shared reborrow of one field.
+        let err_value = (unsafe { &(*sink).write_error })
+            .get()
+            .unwrap_or_else(|| create_lolhtml_error(global, &"The HTMLRewriter failed"));
+        // SAFETY: sink live (fn contract).
+        unsafe {
+            Self::fail_output_stream(
+                sink,
+                global,
+                streams::StreamError::JSValue(jsc::strong::Optional::create(err_value, global)),
+            );
+        }
+        if is_async {
+            // `to_error_instance` only fails when the VM is terminating;
+            // there is nowhere left to report to (same as `done()`).
+            // SAFETY: response kept alive by response_value Strong.
+            let _ = unsafe { (*(*sink).response).get_body_value() }.to_error_instance(
+                webcore::body::ValueError::JSValue(jsc::strong::Optional::create(
+                    err_value, global,
+                )),
+                global,
+            );
+        } else {
+            err_value.ensure_still_alive();
+            err_value.protect();
+            Self::write_tmp_sync_error(sink, err_value);
+        }
+    }
+
+    /// Null every `PendingValue` back-pointer into this sink on the output
+    /// body. The body `Value` (and any `ReadableStream` a consumer holds
+    /// on it) can outlive the sink, so a late `.body`/`.text()` must not
+    /// invoke `on_start_streaming`/`on_readable_stream_available` with a
+    /// freed `task`. Idempotent; called from `Drop` so it covers every
+    /// completion path (done, rewriter failure, source error, early bail).
+    fn detach_from_output_body(&mut self) {
+        // The builder-failure path in `init()` frees `response` before
+        // `response_value` is ever set; only a rooted wrapper guarantees
+        // `self.response` is still live.
+        if self.response_value.get().is_none() {
+            return;
+        }
+        // SAFETY: `response_value` (Strong) roots the JS Response wrapper,
+        // which owns `response` as its m_ctx; both outlive this call.
+        let body_value = unsafe { (*self.response).get_body_value() };
+        let self_usize = std::ptr::from_mut(self) as usize;
+        if let webcore::body::Value::Locked(l) = body_value {
+            if l.task.map_or(0, |p| p as usize) == self_usize {
+                l.task = None;
+                l.on_start_streaming = None;
+                l.on_readable_stream_available = None;
             }
         }
-
-        None
     }
 
     pub fn done(&mut self) {
+        // A consumer is streaming the output: close its `ByteStream`. The
+        // body `Value` stays `Locked { readable }` — the data already went
+        // through the stream, exactly like a completed `fetch()` body.
+        if let Some(out) = self.output_stream.get(&self.global) {
+            if let Some(byte_stream) = out.ptr.bytes() {
+                let _ = byte_stream.on_data(StreamResult::Done);
+            }
+            self.output_stream.deinit();
+            return;
+        }
+
         // SAFETY: self.response is kept alive by self.response_value (Strong
         // root) for the lifetime of this sink.
         let body_value = unsafe { (*self.response).get_body_value() };
+        // An earlier source/handler error already put the body into the
+        // `Error` state; the buffered output is incomplete, so don't
+        // overwrite the error with it.
+        if matches!(body_value, webcore::body::Value::Error(_)) {
+            return;
+        }
         let mut prev_value = core::mem::replace(
             body_value,
             webcore::body::Value::InternalBlob(webcore::InternalBlob {
@@ -945,6 +1385,15 @@ impl BufferOutputSink {
     }
 
     pub fn write(&mut self, bytes: &[u8]) {
+        // A consumer is streaming: hand the rewritten bytes straight to its
+        // `ByteStream`. `on_data` copies `Temporary` slices synchronously
+        // and runs no user JS, so the enclosing `&mut self` stays unique.
+        if let Some(out) = self.output_stream.get(&self.global) {
+            if let Some(byte_stream) = out.ptr.bytes() {
+                let _ = byte_stream.on_data(StreamResult::Temporary(bun_ptr::RawSlice::new(bytes)));
+                return;
+            }
+        }
         let _ = self.bytes.append(bytes); // OOM/capacity: fire-and-forget
     }
 }
@@ -978,10 +1427,15 @@ pub enum BufferOutputSinkSync {
 
 impl Drop for BufferOutputSink {
     fn drop(&mut self) {
-        // bytes, body_value_bufferer, context (Rc), response_value (Strong) drop automatically.
+        // Must run before `response_value` (a struct field) drops: after
+        // that, nothing roots the output Response and its `Locked` body's
+        // callback pointers into this about-to-be-freed sink.
+        self.detach_from_output_body();
+        // bytes, output_stream (Strong), body_value_bufferer, context (Rc),
+        // response_value (Strong) drop automatically.
         if !self.rewriter.is_null() {
             // SAFETY: rewriter heap-allocated by init() and not yet freed
-            // (`run_output_sink` nulls the field before consuming it in `end`).
+            // (`finish` nulls the field before consuming it in `end`).
             unsafe { bun_core::heap::destroy(self.rewriter) };
         }
     }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2248,9 +2248,18 @@ fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Optio
 pub(crate) type ValueBuffererCallback =
     fn(ctx: *mut c_void, bytes: &[u8], err: Option<ValueError>, is_async: bool);
 
+/// Incremental-delivery callback. `bytes` is borrowed for the duration of
+/// the call; the receiver must consume it synchronously.
+pub(crate) type ValueBuffererChunkCallback = fn(ctx: *mut c_void, bytes: &[u8], is_async: bool);
+
 pub struct ValueBufferer<'a> {
     pub ctx: *mut c_void,
     pub on_finished_buffering: ValueBuffererCallback,
+    /// When set, body bytes are handed over through this callback as they
+    /// become available instead of being accumulated into `stream_buffer`,
+    /// and `on_finished_buffering` only ever signals completion (empty
+    /// slice, `err == None`) or an error.
+    pub on_chunk: Option<ValueBuffererChunkCallback>,
 
     pub js_sink: Option<Box<ArrayBufferJSSink>>,
     pub byte_stream: Option<NonNull<ByteStream>>,
@@ -2285,16 +2294,32 @@ impl<'a> ValueBufferer<'a> {
     pub(crate) fn init(
         ctx: *mut c_void,
         on_finish: ValueBuffererCallback,
+        on_chunk: Option<ValueBuffererChunkCallback>,
         global: &'a JSGlobalObject,
     ) -> Self {
         Self {
             ctx,
             on_finished_buffering: on_finish,
+            on_chunk,
             js_sink: None,
             byte_stream: None,
             readable_stream_ref: Default::default(),
             global,
             stream_buffer: MutableString::default(),
+        }
+    }
+
+    /// Hand a complete, already-materialized body to the sink. With a
+    /// per-chunk callback registered the bytes go through it first so the
+    /// completion callback never carries data.
+    fn deliver(&mut self, bytes: &[u8], is_async: bool) {
+        if let Some(on_chunk) = self.on_chunk {
+            if !bytes.is_empty() {
+                on_chunk(self.ctx, bytes, is_async);
+            }
+            (self.on_finished_buffering)(self.ctx, b"", None, is_async);
+        } else {
+            (self.on_finished_buffering)(self.ctx, bytes, None, is_async);
         }
     }
 
@@ -2354,7 +2379,7 @@ impl<'a> ValueBufferer<'a> {
                 } else {
                     let bytes = input.slice();
                     bun_core::scoped_log!(BodyValueBufferer, "Blob {}", bytes.len());
-                    (self.on_finished_buffering)(self.ctx, bytes, None, false);
+                    self.deliver(bytes, false);
                     input.detach();
                 }
                 return Ok(());
@@ -2386,7 +2411,7 @@ impl<'a> ValueBufferer<'a> {
                     "onFinishedLoadingFile Data {}",
                     buf.len()
                 );
-                (self.on_finished_buffering)(self.ctx, &buf, None, true);
+                self.deliver(&buf, true);
             }
         }
     }
@@ -2401,6 +2426,16 @@ impl<'a> ValueBufferer<'a> {
         }
         let chunk = stream.slice();
         bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe chunk {}", chunk.len());
+        if let Some(on_chunk) = self.on_chunk {
+            if !chunk.is_empty() {
+                on_chunk(self.ctx, chunk, true);
+            }
+            if stream.is_done() {
+                bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe done");
+                (self.on_finished_buffering)(self.ctx, b"", None, true);
+            }
+            return;
+        }
         let _ = self.stream_buffer.write(chunk);
         if stream.is_done() {
             let bytes = self.stream_buffer.list.as_slice();
@@ -2553,23 +2588,39 @@ impl<'a> ValueBufferer<'a> {
                             "byte stream has_received_last_chunk {}",
                             bytes.len()
                         );
-                        (self.on_finished_buffering)(self.ctx, bytes, None, false);
+                        self.deliver(bytes, false);
                         // is safe to detach here because we're not going to receive any more data
                         stream.done(self.global);
                         return Ok(());
                     }
 
-                    byte_stream
-                        .pipe
-                        .set(crate::webcore::Wrap::<Self>::init(self));
-                    self.byte_stream = NonNull::new(byte_stream_ptr);
                     bun_core::scoped_log!(
                         BodyValueBufferer,
                         "byte stream pre-buffered {}",
                         bytes.len()
                     );
-
-                    let _ = self.stream_buffer.write(bytes);
+                    // Install the pipe FIRST so that data arriving while
+                    // the (deferred) prefix is being rewritten is diverted
+                    // to `on_stream_pipe` rather than appended to the
+                    // `byte_stream.buffer` that `bytes` aliases. The prefix
+                    // is handed over with `is_async == true`, exactly like
+                    // every other pipe delivery: the per-chunk callback
+                    // copies it out synchronously (no user JS runs while
+                    // `bytes` is borrowed) and drives the rewriter from a
+                    // fresh microtask frame, so no `&mut` of this
+                    // `ValueBufferer` is live if a handler there spins the
+                    // event loop and re-enters the pipe.
+                    byte_stream
+                        .pipe
+                        .set(crate::webcore::Wrap::<Self>::init(self));
+                    self.byte_stream = NonNull::new(byte_stream_ptr);
+                    if let Some(on_chunk) = self.on_chunk {
+                        if !bytes.is_empty() {
+                            on_chunk(self.ctx, bytes, true);
+                        }
+                    } else {
+                        let _ = self.stream_buffer.write(bytes);
+                    }
                     return Ok(());
                 }
             }
@@ -2621,7 +2672,7 @@ impl<'a> ValueBufferer<'a> {
                 let input = value.use_as_any_blob_allow_non_utf8_string();
                 let bytes = input.slice();
                 bun_core::scoped_log!(BodyValueBufferer, "onReceiveValue {}", bytes.len());
-                (sink.on_finished_buffering)(sink.ctx, bytes, None, true);
+                sink.deliver(bytes, true);
             }
         }
     }
@@ -2630,7 +2681,7 @@ impl<'a> ValueBufferer<'a> {
 // `webcore::Wrap<T>` requires `T: PipeHandler`.
 impl<'a> crate::webcore::PipeHandler for ValueBufferer<'a> {
     fn on_pipe(&mut self, stream: streams::Result) {
-        self.on_stream_pipe(&stream)
+        self.on_stream_pipe(&stream);
     }
 }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2607,7 +2607,7 @@ impl<'a> ValueBufferer<'a> {
                     // every other pipe delivery: the per-chunk callback
                     // copies it out synchronously (no user JS runs while
                     // `bytes` is borrowed) and drives the rewriter from a
-                    // fresh microtask frame, so no `&mut` of this
+                    // fresh event-loop task, so no `&mut` of this
                     // `ValueBufferer` is live if a handler there spins the
                     // event loop and re-enters the pipe.
                     byte_stream

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1611,25 +1611,22 @@ describe("HTMLRewriter streaming with async handlers", () => {
     const gate1 = Promise.withResolvers();
     const gate2 = Promise.withResolvers();
     const sourceClosed = Promise.withResolvers();
-    let gated = true;
     using upstream = Bun.serve({
       port: 0,
       fetch() {
-        const waitForGates = gated;
-        gated = false;
         return new Response(
           new ReadableStream({
             type: "direct",
             async pull(controller) {
               controller.write(encoder.encode(PRELUDE));
               await controller.flush();
-              if (waitForGates) await gate1.promise;
+              await gate1.promise;
               controller.write(encoder.encode(P_A));
               await controller.flush();
-              if (waitForGates) await gate2.promise;
+              await gate2.promise;
               controller.write(encoder.encode(CHUNK_B));
               controller.close();
-              if (waitForGates) sourceClosed.resolve();
+              sourceClosed.resolve();
             },
           }),
           { headers: { "content-type": "text/html" } },
@@ -1688,22 +1685,19 @@ describe("HTMLRewriter streaming with async handlers", () => {
     // the gate, so it deadlocks.
     const gate = Promise.withResolvers();
     const sourceClosed = Promise.withResolvers();
-    let gated = true;
     using upstream = Bun.serve({
       port: 0,
       fetch() {
-        const waitForGate = gated;
-        gated = false;
         return new Response(
           new ReadableStream({
             type: "direct",
             async pull(controller) {
               controller.write(encoder.encode(CHUNK_A));
               await controller.flush();
-              if (waitForGate) await gate.promise;
+              await gate.promise;
               controller.write(encoder.encode(CHUNK_B));
               controller.close();
-              if (waitForGate) sourceClosed.resolve();
+              sourceClosed.resolve();
             },
           }),
           { headers: { "content-type": "text/html" } },

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { gcTick, tempDir, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -213,12 +213,23 @@ describe("HTMLRewriter", () => {
       await withPartialBodyServer(async (url, release) => {
         const res = await fetch(url);
         const transformed = rewriter().transform(res);
-        // Start the read BEFORE the upstream fails. This is the one shape
+        // Start reading BEFORE the upstream fails. This is the one shape
         // (readable attached, no pending promise) where the error must reach
-        // the attached stream; discarding it would strand this read forever.
-        const read = settle(transformed.body.getReader().read());
+        // the attached stream; discarding it would strand the reader forever.
+        // The transform streams, so reads may first be satisfied by the
+        // rewritten bytes that arrived before the failure; the stream must
+        // then reject with the upstream error, never complete cleanly.
+        const reader = transformed.body.getReader();
+        const settled = settle(
+          (async () => {
+            for (;;) {
+              const { done } = await reader.read();
+              if (done) throw new Error("stream closed cleanly after a truncated upstream");
+            }
+          })(),
+        );
         release();
-        expect(await read).toEqual(rejectedWithConnectionError);
+        expect(await settled).toEqual(rejectedWithConnectionError);
       });
     });
 
@@ -1259,5 +1270,469 @@ describe("tagName, endTag.name, and comment.text setters", () => {
     expect(savedElement.tagName).toBeUndefined();
     expect(savedEndTag.name).toBeUndefined();
     expect(savedComment.text).toBeNull();
+  });
+});
+
+// Shared by the two "HTMLRewriter streaming" describe blocks below.
+const encoder = new TextEncoder();
+const CHUNK_A = `<!DOCTYPE html><html><body><p id="a">one</p>`;
+const CHUNK_B = `<p id="b">two</p></body></html>`;
+const REWRITTEN = CHUNK_A.replace(`id="a"`, `id="a" rewritten="1"`) + CHUNK_B.replace(`id="b"`, `id="b" rewritten="1"`);
+
+// HTMLRewriter must drive lol-html's chunked `write()` from the source
+// stream instead of buffering the whole input first, and the transformed
+// Response's body must be a real stream while the source is still
+// producing. Every test below uses a "gate": the upstream refuses to emit
+// its final chunk and close until the behavior under test has already been
+// observed. A buffer-everything implementation therefore deadlocks
+// (deterministic failure) rather than flaking, and the gate also
+// guarantees the source is never complete before `transform()` runs.
+describe.concurrent("HTMLRewriter streaming", () => {
+  // An upstream whose body emits CHUNK_A, then refuses to emit CHUNK_B and
+  // close until `gate` resolves.
+  function gatedUpstream(gate) {
+    return Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              controller.write(encoder.encode(CHUNK_A));
+              await controller.flush();
+              await gate;
+              controller.write(encoder.encode(CHUNK_B));
+              controller.close();
+            },
+          }),
+          { headers: { "content-type": "text/html" } },
+        );
+      },
+    });
+  }
+
+  function rewriter() {
+    return new HTMLRewriter().on("p", {
+      element(element) {
+        element.setAttribute("rewritten", "1");
+      },
+    });
+  }
+
+  it("element handlers fire as source chunks arrive, not only at end-of-stream", async () => {
+    const sawFirstElement = Promise.withResolvers();
+    const gate = Promise.withResolvers();
+    using upstream = gatedUpstream(gate.promise);
+    using _openGateOnExit = { [Symbol.dispose]: () => gate.resolve() };
+
+    const seen = [];
+    const rw = new HTMLRewriter().on("p", {
+      element(element) {
+        seen.push(element.getAttribute("id"));
+        if (element.getAttribute("id") === "a") sawFirstElement.resolve();
+      },
+    });
+
+    const out = rw.transform(await fetch(upstream.url));
+    const textPromise = out.text();
+    // A buffer-everything implementation deadlocks here: the handler only
+    // fires after the source closes, and the source only closes after the
+    // handler has fired.
+    await sawFirstElement.promise;
+    expect(seen).toEqual(["a"]);
+    gate.resolve();
+    expect(await textPromise).toBe(CHUNK_A + CHUNK_B);
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  it(".body of a transformed streaming response yields the rewritten output", async () => {
+    // https://github.com/oven-sh/bun/issues/19305
+    const gate = Promise.withResolvers();
+    using upstream = gatedUpstream(gate.promise);
+    using _openGateOnExit = { [Symbol.dispose]: () => gate.resolve() };
+
+    const out = rewriter().transform(await fetch(upstream.url));
+    // The gate is still shut, so the source body is provably incomplete
+    // when `.body` is materialized. Opening it only afterwards rules out
+    // the already-buffered fast path.
+    const reader = out.body.getReader();
+    gate.resolve();
+
+    const decoder = new TextDecoder();
+    let text = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    expect(text).toBe(REWRITTEN);
+  });
+
+  it("Bun.serve streams a transformed response through to the client", async () => {
+    const gate = Promise.withResolvers();
+    using upstream = gatedUpstream(gate.promise);
+    using proxy = Bun.serve({
+      port: 0,
+      // Bounds the failure: without streaming the proxy never finishes
+      // the response and this turns into a fast, explicit error.
+      idleTimeout: 5,
+      async fetch() {
+        return rewriter().transform(await fetch(upstream.url));
+      },
+    });
+    using _openGateOnExit = { [Symbol.dispose]: () => gate.resolve() };
+
+    // Headers arriving proves the proxy already handed the Locked body to
+    // the server while the upstream was still gated open.
+    const response = await fetch(proxy.url);
+    gate.resolve();
+    expect(await response.text()).toBe(REWRITTEN);
+    expect(response.status).toBe(200);
+  });
+
+  it("Bun.serve streams a transformed Bun.file() response through to the client", async () => {
+    // https://github.com/oven-sh/bun/issues/6068
+    // A Bun.file() body is a file-backed Blob the bufferer reads
+    // asynchronously, a different source path from the piped upstream
+    // above; the server is handed the pending body before the read lands.
+    using dir = tempDir("htmlrewriter-file", { "page.html": CHUNK_A + CHUNK_B });
+    using proxy = Bun.serve({
+      port: 0,
+      // Bounds the failure: without the output stream hooks the server
+      // pipes a ByteStream nothing ever writes to.
+      idleTimeout: 5,
+      fetch() {
+        return rewriter().transform(new Response(Bun.file(path.join(String(dir), "page.html"))));
+      },
+    });
+
+    const response = await fetch(proxy.url);
+    expect(await response.text()).toBe(REWRITTEN);
+    expect(response.status).toBe(200);
+  });
+
+  it("a Bun.serve proxy delivers rewritten bytes before the upstream ends (TTFB)", async () => {
+    const gate = Promise.withResolvers();
+    using upstream = gatedUpstream(gate.promise);
+    using proxy = Bun.serve({
+      port: 0,
+      async fetch() {
+        return rewriter().transform(await fetch(upstream.url));
+      },
+    });
+    using _openGateOnExit = { [Symbol.dispose]: () => gate.resolve() };
+
+    const response = await fetch(proxy.url);
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let received = "";
+    // The upstream cannot finish until the gate opens, and the gate only
+    // opens once the client has already received rewritten output. A
+    // buffer-then-transform implementation deadlocks on the first read.
+    while (!received.includes(`id="a" rewritten="1"`)) {
+      const { done, value } = await reader.read();
+      if (done) {
+        throw new Error(
+          `proxy response closed before any rewritten output arrived; received: ${JSON.stringify(received)}`,
+        );
+      }
+      received += decoder.decode(value, { stream: true });
+    }
+    gate.resolve();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += decoder.decode(value, { stream: true });
+    }
+    received += decoder.decode();
+    expect(received).toBe(REWRITTEN);
+  });
+
+  it("two concurrent transforms with failed handlers each report their own error", async () => {
+    // A `lolhtml::write` on a source chunk can now fail long before the
+    // source ends. lol-html poisons the rewriter after a failed `write`
+    // (`end()` on it panics) and its last-error buffer is a take-once
+    // thread-local, so a second transform failing, or reporting, in that
+    // window must neither drive `end()` on the poisoned rewriter nor
+    // leave this one with an empty or clobbered error message.
+    const gate1 = Promise.withResolvers();
+    const gate2 = Promise.withResolvers();
+    using upstream1 = gatedUpstream(gate1.promise);
+    using upstream2 = gatedUpstream(gate2.promise);
+    using _openGatesOnExit = {
+      [Symbol.dispose]: () => {
+        gate1.resolve();
+        gate2.resolve();
+      },
+    };
+
+    function throwingTransform(upstream, id) {
+      const threw = Promise.withResolvers();
+      const rw = new HTMLRewriter().on("p", {
+        element() {
+          threw.resolve();
+          throw new Error(`boom-${id}`);
+        },
+      });
+      const settled = fetch(upstream.url)
+        .then(response => rw.transform(response).text())
+        .then(
+          text => ({ outcome: "resolved", text }),
+          error => ({ outcome: "rejected", message: error?.message }),
+        );
+      return { settled, threw: threw.promise };
+    }
+
+    const first = throwingTransform(upstream1, "1");
+    const second = throwingTransform(upstream2, "2");
+    // Both handlers have thrown on their first (ungated) chunk, so both
+    // transforms hold a failed lol-html write while their source is open.
+    await Promise.all([first.threw, second.threw]);
+
+    // Let the second report first, then the first.
+    gate2.resolve();
+    const secondResult = await second.settled;
+    gate1.resolve();
+    const firstResult = await first.settled;
+
+    expect(secondResult.outcome).toBe("rejected");
+    expect(firstResult.outcome).toBe("rejected");
+    // On this mid-stream (asynchronous) path the handler's thrown value is
+    // not recoverable: the VM's capture slot is only armed for the
+    // synchronous `transform()` window, so the reported message is
+    // lol-html's generic one rather than `boom-N` (identical to `main`'s
+    // async path). The clobbering this test exists to catch is one
+    // transform reporting the OTHER's error; assert that directly, which
+    // holds for both the specific and generic message shapes.
+    expect(secondResult.message.length).toBeGreaterThan(0);
+    expect(firstResult.message.length).toBeGreaterThan(0);
+    expect(firstResult.message).not.toContain("boom-2");
+    expect(secondResult.message).not.toContain("boom-1");
+  });
+
+  it("an element handler throwing mid-stream rejects a streaming .body reader", async () => {
+    const gate = Promise.withResolvers();
+    using upstream = gatedUpstream(gate.promise);
+    using _openGateOnExit = { [Symbol.dispose]: () => gate.resolve() };
+
+    // `p#a` (first chunk) is rewritten; `p#b` (second chunk, behind the
+    // gate) throws.
+    const rw = new HTMLRewriter().on("p", {
+      element(element) {
+        if (element.getAttribute("id") === "b") throw new Error("handler-boom");
+        element.setAttribute("rewritten", "1");
+      },
+    });
+    const out = rw.transform(await fetch(upstream.url));
+    const reader = out.body.getReader();
+
+    // First prove the output is streaming: drain until the rewritten
+    // first chunk is visible while the upstream is still gated open. A
+    // buffer-everything implementation deadlocks on the first read here.
+    const decoder = new TextDecoder();
+    let received = "";
+    while (!received.includes(`id="a" rewritten="1"`)) {
+      const { done, value } = await reader.read();
+      if (done) {
+        throw new Error(`output closed before any rewritten bytes arrived; received: ${JSON.stringify(received)}`);
+      }
+      received += decoder.decode(value, { stream: true });
+    }
+
+    // Now let the second chunk through; its handler throws and the
+    // already-attached reader must observe the failure. The error is the
+    // original thrown `Error` when the VM's synchronous capture slot
+    // happens to be armed, and lol-html's `HTMLRewriterError` otherwise,
+    // so only assert that a real (non-empty) error was delivered.
+    const settled = (async () => {
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) return { outcome: "resolved" };
+      }
+    })().catch(error => ({ outcome: "rejected", message: error?.message }));
+    gate.resolve();
+    const result = await settled;
+    expect(result.outcome).toBe("rejected");
+    expect(result.message.length).toBeGreaterThan(0);
+  });
+
+  it("a handler throw rejects consumers without waiting for the source to end", async () => {
+    // Unlike every other test here, the gate stays SHUT for the whole
+    // assertion, so the source never ends on its own. A failed `write`
+    // poisons the rewriter and drops every later source chunk, so waiting
+    // for the source's end to report the error strands `.text()` (and
+    // every other consumer) for as long as the upstream stays open. The
+    // only way `settled` can settle below is the immediate report.
+    const gate = Promise.withResolvers();
+    using upstream = gatedUpstream(gate.promise);
+    using _openGateOnExit = { [Symbol.dispose]: () => gate.resolve() };
+
+    const rw = new HTMLRewriter().on("p", {
+      element() {
+        throw new Error("boom-early");
+      },
+    });
+    const settled = fetch(upstream.url)
+      .then(response => rw.transform(response).text())
+      .then(
+        text => ({ outcome: "resolved", text }),
+        error => ({ outcome: "rejected", message: error?.message }),
+      );
+    const result = await settled;
+    expect(result.outcome).toBe("rejected");
+    expect(result.message.length).toBeGreaterThan(0);
+    // Only the `using` disposer above opens the gate, after the assertions.
+  });
+});
+
+// These two tests use async element handlers, which block `lolhtml::write`
+// by spinning the full event loop (`wait_for_promise`) for the duration of
+// the handler's await. Running them concurrently with other server/fetch
+// tests nests that spin inside theirs and can corrupt an unrelated
+// in-flight response, so they get their own sequential block.
+describe("HTMLRewriter streaming with async handlers", () => {
+  it("an async element handler on a chunk delivered mid-stream does not stall the HTTP client", async () => {
+    // The source's pipe handler runs inside
+    // `FetchTasklet::on_progress_update`, which holds the tasklet's mutex
+    // until `ByteStream::on_data` returns, and the singleton HTTP-client
+    // thread takes that SAME mutex before delivering the next chunk. So
+    // lol-html's `write` (which an async handler suspends by spinning the
+    // full event loop) must never run inside that callback; if it did,
+    // the handler's inner `fetch` below could never complete and every
+    // in-flight fetch in the process would stall.
+    //
+    // The first chunk deliberately contains no matched element, and the
+    // chunk that does (`p#a`) is gated until after `transform()` has
+    // returned, which guarantees it is delivered through the pipe path
+    // and never the synchronous pre-buffered prefix.
+    const PRELUDE = `<!DOCTYPE html><html><body>`;
+    const P_A = CHUNK_A.slice(PRELUDE.length);
+    const gate1 = Promise.withResolvers();
+    const gate2 = Promise.withResolvers();
+    const sourceClosed = Promise.withResolvers();
+    let gated = true;
+    using upstream = Bun.serve({
+      port: 0,
+      fetch() {
+        const waitForGates = gated;
+        gated = false;
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              controller.write(encoder.encode(PRELUDE));
+              await controller.flush();
+              if (waitForGates) await gate1.promise;
+              controller.write(encoder.encode(P_A));
+              await controller.flush();
+              if (waitForGates) await gate2.promise;
+              controller.write(encoder.encode(CHUNK_B));
+              controller.close();
+              if (waitForGates) sourceClosed.resolve();
+            },
+          }),
+          { headers: { "content-type": "text/html" } },
+        );
+      },
+    });
+    // A separate server for the handler's round trip: sharing the streaming
+    // source's host:port can reuse its pooled connection before its chunked
+    // trailer is drained (mid-spin), which reads as a malformed response.
+    using sidecar = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+    using _openGatesOnExit = {
+      [Symbol.dispose]: () => {
+        gate1.resolve();
+        gate2.resolve();
+      },
+    };
+
+    const seen = [];
+    const rw = new HTMLRewriter().on("p", {
+      async element(element) {
+        seen.push(element.getAttribute("id"));
+        element.setAttribute("rewritten", "1");
+        if (element.getAttribute("id") === "a") {
+          gate2.resolve();
+          await sourceClosed.promise;
+          // An independent round trip through the HTTP client. If this
+          // handler were running inside the source fetch tasklet's
+          // critical section, the HTTP-client thread would be parked on
+          // that mutex and this could never complete.
+          await fetch(sidecar.url).then(response => response.arrayBuffer());
+        }
+      },
+    });
+
+    const textPromise = rw.transform(await fetch(upstream.url)).text();
+    // `transform()` has returned, so `p#a`'s chunk must arrive through
+    // the pipe path.
+    gate1.resolve();
+    expect(await textPromise).toBe(REWRITTEN);
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  it("an async element handler that spans a source chunk boundary still produces correct output", async () => {
+    // `lolhtml::HTMLRewriter::write` blocks on an async handler by
+    // spinning the full event loop (`wait_for_promise`), during which the
+    // source can deliver its remaining chunks and finish. lol-html is not
+    // re-entrant: those arrivals must be queued and fed by the suspended
+    // `write` once it resumes, never fed re-entrantly.
+    //
+    // The handler on `p#a` (the first chunk) opens the upstream's gate
+    // itself and then awaits a full independent HTTP round trip, so the
+    // second chunk and the source's end both arrive while `write` is
+    // still suspended on the first. This also proves input streaming: a
+    // buffer-everything implementation only runs the handler after the
+    // source closes, but the source cannot close until the handler opens
+    // the gate, so it deadlocks.
+    const gate = Promise.withResolvers();
+    const sourceClosed = Promise.withResolvers();
+    let gated = true;
+    using upstream = Bun.serve({
+      port: 0,
+      fetch() {
+        const waitForGate = gated;
+        gated = false;
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              controller.write(encoder.encode(CHUNK_A));
+              await controller.flush();
+              if (waitForGate) await gate.promise;
+              controller.write(encoder.encode(CHUNK_B));
+              controller.close();
+              if (waitForGate) sourceClosed.resolve();
+            },
+          }),
+          { headers: { "content-type": "text/html" } },
+        );
+      },
+    });
+    // A separate server for the handler's round trip: sharing the streaming
+    // source's host:port can reuse its pooled connection before its chunked
+    // trailer is drained (mid-spin), which reads as a malformed response.
+    using sidecar = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+    using _openGateOnExit = { [Symbol.dispose]: () => gate.resolve() };
+
+    const seen = [];
+    const rw = new HTMLRewriter().on("p", {
+      async element(element) {
+        seen.push(element.getAttribute("id"));
+        element.setAttribute("rewritten", "1");
+        if (element.getAttribute("id") === "a") {
+          gate.resolve();
+          await sourceClosed.promise;
+          // A full independent round trip forces enough event-loop work
+          // that the second chunk (already written) has reached the
+          // suspended transform's pipe by the time the handler resumes.
+          await fetch(sidecar.url).then(response => response.arrayBuffer());
+        }
+      },
+    });
+
+    expect(await rw.transform(await fetch(upstream.url)).text()).toBe(REWRITTEN);
+    expect(seen).toEqual(["a", "b"]);
   });
 });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1451,11 +1451,11 @@ describe.concurrent("HTMLRewriter streaming", () => {
 
   it("two concurrent transforms with failed handlers each report their own error", async () => {
     // A `lolhtml::write` on a source chunk can now fail long before the
-    // source ends. lol-html poisons the rewriter after a failed `write`
-    // (`end()` on it panics) and its last-error buffer is a take-once
-    // thread-local, so a second transform failing, or reporting, in that
-    // window must neither drive `end()` on the poisoned rewriter nor
-    // leave this one with an empty or clobbered error message.
+    // source ends, and lol-html poisons the rewriter after a failed
+    // `write` (`end()` on it panics). A second transform failing, or
+    // reporting, in that window must neither drive `end()` on the
+    // poisoned rewriter nor leave this one with an empty or clobbered
+    // error message.
     const gate1 = Promise.withResolvers();
     const gate2 = Promise.withResolvers();
     using upstream1 = gatedUpstream(gate1.promise);


### PR DESCRIPTION
Fixes #19305
Fixes #6068

### Problem

`HTMLRewriter.transform(response)` fully buffers the source body before running lol-html, then does a single `write()` + `end()`. The output `Response`'s pending body also has none of the stream callbacks fetch bodies install, so no consumer that wants a stream is ever told about the `ByteStream` it is reading. Three user-visible consequences, all reproducible with a plain streaming upstream:

```js
// upstream: a Bun.serve that emits "<p>1</p>", waits, emits "<p>2</p>", closes
const rw = () => new HTMLRewriter().on("p", { element(e) { e.setAttribute("x", "1"); } });
const res = rw().transform(await fetch(upstream));
```

1. Handlers only fire when the source closes, never as chunks arrive. An element handler on the first chunk fires at T = upstream-end, not at T = first-chunk. Memory is proportional to the document, and the TTFB of a transformed proxy response equals the full upstream download time.
2. `res.body` yields an empty, closed stream: the `.body` getter creates a `ByteStream` the producer never learns about (`on_readable_stream_available` is not set), then `done()`'s `Value::resolve` sees the orphan readable and closes it empty. Every `.body` consumer (a reader, `new Response(res.body)`, `S3.write`) gets `""`. That is #19305.
3. `Bun.serve` returning the transformed response hangs forever: the server sees `Locked { task: Some }`, calls `Value::to_readable_stream`, and pipes a `ByteStream` nobody ever writes to. #6068 is the `Bun.file()` shape of the same bug (a file-backed body is read asynchronously, so the server always gets the pending body first).

### Rebased twice: onto #32927 / #32840, then onto #33048

An earlier revision of this PR also fixed the source-stream error swallowing (`ValueBufferer::on_stream_pipe` treating `StreamResult::Err` as a clean zero-byte end), the `ValueBufferer` half of #31964. #32927 landed that fix first and more completely (it also covers the parked-error short-circuit, the synchronous `transform()` error shape, and a `Value::Error` guard on every body reader), so in the rebase main's version wins and this PR's copy is removed. This PR no longer claims #31964, and its two source-stream-error tests are deleted as exact functional duplicates of #32927's merged suite (verified: both pass on post-#32927 `main`). What remains is purely the streaming change this PR was filed for.

**One merged test is adapted, and it is the part of the resolution to review.** #32927's `a read already pending on .body when the upstream fails rejects` starts a single `reader.read()` before the upstream fails and asserts that that read rejects. That is only true of a fully buffered implementation, where nothing can reach `.body` until the whole input has arrived. With this PR the bytes that arrive before the failure are rewritten and delivered immediately (that is the point), so the pending read is legitimately satisfied by a chunk of rewritten output first. The test now reads in a loop, which protects the same invariant its author named ("the error must reach the attached stream; a read must never be stranded") and is strictly stronger: it still fails if the stream closes cleanly (the exact bug #32927 fixed), still fails on a hang, and passes only when a read eventually rejects with the upstream error. I verified the invariant holds before changing anything: on this branch a subsequent read does reject with the connection error. Every other test #32927 and #32840 added passes unmodified.

Separately, the post-rebase soak surfaced a real, pre-existing HTTP-client race that is independent of this PR. An async element handler runs inside `wait_for_promise` (`handler_callback` has always spun the full event loop for an async handler; that is not introduced here). The two async-handler tests' "independent round trip" fetched the same `host:port` as the still-streaming chunked source, and about 1 in 20 full-file runs got a `Malformed_HTTP_Response` whose raw bytes were the previous response's terminal chunked trailer (`0\r\n\r\n`) prepended to the next response: the source's connection returns to the pool while the nested loop is spinning, before its trailer is drained, and the handler's fetch reuses it. The two tests now give that round trip its own sidecar server so it cannot share a pooled connection with the source under test; their purpose (prove the HTTP-client thread is not parked) is unchanged. After the change: 0 failures in 110 consecutive runs (50 full-file, 60 filtered). The underlying client bug (a chunked keep-alive connection re-pooled with an unconsumed trailer under a re-entrant event loop) is worth a separate issue.

**#33048 (requested in review on this PR) then landed, and this diff is now re-expressed on top of its `lol_html` Rust-crate bindings.** The streaming design turned out to be orthogonal to the bindings: of the fourteen functions it adds, eleven never touch lol-html and ported verbatim, and only three places changed shape. `write_chunk` now destructures the typed per-call `Result<(), RewritingError>` and builds the JS error from it directly; `finish`'s flush uses the crate's consuming `end(self)` (null the field, `heap::take(rewriter).end()`); and `Drop` uses `heap::destroy`. `Body.rs` needed nothing (#33048 never touched it). This is also what resolves the original review concern on this PR: the `extern "C"` trampolines, the opaque-handle FFI, and lol-html's take-once thread-local error buffer that this diff previously had to reason about are all gone from the code it is built on.

One honest finding from re-verifying on the new bindings: on the asynchronous (mid-stream) path, a throwing handler's JS error value is not recoverable by the time the failure is reported, because the VM's exception-capture slot is only armed for the synchronous `transform()` window, so the reported message is lol-html's generic one. That is byte-for-byte `main`'s behavior on its own asynchronous path (which formats the same `RewritingError` display), so it is preserved here, not introduced, and it is why the concurrent-failure test asserts the absence of cross-contamination rather than each handler's literal message. Recovering the thrown value on the asynchronous path is a worthwhile follow-up, independent of streaming.

### Fix

Input side (`Body.rs`): `ValueBufferer` gains an optional per-chunk callback. When set, body bytes are delivered incrementally and `on_finished_buffering` only ever signals completion or an error.

HTMLRewriter (`html_rewriter.rs`): `BufferOutputSink` registers that callback and feeds each source chunk into `HtmlRewriter::write`. The output body's `PendingValue` gets `on_start_streaming` (hands over any already-rewritten bytes as the new stream's initial buffer) and `on_readable_stream_available`, the same lazy contract `FetchTasklet` uses. The second hook stashes the consumer's new `ReadableStream` into the output `Response` cell's `stream` WriteBarrier slot (`values: ["stream"]` in `response.classes.ts`, visited by the generated `visitChildrenImpl`); the sink holds no reference of its own and reads it back through `Response::get_body_readable_stream`. The cell slot, not the body `Value`, is the right owner because `Bun.serve`'s `do_render_with_body` moves the stream out of the body and replaces the `Value` with `Used`. Once a consumer streams, `OutputSink::write` pushes rewritten bytes straight into that stream and `done()` closes it. With no streaming consumer, `done()`'s buffered `Value::resolve` path is unchanged, so `.text()` / `.json()` and string / blob inputs behave exactly as before.

**The pipe callback must never drive lol-html inline.** `ValueBufferer`'s pipe handler runs inside `FetchTasklet::on_progress_update`, which holds the tasklet's mutex until `ByteStream::on_data` returns, and the singleton HTTP-client thread takes that same mutex before delivering the next chunk. `HtmlRewriter::write` can suspend on an **async** element handler spinning the full event loop (`vm().wait_for_promise`), which would park the HTTP thread (and every in-flight `fetch`) on that mutex for the whole await, and deadlock outright if the handler's own `await` needs it. lol-html is also not re-entrant, so a chunk or source end arriving during that spin must not re-enter it. So:

- The asynchronous delivery paths copy the chunk into a queue on the sink and schedule a drain as an event-loop task (an `AnyTask` embedded on the sink + `VirtualMachine::enqueue_task`, the `FetchTasklet` shape). A task runs on a fresh stack, strictly after the producer's critical section ends, and at the top of an event-loop turn. It must be a task and not a microtask: an async handler's `wait_for_promise` drains the microtask queue, and doing that from inside a microtask callback would re-enter the microtask drain.
- `drive_rewriter` sets `writing` for the duration of its lol-html calls; chunks, the source's end, or an error arriving while a `write` is suspended are queued / deferred and drained by that suspended call's own loop and tail.
- The synchronous paths (`transform(string/blob)` and a source that is already complete) drive lol-html directly: no producer lock exists there, which preserves `transform()`'s synchronous contract for non-streaming inputs. The pre-buffered prefix of a still-streaming source goes through the deferred path like every other pipe delivery: the slice handoff stays synchronous (no user JS runs while it is borrowed), and no `&mut ValueBufferer` is ever live when a handler spins the event loop and re-enters the pipe.

Lifetime: the sink's only GC reference is a `JsRef` on the output `Response` wrapper, strong for the sink's active lifetime (the pattern `JsRef` documents and `ServerWebSocket` / `UDPSocket` use); the cell's `visitChildrenImpl` keeps everything else reachable. It holds no `JSC::Strong`. In the other direction, the output body `Value` (and any `ReadableStream` a consumer holds on it) can outlive the sink, so `Drop for BufferOutputSink` nulls every `PendingValue` back-pointer into the sink (`detach_from_output_body`) and a late `.body` / `.text()` can never invoke `on_start_streaming` on freed memory.

Three more corrections the per-chunk input made load-bearing:

- `done()` no longer overwrites a body already in the `Error` state with a partial `InternalBlob`.
- The error for a failed `write` is built at the failing call rather than when the source ends. The typed `RewritingError` exists only on that call's frame, and the pending JS exception a throwing handler may have left is consume-once, so neither can be read later (at source end) without having been lost or consumed in between. The JS error is carried as a stack value and reported from that same `drive_rewriter` invocation; it is never stored on the sink.
- `end()` is skipped when an earlier `write` already failed (a handler threw mid-stream and the source then ended cleanly). lol-html poisons the rewriter after a failed `write` and panics (`Attempt to use the HtmlRewriter after a fatal error`) if it is used again. A source that ends with an error never reaches `end()` at all; that path is #32927's and is unchanged here.
- A `write` failure on a still-open source is reported to every consumer immediately instead of when the source eventually ends. A failed `write` poisons the rewriter and drops every later chunk, so there is nothing left to wait for, and a `.text()` / `.body` / `Bun.serve` consumer of a long or never-ending upstream would otherwise hang. The eventual source end then has nothing left to do; `finish` on a poisoned sink returns without touching the rewriter.

The task deferral, the re-entrancy guard, the four corrections above, the removal of every `JSC::Strong` from the sink (in favor of the `Response` cell's WriteBarrier graph plus one `JsRef`), and the replacement of the raw-pointer `(*sink).field` access pattern with three disjoint `RefCell` domains (so every entry point forms only a shared `&Self`, and an aliasing violation is a deterministic panic instead of UB) were all surfaced by review on this PR.

Not included: JS / direct `ReadableStream` sources (#11758, #14216) still return `ERR_STREAM_CANNOT_PIPE`. That path needs the disabled `ArrayBufferJSSink` pump, a separate mechanism.

### Verification

Ten new tests in `test/js/workerd/html-rewriter.test.js`, in a `describe.concurrent("HTMLRewriter streaming")` block plus a sequential `describe("HTMLRewriter streaming with async handlers")` for the two whose handlers spin the event loop (a nested `wait_for_promise` is hostile to concurrently running server / fetch tests). Each is gate-driven: the upstream refuses to emit its final chunk until the behavior under test has already been observed, so a buffer-everything implementation deadlocks deterministically rather than flaking, and the gate also guarantees the source is never already complete when `transform()` runs.

- element handlers fire on the first chunk while the source is provably still open
- `.body` of a transformed streaming response yields the rewritten output
- `Bun.serve` streams a transformed response through to the client
- `Bun.serve` streams a transformed `Bun.file()` response through to the client (#6068)
- a `Bun.serve` proxy delivers rewritten bytes to the client before the upstream ends
- an element handler throwing mid-stream rejects an already-streaming `.body` reader
- a handler throw rejects consumers WITHOUT waiting for the source to end: the only test whose upstream gate stays shut for the whole assertion, so the immediate failure report is the only thing that can settle the consumer (pre-fix it fails by timing out)
- two concurrent transforms whose handlers both fail mid-stream each report their own error
- an **async** element handler on a chunk delivered mid-stream does not stall the HTTP client: the chunk containing the matched element is gated until after `transform()` has returned (forcing the pipe path), and the handler then awaits an independent round trip through the HTTP client, which can never complete if the rewriter is driven from inside the fetch tasklet's critical section
- an **async** element handler that spans a source chunk boundary still produces correct, in-order output (the re-entrancy guard)

With this change all ten pass, and at the final revision (re-expressed on the #33048 bindings) the full file passes 0 failures across 80 consecutive runs (40 of the whole file, 40 filtered to the streaming describes), on top of the earlier 110 and 80 clean runs at the prior revisions. With `src/` reverted to post-#33048 `main` (the gate's fail-before base) exactly these ten fail, deterministically, by timeout or a missing-first-chunk assertion, and every pre-existing test in the file, including everything #32927, #32840, and #33048 added, still passes.

<details>
<summary>Existing suite and soaks</summary>

Re-run after the rebase, on a debug + ASAN build:

- Full HTMLRewriter suite (5 files, 87 tests): 0 fail, 2 todo (the pre-existing JS-ReadableStream `it.todo`s, intentionally unchanged), 1 skip.
- `test/js/web/fetch/{body,body-stream,body-clone,body-mixin-errors,body-async-iterator,blob,content-length}.test.*` (this PR's `Body.rs` change now merges with #32927's `Body.rs` and body-reader changes): 9489 pass, 0 fail.
- 110 consecutive runs of `html-rewriter.test.js` (50 of the whole file, 60 filtered to the streaming describes): 0 failures.

Run on the pre-rebase revision; the streaming and lifetime code they exercise is unchanged by the rebase resolution:

- ASAN soak: 200 iterations across 6 consumer shapes (`.text()`, fully-drained `.body`, abandoned reader, dropped Response, `Bun.serve` proxy, mid-transform cancel) with `Bun.gc(true)` every 5: clean.
- ASAN soak: 160 iterations across the re-entrancy shapes (handler grabs `out.body.getReader()` from inside `lolhtml::write`, handler throws mid-stream with a `.body` reader attached, reader cancelled from inside a handler, handler throws with a `.text()` consumer): clean.

</details>

### Related PRs

Related PRs touching the same code. This one was originally written against `main` without any of them.

- #32956 registers the same `on_readable_stream_available` hook and delivers the output as a single terminal chunk at `done()` time. That fixes the `.body`-empty and `Bun.serve`-hang symptoms, but the input is still fully buffered and the output still arrives only at end-of-stream. This PR supersedes that mechanism; the two cannot merge cleanly. #32956's separate `Bun.file()` size-sentinel fix (non-seekable or missing files report their length as `u64::MAX` and trip a lol-html preallocation assert) is a distinct pre-existing bug, is not made more reachable here, and is not duplicated here.
- #32927 (now merged) is the deeper fix for the error swallowing: it also covers the `has_received_last_chunk` parked-error short-circuit, surfaces the real body error from the synchronous `transform()` branch, and adds a `Value::Error` guard to every body reader. The one change both made (the `Err` arm in `on_stream_pipe`) is removed from this PR in the rebase in favor of main's; see the rebase section above.
- #31835 reworks `ValueBufferer::run`'s error return (exception fidelity, a different concern). Semantically independent; textually conflicts with the new `ValueBufferer` field and `init` signature.






