### PR TITLE
process: fill the nextTick ring buffer so a numeric Array.prototype index cannot corrupt it

### DIFF
--- a/src/js/internal/fixed_queue.ts
+++ b/src/js/internal/fixed_queue.ts
@@ -1,5 +1,7 @@
 // https://github.com/nodejs/node/blob/bae03c4e30f927676203f61ff5a34fe0a0c0bbc9/lib/internal/fixed_queue.js
 
+const ArrayPrototypeFill = Array.prototype.fill;
+
 // Currently optimal queue size, tested on V8 6.0 - 6.6. Must be power of two.
 const kSize = 2048;
 const kMask = kSize - 1;
@@ -61,7 +63,10 @@ class FixedCircularBuffer<T> {
   constructor() {
     this.bottom = 0;
     this.top = 0;
-    this.list = $newArrayWithSize(kSize);
+    // Fill so every slot is an own property: `shift()` reads never-pushed
+    // slots, and on a holey array that read walks the prototype chain, so
+    // `Array.prototype[n] = x` becomes a phantom entry that corrupts the ring.
+    this.list = ArrayPrototypeFill.$call($newArrayWithSize(kSize), undefined) as Array<T | undefined>;
     this.next = null;
   }
 

--- a/test/js/node/process/process-nexttick.test.js
+++ b/test/js/node/process/process-nexttick.test.js
@@ -2,6 +2,7 @@
 // mess with timers, producing unreliable results. You must manually test this
 // in Node.
 import { expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 const isBun = !!process.versions.bun;
 
 it("process.nextTick", async () => {
@@ -1035,4 +1036,35 @@ it("process.nextTick and AsyncLocalStorage.enterWith don't conflict", async () =
 
   expect(call1).toBe(true);
   expect(call2).toBe(true);
+});
+
+// The nextTick queue is a ring of fixed-size buffers. Node fills each buffer
+// with `undefined` up front so that `shift()` never reads a never-written slot
+// through the prototype chain; without that fill, `Array.prototype[n] = x`
+// becomes a phantom tick (whose `.callback` is undefined) and the mismatched
+// bottom/top indices then hang the drain loop forever. 1 and 2000 pin both
+// ends of the 2048-slot buffer; the chain queues exactly n ticks so the
+// terminating read lands on slot n. The mutation is a process global, so each
+// case runs in its own subprocess.
+// Regressing this hangs the child, so an uncaughtException listener converts
+// the symptom into a fast nonzero exit.
+it.each([1, 2000])("a numeric index %i on Array.prototype does not corrupt the nextTick queue", async index => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const index = ${index};
+       Array.prototype[index] = 99;
+       process.on("uncaughtException", e => { console.log("UNCAUGHT " + e); process.exit(1); });
+       let ran = 0;
+       const chain = () => { if (++ran < index) process.nextTick(chain); };
+       process.nextTick(chain);
+       setTimeout(() => console.log("ran " + ran), 0);`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: `ran ${index}`, stderr: "", exitCode: 0 });
 });


### PR DESCRIPTION
### Problem

Adding a numeric index to `Array.prototype` breaks `process.nextTick` entirely.

```js
Array.prototype[1] = 99;
process.nextTick(() => console.log("ran"));
```

```
$ node repro.js
ran
$ bun repro.js
TypeError: undefined is not a function
```

Without the uncaught exception, the symptom is a permanent hang: the nextTick queue never drains again for the rest of the process.

Numeric indices on `Array.prototype` are something real code does (legacy polyfills, a few test frameworks), and Node handles it. I hit this from a test that set `Array.prototype[1]` to exercise inherited array indices.

### Cause

`FixedCircularBuffer` (the ring each `FixedQueue` segment uses for the nextTick queue) allocates its 2048-slot list with `$newArrayWithSize(kSize)`, which produces a holey array. `shift()` reads `list[bottom]` and treats a non-`undefined` result as the next tick:

```js
shift() {
  const nextItem = this.list[this.bottom];
  if (nextItem === undefined) return null;
  ...
}
```

After the one real tick is shifted, `bottom` points at a slot that was never written. On a holey array that read walks the prototype chain, so `Array.prototype[1] === 99` makes `shift()` return `99` as a tick. The drain loop calls `(99).callback(...)`, which is `undefined(...)`. Worse, `bottom` has now advanced past `top`, so `isEmpty()` (`top === bottom`) never becomes true again and every later drain pulls more phantoms.

Node fills the ring for exactly this reason (`lib/internal/fixed_queue.js`):

```js
this.list = ArrayPrototypeFill(new Array(kSize), undefined);
```

Bun's port of this file dropped the fill when it switched to `$newArrayWithSize`.

### Fix

Fill the ring with `undefined` at construction so every slot is an own property and `list[bottom]` never reaches the prototype chain. This is the upstream behavior. The fill runs once per 2048 ticks, so it is not on the hot path.

### Verification

New `it.each([1, 2000])` case in `test/js/node/process/process-nexttick.test.js`. The two indices pin both ends of the 2048-slot ring; each case queues exactly that many ticks so the terminating `shift()` lands on the polluted slot. Because the mutation is a process global, each case runs in its own subprocess, and an `uncaughtException` listener turns the hang into a fast nonzero exit so a regression fails immediately instead of timing out.

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/process/process-nexttick.test.js -t "Array.prototype"
2 fail
$ bun bd test test/js/node/process/process-nexttick.test.js
9 pass
```