### PR TITLE
semver: return false from satisfies() for an invalid version argument

### DIFF
--- a/src/semver_jsc/SemverObject.rs
+++ b/src/semver_jsc/SemverObject.rs
@@ -89,8 +89,15 @@ pub(crate) fn satisfies(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
         return Ok(JSValue::FALSE);
     }
 
-    let left_result = Version::parse(SlicedString::init(left.slice(), left.slice()));
-    if left_result.wildcard != query::token::Wildcard::None {
+    // node-semver trims the version and requires the whole remainder to parse:
+    // an invalid version ("1.2.3.4", "", "1.2.3 x") never satisfies any range
+    // instead of being truncated or coerced to 0.0.0 and matched anyway.
+    let left_trimmed = strings::trim_spaces(left.slice());
+    let left_result = Version::parse(SlicedString::init(left.slice(), left_trimmed));
+    if !left_result.valid
+        || left_result.wildcard != query::token::Wildcard::None
+        || left_result.len as usize != left_trimmed.len()
+    {
         return Ok(JSValue::FALSE);
     }
 

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -735,6 +735,44 @@ describe("Bun.semver.satisfies()", () => {
     }
   });
 
+  test("invalid versions never satisfy any range", () => {
+    // node-semver: an unparseable version never satisfies anything. The version
+    // argument used to be silently truncated ("1.2.3.4" -> 1.2.3) or coerced
+    // ("" -> 0.0.0) and then matched against the range anyway.
+    const invalid: [version: string, range: string][] = [
+      ["1.2.3.4", "1.2.3"],
+      ["1.2.3.4", "*"],
+      ["1.2.3.4", ">=1.0.0"],
+      ["", "*"],
+      ["", ">=0.0.0"],
+      ["", "0.x"],
+      ["1.2.3 junk", "1.2.3"],
+      ["1.2.3 || 1.2.4", "1.2.3"],
+      ["1.2.3,", "1.2.3"],
+      ["1.2.3-beta x", "1.2.3-beta"],
+    ];
+    expect(invalid.map(([version, range]) => ({ version, range, satisfies: satisfies(version, range) }))).toEqual(
+      invalid.map(([version, range]) => ({ version, range, satisfies: false })),
+    );
+
+    // Versions node-semver accepts (leading "v", surrounding whitespace, build
+    // metadata) and the deliberate "1.0.0rc1" npm-ism must keep matching.
+    const valid: [version: string, range: string][] = [
+      ["1.2.3", "1.2.3"],
+      ["v1.2.3", "1.2.3"],
+      [" 1.2.3 ", "1.2.3"],
+      ["1.2.3\n", "1.2.3"],
+      ["\t1.2.3", "^1.0.0"],
+      ["1.2.3-beta.1", "1.2.3-beta.1"],
+      ["1.2.3-beta.1+build.5", "1.2.3-beta.1"],
+      ["1.2.3+build", ">=1.2.3"],
+      ["1.0.0rc1", "1.0.0-rc1"],
+    ];
+    expect(valid.map(([version, range]) => ({ version, range, satisfies: satisfies(version, range) }))).toEqual(
+      valid.map(([version, range]) => ({ version, range, satisfies: true })),
+    );
+  });
+
   test("pre-release snapshot", () => {
     expect(unsortedPrereleases.sort(Bun.semver.order)).toMatchSnapshot();
   });
@@ -760,6 +798,7 @@ test("a range with a dangling '-' after a skipped tag does not crash the parser"
   // already been parsed, crashing the process.
   const fuzzed = "> > > > > > > `{" + "`${".repeat(34) + "- - - 1e-323-alpha.1";
   const cases = [
+    // "" is not a valid version, so it never satisfies anything
     ["", fuzzed],
     ["1.0.0", fuzzed],
     ["", "1 || -"],
@@ -781,7 +820,7 @@ test("a range with a dangling '-' after a skipped tag does not crash the parser"
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   if (exitCode !== 0) expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual([true, true, false, true, false, true, true]);
+  expect(JSON.parse(stdout)).toEqual([false, true, false, true, false, true, true]);
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### Problem

`Bun.semver.satisfies()` accepts invalid version strings by silently truncating or coercing them:

```js
Bun.semver.satisfies("1.2.3.4", "1.2.3"); // true,  parsed as 1.2.3, the trailing ".4" dropped
Bun.semver.satisfies("", "*");            // true,  "" coerces to 0.0.0
Bun.semver.satisfies("1.2.3 junk", "1.2.3"); // true, parsing stops at the space
```

node-semver returns `false` for all of these (an unparseable version never satisfies anything), and `docs/runtime/semver.mdx` already documents that behavior: "If `version` is invalid, it returns false." Version strings come from package metadata, user agents and lockfiles, so a four-part build number or a truncated string should fail a semver gate rather than silently match a different version than written.

Found by differential fuzzing against node-semver.

### Cause

`satisfies()` in `src/semver_jsc/SemverObject.rs` parses the version argument with `Version::parse`, which returns a `valid` flag, and then never reads it. `order()`, defined right above it, does check the same flag (and throws `Invalid SemVer`). So `order("1.2.3.4", "1.2.3")` throws while `satisfies("1.2.3.4", "1.2.3")` returns `true`.

`"1.2.3 junk"` is a second shape of the same bug: the shared parser treats a space as a comparator separator (range context) and stops there without setting the flag, so the binding also has to require that the whole (trimmed) argument was consumed.

### Fix

Mirror node-semver, which trims the version string and then requires the entire remainder to match: reject the version when the parser flagged it invalid, when it is a partial/wildcard version (already handled), or when the parser consumed only a prefix of the trimmed input.

The trimmed window is passed as the `SlicedString` `slice` while the full argument stays the `buf`, so the prerelease/build offsets consumed later by `Group::satisfies` are unchanged.

This is deliberately scoped to the `Bun.semver.satisfies` binding. `Version::parse` and its `valid` flag are shared with `bun install` (registry manifests, lockfiles, yarn migration), which is intentionally npm-loose, so the strictness belongs in the node-semver-compat surface, not the shared parser.

Not addressed here (different root causes, same fuzz corpus):

- `'-'` inside build metadata: #32985
- space-separated comparators parsed as alternatives: #32993
- the range side of the same doc line (unparseable ranges match everything, `>x`, an empty `||` alternative) lives in `query::parse`, which is the range parser for every dependency specifier in `bun install`
- bun's version grammar staying looser than node-semver's regex (leading zeros, a leading `=`, the deliberate `1.0.0rc1` npm-ism)

`order()` is intentionally unchanged: it already honors the flag, and its wider acceptance of partial versions (`1.2`, `x`) is a separate, pre-existing behavior.

### Verification

New test in `test/cli/install/semver.test.ts` with 10 invalid version/range pairs that must all be `false` and 9 valid ones (leading `v`, surrounding whitespace, build metadata, the `1.0.0rc1` npm-ism) that must stay `true`. It fails on the unfixed build with all 10 invalid entries returning `true` and passes with the fix; the other 25 tests in the file still pass.

One expectation in the existing "dangling '-'" parser-crash test changed from `true` to `false`: it had pinned `satisfies("", <range>) === true`, i.e. the empty-version coercion this fixes. That test's purpose is "does not SIGSEGV" and is unaffected.

To check for collateral damage I ran a deterministic 200k-case differential against real node-semver 7.7.4 (generated version x range pairs, same seed on both builds):

| | stock `bun` | with this fix |
|---|---|---|
| agreement with node-semver | 93.35% | 95.91% |
| `node=false`, `bun=true` (the reported class) | 12551 | 7437 |
| `node=true`, `bun=false` (false negatives) | 748 | 748 |

The 748 false negatives on the fixed build are the identical set as on stock (`comm -13` of the two sorted lists is empty), so the change introduces no case where node-semver matches and Bun no longer does. They are the build-metadata (#32985) and range-grammar divergences above.

```
bun bd test test/cli/install/semver.test.ts
26 pass, 0 fail, 1770 expect() calls
```
