### PR TITLE
buffer: match Node's Buffer.prototype.fill offset and end argument handling

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1353,12 +1353,18 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
         break;
     }
 
-    if (offsetValue.isUndefined() || offsetValue.isString()) {
-        encodingValue = offsetValue;
-        offsetValue = jsUndefined();
-    } else if (endValue.isString()) {
-        encodingValue = endValue;
-        endValue = jsUndefined();
+    // Node's _fill only reinterprets a string offset/end as the encoding when the
+    // fill value is itself a string; otherwise validateInteger below rejects them.
+    // The offset-slot branch also discards end: fill("a", "hex", 3) fills everything.
+    if (value.isString()) {
+        if (offsetValue.isUndefined() || offsetValue.isString()) {
+            encodingValue = offsetValue;
+            offsetValue = jsUndefined();
+            endValue = jsUndefined();
+        } else if (endValue.isString()) {
+            encodingValue = endValue;
+            endValue = jsUndefined();
+        }
     }
 
     // ── 1. Encoding parse (FIRST validation) ────────────────────────────
@@ -1386,10 +1392,12 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     if (!offsetValue.isUndefined()) {
         Bun::V::validateInteger(scope, lexicalGlobalObject, offsetValue, "offset"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &offset);
         RETURN_IF_EXCEPTION(scope, {});
-    }
-    if (!endValue.isUndefined()) {
-        Bun::V::validateInteger(scope, lexicalGlobalObject, endValue, "end"_s, jsNumber(0), jsNumber(limit), &end);
-        RETURN_IF_EXCEPTION(scope, {});
+        // Node only reads `end` once `offset` is present: fill(v, undefined, end)
+        // ignores end (it is never validated) and fills the whole buffer.
+        if (!endValue.isUndefined()) {
+            Bun::V::validateInteger(scope, lexicalGlobalObject, endValue, "end"_s, jsNumber(0), jsNumber(limit), &end);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
     }
 
     // Node short-circuits empty/inverted ranges before coercing `value`,

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1313,11 +1313,9 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (callFrame->argumentCount() < 1) {
-        return JSValue::encode(castedThis);
-    }
-
-    auto value = callFrame->uncheckedArgument(0);
+    // No early return for 0 arguments: Node's fill() forwards an undefined
+    // value into the numeric path, which zero-fills the whole buffer.
+    auto value = callFrame->argument(0);
     // Capture byteLength up front for two orthogonal purposes:
     //  1. The upper-bound argument to validateInteger(end) so `end >
     //     buf.length` throws ERR_OUT_OF_RANGE with Node's wording and
@@ -1335,23 +1333,12 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     size_t offset = 0;
     size_t end = limit;
     WebCore::BufferEncodingType encoding = WebCore::BufferEncodingType::utf8;
-    JSValue encodingValue = jsUndefined();
-    JSValue offsetValue = jsUndefined();
-    JSValue endValue = jsUndefined();
-
-    switch (callFrame->argumentCount()) {
-    case 4:
-        encodingValue = callFrame->uncheckedArgument(3);
-        [[fallthrough]];
-    case 3:
-        endValue = callFrame->uncheckedArgument(2);
-        [[fallthrough]];
-    case 2:
-        offsetValue = callFrame->uncheckedArgument(1);
-        [[fallthrough]];
-    default:
-        break;
-    }
+    // argument() (not uncheckedArgument) so trailing positional arguments past
+    // the fourth are ignored like Node's plain-JS fill(value, offset, end,
+    // encoding) signature, instead of degrading every slot to undefined.
+    JSValue offsetValue = callFrame->argument(1);
+    JSValue endValue = callFrame->argument(2);
+    JSValue encodingValue = callFrame->argument(3);
 
     // Node's _fill only reinterprets a string offset/end as the encoding when the
     // fill value is itself a string; otherwise validateInteger below rejects them.

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -274,11 +274,11 @@ static int normalizeCompareVal(int val, size_t a_length, size_t b_length)
     return val;
 }
 
-static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JSGlobalObject* lexicalGlobalObject, JSValue arg, bool validateUnknown)
+// `arg` is the original, uncoerced encoding argument; it only shapes the
+// ERR_INVALID_ARG_TYPE message. `argString` is its resolved JSString.
+static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JSGlobalObject* lexicalGlobalObject, JSString* argString, JSValue arg, bool validateUnknown)
 {
-    auto arg_ = arg.toStringOrNull(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    const auto& view = arg_->view(lexicalGlobalObject);
+    const auto& view = argString->view(lexicalGlobalObject);
 
     std::optional<BufferEncodingType> encoded = parseEnumerationFromView<BufferEncodingType>(view);
     if (!encoded) [[unlikely]] {
@@ -293,12 +293,29 @@ static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JS
     return encoded.value();
 }
 
-// Node's normalizeEncoding (lib/internal/util.js) treats undefined, null, and
-// the empty string as an absent encoding (utf8). buf.toString rejects all three
-// (getEncodingOps), so this lives at the fill/alloc gates, not in parseEncoding.
-static bool isAbsentEncoding(JSC::JSValue value)
+static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JSGlobalObject* lexicalGlobalObject, JSValue arg, bool validateUnknown)
 {
-    return value.isUndefinedOrNull() || (value.isString() && asString(value)->length() == 0);
+    auto arg_ = arg.toStringOrNull(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return parseEncoding(scope, lexicalGlobalObject, arg_, arg, validateUnknown);
+}
+
+// Node's normalizeEncoding treats undefined, null, and the primitive empty string
+// as an absent encoding (utf8); buf.toString (Node's getEncodingOps) rejects all
+// three, so this lives at the fill/alloc gates and hands back the resolved JSString.
+static std::optional<JSString*> resolveEncodingString(JSC::ThrowScope& scope, JSC::JSGlobalObject* lexicalGlobalObject, JSValue value)
+{
+    if (value.isUndefinedOrNull())
+        return std::nullopt;
+    if (value.isString()) {
+        auto* str = asString(value);
+        if (!str->length())
+            return std::nullopt;
+        return str;
+    }
+    auto* str = value.toStringOrNull(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return str;
 }
 
 // Matches Node's validateOffset (lib/buffer.js), which is validateInteger and
@@ -670,8 +687,10 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_allocBody(JSC::JSGlobalOb
             WebCore::BufferEncodingType encoding = WebCore::BufferEncodingType::utf8;
             if (callFrame->argumentCount() > 2) {
                 EnsureStillAliveScope arg2 = callFrame->uncheckedArgument(2);
-                if (!isAbsentEncoding(arg2.value())) {
-                    encoding = parseEncoding(scope, lexicalGlobalObject, arg2.value(), true);
+                std::optional<JSString*> encodingString = resolveEncodingString(scope, lexicalGlobalObject, arg2.value());
+                RETURN_IF_EXCEPTION(scope, {});
+                if (encodingString) {
+                    encoding = parseEncoding(scope, lexicalGlobalObject, *encodingString, arg2.value(), true);
                     RETURN_IF_EXCEPTION(scope, {});
                 }
             }
@@ -1366,13 +1385,17 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     // Node validates encoding before either `validateInteger` call, so
     // `fill("a", 0, buf.length + 1, "bogus")` and `fill("a", -1, 0,
     // "bogus")` throw ERR_UNKNOWN_ENCODING (not ERR_OUT_OF_RANGE) — the
-    // encoding error wins. parseEncoding is also the first
+    // encoding error wins. Resolving the encoding is also the first
     // user-JS-visible call: `toString` on an object encoding can detach
     // or resize castedThis; the post-coercion clamp further down reads
     // byteLength() once more to catch any such effect.
-    if (!isAbsentEncoding(encodingValue) && value.isString()) {
-        encoding = parseEncoding(scope, lexicalGlobalObject, encodingValue, true);
+    if (value.isString()) {
+        std::optional<JSString*> encodingString = resolveEncodingString(scope, lexicalGlobalObject, encodingValue);
         RETURN_IF_EXCEPTION(scope, {});
+        if (encodingString) {
+            encoding = parseEncoding(scope, lexicalGlobalObject, *encodingString, encodingValue, true);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
     }
 
     // ── 2. Pure offset / end coercion (no user JS) ──────────────────────

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -295,7 +295,7 @@ static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JS
 
 static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JSGlobalObject* lexicalGlobalObject, JSValue arg, bool validateUnknown)
 {
-    auto arg_ = arg.toStringOrNull(lexicalGlobalObject);
+    auto arg_ = arg.toString(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
     return parseEncoding(scope, lexicalGlobalObject, arg_, arg, validateUnknown);
 }
@@ -313,7 +313,9 @@ static std::optional<JSString*> resolveEncodingString(JSC::ThrowScope& scope, JS
             return std::nullopt;
         return str;
     }
-    auto* str = value.toStringOrNull(lexicalGlobalObject);
+    // toString() can run user JS and throw; unlike toStringOrNull it returns the
+    // empty string on the exception path, so an engaged optional never holds null.
+    auto* str = value.toString(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
     return str;
 }

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -662,7 +662,9 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_allocBody(JSC::JSGlobalOb
             WebCore::BufferEncodingType encoding = WebCore::BufferEncodingType::utf8;
             if (callFrame->argumentCount() > 2) {
                 EnsureStillAliveScope arg2 = callFrame->uncheckedArgument(2);
-                if (!arg2.value().isUndefined()) {
+                // A null encoding is the same as an absent one (Node's
+                // normalizeEncoding tests `enc == null`), not an error.
+                if (!arg2.value().isUndefinedOrNull()) {
                     encoding = parseEncoding(scope, lexicalGlobalObject, arg2.value(), true);
                     RETURN_IF_EXCEPTION(scope, {});
                 }
@@ -1361,8 +1363,9 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     // encoding error wins. parseEncoding is also the first
     // user-JS-visible call: `toString` on an object encoding can detach
     // or resize castedThis; the post-coercion clamp further down reads
-    // byteLength() once more to catch any such effect.
-    if (!encodingValue.isUndefined() && value.isString()) {
+    // byteLength() once more to catch any such effect. A null encoding is the
+    // same as an absent one (Node's normalizeEncoding tests `enc == null`).
+    if (!encodingValue.isUndefinedOrNull() && value.isString()) {
         encoding = parseEncoding(scope, lexicalGlobalObject, encodingValue, true);
         RETURN_IF_EXCEPTION(scope, {});
     }

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -293,6 +293,14 @@ static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JS
     return encoded.value();
 }
 
+// Node's normalizeEncoding (lib/internal/util.js) treats undefined, null, and
+// the empty string as an absent encoding (utf8). buf.toString rejects all three
+// (getEncodingOps), so this lives at the fill/alloc gates, not in parseEncoding.
+static bool isAbsentEncoding(JSC::JSValue value)
+{
+    return value.isUndefinedOrNull() || (value.isString() && asString(value)->length() == 0);
+}
+
 // Matches Node's validateOffset (lib/buffer.js), which is validateInteger and
 // therefore renders its range as ">= min && <= max", unlike boundsError's
 // ">= min and <= max".
@@ -662,9 +670,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_allocBody(JSC::JSGlobalOb
             WebCore::BufferEncodingType encoding = WebCore::BufferEncodingType::utf8;
             if (callFrame->argumentCount() > 2) {
                 EnsureStillAliveScope arg2 = callFrame->uncheckedArgument(2);
-                // A null encoding is the same as an absent one (Node's
-                // normalizeEncoding tests `enc == null`), not an error.
-                if (!arg2.value().isUndefinedOrNull()) {
+                if (!isAbsentEncoding(arg2.value())) {
                     encoding = parseEncoding(scope, lexicalGlobalObject, arg2.value(), true);
                     RETURN_IF_EXCEPTION(scope, {});
                 }
@@ -1363,9 +1369,8 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     // encoding error wins. parseEncoding is also the first
     // user-JS-visible call: `toString` on an object encoding can detach
     // or resize castedThis; the post-coercion clamp further down reads
-    // byteLength() once more to catch any such effect. A null encoding is the
-    // same as an absent one (Node's normalizeEncoding tests `enc == null`).
-    if (!encodingValue.isUndefinedOrNull() && value.isString()) {
+    // byteLength() once more to catch any such effect.
+    if (!isAbsentEncoding(encodingValue) && value.isString()) {
         encoding = parseEncoding(scope, lexicalGlobalObject, encodingValue, true);
         RETURN_IF_EXCEPTION(scope, {});
     }

--- a/test/js/node/buffer-fill-args-fixture.js
+++ b/test/js/node/buffer-fill-args-fixture.js
@@ -26,6 +26,22 @@ const cases = [
   // fill(string, encoding) has no end slot, so anything there is discarded.
   ['fill("b", "utf8", 3)', b => b.fill("b", "utf8", 3)],
 
+  // An undefined offset also takes the encoding slot in Node, shadowing an
+  // explicit 4th-argument encoding. A numeric offset keeps it.
+  ['fill("ab", undefined, undefined, "utf16le")', b => b.fill("ab", undefined, undefined, "utf16le")],
+  ['fill("a", undefined, undefined, "bogus")', b => b.fill("a", undefined, undefined, "bogus")],
+  ['fill("ab", 0, undefined, "utf16le")', b => b.fill("ab", 0, undefined, "utf16le")],
+  ['fill("a", 1, undefined, "bogus")', b => b.fill("a", 1, undefined, "bogus")],
+
+  // No arguments: Node routes an undefined value into the numeric path (0).
+  ["fill()", b => b.fill()],
+  ["fill(undefined)", b => b.fill(undefined)],
+
+  // Positional arguments past the fourth are ignored.
+  ['fill(0, 1, 3, "utf8", "x")', b => b.fill(0, 1, 3, "utf8", "x")],
+  ['fill("b", 1, 3, "utf8", "x")', b => b.fill("b", 1, 3, "utf8", "x")],
+  ['fill("ab", 0, 4, "utf16le", "x")', b => b.fill("ab", 0, 4, "utf16le", "x")],
+
   // Shapes that already agreed, pinned so a regression in either direction shows up.
   ["fill(0)", b => b.fill(0)],
   ["fill(0, 1)", b => b.fill(0, 1)],
@@ -61,6 +77,6 @@ for (const [name, run] of cases) {
     // separately in buffer.test.js.
     result = "throws " + err.name + " " + err.code;
   }
-  lines.push(name.padEnd(26) + " " + result);
+  lines.push(name.padEnd(44) + " " + result);
 }
 process.stdout.write(lines.join("\n") + "\n");

--- a/test/js/node/buffer-fill-args-fixture.js
+++ b/test/js/node/buffer-fill-args-fixture.js
@@ -33,9 +33,13 @@ const cases = [
   ['fill("ab", 0, undefined, "utf16le")', b => b.fill("ab", 0, undefined, "utf16le")],
   ['fill("a", 1, undefined, "bogus")', b => b.fill("a", 1, undefined, "bogus")],
 
-  // A null encoding is the same as an absent one (Node's normalizeEncoding).
+  // A null or empty-string encoding is the same as an absent one: Node's
+  // normalizeEncoding returns utf8 for undefined, null, and "".
   ['fill("a", 1, 3, null)', b => b.fill("a", 1, 3, null)],
   ['fill("a", undefined, undefined, null)', b => b.fill("a", undefined, undefined, null)],
+  ['fill("a", 1, 3, "")', b => b.fill("a", 1, 3, "")],
+  ['fill("a", "")', b => b.fill("a", "")],
+  ['fill("a", 1, "")', b => b.fill("a", 1, "")],
 
   // No arguments: Node routes an undefined value into the numeric path (0).
   ["fill()", b => b.fill()],

--- a/test/js/node/buffer-fill-args-fixture.js
+++ b/test/js/node/buffer-fill-args-fixture.js
@@ -1,0 +1,66 @@
+// Prints one deterministic line per Buffer.prototype.fill() argument shape.
+// buffer.test.js runs this fixture under both Node.js and Bun and requires
+// the two outputs to be byte-identical.
+// https://github.com/oven-sh/bun/pull/33033
+"use strict";
+
+const cases = [
+  // value is NOT a string: Node never reinterprets a string offset/end as the encoding.
+  ['fill(0, "1", 3)', b => b.fill(0, "1", 3)],
+  ['fill(0, 1, "3")', b => b.fill(0, 1, "3")],
+  ['fill(0, "hex")', b => b.fill(0, "hex")],
+  ['fill(0, "bogus")', b => b.fill(0, "bogus")],
+  ['fill(true, "1", 3)', b => b.fill(true, "1", 3)],
+  ['fill(uint8, "1", 3)', b => b.fill(new Uint8Array([1]), "1", 3)],
+  ['fill(uint8, 1, "3")', b => b.fill(new Uint8Array([1]), 1, "3")],
+  ["fill(0, null, 3)", b => b.fill(0, null, 3)],
+  ["fill(0, 1, null)", b => b.fill(0, 1, null)],
+
+  // `end` is never read (or validated) when `offset` is undefined.
+  ['fill(0, undefined, "3")', b => b.fill(0, undefined, "3")],
+  ["fill(0, undefined, 3)", b => b.fill(0, undefined, 3)],
+  ["fill(0, undefined, null)", b => b.fill(0, undefined, null)],
+  ["fill(0, undefined, -1)", b => b.fill(0, undefined, -1)],
+  ['fill("b", undefined, 3)', b => b.fill("b", undefined, 3)],
+
+  // fill(string, encoding) has no end slot, so anything there is discarded.
+  ['fill("b", "utf8", 3)', b => b.fill("b", "utf8", 3)],
+
+  // Shapes that already agreed, pinned so a regression in either direction shows up.
+  ["fill(0)", b => b.fill(0)],
+  ["fill(0, 1)", b => b.fill(0, 1)],
+  ["fill(0, 1, 3)", b => b.fill(0, 1, 3)],
+  ["fill(0, 1.5, 3)", b => b.fill(0, 1.5, 3)],
+  ["fill(0, -1, 3)", b => b.fill(0, -1, 3)],
+  ["fill(0, 1, 99)", b => b.fill(0, 1, 99)],
+  ["fill(0, NaN, 3)", b => b.fill(0, NaN, 3)],
+  ['fill(0, 1, 3, "bogus")', b => b.fill(0, 1, 3, "bogus")],
+  ['fill("b")', b => b.fill("b")],
+  ['fill("b", "utf8")', b => b.fill("b", "utf8")],
+  ['fill("b", 1)', b => b.fill("b", 1)],
+  ['fill("b", 1, 3)', b => b.fill("b", 1, 3)],
+  ['fill("b", 1, "utf8")', b => b.fill("b", 1, "utf8")],
+  ['fill("b", 1, 3, "utf8")', b => b.fill("b", 1, 3, "utf8")],
+  ['fill("b", "1", 3)', b => b.fill("b", "1", 3)],
+  ['fill("b", 1, "3")', b => b.fill("b", 1, "3")],
+  ['fill("b", "bogus")', b => b.fill("b", "bogus")],
+  ['fill("b", -1)', b => b.fill("b", -1)],
+  ['fill("abc", "hex")', b => b.fill("abc", "hex")],
+];
+
+const lines = [];
+for (const [name, run] of cases) {
+  const buf = Buffer.alloc(5, 0xaa);
+  let result;
+  try {
+    run(buf);
+    result = "ok     " + buf.toString("hex");
+  } catch (err) {
+    // Only the class and code are printed: Node rewords messages far more
+    // often than it changes codes, and the exact messages are pinned
+    // separately in buffer.test.js.
+    result = "throws " + err.name + " " + err.code;
+  }
+  lines.push(name.padEnd(26) + " " + result);
+}
+process.stdout.write(lines.join("\n") + "\n");

--- a/test/js/node/buffer-fill-args-fixture.js
+++ b/test/js/node/buffer-fill-args-fixture.js
@@ -33,6 +33,10 @@ const cases = [
   ['fill("ab", 0, undefined, "utf16le")', b => b.fill("ab", 0, undefined, "utf16le")],
   ['fill("a", 1, undefined, "bogus")', b => b.fill("a", 1, undefined, "bogus")],
 
+  // A null encoding is the same as an absent one (Node's normalizeEncoding).
+  ['fill("a", 1, 3, null)', b => b.fill("a", 1, 3, null)],
+  ['fill("a", undefined, undefined, null)', b => b.fill("a", undefined, undefined, null)],
+
   // No arguments: Node routes an undefined value into the numeric path (0).
   ["fill()", b => b.fill()],
   ["fill(undefined)", b => b.fill(undefined)],

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3768,6 +3768,85 @@ describe("ERR_BUFFER_OUT_OF_BOUNDS", () => {
   }
 });
 
+// Node's _fill (lib/buffer.js) only reinterprets a string `offset`/`end` as
+// the encoding when the fill value is itself a string; otherwise they reach
+// validateOffset and a non-number throws ERR_INVALID_ARG_TYPE. And `end` is
+// only read at all once `offset` is present.
+describe("Buffer.fill offset/end argument handling", () => {
+  it("rejects a string offset when the fill value is not a string", () => {
+    for (const value of [0, true, new Uint8Array([1])]) {
+      expect(() => Buffer.alloc(5).fill(value, "1", 3)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: `The "offset" argument must be of type number. Received type string ('1')`,
+        }),
+      );
+      // Two-argument form: a string in the offset slot is not an encoding either.
+      expect(() => Buffer.alloc(5).fill(value, "hex")).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+          message: `The "offset" argument must be of type number. Received type string ('hex')`,
+        }),
+      );
+    }
+    expect(() => Buffer.alloc(5).fill(0, null, 3)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "offset" argument must be of type number. Received null',
+      }),
+    );
+  });
+
+  it("rejects a string end when the fill value is not a string", () => {
+    for (const value of [0, true, new Uint8Array([1])]) {
+      expect(() => Buffer.alloc(5).fill(value, 1, "3")).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: `The "end" argument must be of type number. Received type string ('3')`,
+        }),
+      );
+    }
+    expect(() => Buffer.alloc(5).fill(0, 1, null)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "end" argument must be of type number. Received null',
+      }),
+    );
+  });
+
+  it("ignores end entirely when offset is undefined", () => {
+    // Node resets end = buf.length when offset === undefined; end is never
+    // validated, so even an otherwise invalid value there is accepted.
+    expect(Array.from(Buffer.alloc(5, 0xaa).fill(0, undefined, 3))).toEqual([0, 0, 0, 0, 0]);
+    expect(Array.from(Buffer.alloc(5, 0xaa).fill(0, undefined, "3"))).toEqual([0, 0, 0, 0, 0]);
+    expect(Array.from(Buffer.alloc(5, 0xaa).fill(0, undefined, -1))).toEqual([0, 0, 0, 0, 0]);
+    expect(Array.from(Buffer.alloc(5, 0xaa).fill(0, undefined, null))).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it("discards end when a string value's offset slot holds the encoding", () => {
+    // fill(value, encoding) has no end slot, so anything there is ignored.
+    expect(Buffer.alloc(5, 0xaa).fill("b", "utf8", 3).toString()).toBe("bbbbb");
+    expect(Buffer.alloc(5, 0xaa).fill("b", undefined, 3).toString()).toBe("bbbbb");
+    // An explicit numeric offset keeps end meaningful.
+    expect(Array.from(Buffer.alloc(5, 0xaa).fill("b", 1, 3))).toEqual([0xaa, 0x62, 0x62, 0xaa, 0xaa]);
+  });
+
+  it("still treats a string offset/end as the encoding when the value is a string", () => {
+    expect(Buffer.alloc(4, 0xaa).fill("ab", "utf16le").toString("hex")).toBe("61006200");
+    expect(Buffer.alloc(4, 0xaa).fill("ab", 0, "utf16le").toString("hex")).toBe("61006200");
+    expect(() => Buffer.alloc(4).fill("a", "bogus")).toThrow(expect.objectContaining({ code: "ERR_UNKNOWN_ENCODING" }));
+    expect(() => Buffer.alloc(4).fill("a", 0, "bogus")).toThrow(
+      expect.objectContaining({ code: "ERR_UNKNOWN_ENCODING" }),
+    );
+  });
+
+  it("never treats the 4-argument encoding as meaningful for a non-string value", () => {
+    expect(Array.from(Buffer.alloc(5, 0xaa).fill(0, 1, 3, "bogus"))).toEqual([0xaa, 0, 0, 0xaa, 0xaa]);
+  });
+});
+
 describe("*Write methods with NaN/invalid offset and length", () => {
   // Regression test: NaN offset/length values must be handled safely.
   // NaN offset should be treated as 0, and length should be clamped to buffer size.

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3847,6 +3847,30 @@ describe("Buffer.fill offset/end argument handling", () => {
     expect(Array.from(Buffer.alloc(5, 0xaa).fill(0, 1, 3, "bogus"))).toEqual([0xaa, 0, 0, 0xaa, 0xaa]);
   });
 
+  it("zero-fills the whole buffer when called with no arguments", () => {
+    // Node forwards the undefined value into the numeric path, which coerces to 0.
+    expect(Array.from(Buffer.alloc(3, 0xaa).fill())).toEqual([0, 0, 0]);
+    expect(Array.from(Buffer.alloc(3, 0xaa).fill(undefined))).toEqual([0, 0, 0]);
+  });
+
+  it("ignores positional arguments past the fourth", () => {
+    expect(Array.from(Buffer.alloc(5, 0xaa).fill(0, 1, 3, "utf8", "x"))).toEqual([0xaa, 0, 0, 0xaa, 0xaa]);
+    expect(Buffer.alloc(5, 0xaa).fill("ab", 0, 4, "utf16le", "x").toString("hex")).toBe("61006200aa");
+  });
+
+  it("lets an undefined offset shadow an explicit 4th-argument encoding, like Node", () => {
+    // Node's _fill assigns `encoding = offset` whenever offset is undefined or
+    // a string, so fill(str, undefined, ..., encoding) falls back to utf8 and a
+    // bogus 4th-argument encoding is never even validated.
+    expect(Buffer.alloc(4, 0xaa).fill("ab", undefined, undefined, "utf16le").toString("hex")).toBe("61626162");
+    expect(Buffer.alloc(4, 0xaa).fill("a", undefined, undefined, "bogus").toString("hex")).toBe("61616161");
+    // With a numeric offset the explicit encoding is honored.
+    expect(Buffer.alloc(4, 0xaa).fill("ab", 0, undefined, "utf16le").toString("hex")).toBe("61006200");
+    expect(() => Buffer.alloc(4).fill("a", 1, undefined, "bogus")).toThrow(
+      expect.objectContaining({ code: "ERR_UNKNOWN_ENCODING" }),
+    );
+  });
+
   // Differential test: the fixture enumerates every fill() argument shape and
   // prints the resulting bytes or the thrown error class + code. Running it
   // under Node.js and under Bun must produce byte-identical output.

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3871,13 +3871,25 @@ describe("Buffer.fill offset/end argument handling", () => {
     );
   });
 
-  it("treats a null encoding like an absent one, as Node's normalizeEncoding does", () => {
+  it("treats a null or empty-string encoding like an absent one, as Node's normalizeEncoding does", () => {
+    // normalizeEncoding returns utf8 for exactly undefined, null, and "".
     expect(Buffer.alloc(5, 0xaa).fill("a", 1, 3, null).toString("hex")).toBe("aa6161aaaa");
+    expect(Buffer.alloc(5, 0xaa).fill("a", 1, 3, "").toString("hex")).toBe("aa6161aaaa");
+    // A string "" in the offset or end slot becomes the encoding first, then
+    // that encoding is treated as absent.
+    expect(Buffer.alloc(5, 0xaa).fill("a", "").toString("hex")).toBe("6161616161");
+    expect(Buffer.alloc(5, 0xaa).fill("a", 1, "").toString("hex")).toBe("aa61616161");
     expect(Buffer.alloc(3, "a", null).toString("hex")).toBe("616161");
+    expect(Buffer.alloc(3, "a", "").toString("hex")).toBe("616161");
     // toString goes through Node's getEncodingOps, not normalizeEncoding, so a
-    // null encoding there is still ERR_UNKNOWN_ENCODING. Pins that the null
-    // handling lives at the fill/alloc gates, not inside parseEncoding.
+    // null or empty-string encoding there is still ERR_UNKNOWN_ENCODING. Pins
+    // that the handling lives at the fill/alloc gates, not inside parseEncoding.
     expect(() => Buffer.from("ab").toString(null)).toThrow(expect.objectContaining({ code: "ERR_UNKNOWN_ENCODING" }));
+    expect(() => Buffer.from("ab").toString("")).toThrow(expect.objectContaining({ code: "ERR_UNKNOWN_ENCODING" }));
+    // A String object is not a string primitive, so it is not "absent".
+    expect(() => Buffer.alloc(3, "a", new String(""))).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
   });
 
   // Differential test: the fixture enumerates every fill() argument shape and

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1,7 +1,8 @@
 import { Buffer, SlowBuffer, isAscii, isUtf8, kMaxLength } from "buffer";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, gc, isASAN, isDebug, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, gc, isASAN, isDebug, nodeExe, withoutAggressiveGC } from "harness";
 import { createHash } from "node:crypto";
+import { join } from "node:path";
 import vm from "node:vm";
 
 const BufferModule = await import("buffer");
@@ -3844,6 +3845,23 @@ describe("Buffer.fill offset/end argument handling", () => {
 
   it("never treats the 4-argument encoding as meaningful for a non-string value", () => {
     expect(Array.from(Buffer.alloc(5, 0xaa).fill(0, 1, 3, "bogus"))).toEqual([0xaa, 0, 0, 0xaa, 0xaa]);
+  });
+
+  // Differential test: the fixture enumerates every fill() argument shape and
+  // prints the resulting bytes or the thrown error class + code. Running it
+  // under Node.js and under Bun must produce byte-identical output.
+  it.skipIf(!nodeExe())("every fill() argument shape produces the same output in Node.js and Bun", async () => {
+    const fixture = join(import.meta.dir, "buffer-fill-args-fixture.js");
+    async function run(exe) {
+      await using proc = Bun.spawn({ cmd: [exe, fixture], env: bunEnv, stdout: "pipe" });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      return { stdout, exitCode };
+    }
+    const [bunRun, nodeRun] = await Promise.all([run(bunExe()), run(nodeExe())]);
+    expect(nodeRun.stdout).toContain("fill(");
+    expect(bunRun.stdout).toBe(nodeRun.stdout);
+    expect(nodeRun.exitCode).toBe(0);
+    expect(bunRun.exitCode).toBe(0);
   });
 });
 

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3871,6 +3871,15 @@ describe("Buffer.fill offset/end argument handling", () => {
     );
   });
 
+  it("treats a null encoding like an absent one, as Node's normalizeEncoding does", () => {
+    expect(Buffer.alloc(5, 0xaa).fill("a", 1, 3, null).toString("hex")).toBe("aa6161aaaa");
+    expect(Buffer.alloc(3, "a", null).toString("hex")).toBe("616161");
+    // toString goes through Node's getEncodingOps, not normalizeEncoding, so a
+    // null encoding there is still ERR_UNKNOWN_ENCODING. Pins that the null
+    // handling lives at the fill/alloc gates, not inside parseEncoding.
+    expect(() => Buffer.from("ab").toString(null)).toThrow(expect.objectContaining({ code: "ERR_UNKNOWN_ENCODING" }));
+  });
+
   // Differential test: the fixture enumerates every fill() argument shape and
   // prints the resulting bytes or the thrown error class + code. Running it
   // under Node.js and under Bun must produce byte-identical output.

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3892,6 +3892,19 @@ describe("Buffer.fill offset/end argument handling", () => {
     );
   });
 
+  // Bun coerces an object encoding via toString (Node rejects a non-string
+  // encoding up front with ERR_INVALID_ARG_TYPE instead). An exception thrown
+  // from that toString must surface, not degrade to an empty or null string.
+  it("propagates an exception thrown from an object encoding's toString", () => {
+    const boom = {
+      toString() {
+        throw new Error("boom");
+      },
+    };
+    expect(() => Buffer.alloc(4, 0xaa).fill("a", 0, 4, boom)).toThrow("boom");
+    expect(() => Buffer.alloc(4, "a", boom)).toThrow("boom");
+  });
+
   // Differential test: the fixture enumerates every fill() argument shape and
   // prints the resulting bytes or the thrown error class + code. Running it
   // under Node.js and under Bun must produce byte-identical output.


### PR DESCRIPTION
`Buffer.prototype.fill` diverges from Node on several argument shapes. Most of them silently produce a wrong fill range (no error), and a few throw where Node does not.

### Reproduction

```js
// value is NOT a string: Node never reinterprets a string offset/end as the encoding
Buffer.alloc(5, 0xaa).fill(0, "1", 3);         // bun <00 00 00 aa aa>       node ERR_INVALID_ARG_TYPE
Buffer.alloc(5, 0xaa).fill(0, 1, "3");         // bun <aa 00 00 00 00>       node ERR_INVALID_ARG_TYPE
Buffer.alloc(5, 0xaa).fill(0, "hex");          // bun <00 00 00 00 00>       node ERR_INVALID_ARG_TYPE

// Node never reads (or validates) `end` when `offset` is undefined
Buffer.alloc(5, 0xaa).fill(0, undefined, "3"); // bun ERR_INVALID_ARG_TYPE   node <00 00 00 00 00>
Buffer.alloc(5, 0xaa).fill(0, undefined, 3);   // bun <00 00 00 aa aa>       node <00 00 00 00 00>

// fill(string, encoding) has no `end` slot, so anything there is discarded
Buffer.alloc(5, 0xaa).fill("b", "utf8", 3);    // bun <62 62 62 aa aa>       node <62 62 62 62 62>
Buffer.alloc(5, 0xaa).fill("b", undefined, 3); // bun <62 62 62 aa aa>       node <62 62 62 62 62>

// Argument counts the intake did not handle
Buffer.alloc(3, 0xaa).fill();                     // bun no-op <aa aa aa>    node <00 00 00>
Buffer.alloc(5, 0xaa).fill(0, 1, 3, "utf8", "x"); // bun <00 00 00 00 00>    node <aa 00 00 aa aa>

// A null or empty-string encoding is the same as an absent one (utf8)
Buffer.alloc(5, 0xaa).fill("a", 1, 3, null);   // bun ERR_INVALID_ARG_TYPE   node <aa 61 61 aa aa>
Buffer.alloc(5, 0xaa).fill("a", 1, 3, "");     // bun ERR_UNKNOWN_ENCODING   node <aa 61 61 aa aa>
Buffer.alloc(3, "a", null);                    // bun ERR_INVALID_ARG_TYPE   node <61 61 61>
Buffer.alloc(3, "a", "");                      // bun ERR_UNKNOWN_ENCODING   node <61 61 61>
```

The first case is the one a caller is most likely to hit by accident: `buf.fill(0, "1", 3)` looks like a typo'd offset and Node rejects it, but Bun quietly treats `"1"` as an encoding, drops it (the value is not a string), and fills `[0, 3)`.

### Cause

`jsBufferPrototypeFunction_fillBody` unconditionally moves a string `offset` (or, failing that, a string `end`) into the encoding slot, and always validates `end`. In Node's `_fill` (`lib/buffer.js`) that reinterpretation lives inside `if (typeof value === 'string')`, the offset-slot branch also resets `end = buf.length`, and `end` is only validated once `offset` is present:

```js
if (typeof value === 'string') {
  if (offset === undefined || typeof offset === 'string') {
    encoding = offset;  offset = 0;  end = buf.length;
  } else if (typeof end === 'string') {
    encoding = end;  end = buf.length;
  }
  // ... encoding validation, single-char fast path ...
}
// ...
if (offset === undefined) {
  offset = 0;
  end = buf.length;
} else {
  validateOffset(offset, 'offset');
  if (end === undefined) end = buf.length;
  else validateOffset(end, 'end', 0, buf.length);
  if (offset >= end) return buf;
}
```

For a non-string value the string stays put and `validateOffset` rejects it with `ERR_INVALID_ARG_TYPE`; Bun consumed it as a (then-unused) encoding instead. And because Bun validated `end` even with no `offset`, `fill(0, undefined, "3")` threw where Node accepts.

Three more pre-existing shapes in the same intake were flagged in review and folded in:
- `fill()` with no arguments took an early return instead of Node's path, where the `undefined` value reaches the numeric branch and coerces to 0.
- The argument `switch` had cases for 2, 3, and 4 arguments but none for 5 or more, so a stray extra argument made every slot degrade to `undefined` and the whole buffer got filled.
- Node's `normalizeEncoding` treats exactly `undefined`, `null`, and `""` as an absent encoding (utf8). Bun's encoding gate only skipped `undefined`, so `null` and `""` reached `parseEncoding` and threw. `Buffer.alloc(size, fill, encoding)` has the identical gate, so both now go through one shared `resolveEncodingString` helper.

### Fix

Mirror Node's rules in `jsBufferPrototypeFunction_fillBody`:
- gate the string-offset/end to encoding reinterpretation on `value.isString()`, and discard `end` in the offset-slot branch (Node's `end = buf.length`);
- nest the `end` validation inside the offset-present branch so `end` is never read without an `offset`;
- replace the argument `switch` and the zero-argument early return with the bounds-checked `callFrame->argument(n)` (the idiom `jsBufferPrototypeFunction_writeBody` already uses), which returns `undefined` for an absent argument and ignores trailing ones;
- route the encoding gate in `fill()` and `Buffer.alloc()` through a new `resolveEncodingString` helper covering `undefined`, `null`, and `""`. `parseEncoding` itself is unchanged on purpose: `buf.toString(null)` and `buf.toString("")` must stay `ERR_UNKNOWN_ENCODING`, because Node routes `toString` through `getEncodingOps`, which rejects both.

The error-ordering contract is unchanged: for a string value, a bad encoding still wins over a bad range (`fill("a", -1, 0, "bogus")` is still `ERR_UNKNOWN_ENCODING`).

### Deliberately excluded

Two adjacent divergences turned up while mapping this. Each is real, pre-existing, and left for its own change rather than half-fixed here:

- `Buffer.from("ab", "")` throws `ERR_UNKNOWN_ENCODING` where Node returns `<61 62>`. Node's `fromString` treats any non-string or empty-string encoding as utf8 there, and Bun already matches it for every non-string value (`null`, `5`, `false`, `{}`); only `""` diverges. Its gate lives outside this file's fill/alloc path.
- A non-primitive encoding whose `toString` yields a valid encoding name is honored by Bun but ignored or rejected by Node: `fill("ab", 0, 4, new String("utf16le"))` is `<61 62 61 62 aa>` (utf8) in Node and `<61 00 62 00 aa>` (utf16le) in Bun, and `fill("ab", 0, 4, {toString: () => "hex"})` throws `ERR_INVALID_ARG_TYPE` in Node but is honored in Bun. Bun's `parseEncoding` coerces its argument via `toStringOrNull` before any type check. Changing that touches six callers, and the coercion is load-bearing for the TOCTOU-hardening suite in `test/js/node/buffer-copy-fill-detach.test.ts`, which deliberately documents this divergence and detaches the buffer from inside the encoding object's `toString` to prove `fill` survives. That behavior and that safety suite have to change together.

### Verification

- **Node/Bun differential test**: `test/js/node/buffer-fill-args-fixture.js` enumerates 48 `fill()` argument shapes and prints the resulting bytes or the thrown error class + code for each. `buffer.test.js` spawns the fixture under `nodeExe()` and `bunExe()` and requires the two outputs to be byte-identical. With this PR they match exactly; without the `src/` change they diverge on every shape the PR targets. The fixture's Node output is identical between v24.3.0 (the version the CI image pins) and v26.3.0.
- `test/js/node/buffer.test.js`: all existing tests pass; the new `Buffer.fill offset/end argument handling` describe adds 11 tests, of which 8 fail on the unfixed build (the other 3 are controls pinning behavior that already matched Node).
- Vendored Node suite: `test-buffer-fill.js`, `test-buffer-alloc.js`, `test-buffer-write.js`, `test-buffer-write-fast.js` all pass.
- `test/js/node/buffer-copy-fill-detach.test.ts` (detach-during-fill and detach-from-encoding-toString) passes unchanged.

<details>
<summary>Fixture output (Node v24.3.0 == Node v26.3.0 == Bun with this PR)</summary>

```
fill(0, "1", 3)                              throws TypeError ERR_INVALID_ARG_TYPE
fill(0, 1, "3")                              throws TypeError ERR_INVALID_ARG_TYPE
fill(0, "hex")                               throws TypeError ERR_INVALID_ARG_TYPE
fill(0, "bogus")                             throws TypeError ERR_INVALID_ARG_TYPE
fill(true, "1", 3)                           throws TypeError ERR_INVALID_ARG_TYPE
fill(uint8, "1", 3)                          throws TypeError ERR_INVALID_ARG_TYPE
fill(uint8, 1, "3")                          throws TypeError ERR_INVALID_ARG_TYPE
fill(0, null, 3)                             throws TypeError ERR_INVALID_ARG_TYPE
fill(0, 1, null)                             throws TypeError ERR_INVALID_ARG_TYPE
fill(0, undefined, "3")                      ok     0000000000
fill(0, undefined, 3)                        ok     0000000000
fill(0, undefined, null)                     ok     0000000000
fill(0, undefined, -1)                       ok     0000000000
fill("b", undefined, 3)                      ok     6262626262
fill("b", "utf8", 3)                         ok     6262626262
fill("ab", undefined, undefined, "utf16le")  ok     6162616261
fill("a", undefined, undefined, "bogus")     ok     6161616161
fill("ab", 0, undefined, "utf16le")          ok     6100620061
fill("a", 1, undefined, "bogus")             throws TypeError ERR_UNKNOWN_ENCODING
fill("a", 1, 3, null)                        ok     aa6161aaaa
fill("a", undefined, undefined, null)        ok     6161616161
fill("a", 1, 3, "")                          ok     aa6161aaaa
fill("a", "")                                ok     6161616161
fill("a", 1, "")                             ok     aa61616161
fill()                                       ok     0000000000
fill(undefined)                              ok     0000000000
fill(0, 1, 3, "utf8", "x")                   ok     aa0000aaaa
fill("b", 1, 3, "utf8", "x")                 ok     aa6262aaaa
fill("ab", 0, 4, "utf16le", "x")             ok     61006200aa
fill(0)                                      ok     0000000000
fill(0, 1)                                   ok     aa00000000
fill(0, 1, 3)                                ok     aa0000aaaa
fill(0, 1.5, 3)                              throws RangeError ERR_OUT_OF_RANGE
fill(0, -1, 3)                               throws RangeError ERR_OUT_OF_RANGE
fill(0, 1, 99)                               throws RangeError ERR_OUT_OF_RANGE
fill(0, NaN, 3)                              throws RangeError ERR_OUT_OF_RANGE
fill(0, 1, 3, "bogus")                       ok     aa0000aaaa
fill("b")                                    ok     6262626262
fill("b", "utf8")                            ok     6262626262
fill("b", 1)                                 ok     aa62626262
fill("b", 1, 3)                              ok     aa6262aaaa
fill("b", 1, "utf8")                         ok     aa62626262
fill("b", 1, 3, "utf8")                      ok     aa6262aaaa
fill("b", "1", 3)                            throws TypeError ERR_UNKNOWN_ENCODING
fill("b", 1, "3")                            throws TypeError ERR_UNKNOWN_ENCODING
fill("b", "bogus")                           throws TypeError ERR_UNKNOWN_ENCODING
fill("b", -1)                                throws RangeError ERR_OUT_OF_RANGE
fill("abc", "hex")                           ok     ababababab
```

</details>

