### PR TITLE
Fix ReadableStream async iteration with preventCancel losing buffered data

### DIFF
--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -501,15 +501,15 @@ export function locked(this) {
   return $isReadableStreamLocked(this);
 }
 
+// This function is also installed as ReadableStream.prototype[Symbol.asyncIterator].
 export function values(this, options) {
-  var prototype = ReadableStream.prototype;
-  $readableStreamDefineLazyIterators(prototype);
-  return prototype.values.$call(this, options);
-}
+  if (!$isReadableStream(this)) throw $ERR_INVALID_THIS("ReadableStream");
 
-$linkTimeConstant;
-export function lazyAsyncIterator(this) {
-  var prototype = ReadableStream.prototype;
-  $readableStreamDefineLazyIterators(prototype);
-  return prototype[globalThis.Symbol.asyncIterator].$call(this);
+  let preventCancel = false;
+  if (!$isUndefinedOrNull(options)) {
+    if (!$isObject(options)) throw $makeTypeError("ReadableStream.values takes an object as first argument");
+    preventCancel = !!options["preventCancel"];
+  }
+
+  return $readableStreamAsyncIterator(this, preventCancel);
 }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2579,6 +2579,9 @@ export async function readableStreamToArrayDirect(stream, underlyingSource) {
 }
 
 // https://streams.spec.whatwg.org/#rs-asynciterator
+// The iterator's state lives in a plain object stored on the iterator under
+// the "state" private field, and next()/return() are shared hoisted functions,
+// so creating an iterator captures no lexical environment.
 export function readableStreamAsyncIterator(stream, preventCancel) {
   // AcquireReadableStreamDefaultReader. Run the deferred start exactly once,
   // the same way getReader() does, so lazy native streams are initialized.
@@ -2587,79 +2590,102 @@ export function readableStreamAsyncIterator(stream, preventCancel) {
     $putByIdDirectPrivate(stream, "start", undefined);
     start.$call(stream);
   }
-  var reader = new ReadableStreamDefaultReader(stream);
 
-  var isFinished = false;
-  var ongoingPromise;
+  const state = {
+    __proto__: null,
+    reader: new ReadableStreamDefaultReader(stream),
+    preventCancel: !!preventCancel,
+    isFinished: false,
+    ongoingPromise: undefined,
+    boundNextSteps: undefined,
+    onNextFulfilled: undefined,
+    onNextRejected: undefined,
+  };
 
-  // One read request per next() call, so chunks that were never delivered to
-  // the loop body stay queued in the stream (observable with preventCancel).
-  function nextSteps() {
-    if (isFinished) return $createFulfilledPromise({ value: undefined, done: true });
+  // Inherits from %AsyncIteratorPrototype% so the iterator is itself async iterable.
+  const iterator = {
+    __proto__: $getPrototypeOf($getPrototypeOf(async function* () {}).prototype),
+    next: $readableStreamAsyncIteratorNext,
+    return: $readableStreamAsyncIteratorReturn,
+  };
+  $putByIdDirectPrivate(iterator, "state", state);
+  return iterator;
+}
 
-    const readPromise = $readableStreamDefaultReaderRead(reader);
-    if ($isPromiseFulfilled(readPromise)) {
-      // The chunk (or close) was available synchronously, and the read promise
-      // already resolves to the { value, done } the iterator needs.
-      if ($peekPromiseSettledValue(readPromise).done) {
-        isFinished = true;
-        $readableStreamDefaultReaderRelease(reader);
-      }
-      return readPromise;
+// next()/return() only serialize behind a still-pending step; chaining onto a
+// settled ongoingPromise would cost an extra microtask per chunk.
+export function readableStreamAsyncIteratorNext(this: unknown) {
+  const state = $isObject(this) ? $getByIdDirectPrivate(this, "state") : undefined;
+  if (!state) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
+
+  const ongoingPromise = state.ongoingPromise;
+  if (ongoingPromise && !$isPromiseFulfilled(ongoingPromise)) {
+    const boundNextSteps = (state.boundNextSteps ??= $readableStreamAsyncIteratorNextSteps.bind(undefined, state));
+    return (state.ongoingPromise = ongoingPromise.$then(boundNextSteps, boundNextSteps));
+  }
+  return (state.ongoingPromise = $readableStreamAsyncIteratorNextSteps(state));
+}
+
+export function readableStreamAsyncIteratorReturn(this: unknown, value) {
+  const state = $isObject(this) ? $getByIdDirectPrivate(this, "state") : undefined;
+  if (!state) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
+
+  const ongoingPromise = state.ongoingPromise;
+  if (ongoingPromise && !$isPromiseFulfilled(ongoingPromise)) {
+    const returnSteps = $readableStreamAsyncIteratorReturnSteps.bind(undefined, state, value);
+    return (state.ongoingPromise = ongoingPromise.$then(returnSteps, returnSteps));
+  }
+  return (state.ongoingPromise = $readableStreamAsyncIteratorReturnSteps(state, value));
+}
+
+// One read request per next() call, so chunks that were never delivered to
+// the loop body stay queued in the stream (observable with preventCancel).
+export function readableStreamAsyncIteratorNextSteps(state) {
+  if (state.isFinished) return $createFulfilledPromise({ value: undefined, done: true });
+
+  const readPromise = $readableStreamDefaultReaderRead(state.reader);
+  if ($isPromiseFulfilled(readPromise)) {
+    // The chunk (or close) was available synchronously, and the read promise
+    // already resolves to the { value, done } the iterator needs.
+    if ($peekPromiseSettledValue(readPromise).done) {
+      state.isFinished = true;
+      $readableStreamDefaultReaderRelease(state.reader);
     }
-
-    return readPromise.$then(
-      function (result) {
-        if (result.done) {
-          isFinished = true;
-          $readableStreamDefaultReaderRelease(reader);
-          return { value: undefined, done: true };
-        }
-        return { value: result.value, done: false };
-      },
-      function (error) {
-        isFinished = true;
-        $readableStreamDefaultReaderRelease(reader);
-        throw error;
-      },
-    );
+    return readPromise;
   }
 
-  async function returnSteps(value) {
-    if (isFinished) return { value, done: true };
-    isFinished = true;
+  return readPromise.$then(
+    (state.onNextFulfilled ??= $readableStreamAsyncIteratorOnFulfilled.bind(state)),
+    (state.onNextRejected ??= $readableStreamAsyncIteratorOnRejected.bind(state)),
+  );
+}
 
-    if (!preventCancel) {
-      const cancelPromise = $readableStreamReaderGenericCancel(reader, value);
-      $readableStreamDefaultReaderRelease(reader);
-      await cancelPromise;
-      return { value, done: true };
-    }
+export function readableStreamAsyncIteratorOnFulfilled(this, result) {
+  if (result.done) {
+    this.isFinished = true;
+    $readableStreamDefaultReaderRelease(this.reader);
+    return { value: undefined, done: true };
+  }
+  return { value: result.value, done: false };
+}
 
-    $readableStreamDefaultReaderRelease(reader);
+export function readableStreamAsyncIteratorOnRejected(this, error) {
+  this.isFinished = true;
+  $readableStreamDefaultReaderRelease(this.reader);
+  throw error;
+}
+
+export async function readableStreamAsyncIteratorReturnSteps(state, value) {
+  if (state.isFinished) return { value, done: true };
+  state.isFinished = true;
+
+  if (!state.preventCancel) {
+    const cancelPromise = $readableStreamReaderGenericCancel(state.reader, value);
+    $readableStreamDefaultReaderRelease(state.reader);
+    await cancelPromise;
     return { value, done: true };
   }
 
-  // Inherits from %AsyncIteratorPrototype% so the iterator is itself async
-  // iterable. next()/return() only serialize behind a still-pending step;
-  // chaining onto a settled ongoingPromise would cost a microtask per chunk.
-  const iterator = {
-    __proto__: $getPrototypeOf($getPrototypeOf(async function* () {}).prototype),
-    next() {
-      if (this !== iterator) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
-      return (ongoingPromise =
-        ongoingPromise && !$isPromiseFulfilled(ongoingPromise)
-          ? ongoingPromise.$then(nextSteps, nextSteps)
-          : nextSteps());
-    },
-    return(value) {
-      if (this !== iterator) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
-      const chainedReturnSteps = () => returnSteps(value);
-      return (ongoingPromise =
-        ongoingPromise && !$isPromiseFulfilled(ongoingPromise)
-          ? ongoingPromise.$then(chainedReturnSteps, chainedReturnSteps)
-          : chainedReturnSteps());
-    },
-  };
-  return iterator;
+  $readableStreamDefaultReaderRelease(state.reader);
+  return { value, done: true };
 }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2597,7 +2597,18 @@ export function readableStreamAsyncIterator(stream, preventCancel) {
   function nextSteps() {
     if (isFinished) return $createFulfilledPromise({ value: undefined, done: true });
 
-    return $readableStreamDefaultReaderRead(reader).$then(
+    const readPromise = $readableStreamDefaultReaderRead(reader);
+    if ($isPromiseFulfilled(readPromise)) {
+      // The chunk (or close) was available synchronously, and the read promise
+      // already resolves to the { value, done } the iterator needs.
+      if ($peekPromiseSettledValue(readPromise).done) {
+        isFinished = true;
+        $readableStreamDefaultReaderRelease(reader);
+      }
+      return readPromise;
+    }
+
+    return readPromise.$then(
       function (result) {
         if (result.done) {
           isFinished = true;
@@ -2630,19 +2641,24 @@ export function readableStreamAsyncIterator(stream, preventCancel) {
   }
 
   // Inherits from %AsyncIteratorPrototype% so the iterator is itself async
-  // iterable. next()/return() calls are serialized through ongoingPromise.
+  // iterable. next()/return() only serialize behind a still-pending step;
+  // chaining onto a settled ongoingPromise would cost a microtask per chunk.
   const iterator = {
     __proto__: $getPrototypeOf($getPrototypeOf(async function* () {}).prototype),
     next() {
       if (this !== iterator) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
-      return (ongoingPromise = ongoingPromise ? ongoingPromise.$then(nextSteps, nextSteps) : nextSteps());
+      return (ongoingPromise =
+        ongoingPromise && !$isPromiseFulfilled(ongoingPromise)
+          ? ongoingPromise.$then(nextSteps, nextSteps)
+          : nextSteps());
     },
     return(value) {
       if (this !== iterator) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
       const chainedReturnSteps = () => returnSteps(value);
-      return (ongoingPromise = ongoingPromise
-        ? ongoingPromise.$then(chainedReturnSteps, chainedReturnSteps)
-        : chainedReturnSteps());
+      return (ongoingPromise =
+        ongoingPromise && !$isPromiseFulfilled(ongoingPromise)
+          ? ongoingPromise.$then(chainedReturnSteps, chainedReturnSteps)
+          : chainedReturnSteps());
     },
   };
   return iterator;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2615,8 +2615,10 @@ export function readableStreamAsyncIterator(stream, preventCancel) {
 // next()/return() only serialize behind a still-pending step; chaining onto a
 // settled ongoingPromise would cost an extra microtask per chunk.
 export function readableStreamAsyncIteratorNext(this: unknown) {
+  // Streams store a number or a string in their own "state" private field, so
+  // requiring an object makes sure the receiver is one of our iterators.
   const state = $isObject(this) ? $getByIdDirectPrivate(this, "state") : undefined;
-  if (!state) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
+  if (!$isObject(state)) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
 
   const ongoingPromise = state.ongoingPromise;
   if (ongoingPromise && !$isPromiseFulfilled(ongoingPromise)) {
@@ -2628,7 +2630,7 @@ export function readableStreamAsyncIteratorNext(this: unknown) {
 
 export function readableStreamAsyncIteratorReturn(this: unknown, value) {
   const state = $isObject(this) ? $getByIdDirectPrivate(this, "state") : undefined;
-  if (!state) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
+  if (!$isObject(state)) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
 
   const ongoingPromise = state.ongoingPromise;
   if (ongoingPromise && !$isPromiseFulfilled(ongoingPromise)) {

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2578,48 +2578,69 @@ export async function readableStreamToArrayDirect(stream, underlyingSource) {
   }
 }
 
-export function readableStreamDefineLazyIterators(prototype) {
-  var asyncIterator = globalThis.Symbol.asyncIterator;
+// https://streams.spec.whatwg.org/#rs-asynciterator
+export function readableStreamAsyncIterator(stream, preventCancel) {
+  // AcquireReadableStreamDefaultReader. Run the deferred start exactly once,
+  // the same way getReader() does, so lazy native streams are initialized.
+  var start = $getByIdDirectPrivate(stream, "start");
+  if (start) {
+    $putByIdDirectPrivate(stream, "start", undefined);
+    start.$call(stream);
+  }
+  var reader = new ReadableStreamDefaultReader(stream);
 
-  var ReadableStreamAsyncIterator = async function* ReadableStreamAsyncIterator(stream, preventCancel) {
-    var reader = stream.getReader();
-    var deferredError;
-    try {
-      while (true) {
-        var done, value;
-        const firstResult = reader.readMany();
-        if ($isPromise(firstResult)) {
-          ({ done, value } = await firstResult);
-        } else {
-          ({ done, value } = firstResult);
-        }
+  var isFinished = false;
+  var ongoingPromise;
 
-        if (done) {
-          return;
-        }
-        yield* value;
-      }
-    } catch (e) {
-      deferredError = e;
-      throw e;
-    } finally {
-      reader.releaseLock();
+  // One read request per next() call, so chunks that were never delivered to
+  // the loop body stay queued in the stream (observable with preventCancel).
+  function nextSteps() {
+    if (isFinished) return $createFulfilledPromise({ value: undefined, done: true });
 
-      if (!preventCancel && !$isReadableStreamLocked(stream)) {
-        const promise = stream.cancel(deferredError);
-        if (Bun.peek.status(promise) === "rejected") {
-          $markPromiseAsHandled(promise);
+    return $readableStreamDefaultReaderRead(reader).$then(
+      function (result) {
+        if (result.done) {
+          isFinished = true;
+          $readableStreamDefaultReaderRelease(reader);
+          return { value: undefined, done: true };
         }
-      }
+        return { value: result.value, done: false };
+      },
+      function (error) {
+        isFinished = true;
+        $readableStreamDefaultReaderRelease(reader);
+        throw error;
+      },
+    );
+  }
+
+  async function returnSteps(value) {
+    if (isFinished) return { value, done: true };
+    isFinished = true;
+
+    if (!preventCancel) {
+      const cancelPromise = $readableStreamReaderGenericCancel(reader, value);
+      $readableStreamDefaultReaderRelease(reader);
+      await cancelPromise;
+      return { value, done: true };
     }
+
+    $readableStreamDefaultReaderRelease(reader);
+    return { value, done: true };
+  }
+
+  // Inherits from %AsyncIteratorPrototype% so the iterator is itself async
+  // iterable. next()/return() calls are serialized through ongoingPromise.
+  return {
+    __proto__: $getPrototypeOf($getPrototypeOf(async function* () {}).prototype),
+    next() {
+      return (ongoingPromise = ongoingPromise ? ongoingPromise.$then(nextSteps, nextSteps) : nextSteps());
+    },
+    return(value) {
+      const chainedReturnSteps = () => returnSteps(value);
+      return (ongoingPromise = ongoingPromise
+        ? ongoingPromise.$then(chainedReturnSteps, chainedReturnSteps)
+        : chainedReturnSteps());
+    },
   };
-  var createAsyncIterator = function asyncIterator() {
-    return ReadableStreamAsyncIterator(this, false);
-  };
-  var createValues = function values({ preventCancel = false } = { preventCancel: false }) {
-    return ReadableStreamAsyncIterator(this, preventCancel);
-  };
-  $Object.$defineProperty(prototype, asyncIterator, { value: createAsyncIterator });
-  $Object.$defineProperty(prototype, "values", { value: createValues });
-  return prototype;
 }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2631,16 +2631,19 @@ export function readableStreamAsyncIterator(stream, preventCancel) {
 
   // Inherits from %AsyncIteratorPrototype% so the iterator is itself async
   // iterable. next()/return() calls are serialized through ongoingPromise.
-  return {
+  const iterator = {
     __proto__: $getPrototypeOf($getPrototypeOf(async function* () {}).prototype),
     next() {
+      if (this !== iterator) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
       return (ongoingPromise = ongoingPromise ? ongoingPromise.$then(nextSteps, nextSteps) : nextSteps());
     },
     return(value) {
+      if (this !== iterator) return Promise.$reject($ERR_INVALID_THIS("ReadableStreamAsyncIterator"));
       const chainedReturnSteps = () => returnSteps(value);
       return (ongoingPromise = ongoingPromise
         ? ongoingPromise.$then(chainedReturnSteps, chainedReturnSteps)
         : chainedReturnSteps());
     },
   };
+  return iterator;
 }

--- a/src/jsc/bindings/webcore/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/JSReadableStream.cpp
@@ -234,8 +234,10 @@ void JSReadableStreamPrototype::finishCreation(VM& vm)
     this->putDirectCustomAccessor(vm, clientData->builtinNames().disturbedPrivateName(), DOMAttributeGetterSetter::create(vm, JSReadableStreamPrototype__disturbedGetterWrap, JSReadableStreamPrototype__disturbedSetterWrap, DOMAttributeAnnotation { JSReadableStream::info(), nullptr }), JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete);
 
     reifyStaticProperties(vm, JSReadableStream::info(), JSReadableStreamPrototypeTableValues, *this);
-    this->putDirectBuiltinFunction(vm, globalObject(), vm.propertyNames->asyncIteratorSymbol, readableStreamLazyAsyncIteratorCodeGenerator(vm), JSC::PropertyAttribute::DontDelete | 0);
-    this->putDirectBuiltinFunction(vm, globalObject(), vm.propertyNames->builtinNames().valuesPublicName(), readableStreamValuesCodeGenerator(vm), JSC::PropertyAttribute::DontDelete | 0);
+    // https://webidl.spec.whatwg.org/#define-the-asynchronous-iteration-methods
+    // @@asyncIterator must be the same function object as values().
+    auto* values = this->putDirectBuiltinFunction(vm, globalObject(), vm.propertyNames->builtinNames().valuesPublicName(), readableStreamValuesCodeGenerator(vm), JSC::PropertyAttribute::DontDelete | 0);
+    this->putDirect(vm, vm.propertyNames->asyncIteratorSymbol, values, JSC::PropertyAttribute::DontDelete | 0);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/test/js/web/streams/readable-stream-async-iterator.test.ts
+++ b/test/js/web/streams/readable-stream-async-iterator.test.ts
@@ -213,6 +213,11 @@ test("next() and return() reject when called on the wrong receiver", async () =>
   const iterator = stream.values();
   await expect(iterator.next.call({})).rejects.toThrow(TypeError);
   await expect((iterator.return as Function).call({}, "x")).rejects.toThrow(TypeError);
+  // Streams keep a number or a string in their own "state" private field;
+  // they must reject as receivers instead of being mistaken for an iterator.
+  const foreign = new ReadableStream();
+  await expect(iterator.next.call(foreign)).rejects.toThrow(TypeError);
+  await expect((iterator.return as Function).call(foreign, "x")).rejects.toThrow(TypeError);
   // The detached calls did not consume or cancel the stream.
   expect(await iterator.next()).toEqual({ value: "a", done: false });
 });

--- a/test/js/web/streams/readable-stream-async-iterator.test.ts
+++ b/test/js/web/streams/readable-stream-async-iterator.test.ts
@@ -1,0 +1,226 @@
+// https://streams.spec.whatwg.org/#rs-asynciterator
+import { expect, test } from "bun:test";
+
+test("values() preventCancel keeps the remaining chunks readable after break", async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const value of [1, 2, 3, 4, 5]) controller.enqueue(value);
+      controller.close();
+    },
+  });
+
+  for await (const chunk of stream.values({ preventCancel: true })) {
+    expect(chunk).toBe(1);
+    break;
+  }
+
+  expect(stream.locked).toBe(false);
+
+  const rest = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    rest.push(value);
+  }
+  expect(rest).toEqual([2, 3, 4, 5]);
+});
+
+// https://github.com/oven-sh/bun/issues/10431
+test("a second iteration continues from where the first stopped with preventCancel", async () => {
+  let cancelled = false;
+  const stream = new ReadableStream({
+    async start(controller) {
+      for (const value of [1, 2, 3, 4, 5]) controller.enqueue(value);
+      controller.close();
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+
+  const first = [];
+  for await (const chunk of stream.values({ preventCancel: true })) {
+    first.push(chunk);
+    if (chunk === 3) break;
+  }
+
+  const rest = [];
+  for await (const chunk of stream.values()) {
+    rest.push(chunk);
+  }
+
+  expect(first).toEqual([1, 2, 3]);
+  expect(rest).toEqual([4, 5]);
+  expect(cancelled).toBe(false);
+});
+
+test("Symbol.asyncIterator is the values method", () => {
+  expect(ReadableStream.prototype[Symbol.asyncIterator]).toBe(ReadableStream.prototype.values);
+
+  const stream = new ReadableStream();
+  expect(stream[Symbol.asyncIterator]).toBe(stream.values);
+});
+
+test("Symbol.asyncIterator accepts preventCancel", async () => {
+  let cancelled = false;
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("a");
+      controller.enqueue("b");
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+
+  for await (const chunk of (stream as any)[Symbol.asyncIterator]({ preventCancel: true })) {
+    break;
+  }
+
+  expect(cancelled).toBe(false);
+  expect(stream.locked).toBe(false);
+  expect(await stream.getReader().read()).toEqual({ value: "b", done: false });
+});
+
+test("for await over the stream cancels it on break by default", async () => {
+  let cancelled = false;
+  const stream = new ReadableStream({
+    pull(controller) {
+      controller.enqueue("hello");
+      controller.enqueue("world");
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+
+  for await (const chunk of stream) {
+    break;
+  }
+
+  expect(cancelled).toBe(true);
+  expect(stream.locked).toBe(false);
+});
+
+test("return() passes the reason to cancel", async () => {
+  const { promise: cancelReason, resolve } = Promise.withResolvers();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("a");
+      controller.enqueue("b");
+    },
+    cancel(reason) {
+      resolve(reason);
+    },
+  });
+
+  const iterator = stream.values();
+  expect(await iterator.next()).toEqual({ value: "a", done: false });
+  expect(await iterator.return("the reason")).toEqual({ value: "the reason", done: true });
+  expect(await cancelReason).toBe("the reason");
+  expect(await iterator.next()).toEqual({ value: undefined, done: true });
+  expect(stream.locked).toBe(false);
+});
+
+test("return() with preventCancel releases the lock without cancelling", async () => {
+  let cancelCalls = 0;
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("a");
+      controller.enqueue("b");
+    },
+    cancel() {
+      cancelCalls++;
+    },
+  });
+
+  const iterator = stream.values({ preventCancel: true });
+  expect(await iterator.next()).toEqual({ value: "a", done: false });
+  expect(await iterator.return("ignored")).toEqual({ value: "ignored", done: true });
+  expect(cancelCalls).toBe(0);
+  expect(stream.locked).toBe(false);
+  expect(await stream.getReader().read()).toEqual({ value: "b", done: false });
+});
+
+test("values() locks the stream and throws if it is already locked", () => {
+  const stream = new ReadableStream();
+  stream.values();
+  expect(stream.locked).toBe(true);
+  expect(() => stream.values()).toThrow(TypeError);
+});
+
+test("values() rejects non-object options", () => {
+  const stream = new ReadableStream();
+  expect(() => stream.values(42 as any)).toThrow(TypeError);
+  // null and undefined are valid per WebIDL dictionary conversion.
+  stream.values(null as any);
+  expect(stream.locked).toBe(true);
+});
+
+test("the lock is released when the stream errors during iteration", async () => {
+  const error = new Error("boom");
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("a");
+    },
+    pull(controller) {
+      controller.error(error);
+    },
+  });
+
+  const chunks = [];
+  try {
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    expect.unreachable();
+  } catch (e) {
+    expect(e).toBe(error);
+  }
+  expect(chunks).toEqual(["a"]);
+  expect(stream.locked).toBe(false);
+});
+
+test("interleaved next() and return() calls resolve in order", async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(1);
+      controller.enqueue(2);
+      controller.enqueue(3);
+      controller.close();
+    },
+  });
+
+  const iterator = stream[Symbol.asyncIterator]();
+  const results = await Promise.all([iterator.next(), iterator.next(), iterator.return(9), iterator.next()]);
+  expect(results).toEqual([
+    { value: 1, done: false },
+    { value: 2, done: false },
+    { value: 9, done: true },
+    { value: undefined, done: true },
+  ]);
+});
+
+test("full iteration releases the lock and does not call cancel", async () => {
+  let cancelCalls = 0;
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("hello");
+      controller.enqueue("world");
+      controller.close();
+    },
+    cancel() {
+      cancelCalls++;
+    },
+  });
+
+  const chunks = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+
+  expect(chunks).toEqual(["hello", "world"]);
+  expect(cancelCalls).toBe(0);
+  expect(stream.locked).toBe(false);
+});

--- a/test/js/web/streams/readable-stream-async-iterator.test.ts
+++ b/test/js/web/streams/readable-stream-async-iterator.test.ts
@@ -202,6 +202,21 @@ test("interleaved next() and return() calls resolve in order", async () => {
   ]);
 });
 
+test("next() and return() reject when called on the wrong receiver", async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("a");
+      controller.close();
+    },
+  });
+
+  const iterator = stream.values();
+  await expect(iterator.next.call({})).rejects.toThrow(TypeError);
+  await expect((iterator.return as Function).call({}, "x")).rejects.toThrow(TypeError);
+  // The detached calls did not consume or cancel the stream.
+  expect(await iterator.next()).toEqual({ value: "a", done: false });
+});
+
 test("full iteration releases the lock and does not call cancel", async () => {
   let cancelCalls = 0;
   const stream = new ReadableStream({


### PR DESCRIPTION
Fixes #10431

## Problem

Breaking out of `for await (const c of rs.values({ preventCancel: true }))` loses the stream's buffered chunks. Per the Streams spec, `preventCancel` means "stop iterating but keep the stream usable", which is the peek-then-hand-off pattern (sniff the first chunk, give the rest to a parser or file). In Bun the remaining data silently evaporated:

```js
const rs = new ReadableStream({
  start(c) { [1, 2, 3, 4, 5].forEach(v => c.enqueue(v)); c.close(); },
});
for await (const c of rs.values({ preventCancel: true })) break;

const rest = [];
const r = rs.getReader();
for (;;) { const { done, value } = await r.read(); if (done) break; rest.push(value); }
console.log(rest);
// Node:  [2, 3, 4, 5]
// Bun:   []
```

Two more spec violations in the same code:

- `rs[Symbol.asyncIterator] !== rs.values`. WebIDL requires the `@@asyncIterator` property to be the same function object as `values`. Bun's `@@asyncIterator` was a separate function that hardcoded `preventCancel: false`, so the option was ignored for `rs[Symbol.asyncIterator](opts)`.
- `iterator.return(reason)` never forwarded the reason to the underlying source's `cancel()`; it always received `undefined`.

## Cause

The iterator was an async generator built on `reader.readMany()`:

```js
const firstResult = reader.readMany();   // dequeues EVERY buffered chunk
...
yield* value;                            // hands them out one at a time
```

`readMany()` empties the stream's queue into a JS array up front. Breaking after the first `yield` discards the rest of that array; the chunks are already gone from the stream, so `preventCancel` has nothing left to preserve. A generator also cannot observe the argument passed to `.return(reason)`, which is why the cancel reason was lost.

## Fix

Replace the generator with the spec's iterator object (`readableStreamAsyncIterator` in `ReadableStreamInternals.ts`, modeled on the spec text and Node's implementation):

- `next()` issues exactly one read request, so undelivered chunks stay queued in the stream.
- `return(reason)` runs `ReadableStreamReaderGenericCancel(reader, reason)` then releases, or just releases when `preventCancel` is set.
- `next()`/`return()` are serialized through the ongoing promise, brand-check their receiver, and the iterator inherits from `%AsyncIteratorPrototype%`.
- `values()` acquires the reader synchronously (throws if the stream is locked), per the WebIDL async iterator initialization steps.

`JSReadableStream.cpp` now installs one `values` function at both `values` and `@@asyncIterator`, giving identity and making `preventCancel` work through either entry point. The `lazyAsyncIterator` builtin and the lazy prototype redefinition are deleted.

`readMany()` is unchanged and still used by the bulk consumers (`readableStreamIntoArray`, `node:stream` adapters, `console.log`), which always drain the whole stream.

## Verification

New file `test/js/web/streams/readable-stream-async-iterator.test.ts` with 13 tests: data retention after break with `preventCancel`, the issue's resume-with-a-second-iterator repro, `values === @@asyncIterator`, `preventCancel` through `rs[Symbol.asyncIterator](opts)`, reason forwarding, release-without-cancel, synchronous lock acquisition, option validation, lock release on stream error, interleaved `next()`/`return()`, receiver validation, and the default cancel-on-break behavior.

```
bun bd test test/js/web/streams/readable-stream-async-iterator.test.ts
 13 pass, 0 fail
```

8 of the 13 fail on the unfixed build (the rest are regression coverage for the rewritten paths). The repro above now prints `[2, 3, 4, 5]`, matching Node, and the existing streams, fetch-body, spawn-stdout, and `node:stream` interop suites pass.
