### PR TITLE
Reject a new data frame interleaved in a fragmented WebSocket message

### DIFF
--- a/packages/bun-uws/src/WebSocketProtocol.h
+++ b/packages/bun-uws/src/WebSocketProtocol.h
@@ -283,7 +283,10 @@ protected:
     template <unsigned int MESSAGE_HEADER, typename T>
     static inline bool consumeMessage(T payLength, char *&src, unsigned int &length, WebSocketState<isServer> *wState, void *user) {
         if (getOpCode(src)) {
-            if (wState->state.opStack == 1 || (!wState->state.lastFin && getOpCode(src) < 2)) {
+            /* RFC 6455 5.4: while a data message is still fragmented (opStack != -1), a new
+             * text/binary frame (opcode < 3) must fail the connection; only continuation
+             * frames (opcode 0) and interleaved control frames (opcode >= 8) are allowed. */
+            if (wState->state.opStack == 1 || (getOpCode(src) < 3 && wState->state.opStack != -1)) {
                 Impl::forceClose(wState, user);
                 return true;
             }

--- a/test/js/web/websocket/websocket-pong-fragmented.test.ts
+++ b/test/js/web/websocket/websocket-pong-fragmented.test.ts
@@ -483,13 +483,22 @@ describe("WebSocket server rejects a new data frame mid-fragment (RFC 6455 5.4)"
     sock.on("data", chunk => {
       if (handshakeDone) return;
       buf = Buffer.concat([buf, chunk]);
-      if (buf.includes("\r\n\r\n")) {
-        handshakeDone = true;
-        sock.write(Buffer.concat(frames));
+      const headerEnd = buf.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      // The test only means anything if the upgrade succeeded; otherwise a
+      // closed non-websocket connection would masquerade as { outcome: "closed" }.
+      const response = buf.subarray(0, headerEnd).toString("utf8");
+      if (!response.startsWith("HTTP/1.1 101 ")) {
+        sock.destroy();
+        reject(new Error(`websocket upgrade failed:\n${response}`));
+        return;
       }
+      handshakeDone = true;
+      sock.write(Buffer.concat(frames));
     });
     sock.on("close", () => {
       if (handshakeDone) resolve({ outcome: "closed" });
+      else reject(new Error("socket closed before the websocket upgrade completed"));
     });
 
     sock.write(

--- a/test/js/web/websocket/websocket-pong-fragmented.test.ts
+++ b/test/js/web/websocket/websocket-pong-fragmented.test.ts
@@ -1,6 +1,7 @@
 import { TCPSocketListener } from "bun";
 import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
+import net from "node:net";
 
 const hostname = "127.0.0.1";
 const MAX_HEADER_SIZE = 16 * 1024;
@@ -435,5 +436,103 @@ describe("WebSocket", () => {
       client?.close();
       server?.stop(true);
     }
+  });
+});
+
+// RFC 6455 5.4: once a data message is fragmented (a data frame with FIN=0),
+// only continuation frames and control frames may follow until it completes.
+// A new text/binary frame before the message ends must fail the connection.
+describe("WebSocket server rejects a new data frame mid-fragment (RFC 6455 5.4)", () => {
+  const CONT = 0x0;
+  const TEXT = 0x1;
+  const BINARY = 0x2;
+  const PING = 0x9;
+
+  function maskedFrame(opcode: number, payload: Buffer, fin: boolean): Buffer {
+    const mask = Buffer.from([1, 2, 3, 4]);
+    const masked = Buffer.from(payload.map((b, i) => b ^ mask[i % 4]));
+    return Buffer.concat([Buffer.from([(fin ? 0x80 : 0) | opcode, 0x80 | payload.length]), mask, masked]);
+  }
+
+  // Connect a raw client, finish the handshake, send `frames`, and report whether
+  // the server delivered a message or failed (closed) the connection.
+  async function outcomeFor(frames: Buffer[]): Promise<{ outcome: "message" | "closed"; data?: string }> {
+    const { promise, resolve, reject } = Promise.withResolvers<{ outcome: "message" | "closed"; data?: string }>();
+
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        if (srv.upgrade(req)) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        message(ws, m) {
+          resolve({ outcome: "message", data: Buffer.from(m as Buffer).toString() });
+        },
+      },
+    });
+
+    const sock = net.connect(server.port, "127.0.0.1");
+    let handshakeDone = false;
+    let buf = Buffer.alloc(0);
+
+    sock.on("error", err => {
+      if (handshakeDone) resolve({ outcome: "closed" });
+      else reject(err);
+    });
+    sock.on("data", chunk => {
+      if (handshakeDone) return;
+      buf = Buffer.concat([buf, chunk]);
+      if (buf.includes("\r\n\r\n")) {
+        handshakeDone = true;
+        sock.write(Buffer.concat(frames));
+      }
+    });
+    sock.on("close", () => {
+      if (handshakeDone) resolve({ outcome: "closed" });
+    });
+
+    sock.write(
+      "GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n" +
+        "Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n",
+    );
+
+    try {
+      return await promise;
+    } finally {
+      sock.destroy();
+    }
+  }
+
+  test("a new BINARY frame inside a fragmented BINARY message fails the connection", async () => {
+    expect(
+      await outcomeFor([maskedFrame(BINARY, Buffer.from("he"), false), maskedFrame(BINARY, Buffer.from("llo"), true)]),
+    ).toEqual({ outcome: "closed" });
+  });
+
+  test("a new TEXT frame inside a fragmented TEXT message fails the connection", async () => {
+    expect(
+      await outcomeFor([maskedFrame(TEXT, Buffer.from("he"), false), maskedFrame(TEXT, Buffer.from("llo"), true)]),
+    ).toEqual({ outcome: "closed" });
+  });
+
+  test("a new data frame after an interleaved control frame fails the connection", async () => {
+    expect(
+      await outcomeFor([
+        maskedFrame(BINARY, Buffer.from("he"), false),
+        maskedFrame(PING, Buffer.from("p"), true),
+        maskedFrame(BINARY, Buffer.from("llo"), true),
+      ]),
+    ).toEqual({ outcome: "closed" });
+  });
+
+  test("a fragmented message with a legitimately interleaved control frame is delivered", async () => {
+    expect(
+      await outcomeFor([
+        maskedFrame(BINARY, Buffer.from("he"), false),
+        maskedFrame(PING, Buffer.from("p"), true),
+        maskedFrame(CONT, Buffer.from("llo"), true),
+      ]),
+    ).toEqual({ outcome: "message", data: "hello" });
   });
 });


### PR DESCRIPTION
Fixes #33010

### What

`Bun.serve` accepted a new binary data frame sent inside a fragmented binary message, violating RFC 6455 §5.4. The frame's payload was appended to the in-progress message, so the handler received the concatenation of two frames that were never part of one message. The connection stayed open instead of failing.

RFC 6455 §5.4: after a data frame with `FIN=0`, only continuation frames (opcode 0) and control frames may arrive; a server must fail the connection otherwise. Only the TEXT case was enforced.

### Repro

```ts
import net from "node:net";

const server = Bun.serve({
  port: 0,
  fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", { status: 400 }); },
  websocket: { message(ws, m) { console.log("received:", Buffer.from(m).toString()); } },
});

function frame(opcode, payload, fin) {
  const mask = Buffer.from([1, 2, 3, 4]);
  const masked = Buffer.from(payload.map((b, i) => b ^ mask[i % 4]));
  return Buffer.concat([Buffer.from([(fin ? 0x80 : 0) | opcode, 0x80 | payload.length]), mask, masked]);
}

const sock = net.connect(server.port, "127.0.0.1");
await new Promise(r => { let b = Buffer.alloc(0); sock.on("data", c => { b = Buffer.concat([b, c]); if (b.includes("\r\n\r\n")) r(); }); sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n"); });
// fragmented binary start (FIN=0), then a NEW binary frame (not a continuation)
sock.write(Buffer.concat([frame(0x2, Buffer.from("he"), false), frame(0x2, Buffer.from("llo"), true)]));
```

Before: `message()` receives `"hello"` and the connection stays open.
After: no message, the server fails the connection.

### Cause

`packages/bun-uws/src/WebSocketProtocol.h`, `consumeMessage()`:

```cpp
if (wState->state.opStack == 1 || (!wState->state.lastFin && getOpCode(src) < 2)) {
```

`getOpCode(src) < 2` only matches TEXT (opcode 1), so a BINARY frame (opcode 2) slipped through. A second, related gap: an interleaved control frame (e.g. a `FIN=1` PING) runs `lastFin = isFin(src)` and resets `lastFin` to `true`, so a new data frame after it also passed the `!lastFin` guard. That variant affected TEXT too.

### Fix

Gate the rejection on `opStack` (a data message is still open) rather than `lastFin`, which control frames overwrite. `opStack != -1` at the start of `consumeMessage()` means a fragmented data message is in progress, which is exactly when a new text/binary frame (`opcode < 3`) must fail the connection. Control frames (`opcode >= 8`) are unaffected and still interleave normally, pushing and popping `opStack` net-zero.

```cpp
if (wState->state.opStack == 1 || (getOpCode(src) < 3 && wState->state.opStack != -1)) {
```

This is strictly equivalent to the old condition except in the control-frame-interleaved case, which it now also fixes: `lastFin` is false only after a data frame with `FIN=0`, which also leaves `opStack != -1`, so the only behavioral change is closing the two holes above.

### Verification

`test/js/web/websocket/websocket-pong-fragmented.test.ts` gains four server-side cases driven by a raw client:

- a new BINARY frame inside a fragmented BINARY message fails the connection (the report)
- a new TEXT frame inside a fragmented TEXT message fails the connection (already worked; guards it)
- a new data frame after an interleaved control frame fails the connection (the control-frame hole)
- a fragmented message with a legitimately interleaved control frame is still delivered (negative contract)

The first and third fail on the released binary and on `main` and pass with this change; the existing client-side fragmentation/streaming tests in the same file still pass.

Not a regression: `getOpCode(src) < 2` has been in the parser since the uWS fork (#4372, 2023).