### PR TITLE
Don't surface an unhandled EPIPE rejection when a subprocess with a ReadableStream stdin dies mid-write

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1025,11 +1025,17 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       // (Windows pipes are always async); awaiting that here would serialize
       // every chunk behind a uv_write round-trip, so the negative-number check
       // intentionally lets those fall through.
-      if (sink.write(values[i]) < 0) {
+      const wrote = sink.write(values[i]);
+      if (wrote < 0) {
         await sink.flush(true);
         // The sink's close path resolves the same promise; stop writing into a
         // dead sink.
         if (state.didClose) break;
+      } else if ($isPromise(wrote)) {
+        // Intentionally unawaited (see above). The sink rejects it if the
+        // destination goes away mid-write (e.g. the subprocess exited); that
+        // already cancels the stream, so don't report an unhandled rejection.
+        $markPromiseAsHandled(wrote);
       }
     }
     values = many = undefined;
@@ -1047,9 +1053,13 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
         return sink.end();
       }
 
-      if (sink.write(value) < 0) {
+      const wrote = sink.write(value);
+      if (wrote < 0) {
         await sink.flush(true);
         if (state.didClose) return sink.end();
+      } else if ($isPromise(wrote)) {
+        // See the identical branch above.
+        $markPromiseAsHandled(wrote);
       }
     }
   } catch (e) {
@@ -1999,11 +2009,14 @@ export function readableStreamFromAsyncIterator(target, fn) {
           // See readStreamIntoSink: the HTTP response sink returns a negative
           // number when the socket is backed up; await the drain via
           // flush(true). FileSink's Promise return is intentionally not
-          // awaited here.
-          if (controller.write(value) < 0) {
+          // awaited here, so mark it handled.
+          const wrote = controller.write(value);
+          if (wrote < 0) {
             clearImmediate(immediateTask);
             immediateTask = undefined;
             await controller.flush(true);
+          } else if ($isPromise(wrote)) {
+            $markPromiseAsHandled(wrote);
           }
         }
       }

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -373,6 +373,10 @@ describe("spawn stdin ReadableStream", () => {
         }
         await Promise.all(Array.from({ length: 8 }, round));
 
+        // Unhandled rejections are only reported after a microtask drain; give
+        // the tracker a turn so rejections from the last exits are counted.
+        await Bun.sleep(0);
+
         // Exit explicitly: on Windows an async iterable stdin does not tear
         // down after the child dies and would keep the event loop alive.
         // https://github.com/oven-sh/bun/issues/33020

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, mock, test } from "bun:test";
-import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isCI } from "harness";
+import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN } from "harness";
 
 describe("spawn stdin ReadableStream", () => {
   test("basic ReadableStream as stdin", async () => {
@@ -321,6 +321,83 @@ describe("spawn stdin ReadableStream", () => {
     expect(exitCode).toBe(0);
   });
 
+  // The ReadableStream -> stdin FileSink pump intentionally does not await the
+  // Promise FileSink.write() returns for writes it cannot complete synchronously
+  // (a full pipe on POSIX, every pipe write on Windows). When the child dies
+  // while one is in flight, the sink rejects that Promise with EPIPE; the pump
+  // must mark it handled or it surfaces as an unhandled rejection in the parent.
+  // Run in a child process so a stray rejection lands on its counter.
+  async function expectNoUnhandledRejectionWhenChildDies(useIterator: boolean) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        let uncaught = 0;
+        process.on("unhandledRejection", () => { uncaught++; });
+        process.on("exit", () => console.log("uncaught=" + uncaught));
+
+        const chunk = Buffer.alloc(256 * 1024, "x");
+        async function* iterate(producedOne) {
+          while (true) {
+            await Bun.sleep(0);
+            producedOne();
+            yield chunk;
+          }
+        }
+        function readable(producedOne) {
+          return new ReadableStream({
+            async pull(controller) {
+              await Bun.sleep(0);
+              producedOne();
+              controller.enqueue(chunk);
+            },
+          });
+        }
+
+        // The child never reads its stdin, so a 256 KiB write can never finish
+        // and the sink always holds an in-flight write. Once a few chunks have
+        // been handed to the sink, kill the child. How far the pump gets before
+        // the parent notices the death varies, so run several rounds.
+        function round() {
+          let produced = 0;
+          const child = Bun.spawn({
+            cmd: [process.execPath, "-e", "setTimeout(() => {}, 1e9)"],
+            stdin: (${useIterator} ? iterate : readable)(() => {
+              if (++produced === 4) child.kill();
+            }),
+            stdout: "ignore",
+            stderr: "ignore",
+          });
+          return child.exited;
+        }
+        await Promise.all(Array.from({ length: 8 }, round));
+
+        // Exit explicitly: on Windows an async iterable stdin does not tear
+        // down after the child dies and would keep the event loop alive.
+        // https://github.com/oven-sh/bun/issues/33020
+        process.exit(0);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("EPIPE");
+    expect(stdout.trim()).toBe("uncaught=0");
+    expect(exitCode).toBe(0);
+  }
+
+  test("in-flight write when the child dies does not surface an unhandled rejection", async () => {
+    await expectNoUnhandledRejectionWhenChildDies(false);
+  });
+
+  test("in-flight write from an async iterator stdin when the child dies does not surface an unhandled rejection", async () => {
+    await expectNoUnhandledRejectionWhenChildDies(true);
+  });
+
   test("ReadableStream with process that exits immediately", async () => {
     const stream = new ReadableStream({
       start(controller) {
@@ -598,11 +675,12 @@ describe("spawn stdin ReadableStream", () => {
   });
 
   test("ReadableStream object type count", async () => {
-    const iterations =
-      isASAN && isCI
-        ? // With ASAN, entire process gets killed, including the test runner in CI. Likely an OOM or out of file descriptors.
-          10
-        : 50;
+    const iterations = isASAN
+      ? // With ASAN, entire process gets killed. Likely an OOM or out of file
+        // descriptors. 50 concurrent ASAN subprocesses also overrun the
+        // per-test timeout.
+        10
+      : 50;
 
     async function main() {
       async function iterate(i: number) {


### PR DESCRIPTION
### What does this PR do?

Fixes the flaky `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts > ReadableStream with abort signal calls cancel` failure on Windows CI ([example annotation](https://buildkite.com/bun/bun/builds/66387/annotations)):

```
1 | (async function (stream, sink, isNative) {"use strict";
                                             ^
EPIPE: broken pipe, write
 syscall: "write",
   errno: -32,
    code: "EPIPE"

(fail) spawn stdin ReadableStream > ReadableStream with abort signal calls cancel
```

The bug is not test-specific. Any `Bun.spawn({ stdin: readableStream })` whose child exits while the internal pump still has a write in flight can surface a spurious unhandled `EPIPE` rejection in the parent, which with no `unhandledRejection` listener prints the error and makes the process exit nonzero. Standalone repro on Linux, no test runner involved (reproduces 5/5 on `bun-v1.3.x`):

```js
const bigChunk = Buffer.alloc(256 * 1024, "x");
const stream = new ReadableStream({
  async pull(controller) {
    await Bun.sleep(1);
    controller.enqueue(bigChunk);
  },
});
const proc = Bun.spawn({
  // Never reads stdin; exits on its own.
  cmd: [process.execPath, "-e", "setTimeout(() => {}, 100)"],
  stdin: stream,
  stdout: "ignore",
});
await proc.exited;
// => unhandled "EPIPE: broken pipe" rejection
```

### Cause

The ReadableStream-to-native-sink pump (`readStreamIntoSink`, and its async iterator variant in `readableStreamFromAsyncIterator`) only inspects the return value of `sink.write()` for the HTTP sink's negative backpressure signal:

```js
if (sink.write(values[i]) < 0) {
  await sink.flush(true);
}
```

For `FileSink`, `write()` returns a Promise whenever the write cannot complete synchronously: every pipe write on Windows (libuv writes are asynchronous), and a full pipe on POSIX. `Promise < 0` is `false`, so the Promise is discarded; that is intentional (awaiting each one would serialize every chunk behind an I/O round trip, see #32553). But when the destination then goes away mid-write, for example because the subprocess on the other end of stdin exited or was killed, the native sink rejects that Promise (via `FileSink::on_attached_process_exit`, `on_error`, or a synchronous `Writable::Err` return), and since nothing observes it, it is reported as an unhandled rejection. Inside `bun test` the rejection gets attributed to whichever test happens to be running, which is the Windows flake.

### Fix

Mark the Promise as handled at the three write sites that intentionally do not await it. Nothing is lost: the sink's close signal already cancels the ReadableStream on failure, which is how the pump terminates and how callers observe the outcome.

### Tests

Two new tests (plain `ReadableStream` stdin and async iterable stdin) spawn children that never read their stdin and are killed while a write is in flight, and assert that the parent saw zero unhandled rejections. Both fail before the fix and pass after it, on Linux and Windows:

```
# Linux, src/ from main, new tests only
0 pass, 10 fail
# Linux, with this branch
10 pass, 0 fail
```

The originally flaky test, on Windows:

- before: `bun test ... -t "abort signal" --rerun-each=40` fails 12/40
- after: 40/40 pass

Also in this PR:

- `ReadableStream object type count` in the same file now applies its existing ASAN iteration reduction outside of CI too. 50 concurrent ASAN subprocesses exceed the 5s per-test timeout, which made the file fail under a local `bun bd test` (ASAN) build regardless of this change.
- Writing the async iterable variant uncovered a separate pre-existing Windows bug: the parent never exits after the child dies when stdin is an async iterable. Filed as #33020; the new test exits explicitly so it does not depend on that teardown.
