### PR TITLE
Reject RSV1 on WebSocket control and continuation frames

### DIFF
--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -71,16 +71,17 @@ public:
     }
 
 private:
-    /* If we have negotiated compression, set this frame compressed */
+    /* If we have negotiated compression, mark the message as compressed. Idempotent:
+     * consume() re-validates the same header when an extended-length header straddles
+     * a read boundary and is spilled, so this must keep returning true for it. */
     static bool setCompressed(WebSocketState<isServer> */*wState*/, void *s) {
         WebSocketData *webSocketData = (WebSocketData *) us_socket_ext((us_socket_t *) s);
 
-        if (webSocketData->compressionStatus == WebSocketData::CompressionStatus::ENABLED) {
-            webSocketData->compressionStatus = WebSocketData::CompressionStatus::COMPRESSED_FRAME;
-            return true;
-        } else {
+        if (webSocketData->compressionStatus == WebSocketData::CompressionStatus::DISABLED) {
             return false;
         }
+        webSocketData->compressionStatus = WebSocketData::CompressionStatus::COMPRESSED_FRAME;
+        return true;
     }
 
     static void forceClose(WebSocketState<isServer> */*wState*/, void *s, std::string_view reason = {}) {

--- a/packages/bun-uws/src/WebSocketProtocol.h
+++ b/packages/bun-uws/src/WebSocketProtocol.h
@@ -37,6 +37,7 @@ const std::string_view ERR_INVALID_TEXT("Received invalid UTF-8");
 const std::string_view ERR_TOO_BIG_MESSAGE_INFLATION("Received too big message, or other inflation error");
 const std::string_view ERR_INVALID_CLOSE_PAYLOAD("Received invalid close payload");
 const std::string_view ERR_INVALID_MASKING("Received an incorrectly masked frame");
+const std::string_view ERR_INVALID_RSV1("Received unexpected RSV1 bit");
 
 enum OpCode : unsigned char {
     CONTINUATION = 0,
@@ -414,8 +415,16 @@ public:
                     return;
                 }
 
-                // invalid reserved bits / invalid opcodes / invalid control frames / set compressed frame
-                if ((rsv1(src) && !Impl::setCompressed(wState, user)) || rsv23(src) || (getOpCode(src) > 2 && getOpCode(src) < 8) ||
+                /* RSV1 (compression) is only valid on the first frame of a data message, and
+                 * only if negotiated (RFC 7692 6.1). A control frame or continuation must never
+                 * reach setCompressed(): the armed flag would inflate the next data frame. */
+                if (rsv1(src) && (getOpCode(src) == 0 || getOpCode(src) > 2 || !Impl::setCompressed(wState, user))) {
+                    Impl::forceClose(wState, user, ERR_INVALID_RSV1);
+                    return;
+                }
+
+                // invalid reserved bits / invalid opcodes / invalid control frames
+                if (rsv23(src) || (getOpCode(src) > 2 && getOpCode(src) < 8) ||
                     getOpCode(src) > 10 || (getOpCode(src) > 2 && (!isFin(src) || payloadLength(src) > 125))) {
                     Impl::forceClose(wState, user);
                     return;

--- a/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
@@ -1,10 +1,6 @@
-// RFC 6455 section 5.2 + RFC 7692 section 6.1: the RSV1 ("per-message
-// compressed") bit is only valid on the first frame of a data message, and a
-// server MUST fail the connection when a control frame or a continuation frame
-// sets it. Bun.serve used to accept such frames and arm the connection-level
-// "next message is compressed" flag, which only data frames consume: one RSV1
-// ping made the next uncompressed data frame get inflated, so the message
-// handler observed bytes the peer never sent.
+// RFC 6455 5.2 + RFC 7692 6.1: RSV1 ("per-message compressed") is only valid on
+// the first frame of a data message. A control or continuation frame setting it
+// must fail the connection, and must not arm the connection's compressed flag.
 import { serve } from "bun";
 import { describe, expect, it } from "bun:test";
 import net from "node:net";
@@ -151,8 +147,7 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
     };
   }
 
-  // An RSV1 ping must fail the connection (RFC 7692 6.1). It used to be
-  // answered with a pong and silently arm the "next message is compressed" flag.
+  // A conforming server neither answers an RSV1 ping nor lets it reach ping().
   it("a ping with RSV1 set fails the connection and is not answered", async () => {
     using raw = await connectDeflated();
     raw.socket.write(frame(0x9, pmdDeflate(Buffer.from("pingy")), { rsv1: true }));
@@ -208,7 +203,7 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
 
   // Control: a genuinely compressed message (RSV1 on the first data frame) is
   // still inflated and delivered, so rejecting the frames above is not
-  // over-rejection.
+  // over-rejection. TEXT and BINARY are the two opcodes that may carry RSV1.
   it("a compressed binary message is still inflated and delivered", async () => {
     using raw = await connectDeflated();
     const original = Buffer.alloc(80, "ab");
@@ -217,10 +212,16 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
     expect(raw.received).toEqual([original.toString("hex")]);
   });
 
-  // A compressed frame needing the 16-bit extended length has an 8 byte header,
-  // but the parser validates a header once 6 bytes arrive and spills the rest.
-  // Re-validating the same header after the spill must not trip the RSV1 check
-  // (arming the compressed flag used to be one-shot, so the second pass failed).
+  it("a compressed text message is still inflated and delivered", async () => {
+    using raw = await connectDeflated();
+    const original = Buffer.from("hello rsv1 text");
+    raw.socket.write(frame(0x1, pmdDeflate(original), { rsv1: true }));
+    expect(await Promise.race([raw.firstMessage, raw.serverClose])).toBe(`message:${original.toString("hex")}`);
+    expect(raw.received).toEqual([original.toString("hex")]);
+  });
+
+  // An extended-length header is validated once its first 6 bytes arrive, then
+  // spilled and validated again whole: the second pass must also accept RSV1.
   it("a compressed frame whose extended-length header is split is still delivered", async () => {
     using raw = await connectDeflated();
     // 256 distinct bytes do not compress, forcing a payload longer than 125.

--- a/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
@@ -1,0 +1,225 @@
+// RFC 6455 section 5.2 + RFC 7692 section 6.1: the RSV1 ("per-message
+// compressed") bit is only valid on the first frame of a data message, and a
+// server MUST fail the connection when a control frame or a continuation frame
+// sets it. Bun.serve used to accept such frames and arm the connection-level
+// "next message is compressed" flag, which only data frames consume: one RSV1
+// ping made the next uncompressed data frame get inflated, so the message
+// handler observed bytes the peer never sent.
+import { serve } from "bun";
+import { describe, expect, it } from "bun:test";
+import net from "node:net";
+import { constants, deflateRawSync } from "node:zlib";
+
+const RSV1_CLOSE = { code: 1006, reason: "Received unexpected RSV1 bit" };
+
+// A permessage-deflate message payload: raw deflate, sync flushed, with the
+// trailing 0x00 0x00 0xff 0xff removed (RFC 7692 section 7.2.1).
+function pmdDeflate(payload: Buffer): Buffer {
+  const deflated = deflateRawSync(payload, { finishFlush: constants.Z_SYNC_FLUSH });
+  expect(deflated.subarray(-4)).toEqual(Buffer.from([0x00, 0x00, 0xff, 0xff]));
+  return deflated.subarray(0, -4);
+}
+
+describe.concurrent("permessage-deflate RSV1 frames", () => {
+  function frame(opcode: number, payload: Buffer, opts: { fin?: boolean; rsv1?: boolean } = {}): Buffer {
+    const { fin = true, rsv1 = false } = opts;
+    if (payload.length > 125) throw new Error("these tests only build short frames");
+    const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+    const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
+    const flags = (fin ? 0x80 : 0x00) | (rsv1 ? 0x40 : 0x00) | opcode;
+    return Buffer.concat([Buffer.from([flags, 0x80 | payload.length]), mask, masked]);
+  }
+
+  // Raw TCP WebSocket client that negotiates permessage-deflate against a
+  // Bun.serve websocket server, then exposes exactly what the server observed
+  // (message/ping/close handlers) and every frame byte the server wrote back.
+  async function connectDeflated() {
+    const received: string[] = [];
+    const pings: string[] = [];
+    const firstMessage = Promise.withResolvers<string>();
+    const serverClose = Promise.withResolvers<{ code: number; reason: string }>();
+    const server = serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("upgrade failed", { status: 400 });
+      },
+      websocket: {
+        perMessageDeflate: true,
+        message(ws, message) {
+          const hex = Buffer.from(message as Buffer).toString("hex");
+          received.push(hex);
+          firstMessage.resolve(`message:${hex}`);
+        },
+        ping(ws, data) {
+          pings.push(Buffer.from(data).toString("hex"));
+        },
+        close(ws, code, reason) {
+          serverClose.resolve({ code, reason });
+        },
+      },
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    socket.setNoDelay(true);
+    const upgraded = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<string>();
+    socket.on("close", () => {
+      closed.resolve("socket-closed-by-server");
+      // No-op once the 101 already resolved it; fails the handshake fast otherwise.
+      upgraded.reject(new Error("socket closed before the 101 response"));
+    });
+    socket.on("error", (error: Error) => {
+      closed.resolve("socket-closed-by-server");
+      upgraded.reject(error);
+    });
+
+    // Every byte the server sends after the 101 head is WebSocket frame data.
+    let frameBytes = Buffer.alloc(0);
+    const frameByteListeners: (() => void)[] = [];
+    const onFrameData = (chunk: Buffer) => {
+      frameBytes = Buffer.concat([frameBytes, chunk]);
+      for (const notify of frameByteListeners) notify();
+    };
+
+    let head = Buffer.alloc(0);
+    let negotiated = "";
+    const onHead = (chunk: Buffer) => {
+      head = Buffer.concat([head, chunk]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      socket.off("data", onHead);
+      socket.on("data", onFrameData);
+      const headText = head.subarray(0, end).toString();
+      if (!headText.startsWith("HTTP/1.1 101")) {
+        upgraded.reject(new Error(`upgrade failed: ${headText.split("\r\n")[0]}`));
+        return;
+      }
+      negotiated = headText.split("\r\n").find(line => /^sec-websocket-extensions:/i.test(line)) ?? "";
+      const rest = head.subarray(end + 4);
+      if (rest.length) onFrameData(rest);
+      upgraded.resolve();
+    };
+    socket.on("data", onHead);
+    socket.write(
+      "GET / HTTP/1.1\r\n" +
+        "Host: localhost\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Sec-WebSocket-Version: 13\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" +
+        "\r\n",
+    );
+    try {
+      await upgraded.promise;
+      // Every test here needs a connection that really negotiated compression.
+      expect(negotiated.toLowerCase()).toContain("permessage-deflate");
+    } catch (error) {
+      // The disposable below (the only thing that stops the server) is never
+      // created when the handshake fails, so release everything here.
+      socket.destroy();
+      server.stop(true);
+      throw error;
+    }
+
+    return {
+      socket,
+      received,
+      pings,
+      firstMessage: firstMessage.promise,
+      serverClose: serverClose.promise,
+      closed: closed.promise,
+      frames: () => frameBytes,
+      // Resolves once the server has written `count` bytes of frame data.
+      waitForFrameBytes(count: number): Promise<string> {
+        if (frameBytes.length >= count) return Promise.resolve("server-sent-a-frame");
+        const { promise, resolve } = Promise.withResolvers<string>();
+        frameByteListeners.push(() => {
+          if (frameBytes.length >= count) resolve("server-sent-a-frame");
+        });
+        return promise;
+      },
+      [Symbol.dispose]() {
+        socket.destroy();
+        server.stop(true);
+      },
+    };
+  }
+
+  // https://github.com/oven-sh/bun: an RSV1 ping must fail the connection
+  // (RFC 7692 6.1). It used to be answered with a pong and silently arm the
+  // "next message is compressed" flag.
+  it("a ping with RSV1 set fails the connection and is not answered", async () => {
+    using raw = await connectDeflated();
+    raw.socket.write(frame(0x9, pmdDeflate(Buffer.from("pingy")), { rsv1: true }));
+    expect(await Promise.race([raw.serverClose, raw.waitForFrameBytes(1)])).toEqual(RSV1_CLOSE);
+    expect(raw.pings).toEqual([]);
+    expect(raw.frames()).toEqual(Buffer.alloc(0));
+  });
+
+  it("an RSV1 ping must not make the next uncompressed data frame get inflated", async () => {
+    using raw = await connectDeflated();
+    // What a poisoned server hands to message(): the inflation of `wire`.
+    const inflated = Buffer.alloc(80, "ab");
+    const wire = pmdDeflate(inflated);
+    expect(wire.equals(inflated)).toBe(false);
+    raw.socket.write(
+      Buffer.concat([
+        frame(0x9, pmdDeflate(Buffer.from("pingy")), { rsv1: true }),
+        // An ordinary binary frame with RSV1 clear: its payload is *not* compressed.
+        frame(0x2, wire),
+      ]),
+    );
+    // The connection dies at the ping; the data frame is never delivered, and
+    // in particular never delivered inflated.
+    expect(await Promise.race([raw.serverClose, raw.firstMessage])).toEqual(RSV1_CLOSE);
+    expect(raw.received).toEqual([]);
+  });
+
+  it("a pong with RSV1 set fails the connection", async () => {
+    using raw = await connectDeflated();
+    raw.socket.write(
+      Buffer.concat([
+        frame(0xa, pmdDeflate(Buffer.from("pongy")), { rsv1: true }),
+        // Sentinel: must never be delivered (it would be wrongly inflated).
+        frame(0x2, Buffer.from("after")),
+      ]),
+    );
+    expect(await Promise.race([raw.serverClose, raw.firstMessage])).toEqual(RSV1_CLOSE);
+    expect(raw.received).toEqual([]);
+  });
+
+  it("a continuation frame with RSV1 set fails the connection", async () => {
+    using raw = await connectDeflated();
+    // RFC 7692 6.1: only the *first* fragment of a data message may set RSV1.
+    raw.socket.write(
+      Buffer.concat([
+        frame(0x2, Buffer.from("he"), { fin: false }),
+        frame(0x0, Buffer.from("llo"), { fin: true, rsv1: true }),
+      ]),
+    );
+    expect(await Promise.race([raw.serverClose, raw.firstMessage])).toEqual(RSV1_CLOSE);
+    expect(raw.received).toEqual([]);
+  });
+
+  // Control: a genuinely compressed message (RSV1 on the first data frame) is
+  // still inflated and delivered, so rejecting the frames above is not
+  // over-rejection.
+  it("a compressed binary message is still inflated and delivered", async () => {
+    using raw = await connectDeflated();
+    const original = Buffer.alloc(80, "ab");
+    raw.socket.write(frame(0x2, pmdDeflate(original), { rsv1: true }));
+    expect(await Promise.race([raw.firstMessage, raw.closed])).toBe(`message:${original.toString("hex")}`);
+    expect(raw.received).toEqual([original.toString("hex")]);
+  });
+
+  // Control: a well-formed ping on the same connection is still answered.
+  it("a ping without RSV1 is still answered with a pong", async () => {
+    using raw = await connectDeflated();
+    raw.socket.write(frame(0x9, Buffer.from("hi")));
+    expect(await Promise.race([raw.waitForFrameBytes(4), raw.closed])).toBe("server-sent-a-frame");
+    expect(raw.frames()).toEqual(Buffer.from([0x8a, 0x02, 0x68, 0x69]));
+    expect(raw.pings).toEqual([Buffer.from("hi").toString("hex")]);
+  });
+});

--- a/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
@@ -23,11 +23,15 @@ function pmdDeflate(payload: Buffer): Buffer {
 describe.concurrent("permessage-deflate RSV1 frames", () => {
   function frame(opcode: number, payload: Buffer, opts: { fin?: boolean; rsv1?: boolean } = {}): Buffer {
     const { fin = true, rsv1 = false } = opts;
-    if (payload.length > 125) throw new Error("these tests only build short frames");
+    if (payload.length > 0xffff) throw new Error("these tests only build short and medium frames");
     const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
     const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
     const flags = (fin ? 0x80 : 0x00) | (rsv1 ? 0x40 : 0x00) | opcode;
-    return Buffer.concat([Buffer.from([flags, 0x80 | payload.length]), mask, masked]);
+    const head =
+      payload.length < 126
+        ? Buffer.from([flags, 0x80 | payload.length])
+        : Buffer.from([flags, 0x80 | 126, payload.length >> 8, payload.length & 0xff]);
+    return Buffer.concat([head, mask, masked]);
   }
 
   // Raw TCP WebSocket client that negotiates permessage-deflate against a
@@ -211,6 +215,26 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
     raw.socket.write(frame(0x2, pmdDeflate(original), { rsv1: true }));
     expect(await Promise.race([raw.firstMessage, raw.closed])).toBe(`message:${original.toString("hex")}`);
     expect(raw.received).toEqual([original.toString("hex")]);
+  });
+
+  // A compressed frame needing the 16-bit extended length has an 8 byte header,
+  // but the parser validates a header once 6 bytes arrive and spills the rest.
+  // Re-validating the same header after the spill must not trip the RSV1 check
+  // (arming the compressed flag used to be one-shot, so the second pass failed).
+  it("a compressed frame whose extended-length header is split is still delivered", async () => {
+    using raw = await connectDeflated();
+    // 256 distinct bytes do not compress, forcing a payload longer than 125.
+    const original = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+    const compressed = pmdDeflate(original);
+    expect(compressed.length).toBeGreaterThan(125);
+    const big = frame(0x2, compressed, { rsv1: true });
+    // End the first write 7 bytes into big's header; the ping in front of it is
+    // answered in the same parse pass, so its pong proves the server consumed
+    // (and spilled) those 7 bytes before the rest is sent.
+    raw.socket.write(Buffer.concat([frame(0x9, Buffer.from("sync")), big.subarray(0, 7)]));
+    expect(await Promise.race([raw.waitForFrameBytes(6), raw.closed])).toBe("server-sent-a-frame");
+    raw.socket.write(big.subarray(7));
+    expect(await Promise.race([raw.firstMessage, raw.serverClose])).toBe(`message:${original.toString("hex")}`);
   });
 
   // Control: a well-formed ping on the same connection is still answered.

--- a/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
@@ -147,9 +147,8 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
     };
   }
 
-  // https://github.com/oven-sh/bun: an RSV1 ping must fail the connection
-  // (RFC 7692 6.1). It used to be answered with a pong and silently arm the
-  // "next message is compressed" flag.
+  // An RSV1 ping must fail the connection (RFC 7692 6.1). It used to be
+  // answered with a pong and silently arm the "next message is compressed" flag.
   it("a ping with RSV1 set fails the connection and is not answered", async () => {
     using raw = await connectDeflated();
     raw.socket.write(frame(0x9, pmdDeflate(Buffer.from("pingy")), { rsv1: true }));


### PR DESCRIPTION
### What

`Bun.serve`'s WebSocket frame parser calls `setCompressed()` for any frame that has the RSV1 bit set, including control frames and continuation frames. `setCompressed()` arms a connection level "the next message is compressed" flag (`WebSocketData::compressionStatus = COMPRESSED_FRAME`) that only the data message path consumes. So, on a connection that negotiated `permessage-deflate`:

1. A ping with RSV1 set is accepted and answered. RFC 6455 5.2 and RFC 7692 6.1 require failing the connection here (the `ws` package closes with 1002), and accepting it arms the flag.
2. The next data frame, with its own RSV1 bit clear, is run through the inflater anyway. The `message()` handler receives the inflated bytes instead of the bytes that were actually sent, or, if the payload is not valid DEFLATE, the connection is torn down with the misleading `Received too big message, or other inflation error`.

The same applies to RSV1 on a pong and on a continuation frame (RFC 7692 6.1 only allows RSV1 on the first frame of a data message).

Observed on v1.4.0: a raw client sends an RSV1 ping, then a 7 byte binary frame (RSV1 clear). The server's `message()` handler receives the 80 byte inflation of that payload:

```
expect(received).toEqual(expected)
- { "code": 1006, "reason": "Received unexpected RSV1 bit" }
+ "message:61626162616261626162...  (80 bytes: the inflation of the 7 that were sent)"
```

### Fix

`packages/bun-uws/src/WebSocketProtocol.h`: only a TEXT or BINARY opcode may reach `setCompressed()`. Every other frame with RSV1 set (control frames, continuations, and, as before, any frame when compression was not negotiated) fails the connection, now with a named close reason (`Received unexpected RSV1 bit`) instead of an empty one.

`packages/bun-uws/src/WebSocketContext.h`: review caught a second, pre-existing bug in the same check. `consume()` validates a header as soon as 6 bytes of it are present, but a frame using the 16 or 64 bit extended length has an 8 or 14 byte header, so the parser spills those bytes and re-validates the same header once the rest arrives. Arming the compressed flag was a one shot `ENABLED -> COMPRESSED_FRAME` transition, so the second pass returned false and a valid compressed frame of 126 bytes or more closed the connection whenever a read boundary landed inside its header. `setCompressed()` is now idempotent (it only refuses when compression is not negotiated), which is also what makes the new named close reason truthful.

### Tests

`test/js/bun/websocket/websocket-server-rsv-frames.test.ts` drives raw frames over a negotiated `permessage-deflate` connection:

- an RSV1 ping fails the connection, is not answered with a pong, and never reaches the `ping()` handler
- an RSV1 ping followed by an uncompressed binary frame: nothing is delivered (previously the inflated bytes were)
- an RSV1 pong and an RSV1 continuation frame fail the connection
- a compressed frame whose extended length header is split across reads is still delivered (previously the connection was closed at the second look at the header)
- control: genuinely compressed text and binary messages are still inflated and delivered
- control: a normal ping is still answered with a pong

On the unfixed build five of the eight fail (the three controls pass); with the fix all eight pass. `test/js/bun/websocket/` and the `test/js/web/websocket/websocket-permessage-deflate*` suites still pass.
