### PR TITLE
node:dgram: throw ERR_SOCKET_DGRAM_NOT_RUNNING from socket methods after close()

### DIFF
--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -219,6 +219,7 @@ function bufferSize(self, size, _buffer) {
 Socket.prototype.bind = function (port_, address_ /* , callback */) {
   let port = port_;
 
+  healthCheck(this);
   const state = this[kStateSymbol];
 
   if (state.bindState !== BIND_STATE_UNBOUND) {
@@ -578,6 +579,8 @@ Socket.prototype.send = function (buffer, offset, length, port, address, callbac
     validateString(address, "address");
   }
 
+  healthCheck(this);
+
   if (state.bindState === BIND_STATE_UNBOUND) this.bind({ port: 0, exclusive: true }, null);
 
   if (list.length === 0) list.push(Buffer.alloc(0));
@@ -702,6 +705,7 @@ Socket.prototype.close = function (callback) {
     return this;
   }
 
+  healthCheck(this);
   state.receiving = false;
   state.handle.socket?.close();
   state.handle = null;
@@ -711,7 +715,7 @@ Socket.prototype.close = function (callback) {
 };
 
 Socket.prototype[SymbolAsyncDispose] = async function () {
-  if (!this[kStateSymbol].handle.socket) {
+  if (!this[kStateSymbol].handle) {
     return;
   }
   const { promise, resolve, reject } = $newPromiseCapability(Promise);
@@ -731,12 +735,16 @@ function socketCloseNT(self) {
 }
 
 Socket.prototype.address = function () {
+  healthCheck(this);
+
   const addr = this[kStateSymbol].handle.socket?.address;
   if (!addr) throw $ERR_SOCKET_DGRAM_NOT_RUNNING();
   return addr;
 };
 
 Socket.prototype.remoteAddress = function () {
+  healthCheck(this);
+
   const state = this[kStateSymbol];
   const socket = state.handle.socket;
 

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -206,3 +206,74 @@ describe("unref()", () => {
     expect([path.join(import.meta.dir, "dgram-unref-hang-fixture.ts")]).toRun();
   });
 });
+
+describe("after close()", () => {
+  // Node throws ERR_SOCKET_DGRAM_NOT_RUNNING from these methods once the
+  // socket is closed. They must not surface an internal TypeError instead.
+  async function boundThenClosed() {
+    const socket = createSocket("udp4");
+    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+    socket.bind(0, onListening);
+    await listening;
+    const port = socket.address().port;
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    socket.close(onClose);
+    await closed;
+    return { socket, port };
+  }
+
+  test("address() throws ERR_SOCKET_DGRAM_NOT_RUNNING", async () => {
+    const { socket } = await boundThenClosed();
+    let err: any;
+    try {
+      socket.address();
+    } catch (e) {
+      err = e;
+    }
+    expect({ name: err?.name, code: err?.code }).toEqual({ name: "Error", code: "ERR_SOCKET_DGRAM_NOT_RUNNING" });
+  });
+
+  test("remoteAddress() throws ERR_SOCKET_DGRAM_NOT_RUNNING", async () => {
+    const { socket } = await boundThenClosed();
+    expect(() => socket.remoteAddress()).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+  });
+
+  test("send() throws ERR_SOCKET_DGRAM_NOT_RUNNING", async () => {
+    const { socket, port } = await boundThenClosed();
+    expect(() => socket.send(Buffer.from("hello"), port, "127.0.0.1")).toThrowWithCode(
+      Error,
+      "ERR_SOCKET_DGRAM_NOT_RUNNING",
+    );
+  });
+
+  test("send() with a callback throws ERR_SOCKET_DGRAM_NOT_RUNNING synchronously", async () => {
+    const { socket, port } = await boundThenClosed();
+    expect(() => socket.send(Buffer.from("hello"), port, "127.0.0.1", () => {})).toThrowWithCode(
+      Error,
+      "ERR_SOCKET_DGRAM_NOT_RUNNING",
+    );
+  });
+
+  test("close() throws ERR_SOCKET_DGRAM_NOT_RUNNING", async () => {
+    const { socket } = await boundThenClosed();
+    expect(() => socket.close()).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+  });
+
+  test("bind() throws ERR_SOCKET_DGRAM_NOT_RUNNING", async () => {
+    const { socket } = await boundThenClosed();
+    expect(() => socket.bind(0)).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+  });
+
+  test("close() of a never-bound socket can only be called once", async () => {
+    const socket = createSocket("udp4");
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    socket.close(onClose);
+    await closed;
+    expect(() => socket.close()).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+  });
+
+  test("Symbol.asyncDispose resolves when the socket is already closed", async () => {
+    const { socket } = await boundThenClosed();
+    expect(await socket[Symbol.asyncDispose]()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Any `dgram.Socket` method called after `close()` throws an internal, uncoded `TypeError` instead of Node's `ERR_SOCKET_DGRAM_NOT_RUNNING`:

```js
const s = require("dgram").createSocket("udp4");
s.bind(0, () => {
  s.close();
  setTimeout(() => {
    try { s.address() } catch (e) { console.log(e.constructor.name, e.code, e.message) }
  }, 50);
});
// node: Error ERR_SOCKET_DGRAM_NOT_RUNNING "Not running"
// bun:  TypeError undefined "null is not an object (evaluating 'kStateSymbol')"
```

The same happens for `send()`, `remoteAddress()`, a second `close()`, and `bind()` after close. "The socket might already be closed" is a race UDP consumers handle by checking `err.code === "ERR_SOCKET_DGRAM_NOT_RUNNING"`, so the uncoded TypeError (whose message also leaks an internal symbol name) turns a benign condition into an unclassifiable error.

Cause: `close()` sets `state.handle = null`, and the other methods dereference `state.handle` with no guard. `dgram.ts` already defines the same `healthCheck()` helper Node has (it throws `ERR_SOCKET_DGRAM_NOT_RUNNING` when the handle is gone), but nothing called it.

Fix: call `healthCheck(this)` from `bind()`, `send()`, `close()`, `address()` and `remoteAddress()`, at the same points Node's `lib/dgram.js` does. Also make `Socket.prototype[Symbol.asyncDispose]` check `state.handle` rather than `state.handle.socket`, again matching Node, so disposing an already-closed socket resolves instead of throwing the same TypeError.

Post-close behavior now matches Node v26.3.0 for every method Node guards:

| after `close()` | node | bun before | bun after |
|---|---|---|---|
| `address()` | `ERR_SOCKET_DGRAM_NOT_RUNNING` | uncoded `TypeError` | `ERR_SOCKET_DGRAM_NOT_RUNNING` |
| `remoteAddress()` | `ERR_SOCKET_DGRAM_NOT_RUNNING` | uncoded `TypeError` | `ERR_SOCKET_DGRAM_NOT_RUNNING` |
| `send()` | `ERR_SOCKET_DGRAM_NOT_RUNNING` | uncoded `TypeError` | `ERR_SOCKET_DGRAM_NOT_RUNNING` |
| `close()` | `ERR_SOCKET_DGRAM_NOT_RUNNING` | uncoded `TypeError` | `ERR_SOCKET_DGRAM_NOT_RUNNING` |
| `bind()` | `ERR_SOCKET_DGRAM_NOT_RUNNING` | `error` event with `ERR_SOCKET_ALREADY_BOUND` | `ERR_SOCKET_DGRAM_NOT_RUNNING` |
| `[Symbol.asyncDispose]()` | resolves | rejects with `TypeError` | resolves |

Methods Node itself does not guard after close (`connect()`, `setBroadcast()`, `setTTL()`, the buffer-size accessors) are unchanged; the goal is parity with Node, and Node throws an unguarded error from those too.

### How did you verify your code works?

- New tests in `test/js/bun/udp/dgram.test.ts` (`describe("after close()")`). All 8 fail on current main and pass with this change.
- The 29 existing tests in that file still pass.
- Every vendored `test/js/node/test/parallel/test-dgram-*` file behaves identically before and after the change.

Note: the larger dgram sync in #32625 (draft) overlaps on `address()` and `Symbol.asyncDispose`, but does not cover `send()`, `close()`, `remoteAddress()` or `bind()` after close.
