### PR TITLE
Expose the 'module.exports' named export on CommonJS module namespaces

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -971,6 +971,7 @@ void populateESMExports(
 {
     auto& vm = JSC::getVM(globalObject);
     const Identifier& esModuleMarker = vm.propertyNames->__esModule;
+    const Identifier moduleExportsIdentifier = Identifier::fromString(vm, "module.exports"_s);
 
     // Bun's interpretation of the "__esModule" annotation:
     //
@@ -1023,8 +1024,8 @@ void populateESMExports(
         auto* structure = exports->structure();
 
         uint32_t size = structure->inlineSize() + structure->outOfLineSize();
-        exportNames.reserveCapacity(size + 2);
-        exportValues.ensureCapacity(size + 2);
+        exportNames.reserveCapacity(size + 3);
+        exportValues.ensureCapacity(size + 3);
 
         CLEAR_IF_EXCEPTION(scope);
 
@@ -1032,7 +1033,7 @@ void populateESMExports(
             if (canPerformFastEnumeration(structure)) {
                 exports->structure()->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                     auto key = entry.key();
-                    if (key->isSymbol() || key == esModuleMarker)
+                    if (key->isSymbol() || key == esModuleMarker || key == moduleExportsIdentifier)
                         return true;
 
                     needsToAssignDefault = needsToAssignDefault && key != vm.propertyNames->defaultKeyword;
@@ -1052,7 +1053,7 @@ void populateESMExports(
                 }
 
                 for (auto property : properties) {
-                    if (property.isEmpty() || property.isNull() || property == esModuleMarker || property.isPrivateName() || property.isSymbol()) [[unlikely]]
+                    if (property.isEmpty() || property.isNull() || property == esModuleMarker || property == moduleExportsIdentifier || property.isPrivateName() || property.isSymbol()) [[unlikely]]
                         continue;
 
                     // ignore constructor
@@ -1092,7 +1093,7 @@ void populateESMExports(
         } else if (canPerformFastEnumeration(structure)) {
             exports->structure()->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                 auto key = entry.key();
-                if (key->isSymbol() || key == vm.propertyNames->defaultKeyword)
+                if (key->isSymbol() || key == vm.propertyNames->defaultKeyword || key == moduleExportsIdentifier)
                     return true;
 
                 JSValue value = exports->getDirect(entry.offset());
@@ -1110,7 +1111,7 @@ void populateESMExports(
             }
 
             for (auto property : properties) {
-                if (property.isEmpty() || property.isNull() || property == vm.propertyNames->defaultKeyword || property.isPrivateName() || property.isSymbol()) [[unlikely]]
+                if (property.isEmpty() || property.isNull() || property == vm.propertyNames->defaultKeyword || property == moduleExportsIdentifier || property.isPrivateName() || property.isSymbol()) [[unlikely]]
                     continue;
 
                 // ignore constructor
@@ -1150,6 +1151,12 @@ void populateESMExports(
         exportNames.append(vm.propertyNames->defaultKeyword);
         exportValues.append(result);
     }
+
+    // Node.js >= 22 always exposes the raw `module.exports` value as a string-named
+    // export, overriding an own property of the exports object with that literal name.
+    // https://nodejs.org/api/esm.html#commonjs-namespaces
+    exportNames.append(moduleExportsIdentifier);
+    exportValues.append(result);
 }
 
 void JSCommonJSModule::toSyntheticSource(JSC::JSGlobalObject* globalObject,

--- a/test/cli/run/esm-defineProperty.test.ts
+++ b/test/cli/run/esm-defineProperty.test.ts
@@ -41,5 +41,12 @@ test("arraylike", () => {
     "3": 4,
     "4": [Getter],
   },
+  "module.exports": {
+    "0": 0,
+    "1": 1,
+    "2": [Getter],
+    "3": 4,
+    "4": [Getter],
+  },
 }`);
 });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -231,6 +231,67 @@ describe.concurrent("node-module-module", () => {
   });
   test("require a cjs file uses the 'module.exports' export", () => {
     expect(require("./esm_to_cjs_interop.mjs")).toEqual(Symbol.for("meow"));
+  });
+
+  // https://nodejs.org/api/esm.html#commonjs-namespaces
+  test("importing a cjs module exposes the 'module.exports' named export", async () => {
+    using dir = tempDir("cjs-module-exports-named-export", {
+      "named.cjs": `exports.a = 1;\nexports.b = 2;\n`,
+      "object.cjs": `module.exports = { hello: "world" };\n`,
+      "primitive.cjs": `module.exports = 42;\n`,
+      "esmodule-flag.cjs": `module.exports = { __esModule: true, default: "unwrapped", x: 1 };\n`,
+      "collision.cjs": `module.exports = { a: 1, "module.exports": "shadow" };\n`,
+      "star-reexport.mjs": `export * from "./named.cjs";\nexport const extra = 99;\n`,
+      "main.mjs": `
+        import assert from "node:assert";
+        import { "module.exports" as staticModuleExports } from "./object.cjs";
+        import objectDefault, * as objectNs from "./object.cjs";
+        import * as namedNs from "./named.cjs";
+        import * as primitiveNs from "./primitive.cjs";
+        import * as flaggedNs from "./esmodule-flag.cjs";
+        import * as collisionNs from "./collision.cjs";
+        import * as starNs from "./star-reexport.mjs";
+
+        // The static string-named import binding resolves, and it is the raw exports object.
+        assert.deepStrictEqual(staticModuleExports, { hello: "world" });
+        assert.strictEqual(staticModuleExports, objectNs["module.exports"]);
+        assert.strictEqual(objectNs["module.exports"], objectDefault);
+
+        // It sits alongside the real named exports, in lexicographic order.
+        assert.deepStrictEqual(Object.keys(namedNs), ["a", "b", "default", "module.exports"]);
+        assert.strictEqual(namedNs["module.exports"], namedNs.default);
+        assert.strictEqual(namedNs["module.exports"].a, 1);
+
+        // Present even when module.exports is not an object.
+        assert.deepStrictEqual(Object.keys(primitiveNs), ["default", "module.exports"]);
+        assert.strictEqual(primitiveNs["module.exports"], 42);
+        assert.strictEqual(primitiveNs.default, 42);
+
+        // "module.exports" is the raw exports object regardless of __esModule interop.
+        assert.deepStrictEqual(flaggedNs["module.exports"], { __esModule: true, default: "unwrapped", x: 1 });
+
+        // An own property literally named "module.exports" is overridden, matching node.
+        assert.deepStrictEqual(Object.keys(collisionNs), ["a", "default", "module.exports"]);
+        assert.strictEqual(collisionNs["module.exports"], collisionNs.default);
+        assert.strictEqual(collisionNs.default["module.exports"], "shadow");
+
+        // export * re-exports it ("default" is the only name a star export excludes).
+        assert.deepStrictEqual(Object.keys(starNs), ["a", "b", "extra", "module.exports"]);
+        assert.strictEqual(starNs["module.exports"], namedNs["module.exports"]);
+
+        console.log("pass");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "pass\n", stderr: "", exitCode: 0 });
   });
 
   test("Module.runMain", async () => {


### PR DESCRIPTION
## What

Node.js >= 22 exposes the raw `module.exports` value of a CommonJS module as a string-named export on its ES module namespace, so ESM consumers can get the exact exports object without going through the synthesized named exports or the `__esModule` default interop. Bun never emitted that export, so the import failed at load time.

## Reproduction

```js
// x.cjs
module.exports = { a: 1 };
```

```js
// main.mjs
import { "module.exports" as m } from "./x.cjs";
console.log(m);
```

`node main.mjs` (v22+) prints `{ a: 1 }`. `bun main.mjs` fails to load:

```
SyntaxError: Export named 'module.exports' not found in module '/tmp/x/x.cjs'.
```

Because it is a load-time linking error, any package whose entry point uses this import shape fails to load at all under Bun.

## Cause

`populateESMExports` in `src/jsc/bindings/JSCommonJSModule.cpp` builds the export name list for the synthetic module record of a CommonJS module imported from ESM. It only ever appended `default` plus the enumerated own properties of the exports object, so `'module.exports'` was never an export entry and JSC rejected the binding at link time.

## Fix

Unconditionally append `'module.exports'` with the raw exports value at the end of the list, and skip an own property literally named `"module.exports"` during enumeration so the synthesized export always wins. All of the following match Node (verified against Node v26.3.0 before writing the code):

- present for non-object exports too: `module.exports = 42` gives `ns['module.exports'] === 42`
- the raw exports object even for `__esModule`-annotated modules, where `default` is unwrapped
- overrides an own property literally named `"module.exports"` on the exports object
- participates in `export * from "./x.cjs"`, since star exports exclude only `default`; as in Node, this also makes `require()` of such a re-exporting ESM file return the CJS exports object through the existing `"module.exports"` handling in `require(esm)`

`bun build`'s CJS interop (the `__toESM` helper) is a separate code path and is unchanged here; this PR is scoped to the runtime, which is where the load-time failure occurs.

## Verification

New test in `test/js/node/module/node-module-module.test.js` (next to the existing `require(esm)` half of this feature) spawns a fixture covering every case above. Every assertion shared with Node was first confirmed to pass under Node v26.3.0. The test fails on current `main` with the exact `SyntaxError` shown above.

`test/cli/run/esm-defineProperty.test.ts` is updated for the extra namespace key.
