### PR TITLE
node:http2: tie the stream receive window to what the JS readable consumes

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2099,29 +2099,32 @@ function rstNextTick(id: number, rstCode: number) {
 function uncorkNT(stream: Http2Stream) {
   stream.uncork();
 }
-// 'finish' handler registered from _final (node: Http2Stream[kMaybeDestroy], server branch).
-// RFC 9113 8.1: a server that sent a complete response (any trailers included: _final resolves
-// the wantTrailers path before the writable can finish) and never attempted to read the request
-// body closes the stream with RST_STREAM(NO_ERROR) so the client stops uploading. Without the
-// reset an upload larger than the stream's receive window deadlocks: the server will never
-// consume the body, so it never re-opens the window. node defers to setImmediate so pushStreams
-// submitted from the same tick reach the wire first; we match.
-function maybeResetUnreadRequest() {
-  const session = this[bunHTTP2Session];
-  if (
+// node's Http2Stream[kMaybeDestroy], server branch (RFC 9113 8.1): a server stream that sent a
+// complete response (any trailers included: _final resolves the wantTrailers path before the
+// writable can finish) and never attempted to read the request body must reset the stream with
+// RST_STREAM(NO_ERROR) so the client stops uploading. Without the reset an upload larger than
+// the stream's receive window deadlocks: the server will never consume the body, so it never
+// re-opens the window.
+function shouldResetUnreadRequest(stream) {
+  const session = stream[bunHTTP2Session];
+  return (
     session != null &&
     session.type === NGHTTP2_SESSION_SERVER &&
-    (this[bunHTTP2StreamStatus] & StreamState.Closed) === 0 &&
-    this.headersSent &&
-    !this[kDidRead] &&
-    this.readableFlowing === null
-  ) {
-    setImmediate(resetUnreadRequestNT, this);
-  }
+    (stream[bunHTTP2StreamStatus] & StreamState.Closed) === 0 &&
+    stream.headersSent &&
+    !stream[kDidRead] &&
+    stream.readableFlowing === null
+  );
+}
+// 'finish' handler registered from _final. node defers the close to setImmediate so pushStreams
+// submitted from the same tick reach the wire first; we match, and re-check the predicate there
+// so a handler that only starts reading the request body after its response finished is not
+// cut off by the deferral.
+function maybeResetUnreadRequest() {
+  if (shouldResetUnreadRequest(this)) setImmediate(resetUnreadRequestNT, this);
 }
 function resetUnreadRequestNT(stream: ServerHttp2Stream) {
-  // The stream may have closed naturally in the meantime (the peer finished or reset it).
-  if (!stream.closed && !stream.destroyed) stream.close(NGHTTP2_NO_ERROR);
+  if (!stream.destroyed && shouldResetUnreadRequest(stream)) stream.close(NGHTTP2_NO_ERROR);
 }
 class Http2Stream extends Duplex {
   #id: number;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2037,7 +2037,12 @@ function pushToStream(stream, data) {
     return;
   }
 
-  stream.push(data);
+  if (!stream.push(data) && data !== null) {
+    // The readable buffer reached its highWaterMark: stop crediting this stream's HTTP/2
+    // receive window so the peer stalls at the window instead of ballooning an unread
+    // buffer. _read resumes the crediting (mirrors node's handle.readStop/readStart).
+    stream[bunHTTP2Session]?.[bunHTTP2Native]?.readStop(stream.id);
+  }
 }
 
 enum StreamState {
@@ -2092,6 +2097,7 @@ function uncorkNT(stream: Http2Stream) {
 }
 class Http2Stream extends Duplex {
   #id: number;
+  #didRead: boolean = false;
   [bunHTTP2Session]: ClientHttp2Session | ServerHttp2Session | null = null;
   [bunHTTP2StreamFinal]: VoidFunction | null = null;
   [bunHTTP2StreamStatus]: number = 0;
@@ -2107,6 +2113,11 @@ class Http2Stream extends Duplex {
       decodeStrings: false,
       autoDestroy: false,
     });
+    // node: suppress the Readable's speculative read-ahead until something actually reads the
+    // stream (_read clears this on its first run). Data is push-driven here, so read-ahead only
+    // pulls up to a highWaterMark into a stream nobody is reading, crediting that much HTTP/2
+    // receive window back to the peer for free.
+    this._readableState.readingMore = true;
     this.#id = streamId;
     this[bunHTTP2Session] = session;
     this[bunHTTP2Headers] = headers;
@@ -2465,7 +2476,17 @@ class Http2Stream extends Duplex {
   }
 
   _read(_size) {
-    // we always use the internal stream queue now
+    // Data is delivered by the native parser (pushToStream), not pulled here. _read still marks
+    // when the JS readable wants more: re-enable read-ahead and resume crediting this stream's
+    // HTTP/2 receive window, granting back bytes that arrived while nothing was reading (node's
+    // handle.readStart()). A pending request has no wire stream yet; the _read triggered by its
+    // first delivered chunk runs with the id assigned.
+    if (!this.#didRead) {
+      this._readableState.readingMore = false;
+      this.#didRead = true;
+    }
+    const id = this.#id;
+    if (id) this[bunHTTP2Session]?.[bunHTTP2Native]?.readStart(id);
   }
 
   end(chunk, encoding, callback) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -369,6 +369,10 @@ const kRequestHeaders = Symbol("requestHeaders");
 let priorityDeprecationWarned = false;
 // Marks a client stream created from a received PUSH_PROMISE: its response HEADERS fire 'push'.
 const kPush = Symbol("pushStream");
+// True once Http2Stream._read has run at least once, i.e. something is reading this stream.
+// node keeps the same flag (kState.didRead); it gates both the Readable read-ahead and the
+// server-side "responded without consuming the request body" reset below.
+const kDidRead = Symbol("didRead");
 const kNeverAnnounced = Symbol("neverAnnounced");
 const kReceivedGoaway = Symbol("receivedGoaway");
 // The error code carried by a received GOAWAY; like Node's state.goawayCode it
@@ -2095,9 +2099,33 @@ function rstNextTick(id: number, rstCode: number) {
 function uncorkNT(stream: Http2Stream) {
   stream.uncork();
 }
+// 'finish' handler registered from _final (node: Http2Stream[kMaybeDestroy], server branch).
+// RFC 9113 8.1: a server that sent a complete response (any trailers included: _final resolves
+// the wantTrailers path before the writable can finish) and never attempted to read the request
+// body closes the stream with RST_STREAM(NO_ERROR) so the client stops uploading. Without the
+// reset an upload larger than the stream's receive window deadlocks: the server will never
+// consume the body, so it never re-opens the window. node defers to setImmediate so pushStreams
+// submitted from the same tick reach the wire first; we match.
+function maybeResetUnreadRequest() {
+  const session = this[bunHTTP2Session];
+  if (
+    session != null &&
+    session.type === NGHTTP2_SESSION_SERVER &&
+    (this[bunHTTP2StreamStatus] & StreamState.Closed) === 0 &&
+    this.headersSent &&
+    !this[kDidRead] &&
+    this.readableFlowing === null
+  ) {
+    setImmediate(resetUnreadRequestNT, this);
+  }
+}
+function resetUnreadRequestNT(stream: ServerHttp2Stream) {
+  // The stream may have closed naturally in the meantime (the peer finished or reset it).
+  if (!stream.closed && !stream.destroyed) stream.close(NGHTTP2_NO_ERROR);
+}
 class Http2Stream extends Duplex {
   #id: number;
-  #didRead: boolean = false;
+  [kDidRead]: boolean = false;
   [bunHTTP2Session]: ClientHttp2Session | ServerHttp2Session | null = null;
   [bunHTTP2StreamFinal]: VoidFunction | null = null;
   [bunHTTP2StreamStatus]: number = 0;
@@ -2432,6 +2460,10 @@ class Http2Stream extends Duplex {
       const native = session[bunHTTP2Native];
       if (native) {
         this[bunHTTP2StreamStatus] |= StreamState.FinalCalled;
+        // The writable side is shutting down at the protocol level. Once it finishes, a server
+        // stream that sent a complete response without ever consuming the request body must
+        // reset the stream (node registers the same hook from its afterShutdown).
+        this.once("finish", maybeResetUnreadRequest);
         // When waitForTrailers is active, writing an empty DATA frame with
         // close=true emits a bare empty DATA frame (flags=0) to the wire
         // before the trailer/noTrailers path runs, which then emits ANOTHER
@@ -2481,9 +2513,9 @@ class Http2Stream extends Duplex {
     // HTTP/2 receive window, granting back bytes that arrived while nothing was reading (node's
     // handle.readStart()). A pending request has no wire stream yet; the _read triggered by its
     // first delivered chunk runs with the id assigned.
-    if (!this.#didRead) {
+    if (!this[kDidRead]) {
       this._readableState.readingMore = false;
-      this.#didRead = true;
+      this[kDidRead] = true;
     }
     const id = this.#id;
     if (id) this[bunHTTP2Session]?.[bunHTTP2Native]?.readStart(id);

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -25,6 +25,12 @@ pub struct Stream {
     pub content_length: Option<u64>,
     /// DATA payload bytes (padding excluded) received so far.
     pub recv_body_bytes: u64,
+    /// DATA bytes delivered to the embedder while its reader was not consuming
+    /// (`Sink::is_stream_reading` == false). They are already charged against `recv_window`
+    /// (the peer spent window on them) but are only credited back — and thus granted via
+    /// WINDOW_UPDATE — once the reader resumes. This is what bounds how far a peer can get
+    /// ahead of a slow/paused reader (node: `inbound_consumed_data_while_paused_`).
+    pub recv_deferred: i64,
 }
 
 impl Stream {
@@ -36,6 +42,7 @@ impl Stream {
             recv_final_headers: false,
             content_length: None,
             recv_body_bytes: 0,
+            recv_deferred: 0,
         }
     }
 }
@@ -142,6 +149,16 @@ pub trait Sink {
     /// inbound frames for it are not treated as frames on an idle stream.
     fn is_local_stream(&self, _stream_id: u32) -> bool {
         false
+    }
+
+    /// Whether the embedder's application-level reader for `stream_id` is currently consuming
+    /// (node: `!kReadPaused`). Queried right after `on_data` so a reader that stopped inside the
+    /// dispatch takes effect for the rest of the batch. While false, delivered DATA is not
+    /// credited back to the stream's receive window (no WINDOW_UPDATE) until the reader resumes
+    /// and `replenish_windows` runs again — the peer stalls at the advertised window instead of
+    /// ballooning an unread buffer.
+    fn is_stream_reading(&self, _stream_id: u32) -> bool {
+        true
     }
 }
 
@@ -369,6 +386,7 @@ impl Connection {
             let data_now = avail.min(inflight.data_remaining as usize);
             if data_now > 0 && !inflight.discard {
                 sink.on_data(inflight.stream_id, &bytes[offset..offset + data_now]);
+                self.credit_stream_recv(sink, inflight.stream_id, data_now as i64);
             }
             inflight.data_remaining -= data_now as u32;
             inflight.payload_remaining -= avail as u32;
@@ -452,8 +470,27 @@ impl Connection {
         }
     }
 
-    /// Send WINDOW_UPDATE for every receive window that has consumed at least half its size.
-    fn replenish_windows(&mut self, sink: &impl Sink) {
+    /// Credit `n` delivered DATA bytes back to `stream_id`'s receive window if its reader is
+    /// consuming, otherwise park them on `recv_deferred` until it resumes. Called after each
+    /// `sink.on_data`, so a reader that stopped inside that dispatch defers the remainder of
+    /// the batch.
+    fn credit_stream_recv(&mut self, sink: &impl Sink, stream_id: u32, n: i64) {
+        // Re-fetch: the on_data dispatch runs arbitrary embedder code.
+        let Some(s) = self.streams.get_mut(&stream_id) else {
+            return;
+        };
+        if sink.is_stream_reading(stream_id) {
+            s.recv_window.consume(n);
+        } else {
+            s.recv_deferred += n;
+        }
+    }
+
+    /// Send WINDOW_UPDATE for every receive window whose application has consumed at least half
+    /// its size. Bytes delivered while a stream's reader was paused sit in `recv_deferred` and
+    /// are credited here once `Sink::is_stream_reading` reports the reader resumed — so the
+    /// embedder's readStart only has to flip its flag and call this (see `H2FrameParser::read_start`).
+    pub(crate) fn replenish_windows(&mut self, sink: &impl Sink) {
         if self.recv_window.needs_update() {
             let inc = self.recv_window.take_update();
             if inc > 0 {
@@ -463,7 +500,15 @@ impl Connection {
         let mut buf = std::mem::take(&mut self.replenish_buf);
         buf.clear();
         for (id, s) in self.streams.iter_mut() {
-            if s.state != State::Closed && s.recv_window.needs_update() {
+            if s.state == State::Closed {
+                continue;
+            }
+            if s.recv_deferred > 0 && sink.is_stream_reading(*id) {
+                let deferred = s.recv_deferred;
+                s.recv_deferred = 0;
+                s.recv_window.consume(deferred);
+            }
+            if s.recv_window.needs_update() {
                 let inc = s.recv_window.take_update();
                 if inc > 0 {
                     buf.push((*id, inc));
@@ -1083,6 +1128,10 @@ impl Connection {
             );
             return StreamedDataStart::Fatal;
         }
+        // The connection window is re-opened on receipt: a paused reader on one stream must not
+        // starve every other stream on the session. Per-stream back-pressure lives in the stream
+        // window below (node does the same: nghttp2_session_consume_connection on receipt).
+        self.recv_window.consume(hdr.length as i64);
 
         if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
             let send_init = self.remote_settings.initial_window_size;
@@ -1127,8 +1176,18 @@ impl Connection {
 
         let body_avail = &payload_avail[off..];
         let data_now = body_avail.len().min(data_total);
-        if data_now > 0 && !discard {
-            sink.on_data(hdr.stream_id, &body_avail[..data_now]);
+        if !discard {
+            // Padding and the Pad Length octet never reach the reader: credit them back on
+            // receipt. The data bytes are credited per delivered slice (here and in the
+            // DataInFlight continuation), gated on the reader actually consuming.
+            if let Some(st) = self.streams.get_mut(&hdr.stream_id) {
+                st.recv_window
+                    .consume((hdr.length as usize - data_total) as i64);
+            }
+            if data_now > 0 {
+                sink.on_data(hdr.stream_id, &body_avail[..data_now]);
+                self.credit_stream_recv(sink, hdr.stream_id, data_now as i64);
+            }
         }
         let consumed_payload = off + body_avail.len();
         let inflight = DataInFlight {
@@ -1181,10 +1240,11 @@ impl Connection {
             }
             end -= pad;
         }
-        let consumed = payload.len() as i64; // full frame counts against flow control, incl. padding
+        let frame_len = payload.len() as i64; // full frame counts against flow control, incl. padding
+        let data_len = (end - off) as i64;
 
         // §6.9: the whole frame counts against the connection recv window.
-        self.recv_window.on_data(consumed);
+        self.recv_window.on_data(frame_len);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,
@@ -1193,6 +1253,10 @@ impl Connection {
             );
             return true;
         }
+        // The connection window is re-opened on receipt: a paused reader on one stream must not
+        // starve every other stream on the session. Per-stream back-pressure lives in the stream
+        // window below (node does the same: nghttp2_session_consume_connection on receipt).
+        self.recv_window.consume(frame_len);
 
         // An empty DATA frame that does not end the stream carries no information and is only
         // useful for flooding: count it against the session's invalid-frame allowance (node's
@@ -1231,11 +1295,15 @@ impl Connection {
                 if !stream::can_receive_data(s.state) {
                     DataDecision::Rst(ErrorCode::StreamClosed)
                 } else {
-                    s.recv_window.on_data(consumed);
+                    s.recv_window.on_data(frame_len);
                     if s.recv_window.is_overflowed_with(recv_limit) {
                         DataDecision::Rst(ErrorCode::FlowControlError)
                     } else {
-                        s.recv_body_bytes = s.recv_body_bytes.saturating_add((end - off) as u64);
+                        s.recv_body_bytes = s.recv_body_bytes.saturating_add(data_len as u64);
+                        // Padding and the Pad Length octet never reach the reader: credit them
+                        // back on receipt. The data bytes are credited after delivery, gated
+                        // on the reader actually consuming (credit_stream_recv below).
+                        s.recv_window.consume(frame_len - data_len);
                         DataDecision::Deliver(0)
                     }
                 }
@@ -1258,6 +1326,7 @@ impl Connection {
         let end_stream = wire::flags::has(hdr.flags, wire::flags::END_STREAM);
         if end != off {
             sink.on_data(hdr.stream_id, &payload[off..end]);
+            self.credit_stream_recv(sink, hdr.stream_id, data_len);
         }
 
         // Window replenishment is deferred to the end of the receive() batch (replenish_windows):

--- a/src/runtime/api/bun/h2/flow_control.rs
+++ b/src/runtime/api/bun/h2/flow_control.rs
@@ -67,19 +67,26 @@ impl SendWindow {
     }
 }
 
-/// Inbound (recv) window. We advertise `size` and track `consumed`; once enough is consumed we
-/// emit a WINDOW_UPDATE of the consumed amount and reset.
+/// Inbound (recv) window. The peer charges `received` on arrival (§6.9.1 overflow check); the
+/// application credits `consumable` as it actually consumes the bytes. Only `consumable` is ever
+/// granted back via WINDOW_UPDATE — that gap is what gives a slow reader real back-pressure.
+/// Invariant: `consumable <= received` (bytes can only be consumed after they were received).
 #[derive(Clone, Copy, Debug)]
 pub struct RecvWindow {
     pub size: i64,
-    pub consumed: i64,
+    /// Bytes received since the last WINDOW_UPDATE we sent. Exceeding `size` is the §6.9.1
+    /// FLOW_CONTROL_ERROR.
+    pub received: i64,
+    /// Of `received`, bytes the application has consumed and we may grant back to the peer.
+    pub consumable: i64,
 }
 
 impl Default for RecvWindow {
     fn default() -> Self {
         RecvWindow {
             size: DEFAULT_WINDOW_SIZE as i64,
-            consumed: 0,
+            received: 0,
+            consumable: 0,
         }
     }
 }
@@ -88,41 +95,52 @@ impl RecvWindow {
     pub fn new(initial: u32) -> Self {
         RecvWindow {
             size: initial as i64,
-            consumed: 0,
+            received: 0,
+            consumable: 0,
         }
     }
 
+    /// Charge `n` received bytes against the window. Does NOT make them grantable; callers
+    /// pair this with `consume()` once the bytes actually reach (or bypass) the application.
     #[inline]
     pub fn on_data(&mut self, n: i64) {
-        self.consumed += n;
+        self.received += n;
+    }
+
+    /// `n` of the received bytes were consumed by the application: eligible for WINDOW_UPDATE.
+    #[inline]
+    pub fn consume(&mut self, n: i64) {
+        self.consumable += n;
     }
 
     /// Whether the peer exceeded our advertised window (a FLOW_CONTROL_ERROR, §6.9.1).
     #[inline]
     pub fn is_overflowed(&self) -> bool {
-        self.consumed > self.size
+        self.received > self.size
     }
 
     /// Overflow check with an enforcement limit that may exceed the advertised size:
     /// until our SETTINGS shrinking the window is ACKed, the peer may legitimately send
     /// according to the previous (larger) value (RFC 9113 6.5.3).
     pub fn is_overflowed_with(&self, limit: i64) -> bool {
-        self.consumed > limit.max(self.size)
+        self.received > limit.max(self.size)
     }
 
-    /// Replenish heuristic: update once at least half the window has been consumed.
+    /// Replenish heuristic: update once the application has consumed at least half the window.
     #[inline]
     pub fn needs_update(&self) -> bool {
-        self.consumed > 0 && self.consumed >= self.size / 2
+        self.consumable > 0 && self.consumable >= self.size / 2
     }
 
-    /// Take the pending WINDOW_UPDATE increment and reset the consumed counter (0 if none).
+    /// Take the pending WINDOW_UPDATE increment (the consumed bytes) and re-open that much of
+    /// the receive window. Returns 0 if nothing was consumed.
     pub fn take_update(&mut self) -> u32 {
-        if self.consumed <= 0 {
+        if self.consumable <= 0 {
             return 0;
         }
-        let inc = self.consumed.min(MAX_WINDOW_SIZE as i64);
-        self.consumed -= inc;
+        let inc = self.consumable.min(MAX_WINDOW_SIZE as i64);
+        self.consumable -= inc;
+        self.received -= inc;
         inc as u32
     }
 
@@ -146,8 +164,29 @@ mod tests {
     fn recv_window_replenish() {
         let mut w = RecvWindow::new(100);
         w.on_data(60);
+        w.consume(60);
         assert!(w.needs_update());
         assert_eq!(w.take_update(), 60);
-        assert_eq!(w.consumed, 0);
+        assert_eq!(w.received, 0);
+        assert_eq!(w.consumable, 0);
+    }
+
+    #[test]
+    fn recv_window_only_grants_consumed_bytes() {
+        let mut w = RecvWindow::new(100);
+        // 90 bytes arrive but the application only consumes 10: nothing to grant yet, and the
+        // window stays 90 consumed from the peer's point of view.
+        w.on_data(90);
+        w.consume(10);
+        assert!(!w.needs_update());
+        assert!(!w.is_overflowed());
+        // The application catches up: the whole 90 is grantable and the window re-opens.
+        w.consume(80);
+        assert!(w.needs_update());
+        assert_eq!(w.take_update(), 90);
+        assert_eq!(w.received, 0);
+        // 11 more than advertised is still an overflow.
+        w.on_data(101);
+        assert!(w.is_overflowed());
     }
 }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1518,6 +1518,12 @@ pub struct Stream {
     remote_window_size: u64,
     // remote used window size for the stream
     remote_used_window_size: u64,
+    // Whether the JS Readable backing this stream is consuming (node: !kReadPaused). The engine
+    // only replenishes the stream's receive window (§6.9) for bytes delivered while this is true;
+    // while false they accumulate in the engine stream's `recv_deferred` so a peer can get at most
+    // one window ahead of a paused reader. Starts false: the JS side flips it from
+    // Http2Stream._read (readStart) and back from a rejected push (readStop).
+    reading: bool,
     signal: Option<Box<SignalRef>>,
 
     // when we have backpressure we queue the data e round robin the Streams
@@ -2078,6 +2084,7 @@ impl Stream {
             used_window_size: 0,
             remote_window_size: remote_window_size as u64,
             remote_used_window_size: 0,
+            reading: false,
             signal: None,
             data_frame_queue: PendingQueue::default(),
         }
@@ -5695,6 +5702,18 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         self.streams.get().contains_key(&stream_id)
     }
 
+    fn is_stream_reading(&self, stream_id: u32) -> bool {
+        // `reading` is updated synchronously from inside the on_data dispatch (readStop from a
+        // rejected push) and from the Readable's _read (readStart), so the engine sees the flip
+        // for the remaining frames of the current batch. A stream with no legacy entry cannot
+        // have a JS reader: treat it as not consuming.
+        match self.streams.get().get(&stream_id) {
+            // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
+            Some(&stream) => unsafe { (*stream).reading },
+            None => false,
+        }
+    }
+
     fn on_push_promise(&self, _parent_id: u32, promised_id: u32) {
         // The promised request headers follow via on_header/on_headers_complete for promised_id;
         // remember it so that completion dispatches onStreamPush instead of onStreamHeaders.
@@ -6599,6 +6618,81 @@ impl H2FrameParser {
         Ok(JSValue::from(
             stream.state == StreamState::CLOSED && stream.rst_code == ErrorCode::CANCEL.0,
         ))
+    }
+
+    /// Shared argument handling for readStart/readStop. Unlike the other stream-id host fns,
+    /// a missing stream (or id 0) is a silent no-op rather than an error: both are fired from
+    /// the Readable machinery's hot path and race with stream teardown and with pending
+    /// (not-yet-submitted) requests that have no id yet.
+    fn read_state_stream(
+        this: &Self,
+        global_object: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<Option<*mut Stream>> {
+        let args_list = callframe.arguments_old::<1>();
+        if args_list.len < 1 {
+            return Err(global_object.throw(format_args!("Expected stream argument")));
+        }
+        let stream_arg = args_list.ptr[0];
+        if !stream_arg.is_number() {
+            return Err(global_object.throw(format_args!("Invalid stream id")));
+        }
+        let stream_id = stream_arg.to_u32();
+        if stream_id == 0 {
+            return Ok(None);
+        }
+        Ok(this.streams.get().get(&stream_id).copied())
+    }
+
+    /// node: `Http2Stream::ReadStart` — the JS Readable's `_read` ran, so the reader is
+    /// consuming. Credits bytes delivered while it was paused back to the stream's receive
+    /// window and flushes the resulting WINDOW_UPDATE, otherwise a peer stalled on the window
+    /// never resumes.
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn read_start(
+        this: &Self,
+        global_object: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let Some(stream) = Self::read_state_stream(this, global_object, callframe)? else {
+            return Ok(JSValue::UNDEFINED);
+        };
+        // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
+        if unsafe { (*stream).reading } {
+            return Ok(JSValue::UNDEFINED);
+        }
+        // SAFETY: as above
+        unsafe { (*stream).reading = true };
+        // When a receive() batch holds the engine borrow (drained microtasks ran _read), the
+        // batch-end replenish_windows observes the flag; outside one, replenish here so the
+        // deferred grant goes on the wire now rather than waiting for the next inbound read.
+        let mut replenished = false;
+        if let Ok(mut guard) = this.engine.try_borrow_mut() {
+            if let Some(engine) = guard.as_mut() {
+                engine.replenish_windows(this);
+                replenished = true;
+            }
+        }
+        if replenished {
+            let _ = this.flush();
+        }
+        Ok(JSValue::UNDEFINED)
+    }
+
+    /// node: `Http2Stream::ReadStop` — the JS Readable's buffer is full (push returned false).
+    /// Stop crediting this stream's receive window so the peer stalls at the window instead
+    /// of ballooning an unread buffer. Takes effect for the rest of the current receive batch.
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn read_stop(
+        this: &Self,
+        global_object: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        if let Some(stream) = Self::read_state_stream(this, global_object, callframe)? {
+            // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
+            unsafe { (*stream).reading = false };
+        }
+        Ok(JSValue::UNDEFINED)
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/api/h2.classes.ts
+++ b/src/runtime/api/h2.classes.ts
@@ -41,6 +41,14 @@ export default [
         fn: "setLocalWindowSize",
         length: 1,
       },
+      readStart: {
+        fn: "readStart",
+        length: 1,
+      },
+      readStop: {
+        fn: "readStop",
+        length: 1,
+      },
       read: {
         fn: "read",
         length: 1,

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1183,12 +1183,8 @@ describe("inbound flow control (RFC 9113 §6.9)", () => {
     try {
       c.sendPreface();
       c.sendEmptySettings();
-      // HPACK static-table request block (RFC 7541 appendix A): `:method POST` (3), `:path /` (4),
-      // `:scheme http` (6) as indexed fields, plus `:authority` (name index 1) as a
-      // literal-without-indexing with a 9-octet non-Huffman value.
-      const request = Buffer.concat([Buffer.from([0x83, 0x84, 0x86, 0x01, 0x09]), Buffer.from("localhost")]);
       // END_HEADERS only, no END_STREAM: the request body is still incoming and is never sent.
-      c.sendFrame(FrameType.HEADERS, 0x4, 1, request);
+      c.sendFrame(FrameType.HEADERS, 0x4, 1, requestHeaderBlock("POST"));
 
       const headers = await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
       const endStream = await c.waitFor(f => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0);

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1154,4 +1154,43 @@ describe("inbound flow control (RFC 9113 §6.9)", () => {
       raw.close();
     }
   });
+
+  // The server-side consequence of consumption-driven windows. RFC 9113 §8.1: a server that sent
+  // a complete response and never consumed the request body MUST tell the client to stop sending
+  // it, via RST_STREAM(NO_ERROR). Without it, an upload larger than the stream window deadlocks:
+  // the server will never re-open a window nothing is reading. Node closes the stream from
+  // Http2Stream[kMaybeDestroy] in exactly this case.
+  test("a server that responds without reading the request body resets the stream with NO_ERROR", async () => {
+    const srv = http2.createServer();
+    srv.on("stream", stream => {
+      // Respond without ever touching the request body: no data listener, no resume, no pipe.
+      setImmediate(() => {
+        stream.respond({ ":status": 400 });
+        stream.end();
+      });
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const c = await RawH2.connect((srv.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      // HPACK static-table request block (RFC 7541 appendix A): `:method POST` (3), `:path /` (4),
+      // `:scheme http` (6) as indexed fields, plus `:authority` (name index 1) as a
+      // literal-without-indexing with a 9-octet non-Huffman value.
+      const request = Buffer.concat([Buffer.from([0x83, 0x84, 0x86, 0x01, 0x09]), Buffer.from("localhost")]);
+      // END_HEADERS only, no END_STREAM: the request body is still incoming and is never sent.
+      c.sendFrame(FrameType.HEADERS, 0x4, 1, request);
+
+      const headers = await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
+      // The reset follows the complete response, it does not replace it.
+      expect(c.frames.indexOf(headers)).toBeLessThan(c.frames.indexOf(rst));
+      expect(c.frames.some(f => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0)).toBe(true);
+    } finally {
+      c.destroy();
+      srv.close();
+    }
+  });
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1068,3 +1068,90 @@ describe("inbound stream lifecycle", () => {
     }
   });
 });
+
+describe("inbound flow control (RFC 9113 §6.9)", () => {
+  // A stream's receive window must track what the application has actually read, not what the
+  // wire has delivered: a paused reader that keeps granting WINDOW_UPDATE lets the peer push an
+  // unbounded amount of data into the process (and loses per-stream fairness). Node ties the
+  // stream window to the JS Readable via handle.readStart/readStop; this locks in the same.
+  test("a client that never reads the response stops crediting the stream's receive window", async () => {
+    // Must be well over twice the readable's highWaterMark (64 KiB): the readable legitimately
+    // pre-buffers up to ~HWM before its first rejected push() pauses window crediting, and only
+    // a credited half-window triggers a WINDOW_UPDATE.
+    const STREAM_WINDOW = 512 * 1024; // SETTINGS_INITIAL_WINDOW_SIZE the client advertises
+    const CHUNK = Buffer.alloc(16384, 0x61);
+
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`, {
+      settings: { initialWindowSize: STREAM_WINDOW },
+    });
+    client.on("error", () => {});
+    try {
+      // The readable is never read: _read never runs, so the client must not re-open the
+      // stream window no matter how much the readable buffers internally.
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0); // server SETTINGS
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0); // ACK the client's SETTINGS
+      raw.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, Buffer.from([0x88])); // :status 200
+
+      // Push STREAM_WINDOW bytes of DATA, pacing only on the connection-level window (which a
+      // conformant client re-opens on receipt so one slow stream can't starve the session).
+      // The stream-level window is deliberately ignored: whether the never-read client keeps
+      // re-opening it is exactly what this test measures.
+      let connWindow = 65535;
+      let scanned = 0;
+      const connIncrementAt = (f: Frame) => (f.streamId === 0 ? f.payload.readUInt32BE(0) & 0x7fffffff : 0);
+      for (let sent = 0; sent < STREAM_WINDOW; ) {
+        for (; scanned < raw.frames.length; scanned++) {
+          if (raw.frames[scanned].type === FrameType.WINDOW_UPDATE) {
+            connWindow += connIncrementAt(raw.frames[scanned]);
+          }
+        }
+        if (connWindow === 0) {
+          await raw.waitFor(
+            f => f.type === FrameType.WINDOW_UPDATE && f.streamId === 0 && raw.frames.indexOf(f) >= scanned,
+          );
+          continue;
+        }
+        const n = Math.min(CHUNK.length, connWindow, STREAM_WINDOW - sent);
+        raw.sendFrame(FrameType.DATA, 0, 1, CHUNK.subarray(0, n));
+        connWindow -= n;
+        sent += n;
+      }
+
+      // Two PING round trips fence the assertion: the client writes a receipt-driven
+      // WINDOW_UPDATE at the end of the receive batch that crossed the half-window mark, so
+      // the batch that answers the SECOND ping is strictly after any such write.
+      for (const payload of [Buffer.from("fc-barr1"), Buffer.from("fc-barr2")]) {
+        raw.sendFrame(FrameType.PING, 0, 0, payload);
+        await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0 && f.payload.equals(payload));
+      }
+
+      // The whole window was delivered but nothing was consumed: the client must not have
+      // granted any of it back.
+      const streamWindowUpdates = () => raw.frames.filter(f => f.type === FrameType.WINDOW_UPDATE && f.streamId === 1);
+      expect(streamWindowUpdates()).toEqual([]);
+
+      // Now consume: the readable must deliver every buffered byte and re-open the whole
+      // window in one WINDOW_UPDATE (nothing was granted incrementally above).
+      const windowUpdate = raw.waitFor(f => f.type === FrameType.WINDOW_UPDATE && f.streamId === 1);
+      let received = 0;
+      const drained = new Promise<void>(resolve =>
+        req.on("data", (d: Buffer) => {
+          received += d.length;
+          if (received >= STREAM_WINDOW) resolve();
+        }),
+      );
+      expect((await windowUpdate).payload.readUInt32BE(0) & 0x7fffffff).toBe(STREAM_WINDOW);
+      await drained;
+      expect(received).toBe(STREAM_WINDOW);
+      expect(streamWindowUpdates()).toHaveLength(1);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+});

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1139,14 +1139,22 @@ describe("inbound flow control (RFC 9113 §6.9)", () => {
       // window in one WINDOW_UPDATE (nothing was granted incrementally above).
       const windowUpdate = raw.waitFor(f => f.type === FrameType.WINDOW_UPDATE && f.streamId === 1);
       let received = 0;
-      const drained = new Promise<void>(resolve =>
+      const drained = new Promise<void>((resolve, reject) => {
+        // An early close (including the one after a swallowed 'error') fails the drain with
+        // the cause instead of hanging it until the test timeout.
+        req.once("close", () => reject(new Error(`stream closed after ${received} of ${STREAM_WINDOW} bytes`)));
         req.on("data", (d: Buffer) => {
           received += d.length;
           if (received >= STREAM_WINDOW) resolve();
-        }),
-      );
-      expect((await windowUpdate).payload.readUInt32BE(0) & 0x7fffffff).toBe(STREAM_WINDOW);
-      await drained;
+        });
+      });
+      const [windowUpdateFrame] = await Promise.all([windowUpdate, drained]);
+      expect(windowUpdateFrame.payload.readUInt32BE(0) & 0x7fffffff).toBe(STREAM_WINDOW);
+      // Fence again before asserting "exactly one": any further WINDOW_UPDATE the drain could
+      // have produced must have reached the wire by the time the client answers this ping.
+      const drainFence = Buffer.from("fc-barr3");
+      raw.sendFrame(FrameType.PING, 0, 0, drainFence);
+      await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0 && f.payload.equals(drainFence));
       expect(received).toBe(STREAM_WINDOW);
       expect(streamWindowUpdates()).toHaveLength(1);
     } finally {
@@ -1183,11 +1191,12 @@ describe("inbound flow control (RFC 9113 §6.9)", () => {
       c.sendFrame(FrameType.HEADERS, 0x4, 1, request);
 
       const headers = await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      const endStream = await c.waitFor(f => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0);
       const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
       expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
-      // The reset follows the complete response, it does not replace it.
-      expect(c.frames.indexOf(headers)).toBeLessThan(c.frames.indexOf(rst));
-      expect(c.frames.some(f => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0)).toBe(true);
+      // The reset follows the COMPLETE response (HEADERS then END_STREAM); it does not replace it.
+      expect(c.frames.indexOf(headers)).toBeLessThan(c.frames.indexOf(endStream));
+      expect(c.frames.indexOf(endStream)).toBeLessThan(c.frames.indexOf(rst));
     } finally {
       c.destroy();
       srv.close();


### PR DESCRIPTION
### What does this PR do?

`node:http2` has no inbound flow control: the engine re-opens its receive windows as DATA arrives instead of as it is consumed, so a paused (or never-read) stream keeps granting `WINDOW_UPDATE`. Any server can push tens of MB per second into a client that is not reading, and Bun's own multiplexed connections lose the per-stream fairness HTTP/2's stream windows are supposed to provide. Node bounds this to one stream window.

#### Reproduction

Against a raw HTTP/2 server that pushes DATA as fast as the client's advertised windows allow, into a client that never reads the response:

| client | bytes the server got onto the wire in 1s |
| --- | --- |
| node v26 | 65,535 (exactly one `SETTINGS_INITIAL_WINDOW_SIZE`) |
| bun 1.4.0 | 1,654,759 and growing linearly with time |
| bun with this PR | 65,535 |

<details>
<summary>standalone repro scripts (raw h2 server + client)</summary>

```js
// h2srv.mjs: raw HTTP/2 over TCP. Responds ":status 200" and then pushes 16 KiB DATA
// frames as fast as the client's connection + stream windows allow.
import net from "node:net";
const T = { DATA: 0, HEADERS: 1, SETTINGS: 4, PING: 6, WINDOW_UPDATE: 8 };
function frame(type, flags, sid, payload = Buffer.alloc(0)) {
  const h = Buffer.alloc(9);
  h.writeUIntBE(payload.length, 0, 3); h.writeUInt8(type, 3); h.writeUInt8(flags, 4); h.writeUInt32BE(sid >>> 0, 5);
  return Buffer.concat([h, payload]);
}
const CHUNK = Buffer.alloc(16384, 0x61);
const server = net.createServer(sock => {
  sock.on("error", () => {});
  let buf = Buffer.alloc(0), gotPreface = false, peerInitialWindow = 65535, connWindow = 65535, target = 0;
  const streamWindows = new Map();
  sock.write(frame(T.SETTINGS, 0, 0));
  function pump() {
    if (!target) return;
    let sw = streamWindows.get(target);
    while (connWindow > 0 && sw > 0) {
      const n = Math.min(CHUNK.length, connWindow, sw);
      sock.write(frame(T.DATA, 0, target, CHUNK.subarray(0, n)));
      connWindow -= n; sw -= n;
    }
    streamWindows.set(target, sw);
  }
  sock.on("data", d => {
    buf = Buffer.concat([buf, d]);
    if (!gotPreface) { if (buf.length < 24) return; buf = buf.subarray(24); gotPreface = true; }
    while (buf.length >= 9) {
      const len = buf.readUIntBE(0, 3);
      if (buf.length < 9 + len) break;
      const type = buf.readUInt8(3), flags = buf.readUInt8(4), sid = buf.readUInt32BE(5) & 0x7fffffff;
      const payload = buf.subarray(9, 9 + len);
      buf = buf.subarray(9 + len);
      if (type === T.SETTINGS && !(flags & 1)) {
        for (let i = 0; i + 6 <= payload.length; i += 6)
          if (payload.readUInt16BE(i) === 0x4) peerInitialWindow = payload.readUInt32BE(i + 2);
        sock.write(frame(T.SETTINGS, 0x1, 0));
      } else if (type === T.WINDOW_UPDATE) {
        const inc = payload.readUInt32BE(0) & 0x7fffffff;
        if (sid === 0) connWindow += inc; else streamWindows.set(sid, (streamWindows.get(sid) ?? peerInitialWindow) + inc);
        pump();
      } else if (type === T.HEADERS) {
        target = sid; streamWindows.set(sid, peerInitialWindow);
        sock.write(frame(T.HEADERS, 0x4, sid, Buffer.from([0x88]))); // HPACK ":status: 200"
        pump();
      } else if (type === T.PING && !(flags & 1)) sock.write(frame(T.PING, 0x1, 0, payload));
    }
  });
});
server.listen(0, "127.0.0.1", () => console.log("PORT", server.address().port));
```

```js
// h2client.mjs <port>: requests "/", reads nothing for 1s after the response headers,
// then reports how many bytes the server managed to deliver into the unread stream.
import http2 from "node:http2";
const session = http2.connect(`http://127.0.0.1:${process.argv[2]}`);
session.on("error", () => {});
const req = session.request({ ":path": "/" });
req.on("error", () => {});
req.on("response", () => {
  setTimeout(() => {
    console.log("bufferedWhileUnread:", req._readableState.length);
    process.exit(0);
  }, 1000);
});
```

</details>

#### Cause

`RecvWindow` tracked a single counter that was charged when DATA arrived and emitted back as a `WINDOW_UPDATE` at the end of every receive batch (`replenish_windows` in `src/runtime/api/bun/h2/connection.rs`). Nothing consulted whether the JS `Readable` had accepted, or ever would accept, the bytes.

#### Fix

Mirror node's model (`handle.readStart`/`handle.readStop` driving `nghttp2_session_consume_stream`):

- `RecvWindow` splits the counter into `received` (charged on arrival, drives the RFC 9113 6.9.1 overflow check, unchanged) and `consumable` (credited by the application, drives `WINDOW_UPDATE`).
- The **connection** window is still credited on receipt so one slow stream cannot starve the session; node does the same (`nghttp2_session_consume_connection` on receipt).
- The **stream** window is only credited for bytes its reader accepted (`Sink::is_stream_reading`, queried right after each `on_data` so a reader that stopped inside the dispatch takes effect for the rest of the batch). Bytes delivered while it was not reading accumulate in the stream's `recv_deferred` and are granted back once it resumes.
- Two new `H2FrameParser` host functions, `readStart(id)` and `readStop(id)`: `Http2Stream._read` calls `readStart` and `pushToStream` calls `readStop` when `push()` returns `false`.
- The `Http2Stream` constructor sets `_readableState.readingMore = true` (cleared by the first `_read`), node's mechanism for suppressing the `Readable`'s speculative read-ahead into a stream nothing is reading. Without it the readable pre-pulls a `highWaterMark`'s worth and credits it, landing at 2x node's bound instead of matching it exactly.

- The server side exposes a second bug the old over-granting was masking: a server that sends a complete response **without ever reading the request body** must reset the stream with `RST_STREAM(NO_ERROR)` so the client stops uploading (RFC 9113 8.1; node does this from `Http2Stream[kMaybeDestroy]` whenever a finished server stream has `headersSent`, `!didRead`, and `readableFlowing === null`). Bun never had it, so with the window now correctly closed, `test-http2-client-upload-reject.js` and its compat variant (a 139,837-byte upload to a handler that responds 400 and never reads it) deadlocked at 65,535 bytes and timed out on every Linux CI lane. Ported as a `'finish'` listener registered when `_final` shuts the writable down; `Http2Stream.close(NGHTTP2_NO_ERROR)` is already node's `closeStream()` for this case.

#### Verification

Two new tests in `test/js/node/http2/h2-conformance.test.ts` under "inbound flow control (RFC 9113 6.9)".

The first: a raw HTTP/2 server delivers a full 512 KiB stream window to a client that never reads (pacing only on the connection window), then uses two PING round trips as an ordering fence and asserts the client emitted zero stream-level `WINDOW_UPDATE`s. It then attaches a `data` listener and asserts every buffered byte is delivered and the whole window is re-opened in a single `WINDOW_UPDATE(524288)`.

The second drives a raw HTTP/2 client against a Bun server whose handler responds `400` without ever touching the request body, and asserts the server sends `RST_STREAM(NO_ERROR)` after (not instead of) the complete response. On the unfixed build no reset is ever sent and the test times out waiting for the frame. `test-http2-client-upload-reject.js` and `test-http2-compat-client-upload-reject.js` from the vendored Node suite, which hung before the second commit, now pass.

The first test fails on the unfixed build with

```
expect(received).toEqual(expected)
- []
+ [{ "type": 8, "streamId": 1, "payload": [0, 4, 255, 251] }]   // WINDOW_UPDATE(327675) on stream 1
```

Also run against the fixed build with no failures introduced:

- `test/js/node/http2/h2-conformance.test.ts` (24)
- `test/js/node/http2/node-http2.test.js` (287)
- `test/js/node/http2/node-http2-{continuation,invalid-padding,upgrade,syscall-fault}.test.*`
- `test/regression/issue/{24924,25589*,26915,29073}.test.ts` (42)
- `test/js/third_party/{grpc-js,undici-h2,wpt-h2}` and `test/js/web/fetch/fetch-http2-*.test.ts` (222)
- the flow-control and upload subset of the vendored Node suite (`test-http2-window-size.js`, `test-http2-dont-lose-data.js`, `test-http2-compat-serverrequest-pause.js`, `test-http2-compat-serverrequest-pipe.js`, `test-http2-client-upload.js`, `test-http2-large-write-*.js`, `test-http2-multiplex.js`, `test-http2-cancel-while-client-reading.js`, ...)
- the server response/trailers/push subset of the vendored Node suite (`test-http2-compat-serverresponse-*.js`, `test-http2-compat-serverrequest-*.js`, `test-http2-respond-*.js`, `test-http2-*trailers*.js`, `test-http2-server-push-*.js`), since the reset fires from every finished server stream

A handful of vendored Node http2 tests in those subsets fail identically before and after on the release binary (`test-http2-misbehaving-flow-control{,-paused}.js`, `test-http2-backpressure.js`, `test-http2-client-setLocalWindowSize.js`, `test-http2-compat-serverresponse-drain.js`, `test-http2-respond-{errors,nghttperrors,with-fd-errors,file-fd-leak}.js`, `test-http2-server-push-stream-{errors,head}.js`, `test-http2-server-stream-session-destroy.js`); they are pre-existing and unrelated (error taxonomy, write-side high-water-mark, fd accounting).

