### PR TITLE
Report DNS lookup failures from fetch() and Bun.connect as ENOTFOUND

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -583,20 +583,21 @@ void *us_socket_group_connect(struct us_socket_group_t *group, unsigned char kin
     struct addrinfo_request *ai_req;
     if (Bun__addrinfo_get(loop, host, (uint16_t)port, &ai_req) == 0) {
         struct addrinfo_result *result = Bun__addrinfo_getRequestResult(ai_req);
-        if (result->error) {
-            errno = result->error;
-            Bun__addrinfo_freeRequest(ai_req, 1);
-            return NULL;
-        }
-
-        struct addrinfo_result_entry *entries = result->entries;
-        if (entries && entries->info.ai_next == NULL) {
-            struct sockaddr_storage a;
-            init_addr_with_port(&entries->info, port, &a);
-            *has_dns_resolved = 1;
-            struct us_socket_t *s = us_socket_group_connect_resolved_dns(group, kind, ssl_ctx, &a, local_addr, options, socket_ext_size);
-            Bun__addrinfo_freeRequest(ai_req, s == NULL);
-            return s;
+        /* A cached resolver failure falls through to the connecting-socket path
+         * below (same as a multi-address result) so it is reported through the
+         * same connect-error callback, with dns_error set, as an uncached one.
+         * Bun__addrinfo_set on an already-resolved request defers to the loop's
+         * dns_ready_head, never re-enters. */
+        if (!result->error) {
+            struct addrinfo_result_entry *entries = result->entries;
+            if (entries && entries->info.ai_next == NULL) {
+                struct sockaddr_storage a;
+                init_addr_with_port(&entries->info, port, &a);
+                *has_dns_resolved = 1;
+                struct us_socket_t *s = us_socket_group_connect_resolved_dns(group, kind, ssl_ctx, &a, local_addr, options, socket_ext_size);
+                Bun__addrinfo_freeRequest(ai_req, s == NULL);
+                return s;
+            }
         }
     }
 
@@ -718,6 +719,10 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
 #endif
     struct addrinfo_result *result = Bun__addrinfo_getRequestResult(c->addrinfo_req);
     if (result->error) {
+        /* Preserve the getaddrinfo failure so the connect-error callback can
+         * report the resolver error (ENOTFOUND, ...) instead of the fabricated
+         * ECONNABORTED that us_connecting_socket_close fills into c->error. */
+        c->dns_error = result->error;
         us_connecting_socket_close(c);
         return;
     }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -585,9 +585,9 @@ void *us_socket_group_connect(struct us_socket_group_t *group, unsigned char kin
         struct addrinfo_result *result = Bun__addrinfo_getRequestResult(ai_req);
         /* A cached resolver failure falls through to the connecting-socket path
          * below (same as a multi-address result) so it is reported through the
-         * same connect-error callback, with dns_error set, as an uncached one.
-         * Bun__addrinfo_set on an already-resolved request defers to the loop's
-         * dns_ready_head, never re-enters. */
+         * same connect-error callback, tagged `error_is_dns`, as an uncached
+         * one. Bun__addrinfo_set on an already-resolved request defers to the
+         * loop's dns_ready_head, never re-enters. */
         if (!result->error) {
             struct addrinfo_result_entry *entries = result->entries;
             if (entries && entries->info.ai_next == NULL) {
@@ -721,8 +721,11 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
     if (result->error) {
         /* Preserve the getaddrinfo failure so the connect-error callback can
          * report the resolver error (ENOTFOUND, ...) instead of the fabricated
-         * ECONNABORTED that us_connecting_socket_close fills into c->error. */
-        c->dns_error = result->error;
+         * ECONNABORTED that us_connecting_socket_close fills in when `error`
+         * is still 0. `error_is_dns` tags the namespace: getaddrinfo return
+         * codes and errnos overlap numerically. */
+        c->error = result->error;
+        c->error_is_dns = 1;
         us_connecting_socket_close(c);
         return;
     }

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -318,6 +318,10 @@ struct us_connecting_socket_t {
     unsigned char kind;
     uint16_t port;
     int error;
+    /* Raw getaddrinfo(3) return code when the name lookup for this connect
+     * failed; 0 otherwise. Kept out of `error`: the EAI_* and errno
+     * constant sets are different namespaces and overlap numerically. */
+    int dns_error;
     struct addrinfo *addrinfo_head;
     // this is used to track pending connecting sockets in the context
     struct us_connecting_socket_t* next_pending;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -312,16 +312,16 @@ struct us_connecting_socket_t {
     struct us_socket_t *connecting_head;
     int options;
     int socket_ext_size;
-    unsigned int closed : 1, shutdown : 1, shutdown_read : 1, pending_resolve_callback : 1;
+    /* error_is_dns: `error` holds the raw getaddrinfo(3) return code for a
+     * failed name lookup rather than an errno. The two constant sets are
+     * different namespaces that overlap numerically, so consumers of `error`
+     * must check this bit first. */
+    unsigned int closed : 1, shutdown : 1, shutdown_read : 1, pending_resolve_callback : 1, error_is_dns : 1;
     unsigned char timeout;
     unsigned char long_timeout;
     unsigned char kind;
     uint16_t port;
     int error;
-    /* Raw getaddrinfo(3) return code when the name lookup for this connect
-     * failed; 0 otherwise. Kept out of `error`: the EAI_* and errno
-     * constant sets are different namespaces and overlap numerically. */
-    int dns_error;
     struct addrinfo *addrinfo_head;
     // this is used to track pending connecting sockets in the context
     struct us_connecting_socket_t* next_pending;

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -395,6 +395,10 @@ void us_connecting_socket_shutdown_read(struct us_connecting_socket_t *c) nonnul
 int us_connecting_socket_is_shut_down(struct us_connecting_socket_t *c) nonnull_fn_decl;
 int us_connecting_socket_is_closed(struct us_connecting_socket_t *c) nonnull_fn_decl;
 int us_connecting_socket_get_error(struct us_connecting_socket_t *c) nonnull_fn_decl;
+/* Raw getaddrinfo(3) return code when the name lookup itself failed; 0 for a
+ * connect failure past name resolution. A different namespace from
+ * us_connecting_socket_get_error (errno). */
+int us_connecting_socket_get_dns_error(struct us_connecting_socket_t *c) nonnull_fn_decl;
 void *us_connecting_socket_get_native_handle(struct us_connecting_socket_t *c) nonnull_fn_decl;
 struct us_loop_t *us_connecting_socket_get_loop(struct us_connecting_socket_t *c) nonnull_fn_decl;
 struct us_socket_group_t *us_connecting_socket_group(struct us_connecting_socket_t *c) nonnull_fn_decl;

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -396,8 +396,8 @@ int us_connecting_socket_is_shut_down(struct us_connecting_socket_t *c) nonnull_
 int us_connecting_socket_is_closed(struct us_connecting_socket_t *c) nonnull_fn_decl;
 int us_connecting_socket_get_error(struct us_connecting_socket_t *c) nonnull_fn_decl;
 /* Raw getaddrinfo(3) return code when the name lookup itself failed; 0 for a
- * connect failure past name resolution. A different namespace from
- * us_connecting_socket_get_error (errno). */
+ * connect failure past name resolution. Nonzero means us_connecting_socket_get_error
+ * returns the same getaddrinfo code, not an errno (the two namespaces overlap). */
 int us_connecting_socket_get_dns_error(struct us_connecting_socket_t *c) nonnull_fn_decl;
 void *us_connecting_socket_get_native_handle(struct us_connecting_socket_t *c) nonnull_fn_decl;
 struct us_loop_t *us_connecting_socket_get_loop(struct us_connecting_socket_t *c) nonnull_fn_decl;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -245,7 +245,9 @@ void us_connecting_socket_close(struct us_connecting_socket_t *c) {
     }
 
     if (c->addrinfo_req) {
-        Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == ECONNREFUSED);
+        /* Invalidate the cache entry for a refused connect (addresses may be
+         * stale) and for a resolver failure (never cache a negative result). */
+        Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == ECONNREFUSED || c->dns_error != 0);
         c->addrinfo_req = 0;
     }
     us_dispatch_connecting_error(c, c->error);
@@ -630,6 +632,10 @@ void us_connecting_socket_shutdown(struct us_connecting_socket_t *c) {
 
 int us_connecting_socket_get_error(struct us_connecting_socket_t *c) {
     return c->error;
+}
+
+int us_connecting_socket_get_dns_error(struct us_connecting_socket_t *c) {
+    return c->dns_error;
 }
 
 struct us_socket_t *us_socket_open(struct us_socket_t *s, int is_client, char *ip, int ip_length) {

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -247,7 +247,7 @@ void us_connecting_socket_close(struct us_connecting_socket_t *c) {
     if (c->addrinfo_req) {
         /* Invalidate the cache entry for a refused connect (addresses may be
          * stale) and for a resolver failure (never cache a negative result). */
-        Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == ECONNREFUSED || c->dns_error != 0);
+        Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == ECONNREFUSED || c->error_is_dns);
         c->addrinfo_req = 0;
     }
     us_dispatch_connecting_error(c, c->error);
@@ -635,7 +635,7 @@ int us_connecting_socket_get_error(struct us_connecting_socket_t *c) {
 }
 
 int us_connecting_socket_get_dns_error(struct us_connecting_socket_t *c) {
-    return c->dns_error;
+    return c->error_is_dns ? c->error : 0;
 }
 
 struct us_socket_t *us_socket_open(struct us_socket_t *s, int is_client, char *ip, int ip_length) {

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1327,10 +1327,13 @@ impl<const SSL: bool> Handler<SSL> {
     }
 
     pub fn on_connect_error(ptr: *mut c_void, socket: HTTPSocket<SSL>, _: c_int) {
+        // Read before the socket is marked dead: uSockets keeps the
+        // connecting socket alive for the whole dispatch.
+        let dns_error = socket.dns_error();
         let tagged = HTTPContext::<SSL>::get_tagged(ptr);
         HTTPContext::<SSL>::mark_tagged_socket_as_dead(socket, tagged);
         if let Some(client) = tagged.client_mut() {
-            client.on_connect_error();
+            client.on_connect_error(dns_error);
         } else {
             // Same backstop as `on_close`: a SEMI_SOCKET/connecting socket
             // whose ext is no longer a client never dispatches `on_close`,

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -43,6 +43,10 @@ pub struct InternalState<'a> {
     pub original_request_body: HTTPRequestBody<'a>,
     pub request_sent_len: usize,
     pub fail: Option<Error>,
+    /// Raw `getaddrinfo(3)` return code when `fail` is `DNSResolveFailed`;
+    /// 0 otherwise. The JS side turns it into the resolver error
+    /// (`ENOTFOUND`, ...) with `syscall`/`hostname`, matching `node:dns`.
+    pub dns_error: i32,
     pub request_stage: HTTPStage,
     pub response_stage: HTTPStage,
     pub certificate_info: Option<CertificateInfo>,
@@ -128,6 +132,7 @@ impl Default for InternalState<'_> {
             original_request_body: HTTPRequestBody::Bytes(b""),
             request_sent_len: 0,
             fail: None,
+            dns_error: 0,
             request_stage: HTTPStage::Pending,
             response_stage: HTTPStage::Pending,
             certificate_info: None,

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -47,6 +47,11 @@ pub struct InternalState<'a> {
     /// 0 otherwise. The JS side turns it into the resolver error
     /// (`ENOTFOUND`, ...) with `syscall`/`hostname`, matching `node:dns`.
     pub dns_error: i32,
+    /// Owned copy of the hostname the failed lookup was for
+    /// (`connected_url.hostname`: the proxy's when one is configured, else
+    /// the post-redirect target). Captured on the HTTP thread at the failure
+    /// so the JS side never dereferences the client's borrowed URL buffers.
+    pub dns_hostname: Option<Box<[u8]>>,
     pub request_stage: HTTPStage,
     pub response_stage: HTTPStage,
     pub certificate_info: Option<CertificateInfo>,
@@ -133,6 +138,7 @@ impl Default for InternalState<'_> {
             request_sent_len: 0,
             fail: None,
             dns_error: 0,
+            dns_hostname: None,
             request_stage: HTTPStage::Pending,
             response_stage: HTTPStage::Pending,
             certificate_info: None,

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -421,6 +421,10 @@ pub struct HTTPClientResult<'a> {
     pub is_http2: bool,
 
     pub fail: Option<bun_core::Error>,
+    /// Raw `getaddrinfo(3)` return code when `fail` is `DNSResolveFailed`;
+    /// 0 otherwise. Lets the JS side report the resolver error (`ENOTFOUND`,
+    /// ...) with `syscall`/`hostname` instead of a generic connect failure.
+    pub dns_error: i32,
 
     /// Owns the response metadata aka headers, url and status code
     pub metadata: Option<HTTPResponseMetadata>,
@@ -478,6 +482,7 @@ impl<'a> HTTPClientResult<'a> {
             can_stream: self.can_stream,
             is_http2: self.is_http2,
             fail: self.fail,
+            dns_error: self.dns_error,
             metadata: self.metadata,
             body_size: self.body_size,
             certificate_info: self.certificate_info,
@@ -1955,8 +1960,20 @@ impl<'a> HTTPClient<'a> {
         GenHttpContext::<IS_SSL>::terminate_socket(socket);
     }
 
-    pub fn on_connect_error(&mut self) {
-        bun_core::scoped_log!(fetch, "onConnectError  {}\n", BStr::new(self.url.href));
+    /// `dns_error` is the raw `getaddrinfo(3)` return code when the name
+    /// lookup itself failed; 0 for a connect failure past name resolution.
+    pub fn on_connect_error(&mut self, dns_error: i32) {
+        bun_core::scoped_log!(
+            fetch,
+            "onConnectError  {} dns_error={}\n",
+            BStr::new(self.url.href),
+            dns_error
+        );
+        if dns_error != 0 {
+            self.state.dns_error = dns_error;
+            self.fail(err!(DNSResolveFailed));
+            return;
+        }
         self.fail(err!(ConnectionRefused));
     }
 
@@ -3946,6 +3963,7 @@ impl<'a> HTTPClient<'a> {
             can_stream,
             is_http2,
             fail,
+            dns_error,
             metadata,
             body_size,
             certificate_info,
@@ -3957,6 +3975,7 @@ impl<'a> HTTPClient<'a> {
                 r.can_stream,
                 r.is_http2,
                 r.fail,
+                r.dns_error,
                 r.metadata,
                 r.body_size,
                 r.certificate_info,
@@ -4098,6 +4117,7 @@ impl<'a> HTTPClient<'a> {
             can_stream,
             is_http2,
             fail,
+            dns_error,
             metadata,
             body_size,
             certificate_info,
@@ -4141,6 +4161,7 @@ impl<'a> HTTPClient<'a> {
             can_stream,
             is_http2,
             fail,
+            dns_error,
             metadata,
             body_size,
             certificate_info,
@@ -4152,6 +4173,7 @@ impl<'a> HTTPClient<'a> {
                 r.can_stream,
                 r.is_http2,
                 r.fail,
+                r.dns_error,
                 r.metadata,
                 r.body_size,
                 r.certificate_info,
@@ -4179,6 +4201,7 @@ impl<'a> HTTPClient<'a> {
             can_stream,
             is_http2,
             fail,
+            dns_error,
             metadata,
             body_size,
             certificate_info,
@@ -4343,6 +4366,7 @@ impl<'a> HTTPClient<'a> {
                 body: body_out::opt_mut(self.state.body_out_str),
                 redirected: self.flags.redirected,
                 fail: self.state.fail,
+                dns_error: self.state.dns_error,
                 // check if we are reporting cert errors, do not have a fail state and we are not done
                 has_more: certificate_info.is_some()
                     || (self.state.fail.is_none() && !self.state.is_done()),
@@ -4359,6 +4383,7 @@ impl<'a> HTTPClient<'a> {
             metadata: None,
             redirected: self.flags.redirected,
             fail: self.state.fail,
+            dns_error: self.state.dns_error,
             // check if we are reporting cert errors, do not have a fail state and we are not done
             has_more: certificate_info.is_some()
                 || (self.state.fail.is_none() && !self.state.is_done()),

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -425,6 +425,11 @@ pub struct HTTPClientResult<'a> {
     /// 0 otherwise. Lets the JS side report the resolver error (`ENOTFOUND`,
     /// ...) with `syscall`/`hostname` instead of a generic connect failure.
     pub dns_error: i32,
+    /// Owned copy of the hostname the failed lookup was for (the proxy's
+    /// when one is configured, else the post-redirect target). Owned so the
+    /// JS side never dereferences the client's borrowed URL buffers, which
+    /// the HTTP thread frees after the result callback returns.
+    pub dns_hostname: Option<Box<[u8]>>,
 
     /// Owns the response metadata aka headers, url and status code
     pub metadata: Option<HTTPResponseMetadata>,
@@ -483,6 +488,7 @@ impl<'a> HTTPClientResult<'a> {
             is_http2: self.is_http2,
             fail: self.fail,
             dns_error: self.dns_error,
+            dns_hostname: self.dns_hostname,
             metadata: self.metadata,
             body_size: self.body_size,
             certificate_info: self.certificate_info,
@@ -1971,6 +1977,11 @@ impl<'a> HTTPClient<'a> {
         );
         if dns_error != 0 {
             self.state.dns_error = dns_error;
+            // `connected_url.hostname` is the exact name the connect resolved
+            // (the proxy's when one is set, else the post-redirect `url`), set
+            // by `HTTPContext::connect` and valid for the connect attempt.
+            // Copy it: the JS side outlives this client's borrowed URL buffers.
+            self.state.dns_hostname = Some(self.connected_url.hostname.into());
             self.fail(err!(DNSResolveFailed));
             return;
         }
@@ -3964,6 +3975,7 @@ impl<'a> HTTPClient<'a> {
             is_http2,
             fail,
             dns_error,
+            dns_hostname,
             metadata,
             body_size,
             certificate_info,
@@ -3976,6 +3988,7 @@ impl<'a> HTTPClient<'a> {
                 r.is_http2,
                 r.fail,
                 r.dns_error,
+                r.dns_hostname,
                 r.metadata,
                 r.body_size,
                 r.certificate_info,
@@ -4118,6 +4131,7 @@ impl<'a> HTTPClient<'a> {
             is_http2,
             fail,
             dns_error,
+            dns_hostname,
             metadata,
             body_size,
             certificate_info,
@@ -4162,6 +4176,7 @@ impl<'a> HTTPClient<'a> {
             is_http2,
             fail,
             dns_error,
+            dns_hostname,
             metadata,
             body_size,
             certificate_info,
@@ -4174,6 +4189,7 @@ impl<'a> HTTPClient<'a> {
                 r.is_http2,
                 r.fail,
                 r.dns_error,
+                r.dns_hostname,
                 r.metadata,
                 r.body_size,
                 r.certificate_info,
@@ -4202,6 +4218,7 @@ impl<'a> HTTPClient<'a> {
             is_http2,
             fail,
             dns_error,
+            dns_hostname,
             metadata,
             body_size,
             certificate_info,
@@ -4367,6 +4384,7 @@ impl<'a> HTTPClient<'a> {
                 redirected: self.flags.redirected,
                 fail: self.state.fail,
                 dns_error: self.state.dns_error,
+                dns_hostname: self.state.dns_hostname.take(),
                 // check if we are reporting cert errors, do not have a fail state and we are not done
                 has_more: certificate_info.is_some()
                     || (self.state.fail.is_none() && !self.state.is_done()),
@@ -4384,6 +4402,7 @@ impl<'a> HTTPClient<'a> {
             redirected: self.flags.redirected,
             fail: self.state.fail,
             dns_error: self.state.dns_error,
+            dns_hostname: self.state.dns_hostname.take(),
             // check if we are reporting cert errors, do not have a fail state and we are not done
             has_more: certificate_info.is_some()
                 || (self.state.fail.is_none() && !self.state.is_done()),

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -775,14 +775,18 @@ pub(crate) fn error_to_js_with_syscall(
     Ok(instance)
 }
 
-pub(crate) fn error_to_js_with_syscall_and_hostname(
+/// `SystemError` fields for a resolver failure, in the shape `node:dns`
+/// reports them: `code`/`errno` derived from the DNS error, message
+/// `"<syscall> <CODE> <hostname>"`, plus `syscall` and `hostname`.
+/// `fetch()`/`Bun.connect` reuse this so a failed name lookup surfaces the
+/// same error the resolver APIs do.
+pub(crate) fn system_error_with_syscall_and_hostname(
     this: c_ares::Error,
-    global_this: &JSGlobalObject,
     syscall: &'static [u8],
     hostname: &[u8],
-) -> JsResult<JSValue> {
+) -> SystemError {
     let code = this.code();
-    let instance = SystemError {
+    SystemError {
         errno: this as i32,
         code: bstr::String::static_(&code[4..]),
         message: bstr::String::create_format(format_args!(
@@ -795,7 +799,16 @@ pub(crate) fn error_to_js_with_syscall_and_hostname(
         hostname: bstr::String::clone_utf8(hostname),
         ..Default::default()
     }
-    .to_error_instance(global_this);
+}
+
+pub(crate) fn error_to_js_with_syscall_and_hostname(
+    this: c_ares::Error,
+    global_this: &JSGlobalObject,
+    syscall: &'static [u8],
+    hostname: &[u8],
+) -> JsResult<JSValue> {
+    let instance = system_error_with_syscall_and_hostname(this, syscall, hostname)
+        .to_error_instance(global_this);
     instance.put(
         global_this,
         b"name",

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1597,7 +1597,7 @@ fn connect_finish<const IS_SSL: bool>(
         // longer used on this branch. `handle_connect_error` takes `*mut Self`
         // (noalias re-entrancy) — no `&mut NewSocket` held across its JS call.
         unsafe {
-            let _ = NewSocket::<IS_SSL>::handle_connect_error(socket, errno);
+            let _ = NewSocket::<IS_SSL>::handle_connect_error(socket, errno, 0);
             // Balance the unconditional `socket_ref.ref_()` above.
             (*socket).deref();
         }

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -226,7 +226,7 @@ impl WindowsNamedPipeContext {
         } else {
             // SAFETY: see `on_open`.
             match_socket!(unsafe { (*this).socket }, |s: NewSocket<SSL>| unsafe {
-                _ = NewSocket::handle_connect_error(s, err.errno as i32)
+                _ = NewSocket::handle_connect_error(s, err.errno as i32, 0)
             });
         }
     }
@@ -409,7 +409,7 @@ impl WindowsNamedPipeContext {
             // SAFETY: `this` is live; create() returned it and no deref has fired yet.
             // +1 ref held on the inner socket; live until `Self::deref` below.
             match_socket!(unsafe { (*this).socket }, |s: NewSocket<SSL>| unsafe {
-                _ = NewSocket::handle_connect_error(s, SystemErrno::ENOENT as i32)
+                _ = NewSocket::handle_connect_error(s, SystemErrno::ENOENT as i32, 0)
             });
             // SAFETY: `this` was just returned from `create()` (refcount==1);
             // release the only ref on the errdefer path.
@@ -439,7 +439,7 @@ impl WindowsNamedPipeContext {
             // SAFETY: `this` is live; create() returned it and no deref has fired yet.
             // +1 ref held on the inner socket; live until `Self::deref` below.
             match_socket!(unsafe { (*this).socket }, |s: NewSocket<SSL>| unsafe {
-                _ = NewSocket::handle_connect_error(s, SystemErrno::ENOENT as i32)
+                _ = NewSocket::handle_connect_error(s, SystemErrno::ENOENT as i32, 0)
             });
             // SAFETY: `this` was just returned from `create()` (refcount==1);
             // release the only ref on the errdefer path.

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -29,6 +29,7 @@ use crate::crypto::boringssl_jsc::err_to_js as boringssl_err_to_js;
 use crate::node::{BlobOrStringOrBuffer, StringOrBuffer};
 use crate::socket::{SSLConfig, SSLConfigFromJs};
 use bun_boringssl_sys as boringssl_sys;
+use bun_cares_sys::c_ares_draft as c_ares;
 use bun_core::String as BunString;
 use bun_event_loop::AnyTask::AnyTask;
 use bun_jsc::virtual_machine::VirtualMachine;
@@ -940,9 +941,17 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// this socket via `m_ptr` (node:net `autoSelectFamily` retries inside the
     /// `connectError` callback).
     ///
+    /// `dns_error` is the raw `getaddrinfo(3)` return code when the name
+    /// lookup itself failed; 0 for a connect failure past name resolution
+    /// (then `errno` carries the connect error).
+    ///
     /// # Safety
     /// `this` points at a live `NewSocket`; JS-thread only.
-    pub unsafe fn handle_connect_error(this: *mut Self, errno: c_int) -> JsResult<()> {
+    pub unsafe fn handle_connect_error(
+        this: *mut Self,
+        errno: c_int,
+        dns_error: i32,
+    ) -> JsResult<()> {
         // SAFETY: per fn contract; R-2 — shared reborrow, all
         // mutated fields are `Cell`/`JsCell`.
         let this: &Self = unsafe { &*this };
@@ -1026,62 +1035,77 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         debug_assert!(errno >= 0);
-        // Unix-path connect errors keep their real code (a non-socket file is
-        // ENOTSOCK, a permission-denied path is EACCES, a missing one is
-        // ENOENT, an inexpressible path is EINVAL); everything else stays
-        // ECONNREFUSED.
-        let errno_: c_int = if errno == sys::SystemErrno::ENOENT as c_int
-            || errno == sys::SystemErrno::ENOTSOCK as c_int
-            || errno == sys::SystemErrno::EACCES as c_int
-            || errno == sys::SystemErrno::EINVAL as c_int
-            || errno == sys::SystemErrno::ECONNRESET as c_int
-            || errno == sys::SystemErrno::EADDRINUSE as c_int
-            || errno == sys::SystemErrno::EADDRNOTAVAIL as c_int
-        {
-            errno
-        } else {
-            sys::SystemErrno::ECONNREFUSED as c_int
-        };
-        let code_ = if errno == sys::SystemErrno::ENOENT as c_int {
-            BunString::static_("ENOENT")
-        } else if errno == sys::SystemErrno::ENOTSOCK as c_int {
-            BunString::static_("ENOTSOCK")
-        } else if errno == sys::SystemErrno::EACCES as c_int {
-            BunString::static_("EACCES")
-        } else if errno == sys::SystemErrno::EINVAL as c_int {
-            BunString::static_("EINVAL")
-        } else if errno == sys::SystemErrno::ECONNRESET as c_int {
-            BunString::static_("ECONNRESET")
-        } else if errno == sys::SystemErrno::EADDRINUSE as c_int {
-            BunString::static_("EADDRINUSE")
-        } else if errno == sys::SystemErrno::EADDRNOTAVAIL as c_int {
-            BunString::static_("EADDRNOTAVAIL")
-        } else {
-            BunString::static_("ECONNREFUSED")
-        };
-        #[cfg(windows)]
-        let errno_ = {
-            let mut errno_ = errno_;
-            if errno_ == sys::SystemErrno::ENOENT as c_int {
-                errno_ = sys::SystemErrno::UV_ENOENT as c_int;
-            }
-            if errno_ == sys::SystemErrno::ECONNREFUSED as c_int {
-                errno_ = sys::SystemErrno::UV_ECONNREFUSED as c_int;
-            }
-            errno_
-        };
-
         let callback = handlers.on_connect_error;
         let global = handlers.global_object;
-        let err = SystemError {
-            errno: -errno_,
-            message: BunString::static_("Failed to connect"),
-            syscall: BunString::static_("connect"),
-            code: code_,
-            path: BunString::EMPTY,
-            hostname: BunString::EMPTY,
-            fd: c_int::MIN,
-            dest: BunString::EMPTY,
+        // A failed name lookup is reported as the resolver error
+        // (`getaddrinfo ENOTFOUND <hostname>`, `syscall`/`hostname` set),
+        // matching `node:dns` — never collapsed into ECONNREFUSED.
+        let dns_err = c_ares::Error::init_eai(dns_error).filter(|_| dns_error != 0);
+        let err = if let Some(dns_err) = dns_err {
+            let hostname: &[u8] = match this.connection.get() {
+                Some(super::listener::UnixOrHost::Host { host, .. }) => host,
+                _ => b"",
+            };
+            crate::dns_jsc::cares_jsc::system_error_with_syscall_and_hostname(
+                dns_err,
+                b"getaddrinfo",
+                hostname,
+            )
+        } else {
+            // Unix-path connect errors keep their real code (a non-socket file
+            // is ENOTSOCK, a permission-denied path is EACCES, a missing one is
+            // ENOENT, an inexpressible path is EINVAL); everything else stays
+            // ECONNREFUSED.
+            let errno_: c_int = if errno == sys::SystemErrno::ENOENT as c_int
+                || errno == sys::SystemErrno::ENOTSOCK as c_int
+                || errno == sys::SystemErrno::EACCES as c_int
+                || errno == sys::SystemErrno::EINVAL as c_int
+                || errno == sys::SystemErrno::ECONNRESET as c_int
+                || errno == sys::SystemErrno::EADDRINUSE as c_int
+                || errno == sys::SystemErrno::EADDRNOTAVAIL as c_int
+            {
+                errno
+            } else {
+                sys::SystemErrno::ECONNREFUSED as c_int
+            };
+            let code_ = if errno == sys::SystemErrno::ENOENT as c_int {
+                BunString::static_("ENOENT")
+            } else if errno == sys::SystemErrno::ENOTSOCK as c_int {
+                BunString::static_("ENOTSOCK")
+            } else if errno == sys::SystemErrno::EACCES as c_int {
+                BunString::static_("EACCES")
+            } else if errno == sys::SystemErrno::EINVAL as c_int {
+                BunString::static_("EINVAL")
+            } else if errno == sys::SystemErrno::ECONNRESET as c_int {
+                BunString::static_("ECONNRESET")
+            } else if errno == sys::SystemErrno::EADDRINUSE as c_int {
+                BunString::static_("EADDRINUSE")
+            } else if errno == sys::SystemErrno::EADDRNOTAVAIL as c_int {
+                BunString::static_("EADDRNOTAVAIL")
+            } else {
+                BunString::static_("ECONNREFUSED")
+            };
+            #[cfg(windows)]
+            let errno_ = {
+                let mut errno_ = errno_;
+                if errno_ == sys::SystemErrno::ENOENT as c_int {
+                    errno_ = sys::SystemErrno::UV_ENOENT as c_int;
+                }
+                if errno_ == sys::SystemErrno::ECONNREFUSED as c_int {
+                    errno_ = sys::SystemErrno::UV_ECONNREFUSED as c_int;
+                }
+                errno_
+            };
+            SystemError {
+                errno: -errno_,
+                message: BunString::static_("Failed to connect"),
+                syscall: BunString::static_("connect"),
+                code: code_,
+                path: BunString::EMPTY,
+                hostname: BunString::EMPTY,
+                fd: c_int::MIN,
+                dest: BunString::EMPTY,
+            }
         };
 
         // the handlers must be kept alive for the duration of the function call
@@ -1180,12 +1204,12 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// `this` points at a live `NewSocket`; JS-thread only.
     pub unsafe fn on_connect_error(
         this: *mut Self,
-        _socket: SocketHandler<SSL>,
+        socket: SocketHandler<SSL>,
         errno: c_int,
     ) -> JsResult<()> {
         jsc::mark_binding!();
         // SAFETY: per fn contract.
-        unsafe { Self::handle_connect_error(this, errno) }
+        unsafe { Self::handle_connect_error(this, errno, socket.dns_error()) }
     }
 
     pub fn mark_active(&self) {
@@ -4191,7 +4215,7 @@ impl DuplexUpgradeContext {
                 // UpgradedDuplex, not Detached) — do NOT reconstruct the
                 // IntrusiveRc. `handle_connect_error` takes `*mut Self`.
                 let _ = unsafe {
-                    TLSSocket::handle_connect_error(p, sys::SystemErrno::ECONNREFUSED as c_int)
+                    TLSSocket::handle_connect_error(p, sys::SystemErrno::ECONNREFUSED as c_int, 0)
                 };
             }
         }
@@ -4291,7 +4315,7 @@ impl DuplexUpgradeContext {
                         // `needs_deref` arm releases the +1 transferred via
                         // `into_raw` (socket is UpgradedDuplex, not Detached).
                         // `handle_connect_error` takes `*mut Self`.
-                        let _ = unsafe { TLSSocket::handle_connect_error(p, errno) };
+                        let _ = unsafe { TLSSocket::handle_connect_error(p, errno, 0) };
                     }
                     // `startTLS`/`startTLSWithCTX` failed before the
                     // SSLWrapper was assigned, so its close callback

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1034,12 +1034,13 @@ impl<const SSL: bool> NewSocket<SSL> {
             return Ok(());
         }
 
-        debug_assert!(errno >= 0);
         let callback = handlers.on_connect_error;
         let global = handlers.global_object;
         // A failed name lookup is reported as the resolver error
         // (`getaddrinfo ENOTFOUND <hostname>`, `syscall`/`hostname` set),
-        // matching `node:dns` — never collapsed into ECONNREFUSED.
+        // matching `node:dns` — never collapsed into ECONNREFUSED. On that
+        // path `errno` carries the same (possibly negative) getaddrinfo code
+        // as `dns_error`, so it is only treated as an errno in the else arm.
         let dns_err = c_ares::Error::init_eai(dns_error).filter(|_| dns_error != 0);
         let err = if let Some(dns_err) = dns_err {
             let hostname: &[u8] = match this.connection.get() {
@@ -1052,6 +1053,7 @@ impl<const SSL: bool> NewSocket<SSL> {
                 hostname,
             )
         } else {
+            debug_assert!(errno >= 0);
             // Unix-path connect errors keep their real code (a non-socket file
             // is ENOTSOCK, a permission-denied path is EACCES, a missing one is
             // ENOENT, an inexpressible path is EINVAL); everything else stays

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1307,7 +1307,12 @@ impl FetchTasklet {
         // is always `Some`.
         if fail == err!("DNSResolveFailed") {
             if let Some(dns_err) = c_ares::Error::init_eai(self.result.dns_error) {
-                let hostname: &[u8] = self.http.as_ref().map_or(b"", |h| h.url.hostname);
+                // With a proxy configured, the HTTP thread resolves the proxy
+                // hostname, not the origin's; report the one getaddrinfo
+                // actually failed on.
+                let hostname: &[u8] = self.http.as_ref().map_or(b"", |h| {
+                    h.http_proxy.as_ref().map_or(h.url.hostname, |p| p.hostname)
+                });
                 let mut err = crate::dns_jsc::cares_jsc::system_error_with_syscall_and_hostname(
                     dns_err,
                     b"getaddrinfo",

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2,6 +2,7 @@ use core::ffi::c_void;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use bun_boringssl as boringssl;
+use bun_cares_sys::c_ares_draft as c_ares;
 use bun_core::{Error as BunError, err};
 use bun_core::{MutableString, OwnedString, String as BunString, ZigStringSlice};
 use bun_event_loop::{
@@ -1298,6 +1299,24 @@ impl FetchTasklet {
         } else {
             BunString::EMPTY
         };
+
+        // The hostname never resolved: report the resolver error (`ENOTFOUND`,
+        // ...) with `syscall`/`hostname`, the same shape `node:dns` produces,
+        // rather than a generic connect-failure message. `dns_error` is the
+        // raw getaddrinfo(3) code and is nonzero on this path, so `init_eai`
+        // is always `Some`.
+        if fail == err!("DNSResolveFailed") {
+            if let Some(dns_err) = c_ares::Error::init_eai(self.result.dns_error) {
+                let hostname: &[u8] = self.http.as_ref().map_or(b"", |h| h.url.hostname);
+                let mut err = crate::dns_jsc::cares_jsc::system_error_with_syscall_and_hostname(
+                    dns_err,
+                    b"getaddrinfo",
+                    hostname,
+                );
+                err.path = path;
+                return BodyValueError::SystemError(err);
+            }
+        }
 
         let code = if fail == err!("ConnectionClosed") {
             BunString::static_("ECONNRESET")

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1307,12 +1307,11 @@ impl FetchTasklet {
         // is always `Some`.
         if fail == err!("DNSResolveFailed") {
             if let Some(dns_err) = c_ares::Error::init_eai(self.result.dns_error) {
-                // With a proxy configured, the HTTP thread resolves the proxy
-                // hostname, not the origin's; report the one getaddrinfo
-                // actually failed on.
-                let hostname: &[u8] = self.http.as_ref().map_or(b"", |h| {
-                    h.http_proxy.as_ref().map_or(h.url.hostname, |p| p.hostname)
-                });
+                // `dns_hostname` is the owned copy of the exact name the
+                // connect resolved (proxy or post-redirect target), captured
+                // on the HTTP thread; never reconstruct it from `self.http`,
+                // whose post-redirect URL slices are freed by then.
+                let hostname: &[u8] = self.result.dns_hostname.as_deref().unwrap_or(b"");
                 let mut err = crate::dns_jsc::cares_jsc::system_error_with_syscall_and_hostname(
                     dns_err,
                     b"getaddrinfo",

--- a/src/uws_sys/ConnectingSocket.rs
+++ b/src/uws_sys/ConnectingSocket.rs
@@ -47,6 +47,13 @@ impl ConnectingSocket {
         us_connecting_socket_get_error(self)
     }
 
+    /// Raw `getaddrinfo(3)` return code when the name lookup itself failed;
+    /// 0 for a connect failure past name resolution. A different namespace
+    /// from [`Self::get_error`] (errno).
+    pub fn get_dns_error(&mut self) -> i32 {
+        us_connecting_socket_get_dns_error(self)
+    }
+
     pub fn get_native_handle(&mut self) -> *mut c_void {
         us_connecting_socket_get_native_handle(self)
     }
@@ -87,6 +94,7 @@ unsafe extern "C" {
     pub(crate) safe fn us_connecting_socket_kind(s: &mut ConnectingSocket) -> u8;
     pub(crate) safe fn us_connecting_socket_ext(s: &mut ConnectingSocket) -> *mut c_void;
     pub(crate) safe fn us_connecting_socket_get_error(s: &mut ConnectingSocket) -> i32;
+    pub(crate) safe fn us_connecting_socket_get_dns_error(s: &mut ConnectingSocket) -> i32;
     pub(crate) safe fn us_connecting_socket_get_native_handle(
         s: &mut ConnectingSocket,
     ) -> *mut c_void;

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -322,6 +322,17 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         )
     }
 
+    /// Raw `getaddrinfo(3)` return code for a pending connect whose name
+    /// lookup failed; 0 otherwise (a connect failure past name resolution, or
+    /// any non-connecting handle). A different namespace from
+    /// [`Self::get_error`] (errno).
+    pub fn dns_error(&self) -> i32 {
+        match self.socket {
+            InternalSocket::Connecting(c) => conn(c).get_dns_error(),
+            _ => 0,
+        }
+    }
+
     // ── lifecycle ───────────────────────────────────────────────────────────
 
     pub fn close(&self, code: CloseCode) {

--- a/test/js/bun/net/socket-dns-error.test.ts
+++ b/test/js/bun/net/socket-dns-error.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test";
+
+// `Bun.connect` to a hostname that fails to resolve must surface the resolver
+// error (code `ENOTFOUND`, `syscall: "getaddrinfo"`, `hostname`), matching
+// `node:dns`, rather than collapsing it into `ECONNREFUSED` / `syscall:
+// "connect"` as if a listener had refused the connection.
+//
+// These live in their own file because `socket.test.ts` is a large
+// `describe.concurrent` block whose dual-stack `localhost` tests are
+// environment-sensitive; the name-resolution contract needs a deterministic,
+// hermetic home.
+
+// A DNS label longer than 63 bytes is illegal (RFC 1035 section 2.3.4), so
+// getaddrinfo rejects it locally without touching the network.
+const UNRESOLVABLE_HOST = Buffer.alloc(64, "a").toString() + ".com";
+
+const EXPECTED = {
+  name: "Error",
+  code: "ENOTFOUND",
+  syscall: "getaddrinfo",
+  hostname: UNRESOLVABLE_HOST,
+  message: `getaddrinfo ENOTFOUND ${UNRESOLVABLE_HOST}`,
+};
+
+function pick({ name, code, syscall, hostname, message }: any) {
+  return { name, code, syscall, hostname, message };
+}
+
+test("Bun.connect reports a failed hostname lookup as the resolver error, not ECONNREFUSED", async () => {
+  const { promise: connectErrored, resolve: onConnectError } = Promise.withResolvers<Error>();
+  let connectErrorCalls = 0;
+  const promiseError: Error = await Bun.connect({
+    hostname: UNRESOLVABLE_HOST,
+    port: 80,
+    socket: {
+      open() {},
+      data() {},
+      connectError(_socket, error) {
+        connectErrorCalls++;
+        onConnectError(error as Error);
+      },
+    },
+  }).then(
+    () => Promise.reject(new Error("expected the connect promise to reject")),
+    (e: Error) => e,
+  );
+
+  expect(pick(await connectErrored)).toEqual(EXPECTED);
+  expect(pick(promiseError)).toEqual(EXPECTED);
+  expect(connectErrorCalls).toBe(1);
+});
+
+test("Bun.connect rejects the promise with the resolver error when connectError is not set", async () => {
+  const error: Error = await Bun.connect({
+    hostname: UNRESOLVABLE_HOST,
+    port: 80,
+    socket: { open() {}, data() {} },
+  }).then(
+    () => Promise.reject(new Error("expected the connect promise to reject")),
+    (e: Error) => e,
+  );
+  expect(pick(error)).toEqual(EXPECTED);
+});
+
+test("consecutive Bun.connect calls to the same unresolvable hostname all get the resolver error", async () => {
+  // The second attempt exercises the in-process DNS cache, which used to take
+  // a different code path and report a different (also wrong) error.
+  const errors = [];
+  for (let i = 0; i < 3; i++) {
+    errors.push(
+      await Bun.connect({
+        hostname: UNRESOLVABLE_HOST,
+        port: 80,
+        socket: { open() {}, data() {} },
+      }).then(
+        () => "resolved",
+        (e: Error) => pick(e),
+      ),
+    );
+  }
+  expect(errors).toEqual([EXPECTED, EXPECTED, EXPECTED]);
+});

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -1,6 +1,7 @@
 /* globals AbortController */
 
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { createHash, randomFillSync } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:http";
@@ -399,12 +400,46 @@ test("post FormData with File", async () => {
   expect(/filename123/.test(result)).toBeTrue();
 });
 
-test("invalid url", async () => {
-  try {
-    await fetch("http://invalid");
-  } catch (e) {
-    expect(e.message).toBe("Unable to connect. Is the computer able to access the url?");
-  }
+test("unresolvable hostname rejects with the resolver error", async () => {
+  // A DNS label longer than 63 bytes is illegal (RFC 1035 section 2.3.4), so
+  // getaddrinfo rejects it locally without touching the network. Three fetches
+  // in a row: the second hits the in-process DNS cache, which used to take a
+  // different path and report a different (also wrong) error. Runs in a
+  // subprocess with the proxy env cleared so fetch actually resolves the name.
+  const host = Buffer.alloc(64, "a").toString() + ".com";
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const out = [];
+       for (let i = 0; i < 3; i++) {
+         try {
+           await fetch("http://" + ${JSON.stringify(host)} + "/");
+           out.push("resolved");
+         } catch ({ name, code, syscall, hostname, message }) {
+           out.push({ name, code, syscall, hostname, message });
+         }
+       }
+       console.log(JSON.stringify(out));`,
+    ],
+    env: {
+      ...bunEnv,
+      HTTP_PROXY: undefined,
+      HTTPS_PROXY: undefined,
+      http_proxy: undefined,
+      https_proxy: undefined,
+    },
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const expected = {
+    name: "Error",
+    code: "ENOTFOUND",
+    syscall: "getaddrinfo",
+    hostname: host,
+    message: `getaddrinfo ENOTFOUND ${host}`,
+  };
+  expect({ out: JSON.parse(stdout), exitCode }).toEqual({ out: [expected, expected, expected], exitCode: 0 });
 });
 
 test("do not decode redirect body", async () => {

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -404,22 +404,26 @@ test("unresolvable hostname rejects with the resolver error", async () => {
   // A DNS label longer than 63 bytes is illegal (RFC 1035 section 2.3.4), so
   // getaddrinfo rejects it locally without touching the network. Three fetches
   // in a row: the second hits the in-process DNS cache, which used to take a
-  // different path and report a different (also wrong) error. Runs in a
-  // subprocess with the proxy env cleared so fetch actually resolves the name.
+  // different path and report a different (also wrong) error. The fourth uses
+  // an explicit unresolvable proxy: with a proxy configured it is the proxy
+  // hostname that getaddrinfo resolves, so the error must name the proxy, not
+  // the origin. Runs in a subprocess with the proxy env cleared so the first
+  // three fetches actually resolve the origin.
   const host = Buffer.alloc(64, "a").toString() + ".com";
+  const proxyHost = Buffer.alloc(64, "b").toString() + ".com";
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `const out = [];
+       const report = p => p.then(
+         () => "resolved",
+         ({ name, code, syscall, hostname, message }) => ({ name, code, syscall, hostname, message }),
+       );
        for (let i = 0; i < 3; i++) {
-         try {
-           await fetch("http://" + ${JSON.stringify(host)} + "/");
-           out.push("resolved");
-         } catch ({ name, code, syscall, hostname, message }) {
-           out.push({ name, code, syscall, hostname, message });
-         }
+         out.push(await report(fetch("http://" + ${JSON.stringify(host)} + "/")));
        }
+       out.push(await report(fetch("http://origin.invalid/", { proxy: "http://" + ${JSON.stringify(proxyHost)} + ":3128" })));
        console.log(JSON.stringify(out));`,
     ],
     env: {
@@ -428,18 +432,30 @@ test("unresolvable hostname rejects with the resolver error", async () => {
       HTTPS_PROXY: undefined,
       http_proxy: undefined,
       https_proxy: undefined,
+      NO_PROXY: undefined,
+      no_proxy: undefined,
     },
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const expected = {
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const notFound = (hostname: string) => ({
     name: "Error",
     code: "ENOTFOUND",
     syscall: "getaddrinfo",
-    hostname: host,
-    message: `getaddrinfo ENOTFOUND ${host}`,
-  };
-  expect({ out: JSON.parse(stdout), exitCode }).toEqual({ out: [expected, expected, expected], exitCode: 0 });
+    hostname,
+    message: `getaddrinfo ENOTFOUND ${hostname}`,
+  });
+  // `out` is the raw stdout if it is not JSON (the subprocess crashed), so the
+  // failure diff shows what the child actually printed alongside stderr.
+  let out: unknown = stdout;
+  try {
+    out = JSON.parse(stdout);
+  } catch {}
+  expect({ out, stderr, exitCode }).toEqual({
+    out: [notFound(host), notFound(host), notFound(host), notFound(proxyHost)],
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test("do not decode redirect body", async () => {

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -402,15 +402,19 @@ test("post FormData with File", async () => {
 
 test("unresolvable hostname rejects with the resolver error", async () => {
   // A DNS label longer than 63 bytes is illegal (RFC 1035 section 2.3.4), so
-  // getaddrinfo rejects it locally without touching the network. Three fetches
-  // in a row: the second hits the in-process DNS cache, which used to take a
-  // different path and report a different (also wrong) error. The fourth uses
-  // an explicit unresolvable proxy: with a proxy configured it is the proxy
-  // hostname that getaddrinfo resolves, so the error must name the proxy, not
-  // the origin. Runs in a subprocess with the proxy env cleared so the first
-  // three fetches actually resolve the origin.
+  // getaddrinfo rejects it locally without touching the network. The cases,
+  // each of which must name the hostname getaddrinfo actually failed on:
+  //   1-3. Direct fetches: the second hits the in-process DNS cache, which
+  //        used to take a different path and report a different wrong error.
+  //   4.   An explicit unresolvable proxy: the error must name the proxy,
+  //        not the origin, since the proxy is what gets resolved.
+  //   5.   A redirect to an unresolvable host: the error must name the
+  //        redirect target, not the original (resolvable) origin.
+  // Runs in a subprocess with the proxy env cleared so the direct fetches
+  // actually resolve their hostnames.
   const host = Buffer.alloc(64, "a").toString() + ".com";
   const proxyHost = Buffer.alloc(64, "b").toString() + ".com";
+  const redirectHost = Buffer.alloc(64, "c").toString() + ".com";
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -424,6 +428,11 @@ test("unresolvable hostname rejects with the resolver error", async () => {
          out.push(await report(fetch("http://" + ${JSON.stringify(host)} + "/")));
        }
        out.push(await report(fetch("http://origin.invalid/", { proxy: "http://" + ${JSON.stringify(proxyHost)} + ":3128" })));
+       using server = Bun.serve({
+         port: 0,
+         fetch: () => Response.redirect("http://" + ${JSON.stringify(redirectHost)} + "/", 302),
+       });
+       out.push(await report(fetch(server.url)));
        console.log(JSON.stringify(out));`,
     ],
     env: {
@@ -452,7 +461,7 @@ test("unresolvable hostname rejects with the resolver error", async () => {
     out = JSON.parse(stdout);
   } catch {}
   expect({ out, stderr, exitCode }).toEqual({
-    out: [notFound(host), notFound(host), notFound(host), notFound(proxyHost)],
+    out: [notFound(host), notFound(host), notFound(host), notFound(proxyHost), notFound(redirectHost)],
     stderr: "",
     exitCode: 0,
   });


### PR DESCRIPTION
Fixes NXDOMAIN (and every other resolver failure) from `fetch()` and `Bun.connect()` being reported as a refused connection.

### Repro

```js
const host = "a".repeat(64) + ".com"; // >63-byte DNS label: getaddrinfo rejects it locally

await fetch(`http://${host}/`).catch(e => console.log(e.code, e.syscall, e.hostname));
// before:  ConnectionRefused  undefined  undefined   "Unable to connect. Is the computer able to access the url?"
// (a second fetch to the same host hits the DNS cache and gets a *different* wrong error:
//  FailedToOpenSocket  "Was there a typo in the url or port?")

await Bun.connect({ hostname: host, port: 80, socket: { open() {}, data() {} } })
  .catch(e => console.log(e.code, e.syscall, e.hostname));
// before:  ECONNREFUSED  connect  undefined   "Failed to connect"

// node, and Bun's own node:dns / node:net for the same name:
//          ENOTFOUND  getaddrinfo  <host>   "getaddrinfo ENOTFOUND <host>"
```

"name does not resolve" and "host refused the connection" drive opposite reactions (fix the hostname vs. retry and back off), and HTTP client libraries and retry wrappers branch on exactly this distinction, so under Bun they all misdiagnose NXDOMAIN.

### Cause

The `getaddrinfo(3)` return code was discarded twice in uSockets:

- `us_internal_socket_after_resolve` dropped `result->error`, so `us_connecting_socket_close` fabricated `ECONNABORTED` (`c->error` was still 0). The Rust handlers then mapped that to `ConnectionRefused` (fetch) / `ECONNREFUSED` (`Bun.connect`).
- For a *cached* resolver failure, `us_socket_group_connect` stuffed the EAI code into `errno` and returned `NULL`, which surfaced as `FailedToOpenSocket`. So the same bad hostname produced two different wrong errors on consecutive lookups.

### Fix

- Store the raw getaddrinfo return code in `us_connecting_socket_t.error` and tag its namespace with a new 1-bit `error_is_dns` field in the existing bitfield (getaddrinfo return codes and errnos overlap numerically, so the tag is what disambiguates them). This also removes the fabricated `ECONNABORTED` that `error` carried on the resolver-failure path.
- Remove the cached-failure short-circuit so a cached resolver failure takes the same connecting-socket path (and the same error callback) as an uncached one, and invalidate the DNS cache entry on a resolver failure so a negative result is never served from the cache.
- `HTTPContext` / `NewSocket` read `dns_error` from the connecting socket and, when it is nonzero, build the error with the same `init_eai` + `getaddrinfo <CODE> <hostname>` machinery Bun's `node:dns` already uses (factored into `system_error_with_syscall_and_hostname`).
- The reported `hostname` is captured as an owned copy on the HTTP thread at the failure, from `connected_url.hostname`: the exact name `HTTPContext::connect` was told to resolve (the proxy's when one is configured, the post-redirect target after a redirect). The JS side never reconstructs it from the client's borrowed URL buffers, which the HTTP thread frees after the result callback returns.

After:

```
fetch:        ENOTFOUND  getaddrinfo  <host>  "getaddrinfo ENOTFOUND <host>"
Bun.connect:  ENOTFOUND  getaddrinfo  <host>  "getaddrinfo ENOTFOUND <host>"
```

and the second fetch to the same host now reports the same error as the first.

On Windows, `init_eai` only matches `UV_EAI_*` constants in its `#[cfg(windows)]` arm (it already carries a `TODO: revisit this`), so the raw `ws2_32::getaddrinfo` code falls through to the `ENOTFOUND` catch-all. NXDOMAIN (`WSAHOST_NOT_FOUND`) lands on the right answer, and the `syscall`/`hostname` are correct, but a transient `WSATRY_AGAIN` is also reported as `ENOTFOUND`. The POSIX arm has the same class of imprecision (`EAI_AGAIN` falls through to `ENOTIMP`, which `test/js/bun/dns/resolve-dns.test.ts` already pins). Both halves of `init_eai`'s non-NXDOMAIN mapping deserve one follow-up with platform test coverage rather than a partial, untested patch here; every case is still a strict improvement over the unconditional `ECONNREFUSED` it replaces.

Intentionally not covered here: the HTTP/3 (QUIC) connect path has its own DNS registration (`Bun__addrinfo_registerQuic`) and still maps every connect failure to `ConnectionRefused`.

### Tests

- `test/js/bun/net/socket-dns-error.test.ts` (new): `Bun.connect` reports `ENOTFOUND` / `getaddrinfo` / `hostname` through both `connectError` and the rejected promise, exactly once, and consistently across consecutive (cached) attempts. Uses a >63-byte DNS label (illegal per RFC 1035 section 2.3.4), which getaddrinfo rejects locally with no network, the same fixture as Node's own `test-net-dns-error.js`.
- `test/js/web/fetch/client-fetch.test.ts`: the existing `"invalid url"` test asserted the buggy `"Unable to connect. Is the computer able to access the url?"` message from inside a `catch` block that never fires when an HTTP proxy is configured. Rewritten to a subprocess with the proxy env cleared, asserting the full error shape across five cases: three consecutive direct fetches (the uncached and the cached path), one through an explicit unresolvable `proxy:` option (must name the proxy, not the origin), and one to a local server that 302s to an unresolvable host (must name the redirect target, not the original origin).

Every other consumer of `HTTPClientResult.fail` (`bun install`, S3, the sync CLI requests) formats the error name generically, so the new `DNSResolveFailed` variant falls through to, for example, `error: DNSResolveFailed downloading package manifest ...` instead of `ConnectionRefused`.


Fixes #11345

This also addresses Case 1 (NXDOMAIN reported as `ConnectionRefused` instead of `ENOTFOUND`) of #20486. The other cases in that issue (wrapping the rejection in `TypeError: fetch failed` with a `cause`, `ERR_INVALID_URL`, and the invalid-protocol code) are about the overall fetch error shape and are not covered here.



