### PR TITLE
Fix bun-types CI: resolve tsgo entrypoint from the package bin field

### DIFF
--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -327,7 +327,11 @@ describe("@types/bun integration test", () => {
       tsconfig.include = ["*.ts", "*.tsx"];
       await Bun.write(join(fixtureDir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
 
-      const tsgo = join(fixtureDir, "node_modules", "@typescript", "native-preview", "bin", "tsgo.js");
+      // Resolve the entrypoint from the package's own bin field; the nightly
+      // has renamed it before (bin/tsgo.js -> bin/tsgo).
+      const tsgoPkgDir = join(fixtureDir, "node_modules", "@typescript", "native-preview");
+      const tsgoPkg = await Bun.file(join(tsgoPkgDir, "package.json")).json();
+      const tsgo = join(tsgoPkgDir, typeof tsgoPkg.bin === "string" ? tsgoPkg.bin : tsgoPkg.bin.tsgo);
 
       await using proc = Bun.spawn({
         cmd: [bunExe(), tsgo, "-p", "."],


### PR DESCRIPTION
## What this fixes

The `bun-types.yml` workflow has been failing on every branch since 2026-06-27:

```
error: Module not found ".../node_modules/@typescript/native-preview/bin/tsgo.js"
```

The tsgo integration test installs `@typescript/native-preview` unpinned and hardcodes the entrypoint path `bin/tsgo.js`. The `7.0.0-dev.20260627` nightly renamed the bin to the extensionless `bin/tsgo` (`"bin": { "tsgo": "./bin/tsgo" }`), so the hardcoded path stopped existing.

## The fix

Resolve the entrypoint from the installed package's own `bin` field instead of hardcoding it, handling both the string and object `bin` shapes. This keeps working across upstream renames in either direction.

Verified by running the test against both layouts: `7.0.0-dev.20260624.1` (`bin/tsgo.js`) and `7.0.0-dev.20260628.1` (`bin/tsgo`) — both pass; the unfixed test fails on the latter, which is exactly the CI failure.