### PR TITLE
bun-plugin-svelte: stop pinning the exact __commonJS callback syntax in the CJS wrapper test

### DIFF
--- a/packages/bun-plugin-svelte/test/index.test.ts
+++ b/packages/bun-plugin-svelte/test/index.test.ts
@@ -97,7 +97,11 @@ describe("when importing `.svelte.ts` files with CJS", () => {
     expect(ts).toBeDefined();
     const code = await ts!.text();
     expect(code).toContain("require_todo_cjs_svelte");
-    expect(code).toContain("var require_todo_cjs_svelte = __commonJS(function(exports, module) {\n");
+    // The bundler wraps the module exactly once, with its own __commonJS((exports, module))
+    // helper. Packages CI runs against a released bun, so don't pin the callback's exact
+    // syntax (arrow vs. function expression): it has changed across bun versions.
+    expect(code).toMatch(/var require_todo_cjs_svelte = __commonJS\((?:function\s*)?\(exports, module\)/);
+    expect(code).not.toContain("__filename, __dirname");
   });
 });
 


### PR DESCRIPTION
### What's broken

The `bun-plugin-svelte` job in Packages CI has failed on every push to main since #32846 landed (first red run: https://github.com/oven-sh/bun/actions/runs/28298488470).

```
error: expect(received).toContain(expected)

Expected to contain: "var require_todo_cjs_svelte = __commonJS(function(exports, module) {\n"
```

### Cause

`packages/bun-plugin-svelte/test/index.test.ts` asserted the literal text of the bundler's CommonJS wrapper. #32846 changed that wrapper from an arrow function to a function expression (so `arguments` works inside bundled CJS) and updated this assertion in the same commit.

But Packages CI runs this package's tests with the *published canary* bun (`BUN_VERSION: canary`), not a bun built from the commit under test, and the canary lagged the bundler change by over a day. So the updated assertion could never pass in that PR's own `bun-plugin-svelte` check (it was already red at merge), nor on any push to main until the canary caught up.

This will recur for any future bundler codegen change: a test in `packages/` cannot pin exact bundler output and be updated atomically with it, because Packages CI always runs against a released bun. Exact-output coverage for the `function(exports, module)` wrapper already lives in `test/bundler/bundler_cjs.test.ts`, which does run against the built-from-source bun.

### Fix

Assert the property the test is named for instead of the literal codegen: the module is wrapped once by the bundler's `__commonJS` helper with an `(exports, module)` callback, and is not re-wrapped in a Node-style `(module, exports, __filename, __dirname)` function. Both the arrow form (pre-#32846) and the function-expression form (post-#32846) satisfy it.

### Scope

The only changed file is `packages/bun-plugin-svelte/test/index.test.ts`, that package's own test. Nothing under `src/` or `test/` changes: bun's bundler output is identical before and after this PR, so there is no runtime behavior here for a new regression test to cover, and a bun built from this branch already satisfies both the old and the new assertion. The only builds that distinguish them are released bun binaries from before #32846, which is what Packages CI downloads and what the verification below uses.

### Verification

The suite now passes with a bun from either side of #32846:

```
# 1.4.0-canary.1+df92f8fd6 (before #32846, emits an arrow)
10 pass, 0 fail

# 1.4.0-canary.1+4f2932980 (after #32846, emits a function expression)
35 pass, 0 fail
```

The new assertions still reject every regression shape the test exists for: a `(module, exports, __filename, __dirname)` parameter list, a nested Node-style wrapper, and the module not being wrapped at all. The job's other steps (`oxlint`, `prettier --check`, `bun check:types`) pass unchanged.

On this PR, the previously failing `bun-plugin-svelte` check is green: https://github.com/oven-sh/bun/actions/runs/28338188901/job/83947966781
