### PR TITLE
shell: don't re-enter the Yield trampoline on synchronous write errors

### DIFF
--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -685,9 +685,9 @@ impl IOWriter {
 
     // ── file write (non-pollable sync path) ─────────────────────────────
 
-    /// POSIX-only.
+    /// POSIX-only. `child` is the writer being enqueued (see `on_sync_error`).
     #[cfg(not(windows))]
-    fn do_file_write(&self) -> Yield {
+    fn do_file_write(&self, child: ChildPtr) -> Yield {
         {
             let s = self.state();
             debug_assert!(!s.flags.pollable);
@@ -715,7 +715,7 @@ impl IOWriter {
             }
             // The caller is inside the enqueuing child's trampoline, so the
             // error completion is returned, not `Yield::run` from here.
-            bun_io::WriteResult::Err(e) => return self.on_sync_error(&e),
+            bun_io::WriteResult::Err(e) => return self.on_sync_error(child, &e),
         };
         let s = self.state();
         let lo = s.total_bytes_written;
@@ -878,25 +878,36 @@ impl IOWriter {
         }
     }
 
-    /// Synchronous write failure, i.e. the enqueuing child's trampoline is
-    /// still on the stack (`enqueue` → `write`/`do_file_write`). Returning the
-    /// error completion lets that trampoline deliver it once we unwind back to
-    /// it; calling `on_error` here instead would re-enter `Yield::run`, which
-    /// nests once per command-substitution level and fires the child's
-    /// callback while its `enqueue` call is still executing.
-    fn on_sync_error(&self, err: &sys::Error) -> Yield {
-        let pending = self.fail_pending_writers(err);
-        // A synchronous failure only happens on the first write attempt of a
-        // batch, so the writer `enqueue` just pushed is the only pending one.
-        debug_assert_eq!(pending.len(), 1);
-        match pending.first() {
-            Some(&child) => Yield::OnIoWriterChunk {
-                child,
+    /// Synchronous write failure while `child`'s `enqueue` call (and therefore
+    /// its trampoline) is still on the stack. `child`'s error completion is
+    /// *returned* so that trampoline delivers it after `enqueue` unwinds;
+    /// calling `on_error` here instead would re-enter `Yield::run` once per
+    /// failing command and fire `child`'s callback from inside its own
+    /// `enqueue`. Usually `child`'s chunk is the only pending one (a
+    /// synchronous failure is the first write attempt of a batch); if a poll
+    /// re-registration fails while other children are still queued, those are
+    /// dispatched the way the async path dispatches them.
+    fn on_sync_error(&self, child: ChildPtr, err: &sys::Error) -> Yield {
+        let _keepalive = self.keepalive();
+        let mut completion = None;
+        for ptr in self.fail_pending_writers(err) {
+            // `SystemError` owns `bun_core::String`s by value (no shared
+            // refcount yet), so re-derive a fresh one per callee.
+            let y = Yield::OnIoWriterChunk {
+                child: ptr,
                 written: 0,
                 err: Some(err.to_shell_system_error()),
-            },
-            None => Yield::done(),
+            };
+            if completion.is_none() && ptr == child {
+                completion = Some(y);
+            } else {
+                self.run_yield(y);
+            }
         }
+        // The writer `enqueue` just pushed for `child` is live and at or past
+        // `writer_idx`, so it is always in the pending list.
+        debug_assert!(completion.is_some());
+        completion.unwrap_or_else(Yield::done)
     }
 
     fn on_close(&self) {
@@ -935,7 +946,7 @@ impl IOWriter {
     }
 
     #[cfg(not(windows))]
-    fn enqueue_file(&self) -> Yield {
+    fn enqueue_file(&self, child: ChildPtr) -> Yield {
         let s = self.state();
         if s.is_writing {
             return Yield::suspended();
@@ -944,21 +955,22 @@ impl IOWriter {
         // path bypasses write() entirely, so set it here.
         s.started = true;
         self.set_writing(true);
-        self.do_file_write()
+        self.do_file_write(child)
     }
 
     /// You MUST have already added the data to `self.buf`!
-    fn enqueue_internal(&self) -> Yield {
+    /// `child` is the writer that was just pushed (see `on_sync_error`).
+    fn enqueue_internal(&self, child: ChildPtr) -> Yield {
         debug_assert!(!self.state().flags.broken_pipe);
         #[cfg(not(windows))]
         if !self.state().flags.pollable {
-            return self.enqueue_file();
+            return self.enqueue_file(child);
         }
         match self.write() {
             WriteOutcome::Suspended => Yield::suspended(),
             #[cfg(not(windows))]
-            WriteOutcome::IsActuallyFile => self.enqueue_file(),
-            WriteOutcome::Failed(e) => self.on_sync_error(&e),
+            WriteOutcome::IsActuallyFile => self.enqueue_file(child),
+            WriteOutcome::Failed(e) => self.on_sync_error(child, &e),
         }
     }
 
@@ -983,7 +995,7 @@ impl IOWriter {
             written: 0,
             bytelist,
         });
-        self.enqueue_internal()
+        self.enqueue_internal(child)
     }
 
     /// Prefix `"{kind}: "` then format.
@@ -1021,7 +1033,7 @@ impl IOWriter {
             written: 0,
             bytelist,
         });
-        self.enqueue_internal()
+        self.enqueue_internal(child)
     }
 
     /// Format `args` into the write buffer and enqueue the resulting chunk

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -214,7 +214,6 @@ struct State {
     winbuf: Vec<u8>,
     writer_idx: usize,
     total_bytes_written: usize,
-    err: Option<sys::SystemError>,
     evtloop: EventLoopHandle,
     is_writing: bool,
     started: bool,
@@ -291,7 +290,6 @@ impl IOWriter {
                 winbuf: Vec::new(),
                 writer_idx: 0,
                 total_bytes_written: 0,
-                err: None,
                 evtloop,
                 is_writing: false,
                 started: false,
@@ -470,6 +468,11 @@ impl IOWriter {
     }
 
     /// Idempotent write call.
+    ///
+    /// Failures are *returned* (`WriteOutcome::Failed`), never dispatched from
+    /// here: the caller sits inside the enqueuing child's trampoline, so the
+    /// error completion has to bounce off it (`on_sync_error`) instead of
+    /// re-entering `Yield::run` (see `DbgDepthGuard`).
     fn write(&self) -> WriteOutcome {
         let s = self.state();
         #[cfg(not(windows))]
@@ -477,13 +480,11 @@ impl IOWriter {
 
         if !s.started {
             crate::shell_log!("IOWriter(fd={}) starting", s.fd);
-            // Set before on_error: the callback chain may drop the last Arc
-            // strong ref, and `Drop` would then run synchronously
-            // mid-on_error.
+            // Set before the fallible `__start` so a later enqueue does not
+            // retry it.
             s.started = true;
             if let Err(e) = self.__start() {
-                self.on_error(&e);
-                return WriteOutcome::Failed;
+                return WriteOutcome::Failed(e);
             }
             #[cfg(not(windows))]
             {
@@ -511,8 +512,7 @@ impl IOWriter {
             }
             s.is_writing = true;
             if let Err(e) = s.writer.start_with_current_pipe() {
-                self.on_error(&e);
-                return WriteOutcome::Failed;
+                return WriteOutcome::Failed(e);
             }
             return WriteOutcome::Suspended;
         }
@@ -531,8 +531,7 @@ impl IOWriter {
                 }
             }
             if let Err(e) = s.writer.start(s.fd, s.flags.pollable) {
-                self.on_error(&e);
-                return WriteOutcome::Failed;
+                return WriteOutcome::Failed(e);
             }
             WriteOutcome::Suspended
         }
@@ -689,10 +688,6 @@ impl IOWriter {
     /// POSIX-only.
     #[cfg(not(windows))]
     fn do_file_write(&self) -> Yield {
-        // `drain_buffered_data`/`on_error` below re-enter the interpreter and
-        // may drop the last external Arc; hold one across the whole body so the
-        // trailing `set_writing(false)` defer runs on a live `self`.
-        let _keepalive = self.keepalive();
         {
             let s = self.state();
             debug_assert!(!s.flags.pollable);
@@ -709,28 +704,18 @@ impl IOWriter {
         debug_assert!(!buf.is_empty());
 
         let result = drain_buffered_data(self, buf, u32::MAX as usize);
-        // NOTE: re-derive `state()` after `drain_buffered_data` (which may
-        // have called `on_error`) instead of holding a stale `&mut`.
+        // NOTE: re-derive `state()` after `drain_buffered_data` instead of
+        // holding a stale `&mut`.
         let amt = match result {
-            bun_io::WriteResult::Done(amt) => amt,
-            bun_io::WriteResult::Wrote(amt) => {
-                // .wrote can be returned if an error was encountered but we
-                // wrote some data before it happened. on_error was already
-                // called inside drain_buffered_data.
-                if self.state().err.is_some() {
-                    return Yield::done();
-                }
-                amt
-            }
+            bun_io::WriteResult::Done(amt) | bun_io::WriteResult::Wrote(amt) => amt,
             bun_io::WriteResult::Pending(_) => {
                 unreachable!(
                     "drainBufferedData returning .pending in IOWriter.doFileWrite should not happen"
                 );
             }
-            bun_io::WriteResult::Err(e) => {
-                self.on_error(&e);
-                return Yield::done();
-            }
+            // The caller is inside the enqueuing child's trampoline, so the
+            // error completion is returned, not `Yield::run` from here.
+            bun_io::WriteResult::Err(e) => return self.on_sync_error(&e),
         };
         let s = self.state();
         let lo = s.total_bytes_written;
@@ -846,29 +831,41 @@ impl IOWriter {
         s.writer_idx = 0;
     }
 
-    fn on_error(&self, err: &sys::Error) {
-        let _keepalive = self.keepalive();
+    /// Shared failure bookkeeping: mark broken pipes, reset the queue, and
+    /// return the still-pending children that have to be told their chunk
+    /// failed. The queue is reset *before* any of them runs so that a child
+    /// re-enqueueing from its callback is not wiped afterwards.
+    fn fail_pending_writers(&self, err: &sys::Error) -> Vec<ChildPtr> {
         self.set_writing(false);
         let s = self.state();
         if err.get_errno() == E::EPIPE {
             s.flags.broken_pipe = true;
         }
-        s.err = Some(err.to_shell_system_error());
         // Writers before writer_idx have already had their callback fired and
         // may have been freed; only notify the still-pending ones, dedup'd.
-        let mut seen: Vec<ChildPtr> = Vec::with_capacity(64);
-        let start = s.writer_idx;
-        // NOTE: reshaped for borrowck — copy out the child ptrs first.
-        let pending: Vec<ChildPtr> = s.writers[start..]
-            .iter()
-            .filter(|w| !w.is_dead())
-            .map(|w| w.ptr)
-            .collect();
-        for ptr in pending {
-            if seen.contains(&ptr) {
-                continue;
+        let mut pending: Vec<ChildPtr> = Vec::new();
+        for w in &s.writers[s.writer_idx..] {
+            if !w.is_dead() && !pending.contains(&w.ptr) {
+                pending.push(w.ptr);
             }
-            seen.push(ptr);
+        }
+        s.total_bytes_written = 0;
+        s.writer_idx = 0;
+        s.buf.clear();
+        s.writers.clear();
+        pending
+    }
+
+    /// Write failure reported by the `bun_io` writer callbacks. Each pending
+    /// child's error completion is driven through its own `Yield::run`; on
+    /// POSIX these callbacks only fire from the event loop, with no trampoline
+    /// on the stack. On Windows uv can also deliver a synchronous submission
+    /// failure from under `write()` (`start_with_current_pipe` returns `Ok`
+    /// unconditionally), a re-entry `write()` cannot turn into a
+    /// `WriteOutcome::Failed`.
+    fn on_error(&self, err: &sys::Error) {
+        let _keepalive = self.keepalive();
+        for ptr in self.fail_pending_writers(err) {
             // `SystemError` owns `bun_core::String`s by value (no shared
             // refcount yet), so re-derive a fresh one per callee instead of
             // cloning the stored error.
@@ -879,11 +876,27 @@ impl IOWriter {
                 err: Some(ee),
             });
         }
-        let s = self.state();
-        s.total_bytes_written = 0;
-        s.writer_idx = 0;
-        s.buf.clear();
-        s.writers.clear();
+    }
+
+    /// Synchronous write failure, i.e. the enqueuing child's trampoline is
+    /// still on the stack (`enqueue` → `write`/`do_file_write`). Returning the
+    /// error completion lets that trampoline deliver it once we unwind back to
+    /// it; calling `on_error` here instead would re-enter `Yield::run`, which
+    /// nests once per command-substitution level and fires the child's
+    /// callback while its `enqueue` call is still executing.
+    fn on_sync_error(&self, err: &sys::Error) -> Yield {
+        let pending = self.fail_pending_writers(err);
+        // A synchronous failure only happens on the first write attempt of a
+        // batch, so the writer `enqueue` just pushed is the only pending one.
+        debug_assert_eq!(pending.len(), 1);
+        match pending.first() {
+            Some(&child) => Yield::OnIoWriterChunk {
+                child,
+                written: 0,
+                err: Some(err.to_shell_system_error()),
+            },
+            None => Yield::done(),
+        }
     }
 
     fn on_close(&self) {
@@ -945,7 +958,7 @@ impl IOWriter {
             WriteOutcome::Suspended => Yield::suspended(),
             #[cfg(not(windows))]
             WriteOutcome::IsActuallyFile => self.enqueue_file(),
-            WriteOutcome::Failed => Yield::failed(),
+            WriteOutcome::Failed(e) => self.on_sync_error(&e),
         }
     }
 
@@ -1025,7 +1038,9 @@ impl IOWriter {
 
 enum WriteOutcome {
     Suspended,
-    Failed,
+    /// The write/poll-registration failed synchronously; the caller turns this
+    /// into the enqueuing child's error completion (`on_sync_error`).
+    Failed(sys::Error),
     #[cfg(not(windows))]
     IsActuallyFile,
 }
@@ -1110,10 +1125,9 @@ fn drain_buffered_data(
                 drained += amt;
             }
             bun_io::WriteResult::Err(err) => {
-                if drained > 0 {
-                    parent.on_error(&err);
-                    return bun_io::WriteResult::Wrote(drained);
-                }
+                // Reported as an error even after a partial write: the caller
+                // (`do_file_write`) fails the whole chunk either way, and it
+                // must not dispatch the failure from under the trampoline.
                 return bun_io::WriteResult::Err(err);
             }
             bun_io::WriteResult::Done(amt) => {

--- a/test/js/bun/shell/yield.test.ts
+++ b/test/js/bun/shell/yield.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
 import { createTestBuilder } from "./test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -8,4 +9,57 @@ describe("yield", async () => {
     .exitCode(0)
     .fileEquals("myfile.txt", array.join(" "))
     .runAsTest("doesn't stackoverflow");
+
+  // A synchronously failing write (/dev/full, Linux-only: write(2) gives ENOSPC)
+  // used to re-enter the `Yield::run` trampoline from `IOWriter::on_error`, one
+  // nesting level per failing command, tripping the interpreter's re-entrancy
+  // guard. Spawn a subprocess so the aborting child stays contained.
+  async function expectShellOutput(script: string, expected: { stdout: string; exitCode: number }) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { $ } from "bun";
+        $.nothrow();
+        const r = await $\`${script}\`.quiet();
+        console.log(JSON.stringify({ stdout: r.stdout.toString(), exitCode: r.exitCode }));
+        `,
+        // If the child does crash, skip the debug build's slow symbolized
+        // backtrace so the failure is the panic message, not a test timeout.
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ result: stdout.trim(), stderr, exitCode }).toEqual({
+      result: JSON.stringify(expected),
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  }
+
+  // Each nested command substitution opens its own /dev/full fd, and every
+  // level's error completion used to start one more nested trampoline. The
+  // `|| echo` only runs if the outer write really got ENOSPC.
+  test.if(isLinux)("synchronous write errors in nested command substitutions", async () => {
+    await expectShellOutput(
+      "echo $(echo $(echo $(echo a > /dev/full) > /dev/full) > /dev/full) > /dev/full || echo outer_write_failed",
+      { stdout: "outer_write_failed\n", exitCode: 0 },
+    );
+  });
+
+  // Same without any nesting: each statement's error completion used to start
+  // the next statement from inside one more nested trampoline. Every `|| echo`
+  // branch runs only if its /dev/full write failed.
+  test.if(isLinux)("synchronous write errors in sequential statements", async () => {
+    await expectShellOutput(
+      "echo a > /dev/full || echo f1; echo b > /dev/full || echo f2; echo c > /dev/full || echo f3; echo d > /dev/full || echo f4",
+      { stdout: "f1\nf2\nf3\nf4\n", exitCode: 0 },
+    );
+  });
 });


### PR DESCRIPTION
### What does this PR do?

In Bun Shell, a write that fails synchronously while a chunk is being enqueued (for example a file redirect hitting `ENOSPC`) was reported through `IOWriter::on_error`, which calls `Yield::run`. That re-enters the interpreter's trampoline while the enqueuing child's trampoline is still on the stack, and it fires the child's `on_io_writer_chunk` callback from inside that same child's `enqueue` call.

Whatever runs next (the next statement, or the expansion that was waiting on a command substitution) is then started from inside the nested `Yield::run`, so every command whose write fails this way adds one more level. Three levels trip the interpreter's re-entrancy guard in debug builds:

```
panic: assertion failed: n <= Self::MAX_DEPTH
<bun_runtime::shell::yield_::DbgDepthGuard>::enter   src/runtime/shell/Yield.rs:86
<bun_runtime::shell::yield_::Yield>::run
<bun_runtime::shell::io_writer::IOWriter>::run_yield
<bun_runtime::shell::io_writer::IOWriter>::on_error
<bun_runtime::shell::io_writer::IOWriter>::do_file_write
<bun_runtime::shell::io_writer::IOWriter>::enqueue
```

Repro on Linux (`/dev/full` makes every `write(2)` fail synchronously with `ENOSPC`). Both of these panic a debug build of current main:

```js
import { $ } from "bun";
$.nothrow();
// one level per statement
await $`echo a > /dev/full; echo b > /dev/full; echo c > /dev/full; echo d > /dev/full`;
// one level per command substitution
await $`echo $(echo $(echo a > /dev/full) > /dev/full) > /dev/full`;
```

In release builds the guard compiles out and the same path recurses on the native stack, one set of frames per failing command. The trampoline exists so that shell execution never recurses, and the success path already honors it: a synchronously completed chunk is returned to the caller as `Yield::OnIoWriterChunk` (`bump`, `handle_broken_pipe`) and dispatched by the trampoline that is already running. The Zig implementation this was ported from carried a `// TODO: This probably shouldn't call .run()` in `onError`.

This PR makes the synchronous error path take that same bounce:

- `write()` returns the error in `WriteOutcome::Failed(err)` instead of calling `on_error`.
- `do_file_write()` / `drain_buffered_data()` return the write error instead of dispatching it mid-write.
- Both are turned into a `Yield` by the new `on_sync_error`, which shares the bookkeeping with `on_error` (`fail_pending_writers`). The enqueuing child is passed down from `enqueue`, its completion is the returned `Yield`, and any other writers still pending (only possible when a poll re-registration fails while other children are queued) are dispatched the way the async path dispatches them.

`on_error` still drives `Yield::run` itself and is now only reachable from the `bun_io` writer callbacks. Since the queue is reset before the completion callbacks run instead of after, a child that re-enqueues from its error callback is no longer wiped from the queue. Two deletions that fall out of this:

- `State::err` is removed. Its only reader was the `do_file_write` check that existed because `drain_buffered_data` used to call `on_error` from under it.
- The `_keepalive` in `do_file_write` is dropped because nothing in its body can re-enter child code (and drop the last `Arc`) anymore.

Two neighboring holes of the same shape are left alone deliberately and are documented in the code:

- `IOReader::start` calls `on_reader_error` for a synchronous `FilePoll` registration failure. It needs `epoll_ctl` itself to fail, so it cannot be exercised without fault injection, and the reader list semantics need their own treatment.
- On Windows, uv can report a synchronous submission failure from under `WindowsBufferedWriter::write()`; `start_with_current_pipe` swallows it and returns `Ok`, so `IOWriter::write()` cannot turn it into `WriteOutcome::Failed`. Fixing that means changing the `PipeWriter` Windows error flow, which I did not want to do untested here.

Independent of #32946, which is about new chunks enqueued after a previous fatal error on the same writer; the two touch neighboring code in `IOWriter.rs`. See the comments below for how this relates to #29996.

### How did you verify your code works?

Two new tests in `test/js/bun/shell/yield.test.ts` (Linux only, they need `/dev/full`), one per repro above. Each failing write carries an `|| echo <marker>` branch and the test asserts the markers exactly, so it only passes if every `/dev/full` write really failed and the interpreter kept going. On an unfixed debug build the spawned child dies on the assertion and both fail; with the fix they pass and the whole script runs on a single trampoline (`BUN_DEBUG_SHELL=1` shows `Yield(...) depth = 0 + 1` only).

Also ran the shell suites (`bunshell`, `file-io`, `epipe`, `shelloutput`, `pipeline_stack`, `shell-blocking-pipe`, `shell-cmdsub-crash`, `throw`, `commands/`) on a debug ASAN build: no new failures (the only failing tests are pre-existing in this environment: hardcoded time budgets a debug binary cannot meet, and `ls` permission tests that need a non-root user).

`cargo check -p bun_runtime --target x86_64-pc-windows-msvc` passes for the Windows arm of `write()`.
