### PR TITLE
Fix WebSocket server inflate for clients using context takeover

### DIFF
--- a/packages/bun-uws/src/PerMessageDeflate.h
+++ b/packages/bun-uws/src/PerMessageDeflate.h
@@ -234,22 +234,27 @@ struct InflationStream {
     std::optional<std::string_view> inflate(ZlibContext *zlibContext, std::string_view compressed, size_t maxPayloadLength, bool reset) {
 
 #ifdef UWS_USE_LIBDEFLATE
-        /* Try fast path first */
-        size_t written = 0;
+        /* The libdeflate fast path is stateless: it cannot resolve back-references into a
+         * previous message's sliding window, and whatever it inflates never reaches the zlib
+         * stream's window. Both are only correct without context takeover, i.e. when reset is set. */
+        if (reset) {
+            /* Try fast path first */
+            size_t written = 0;
 
-        /* We have to pad 9 bytes and restore those bytes when done since 9 is more than 6 of next WebSocket message */
-        char tmp[9];
-        memcpy(tmp, (char *) compressed.data() + compressed.length(), 9);
-        memcpy((char *) compressed.data() + compressed.length(), "\x00\x00\xff\xff\x01\x00\x00\xff\xff", 9);
-        libdeflate_result res = libdeflate_deflate_decompress(zlibContext->decompressor, compressed.data(), compressed.length() + 9, buf, 4096, &written);
-        memcpy((char *) compressed.data() + compressed.length(), tmp, 9);
+            /* We have to pad 9 bytes and restore those bytes when done since 9 is more than 6 of next WebSocket message */
+            char tmp[9];
+            memcpy(tmp, (char *) compressed.data() + compressed.length(), 9);
+            memcpy((char *) compressed.data() + compressed.length(), "\x00\x00\xff\xff\x01\x00\x00\xff\xff", 9);
+            libdeflate_result res = libdeflate_deflate_decompress(zlibContext->decompressor, compressed.data(), compressed.length() + 9, buf, 4096, &written);
+            memcpy((char *) compressed.data() + compressed.length(), tmp, 9);
 
-        if (res == 0) {
-            /* Fast path wins */
-            if (written > maxPayloadLength) {
-                return std::nullopt;
+            if (res == 0) {
+                /* Fast path wins */
+                if (written > maxPayloadLength) {
+                    return std::nullopt;
+                }
+                return std::string_view(buf, written);
             }
-            return std::string_view(buf, written);
         }
 #endif
 

--- a/test/js/web/websocket/websocket-permessage-deflate.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate.test.ts
@@ -249,6 +249,82 @@ test.skip("WebSocket client rejects compressed control frames", async () => {
   // Skip for now as it requires low-level WebSocket frame manipulation
 });
 
+// The "dedicated" decompressor is the only server mode whose handshake response
+// omits client_no_context_takeover, so a compliant client may let message N's
+// deflate stream back-reference message N-1's sliding window (RFC 7692 7.2.1).
+// Such a stream must go through the server's stateful inflater; the stateless
+// 4096-byte libdeflate fast path can neither resolve those back-references nor
+// keep the zlib stream's window in sync for later messages.
+const takeoverBody = Buffer.alloc(1040, "abcdefghijklmnopqrstuvwxyz").toString();
+const takeoverLargeBody = Buffer.alloc(8320, "abcdefghijklmnopqrstuvwxyz").toString();
+test.each([
+  // Message 1's back-references are unresolvable without message 0's window.
+  ["every message fits the fast-path buffer", [0, 1, 2, 3].map(i => `message ${i}: ${takeoverBody}`)],
+  // Message 0 fits the fast path (bypassing the zlib stream); message 1
+  // overflows it and falls back to a zlib stream missing message 0's window.
+  [
+    "message 1 overflows the fast-path buffer",
+    [takeoverBody, takeoverLargeBody, takeoverBody, takeoverBody].map((body, i) => `message ${i}: ${body}`),
+  ],
+])("server with decompress: 'dedicated' inflates a client context-takeover stream (%s)", async (_name, messages) => {
+  const serverReceived: string[] = [];
+  let serverClose: { code: number; reason: string } | null = null;
+
+  using server = serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) {
+        return;
+      }
+      return new Response("Not found", { status: 404 });
+    },
+    websocket: {
+      perMessageDeflate: { decompress: "dedicated" },
+      message(ws, message) {
+        serverReceived.push(String(message));
+        ws.send(String(message));
+      },
+      close(ws, code, reason) {
+        serverClose = { code, reason };
+      },
+    },
+  });
+
+  const client = new WebSocket(`ws://localhost:${server.port}`);
+  await new Promise((resolve, reject) => {
+    client.onopen = resolve;
+    client.onerror = reject;
+  });
+
+  // The server must grant the client context takeover, otherwise the client
+  // resets its deflater per message and this test exercises nothing.
+  expect(client.extensions).toContain("permessage-deflate");
+  expect(client.extensions).not.toContain("client_no_context_takeover");
+
+  const echoed: string[] = [];
+  const { promise: done, resolve: finish, reject: fail } = Promise.withResolvers<void>();
+  // An inflation error makes the server force-close the connection.
+  client.onclose = event => fail(new Error(`client closed: code=${event.code} reason=${event.reason}`));
+  client.onerror = () => fail(new Error("client errored"));
+  client.onmessage = event => {
+    echoed.push(event.data);
+    if (echoed.length === messages.length) finish();
+  };
+
+  // Every message is over Bun's 860-byte compression threshold and shares its
+  // body with the previous one, so the client's deflater emits back-references
+  // that cross the message boundary.
+  for (const message of messages) client.send(message);
+  await done;
+
+  expect(serverReceived).toEqual(messages);
+  expect(echoed).toEqual(messages);
+  expect(serverClose).toBeNull();
+
+  client.onclose = null;
+  client.close();
+});
+
 test("server enforces maxPayloadLength on compressed messages inflated through the fast path", async () => {
   // The server limits messages to 1024 bytes. A compressed frame is tiny on the
   // wire but can inflate to 4000 bytes, which is over the configured limit yet


### PR DESCRIPTION
### What

`Bun.serve` with `websocket: { perMessageDeflate: { decompress: "dedicated" } }` kills any compliant context-takeover client on its second compressed message. "dedicated" is the only decompressor mode whose handshake response omits `client_no_context_takeover`, so it is precisely the mode that grants the client context takeover, and standard clients (browsers, `ws` with defaults, Bun's own client) all use it when granted. The server closes the connection with 1006 and the close handler reports `Received too big message, or other inflation error`.

### Repro

```js
const received = [];
const server = Bun.serve({
  port: 0,
  fetch(req, server) { if (server.upgrade(req)) return; },
  websocket: {
    perMessageDeflate: { decompress: "dedicated" },
    message(ws, msg) { received.push(String(msg).slice(0, 12)); },
    close(ws, code, reason) { console.log("close:", code, reason); },
  },
});

const ws = new WebSocket(`ws://localhost:${server.port}`);
await new Promise(r => (ws.onopen = r));
console.log(ws.extensions); // "permessage-deflate; server_no_context_takeover"

const body = "abcdefghijklmnopqrstuvwxyz".repeat(40); // > 860B so the client compresses
for (let i = 0; i < 4; i++) ws.send(`msg${i}:` + body);
```

On 1.4.0:

```
close: 1006 Received too big message, or other inflation error
received 1 of 4
```

### Cause

`InflationStream::inflate` in `packages/bun-uws/src/PerMessageDeflate.h` tries a stateless `libdeflate` fast path for every incoming message before falling back to the stateful zlib stream. Under context takeover (`reset == false`) that is wrong twice over:

1. libdeflate starts with an empty sliding window, so it cannot resolve a back-reference into the previous message's output. RFC 7692 7.2.1 explicitly allows that, and it is the normal case for a deflater whose context is kept between similar messages.
2. A message the fast path does decode never reaches the zlib stream, so the stream's window is missing it. A later message that back-references it then fails in the zlib fallback as well, even if that later message is too large for the fast path.

`DeflationStream::deflate` in the same file already gates its libdeflate fast path on `if (reset)` for exactly this reason; the inflate side did not.

### Fix

Gate the inflate fast path on `reset` so that every message flows through the stateful zlib inflater whenever context takeover was negotiated. `client_no_context_takeover` mode (the shared decompressor) keeps the fast path.

Bun's WebSocket client has a similar-looking libdeflate attempt in `src/http_jsc/websocket_client/WebSocketDeflate.rs`, but it never re-appends the final stored block a permessage-deflate payload lacks, so it always fails and falls through to its zlib stream. It is not affected and is left alone here.

### Tests

Two new cases in `test/js/web/websocket/websocket-permessage-deflate.test.ts`, one for each failure mode above (all messages small enough for the fast path, and a mix where a later message overflows it). Both assert that the server received and echoed every message and that its close handler never fired, and both require `client.extensions` to omit `client_no_context_takeover` so they cannot pass vacuously.

Before the fix, both fail with `client closed: code=1006 reason=Connection ended`. After, both pass, along with the rest of the file.
