### PR TITLE
sql(postgres): stop dispatching messages once the connection has failed

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -5,6 +5,7 @@ use bun_core::fmt as bun_fmt;
 use bun_sql::postgres::PostgresProtocol as protocol;
 use bun_sql::postgres::PostgresTypes as types;
 use bun_sql::postgres::PostgresTypes::{AnyPostgresError, Int4, Short};
+use bun_sql::postgres::Status;
 use bun_sql::postgres::protocol::{ReaderContext, WriterContext};
 
 use crate::jsc::js_error_to_postgres;
@@ -437,6 +438,12 @@ pub(crate) fn on_data<Context: ReaderContext>(
 ) -> Result<(), AnyPostgresError> {
     use MessageType as M;
     loop {
+        // `fail()` inside a handler tears the connection down (status = Failed,
+        // socket closed, queue rejected). Stop dispatching: later messages in
+        // the same read must not act on the dead connection.
+        if connection.status.get() == Status::Failed {
+            return Ok(());
+        }
         reader.mark_message_start();
         let c = reader.int::<u8>()?;
         bun_core::scoped_log!(Postgres, "read: {}", c as char);

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -616,7 +616,13 @@ impl PostgresSQLConnection {
     }
 
     pub fn set_status(&self, status: Status) {
-        if self.status.get() == status {
+        let current = self.status.get();
+        if current == status {
+            return;
+        }
+        // `Failed` is terminal: `fail_with_js_value` already closed the socket
+        // and rejected every pending request. Nothing may transition out of it.
+        if current == Status::Failed {
             return;
         }
         // reshaped for borrowck — `defer this.updateHasPendingActivity()` moved to explicit calls below.

--- a/test/js/sql/postgres-failed-connection-resurrection.fixture.ts
+++ b/test/js/sql/postgres-failed-connection-resurrection.fixture.ts
@@ -1,0 +1,43 @@
+// Fixture for postgres-failed-connection-resurrection.test.ts. Run as a
+// subprocess so that an AddressSanitizer abort is observable as a non-zero
+// exit code from the test.
+//
+// Mock backend that answers the StartupMessage with ONE write carrying TWO
+// backend messages: an Authentication request with an unrecognized type (99),
+// immediately followed by ReadyForQuery. The unrecognized type fails the
+// connection mid-read; the trailing ReadyForQuery from the same read must not
+// be dispatched against the now-dead connection.
+import { SQL } from "bun";
+import { listeningServer, pgInt32, pgRaw, pgReadyForQuery } from "./wire-frames";
+
+const { port, server } = await listeningServer(socket => {
+  socket.once("data", () => {
+    socket.write(Buffer.concat([pgRaw("R", pgInt32(99)), pgReadyForQuery()]));
+  });
+  socket.on("error", () => {});
+});
+
+const sql = new SQL({
+  url: `postgres://postgres@127.0.0.1:${port}/postgres`,
+  max: 1,
+  idleTimeout: 1,
+  connectionTimeout: 5,
+});
+
+try {
+  await sql`select 1`;
+  console.log("RESOLVED");
+} catch (err: any) {
+  console.log(err?.code ?? String(err));
+}
+
+// Before the fix, the ReadyForQuery flipped the failed connection back to
+// Connected and re-armed its 1s idle timer on a socket uSockets had already
+// scheduled to free; the timer callback then dereferenced the freed socket.
+// Keep the process alive past that window. There is no event to await: a
+// correct build simply never fires that timer again.
+await Bun.sleep(1600);
+console.log("SURVIVED");
+
+await sql.close({ timeout: 0 });
+await new Promise<void>(resolve => server.close(() => resolve()));

--- a/test/js/sql/postgres-failed-connection-resurrection.test.ts
+++ b/test/js/sql/postgres-failed-connection-resurrection.test.ts
@@ -1,0 +1,47 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// A backend message that fails the connection can share a read with messages
+// that follow it. The message loop used to keep dispatching those trailing
+// messages against the already-failed connection; a ReadyForQuery in that
+// position flipped the status back to Connected and re-armed the idle timer
+// on a socket uSockets had already scheduled to free, so the timer callback
+// later read freed memory:
+//   AddressSanitizer: heap-use-after-free in us_socket_is_closed
+//     PostgresSQLConnection::ref_and_close <- fail_with_js_value
+//     <- fail_fmt <- on_connection_timeout
+// The read of freed memory is only detectable under ASan, so this is gated to
+// ASan builds; release lanes would pass regardless of the bug.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+import path from "node:path";
+
+test.skipIf(!isASAN)(
+  "a failed connection is not resurrected by trailing messages in the same read",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "postgres-failed-connection-resurrection.fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 25_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({
+      stdout: stdout.trim().split(/\r?\n/),
+      exitCode,
+      // not asserted (ASan/debug builds emit benign notes); included so the
+      // ASan report shows up in the diff when the fixture dies
+      stderr,
+    }).toEqual({
+      stdout: ["ERR_POSTGRES_UNKNOWN_AUTHENTICATION_METHOD", "SURVIVED"],
+      exitCode: 0,
+      stderr: expect.any(String),
+    });
+  },
+  // the fixture is a debug+ASan bun that intentionally outlives a 1s timer
+  30_000,
+);


### PR DESCRIPTION
A backend message that fails the connection can share a TCP read with messages that follow it. `PostgresRequest::on_data`'s message loop had no bail-out once `fail()` had run, so the trailing messages in that read kept being dispatched against the already-failed connection.

### Repro

A mock backend that answers the StartupMessage with one write carrying two messages:

```
R  int32(8) int32(99)   Authentication, unrecognized type
Z  int32(5) 'I'         ReadyForQuery
```

```ts
const sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 1, connectionTimeout: 5 });
await sql`select 1`.catch(() => {});
await Bun.sleep(1600);
```

### Cause

The unrecognized `Authentication` type calls `fail()`, which sets the status to `Failed`, closes the socket, and rejects the pending requests, but the message loop keeps going and dispatches the `ReadyForQuery` from the same read. That calls `set_status(Status::Connected)`, which has no guard against leaving `Failed`, so the dead connection is flipped back to `Connected` and the `on_data` epilogue re-arms its idle timer. uSockets frees a closed `us_socket_t` at the end of the event-loop iteration, so when the timer later fires, `ref_and_close` reads the freed socket:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 1 at 0x71f2125605d2 thread T0
    #0 us_socket_is_closed                              packages/bun-usockets/src/socket.c:143:21
    #4 PostgresSQLConnection::ref_and_close             src/sql_jsc/postgres/PostgresSQLConnection.rs:1528:31
    #5 PostgresSQLConnection::fail_with_js_value        src/sql_jsc/postgres/PostgresSQLConnection.rs:726:14
    #6 PostgresSQLConnection::fail_fmt                  src/sql_jsc/postgres/PostgresSQLConnection.rs:749:14
    #7 PostgresSQLConnection::on_connection_timeout     src/sql_jsc/postgres/PostgresSQLConnection.rs:557:14
    #8 __bun_fire_timer                                 src/runtime/dispatch.rs:1020:35
0x71f2125605d2 is located 18 bytes inside of 104-byte region
freed by thread T0 here:
    #2 us_internal_free_closed_sockets                  packages/bun-usockets/src/loop.c:305:9
```

### Fix

- `PostgresRequest::on_data`: the message loop returns once the connection's status is `Failed`. `fail()` is terminal; nothing after it in the same read should be handled (a `DataRow`, `CommandComplete`, or `ErrorResponse` in that position would be just as wrong as the `ReadyForQuery`).
- `PostgresSQLConnection::set_status`: refuses to transition out of `Failed`. The transition function owns that invariant; every other consumer of `Status` (the timer interval, `update_has_pending_activity`, the idempotency check in `fail_with_js_value`) already assumes `Failed` is terminal.

### Verification

`test/js/sql/postgres-failed-connection-resurrection.test.ts` runs a fixture against the mock backend above and lets it outlive the idle-timer window. Without the fix the fixture dies with the ASan report above; with it the fixture exits 0. Gated to ASan builds because the bug is a read of freed memory, which release lanes do not detect.

The postgres fault-injection and integration suites still pass locally (90 tests across `test/js/sql/postgres-*.test.ts`, `sql*.test.ts`, `tls-sql.test.ts`).

### Related

- #32861 detaches the stored socket handle in `on_close` / `on_connect_error` so nothing can dereference the freed `us_socket_t` regardless of how the stale read is reached. It removes the last step of this chain from the other end; this PR stops the failed connection from being resurrected at all.
- #30950 guards the JS pool's `handleConnected` against the reverse ordering within one read (a legitimately queued `onconnect` microtask arriving after a synchronous `onclose`).
