### PR TITLE
node:dgram: implicitly bind before membership operations

### DIFF
--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -299,66 +299,81 @@ Socket.prototype.bind = function (port_, address_ /* , callback */) {
       return;
     }
 
-    let flags = uSockets.LISTEN_DISALLOW_REUSE_PORT_FAILURE;
-
-    if (state.reuseAddr) {
-      flags |= uSockets.LISTEN_REUSE_ADDR;
-    }
-
-    if (state.ipv6Only) {
-      flags |= uSockets.SOCKET_IPV6_ONLY;
-    }
-
-    if (state.reusePort) {
-      flags |= uSockets.LISTEN_REUSE_PORT;
-    }
-
-    // TODO flags
-    const family = this.type === "udp4" ? "IPv4" : "IPv6";
     try {
-      Bun.udpSocket({
-        hostname: ip,
-        port: port || 0,
-        flags,
-        socket: {
-          data: (_socket, data, port, address) => {
-            this.emit("message", data, {
-              port: port,
-              address: address,
-              size: data.length,
-              // TODO check if this is correct
-              family,
-            });
-          },
-          error: error => {
-            this.emit("error", error);
-          },
-        },
-      }).$then(
-        socket => {
-          if (state.unrefOnBind) {
-            socket.unref();
-            state.unrefOnBind = false;
-          }
-          state.handle.socket = socket;
-          state.receiving = true;
-          state.bindState = BIND_STATE_BOUND;
-
-          this.emit("listening");
-        },
-        err => {
-          state.bindState = BIND_STATE_UNBOUND;
-          this.emit("error", err);
-        },
-      );
+      attachSocket(this, ip, port);
     } catch (err) {
       state.bindState = BIND_STATE_UNBOUND;
       this.emit("error", err);
+      return;
     }
+
+    this.emit("listening");
   });
 
   return this;
 };
+
+const createSocketFn = $newRustFunction("udp_socket.rs", "UDPSocket.jsCreate", 1);
+
+// Synchronously creates + binds the native socket for `self`, attaches it to
+// the handle, and marks the socket BOUND. On failure, throws without touching
+// `bindState`; callers own error reporting and the `listening` event.
+function attachSocket(self, ip, port) {
+  const state = self[kStateSymbol];
+
+  let flags = uSockets.LISTEN_DISALLOW_REUSE_PORT_FAILURE;
+
+  if (state.reuseAddr) {
+    flags |= uSockets.LISTEN_REUSE_ADDR;
+  }
+
+  if (state.ipv6Only) {
+    flags |= uSockets.SOCKET_IPV6_ONLY;
+  }
+
+  if (state.reusePort) {
+    flags |= uSockets.LISTEN_REUSE_PORT;
+  }
+
+  const family = self.type === "udp4" ? "IPv4" : "IPv6";
+  const socket = createSocketFn({
+    hostname: ip,
+    port: port || 0,
+    flags,
+    socket: {
+      data: (_socket, data, port, address) => {
+        self.emit("message", data, {
+          port: port,
+          address: address,
+          size: data.length,
+          family,
+        });
+      },
+      error: error => {
+        self.emit("error", error);
+      },
+    },
+  });
+
+  if (state.unrefOnBind) {
+    socket.unref();
+    state.unrefOnBind = false;
+  }
+  state.handle.socket = socket;
+  state.receiving = true;
+  state.bindState = BIND_STATE_BOUND;
+}
+
+// node binds an unbound socket to a random port before a membership operation
+// (libuv's `uv__udp_maybe_deferred_bind`), synchronously and without emitting
+// "listening". A closed or already-binding socket is "not running".
+function implicitBind(self) {
+  const state = self[kStateSymbol];
+  if (!state.handle || state.bindState !== BIND_STATE_UNBOUND) {
+    throw $ERR_SOCKET_DGRAM_NOT_RUNNING();
+  }
+  attachSocket(self, self.type === "udp4" ? "0.0.0.0" : "::", 0);
+}
 
 Socket.prototype.connect = function (port, address, callback) {
   port = validatePort(port, "Port", false);
@@ -815,15 +830,12 @@ Socket.prototype.addMembership = function (multicastAddress, interfaceAddress) {
   if (typeof interfaceAddress !== "undefined") {
     validateString(interfaceAddress, "interfaceAddress");
   }
-  const { handle, bindState } = this[kStateSymbol];
+  const { handle } = this[kStateSymbol];
   if (!handle?.socket) {
     if (!isIP(multicastAddress)) {
       throw EINVAL("addMembership");
     }
-    throw $ERR_SOCKET_DGRAM_NOT_RUNNING();
-  }
-  if (bindState === BIND_STATE_UNBOUND) {
-    this.bind({ port: 0, exclusive: true }, null);
+    implicitBind(this);
   }
   return handle.socket.addMembership(multicastAddress, interfaceAddress);
 };
@@ -841,7 +853,7 @@ Socket.prototype.dropMembership = function (multicastAddress, interfaceAddress) 
     if (!isIP(multicastAddress)) {
       throw EINVAL("dropMembership");
     }
-    throw $ERR_SOCKET_DGRAM_NOT_RUNNING();
+    implicitBind(this);
   }
   return handle.socket.dropMembership(multicastAddress, interfaceAddress);
 };
@@ -853,15 +865,12 @@ Socket.prototype.addSourceSpecificMembership = function (sourceAddress, groupAdd
     validateString(interfaceAddress, "interfaceAddress");
   }
 
-  const { handle, bindState } = this[kStateSymbol];
+  const { handle } = this[kStateSymbol];
   if (!handle?.socket) {
     if (!isIP(sourceAddress) || !isIP(groupAddress)) {
       throw EINVAL("addSourceSpecificMembership");
     }
-    throw $ERR_SOCKET_DGRAM_NOT_RUNNING();
-  }
-  if (bindState === BIND_STATE_UNBOUND) {
-    this.bind(0);
+    implicitBind(this);
   }
   return handle.socket.addSourceSpecificMembership(sourceAddress, groupAddress, interfaceAddress);
 };
@@ -873,15 +882,12 @@ Socket.prototype.dropSourceSpecificMembership = function (sourceAddress, groupAd
     validateString(interfaceAddress, "interfaceAddress");
   }
 
-  const { handle, bindState } = this[kStateSymbol];
+  const { handle } = this[kStateSymbol];
   if (!handle?.socket) {
     if (!isIP(sourceAddress) || !isIP(groupAddress)) {
       throw EINVAL("dropSourceSpecificMembership");
     }
-    throw $ERR_SOCKET_DGRAM_NOT_RUNNING();
-  }
-  if (bindState === BIND_STATE_UNBOUND) {
-    this.bind(0);
+    implicitBind(this);
   }
   return handle.socket.dropSourceSpecificMembership(sourceAddress, groupAddress, interfaceAddress);
 };

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -306,6 +306,9 @@ function lookup(hostname, options, callback) {
     return;
   }
 
+  // The callback runs from process.nextTick so that if it throws, the chained
+  // `.catch` cannot see the throw and invoke the callback a second time (node
+  // surfaces it as an uncaughtException). `throwIfEmpty` still needs `.catch`.
   dns
     .lookup(hostname, options)
     .then(res => {
@@ -318,10 +321,10 @@ function lookup(hostname, options, callback) {
       }
 
       if (options?.all) {
-        callback(null, res.map(mapLookupAll));
+        process.nextTick(callback, null, res.map(mapLookupAll));
       } else {
         const [{ address, family }] = res;
-        callback(null, address, family);
+        process.nextTick(callback, null, address, family);
       }
     })
     .catch(err => {
@@ -333,7 +336,7 @@ function lookup(hostname, options, callback) {
         err.hostname = hostname;
         err.message = `${syscall} ${err.code} ${hostname}`;
       }
-      callback(err, undefined, undefined);
+      process.nextTick(callback, err, undefined, undefined);
     });
 }
 

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -306,9 +306,6 @@ function lookup(hostname, options, callback) {
     return;
   }
 
-  // The callback runs from process.nextTick so that if it throws, the chained
-  // `.catch` cannot see the throw and invoke the callback a second time (node
-  // surfaces it as an uncaughtException). `throwIfEmpty` still needs `.catch`.
   dns
     .lookup(hostname, options)
     .then(res => {
@@ -320,11 +317,15 @@ function lookup(hostname, options, callback) {
         res.sort((a, b) => b.family - a.family);
       }
 
-      if (options?.all) {
-        process.nextTick(callback, null, res.map(mapLookupAll));
-      } else {
-        const [{ address, family }] = res;
-        process.nextTick(callback, null, address, family);
+      try {
+        if (options?.all) {
+          callback(null, res.map(mapLookupAll));
+        } else {
+          const [{ address, family }] = res;
+          callback(null, address, family);
+        }
+      } catch (err) {
+        rethrowAsUncaughtException(err);
       }
     })
     .catch(err => {
@@ -336,8 +337,21 @@ function lookup(hostname, options, callback) {
         err.hostname = hostname;
         err.message = `${syscall} ${err.code} ${hostname}`;
       }
-      process.nextTick(callback, err, undefined, undefined);
+      try {
+        callback(err, undefined, undefined);
+      } catch (err) {
+        rethrowAsUncaughtException(err);
+      }
     });
+}
+
+// Re-raises a throw from a user-supplied lookup() callback as an
+// uncaughtException, matching node. Without this the chained `.catch` above
+// would receive it and invoke the callback a second time.
+function rethrowAsUncaughtException(err) {
+  queueMicrotask(() => {
+    throw err;
+  });
 }
 
 function lookupService(address, port, callback) {

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -483,7 +483,7 @@ impl UDPSocket {
     /// Recover `&UDPSocket` from the uws user-data slot. Centralises the
     /// `unsafe { &*(*socket).user().cast() }` back-ref deref shared by every
     /// `extern "C"` callback below — the user pointer was set to the
-    /// heap-allocated `UDPSocket` in [`udp_socket`] via
+    /// heap-allocated `UDPSocket` in [`Self::create`] via
     /// `uws::udp::Socket::create(.., user_data = this_ptr)` and remains live
     /// until `on_close` (uws guarantees no callback after close). All mutated
     /// fields are `Cell`/`JsCell`, so a shared borrow is sufficient (R-2).
@@ -496,7 +496,26 @@ impl UDPSocket {
         unsafe { &*user.cast::<UDPSocket>() }
     }
 
+    /// `Bun.udpSocket(options)`. The bind happens synchronously inside
+    /// [`Self::create`]; the Promise is only the public API shape.
     pub fn udp_socket(global_this: &JSGlobalObject, options: JSValue) -> JsResult<JSValue> {
+        let this_value = Self::create(global_this, options)?;
+        Ok(bun_jsc::JSPromise::resolved_promise_value(
+            global_this,
+            this_value,
+        ))
+    }
+
+    // See `js_connect` — codegen `JsClass` derive owns the link name.
+    // `node:dgram` implicitly binds before a membership operation (libuv's
+    // deferred bind), so it needs the socket without a promise round-trip.
+    pub fn js_create(global_this: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
+        Self::create(global_this, call_frame.argument(0))
+    }
+
+    /// Creates, binds, and (optionally) connects the socket. Returns the JS
+    /// wrapper directly; every failure is thrown synchronously.
+    fn create(global_this: &JSGlobalObject, options: JSValue) -> JsResult<JSValue> {
         bun_output::scoped_log!(UdpSocket, "udpSocket");
 
         let vm = global_this.bun_vm_ptr();
@@ -643,10 +662,7 @@ impl UDPSocket {
         scopeguard::ScopeGuard::into_inner(guard);
 
         this.poll_ref.with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
-        Ok(bun_jsc::JSPromise::resolved_promise_value(
-            global_this,
-            this_value,
-        ))
+        Ok(this_value)
     }
 
     pub fn call_error_handler(&self, this_value_: JSValue, err: JSValue) {

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, jest, test } from "bun:test";
 import { createSocket } from "dgram";
 
-import { disableAggressiveGCScope, isIPv6, isMacOS, isWindows } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isIPv6, isMacOS, isWindows } from "harness";
 import path from "path";
 import { nodeDataCases } from "./testdata";
 
@@ -414,4 +414,34 @@ describe("membership on an unbound socket", () => {
     await listening;
     socket.close();
   });
+});
+
+// "listening" is now emitted from inside dns.lookup's callback when bind()
+// gets a hostname. A throw from a listener must not re-enter that callback
+// as a lookup error and reset the bind state (see node-dns.test.js).
+test("a throwing 'listening' listener on a hostname bind() does not corrupt the socket", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const s = require("dgram").createSocket("udp4");
+      process.on("uncaughtException", () => {});
+      s.on("error", e => console.log("error:" + e.message));
+      s.bind(0, "localhost", () => {
+        const port = s.address().port;
+        setImmediate(() => {
+          s.send("x", port, "127.0.0.1", () => {
+            console.log(s.address().port === port ? "same-port" : "rebound");
+            s.close();
+          });
+        });
+        throw new Error("boom from the listening listener");
+      });`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({ stdout: "same-port\n", exitCode: 0 });
 });

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -408,11 +408,14 @@ describe("membership on an unbound socket", () => {
 
   test("a bind() already in flight still throws ERR_SOCKET_DGRAM_NOT_RUNNING", async () => {
     const socket = createSocket("udp4");
-    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
-    socket.bind(0, onListening);
-    expect(() => socket.addMembership(GROUP4, LO4)).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
-    await listening;
-    socket.close();
+    try {
+      const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+      socket.bind(0, onListening);
+      expect(() => socket.addMembership(GROUP4, LO4)).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+      await listening;
+    } finally {
+      socket.close();
+    }
   });
 });
 

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -372,10 +372,17 @@ describe("membership on an unbound socket", () => {
 
       // Handle unreliable transmission in UDP: keep re-sending until the
       // receiver sees a datagram, like the other send tests in this file.
+      // `send()` reports errors only through this callback, never "error".
       const port = receiver.address().port;
       function sendRec() {
         if (done) return;
-        sender.send("via implicit bind", port, LO4, () => setTimeout(sendRec, 10));
+        sender.send("via implicit bind", port, LO4, err => {
+          if (err) {
+            received.reject(err);
+            return;
+          }
+          setTimeout(sendRec, 10);
+        });
       }
       sendRec();
 

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -418,7 +418,7 @@ describe("membership on an unbound socket", () => {
 
 // "listening" is now emitted from inside dns.lookup's callback when bind()
 // gets a hostname. A throw from a listener must not re-enter that callback
-// as a lookup error and reset the bind state (see node-dns.test.js).
+// as a lookup error and reset the bind state (see dns-lookup-keepalive.test.ts).
 test("a throwing 'listening' listener on a hostname bind() does not corrupt the socket", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -442,6 +442,10 @@ test("a throwing 'listening' listener on a hostname bind() does not corrupt the 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "same-port\n", exitCode: 0 });
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderr = rawStderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "same-port\n", stderr: "", exitCode: 0 });
 });

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, jest, test } from "bun:test";
 import { createSocket } from "dgram";
 
-import { disableAggressiveGCScope } from "harness";
+import { disableAggressiveGCScope, isIPv6, isMacOS, isWindows } from "harness";
 import path from "path";
 import { nodeDataCases } from "./testdata";
 
@@ -302,5 +302,116 @@ describe("bind()", () => {
     // The in-flight first bind must still complete normally.
     await listening;
     expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+// Node implicitly binds an unbound socket to a random port before a membership
+// operation (libuv's deferred bind) rather than throwing "not running". The
+// loopback interface is explicit so the joins don't need a multicast route.
+describe("membership on an unbound socket", () => {
+  const GROUP4 = "224.0.0.114";
+  const SSM_GROUP4 = "232.0.0.114";
+  const SSM_SOURCE4 = "127.0.0.2";
+  const LO4 = "127.0.0.1";
+
+  // Same loopback scope ids node-dgram.test.js uses for the bound-socket case.
+  const LO6 = isWindows ? "::%1" : isMacOS ? "::%lo0" : "::%lo";
+
+  test("addMembership() implicitly binds", () => {
+    const socket = createSocket("udp4");
+    try {
+      socket.addMembership(GROUP4, LO4);
+      expect(socket.address()).toMatchObject({ address: "0.0.0.0", family: "IPv4" });
+      expect(socket.address().port).toBeGreaterThan(0);
+      socket.dropMembership(GROUP4, LO4);
+    } finally {
+      socket.close();
+    }
+  });
+
+  test("addSourceSpecificMembership() implicitly binds", () => {
+    const socket = createSocket("udp4");
+    try {
+      socket.addSourceSpecificMembership(SSM_SOURCE4, SSM_GROUP4, LO4);
+      expect(socket.address()).toMatchObject({ address: "0.0.0.0", family: "IPv4" });
+      expect(socket.address().port).toBeGreaterThan(0);
+      socket.dropSourceSpecificMembership(SSM_SOURCE4, SSM_GROUP4, LO4);
+    } finally {
+      socket.close();
+    }
+  });
+
+  test.skipIf(!isIPv6())("addMembership() on a udp6 socket implicitly binds to [::]", () => {
+    const socket = createSocket("udp6");
+    try {
+      socket.addMembership("ff01::1", LO6);
+      expect(socket.address()).toMatchObject({ address: "::", family: "IPv6" });
+      expect(socket.address().port).toBeGreaterThan(0);
+      socket.dropMembership("ff01::1", LO6);
+    } finally {
+      socket.close();
+    }
+  });
+
+  test("the implicitly bound socket can send", async () => {
+    const receiver = createSocket("udp4");
+    const sender = createSocket("udp4");
+    try {
+      const received = Promise.withResolvers<Buffer>();
+      receiver.on("message", received.resolve);
+      receiver.on("error", received.reject);
+
+      const listening = Promise.withResolvers<void>();
+      receiver.on("listening", listening.resolve);
+      receiver.bind(0, LO4);
+      await listening.promise;
+
+      sender.addMembership(GROUP4, LO4);
+      const sent = Promise.withResolvers<void>();
+      sender.on("error", sent.reject);
+      sender.send("via implicit bind", receiver.address().port, LO4, err => (err ? sent.reject(err) : sent.resolve()));
+
+      await sent.promise;
+      expect((await received.promise).toString()).toBe("via implicit bind");
+    } finally {
+      sender.close();
+      receiver.close();
+    }
+  });
+
+  test("an invalid multicast address does not trigger the implicit bind", () => {
+    const socket = createSocket("udp4");
+    try {
+      expect(() => socket.addMembership("256.256.256.256")).toThrowWithCode(Error, "EINVAL");
+      expect(() => socket.address()).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+    } finally {
+      socket.close();
+    }
+  });
+
+  test("a closed socket still throws ERR_SOCKET_DGRAM_NOT_RUNNING", async () => {
+    const socket = createSocket("udp4");
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    socket.close(onClose);
+    await closed;
+    expect(() => socket.addMembership(GROUP4, LO4)).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+    expect(() => socket.dropMembership(GROUP4, LO4)).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+    expect(() => socket.addSourceSpecificMembership(SSM_SOURCE4, SSM_GROUP4, LO4)).toThrowWithCode(
+      Error,
+      "ERR_SOCKET_DGRAM_NOT_RUNNING",
+    );
+    expect(() => socket.dropSourceSpecificMembership(SSM_SOURCE4, SSM_GROUP4, LO4)).toThrowWithCode(
+      Error,
+      "ERR_SOCKET_DGRAM_NOT_RUNNING",
+    );
+  });
+
+  test("a bind() already in flight still throws ERR_SOCKET_DGRAM_NOT_RUNNING", async () => {
+    const socket = createSocket("udp4");
+    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+    socket.bind(0, onListening);
+    expect(() => socket.addMembership(GROUP4, LO4)).toThrowWithCode(Error, "ERR_SOCKET_DGRAM_NOT_RUNNING");
+    await listening;
+    socket.close();
   });
 });

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -356,10 +356,12 @@ describe("membership on an unbound socket", () => {
   test("the implicitly bound socket can send", async () => {
     const receiver = createSocket("udp4");
     const sender = createSocket("udp4");
+    let done = false;
     try {
       const received = Promise.withResolvers<Buffer>();
       receiver.on("message", received.resolve);
       receiver.on("error", received.reject);
+      sender.on("error", received.reject);
 
       const listening = Promise.withResolvers<void>();
       receiver.on("listening", listening.resolve);
@@ -367,13 +369,19 @@ describe("membership on an unbound socket", () => {
       await listening.promise;
 
       sender.addMembership(GROUP4, LO4);
-      const sent = Promise.withResolvers<void>();
-      sender.on("error", sent.reject);
-      sender.send("via implicit bind", receiver.address().port, LO4, err => (err ? sent.reject(err) : sent.resolve()));
 
-      await sent.promise;
+      // Handle unreliable transmission in UDP: keep re-sending until the
+      // receiver sees a datagram, like the other send tests in this file.
+      const port = receiver.address().port;
+      function sendRec() {
+        if (done) return;
+        sender.send("via implicit bind", port, LO4, () => setTimeout(sendRec, 10));
+      }
+      sendRec();
+
       expect((await received.promise).toString()).toBe("via implicit bind");
     } finally {
+      done = true;
       sender.close();
       receiver.close();
     }

--- a/test/js/bun/udp/sendMany-reentrancy-fixture.ts
+++ b/test/js/bun/udp/sendMany-reentrancy-fixture.ts
@@ -41,14 +41,18 @@ const syncLookup: dgram.SocketOptions["lookup"] = (_host, opts: any, cb: any) =>
   cb(null, "127.0.0.1", 4);
 };
 
+// With a synchronous lookup, bind() emits "listening" before it returns (node
+// does the same), so the listener has to be registered before the bind call.
 const target = dgram.createSocket({ type: "udp4", lookup: syncLookup });
+const targetListening = once(target, "listening");
 target.bind(0, "127.0.0.1");
-await once(target, "listening");
+await targetListening;
 const targetPort = target.address().port;
 
 const sock = dgram.createSocket({ type: "udp4", lookup: syncLookup });
+const sockListening = once(sock, "listening");
 sock.bind(0, "127.0.0.1");
-await once(sock, "listening");
+await sockListening;
 
 let flipped = false;
 

--- a/test/js/node/dns/dns-lookup-keepalive.test.ts
+++ b/test/js/node/dns/dns-lookup-keepalive.test.ts
@@ -30,6 +30,10 @@ test("dns.lookup invokes its callback exactly once when the callback throws", as
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "calls=1\n", exitCode: 0 });
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderr = rawStderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "calls=1\n", stderr: "", exitCode: 0 });
 });

--- a/test/js/node/dns/dns-lookup-keepalive.test.ts
+++ b/test/js/node/dns/dns-lookup-keepalive.test.ts
@@ -1,7 +1,35 @@
 import { expect, test } from "bun:test";
-import "harness";
+import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
 test("expect dns.lookup to keep the process alive", () => {
   expect([join(import.meta.dir, "dns-fixture.js")]).toRun();
+});
+
+// The callback used to run inside lookup()'s `.then`, whose chained `.catch`
+// re-invoked it with the callback's own exception as the lookup error.
+test("dns.lookup invokes its callback exactly once when the callback throws", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let calls = 0;
+      process.on("uncaughtException", () => {});
+      require("dns").lookup("localhost", err => {
+        calls++;
+        if (calls === 1) {
+          if (err) throw new Error("localhost did not resolve: " + err.code);
+          // setImmediate runs after every microtask + nextTick the first
+          // invocation can schedule, so it observes any second invocation.
+          setImmediate(() => console.log("calls=" + calls));
+          throw new Error("boom from the lookup callback");
+        }
+      });`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({ stdout: "calls=1\n", exitCode: 0 });
 });


### PR DESCRIPTION
### Problem

Calling `addMembership()` on a `node:dgram` socket before `bind()` throws `ERR_SOCKET_DGRAM_NOT_RUNNING` in Bun. Node implicitly binds the socket to a random port first (libuv's `uv__udp_maybe_deferred_bind`) and then joins the group, as documented:

> When calling `addMembership` for the first time on an unbound socket, it is implicitly bound to a random port, listening on all interfaces.

```js
const s = require("dgram").createSocket("udp4");
s.addMembership("224.0.0.114", "127.0.0.1");
// node: ok, s.address() now reports a port
// bun:  Error: Socket is not running  (ERR_SOCKET_DGRAM_NOT_RUNNING)
```

The same applies to `dropMembership`, `addSourceSpecificMembership`, and `dropSourceSpecificMembership`, which all go through the same libuv deferred bind.

### Cause

`dgram.ts`'s membership functions throw `ERR_SOCKET_DGRAM_NOT_RUNNING` whenever `handle.socket` is missing. #16446 added a `this.bind({ port: 0, exclusive: true })` for the unbound case, but placed it after that throw, so it was unreachable. It could not have worked anyway: `Socket.prototype.bind` is asynchronous (address lookup, then a `.then` on the `Bun.udpSocket()` promise), and Node's membership operations are synchronous, so there is nothing for them to wait on.

### Fix

`Bun.udpSocket()` already creates and binds the uws socket synchronously; the Promise it returns is only the public API shape. This splits that body into a `UDPSocket::create` that returns the socket directly and exposes it to the dgram builtin as `UDPSocket.jsCreate`. A new `implicitBind()` helper calls it when a membership function is invoked on an unbound socket, binding to `0.0.0.0:0` (or `[::]:0`) synchronously, exactly like libuv's deferred bind.

`Socket.prototype.bind` now goes through the same `attachSocket()` helper instead of `Bun.udpSocket(...).then(...)`, so there is a single place that creates the handle's socket. That also removes an extra microtask hop between the address lookup resolving and `listening` firing, matching Node: Node emits `listening` synchronously from inside the lookup callback. The only place the hop was observable is with a *synchronous* custom `lookup` option; the `sendMany` reentrancy fixture relied on it and now registers its `listening` listeners before calling `bind()` (the reentrancy assertions it exists for are unchanged).

Behavior preserved:
- A closed socket, or one with a `bind()` still in flight, still throws `ERR_SOCKET_DGRAM_NOT_RUNNING`.
- An invalid multicast address on an unbound socket still throws `addMembership EINVAL` without binding (Node validates the address before the deferred bind).

One deliberate divergence: after Node's implicit bind, a subsequent `socket.bind(port)` or `socket.send(...)` fails with `EINVAL`, because libuv binds the fd while the JS-level bind state stays unbound, and the later JS-level bind retries the `bind(2)` syscall on the already-bound fd. Bun marks the socket bound instead, so a later `bind()` throws `ERR_SOCKET_ALREADY_BOUND` synchronously, exactly as Node does (#33037, which landed on `main` during review, changed that from an `"error"` emit to a throw), and a later `send()` just works. Reproducing the `EINVAL` would mean deliberately creating a second, conflicting native socket.

### A second bug this surfaced: `dns.lookup` invokes its callback twice

Review on this PR pointed out that emitting `listening` synchronously from the lookup callback means a throwing `listening` listener would re-enter that callback. Investigating it turned up a pre-existing `node:dns` bug (reproducible on `main`, independent of this PR):

```js
let calls = 0;
require("dns").lookup("localhost", (err) => {
  calls++;                       // node: 1     bun (main): 2
  if (calls === 1) throw new Error("boom");
});
```

`lookup()` invokes the user callback from inside the `.then` of a `.then(...).catch(...)` chain, so the callback's own throw falls into the chained `.catch`, which invokes the callback a second time with that throw presented as the lookup error. Node invokes the callback exactly once and surfaces the throw as `uncaughtException`. For `node:dgram`, that double invocation would have turned a throwing `listening` listener into `bindState = UNBOUND` with a live `handle.socket`, so the next `send()` would silently create and leak a second socket.

The fix leaves the callback invocation exactly where it is (synchronous, inside the same `.then` reaction) and wraps only that invocation in a `try/catch` that re-raises the callback's own throw from a `queueMicrotask`. It surfaces as an `uncaughtException` exactly as in Node, and it can never reach the chained `.catch`. The error arm gets the same treatment. `throwIfEmpty`'s intentional throw into the `.catch` is unaffected, and the whole `node:dns` module keeps invoking every callback exactly once.

An earlier iteration of this fix deferred the callback through `process.nextTick` instead. That regressed the upstream `test/js/node/test/parallel/test-net-connect-memleak.js`: the test is conservative-GC sensitive (its outcome already flips between a debug and a release build of the same `main` commit), `net.connect(port)` resolves `localhost` through `dns.lookup`, and adding any deferral (a `process.nextTick` or an extra promise reaction) to that path keeps the `once('connect')` listener's closure reachable across the test's `gc()`. That reproduces 30/30 on an otherwise unmodified `main` build with no build of this branch needed, which is how it was caught and why the deferral was dropped. The landed shape adds zero deferral and zero allocation to the success path, and the test is 40/40 green against this branch.

### Verification

New tests, all failing on an unfixed build:
- `test/js/bun/udp/dgram.test.ts`, "membership on an unbound socket": the implicit bind for all four operations plus the udp6 wildcard, that the implicitly bound socket can send, and the preserved not-running/EINVAL behaviors. Four fail with `ERR_SOCKET_DGRAM_NOT_RUNNING`.
- `test/js/bun/udp/dgram.test.ts`: a throwing `listening` listener on `bind(0, "localhost", cb)` followed by a `send()` keeps the same socket and port, and the throw surfaces through `uncaughtException` like Node. Fails on `main`.
- `test/js/node/dns/dns-lookup-keepalive.test.ts`: `dns.lookup` invokes its callback exactly once when the callback throws. Fails on `main` with two invocations.

`test/js/bun/udp/`, `test/js/node/net/`, `test/js/node/dns/`, `test/js/node/test/parallel/test-net-connect-memleak.js` (40/40), and the upstream `test/js/node/test/parallel/` `test-dgram-*`, `test-dns*`, `test-net-connect*`, and `test-net-autoselectfamily*` suites all pass against the debug build with no failures beyond the pre-existing ones already present with the released binary.

### Rebase

Rebased onto `main` after #33037 (`dgram.Socket#bind()` on an already-bound socket now throws `ERR_SOCKET_ALREADY_BOUND` synchronously instead of emitting `"error"`) and #33035 (a `bun_core::strings` module-path cleanup) landed. The only conflict was the two dgram PRs appending independent `describe` blocks to the same point in `test/js/bun/udp/dgram.test.ts`; both blocks are kept. #33037 is compatible with and strengthens this change, and its two new `bind()` tests pass alongside this PR's on the rebased tree (229 passing across `test/js/bun/udp/` plus the dns test).
