### PR TITLE
node:http2: enforce RFC 9113 message framing on received responses

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4103,7 +4103,7 @@ function streamSocketClosed(stream: Http2Stream) {
   }
 }
 // A stream whose session was close()d before the socket finished connecting never reached the
-// peer; node destroys it with ERR_HTTP2_GOAWAY_SESSION (no $ERR intrinsic exists for this code).
+// peer; node destroys it with ERR_HTTP2_GOAWAY_SESSION.
 function rejectStreamAboveGoawayLastId(lastStreamId: number, stream: Http2Stream) {
   if (typeof stream?.id === "number" && stream.id > lastStreamId) {
     streamRejectedByGoawaySession(stream);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -376,7 +376,6 @@ const kReceivedGoaway = Symbol("receivedGoaway");
 const kGoawayCode = Symbol("goawayCode");
 const kReleaseUnannouncedStream = Symbol("releaseUnannouncedStream");
 const kGoawaySent = Symbol("goawaySent");
-const kSocketTeardown = Symbol("socketTeardown");
 const kMaxStreams = 2 ** 32 - 1;
 const kMaxUint32 = 4294967295;
 const kMaxInt = 4294967295;
@@ -3159,6 +3158,9 @@ function emitConnectNT(self, socket) {
 function destroyWithInvalidSessionNT(stream) {
   if (!stream.destroyed) stream.destroy($ERR_HTTP2_INVALID_SESSION());
 }
+function destroyWithGoawaySessionNT(stream) {
+  if (!stream.destroyed) stream.destroy($ERR_HTTP2_GOAWAY_SESSION());
+}
 function destroyIfNotDestroyedNT(target) {
   if (!target.destroyed) target.destroy();
 }
@@ -4109,12 +4111,10 @@ function rejectStreamAboveGoawayLastId(lastStreamId: number, stream: Http2Stream
 }
 function streamRejectedByGoawaySession(stream: Http2Stream) {
   if (!stream.destroyed) {
-    const err = new Error("New streams cannot be created after receiving a GOAWAY");
-    err.code = "ERR_HTTP2_GOAWAY_SESSION";
     // nghttp2 closes unprocessed streams with REFUSED_STREAM, the signal clients (grpc) treat
     // as safely retryable on a fresh connection.
     stream.rstCode = constants.NGHTTP2_REFUSED_STREAM;
-    stream.destroy(err);
+    stream.destroy($ERR_HTTP2_GOAWAY_SESSION());
   }
 }
 class ClientHttp2Session extends Http2Session {
@@ -4388,8 +4388,8 @@ class ClientHttp2Session extends Http2Session {
       if (self.destroyed) return;
       self[kGoawayCode] = errorCode;
       // node: once a GOAWAY is received, new streams cannot be created on this session -
-      // request() throws ERR_HTTP2_GOAWAY_SESSION (clients like grpc rely on the throw to
-      // fail over to a fresh connection).
+      // request() returns a stream that errors with ERR_HTTP2_GOAWAY_SESSION (clients like
+      // grpc rely on that error class to fail over to a fresh connection).
       self[kReceivedGoaway] = true;
       self.emit("goaway", errorCode, lastStreamId, opaqueData || Buffer.allocUnsafe(0));
       // node: streams the peer did not process (id above the GOAWAY's lastStreamId) are
@@ -4417,7 +4417,6 @@ class ClientHttp2Session extends Http2Session {
     },
     end(self: ClientHttp2Session, errorCode: number, lastStreamId: number, opaqueData: Buffer) {
       if (!self) return;
-      self[kSocketTeardown] = true;
       self.destroy();
     },
     altsvc(self: ClientHttp2Session, origin: string, value: string, streamId: number) {
@@ -4503,14 +4502,10 @@ class ClientHttp2Session extends Http2Session {
       parser.detach();
       this.#parser = null;
     }
-    // Socket-driven teardown: node's destroyed flag flips asynchronously in this path, so a
-    // request() racing the teardown returns a stream that errors instead of throwing.
-    this[kSocketTeardown] = true;
     this.destroy(err, NGHTTP2_NO_ERROR);
     this[bunHTTP2Socket] = null;
   }
   #onError(error: Error) {
-    this[kSocketTeardown] = true;
     this[bunHTTP2Socket] = null;
     if (this.#closed) {
       this.destroy();
@@ -4900,30 +4895,19 @@ class ClientHttp2Session extends Http2Session {
     // throws before that point must not decrement.
     let connectionsCounted = false;
     try {
-      // node: a destroyed session reports INVALID_SESSION; a closed (GOAWAY) one reports
-      // GOAWAY_SESSION. When the destruction came from the socket
-      // tearing down (not an explicit destroy()), node's destroyed flag flips asynchronously -
-      // a racing request() must not throw, it returns a stream that errors.
+      // node: request() on a destroyed or closed session never throws. It returns a stream that
+      // is destroyed on the next tick with the matching error: ERR_HTTP2_INVALID_SESSION for a
+      // destroyed session, ERR_HTTP2_GOAWAY_SESSION for a closed one or after a received GOAWAY
+      // (verified node v26.3.0).
       if (this.destroyed) {
-        if (this[kSocketTeardown]) {
-          const req = new ClientHttp2Stream(undefined, this, headers);
-          process.nextTick(destroyWithInvalidSessionNT, req);
-          return req;
-        }
-        throw $ERR_HTTP2_INVALID_SESSION();
+        const req = new ClientHttp2Stream(undefined, this, headers);
+        process.nextTick(destroyWithInvalidSessionNT, req);
+        return req;
       }
-      if (this[kReceivedGoaway]) {
-        const err = new Error("New streams cannot be created after receiving a GOAWAY");
-        err.code = "ERR_HTTP2_GOAWAY_SESSION";
-        throw err;
-      }
-      if (this.closed) {
-        // node: a closed (close() called / GOAWAY pending) session reports
-        // ERR_HTTP2_GOAWAY_SESSION on the stream (verified node v26.3.0); the test
-        // contract accepts a synchronous throw of the same error.
-        const err = new Error("New streams cannot be created after receiving a GOAWAY");
-        err.code = "ERR_HTTP2_GOAWAY_SESSION";
-        throw err;
+      if (this.closed || this[kReceivedGoaway]) {
+        const req = new ClientHttp2Stream(undefined, this, headers);
+        process.nextTick(destroyWithGoawaySessionNT, req);
+        return req;
       }
 
       if (this.sentTrailers) {

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -534,7 +534,12 @@ impl Connection {
         let mut evict = std::mem::take(&mut self.evict_buf);
         evict.clear();
         for (id, s) in self.streams.iter() {
-            if s.state == State::Closed {
+            // A Closed stream whose header block is still being reassembled across CONTINUATION
+            // frames (§4.3) must survive to finish_header_block: the entry carries the message
+            // state that categorizes the block and validates it (a pushed request's `:method`).
+            if s.state == State::Closed
+                && (self.continuation_stream == 0 || *id != self.header_target)
+            {
                 evict.push(*id);
             }
         }

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -25,6 +25,10 @@ pub struct Stream {
     pub content_length: Option<u64>,
     /// DATA payload bytes (padding excluded) received so far.
     pub recv_body_bytes: u64,
+    /// `:method` of the request this stream's response answers, recorded from a PUSH_PROMISE
+    /// header block the engine decoded itself (nghttp2's `nghttp2_http_record_request_method`).
+    /// `Other` for a request the embedder encoded locally; the `Sink` shim reports those.
+    pub local_method: LocalRequestMethod,
 }
 
 impl Stream {
@@ -36,8 +40,49 @@ impl Stream {
             recv_final_headers: false,
             content_length: None,
             recv_body_bytes: 0,
+            local_method: LocalRequestMethod::Other,
         }
     }
+}
+
+/// `:method` of the request a response answers. Only HEAD and CONNECT change whether that
+/// response may carry a `content-length`-governed body (RFC 9113 §8.1.1).
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum LocalRequestMethod {
+    #[default]
+    Other,
+    /// HEAD: the response never carries a body, whatever `content-length` it declares.
+    Head,
+    /// CONNECT: DATA on the response is a tunnel, not a `content-length`-governed body. nghttp2
+    /// exempts every CONNECT response, not only the 2xx that opens the tunnel; node matches.
+    Connect,
+}
+
+impl LocalRequestMethod {
+    /// Classify an outbound `:method` the way nghttp2_http_record_request_method does.
+    /// Methods are case-sensitive.
+    pub fn from_method(value: &[u8]) -> Self {
+        match value {
+            b"HEAD" => LocalRequestMethod::Head,
+            b"CONNECT" => LocalRequestMethod::Connect,
+            _ => LocalRequestMethod::Other,
+        }
+    }
+}
+
+/// RFC 9113 §8.3.2: `:status` is exactly three ASCII digits, >= 100, and never 101 (Switching
+/// Protocols has no HTTP/2 meaning). Returns `None` for an invalid value.
+fn parse_status(value: &[u8]) -> Option<u16> {
+    if value.len() != 3 || !value.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    let code = (u16::from(value[0] - b'0')) * 100
+        + (u16::from(value[1] - b'0')) * 10
+        + u16::from(value[2] - b'0');
+    if code < 100 || code == 101 {
+        return None;
+    }
+    Some(code)
 }
 
 /// RFC 9110 §8.6: `content-length` is 1*DIGIT. Anything else, or a value that does not fit
@@ -142,6 +187,13 @@ pub trait Sink {
     /// inbound frames for it are not treated as frames on an idle stream.
     fn is_local_stream(&self, _stream_id: u32) -> bool {
         false
+    }
+    /// Transition shim (same reason as `is_local_stream`): the `:method` the embedder sent on
+    /// `stream_id`. Consulted only for a client's final response header block, because HEAD and
+    /// CONNECT change the content-length semantics of the response (RFC 9113 §8.1.1) and the
+    /// engine never saw the outbound request HEADERS.
+    fn local_request_method(&self, _stream_id: u32) -> LocalRequestMethod {
+        LocalRequestMethod::Other
     }
 }
 
@@ -875,10 +927,23 @@ impl Connection {
                 .streams
                 .get(&target)
                 .is_some_and(|s| s.recv_final_headers);
+        // §8.3: the pseudo-header fields a block of this category may carry, as a bitmask over the
+        // `bit` values assigned below. A request block is a server's inbound block or a client's
+        // PUSH_PROMISE block (the promised request); everything else inbound is a response. §8.1:
+        // a trailer section carries none.
+        let allowed_pseudo: u8 = if is_trailer {
+            0
+        } else if self.is_server || push_parent != 0 {
+            1 | 2 | 4 | 8 | 32 // :method :scheme :authority :path :protocol
+        } else {
+            16 // :status
+        };
         let mut rejected = false;
         let mut malformed = is_trailer && !self.header_end_stream;
         let mut seen_regular = false;
         let mut seen_pseudo: u8 = 0;
+        let mut status: Option<u16> = None;
+        let mut block_method = LocalRequestMethod::Other;
         let mut informational = false;
         let mut content_length: Option<u64> = None;
         let mut connect = false;
@@ -921,26 +986,28 @@ impl Connection {
                                 b"protocol" => 32,
                                 _ => 64,
                             };
-                            // 8.3.1: requests never carry :status - a server seeing it inbound is
-                            // a malformed block. (The client direction also constrains pseudo
-                            // headers, but inbound PUSH_PROMISE blocks legitimately carry request
-                            // pseudo-headers, so that check needs the push context first.)
-                            let wrong_direction = self.is_server && rest == b"status";
+                            // §8.3: a pseudo-header following a regular field, an unknown or
+                            // repeated pseudo-header, or one outside the set its block's category
+                            // defines (`:status` in a request, a request pseudo-header in a
+                            // response, any pseudo-header in a trailer section) is malformed.
                             if seen_regular
                                 || bit == 64
                                 || (seen_pseudo & bit) != 0
-                                || wrong_direction
-                                || is_trailer
+                                || (bit & allowed_pseudo) == 0
                             {
                                 malformed = true;
-                            }
-                            if rest == b"status" && value_b.len() == 3 && value_b[0] == b'1' {
-                                informational = true;
+                            } else if bit == 16 {
+                                // §8.3.2: three digits, >= 100, never 101.
+                                status = parse_status(value_b);
+                                match status {
+                                    None => malformed = true,
+                                    Some(code) => informational = code / 100 == 1,
+                                }
+                            } else if bit == 1 {
+                                block_method = LocalRequestMethod::from_method(value_b);
+                                connect = value_b == b"CONNECT";
                             }
                             seen_pseudo |= bit;
-                            if rest == b"method" && value_b == b"CONNECT" {
-                                connect = true;
-                            }
                         } else {
                             seen_regular = true;
                             match name_b {
@@ -996,11 +1063,64 @@ impl Connection {
             sink.on_stream_reset(target, ErrorCode::StreamClosed.as_u32());
             return false;
         }
-        if push_parent == 0 && self.is_server && !malformed && !rejected {
-            if let Some(s) = self.streams.get_mut(&target) {
-                if !connect && s.content_length.is_none() {
-                    s.content_length = content_length;
+        // RFC 9113 §8.1.1/§8.3 message-body rules, the equivalent of nghttp2's
+        // nghttp2_http_on_{request,response,trailer}_headers. `declared` is what this block says
+        // the message body's length is; a block that does not bind it (an interim response, a
+        // tunnel, a trailer section) only has to meet what the header section already declared.
+        if push_parent != 0 {
+            // A PUSH_PROMISE block is the promised stream's request: only its `:method` binds,
+            // deciding whether the pushed response may carry a body (the stream's own first
+            // inbound HEADERS is that response). nghttp2_http_record_request_method.
+            if !malformed
+                && !rejected
+                && let Some(s) = self.streams.get_mut(&target)
+            {
+                s.local_method = block_method;
+            }
+        } else if !malformed && !rejected {
+            let mut binds = true;
+            let declared: Option<u64> = if is_trailer {
+                binds = false;
+                None
+            } else if self.is_server {
+                // §8.5: a (non-extended) CONNECT request's DATA is a tunnel, not a body.
+                if connect { None } else { content_length }
+            } else if (seen_pseudo & 16) == 0 {
+                // §8.3.2: a response header section carries exactly one `:status` (its validity
+                // was checked as it was decoded).
+                malformed = true;
+                binds = false;
+                None
+            } else if informational {
+                // An interim response: the final header section follows on this stream, so this
+                // block cannot also end it, and its fields don't bind the message.
+                if self.header_end_stream {
+                    malformed = true;
                 }
+                binds = false;
+                None
+            } else {
+                // §8.1.1: a HEAD response and a 204/304 carry no body; a CONNECT response is a
+                // tunnel (nghttp2's expect_response_body()). The request's `:method` comes from
+                // the promised request's block for a pushed stream, and from the Sink shim (the
+                // embedder's legacy encoder sent it) for a locally-initiated one.
+                let method = match self.streams.get(&target).map(|s| s.local_method) {
+                    Some(m) if m != LocalRequestMethod::Other => m,
+                    _ => sink.local_request_method(target),
+                };
+                match status {
+                    Some(204) | Some(304) => Some(0),
+                    _ if method == LocalRequestMethod::Head => Some(0),
+                    _ if method == LocalRequestMethod::Connect => None,
+                    _ => content_length,
+                }
+            };
+            if !malformed && let Some(s) = self.streams.get_mut(&target) {
+                if binds && s.content_length.is_none() {
+                    s.content_length = declared;
+                }
+                // The declared length must be met by the DATA actually received once this block
+                // ends the stream; `enforce_content_length` covers an END_STREAM on DATA.
                 if self.header_end_stream
                     && s.content_length
                         .is_some_and(|declared| declared != s.recv_body_bytes)
@@ -1120,6 +1240,19 @@ impl Connection {
                         discard = true;
                     } else {
                         st.recv_body_bytes = st.recv_body_bytes.saturating_add(data_total as u64);
+                        // §8.1.1: DATA beyond the declared content-length is a stream
+                        // PROTOCOL_ERROR, and the excess never reaches the application.
+                        if st
+                            .content_length
+                            .is_some_and(|declared| st.recv_body_bytes > declared)
+                        {
+                            self.send_rst_stream(sink, hdr.stream_id, ErrorCode::ProtocolError);
+                            if let Some(st2) = self.streams.get_mut(&hdr.stream_id) {
+                                st2.state = State::Closed;
+                            }
+                            sink.on_stream_reset(hdr.stream_id, ErrorCode::ProtocolError.as_u32());
+                            discard = true;
+                        }
                     }
                 }
             }
@@ -1236,7 +1369,15 @@ impl Connection {
                         DataDecision::Rst(ErrorCode::FlowControlError)
                     } else {
                         s.recv_body_bytes = s.recv_body_bytes.saturating_add((end - off) as u64);
-                        DataDecision::Deliver(0)
+                        // §8.1.1: DATA beyond the declared content-length is a stream
+                        // PROTOCOL_ERROR; the excess never reaches the application.
+                        if s.content_length
+                            .is_some_and(|declared| s.recv_body_bytes > declared)
+                        {
+                            DataDecision::Rst(ErrorCode::ProtocolError)
+                        } else {
+                            DataDecision::Deliver(0)
+                        }
                     }
                 }
             }
@@ -1284,13 +1425,11 @@ impl Connection {
         false
     }
 
-    /// RFC 9113 §8.1.1: once END_STREAM arrives, a request whose received DATA total contradicts
+    /// RFC 9113 §8.1.1: once END_STREAM arrives, a message whose received DATA total contradicts
     /// its declared `content-length` is malformed. Resets the stream with PROTOCOL_ERROR instead
-    /// of signalling end-of-stream and returns true if it did so.
+    /// of signalling end-of-stream and returns true if it did so. Applies in both directions: a
+    /// truncated response is the only signal a client gets that it did not receive the whole body.
     fn enforce_content_length(&mut self, sink: &impl Sink, stream_id: u32) -> bool {
-        if !self.is_server {
-            return false;
-        }
         let mismatch = self.streams.get(&stream_id).is_some_and(|s| {
             s.content_length
                 .is_some_and(|declared| declared != s.recv_body_bytes)

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1510,6 +1510,10 @@ pub struct Stream {
     stream_dependency: u32,
     exclusive: bool,
     weight: u16,
+    /// `:method` of the request the local endpoint sent on this stream. Queried by the engine via
+    /// `Sink::local_request_method` to apply RFC 9113 §8.1.1 response-body semantics (HEAD /
+    /// CONNECT) to streams whose outbound HEADERS it never saw (they flow through this encoder).
+    local_method: crate::api::h2::connection::LocalRequestMethod,
     // current window size for the stream
     window_size: u64,
     // used window size for the stream
@@ -2074,6 +2078,7 @@ impl Stream {
             stream_dependency: 0,
             exclusive: false,
             weight: 36,
+            local_method: crate::api::h2::connection::LocalRequestMethod::Other,
             window_size: initial_window_size as u64,
             used_window_size: 0,
             remote_window_size: remote_window_size as u64,
@@ -5695,6 +5700,18 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         self.streams.get().contains_key(&stream_id)
     }
 
+    fn local_request_method(
+        &self,
+        stream_id: u32,
+    ) -> crate::api::h2::connection::LocalRequestMethod {
+        match self.streams.get().get(&stream_id).copied() {
+            // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the
+            // map entry exists
+            Some(stream) => unsafe { (*stream).local_method },
+            None => crate::api::h2::connection::LocalRequestMethod::Other,
+        }
+    }
+
     fn on_push_promise(&self, _parent_id: u32, promised_id: u32) {
         // The promised request headers follow via on_header/on_headers_complete for promised_id;
         // remember it so that completion dispatches onStreamPush instead of onStreamHeaders.
@@ -8174,6 +8191,9 @@ impl H2FrameParser {
         }
         // max header name length for lshpack
         let mut name_buffer = [0u8; 4096];
+        // Recorded from the `:method` actually encoded; the inbound engine queries it via
+        // Sink::local_request_method to apply the HEAD/CONNECT response-body exemptions.
+        let mut local_method = crate::api::h2::connection::LocalRequestMethod::Other;
         let stream_id: u32 =
             if !stream_id_arg.is_empty_or_undefined_or_null() && stream_id_arg.is_number() {
                 stream_id_arg.to_u32()
@@ -8296,6 +8316,10 @@ impl H2FrameParser {
                                 ),
                             )
                             .throw());
+                    }
+                    if validated_name == b":method" {
+                        local_method =
+                            crate::api::h2::connection::LocalRequestMethod::from_method(value);
                     }
                     bun_output::scoped_log!(
                         H2FrameParser,
@@ -8484,6 +8508,10 @@ impl H2FrameParser {
                                 )
                                 .throw());
                         }
+                        if validated_name == b":method" {
+                            local_method =
+                                crate::api::h2::connection::LocalRequestMethod::from_method(value);
+                        }
                         bun_output::scoped_log!(
                             H2FrameParser,
                             "encode header {} {}",
@@ -8574,6 +8602,10 @@ impl H2FrameParser {
                             )
                             .throw());
                     }
+                    if validated_name == b":method" {
+                        local_method =
+                            crate::api::h2::connection::LocalRequestMethod::from_method(value);
+                    }
                     bun_output::scoped_log!(
                         H2FrameParser,
                         "encode header {} {}",
@@ -8620,6 +8652,7 @@ impl H2FrameParser {
         };
         // The `options` getters below can run user JS while `stream` is borrowed.
         let mut stream = this.enter_stream_dispatch(stream_ptr);
+        stream.local_method = local_method;
         if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
             stream.set_context(stream_ctx_arg, global_object);
         }

--- a/test/js/node/http2/node-http2-http-messaging.test.ts
+++ b/test/js/node/http2/node-http2-http-messaging.test.ts
@@ -1,0 +1,681 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import http2 from "node:http2";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+import h2utils from "./helpers";
+
+// RFC 9113 §8 HTTP-messaging conformance for the `node:http2` client (and the symmetric server
+// inbound path). A raw TCP server writes byte-exact HTTP/2 frames so each malformed response is
+// under full control; node v26.3.0 against the same frames is the reference for every case.
+
+const { NGHTTP2_PROTOCOL_ERROR } = http2.constants;
+
+// HPACK "literal header field with incremental indexing - new name", no Huffman
+// (RFC 7541 §6.2.1). Accepted by any decoder and keeps the crafted bytes readable.
+function hpackLiteral(name: string, value: string): Buffer {
+  const n = Buffer.from(name, "latin1");
+  const v = Buffer.from(value, "latin1");
+  if (n.length > 126 || v.length > 126) throw new Error("field too long for the 7-bit test encoder");
+  return Buffer.concat([Buffer.from([0x40, n.length]), n, Buffer.from([v.length]), v]);
+}
+function headerBlock(pairs: [string, string | number][]): Buffer {
+  return Buffer.concat(pairs.map(([name, value]) => hpackLiteral(name, String(value))));
+}
+function headersFrame(streamId: number, pairs: [string, string | number][], endStream: boolean): Buffer {
+  return new h2utils.HeadersFrame(streamId, headerBlock(pairs), 0, true, endStream).data;
+}
+function dataFrame(streamId: number, body: string, endStream: boolean): Buffer {
+  return new h2utils.DataFrame(streamId, Buffer.from(body, "latin1"), 0, endStream).data;
+}
+// PUSH_PROMISE: type 0x5, END_HEADERS; payload = 4-byte promised stream id + the header block.
+function pushPromiseFrame(parentId: number, promisedId: number, pairs: [string, string | number][]): Buffer {
+  const payload = Buffer.concat([Buffer.alloc(4), headerBlock(pairs)]);
+  payload.writeUInt32BE(promisedId & 0x7fffffff, 0);
+  return Buffer.concat([new h2utils.Frame(payload.length, 0x5, 0x4, parentId).data, payload]);
+}
+
+type Exchange = {
+  /** Stream events in emission order; the most precise record of what the application saw. */
+  events: string[];
+  /** Resolves with the error code of the first RST_STREAM the client sent back to the server. */
+  rstSentToServer: Promise<number>;
+};
+
+/**
+ * Stands up a raw TCP server speaking just enough HTTP/2 to answer one request with whatever
+ * frames `respond` writes, drives a single `node:http2` client request at it, and returns the
+ * ordered stream events once the stream closes.
+ */
+async function exchange(
+  requestHeaders: Record<string, string>,
+  respond: (socket: net.Socket, streamId: number) => void,
+): Promise<Exchange> {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+  const { promise: rstSentToServer, resolve: onRst, reject: onMissingRst } = Promise.withResolvers<number>();
+  const server = net.createServer(socket => {
+    socket.on("error", () => {});
+    // A missing RST_STREAM must fail the awaiting assertion, never hang: the connection
+    // closing (client.destroy() below) before a RST_STREAM was seen rejects the promise.
+    // Settle-once semantics make this a no-op when the RST already arrived.
+    socket.on("close", () => onMissingRst(new Error("the client closed without sending RST_STREAM")));
+    socket.setNoDelay(true);
+    socket.write(new h2utils.SettingsFrame(false).data);
+    let buf = Buffer.alloc(0);
+    let sawPreface = false;
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      if (!sawPreface) {
+        if (buf.length < h2utils.kClientMagic.length) return;
+        buf = buf.subarray(h2utils.kClientMagic.length);
+        sawPreface = true;
+      }
+      while (buf.length >= 9) {
+        const length = buf.readUIntBE(0, 3);
+        if (buf.length < 9 + length) break;
+        const type = buf[3];
+        const flags = buf[4];
+        const streamId = buf.readUInt32BE(5) & 0x7fffffff;
+        const payload = buf.subarray(9, 9 + length);
+        buf = buf.subarray(9 + length);
+        if (type === 0x4 && (flags & 0x1) === 0) socket.write(new h2utils.SettingsFrame(true).data);
+        else if (type === 0x1) respond(socket, streamId);
+        else if (type === 0x3) onRst(payload.readUInt32BE(0));
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1", onListening);
+  await listening;
+
+  const events: string[] = [];
+  const client = http2.connect(`http://127.0.0.1:${(server.address() as AddressInfo).port}`);
+  client.on("error", () => {});
+  try {
+    await once(client, "connect");
+    const req = client.request(requestHeaders);
+    let body = "";
+    req.setEncoding("latin1");
+    req.on("headers", h => events.push(`headers ${h[":status"]}`));
+    req.on("response", h => events.push(`response ${h[":status"]} cl=${h["content-length"]}`));
+    req.on("trailers", h => events.push(`trailers ${JSON.stringify(h)}`));
+    req.on("data", chunk => (body += chunk));
+    req.on("end", () => events.push(`end ${JSON.stringify(body)}`));
+    req.on("error", (e: NodeJS.ErrnoException) => events.push(`error ${e.code}`));
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    req.on("close", () => {
+      events.push(`close rst=${req.rstCode}`);
+      onClose();
+    });
+    req.end();
+    await closed;
+  } finally {
+    client.destroy();
+    server.close();
+  }
+  // Most cases never send (or await) a RST_STREAM, so the teardown above rejects the promise.
+  // Mark it handled here so that never surfaces as an unhandled rejection; callers that do
+  // await it still observe the rejection.
+  rstSentToServer.catch(() => {});
+  return { events, rstSentToServer };
+}
+
+// Like `exchange`, but the raw server also PUSH_PROMISEs stream 2 (carrying `promisedRequest`)
+// and answers it with the frames `respondPushed` writes. Returns the PUSHED stream's events.
+// `mainRequestClosed` settles after a `receive()` batch containing the main response has been
+// fully processed (including the engine's end-of-batch stream eviction): a `respondPushed` that
+// defers a frame behind it is guaranteed a fresh batch for it.
+async function pushExchange(
+  promisedRequest: [string, string | number][],
+  respondPushed: (socket: net.Socket, promisedId: number, mainRequestClosed: Promise<void>) => void,
+): Promise<string[]> {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+  const { promise: mainRequestClosed, resolve: onMainRequestClosed } = Promise.withResolvers<void>();
+  const server = net.createServer(socket => {
+    socket.on("error", () => {});
+    socket.setNoDelay(true);
+    socket.write(new h2utils.SettingsFrame(false).data);
+    let buf = Buffer.alloc(0);
+    let sawPreface = false;
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      if (!sawPreface) {
+        if (buf.length < h2utils.kClientMagic.length) return;
+        buf = buf.subarray(h2utils.kClientMagic.length);
+        sawPreface = true;
+      }
+      while (buf.length >= 9) {
+        const length = buf.readUIntBE(0, 3);
+        if (buf.length < 9 + length) break;
+        const type = buf[3];
+        const flags = buf[4];
+        const streamId = buf.readUInt32BE(5) & 0x7fffffff;
+        buf = buf.subarray(9 + length);
+        if (type === 0x4 && (flags & 0x1) === 0) socket.write(new h2utils.SettingsFrame(true).data);
+        else if (type === 0x1) {
+          socket.write(pushPromiseFrame(streamId, 2, promisedRequest));
+          socket.write(headersFrame(streamId, [[":status", 200]], true));
+          respondPushed(socket, 2, mainRequestClosed);
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1", onListening);
+  await listening;
+
+  const events: string[] = [];
+  const client = http2.connect(`http://127.0.0.1:${(server.address() as AddressInfo).port}`);
+  client.on("error", () => {});
+  const { promise: pushClosed, resolve: onPushClose, reject: onNoPush } = Promise.withResolvers<void>();
+  // The server writes the PUSH_PROMISE before the main response, so 'stream' always fires
+  // before the main request's 'close'; a main request ending without one is a terminal failure.
+  let sawPush = false;
+  client.on("stream", pushed => {
+    sawPush = true;
+    let body = "";
+    pushed.setEncoding("latin1");
+    pushed.on("push", h => events.push(`push-response ${h[":status"]} cl=${h["content-length"]}`));
+    pushed.on("data", chunk => (body += chunk));
+    pushed.on("end", () => events.push(`push-end ${JSON.stringify(body)}`));
+    pushed.on("error", (e: NodeJS.ErrnoException) => events.push(`push-error ${e.code}`));
+    pushed.on("close", () => {
+      events.push(`push-close rst=${pushed.rstCode}`);
+      onPushClose();
+    });
+  });
+  client.on("close", () => onNoPush(new Error("the session closed before the pushed stream did")));
+  try {
+    await once(client, "connect");
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    req.on("close", () => {
+      if (!sawPush) onNoPush(new Error("the main request closed before a pushed stream arrived"));
+      onMainRequestClosed();
+    });
+    req.resume();
+    req.end();
+    await pushClosed;
+  } finally {
+    client.destroy();
+    server.close();
+  }
+  return events;
+}
+
+describe.concurrent("node:http2 client rejects RFC 9113 §8.1.1 content-length violations", () => {
+  test("response shorter than its content-length (END_STREAM on DATA) is a stream error", async () => {
+    // HEADERS{:status 200, content-length: 5} then DATA("xy", END_STREAM): 2 bytes, claims 5.
+    const { events, rstSentToServer } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 5],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "xy", true));
+    });
+    // The truncated body must never be delivered as a clean 'end'.
+    expect(events).toEqual(["response 200 cl=5", "error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+    // The stream error also goes on the wire (nghttp2 / node do the same).
+    expect(await rstSentToServer).toBe(NGHTTP2_PROTOCOL_ERROR);
+  });
+
+  test("response shorter than its content-length (END_STREAM on HEADERS) is a stream error", async () => {
+    // The violation is detected on the same header block, so no 'response' is ever emitted.
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 5],
+          ],
+          true,
+        ),
+      );
+    });
+    expect(events).toEqual(["error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test("response shorter than its content-length (END_STREAM on trailers) is a stream error", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 5],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "xy", false));
+      socket.write(headersFrame(id, [["x-trailer", "1"]], true));
+    });
+    expect(events).toEqual(["response 200 cl=5", "error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test("DATA exceeding the declared content-length is a stream error", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 1],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "xy", true));
+    });
+    // The excess is never delivered and the stream never reports a clean end.
+    expect(events).toEqual(["response 200 cl=1", "error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test("repeated content-length is a stream error and the response is never surfaced", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 2],
+            ["content-length", 2],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "xy", true));
+    });
+    expect(events).toEqual(["error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test("non-integer content-length is a stream error and the response is never surfaced", async () => {
+    // RFC 9110 §8.6: digits only. "+5" parses with a lenient parser but is not a valid value.
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", "+5"],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "abcde", true));
+    });
+    expect(events).toEqual(["error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+});
+
+describe.concurrent("node:http2 client accepts valid content-length shapes", () => {
+  test("a body exactly matching its content-length ends cleanly", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 2],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "xy", true));
+    });
+    expect(events).toEqual(["response 200 cl=2", 'end "xy"', "close rst=0"]);
+  });
+
+  test("a body with no content-length ends cleanly", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(headersFrame(id, [[":status", 200]], false));
+      socket.write(dataFrame(id, "xy", true));
+    });
+    expect(events).toEqual(["response 200 cl=undefined", 'end "xy"', "close rst=0"]);
+  });
+
+  test("trailers after an exact-length body are delivered", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 2],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "xy", false));
+      socket.write(headersFrame(id, [["x-trailer", "1"]], true));
+    });
+    expect(events).toEqual(["response 200 cl=2", 'trailers {"x-trailer":"1"}', 'end "xy"', "close rst=0"]);
+  });
+
+  test("HEAD response with a content-length and no body is not an error", async () => {
+    // RFC 9113 §8.1.1: the response to a HEAD never carries a body, whatever content-length it
+    // declares. This is the case that needs the engine to know the request's method.
+    const { events } = await exchange({ ":method": "HEAD" }, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 1234],
+          ],
+          true,
+        ),
+      );
+    });
+    expect(events).toEqual(["response 200 cl=1234", 'end ""', "close rst=0"]);
+  });
+
+  test("204 and 304 responses with a content-length and no body are not errors", async () => {
+    const r204 = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 204],
+            ["content-length", 0],
+          ],
+          true,
+        ),
+      );
+    });
+    expect(r204.events).toEqual(["response 204 cl=0", 'end ""', "close rst=0"]);
+    const r304 = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 304],
+            ["content-length", 100],
+          ],
+          true,
+        ),
+      );
+    });
+    expect(r304.events).toEqual(["response 304 cl=100", 'end ""', "close rst=0"]);
+  });
+
+  test("the content-length governing the body comes from the final (non-1xx) response", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(headersFrame(id, [[":status", 100]], false));
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 2],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "xy", true));
+    });
+    expect(events).toEqual(["headers 100", "response 200 cl=2", 'end "xy"', "close rst=0"]);
+  });
+});
+
+describe.concurrent("node:http2 client rejects malformed response header sections (RFC 9113 §8.3)", () => {
+  test("a response with no :status pseudo-header is a stream error, never surfaced to JS", async () => {
+    const { events, rstSentToServer } = await exchange({}, (socket, id) => {
+      socket.write(headersFrame(id, [["cache-control", "private"]], true));
+    });
+    expect(events).toEqual(["error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+    expect(await rstSentToServer).toBe(NGHTTP2_PROTOCOL_ERROR);
+  });
+
+  test("a response with an empty header block is a stream error", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(new h2utils.HeadersFrame(id, Buffer.alloc(0), 0, true, true).data);
+    });
+    expect(events).toEqual(["error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test("the header block following a 1xx interim response still requires :status", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(headersFrame(id, [[":status", 100]], false));
+      socket.write(headersFrame(id, [["x-foo", "bar"]], true));
+    });
+    expect(events).toEqual(["headers 100", "error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test.each([["abc"], ["99"], ["101"]])("an invalid :status value (%s) is a stream error", async value => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(headersFrame(id, [[":status", value]], true));
+    });
+    expect(events).toEqual(["error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test("a request pseudo-header in a response is a stream error", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            [":method", "GET"],
+          ],
+          true,
+        ),
+      );
+    });
+    expect(events).toEqual(["error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test("a pseudo-header in a trailer section is a stream error", async () => {
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(headersFrame(id, [[":status", 200]], false));
+      socket.write(dataFrame(id, "xy", false));
+      socket.write(headersFrame(id, [[":status", 200]], true));
+    });
+    expect(events).toEqual(["response 200 cl=undefined", "error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+
+  test("a trailer section without END_STREAM is a stream error, not a hung stream", async () => {
+    // RFC 9113 §8.1: a trailer section ends the stream. Previously this left the stream open
+    // forever (neither 'end' nor 'error' nor 'close').
+    const { events } = await exchange({}, (socket, id) => {
+      socket.write(headersFrame(id, [[":status", 200]], false));
+      socket.write(dataFrame(id, "xy", false));
+      socket.write(headersFrame(id, [["x-trailer", "1"]], false));
+    });
+    expect(events).toEqual(["response 200 cl=undefined", "error ERR_HTTP2_STREAM_ERROR", "close rst=1"]);
+  });
+});
+
+describe.concurrent("node:http2 pushed streams get the same RFC 9113 §8.1.1 semantics", () => {
+  // The engine learns the promised request's :method from the PUSH_PROMISE block it decoded
+  // (nghttp2's nghttp2_http_record_request_method): the Sink shim only knows request()-opened
+  // streams, so without this a pushed HEAD response with a content-length would be reset.
+  const promised = (method: string): [string, string | number][] => [
+    [":method", method],
+    [":scheme", "http"],
+    [":path", "/pushed"],
+    [":authority", "raw"],
+  ];
+
+  test("a pushed HEAD response with a content-length and no body is not an error", async () => {
+    const events = await pushExchange(promised("HEAD"), (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 1234],
+          ],
+          true,
+        ),
+      );
+    });
+    expect(events).toEqual(["push-response 200 cl=1234", 'push-end ""', "push-close rst=0"]);
+  });
+
+  test("a pushed response shorter than its content-length is a stream error", async () => {
+    const events = await pushExchange(promised("GET"), (socket, id) => {
+      socket.write(
+        headersFrame(
+          id,
+          [
+            [":status", 200],
+            ["content-length", 5],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(id, "xy", true));
+    });
+    expect(events).toEqual(["push-response 200 cl=5", "push-error ERR_HTTP2_STREAM_ERROR", "push-close rst=1"]);
+  });
+
+  test("a pushed response with no :status pseudo-header is a stream error", async () => {
+    const events = await pushExchange(promised("GET"), (socket, id) => {
+      socket.write(headersFrame(id, [["x-foo", "1"]], true));
+    });
+    expect(events).toEqual(["push-error ERR_HTTP2_STREAM_ERROR", "push-close rst=1"]);
+  });
+
+  test("a pushed HEAD response split across HEADERS and CONTINUATION is not an error", async () => {
+    // The promised stream's engine entry carries the request's :method for the HEAD exemption;
+    // it must survive the receive() batch boundary between HEADERS(END_STREAM, no END_HEADERS)
+    // and the CONTINUATION that completes the block (RFC 9113 §4.3).
+    const events = await pushExchange(promised("HEAD"), (socket, id, mainRequestClosed) => {
+      const block = headerBlock([
+        [":status", 200],
+        ["content-length", 1234],
+      ]);
+      socket.write(new h2utils.HeadersFrame(id, block, 0, /* endOfHeaders */ false, /* final */ true).data);
+      // Complete the block only after the client has fully processed the batch above.
+      void mainRequestClosed.then(() =>
+        socket.write(new h2utils.ContinuationFrame(id, Buffer.alloc(0), 0, false).data),
+      );
+    });
+    expect(events).toEqual(["push-response 200 cl=1234", 'push-end ""', "push-close rst=0"]);
+  });
+});
+
+describe.concurrent("node:http2 server rejects RFC 9113 §8.1.1 content-length violations", () => {
+  test("a request body shorter than its content-length is a stream error", async () => {
+    const { promise: gotStream, resolve: onStream } = Promise.withResolvers<http2.ServerHttp2Stream>();
+    const { promise: errored, resolve: onError, reject: onNoError } = Promise.withResolvers<NodeJS.ErrnoException>();
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      // The violating DATA is already on the wire behind the request HEADERS, so the error
+      // can fire before the awaited `gotStream` continuation runs: subscribe synchronously.
+      // A stream that closes without erroring is a regression, never a hang.
+      stream.once("error", onError);
+      stream.once("close", () => onNoError(new Error("the server stream closed without emitting 'error'")));
+      onStream(stream);
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+
+    const { promise: rstFromServer, resolve: onRst, reject: onMissingRst } = Promise.withResolvers<number>();
+    const socket = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
+    socket.on("error", () => {});
+    // A missing RST_STREAM must fail the assertion, never hang the test.
+    socket.on("close", () => onMissingRst(new Error("the server closed without sending RST_STREAM")));
+    // One rejecting fails the test before the other is awaited; mark both handled so neither
+    // surfaces as a stray unhandled rejection.
+    errored.catch(() => {});
+    rstFromServer.catch(() => {});
+    try {
+      await once(socket, "connect");
+      let buf = Buffer.alloc(0);
+      socket.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        while (buf.length >= 9) {
+          const length = buf.readUIntBE(0, 3);
+          if (buf.length < 9 + length) break;
+          if (buf[3] === 0x3) onRst(buf.readUInt32BE(9));
+          buf = buf.subarray(9 + length);
+        }
+      });
+      socket.write(h2utils.kClientMagic);
+      socket.write(new h2utils.SettingsFrame(false).data);
+      // POST /, content-length: 5, then a 2-byte body with END_STREAM.
+      socket.write(
+        headersFrame(
+          1,
+          [
+            [":method", "POST"],
+            [":scheme", "http"],
+            [":path", "/"],
+            [":authority", "raw"],
+            ["content-length", "5"],
+          ],
+          false,
+        ),
+      );
+      socket.write(dataFrame(1, "xy", true));
+
+      const stream = await gotStream;
+      stream.resume();
+      // §8.1.1: the server must reset the stream, never report a complete request body.
+      expect((await errored).code).toBe("ERR_HTTP2_STREAM_ERROR");
+      expect(stream.rstCode).toBe(NGHTTP2_PROTOCOL_ERROR);
+      expect(await rstFromServer).toBe(NGHTTP2_PROTOCOL_ERROR);
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  });
+});
+
+describe.concurrent("node:http2 client request() on a dead session returns an erroring stream", () => {
+  // node (v26.3.0) never throws from request(): a destroyed session yields a stream destroyed
+  // on the next tick with ERR_HTTP2_INVALID_SESSION, a closed one with ERR_HTTP2_GOAWAY_SESSION.
+  async function withServer(run: (client: http2.ClientHttp2Session) => Promise<void>) {
+    const server = http2.createServer((req, res) => res.end("ok"));
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as AddressInfo).port}`);
+    client.on("error", () => {});
+    try {
+      await once(client, "connect");
+      await run(client);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  }
+
+  // Resolves with the emitted error once the stream also closes. The terminal paths a regression
+  // would produce (the request reaching the peer, or a close with no error) reject immediately.
+  function streamErroredAndClosed(req: http2.ClientHttp2Stream): Promise<NodeJS.ErrnoException> {
+    const { promise, resolve, reject } = Promise.withResolvers<NodeJS.ErrnoException>();
+    let error: NodeJS.ErrnoException | undefined;
+    req.on("error", e => (error = e));
+    req.on("response", () => reject(new Error("request() on a dead session reached the peer")));
+    req.on("close", () => (error ? resolve(error) : reject(new Error("the stream closed without emitting 'error'"))));
+    return promise;
+  }
+
+  test("after destroy(): ERR_HTTP2_INVALID_SESSION on the stream", async () => {
+    await withServer(async client => {
+      client.destroy();
+      const req = client.request({ ":path": "/" });
+      expect(await streamErroredAndClosed(req)).toEqual(
+        expect.objectContaining({ code: "ERR_HTTP2_INVALID_SESSION", message: "The session has been destroyed" }),
+      );
+    });
+  });
+
+  test("after close(): ERR_HTTP2_GOAWAY_SESSION on the stream", async () => {
+    await withServer(async client => {
+      client.close();
+      const req = client.request({ ":path": "/" });
+      expect(await streamErroredAndClosed(req)).toEqual(
+        expect.objectContaining({
+          code: "ERR_HTTP2_GOAWAY_SESSION",
+          message: "New streams cannot be created after receiving a GOAWAY",
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
The HTTP/2 engine enforces RFC 9113 §8 message framing on **inbound requests only**. `enforce_content_length` returns early for a client, and the commit phase in `finish_header_block` is gated on `is_server`. So the `node:http2` **client** delivers a response shorter than its declared `content-length` as a clean, successful `'end'` with `rstCode 0`. HTTP/2 has no other framing signal, which makes a truncated download or JSON body indistinguishable from a complete one. Bun's HTTP/1 side already gets this right, and node errors the stream with `NGHTTP2_PROTOCOL_ERROR`.

> **Rebased onto #33072 ("hardening round 11"), which landed the same enforcement for the request direction while this PR was open.** This PR is now scoped to the response direction plus the `:status` rules, and is written on top of that work rather than beside it: the same `Stream.content_length`/`recv_body_bytes`/`recv_final_headers` fields, the same `enforce_content_length`, the same commit phase. See "What the rebase changed" below.

### Repro

```js
// raw h2 server answers: HEADERS{ :status: 200, content-length: 5 } + DATA("xy", END_STREAM)
const req = http2.connect(origin).request({ ":path": "/" });
req.resume();
req.on("close", () => console.log("rstCode =", req.rstCode));
// node v26.3.0: stream 'error' ERR_HTTP2_STREAM_ERROR + rstCode 1 (NGHTTP2_PROTOCOL_ERROR)
// bun:          clean 'end' + rstCode 0, body "xy"
```

Every case below was confirmed against node v26.3.0 with byte-exact raw frames. Bun before this change:

| response on the wire | node | bun |
| --- | --- | --- |
| `content-length: 5`, 2-byte body | stream error, rst 1 | clean end, rst 0 |
| `content-length: 5`, END_STREAM on HEADERS | stream error, rst 1 | clean end, rst 0 |
| `content-length: 5`, END_STREAM on trailers | stream error, rst 1 | clean end, rst 0 |
| `content-length: 1`, 2-byte body | stream error | clean end, both bytes delivered |
| no `:status` pseudo-header at all | stream error, no `response` event | `response` with `:status === undefined` |
| `:status` that is not 3 digits / < 100 / `101` | stream error | delivered |
| a request pseudo-header (`:method`) in a response | stream error | delivered |
| pushed response, short body or no `:status` | stream error | delivered |

### Fix

`Stream` gains `local_method`; the §8.1.1/§8.3 commit phase in `finish_header_block` is extended from the request direction to all three block categories, mirroring nghttp2's `nghttp2_http_on_{request,response,trailer}_headers`:

- `content-length` not met at the inbound END_STREAM (on HEADERS, DATA, or trailers), or exceeded by a DATA chunk, is a stream error of type PROTOCOL_ERROR in **both** directions; the excess never reaches the application. (`enforce_content_length` loses its `!is_server` early return.)
- A response header section must carry exactly one `:status`, and it must be three digits, `>= 100`, and never `101` (§8.3.2).
- The pseudo-headers a block may carry are now a single allowlist keyed on its category (request / response / trailer). This **replaces** the two partial checks that were there (`wrong_direction`, which only rejected `:status` inbound on a server, and the `is_trailer` clause) and additionally rejects request pseudo-headers in a response.
- §8.1.1 no-body exemptions, exactly as nghttp2 applies them: HEAD, 204/304, CONNECT (every CONNECT response, not only 2xx), and 1xx interim responses (the next block is still the response).

HEAD and CONNECT responses need the request's `:method`, and the engine has two ways to learn it: for a locally-initiated stream it never sees the outbound request headers (they flow through the legacy encoder), so the `Sink` trait gains a `local_request_method()` transition shim alongside the existing `is_local_stream()` and `request()` records the `:method`; for a server-pushed stream the request arrives in the PUSH_PROMISE block the engine decodes itself, so it records that `:method` on its own `Stream` (nghttp2's `nghttp2_http_record_request_method`) and the response arm prefers it.

Second commit: `replenish_windows()` evicted every `Closed` stream at the end of each `receive()` batch, including one whose header block was still being reassembled across a CONTINUATION. That is a **pre-existing** bug (a header block that both closes the stream and spans a CONTINUATION lost its entry, so `on_stream_end` never fired and the stream stayed open forever); with the response-direction checks it also loses the message state, so a valid pushed HEAD response was reset. The sweep now skips the stream whose block is mid-assembly.

This PR also folds in the related `request()`-after-teardown fix: node (verified v26.3.0, and node's own `test-http2-client-destroy.js`) never throws from `request()` on a destroyed or closed session; it returns a stream that errors on the next tick with `ERR_HTTP2_INVALID_SESSION` (destroyed) or `ERR_HTTP2_GOAWAY_SESSION` (closed / GOAWAY received). Bun threw synchronously except on one socket-teardown path gated by a `kSocketTeardown` flag; that flag is now write-only dead code and is removed.

### What the rebase changed

#33072 landed `Stream.content_length`/`recv_body_bytes`/`recv_final_headers`, `parse_content_length`, `enforce_content_length`, the trailer rules, and the 1xx-vs-trailer distinction — all for the **request** direction (`enforce_content_length` opens with `if !self.is_server { return false; }`, and its new `h2-conformance.test.ts` cases are all `"a request …"`). The conflict was resolved by **rewriting this change on top of that structure** instead of merging two parallel implementations: no duplicated field, no second parser, and the pseudo-header allowlist replaces rather than sits beside the checks it subsumes. Net result is ~190 lines in `connection.rs` instead of the ~270 this PR carried before. 16 of this PR's 28 tests still fail on current main; the other 12 (repeated/non-integer `content-length`, the trailer rules, and the negative-contract cases) are now covered by #33072 and are kept as regression cover.

### Intentionally out of scope

- Required request pseudo-headers on the server (`:method`/`:scheme`/`:path`, §8.3.1).
- Status-specific `content-length` field rules (prohibited on 1xx, restricted on 204).
- When DATA exceeds the declared `content-length`, node tears down the whole session (`ERR_HTTP2_ERROR` + GOAWAY `INTERNAL_ERROR`). Bun surfaces a per-stream PROTOCOL_ERROR, which is what §8.1.1 specifies; matching node's session teardown there would be a regression.

### Verification

`test/js/node/http2/node-http2-http-messaging.test.ts`: 28 cases (a raw-frame TCP server driving the `node:http2` client, the same driving a server-pushed stream, plus one raw client driving the `node:http2` server). **16 fail on current main, all 28 pass with the fix.** The negative-contract cases (exact-length body, HEAD/204/304 with a `content-length`, 1xx-then-final, a pushed HEAD with a `content-length`) prove valid traffic is untouched and that both `:method` sources are load-bearing.

- `bun bd test test/js/node/http2/h2-conformance.test.ts` (#33072's own suite, which the pseudo-header allowlist rewrites): 37 pass, 0 fail.
- `bun bd test test/js/node/http2/`: 398 pass, 1 fail. The failure (`node-http2-streams-rehash.test.ts`, 128 concurrent streams in a subprocess) is a pre-existing 5-second-timeout flake on debug+ASAN builds: it reproduces identically on unmodified main (3/3 runs).
- `cargo clippy -p bun_runtime` and `cargo fmt --check` clean; the first commit compiles on its own.
