### PR TITLE
install(windows): fall back to FileRenameInformation on non-NTFS volumes

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1932,7 +1932,7 @@ pub fn move_opened_file_at(
         );
     }
     // SAFETY: src_fd valid; rename_info has struct_len initialized bytes
-    let rc = unsafe {
+    let mut rc = unsafe {
         ntdll::NtSetInformationFile(
             src_fd.native(),
             &mut io_status_block,
@@ -1953,6 +1953,35 @@ pub fn move_opened_file_at(
         },
         format_args!("{:?}", rc)
     );
+
+    // Non-NTFS filesystems (exFAT, FAT32) only implement the legacy class;
+    // same fallback as `DeleteFileBun` above.
+    if rc == win32::ntstatus::INVALID_PARAMETER {
+        let legacy_info: *mut win32::FILE_RENAME_INFORMATION = rename_info.cast();
+        // SAFETY: the buffer behind rename_info is aligned and fully initialized
+        // above, and the two structs share every field offset except this one
+        // (asserted at their definitions), so only the leading field changes.
+        unsafe {
+            ptr::addr_of_mut!((*legacy_info).ReplaceIfExists)
+                .write(win32::BOOLEAN::from(replace_if_exists));
+        }
+        // SAFETY: src_fd valid; legacy_info has struct_len initialized bytes
+        // (the two structs have the same size, asserted at their definitions).
+        rc = unsafe {
+            ntdll::NtSetInformationFile(
+                src_fd.native(),
+                &mut io_status_block,
+                legacy_info.cast::<c_void>(),
+                u32::try_from(struct_len).expect("int cast"), // already checked for error.NameTooLong
+                win32::FileInformationClass::FileRenameInformation,
+            )
+        };
+        bun_sys::syslog!(
+            "moveOpenedFileAt({}) FileRenameInformation fallback = {}",
+            src_fd,
+            format_args!("{:?}", rc)
+        );
+    }
 
     #[cfg(debug_assertions)]
     if rc == win32::ntstatus::ACCESS_DENIED {

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -390,6 +390,7 @@ pub struct FILE_INFORMATION_CLASS(pub u32);
 impl FILE_INFORMATION_CLASS {
     pub const FileDirectoryInformation: Self = Self(1);
     pub const FileBasicInformation: Self = Self(4);
+    pub const FileRenameInformation: Self = Self(10);
     pub const FileDispositionInformation: Self = Self(13);
     pub const FileAllInformation: Self = Self(18);
     pub const FileEndOfFileInformation: Self = Self(20);
@@ -512,6 +513,36 @@ pub struct FILE_RENAME_INFORMATION_EX {
     pub FileNameLength: ULONG,
     pub FileName: [u16; 1],
 }
+
+/// `FILE_RENAME_INFORMATION` legacy variant (`ntifs.h`): the SDK declares the
+/// leading field as `union { BOOLEAN ReplaceIfExists; ULONG Flags; }`.
+#[repr(C)]
+pub struct FILE_RENAME_INFORMATION {
+    pub ReplaceIfExists: BOOLEAN,
+    pub RootDirectory: HANDLE,
+    pub FileNameLength: ULONG,
+    pub FileName: [u16; 1],
+}
+
+// `move_opened_file_at` reinterprets a populated `_EX` buffer as the legacy struct.
+const _: () = {
+    assert!(
+        core::mem::size_of::<FILE_RENAME_INFORMATION>()
+            == core::mem::size_of::<FILE_RENAME_INFORMATION_EX>()
+    );
+    assert!(
+        core::mem::offset_of!(FILE_RENAME_INFORMATION, RootDirectory)
+            == core::mem::offset_of!(FILE_RENAME_INFORMATION_EX, RootDirectory)
+    );
+    assert!(
+        core::mem::offset_of!(FILE_RENAME_INFORMATION, FileNameLength)
+            == core::mem::offset_of!(FILE_RENAME_INFORMATION_EX, FileNameLength)
+    );
+    assert!(
+        core::mem::offset_of!(FILE_RENAME_INFORMATION, FileName)
+            == core::mem::offset_of!(FILE_RENAME_INFORMATION_EX, FileName)
+    );
+};
 
 // `FILE_DISPOSITION_INFORMATION_EX.Flags` bits (winnt.h).
 

--- a/test/cli/install/bun-install-non-ntfs-windows.test.ts
+++ b/test/cli/install/bun-install-non-ntfs-windows.test.ts
@@ -1,0 +1,125 @@
+// `FileRenameInformationEx`, the NT rename class bun replaces `bun.lock` with,
+// is only implemented by NTFS, so exFAT and FAT32 volumes need the legacy
+// `FileRenameInformation` fallback. https://github.com/oven-sh/bun/issues/10169
+
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+setDefaultTimeout(1000 * 60 * 5);
+
+// `net session` exits non-zero with "Access is denied" unless the process is
+// elevated; diskpart's `create vdisk` / `attach vdisk` need elevation too.
+const isElevatedWindows =
+  isWindows && Bun.spawnSync({ cmd: ["net", "session"], stdio: ["ignore", "ignore", "ignore"] }).exitCode === 0;
+
+function diskpart(root: string, name: string, lines: string[]) {
+  const scriptPath = join(root, name);
+  writeFileSync(scriptPath, lines.join("\r\n") + "\r\n");
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: ["diskpart", "/s", scriptPath],
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return { exitCode, output: `${stdout}${stderr}` };
+}
+
+describe.skipIf(!isElevatedWindows)("bun install on a non-NTFS Windows volume", () => {
+  test("saves and replaces bun.lock in a project on a FAT32 volume", async () => {
+    using dir = tempDir("install-fat32", {});
+    const root = String(dir);
+    // diskpart's `assign mount=` needs an existing, empty NTFS directory.
+    const mount = join(root, "volume");
+    mkdirSync(mount);
+    const vhd = join(root, "fat32.vhd");
+
+    // 64 MB keeps the FAT32 formatter above its ~33 MB floor while the
+    // expandable backing file stays a few MB on disk.
+    const created = diskpart(root, "create.txt", [
+      `create vdisk file="${vhd}" maximum=64 type=expandable`,
+      `select vdisk file="${vhd}"`,
+      `attach vdisk`,
+      `create partition primary`,
+      `format fs=fat32 quick`,
+      `assign mount="${mount}"`,
+    ]);
+    try {
+      // diskpart's text is localized, so only the exit code is asserted here;
+      // `output` rides along to make a setup failure's diff readable.
+      expect(created).toEqual({ exitCode: 0, output: expect.any(String) });
+
+      // Locale-independent proof that diskpart created, formatted (FAT32, not
+      // NTFS), and mounted the volume; `FileSystemType` would be the parent's
+      // `NTFS` if any step silently failed. The path rides in an env var.
+      const fsinfo = Bun.spawnSync({
+        cmd: [
+          "powershell.exe",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          "(Get-Volume -FilePath $env:BUN_TEST_MOUNT).FileSystemType",
+        ],
+        env: { ...bunEnv, BUN_TEST_MOUNT: mount },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      expect(fsinfo.stdout.toString().trim()).toBe("FAT32");
+
+      // Match every report on the issue: install cache on NTFS, project (and
+      // therefore bun.lock and node_modules) on the non-NTFS volume.
+      const cache = join(root, "cache");
+      mkdirSync(cache);
+      const project = join(mount, "project");
+      mkdirSync(project);
+      const lockPath = join(project, "bun.lock");
+      const manifest = (dependencies: Record<string, string>) =>
+        JSON.stringify({ name: "fat32-project", version: "1.0.0", dependencies });
+      copyFileSync(join(import.meta.dir, "bar-0.0.2.tgz"), join(project, "bar-0.0.2.tgz"));
+      copyFileSync(join(import.meta.dir, "baz-0.0.3.tgz"), join(project, "baz-0.0.3.tgz"));
+      writeFileSync(join(project, "package.json"), manifest({ bar: "file:./bar-0.0.2.tgz" }));
+
+      // The first run creates bun.lock. The second adds a dependency so bun has
+      // to re-save (an unchanged install skips the save entirely) and replace
+      // the existing lockfile through the same rename.
+      let lockAfterCreate = "";
+      for (const run of ["create", "replace"]) {
+        if (run === "replace") {
+          writeFileSync(
+            join(project, "package.json"),
+            manifest({ bar: "file:./bar-0.0.2.tgz", baz: "file:./baz-0.0.3.tgz" }),
+          );
+        }
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install"],
+          cwd: project,
+          env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cache },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ run, exitCode, stdout, stderr }).toEqual({
+          run,
+          exitCode: 0,
+          stdout: expect.any(String),
+          stderr: expect.any(String),
+        });
+        expect(existsSync(lockPath)).toBe(true);
+        if (run === "create") lockAfterCreate = readFileSync(lockPath, "utf8");
+      }
+
+      // The second save replaced the lockfile the first one wrote.
+      const lockAfterReplace = readFileSync(lockPath, "utf8");
+      expect(lockAfterReplace).toContain("baz-0.0.3.tgz");
+      expect(lockAfterReplace).not.toBe(lockAfterCreate);
+
+      // The dependencies were linked onto the FAT32 volume, not just resolved.
+      expect(JSON.parse(readFileSync(join(project, "node_modules", "bar", "package.json"), "utf8"))).toEqual({
+        name: "bar",
+        version: "0.0.2",
+      });
+    } finally {
+      // The vdisk has to be detached before `dir`'s disposal can remove the
+      // mount point and the backing .vhd; failures here are non-actionable.
+      diskpart(root, "detach.txt", [`select vdisk file="${vhd}"`, `detach vdisk`]);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #10169

### What happens

`bun install` / `bun add` in a project on a Windows volume that is not NTFS (exFAT or FAT32: external and USB drives, many VeraCrypt and cloud-sync mounts) fails while saving the lockfile:

```
D:\Projects\BunTest>bun add discord.js
bun add v1.1.3 (2615dc74)
  Saving lockfile... EINVAL: Failed to replace old lockfile with new lockfile on disk
```

Every report on the issue says "any drive other than C:", but the drive letter is a proxy. C: is always NTFS, and the failing D:/E:/F:/G: drives are the ones that happen not to be (one commenter confirmed that reformatting their VeraCrypt volume to NTFS made the error go away). I could not reproduce on three NTFS volumes with three different drive letters, including a `subst` drive, and reproduced immediately on an exFAT VHD and a FAT32 VHD.

### Root cause

`lockfile.save()` writes a `.lock-XXXX.tmp` next to `bun.lock` and renames it over the old lockfile with `File::close_and_move_to`, which on Windows bottoms out in `move_opened_file_at`:

```
NtSetInformationFile(src_fd, ..., FileRenameInformationEx)
```

`FileRenameInformationEx` (and `FILE_RENAME_POSIX_SEMANTICS`) is only implemented by NTFS. exFAT and FAT32 reject the information class with `STATUS_INVALID_PARAMETER`, which maps to `EINVAL`.

`DeleteFileBun` in the same file already retries `FileDispositionInformationEx` through the legacy class on exactly this status, with a comment explaining the non-NTFS limitation. The rename path never got the same treatment.

The lockfile is the surface users hit: it is the one rename bun issues into the project directory through its own `NtSetInformationFile(FileRenameInformationEx)` wrapper. bun's other renames into a project (`yarn.lock`, `bun build --compile --outfile`, `node:fs.rename`) go through `MoveFileExW`, which Windows implements with the legacy class, so they already work on non-NTFS volumes; I verified the first two on exFAT with v1.3.14. The same wrapper does back `bun patch`'s moves into `node_modules` and the install cache's tarball promotion, so those are covered too when they land on a non-NTFS volume.

### The fix

When `FileRenameInformationEx` returns `STATUS_INVALID_PARAMETER`, retry through the legacy `FileRenameInformation` class, mirroring `DeleteFileBun`. In the Windows SDK the two are one struct whose leading field is a `union { BOOLEAN ReplaceIfExists; ULONG Flags; }`, so the already-populated rename buffer is reused and only that field is rewritten; compile-time assertions next to the two struct definitions prove every other field and the `FileName` tail line up.

There is no behavior change on NTFS: the fallback only runs on `STATUS_INVALID_PARAMETER`, which NTFS does not return for this class.

The `FileRenameInformation` class constant had been removed from `FILE_INFORMATION_CLASS` as dead code in #35002 (nothing used it until now); this restores it.

### Verification

The new test (`test/cli/install/bun-install-non-ntfs-windows.test.ts`) creates a 64 MB FAT32 VHD with `diskpart`, mounts it at an NTFS directory, asserts the mounted filesystem really is FAT32, and runs `bun install` from a project on it twice. The second run adds a dependency so bun has to re-save (an unchanged install skips the lockfile save entirely), and the test asserts the replaced `bun.lock` differs from the one the first run created. The whole test runs in about 5 seconds. It needs elevation, so it skips where `diskpart` cannot attach a vdisk.

Against the released binary it fails with the reported error:

```
bun test v1.3.14 (0d9b296a)
  {
-   "exitCode": 0,
+   "exitCode": 1,
+   "stderr":
+ "Resolving dependencies
+ Resolved, downloaded and extracted [1]
+ EINVAL: Failed to replace old lockfile with new lockfile on disk
+ "
(fail) bun install on a non-NTFS Windows volume > saves and replaces bun.lock in a project on a FAT32 volume
```

Against the debug build of this branch (rebased onto current main) it passes:

```
bun test v1.4.0-debug (6be60564d)
(pass) bun install on a non-NTFS Windows volume > saves and replaces bun.lock in a project on a FAT32 volume [4980.81ms]
 1 pass
 0 fail
 9 expect() calls
```

The same test still fails against a current main canary (`1.4.0`, built after #35002) with `EINVAL: Invalid argument: Failed to replace old lockfile with new lockfile on disk (NtSetInformationFile)`, so the bug is live on today's main as well as on the v1.3.14 release shown above.

<details>
<summary>Full matrix on Windows Server 2019 (system NTFS, NTFS subst, and three diskpart VHDs), each project installed twice</summary>

```
================ bun 1.3.14 (released, unfixed) ================
bun-1.3.14   C: NTFS   install#1=0 install#2=0 lock=True  :: 2 packages installed [54.00ms]
bun-1.3.14   S: NTFS   install#1=0 install#2=0 lock=True  :: 2 packages installed [9.00ms]
bun-1.3.14   Z: NTFS   install#1=0 install#2=0 lock=True  :: 2 packages installed [9.00ms]
bun-1.3.14   X: exFAT  install#1=1 install#2=1 lock=False :: EINVAL: Failed to replace old lockfile with new lockfile on disk
bun-1.3.14   Y: FAT32  install#1=1 install#2=1 lock=False :: EINVAL: Failed to replace old lockfile with new lockfile on disk
================ bun-debug (this branch) ======================
bun-debug    C: NTFS   install#1=0 install#2=0 lock=True  :: 2 packages installed [169.00ms]
bun-debug    S: NTFS   install#1=0 install#2=0 lock=True  :: 2 packages installed [164.00ms]
bun-debug    Z: NTFS   install#1=0 install#2=0 lock=True  :: 2 packages installed [157.00ms]
bun-debug    X: exFAT  install#1=0 install#2=0 lock=True  :: 2 packages installed [164.00ms]
bun-debug    Y: FAT32  install#1=0 install#2=0 lock=True  :: 2 packages installed [158.00ms]

================ bun add on X: (exFAT) ========================
bun-1.3.14   bun add is-odd: exit=1 :: EINVAL: Failed to replace old lockfile with new lockfile on disk
bun-debug    bun add is-odd: exit=0 :: installed is-odd@3.0.1
```

</details>

`cargo check -p bun_sys -p bun_windows_sys` passes for both `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`.

Related: #31185 proposes the same `FileRenameInformation` retry, plus a byte-copy last resort for filter drivers that reject the legacy class as well. This PR keeps the rename atomic and does not add the copy fallback, since the copy can leave a truncated destination and nothing in the issue requires it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-non-ntfs-windows.test.ts

<!-- robobun:evidence:end -->