### PR TITLE
Add SIMD JSON parser and on-demand cursor for npm manifest parsing

### DIFF
--- a/bench/json-simd/bench.ts
+++ b/bench/json-simd/bench.ts
@@ -1,0 +1,61 @@
+// Benchmark the SIMD JSON parser against the scalar lexer-based parser.
+// Timing happens entirely inside Rust (json_simd_testing::js_bench); this
+// script only formats the results.
+//
+// Usage: bun-debug bench/json-simd/bench.ts [path-to-json] [iters]
+
+import { simdJSONInternals } from "bun:internal-for-testing";
+
+const inputs: { name: string; text: string }[] = [];
+
+const arg = process.argv[2];
+if (arg) {
+  inputs.push({ name: arg, text: await Bun.file(arg).text() });
+} else {
+  inputs.push({ name: "package.json", text: await Bun.file("package.json").text() });
+  // Synthetic: number-heavy array.
+  inputs.push({
+    name: "numbers (1e5 ints)",
+    text: JSON.stringify(Array.from({ length: 100_000 }, (_, i) => i)),
+  });
+  // Synthetic: object with many short string keys/values.
+  inputs.push({
+    name: "small-strings (1e4 keys)",
+    text: JSON.stringify(
+      Object.fromEntries(Array.from({ length: 10_000 }, (_, i) => [`key_${i}`, `value_${i}`])),
+    ),
+  });
+  // Synthetic: one long string (sourcemap-like).
+  inputs.push({
+    name: "long-string (1 MB)",
+    text: JSON.stringify({ mappings: Buffer.alloc(1_000_000, "ABCDabcd0123;,").toString() }),
+  });
+}
+
+const iters = Number(process.argv[3] ?? 200);
+
+console.log(`iters=${iters}\n`);
+console.log("─── stage-1 only (index buffer reused) ───");
+for (const { name, text } of inputs) {
+  const r = simdJSONInternals.benchStage1(text, iters);
+  const per = r.ns / iters;
+  console.log(
+    `${name.padEnd(24)} ${(r.bytes / 1024).toFixed(1).padStart(8)} KB  ` +
+      `${per.toFixed(0).padStart(9)} ns  ` +
+      `${((r.bytes * 1000) / per).toFixed(1).padStart(8)} MB/s  ` +
+      `${r.count} structurals`,
+  );
+}
+console.log("\n─── full parse (stage-1 + stage-2 → Expr AST) ───");
+for (const { name, text } of inputs) {
+  const r = simdJSONInternals.bench(text, iters);
+  const simdPer = r.simdNs / r.iters;
+  const scalarPer = r.scalarNs / r.iters;
+  const mb = (ns: number) => ((r.bytes * 1000) / ns).toFixed(1);
+  console.log(
+    `${name.padEnd(24)} ${(r.bytes / 1024).toFixed(1).padStart(8)} KB  ` +
+      `simd ${simdPer.toFixed(0).padStart(9)} ns (${mb(simdPer).padStart(6)} MB/s)  ` +
+      `scalar ${scalarPer.toFixed(0).padStart(9)} ns (${mb(scalarPer).padStart(6)} MB/s)  ` +
+      `${(scalarPer / simdPer).toFixed(2)}x`,
+  );
+}

--- a/bench/json-simd/dry-run-hyperfine.sh
+++ b/bench/json-simd/dry-run-hyperfine.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# End-to-end wall-clock: cold-cache `bun install --dry-run` against a local
+# HTTP registry serving real packuments from disk. Full HTTP + decompress +
+# parse path; no internet jitter.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BUN="${BUN:-$ROOT/build/release/bun}"
+SCRATCH="${TMPDIR:-/tmp}/bun-dry-run-hf"
+RUNS="${RUNS:-15}"
+WARMUP="${WARMUP:-3}"
+
+rm -rf "$SCRATCH"; mkdir -p "$SCRATCH"; cd "$SCRATCH"
+cat > package.json <<'EOF'
+{
+  "name": "dry-run-bench",
+  "private": true,
+  "dependencies": {
+    "next": "^14",
+    "react": "^18",
+    "react-dom": "^18",
+    "typescript": "^5",
+    "@types/react": "^18",
+    "@types/node": "^20",
+    "tailwindcss": "^3",
+    "eslint": "^8",
+    "prettier": "^3",
+    "vite": "^5",
+    "vitest": "^1",
+    "express": "^4",
+    "lodash": "^4",
+    "axios": "^1",
+    "zod": "^3"
+  }
+}
+EOF
+
+# Start the local registry; capture its URL from stdout.
+REGISTRY_URL_FILE="$SCRATCH/registry-url"
+"$BUN" "$ROOT/bench/json-simd/local-registry.ts" > "$REGISTRY_URL_FILE" 2>"$SCRATCH/registry.log" &
+REG_PID=$!
+trap 'kill $REG_PID 2>/dev/null || true' EXIT
+for _ in $(seq 1 50); do [[ -s "$REGISTRY_URL_FILE" ]] && break; sleep 0.05; done
+REGISTRY_URL="$(cat "$REGISTRY_URL_FILE")"
+echo "registry: $REGISTRY_URL"
+
+# Prime: one real install through the proxy to fill the packument cache.
+CACHE="$SCRATCH/cache"
+rm -rf "$CACHE" bun.lock
+BUN_INSTALL_CACHE_DIR="$CACHE" "$BUN" install --lockfile-only --registry "$REGISTRY_URL" >/dev/null 2>&1
+echo "primed: $(ls /tmp/bun-packument-cache | wc -l) packuments"
+
+PREP="rm -rf '$CACHE' bun.lock node_modules"
+
+hyperfine --warmup "$WARMUP" --runs "$RUNS" --prepare "$PREP" \
+  --command-name "scalar (production today)" \
+    "BUN_INSTALL_CACHE_DIR='$CACHE' BUN_NPM_PARSE_SCALAR=1 '$BUN' install --lockfile-only --registry '$REGISTRY_URL'" \
+  --command-name "expr+SIMD" \
+    "BUN_INSTALL_CACHE_DIR='$CACHE' '$BUN' install --lockfile-only --registry '$REGISTRY_URL'" \
+  --command-name "cursor" \
+    "BUN_INSTALL_CACHE_DIR='$CACHE' BUN_NPM_PARSE_CURSOR=1 '$BUN' install --lockfile-only --registry '$REGISTRY_URL'"

--- a/bench/json-simd/dry-run-install.sh
+++ b/bench/json-simd/dry-run-install.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Cold-cache `bun install --dry-run` benchmark: PackageManifest::parse() vs
+# parse_cursor(). --dry-run resolves (downloads + parses every packument) but
+# never fetches tarballs, links node_modules, or runs lifecycle scripts.
+#
+# Network is hit on every run (cold cache), so wall-clock includes registry
+# round-trips; the [npm parse] line isolates the manifest-parse time.
+
+set -euo pipefail
+BUN="${BUN:-$(cd "$(dirname "$0")/../.." && pwd)/build/release/bun}"
+SCRATCH="${TMPDIR:-/tmp}/bun-dry-run-bench"
+RUNS="${RUNS:-3}"
+
+rm -rf "$SCRATCH"
+mkdir -p "$SCRATCH"
+cd "$SCRATCH"
+
+cat > package.json <<'EOF'
+{
+  "name": "dry-run-bench",
+  "private": true,
+  "dependencies": {
+    "next": "^14",
+    "react": "^18",
+    "react-dom": "^18",
+    "typescript": "^5",
+    "@types/react": "^18",
+    "@types/node": "^20",
+    "tailwindcss": "^3",
+    "eslint": "^8",
+    "prettier": "^3",
+    "vite": "^5",
+    "vitest": "^1",
+    "express": "^4",
+    "lodash": "^4",
+    "axios": "^1",
+    "zod": "^3"
+  }
+}
+EOF
+
+run_mode () {
+  local label="$1"; shift
+  echo
+  echo "── mode: $label ──"
+  for i in $(seq 1 "$RUNS"); do
+    rm -rf bun.lock node_modules cache
+    local out
+    out=$(BUN_INSTALL_CACHE_DIR="$SCRATCH/cache" BUN_NPM_PARSE_STATS=1 \
+      "$@" /usr/bin/time -f 'wall=%es' "$BUN" install --dry-run 2>&1)
+    local parse wall
+    parse=$(printf '%s\n' "$out" | grep '^\[npm parse\]' || true)
+    wall=$(printf '%s\n' "$out" | grep '^wall=' || true)
+    printf '  [%d] %s  %s\n' "$i" "$wall" "$parse"
+    rm -rf cache
+  done
+}
+
+# Warm DNS + TCP once so the first timed run isn't penalised.
+rm -rf cache bun.lock
+BUN_INSTALL_CACHE_DIR="$SCRATCH/cache" "$BUN" install --dry-run >/dev/null 2>&1 || true
+rm -rf cache bun.lock
+
+run_mode "parse() — Expr + scalar JSON (production today)" env BUN_NPM_PARSE_SCALAR=1
+run_mode "parse() — Expr + SIMD JSON" env
+run_mode "parse_cursor() — JsonCursor" env BUN_NPM_PARSE_CURSOR=1
+
+echo
+echo "(wall-clock includes network; [npm parse] is the manifest-parse total)"

--- a/bench/json-simd/local-registry.ts
+++ b/bench/json-simd/local-registry.ts
@@ -1,0 +1,50 @@
+// Minimal local npm registry that serves packuments from a disk cache.
+// First run with `--prime` to download everything via the real registry;
+// subsequent runs serve from disk so wall-clock excludes network entirely.
+
+import { mkdirSync, existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const CACHE = process.env.PACKUMENT_CACHE ?? "/tmp/bun-packument-cache";
+mkdirSync(CACHE, { recursive: true });
+
+const upstream = "https://registry.npmjs.org";
+
+function cachePath(name: string) {
+  return join(CACHE, encodeURIComponent(name) + ".json");
+}
+
+// Preload everything into memory so the server adds zero disk I/O variance.
+const mem = new Map<string, Uint8Array>();
+for (const f of readdirSync(CACHE)) {
+  mem.set(decodeURIComponent(f.replace(/\.json$/, "")), new Uint8Array(readFileSync(join(CACHE, f))));
+}
+
+const server = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    const url = new URL(req.url);
+    let name = decodeURIComponent(url.pathname.slice(1));
+    if (!name) return new Response("ok");
+    const cached = mem.get(name);
+    if (cached) {
+      return new Response(cached, { headers: { "content-type": "application/json" } });
+    }
+    // Miss → fetch upstream, cache, serve.
+    const r = await fetch(`${upstream}/${encodeURIComponent(name)}`, {
+      headers: { accept: "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8" },
+    });
+    const body = new Uint8Array(await r.arrayBuffer());
+    writeFileSync(cachePath(name), body);
+    mem.set(name, body);
+    return new Response(body, {
+      status: r.status,
+      headers: { "content-type": "application/json" },
+    });
+  },
+});
+
+console.log(`http://localhost:${server.port}/`);
+console.error(
+  `[local-registry] cache=${CACHE} (${readdirSync(CACHE).length} cached) port=${server.port}`,
+);

--- a/bench/json-simd/vs_simdjson.cpp
+++ b/bench/json-simd/vs_simdjson.cpp
@@ -1,0 +1,139 @@
+// Standalone tape-vs-tape benchmark: simdjson DOM parse vs Bun's
+// highway_json_parse on the same inputs. Both build a flat tape; neither
+// builds Bun's Expr AST.
+//
+// Build (from repo root):
+//   clang++ -O3 -march=native -std=c++20 \
+//     -I$HOME/code/simdjson/singleheader -Ivendor/highway \
+//     bench/json-simd/vs_simdjson.cpp \
+//     $HOME/code/simdjson/singleheader/simdjson.cpp \
+//     src/jsc/bindings/highway_json.cpp \
+//     vendor/highway/hwy/targets.cc vendor/highway/hwy/per_target.cc \
+//     vendor/highway/hwy/abort.cc \
+//     -o /tmp/vs_simdjson
+//
+// Run:
+//   /tmp/vs_simdjson <iters> <file...>
+
+#include "simdjson.h"
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+extern "C" uint32_t highway_json_parse(const uint8_t* buf, size_t len,
+    uint32_t* indices, size_t indices_cap,
+    uint64_t* tape, uint8_t* strbuf,
+    uint32_t* out_tape_len, uint32_t* out_strbuf_len,
+    uint32_t* out_flags, uint32_t* out_err_pos);
+
+using clk = std::chrono::high_resolution_clock;
+
+template<class F>
+static double time_ns(int iters, F&& f)
+{
+    for (int i = 0; i < 3; ++i) f(); // warmup
+    auto t0 = clk::now();
+    for (int i = 0; i < iters; ++i) f();
+    auto t1 = clk::now();
+    return std::chrono::duration<double, std::nano>(t1 - t0).count() / iters;
+}
+
+// Recursively visit every value in a simdjson DOM — forces every string,
+// number, and container to be materialized. This is the work a real consumer
+// (e.g. building an AST) has to do on top of `parser.parse()`.
+static uint64_t walk_dom(simdjson::dom::element e)
+{
+    using namespace simdjson::dom;
+    uint64_t h = 0;
+    switch (e.type()) {
+    case element_type::ARRAY:
+        for (element child : array(e)) h += walk_dom(child);
+        return h + 1;
+    case element_type::OBJECT:
+        for (auto kv : object(e)) {
+            h += kv.key.size();
+            h += walk_dom(kv.value);
+        }
+        return h + 1;
+    case element_type::STRING:
+        return std::string_view(e).size();
+    case element_type::INT64:
+        return static_cast<uint64_t>(int64_t(e));
+    case element_type::UINT64:
+        return uint64_t(e);
+    case element_type::DOUBLE: {
+        double d = double(e);
+        uint64_t b;
+        std::memcpy(&b, &d, sizeof b);
+        return b;
+    }
+    case element_type::BOOL:
+        return bool(e) ? 1 : 0;
+    case element_type::NULL_VALUE:
+        return 0;
+    }
+    return 0;
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s <iters> <file...>\n", argv[0]);
+        return 1;
+    }
+    const int iters = std::atoi(argv[1]);
+    std::printf("simdjson active impl: %s\n\n", simdjson::get_active_implementation()->name().c_str());
+    std::printf("%-24s %9s  %14s  %14s  %14s\n",
+        "file", "bytes", "sj tape-only", "sj parse+walk", "bun tape-only");
+
+    for (int a = 2; a < argc; ++a) {
+        simdjson::padded_string json;
+        if (simdjson::padded_string::load(argv[a]).get(json)) {
+            std::fprintf(stderr, "failed to load %s\n", argv[a]);
+            continue;
+        }
+        const size_t len = json.size();
+
+        // simdjson DOM (stage1 + stage2 → tape).
+        simdjson::dom::parser parser;
+        // Pre-allocate so we measure parsing, not allocation.
+        if (parser.allocate(len)) {
+            std::fprintf(stderr, "simdjson allocate failed\n");
+            continue;
+        }
+        double ns_sj_tape = time_ns(iters, [&] {
+            simdjson::dom::element doc;
+            auto err = parser.parse(json).get(doc);
+            if (err) std::abort();
+        });
+        // simdjson parse + visit every value (the work a consumer must do).
+        volatile uint64_t sink = 0;
+        double ns_sj_walk = time_ns(iters, [&] {
+            simdjson::dom::element doc;
+            auto err = parser.parse(json).get(doc);
+            if (err) std::abort();
+            sink += walk_dom(doc);
+        });
+
+        // Bun highway_json_parse (stage1 + stage2 → tape). Buffers reused.
+        std::vector<uint32_t> idx(len + 64 + 4);
+        std::vector<uint64_t> tape(len + len / 2 + 8);
+        std::vector<uint8_t> strbuf(len + 32);
+        uint32_t tlen, slen, flags, epos;
+        double ns_bun = time_ns(iters, [&] {
+            uint32_t rc = highway_json_parse(
+                reinterpret_cast<const uint8_t*>(json.data()), len,
+                idx.data(), idx.size(), tape.data(), strbuf.data(),
+                &tlen, &slen, &flags, &epos);
+            if (rc != 0) std::abort();
+        });
+
+        const char* name = argv[a];
+        if (const char* s = std::strrchr(name, '/')) name = s + 1;
+        std::printf("%-24s %9zu  %11.0f ns  %11.0f ns  %11.0f ns\n",
+            name, len, ns_sj_tape, ns_sj_walk, ns_bun);
+    }
+    return 0;
+}

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -134,6 +134,8 @@ const noUnify: readonly string[] = [
   "src/jsc/bindings/xxhash3.cpp",
   // Fourth highway TU — same foreach_target.h include-guard reason.
   "src/jsc/bindings/highway_sourcemap.cpp",
+  // Fifth highway TU — same foreach_target.h include-guard reason.
+  "src/jsc/bindings/highway_json.cpp",
   // Declares its own minimal CGRect/kCFStringEncodingUTF8/kCFNumberDoubleType
   // so it doesn't pull a CoreGraphics load command; bundled with files that
   // include the real CF headers those names become ambiguous.

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -65,6 +65,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "ini.rs": "ini/ini.rs",
   "install_binding.rs": "install_jsc/install_binding.rs",
   "ipc.rs": "jsc/ipc.rs",
+  "json_simd_testing.rs": "runtime/api/json_simd_testing.rs",
   "mysql.rs": "sql_jsc/mysql.rs",
   "node_assert_binding.rs": "runtime/node/node_assert_binding.rs",
   "node_cluster_binding.rs": "runtime/node/node_cluster_binding.rs",

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -87,6 +87,214 @@ unsafe extern "C" {
     ) -> usize;
 
     fn highway_count_mapping_delims(bytes: *const u8, len: usize) -> usize;
+
+    fn highway_json_index(
+        buf: *const u8,
+        len: usize,
+        indices: *mut u32,
+        cap: usize,
+        out_count: *mut u32,
+        out_flags: *mut u32,
+    ) -> usize;
+
+    fn highway_json_string_scan(src: *const u8, len: usize, out_pos: *mut u32) -> usize;
+
+    fn highway_json_parse(
+        buf: *const u8,
+        len: usize,
+        indices: *mut u32,
+        indices_cap: usize,
+        tape: *mut u64,
+        strbuf: *mut u8,
+        out_tape_len: *mut u32,
+        out_strbuf_len: *mut u32,
+        out_flags: *mut u32,
+        out_err_pos: *mut u32,
+    ) -> u32;
+}
+
+/// Bytes the SIMD JSON kernels may over-read past the input. Callers must
+/// allocate `len + JSON_PADDING` and may leave the padding uninitialised for
+/// [`json_index`] (it copies the tail block) but MUST zero-fill or otherwise
+/// populate it for [`json_string_scan`].
+pub const JSON_PADDING: usize = 64;
+
+/// Stage-1 result code.
+#[repr(usize)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum JsonIndexError {
+    Ok = 0,
+    UnclosedString = 1,
+    UnescapedCtrlInString = 2,
+    Capacity = 3,
+    Empty = 4,
+}
+
+bitflags::bitflags! {
+    #[derive(Copy, Clone, Default)]
+    pub struct JsonIndexFlags: u32 {
+        const NON_ASCII = 1;
+    }
+}
+
+/// SIMD JSON stage-1: scan `buf[..len]` for structural-character byte
+/// offsets and write them to `indices`. Returns
+/// (`JsonIndexError`, count, flags).
+///
+/// `indices.len()` must be at least `len + 64` so the per-block over-write
+/// never spills.
+///
+/// # Safety
+/// `buf` must be readable for `len` bytes (the kernel internally copies the
+/// final partial block, so no over-read past `len` here).
+#[inline]
+pub fn json_index(buf: &[u8], indices: &mut [u32]) -> (JsonIndexError, u32, JsonIndexFlags) {
+    debug_assert!(indices.len() >= buf.len() + 64);
+    let mut count: u32 = 0;
+    let mut flags: u32 = 0;
+    // SAFETY: buf.ptr/len readable; indices.ptr writable for indices.len()
+    // u32s; out-params are valid stack writes.
+    let rc = unsafe {
+        highway_json_index(
+            buf.as_ptr(),
+            buf.len(),
+            indices.as_mut_ptr(),
+            indices.len(),
+            &mut count,
+            &mut flags,
+        )
+    };
+    let err = match rc {
+        0 => JsonIndexError::Ok,
+        1 => JsonIndexError::UnclosedString,
+        2 => JsonIndexError::UnescapedCtrlInString,
+        3 => JsonIndexError::Capacity,
+        _ => JsonIndexError::Empty,
+    };
+    (err, count, JsonIndexFlags::from_bits_truncate(flags))
+}
+
+/// Tape word tags written by `highway_json_parse`.
+pub mod json_tape {
+    pub const ROOT: u8 = b'r';
+    pub const START_OBJ: u8 = b'{';
+    pub const END_OBJ: u8 = b'}';
+    pub const START_ARR: u8 = b'[';
+    pub const END_ARR: u8 = b']';
+    pub const STR: u8 = b'"';
+    pub const DBL: u8 = b'd';
+    pub const TRUE: u8 = b't';
+    pub const FALSE: u8 = b'f';
+    pub const NULL: u8 = b'n';
+
+    #[inline]
+    pub fn tag(w: u64) -> u8 {
+        (w >> 56) as u8
+    }
+    #[inline]
+    pub fn payload(w: u64) -> u64 {
+        w & 0x00FF_FFFF_FFFF_FFFF
+    }
+}
+
+/// Stage-2 result code (matches `err::*` in `highway_json.cpp`).
+#[repr(u32)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum JsonParseError {
+    Ok = 0,
+    UnclosedString = 1,
+    UnescapedCtrl = 2,
+    Capacity = 3,
+    Empty = 4,
+    DepthExceeded = 5,
+    Tape = 6,
+    Number = 7,
+    Atom = 8,
+    Utf8 = 9,
+    StringEscape = 10,
+    Trailing = 11,
+}
+
+pub struct JsonParseOutput {
+    pub tape_len: u32,
+    pub strbuf_len: u32,
+    pub flags: JsonIndexFlags,
+    pub err_pos: u32,
+}
+
+/// Full simdjson-style parse: stage-1 + stage-2 in one call.
+///
+/// # Safety
+/// - `buf` must be readable for exactly `len` bytes (no padding required).
+/// - `indices` writable for `len + 64 + 4` u32s.
+/// - `tape` writable for `len + len/2 + 8` u64s.
+/// - `strbuf` writable for `len + 32` u8s.
+#[inline]
+pub unsafe fn json_parse(
+    buf: *const u8,
+    len: usize,
+    indices: *mut u32,
+    indices_cap: usize,
+    tape: *mut u64,
+    strbuf: *mut u8,
+) -> (JsonParseError, JsonParseOutput) {
+    let mut tlen = 0u32;
+    let mut slen = 0u32;
+    let mut flags = 0u32;
+    let mut epos = 0u32;
+    // SAFETY: caller contract.
+    let rc = unsafe {
+        highway_json_parse(
+            buf,
+            len,
+            indices,
+            indices_cap,
+            tape,
+            strbuf,
+            &mut tlen,
+            &mut slen,
+            &mut flags,
+            &mut epos,
+        )
+    };
+    let err = match rc {
+        0 => JsonParseError::Ok,
+        1 => JsonParseError::UnclosedString,
+        2 => JsonParseError::UnescapedCtrl,
+        3 => JsonParseError::Capacity,
+        4 => JsonParseError::Empty,
+        5 => JsonParseError::DepthExceeded,
+        6 => JsonParseError::Tape,
+        7 => JsonParseError::Number,
+        8 => JsonParseError::Atom,
+        9 => JsonParseError::Utf8,
+        10 => JsonParseError::StringEscape,
+        _ => JsonParseError::Trailing,
+    };
+    (
+        err,
+        JsonParseOutput {
+            tape_len: tlen,
+            strbuf_len: slen,
+            flags: JsonIndexFlags::from_bits_truncate(flags),
+            err_pos: epos,
+        },
+    )
+}
+
+/// First `"` or `\` in `src[..len]`. Returns (kind, pos) where kind is 0 if
+/// neither found in the window, 1 if a quote comes first, 2 if a backslash
+/// comes first. May over-read into padding; pass `len` no larger than
+/// `buf.len() - JSON_PADDING` worth of remaining + JSON_PADDING.
+///
+/// # Safety
+/// `src` must be readable for `len` bytes.
+#[inline]
+pub unsafe fn json_string_scan(src: *const u8, len: usize) -> (u32, u32) {
+    let mut pos: u32 = 0;
+    // SAFETY: caller contract.
+    let kind = unsafe { highway_json_string_scan(src, len, &mut pos) };
+    (kind as u32, pos)
 }
 
 // NOTE: every public wrapper below is `#[inline(always)]`. They are thin

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1970,7 +1970,7 @@ impl PackageManifest {
         // `IntoStr`; the Source only lives for the duration of this function,
         // so pass the caller's buffers through directly without manufacturing
         // `'static` references here (PORTING.md §Forbidden lifetime extension).
-let _t0 = std::time::Instant::now();
+        let _t0 = std::time::Instant::now();
         let source = bun_ast::Source::init_path_string(expected_name, json_buffer);
         initialize_store();
         // `initialize_mini_store` deliberately keeps the allocator pushed
@@ -1993,7 +1993,7 @@ let _t0 = std::time::Instant::now();
             }
         };
 
-let _t_json = _t0.elapsed();
+        let _t_json = _t0.elapsed();
 
         if let Some(error_q) = json.as_property(b"error") {
             if let Some(err) = error_q.expr.as_string(&bump) {
@@ -2379,7 +2379,7 @@ let _t_json = _t0.elapsed();
         string_builder.cap += (string_builder.cap % 64) + 64;
         string_builder.cap *= 2;
 
-let _t_count = _t0.elapsed();
+        let _t_count = _t0.elapsed();
 
         string_builder.allocate()?;
 
@@ -3485,7 +3485,7 @@ let _t_count = _t0.elapsed();
 
         let _ = all_tarball_url_strings; // suppress unused-mut warnings
 
-{
+        {
             let total = _t0.elapsed();
             PARSE_TOTAL_NS.fetch_add(
                 total.as_nanos() as u64,
@@ -3819,8 +3819,11 @@ impl PackageManifest {
             vec![PackageVersion::default(); release_versions_len + pre_versions_len]
                 .into_boxed_slice();
         let mut all_semver_versions: Box<[Semver::Version]> =
-            vec![Semver::Version::default(); release_versions_len + pre_versions_len + dist_tags_count]
-                .into_boxed_slice();
+            vec![
+                Semver::Version::default();
+                release_versions_len + pre_versions_len + dist_tags_count
+            ]
+            .into_boxed_slice();
         let mut all_extern_strings: Box<[ExternalString]> =
             vec![ExternalString::default(); extern_string_count + tarball_urls_count]
                 .into_boxed_slice();
@@ -4013,13 +4016,11 @@ impl PackageManifest {
                                             let Some(k) = decode_key(k_raw, &bump) else {
                                                 break 'bin;
                                             };
-                                            let cur =
-                                                string_builder.append::<ExternalString>(k);
+                                            let cur = string_builder.append::<ExternalString>(k);
                                             all_extern_strings_bin_entries
                                                 [group_start + group_i as usize] = cur;
                                             if is_identical {
-                                                let prev =
-                                                    prev_extern_bin_group.as_ref().unwrap();
+                                                let prev = prev_extern_bin_group.as_ref().unwrap();
                                                 is_identical = cur.hash
                                                     == all_extern_strings_bin_entries
                                                         [prev.start + group_i as usize]
@@ -4029,13 +4030,11 @@ impl PackageManifest {
                                             let Some(v) = v.as_str_decoded(&bump) else {
                                                 break 'bin;
                                             };
-                                            let cur =
-                                                string_builder.append::<ExternalString>(v);
+                                            let cur = string_builder.append::<ExternalString>(v);
                                             all_extern_strings_bin_entries
                                                 [group_start + group_i as usize] = cur;
                                             if is_identical {
-                                                let prev =
-                                                    prev_extern_bin_group.as_ref().unwrap();
+                                                let prev = prev_extern_bin_group.as_ref().unwrap();
                                                 is_identical = cur.hash
                                                     == all_extern_strings_bin_entries
                                                         [prev.start + group_i as usize]
@@ -4054,12 +4053,10 @@ impl PackageManifest {
                                         package_version.bin = Bin {
                                             tag: bin::Tag::Map,
                                             _padding_tag: [0; 3],
-                                            value: bin::Value::init_map(
-                                                ExternalStringList::init(
-                                                    &all_extern_strings_bin_entries,
-                                                    &all_extern_strings_bin_entries[final_range],
-                                                ),
-                                            ),
+                                            value: bin::Value::init_map(ExternalStringList::init(
+                                                &all_extern_strings_bin_entries,
+                                                &all_extern_strings_bin_entries[final_range],
+                                            )),
                                         };
                                     }
                                 }
@@ -4090,9 +4087,7 @@ impl PackageManifest {
                         package_version.bin = Bin {
                             tag: bin::Tag::Dir,
                             _padding_tag: [0; 3],
-                            value: bin::Value::init_dir(
-                                string_builder.append::<SemverString>(s),
-                            ),
+                            value: bin::Value::init_dir(string_builder.append::<SemverString>(s)),
                         };
                         break 'bin;
                     }
@@ -4170,17 +4165,14 @@ impl PackageManifest {
                             {
                                 optional_peer_dep_names.reserve(meta_c.len());
                                 for (mk_raw, mv) in meta_c.iter_object() {
-                                    if mv.get(b"optional").and_then(|c| c.as_bool())
-                                        != Some(true)
-                                    {
+                                    if mv.get(b"optional").and_then(|c| c.as_bool()) != Some(true) {
                                         continue;
                                     }
                                     let Some(mk) = decode_key(mk_raw, &bump) else {
                                         continue;
                                     };
-                                    optional_peer_dep_names.push(
-                                        Semver::semver_string::Builder::string_hash(mk),
-                                    );
+                                    optional_peer_dep_names
+                                        .push(Semver::semver_string::Builder::string_hash(mk));
                                 }
                             }
                         }
@@ -4204,37 +4196,32 @@ impl PackageManifest {
                                 if !bundle_all_deps && bundled_deps_set.swap_remove(name_str) {
                                     // SAFETY: bundled_deps_buf sized in counting pass.
                                     unsafe {
-                                        *bundled_deps_buf
-                                            .as_mut_ptr()
-                                            .add(bundled_deps_offset) =
+                                        *bundled_deps_buf.as_mut_ptr().add(bundled_deps_offset) =
                                             all_extern_strings[names_base + i].hash;
                                     }
                                     bundled_deps_offset += 1;
                                 }
 
                                 if is_peer {
-                                    if optional_peer_dep_names.iter().any(|h| {
-                                        *h == all_extern_strings[names_base + i].hash
-                                    }) {
+                                    if optional_peer_dep_names
+                                        .iter()
+                                        .any(|h| *h == all_extern_strings[names_base + i].hash)
+                                    {
                                         if non_optional_peer_dependency_offset != i {
                                             all_extern_strings.swap(
                                                 names_base + i,
-                                                names_base
-                                                    + non_optional_peer_dependency_offset,
+                                                names_base + non_optional_peer_dependency_offset,
                                             );
                                             version_extern_strings.swap(
                                                 values_base + i,
-                                                values_base
-                                                    + non_optional_peer_dependency_offset,
+                                                values_base + non_optional_peer_dependency_offset,
                                             );
                                         }
                                         non_optional_peer_dependency_offset += 1;
                                     }
                                     if optional_peer_dep_names.is_empty() {
                                         name_hasher.update(
-                                            &all_extern_strings[names_base + i]
-                                                .hash
-                                                .to_ne_bytes(),
+                                            &all_extern_strings[names_base + i].hash.to_ne_bytes(),
                                         );
                                         version_hasher.update(
                                             &version_extern_strings[values_base + i]
@@ -4244,14 +4231,10 @@ impl PackageManifest {
                                     }
                                 } else {
                                     name_hasher.update(
-                                        &all_extern_strings[names_base + i]
-                                            .hash
-                                            .to_ne_bytes(),
+                                        &all_extern_strings[names_base + i].hash.to_ne_bytes(),
                                     );
                                     version_hasher.update(
-                                        &version_extern_strings[values_base + i]
-                                            .hash
-                                            .to_ne_bytes(),
+                                        &version_extern_strings[values_base + i].hash.to_ne_bytes(),
                                     );
                                 }
                                 i += 1;
@@ -4269,10 +4252,8 @@ impl PackageManifest {
                                 let Some(mk) = decode_key(mk_raw, &bump) else {
                                     continue;
                                 };
-                                let meta_hash =
-                                    Semver::semver_string::Builder::string_hash(mk);
-                                for existing in &all_extern_strings[names_base..names_base + i]
-                                {
+                                let meta_hash = Semver::semver_string::Builder::string_hash(mk);
+                                for existing in &all_extern_strings[names_base..names_base + i] {
                                     if existing.hash == meta_hash {
                                         continue 'outer;
                                     }
@@ -4309,8 +4290,7 @@ impl PackageManifest {
                                 package_version.bundled_dependencies =
                                     ExternalPackageNameHashList::init(
                                         &bundled_deps_buf,
-                                        &bundled_deps_buf
-                                            [bundled_deps_begin..bundled_deps_offset],
+                                        &bundled_deps_buf[bundled_deps_begin..bundled_deps_offset],
                                     );
                             }
                         }
@@ -4336,8 +4316,8 @@ impl PackageManifest {
                                 *name_entry.value_ptr = name_list;
                                 dependency_names_cursor += count;
                             }
-                            let version_entry = version_extern_strings_dedupe_map
-                                .get_or_put(version_map_hash)?;
+                            let version_entry =
+                                version_extern_strings_dedupe_map.get_or_put(version_map_hash)?;
                             if version_entry.found_existing {
                                 version_list = *version_entry.value_ptr;
                             } else {
@@ -4363,8 +4343,8 @@ impl PackageManifest {
                     }
                 }
 
-                if let Some(t) = time_map
-                    .get(&Semver::semver_string::Builder::string_hash(version_name))
+                if let Some(t) =
+                    time_map.get(&Semver::semver_string::Builder::string_hash(version_name))
                     && let Some(s) = t.as_str_decoded(&bump)
                     && let Ok(ms) = bun_core::wtf::parse_es5_date(s)
                 {
@@ -4372,14 +4352,12 @@ impl PackageManifest {
                 }
 
                 if !parsed_version.version.tag.has_pre() {
-                    all_semver_versions[release_versions_cursor] =
-                        parsed_version.version.min();
+                    all_semver_versions[release_versions_cursor] = parsed_version.version.min();
                     versioned_packages[versioned_package_releases_start] = package_version;
                     release_versions_cursor += 1;
                     versioned_package_releases_start += 1;
                 } else {
-                    all_semver_versions[prerelease_versions_cursor] =
-                        parsed_version.version.min();
+                    all_semver_versions[prerelease_versions_cursor] = parsed_version.version.min();
                     versioned_packages[versioned_package_prereleases_start] = package_version;
                     prerelease_versions_cursor += 1;
                     versioned_package_prereleases_start += 1;
@@ -4404,8 +4382,7 @@ impl PackageManifest {
                 let Some(version_name) = value.as_str_decoded(&bump) else {
                     continue;
                 };
-                let dist_tag_value_literal =
-                    string_builder.append::<ExternalString>(version_name);
+                let dist_tag_value_literal = string_builder.append::<ExternalString>(version_name);
                 let sliced_string = dist_tag_value_literal
                     .value
                     .sliced(string_builder.allocated_slice());
@@ -4612,14 +4589,11 @@ thread_local! {
 
 static USE_CURSOR_PARSE: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
-static USE_SCALAR_JSON: core::sync::atomic::AtomicBool =
-    core::sync::atomic::AtomicBool::new(false);
+static USE_SCALAR_JSON: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 static PARSE_BENCH_INIT: std::sync::Once = std::sync::Once::new();
 pub static PARSE_TOTAL_NS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
-pub static PARSE_TOTAL_BYTES: core::sync::atomic::AtomicU64 =
-    core::sync::atomic::AtomicU64::new(0);
-pub static PARSE_CALL_COUNT: core::sync::atomic::AtomicU64 =
-    core::sync::atomic::AtomicU64::new(0);
+pub static PARSE_TOTAL_BYTES: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+pub static PARSE_CALL_COUNT: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
 fn parse_bench_init() {
     PARSE_BENCH_INIT.call_once(|| {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1953,10 +1953,24 @@ impl PackageManifest {
         public_max_age: u32,
         is_extended_manifest: bool,
     ) -> Result<Option<PackageManifest>, Error> {
+        parse_bench_init();
+        if USE_CURSOR_PARSE.load(core::sync::atomic::Ordering::Relaxed) {
+            return Self::parse_cursor(
+                scope,
+                log,
+                json_buffer,
+                expected_name,
+                last_modified,
+                etag,
+                public_max_age,
+                is_extended_manifest,
+            );
+        }
         // `bun_ast::Source::init_path_string` accepts borrowed `&[u8]` via
         // `IntoStr`; the Source only lives for the duration of this function,
         // so pass the caller's buffers through directly without manufacturing
         // `'static` references here (PORTING.md §Forbidden lifetime extension).
+let _t0 = std::time::Instant::now();
         let source = bun_ast::Source::init_path_string(expected_name, json_buffer);
         initialize_store();
         // `initialize_mini_store` deliberately keeps the allocator pushed
@@ -1964,7 +1978,11 @@ impl PackageManifest {
         // bulk-frees via `reset_retain_with_limit` on the next call — see
         // `initialize_mini_store` in lib.rs for why.
         let bump = bun_alloc::Arena::new();
-        let json = match JSON::parse_utf8(&source, log, &bump) {
+        let json = match if USE_SCALAR_JSON.load(core::sync::atomic::Ordering::Relaxed) {
+            JSON::parse_utf8_scalar(&source, log, &bump)
+        } else {
+            JSON::parse_utf8(&source, log, &bump)
+        } {
             Ok(j) => j,
             Err(_) => {
                 // don't use the arena memory!
@@ -1974,6 +1992,8 @@ impl PackageManifest {
                 return Ok(None);
             }
         };
+
+let _t_json = _t0.elapsed();
 
         if let Some(error_q) = json.as_property(b"error") {
             if let Some(err) = error_q.expr.as_string(&bump) {
@@ -2358,6 +2378,8 @@ impl PackageManifest {
         let mut extern_strings_consumed: usize = 0; // tracks `all_extern_strings.len - extern_strings.len`
         string_builder.cap += (string_builder.cap % 64) + 64;
         string_builder.cap *= 2;
+
+let _t_count = _t0.elapsed();
 
         string_builder.allocate()?;
 
@@ -3463,6 +3485,1178 @@ impl PackageManifest {
 
         let _ = all_tarball_url_strings; // suppress unused-mut warnings
 
+{
+            let total = _t0.elapsed();
+            PARSE_TOTAL_NS.fetch_add(
+                total.as_nanos() as u64,
+                core::sync::atomic::Ordering::Relaxed,
+            );
+            PARSE_TOTAL_BYTES.fetch_add(
+                json_buffer.len() as u64,
+                core::sync::atomic::Ordering::Relaxed,
+            );
+            PARSE_CALL_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+            PARSE_TIMING.with(|t| {
+                t.set(ParseTiming {
+                    json_ns: _t_json.as_nanos() as u64,
+                    count_ns: (_t_count - _t_json).as_nanos() as u64,
+                    build_ns: (total - _t_count).as_nanos() as u64,
+                    total_ns: total.as_nanos() as u64,
+                });
+            });
+        }
         Ok(Some(result))
     }
+}
+
+fn negatable_from_cursor<T: NegatableEnum>(c: &cursor::JsonCursor<'_>) -> T {
+    let mut this = T::NONE.negatable();
+    match c.kind() {
+        cursor::JsonKind::Array => {
+            for item in c.iter_array() {
+                if let Some(value) = item.as_str() {
+                    this.apply(value);
+                }
+            }
+        }
+        cursor::JsonKind::String => {
+            if let Some(s) = c.as_str() {
+                this.apply(s);
+            }
+        }
+        _ => {}
+    }
+    this.combine()
+}
+
+use bun_parsers::json_cursor as cursor;
+
+impl PackageManifest {
+    /// Port of [`PackageManifest::parse`] over [`cursor::JsonCursor`] instead
+    /// of `Expr`. Produces an identical `PackageManifest`; kept side-by-side
+    /// for benchmarking until one supersedes the other.
+    pub fn parse_cursor(
+        scope: &registry::Scope,
+        log: &mut bun_ast::Log,
+        json_buffer: &[u8],
+        expected_name: &[u8],
+        last_modified: &[u8],
+        etag: &[u8],
+        public_max_age: u32,
+        is_extended_manifest: bool,
+    ) -> Result<Option<PackageManifest>, Error> {
+        let _t0 = std::time::Instant::now();
+        let source = bun_ast::Source::init_path_string(expected_name, json_buffer);
+        // No `initialize_store()` / `Arena::new()` — the cursor never allocates
+        // AST nodes. `bump` is kept only for `as_str_decoded` (escaped strings).
+        let bump = bun_alloc::Arena::new();
+        let doc = match cursor::JsonDoc::parse(&source, log) {
+            Ok(d) => d,
+            Err(_) => {
+                let mut cloned_log = bun_ast::Log::init();
+                log.clone_to_with_recycled(&mut cloned_log, true);
+                *log = cloned_log;
+                return Ok(None);
+            }
+        };
+        let json = doc.root();
+        let _t_json = _t0.elapsed();
+
+        if let Some(err_c) = json.get(b"error")
+            && let Some(err) = err_c.as_str_decoded(&bump)
+        {
+            log.add_error_fmt(
+                Some(&source),
+                bun_ast::Loc::EMPTY,
+                format_args!("npm error: {}", bstr::BStr::new(err)),
+            );
+            return Ok(None);
+        }
+
+        let mut result: PackageManifest = PackageManifest::default();
+        let mut all_extern_strings_dedupe_map = ExternalStringMapDeduper::default();
+        let mut version_extern_strings_dedupe_map = ExternalStringMapDeduper::default();
+        let mut optional_peer_dep_names: Vec<u64> = Vec::new();
+        let mut bundled_deps_set = StringSet::init();
+        let mut bundle_all_deps: bool;
+        let mut bundled_deps_count: usize = 0;
+        let mut string_builder = Semver::semver_string::Builder {
+            string_pool: Semver::semver_string::StringPool::default(),
+            ..Default::default()
+        };
+
+        if PackageManager::verbose_install()
+            && let Some(name_c) = json.get(b"name")
+        {
+            let Some(received_name) = name_c.as_str_decoded(&bump) else {
+                return Ok(None);
+            };
+            if scope.url_hash == *registry::DEFAULT_URL_HASH
+                && !strings::eql_long(expected_name, received_name, true)
+            {
+                bun_core::warn!(
+                    "Package name mismatch. Expected <b>\"{}\"<r> but received <red>\"{}\"<r>",
+                    bstr::BStr::new(expected_name),
+                    bstr::BStr::new(received_name),
+                );
+            }
+        }
+
+        string_builder.count(expected_name);
+
+        if let Some(modified_c) = json.get(b"modified") {
+            let Some(field) = modified_c.as_str_decoded(&bump) else {
+                return Ok(None);
+            };
+            string_builder.count(field);
+        }
+
+        let mut release_versions_len: usize = 0;
+        let mut pre_versions_len: usize = 0;
+        let mut dependency_sum: usize = 0;
+        let mut extern_string_count: usize = 0;
+        let mut extern_string_count_bin: usize = 0;
+        let mut tarball_urls_count: usize = 0;
+
+        // ── count pass ───────────────────────────────────────────────────
+        'get_versions: {
+            let Some(versions_c) = json.get(b"versions") else {
+                break 'get_versions;
+            };
+            if !versions_c.is_object() {
+                break 'get_versions;
+            }
+            for (version_name_raw, ver) in versions_c.iter_object() {
+                let version_name: &[u8] = if version_name_raw.contains(&b'\\') {
+                    match versions_c.get(version_name_raw) {
+                        // Unreachable in practice — version keys are semver.
+                        _ => continue,
+                    }
+                } else {
+                    version_name_raw
+                };
+                let sliced_version = SlicedString::init(version_name, version_name);
+                let parsed_version = Semver::Version::parse(sliced_version);
+                if cfg!(debug_assertions) {
+                    debug_assert!(parsed_version.valid);
+                }
+                if !parsed_version.valid {
+                    log.add_error_fmt(
+                        Some(&source),
+                        ver.loc(),
+                        format_args!(
+                            "Failed to parse dependency {}",
+                            bstr::BStr::new(version_name)
+                        ),
+                    );
+                    continue;
+                }
+                if parsed_version.version.tag.has_pre() {
+                    pre_versions_len += 1;
+                    extern_string_count += 1;
+                } else {
+                    extern_string_count +=
+                        (strings::index_of_char(version_name, b'+').is_some()) as usize;
+                    release_versions_len += 1;
+                }
+                string_builder.count(version_name);
+
+                let mut f_dist = None;
+                let mut f_bin = None;
+                let mut f_dirs = None;
+                let mut f_bundle = None;
+                let mut f_deps: [Option<cursor::JsonCursor<'_>>; 3] = [None, None, None];
+                let mut f_pmeta = None;
+                for (k, v) in ver.iter_object() {
+                    match k {
+                        b"dist" => f_dist = Some(v),
+                        b"bin" => f_bin = Some(v),
+                        b"directories" => f_dirs = Some(v),
+                        b"bundleDependencies" => f_bundle = Some(v),
+                        b"bundledDependencies" => {
+                            if f_bundle.is_none() {
+                                f_bundle = Some(v)
+                            }
+                        }
+                        b"dependencies" => f_deps[0] = Some(v),
+                        b"optionalDependencies" => f_deps[1] = Some(v),
+                        b"peerDependencies" => f_deps[2] = Some(v),
+                        b"peerDependenciesMeta" => f_pmeta = Some(v),
+                        _ => {}
+                    }
+                }
+
+                if let Some(dist_c) = f_dist
+                    && let Some(tarball_c) = dist_c.get(b"tarball")
+                    && let Some(tarball) = tarball_c.as_str_decoded(&bump)
+                {
+                    string_builder.count(tarball);
+                    tarball_urls_count += (!tarball.is_empty()) as usize;
+                }
+
+                'bin: {
+                    if let Some(bin_c) = f_bin {
+                        match bin_c.kind() {
+                            cursor::JsonKind::Object => {
+                                let bin_len = bin_c.len();
+                                match bin_len {
+                                    0 => break 'bin,
+                                    1 => {}
+                                    _ => extern_string_count_bin += bin_len * 2,
+                                }
+                                for (k, v) in bin_c.iter_object() {
+                                    let Some(k) = decode_key(k, &bump) else {
+                                        break 'bin;
+                                    };
+                                    string_builder.count(k);
+                                    let Some(v) = v.as_str_decoded(&bump) else {
+                                        break 'bin;
+                                    };
+                                    string_builder.count(v);
+                                }
+                            }
+                            cursor::JsonKind::String => {
+                                if let Some(s) = bin_c.as_str_decoded(&bump) {
+                                    string_builder.count(s);
+                                    break 'bin;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    if let Some(dirs_c) = f_dirs
+                        && let Some(bin_c) = dirs_c.get(b"bin")
+                        && let Some(s) = bin_c.as_str_decoded(&bump)
+                    {
+                        string_builder.count(s);
+                        break 'bin;
+                    }
+                }
+
+                bundled_deps_set.map.clear_retaining_capacity();
+                bundle_all_deps = false;
+                if let Some(bd) = f_bundle {
+                    match bd.kind() {
+                        cursor::JsonKind::True | cursor::JsonKind::False => {
+                            bundle_all_deps = bd.as_bool().unwrap_or(false);
+                        }
+                        cursor::JsonKind::Array => {
+                            for item in bd.iter_array() {
+                                let Some(s) = item.as_str_decoded(&bump) else {
+                                    continue;
+                                };
+                                bundled_deps_set.insert(s)?;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                for (gi, _pair) in DEPENDENCY_GROUPS.iter().enumerate() {
+                    if let Some(deps_c) = f_deps[gi]
+                        && deps_c.is_object()
+                    {
+                        for (key_raw, value) in deps_c.iter_object() {
+                            let Some(key) = decode_key(key_raw, &bump) else {
+                                continue;
+                            };
+                            dependency_sum += 1;
+                            if !bundle_all_deps && bundled_deps_set.swap_remove(key) {
+                                bundled_deps_count += 1;
+                            }
+                            string_builder.count(key);
+                            string_builder.count(value.as_str_decoded(&bump).unwrap_or(b""));
+                        }
+                    }
+                }
+
+                if let Some(meta_c) = f_pmeta
+                    && meta_c.is_object()
+                {
+                    for (key_raw, mv) in meta_c.iter_object() {
+                        let Some(opt_c) = mv.get(b"optional") else {
+                            continue;
+                        };
+                        if opt_c.as_bool() != Some(true) {
+                            continue;
+                        }
+                        let Some(key) = decode_key(key_raw, &bump) else {
+                            continue;
+                        };
+                        dependency_sum += 1;
+                        string_builder.count(key);
+                        string_builder.count(b"*");
+                    }
+                }
+            }
+        }
+
+        extern_string_count += dependency_sum;
+
+        let mut dist_tags_count: usize = 0;
+        if let Some(dist_c) = json.get(b"dist-tags")
+            && dist_c.is_object()
+        {
+            for (key_raw, value) in dist_c.iter_object() {
+                let Some(key) = decode_key(key_raw, &bump) else {
+                    continue;
+                };
+                string_builder.count(key);
+                extern_string_count += 2;
+                string_builder.count(value.as_str_decoded(&bump).unwrap_or(b""));
+                dist_tags_count += 1;
+            }
+        }
+
+        if !last_modified.is_empty() {
+            string_builder.count(last_modified);
+        }
+        if !etag.is_empty() {
+            string_builder.count(etag);
+        }
+
+        let mut versioned_packages: Box<[PackageVersion]> =
+            vec![PackageVersion::default(); release_versions_len + pre_versions_len]
+                .into_boxed_slice();
+        let mut all_semver_versions: Box<[Semver::Version]> =
+            vec![Semver::Version::default(); release_versions_len + pre_versions_len + dist_tags_count]
+                .into_boxed_slice();
+        let mut all_extern_strings: Box<[ExternalString]> =
+            vec![ExternalString::default(); extern_string_count + tarball_urls_count]
+                .into_boxed_slice();
+        let mut version_extern_strings: Box<[ExternalString]> =
+            vec![ExternalString::default(); dependency_sum].into_boxed_slice();
+        let mut all_extern_strings_bin_entries: Box<[ExternalString]> =
+            vec![ExternalString::default(); extern_string_count_bin].into_boxed_slice();
+        let mut all_tarball_url_strings: Box<[ExternalString]> =
+            vec![ExternalString::default(); tarball_urls_count].into_boxed_slice();
+        let mut bundled_deps_buf: Box<[PackageNameHash]> =
+            vec![PackageNameHash::default(); bundled_deps_count].into_boxed_slice();
+        let mut bundled_deps_offset: usize = 0;
+
+        let mut versioned_package_releases_start: usize = 0;
+        let all_versioned_package_releases_range = 0..release_versions_len;
+        let mut versioned_package_prereleases_start: usize = release_versions_len;
+        let all_versioned_package_prereleases_range =
+            release_versions_len..release_versions_len + pre_versions_len;
+        let all_release_versions_range = 0..release_versions_len;
+        let all_prerelease_versions_range =
+            release_versions_len..release_versions_len + pre_versions_len;
+        let dist_tag_versions_start = release_versions_len + pre_versions_len;
+        let mut release_versions_cursor: usize = 0;
+        let mut prerelease_versions_cursor: usize = release_versions_len;
+        let mut extern_strings_bin_entries_cursor: usize = 0;
+        let mut tarball_url_strings_cursor: usize = 0;
+        let mut extern_strings_consumed: usize = 0;
+
+        string_builder.cap += (string_builder.cap % 64) + 64;
+        string_builder.cap *= 2;
+        let _t_count = _t0.elapsed();
+        string_builder.allocate()?;
+
+        result.pkg.name = string_builder.append::<ExternalString>(expected_name);
+
+        let mut dependency_names_cursor: usize = 0;
+        let mut dependency_values_cursor: usize = 0;
+
+        // ── build pass ───────────────────────────────────────────────────
+        'get_versions2: {
+            let Some(versions_c) = json.get(b"versions") else {
+                break 'get_versions2;
+            };
+            if !versions_c.is_object() {
+                break 'get_versions2;
+            }
+            let mut prev_extern_bin_group: Option<core::ops::Range<usize>> = None;
+            let empty_version = PackageVersion {
+                bin: Bin::init(),
+                ..PackageVersion::default()
+            };
+
+            // `time` has one key per version; a per-version `get()` over it
+            // is O(n²). Index it once.
+            let mut time_map: HashMap<u64, cursor::JsonCursor<'_>, IdentityContext<u64>> =
+                HashMap::default();
+            if let Some(time_c) = json.get(b"time")
+                && time_c.is_object()
+            {
+                for (k, v) in time_c.iter_object() {
+                    time_map.insert(Semver::semver_string::Builder::string_hash(k), v);
+                }
+            }
+
+            for (version_name, ver) in versions_c.iter_object() {
+                if version_name.contains(&b'\\') {
+                    continue;
+                }
+                let mut sliced_version = SlicedString::init(version_name, version_name);
+                let mut parsed_version = Semver::Version::parse(sliced_version);
+                if cfg!(debug_assertions) {
+                    debug_assert!(parsed_version.valid);
+                }
+                if parsed_version.version.tag.has_build() || parsed_version.version.tag.has_pre() {
+                    let version_string = string_builder.append::<SemverString>(version_name);
+                    sliced_version = version_string.sliced(string_builder.allocated_slice());
+                    parsed_version = Semver::Version::parse(sliced_version);
+                }
+                if !parsed_version.valid {
+                    continue;
+                }
+
+                // One pass over this version's keys — capture cursors for the
+                // fields we need instead of calling `ver.get()` ~12 times.
+                let mut f_dist = None;
+                let mut f_bin = None;
+                let mut f_dirs = None;
+                let mut f_bundle = None;
+                let mut f_cpu = None;
+                let mut f_os = None;
+                let mut f_libc = None;
+                let mut f_his = None;
+                let mut f_deps: [Option<cursor::JsonCursor<'_>>; 3] = [None, None, None];
+                let mut f_pmeta = None;
+                for (k, v) in ver.iter_object() {
+                    match k {
+                        b"dist" => f_dist = Some(v),
+                        b"bin" => f_bin = Some(v),
+                        b"directories" => f_dirs = Some(v),
+                        b"bundleDependencies" => f_bundle = Some(v),
+                        b"bundledDependencies" => {
+                            if f_bundle.is_none() {
+                                f_bundle = Some(v)
+                            }
+                        }
+                        b"cpu" => f_cpu = Some(v),
+                        b"os" => f_os = Some(v),
+                        b"libc" => f_libc = Some(v),
+                        b"hasInstallScript" => f_his = Some(v),
+                        b"dependencies" => f_deps[0] = Some(v),
+                        b"optionalDependencies" => f_deps[1] = Some(v),
+                        b"peerDependencies" => f_deps[2] = Some(v),
+                        b"peerDependenciesMeta" => f_pmeta = Some(v),
+                        _ => {}
+                    }
+                }
+
+                bundled_deps_set.map.clear_retaining_capacity();
+                bundle_all_deps = false;
+                if let Some(bd) = f_bundle {
+                    match bd.kind() {
+                        cursor::JsonKind::True | cursor::JsonKind::False => {
+                            bundle_all_deps = bd.as_bool().unwrap_or(false);
+                        }
+                        cursor::JsonKind::Array => {
+                            for item in bd.iter_array() {
+                                let Some(s) = item.as_str_decoded(&bump) else {
+                                    continue;
+                                };
+                                bundled_deps_set.insert(s)?;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                let mut package_version: PackageVersion = empty_version;
+
+                if let Some(c) = f_cpu {
+                    package_version.cpu = negatable_from_cursor::<Architecture>(&c);
+                }
+                if let Some(c) = f_os {
+                    package_version.os = negatable_from_cursor::<OperatingSystem>(&c);
+                }
+                if let Some(c) = f_libc {
+                    package_version.libc = negatable_from_cursor::<Libc>(&c);
+                }
+                if let Some(c) = f_his
+                    && let Some(v) = c.as_bool()
+                {
+                    package_version.has_install_script = v;
+                }
+
+                'bin: {
+                    if let Some(bin_c) = f_bin {
+                        match bin_c.kind() {
+                            cursor::JsonKind::Object => {
+                                let bin_len = bin_c.len();
+                                match bin_len {
+                                    0 => {}
+                                    1 => {
+                                        let mut it = bin_c.iter_object();
+                                        let Some((k_raw, v)) = it.next() else {
+                                            break 'bin;
+                                        };
+                                        let Some(bin_name) = decode_key(k_raw, &bump) else {
+                                            break 'bin;
+                                        };
+                                        let Some(value) = v.as_str_decoded(&bump) else {
+                                            break 'bin;
+                                        };
+                                        package_version.bin = Bin {
+                                            tag: bin::Tag::NamedFile,
+                                            _padding_tag: [0; 3],
+                                            value: bin::Value::init_named_file([
+                                                string_builder.append::<SemverString>(bin_name),
+                                                string_builder.append::<SemverString>(value),
+                                            ]),
+                                        };
+                                    }
+                                    _ => {
+                                        let group_start = extern_strings_bin_entries_cursor;
+                                        let group_len = bin_len * 2;
+                                        let mut is_identical = match &prev_extern_bin_group {
+                                            Some(r) => r.len() == group_len,
+                                            None => false,
+                                        };
+                                        let mut group_i: u32 = 0;
+                                        for (k_raw, v) in bin_c.iter_object() {
+                                            let Some(k) = decode_key(k_raw, &bump) else {
+                                                break 'bin;
+                                            };
+                                            let cur =
+                                                string_builder.append::<ExternalString>(k);
+                                            all_extern_strings_bin_entries
+                                                [group_start + group_i as usize] = cur;
+                                            if is_identical {
+                                                let prev =
+                                                    prev_extern_bin_group.as_ref().unwrap();
+                                                is_identical = cur.hash
+                                                    == all_extern_strings_bin_entries
+                                                        [prev.start + group_i as usize]
+                                                        .hash;
+                                            }
+                                            group_i += 1;
+                                            let Some(v) = v.as_str_decoded(&bump) else {
+                                                break 'bin;
+                                            };
+                                            let cur =
+                                                string_builder.append::<ExternalString>(v);
+                                            all_extern_strings_bin_entries
+                                                [group_start + group_i as usize] = cur;
+                                            if is_identical {
+                                                let prev =
+                                                    prev_extern_bin_group.as_ref().unwrap();
+                                                is_identical = cur.hash
+                                                    == all_extern_strings_bin_entries
+                                                        [prev.start + group_i as usize]
+                                                        .hash;
+                                            }
+                                            group_i += 1;
+                                        }
+                                        let final_range = if is_identical {
+                                            prev_extern_bin_group.clone().unwrap()
+                                        } else {
+                                            let r = group_start..group_start + group_len;
+                                            prev_extern_bin_group = Some(r.clone());
+                                            extern_strings_bin_entries_cursor += group_len;
+                                            r
+                                        };
+                                        package_version.bin = Bin {
+                                            tag: bin::Tag::Map,
+                                            _padding_tag: [0; 3],
+                                            value: bin::Value::init_map(
+                                                ExternalStringList::init(
+                                                    &all_extern_strings_bin_entries,
+                                                    &all_extern_strings_bin_entries[final_range],
+                                                ),
+                                            ),
+                                        };
+                                    }
+                                }
+                                break 'bin;
+                            }
+                            cursor::JsonKind::String => {
+                                if let Some(s) = bin_c.as_str_decoded(&bump) {
+                                    if !s.is_empty() {
+                                        package_version.bin = Bin {
+                                            tag: bin::Tag::File,
+                                            _padding_tag: [0; 3],
+                                            value: bin::Value::init_file(
+                                                string_builder.append::<SemverString>(s),
+                                            ),
+                                        };
+                                        break 'bin;
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    if let Some(dirs_c) = f_dirs
+                        && let Some(bin_c) = dirs_c.get(b"bin")
+                        && let Some(s) = bin_c.as_str_decoded(&bump)
+                        && !s.is_empty()
+                    {
+                        package_version.bin = Bin {
+                            tag: bin::Tag::Dir,
+                            _padding_tag: [0; 3],
+                            value: bin::Value::init_dir(
+                                string_builder.append::<SemverString>(s),
+                            ),
+                        };
+                        break 'bin;
+                    }
+                }
+
+                'integrity: {
+                    if let Some(dist_c) = f_dist
+                        && dist_c.is_object()
+                    {
+                        let mut d_shasum = None;
+                        for (k, v) in dist_c.iter_object() {
+                            match k {
+                                b"tarball" => {
+                                    if let Some(s) = v.as_str_decoded(&bump)
+                                        && !s.is_empty()
+                                    {
+                                        package_version.tarball_url =
+                                            string_builder.append::<ExternalString>(s);
+                                        all_tarball_url_strings[tarball_url_strings_cursor] =
+                                            package_version.tarball_url;
+                                        tarball_url_strings_cursor += 1;
+                                    }
+                                }
+                                b"fileCount" => {
+                                    if let Some(n) = v.as_f64() {
+                                        package_version.file_count = n as u32;
+                                    }
+                                }
+                                b"unpackedSize" => {
+                                    if let Some(n) = v.as_f64() {
+                                        package_version.unpacked_size = n as u32;
+                                    }
+                                }
+                                b"integrity" => {
+                                    if let Some(s) = v.as_str_decoded(&bump) {
+                                        package_version.integrity = Integrity::parse(s);
+                                    }
+                                }
+                                b"shasum" => d_shasum = Some(v),
+                                _ => {}
+                            }
+                        }
+                        if package_version.integrity.tag.is_supported() {
+                            break 'integrity;
+                        }
+                        if let Some(c) = d_shasum
+                            && let Some(s) = c.as_str_decoded(&bump)
+                        {
+                            package_version.integrity =
+                                Integrity::parse_sha_sum(s).unwrap_or_default();
+                        }
+                    }
+                }
+
+                let mut non_optional_peer_dependency_offset: usize = 0;
+
+                for (group_idx, pair) in DEPENDENCY_GROUPS.iter().enumerate() {
+                    let is_peer = pair.prop == b"peerDependencies";
+                    let deps_c = f_deps[group_idx].filter(|c| c.is_object());
+                    let has_meta_only_peers = is_peer
+                        && f_pmeta
+                            .map(|m| m.is_object() && m.len() > 0)
+                            .unwrap_or(false);
+
+                    if deps_c.is_some() || has_meta_only_peers {
+                        let names_base = dependency_names_cursor;
+                        let values_base = dependency_values_cursor;
+                        let mut name_hasher = Wyhash11::init(0);
+                        let mut version_hasher = Wyhash11::init(0);
+
+                        if is_peer {
+                            optional_peer_dep_names.clear();
+                            if let Some(meta_c) = f_pmeta
+                                && meta_c.is_object()
+                            {
+                                optional_peer_dep_names.reserve(meta_c.len());
+                                for (mk_raw, mv) in meta_c.iter_object() {
+                                    if mv.get(b"optional").and_then(|c| c.as_bool())
+                                        != Some(true)
+                                    {
+                                        continue;
+                                    }
+                                    let Some(mk) = decode_key(mk_raw, &bump) else {
+                                        continue;
+                                    };
+                                    optional_peer_dep_names.push(
+                                        Semver::semver_string::Builder::string_hash(mk),
+                                    );
+                                }
+                            }
+                        }
+
+                        let bundled_deps_begin = bundled_deps_offset;
+                        let mut i: usize = 0;
+
+                        if let Some(deps_c) = deps_c {
+                            for (name_raw, value) in deps_c.iter_object() {
+                                let Some(name_str) = decode_key(name_raw, &bump) else {
+                                    continue;
+                                };
+                                let Some(version_str) = value.as_str_decoded(&bump) else {
+                                    continue;
+                                };
+                                all_extern_strings[names_base + i] =
+                                    string_builder.append::<ExternalString>(name_str);
+                                version_extern_strings[values_base + i] =
+                                    string_builder.append::<ExternalString>(version_str);
+
+                                if !bundle_all_deps && bundled_deps_set.swap_remove(name_str) {
+                                    // SAFETY: bundled_deps_buf sized in counting pass.
+                                    unsafe {
+                                        *bundled_deps_buf
+                                            .as_mut_ptr()
+                                            .add(bundled_deps_offset) =
+                                            all_extern_strings[names_base + i].hash;
+                                    }
+                                    bundled_deps_offset += 1;
+                                }
+
+                                if is_peer {
+                                    if optional_peer_dep_names.iter().any(|h| {
+                                        *h == all_extern_strings[names_base + i].hash
+                                    }) {
+                                        if non_optional_peer_dependency_offset != i {
+                                            all_extern_strings.swap(
+                                                names_base + i,
+                                                names_base
+                                                    + non_optional_peer_dependency_offset,
+                                            );
+                                            version_extern_strings.swap(
+                                                values_base + i,
+                                                values_base
+                                                    + non_optional_peer_dependency_offset,
+                                            );
+                                        }
+                                        non_optional_peer_dependency_offset += 1;
+                                    }
+                                    if optional_peer_dep_names.is_empty() {
+                                        name_hasher.update(
+                                            &all_extern_strings[names_base + i]
+                                                .hash
+                                                .to_ne_bytes(),
+                                        );
+                                        version_hasher.update(
+                                            &version_extern_strings[values_base + i]
+                                                .hash
+                                                .to_ne_bytes(),
+                                        );
+                                    }
+                                } else {
+                                    name_hasher.update(
+                                        &all_extern_strings[names_base + i]
+                                            .hash
+                                            .to_ne_bytes(),
+                                    );
+                                    version_hasher.update(
+                                        &version_extern_strings[values_base + i]
+                                            .hash
+                                            .to_ne_bytes(),
+                                    );
+                                }
+                                i += 1;
+                            }
+                        }
+
+                        if is_peer
+                            && let Some(meta_c) = f_pmeta
+                            && meta_c.is_object()
+                        {
+                            'outer: for (mk_raw, mv) in meta_c.iter_object() {
+                                if mv.get(b"optional").and_then(|c| c.as_bool()) != Some(true) {
+                                    continue;
+                                }
+                                let Some(mk) = decode_key(mk_raw, &bump) else {
+                                    continue;
+                                };
+                                let meta_hash =
+                                    Semver::semver_string::Builder::string_hash(mk);
+                                for existing in &all_extern_strings[names_base..names_base + i]
+                                {
+                                    if existing.hash == meta_hash {
+                                        continue 'outer;
+                                    }
+                                }
+                                all_extern_strings[names_base + i] =
+                                    string_builder.append::<ExternalString>(mk);
+                                version_extern_strings[values_base + i] =
+                                    string_builder.append::<ExternalString>(b"*");
+                                if non_optional_peer_dependency_offset != i {
+                                    all_extern_strings.swap(
+                                        names_base + i,
+                                        names_base + non_optional_peer_dependency_offset,
+                                    );
+                                    version_extern_strings.swap(
+                                        values_base + i,
+                                        values_base + non_optional_peer_dependency_offset,
+                                    );
+                                }
+                                non_optional_peer_dependency_offset += 1;
+                                i += 1;
+                            }
+                        }
+
+                        let count = i;
+                        let this_names = &all_extern_strings[names_base..names_base + count];
+                        let this_versions =
+                            &version_extern_strings[values_base..values_base + count];
+
+                        if !is_peer {
+                            if bundle_all_deps {
+                                package_version.bundled_dependencies =
+                                    ExternalPackageNameHashList::INVALID;
+                            } else {
+                                package_version.bundled_dependencies =
+                                    ExternalPackageNameHashList::init(
+                                        &bundled_deps_buf,
+                                        &bundled_deps_buf
+                                            [bundled_deps_begin..bundled_deps_offset],
+                                    );
+                            }
+                        }
+
+                        let mut name_list =
+                            ExternalStringList::init(&all_extern_strings, this_names);
+                        let mut version_list =
+                            ExternalStringList::init(&version_extern_strings, this_versions);
+
+                        if is_peer {
+                            package_version.non_optional_peer_dependencies_start =
+                                non_optional_peer_dependency_offset as u32;
+                        }
+
+                        if count > 0 && (!is_peer || optional_peer_dep_names.is_empty()) {
+                            let name_map_hash = name_hasher.final_();
+                            let version_map_hash = version_hasher.final_();
+                            let name_entry =
+                                all_extern_strings_dedupe_map.get_or_put(name_map_hash)?;
+                            if name_entry.found_existing {
+                                name_list = *name_entry.value_ptr;
+                            } else {
+                                *name_entry.value_ptr = name_list;
+                                dependency_names_cursor += count;
+                            }
+                            let version_entry = version_extern_strings_dedupe_map
+                                .get_or_put(version_map_hash)?;
+                            if version_entry.found_existing {
+                                version_list = *version_entry.value_ptr;
+                            } else {
+                                *version_entry.value_ptr = version_list;
+                                dependency_values_cursor += count;
+                            }
+                        }
+                        if is_peer && !optional_peer_dep_names.is_empty() {
+                            dependency_names_cursor += count;
+                            dependency_values_cursor += count;
+                        }
+
+                        let map = ExternalStringMap {
+                            name: name_list,
+                            value: version_list,
+                        };
+                        match group_idx {
+                            0 => package_version.dependencies = map,
+                            1 => package_version.optional_dependencies = map,
+                            2 => package_version.peer_dependencies = map,
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+
+                if let Some(t) = time_map
+                    .get(&Semver::semver_string::Builder::string_hash(version_name))
+                    && let Some(s) = t.as_str_decoded(&bump)
+                    && let Ok(ms) = bun_core::wtf::parse_es5_date(s)
+                {
+                    package_version.publish_timestamp_ms = ms;
+                }
+
+                if !parsed_version.version.tag.has_pre() {
+                    all_semver_versions[release_versions_cursor] =
+                        parsed_version.version.min();
+                    versioned_packages[versioned_package_releases_start] = package_version;
+                    release_versions_cursor += 1;
+                    versioned_package_releases_start += 1;
+                } else {
+                    all_semver_versions[prerelease_versions_cursor] =
+                        parsed_version.version.min();
+                    versioned_packages[versioned_package_prereleases_start] = package_version;
+                    prerelease_versions_cursor += 1;
+                    versioned_package_prereleases_start += 1;
+                }
+            }
+            extern_strings_consumed = dependency_names_cursor;
+        }
+        let version_extern_strings_len = dependency_values_cursor;
+        let mut extern_strings_cursor = extern_strings_consumed;
+
+        if let Some(dist_c) = json.get(b"dist-tags")
+            && dist_c.is_object()
+        {
+            let extern_strings_slice_start = extern_strings_cursor;
+            let mut dist_tag_i: usize = 0;
+            for (key_raw, value) in dist_c.iter_object() {
+                let Some(key) = decode_key(key_raw, &bump) else {
+                    continue;
+                };
+                all_extern_strings[extern_strings_slice_start + dist_tag_i] =
+                    string_builder.append::<ExternalString>(key);
+                let Some(version_name) = value.as_str_decoded(&bump) else {
+                    continue;
+                };
+                let dist_tag_value_literal =
+                    string_builder.append::<ExternalString>(version_name);
+                let sliced_string = dist_tag_value_literal
+                    .value
+                    .sliced(string_builder.allocated_slice());
+                all_semver_versions[dist_tag_versions_start + dist_tag_i] =
+                    Semver::Version::parse(sliced_string).version.min();
+                dist_tag_i += 1;
+            }
+            result.pkg.dist_tags = DistTagMap {
+                tags: ExternalStringList::init(
+                    &all_extern_strings,
+                    &all_extern_strings
+                        [extern_strings_slice_start..extern_strings_slice_start + dist_tag_i],
+                ),
+                versions: VersionSlice::init(
+                    &all_semver_versions,
+                    &all_semver_versions
+                        [dist_tag_versions_start..dist_tag_versions_start + dist_tag_i],
+                ),
+            };
+            extern_strings_cursor += dist_tag_i;
+        }
+
+        if !last_modified.is_empty() {
+            result.pkg.last_modified = string_builder.append::<SemverString>(last_modified);
+        }
+        if !etag.is_empty() {
+            result.pkg.etag = string_builder.append::<SemverString>(etag);
+        }
+        if let Some(modified_c) = json.get(b"modified") {
+            let Some(field) = modified_c.as_str_decoded(&bump) else {
+                return Ok(None);
+            };
+            result.pkg.modified = string_builder.append::<SemverString>(field);
+        }
+
+        result.pkg.releases.keys = VersionSlice::init(
+            &all_semver_versions,
+            &all_semver_versions[all_release_versions_range.clone()],
+        );
+        result.pkg.releases.values = PackageVersionList::init(
+            &versioned_packages,
+            &versioned_packages[all_versioned_package_releases_range],
+        );
+        result.pkg.prereleases.keys = VersionSlice::init(
+            &all_semver_versions,
+            &all_semver_versions[all_prerelease_versions_range.clone()],
+        );
+        result.pkg.prereleases.values = PackageVersionList::init(
+            &versioned_packages,
+            &versioned_packages[all_versioned_package_prereleases_range],
+        );
+
+        let max_versions_count = all_release_versions_range
+            .len()
+            .max(all_prerelease_versions_range.len());
+        let how_many_bytes_to_store_indices: usize = match max_versions_count {
+            0 => 0,
+            1 => 1,
+            n => {
+                let bits = (usize::BITS - (n - 1).leading_zeros()) as usize;
+                bits.div_ceil(8)
+            }
+        };
+        macro_rules! sort_with_int {
+            ($Int:ty) => {{
+                type Int = $Int;
+                let mut all_indices: Vec<Int> = vec![0 as Int; max_versions_count];
+                let mut all_cloned_versions: Vec<Semver::Version> =
+                    vec![Semver::Version::default(); max_versions_count];
+                let mut all_cloned_packages: Vec<PackageVersion> =
+                    vec![PackageVersion::default(); max_versions_count];
+                let releases_list = [result.pkg.releases, result.pkg.prereleases];
+                for release_i in 0..2usize {
+                    let release = releases_list[release_i];
+                    let len = release.keys.len as usize;
+                    let indices = &mut all_indices[..len];
+                    let cloned_packages = &mut all_cloned_packages[..len];
+                    let cloned_versions = &mut all_cloned_versions[..len];
+                    let versioned_packages_ =
+                        &mut versioned_packages[release.values.off as usize..][..len];
+                    let semver_versions_ =
+                        &mut all_semver_versions[release.keys.off as usize..][..len];
+                    cloned_packages.copy_from_slice(versioned_packages_);
+                    cloned_versions.copy_from_slice(semver_versions_);
+                    for (idx, dest) in indices.iter_mut().enumerate() {
+                        *dest = idx as Int;
+                    }
+                    let string_bytes = string_builder.allocated_slice();
+                    indices.sort_by(|&left, &right| {
+                        cloned_versions[left as usize].order(
+                            cloned_versions[right as usize],
+                            string_bytes,
+                            string_bytes,
+                        )
+                    });
+                    for ((idx, pkg), version) in indices
+                        .iter()
+                        .copied()
+                        .zip(versioned_packages_.iter_mut())
+                        .zip(semver_versions_.iter_mut())
+                    {
+                        *pkg = cloned_packages[idx as usize];
+                        *version = cloned_versions[idx as usize];
+                    }
+                }
+            }};
+        }
+        match how_many_bytes_to_store_indices {
+            1 => sort_with_int!(u8),
+            2 => sort_with_int!(u16),
+            3 => sort_with_int!(u32),
+            4 => sort_with_int!(u32),
+            5..=8 => sort_with_int!(u64),
+            _ => debug_assert!(max_versions_count == 0),
+        }
+
+        let extern_strings_remaining = all_extern_strings.len() - extern_strings_cursor;
+        if extern_strings_remaining + tarball_urls_count > 0 {
+            let src_len = tarball_url_strings_cursor;
+            if src_len > 0 {
+                debug_assert!(all_extern_strings.len() - extern_strings_cursor >= src_len);
+                all_extern_strings[extern_strings_cursor..extern_strings_cursor + src_len]
+                    .copy_from_slice(&all_tarball_url_strings[..src_len]);
+            }
+            let new_len = all_extern_strings.len() - extern_strings_remaining;
+            let mut v = core::mem::take(&mut all_extern_strings).into_vec();
+            v.truncate(new_len);
+            all_extern_strings = v.into_boxed_slice();
+        }
+
+        result.pkg.string_lists_buf.off = 0;
+        result.pkg.string_lists_buf.len = all_extern_strings.len() as u32;
+        result.pkg.versions_buf.off = 0;
+        result.pkg.versions_buf.len = all_semver_versions.len() as u32;
+
+        result.versions = all_semver_versions;
+        result.external_strings = all_extern_strings;
+        result.external_strings_for_versions = {
+            let mut v = version_extern_strings.into_vec();
+            v.truncate(version_extern_strings_len);
+            v.into_boxed_slice()
+        };
+        result.package_versions = versioned_packages;
+        result.extern_strings_bin_entries = {
+            let mut v = all_extern_strings_bin_entries.into_vec();
+            v.truncate(extern_strings_bin_entries_cursor);
+            v.into_boxed_slice()
+        };
+        result.bundled_deps_buf = bundled_deps_buf;
+        result.pkg.public_max_age = public_max_age;
+        result.pkg.has_extended_manifest = is_extended_manifest;
+
+        if let Some(buf) = string_builder.ptr.take() {
+            let mut v = buf.into_vec();
+            v.truncate(string_builder.len);
+            result.string_buf = v.into_boxed_slice();
+        }
+        let _ = all_tarball_url_strings;
+
+        let total = _t0.elapsed();
+        PARSE_TIMING.with(|t| {
+            t.set(ParseTiming {
+                json_ns: _t_json.as_nanos() as u64,
+                count_ns: (_t_count - _t_json).as_nanos() as u64,
+                build_ns: (total - _t_count).as_nanos() as u64,
+                total_ns: total.as_nanos() as u64,
+            });
+        });
+        PARSE_TOTAL_NS.fetch_add(
+            total.as_nanos() as u64,
+            core::sync::atomic::Ordering::Relaxed,
+        );
+        PARSE_TOTAL_BYTES.fetch_add(
+            json_buffer.len() as u64,
+            core::sync::atomic::Ordering::Relaxed,
+        );
+        PARSE_CALL_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        Ok(Some(result))
+    }
+}
+
+/// `iter_object()` yields raw key bytes; decode escapes when present (rare —
+/// npm package names and packument keys are ASCII).
+#[inline]
+fn decode_key<'a>(raw: &'a [u8], bump: &'a bun_alloc::Arena) -> Option<&'a [u8]> {
+    if raw.contains(&b'\\') {
+        Some(bun_parsers::json_cursor::decode_escapes_into(raw, bump))
+    } else {
+        Some(raw)
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct ParseTiming {
+    pub json_ns: u64,
+    pub count_ns: u64,
+    pub build_ns: u64,
+    pub total_ns: u64,
+}
+thread_local! {
+    pub static PARSE_TIMING: core::cell::Cell<ParseTiming> =
+        const { core::cell::Cell::new(ParseTiming { json_ns: 0, count_ns: 0, build_ns: 0, total_ns: 0 }) };
+}
+
+static USE_CURSOR_PARSE: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+static USE_SCALAR_JSON: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+static PARSE_BENCH_INIT: std::sync::Once = std::sync::Once::new();
+pub static PARSE_TOTAL_NS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+pub static PARSE_TOTAL_BYTES: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0);
+pub static PARSE_CALL_COUNT: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0);
+
+fn parse_bench_init() {
+    PARSE_BENCH_INIT.call_once(|| {
+        if std::env::var_os("BUN_NPM_PARSE_CURSOR").is_some() {
+            USE_CURSOR_PARSE.store(true, core::sync::atomic::Ordering::Relaxed);
+        }
+        if std::env::var_os("BUN_NPM_PARSE_SCALAR").is_some() {
+            USE_SCALAR_JSON.store(true, core::sync::atomic::Ordering::Relaxed);
+        }
+        if std::env::var_os("BUN_NPM_PARSE_STATS").is_some() {
+            bun_core::add_exit_callback(print_parse_stats_c);
+        }
+    });
+}
+
+extern "C" fn print_parse_stats_c() {
+    print_parse_stats();
+}
+
+pub fn print_parse_stats() {
+    let calls = PARSE_CALL_COUNT.load(core::sync::atomic::Ordering::Relaxed);
+    if calls == 0 {
+        return;
+    }
+    let ns = PARSE_TOTAL_NS.load(core::sync::atomic::Ordering::Relaxed);
+    let bytes = PARSE_TOTAL_BYTES.load(core::sync::atomic::Ordering::Relaxed);
+    eprintln!(
+        "[npm parse] {} manifests, {:.1} MB, {:.1} ms total ({})",
+        calls,
+        bytes as f64 / 1024.0 / 1024.0,
+        ns as f64 / 1_000_000.0,
+        if USE_CURSOR_PARSE.load(core::sync::atomic::Ordering::Relaxed) {
+            "cursor"
+        } else if USE_SCALAR_JSON.load(core::sync::atomic::Ordering::Relaxed) {
+            "expr-scalar"
+        } else {
+            "expr-simd"
+        },
+    );
 }

--- a/src/install_jsc/npm_jsc.rs
+++ b/src/install_jsc/npm_jsc.rs
@@ -135,13 +135,10 @@ pub(crate) fn js_bench_manifest_parse(
             match which(&scope, &mut log, json, name, b"", b"", 0, false) {
                 Ok(Some(m)) => {
                     versions = m.versions.len();
-                    string_buf_hash =
-                        npm::registry::Scope::hash(&m.string_buf);
+                    string_buf_hash = npm::registry::Scope::hash(&m.string_buf);
                 }
                 Ok(None) => {
-                    return Err(
-                        global.throw(format_args!("PackageManifest::parse returned None"))
-                    );
+                    return Err(global.throw(format_args!("PackageManifest::parse returned None")));
                 }
                 Err(e) => {
                     return Err(global.throw(format_args!(

--- a/src/install_jsc/npm_jsc.rs
+++ b/src/install_jsc/npm_jsc.rs
@@ -58,7 +58,7 @@ pub struct ManifestBindings;
 impl ManifestBindings {
     pub fn generate(global: &JSGlobalObject) -> JSValue {
         use bun_jsc::JSFunction;
-        let obj = JSValue::create_empty_object(global, 1);
+        let obj = JSValue::create_empty_object(global, 2);
         obj.put(
             global,
             b"parseManifest",
@@ -72,8 +72,115 @@ impl ManifestBindings {
                 Default::default(),
             ),
         );
+        obj.put(
+            global,
+            b"benchManifestParse",
+            JSFunction::create(
+                global,
+                bun_core::String::static_(b"benchManifestParse"),
+                __jsc_host_js_bench_manifest_parse,
+                3,
+                Default::default(),
+            ),
+        );
         obj
     }
+}
+
+/// Time the real `PackageManifest::parse()` on raw packument JSON bytes.
+/// Args: (jsonString, packageName, iters). Returns timing breakdown from
+/// `npm::PARSE_TIMING` (json/count/build/total) averaged over `iters`.
+#[bun_jsc::host_fn]
+pub(crate) fn js_bench_manifest_parse(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    use bun_install::npm;
+
+    let json_str = frame.argument(0).to_slice(global)?;
+    let name_str = frame.argument(1).to_slice(global)?;
+    let iters = frame.argument(2).coerce_to_i32(global)?.max(1) as u32;
+
+    let json = json_str.slice();
+    let name = name_str.slice();
+
+    let scope = npm::registry::Scope {
+        url_hash: *npm::registry::DEFAULT_URL_HASH,
+        url: bun_url::OwnedURL::from_href(Box::from(b"https://registry.npmjs.org/".as_slice())),
+        ..Default::default()
+    };
+
+    type ParseFn = fn(
+        &npm::registry::Scope,
+        &mut bun_ast::Log,
+        &[u8],
+        &[u8],
+        &[u8],
+        &[u8],
+        u32,
+        bool,
+    ) -> Result<Option<npm::PackageManifest>, bun_core::Error>;
+
+    let run = |which: ParseFn| -> JsResult<(npm::ParseTiming, usize, u64)> {
+        // Warmup.
+        for _ in 0..2 {
+            let mut log = bun_ast::Log::init();
+            let _ = which(&scope, &mut log, json, name, b"", b"", 0, false);
+        }
+        let mut sum = npm::ParseTiming::default();
+        let mut versions = 0usize;
+        let mut string_buf_hash = 0u64;
+        for _ in 0..iters {
+            let mut log = bun_ast::Log::init();
+            match which(&scope, &mut log, json, name, b"", b"", 0, false) {
+                Ok(Some(m)) => {
+                    versions = m.versions.len();
+                    string_buf_hash =
+                        npm::registry::Scope::hash(&m.string_buf);
+                }
+                Ok(None) => {
+                    return Err(
+                        global.throw(format_args!("PackageManifest::parse returned None"))
+                    );
+                }
+                Err(e) => {
+                    return Err(global.throw(format_args!(
+                        "PackageManifest::parse failed: {}",
+                        bstr::BStr::new(e.name().as_bytes())
+                    )));
+                }
+            }
+            let t = npm::PARSE_TIMING.with(|c| c.get());
+            sum.json_ns += t.json_ns;
+            sum.count_ns += t.count_ns;
+            sum.build_ns += t.build_ns;
+            sum.total_ns += t.total_ns;
+        }
+        Ok((sum, versions, string_buf_hash))
+    };
+
+    let (sum_expr, ver_expr, hash_expr) = run(npm::PackageManifest::parse)?;
+    let (sum_cur, ver_cur, hash_cur) = run(npm::PackageManifest::parse_cursor)?;
+
+    let obj = JSValue::create_empty_object(global, 12);
+    let f = |n: u64| JSValue::js_number(n as f64 / iters as f64);
+    obj.put(global, b"exprJsonNs", f(sum_expr.json_ns));
+    obj.put(global, b"exprCountNs", f(sum_expr.count_ns));
+    obj.put(global, b"exprBuildNs", f(sum_expr.build_ns));
+    obj.put(global, b"exprTotalNs", f(sum_expr.total_ns));
+    obj.put(global, b"curJsonNs", f(sum_cur.json_ns));
+    obj.put(global, b"curCountNs", f(sum_cur.count_ns));
+    obj.put(global, b"curBuildNs", f(sum_cur.build_ns));
+    obj.put(global, b"curTotalNs", f(sum_cur.total_ns));
+    obj.put(global, b"versionsExpr", JSValue::js_number(ver_expr as f64));
+    obj.put(global, b"versionsCur", JSValue::js_number(ver_cur as f64));
+    obj.put(
+        global,
+        b"outputsMatch",
+        JSValue::js_boolean(ver_expr == ver_cur && hash_expr == hash_cur),
+    );
+    obj.put(global, b"bytes", JSValue::js_number(json.len() as f64));
+    Ok(obj)
 }
 
 // Lives at module scope (not `impl ManifestBindings`) because the

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -85,6 +85,31 @@ export const iniInternals = {
   loadNpmrc: $newRustFunction("ini.rs", "IniTestingAPIs.loadNpmrcFromJS", 2),
 };
 
+export const simdJSONInternals = {
+  parse: $newRustFunction("json_simd_testing.rs", "jsParse", 1) as (input: string) => unknown,
+  index: $newRustFunction("json_simd_testing.rs", "jsIndex", 1) as (input: string) => number[],
+  bench: $newRustFunction("json_simd_testing.rs", "jsBench", 2) as (
+    input: string,
+    iters: number,
+  ) => { bytes: number; iters: number; simdNs: number; scalarNs: number },
+  benchStage1: $newRustFunction("json_simd_testing.rs", "jsBenchStage1", 2) as (
+    input: string,
+    iters: number,
+  ) => { ns: number; count: number; bytes: number },
+  benchTape: $newRustFunction("json_simd_testing.rs", "jsBenchTape", 2) as (
+    input: string,
+    iters: number,
+  ) => { ns: number; tapeLen: number; bytes: number },
+  benchCursor: $newRustFunction("json_simd_testing.rs", "jsBenchCursor", 2) as (
+    input: string,
+    iters: number,
+  ) => { ns: number; versions: number; fields: number; bytes: number },
+  cursorGet: $newRustFunction("json_simd_testing.rs", "jsCursorGet", 2) as (
+    input: string,
+    path: string,
+  ) => string | null | undefined,
+};
+
 export const cssInternals = {
   minifyTestWithOptions: $newRustFunction("css_internals.rs", "minifyTestWithOptions", 3),
   minifyErrorTestWithOptions: $newRustFunction("css_internals.rs", "minifyErrorTestWithOptions", 3),

--- a/src/jsc/bindings/highway_json.cpp
+++ b/src/jsc/bindings/highway_json.cpp
@@ -565,7 +565,8 @@ struct Stage2 {
         const size_t digits = static_cast<size_t>(s - int_start);
         if (!fexp && digits <= 15) {
             uint64_t n = 0;
-            for (const uint8_t* q = int_start; q < s; ++q) n = n * 10 + (*q - '0');
+            for (const uint8_t* q = int_start; q < s; ++q)
+                n = n * 10 + (*q - '0');
             v = static_cast<double>(n);
             if (neg) v = -v;
         } else {

--- a/src/jsc/bindings/highway_json.cpp
+++ b/src/jsc/bindings/highway_json.cpp
@@ -1,0 +1,905 @@
+// SIMD JSON parser — full simdjson-style stage-1 + stage-2.
+//
+// Stage 1: 64-byte block → uint64_t bitmask per character class; backslash-run
+// parity via the borrow-chain subtraction; in-string regions via prefix-XOR;
+// structural-start = (op | scalar-start) & ~string. Emits a flat uint32_t[] of
+// byte offsets.
+//
+// Stage 2: walk the index array as a token stream; emit a tape (uint64_t[]
+// of (tag<<56)|payload words) and a string_buf with all string bodies
+// unescaped. Container start words are back-patched with child count + tape
+// index of the matching end so the consumer can size allocations exactly.
+//
+// One FFI call (`highway_json_parse`) does both stages. Caller supplies a
+// padded input buffer and pre-sized output buffers.
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "highway_json.cpp"
+#include <hwy/foreach_target.h>
+
+#include <hwy/highway.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+HWY_BEFORE_NAMESPACE();
+namespace bun {
+namespace HWY_NAMESPACE {
+
+namespace hn = hwy::HWY_NAMESPACE;
+
+using D8 = hn::CappedTag<uint8_t, 64>;
+
+static constexpr uint64_t ODD_BITS = 0xAAAAAAAAAAAAAAAAULL;
+
+// ─── stage-1 scanning ──────────────────────────────────────────────────────
+
+static HWY_INLINE uint64_t PrefixXor(uint64_t x)
+{
+    x ^= x << 1;
+    x ^= x << 2;
+    x ^= x << 4;
+    x ^= x << 8;
+    x ^= x << 16;
+    x ^= x << 32;
+    return x;
+}
+
+struct BlockMasks {
+    uint64_t backslash, quote, op, ws, ctrl, non_ascii;
+};
+
+static HWY_INLINE uint64_t MaskBitsU64(D8 d, hn::Mask<D8> m)
+{
+#if HWY_MAX_BYTES <= 64
+    return hn::BitsFromMask(d, m);
+#else
+    alignas(8) uint8_t bytes[8] = {};
+    hn::StoreMaskBits(d, m, bytes);
+    uint64_t out;
+    std::memcpy(&out, bytes, sizeof(out));
+    return out;
+#endif
+}
+
+static HWY_INLINE BlockMasks ClassifyBlock(D8 d, const uint8_t* HWY_RESTRICT p)
+{
+    const size_t N = hn::Lanes(d);
+    BlockMasks m {};
+    const auto vbs = hn::Set(d, uint8_t { '\\' });
+    const auto vq = hn::Set(d, uint8_t { '"' });
+    const auto vsp = hn::Set(d, uint8_t { ' ' });
+    const auto vtab = hn::Set(d, uint8_t { '\t' });
+    const auto vlf = hn::Set(d, uint8_t { '\n' });
+    const auto vcr = hn::Set(d, uint8_t { '\r' });
+    const auto vlb = hn::Set(d, uint8_t { '{' });
+    const auto vrb = hn::Set(d, uint8_t { '}' });
+    const auto vlk = hn::Set(d, uint8_t { '[' });
+    const auto vrk = hn::Set(d, uint8_t { ']' });
+    const auto vco = hn::Set(d, uint8_t { ':' });
+    const auto vcm = hn::Set(d, uint8_t { ',' });
+    const auto v20 = hn::Set(d, uint8_t { 0x20 });
+    const auto v7f = hn::Set(d, uint8_t { 0x7F });
+
+    for (size_t i = 0; i < 64; i += N) {
+        const auto v = hn::LoadU(d, p + i);
+        const auto mws = hn::Or(hn::Or(hn::Eq(v, vsp), hn::Eq(v, vtab)),
+            hn::Or(hn::Eq(v, vlf), hn::Eq(v, vcr)));
+        const auto mop = hn::Or(
+            hn::Or(hn::Or(hn::Eq(v, vlb), hn::Eq(v, vrb)),
+                hn::Or(hn::Eq(v, vlk), hn::Eq(v, vrk))),
+            hn::Or(hn::Eq(v, vco), hn::Eq(v, vcm)));
+        m.backslash |= MaskBitsU64(d, hn::Eq(v, vbs)) << i;
+        m.quote |= MaskBitsU64(d, hn::Eq(v, vq)) << i;
+        m.op |= MaskBitsU64(d, mop) << i;
+        m.ws |= MaskBitsU64(d, mws) << i;
+        m.ctrl |= MaskBitsU64(d, hn::Lt(v, v20)) << i;
+        m.non_ascii |= MaskBitsU64(d, hn::Gt(v, v7f)) << i;
+    }
+    return m;
+}
+
+struct EscapeState {
+    uint64_t next_is_escaped = 0;
+    HWY_INLINE uint64_t next(uint64_t backslash)
+    {
+        if (!backslash) {
+            const uint64_t e = next_is_escaped;
+            next_is_escaped = 0;
+            return e;
+        }
+        const uint64_t potential = backslash & ~next_is_escaped;
+        const uint64_t maybe_escaped = potential << 1;
+        const uint64_t escape_and_term = ((maybe_escaped | ODD_BITS) - potential) ^ ODD_BITS;
+        const uint64_t escaped = escape_and_term ^ (backslash | next_is_escaped);
+        next_is_escaped = (escape_and_term & backslash) >> 63;
+        return escaped;
+    }
+};
+
+static HWY_INLINE size_t WriteIndices(uint32_t* HWY_RESTRICT out, uint32_t base, uint64_t bits)
+{
+    if (bits == 0) return 0;
+    const size_t cnt = static_cast<size_t>(hwy::PopCount(bits));
+    size_t i = 0;
+    do {
+        out[i++] = base + static_cast<uint32_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(bits));
+        bits &= bits - 1;
+    } while (bits != 0);
+    return cnt;
+}
+
+static HWY_INLINE uint64_t Follows(uint64_t match, uint64_t& overflow)
+{
+    const uint64_t result = (match << 1) | overflow;
+    overflow = match >> 63;
+    return result;
+}
+
+struct Stage1 {
+    EscapeState esc {};
+    uint64_t prev_in_string = 0, prev_scalar = 0, prev_structurals = 0;
+    uint64_t err_ctrl = 0, any_non_ascii = 0;
+
+    HWY_INLINE uint64_t step(D8 d, const uint8_t* HWY_RESTRICT p)
+    {
+        const BlockMasks bm = ClassifyBlock(d, p);
+        any_non_ascii |= bm.non_ascii;
+        const uint64_t escaped = esc.next(bm.backslash);
+        const uint64_t quote = bm.quote & ~escaped;
+        const uint64_t in_string = PrefixXor(quote) ^ prev_in_string;
+        prev_in_string = static_cast<uint64_t>(static_cast<int64_t>(in_string) >> 63);
+        const uint64_t string_tail = in_string ^ quote;
+        const uint64_t scalar = ~(bm.op | bm.ws);
+        const uint64_t nq_scalar = scalar & ~quote;
+        const uint64_t follows_nq = Follows(nq_scalar, prev_scalar);
+        const uint64_t structurals = (bm.op | (scalar & ~follows_nq)) & ~string_tail;
+        err_ctrl |= bm.ctrl & in_string;
+        const uint64_t out = prev_structurals;
+        prev_structurals = structurals;
+        return out;
+    }
+};
+
+// 0 ok, 1 unclosed string, 2 unescaped ctrl in string, 3 capacity, 4 empty.
+size_t JsonIndexImpl(const uint8_t* HWY_RESTRICT buf, size_t len,
+    uint32_t* HWY_RESTRICT indices, size_t cap,
+    uint32_t* HWY_RESTRICT out_count, uint32_t* HWY_RESTRICT out_flags)
+{
+    *out_count = 0;
+    *out_flags = 0;
+    if (len == 0) return 4;
+
+    D8 d;
+    Stage1 st;
+    size_t n = 0, pos = 0;
+
+    for (; pos + 64 <= len; pos += 64) {
+        if (HWY_UNLIKELY(n + 64 > cap)) return 3;
+        n += WriteIndices(indices + n, static_cast<uint32_t>(pos) - 64, st.step(d, buf + pos));
+    }
+    {
+        uint8_t tail[64];
+        std::memset(tail, ' ', 64);
+        std::memcpy(tail, buf + pos, len - pos);
+        if (HWY_UNLIKELY(n + 64 > cap)) return 3;
+        n += WriteIndices(indices + n, static_cast<uint32_t>(pos) - 64, st.step(d, tail));
+    }
+    if (HWY_UNLIKELY(n + 64 > cap)) return 3;
+    n += WriteIndices(indices + n, static_cast<uint32_t>(pos), st.prev_structurals);
+
+    *out_count = static_cast<uint32_t>(n);
+    *out_flags = (st.any_non_ascii != 0) ? 1u : 0u;
+    if (st.prev_in_string) return 1;
+    if (st.err_ctrl) return 2;
+    if (n == 0) return 4;
+    return 0;
+}
+
+size_t JsonStringScanImpl(const uint8_t* HWY_RESTRICT src, size_t len, uint32_t* HWY_RESTRICT out_pos)
+{
+    D8 d;
+    const size_t N = hn::Lanes(d);
+    const auto vq = hn::Set(d, uint8_t { '"' });
+    const auto vbs = hn::Set(d, uint8_t { '\\' });
+    size_t i = 0;
+    const size_t simd_len = len - (len % N);
+    for (; i < simd_len; i += N) {
+        const auto v = hn::LoadU(d, src + i);
+        const auto mq = hn::Eq(v, vq);
+        const auto mbs = hn::Eq(v, vbs);
+        const intptr_t p = hn::FindFirstTrue(d, hn::Or(mq, mbs));
+        if (p >= 0) {
+            *out_pos = static_cast<uint32_t>(i + static_cast<size_t>(p));
+            const uint64_t qb = MaskBitsU64(d, mq);
+            const uint64_t bb = MaskBitsU64(d, mbs);
+            return (((bb - 1) & qb) != 0) ? 1 : 2;
+        }
+    }
+    for (; i < len; ++i) {
+        const uint8_t c = src[i];
+        if (c == '"' || c == '\\') {
+            *out_pos = static_cast<uint32_t>(i);
+            return c == '"' ? 1 : 2;
+        }
+    }
+    *out_pos = static_cast<uint32_t>(len);
+    return 0;
+}
+
+// ─── stage-2 tape builder ──────────────────────────────────────────────────
+//
+// Tape word: (tag << 56) | payload.
+//   '{' '['   payload bits 0-31 = tape index of matching '}'/']',
+//             bits 32-55 = child count (saturated at 0xFFFFFF)
+//   '}' ']'   payload = tape index of matching '{'/'['
+//   '"'       payload = string_buf offset; next word = (len << 32) | src_loc
+//   'd'       next word = raw f64 bits; payload = src_loc
+//   't' 'f' 'n'  payload = src_loc
+//   'r'       root sentinel pair (start: payload = end index; end: payload = 0)
+
+namespace tape {
+enum : uint8_t {
+    Root = 'r',
+    StartObj = '{',
+    EndObj = '}',
+    StartArr = '[',
+    EndArr = ']',
+    Str = '"',
+    Dbl = 'd',
+    True = 't',
+    False = 'f',
+    Null = 'n',
+};
+}
+
+namespace err {
+enum : uint32_t {
+    Ok = 0,
+    UnclosedString = 1,
+    UnescapedCtrl = 2,
+    Capacity = 3,
+    Empty = 4,
+    DepthExceeded = 5,
+    Tape = 6, // generic structural error; out_err_pos points at the byte
+    Number = 7,
+    Atom = 8,
+    Utf8 = 9,
+    StringEscape = 10,
+    Trailing = 11,
+};
+}
+
+static constexpr size_t kMaxDepth = 1024;
+
+static HWY_INLINE uint64_t TapeWord(uint8_t tag, uint64_t payload)
+{
+    return (static_cast<uint64_t>(tag) << 56) | (payload & 0x00FFFFFFFFFFFFFFULL);
+}
+
+static const uint8_t kEscapeMap[256] = {
+    // clang-format off
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,'"',0,0,0,0,0, 0,0,0,0,0,0,0,'/', 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,'\\',0,0,0,
+    0,0,0x08,0,0,0,0x0c,0, 0,0,0,0,0,0,0x0a,0, 0,0,0x0d,0,0x09,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    // clang-format on
+};
+
+static const uint8_t kStructuralOrWs[256] = {
+    // clang-format off
+    1,0,0,0,0,0,0,0, 0,1,1,0,0,1,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    1,0,0,0,0,0,0,0, 0,0,0,0,1,0,0,0, 0,0,0,0,0,0,0,0, 0,0,1,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,1,0,1,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,1,0,1,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,
+    // clang-format on
+};
+
+static HWY_INLINE int HexVal(uint8_t c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+static HWY_INLINE size_t Utf8Encode(uint32_t cp, uint8_t* dst)
+{
+    if (cp < 0x80) {
+        dst[0] = static_cast<uint8_t>(cp);
+        return 1;
+    }
+    if (cp < 0x800) {
+        dst[0] = static_cast<uint8_t>(0xC0 | (cp >> 6));
+        dst[1] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+        return 2;
+    }
+    if (cp < 0x10000) {
+        dst[0] = static_cast<uint8_t>(0xE0 | (cp >> 12));
+        dst[1] = static_cast<uint8_t>(0x80 | ((cp >> 6) & 0x3F));
+        dst[2] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+        return 3;
+    }
+    dst[0] = static_cast<uint8_t>(0xF0 | (cp >> 18));
+    dst[1] = static_cast<uint8_t>(0x80 | ((cp >> 12) & 0x3F));
+    dst[2] = static_cast<uint8_t>(0x80 | ((cp >> 6) & 0x3F));
+    dst[3] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+    return 4;
+}
+
+struct Stage2 {
+    const uint8_t* buf;
+    const uint8_t* buf_end; // buf + len
+    const uint32_t* idx;
+    size_t n_idx;
+    size_t next;
+    uint64_t* tape;
+    size_t tape_n;
+    uint8_t* strbuf;
+    size_t strbuf_n;
+    uint32_t depth;
+    uint32_t open_tape[kMaxDepth];
+    uint32_t open_count[kMaxDepth];
+    bool is_array[kMaxDepth];
+    uint32_t err_pos;
+
+    HWY_INLINE uint32_t advance() { return idx[next++]; }
+    // Sentinel indices equal `len`; map them to NUL so every dispatch falls
+    // into an error arm without reading past the buffer.
+    HWY_INLINE uint8_t at(uint32_t i) const
+    {
+        return HWY_LIKELY(buf + i < buf_end) ? buf[i] : 0;
+    }
+
+    HWY_INLINE void emit(uint8_t tag, uint64_t payload) { tape[tape_n++] = TapeWord(tag, payload); }
+    HWY_INLINE void emit_raw(uint64_t w) { tape[tape_n++] = w; }
+
+    uint32_t fail(uint32_t e, uint32_t at)
+    {
+        err_pos = at;
+        return e;
+    }
+
+    // One copy-and-find round: load up to 32 bytes from `src` (LoadN — lanes
+    // past the bound read as 0, which is neither '"' nor '\\'), speculatively
+    // store to `dst`, return quote/backslash bitmasks.
+    template<class D>
+    HWY_INLINE void copy_and_find(D d, const uint8_t* src, size_t avail, uint8_t* dst,
+        uint64_t& qbits, uint64_t& bbits)
+    {
+        const auto vq = hn::Set(d, uint8_t { '"' });
+        const auto vbs = hn::Set(d, uint8_t { '\\' });
+        const auto v = hn::LoadN(d, src, avail);
+        hn::StoreU(v, d, dst);
+        alignas(8) uint8_t mb[8] = {};
+        hn::StoreMaskBits(d, hn::Eq(v, vq), mb);
+        std::memcpy(&qbits, mb, sizeof qbits);
+        std::memset(mb, 0, sizeof mb);
+        hn::StoreMaskBits(d, hn::Eq(v, vbs), mb);
+        std::memcpy(&bbits, mb, sizeof bbits);
+    }
+
+    HWY_INLINE bool handle_escape(const uint8_t*& src, uint8_t*& dst)
+    {
+        // `src` is at the backslash; stage 1 guarantees an escape body exists
+        // (an unescaped backslash before end-of-input would have left the
+        // following byte escaped → no unclosed-string failure unless past it).
+        // We still bound-check via the closing quote: any over-read here would
+        // first hit the quote and the qbits branch would have fired.
+        const uint8_t* end = buf_end;
+        const uint8_t e = (src + 1 < end) ? src[1] : 0;
+        if (e == 'u') {
+            if (src + 6 > end) return false;
+            int h0 = HexVal(src[2]), h1 = HexVal(src[3]);
+            int h2 = HexVal(src[4]), h3 = HexVal(src[5]);
+            if ((h0 | h1 | h2 | h3) < 0) return false;
+            uint32_t cp = static_cast<uint32_t>((h0 << 12) | (h1 << 8) | (h2 << 4) | h3);
+            src += 6;
+            if (cp >= 0xD800 && cp < 0xDC00 && src + 6 <= end && src[0] == '\\' && src[1] == 'u') {
+                int g0 = HexVal(src[2]), g1 = HexVal(src[3]);
+                int g2 = HexVal(src[4]), g3 = HexVal(src[5]);
+                if ((g0 | g1 | g2 | g3) >= 0) {
+                    uint32_t lo = static_cast<uint32_t>((g0 << 12) | (g1 << 8) | (g2 << 4) | g3);
+                    if (lo >= 0xDC00 && lo < 0xE000) {
+                        cp = 0x10000 + (((cp - 0xD800) << 10) | (lo - 0xDC00));
+                        src += 6;
+                    }
+                }
+            }
+            dst += Utf8Encode(cp, dst);
+            return true;
+        }
+        const uint8_t r = kEscapeMap[e];
+        if (r == 0) return false;
+        *dst++ = r;
+        src += 2;
+        return true;
+    }
+
+    // Find the next '"' or '\\' in `[src, buf_end)` without writing.
+    template<class D>
+    HWY_INLINE void find_only(D d, const uint8_t* src, size_t avail,
+        uint64_t& qbits, uint64_t& bbits)
+    {
+        const auto vq = hn::Set(d, uint8_t { '"' });
+        const auto vbs = hn::Set(d, uint8_t { '\\' });
+        const auto v = hn::LoadN(d, src, avail);
+        alignas(8) uint8_t mb[8] = {};
+        hn::StoreMaskBits(d, hn::Eq(v, vq), mb);
+        std::memcpy(&qbits, mb, sizeof qbits);
+        std::memset(mb, 0, sizeof mb);
+        hn::StoreMaskBits(d, hn::Eq(v, vbs), mb);
+        std::memcpy(&bbits, mb, sizeof bbits);
+    }
+
+    HWY_INLINE uint32_t parse_string(uint32_t pos)
+    {
+        const hn::CappedTag<uint8_t, 32> d;
+        const size_t N = hn::Lanes(d);
+        const uint8_t* src = buf + pos + 1;
+
+        // Phase 1: scan-only. If the closing quote arrives before any
+        // backslash, emit a borrowed-span tape word — zero copies.
+        for (;;) {
+            uint64_t qbits, bbits;
+            const size_t avail = static_cast<size_t>(buf_end - src);
+            find_only(d, src, avail < N ? avail : N, qbits, bbits);
+            if (((bbits - 1) & qbits) != 0) {
+                const size_t qi = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(qbits));
+                const uint32_t body = pos + 1;
+                const uint32_t slen = static_cast<uint32_t>((src - buf) + qi - body);
+                emit(tape::Str, body | (1ull << 55)); // bit 55: borrowed-from-source
+                emit_raw((static_cast<uint64_t>(slen) << 32) | pos);
+                return err::Ok;
+            }
+            if (bbits != 0) {
+                const size_t bi = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(bbits));
+                src += bi;
+                break; // escape present → phase 2
+            }
+            if (HWY_UNLIKELY(avail < N)) return fail(err::UnclosedString, pos);
+            src += N;
+        }
+
+        // Phase 2: copy-and-unescape into strbuf. `src` is at the first
+        // backslash; bytes `[pos+1, src)` are escape-free — bulk-copy them.
+        uint8_t* dst = strbuf + strbuf_n;
+        const uint32_t off0 = static_cast<uint32_t>(strbuf_n);
+        const size_t prefix = static_cast<size_t>(src - (buf + pos + 1));
+        std::memcpy(dst, buf + pos + 1, prefix);
+        dst += prefix;
+        if (!handle_escape(src, dst))
+            return fail(err::StringEscape, static_cast<uint32_t>(src - buf));
+
+        for (;;) {
+            uint64_t qbits, bbits;
+            const size_t avail = static_cast<size_t>(buf_end - src);
+            copy_and_find(d, src, avail < N ? avail : N, dst, qbits, bbits);
+            if (((bbits - 1) & qbits) != 0) {
+                const size_t qi = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(qbits));
+                dst += qi;
+                const uint32_t slen = static_cast<uint32_t>(dst - (strbuf + off0));
+                strbuf_n = static_cast<size_t>(dst - strbuf);
+                emit(tape::Str, off0);
+                emit_raw((static_cast<uint64_t>(slen) << 32) | pos);
+                return err::Ok;
+            }
+            if (bbits != 0) {
+                const size_t bi = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(bbits));
+                src += bi;
+                dst += bi;
+                if (!handle_escape(src, dst))
+                    return fail(err::StringEscape, static_cast<uint32_t>(src - buf));
+            } else {
+                if (HWY_UNLIKELY(avail < N)) return fail(err::UnclosedString, pos);
+                src += N;
+                dst += N;
+            }
+        }
+    }
+
+    HWY_INLINE uint32_t parse_number(uint32_t pos)
+    {
+        // `buf[idx[next]]` is the byte after this scalar run — a structural or
+        // whitespace char that terminates every digit loop and strtod, so we
+        // can read `buf` directly. Only when `idx[next] == len` (last value,
+        // sentinel) is that byte out of bounds; then copy to a NUL-terminated
+        // local.
+        const uint32_t end = idx[next];
+        uint8_t local[64];
+        const uint8_t* p;
+        if (HWY_LIKELY(buf + end < buf_end)) {
+            p = buf + pos;
+        } else {
+            const size_t span = end - pos;
+            if (HWY_UNLIKELY(span >= sizeof local)) return parse_number_long(pos, end);
+            std::memcpy(local, buf + pos, span);
+            local[span] = 0;
+            p = local;
+        }
+
+        const uint8_t* s = p;
+        const bool neg = (*s == '-');
+        if (neg) ++s;
+        const uint8_t* int_start = s;
+        if (*s == '0') {
+            ++s;
+            if (*s >= '0' && *s <= '9') return fail(err::Number, pos);
+        } else if (*s >= '1' && *s <= '9') {
+            do {
+                ++s;
+            } while (*s >= '0' && *s <= '9');
+        } else {
+            return fail(err::Number, pos);
+        }
+        bool fexp = false;
+        if (*s == '.') {
+            fexp = true;
+            ++s;
+            if (!(*s >= '0' && *s <= '9')) return fail(err::Number, pos);
+            do {
+                ++s;
+            } while (*s >= '0' && *s <= '9');
+        }
+        if (*s == 'e' || *s == 'E') {
+            fexp = true;
+            ++s;
+            if (*s == '+' || *s == '-') ++s;
+            if (!(*s >= '0' && *s <= '9')) return fail(err::Number, pos);
+            do {
+                ++s;
+            } while (*s >= '0' && *s <= '9');
+        }
+        if (!kStructuralOrWs[*s]) return fail(err::Number, pos + static_cast<uint32_t>(s - p));
+
+        double v;
+        const size_t digits = static_cast<size_t>(s - int_start);
+        if (!fexp && digits <= 15) {
+            uint64_t n = 0;
+            for (const uint8_t* q = int_start; q < s; ++q) n = n * 10 + (*q - '0');
+            v = static_cast<double>(n);
+            if (neg) v = -v;
+        } else {
+            char* unused;
+            v = std::strtod(reinterpret_cast<const char*>(p), &unused);
+        }
+        emit(tape::Dbl, pos);
+        uint64_t bits;
+        std::memcpy(&bits, &v, sizeof bits);
+        emit_raw(bits);
+        return err::Ok;
+    }
+
+    HWY_NOINLINE uint32_t parse_number_long(uint32_t pos, uint32_t end)
+    {
+        const uint8_t* p = buf + pos;
+        const uint8_t* lim = buf + end;
+        auto get = [&](const uint8_t* s) { return s < lim ? *s : uint8_t(0); };
+        const uint8_t* s = p;
+        if (get(s) == '-') ++s;
+        if (get(s) == '0') {
+            ++s;
+            if (get(s) >= '0' && get(s) <= '9') return fail(err::Number, pos);
+        } else if (get(s) >= '1' && get(s) <= '9') {
+            do {
+                ++s;
+            } while (get(s) >= '0' && get(s) <= '9');
+        } else {
+            return fail(err::Number, pos);
+        }
+        if (get(s) == '.') {
+            ++s;
+            if (!(get(s) >= '0' && get(s) <= '9')) return fail(err::Number, pos);
+            do {
+                ++s;
+            } while (get(s) >= '0' && get(s) <= '9');
+        }
+        if (get(s) == 'e' || get(s) == 'E') {
+            ++s;
+            if (get(s) == '+' || get(s) == '-') ++s;
+            if (!(get(s) >= '0' && get(s) <= '9')) return fail(err::Number, pos);
+            do {
+                ++s;
+            } while (get(s) >= '0' && get(s) <= '9');
+        }
+        if (!kStructuralOrWs[get(s)]) return fail(err::Number, pos);
+        // strtod over a NUL-terminated heap copy.
+        const size_t n = static_cast<size_t>(s - p);
+        char* tmp = static_cast<char*>(std::malloc(n + 1));
+        if (!tmp) return fail(err::Capacity, pos);
+        std::memcpy(tmp, p, n);
+        tmp[n] = 0;
+        char* unused;
+        const double v = std::strtod(tmp, &unused);
+        std::free(tmp);
+        emit(tape::Dbl, pos);
+        uint64_t bits;
+        std::memcpy(&bits, &v, sizeof bits);
+        emit_raw(bits);
+        return err::Ok;
+    }
+
+    HWY_INLINE uint32_t parse_atom(uint32_t pos, uint8_t c)
+    {
+        uint8_t a[8] = {};
+        const size_t avail = static_cast<size_t>(buf_end - (buf + pos));
+        std::memcpy(a, buf + pos, avail < 8 ? avail : 8);
+        auto str4 = [](const void* q) {
+            uint32_t v;
+            std::memcpy(&v, q, 4);
+            return v;
+        };
+        switch (c) {
+        case 't':
+            if (str4(a) == str4("true") && kStructuralOrWs[a[4]]) {
+                emit(tape::True, pos);
+                return err::Ok;
+            }
+            break;
+        case 'f':
+            if (str4(a + 1) == str4("alse") && kStructuralOrWs[a[5]]) {
+                emit(tape::False, pos);
+                return err::Ok;
+            }
+            break;
+        case 'n':
+            if (str4(a) == str4("null") && kStructuralOrWs[a[4]]) {
+                emit(tape::Null, pos);
+                return err::Ok;
+            }
+            break;
+        }
+        return fail(err::Atom, pos);
+    }
+
+    HWY_INLINE uint32_t visit_primitive(uint32_t pos, uint8_t c)
+    {
+        switch (c) {
+        case '"':
+            return parse_string(pos);
+        case '-':
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            return parse_number(pos);
+        case 't':
+        case 'f':
+        case 'n':
+            return parse_atom(pos, c);
+        default:
+            return fail(err::Tape, pos);
+        }
+    }
+
+    HWY_INLINE uint32_t open_container(uint32_t pos, bool array)
+    {
+        if (depth >= kMaxDepth) return fail(err::DepthExceeded, pos);
+        is_array[depth] = array;
+        open_tape[depth] = static_cast<uint32_t>(tape_n);
+        open_count[depth] = 0;
+        ++depth;
+        emit(array ? tape::StartArr : tape::StartObj, 0); // back-patched
+        emit_raw(pos);
+        return err::Ok;
+    }
+
+    HWY_INLINE void close_container(bool array)
+    {
+        --depth;
+        const uint32_t start = open_tape[depth];
+        const uint32_t count = open_count[depth] > 0x00FFFFFFu ? 0x00FFFFFFu : open_count[depth];
+        const uint32_t end = static_cast<uint32_t>(tape_n);
+        emit(array ? tape::EndArr : tape::EndObj, start);
+        // Back-patch start: bits 0-31 end index, 32-55 count.
+        tape[start] = TapeWord(array ? tape::StartArr : tape::StartObj,
+            (static_cast<uint64_t>(count) << 32) | end);
+    }
+
+    uint32_t walk()
+    {
+        emit(tape::Root, 0);
+        uint32_t pos = advance();
+        uint8_t c = at(pos);
+        if (c == '{') {
+            if (auto e = open_container(pos, false)) return e;
+            goto object_begin;
+        }
+        if (c == '[') {
+            if (auto e = open_container(pos, true)) return e;
+            goto array_begin;
+        }
+        if (auto e = visit_primitive(pos, c)) return e;
+        goto document_end;
+
+    object_begin:
+        pos = advance();
+        if (at(pos) == '}') {
+            close_container(false);
+            goto scope_end;
+        }
+        if (at(pos) != '"') return fail(err::Tape, pos);
+        goto object_field;
+
+    object_field:
+        if (auto e = parse_string(pos)) return e;
+        pos = advance();
+        if (at(pos) != ':') return fail(err::Tape, pos);
+        ++open_count[depth - 1];
+        pos = advance();
+        c = at(pos);
+        if (c == '{') {
+            if (auto e = open_container(pos, false)) return e;
+            goto object_begin;
+        }
+        if (c == '[') {
+            if (auto e = open_container(pos, true)) return e;
+            goto array_begin;
+        }
+        if (auto e = visit_primitive(pos, c)) return e;
+        // fallthrough
+    object_continue:
+        pos = advance();
+        if (at(pos) == ',') {
+            pos = advance();
+            if (at(pos) != '"') return fail(err::Tape, pos);
+            goto object_field;
+        }
+        if (at(pos) == '}') {
+            close_container(false);
+            goto scope_end;
+        }
+        return fail(err::Tape, pos);
+
+    array_begin:
+        pos = idx[next];
+        if (at(pos) == ']') {
+            ++next;
+            close_container(true);
+            goto scope_end;
+        }
+        // fallthrough
+    array_value:
+        ++open_count[depth - 1];
+        pos = advance();
+        c = at(pos);
+        if (c == '{') {
+            if (auto e = open_container(pos, false)) return e;
+            goto object_begin;
+        }
+        if (c == '[') {
+            if (auto e = open_container(pos, true)) return e;
+            goto array_begin;
+        }
+        if (auto e = visit_primitive(pos, c)) return e;
+        // fallthrough
+    array_continue:
+        pos = advance();
+        if (at(pos) == ',') goto array_value;
+        if (at(pos) == ']') {
+            close_container(true);
+            goto scope_end;
+        }
+        return fail(err::Tape, pos);
+
+    scope_end:
+        if (depth == 0) goto document_end;
+        if (is_array[depth - 1]) goto array_continue;
+        goto object_continue;
+
+    document_end:
+        if (next < n_idx) return fail(err::Trailing, idx[next]);
+        tape[0] = TapeWord(tape::Root, static_cast<uint64_t>(tape_n));
+        emit(tape::Root, 0);
+        return err::Ok;
+    }
+};
+
+// Full parse. Caller contract:
+//   - `buf` readable for exactly `len` bytes — no padding required. Stage 1
+//     stack-copies the tail block; stage 2 uses LoadN / span-bounded copies
+//     so nothing reads `buf[len]`.
+//   - `indices` writable for `len + 64 + 4` u32s.
+//   - `tape` writable for `len + len/2 + 8` u64s (worst case is `[[[...]]]`:
+//     3 words per 2 input bytes, plus root pair).
+//   - `strbuf` writable for `len + 32` bytes (unescaped output ≤ input;
+//     +32 for the speculative over-store past the closing quote).
+//
+// Returns err code; on success out_tape_len/out_strbuf_len/out_flags are set.
+uint32_t JsonParseImpl(const uint8_t* buf, size_t len,
+    uint32_t* indices, size_t indices_cap,
+    uint64_t* tape, uint8_t* strbuf,
+    uint32_t* out_tape_len, uint32_t* out_strbuf_len,
+    uint32_t* out_flags, uint32_t* out_err_pos)
+{
+    *out_tape_len = 0;
+    *out_strbuf_len = 0;
+    *out_err_pos = 0;
+
+    uint32_t n = 0, flags = 0;
+    const size_t rc = JsonIndexImpl(buf, len, indices, indices_cap, &n, &flags);
+    *out_flags = flags;
+    if (rc != 0) {
+        *out_err_pos = static_cast<uint32_t>(len);
+        return static_cast<uint32_t>(rc);
+    }
+    // Sentinels at `len`: `at(len)` returns NUL, and `parse_number`/
+    // `parse_atom` use `idx[next] - pos` as the span so the last value's run
+    // is `[pos, len)`.
+    indices[n] = static_cast<uint32_t>(len);
+    indices[n + 1] = static_cast<uint32_t>(len);
+    indices[n + 2] = static_cast<uint32_t>(len);
+
+    Stage2 st {};
+    st.buf = buf;
+    st.buf_end = buf + len;
+    st.idx = indices;
+    st.n_idx = n;
+    st.next = 0;
+    st.tape = tape;
+    st.tape_n = 0;
+    st.strbuf = strbuf;
+    st.strbuf_n = 0;
+    st.depth = 0;
+    st.err_pos = 0;
+
+    const uint32_t e = st.walk();
+    *out_tape_len = static_cast<uint32_t>(st.tape_n);
+    *out_strbuf_len = static_cast<uint32_t>(st.strbuf_n);
+    *out_err_pos = st.err_pos;
+    return e;
+}
+
+} // namespace HWY_NAMESPACE
+} // namespace bun
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace bun {
+
+HWY_EXPORT(JsonIndexImpl);
+HWY_EXPORT(JsonStringScanImpl);
+HWY_EXPORT(JsonParseImpl);
+
+extern "C" {
+
+size_t highway_json_index(const uint8_t* buf, size_t len,
+    uint32_t* indices, size_t cap,
+    uint32_t* out_count, uint32_t* out_flags)
+{
+    return HWY_DYNAMIC_DISPATCH(JsonIndexImpl)(buf, len, indices, cap, out_count, out_flags);
+}
+
+size_t highway_json_string_scan(const uint8_t* src, size_t len, uint32_t* out_pos)
+{
+    return HWY_DYNAMIC_DISPATCH(JsonStringScanImpl)(src, len, out_pos);
+}
+
+uint32_t highway_json_parse(const uint8_t* buf, size_t len,
+    uint32_t* indices, size_t indices_cap,
+    uint64_t* tape, uint8_t* strbuf,
+    uint32_t* out_tape_len, uint32_t* out_strbuf_len,
+    uint32_t* out_flags, uint32_t* out_err_pos)
+{
+    return HWY_DYNAMIC_DISPATCH(JsonParseImpl)(buf, len, indices, indices_cap,
+        tape, strbuf, out_tape_len, out_strbuf_len, out_flags, out_err_pos);
+}
+
+} // extern "C"
+} // namespace bun
+#endif // HWY_ONCE

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -742,6 +742,25 @@ impl ToAst for bun_core::Error {
 // site converts a struct/enum value — only the primitive/slice impls above are
 // used.
 
+/// Old recursive-descent strict-JSON path. Kept for benchmarking against
+/// `json_simd::SimdJSON`.
+pub fn parse_utf8_scalar(
+    source: &bun_ast::Source,
+    log: &mut bun_ast::Log,
+    bump: &Bump,
+) -> Result<Expr, bun_core::Error> {
+    let mut parser = JSONLikeParser::init(
+        js_lexer::JSONOptions {
+            is_json: true,
+            ..js_lexer::JSONOptions::DEFAULT
+        },
+        bump,
+        source,
+        log,
+    )?;
+    parser.parse_expr(false, true)
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Parser option presets
 // ──────────────────────────────────────────────────────────────────────────
@@ -751,11 +770,6 @@ impl ToAst for bun_core::Error {
 //
 // `json_warn_duplicate_keys: bool = true` is the DEFAULT; the first four
 // presets do not override it.
-
-const JSON_OPTS: js_lexer::JSONOptions = js_lexer::JSONOptions {
-    is_json: true,
-    ..js_lexer::JSONOptions::DEFAULT
-};
 
 const DOTENV_JSON_OPTS: js_lexer::JSONOptions = js_lexer::JSONOptions {
     is_json: true,
@@ -827,7 +841,8 @@ pub fn parse<const FORCE_UTF8: bool>(
     log: &mut bun_ast::Log,
     bump: &Bump,
 ) -> Result<Expr, bun_core::Error> {
-    let mut parser = JSONLikeParser::init(JSON_OPTS, bump, source, log)?;
+    Expr::data_store_assert();
+    Stmt::data_store_assert();
     match source.contents.len() {
         // This is to be consisntent with how disabled JS files are handled
         0 => {
@@ -858,7 +873,7 @@ pub fn parse<const FORCE_UTF8: bool>(
         _ => {}
     }
 
-    parser.parse_expr(false, FORCE_UTF8)
+    crate::json_simd::SimdJSON::parse_with_flags(source, log, bump, FORCE_UTF8).map(|(e, _)| e)
 }
 
 /// Parse Package JSON
@@ -1071,17 +1086,8 @@ pub fn parse_utf8_impl<const CHECK_LEN: bool>(
         _ => {}
     }
 
-    let mut parser = JSONLikeParser::init(JSON_OPTS, bump, source, log)?;
-    debug_assert!(!parser.source().contents.is_empty());
-
-    let result = parser.parse_expr(false, true)?;
-    if CHECK_LEN {
-        if parser.lexer.end >= source.contents.len() {
-            return Ok(result);
-        }
-        parser.lexer.unexpected()?;
-        return Err(bun_core::err!("ParserError"));
-    }
+    let result = crate::json_simd::SimdJSON::parse(source, log, bump)?;
+    let _ = CHECK_LEN; // SimdJSON::parse always rejects trailing tokens.
     Ok(result)
 }
 
@@ -1185,10 +1191,10 @@ pub fn parse_for_bundling(
         _ => {}
     }
 
-    let mut parser = JSONLikeParser::init(JSON_OPTS, bump, source, log)?;
-    let result = parser.parse_expr(false, true)?;
+    let (result, is_ascii_only) =
+        crate::json_simd::SimdJSON::parse_with_flags(source, log, bump, true)?;
     Ok(JSONParseResult {
-        tag: if !LEXER_DEBUGGER_WORKAROUND && parser.lexer.is_ascii_only {
+        tag: if !LEXER_DEBUGGER_WORKAROUND && is_ascii_only {
             JSONParseResultTag::Ascii
         } else {
             JSONParseResultTag::Expr

--- a/src/parsers/json_cursor.rs
+++ b/src/parsers/json_cursor.rs
@@ -34,7 +34,11 @@ impl<'a> JsonDoc<'a> {
         let src = &source.contents;
         let len = src.len();
         if len > i32::MAX as usize {
-            log.add_error(Some(source), js_ast::Loc::default(), b"JSON input too large");
+            log.add_error(
+                Some(source),
+                js_ast::Loc::default(),
+                b"JSON input too large",
+            );
             return Err(bun_core::err!("ParserError"));
         }
         let cap = len + 64 + 4;

--- a/src/parsers/json_cursor.rs
+++ b/src/parsers/json_cursor.rs
@@ -1,0 +1,546 @@
+//! On-demand JSON cursor over stage-1 structural indices.
+//!
+//! Stage 1 (`highway_json_index`) emits a flat `u32[]` of byte offsets for
+//! every structural character and scalar start. A `JsonCursor` is a position
+//! in that array; navigation walks indices, skipping unrequested values by
+//! depth-counting `{`/`}` (or `[`/`]`) — no allocation, no `Expr`, no parse
+//! of skipped subtrees. Values are decoded only when a leaf accessor
+//! (`as_str`, `as_f64`, …) is called.
+//!
+//! Use this when the consumer reads a small fraction of a large document
+//! (npm packuments, package.json `name`/`version` probes). For consumers
+//! that need the full tree (bundler, printer), use `json_simd::SimdJSON`.
+
+use bun_alloc::Arena as Bump;
+use bun_ast::{self as js_ast, Expr};
+use bun_highway as hwy;
+
+/// Owns the stage-1 output; hand out cursors via [`JsonDoc::root`].
+pub struct JsonDoc<'a> {
+    src: &'a [u8],
+    indices: Vec<u32>,
+    /// `skip[i]` = index of the structural after the value starting at `i`
+    /// (i.e. one past the matching `}`/`]` for containers, `i+1` for leaves).
+    /// O(1) `after()` — built in one O(n) pass with a depth stack.
+    skip: Vec<u32>,
+    n: usize,
+}
+
+impl<'a> JsonDoc<'a> {
+    pub fn parse(
+        source: &'a js_ast::Source,
+        log: &mut js_ast::Log,
+    ) -> Result<Self, bun_core::Error> {
+        let src = &source.contents;
+        let len = src.len();
+        if len > i32::MAX as usize {
+            log.add_error(Some(source), js_ast::Loc::default(), b"JSON input too large");
+            return Err(bun_core::err!("ParserError"));
+        }
+        let cap = len + 64 + 4;
+        let mut indices = Vec::<u32>::with_capacity(cap);
+        // SAFETY: capacity reserved; u32 is POD; stage-1 writes `[..count]`
+        // and we write 3 sentinels; nothing else is read.
+        unsafe { indices.set_len(cap) };
+        let (rc, count, _flags) = hwy::json_index(src, &mut indices);
+        if rc != hwy::JsonIndexError::Ok {
+            let msg: &'static [u8] = match rc {
+                hwy::JsonIndexError::UnclosedString => b"Unterminated string literal",
+                hwy::JsonIndexError::UnescapedCtrlInString => {
+                    b"Unescaped control character in string literal"
+                }
+                hwy::JsonIndexError::Empty => b"Unexpected end of file",
+                _ => b"JSON parse error",
+            };
+            log.add_error(Some(source), js_ast::Loc::default(), msg);
+            return Err(bun_core::err!("ParserError"));
+        }
+        let n = count as usize;
+        indices[n] = len as u32;
+        indices[n + 1] = len as u32;
+        indices[n + 2] = len as u32;
+        let skip = build_skip(src, &indices[..n], n);
+        Ok(Self {
+            src,
+            indices,
+            skip,
+            n,
+        })
+    }
+
+    #[inline]
+    pub fn root(&self) -> JsonCursor<'_> {
+        JsonCursor {
+            src: self.src,
+            idx: &self.indices,
+            skip: &self.skip,
+            pos: 0,
+            end: self.n,
+        }
+    }
+}
+
+/// One linear pass: stack of open `{`/`[` positions; on the matching close,
+/// pop and record `skip[open] = close+1`. Only container slots are written —
+/// `after()` reads `skip[i]` only when `byte(i)` is `{`/`[`, so leaf slots
+/// stay uninitialised.
+fn build_skip(src: &[u8], idx: &[u32], n: usize) -> Vec<u32> {
+    let mut skip = Vec::<u32>::with_capacity(n + 1);
+    // SAFETY: u32 is POD; only indices `i` where `byte(i)∈{'{','['}` are ever
+    // read by `after()`, and every such `i` is written below (matched → in the
+    // pop, unmatched → in the drain).
+    #[allow(clippy::uninit_vec)]
+    unsafe {
+        skip.set_len(n + 1)
+    };
+    let mut stack: Vec<u32> = Vec::with_capacity(64);
+    for (i, &off) in idx.iter().enumerate() {
+        // `idx[..n]` are real structurals (sentinels excluded), so `off < len`.
+        match src[off as usize] {
+            b'{' | b'[' => stack.push(i as u32),
+            b'}' | b']' => {
+                if let Some(open) = stack.pop() {
+                    skip[open as usize] = i as u32 + 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    for &open in &stack {
+        skip[open as usize] = n as u32;
+    }
+    skip
+}
+
+/// A position in the structural-index array. Cheap to copy.
+#[derive(Clone, Copy)]
+pub struct JsonCursor<'a> {
+    src: &'a [u8],
+    idx: &'a [u32],
+    skip: &'a [u32],
+    /// Index into `idx` of this value's first structural.
+    pos: usize,
+    /// One past the last structural that may belong to this value.
+    end: usize,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum JsonKind {
+    Object,
+    Array,
+    String,
+    Number,
+    True,
+    False,
+    Null,
+    Invalid,
+}
+
+impl<'a> JsonCursor<'a> {
+    #[inline]
+    fn byte(&self, p: usize) -> u8 {
+        self.src.get(self.idx[p] as usize).copied().unwrap_or(0)
+    }
+
+    #[inline]
+    pub fn loc(&self) -> js_ast::Loc {
+        js_ast::usize2loc(self.idx[self.pos] as usize)
+    }
+
+    pub fn kind(&self) -> JsonKind {
+        match self.byte(self.pos) {
+            b'{' => JsonKind::Object,
+            b'[' => JsonKind::Array,
+            b'"' => JsonKind::String,
+            b'-' | b'0'..=b'9' => JsonKind::Number,
+            b't' => JsonKind::True,
+            b'f' => JsonKind::False,
+            b'n' => JsonKind::Null,
+            _ => JsonKind::Invalid,
+        }
+    }
+
+    /// Index of the structural after this value. O(1) via the skip table.
+    #[inline]
+    fn after(&self) -> usize {
+        match self.byte(self.pos) {
+            b'{' | b'[' => self.skip[self.pos] as usize,
+            _ => self.pos + 1,
+        }
+    }
+
+    #[inline]
+    fn child(&self, pos: usize) -> JsonCursor<'a> {
+        JsonCursor {
+            src: self.src,
+            idx: self.idx,
+            skip: self.skip,
+            pos,
+            end: self.end,
+        }
+    }
+
+    /// First child of an object: cursor at the key string. `None` if not an
+    /// object or empty.
+    fn first_field(&self) -> Option<usize> {
+        if self.byte(self.pos) != b'{' {
+            return None;
+        }
+        let p = self.pos + 1;
+        if self.byte(p) == b'}' {
+            return None;
+        }
+        Some(p)
+    }
+
+    /// Compare the string at `idx[p]` (an opening `"`) against `key` without
+    /// scanning for the closing quote: match iff `src[open+1..open+1+len]==key`
+    /// and the next byte is `"`. Correct for keys with no escapes; an escaped
+    /// key falls through to the slow `string_body` compare.
+    #[inline]
+    fn key_eq(&self, p: usize, key: &[u8]) -> bool {
+        let open = self.idx[p] as usize;
+        let body = open + 1;
+        if let Some(slice) = self.src.get(body..body + key.len()) {
+            if slice == key && self.src.get(body + key.len()) == Some(&b'"') {
+                return true;
+            }
+        }
+        // Escape-aware fallback (rare).
+        matches!(self.string_body(p), Some((s, _)) if s == key)
+    }
+
+    /// Raw key slice for the string at `idx[p]`: `src[open+1 .. close)`.
+    /// Scalar scan — keys are short and escape-free in practice, so the FFI
+    /// round-trip of `string_body` isn't worth it here.
+    #[inline]
+    fn raw_key(&self, p: usize) -> Option<&'a [u8]> {
+        if self.byte(p) != b'"' {
+            return None;
+        }
+        let start = self.idx[p] as usize + 1;
+        // The next structural is `:` (or `,`/`}` for malformed input); the
+        // closing `"` precedes it.
+        let limit = self
+            .idx
+            .get(p + 1)
+            .map(|&i| i as usize)
+            .unwrap_or(self.src.len())
+            .min(self.src.len());
+        let mut i = start;
+        while i < limit {
+            match self.src[i] {
+                b'"' => return Some(&self.src[start..i]),
+                b'\\' => return self.string_body(p).map(|(s, _)| s),
+                _ => i += 1,
+            }
+        }
+        None
+    }
+
+    /// Body of the string at `idx[p]`, plus whether it contains an escape.
+    /// Returns a borrowed slice into `src` (caller must decode if escaped).
+    fn string_body(&self, p: usize) -> Option<(&'a [u8], bool)> {
+        if self.byte(p) != b'"' {
+            return None;
+        }
+        let start = self.idx[p] as usize + 1;
+        let mut cur = start;
+        let mut has_escape = false;
+        loop {
+            let s = &self.src[cur..];
+            // SAFETY: `s` is a valid in-bounds subslice; the kernel reads at
+            // most `s.len()` bytes (length-bounded SIMD with scalar tail).
+            let (k, off) = unsafe { hwy::json_string_scan(s.as_ptr(), s.len()) };
+            cur += off as usize;
+            match k {
+                1 => return Some((&self.src[start..cur], has_escape)),
+                2 => {
+                    has_escape = true;
+                    // Skip the escape pair; `\uXXXX` is 6 bytes, others 2.
+                    let esc = self.src.get(cur + 1).copied().unwrap_or(0);
+                    cur += if esc == b'u' { 6 } else { 2 };
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    // ── navigation ───────────────────────────────────────────────────────
+
+    /// Object field lookup. Walks keys in order; values whose key doesn't
+    /// match are skipped via [`Self::after`] without being parsed.
+    pub fn get(&self, key: &[u8]) -> Option<JsonCursor<'a>> {
+        let mut p = self.first_field()?;
+        loop {
+            // p: key string; p+1: `:`; p+2: value.
+            let val_pos = p + 2;
+            if val_pos >= self.end {
+                return None;
+            }
+            let val = self.child(val_pos);
+            if self.key_eq(p, key) {
+                return Some(val);
+            }
+            let next = val.after();
+            match self.byte(next) {
+                b',' => p = next + 1,
+                _ => return None, // `}` or malformed
+            }
+        }
+    }
+
+    /// Iterate `(key, value)` pairs of an object. Keys are raw source slices
+    /// (escapes not decoded — packument keys never have them).
+    pub fn iter_object(&self) -> ObjectIter<'a> {
+        ObjectIter {
+            c: *self,
+            p: self.first_field(),
+        }
+    }
+
+    pub fn iter_array(&self) -> ArrayIter<'a> {
+        let p = if self.byte(self.pos) == b'[' && self.byte(self.pos + 1) != b']' {
+            Some(self.pos + 1)
+        } else {
+            None
+        };
+        ArrayIter { c: *self, p }
+    }
+
+    // ── leaf accessors ───────────────────────────────────────────────────
+
+    /// Borrowed string body. `None` if not a string or contains escapes (use
+    /// [`Self::as_str_decoded`] for those).
+    pub fn as_str(&self) -> Option<&'a [u8]> {
+        match self.string_body(self.pos) {
+            Some((s, false)) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// String body with escapes decoded into `bump`.
+    pub fn as_str_decoded(&self, bump: &'a Bump) -> Option<&'a [u8]> {
+        let (raw, has_escape) = self.string_body(self.pos)?;
+        if !has_escape {
+            return Some(raw);
+        }
+        Some(decode_escapes(raw, bump))
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        if !matches!(self.kind(), JsonKind::Number) {
+            return None;
+        }
+        let start = self.idx[self.pos] as usize;
+        let stop = self
+            .idx
+            .get(self.pos + 1)
+            .map(|&i| i as usize)
+            .unwrap_or(self.src.len())
+            .min(self.src.len());
+        let mut end = start;
+        while end < stop
+            && matches!(
+                self.src[end],
+                b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E'
+            )
+        {
+            end += 1;
+        }
+        core::str::from_utf8(&self.src[start..end])
+            .ok()?
+            .parse::<f64>()
+            .ok()
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match self.kind() {
+            JsonKind::True => Some(true),
+            JsonKind::False => Some(false),
+            _ => None,
+        }
+    }
+
+    pub fn is_null(&self) -> bool {
+        matches!(self.kind(), JsonKind::Null)
+    }
+
+    #[inline]
+    pub fn is_object(&self) -> bool {
+        matches!(self.kind(), JsonKind::Object)
+    }
+
+    #[inline]
+    pub fn is_array(&self) -> bool {
+        matches!(self.kind(), JsonKind::Array)
+    }
+
+    /// Count of an object's keys (or array's elements). O(k) — walks one
+    /// level via `iter_object`/`iter_array`; use sparingly.
+    pub fn len(&self) -> usize {
+        match self.kind() {
+            JsonKind::Object => self.iter_object().count(),
+            JsonKind::Array => self.iter_array().count(),
+            _ => 0,
+        }
+    }
+
+    /// Build a full `Expr` subtree for this value. Use when a downstream
+    /// consumer needs the AST shape.
+    pub fn materialize(
+        &self,
+        log: &mut js_ast::Log,
+        bump: &'a Bump,
+    ) -> Result<Expr, bun_core::Error> {
+        // Slice the source to just this value and feed it to the full SIMD
+        // parser. Re-indexing the slice is cheap relative to building the
+        // tree, and keeps `materialize` independent of the cursor's index
+        // bookkeeping.
+        let start = self.idx[self.pos] as usize;
+        let after = self.after();
+        let stop = if after < self.idx.len() {
+            self.idx[after] as usize
+        } else {
+            self.src.len()
+        }
+        .min(self.src.len());
+        let sub = js_ast::Source::init_path_string(b"", &self.src[start..stop]);
+        crate::json_simd::SimdJSON::parse(&sub, log, bump)
+    }
+}
+
+pub struct ObjectIter<'a> {
+    c: JsonCursor<'a>,
+    p: Option<usize>,
+}
+
+impl<'a> Iterator for ObjectIter<'a> {
+    type Item = (&'a [u8], JsonCursor<'a>);
+    fn next(&mut self) -> Option<Self::Item> {
+        let p = self.p?;
+        let val_pos = p + 2;
+        if val_pos >= self.c.end {
+            self.p = None;
+            return None;
+        }
+        let key = self.c.raw_key(p)?;
+        let val = self.c.child(val_pos);
+        let next = val.after();
+        self.p = match self.c.byte(next) {
+            b',' => Some(next + 1),
+            _ => None,
+        };
+        Some((key, val))
+    }
+}
+
+pub struct ArrayIter<'a> {
+    c: JsonCursor<'a>,
+    p: Option<usize>,
+}
+
+impl<'a> Iterator for ArrayIter<'a> {
+    type Item = JsonCursor<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let p = self.p?;
+        let val = self.c.child(p);
+        let next = val.after();
+        self.p = match self.c.byte(next) {
+            b',' => Some(next + 1),
+            _ => None,
+        };
+        Some(val)
+    }
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+pub fn decode_escapes_into<'a>(raw: &[u8], bump: &'a Bump) -> &'a [u8] {
+    decode_escapes(raw, bump)
+}
+
+fn decode_escapes<'a>(raw: &[u8], bump: &'a Bump) -> &'a [u8] {
+    let mut out = Vec::with_capacity(raw.len());
+    let mut i = 0;
+    while i < raw.len() {
+        let b = raw[i];
+        if b != b'\\' {
+            out.push(b);
+            i += 1;
+            continue;
+        }
+        let e = raw.get(i + 1).copied().unwrap_or(0);
+        match e {
+            b'"' | b'\\' | b'/' => {
+                out.push(e);
+                i += 2;
+            }
+            b'b' => {
+                out.push(0x08);
+                i += 2;
+            }
+            b'f' => {
+                out.push(0x0c);
+                i += 2;
+            }
+            b'n' => {
+                out.push(0x0a);
+                i += 2;
+            }
+            b'r' => {
+                out.push(0x0d);
+                i += 2;
+            }
+            b't' => {
+                out.push(0x09);
+                i += 2;
+            }
+            b'u' => {
+                let hex = &raw.get(i + 2..i + 6).unwrap_or(&[]);
+                let cp = hex4(hex).unwrap_or(0xFFFD);
+                let mut cp = cp as u32;
+                i += 6;
+                if (0xD800..0xDC00).contains(&cp)
+                    && raw.get(i..i + 2) == Some(b"\\u")
+                    && let Some(lo) = hex4(&raw[i + 2..i + 6])
+                    && (0xDC00..0xE000).contains(&(lo as u32))
+                {
+                    cp = 0x10000 + (((cp - 0xD800) << 10) | (lo as u32 - 0xDC00));
+                    i += 6;
+                }
+                push_utf8(&mut out, cp);
+            }
+            _ => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    bump.alloc_slice_copy(&out)
+}
+
+fn hex4(h: &[u8]) -> Option<u16> {
+    if h.len() < 4 {
+        return None;
+    }
+    let mut v = 0u32;
+    for &b in &h[..4] {
+        let d = match b {
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            b'A'..=b'F' => b - b'A' + 10,
+            _ => return None,
+        };
+        v = (v << 4) | u32::from(d);
+    }
+    Some(v as u16)
+}
+
+fn push_utf8(out: &mut Vec<u8>, cp: u32) {
+    let mut buf = [0u8; 4];
+    let s = char::from_u32(cp)
+        .unwrap_or('\u{FFFD}')
+        .encode_utf8(&mut buf);
+    out.extend_from_slice(s.as_bytes());
+}

--- a/src/parsers/json_simd.rs
+++ b/src/parsers/json_simd.rs
@@ -1,0 +1,304 @@
+//! SIMD JSON parser — strict RFC 8259.
+//!
+//! Both stages live in C++ (`highway_json.cpp`): stage 1 emits structural
+//! indices; stage 2 walks them and writes a simdjson-style tape (`u64[]` of
+//! `(tag<<56)|payload` words) plus a `string_buf` with every string body
+//! pre-unescaped to UTF-8. One FFI call.
+//!
+//! This file walks the tape linearly to build `bun_ast::Expr`. Container child
+//! counts are encoded in the start word so each `Vec` is sized exactly once.
+
+use bun_alloc::{Arena as Bump, AstAlloc};
+use bun_ast::{self as js_ast, E, Expr, ExprNodeList, G, Loc};
+use bun_core::strings;
+use bun_highway as hwy;
+use hwy::json_tape as T;
+
+/// Working buffers for one parse. Reusable across calls when parsing many
+/// documents (npm registry responses, package.json scans).
+#[derive(Default)]
+pub struct SimdJSONBuffers {
+    indices: Vec<u32>,
+    tape: Vec<u64>,
+}
+
+impl SimdJSONBuffers {
+    fn prepare(&mut self, len: usize) {
+        let icap = len + 64 + 4;
+        // Worst-case tape words per byte is 1.5 (`[[[...]]]` → 3 words per
+        // 2 bytes) plus the root pair.
+        let tcap = len + len / 2 + 8;
+        macro_rules! ensure {
+            ($v:expr, $cap:expr) => {
+                if $v.capacity() < $cap {
+                    $v.reserve($cap - $v.len());
+                }
+                // SAFETY: capacity ensured; POD elements; the C++ kernel
+                // writes every slot it later reads, and we only read the
+                // length-prefixed slice the kernel reports.
+                #[allow(clippy::uninit_vec)]
+                unsafe {
+                    $v.set_len($cap)
+                };
+            };
+        }
+        ensure!(self.indices, icap);
+        ensure!(self.tape, tcap);
+    }
+}
+
+pub struct SimdJSON;
+
+impl SimdJSON {
+    pub fn parse<'a, 'bump: 'a>(
+        source: &'a js_ast::Source,
+        log: &'a mut js_ast::Log,
+        bump: &'bump Bump,
+    ) -> Result<Expr, bun_core::Error> {
+        Self::parse_with_flags(source, log, bump, true).map(|(e, _)| e)
+    }
+
+    pub fn parse_with_flags<'a, 'bump: 'a>(
+        source: &'a js_ast::Source,
+        log: &'a mut js_ast::Log,
+        bump: &'bump Bump,
+        force_utf8: bool,
+    ) -> Result<(Expr, bool), bun_core::Error> {
+        let mut bufs = SimdJSONBuffers::default();
+        Self::parse_into(&mut bufs, source, log, bump, force_utf8)
+    }
+
+    pub fn parse_into<'a, 'bump: 'a>(
+        bufs: &mut SimdJSONBuffers,
+        source: &'a js_ast::Source,
+        log: &'a mut js_ast::Log,
+        bump: &'bump Bump,
+        force_utf8: bool,
+    ) -> Result<(Expr, bool), bun_core::Error> {
+        Expr::data_store_assert();
+        js_ast::Stmt::data_store_assert();
+        let _ = force_utf8; // strings are UTF-8 in string_buf already
+
+        let src = &source.contents;
+        let len = src.len();
+        // Stage-1 emits u32 byte offsets; the tape encodes locs as u32. The
+        // public entry points (`with_text_format_source`) already cap at
+        // i32::MAX, but direct callers (sourcemap, npm) reach this without
+        // that guard.
+        if len > i32::MAX as usize {
+            return fail(log, source, 0, hwy::JsonParseError::Capacity);
+        }
+        bufs.prepare(len);
+
+        // strbuf lives in the bump arena so `E::String` can borrow directly
+        // into it (same lifetime as the returned Expr) — eliminates the
+        // per-string `mi_heap_malloc + memcpy` from `alloc_slice_copy`.
+        // Uninitialised: the kernel writes `[0..strbuf_len)` (plus up to 32
+        // speculative over-store bytes); we only ever read `[..strbuf_len]`.
+        let strbuf_ptr = bump
+            .alloc_layout(core::alloc::Layout::array::<u8>(len + 32).unwrap())
+            .as_ptr();
+
+        // SAFETY: `prepare` sized indices/tape per the kernel's contract;
+        // the kernel reads exactly `src[..len]` (no padding required) and
+        // writes at most `len+32` into `strbuf_ptr`.
+        let (rc, out) = unsafe {
+            hwy::json_parse(
+                src.as_ptr(),
+                len,
+                bufs.indices.as_mut_ptr(),
+                bufs.indices.len(),
+                bufs.tape.as_mut_ptr(),
+                strbuf_ptr,
+            )
+        };
+
+        if rc != hwy::JsonParseError::Ok {
+            return fail(log, source, out.err_pos, rc);
+        }
+
+        let tape = &bufs.tape[..out.tape_len as usize];
+        // SAFETY: `[0..strbuf_len)` was fully written by the kernel; the
+        // arena allocation lives for `'bump: 'a`.
+        let strbuf: &[u8] =
+            unsafe { core::slice::from_raw_parts(strbuf_ptr, out.strbuf_len as usize) };
+        let mut w = TapeWalker {
+            tape,
+            strbuf,
+            src,
+            i: 1, // [0] is the root start word
+            bump,
+        };
+        let root = w.value();
+        debug_assert_eq!(w.i, tape.len().saturating_sub(1)); // root end word
+
+        let is_ascii_only = !out.flags.contains(hwy::JsonIndexFlags::NON_ASCII)
+            && strings::first_non_ascii(strbuf).is_none();
+        Ok((root, is_ascii_only))
+    }
+}
+
+struct TapeWalker<'a, 't, 'bump> {
+    tape: &'t [u64],
+    strbuf: &'a [u8],
+    src: &'a [u8],
+    i: usize,
+    bump: &'bump Bump,
+}
+
+#[inline]
+fn loc32(p: u64) -> Loc {
+    js_ast::usize2loc((p & 0xFFFF_FFFF) as usize)
+}
+
+impl<'a, 't, 'bump> TapeWalker<'a, 't, 'bump> {
+    /// `Expr::allocate` — bypasses the `Store::append` TLS lookup since we
+    /// already hold the arena.
+    #[inline(always)]
+    fn expr<Ty: js_ast::IntoExprData>(&self, t: Ty, l: Loc) -> Expr {
+        Expr::allocate(self.bump, t, l)
+    }
+
+    #[inline(always)]
+    fn next(&mut self) -> u64 {
+        let w = self.tape[self.i];
+        self.i += 1;
+        w
+    }
+
+    #[inline(always)]
+    fn read_string(&mut self, w: u64) -> (E::String, Loc) {
+        const BORROWED: u64 = 1 << 55;
+        let p = T::payload(w);
+        let off = (p & (BORROWED - 1)) as usize;
+        let extra = self.next();
+        let len = (extra >> 32) as usize;
+        let l = loc32(extra);
+        // Both arms borrow with lifetime `'a`: source for escape-free bodies,
+        // bump-arena `strbuf` for unescaped bodies.
+        let body: &'a [u8] = if p & BORROWED != 0 {
+            &self.src[off..off + len]
+        } else {
+            &self.strbuf[off..off + len]
+        };
+        (E::String::init(body), l)
+    }
+
+    #[inline(always)]
+    fn read_property(&mut self) -> G::Property {
+        let kw = self.next();
+        debug_assert_eq!(T::tag(kw), T::STR);
+        let (ks, kl) = self.read_string(kw);
+        let key = self.expr(ks, kl);
+        let val = self.value();
+        G::Property {
+            key: Some(key),
+            value: Some(val),
+            kind: js_ast::G::PropertyKind::Normal,
+            ..Default::default()
+        }
+    }
+
+    fn value(&mut self) -> Expr {
+        let w = self.next();
+        match T::tag(w) {
+            T::STR => {
+                let (s, l) = self.read_string(w);
+                self.expr(s, l)
+            }
+            T::DBL => {
+                let l = loc32(T::payload(w));
+                let bits = self.next();
+                self.expr(E::Number::new(f64::from_bits(bits)), l)
+            }
+            T::TRUE => self.expr(E::Boolean { value: true }, loc32(T::payload(w))),
+            T::FALSE => self.expr(E::Boolean { value: false }, loc32(T::payload(w))),
+            T::NULL => self.expr(E::Null {}, loc32(T::payload(w))),
+            T::START_ARR => {
+                let count = (T::payload(w) >> 32) as usize;
+                let l = loc32(self.next());
+                // Allocate directly with `AstAlloc` so the result IS an
+                // `ExprNodeList` — no `move_from_list` realloc + memcpy.
+                // `count` is a 24-bit hint (saturates past 16M); iterate until
+                // END_ARR so larger arrays remain correct, and `push` after
+                // the hinted prefix is full.
+                let mut items: ExprNodeList = AstAlloc::vec_with_capacity(count);
+                let dst = items.spare_capacity_mut();
+                let mut filled = 0;
+                while filled < count {
+                    dst[filled].write(self.value());
+                    filled += 1;
+                }
+                // SAFETY: `[0, count)` fully written; capacity reserved.
+                unsafe { items.set_len(count) };
+                while T::tag(self.tape[self.i]) != T::END_ARR {
+                    items.push(self.value());
+                }
+                self.i += 1;
+                self.expr(
+                    E::Array {
+                        items,
+                        is_single_line: true,
+                        ..Default::default()
+                    },
+                    l,
+                )
+            }
+            T::START_OBJ => {
+                let count = (T::payload(w) >> 32) as usize;
+                let l = loc32(self.next());
+                let mut props: G::PropertyList = AstAlloc::vec_with_capacity(count);
+                let dst = props.spare_capacity_mut();
+                let mut filled = 0;
+                while filled < count {
+                    dst[filled].write(self.read_property());
+                    filled += 1;
+                }
+                // SAFETY: `[0, count)` fully written; capacity reserved.
+                unsafe { props.set_len(count) };
+                while T::tag(self.tape[self.i]) != T::END_OBJ {
+                    props.push(self.read_property());
+                }
+                self.i += 1;
+                self.expr(
+                    E::Object {
+                        properties: props,
+                        is_single_line: true,
+                        ..Default::default()
+                    },
+                    l,
+                )
+            }
+            // ROOT/END_* are handled by callers; reaching them here is a bug.
+            t => unreachable!("unexpected tape tag {}", t as char),
+        }
+    }
+}
+
+#[cold]
+fn fail<T>(
+    log: &mut js_ast::Log,
+    source: &js_ast::Source,
+    pos: u32,
+    rc: hwy::JsonParseError,
+) -> Result<T, bun_core::Error> {
+    let msg: &'static [u8] = match rc {
+        hwy::JsonParseError::UnclosedString => b"Unterminated string literal",
+        hwy::JsonParseError::UnescapedCtrl => b"Unescaped control character in string literal",
+        hwy::JsonParseError::Empty => b"Unexpected end of file",
+        hwy::JsonParseError::DepthExceeded => b"JSON nesting too deep",
+        hwy::JsonParseError::Number => b"Invalid number literal",
+        hwy::JsonParseError::Atom => b"Invalid JSON value",
+        hwy::JsonParseError::StringEscape => b"Invalid escape sequence",
+        hwy::JsonParseError::Trailing => b"Unexpected token after end of JSON value",
+        hwy::JsonParseError::Tape => b"Unexpected token",
+        hwy::JsonParseError::Utf8 => b"Invalid UTF-8 in string literal",
+        hwy::JsonParseError::Capacity | hwy::JsonParseError::Ok => b"JSON parse error",
+    };
+    let r = js_ast::Range {
+        loc: js_ast::usize2loc((pos as usize).min(source.contents.len())),
+        len: 1,
+    };
+    log.add_range_error(Some(source), r, msg);
+    Err(bun_core::err!("ParserError"))
+}

--- a/src/parsers/lib.rs
+++ b/src/parsers/lib.rs
@@ -19,6 +19,18 @@ pub mod json;
 /// latter here.
 pub use json as json_parser;
 
+// ───── json_simd ──────────────────────────────────────────────────────────
+// simdjson-style two-stage strict-JSON parser. Stage 1 lives in
+// `highway_json.cpp`; stage 2 here.
+#[path = "json_simd.rs"]
+pub mod json_simd;
+
+// ───── json_cursor ────────────────────────────────────────────────────────
+// On-demand cursor over stage-1 indices for sparse reads (npm packuments,
+// package.json name/version).
+#[path = "json_cursor.rs"]
+pub mod json_cursor;
+
 // ───── json5 ──────────────────────────────────────────────────────────────
 #[path = "json5.rs"]
 pub mod json5;

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -67,10 +67,10 @@ pub mod js_bundler;
 pub mod js_transpiler;
 #[path = "api/JSON5Object.rs"]
 pub mod json5_object;
-#[path = "api/JSONCObject.rs"]
-pub mod jsonc_object;
 #[path = "api/json_simd_testing.rs"]
 pub mod json_simd_testing;
+#[path = "api/JSONCObject.rs"]
+pub mod jsonc_object;
 #[path = "api/lolhtml_jsc.rs"]
 pub mod lolhtml_jsc;
 #[path = "api/MarkdownObject.rs"]

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -69,6 +69,8 @@ pub mod js_transpiler;
 pub mod json5_object;
 #[path = "api/JSONCObject.rs"]
 pub mod jsonc_object;
+#[path = "api/json_simd_testing.rs"]
+pub mod json_simd_testing;
 #[path = "api/lolhtml_jsc.rs"]
 pub mod lolhtml_jsc;
 #[path = "api/MarkdownObject.rs"]

--- a/src/runtime/api/json_simd_testing.rs
+++ b/src/runtime/api/json_simd_testing.rs
@@ -1,0 +1,262 @@
+//! `bun:internal-for-testing` — drive `bun_parsers::json_simd` directly.
+
+use bun_ast::ToJSError;
+use bun_js_parser_jsc::ExprJsc;
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsError, JsResult, LogJsc, StringJsc};
+use bun_parsers::json;
+use bun_parsers::json_simd::SimdJSON;
+
+pub fn js_parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    super::with_text_format_source(
+        global,
+        frame,
+        b"input.json",
+        false,
+        true,
+        |arena, log, source| {
+            let parse_result = match SimdJSON::parse(source, log, arena) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(global.throw_value(log.to_js(global, "Failed to parse JSON")?));
+                }
+            };
+
+            match parse_result.to_js(global) {
+                Ok(v) => Ok(v),
+                Err(ToJSError::OutOfMemory) => Err(JsError::OutOfMemory),
+                Err(ToJSError::JSError) => Err(JsError::Thrown),
+                Err(ToJSError::JSTerminated) => Err(JsError::Terminated),
+                Err(_) => unreachable!(),
+            }
+        },
+    )
+}
+
+/// Stage-1 only: returns a regular Array of structural-index integers. For
+/// debugging the SIMD scanner.
+pub fn js_index(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    use bun_highway as hwy;
+    let input = frame.argument(0).to_slice(global)?;
+    let bytes = input.slice();
+    let mut indices = vec![0u32; bytes.len() + 64 + 4];
+    let (rc, count, _flags) = hwy::json_index(bytes, &mut indices);
+    if rc != hwy::JsonIndexError::Ok && rc != hwy::JsonIndexError::Empty {
+        return Err(global.throw(format_args!("json_index error: {:?}", rc)));
+    }
+    let n = count as usize;
+    let arr = bun_jsc::JSValue::create_empty_array(global, n)?;
+    for (i, &idx) in indices[..n].iter().enumerate() {
+        arr.put_index(global, i as u32, JSValue::js_number(idx as f64))?;
+    }
+    Ok(arr)
+}
+
+/// Benchmark: parse `input` `iters` times entirely inside Rust, returning
+/// `{ simdNs, scalarNs, bytes, iters }`. The Expr→JSValue conversion is NOT
+/// included; only the parser hot path is measured.
+pub fn js_bench(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let input = frame.argument(0).to_slice(global)?;
+    let iters = frame.argument(1).coerce_to_i32(global)?.max(1) as u32;
+    let bytes = input.slice();
+
+    let arena = bun_alloc::Arena::new();
+    let mut alloc_guard = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+    let _scope = alloc_guard.enter();
+    let source = bun_ast::Source::init_path_string(b"bench.json", bytes);
+
+    // Warm-up + correctness check.
+    {
+        let mut log = bun_ast::Log::init();
+        if SimdJSON::parse(&source, &mut log, &arena).is_err() {
+            return Err(global.throw_value(log.to_js(global, "SIMD parse failed")?));
+        }
+    }
+
+    // arg[2] = 0 simd-only, 1 scalar-only, else both (default).
+    let which = if frame.arguments_count() > 2 {
+        frame.argument(2).coerce_to_i32(global)? as i32
+    } else {
+        2
+    };
+
+    let mut bufs = bun_parsers::json_simd::SimdJSONBuffers::default();
+    let simd_ns = if which == 1 { 0 } else { time_iters(iters, || {
+        let mut log = bun_ast::Log::init();
+        let arena = bun_alloc::Arena::new();
+        let mut g = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+        let _s = g.enter();
+        let _ = std::hint::black_box(SimdJSON::parse_into(
+            &mut bufs, &source, &mut log, &arena, true,
+        ));
+    }) };
+
+    let scalar_ns = if which == 0 { 0 } else { time_iters(iters, || {
+        let mut log = bun_ast::Log::init();
+        let arena = bun_alloc::Arena::new();
+        let mut g = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+        let _s = g.enter();
+        let _ = std::hint::black_box(json::parse_utf8_scalar(&source, &mut log, &arena));
+    }) };
+
+    let result = bun_jsc::JSValue::create_empty_object(global, 4);
+    result.put(global, b"bytes", JSValue::js_number(bytes.len() as f64));
+    result.put(global, b"iters", JSValue::js_number(iters as f64));
+    result.put(global, b"simdNs", JSValue::js_number(simd_ns as f64));
+    result.put(global, b"scalarNs", JSValue::js_number(scalar_ns as f64));
+    Ok(result)
+}
+
+fn time_iters(iters: u32, mut f: impl FnMut()) -> u64 {
+    // Warmup: first iteration on a fresh allocation pattern is consistently
+    // slow (cold caches / page faults).
+    for _ in 0..3 {
+        f();
+    }
+    let start = std::time::Instant::now();
+    for _ in 0..iters {
+        f();
+    }
+    start.elapsed().as_nanos() as u64
+}
+
+/// Stage-1 + stage-2 (C++ tape only, no Rust Expr build). Direct comparison
+/// target for simdjson's DOM parse.
+pub fn js_bench_tape(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    use bun_highway as hwy;
+    let input = frame.argument(0).to_slice(global)?;
+    let iters = frame.argument(1).coerce_to_i32(global)?.max(1) as u32;
+    let bytes = input.slice();
+    let len = bytes.len();
+    let mut indices = vec![0u32; len + 64 + 4];
+    let mut tape = vec![0u64; len + len / 2 + 8];
+    let mut strbuf = vec![0u8; len + 32];
+    let mut tape_len = 0u32;
+    let ns = time_iters(iters, || {
+        // SAFETY: buffers sized per the kernel's contract.
+        let (_rc, out) = unsafe {
+            hwy::json_parse(
+                bytes.as_ptr(),
+                len,
+                indices.as_mut_ptr(),
+                indices.len(),
+                tape.as_mut_ptr(),
+                strbuf.as_mut_ptr(),
+            )
+        };
+        tape_len = out.tape_len;
+        std::hint::black_box(&tape);
+    });
+    let result = bun_jsc::JSValue::create_empty_object(global, 3);
+    result.put(global, b"ns", JSValue::js_number(ns as f64));
+    result.put(global, b"tapeLen", JSValue::js_number(tape_len as f64));
+    result.put(global, b"bytes", JSValue::js_number(len as f64));
+    Ok(result)
+}
+
+/// On-demand cursor: simulate npm.rs's packument reads (iterate every
+/// version, read `dist.tarball` + `bin` + `directories.bin` + dependency
+/// groups). Times stage-1 + cursor walk; no Expr.
+pub fn js_bench_cursor(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    use bun_parsers::json_cursor::JsonDoc;
+    let input = frame.argument(0).to_slice(global)?;
+    let iters = frame.argument(1).coerce_to_i32(global)?.max(1) as u32;
+    let bytes = input.slice();
+    let source = bun_ast::Source::init_path_string(b"packument.json", bytes);
+    let mut versions_seen = 0u32;
+    let mut fields_read = 0u64;
+    let ns = time_iters(iters, || {
+        let mut log = bun_ast::Log::init();
+        let doc = JsonDoc::parse(&source, &mut log).unwrap();
+        let root = doc.root();
+        versions_seen = 0;
+        fields_read = 0;
+        // One pass over top-level keys — no repeated skip past `versions`.
+        let mut versions = None;
+        for (k, v) in root.iter_object() {
+            match k {
+                b"name" | b"modified" => fields_read += v.as_str().is_some() as u64,
+                b"versions" => versions = Some(v),
+                _ => {}
+            }
+        }
+        if let Some(versions) = versions {
+            for (_ver_key, ver) in versions.iter_object() {
+                versions_seen += 1;
+                // One pass over keys — what npm.rs would do.
+                for (k, v) in ver.iter_object() {
+                    match k {
+                        b"dist" => {
+                            for (dk, dv) in v.iter_object() {
+                                if matches!(dk, b"tarball" | b"integrity") {
+                                    fields_read += dv.as_str().is_some() as u64;
+                                }
+                            }
+                        }
+                        b"bin" | b"directories" => fields_read += 1,
+                        b"dependencies"
+                        | b"peerDependencies"
+                        | b"optionalDependencies" => {
+                            for (_, dv) in v.iter_object() {
+                                fields_read += dv.as_str().is_some() as u64;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        std::hint::black_box((versions_seen, fields_read));
+    });
+    let result = bun_jsc::JSValue::create_empty_object(global, 4);
+    result.put(global, b"ns", JSValue::js_number(ns as f64));
+    result.put(global, b"versions", JSValue::js_number(versions_seen as f64));
+    result.put(global, b"fields", JSValue::js_number(fields_read as f64));
+    result.put(global, b"bytes", JSValue::js_number(bytes.len() as f64));
+    Ok(result)
+}
+
+/// Cursor `get` correctness: returns the value at `path` (dotted) as a string.
+pub fn js_cursor_get(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    use bun_parsers::json_cursor::JsonDoc;
+    let input = frame.argument(0).to_slice(global)?;
+    let path = frame.argument(1).to_slice(global)?;
+    let source = bun_ast::Source::init_path_string(b"input.json", input.slice());
+    let mut log = bun_ast::Log::init();
+    let doc = match JsonDoc::parse(&source, &mut log) {
+        Ok(d) => d,
+        Err(_) => return Ok(JSValue::UNDEFINED),
+    };
+    let mut cur = doc.root();
+    for seg in path.slice().split(|&b| b == b'.') {
+        match cur.get(seg) {
+            Some(c) => cur = c,
+            None => return Ok(JSValue::UNDEFINED),
+        }
+    }
+    let bump = bun_alloc::Arena::new();
+    match cur.as_str_decoded(&bump) {
+        Some(s) => bun_core::String::clone_utf8(s).to_js(global),
+        None => Ok(JSValue::NULL),
+    }
+}
+
+/// Stage-1 throughput in isolation: index `input` `iters` times into a reused
+/// buffer. Returns total ns and the structural count.
+pub fn js_bench_stage1(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    use bun_highway as hwy;
+    let input = frame.argument(0).to_slice(global)?;
+    let iters = frame.argument(1).coerce_to_i32(global)?.max(1) as u32;
+    let bytes = input.slice();
+    let mut indices = vec![0u32; bytes.len() + 64 + 4];
+    let mut count = 0u32;
+    let ns = time_iters(iters, || {
+        let (_rc, c, _f) = hwy::json_index(bytes, &mut indices);
+        count = c;
+        std::hint::black_box(&indices);
+    });
+    let result = bun_jsc::JSValue::create_empty_object(global, 3);
+    result.put(global, b"ns", JSValue::js_number(ns as f64));
+    result.put(global, b"count", JSValue::js_number(count as f64));
+    result.put(global, b"bytes", JSValue::js_number(bytes.len() as f64));
+    Ok(result)
+}

--- a/src/runtime/api/json_simd_testing.rs
+++ b/src/runtime/api/json_simd_testing.rs
@@ -80,23 +80,31 @@ pub fn js_bench(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue>
     };
 
     let mut bufs = bun_parsers::json_simd::SimdJSONBuffers::default();
-    let simd_ns = if which == 1 { 0 } else { time_iters(iters, || {
-        let mut log = bun_ast::Log::init();
-        let arena = bun_alloc::Arena::new();
-        let mut g = bun_ast::ASTMemoryAllocator::borrowing(&arena);
-        let _s = g.enter();
-        let _ = std::hint::black_box(SimdJSON::parse_into(
-            &mut bufs, &source, &mut log, &arena, true,
-        ));
-    }) };
+    let simd_ns = if which == 1 {
+        0
+    } else {
+        time_iters(iters, || {
+            let mut log = bun_ast::Log::init();
+            let arena = bun_alloc::Arena::new();
+            let mut g = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+            let _s = g.enter();
+            let _ = std::hint::black_box(SimdJSON::parse_into(
+                &mut bufs, &source, &mut log, &arena, true,
+            ));
+        })
+    };
 
-    let scalar_ns = if which == 0 { 0 } else { time_iters(iters, || {
-        let mut log = bun_ast::Log::init();
-        let arena = bun_alloc::Arena::new();
-        let mut g = bun_ast::ASTMemoryAllocator::borrowing(&arena);
-        let _s = g.enter();
-        let _ = std::hint::black_box(json::parse_utf8_scalar(&source, &mut log, &arena));
-    }) };
+    let scalar_ns = if which == 0 {
+        0
+    } else {
+        time_iters(iters, || {
+            let mut log = bun_ast::Log::init();
+            let arena = bun_alloc::Arena::new();
+            let mut g = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+            let _s = g.enter();
+            let _ = std::hint::black_box(json::parse_utf8_scalar(&source, &mut log, &arena));
+        })
+    };
 
     let result = bun_jsc::JSValue::create_empty_object(global, 4);
     result.put(global, b"bytes", JSValue::js_number(bytes.len() as f64));
@@ -193,9 +201,7 @@ pub fn js_bench_cursor(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<J
                             }
                         }
                         b"bin" | b"directories" => fields_read += 1,
-                        b"dependencies"
-                        | b"peerDependencies"
-                        | b"optionalDependencies" => {
+                        b"dependencies" | b"peerDependencies" | b"optionalDependencies" => {
                             for (_, dv) in v.iter_object() {
                                 fields_read += dv.as_str().is_some() as u64;
                             }
@@ -209,7 +215,11 @@ pub fn js_bench_cursor(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<J
     });
     let result = bun_jsc::JSValue::create_empty_object(global, 4);
     result.put(global, b"ns", JSValue::js_number(ns as f64));
-    result.put(global, b"versions", JSValue::js_number(versions_seen as f64));
+    result.put(
+        global,
+        b"versions",
+        JSValue::js_number(versions_seen as f64),
+    );
     result.put(global, b"fields", JSValue::js_number(fields_read as f64));
     result.put(global, b"bytes", JSValue::js_number(bytes.len() as f64));
     Ok(result)

--- a/test/js/bun/json/simd-json.test.ts
+++ b/test/js/bun/json/simd-json.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, test } from "bun:test";
+import { simdJSONInternals } from "bun:internal-for-testing";
+
+const { parse, index, cursorGet } = simdJSONInternals;
+
+// Compares the SIMD parser against the engine's JSON.parse on inputs both must
+// accept. Differences are bugs in the new parser.
+function ok(input: string) {
+  expect(parse(input)).toEqual(JSON.parse(input));
+}
+
+function err(input: string) {
+  expect(() => parse(input)).toThrow();
+  expect(() => JSON.parse(input)).toThrow();
+}
+
+describe("simdjson stage-1 indexer", () => {
+  test("structural indices for a small document", () => {
+    //          0         1
+    //          0123456789012345
+    const s = '{"a": [1, true]}';
+    expect(index(s)).toEqual([0, 1, 4, 6, 7, 8, 10, 14, 15]);
+  });
+
+  test("ignores characters inside strings", () => {
+    const s = '{"key,with:ops[]{}": 1}';
+    // {  "  :  1  }
+    expect(index(s)).toEqual([0, 1, 19, 21, 22]);
+  });
+
+  test("escaped quotes do not terminate strings", () => {
+    expect(index('["a\\"b", 1]')).toEqual([0, 1, 7, 9, 10]);
+  });
+
+  test("backslash run parity across many backslashes", () => {
+    // 4 backslashes then quote: quote is unescaped → string ends at pos 6.
+    expect(index(String.raw`["\\\\", 1]`)).toEqual([0, 1, 7, 9, 10]);
+    // 3 backslashes then quote: quote at 5 is escaped, real close at 6.
+    expect(index(String.raw`["\\\"", 1]`)).toEqual([0, 1, 7, 9, 10]);
+  });
+
+  test("unclosed string is reported", () => {
+    expect(() => index('["never ends')).toThrow(/UnclosedString/);
+  });
+});
+
+describe("simdjson stage-2 — leaves", () => {
+  test.each([
+    "true",
+    "false",
+    "null",
+    "0",
+    "1",
+    "-0",
+    "-1",
+    "42",
+    "1234567890",
+    "-1234567890",
+    "1.5",
+    "-1.5",
+    "0.0001",
+    "1e10",
+    "1E10",
+    "1e+10",
+    "1e-10",
+    "1.234e56",
+    "-1.234e-56",
+    "9007199254740993",
+    "1.7976931348623157e308",
+    '""',
+    '"hello"',
+    '"with spaces and\\ttabs"',
+    '"escaped \\"quote\\""',
+    '"\\\\"',
+    '"\\/"',
+    '"\\b\\f\\n\\r\\t"',
+    '"\\u0041"',
+    '"\\u00e9"',
+    '"\\ud83d\\ude00"',
+    '"日本語"',
+    '"😀"',
+  ])("parses %s", ok);
+
+  test.each([
+    "",
+    "  ",
+    "tru",
+    "truee",
+    "nul",
+    "fals",
+    "falsey",
+    "01",
+    "-",
+    ".5",
+    "1.",
+    "1e",
+    "1e+",
+    "+1",
+    "--1",
+    "0x1",
+    "1_000",
+    "Infinity",
+    "NaN",
+    '"',
+    '"unterminated',
+    '"\\x41"',
+    '"\\u12"',
+    '"\\"',
+    '"control\nchar"',
+    "'single'",
+  ])("rejects %s", err);
+});
+
+describe("simdjson stage-2 — containers", () => {
+  test.each([
+    "[]",
+    "{}",
+    "[1,2,3]",
+    "[[]]",
+    "[[],[]]",
+    "[{},{}]",
+    '{"a":1}',
+    '{"a":1,"b":2}',
+    '{"a":[1,2,{"b":[true,false,null]}]}',
+    '{"":""}',
+    "[1, 2 ,3 ]",
+    " { \"a\" : 1 } ",
+    "[\n  1,\n  2\n]",
+  ])("parses %s", ok);
+
+  test.each([
+    "[",
+    "]",
+    "{",
+    "}",
+    "[,]",
+    "[1,]",
+    "[1,,2]",
+    "[1 2]",
+    "{,}",
+    '{"a":1,}',
+    '{"a"}',
+    '{"a":}',
+    '{"a" 1}',
+    "{a:1}",
+    "{1:1}",
+    "[1]]",
+    "{}{}",
+    "1 2",
+    "[1] [2]",
+  ])("rejects %s", err);
+});
+
+describe("simdjson — block boundaries", () => {
+  // Stage 1 processes 64-byte blocks; place tokens straddling the boundary.
+  test("string spanning multiple 64-byte blocks", () => {
+    const body = "x".repeat(200);
+    ok(JSON.stringify({ k: body }));
+  });
+
+  test("escaped quote straddling block boundary", () => {
+    for (let pad = 55; pad <= 70; pad++) {
+      const s = `{"${"a".repeat(pad)}\\"tail": 1}`;
+      ok(s);
+    }
+  });
+
+  test("backslash run ending at block boundary", () => {
+    for (let pad = 55; pad <= 70; pad++) {
+      // Even-length run → following quote is real.
+      ok(`["${"a".repeat(pad)}\\\\", 1]`);
+      // Odd-length run → following quote is escaped, then a real one.
+      ok(`["${"a".repeat(pad)}\\\\\\"", 1]`);
+    }
+  });
+
+  test("number straddling block boundary", () => {
+    for (let pad = 55; pad <= 70; pad++) {
+      ok(`[${" ".repeat(pad)}12345.6789e10]`);
+    }
+  });
+
+  test("scalar start at every offset within a block", () => {
+    for (let pad = 0; pad < 130; pad++) {
+      ok(`${" ".repeat(pad)}[true,false,null,42]`);
+    }
+  });
+});
+
+describe("simdjson — depth and size", () => {
+  test("deeply nested arrays", () => {
+    const depth = 512;
+    const s = "[".repeat(depth) + "1" + "]".repeat(depth);
+    ok(s);
+  });
+
+  test("nesting beyond MAX_DEPTH is rejected without crashing", () => {
+    const depth = 2000;
+    const s = "[".repeat(depth) + "1" + "]".repeat(depth);
+    expect(() => parse(s)).toThrow();
+  });
+
+  test("large array of integers", () => {
+    const arr = Array.from({ length: 10000 }, (_, i) => i);
+    ok(JSON.stringify(arr));
+  });
+
+  test("large object", () => {
+    const obj: Record<string, number> = {};
+    for (let i = 0; i < 5000; i++) obj[`key_${i}`] = i;
+    ok(JSON.stringify(obj));
+  });
+
+  test("real-world: this repo's package.json", async () => {
+    const text = await Bun.file(new URL("../../../../package.json", import.meta.url)).text();
+    ok(text);
+  });
+});
+
+describe("JsonCursor — on-demand navigation", () => {
+  const doc = JSON.stringify({
+    name: "pkg",
+    versions: {
+      "1.0.0": { dist: { tarball: "https://a/1.tgz" }, bin: { x: "y" } },
+      "2.0.0": { dist: { tarball: "https://a/2.tgz", integrity: "sha512-abc" } },
+    },
+    nested: { a: { b: { c: "deep" } } },
+    esc: "line1\nline2",
+    arr: [1, [2, 3], { k: "v" }],
+  });
+
+  test("get() walks dotted paths", () => {
+    expect(cursorGet(doc, "name")).toBe("pkg");
+    expect(cursorGet(doc, "nested.a.b.c")).toBe("deep");
+  });
+
+  test("missing keys return undefined", () => {
+    expect(cursorGet(doc, "nope")).toBeUndefined();
+    expect(cursorGet(doc, "versions.nope")).toBeUndefined();
+    expect(cursorGet(doc, "name.foo")).toBeUndefined();
+  });
+
+  test("escapes are decoded", () => {
+    expect(cursorGet(doc, "esc")).toBe("line1\nline2");
+    expect(cursorGet('{"k":"a\\u00e9b"}', "k")).toBe("aéb");
+    expect(cursorGet('{"k":"\\ud83d\\ude00"}', "k")).toBe("😀");
+  });
+
+  test("non-string values return null from cursorGet", () => {
+    expect(cursorGet(doc, "arr")).toBeNull();
+    expect(cursorGet(doc, "versions")).toBeNull();
+  });
+
+  test("skipping deep/large values", () => {
+    // a 10K-element array that get() must skip past to reach "after"
+    const big = JSON.stringify({
+      before: "x",
+      huge: Array.from({ length: 10000 }, (_, i) => ({ n: i })),
+      after: "found",
+    });
+    expect(cursorGet(big, "after")).toBe("found");
+  });
+
+  test("real-world: this repo's package.json", async () => {
+    const text = await Bun.file(new URL("../../../../package.json", import.meta.url)).text();
+    const ref = JSON.parse(text);
+    expect(cursorGet(text, "name")).toBe(ref.name);
+    expect(cursorGet(text, "version")).toBe(ref.version);
+  });
+});
+
+describe("simdjson — randomized fuzzing against JSON.parse", () => {
+  function rand(n: number) {
+    return Math.floor(Math.random() * n);
+  }
+  function genValue(depth: number): unknown {
+    if (depth <= 0) return [null, true, false, rand(1e6) - 5e5, Math.random(), randString()][rand(6)];
+    switch (rand(6)) {
+      case 0:
+        return null;
+      case 1:
+        return rand(2) === 0;
+      case 2:
+        return (Math.random() - 0.5) * 1e6;
+      case 3:
+        return randString();
+      case 4: {
+        const n = rand(6);
+        return Array.from({ length: n }, () => genValue(depth - 1));
+      }
+      default: {
+        const n = rand(6);
+        const o: Record<string, unknown> = {};
+        for (let i = 0; i < n; i++) o[randString()] = genValue(depth - 1);
+        return o;
+      }
+    }
+  }
+  function randString() {
+    const chars = 'abc XYZ 012 ,:{}[]"\\\n\t日😀';
+    const cps = [...chars];
+    const n = rand(12);
+    let s = "";
+    for (let i = 0; i < n; i++) s += cps[rand(cps.length)];
+    return s;
+  }
+
+  test("1000 random documents round-trip", () => {
+    for (let i = 0; i < 1000; i++) {
+      const v = genValue(5);
+      const s = JSON.stringify(v);
+      const got = parse(s);
+      if (JSON.stringify(got) !== s) {
+        // Re-assert via expect for a useful diff.
+        expect({ input: s, got }).toEqual({ input: s, got: JSON.parse(s) });
+      }
+    }
+  });
+});

--- a/test/js/bun/json/simd-json.test.ts
+++ b/test/js/bun/json/simd-json.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
 import { simdJSONInternals } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
 
 const { parse, index, cursorGet } = simdJSONInternals;
 
@@ -124,7 +124,7 @@ describe("simdjson stage-2 — containers", () => {
     '{"a":[1,2,{"b":[true,false,null]}]}',
     '{"":""}',
     "[1, 2 ,3 ]",
-    " { \"a\" : 1 } ",
+    ' { "a" : 1 } ',
     "[\n  1,\n  2\n]",
   ])("parses %s", ok);
 


### PR DESCRIPTION
### What does this PR do?

Two related optimizations to `bun_parsers::json`, aimed at registry manifest parsing and other strict-JSON hot paths.

**1. SIMD JSON parser** (`src/jsc/bindings/highway_json.cpp` + `src/parsers/json_simd.rs`)

A simdjson-style two-stage parser using the existing Highway runtime-dispatch pattern (same `foreach_target` setup as `highway_strings.cpp`):

- Stage 1 classifies 64-byte blocks into structural/string bitmasks (escape parity via the odd-backslash-run trick, prefix-XOR for the in-string mask) and expands them to structural indices.
- Stage 2 (also C++, same single FFI call) walks the indices with a goto state machine and emits a type-tagged tape (`(tag<<56)|payload` words, back-patched container counts) plus an unescaped string buffer. The kernel reads the input in place; there is no padding requirement (`LoadN` for the last vector, span-bounded number/atom reads).
- A Rust `TapeWalker` builds the existing `Expr` AST in one linear pass: exact `Vec` capacity per container from the tape counts, escape-free strings borrowed directly from the source (bit-55 flag on the STR word), allocations routed straight into the bump arena via `Expr::allocate` instead of the TLS store, container children written into spare capacity.

The strict entry points (`parse`, `parse_utf8`, `parse_for_bundling`) now route through it. The lenient paths (JSONC, tsconfig, package.json, .env), which need comments and trailing commas, are unchanged. The previous strict path is kept as `parse_utf8_scalar` and selectable via `BUN_NPM_PARSE_SCALAR=1` for comparison.

**2. `JsonCursor`** (`src/parsers/json_cursor.rs`)

On-demand reads over the stage-1 structural indices: a precomputed skip table makes skipping any value O(1), key iteration compares borrowed slices, and nothing is allocated until a value is actually read (or `materialize()` is called for a real `Expr` subtree). npm packuments are the motivating case: a 15 MB typescript packument is ~3,700 versions of ~100 fields each, of which manifest parsing reads about 6 per version.

`PackageManifest::parse_cursor()` is a full port of `parse()` to the cursor, producing byte-identical output (verified via string-buf hash and identical resolution output). It is opt-in via `BUN_NPM_PARSE_CURSOR=1` for now. `BUN_NPM_PARSE_STATS=1` prints per-process manifest parse totals at exit.

**Benchmarks** (Zen 5, AVX-512, release build; simdjson built with `-O3 -march=native` on the same machine for reference)

Full parse vs the previous parser:

| input | new | previous | speedup |
|---|---|---|---|
| twitter.json (617 KB) | 290 µs | 1521 µs | 5.25x |
| citm_catalog.json (1.7 MB) | 729 µs | 3072 µs | 4.21x |
| package.json (6 KB) | 4.4 µs | 12.2 µs | 2.79x |
| react packument (6.6 MB) | 7.0 ms | 16.2 ms | 2.31x |
| 1 MB single string | 92 µs | 16 µs | 0.18x |

The last row is the known worst case of the two-stage architecture (stage 1 classifies every byte; the previous parser borrows the slice after a quote scan). The tape build alone runs at 70-88% of simdjson's AVX-512 kernel on the same inputs.

`PackageManifest::parse` on real packuments (byte-identical output):

| packument | parse() + SIMD JSON | parse_cursor() | speedup |
|---|---|---|---|
| react (6.4 MB, 2852 versions) | 16.8 ms | 4.5 ms | 3.72x |
| typescript (14.7 MB, 3768 versions) | 39.0 ms | 10.0 ms | 3.90x |

End-to-end cold-cache `bun install --lockfile-only` against a local in-memory registry (366 packuments, 100 MB, hyperfine, 30 runs + 5 warmup):

| mode | wall clock | vs previous |
|---|---|---|
| scalar (previous) | 206.5 ms ± 10.6 | 1.00x |
| SIMD + Expr | 179.1 ms ± 6.0 | 1.15x |
| cursor | 113.3 ms ± 5.7 | 1.82x |

Warm installs are unaffected (binary manifest cache, no JSON involved).

### How did you verify your code works?

- `test/js/bun/json/simd-json.test.ts` (new): 113 tests covering stage-1 indices, block-boundary escape parity, adversarial inputs (escaped-quote runs at block boundaries, quote at byte 63/64, unterminated strings), nesting depth, cursor navigation, and a 1000-document randomized fuzz against `JSON.parse`.
- Existing suites pass: `test/js/bun/json/`, `test/js/bun/jsonc/`, `test/bundler/bundler_loader.test.ts`, `test/transpiler/transpiler.test.js`, `test/js/bun/sourcemap`.
- `test/cli/install/bun-install.test.ts` (185 tests) passes with `BUN_NPM_PARSE_CURSOR=1` forced on.
- `parse_cursor()` output verified byte-identical to `parse()` on real packuments, and all three modes produce identical resolution output (528 packages, zero diff) on a cold-cache resolve.
- Generality audit: no input-shape fallbacks. String length, key/element counts, and number lengths have no cliffs; the >16M-element container count field is a capacity hint only (iteration runs to the END tag); input size is guarded at `i32::MAX` to match the AST's `Loc` constraint; nesting depth limit is 1024 (hard error, same class as the previous parser's stack check).

Benchmark harnesses are in `bench/json-simd/` (in-Rust timing via `bun:internal-for-testing` so JS overhead stays out of the measurement, a standalone simdjson comparison harness, and the local-registry install benchmark).
