### PR TITLE
usockets: fix use-after-free from double-parking a TLS socket in the low-priority queue

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -538,6 +538,16 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     } else {
                         struct us_poll_t* poll = &s->p;
                         us_poll_change(poll, loop, us_poll_events(poll) & LIBUS_SOCKET_WRITABLE);
+                        /* Already parked: a writable dispatch re-enabled READABLE on
+                         * this socket (us_socket_raw_write / us_socket_resume issue
+                         * us_poll_change(R|W) without knowing about the queue). It
+                         * sits in loop->data.low_prio_head, NOT in g->head_sockets,
+                         * so the group unlink below would cross-wire the two lists
+                         * (they share prev/next) and the counter bump would leak.
+                         * Readable is disabled again above; leave it where it is. */
+                        if (flags->low_prio_state == 1) {
+                            break;
+                        }
                         struct us_socket_group_t *g = s->group;
                         /* Queued sockets aren't in head_sockets while parked, so
                          * the group's emptiness check needs this counter to know

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -1,0 +1,46 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+import { join } from "node:path";
+
+const skip = !fault.available() || isWindows;
+
+// uSockets' TLS low-priority handshake queue (loop->data.low_prio_head)
+// shares its prev/next links with group->head_sockets. A socket already
+// parked in the queue used to be parked a SECOND time whenever a writable
+// dispatch re-enabled its readable poll bit (a backpressured handshake
+// flight retry does that), running us_internal_socket_group_unlink_socket on
+// low-prio-queue links and cross-wiring the two lists. In debug/ASAN builds
+// the double-incremented low_prio_count trips the group-deinit assertion; in
+// release builds freed sockets stay reachable from both lists
+// (heap-use-after-free in us_internal_socket_group_unlink_socket /
+// us_internal_handle_low_priority_sockets).
+//
+// The fixture is deliberately heavy (a server whose every `send` is faulted
+// to 0 busy-retries its handshake flights), so give it a generous timeout
+// for ASAN builds.
+test.skipIf(skip)(
+  "TLS low-prio queue: a parked socket whose readable poll is re-enabled is not parked twice",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "tls-low-prio-queue-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    // `stderrTail` is only populated when the fixture did not exit cleanly, so
+    // the abort/assertion message shows up in the failure diff.
+    expect({
+      stdout: stdout.trim(),
+      signalCode: proc.signalCode,
+      exitCode,
+      stderrTail: exitCode === 0 ? "" : stderr.slice(-2000),
+    }).toEqual({ stdout: "OK", signalCode: null, exitCode: 0, stderrTail: "" });
+  },
+  90_000,
+);

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -16,9 +16,11 @@ const skip = !fault.available() || isWindows;
 // (heap-use-after-free in us_internal_socket_group_unlink_socket /
 // us_internal_handle_low_priority_sockets).
 //
-// The fixture is deliberately heavy (a server whose every `send` is faulted
-// to 0 busy-retries its handshake flights), so give it a generous timeout
-// for ASAN builds.
+// The explicit timeout is required: a bare `bun bd test <file>` applies Bun's
+// 5000ms default, and this fixture spawns two Bun processes and has to hold
+// 32 concurrent TLS handshakes across several event-loop ticks, which takes
+// ~25s on a debug+ASAN build. 180s keeps comfortable headroom over the
+// CI runner's ASAN per-test budget instead of capping below it.
 test.skipIf(skip)(
   "TLS low-prio queue: a parked socket whose readable poll is re-enabled is not parked twice",
   async () => {
@@ -38,5 +40,5 @@ test.skipIf(skip)(
       stderrTail: exitCode === 0 ? "" : stderr.slice(-2000),
     }).toEqual({ stdout: "OK", signalCode: null, exitCode: 0, stderrTail: "" });
   },
-  90_000,
+  180_000,
 );

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -28,11 +28,7 @@ test.skipIf(skip)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // `stderrTail` is only populated when the fixture did not exit cleanly, so
     // the abort/assertion message shows up in the failure diff.
     expect({

--- a/test/js/bun/net/tls-low-prio-queue-fixture.ts
+++ b/test/js/bun/net/tls-low-prio-queue-fixture.ts
@@ -38,10 +38,23 @@ const ROUNDS = 2;
 async function captureClientHello(): Promise<Buffer> {
   const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
   const srv = net.createServer(sock => {
+    // A `data` event delivers a TCP chunk, not a TLS record, so buffer until
+    // the first record is complete (5-byte header + the length it declares)
+    // and resolve with exactly that record.
+    const chunks: Buffer[] = [];
+    let total = 0;
     sock.on("error", reject);
-    sock.once("data", d => {
+    sock.on("close", () => reject(new Error("socket closed before a full ClientHello record arrived")));
+    sock.on("data", d => {
+      chunks.push(d);
+      total += d.length;
+      const buf = Buffer.concat(chunks, total);
+      if (buf.length < 5) return;
+      const recordLength = 5 + buf.readUInt16BE(3);
+      if (buf.length < recordLength) return;
+      sock.removeAllListeners("close");
       sock.destroy();
-      resolve(d);
+      resolve(buf.subarray(0, recordLength));
     });
   });
   srv.on("error", reject);
@@ -132,25 +145,31 @@ async function round() {
   // Every send from THIS process returns 0 (backpressure): the server flights
   // stay WANT_WRITE forever and every writable retry re-issues
   // us_poll_change(READABLE|WRITABLE), including on already-parked sockets.
-  fault.set({ syscall: "send", action: "zero", repeat: -1 });
-  fault.set({ syscall: "writev", action: "zero", repeat: -1 });
+  // The faults are process-wide, so clear them even if the child fails.
+  try {
+    fault.set({ syscall: "send", action: "zero", repeat: -1 });
+    fault.set({ syscall: "writev", action: "zero", repeat: -1 });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", clientSrc],
-    env: {
-      ...bunEnv,
-      REPRO_PORT: String(server.port),
-      REPRO_N: String(N),
-      REPRO_HELLO: clientHello.toString("hex"),
-    },
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  await proc.exited;
-
-  fault.clear();
-  server.stop(true);
-  server = null;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", clientSrc],
+      env: {
+        ...bunEnv,
+        REPRO_PORT: String(server.port),
+        REPRO_N: String(N),
+        REPRO_HELLO: clientHello.toString("hex"),
+      },
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    const clientExitCode = await proc.exited;
+    // Without the clients the server sockets never park, so a broken client
+    // script must fail the fixture rather than let it still print OK.
+    if (clientExitCode !== 0) throw new Error(`client fixture exited with ${clientExitCode}`);
+  } finally {
+    fault.clear();
+    server.stop(true);
+    server = null;
+  }
 }
 
 for (let i = 0; i < ROUNDS; i++) {

--- a/test/js/bun/net/tls-low-prio-queue-fixture.ts
+++ b/test/js/bun/net/tls-low-prio-queue-fixture.ts
@@ -1,0 +1,148 @@
+// Regression fixture for the TLS low-priority handshake queue.
+//
+// uSockets throttles concurrent TLS handshakes: when the per-tick budget (5)
+// is exhausted, the readable dispatch PARKS the socket in the loop-wide
+// low-priority queue (loop->data.low_prio_head), unlinking it from
+// group->head_sockets (the two lists share the prev/next fields) and
+// disabling READABLE on its poll.
+//
+// A parked socket can still get a WRITABLE dispatch. If its handshake flight
+// is backpressured, us_internal_ssl_on_writable retries the BIO write, and
+// us_socket_raw_write re-issues us_poll_change(READABLE|WRITABLE); readable
+// is now back on a socket that is still in the low-prio queue. The next
+// readable dispatch with an exhausted budget used to park it a SECOND time:
+// us_internal_socket_group_unlink_socket(g, s) ran on a socket whose
+// prev/next are low-prio-queue links, cross-wiring group->head_sockets with
+// loop->data.low_prio_head (heap-use-after-free once either list walks
+// through a freed entry) and double-incrementing group->low_prio_count
+// (aborting at the `low_prio_count == 0` group-deinit assertion in
+// debug/ASAN builds when the Listener is finalized).
+//
+// This fixture is the server: it arms a process-wide `send -> 0` fault so
+// every handshake flight is permanently backpressured, and drives N raw TLS
+// clients from a CHILD process (the fault is process-global, and the clients'
+// ClientHello delivery must not be affected).
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import net from "node:net";
+import tls from "node:tls";
+import { tls as certs, bunEnv, bunExe } from "harness";
+
+if (!fault.available()) throw new Error("socket fault injection is not available in this build");
+
+const N = 32;
+const ROUNDS = 2;
+
+// Capture one real TLS 1.2 ClientHello record so raw net clients can replay
+// it. TLS 1.2 keeps the server waiting for the client's second flight after
+// it sends its own, so SSL_in_init() stays true for the whole window.
+async function captureClientHello(): Promise<Buffer> {
+  const { promise, resolve } = Promise.withResolvers<Buffer>();
+  const srv = net.createServer(sock => sock.once("data", d => (sock.destroy(), resolve(d))));
+  await new Promise<void>(r => srv.listen(0, "127.0.0.1", r));
+  const port = (srv.address() as net.AddressInfo).port;
+  const c = tls.connect({
+    port,
+    host: "127.0.0.1",
+    maxVersion: "TLSv1.2",
+    minVersion: "TLSv1.2",
+    rejectUnauthorized: false,
+  });
+  c.on("error", () => {});
+  const hello = await promise;
+  c.destroy();
+  await new Promise<void>(r => srv.close(() => r()));
+  return hello;
+}
+
+const clientHello = await captureClientHello();
+
+// One "wave": connect N clients, stagger their ClientHellos so the server
+// processes each without parking, then hit all N server sockets with a byte
+// in one synchronous burst so N readables land in one server tick and the
+// budget exhausts. The parked sockets never recv the byte (the low-prio gate
+// breaks before the recv loop) so it stays buffered, keeping them
+// level-readable on every subsequent tick.
+const clientSrc = `
+const net = require("node:net");
+const port = Number(process.env.REPRO_PORT);
+const N = Number(process.env.REPRO_N);
+const hello = Buffer.from(process.env.REPRO_HELLO, "hex");
+function wave() {
+  const socks = [];
+  for (let i = 0; i < N; i++) {
+    const c = net.connect(port, "127.0.0.1");
+    c.setNoDelay(true);
+    c.on("error", () => {});
+    socks.push(c);
+    // ONLY the ClientHello. Trailing bytes in the same segment would trip the
+    // "unread ciphertext after WANT_WRITE" close guard in on_data and destroy
+    // the socket before it can be parked.
+    c.on("connect", () => setTimeout(() => c.write(hello), 40 + Math.floor(i / 3) * 70));
+  }
+  setTimeout(() => {
+    for (let i = 0; i < N; i++) if (!socks[i].destroyed) socks[i].write(Buffer.from([0]));
+    // Mixed staggered teardown so closes land while peers sit in the queue.
+    setTimeout(() => {
+      for (let i = 0; i < N; i++) {
+        const c = socks[i];
+        setTimeout(() => (i % 3 === 0 ? c.resetAndDestroy() : c.destroy()), (i % 9) * 30);
+      }
+    }, 900);
+  }, 40 + Math.ceil(N / 3) * 70 + 500);
+}
+let off = 0;
+for (let w = 0; w < 3; w++) { setTimeout(wave, off); off += 40 + Math.ceil(N / 3) * 70 + 1900; }
+setTimeout(() => process.exit(0), off + 2000);
+`;
+
+async function round() {
+  // Bun.listen({tls}) is the native SSL listen path: us_internal_ssl_attach()
+  // runs inside the accept loop and the accepted socket hits the low-prio
+  // gate on its very first readable dispatch. `server` is local so each
+  // round's Listener can be finalized (which is where the group deinit
+  // asserts low_prio_count == 0).
+  let server: ReturnType<typeof Bun.listen> | null = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    tls: { key: certs.key, cert: certs.cert },
+    socket: {
+      open() {},
+      data() {},
+      close() {},
+      error() {},
+      handshake() {},
+    },
+  });
+
+  // Every send from THIS process returns 0 (backpressure): the server flights
+  // stay WANT_WRITE forever and every writable retry re-issues
+  // us_poll_change(READABLE|WRITABLE), including on already-parked sockets.
+  fault.set({ syscall: "send", action: "zero", repeat: -1 });
+  fault.set({ syscall: "writev", action: "zero", repeat: -1 });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", clientSrc],
+    env: {
+      ...bunEnv,
+      REPRO_PORT: String(server.port),
+      REPRO_N: String(N),
+      REPRO_HELLO: clientHello.toString("hex"),
+    },
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  await proc.exited;
+
+  fault.clear();
+  server.stop(true);
+  server = null;
+}
+
+for (let i = 0; i < ROUNDS; i++) {
+  await round();
+  // Finalize the round's Listener so its socket group deinits.
+  Bun.gc(true);
+  await Bun.sleep(30);
+  Bun.gc(true);
+}
+console.log("OK");

--- a/test/js/bun/net/tls-low-prio-queue-fixture.ts
+++ b/test/js/bun/net/tls-low-prio-queue-fixture.ts
@@ -36,9 +36,19 @@ const ROUNDS = 2;
 // it. TLS 1.2 keeps the server waiting for the client's second flight after
 // it sends its own, so SSL_in_init() stays true for the whole window.
 async function captureClientHello(): Promise<Buffer> {
-  const { promise, resolve } = Promise.withResolvers<Buffer>();
-  const srv = net.createServer(sock => sock.once("data", d => (sock.destroy(), resolve(d))));
-  await new Promise<void>(r => srv.listen(0, "127.0.0.1", r));
+  const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
+  const srv = net.createServer(sock => {
+    sock.on("error", reject);
+    sock.once("data", d => {
+      sock.destroy();
+      resolve(d);
+    });
+  });
+  srv.on("error", reject);
+  await new Promise<void>((r, rej) => {
+    srv.once("error", rej);
+    srv.listen(0, "127.0.0.1", r);
+  });
   const port = (srv.address() as net.AddressInfo).port;
   const c = tls.connect({
     port,
@@ -47,7 +57,12 @@ async function captureClientHello(): Promise<Buffer> {
     minVersion: "TLSv1.2",
     rejectUnauthorized: false,
   });
-  c.on("error", () => {});
+  // The raw server never replies, so the client errors or closes once the
+  // ClientHello has been captured and `sock` is destroyed; by then `promise`
+  // is settled and these rejections are no-ops. Before that point they turn a
+  // setup failure into a real error instead of a hang.
+  c.on("error", reject);
+  c.on("close", () => reject(new Error("tls.connect closed before the ClientHello was captured")));
   const hello = await promise;
   c.destroy();
   await new Promise<void>(r => srv.close(() => r()));

--- a/test/js/bun/net/tls-low-prio-queue-fixture.ts
+++ b/test/js/bun/net/tls-low-prio-queue-fixture.ts
@@ -63,23 +63,26 @@ async function captureClientHello(): Promise<Buffer> {
     srv.listen(0, "127.0.0.1", r);
   });
   const port = (srv.address() as net.AddressInfo).port;
-  const c = tls.connect({
-    port,
-    host: "127.0.0.1",
-    maxVersion: "TLSv1.2",
-    minVersion: "TLSv1.2",
-    rejectUnauthorized: false,
-  });
-  // The raw server never replies, so the client errors or closes once the
-  // ClientHello has been captured and `sock` is destroyed; by then `promise`
-  // is settled and these rejections are no-ops. Before that point they turn a
-  // setup failure into a real error instead of a hang.
-  c.on("error", reject);
-  c.on("close", () => reject(new Error("tls.connect closed before the ClientHello was captured")));
-  const hello = await promise;
-  c.destroy();
-  await new Promise<void>(r => srv.close(() => r()));
-  return hello;
+  let c: tls.TLSSocket | undefined;
+  try {
+    c = tls.connect({
+      port,
+      host: "127.0.0.1",
+      maxVersion: "TLSv1.2",
+      minVersion: "TLSv1.2",
+      rejectUnauthorized: false,
+    });
+    // The raw server never replies, so the client errors or closes once the
+    // ClientHello has been captured and `sock` is destroyed; by then `promise`
+    // is settled and these rejections are no-ops. Before that point they turn
+    // a setup failure into a real error instead of a hang.
+    c.on("error", reject);
+    c.on("close", () => reject(new Error("tls.connect closed before the ClientHello was captured")));
+    return await promise;
+  } finally {
+    c?.destroy();
+    await new Promise<void>(r => srv.close(() => r()));
+  }
 }
 
 const clientHello = await captureClientHello();
@@ -147,8 +150,14 @@ async function round() {
   // us_poll_change(READABLE|WRITABLE), including on already-parked sockets.
   // The faults are process-wide, so clear them even if the child fails.
   try {
-    fault.set({ syscall: "send", action: "zero", repeat: -1 });
-    fault.set({ syscall: "writev", action: "zero", repeat: -1 });
+    // fault.set returns false if the rule could not be armed; without the
+    // forced backpressure nothing ever parks, so that must fail the fixture.
+    if (!fault.set({ syscall: "send", action: "zero", repeat: -1 })) {
+      throw new Error("failed to arm the send socket fault");
+    }
+    if (!fault.set({ syscall: "writev", action: "zero", repeat: -1 })) {
+      throw new Error("failed to arm the writev socket fault");
+    }
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", clientSrc],


### PR DESCRIPTION
### Symptom

AddressSanitizer reports a heap-use-after-free (READ of size 8 and WRITE of size 8 variants) in uSockets' listener bookkeeping while a TLS server accepts connections under load:

```
==ERROR: AddressSanitizer: heap-use-after-free (WRITE of size 8)
  #0 us_internal_socket_group_unlink_socket   bun-usockets/src/context.c:223
  #1 us_internal_socket_close_raw             bun-usockets/src/socket.c:291
  #2 us_internal_ssl_close                    bun-usockets/src/crypto/openssl.c
  #3 close<true>                              src/uws_sys/socket.rs
```

A second manifestation site is the low-priority queue walker, `us_internal_handle_low_priority_sockets`. The trigger is an ordinary `Bun.serve({tls})` / `node:tls` server whose clients connect, handshake, and disconnect at inopportune times. No unusual client behavior is required.

### Cause

uSockets throttles concurrent TLS handshakes. When the 5-per-tick budget runs out, the readable dispatch parks the socket in the loop-wide low-priority queue (`loop->data.low_prio_head`): it is unlinked from `group->head_sockets` and READABLE is removed from its poll. The two lists share the same `prev`/`next` fields, so a socket lives in exactly one at a time.

A parked socket can still get a WRITABLE dispatch. When its handshake flight is backpressured (`send` returned short or 0), `us_internal_ssl_on_writable` retries the BIO write, and `us_socket_raw_write` unconditionally runs `us_poll_change(READABLE | WRITABLE)`. READABLE is now re-enabled on a socket that is still in the low-priority queue.

The next readable dispatch on that socket, with the budget exhausted, parked it a second time. That path ran `us_internal_socket_group_unlink_socket(g, s)` on a socket whose `prev`/`next` are low-priority-queue links, not group links:

- If the socket was the queue head, `group->head_sockets` gets pointed at the next low-priority socket. When that socket is later closed through `us_internal_socket_close_raw`'s low-priority branch, nothing repairs `head_sockets`, and the group list reaches freed memory. `us_internal_socket_group_unlink_socket`'s `next->prev = prev` for a neighbor is the WRITE of size 8.
- `loop->data.low_prio_head` can be left pointing at the re-prepended socket as a self-cycle; the queue walker then reads through entries the close path has already freed. That is the READ of size 8 in `us_internal_handle_low_priority_sockets`.
- `group->low_prio_count` is incremented a second time for a socket that was already counted. It never returns to zero, which is also what `us_socket_group_deinit`'s `low_prio_count == 0` assertion catches in debug/ASan builds.

### Fix

In the parking branch, if `low_prio_state == 1` the socket is already in `loop->data.low_prio_head` and not in `group->head_sockets`. Re-disable READABLE (done just above) and leave it where it is instead of group-unlinking and re-counting it.

`us_connecting_socket_close` also calls `us_internal_socket_group_unlink_socket` without checking `low_prio_state`, but it only runs before any candidate leg has opened, when every socket in `connecting_head` is still a `SEMI_SOCKET` and cannot have been parked, so it is not affected.

### Test

`test/js/bun/net/socket-syscall-fault.test.ts` drives the exact sequence with the in-tree socket fault injection: a `Bun.listen({tls})` server whose every `send` returns 0, and bursts of raw TLS 1.2 clients from a child process. Without the fix the fixture aborts:

```
bun-debug: packages/bun-usockets/src/context.c:68: void us_socket_group_deinit(struct us_socket_group_t *):
Assertion `group->low_prio_count == 0' failed.
```

<details>
<summary>Verification runs</summary>

- Without the fix: 2/2 runs fail with `exitCode: 134`, `signalCode: "SIGABRT"`, and the assertion above.
- With the fix: 3/3 runs pass.
- `test/js/bun/util/socket-fault-injection.test.ts`, `test/js/node/tls/tls-syscall-fault.test.ts`, `test/js/node/tls/node-tls-server.test.ts`, and `test/js/bun/net/socket.test.ts` produce identical results before and after the change. The two pre-existing environment failures in the last two (plain TCP `ECONNREFUSED` to the just-bound port) reproduce identically on unmodified `main`.

</details>
