### PR TITLE
node:http2: fix request() option validation ordering, parent: 0, and the PADDED+PRIORITY HEADERS layout

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8846,9 +8846,20 @@ impl H2FrameParser {
             stream.weight = u16::from(weight);
         }
         // `signal_arg` already passed `AbortSignal::from_js` above; re-derive from the rooted value.
+        // Re-check `aborted()`: the header encode loops can run arbitrary JS (a header value's
+        // toString) which can abort the signal after the pre-encode check, and attaching an
+        // already-aborted signal fires its listener synchronously, which would write RST_STREAM
+        // for a stream the peer has never seen and re-enter the `stream` held `&mut` here.
+        let mut abort_after_write: Option<JSValue> = None;
         if let Some(signal_ptr) = signal.and_then(AbortSignal::from_js) {
             // SAFETY: `from_js` returns a live *mut AbortSignal owned by JSC; rooted via `signal` on the stack.
-            stream.attach_signal(this, unsafe { &mut *signal_ptr });
+            let signal_ = unsafe { &mut *signal_ptr };
+            if signal_.aborted() {
+                abort_after_write =
+                    Some(Bun__wrapAbortError(global_object, signal_.abort_reason()));
+            } else {
+                stream.attach_signal(this, signal_);
+            }
         }
 
         let mut length: usize = encoded_size;
@@ -8936,6 +8947,12 @@ impl H2FrameParser {
             };
             let _ = frame.write(&mut writer);
 
+            // RFC 7540 §6.2: whenever PADDED is set the Pad Length octet is the FIRST payload
+            // byte, before the optional priority fields.
+            if padding != 0 {
+                let _ = writer.write_all(&[padding]);
+            }
+
             // Write priority data if present
             if has_priority {
                 let stream_identifier = UInt31WithReserved::init(parent.unwrap_or(0), exclusive);
@@ -8946,27 +8963,17 @@ impl H2FrameParser {
                 let _ = priority_data.write(&mut writer);
             }
 
-            // Handle padding
             if padding != 0 {
-                if encoded_headers
-                    .try_reserve(encoded_size + padding_overhead - encoded_headers.len())
-                    .is_err()
-                {
+                if encoded_headers.try_reserve(padding as usize).is_err() {
                     return Err(
                         global_object.throw(format_args!("Failed to allocate padding buffer"))
                     );
                 }
                 // Zero-fill the padding region (RFC 7540 §6.2: padding octets MUST be zero) and
                 // ensure the slice we hand to writer covers only initialized bytes.
-                encoded_headers.resize(encoded_size + padding_overhead, 0);
-                let buffer = encoded_headers.as_mut_slice();
-                // memmove: shift right by 1 to make room for the pad-length byte
-                buffer.copy_within(0..encoded_size, 1);
-                buffer[0] = padding;
-                let _ = writer.write_all(buffer);
-            } else {
-                let _ = writer.write_all(&encoded_headers);
+                encoded_headers.resize(encoded_size + padding as usize, 0);
             }
+            let _ = writer.write_all(&encoded_headers);
         } else {
             bun_output::scoped_log!(
                 H2FrameParser,
@@ -9024,6 +9031,14 @@ impl H2FrameParser {
 
                 offset += chunk_size;
             }
+        }
+
+        // The signal aborted while user JS ran inside the header encode. The block is already
+        // committed to the shared encoder so the HEADERS frame had to go out; now abort the
+        // stream, exactly like an abort that arrives one tick after request() returns.
+        if let Some(reason) = abort_after_write {
+            this.abort_stream(&mut stream, reason);
+            return Ok(JSValue::js_number(stream_id as f64));
         }
 
         if end_stream {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8139,6 +8139,33 @@ impl H2FrameParser {
         Ok(JSValue::js_number(this.flush() as f64))
     }
 
+    /// Registers `stream_id`, attaches the JS context, marks it CLOSED with `rst_code` and
+    /// dispatches `onStreamError`. Only for `request()` rejections that run BEFORE any header is
+    /// fed to the shared HPACK encoder; a post-encode bail-out desyncs it from the peer's decoder.
+    fn reject_request_stream(
+        &self,
+        stream_id: u32,
+        stream_ctx_arg: JSValue,
+        global_object: &JSGlobalObject,
+        rst_code: ErrorCode,
+    ) -> JSValue {
+        let Some(stream_ptr) = self.handle_received_stream_id(stream_id) else {
+            return JSValue::js_number(-1.0);
+        };
+        let mut stream = self.enter_stream_dispatch(stream_ptr);
+        if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
+            stream.set_context(stream_ctx_arg, global_object);
+        }
+        stream.state = StreamState::CLOSED;
+        stream.rst_code = rst_code.0;
+        self.dispatch_with_extra(
+            JSH2FrameParser::Gc::onStreamError,
+            stream.get_identifier(),
+            JSValue::js_number(stream.rst_code as f64),
+        );
+        JSValue::js_number(stream_id as f64)
+    }
+
     #[bun_jsc::host_fn(method)]
     pub(crate) fn request(
         this: &Self,
@@ -8182,6 +8209,186 @@ impl H2FrameParser {
             };
         if stream_id > MAX_STREAM_ID {
             return Ok(JSValue::js_number(-1.0));
+        }
+
+        // Options are parsed, validated and the session memory limit is checked before any header
+        // is handed to the shared HPACK encoder: every rejection below must not advance the
+        // encoder's dynamic table (see reject_request_stream).
+        let mut flags: u8 = HeadersFrameFlags::END_HEADERS as u8;
+        let mut exclusive: bool = false;
+        let mut silent: bool = false;
+        let mut wait_for_trailers: bool = false;
+        let mut end_stream: bool = false;
+        let mut parent: Option<u32> = None;
+        let mut weight: Option<u8> = None;
+        let mut padding_strategy: Option<PaddingStrategy> = None;
+        // Kept as the rooted JSValue (not the raw *mut AbortSignal) across the header encode
+        // loops, whose property getters can run arbitrary JS.
+        let mut signal: Option<JSValue> = None;
+        if args_list.len > 4 && !args_list.ptr[4].is_empty_or_undefined_or_null() {
+            let options = args_list.ptr[4];
+            if !options.is_object() {
+                return Ok(this.reject_request_stream(
+                    stream_id,
+                    stream_ctx_arg,
+                    global_object,
+                    ErrorCode::INTERNAL_ERROR,
+                ));
+            }
+
+            if let Some(padding_js) = options.get(global_object, "paddingStrategy")? {
+                if padding_js.is_number() {
+                    padding_strategy = Some(match padding_js.to_u32() {
+                        1 => PaddingStrategy::Aligned,
+                        2 => PaddingStrategy::Max,
+                        _ => PaddingStrategy::None,
+                    });
+                }
+            }
+
+            if let Some(trailes_js) = options.get(global_object, "waitForTrailers")? {
+                if trailes_js.is_boolean() {
+                    wait_for_trailers = trailes_js.as_boolean();
+                }
+            }
+
+            if let Some(silent_js) = options.get(global_object, "silent")? {
+                if silent_js.is_boolean() {
+                    silent = silent_js.as_boolean();
+                } else {
+                    return Err(global_object.throw_invalid_argument_type_value(
+                        b"options.silent",
+                        b"boolean",
+                        silent_js,
+                    ));
+                }
+            }
+
+            if let Some(end_stream_js) = options.get(global_object, "endStream")? {
+                if end_stream_js.is_boolean() {
+                    if end_stream_js.as_boolean() {
+                        end_stream = true;
+                        // will end the stream after trailers
+                        if !wait_for_trailers || this.is_server.get() {
+                            flags |= HeadersFrameFlags::END_STREAM as u8;
+                        }
+                    }
+                } else {
+                    return Err(global_object.throw_invalid_argument_type_value(
+                        b"options.endStream",
+                        b"boolean",
+                        end_stream_js,
+                    ));
+                }
+            }
+
+            if let Some(exclusive_js) = options.get(global_object, "exclusive")? {
+                if exclusive_js.is_boolean() {
+                    if exclusive_js.as_boolean() {
+                        exclusive = true;
+                    }
+                } else {
+                    return Err(global_object.throw_invalid_argument_type_value(
+                        b"options.exclusive",
+                        b"boolean",
+                        exclusive_js,
+                    ));
+                }
+            }
+
+            if let Some(parent_js) = options.get(global_object, "parent")? {
+                if parent_js.is_number() || parent_js.is_int32() {
+                    // node accepts any parent >= 0; 0 is the connection stream (RFC 7540 §5.3.1's
+                    // implicit root) and is what node's own option defaulting fills in.
+                    let parent_value = parent_js.to_int32();
+                    if parent_value < 0 || parent_value as u32 > MAX_STREAM_ID {
+                        return Ok(this.reject_request_stream(
+                            stream_id,
+                            stream_ctx_arg,
+                            global_object,
+                            ErrorCode::INTERNAL_ERROR,
+                        ));
+                    }
+                    parent = Some(parent_value as u32);
+                } else {
+                    return Err(global_object.throw_invalid_argument_type_value(
+                        b"options.parent",
+                        b"number",
+                        parent_js,
+                    ));
+                }
+            }
+
+            if let Some(weight_js) = options.get(global_object, "weight")? {
+                if weight_js.is_number() || weight_js.is_int32() {
+                    // nghttp2 clamps an out-of-range weight to [MIN_WEIGHT, MAX_WEIGHT] instead of
+                    // rejecting the request; node forwards any numeric weight relying on that.
+                    let weight_value = weight_js.to_int32().clamp(1, u8::MAX as i32);
+                    weight = Some(u8::try_from(weight_value).expect("clamped to u8 range"));
+                } else {
+                    return Err(global_object.throw_invalid_argument_type_value(
+                        b"options.weight",
+                        b"number",
+                        weight_js,
+                    ));
+                }
+            }
+
+            if let Some(signal_arg) = options.get(global_object, "signal")? {
+                if let Some(signal_ptr) = AbortSignal::from_js(signal_arg) {
+                    // SAFETY: `from_js` returns a live *mut AbortSignal owned by JSC; rooted via `signal_arg` on the stack.
+                    let signal_ = unsafe { &mut *signal_ptr };
+                    if signal_.aborted() {
+                        let Some(stream_ptr) = this.handle_received_stream_id(stream_id) else {
+                            return Ok(JSValue::js_number(-1.0));
+                        };
+                        let mut stream = this.enter_stream_dispatch(stream_ptr);
+                        if !stream_ctx_arg.is_empty_or_undefined_or_null()
+                            && stream_ctx_arg.is_object()
+                        {
+                            stream.set_context(stream_ctx_arg, global_object);
+                        }
+                        stream.state = StreamState::IDLE;
+                        let wrapped = Bun__wrapAbortError(global_object, signal_.abort_reason());
+                        this.abort_stream(&mut stream, wrapped);
+                        return Ok(JSValue::js_number(stream_id as f64));
+                    }
+                    signal = Some(signal_arg);
+                } else {
+                    return Err(global_object.throw_invalid_argument_type_value(
+                        b"options.signal",
+                        b"AbortSignal",
+                        signal_arg,
+                    ));
+                }
+            }
+        }
+        let has_priority = exclusive || parent.is_some() || weight.is_some();
+
+        // too much memory being use
+        if this.get_session_memory_usage() > this.max_session_memory.get() as usize {
+            this.rejected_streams.set(this.rejected_streams.get() + 1);
+            let ret = this.reject_request_stream(
+                stream_id,
+                stream_ctx_arg,
+                global_object,
+                ErrorCode::ENHANCE_YOUR_CALM,
+            );
+            if this.rejected_streams.get() >= this.max_rejected_streams.get() {
+                let global = this.handlers.get().global();
+                let chunk = this
+                    .handlers
+                    .get()
+                    .binary_type
+                    .to_js(b"ENHANCE_YOUR_CALM", &global)?;
+                this.dispatch_with_2_extra(
+                    JSH2FrameParser::Gc::onError,
+                    JSValue::js_number(ErrorCode::ENHANCE_YOUR_CALM.0 as f64),
+                    JSValue::js_number(this.last_stream_id.get() as f64),
+                    chunk,
+                );
+            }
+            return Ok(ret);
         }
 
         // we iterate twice, because pseudo headers must be sent first, but can appear anywhere in the headers object
@@ -8618,203 +8825,32 @@ impl H2FrameParser {
         let Some(stream_ptr) = this.handle_received_stream_id(stream_id) else {
             return Ok(JSValue::js_number(-1.0));
         };
-        // The `options` getters below can run user JS while `stream` is borrowed.
+        // `attach_signal` and the terminal dispatches below can run user JS while `stream` is borrowed.
         let mut stream = this.enter_stream_dispatch(stream_ptr);
         if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
             stream.set_context(stream_ctx_arg, global_object);
         }
-        let mut flags: u8 = HeadersFrameFlags::END_HEADERS as u8;
-        let mut exclusive: bool = false;
-        let mut has_priority: bool = false;
-        let mut weight: i32 = 0;
-        let mut parent: i32 = 0;
-        let mut silent: bool = false;
-        let mut wait_for_trailers: bool = false;
-        let mut end_stream: bool = false;
-        if args_list.len > 4 && !args_list.ptr[4].is_empty_or_undefined_or_null() {
-            let options = args_list.ptr[4];
-            if !options.is_object() {
-                stream.state = StreamState::CLOSED;
-                stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
-                this.dispatch_with_extra(
-                    JSH2FrameParser::Gc::onStreamError,
-                    stream.get_identifier(),
-                    JSValue::js_number(stream.rst_code as f64),
-                );
-                return Ok(JSValue::js_number(stream_id as f64));
-            }
-
-            if let Some(padding_js) = options.get(global_object, "paddingStrategy")? {
-                if padding_js.is_number() {
-                    stream.padding_strategy = match padding_js.to_u32() {
-                        1 => PaddingStrategy::Aligned,
-                        2 => PaddingStrategy::Max,
-                        _ => PaddingStrategy::None,
-                    };
-                }
-            }
-
-            if let Some(trailes_js) = options.get(global_object, "waitForTrailers")? {
-                if trailes_js.is_boolean() {
-                    wait_for_trailers = trailes_js.as_boolean();
-                    stream.wait_for_trailers = wait_for_trailers;
-                }
-            }
-
-            if let Some(silent_js) = options.get(global_object, "silent")? {
-                if silent_js.is_boolean() {
-                    silent = silent_js.as_boolean();
-                } else {
-                    return Err(global_object.throw_invalid_argument_type_value(
-                        b"options.silent",
-                        b"boolean",
-                        silent_js,
-                    ));
-                }
-            }
-
-            if let Some(end_stream_js) = options.get(global_object, "endStream")? {
-                if end_stream_js.is_boolean() {
-                    if end_stream_js.as_boolean() {
-                        end_stream = true;
-                        // will end the stream after trailers
-                        if !wait_for_trailers || this.is_server.get() {
-                            flags |= HeadersFrameFlags::END_STREAM as u8;
-                        }
-                    }
-                } else {
-                    return Err(global_object.throw_invalid_argument_type_value(
-                        b"options.endStream",
-                        b"boolean",
-                        end_stream_js,
-                    ));
-                }
-            }
-
-            if let Some(exclusive_js) = options.get(global_object, "exclusive")? {
-                if exclusive_js.is_boolean() {
-                    if exclusive_js.as_boolean() {
-                        exclusive = true;
-                        stream.exclusive = true;
-                        has_priority = true;
-                    }
-                } else {
-                    return Err(global_object.throw_invalid_argument_type_value(
-                        b"options.exclusive",
-                        b"boolean",
-                        exclusive_js,
-                    ));
-                }
-            }
-
-            if let Some(parent_js) = options.get(global_object, "parent")? {
-                if parent_js.is_number() || parent_js.is_int32() {
-                    has_priority = true;
-                    parent = parent_js.to_int32();
-                    if parent <= 0 || parent as u32 > MAX_STREAM_ID {
-                        stream.state = StreamState::CLOSED;
-                        stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
-                        );
-                        return Ok(JSValue::js_number(stream.id as f64));
-                    }
-                    stream.stream_dependency = u32::try_from(parent).expect("int cast");
-                } else {
-                    return Err(global_object.throw_invalid_argument_type_value(
-                        b"options.parent",
-                        b"number",
-                        parent_js,
-                    ));
-                }
-            }
-
-            if let Some(weight_js) = options.get(global_object, "weight")? {
-                if weight_js.is_number() || weight_js.is_int32() {
-                    has_priority = true;
-                    weight = weight_js.to_int32();
-                    if weight < 1 || weight > u8::MAX as i32 {
-                        stream.state = StreamState::CLOSED;
-                        stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
-                        );
-                        return Ok(JSValue::js_number(stream_id as f64));
-                    }
-                    stream.weight = u16::try_from(weight).expect("int cast");
-                } else {
-                    return Err(global_object.throw_invalid_argument_type_value(
-                        b"options.weight",
-                        b"number",
-                        weight_js,
-                    ));
-                }
-
-                if weight < 1 || weight > u8::MAX as i32 {
-                    stream.state = StreamState::CLOSED;
-                    stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
-                    this.dispatch_with_extra(
-                        JSH2FrameParser::Gc::onStreamError,
-                        stream.get_identifier(),
-                        JSValue::js_number(stream.rst_code as f64),
-                    );
-                    return Ok(JSValue::js_number(stream_id as f64));
-                }
-
-                stream.weight = u16::try_from(weight).expect("int cast");
-            }
-
-            if let Some(signal_arg) = options.get(global_object, "signal")? {
-                if let Some(signal_ptr) = AbortSignal::from_js(signal_arg) {
-                    // SAFETY: `from_js` returns a live *mut AbortSignal owned by JSC; rooted via `signal_arg` on the stack.
-                    let signal_ = unsafe { &mut *signal_ptr };
-                    if signal_.aborted() {
-                        stream.state = StreamState::IDLE;
-                        let wrapped = Bun__wrapAbortError(global_object, signal_.abort_reason());
-                        this.abort_stream(&mut stream, wrapped);
-                        return Ok(JSValue::js_number(stream_id as f64));
-                    }
-                    stream.attach_signal(this, signal_);
-                } else {
-                    return Err(global_object.throw_invalid_argument_type_value(
-                        b"options.signal",
-                        b"AbortSignal",
-                        signal_arg,
-                    ));
-                }
-            }
+        // Apply the options parsed above. Nothing between here and the frame write may bail out
+        // over them: the header block is already committed to the encoder's dynamic table.
+        if let Some(strategy) = padding_strategy {
+            stream.padding_strategy = strategy;
+        }
+        stream.wait_for_trailers = wait_for_trailers;
+        if exclusive {
+            stream.exclusive = true;
+        }
+        if let Some(parent) = parent {
+            stream.stream_dependency = parent;
+        }
+        if let Some(weight) = weight {
+            stream.weight = u16::from(weight);
+        }
+        // `signal_arg` already passed `AbortSignal::from_js` above; re-derive from the rooted value.
+        if let Some(signal_ptr) = signal.and_then(AbortSignal::from_js) {
+            // SAFETY: `from_js` returns a live *mut AbortSignal owned by JSC; rooted via `signal` on the stack.
+            stream.attach_signal(this, unsafe { &mut *signal_ptr });
         }
 
-        // too much memory being use
-        if this.get_session_memory_usage() > this.max_session_memory.get() as usize {
-            stream.state = StreamState::CLOSED;
-            stream.rst_code = ErrorCode::ENHANCE_YOUR_CALM.0;
-            this.rejected_streams.set(this.rejected_streams.get() + 1);
-            this.dispatch_with_extra(
-                JSH2FrameParser::Gc::onStreamError,
-                stream.get_identifier(),
-                JSValue::js_number(stream.rst_code as f64),
-            );
-            if this.rejected_streams.get() >= this.max_rejected_streams.get() {
-                let global = this.handlers.get().global();
-                let chunk = this
-                    .handlers
-                    .get()
-                    .binary_type
-                    .to_js(b"ENHANCE_YOUR_CALM", &global)?;
-                this.dispatch_with_2_extra(
-                    JSH2FrameParser::Gc::onError,
-                    JSValue::js_number(ErrorCode::ENHANCE_YOUR_CALM.0 as f64),
-                    JSValue::js_number(this.last_stream_id.get() as f64),
-                    chunk,
-                );
-            }
-            return Ok(JSValue::js_number(stream_id as f64));
-        }
         let mut length: usize = encoded_size;
         if has_priority {
             length += 5;
@@ -8902,11 +8938,10 @@ impl H2FrameParser {
 
             // Write priority data if present
             if has_priority {
-                let stream_identifier =
-                    UInt31WithReserved::init(u32::try_from(parent).expect("int cast"), exclusive);
+                let stream_identifier = UInt31WithReserved::init(parent.unwrap_or(0), exclusive);
                 let priority_data = StreamPriority {
                     stream_identifier: stream_identifier.to_uint32(),
-                    weight: u8::try_from(weight).expect("int cast"),
+                    weight: weight.unwrap_or(0),
                 };
                 let _ = priority_data.write(&mut writer);
             }
@@ -8957,11 +8992,10 @@ impl H2FrameParser {
             let _ = headers_frame.write(&mut writer);
 
             if has_priority {
-                let stream_identifier =
-                    UInt31WithReserved::init(u32::try_from(parent).expect("int cast"), exclusive);
+                let stream_identifier = UInt31WithReserved::init(parent.unwrap_or(0), exclusive);
                 let priority_data = StreamPriority {
                     stream_identifier: stream_identifier.to_uint32(),
-                    weight: u8::try_from(weight).expect("int cast"),
+                    weight: weight.unwrap_or(0),
                 };
                 let _ = priority_data.write(&mut writer);
             }
@@ -9022,8 +9056,6 @@ impl H2FrameParser {
                 identifier,
                 JSValue::js_number(stream.state as u8 as f64),
             );
-        } else {
-            stream.wait_for_trailers = wait_for_trailers;
         }
 
         if silent {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3187,21 +3187,26 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
-// request() priority options must be validated BEFORE the header block is fed to the session's
-// shared HPACK encoder: a post-encode rejection leaves the encoder's dynamic table ahead of the
-// peer (the frame is never sent), killing the NEXT request with GOAWAY(COMPRESSION_ERROR).
-it("request() priority options are accepted and never desync the session's HPACK encoder", async () => {
+// Starts a bun h2c server that responds 200 with the request path as the body. Returned via a
+// disposable so `using` tears it down after the assertions.
+async function echoPathServer() {
   const server = http2.createServer();
   server.on("stream", (stream, headers) => {
     stream.respond({ ":status": 200, "content-type": "text/plain" });
     stream.end(headers[":path"]);
   });
   await new Promise(resolve => server.listen(0, resolve));
+  server[Symbol.dispose] = () => server.close();
+  return server;
+}
 
-  const client = http2.connect(`http://localhost:${server.address().port}`);
+// Runs `steps` (each `[path, options?]`) sequentially on one session against `server` and
+// resolves with their `{ status, body, rstCode }` results. Any session-level failure (the
+// poisoned-HPACK / malformed-frame symptom is a server GOAWAY that surfaces as an
+// ERR_HTTP2_SESSION_ERROR) rejects the step that is in flight instead of hanging it.
+async function h2RequestSequence(server, connectOptions, steps) {
+  const client = http2.connect(`http://localhost:${server.address().port}`, connectOptions);
   try {
-    // Any session-level failure (the poisoned-encoder symptom is a server GOAWAY that surfaces as
-    // an ERR_HTTP2_SESSION_ERROR) must fail the step that is in flight, not hang it.
     const sessionFailure = new Promise((_, reject) => {
       client.on("error", reject);
       client.on("goaway", (code, lastStreamID) => {
@@ -3212,43 +3217,118 @@ it("request() priority options are accepted and never desync the session's HPACK
     });
     sessionFailure.catch(() => {}); // only observed through the races below
 
-    const get = (path, options) =>
-      Promise.race([
-        sessionFailure,
-        new Promise((resolve, reject) => {
-          const req =
-            options === undefined ? client.request({ ":path": path }) : client.request({ ":path": path }, options);
-          let body = "";
-          let status;
-          req.setEncoding("utf8");
-          req.on("response", headers => (status = headers[":status"]));
-          req.on("data", chunk => (body += chunk));
-          req.on("error", reject);
-          req.on("close", () => resolve({ status, body, rstCode: req.rstCode }));
-          req.end();
-        }),
-      ]);
-
-    // Every option shape here is accepted by node. The trailing plain request is the real
-    // assertion: it proves none of the optioned requests left the encoder mid-block.
-    const results = [
-      await get("/parent-0", { parent: 0 }),
-      await get("/weight-0", { weight: 0 }),
-      await get("/weight-256", { weight: 256 }),
-      await get("/exclusive", { exclusive: true }),
-      await get("/node-defaults", { parent: 0, weight: 16, exclusive: false }),
-      await get("/plain"),
-    ];
-    expect(results).toEqual([
-      { status: 200, body: "/parent-0", rstCode: 0 },
-      { status: 200, body: "/weight-0", rstCode: 0 },
-      { status: 200, body: "/weight-256", rstCode: 0 },
-      { status: 200, body: "/exclusive", rstCode: 0 },
-      { status: 200, body: "/node-defaults", rstCode: 0 },
-      { status: 200, body: "/plain", rstCode: 0 },
-    ]);
+    const results = [];
+    for (const [path, options] of steps) {
+      results.push(
+        await Promise.race([
+          sessionFailure,
+          new Promise((resolve, reject) => {
+            const req =
+              options === undefined ? client.request({ ":path": path }) : client.request({ ":path": path }, options);
+            let body = "";
+            let status;
+            req.setEncoding("utf8");
+            req.on("response", headers => (status = headers[":status"]));
+            req.on("data", chunk => (body += chunk));
+            req.on("error", reject);
+            req.on("close", () => resolve({ status, body, rstCode: req.rstCode }));
+            req.end();
+          }),
+        ]),
+      );
+    }
+    return results;
   } finally {
     client.close();
-    server.close();
+  }
+}
+
+// request() priority options must be validated BEFORE the header block is fed to the session's
+// shared HPACK encoder: a post-encode rejection leaves the encoder's dynamic table ahead of the
+// peer (the frame is never sent), killing the NEXT request with GOAWAY(COMPRESSION_ERROR).
+it("request() priority options are accepted and never desync the session's HPACK encoder", async () => {
+  using server = await echoPathServer();
+  // Every option shape here is accepted by node. The trailing plain request is the real
+  // assertion: it proves none of the optioned requests left the encoder mid-block.
+  const results = await h2RequestSequence(server, undefined, [
+    ["/parent-0", { parent: 0 }],
+    ["/weight-0", { weight: 0 }],
+    ["/weight-256", { weight: 256 }],
+    ["/exclusive", { exclusive: true }],
+    ["/node-defaults", { parent: 0, weight: 16, exclusive: false }],
+    ["/plain"],
+  ]);
+  expect(results).toEqual([
+    { status: 200, body: "/parent-0", rstCode: 0 },
+    { status: 200, body: "/weight-0", rstCode: 0 },
+    { status: 200, body: "/weight-256", rstCode: 0 },
+    { status: 200, body: "/exclusive", rstCode: 0 },
+    { status: 200, body: "/node-defaults", rstCode: 0 },
+    { status: 200, body: "/plain", rstCode: 0 },
+  ]);
+});
+
+// RFC 7540 section 6.2: when a HEADERS frame carries both PADDED and PRIORITY, the Pad Length
+// octet is the FIRST payload byte, before the priority fields. Emitting priority first makes the
+// peer read the high byte of the stream dependency as the pad length, misalign the header block,
+// and tear the whole connection down.
+it("HEADERS carrying both PADDED and PRIORITY puts Pad Length before the priority fields", async () => {
+  for (const paddingStrategy of [http2.constants.PADDING_STRATEGY_MAX, http2.constants.PADDING_STRATEGY_ALIGNED]) {
+    using server = await echoPathServer();
+    const results = await h2RequestSequence(server, { paddingStrategy }, [
+      ["/padded-priority", { exclusive: true }],
+      ["/plain"],
+    ]);
+    expect({ paddingStrategy, results }).toEqual({
+      paddingStrategy,
+      results: [
+        { status: 200, body: "/padded-priority", rstCode: 0 },
+        { status: 200, body: "/plain", rstCode: 0 },
+      ],
+    });
+  }
+});
+
+// An abort that fires from user JS running inside the header encode (a header value's toString)
+// must be handled after the HEADERS frame is written, like an abort arriving on the next tick.
+// Attaching the already-aborted signal fired its listener synchronously, which wrote RST_STREAM
+// for a stream the peer had never seen; that is a connection error that killed the session.
+it("a signal aborted from a header value's toString during request() does not poison the session", async () => {
+  using server = await echoPathServer();
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  try {
+    const sessionErrors = [];
+    client.on("error", err => sessionErrors.push(err));
+
+    const controller = new AbortController();
+    const abortError = await new Promise((resolve, reject) => {
+      const req = client.request(
+        { ":path": "/abort-mid-encode", "x-abort": { toString: () => (controller.abort(), "v") } },
+        { signal: controller.signal },
+      );
+      req.resume();
+      req.on("error", resolve);
+      req.on("close", () => reject(new Error("stream closed without the expected abort error")));
+      req.end();
+    });
+    expect(abortError.name).toBe("AbortError");
+    expect(controller.signal.aborted).toBe(true);
+
+    // The real assertion: the session is still usable after the mid-encode abort.
+    const plain = await new Promise((resolve, reject) => {
+      const req = client.request({ ":path": "/plain" });
+      let body = "";
+      let status;
+      req.setEncoding("utf8");
+      req.on("response", headers => (status = headers[":status"]));
+      req.on("data", chunk => (body += chunk));
+      req.on("error", reject);
+      req.on("close", () => resolve({ status, body }));
+      req.end();
+    });
+    expect(plain).toEqual({ status: 200, body: "/plain" });
+    expect(sessionErrors).toEqual([]);
+  } finally {
+    client.close();
   }
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3186,3 +3186,69 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
     server.close();
   }
 });
+
+// request() priority options must be validated BEFORE the header block is fed to the session's
+// shared HPACK encoder: a post-encode rejection leaves the encoder's dynamic table ahead of the
+// peer (the frame is never sent), killing the NEXT request with GOAWAY(COMPRESSION_ERROR).
+it("request() priority options are accepted and never desync the session's HPACK encoder", async () => {
+  const server = http2.createServer();
+  server.on("stream", (stream, headers) => {
+    stream.respond({ ":status": 200, "content-type": "text/plain" });
+    stream.end(headers[":path"]);
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  try {
+    // Any session-level failure (the poisoned-encoder symptom is a server GOAWAY that surfaces as
+    // an ERR_HTTP2_SESSION_ERROR) must fail the step that is in flight, not hang it.
+    const sessionFailure = new Promise((_, reject) => {
+      client.on("error", reject);
+      client.on("goaway", (code, lastStreamID) => {
+        if (code !== http2.constants.NGHTTP2_NO_ERROR) {
+          reject(new Error(`unexpected GOAWAY code=${code} lastStreamID=${lastStreamID}`));
+        }
+      });
+    });
+    sessionFailure.catch(() => {}); // only observed through the races below
+
+    const get = (path, options) =>
+      Promise.race([
+        sessionFailure,
+        new Promise((resolve, reject) => {
+          const req =
+            options === undefined ? client.request({ ":path": path }) : client.request({ ":path": path }, options);
+          let body = "";
+          let status;
+          req.setEncoding("utf8");
+          req.on("response", headers => (status = headers[":status"]));
+          req.on("data", chunk => (body += chunk));
+          req.on("error", reject);
+          req.on("close", () => resolve({ status, body, rstCode: req.rstCode }));
+          req.end();
+        }),
+      ]);
+
+    // Every option shape here is accepted by node. The trailing plain request is the real
+    // assertion: it proves none of the optioned requests left the encoder mid-block.
+    const results = [
+      await get("/parent-0", { parent: 0 }),
+      await get("/weight-0", { weight: 0 }),
+      await get("/weight-256", { weight: 256 }),
+      await get("/exclusive", { exclusive: true }),
+      await get("/node-defaults", { parent: 0, weight: 16, exclusive: false }),
+      await get("/plain"),
+    ];
+    expect(results).toEqual([
+      { status: 200, body: "/parent-0", rstCode: 0 },
+      { status: 200, body: "/weight-0", rstCode: 0 },
+      { status: 200, body: "/weight-256", rstCode: 0 },
+      { status: 200, body: "/exclusive", rstCode: 0 },
+      { status: 200, body: "/node-defaults", rstCode: 0 },
+      { status: 200, body: "/plain", rstCode: 0 },
+    ]);
+  } finally {
+    client.close();
+    server.close();
+  }
+});


### PR DESCRIPTION
### What

An `http2.connect()` client request carrying priority options could reject the stream with `NGHTTP2_INTERNAL_ERROR`, and as a side effect corrupt the session's HPACK encoder state so that the next, perfectly normal request on the same connection was killed by the peer with a connection-level `GOAWAY(COMPRESSION_ERROR)`. One bad request poisoned the whole session.

```
A(weight:7)         OK 200
B(excl+parent:0)    ERROR ERR_HTTP2_STREAM_ERROR Stream closed with error code NGHTTP2_INTERNAL_ERROR
C(exclusive only)   ERROR ERR_HTTP2_STREAM_ERROR Stream closed with error code NGHTTP2_PROTOCOL_ERROR
D(plain)            ERROR ERR_HTTP2_STREAM_ERROR Stream closed with error code NGHTTP2_PROTOCOL_ERROR
```

Isolated per option shape against a node v26 http2 server, each on a fresh session followed by a plain request:

| request options | node client | bun client (before) |
|---|---|---|
| `{ parent: 0 }` | 200, 200 | `NGHTTP2_INTERNAL_ERROR`, then plain request dies with server `GOAWAY(COMPRESSION_ERROR)` |
| `{ weight: 0 }` | 200, 200 | same |
| `{ weight: 256 }` | 200, 200 | same |
| session `paddingStrategy: MAX` + `{ exclusive: true }` | 200, 200 | connection torn down (see the second fix below) |
| `{ weight: 7 }` / `{ exclusive: true }` / `{ parent: 3 }` | 200, 200 | 200, 200 |

### Cause

**1. Options were validated after the header block was already fed to the shared HPACK encoder.**

`H2FrameParser.request()` encoded the header block into the session's shared HPACK encoder first, and only then read and validated the `options` object. Every rejection in the options path (`!options.is_object()`, `parent <= 0`, `weight < 1 || weight > 255`, a non-boolean option's `ERR_INVALID_ARG_TYPE`, an already-aborted signal, the `maxSessionMemory` ENHANCE_YOUR_CALM check) returned without writing the HEADERS frame.

`encode_header_into_list` inserts entries into the encoder's dynamic table (lshpack) as it goes. Once the block is encoded, the encoder is committed: the peer's decoder learns those inserts only from the frame that was never sent. The next header block on the session references dynamic-table indices the server does not have, the server's HPACK decode fails, and it tears the connection down with `COMPRESSION_ERROR`.

The trigger people actually hit is `parent: 0`. Node accepts it: `0` is the connection stream, the RFC 7540 section 5.3.1 root, and is exactly what node's own `setAndValidatePriorityOptions` fills in when `parent` is unset. Bun's check was `parent <= 0`. `weight: 0` / `weight: 256` (both legal in node, which forwards any numeric weight and relies on nghttp2's `adjust_weight` clamp) hit the same post-encode rejection.

**2. A HEADERS frame carrying both PADDED and PRIORITY had the wrong payload layout.**

RFC 7540 section 6.2 puts the Pad Length octet first in the payload, before the optional priority fields. `request()` wrote the 5 priority bytes first. A peer parsing per the RFC reads the high byte of the stream-dependency word as the pad length, misaligns the header block, and tears the whole connection down. Bun's own receive side (`handle_headers_frame`) already reads Pad Length first, so a bun client poisoned a bun server too. Any session with `paddingStrategy: PADDING_STRATEGY_MAX` or `ALIGNED` hit this on every priority-optioned request.

### Fix

`src/runtime/api/bun/h2_frame_parser.rs`:

- All of `options` (and the session memory limit) are now parsed and validated at the top of `request()`, before any header is fed to the encoder. The parsed values are applied to the stream after the encode. No options-path rejection can desync the encoder anymore; rejections that need a registered stream go through a new `reject_request_stream` helper.
- `parent: 0` is accepted (`parent < 0` is still rejected).
- `weight` is clamped to the encodable range instead of erroring, matching nghttp2.
- The single-frame HEADERS writer now emits the Pad Length octet before the priority fields.
- Reordering the option parsing separated the signal's `aborted()` check from `attach_signal()` by the encode loops, which can run arbitrary user JS (a header value's `toString`). `addListener` on an already-aborted signal fires its callback synchronously, so an abort raced in during the encode would have written `RST_STREAM` for a stream the peer has never seen and re-entered the `Stream` that `request()` holds `&mut` to, before `request()` then wrote the HEADERS for the same id. `aborted()` is re-checked at the attach site; if the abort raced in, the HEADERS frame is written (the block is already committed to the encoder) and only then is the stream aborted, the same wire shape as an abort that arrives one tick after `request()` returns.

Intentionally excluded, same bug class, different fix:

- A header **name/value** validation failure in the middle of the encode loop (for example a NUL byte in the value of the third header, after the first two were already encoded) still desyncs the encoder through the same mechanism. Fixing that needs the request header loops split into a validate pass and an encode pass (or the encoder snapshot/rolled back), which is a larger restructure than the options hoist; left for a follow-up.
- The `maxSendHeaderBlockLength` rejection still runs after the encode because it measures the encoded block size; nghttp2 terminates the whole session in that case too, and it only applies when the session explicitly opts into that limit.

### Test

`test/js/node/http2/node-http2.test.js`, three tests sharing one helper:

- one session issues a request for each priority-option shape node accepts, then a plain request. The plain request is the load-bearing assertion: it proves none of the optioned requests left the encoder mid-block.
- a session with `paddingStrategy: MAX` / `ALIGNED` issues a priority-optioned request, then a plain request.
- a request whose header value's `toString` aborts its own signal mid-encode errors with an AbortError and leaves the session usable for a plain follow-up.

All three fail on the unfixed build with the reported errors:

```
error: Stream closed with error code NGHTTP2_INTERNAL_ERROR
 code: "ERR_HTTP2_STREAM_ERROR"
(fail) request() priority options are accepted and never desync the session's HPACK encoder
error: Stream closed with error code NGHTTP2_COMPRESSION_ERROR
(fail) HEADERS carrying both PADDED and PRIORITY puts Pad Length before the priority fields
error: New streams cannot be created after receiving a GOAWAY
(fail) a signal aborted from a header value's toString during request() does not poison the session
```

All pass with the fix, and `test/js/node/http2/node-http2.test.js` plus the h2 conformance / padding / continuation suites pass.

<details>
<summary>Standalone repro (works against a node http2 server or a bun one)</summary>

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.on("stream", (s, h) => { s.respond({ ":status": 200 }); s.end("ok"); });
server.listen(0, () => {
  const client = http2.connect(`http://localhost:${server.address().port}`);
  client.on("goaway", code => console.log("goaway", code)); // 9 = COMPRESSION_ERROR
  const go = (p, o) => new Promise(r => {
    const q = o ? client.request({ ":path": p }, o) : client.request({ ":path": p });
    q.resume();
    q.on("error", e => (console.log(p, e.code), r()));
    q.on("close", () => (console.log(p, "ok"), r()));
    q.end();
  });
  (async () => {
    await go("/a", { parent: 0 }); // node-valid; bun: NGHTTP2_INTERNAL_ERROR
    await go("/b");                // collateral: server GOAWAYs with COMPRESSION_ERROR
    process.exit(0);
  })();
});
```

</details>

### Rebase note

Rebased past #33072, whose `enter_stream_dispatch`/`GuardedStream` guard lands at the same `request()` site this PR rewrites. Both changes are kept: this PR's options-before-encode ordering (the HPACK desync fix) plus #33072's dispatch guard at the post-encode `&mut Stream` borrow. The two new pre-encode sites that hold a `&mut Stream` across a JS dispatch (the `reject_request_stream` helper and the already-aborted-signal fast path) now use `enter_stream_dispatch` as well.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (05a902f8f)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [725.85ms]
(pass) node none > Client Basics > should be able to send a POST request [506.00ms]
(pass) node none > Client Basics > constants [18.42ms]
(pass) node none > Client Basics > getDefaultSettings [7.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [23.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.54ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.33ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.20ms
... (truncated)

release without fix: 9 failed, 6 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [1.19ms]
(pass) node none > Client Basics > getDefaultSettings [0.25ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.71ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.11ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.15ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [2.75ms]
(pass) node none > Client Basics > is possible to abort request [1.52ms]
(pass) node none > Client Basics > aborted event should work with abortController [1.05ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.87ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.46ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > close callback [25.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (05a902f8f)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [722.75ms]
(pass) node none > Client Basics > should be able to send a POST request [493.95ms]
(pass) node none > Client Basics > constants [20.04ms]
(pass) node none > Client Basics > getDefaultSettings [7.01ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.49ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.35ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.46ms
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     05a902f8f4
  features     (none)

22 deps, 105 codegen, 1167 objects in 771ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1230] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [8.00ms]
[2/1230] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1230] gen bindgenv2
[4/1230] gen ErrorCode+*.h
[5/1230] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[6/1230] fetch tinycc
[tinycc] up to date
[7/1229] fetch picohttpparser
[picohttpparser] up to date
[8/1229] fetch l
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs | 469 ++++++++++++++++++---------------
 test/js/node/http2/node-http2.test.js  | 146 ++++++++++
 2 files changed, 404 insertions(+), 211 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs     21     19     20
test/js/node/http2/node-http2.test.js       2      6     19
```

</details>

<!-- robobun:evidence:end -->