### PR TITLE
semver: parse space-separated comparators as an intersection, not alternatives

### DIFF
--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -888,7 +888,6 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
             }
             b'=' | b'v' => {
                 token.tag = TokenTag::Version;
-                is_or = true;
                 i += 1;
                 while i < input.len() && input[i] == b' ' {
                     i += 1;
@@ -915,7 +914,6 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
             }
             b'0'..=b'9' | b'X' | b'x' | b'*' => {
                 token.tag = TokenTag::Version;
-                is_or = true;
             }
             b'|' => {
                 i += 1;
@@ -926,6 +924,8 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 while i < input.len() && input[i] == b' ' {
                     i += 1;
                 }
+                // "||" is the only token that starts a new OR alternative; whitespace
+                // between comparators is an intersection (node-semver's range grammar).
                 is_or = true;
                 token.tag = TokenTag::None;
                 skip_round = true;

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -735,6 +735,39 @@ describe("Bun.semver.satisfies()", () => {
     }
   });
 
+  test("space-separated comparators are an intersection, not alternatives", () => {
+    // In npm's range grammar only "||" starts a new alternative; whitespace between
+    // comparators is an intersection. Comparators starting with a digit, "x", "*",
+    // "=", or "v" used to begin a new "||" group. Every expectation matches node-semver.
+    const cases: [version: string, range: string, expected: boolean][] = [
+      ["2.5.0", "1.x 2.x", false],
+      ["1.0.1", "<1.0.0 1.x", false],
+      ["1.2.3", ">=2.0.0 1.2.3", false],
+      ["1.2.3", "1.2.3 4.5.6", false],
+      ["4.5.6", "1.2.3 4.5.6", false],
+      ["1.2.3", ">=2.0.0 =1.2.3", false],
+      ["1.2.3", ">=2.0.0 v1.2.3", false],
+      ["1.0.0", ">=2.0.0 *", false],
+      ["1.0.0", ">=2.0.0 x", false],
+      ["1.0.0", ">=2.0.0 x.x.x", false],
+      ["1.5.0", ">=1.0.0 1.x <1.4.0", false],
+      ["4.5.6", "4.5.6 7.8.9 || 1.2.3", false],
+      // the intersection holds, or an "||" alternative holds
+      ["1.3.0", ">=1.0.0 1.x <1.4.0", true],
+      ["2.5.0", "1.x || 2.x", true],
+      ["1.0.1", "<1.0.0 || 1.x", true],
+      ["1.2.3", ">=2.0.0 || 1.2.3", true],
+      ["1.2.3", "1.2.3 4.5.6 || 1.2.3", true],
+      ["1.2.3", "~1.2.1 1.2.3", true],
+      ["1.2.3", "~1.2.1 =1.2.3", true],
+      ["1.2.3", ">=1.2.1 1.2.3", true],
+      ["1.2.3", "1.2.3 >=1.2.1", true],
+    ];
+    expect(cases.map(([version, range]) => ({ version, range, satisfies: satisfies(version, range) }))).toEqual(
+      cases.map(([version, range, expected]) => ({ version, range, satisfies: expected })),
+    );
+  });
+
   test("pre-release snapshot", () => {
     expect(unsortedPrereleases.sort(Bun.semver.order)).toMatchSnapshot();
   });


### PR DESCRIPTION
`Bun.semver.satisfies` treats the space between two comparators as a new `||` alternative whenever the second comparator starts with a digit, `x`, `X`, `*`, `=`, or `v`. In npm's range grammar whitespace between comparators is an intersection and only `||` starts a new alternative, so this accepts versions outside the requested range, which is the dangerous direction for a "is this version compatible?" check:

```js
Bun.semver.satisfies("2.5.0", "1.x 2.x")     // bun: true   node-semver: false (unsatisfiable intersection)
Bun.semver.satisfies("1.0.1", "<1.0.0 1.x")  // bun: true   node-semver: false
Bun.semver.satisfies("1.0.0", ">=2.0.0 *")   // bun: true   node-semver: false
```

Comparators starting with an operator (`>`, `<`, `~`, `^`) were already ANDed, which is how this survived: node-semver's own `range-exclude` fixture (mirrored in `test/cli/install/semver.test.ts`) has no exclusion row where the second space-separated comparator starts with one of the affected characters, and its `range-include` rows like `~1.2.1 1.2.3` have non-empty intersections so they pass under either interpretation.

### Cause

In `semver::query::parse` (`src/semver/SemverQuery.rs`) the `b'=' | b'v'` and `b'0'..=b'9' | b'X' | b'x' | b'*'` token arms set `is_or = true`, the flag that makes the next emitted comparator start a new `||` alternative (`List::or_range`) instead of extending the current AND chain (`List::and_range`).

This is the single range parser behind `Bun.semver`, `bun install` dependency parsing, `bun why`, and `bun pm view`, so the same ranges are misread everywhere.

### Fix

Only the `||` arm sets `is_or`. Two deleted assignments.

### Verification

- **Zero real-world impact, measured against the npm registry.** I crawled the real npm install graph (2 hops from 157 ecosystem seeds: 2,997 packages, 446,894 published versions, 144,982 distinct dependency range strings) and evaluated `Bun.semver.satisfies` for every dependency range against every real published version of its target, 439,426,138 checks, under the released (unfixed) Bun 1.3.14 and under this branch. The two result vectors are byte-identical: 0 results change. Not one of the 144,982 real range strings is a semver range with the affected shape (the one textual hit is Babel's `condition:BABEL_8_BREAKING ? : 5.1.1-v1` build placeholder in `@babel/eslint-parser`, which node-semver rejects as invalid). So no existing lockfile or published package resolves differently; ranges of the affected shape are already unsatisfiable under npm, yarn, and pnpm, so none exist in the wild.
- **The change is monotone.** The `src/` diff is only the two deleted `is_or = true` assignments, so for every range string the set of `||` cut points can only shrink, and merging two alternatives `S` and `T` replaces `S ∪ T` with `S ∩ T ⊆ S ∪ T`: the accepted version set can only shrink. A version can only stop satisfying a range, never start. Checked on 213,735 `(version, range)` pairs over 14,249 generated range strings with no validity filter (including everything node-semver rejects): 24,463 pairs went `true -> false`, 0 went `false -> true`. So the only possible behavioral change anywhere (`Bun.semver`, `bun install`, `bun why`, `bun pm view`) is that a version which npm, yarn, and pnpm already refuse for a range is now also refused by Bun.

- New test in `test/cli/install/semver.test.ts`. Every expected value was produced by running node-semver 7 on the same inputs, and every range is accepted by `semver.validRange`. 12 of the 21 cases flip on the unfixed build.
- Differential against node-semver 7 over 86,685 generated `(version, range)` cases, restricted to ranges node-semver considers valid: 12,608 mismatches before, 2,864 after. 9,744 fixed, 0 introduced (no case that matched before mismatches after). The remaining mismatch families (`>x`/`>*` bare-wildcard-after-operator, prerelease handling) are unrelated root causes this PR does not touch.
- The existing `semver.test.ts` passes unchanged (26 tests, 1769 assertions); I diffed Bun's inlined `range-include`/`range-exclude` arrays against the upstream node-semver commit they cite and they are complete copies.
- No test fixture in the repo depends on the old interpretation. The only space-separated dependency specifier in a test `package.json` is `>=14.19.1 <=18.x.x`, operator-led on both sides and already an intersection.

Not related to #32843, which changes version selection in `find_best_version` (`src/install/npm.rs`); this changes range parsing.


