### PR TITLE
strings: don't abort on UTF-8 to UTF-16 output buffer allocation failure

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1482,7 +1482,8 @@ impl EString {
         } else {
             // PERF: transcodes to a heap Vec then copies into the bump
             // arena — profile.
-            let utf16 = strings::to_utf16_alloc_for_real(utf8, false, false).expect("unreachable"); // fail_if_invalid=false → never errors
+            // `fail_if_invalid = false` means the only possible error is `OutOfMemory`.
+            let utf16 = bun_core::handle_oom(strings::to_utf16_alloc_for_real(utf8, false, false));
             let arena_slice: &mut [u16] = bump.alloc_slice_copy(&utf16);
             Self::init_utf16(arena_slice)
         }

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2855,7 +2855,9 @@ pub fn to_utf16_alloc_for_real(
         return Ok(v);
     }
     // All-ASCII path: widen each byte.
-    let mut out = Vec::with_capacity(bytes.len() + sentinel as usize);
+    let mut out: Vec<u16> = Vec::new();
+    out.try_reserve_exact(bytes.len() + sentinel as usize)
+        .map_err(|_| ToUTF16Error::OutOfMemory)?;
     out.extend(bytes.iter().map(|&b| u16::from(b)));
     if sentinel {
         out.push(0);
@@ -3069,8 +3071,10 @@ pub fn to_utf16_alloc(
     // spare capacity — avoids the redundant zero-fill of `vec![0u16; cap]`,
     // which for large source files (build/create-next benches) is a measurable
     // memset. `.max(1)` keeps the buffer pointer non-dangling so simdutf never
-    // sees `Vec::with_capacity(0)`'s `0x2` sentinel.
-    let mut out: Vec<u16> = Vec::with_capacity(cap.max(1));
+    // sees `Vec::new()`'s dangling `0x2` sentinel.
+    let mut out: Vec<u16> = Vec::new();
+    out.try_reserve_exact(cap.max(1))
+        .map_err(|_| ToUTF16Error::OutOfMemory)?;
     // SAFETY: `out` has ≥ `out_length` u16 of capacity (just reserved). simdutf
     // never reads from the output buffer and writes at most `out_length` code
     // units (the upper bound returned by `utf16_length_from_utf8`), so passing
@@ -3096,7 +3100,8 @@ pub fn to_utf16_alloc(
     }
     // Slow path: WTF-8 decode with replacement. `out` is still len 0 (we never
     // committed the failed fast-path write); reuse its capacity.
-    out.reserve(bytes.len() + if sentinel { 1 } else { 0 });
+    out.try_reserve(bytes.len() + if sentinel { 1 } else { 0 })
+        .map_err(|_| ToUTF16Error::OutOfMemory)?;
     let mut remaining = bytes;
     while let Some(i) = first_non_ascii(remaining) {
         let i = i as usize;

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -3035,7 +3035,8 @@ pub fn to_utf8_list_with_type(mut list: Vec<u8>, utf16: &[u16]) -> Result<Vec<u8
     Ok(list)
 }
 
-/// Errors from `to_utf16_alloc` when `fail_if_invalid = true`.
+/// Errors from `to_utf16_alloc`. `InvalidByteSequence` is only returned when
+/// `fail_if_invalid = true`; `OutOfMemory` can be returned by any call.
 ///
 /// Re-exported from `unicode_draft` so that `to_utf16_alloc_maybe_buffered`
 /// (defined there) and `to_utf16_alloc` (defined here) share a single error

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -719,7 +719,16 @@ pub fn to_utf16_alloc_maybe_buffered<const FAIL_IF_INVALID: bool, const FLUSH: b
                 break 'output Vec::new();
             }
 
-            let mut out = vec![0u16; out_length];
+            let mut out: Vec<u16> = Vec::new();
+            out.try_reserve_exact(out_length)
+                .map_err(|_| ToUTF16Error::OutOfMemory)?;
+            // SAFETY: `out_length` u16s were just reserved and `write_bytes`
+            // zero-fills all of them before `set_len` exposes them. `write_bytes`
+            // is a memset; `Vec::resize`/`fill` are scalar loops in debug builds.
+            unsafe {
+                core::ptr::write_bytes(out.as_mut_ptr(), 0, out_length);
+                out.set_len(out_length);
+            }
 
             let res = simdutf::convert::utf8::to::utf16::with_errors::le(bytes, &mut out);
             if res.status == simdutf::Status::SUCCESS {
@@ -732,7 +741,7 @@ pub fn to_utf16_alloc_maybe_buffered<const FAIL_IF_INVALID: bool, const FLUSH: b
                 return Ok(Some((out, [0; 3], 0)));
             }
 
-            // `out` was `vec![0u16; out_length]`; `first_non_ascii_idx <= out.len()`.
+            // `out.len() == out_length`; `first_non_ascii_idx <= out.len()`.
             out.truncate(first_non_ascii_idx);
             break 'output out;
         }

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -756,12 +756,17 @@ pub fn to_utf16_alloc_maybe_buffered<const FAIL_IF_INVALID: bool, const FLUSH: b
         0
     };
     let mut remaining = &bytes[start..];
+    // The replacement decode emits at most one code unit per consumed byte, so
+    // `remaining.len()` bounds the tail's growth (the bound `to_utf16_alloc`'s
+    // slow path reserves too); the appends below stay inside this reservation.
+    output
+        .try_reserve(remaining.len())
+        .map_err(|_| ToUTF16Error::OutOfMemory)?;
 
     let mut non_ascii: Option<u32> = Some(0);
     while let Some(i) = non_ascii {
         let i = i as usize;
         {
-            output.reserve(i + 2); // +2 for UTF16 codepoint
             append_u8_as_u16(&mut output, &remaining[..i]);
             remaining = &remaining[i..];
         }
@@ -814,8 +819,6 @@ pub fn to_utf16_alloc_maybe_buffered<const FAIL_IF_INVALID: bool, const FLUSH: b
     }
 
     if !remaining.is_empty() {
-        let need = output.len() + remaining.len();
-        output.reserve_exact(need.saturating_sub(output.len()));
         append_u8_as_u16(&mut output, remaining);
     }
 

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -722,16 +722,20 @@ pub fn to_utf16_alloc_maybe_buffered<const FAIL_IF_INVALID: bool, const FLUSH: b
             let mut out: Vec<u16> = Vec::new();
             out.try_reserve_exact(out_length)
                 .map_err(|_| ToUTF16Error::OutOfMemory)?;
-            // SAFETY: `out_length` u16s were just reserved and `write_bytes`
-            // zero-fills all of them before `set_len` exposes them. `write_bytes`
-            // is a memset; `Vec::resize`/`fill` are scalar loops in debug builds.
-            unsafe {
-                core::ptr::write_bytes(out.as_mut_ptr(), 0, out_length);
-                out.set_len(out_length);
-            }
-
-            let res = simdutf::convert::utf8::to::utf16::with_errors::le(bytes, &mut out);
-            if res.status == simdutf::Status::SUCCESS {
+            // SAFETY: `out` has >= `out_length` u16 of capacity (just reserved).
+            // simdutf never reads the output buffer and writes at most
+            // `out_length` code units, so passing uninitialised storage is
+            // sound; the length is only ever set to what simdutf has written.
+            let res = unsafe {
+                simdutf::simdutf__convert_utf8_to_utf16le_with_errors(
+                    bytes.as_ptr(),
+                    bytes.len(),
+                    out.as_mut_ptr(),
+                )
+            };
+            if res.is_successful() {
+                // SAFETY: on success simdutf initialised exactly `out_length` units.
+                unsafe { out.set_len(out_length) };
                 crate::scoped_log!(
                     strings,
                     "toUTF16 {} UTF8 -> {} UTF16",
@@ -741,8 +745,11 @@ pub fn to_utf16_alloc_maybe_buffered<const FAIL_IF_INVALID: bool, const FLUSH: b
                 return Ok(Some((out, [0; 3], 0)));
             }
 
-            // `out.len() == out_length`; `first_non_ascii_idx <= out.len()`.
-            out.truncate(first_non_ascii_idx);
+            // SAFETY: simdutf converts sequentially and the first error is at or
+            // after the first non-ASCII byte, so the leading `first_non_ascii_idx`
+            // code units (one per ASCII prefix byte, `<= out_length`) are
+            // initialised; keep exactly those.
+            unsafe { out.set_len(first_non_ascii_idx) };
             break 'output out;
         }
     } else {

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -443,8 +443,12 @@ impl<const SSL: bool> WebSocket<SSL> {
                 // we avoid trim since we wanna keep the utf8 validation intact
                 let utf16_bytes = match strings::to_utf16_alloc(data, true, false) {
                     Ok(v) => v,
-                    Err(_) => {
+                    Err(strings::ToUTF16Error::InvalidByteSequence) => {
                         self.terminate(ErrorCode::InvalidUtf8);
+                        return;
+                    }
+                    Err(strings::ToUTF16Error::OutOfMemory) => {
+                        self.terminate(ErrorCode::FailedToAllocateMemory);
                         return;
                     }
                 };

--- a/src/jsc/bun_string_jsc.rs
+++ b/src/jsc/bun_string_jsc.rs
@@ -169,8 +169,8 @@ fn slice_with_underlying_string_to_js_with_options(
         // `ZigStringSlice` encodes ownership in the variant:
         // `Owned`/`WTF` ⇒ allocated, `Static` ⇒ borrowed.
         if this.utf8.is_allocated() {
-            if let Some(utf16) =
-                strings::to_utf16_alloc(this.utf8.slice(), false, false).unwrap_or(None)
+            if let Some(utf16) = strings::to_utf16_alloc(this.utf8.slice(), false, false)
+                .map_err(|_| global_object.throw_out_of_memory())?
             {
                 // Drop the now-unused utf8 allocation.
                 this.utf8 = ZigStringSlice::default();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2744,9 +2744,17 @@ impl BlobExt for Blob {
 
         if could_be_all_ascii.is_none() || !could_be_all_ascii.unwrap() {
             // if to_utf16_alloc returns None, it means there are no non-ASCII characters
-            if let Some(external) = strings::to_utf16_alloc(buf, false, false)
-                .map_err(|_| global.throw_out_of_memory())?
-            {
+            let converted = match strings::to_utf16_alloc(buf, false, false) {
+                Ok(converted) => converted,
+                Err(_) => {
+                    if LIFETIME == Lifetime::Temporary {
+                        // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
+                        unsafe { drop(bun_core::heap::take(raw_bytes)) };
+                    }
+                    return Err(global.throw_out_of_memory());
+                }
+            };
+            if let Some(external) = converted {
                 if LIFETIME != Lifetime::Temporary {
                     self.set_is_ascii_flag(false);
                 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2982,7 +2982,9 @@ impl BlobExt for Blob {
         let _free = (LIFETIME == Lifetime::Temporary).then(|| TemporaryBytes(raw_bytes));
 
         if could_be_all_ascii.is_none() || !could_be_all_ascii.unwrap() {
-            if let Some(external) = strings::to_utf16_alloc(buf, false, false).ok().flatten() {
+            if let Some(external) = strings::to_utf16_alloc(buf, false, false)
+                .map_err(|_| global.throw_out_of_memory())?
+            {
                 if LIFETIME != Lifetime::Temporary {
                     self.set_is_ascii_flag(false);
                 }
@@ -6858,8 +6860,8 @@ impl Internal {
 
     pub fn to_string_owned(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         let bytes_without_bom = strings::without_utf8_bom(&self.bytes);
-        if let Some(out) =
-            strings::to_utf16_alloc(bytes_without_bom, false, false).unwrap_or(Some(Vec::new()))
+        if let Some(out) = strings::to_utf16_alloc(bytes_without_bom, false, false)
+            .map_err(|_| global_this.throw_out_of_memory())?
         {
             let out_len = out.len();
             // Ownership transfers to JSC's external-string finalizer.

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -1,7 +1,8 @@
 import { memfd_create, setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { closeSync, readFileSync, writeSync } from "fs";
-import { isLinux, isPosix } from "harness";
+import { closeSync, readFileSync, writeFileSync, writeSync } from "fs";
+import { bunEnv, bunExe, isASAN, isLinux, isPosix, tempDir } from "harness";
+import { join } from "path";
 setSyntheticAllocationLimitForTesting(128 * 1024 * 1024);
 
 // /dev/zero reports a size of 0. So we need a separate test for reDgular files that are huge.
@@ -46,3 +47,68 @@ if (isLinux) {
     });
   });
 }
+
+// The UTF-8 -> UTF-16 converters behind `fs.readFile*(.., "utf8")`,
+// `Buffer.prototype.toString("utf8")` and `TextDecoder.decode` size their
+// output buffer from a `simdutf` length query. That allocation must fail as a
+// catchable error, not abort the process, when it cannot be satisfied
+// (observed in the wild as a `capacity overflow` panic from an oversized
+// length). Reproduce the failure deterministically with ASAN's per-allocation
+// cap: the 32 MiB input fits under the 48 MiB limit, but the ~64 MiB UTF-16
+// output does not, so exactly that allocation returns null.
+describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catchable", () => {
+  test("readFileSync, readFile, Buffer.toString and TextDecoder recover", async () => {
+    const SIZE = 32 * 1024 * 1024;
+    using dir = tempDir("utf16-alloc-oom", {});
+    const file = join(String(dir), "big-utf8.txt");
+    // Valid UTF-8 whose first character is non-ASCII ('\u00e9' = C3 A9), so the
+    // decoder must build a (SIZE - 1)-code-unit UTF-16 buffer (~2x SIZE bytes).
+    const payload = Buffer.alloc(SIZE, "a");
+    payload[0] = 0xc3;
+    payload[1] = 0xa9;
+    writeFileSync(file, payload);
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const fs = require("fs");
+        const file = ${JSON.stringify(file)};
+        const results = [];
+        const report = e => ({ name: e.name, code: e.code });
+        try { fs.readFileSync(file, "utf8"); results.push("SYNC_UNEXPECTED_SUCCESS"); }
+        catch (e) { results.push(report(e)); }
+        await fs.promises.readFile(file, "utf8").then(
+          () => results.push("ASYNC_UNEXPECTED_SUCCESS"),
+          e => results.push(report(e)),
+        );
+        const big = Buffer.alloc(${SIZE}, "a"); big[0] = 0xc3; big[1] = 0xa9;
+        try { big.toString("utf8"); results.push("TOSTRING_UNEXPECTED_SUCCESS"); }
+        catch (e) { results.push(report(e)); }
+        try { new TextDecoder().decode(big); results.push("DECODE_UNEXPECTED_SUCCESS"); }
+        catch (e) { results.push(report(e)); }
+        console.log(JSON.stringify(results));
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1", "max_allocation_size_mb=48"]
+          .filter(Boolean)
+          .join(":"),
+      },
+      stdout: "pipe",
+      // ASAN prints a benign "failed to allocate" WARNING line per recovered
+      // failure; drain it but do not assert on it.
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
+      { name: "Error", code: "ENOMEM" },
+      { name: "Error", code: "ENOMEM" },
+      { name: "Error", code: "ERR_STRING_TOO_LONG" },
+      { name: "RangeError", code: undefined },
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -61,12 +61,15 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
   const SIZE = 32 * 1024 * 1024;
   const env = {
     ...bunEnv,
-    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1", "max_allocation_size_mb=48"]
+    // `detect_leaks=0` (last wins): natives owned only by a JSC cell
+    // (TextDecoder, Blob) are invisible to LeakSanitizer's reachability scan
+    // and get reported at exit, independently of what these children test.
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1", "max_allocation_size_mb=48", "detect_leaks=0"]
       .filter(Boolean)
       .join(":"),
   };
 
-  test("readFileSync, readFile, Buffer.toString and TextDecoder recover", async () => {
+  test("readFileSync, readFile, Bun.file, Buffer.toString and TextDecoder recover", async () => {
     using dir = tempDir("utf16-alloc-oom", {});
     const file = join(String(dir), "big-utf8.txt");
     // Valid UTF-8 whose first character is non-ASCII ('\u00e9' = C3 A9), so the
@@ -91,10 +94,18 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
           () => results.push("ASYNC_UNEXPECTED_SUCCESS"),
           e => results.push(report(e)),
         );
+        // Lifetime::Temporary: the callee owns the leaked file-read buffer and
+        // must reclaim it on the error path too (CI's ASAN lane runs with
+        // detect_leaks=1:abort_on_error=1, so a leak here fails the exit code).
+        await Bun.file(file).text().then(
+          () => results.push("BUNFILE_UNEXPECTED_SUCCESS"),
+          e => results.push(report(e)),
+        );
         const big = Buffer.alloc(${SIZE}, "a"); big[0] = 0xc3; big[1] = 0xa9;
+        const decoder = new TextDecoder();
         try { big.toString("utf8"); results.push("TOSTRING_UNEXPECTED_SUCCESS"); }
         catch (e) { results.push(report(e)); }
-        try { new TextDecoder().decode(big); results.push("DECODE_UNEXPECTED_SUCCESS"); }
+        try { decoder.decode(big); results.push("DECODE_UNEXPECTED_SUCCESS"); }
         catch (e) { results.push(report(e)); }
         // Slow (WTF-8 replacement) path: the simdutf length query counts ~0
         // code units for a continuation-byte flood, so the output buffer is
@@ -102,7 +113,7 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
         const cont = Buffer.alloc(${SIZE}, 0x80);
         try { cont.toString("utf8"); results.push("TOSTRING_SLOW_UNEXPECTED_SUCCESS"); }
         catch (e) { results.push(report(e)); }
-        try { new TextDecoder().decode(cont); results.push("DECODE_SLOW_UNEXPECTED_SUCCESS"); }
+        try { decoder.decode(cont); results.push("DECODE_SLOW_UNEXPECTED_SUCCESS"); }
         catch (e) { results.push(report(e)); }
         console.log(JSON.stringify(results));
         `,
@@ -117,6 +128,7 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
     expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
       { name: "Error", code: "ENOMEM" },
       { name: "Error", code: "ENOMEM" },
+      { name: "RangeError", code: undefined },
       { name: "Error", code: "ERR_STRING_TOO_LONG" },
       { name: "RangeError", code: undefined },
       { name: "Error", code: "ERR_STRING_TOO_LONG" },

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -58,8 +58,15 @@ if (isLinux) {
 // per-codepoint replacement slow path (a flood of 0x80 continuation bytes,
 // for which the simdutf length query predicts ~0 code units).
 describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catchable", () => {
+  const SIZE = 32 * 1024 * 1024;
+  const env = {
+    ...bunEnv,
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1", "max_allocation_size_mb=48"]
+      .filter(Boolean)
+      .join(":"),
+  };
+
   test("readFileSync, readFile, Buffer.toString and TextDecoder recover", async () => {
-    const SIZE = 32 * 1024 * 1024;
     using dir = tempDir("utf16-alloc-oom", {});
     const file = join(String(dir), "big-utf8.txt");
     // Valid UTF-8 whose first character is non-ASCII ('\u00e9' = C3 A9), so the
@@ -100,12 +107,7 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
         console.log(JSON.stringify(results));
         `,
       ],
-      env: {
-        ...bunEnv,
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1", "max_allocation_size_mb=48"]
-          .filter(Boolean)
-          .join(":"),
-      },
+      env,
       stdout: "pipe",
       // ASAN prints a benign "failed to allocate" WARNING line per recovered
       // failure; drain it but do not assert on it.
@@ -119,6 +121,46 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
       { name: "RangeError", code: undefined },
       { name: "Error", code: "ERR_STRING_TOO_LONG" },
       { name: "RangeError", code: undefined },
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  // Three more callers of `to_utf16_alloc(.., fail_if_invalid = false, ..)`
+  // were written as if that call could never error (before the fix it could
+  // only abort), so they collapsed `Err` into their all-ASCII fallback. Once
+  // the allocation is fallible, `Response.text()` on an `Internal` blob must
+  // throw rather than return an empty string, and a store-backed
+  // `Blob.json()` must throw rather than reinterpret the UTF-8 bytes as
+  // Latin-1. `Blob.text()` is the sibling that was already correct.
+  test("Response.text, Blob.text and Blob.json recover", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const results = [];
+        const buf = Buffer.alloc(${SIZE}, "a"); buf[0] = 0xc3; buf[1] = 0xa9;
+        // '"' + '\\u00e9' + 'a'.repeat(${SIZE} - 4) + '"': a valid JSON string literal.
+        const json = Buffer.alloc(${SIZE}, "a");
+        json[0] = 0x22; json[1] = 0xc3; json[2] = 0xa9; json[${SIZE} - 1] = 0x22;
+        for (const run of [() => new Response(buf).text(), () => new Blob([buf]).text(), () => new Blob([json]).json()]) {
+          await run().then(
+            v => results.push("UNEXPECTED_SUCCESS length=" + JSON.stringify(v).length),
+            e => results.push({ name: e.name, message: e.message }),
+          );
+        }
+        console.log(JSON.stringify(results));
+        `,
+      ],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
+      { name: "RangeError", message: "Out of memory" },
+      { name: "RangeError", message: "Out of memory" },
+      { name: "RangeError", message: "Out of memory" },
     ]);
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -94,9 +94,9 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
           () => results.push("ASYNC_UNEXPECTED_SUCCESS"),
           e => results.push(report(e)),
         );
-        // Lifetime::Temporary: the callee owns the leaked file-read buffer and
-        // must reclaim it on the error path too (CI's ASAN lane runs with
-        // detect_leaks=1:abort_on_error=1, so a leak here fails the exit code).
+        // Bun.file().text() reaches the converter through
+        // Blob::to_string_with_bytes with Lifetime::Temporary, the one caller
+        // that also owns its input buffer across the failing allocation.
         await Bun.file(file).text().then(
           () => results.push("BUNFILE_UNEXPECTED_SUCCESS"),
           e => results.push(report(e)),

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -49,13 +49,14 @@ if (isLinux) {
 }
 
 // The UTF-8 -> UTF-16 converters behind `fs.readFile*(.., "utf8")`,
-// `Buffer.prototype.toString("utf8")` and `TextDecoder.decode` size their
-// output buffer from a `simdutf` length query. That allocation must fail as a
-// catchable error, not abort the process, when it cannot be satisfied
+// `Buffer.prototype.toString("utf8")` and `TextDecoder.decode` must surface a
+// failed output-buffer allocation as a catchable error, never a process abort
 // (observed in the wild as a `capacity overflow` panic from an oversized
-// length). Reproduce the failure deterministically with ASAN's per-allocation
-// cap: the 32 MiB input fits under the 48 MiB limit, but the ~64 MiB UTF-16
-// output does not, so exactly that allocation returns null.
+// length). ASAN's per-allocation cap makes the failure deterministic: every
+// 32 MiB input fits under the 48 MiB cap while its ~64 MiB UTF-16 output does
+// not, on both the simdutf fast path ('\u00e9' followed by ASCII) and the
+// per-codepoint replacement slow path (a flood of 0x80 continuation bytes,
+// for which the simdutf length query predicts ~0 code units).
 describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catchable", () => {
   test("readFileSync, readFile, Buffer.toString and TextDecoder recover", async () => {
     const SIZE = 32 * 1024 * 1024;
@@ -88,6 +89,14 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
         catch (e) { results.push(report(e)); }
         try { new TextDecoder().decode(big); results.push("DECODE_UNEXPECTED_SUCCESS"); }
         catch (e) { results.push(report(e)); }
+        // Slow (WTF-8 replacement) path: the simdutf length query counts ~0
+        // code units for a continuation-byte flood, so the output buffer is
+        // sized by the replacement decoder instead of the fast path.
+        const cont = Buffer.alloc(${SIZE}, 0x80);
+        try { cont.toString("utf8"); results.push("TOSTRING_SLOW_UNEXPECTED_SUCCESS"); }
+        catch (e) { results.push(report(e)); }
+        try { new TextDecoder().decode(cont); results.push("DECODE_SLOW_UNEXPECTED_SUCCESS"); }
+        catch (e) { results.push(report(e)); }
         console.log(JSON.stringify(results));
         `,
       ],
@@ -106,6 +115,8 @@ describe.skipIf(!isASAN)("utf8 to utf16 output buffer allocation failure is catc
     expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
       { name: "Error", code: "ENOMEM" },
       { name: "Error", code: "ENOMEM" },
+      { name: "Error", code: "ERR_STRING_TOO_LONG" },
+      { name: "RangeError", code: undefined },
       { name: "Error", code: "ERR_STRING_TOO_LONG" },
       { name: "RangeError", code: undefined },
     ]);


### PR DESCRIPTION
Fixes a process abort reported by the crash reporter as a Rust panic with the message `capacity overflow`, raised from `Vec::<u16>::with_capacity` inside `bun_core::string::immutable::to_utf16_alloc` (`src/bun_core/string/immutable.rs:3073`). 16 events so far (Sentry BUN-3QQ6), all Windows x64, reached from three entry points:

- `NodeFS::read_file` on the async work pool (`fs.readFile(path, "utf8")`)
- the synchronous `fs.readFileSync(path, "utf8")` host function
- `Bun__encoding__toString` (`Buffer.prototype.toString("utf8")`, `StringDecoder`)

### Cause

`to_utf16_alloc` sizes its UTF-16 output buffer with `Vec::with_capacity(cap)`, where `cap` comes from `simdutf::utf16_length_from_utf8` over the input bytes. `Vec::with_capacity` panics with `capacity overflow` when `cap * 2 > isize::MAX` and aborts the process on allocation failure. Neither is catchable.

The function already returns `Result<_, ToUTF16Error>`, and `ToUTF16Error::OutOfMemory` exists but was unreachable because the allocation panicked or aborted instead of returning it. The pre-port Zig (`src/string/immutable/unicode.zig` at bun-v1.3.14) used `try allocator.alloc(u16, out_length + ..)`, so an unsatisfiable size surfaced as `error.OutOfMemory` there; the Rust port regressed this.

Why `cap` reaches `2^62` in the wild is an open question I was not able to close from the crash data. `simdutf::utf16_length_from_utf8(ptr, len)` is bounded by `2 * len` and has to scan the whole input to produce a count, and on the crashing `read_file_with_options` frame the input slice is the pre-stat read buffer, at most 256 KiB. So a `2^62` count cannot come from a well-formed slice. I checked the FFI declaration (`src/simdutf_sys/simdutf.rs`), the C++ shim (`src/simdutf_sys/bun-simdutf.cpp`), and the vendored simdutf 8.2.0 kernels for `utf16_length_from_utf8`; all are correct. Whatever the upstream corruption is, an unrecoverable abort is the wrong response to it, and making the allocation fallible is correct independently: it also fixes genuine allocation failure, which is reachable and is what the test covers.

### Fix

Replace the panicking allocations in the UTF-8 to UTF-16 converters with `try_reserve_exact` / `try_reserve` mapped to `ToUTF16Error::OutOfMemory`, mirroring the fallible pattern the neighboring `to_utf8_alloc` in the same file already uses:

- `to_utf16_alloc` (`src/bun_core/string/immutable.rs`): the fast-path `Vec::with_capacity(cap.max(1))` (the crash site) and the slow-path `out.reserve(..)`.
- `to_utf16_alloc_for_real` (same file): the all-ASCII widening path.
- `to_utf16_alloc_maybe_buffered` (`src/bun_core/string/immutable/unicode.rs`): the `TextDecoder` variant, which shares the same `ToUTF16Error` contract and had the same bug twice.
  - Fast path: `vec![0u16; out_length]` is now a fallible reservation with no zero-fill at all (per review). simdutf converts into the uninitialised spare capacity, the same shape as `to_utf16_alloc`, and the committed length is only ever what simdutf wrote: all of `out_length` on success, and on invalid input the all-ASCII prefix before the first error, which simdutf always writes since it converts sequentially (the previous zero-filled code already depended on that to avoid emitting NULs). This also removes a full-buffer memset from every `TextDecoder.decode`.
  - Slow (WTF-8 replacement) path, flagged in review: the loop grew `output` through panicking `reserve` calls. This matters more than it looks: for a continuation-byte flood the simdutf length query predicts about zero code units, so the fast-path reservation is tiny and the real (up to 2x input) allocation happened incrementally inside the loop. One up-front `try_reserve(remaining.len())` covers the decoder's output bound (at most one code unit per consumed byte, the same bound `to_utf16_alloc`'s slow path already reserves) and supersedes the two per-iteration / tail reserves, which are removed.

Making `to_utf16_alloc(.., fail_if_invalid = false, ..)` fallible activates `Err` arms in callers that were written when that combination could never error. Review caught four problems there: three callers collapsed `Err` into their all-ASCII fallback (silent corruption instead of the intended error), and one dropped an owned buffer across the newly reachable early return. The first three now throw out-of-memory:

- `Blob::Internal::to_string_owned` (`src/runtime/webcore/Blob.rs`), reached by `Response.text()` on a buffered body: `.unwrap_or(Some(Vec::new()))` returned an empty string.
- `Blob::to_json_with_bytes` (same file), reached by `Blob.json()` on a store-backed blob: `.ok().flatten()` fell through to `set_is_ascii_flag(true)` and a Latin-1 reinterpretation of the UTF-8 bytes.
- `slice_with_underlying_string_to_js` (`src/jsc/bun_string_jsc.rs`): `.unwrap_or(None)` fell through to the Latin-1 external-string path.
- `Blob::to_string_with_bytes` (same file as the first two): its `.map_err(|_| global.throw_out_of_memory())?` already produced the right error, but with `Lifetime::Temporary` (a `Bun.file(path).text()` read) `raw_bytes` is a leaked `Box<[u8]>` the callee must reclaim, and no guard is in scope at that point, so the early return leaked the whole file-read buffer. The error arm now reclaims it exactly like the function's other `Temporary` exits.
- `EString::init_re_encode_utf8` (`src/ast/e.rs`): its `.expect("unreachable")` is now reachable on allocation failure; it routes through `bun_core::handle_oom`, the repo's controlled-crash path for parser allocation failure.
- `websocket_client.rs`: the incoming-text-frame decoder's catch-all `Err(_) => terminate(ErrorCode::InvalidUtf8)` (`fail_if_invalid = true`, the only such caller) would have reported an allocation failure to the JS `close` handler as code 1007, `Server sent invalid UTF8`. It now matches the variants and uses `ErrorCode::FailedToAllocateMemory`, the code the deflate out-of-memory arm in the same function already uses. This is the one caller change without an end-to-end test: I did not find a way to make only the UTF-16 output allocation fail under the per-allocation cap without also putting the frame's receive buffering at risk on the same cap, so it mirrors the adjacent arm by inspection. The connection terminates on the error either way; only the reported close code changes.

The remaining callers already propagate the error (`to_bun_string*` in `encoding.rs`, `expr_jsc.rs`, `dupe_for_js`, the Windows metadata path). Intentionally excluded: the other `Vec::with_capacity` sites in `immutable.rs` (`cat`, `join`, `concat_alloc_t`, `append`); their sizes are sums of the lengths of slices that already exist in memory, so they cannot overflow, and their only out-of-file caller unwraps the result.

### Verification

The capacity-overflow value itself is not constructible from a real byte slice (see the bound above), so the tests exercise the other half of the same `try_reserve*` error path: a real allocation failure, made deterministic with ASAN's per-allocation cap (`ASAN_OPTIONS=allocator_may_return_null=1:max_allocation_size_mb=48`). Every 32 MiB input fits under the cap; its ~64 MiB UTF-16 output buffer does not, so exactly that allocation returns null. Both tests are under `describe.skipIf(!isASAN)` so only sanitizer builds run them.

Without any of the `src/` changes, the first spawned child aborts:

```
==24147==WARNING: AddressSanitizer failed to allocate 0x3fffffe bytes
memory allocation of 67108862 bytes failed
```

With them, both children exit 0 and every case throws a catchable error:

| case | path exercised | error |
| --- | --- | --- |
| `fs.readFileSync(file, "utf8")` | `to_utf16_alloc` fast path | `Error`, code `ENOMEM` |
| `fs.promises.readFile(file, "utf8")` | `to_utf16_alloc` fast path (work pool) | `Error`, code `ENOMEM` |
| `big.toString("utf8")` | `to_utf16_alloc` fast path | `Error`, code `ERR_STRING_TOO_LONG` |
| `new TextDecoder().decode(big)` | `to_utf16_alloc_maybe_buffered` fast path | `RangeError: Out of memory` |
| `cont.toString("utf8")` (0x80 flood) | `to_utf16_alloc` slow path | `Error`, code `ERR_STRING_TOO_LONG` |
| `new TextDecoder().decode(cont)` (0x80 flood) | `to_utf16_alloc_maybe_buffered` slow path | `RangeError: Out of memory` |
| `Bun.file(file).text()` | `to_string_with_bytes`, `Lifetime::Temporary` | `RangeError: Out of memory` |
| `new Response(buf).text()` | `Internal::to_string_owned` | `RangeError: Out of memory` |
| `new Blob([buf]).text()` | `to_string_with_bytes`, store-backed | `RangeError: Out of memory` |
| `new Blob([json]).json()` | `to_json_with_bytes` | `RangeError: Out of memory` |

The children also set `detect_leaks=0`: a native owned only by a JSC cell (a `TextDecoder` or `Blob` wrapper's `Box`) is invisible to LeakSanitizer's reachability scan and gets reported at exit regardless of what the child is testing. The `Lifetime::Temporary` reclaim was still verified with LeakSanitizer directly: running the first child with `detect_leaks=1` against this branch reports no 33554432-byte object, and the only reports are those pre-existing JSC-owned natives.

Each allocation-site case was individually confirmed to abort the process on an unfixed build under the same cap. The `Response.text()` / `Blob.json()` caller fixes are each load-bearing: with only them reverted, `Response.text()` returns `""` and `Blob.json()` returns the one-code-unit-longer mojibake string, and the second test reports both:

```
-   { "message": "Out of memory", "name": "RangeError" },
+   "UNEXPECTED_SUCCESS length=2",
    { "message": "Out of memory", "name": "RangeError" },
+   "UNEXPECTED_SUCCESS length=33554432",
```

`bun bd test test/js/node/fs/fs-oom.test.ts` passes (13/13) and fails with the `src/` changes stashed. `text-decoder.test.js`, `text-decoder-stream.test.ts`, `text-decoder-cjk.test.ts`, `text-decoder-wpt.test.ts`, `text-decoder-single-byte.test.ts`, `encode-bad-chunks.test.ts`, `buffer-utf16.test.ts`, `string-decoder.test.js` (2458 tests), `buffer.test.js`, and `blob.test.ts`, `blob-oom.test.ts`, `blob-cow.test.ts`, `blob-array-fast-path.test.ts`, `body.test.ts`, `body-mixin-errors.test.ts`, `response.test.ts`, `bun-file.test.ts` (422 tests) all still pass.



