### PR TITLE
Key the ES module registry on the host-defined import attribute type

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "7b763944f0ecd0e18cb9ac89a04ef994e3ccb4ae";
+export const WEBKIT_VERSION = "autobuild-preview-pr-258-a024b4c8";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/InspectorLifecycleAgent.cpp
+++ b/src/jsc/bindings/InspectorLifecycleAgent.cpp
@@ -137,8 +137,8 @@ Protocol::ErrorStringOr<ModuleGraph> InspectorLifecycleAgent::getModuleGraph()
     {
         Vector<String> keys;
         for (auto& [key, entry] : global->moduleLoader()->moduleMap()) {
-            if (key.first)
-                keys.append(String { key.first });
+            if (auto* specifier = std::get<0>(key))
+                keys.append(String { specifier });
         }
         // ModuleMap is hash-ordered; sort so the inspector output is stable.
         std::sort(keys.begin(), keys.end(), WTF::codePointCompareLessThan);

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -433,7 +433,7 @@ static bool isModuleGraphLinked(AbstractModuleRecord* root, String& missingSpeci
 
         const auto& loaded = record->loadedModules();
         for (const auto& request : record->requestedModules()) {
-            auto iter = loaded.find(JSC::ModuleMapKey { request.m_specifier.impl(), request.type() });
+            auto iter = loaded.find(request.moduleMapKey());
             if (iter == loaded.end()) {
                 missingSpecifier = request.m_specifier.string();
                 return false;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -800,9 +800,10 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryEvaluatedKeys, (JSC::JSGlobalObject 
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::MarkedArgumentBuffer keys;
     for (auto& [key, entry] : globalObject->moduleLoader()->moduleMap()) {
-        if (!key.first || !entry || !isModuleEvaluated(entry->record()))
+        auto* specifier = std::get<0>(key);
+        if (!specifier || !entry || !isModuleEvaluated(entry->record()))
             continue;
-        keys.append(jsString(vm, String { key.first }));
+        keys.append(jsString(vm, String { specifier }));
     }
     if (keys.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);

--- a/test/js/bun/resolve/import-attributes.test.ts
+++ b/test/js/bun/resolve/import-attributes.test.ts
@@ -1,0 +1,178 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// tc39/proposal-import-attributes: the same specifier imported with different
+// `with { type }` attributes designates different modules, so the module
+// registry key must include the attribute. Without that, every Bun-defined
+// attribute type collapsed onto one registry entry and whichever import
+// evaluated first decided what every other attribute form received.
+// https://github.com/oven-sh/bun/issues/19834
+// https://github.com/oven-sh/WebKit/pull/258
+
+/** Runs `files["index.ts"]` as a module in a temp dir and parses its JSON stdout. */
+async function run(prefix: string, files: Record<string, string>) {
+  using dir = tempDir(prefix, files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) {
+    throw new Error(`bun exited with ${exitCode}\n--- stderr ---\n${stderr}\n--- stdout ---\n${stdout}`);
+  }
+  return JSON.parse(stdout);
+}
+
+const dataTxt = { "data.txt": "hello\n" };
+
+// `type: "text"` yields the file contents and `type: "file"` yields the
+// absolute path. The expected path is computed inside the child so the
+// assertion is independent of tempDir symlink resolution. Both orders are
+// covered because the bug was order dependent: whichever import ran first
+// decided what both received.
+test.each([
+  ["text", "file"],
+  ["file", "text"],
+] as const)(
+  "dynamic import of one path with type %s then type %s yields two distinct modules",
+  async (first, second) => {
+    const out = await run("import-attr-key", {
+      ...dataTxt,
+      "index.ts": /* ts */ `
+      import { join } from "node:path";
+      const a = await import("./data.txt", { with: { type: ${JSON.stringify(first)} } });
+      const b = await import("./data.txt", { with: { type: ${JSON.stringify(second)} } });
+      console.log(JSON.stringify({
+        abs: join(import.meta.dir, "data.txt"),
+        ${JSON.stringify(first)}: a.default,
+        ${JSON.stringify(second)}: b.default,
+        sameNamespace: a === b,
+      }));
+    `,
+    });
+    const { abs, ...rest } = out;
+    expect(rest).toEqual({ text: "hello\n", file: abs, sameNamespace: false });
+  },
+);
+
+// Negative contract: repeating the same attribute must still dedupe to one module.
+test("repeating the same attribute still resolves to one shared module", async () => {
+  const out = await run("import-attr-dedup", {
+    ...dataTxt,
+    "index.ts": /* ts */ `
+      const a = await import("./data.txt", { with: { type: "text" } });
+      const b = await import("./data.txt", { with: { type: "file" } });
+      const a2 = await import("./data.txt", { with: { type: "text" } });
+      const b2 = await import("./data.txt", { with: { type: "file" } });
+      console.log(JSON.stringify({
+        text: a.default,
+        textAgainIsSame: a === a2,
+        fileAgainIsSame: b === b2,
+        textAndFileAreSame: a === b,
+      }));
+    `,
+  });
+  expect(out).toEqual({
+    text: "hello\n",
+    textAgainIsSame: true,
+    fileAgainIsSame: true,
+    textAndFileAreSame: false,
+  });
+});
+
+// Namespace identity is asserted instead of each loader's value so this test
+// does not depend on what `type: "base64"` happens to produce for a .txt file.
+test("three different attribute types on one path yield three distinct module namespaces", async () => {
+  const out = await run("import-attr-three", {
+    ...dataTxt,
+    "index.ts": /* ts */ `
+      const text = await import("./data.txt", { with: { type: "text" } });
+      const file = await import("./data.txt", { with: { type: "file" } });
+      const base64 = await import("./data.txt", { with: { type: "base64" } });
+      console.log(JSON.stringify({
+        text: text.default,
+        textVsFile: text === file,
+        fileVsBase64: file === base64,
+        textVsBase64: text === base64,
+      }));
+    `,
+  });
+  expect(out).toEqual({
+    text: "hello\n",
+    textVsFile: false,
+    fileVsBase64: false,
+    textVsBase64: false,
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/19834
+// The bare import (no attribute) resolves to an HTMLBundle, `type: "html"`
+// also resolves to an HTMLBundle (via its own registry entry), and
+// `type: "file"` resolves to the path string. All three must be distinct
+// modules. The bare form keys on a different Type enum value than the
+// attributed forms; "html" and "file" both key on Type::HostDefined and are
+// only distinguished by the attribute string, in either order.
+test.each([
+  ["html", "file"],
+  ["file", "html"],
+] as const)("an .html imported with no attribute, type %s, and type %s yields three modules", async (first, second) => {
+  const out = await run("import-attr-html", {
+    "index.html": "<!doctype html><title>x</title>\n",
+    "index.ts": /* ts */ `
+      import { join } from "node:path";
+      const bare = await import("./index.html");
+      const a = await import("./index.html", { with: { type: ${JSON.stringify(first)} } });
+      const b = await import("./index.html", { with: { type: ${JSON.stringify(second)} } });
+      const shape = ns => typeof ns.default === "string" ? "path:" + ns.default : "bundle:" + ns.default.index;
+      console.log(JSON.stringify({
+        abs: join(import.meta.dir, "index.html"),
+        bare: shape(bare),
+        ${JSON.stringify(first)}: shape(a),
+        ${JSON.stringify(second)}: shape(b),
+        bareVsFirst: bare === a,
+        firstVsSecond: a === b,
+      }));
+    `,
+  });
+  const { abs, ...rest } = out;
+  expect(rest).toEqual({
+    bare: `bundle:${abs}`,
+    html: `bundle:${abs}`,
+    file: `path:${abs}`,
+    bareVsFirst: false,
+    firstVsSecond: false,
+  });
+});
+
+// Static import and re-export bindings record only the attribute's Type, not its
+// string, so the linker has to recover the full registry key from the module's own
+// request list. This covers that path for a plain static import (an import entry), a
+// re-export (an indirect export entry), and two attributed imports of two different
+// files side by side. Binding two different attribute types of the SAME file
+// statically is not covered: the loader now holds both modules, but the bindings
+// still share one entry per Type, and threading the string through the entries is
+// separate work.
+test("static imports and re-exports with host-defined attributes link to the right modules", async () => {
+  const out = await run("import-attr-static", {
+    ...dataTxt,
+    "other.txt": "other\n",
+    "reexport.ts": /* ts */ `export { default as reexported } from "./data.txt" with { type: "text" };`,
+    "index.ts": /* ts */ `
+      import { join } from "node:path";
+      import dataText from "./data.txt" with { type: "text" };
+      import otherPath from "./other.txt" with { type: "file" };
+      import { reexported } from "./reexport.ts";
+      console.log(JSON.stringify({
+        abs: join(import.meta.dir, "other.txt"),
+        dataText,
+        otherPath,
+        reexported,
+      }));
+    `,
+  });
+  const { abs, ...rest } = out;
+  expect(rest).toEqual({ dataText: "hello\n", otherPath: abs, reexported: "hello\n" });
+});


### PR DESCRIPTION
Importing the same path with two different `with { type }` attributes returned one shared module, and whichever import evaluated first decided what every other attribute form got. The import-attributes proposal requires the module registry to be keyed on `(specifier, attributes)`: different attributes are different modules.

Fixes #19834

> [!IMPORTANT]
> **Blocked on oven-sh/WebKit#258.** The fix is in JavaScriptCore's module map key. `WEBKIT_VERSION` here points at #258's preview build artifact (`autobuild-preview-pr-258-a024b4c8`, built on current oven-sh/WebKit `main`) so CI runs the new tests against the fixed JSC. Once #258 lands I will update it to the merge commit; please do not merge while it still points at the preview tag.

### Reproduction

```js
// data.txt contains "hello\n"
const a = await import("./data.txt", { with: { type: "text" } });
const b = await import("./data.txt", { with: { type: "file" } });
console.log(a.default, b.default, a === b);
// bun:      "hello\n" "hello\n" true   (reverse the order: both become the path)
// expected: "hello\n" "/abs/data.txt" false
```

Deterministic on the released `bun` and on `main`. #19834 is the HTML form of the same bug (`type: "html"` vs `type: "file"` on one `.html` file share a module on `main`).

### Cause

JSC's `ModuleMapKey` is `(UniquedStringImpl* specifier, ScriptFetchParameters::Type)`. `ScriptFetchParameters::parseType` maps every non-`json` / non-`webassembly` attribute value onto the single `Type::HostDefined` enum value, so `with { type: "text" }` and `with { type: "file" }` hash to the same registry bucket. The string that distinguishes them (`ScriptFetchParameters::m_hostDefinedImportType`) never reached the key.

There is no Bun-side seam: `moduleLoaderResolve` (which produces the key's specifier component) does not receive the attributes, and the cache hit in `JSModuleLoader::loadModule` happens before `moduleLoaderFetch` is ever called for the second import.

On #19834 specifically: the exact snippet in its body (a bare `import("./index.html")` vs `import("./index.html", { with: { type: "file" } })`) already behaves correctly on `main`, because an attribute-less import keys on `Type::JavaScript` while an attributed one keys on `Type::HostDefined`, and that two-value key was added to the WebKit fork after the issue was filed on 1.2.13. What the issue's title reports, two different `with { type }` values sharing one cache entry, is exactly what was still broken and what this PR fixes. Both forms are covered by the new tests.

### Fix

oven-sh/WebKit#258 widens the key to `(specifier, Type, hostDefinedImportType)` and routes every key construction through one helper, including the parse-time requested-modules dedup and the static-binding resolution that oven-sh/WebKit#403 moved onto the same key. On the Bun side this PR is:

- `scripts/build/deps/webkit.ts`: the `WEBKIT_VERSION` bump.
- `src/jsc/bindings/NodeVMSourceTextModule.cpp`: the one Bun-side `ModuleMapKey { a, b }` construction moves to the new `ModuleRequest::moduleMapKey()` helper. The key grew a third component, so the two-argument form no longer compiles; that is intentional, so no call site can silently drop the attribute.
- `src/jsc/bindings/InspectorLifecycleAgent.cpp`, `src/jsc/bindings/ZigGlobalObject.cpp`: two diagnostic iterations over the module map read the key's specifier via `.first`; they now use `std::get<0>`. No behavior change.
- `test/js/bun/resolve/import-attributes.test.ts`: the regression tests. Six cover dynamic import (both orders, three distinct types on one path, same-attribute dedup, and the #19834 HTML case in both orders); the seventh covers static imports and a re-export with host-defined attributes, which exercise the binding-resolution path #258 had to extend after #403 (it is a guard for that path, not a fail-before case).

### Verification

Released Bun (`1.3.14`), `bun test test/js/bun/resolve/import-attributes.test.ts`: **1 pass, 6 fail**. The six dynamic-import tests fail with exactly the bug (`file` and `base64` receive the `text` contents; the `.html` imported `with { type: "file" }` receives the HTMLBundle); the static-binding guard passes because a single attributed import per path never collided.

`bun bd test test/js/bun/resolve/import-attributes.test.ts` against the #258 artifact: **7 pass, 0 fail**.

Also against the #258 artifact: `import-empty`, `import-defer`, `import-query`, `esModule`, `regression/issue/16476` (48 tests), plus `text-loader`, `jsonc`, `json5`, `yaml`, `toml`, the attribute regressions 22656 / 26360 / 28042 / 30717 / 31575, and the `node:vm` module tests (337 tests). The only failure is `text-loader`'s "reloaded 10000 times" stress case, which fails identically on a `main` debug+ASAN build in the same container (it times out at 5s; the fixture takes ~15s under ASAN); interleaved 5-run averages of that fixture are 15.48s on `main` vs 15.46s on this branch, so it is not affected by this change.

A note on fail-before: the load-bearing change lives in `vendor/WebKit` (a separate repository) plus `scripts/build/deps/webkit.ts`; the only `src/` edits are compile fixes for the new WebKit API. Stashing `src/` therefore does not reproduce the bug, it just breaks the build against the new WebKit. The released-Bun run above is the fail-before proof.

### What is still not covered

Two narrower siblings remain, each its own PR:

1. **Two static imports of the same path with different host-defined types in one module** still bind to the first one. After #403 and #258, the loader holds both modules, but import/export entries record only the attribute's `Type`, so #258 resolves a `HostDefined` binding to the module's first request for that specifier and type. Finishing it means carrying the attribute string through `ImportEntry` / `ExportEntry` / the star-export set and the seven `JSC_JSModuleRecord__add*` FFI entry points in `src/jsc/bindings/BunAnalyzeTranspiledModule.cpp` plus their Rust callers. Dynamic imports, and static imports of different paths or of one path with one attribute, are fully correct now.

2. **The bundler's module graph.** `PathToSourceIndexMap` keys on `path.text` only; the attribute loader is computed right next to each lookup (`bundle_v2.rs:6390`) and then discarded, so `bun build` of the two-import file also produces one module, order dependent. A naive `(path, loader)` composite key is not safe: the map has 20+ consumers and four of them genuinely need a bare-path lookup.

<details>
<summary>Bundler map consumer audit (why that is its own PR)</summary>

Bare-path dependents that a composite key would break:

- `src/runtime/bake/dev_server/incremental_graph.rs:1620`: `on_file_deleted(abs_path)` calls `map.remove(abs_path)` for every target map with the watcher's bare absolute path. A composite key would silently miss every `(path, loader)` entry and the dev server would serve stale source indices for deleted-then-recreated files.
- `src/bundler/bundle_v2.rs:2494`: the dev-server invalidation re-enqueue does a bare-path `get(path_slice).is_some()` membership check (no import record, no attributes in scope). A miss duplicates parse work and source indices in watch mode.
- `src/bundler/LinkerContext.rs:692`: looks up an HTML import's own source path and `panic!`s on a miss, so the key derivation must be bit-identical between its insert site (`bundle_v2.rs:6509`) and this read.
- `src/bundler/bundle_v2.rs:2107`: the dual-package-hazard rewrite looks up a resolver `secondary_path`, whose effective loader is not the current record's.

On top of that, three sites overwrite an existing key in place (the CJS re-export shim at `bundle_v2.rs:6679`, the HTML manifest alias at `:6771`, the "use client" proxy at `:7149`), so any key function has to be deterministic and identical between the original insert and the overwrite. The shape that works is to keep the bare `path.text` key for every import whose effective loader matches the path's extension-derived one (every existing consumer is in that set) and only suffix the key when a `with { type }` attribute forces a different loader, plus a suffix sweep in `on_file_deleted`. That is roughly 18 touch points across `bundle_v2.rs`, `PathToSourceIndexMap.rs`, `barrel_imports.rs`, `LinkerContext.rs`, and the incremental graph, and deserves its own PR with watch-mode coverage rather than riding on a WebKit version bump. Line numbers are as of the original audit and may have drifted.

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 10 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/import-attributes.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/28] gen cpp.rs (cppbind)
[2/28] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/28] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[11/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-6.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings-6.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -Wno-c23-extensions -ffunction-sections -fdata-sections -faddrsig -fno-semantic-interposition -fno-delete-null-pointer-checks -fdiagnostics-color=a
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/bun/resolve/import-attributes.test.ts:
52 |         sameNamespace: a === b,
53 |       }));
54 |     `,
55 |     });
56 |     const { abs, ...rest } = out;
57 |     expect(rest).toEqual({ text: "hello\n", file: abs, sameNamespace: false });
                      ^
error: expect(received).toEqual(expected)

  {
-   "file": "/tmp/import-attr-key_z1TXSO/data.txt",
-   "sameNamespace": false,
+   "file": 
+ "hello
+ "
+ ,
+   "sameNamespace": true,
    "text": 
  "hello
  "
  ,
  }

- Expected  - 2
+ Received  + 5

      at <anonymous> (/workspace/bun/test/js/bun/resolve/import-attributes.test.ts:57:18)
(fail) dynamic import of one path with type text then type file yields two distinct modules [18.31ms]
52 |         sameNamespace: a === b,
53 |       }));
54 |     `,
55 |     });
56 |     const { abs, ...rest } = out;
57 |     expect(rest).toEqual({ text: "hello\n", file: abs, sameNamespace: false });
                      ^
error: expect(received).toEqual(expected)

  {
    "file": "/tmp/import-attr-key_Iqcj22/data.txt",
-   "sameNamespace": false,
-   "text": 
- "hello
- "
- ,
+   "sameNamespace": true,
+   "text": "/tmp/i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/import-attributes.test.ts
bun test v1.4.0 (29a818ff3)

test/js/bun/resolve/import-attributes.test.ts:
(pass) dynamic import of one path with type text then type file yields two distinct modules [747.22ms]
(pass) dynamic import of one path with type file then type text yields two distinct modules [606.37ms]
(pass) repeating the same attribute still resolves to one shared module [349.69ms]
(pass) three different attribute types on one path yield three distinct module namespaces [370.84ms]
(pass) an .html imported with no attribute, type html, and type file yields three modules [505.16ms]
(pass) an .html imported with no attribute, type file, and type html yields three modules [507.40ms]
(pass) static imports and re-exports with host-defined attributes link to the right modules [507.78ms]

 7 pass
 0 fail
 7 expect() calls
Ran 7 tests across 1 file. [8.11s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     29a818ff39
  features     baseline

22 deps, 107 codegen, 1176 objects in 1111ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/1238] fetch zlib
[zlib] up to date
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1238] gen .bind.ts → GeneratedBindings.cpp
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] subst deps/zlib/zlib.h
[10/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[11/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codege
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                  |   2 +-
 src/jsc/bindings/InspectorLifecycleAgent.cpp  |   4 +-
 src/jsc/bindings/NodeVMSourceTextModule.cpp   |   2 +-
 src/jsc/bindings/ZigGlobalObject.cpp          |   5 +-
 test/js/bun/resolve/import-attributes.test.ts | 178 ++++++++++++++++++++++++++
 5 files changed, 185 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
scripts/build/deps/webkit.ts                       4      6     13
src/jsc/bindings/InspectorLifecycleAgent.cpp       1      1     13
src/jsc/bindings/NodeVMSourceTextModule.cpp        1      1     13
src/jsc/bindings/ZigGlobalObject.cpp               2      1     13
test/js/bun/resolve/import-attributes.test.ts      2      7     13
```

</details>

<!-- robobun:evidence:end -->