### PR TITLE
bun:test: don't leak JSC scope objects through a mock's this value

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -838,7 +838,9 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
+    // For `fn()` calls JSC places the resolved scope (a JSScope) in the `this` slot and expects the
+    // callee to sanitize it. Do so before exposing it to JS, like ProxyObject::performCall does.
+    JSValue thisValue = callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -238,6 +238,20 @@ describe("mock()", () => {
     const obj = { fn };
     expect(obj.fn()).toBe(obj);
   });
+  test("bare call through a captured binding has an undefined this value", () => {
+    const fn = jest.fn().mockReturnThis();
+    let returned;
+    {
+      const ref = fn;
+      // Capturing `ref` in a closure makes the engine resolve `ref()` through a
+      // scope object; that scope must not be observable as the call's `this`.
+      const capture = () => ref;
+      returned = ref();
+      expect(capture()).toBe(fn);
+    }
+    expect(returned).toBeUndefined();
+    expect(fn.mock.contexts).toEqual([undefined]);
+  });
   if (isBun) {
     test("jest.fn(10) return value shorthand", () => {
       expect(jest.fn(10)()).toBe(10);


### PR DESCRIPTION
### What is the problem

`jest.fn()` mocks record the call's `this` value in `mock.contexts` and return it from `mockReturnThis()`. The implementation read `callframe->thisValue()` raw.

For a bare call `fn()` where `fn` is resolved through a scope (a binding captured by a closure, an imported binding, or a top level `let`/`const`), JSC places the resolved scope object in the `this` register and leaves sanitization to the callee: JS functions do it in their prologue (`op_to_this`), and host functions are expected to call `JSValue::toThis()` (see `ProxyObject::performCall`). Because the mock call path skipped that, engine internal scope objects (`JSLexicalEnvironment`, `JSModuleEnvironment`, the global lexical environment) escaped into `mock.contexts` and out of `mockReturnThis()`:

```js
import { mock } from "bun:test";

const fn = mock().mockReturnThis();
const keep = () => fn; // capturing `fn` makes `fn()` resolve through a scope object
console.log(fn()); // [native code: JSLexicalEnvironment]
console.log(fn.mock.contexts[0]); // same object
```

These objects are not meant to be reachable from JavaScript. Ordinary property operations on one break JSC invariants: `Object.defineProperty(leaked, "x", { get() {} })` followed by a read aborts a release build (SIGABRT) and fails `ASSERTION FAILED: !(attributes & PropertyAttribute::Accessor)` in `JSLexicalEnvironment::getOwnPropertySlot` in a debug build. Fuzzilli found a flaky segfault with a script that does exactly this: call a captured mock, then mutate the value it returned.

### What is the fix

Sanitize the incoming `this` once with `toThis(globalObject, ECMAMode::strict())`, the conversion JSC applies for strict JS callees and in `ProxyObject::performCall`. Scope objects become `undefined`; every other receiver is unchanged, so `mock.contexts`, `mockReturnThis()`, and the receiver passed to mock implementations behave exactly as before for normal calls. This also matches Jest, which records `undefined` for a bare call.

Not included: a few chaining helpers (`jest.setSystemTime`, `jest.useRealTimers`, the fake timer functions, the plugin builder methods) also return the raw `this`. They never store it, the leak there needs the method to be detached and called bare, and covering them uniformly needs the same conversion exposed to the Rust side, so they are left for a separate change.

### How did you verify your code works

- New test in `test/js/bun/test/mock-fn.test.js` calls a mock through a captured binding and asserts the returned value and `mock.contexts` are `undefined`. On current Bun it fails with `Received: [native code: JSLexicalEnvironment]`; it passes with this change. The file also runs under Jest and Vitest and the asserted behavior matches both.
- `bun bd test test/js/bun/test/mock-fn.test.js` (73 pass), plus the mock module and `issue-1825-jest-mock-functions` tests.
- The Fuzzilli reproducer and the defineProperty abort case above run clean on the fixed build.
