### PR TITLE
Evict the DNS cache entry when all connections to a host fail

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -726,6 +726,9 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
 
     int opened = start_connections(c, CONCURRENT_CONNECTIONS);
     if (opened == 0) {
+        /* Same as the exhausted path in us_internal_socket_after_open: a
+         * real connect failure must not be reported as a caller abort. */
+        c->error = ECONNREFUSED;
         us_connecting_socket_close(c);
     }
 }
@@ -762,6 +765,11 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
             if (c->connecting_head == NULL || c->connecting_head->connect_next == NULL) {
                 int opened = start_connections(c, c->connecting_head == NULL ? CONCURRENT_CONNECTIONS : 1);
                 if (opened == 0 && c->connecting_head == NULL) {
+                    /* Every resolved address failed to connect. Without this,
+                     * us_connecting_socket_close defaults c->error to
+                     * ECONNABORTED (caller abort) and never invalidates the
+                     * DNS cache entry for the dead host. */
+                    c->error = ECONNREFUSED;
                     us_connecting_socket_close(c);
                 }
             }

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -42,12 +42,17 @@ test("a failed connect evicts the host's DNS cache entry", async () => {
 
 describe("dns.prefetch", () => {
   it("should prefetch", async () => {
+    // A local server keeps the test off the external network. "localhost" is a
+    // real DNS lookup, so prefetch and fetch share the same cache entry.
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+    const url = `http://localhost:${server.port}/`;
+
     const currentStats = dns.getCacheStats();
-    dns.prefetch("example.com", 80);
+    dns.prefetch("localhost", server.port);
     await Bun.sleep(32);
 
     // Must set keepalive: false to ensure it doesn't reuse the socket.
-    await fetch("http://example.com", { method: "HEAD", redirect: "manual", keepalive: false });
+    await fetch(url, { method: "HEAD", redirect: "manual", keepalive: false });
     const newStats = dns.getCacheStats();
     expect(currentStats).not.toEqual(newStats);
     if (
@@ -60,7 +65,7 @@ describe("dns.prefetch", () => {
     }
 
     // Must set keepalive: false to ensure it doesn't reuse the socket.
-    await fetch("http://example.com", { method: "HEAD", redirect: "manual", keepalive: false });
+    await fetch(url, { method: "HEAD", redirect: "manual", keepalive: false });
     const newStats2 = dns.getCacheStats();
     // Ensure it's cached.
     expect(newStats2.cacheHitsCompleted).toBeGreaterThan(currentStats.cacheHitsCompleted);

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -49,8 +49,9 @@ describe("dns.prefetch", () => {
 
     const currentStats = dns.getCacheStats();
     dns.prefetch("localhost", server.port);
-    await Bun.sleep(32);
 
+    // No wait is needed: the fetch cannot connect until the prefetched DNS
+    // resolution lands, and the check below accepts an inflight or completed hit.
     // Must set keepalive: false to ensure it doesn't reuse the socket.
     await fetch(url, { method: "HEAD", redirect: "manual", keepalive: false });
     const newStats = dns.getCacheStats();

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -1,5 +1,44 @@
 import { dns } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// The DNS cache is process-global, so this runs in its own process to get
+// clean counters. Docs promise that a failed connection evicts the host's
+// cache entry; a dead host must never be served as a cache hit.
+test("a failed connect evicts the host's DNS cache entry", async () => {
+  const script = `
+    const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+    const port = listener.port;
+    listener.stop();
+
+    const results = [];
+    for (let i = 0; i < 3; i++) {
+      let code = "none";
+      try {
+        await Bun.connect({ hostname: "localhost", port, socket: { data() {}, open() {} } });
+      } catch (e) {
+        code = e.code;
+      }
+      const { cacheHitsCompleted, size, errors } = Bun.dns.getCacheStats();
+      results.push({ code, cacheHitsCompleted, size, errors });
+    }
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Each connect fails, evicts the entry (size back to 0, one more eviction in
+  // `errors`), so the next attempt is a fresh miss. A dead host must never be
+  // served from the cache (cacheHitsCompleted stays 0).
+  expect({ results: JSON.parse(stdout.trim() || "null"), stderr, exitCode }).toEqual({
+    results: [
+      { code: "ECONNREFUSED", cacheHitsCompleted: 0, size: 0, errors: 1 },
+      { code: "ECONNREFUSED", cacheHitsCompleted: 0, size: 0, errors: 2 },
+      { code: "ECONNREFUSED", cacheHitsCompleted: 0, size: 0, errors: 3 },
+    ],
+    stderr: "",
+    exitCode: 0,
+  });
+});
 
 describe("dns.prefetch", () => {
   it("should prefetch", async () => {


### PR DESCRIPTION
## Problem

`docs/runtime/networking/dns.mdx` says:

> If any connections to a host fail, we remove the entry from the cache.

This has not worked since #13249. The eviction in `us_connecting_socket_close` is gated on `c->error == ECONNREFUSED`, but nothing assigns the connect outcome to `c->error` anymore. The field only ever receives the `ECONNABORTED` default (meaning "caller aborted"), so the gate is always false and a dead host keeps serving cache hits for its full TTL (30s by default).

```js
const stat = () => { const s = Bun.dns.getCacheStats(); return `hits=${s.cacheHitsCompleted} size=${s.size} errors=${s.errors}`; };
await Bun.connect({ hostname: "localhost", port: 1, socket: { data() {}, open() {} } }).catch(() => {});
console.log(stat()); // hits=0 size=1 errors=0
await Bun.connect({ hostname: "localhost", port: 1, socket: { data() {}, open() {} } }).catch(() => {});
console.log(stat()); // hits=1 size=1 errors=0   <- dead host served from the cache, never evicted
```

## Cause

Before #13249, `us_internal_socket_after_open` and `us_internal_socket_after_resolve` set `c->error = ECONNREFUSED` themselves once every resolved address had been tried and failed, then evicted the entry. That PR consolidated the teardown into `us_connecting_socket_close` but dropped those assignments, leaving the consolidated eviction check unreachable.

## Fix

Restore the two assignments. `us_connecting_socket_close` already distinguishes a real connect failure (`ECONNREFUSED`, evict) from a caller abort (the `ECONNABORTED` default, do not evict); the two paths that mean "every address failed" just need to say so again.

No user-visible error code changes: the socket layer normalizes unrecognized connect errnos (including the previous `ECONNABORTED`) to `ECONNREFUSED` before it reaches JS, and the HTTP client ignores the code entirely.

## Intentionally not changed

- A completed cache hit that resolves to a single address takes a shortcut in `us_socket_group_connect` (`entries->info.ai_next == NULL`) that returns a plain `us_socket_t` and releases the DNS request before the connect outcome is known, so a failure on that path still cannot evict. Wiring eviction into it means giving raw connect sockets a connecting-state backpointer and reconciling two different close and dispatch contracts, which is a larger change than this fix should carry.
- Failed resolutions are still cached. The pre-#13249 code deliberately did not evict those, and the next synchronous lookup that consumes a cached failure already evicts it (`us_socket_group_connect`). #32990 handles that side (stop caching resolver failures and report them as `ENOTFOUND`); it does not overlap with this change.

## Verification

`test/js/bun/dns/dns-prefetch.test.ts`: a subprocess fails three connects to a localhost port with no listener and asserts, after each one, that the entry was evicted (`size` back to 0, `errors` incremented) and that `cacheHitsCompleted` stays 0. Without the fix it fails with `size: 1, errors: 0, cacheHitsCompleted: 2`.

The existing `dns.prefetch > should prefetch` test in that file resolved and fetched `example.com`, so it could not pass in an environment without internet access. It now runs against a local `Bun.serve` on `localhost` with the same assertions; `localhost` is still a real DNS lookup, so the prefetch and the fetch still share one cache entry.

