### PR TITLE
fix(windows): segfault in uv__wake_all_loops after system resume

### DIFF
--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -151,6 +151,21 @@ void us_loop_pump(struct us_loop_t *loop) {
   uv_run(loop->uv_loop, UV_RUN_NOWAIT);
 }
 
+/* Same semantics as the deprecated uv_loop_new(): NULL on failure. Allocated
+ * with our own malloc so us_loop_free can pair it with free(); uv_loop_new()
+ * uses libuv's replaceable allocator, which Bun swaps out for mimalloc. */
+static uv_loop_t *create_uv_loop(void) {
+  uv_loop_t *uv_loop = (uv_loop_t *)malloc(sizeof(uv_loop_t));
+  if (!uv_loop) {
+    return 0;
+  }
+  if (uv_loop_init(uv_loop)) {
+    free(uv_loop);
+    return 0;
+  }
+  return uv_loop;
+}
+
 struct us_loop_t *us_create_loop(void *hint,
                                  void (*wakeup_cb)(struct us_loop_t *loop),
                                  void (*pre_cb)(struct us_loop_t *loop),
@@ -159,7 +174,7 @@ struct us_loop_t *us_create_loop(void *hint,
   struct us_loop_t *loop =
       (struct us_loop_t *)calloc(1, sizeof(struct us_loop_t) + ext_size);
 
-  loop->uv_loop = hint ? hint : uv_loop_new();
+  loop->uv_loop = hint ? hint : create_uv_loop();
   loop->is_default = hint != 0;
 
   loop->uv_pre = malloc(sizeof(uv_prepare_t));
@@ -203,8 +218,20 @@ void us_loop_free(struct us_loop_t *loop) {
   // we need to run the loop one last round to call all close callbacks
   // we cannot do this if we do not own the loop, default
   if (!loop->is_default) {
-    uv_run(loop->uv_loop, UV_RUN_NOWAIT);
-    uv_loop_delete(loop->uv_loop);
+    uv_loop_t *uv_loop = loop->uv_loop;
+    /* Closing handles only retire from inside uv_run, and one turn is not
+     * enough when an endgame waits on an in-flight IOCP completion. Bounded so
+     * a handle that can never retire cannot hang teardown. */
+    int spins = 16;
+    do {
+      uv_run(uv_loop, UV_RUN_NOWAIT);
+    } while (uv_loop_alive(uv_loop) && --spins > 0);
+    /* uv_loop_close() succeeding is what removes the loop from libuv's global
+     * uv__loops[] registry, walked by uv__wake_all_loops() on Windows resume.
+     * Never free a loop it refused (UV_EBUSY); leaking it is strictly safer. */
+    if (uv_loop_close(uv_loop) == 0) {
+      free(uv_loop);
+    }
   }
 
   // now we can free our part

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -200,6 +200,16 @@ struct us_loop_t *us_create_loop(void *hint,
   return loop;
 }
 
+/* uv_walk callback for us_loop_free: close every handle still registered on
+ * the loop. Their owners are gone by the time us_loop_free runs, so there is
+ * no close callback to invoke. uv_walk already skips libuv-internal handles. */
+static void close_walk_cb(uv_handle_t *handle, void *arg) {
+  (void)arg;
+  if (!uv_is_closing(handle)) {
+    uv_close(handle, 0);
+  }
+}
+
 // based on if this was default loop or not
 void us_loop_free(struct us_loop_t *loop) {
   // ref and close down prepare and check
@@ -219,19 +229,25 @@ void us_loop_free(struct us_loop_t *loop) {
   // we cannot do this if we do not own the loop, default
   if (!loop->is_default) {
     uv_loop_t *uv_loop = loop->uv_loop;
-    /* Closing handles only retire from inside uv_run, and one turn is not
-     * enough when an endgame waits on an in-flight IOCP completion. Bounded so
-     * a handle that can never retire cannot hang teardown. */
-    int spins = 16;
-    do {
-      uv_run(uv_loop, UV_RUN_NOWAIT);
-    } while (uv_loop_alive(uv_loop) && --spins > 0);
-    /* uv_loop_close() succeeding is what removes the loop from libuv's global
-     * uv__loops[] registry, walked by uv__wake_all_loops() on Windows resume.
-     * Never free a loop it refused (UV_EBUSY); leaking it is strictly safer. */
-    if (uv_loop_close(uv_loop) == 0) {
-      free(uv_loop);
+    /* A handle nothing ever closes would keep the loop registered in libuv
+     * forever; everything else is already closing and only needs uv_run. */
+    uv_walk(uv_loop, close_walk_cb, 0);
+    /* uv_run retires closing handles as their in-flight IOCP completions
+     * arrive; with every handle closed it drains to empty and returns 0. It
+     * returns nonzero only when uv_stop cut it short, so re-enter. */
+    while (uv_run(uv_loop, UV_RUN_DEFAULT)) {
     }
+    int close_rc = uv_loop_close(uv_loop);
+    /* The loop is empty here so the close cannot return UV_EBUSY. Succeeding
+     * is what removes the loop from libuv's global uv__loops[] registry,
+     * which uv__wake_all_loops() walks on every Windows suspend/resume. */
+#if ASSERT_ENABLED
+    if (close_rc != 0) {
+      BUN_PANIC("us_loop_free: uv_loop_close failed after draining the loop");
+    }
+#endif
+    (void)close_rc;
+    free(uv_loop);
   }
 
   // now we can free our part

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -437,15 +437,22 @@ impl Loop {
             }
             // SAFETY: `loop_` is the live per-thread loop initialized in `get()`.
             if let Some(err) = unsafe { uv_loop_close(loop_) }.raw_errno() {
-                // Only EBUSY means handles are
-                // still open; walk + close them, run once to flush close
-                // callbacks, then close again (must succeed). `uv_loop_close`
-                // documents no other failure code.
+                // Only EBUSY means handles are still open; walk + close them,
+                // drain, then close again. `uv_loop_close` documents no other
+                // failure code.
                 if err == (UV_EBUSY as c_int).unsigned_abs() as u16 {
                     unsafe { uv_walk(loop_, Some(close_walk_cb), ptr::null_mut()) };
-                    let _ = unsafe { uv_run(loop_, RunMode::Default) };
-                    // NOTE the call is unconditional — the close must run in
-                    // release builds too.
+                    // One uv_run is not enough: if `loop.stop_flag` is set the
+                    // body is skipped (only clearing the flag), and an endgame
+                    // gated on an in-flight IOCP completion needs extra turns.
+                    let mut spins = 16;
+                    // SAFETY: `loop_` is live; `uv_run` returns 0 once dead.
+                    while unsafe { uv_run(loop_, RunMode::Default) } != 0 && spins > 0 {
+                        spins -= 1;
+                    }
+                    // Unconditional (not debug-only): removing the loop from
+                    // libuv's global uv__loops[] registry is what makes it safe
+                    // to release the TLS storage when this thread exits.
                     let rc = unsafe { uv_loop_close(loop_) };
                     debug_assert_eq!(rc, ReturnCode::ZERO);
                 }

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -442,14 +442,11 @@ impl Loop {
                 // failure code.
                 if err == (UV_EBUSY as c_int).unsigned_abs() as u16 {
                     unsafe { uv_walk(loop_, Some(close_walk_cb), ptr::null_mut()) };
-                    // One uv_run is not enough: if `loop.stop_flag` is set the
-                    // body is skipped (only clearing the flag), and an endgame
-                    // gated on an in-flight IOCP completion needs extra turns.
-                    let mut spins = 16;
-                    // SAFETY: `loop_` is live; `uv_run` returns 0 once dead.
-                    while unsafe { uv_run(loop_, RunMode::Default) } != 0 && spins > 0 {
-                        spins -= 1;
-                    }
+                    // `uv_run(Default)` returns 0 once the loop is dead and
+                    // nonzero only when `uv_stop` cut it short, so re-enter;
+                    // with every handle closed above it must drain to empty.
+                    // SAFETY: `loop_` is the live per-thread loop.
+                    while unsafe { uv_run(loop_, RunMode::Default) } != 0 {}
                     // Unconditional (not debug-only): removing the loop from
                     // libuv's global uv__loops[] registry is what makes it safe
                     // to release the TLS storage when this thread exits.

--- a/test/js/bun/spawn/spawn-many-teardown.test.ts
+++ b/test/js/bun/spawn/spawn-many-teardown.test.ts
@@ -121,11 +121,7 @@ test.skipIf(!isWindows)(
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     if (exitCode !== 0) {
       console.error(stderr);

--- a/test/js/bun/spawn/spawn-many-teardown.test.ts
+++ b/test/js/bun/spawn/spawn-many-teardown.test.ts
@@ -64,8 +64,8 @@ test("tearing down hundreds of spawned subprocesses at exit does not overflow th
 
 // https://github.com/oven-sh/bun/issues/28175
 // Exercises us_loop_free on the per-VM spawnSync libuv loop at Worker teardown
-// under the debug build, where libuv's assert()s are live: a teardown that
-// frees a still-registered (uv_loop_close == UV_EBUSY) loop aborts the child.
+// under the debug build, which aborts the child (BUN_PANIC) if the loop drain
+// leaves uv_loop_close() unable to deregister the loop from uv__loops[].
 test.skipIf(!isWindows)(
   "the per-worker spawnSync libuv loop is fully drained and closed at worker teardown",
   async () => {

--- a/test/js/bun/spawn/spawn-many-teardown.test.ts
+++ b/test/js/bun/spawn/spawn-many-teardown.test.ts
@@ -63,18 +63,9 @@ test("tearing down hundreds of spawned subprocesses at exit does not overflow th
 }, 120_000);
 
 // https://github.com/oven-sh/bun/issues/28175
-//
-// The first Bun.spawnSync in a VM lazily creates a private libuv loop that is
-// freed through us_loop_free when the VM is destroyed, which for a Worker is
-// mid-process. libuv only removes a loop from its global uv__loops[] registry
-// when uv_loop_close() succeeds; us_loop_free used to free the loop even when
-// uv_loop_close() returned UV_EBUSY, leaving a dangling registry pointer that
-// uv__wake_all_loops() dereferences on the next Windows suspend/resume.
-//
-// The debug build keeps libuv's internal assert()s live, so a teardown that
-// frees a still-registered loop aborts the child process below. The stdio
-// shapes are the ones that leave the most handles in CLOSING state on the
-// spawn-sync loop at teardown (extra-fd pipe, timeout timer, stdin writer).
+// Exercises us_loop_free on the per-VM spawnSync libuv loop at Worker teardown
+// under the debug build, where libuv's assert()s are live: a teardown that
+// frees a still-registered (uv_loop_close == UV_EBUSY) loop aborts the child.
 test.skipIf(!isWindows)(
   "the per-worker spawnSync libuv loop is fully drained and closed at worker teardown",
   async () => {
@@ -102,10 +93,11 @@ test.skipIf(!isWindows)(
         import { Worker } from "node:worker_threads";
         for (let i = 0; i < 6; i++) {
           const worker = new Worker(new URL("./worker.mjs", import.meta.url));
-          await new Promise((resolve, reject) => {
-            worker.on("message", resolve);
-            worker.on("error", reject);
-          });
+          const { promise, resolve, reject } = Promise.withResolvers();
+          worker.on("message", resolve);
+          worker.on("error", reject);
+          worker.on("exit", code => reject(new Error("worker exited before posting: " + code)));
+          await promise;
           await worker.terminate();
         }
         console.log("OK");

--- a/test/js/bun/spawn/spawn-many-teardown.test.ts
+++ b/test/js/bun/spawn/spawn-many-teardown.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // Regression coverage for a Windows-only panic: integer overflow in
 // uv.Loop.active_handles during process teardown when a large number of
@@ -61,3 +61,77 @@ test("tearing down hundreds of spawned subprocesses at exit does not overflow th
   // surface as a non-zero exit code.
   expect(exitCode).toBe(0);
 }, 120_000);
+
+// https://github.com/oven-sh/bun/issues/28175
+//
+// The first Bun.spawnSync in a VM lazily creates a private libuv loop that is
+// freed through us_loop_free when the VM is destroyed, which for a Worker is
+// mid-process. libuv only removes a loop from its global uv__loops[] registry
+// when uv_loop_close() succeeds; us_loop_free used to free the loop even when
+// uv_loop_close() returned UV_EBUSY, leaving a dangling registry pointer that
+// uv__wake_all_loops() dereferences on the next Windows suspend/resume.
+//
+// The debug build keeps libuv's internal assert()s live, so a teardown that
+// frees a still-registered loop aborts the child process below. The stdio
+// shapes are the ones that leave the most handles in CLOSING state on the
+// spawn-sync loop at teardown (extra-fd pipe, timeout timer, stdin writer).
+test.skipIf(!isWindows)(
+  "the per-worker spawnSync libuv loop is fully drained and closed at worker teardown",
+  async () => {
+    using dir = tempDir("spawnsync-uvloop-teardown", {
+      "worker.mjs": /* js */ `
+        import { parentPort } from "node:worker_threads";
+        const exe = process.execPath;
+        // An extra "pipe" stdio entry lands a uv_pipe_t on the spawn-sync loop
+        // that nothing reads; finalizeStreams only uv_close()s it, so its close
+        // callback is still pending when the worker tears down.
+        Bun.spawnSync({ cmd: [exe, "-e", "1"], stdio: ["ignore", "pipe", "pipe", "pipe"] });
+        // A stdin write the child never drains plus a timeout, so the timeout
+        // timer (whose callback calls uv_stop on the loop) and the writer are
+        // both live late into the teardown.
+        Bun.spawnSync({
+          cmd: [exe, "-e", "Bun.sleepSync(60_000)"],
+          timeout: 25,
+          stdin: Buffer.alloc(1 << 20, 66),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        parentPort.postMessage("done");
+      `,
+      "main.mjs": /* js */ `
+        import { Worker } from "node:worker_threads";
+        for (let i = 0; i < 6; i++) {
+          const worker = new Worker(new URL("./worker.mjs", import.meta.url));
+          await new Promise((resolve, reject) => {
+            worker.on("message", resolve);
+            worker.on("error", reject);
+          });
+          await worker.terminate();
+        }
+        console.log("OK");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    if (exitCode !== 0) {
+      console.error(stderr);
+    }
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);


### PR DESCRIPTION
Fixes #28175
Closes BUN-2Q1E

### Crash

Windows only. 1646 Sentry events with the same two frames, across bun 1.2.19 through 1.3.14, including compiled standalone executables:

```
uv__system_resume_callback   src/win/detect-wakeup.c
uv__wake_all_loops           src/win/core.c   <- SEGV reading a heap address
```

`uv__wake_all_loops()` is libuv's power-broadcast handler. When Windows resumes from sleep it walks libuv's global `uv__loops[]` registry and dereferences `loop->iocp` on every entry, so the crash means an entry points at a freed `uv_loop_t`. A loop is only removed from that registry when `uv_loop_close()` succeeds.

### Cause

`us_loop_free()` in `packages/bun-usockets/src/eventing/libuv.c` tore down a non-default loop with:

```c
uv_run(loop->uv_loop, UV_RUN_NOWAIT);
uv_loop_delete(loop->uv_loop);
```

`uv_loop_delete()` is the deprecated libuv helper:

```c
err = uv_loop_close(loop);
assert(err == 0);      /* compiled out in release builds */
uv__free(loop);        /* unconditional */
```

If `uv_loop_close()` returns `UV_EBUSY` (any active request, or any non-internal handle still in `handle_queue`), the loop is freed anyway and stays registered in `uv__loops[]`. The next suspend/resume broadcast walks that entry and crashes, which is why the reports look like "crashed after being idle overnight".

The one place bun reaches this code is the per-VM spawnSync event loop: the first `Bun.spawnSync()` in a VM lazily creates a private `uv_loop_t` (`SpawnSyncEventLoop`), which `RareData`'s drop frees through `us_loop_free()` when the VM is destroyed. For a `node:worker_threads` Worker that happens mid-process, so the dangling registry entry survives until the next resume. PR #24811 (shipped in bun 1.3.10) fixed the other registered loop, the worker's thread-local one, and this crash continued at the same rate through 1.3.14.

### What leaves a handle on the loop at `us_loop_free()` time

Two things can:

1. **A handle that was already `uv_close()`d but whose endgame is still gated on an in-flight IOCP completion** (a cancelled overlapped read, a pending write completion, the process exit-wait packet). libuv only retires a closing handle from inside `uv_run`, and the spawn-sync loop is never run between the last explicit close and `us_loop_free()`, so every teardown relied on that single `UV_RUN_NOWAIT` turn racing those kernel completions. This is the reachable class, and a zero-timeout poll is structurally unable to handle it: it cannot wait for a completion that has not arrived.
2. **A handle that nothing ever closes.** I instrumented the unfixed debug build (`uv_print_all_handles()` at the top of `us_loop_free()`) and ran 19 distinct `Bun.spawnSync` shapes across about 70 Worker teardowns: extra-fd pipes, ipc, `stdin: "pipe"`, timeouts, multi-megabyte unread stdin, grandchildren holding pipe ends open, terminating the Worker mid-spawnSync. Every handle on the loop at teardown was already closing (bun's `finalizeStreams()` explicitly `uv_close()`s them all first), so I could not find an instance of this class. The fix still defends against it so a future leak cannot re-introduce the crash.

### Fix

`us_loop_free()` now drains the loop to completion instead of giving up:

- `uv_walk()` issues `uv_close()` for every handle still registered (class 2). Nothing touches them after `us_loop_free()`;
- `uv_run(UV_RUN_DEFAULT)` runs until the loop reports dead. It waits for the in-flight IOCP completions that gate the remaining endgames (class 1), and with every handle closed the loop always drains to empty;
- `uv_loop_close()` then cannot return `UV_EBUSY`, and the storage is freed unconditionally. A debug assertion (live under `bun bd`) catches a future regression.

This is the same walk-then-drain-then-close sequence the worker's thread-local loop shutdown (`Loop::shutdown()`, the #24811 fix) already uses; `us_loop_free()` now matches it. `Loop::shutdown()`'s own drain is made unbounded for the same reason: `uv_run(UV_RUN_DEFAULT)` returns nonzero only when `uv_stop` cut it short.

`uv_loop_new()` is also replaced with `malloc()` + `uv_loop_init()` so the allocation and the free use the same allocator. `uv_loop_new()` goes through libuv's replaceable allocator, which bun points at mimalloc at startup, so a plain `free()` of its result would be an allocator mismatch.

### Verification

The faulting read only happens on a real `PBT_APMRESUMEAUTOMATIC` power broadcast, which CI cannot generate, so there is no end-to-end reproduction. #24811 hit the same wall. The added test in `test/js/bun/spawn/spawn-many-teardown.test.ts` churns Workers through the stdio shapes that leave the most handles on the spawn-sync loop at teardown; under the debug build a drain that leaves the loop still registered aborts the child, so it is a regression canary for the teardown path rather than a reproduction of the IOCP race.

Verified on Windows x64 (debug build):

- `bun bd test test/js/bun/spawn/spawn-many-teardown.test.ts` passes (both tests), with no change in teardown time versus the old single-turn drain (the happy path still drains in one pass).
- A 13-scenario Worker + `Bun.spawnSync` churn probe (39 teardowns, the shapes listed above) runs clean against the new code.

<details>
<summary>Instrumented teardown from the probe against the unfixed build</summary>

The spawn-sync loop is alive going into the drain on every single teardown (the four usockets handles were just `uv_close()`d, and here an extra-fd `uv_pipe_t` is also still closing), so the entire safety of the old code rested on one `UV_RUN_NOWAIT` turn retiring everything before `uv_loop_delete()`:

```
[PROBE us_loop_free] BEFORE alive=1
[-AI] async    000001BA860A08F8   (libuv internal wq_async)
[R--] prepare  000001BAD2D29E00
[R--] check    000001BAD2D2A040
[R--] timer    000001BB23B60050
[R--] async    000001BB1F68E250
[R--] pipe     000001BA86080280   (the extra-fd uv_pipe_t)
[PROBE us_loop_free] AFTER 1x NOWAIT alive=0
[-AI] async    000001BA860A08F8
```

</details>
