### PR TITLE
buffer: byte-truncate string fill patterns and encode lone high surrogates as U+FFFD

### DIFF
--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -999,15 +999,13 @@ pub fn copy_utf16_into_utf8_impl<const ALLOW_TRUNCATED_UTF8_SEQUENCE: bool>(
                 written: 0,
             };
         }
+        // `trim::utf16` strips a single trailing lone high surrogate so simdutf's
+        // length estimate never sees invalid input. If that empties the input, it
+        // was exactly one unpaired surrogate: 3 bytes of U+FFFD, not nothing.
         let trimmed = simdutf::trim::utf16(utf16);
-        if trimmed.is_empty() {
-            return EncodeIntoResult {
-                read: 0,
-                written: 0,
-            };
-        }
-
-        let out_len = if buf.len() <= (trimmed.len() * 3 + 2) {
+        let out_len = if trimmed.is_empty() {
+            3
+        } else if buf.len() <= (trimmed.len() * 3 + 2) {
             simdutf::length::utf8::from::utf16::le(trimmed)
         } else {
             buf.len()

--- a/src/runtime/node/buffer.rs
+++ b/src/runtime/node/buffer.rs
@@ -42,6 +42,9 @@ mod _impl {
             // encoder::write_u8/write_u16 take the encoding as a const-generic
             // `u8` (stable-Rust workaround for `adt_const_params`) — `dispatch_encoding!`
             // expands the runtime `encoding` into nine monomorphized arms.
+            // `ALLOW_PARTIAL_WRITE = true`: Node's `Fill` (node_buffer.cc) copies
+            // `min(encodedLength, fillLength)` raw bytes of the encoding, so the
+            // repeat loop below always doubles a seed equal to the full encoding.
             // SAFETY: `s` and `buf` are valid slices derived above; the source/destination
             // pointers and lengths passed to the encoder are exactly those slice bounds.
             let result = if str.is_16_bit() {
@@ -57,11 +60,11 @@ mod _impl {
                 let s = str.slice();
                 dispatch_encoding!(encoding, {
                     // SAFETY: caller (`extern "C"` fill) guarantees `s`/`buf` are valid disjoint buffers per the Buffer.fill contract.
-                    Encoding::Ucs2 => unsafe { encoder::write_u8::<{ Encoding::Utf16le as u8 }>(
+                    Encoding::Ucs2 => unsafe { encoder::write_u8::<{ Encoding::Utf16le as u8 }, true>(
                         s.as_ptr(), s.len(), buf.as_mut_ptr(), buf.len(),
                     ) },
                 // SAFETY: caller (`extern "C"` fill) guarantees `s`/`buf` are valid disjoint buffers per the Buffer.fill contract.
-                }, |E| unsafe { encoder::write_u8::<E>(s.as_ptr(), s.len(), buf.as_mut_ptr(), buf.len()) })
+                }, |E| unsafe { encoder::write_u8::<E, true>(s.as_ptr(), s.len(), buf.as_mut_ptr(), buf.len()) })
             };
             let Ok(written) = result else {
                 return false;

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -115,9 +115,9 @@ pub(crate) unsafe extern "C" fn Bun__encoding__writeLatin1(
     // SAFETY: forwarded from this fn's contract.
     let r = unsafe {
         dispatch_encoding!(encoding_from_u8(encoding), {
-            Encoding::Ucs2 => write_u8::<{ enc::UTF16LE }>(input, len, to, to_len),
+            Encoding::Ucs2 => write_u8::<{ enc::UTF16LE }, false>(input, len, to, to_len),
             Encoding::Buffer => unreachable!(),
-        }, |E| write_u8::<E>(input, len, to, to_len))
+        }, |E| write_u8::<E, false>(input, len, to, to_len))
     };
     r.unwrap_or(0)
 }
@@ -504,10 +504,14 @@ fn encode_base64_to_bun_string(input: &[u8], url_safe: bool) -> BunString {
     create_external_globally_allocated_latin1(to)
 }
 
+/// `ALLOW_PARTIAL_WRITE` selects Node's `Buffer#fill` semantics: the encoding
+/// is truncated at the byte level, so a code unit / code point that only partly
+/// fits still gets its leading bytes. Without it (`buf.write`), stop at whole units.
+///
 /// # Safety
 /// `input` must be valid for reading `len` bytes and `to_ptr` must be valid for
 /// writing `to_len` bytes; the two ranges must not overlap.
-pub(crate) unsafe fn write_u8<const ENCODING: u8>(
+pub(crate) unsafe fn write_u8<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bool>(
     input: *const u8,
     len: usize,
     to_ptr: *mut u8,
@@ -549,34 +553,48 @@ pub(crate) unsafe fn write_u8<const ENCODING: u8>(
             Ok(written)
         }
         Encoding::Utf8 => {
-            // need to encode
-            Ok(strings::copy_latin1_into_utf8(to_slice, input_slice).written as usize)
+            let r = strings::copy_latin1_into_utf8(to_slice, input_slice);
+            let mut written = r.written as usize;
+            // `copy_latin1_into_utf8` stops at whole code points. Under
+            // byte-level truncation, a Latin-1 char >= 0x80 whose 2-byte
+            // sequence straddles the end still gets its lead byte.
+            if ALLOW_PARTIAL_WRITE && written < to_len && (r.read as usize) < len {
+                debug_assert!(input_slice[r.read as usize] >= 0x80);
+                to_slice[written] = 0xC0 | (input_slice[r.read as usize] >> 6);
+                written += 1;
+            }
+            Ok(written)
         }
         // encode latin1 into UTF16
         Encoding::Ucs2 | Encoding::Utf16le => {
-            if to_len < 2 {
-                return Ok(0);
-            }
-
             let buf = input_slice;
             let out_units = to_len / 2;
             // `to_slice` already covers `to_ptr[..to_len]`; for the aligned fast
             // path, `bytemuck` gives a safe `&mut [u8] → &mut [u16]` view (it
             // re-checks alignment + even length, both proven here).
-            if (to_slice.as_ptr() as usize).is_multiple_of(core::mem::align_of::<u16>()) {
+            let mut written = if out_units == 0 {
+                0
+            } else if (to_slice.as_ptr() as usize).is_multiple_of(core::mem::align_of::<u16>()) {
                 let output: &mut [u16] = bytemuck::cast_slice_mut(&mut to_slice[..out_units * 2]);
-                let written = strings::copy_latin1_into_utf16(output, buf).written as usize;
-                Ok(written * 2)
+                strings::copy_latin1_into_utf16(output, buf).written as usize * 2
             } else {
                 // Rust `&mut [u16]` requires natural alignment, so inline the
                 // (trivial) widen loop for the misaligned-dest case
                 // (each Latin-1 byte → one u16).
-                let written = buf.len().min(out_units);
-                for i in 0..written {
+                let n = buf.len().min(out_units);
+                for i in 0..n {
                     to_slice[i * 2..i * 2 + 2].copy_from_slice(&(buf[i] as u16).to_ne_bytes());
                 }
-                Ok(written * 2)
+                n * 2
+            };
+            // Under byte-level truncation the trailing byte of an odd-length
+            // destination (shorter than the encoded string) is the low byte
+            // of the next code unit.
+            if ALLOW_PARTIAL_WRITE && written < to_len && written < buf.len() * 2 {
+                to_slice[written] = buf[written / 2];
+                written += 1;
             }
+            Ok(written)
         }
 
         Encoding::Hex => Ok(strings::decode_hex_to_bytes_truncate(to_slice, input_slice)),
@@ -633,12 +651,19 @@ pub(crate) fn encode_into_from16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: 
     }
 }
 
-pub(crate) fn encode_into_from8<const ENCODING: u8>(
+pub(crate) fn encode_into_from8<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bool>(
     input: &[u8],
     to: &mut [u8],
 ) -> Result<usize, bun_core::Error> {
     // SAFETY: pointers/lengths come from valid, non-overlapping borrowed slices.
-    unsafe { write_u8::<ENCODING>(input.as_ptr(), input.len(), to.as_mut_ptr(), to.len()) }
+    unsafe {
+        write_u8::<ENCODING, ALLOW_PARTIAL_WRITE>(
+            input.as_ptr(),
+            input.len(),
+            to.as_mut_ptr(),
+            to.len(),
+        )
+    }
 }
 
 /// # Safety
@@ -738,7 +763,14 @@ pub(crate) unsafe fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bo
             strings::copy_u16_into_u8(&mut narrowed, input_slice);
             // SAFETY: `narrowed` is a valid local Vec; `to[..to_len]` validity is
             // forwarded from this fn's contract and is disjoint from `narrowed`.
-            unsafe { write_u8::<ENCODING>(narrowed.as_ptr(), narrowed.len(), to, to_len) }
+            unsafe {
+                write_u8::<ENCODING, ALLOW_PARTIAL_WRITE>(
+                    narrowed.as_ptr(),
+                    narrowed.len(),
+                    to,
+                    to_len,
+                )
+            }
         } // else => return &[_]u8{};
     }
 }
@@ -921,13 +953,15 @@ fn encode_into_from16_dyn(
     dispatch_encoding!(encoding, |E| encode_into_from16::<E, true>(input, to))
 }
 
-/// Runtime-dispatch wrapper over [`encode_into_from8`].
+/// Runtime-dispatch wrapper over [`encode_into_from8`] (passes
+/// `ALLOW_PARTIAL_WRITE = true`, matching the 16-bit twin: the result must
+/// not depend on the string's internal storage width).
 fn encode_into_from8_dyn(
     input: &[u8],
     to: &mut [u8],
     encoding: Encoding,
 ) -> Result<usize, bun_core::Error> {
-    dispatch_encoding!(encoding, |E| encode_into_from8::<E>(input, to))
+    dispatch_encoding!(encoding, |E| encode_into_from8::<E, true>(input, to))
 }
 
 /// Extension trait — see module note above for why this lives in

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1991,6 +1991,46 @@ for (let withOverridenBufferWrite of [false, true]) {
             expect(input.join("")).toBe(demo.join(""));
           });
         }
+
+        // Node copies min(encodedLength, fillLength) raw bytes of the
+        // pattern's encoding (node_buffer.cc `Fill`): a pattern longer than
+        // the destination is cut mid code unit, not restarted on a boundary.
+        it("byte-truncates a ucs2 pattern longer than the destination", () => {
+          // "abc" encodes to 61 00 62 00 63 00
+          expect(Array.from(Buffer.alloc(3, "abc", "ucs2"))).toEqual([0x61, 0x00, 0x62]);
+          expect(Array.from(Buffer.alloc(5, "abc", "ucs2"))).toEqual([0x61, 0x00, 0x62, 0x00, 0x63]);
+          expect(Array.from(Buffer.alloc(1, "abc", "ucs2"))).toEqual([0x61]);
+          expect(Array.from(Buffer.alloc(3, "abc", "utf16le"))).toEqual([0x61, 0x00, 0x62]);
+          expect(Array.from(Buffer.alloc(3).fill("abc", "ucs2"))).toEqual([0x61, 0x00, 0x62]);
+          // an odd start offset exercises the unaligned destination path
+          expect(Array.from(Buffer.alloc(6).fill("abc", 1, 6, "ucs2"))).toEqual([0x00, 0x61, 0x00, 0x62, 0x00, 0x63]);
+          // a two-byte source string (U+0101 forces UTF-16 storage) agrees
+          expect(Array.from(Buffer.alloc(3, "\u0101bc", "ucs2"))).toEqual([0x01, 0x01, 0x62]);
+          // when the pattern fits, it still repeats
+          expect(Array.from(Buffer.alloc(7, "abc", "ucs2"))).toEqual([0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x61]);
+          expect(Array.from(Buffer.alloc(8, "ab", "ucs2"))).toEqual([0x61, 0x00, 0x62, 0x00, 0x61, 0x00, 0x62, 0x00]);
+        });
+
+        it("byte-truncates a utf8 pattern longer than the destination", () => {
+          // "a\xe9" encodes to 61 c3 a9
+          expect(Array.from(Buffer.alloc(2, "a\xe9"))).toEqual([0x61, 0xc3]);
+          expect(Array.from(Buffer.alloc(1, "\xe9\xe9"))).toEqual([0xc3]);
+          // when the pattern fits, it still repeats
+          expect(Array.from(Buffer.alloc(3, "a\xe9"))).toEqual([0x61, 0xc3, 0xa9]);
+          expect(Array.from(Buffer.alloc(4, "a\xe9"))).toEqual([0x61, 0xc3, 0xa9, 0x61]);
+        });
+
+        // A lone high surrogate encodes as U+FFFD (ef bf bd), the same as
+        // every other UTF-16 -> UTF-8 path in Node. It is not an error.
+        it("encodes a lone high surrogate as U+FFFD in fill and write", () => {
+          expect(Array.from(Buffer.alloc(4, "\ud800"))).toEqual([0xef, 0xbf, 0xbd, 0xef]);
+          expect(Array.from(Buffer.alloc(3, "\ud800"))).toEqual([0xef, 0xbf, 0xbd]);
+          expect(Array.from(Buffer.alloc(2, "\ud800"))).toEqual([0xef, 0xbf]);
+          expect(Array.from(Buffer.alloc(4).fill("\ud800"))).toEqual([0xef, 0xbf, 0xbd, 0xef]);
+          const b = Buffer.alloc(4);
+          expect(b.write("\ud800")).toBe(3);
+          expect(Array.from(b)).toEqual([0xef, 0xbf, 0xbd, 0x00]);
+        });
       });
 
       it("Buffer.fill 1 char string", () => {


### PR DESCRIPTION
`Buffer.alloc(n, pattern, encoding)` / `buf.fill(pattern, encoding)` produce different bytes than Node whenever the pattern's encoding is longer than the destination, and throw `ERR_INVALID_ARG_VALUE` for a lone high surrogate where Node writes `U+FFFD`. `buf.write("\ud800")` is also affected (returns 0, Node returns 3). These are silent wrong-bytes and spurious-error divergences in the byte-assembly primitives under every protocol client and file pipeline.

### Reproduction

```js
// ucs2 pattern longer than the buffer: the tail restarts instead of truncating
Buffer.alloc(3, "abc", "ucs2")   // bun  <Buffer 61 00 61>
                                 // node <Buffer 61 00 62>
// same class, utf8
Buffer.alloc(2, "a\xe9")         // bun  <Buffer 61 61>
                                 // node <Buffer 61 c3>
// spurious errors
Buffer.alloc(1, "abc", "ucs2")   // bun throws ERR_INVALID_ARG_VALUE; node <Buffer 61>
Buffer.alloc(4, "\ud800")        // bun throws ERR_INVALID_ARG_VALUE; node <Buffer ef bf bd ef>
Buffer.alloc(4).write("\ud800")  // bun 0; node 3 -> <Buffer ef bf bd 00>
```

### Cause

Node's `Fill` (`node_buffer.cc`) copies `min(encodedLength, fillLength)` raw bytes of the pattern's full encoding into the buffer, so a code unit that straddles the end is cut at the byte level and the repeat seed is the whole encoding. `Bun__Buffer_fill` has the same repeat loop, but it seeds from the bytes the encoder actually wrote, and two encoder paths stop early:

1. `write_u16` (16-bit-source strings) already has an `ALLOW_PARTIAL_WRITE` const generic that implements exactly Node's byte-level truncation. `write_u8` (Latin-1-source strings) had no such concept: its UTF-8 arm stops at whole code points and its UCS-2 arm at whole 2-byte units, so the repeat loop restarts the pattern too early (or sees 0 bytes written and errors). This is why only Latin-1-storable patterns like `"abc"` diverge while `"\u0101bc"` already matched.

2. `copy_utf16_into_utf8_impl` trims a trailing lone high surrogate before asking simdutf for a length estimate, then returned 0 bytes written if that emptied the input. A string that is exactly one lone high surrogate encodes as 3 bytes of `U+FFFD`, like every other UTF-16 to UTF-8 path (`Buffer.from("\ud800")` already did). `buf.write`, the streaming sinks, and WebSocket text frames all go through this converter.

### Fix

- Add `ALLOW_PARTIAL_WRITE` to `write_u8`, mirroring `write_u16`. The UTF-8 arm writes the lead byte of a 2-byte Latin-1 char that straddles the end; the UCS-2 arm writes the low byte of the next code unit into the odd trailing byte. `Bun__Buffer_fill` passes `true`; `Bun__encoding__writeLatin1` (`buf.write`, which Node also truncates at whole code units) keeps `false`.
- `copy_utf16_into_utf8_impl`: an empty trimmed input means exactly one lone high surrogate, whose output length is 3; pass that through instead of bailing with 0 bytes written.
- `encode_into_from8_dyn` now passes `true` like its 16-bit twin `encode_into_from16_dyn`, so `BunString::encode_into` no longer depends on the string's internal storage width.

### Verification

All 19 expected byte sequences in the new `buffer.test.js` assertions are verified against Node v26.3.0. Without the fix, Bun fails 14 of them (the other 5 are pattern-repeats-when-it-fits controls); the file's 517-test baseline was already clean. A 24-case side-by-side of `buf.write` truncation against Node is byte-identical, so the whole-code-unit `write` semantics are unchanged outside the lone-surrogate case. `test-buffer-fill.js`, `test-buffer-alloc.js`, `test-buffer-write.js`, `test-buffer-write-fast.js`, and `test-string-decoder.js` from the vendored Node suite all still pass.