### PR TITLE
node:fs: fix operations on Windows filenames with trailing dots or spaces

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4149,7 +4149,10 @@ fn getcwd_len(buf: &mut PathBuffer) -> crate::CrateResult<usize> {
         unsafe extern "system" {
             fn GetCurrentDirectoryW(nBufferLength: u32, lpBuffer: *mut u16) -> u32;
         }
-        let mut wbuf = WPathBuffer::ZEROED;
+        // Write-only scratch: `GetCurrentDirectoryW` fills `wbuf[..n]` and
+        // only that range is read below, so skip the ~64 KB zero-fill (see
+        // `WPathBuffer::uninit`); relative paths hit this on every syscall.
+        let mut wbuf = WPathBuffer::uninit();
         // SAFETY: `wbuf` has `PATH_MAX_WIDE` writable u16 units.
         let n = unsafe { GetCurrentDirectoryW(wbuf.0.len() as u32, wbuf.0.as_mut_ptr()) } as usize;
         if n == 0 {

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4149,9 +4149,6 @@ fn getcwd_len(buf: &mut PathBuffer) -> crate::CrateResult<usize> {
         unsafe extern "system" {
             fn GetCurrentDirectoryW(nBufferLength: u32, lpBuffer: *mut u16) -> u32;
         }
-        // Write-only scratch: `GetCurrentDirectoryW` fills `wbuf[..n]` and
-        // only that range is read below, so skip the ~64 KB zero-fill (see
-        // `WPathBuffer::uninit`); relative paths hit this on every syscall.
         let mut wbuf = WPathBuffer::uninit();
         // SAFETY: `wbuf` has `PATH_MAX_WIDE` writable u16 units.
         let n = unsafe { GetCurrentDirectoryW(wbuf.0.len() as u32, wbuf.0.as_mut_ptr()) } as usize;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5177,24 +5177,26 @@ impl NodeFS {
 
         #[cfg(windows)]
         {
-            // Paths whose UTF-16 form exceeds the wide buffers can't exist on
-            // disk; reject instead of overflowing the conversion below.
-            for path in [&args.src, &args.dest] {
-                if !strings::fits_in_wide_path_buffer(path.slice()) {
-                    return Err(sys::Error {
-                        errno: E::ENAMETOOLONG as _,
-                        syscall: sys::Tag::copyfile,
-                        path: path.slice().into(),
-                        ..Default::default()
-                    });
-                }
-            }
-            let mut dest_buf = paths::os_path_buffer_pool::get();
-            let src = strings::to_kernel32_path(
-                bun_core::cast_slice_mut::<u8, u16>(&mut self.sync_error_buf),
-                args.src.slice(),
-            );
-            let dest = strings::to_kernel32_path(&mut *dest_buf, args.dest.slice());
+            // `os_path_kernel32` (rather than `to_kernel32_path` on the raw
+            // argument) resolves relative paths against the cwd so they get
+            // the `\\?\` prefix like every other node:fs operation; see
+            // `join_cwd_windows`. It rejects paths whose UTF-16 form cannot
+            // exist on disk instead of overflowing the conversion.
+            let name_too_long = |path: &PathLike| sys::Error {
+                errno: E::ENAMETOOLONG as _,
+                syscall: sys::Tag::copyfile,
+                path: path.slice().into(),
+                ..Default::default()
+            };
+            let mut dest_buf = paths::path_buffer_pool::get();
+            let src = match args.src.os_path_kernel32(&mut self.sync_error_buf) {
+                Ok(p) => p,
+                Err(NameTooLong) => return Err(name_too_long(&args.src)),
+            };
+            let dest = match args.dest.os_path_kernel32(&mut dest_buf) {
+                Ok(p) => p,
+                Err(NameTooLong) => return Err(name_too_long(&args.dest)),
+            };
             // SAFETY: src/dest are NUL-terminated wide paths; CopyFileW is the Win32 FFI
             if unsafe {
                 windows::CopyFileW(
@@ -6237,7 +6239,6 @@ impl NodeFS {
     fn readdir_with_entries<T: ReaddirEntry>(
         args: &args::Readdir,
         fd: FD,
-        basename: &ZStr,
         entries: &mut Vec<T>,
     ) -> Maybe<()> {
         // On Windows, String/Dirent results read native UTF-16 entry names via the
@@ -6245,7 +6246,7 @@ impl NodeFS {
         // use the u8 iterator.
         #[cfg(windows)]
         if T::IS_U16 {
-            return Self::readdir_with_entries_u16::<T>(args, fd, basename, entries);
+            return Self::readdir_with_entries_u16::<T>(args, fd, entries);
         }
 
         let mut dirent_path = BunString::DEAD;
@@ -6259,8 +6260,11 @@ impl NodeFS {
             };
 
             if T::IS_DIRENT && dirent_path.is_empty() {
+                // Use the caller's path, not the (possibly cwd-resolved and
+                // `\\?\`-prefixed) path handed to the syscall: Node reports
+                // `Dirent.parentPath` in terms of the argument it was given.
                 dirent_path = webcore::encoding::to_bun_string(
-                    without_nt_prefix::<u8>(basename.as_bytes()),
+                    without_nt_prefix::<u8>(args.path.slice()),
                     encoding_to_node(args.encoding),
                 );
             }
@@ -6288,7 +6292,6 @@ impl NodeFS {
     fn readdir_with_entries_u16<T: ReaddirEntry>(
         args: &args::Readdir,
         fd: FD,
-        basename: &ZStr,
         entries: &mut Vec<T>,
     ) -> Maybe<()> {
         let mut dirent_path = BunString::DEAD;
@@ -6312,8 +6315,10 @@ impl NodeFS {
             };
 
             if T::IS_DIRENT && dirent_path.is_empty() {
+                // See `readdir_with_entries`: `Dirent.parentPath` reports the
+                // caller's path, not the resolved one handed to the syscall.
                 dirent_path = webcore::encoding::to_bun_string(
-                    without_nt_prefix::<u8>(basename.as_bytes()),
+                    without_nt_prefix::<u8>(args.path.slice()),
                     encoding_to_node(args.encoding),
                 );
             }
@@ -6664,9 +6669,12 @@ impl NodeFS {
                 }
 
                 if T::IS_DIRENT {
+                    // `Dirent.parentPath` is derived from the caller's path
+                    // (`root_basename` may be the cwd-resolved, `\\?\`-prefixed
+                    // form handed to the syscalls).
                     let joined = paths::resolve_path::join_spill::<paths::platform::Auto>(
                         &mut dirent_spill,
-                        &[root_basename.as_bytes(), name_to_copy],
+                        &[args.path.slice(), name_to_copy],
                     );
                     let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                     if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
@@ -6773,8 +6781,7 @@ impl NodeFS {
         let _close = scopeguard::guard(fd, |fd| fd.close());
 
         let mut entries: Vec<T> = Vec::new();
-        Self::readdir_with_entries::<T>(args, fd, path, &mut entries)
-            .map(|()| T::into_readdir(entries))
+        Self::readdir_with_entries::<T>(args, fd, &mut entries).map(|()| T::into_readdir(entries))
     }
 
     /// Caller has already checked `is_bun_standalone_file_path(path)`.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5177,11 +5177,6 @@ impl NodeFS {
 
         #[cfg(windows)]
         {
-            // `os_path_kernel32` (rather than `to_kernel32_path` on the raw
-            // argument) resolves relative paths against the cwd so they get
-            // the `\\?\` prefix like every other node:fs operation; see
-            // `join_cwd_windows`. It rejects paths whose UTF-16 form cannot
-            // exist on disk instead of overflowing the conversion.
             let name_too_long = |path: &PathLike| sys::Error {
                 errno: E::ENAMETOOLONG as _,
                 syscall: sys::Tag::copyfile,
@@ -6260,9 +6255,8 @@ impl NodeFS {
             };
 
             if T::IS_DIRENT && dirent_path.is_empty() {
-                // Use the caller's path, not the (possibly cwd-resolved and
-                // `\\?\`-prefixed) path handed to the syscall: Node reports
-                // `Dirent.parentPath` in terms of the argument it was given.
+                // `Dirent.parentPath` is the caller's argument, as in Node, not
+                // the cwd-resolved path the syscall saw.
                 dirent_path = webcore::encoding::to_bun_string(
                     without_nt_prefix::<u8>(args.path.slice()),
                     encoding_to_node(args.encoding),
@@ -6315,8 +6309,6 @@ impl NodeFS {
             };
 
             if T::IS_DIRENT && dirent_path.is_empty() {
-                // See `readdir_with_entries`: `Dirent.parentPath` reports the
-                // caller's path, not the resolved one handed to the syscall.
                 dirent_path = webcore::encoding::to_bun_string(
                     without_nt_prefix::<u8>(args.path.slice()),
                     encoding_to_node(args.encoding),
@@ -6669,9 +6661,8 @@ impl NodeFS {
                 }
 
                 if T::IS_DIRENT {
-                    // `Dirent.parentPath` is derived from the caller's path
-                    // (`root_basename` may be the cwd-resolved, `\\?\`-prefixed
-                    // form handed to the syscalls).
+                    // `args.path`, not `root_basename`: the latter may be the
+                    // cwd-resolved `\\?\` form the syscalls saw.
                     let joined = paths::resolve_path::join_spill::<paths::platform::Auto>(
                         &mut dirent_spill,
                         &[args.path.slice(), name_to_copy],

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -898,33 +898,18 @@ pub(crate) trait PathOrFdExt {
         Self: Sized;
 }
 
-/// Join a plain relative Windows path onto the process cwd, writing the
-/// unnormalized `cwd ++ '\' ++ path` into `scratch` and returning it.
-///
-/// Relative paths must become drive-absolute before the `\\?\` prefix (which
-/// every drive-absolute path gets in `slice_z_with_force_copy` /
-/// `to_kernel32_path`, mirroring Node's `path.toNamespacedPath()` on every
-/// `fs` path) can apply. Without the prefix, Win32 normalization strips
-/// trailing dots/spaces from the final component, so a relative name can
-/// refer to a different file than the one the NT-based syscalls (`openat`,
-/// used by `writeFile`) created. https://github.com/oven-sh/bun/issues/8836
-///
-/// Returns `None`, keeping the caller on its existing handling, when the
-/// path is not plain relative (empty, absolute, or drive-relative `C:foo`),
-/// the cwd is unavailable or not drive-letter rooted (e.g. a UNC cwd), or
-/// the join would not fit `scratch`.
+/// `cwd ++ '\' ++ path` for a plain relative path, so it can take the `\\?\`
+/// branch like Node's `toNamespacedPath()`: without the prefix Win32 strips
+/// trailing dots and spaces (#8836). `None` keeps the caller's existing handling.
 #[cfg(windows)]
 fn join_cwd_windows<'a>(path: &[u8], scratch: &'a mut PathBuffer) -> Option<&'a [u8]> {
     if path.is_empty() || bun_paths::is_absolute(path) {
         return None;
     }
-    // `C:foo` is relative to drive `C`'s own current directory, which only
-    // the Win32 layer tracks; joining it onto the process cwd would be wrong.
+    // `C:foo` is relative to drive `C`'s own cwd, which only Win32 tracks.
     if path.len() >= 2 && path[1] == b':' && bun_paths::is_drive_letter(path[0]) {
         return None;
     }
-    // Reshaped for borrowck: `getcwd` returns a borrow of `scratch`; capture
-    // the length, drop the borrow, then write after it.
     let cwd_len = match bun_core::getcwd(scratch) {
         Ok(cwd) => cwd.len(),
         Err(_) => return None,
@@ -957,11 +942,9 @@ impl PathLikeExt for PathLike<'_> {
 
         #[cfg(windows)]
         {
-            // Plain relative paths are rebound to their cwd-joined spelling so
-            // the drive-absolute branch below gives them the same `\\?\`
-            // treatment; `join_cwd_windows` explains why. Declared before the
-            // shadowed `sliced` so the pooled buffer outlives the borrow. The
-            // original `sliced` still backs the fallthrough copy at the bottom.
+            // Relative paths take the drive-absolute `\\?\` branch below via
+            // their cwd-joined spelling; the fallthrough copy at the bottom
+            // still sees the original bytes when the join declines.
             let mut cwd_join_scratch;
             let sliced = if !bun_paths::is_absolute(sliced) {
                 cwd_join_scratch = bun_paths::path_buffer_pool::get();
@@ -1149,11 +1132,9 @@ impl PathLikeExt for PathLike<'_> {
                 let buf_u16 = unsafe { bun_core::bytes_as_slice_mut::<u16>(&mut buf[..]) };
                 return Ok(strings::to_kernel32_path(buf_u16, b"."));
             }
-            // Plain relative paths: join onto the cwd so `to_kernel32_path`
-            // sees a drive-absolute path and adds the `\\?\` prefix, matching
-            // `slice_z_with_force_copy`; see `join_cwd_windows`. As in the
-            // rooted branch above, `buf` is the scratch for the cwd join and
-            // the final wide path lands back in `buf`.
+            // Relative paths join onto the cwd so `to_kernel32_path` adds the
+            // `\\?\` prefix, as `slice_z_with_force_copy` does; `buf` is the
+            // join scratch and then receives the final wide path.
             if let Some(joined) = join_cwd_windows(s, buf) {
                 if strings::fits_in_wide_path_buffer(joined) {
                     let normal = bun_paths::resolve_path::normalize_buf::<

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -898,6 +898,53 @@ pub(crate) trait PathOrFdExt {
         Self: Sized;
 }
 
+/// Join a plain relative Windows path onto the process cwd, writing the
+/// unnormalized `cwd ++ '\' ++ path` into `scratch` and returning it.
+///
+/// Relative paths must become drive-absolute before the `\\?\` prefix (which
+/// every drive-absolute path gets in `slice_z_with_force_copy` /
+/// `to_kernel32_path`, mirroring Node's `path.toNamespacedPath()` on every
+/// `fs` path) can apply. Without the prefix, Win32 normalization strips
+/// trailing dots/spaces from the final component, so a relative name can
+/// refer to a different file than the one the NT-based syscalls (`openat`,
+/// used by `writeFile`) created. https://github.com/oven-sh/bun/issues/8836
+///
+/// Returns `None`, keeping the caller on its existing handling, when the
+/// path is not plain relative (empty, absolute, or drive-relative `C:foo`),
+/// the cwd is unavailable or not drive-letter rooted (e.g. a UNC cwd), or
+/// the join would not fit `scratch`.
+#[cfg(windows)]
+fn join_cwd_windows<'a>(path: &[u8], scratch: &'a mut PathBuffer) -> Option<&'a [u8]> {
+    if path.is_empty() || bun_paths::is_absolute(path) {
+        return None;
+    }
+    // `C:foo` is relative to drive `C`'s own current directory, which only
+    // the Win32 layer tracks; joining it onto the process cwd would be wrong.
+    if path.len() >= 2 && path[1] == b':' && bun_paths::is_drive_letter(path[0]) {
+        return None;
+    }
+    // Reshaped for borrowck: `getcwd` returns a borrow of `scratch`; capture
+    // the length, drop the borrow, then write after it.
+    let cwd_len = match bun_core::getcwd(scratch) {
+        Ok(cwd) => cwd.len(),
+        Err(_) => return None,
+    };
+    if !(cwd_len > 2
+        && bun_paths::is_drive_letter(scratch[0])
+        && scratch[1] == b':'
+        && bun_paths::is_sep_any(scratch[2]))
+    {
+        return None;
+    }
+    let total = cwd_len + 1 + path.len();
+    if total > scratch.len() {
+        return None;
+    }
+    scratch[cwd_len] = b'\\';
+    scratch[cwd_len + 1..total].copy_from_slice(path);
+    Some(&scratch[..total])
+}
+
 impl PathLikeExt for PathLike<'_> {
     // Const-generics can't change return mutability, so this always returns
     // `&ZStr`. A future force=true caller that needs `&mut ZStr` will need a
@@ -910,6 +957,18 @@ impl PathLikeExt for PathLike<'_> {
 
         #[cfg(windows)]
         {
+            // Plain relative paths are rebound to their cwd-joined spelling so
+            // the drive-absolute branch below gives them the same `\\?\`
+            // treatment; `join_cwd_windows` explains why. Declared before the
+            // shadowed `sliced` so the pooled buffer outlives the borrow. The
+            // original `sliced` still backs the fallthrough copy at the bottom.
+            let mut cwd_join_scratch;
+            let sliced = if !bun_paths::is_absolute(sliced) {
+                cwd_join_scratch = bun_paths::path_buffer_pool::get();
+                join_cwd_windows(sliced, &mut cwd_join_scratch).unwrap_or(sliced)
+            } else {
+                sliced
+            };
             // Only take the fast path for paths that can exist on NT at
             // all (≤ ~32757 UTF-16 units). That bounds the `\\?\`-prefixed
             // copy below in bytes too (≤ 3×32757 + 5 < MAX_PATH_BYTES);
@@ -1089,6 +1148,22 @@ impl PathLikeExt for PathLike<'_> {
                 // SAFETY: see alignment note above (PathBuffer reinterpreted as [u16]).
                 let buf_u16 = unsafe { bun_core::bytes_as_slice_mut::<u16>(&mut buf[..]) };
                 return Ok(strings::to_kernel32_path(buf_u16, b"."));
+            }
+            // Plain relative paths: join onto the cwd so `to_kernel32_path`
+            // sees a drive-absolute path and adds the `\\?\` prefix, matching
+            // `slice_z_with_force_copy`; see `join_cwd_windows`. As in the
+            // rooted branch above, `buf` is the scratch for the cwd join and
+            // the final wide path lands back in `buf`.
+            if let Some(joined) = join_cwd_windows(s, buf) {
+                if strings::fits_in_wide_path_buffer(joined) {
+                    let normal = bun_paths::resolve_path::normalize_buf::<
+                        bun_paths::platform::Windows,
+                    >(joined, &mut b[..]);
+                    // `joined`'s borrow of `buf` ended at the line above (NLL).
+                    // SAFETY: same alignment note as above.
+                    let buf_u16 = unsafe { bun_core::bytes_as_slice_mut::<u16>(&mut buf[..]) };
+                    return Ok(strings::to_kernel32_path(buf_u16, normal));
+                }
             }
             let normal = bun_paths::resolve_path::normalize_string_buf::<
                 true,

--- a/test/js/node/fs/fs-windows-special-names.test.ts
+++ b/test/js/node/fs/fs-windows-special-names.test.ts
@@ -17,7 +17,11 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // Relative paths only mean something relative to a cwd, so each fixture runs
-// in a child process whose cwd is a fresh temp directory.
+// in a child process whose cwd is a fresh temp directory. On success the
+// child's JSON is returned for a single toEqual; any failure (nonzero exit,
+// unparseable stdout) returns the raw { stdout, stderr, exitCode } instead,
+// so the caller's toEqual mismatch shows the child's actual output. stderr
+// is never asserted to be empty: debug builds write benign warnings there.
 async function runInChild(cwd: string, fixture: string): Promise<unknown> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", fixture],
@@ -27,16 +31,14 @@ async function runInChild(cwd: string, fixture: string): Promise<unknown> {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // stderr is not asserted to be empty (debug builds may write warnings);
-  // it is folded into the result so assertion failures show the real error.
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stdout);
-  } catch {
-    parsed = { stdout, stderr, exitCode };
+  if (exitCode !== 0) {
+    return { stdout, stderr, exitCode };
   }
-  expect(exitCode).toBe(0);
-  return parsed;
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return { stdout, stderr, exitCode };
+  }
 }
 
 for (const name of [" spaces.txt ", ".dots.txt."]) {

--- a/test/js/node/fs/fs-windows-special-names.test.ts
+++ b/test/js/node/fs/fs-windows-special-names.test.ts
@@ -1,17 +1,6 @@
-// NTFS allows file names that end in a dot or a space, but the Win32 path
-// normalizer (everything reached through CreateFileW and friends) silently
-// strips those characters from the final component unless the path carries
-// the `\\?\` prefix. Bun's `writeFile` opens through NtCreateFile, which does
-// no such normalization, so `writeFile(" a.txt ")` created the literal name
-// while `readFile(" a.txt ")`, `stat`, `unlink`, `rename`, and `existsSync`
-// looked up the stripped one and failed with ENOENT.
-//
-// Absolute drive paths were already resolved to `\\?\C:\...` internally;
-// these tests pin the same treatment for relative paths (resolved against
-// the cwd first), which is what Node does by passing every fs path through
-// `path.toNamespacedPath()`.
-//
-// https://github.com/oven-sh/bun/issues/8836
+// Win32 strips trailing dots and spaces from a path's final component unless
+// it carries the `\\?\` prefix; these tests pin the namespaced handling of
+// relative node:fs paths. https://github.com/oven-sh/bun/issues/8836
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";

--- a/test/js/node/fs/fs-windows-special-names.test.ts
+++ b/test/js/node/fs/fs-windows-special-names.test.ts
@@ -16,12 +16,9 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-// Relative paths only mean something relative to a cwd, so each fixture runs
-// in a child process whose cwd is a fresh temp directory. On success the
-// child's JSON is returned for a single toEqual; any failure (nonzero exit,
-// unparseable stdout) returns the raw { stdout, stderr, exitCode } instead,
-// so the caller's toEqual mismatch shows the child's actual output. stderr
-// is never asserted to be empty: debug builds write benign warnings there.
+// Runs the fixture in a child whose cwd is a fresh temp dir (relative paths
+// need one) and returns its parsed JSON, or the raw { stdout, stderr,
+// exitCode } on any failure so the caller's toEqual shows what went wrong.
 async function runInChild(cwd: string, fixture: string): Promise<unknown> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", fixture],

--- a/test/js/node/fs/fs-windows-special-names.test.ts
+++ b/test/js/node/fs/fs-windows-special-names.test.ts
@@ -181,10 +181,5 @@ test.skipIf(!isWindows)("issue 8836 reproduction", async () => {
     }
     process.stdout.write(JSON.stringify(out));
   `;
-  expect(await runInChild(String(dir), fixture)).toEqual([
-    'data:" spaces.txt "',
-    19,
-    'data:".dots.txt."',
-    17,
-  ]);
+  expect(await runInChild(String(dir), fixture)).toEqual(['data:" spaces.txt "', 19, 'data:".dots.txt."', 17]);
 });

--- a/test/js/node/fs/fs-windows-special-names.test.ts
+++ b/test/js/node/fs/fs-windows-special-names.test.ts
@@ -42,7 +42,7 @@ async function runInChild(cwd: string, fixture: string): Promise<unknown> {
 }
 
 for (const name of [" spaces.txt ", ".dots.txt."]) {
-  test.skipIf(!isWindows)(`fs round-trips the relative name ${JSON.stringify(name)}`, async () => {
+  test.concurrent.skipIf(!isWindows)(`fs round-trips the relative name ${JSON.stringify(name)}`, async () => {
     using dir = tempDir("fs-win-names", {});
     const fixture = `
       const fs = require("node:fs");
@@ -76,7 +76,7 @@ for (const name of [" spaces.txt ", ".dots.txt."]) {
   });
 }
 
-test.skipIf(!isWindows)("fs.rename and fs.copyFile see the literal relative name", async () => {
+test.concurrent.skipIf(!isWindows)("fs.rename and fs.copyFile see the literal relative name", async () => {
   using dir = tempDir("fs-win-names", {});
   const fixture = `
     const fs = require("node:fs");
@@ -96,7 +96,7 @@ test.skipIf(!isWindows)("fs.rename and fs.copyFile see the literal relative name
   });
 });
 
-test.skipIf(!isWindows)("fs.mkdir keeps a trailing dot in relative directory names", async () => {
+test.concurrent.skipIf(!isWindows)("fs.mkdir keeps a trailing dot in relative directory names", async () => {
   using dir = tempDir("fs-win-names", {});
   const fixture = `
     const fs = require("node:fs");
@@ -120,7 +120,7 @@ test.skipIf(!isWindows)("fs.mkdir keeps a trailing dot in relative directory nam
   });
 });
 
-test.skipIf(!isWindows)("Dirent.parentPath reports the relative path as given", async () => {
+test.concurrent.skipIf(!isWindows)("Dirent.parentPath reports the relative path as given", async () => {
   using dir = tempDir("fs-win-names", { "sub/a.txt": "a", "sub/b/c.txt": "c" });
   const fixture = `
     const fs = require("node:fs");
@@ -137,7 +137,7 @@ test.skipIf(!isWindows)("Dirent.parentPath reports the relative path as given", 
   });
 });
 
-test.skipIf(!isWindows)("alternate data streams and explicit \\\\?\\ paths keep working", async () => {
+test.concurrent.skipIf(!isWindows)("alternate data streams and explicit \\\\?\\ paths keep working", async () => {
   // Guards the relative-path rewrite: ADS names contain a colon and must not
   // be mistaken for drive-relative paths, and already-namespaced absolute
   // paths must not be prefixed twice.
@@ -168,7 +168,7 @@ test.skipIf(!isWindows)("alternate data streams and explicit \\\\?\\ paths keep 
   });
 });
 
-test.skipIf(!isWindows)("issue 8836 reproduction", async () => {
+test.concurrent.skipIf(!isWindows)("issue 8836 reproduction", async () => {
   // Verbatim shape of the original report: write, read, stat, unlink each
   // name without any of them throwing.
   using dir = tempDir("fs-win-names", {});

--- a/test/js/node/fs/fs-windows-special-names.test.ts
+++ b/test/js/node/fs/fs-windows-special-names.test.ts
@@ -1,0 +1,190 @@
+// NTFS allows file names that end in a dot or a space, but the Win32 path
+// normalizer (everything reached through CreateFileW and friends) silently
+// strips those characters from the final component unless the path carries
+// the `\\?\` prefix. Bun's `writeFile` opens through NtCreateFile, which does
+// no such normalization, so `writeFile(" a.txt ")` created the literal name
+// while `readFile(" a.txt ")`, `stat`, `unlink`, `rename`, and `existsSync`
+// looked up the stripped one and failed with ENOENT.
+//
+// Absolute drive paths were already resolved to `\\?\C:\...` internally;
+// these tests pin the same treatment for relative paths (resolved against
+// the cwd first), which is what Node does by passing every fs path through
+// `path.toNamespacedPath()`.
+//
+// https://github.com/oven-sh/bun/issues/8836
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// Relative paths only mean something relative to a cwd, so each fixture runs
+// in a child process whose cwd is a fresh temp directory.
+async function runInChild(cwd: string, fixture: string): Promise<unknown> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // stderr is not asserted to be empty (debug builds may write warnings);
+  // it is folded into the result so assertion failures show the real error.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    parsed = { stdout, stderr, exitCode };
+  }
+  expect(exitCode).toBe(0);
+  return parsed;
+}
+
+for (const name of [" spaces.txt ", ".dots.txt."]) {
+  test.skipIf(!isWindows)(`fs round-trips the relative name ${JSON.stringify(name)}`, async () => {
+    using dir = tempDir("fs-win-names", {});
+    const fixture = `
+      const fs = require("node:fs");
+      const name = ${JSON.stringify(name)};
+      const data = 'data:"' + name + '"';
+      fs.writeFileSync(name, data);
+      const out = {
+        listed: fs.readdirSync(".").includes(name),
+        exists: fs.existsSync(name),
+        read: fs.readFileSync(name, "utf8"),
+        size: fs.statSync(name).size,
+        opened: (() => { const fd = fs.openSync(name, "r"); fs.closeSync(fd); return true; })(),
+      };
+      fs.appendFileSync(name, "+more");
+      out.appended = fs.readFileSync(name, "utf8");
+      fs.unlinkSync(name);
+      out.existsAfterUnlink = fs.existsSync(name);
+      out.listedAfterUnlink = fs.readdirSync(".").includes(name);
+      process.stdout.write(JSON.stringify(out));
+    `;
+    expect(await runInChild(String(dir), fixture)).toEqual({
+      listed: true,
+      exists: true,
+      read: `data:"${name}"`,
+      size: `data:"${name}"`.length,
+      opened: true,
+      appended: `data:"${name}"+more`,
+      existsAfterUnlink: false,
+      listedAfterUnlink: false,
+    });
+  });
+}
+
+test.skipIf(!isWindows)("fs.rename and fs.copyFile see the literal relative name", async () => {
+  using dir = tempDir("fs-win-names", {});
+  const fixture = `
+    const fs = require("node:fs");
+    fs.writeFileSync(".from.txt.", "payload");
+    fs.copyFileSync(".from.txt.", " copy.txt ");
+    fs.renameSync(".from.txt.", "renamed.txt");
+    process.stdout.write(JSON.stringify({
+      copied: fs.readFileSync(" copy.txt ", "utf8"),
+      renamed: fs.readFileSync("renamed.txt", "utf8"),
+      listing: fs.readdirSync(".").sort(),
+    }));
+  `;
+  expect(await runInChild(String(dir), fixture)).toEqual({
+    copied: "payload",
+    renamed: "payload",
+    listing: [" copy.txt ", "renamed.txt"],
+  });
+});
+
+test.skipIf(!isWindows)("fs.mkdir keeps a trailing dot in relative directory names", async () => {
+  using dir = tempDir("fs-win-names", {});
+  const fixture = `
+    const fs = require("node:fs");
+    fs.mkdirSync("single.dir.");
+    fs.mkdirSync("rec.a./rec.b.", { recursive: true });
+    fs.writeFileSync("single.dir./inner.txt.", "nested");
+    process.stdout.write(JSON.stringify({
+      top: fs.readdirSync(".").sort(),
+      inner: fs.readdirSync("single.dir."),
+      innerRead: fs.readFileSync("single.dir./inner.txt.", "utf8"),
+      nested: fs.readdirSync("rec.a."),
+      statIsDir: fs.statSync("rec.a./rec.b.").isDirectory(),
+    }));
+  `;
+  expect(await runInChild(String(dir), fixture)).toEqual({
+    top: ["rec.a.", "single.dir."],
+    inner: ["inner.txt."],
+    innerRead: "nested",
+    nested: ["rec.b."],
+    statIsDir: true,
+  });
+});
+
+test.skipIf(!isWindows)("Dirent.parentPath reports the relative path as given", async () => {
+  using dir = tempDir("fs-win-names", { "sub/a.txt": "a", "sub/b/c.txt": "c" });
+  const fixture = `
+    const fs = require("node:fs");
+    const flat = fs.readdirSync("sub", { withFileTypes: true }).map(d => d.parentPath).sort();
+    const deep = fs.readdirSync("./sub", { withFileTypes: true, recursive: true })
+      .map(d => d.parentPath).sort();
+    process.stdout.write(JSON.stringify({ flat, deep }));
+  `;
+  expect(await runInChild(String(dir), fixture)).toEqual({
+    flat: ["sub", "sub"],
+    // Recursive parentPath is derived by joining the argument with each
+    // entry's subdirectory, which normalizes the leading "./".
+    deep: ["sub", "sub", "sub\\b"],
+  });
+});
+
+test.skipIf(!isWindows)("alternate data streams and explicit \\\\?\\ paths keep working", async () => {
+  // Guards the relative-path rewrite: ADS names contain a colon and must not
+  // be mistaken for drive-relative paths, and already-namespaced absolute
+  // paths must not be prefixed twice.
+  using dir = tempDir("fs-win-names", {});
+  const fixture = `
+    const fs = require("node:fs");
+    const path = require("node:path");
+    fs.writeFileSync("ads.txt", "base");
+    fs.writeFileSync("ads.txt:meta", "stream");
+    const namespaced = "\\\\\\\\?\\\\" + path.resolve("namespaced.txt");
+    fs.writeFileSync(namespaced, "via nt namespace");
+    process.stdout.write(JSON.stringify({
+      base: fs.readFileSync("ads.txt", "utf8"),
+      stream: fs.readFileSync("ads.txt:meta", "utf8"),
+      streamSize: fs.statSync("ads.txt:meta").size,
+      namespaced: fs.readFileSync(namespaced, "utf8"),
+      namespacedRelative: fs.readFileSync("namespaced.txt", "utf8"),
+      listing: fs.readdirSync(".").sort(),
+    }));
+  `;
+  expect(await runInChild(String(dir), fixture)).toEqual({
+    base: "base",
+    stream: "stream",
+    streamSize: "stream".length,
+    namespaced: "via nt namespace",
+    namespacedRelative: "via nt namespace",
+    listing: ["ads.txt", "namespaced.txt"],
+  });
+});
+
+test.skipIf(!isWindows)("issue 8836 reproduction", async () => {
+  // Verbatim shape of the original report: write, read, stat, unlink each
+  // name without any of them throwing.
+  using dir = tempDir("fs-win-names", {});
+  const fixture = `
+    const fs = require("node:fs/promises");
+    const out = [];
+    for (const filename of [" spaces.txt ", ".dots.txt."]) {
+      await fs.writeFile(filename, 'data:"' + filename + '"');
+      out.push((await fs.readFile(filename)).toString());
+      out.push((await fs.stat(filename)).size);
+      await fs.unlink(filename);
+    }
+    process.stdout.write(JSON.stringify(out));
+  `;
+  expect(await runInChild(String(dir), fixture)).toEqual([
+    'data:" spaces.txt "',
+    19,
+    'data:".dots.txt."',
+    17,
+  ]);
+});


### PR DESCRIPTION
Fixes #8836

On Windows, `fs.writeFile(" spaces.txt ")` created a file literally named ` spaces.txt ` that `readFile`, `stat`, `unlink`, `rename`, `existsSync`, and `copyFile` could not find:

```
ENOENT: no such file or directory, open ' spaces.txt '
    path: " spaces.txt ",
 syscall: "open",
   errno: -2
```

```js
import fs from "node:fs/promises";
for (const filename of [" spaces.txt ", ".dots.txt."]) {
  await fs.writeFile(filename, `data:"${filename}"`);
  console.log((await fs.readFile(filename)).toString()); // ENOENT
}
```

### Cause

NTFS allows names that end in a dot or a space, but Win32 path normalization (everything reached through `CreateFileW`, `DeleteFileW`, `GetFileAttributesW`, `MoveFileExW`, ...) strips them from the final component unless the path carries the `\\?\` prefix. Bun's `writeFile` opens through `NtCreateFile` relative to the cwd handle, which performs no such normalization, so the write and the read disagreed about which file the name refers to.

Absolute drive paths were already rewritten to `\\?\C:\...` in `PathLike::slice_z_with_force_copy`, which is why only relative paths misbehaved.

### Fix

- `PathLike::slice_z_with_force_copy` and `PathLike::os_path_kernel32` (`src/runtime/node/types.rs`): plain relative paths are joined onto the cwd (new `join_cwd_windows` helper) so they take the existing drive-absolute `\\?\` branches. This is what Node does by passing every `fs` path through `path.toNamespacedPath()`.
- `copyFile` (`src/runtime/node/node_fs.rs`) hand-rolled `to_kernel32_path` on the raw argument instead of using the shared slicer; it now uses `os_path_kernel32`.
- `bun_core::getcwd` on Windows no longer zero-fills its 64 KB wide scratch buffer (review feedback: the cwd join makes `getcwd` a per-call cost for relative paths, and `GetCurrentDirectoryW` writes everything that is read back).
- readdir derived `Dirent.parentPath` from the path handed to the syscall. It now uses the caller's argument, as Node does, so the cwd resolution is not observable there.

Drive-relative paths (`C:foo`), UNC cwds, and empty paths keep their existing handling, and error objects still report the path exactly as the caller passed it. Two sites are intentionally not covered because they have their own path layers with the same pre-existing limitation for absolute paths as well: `fs.cp`'s recursive copier (the wide `os_path` slicer) and `fs.watch`. The same applies to a relative name that is exactly a DOS device name such as `nul`: it now takes the same route Bun already uses for absolute paths, where `normalize_path_windows` maps a trailing `\nul` to the NUL device; tightening that pre-existing check is a separate change.

One observable side effect: `fs.mkdirSync("a/b", { recursive: true })` with a relative path now returns the first created directory as `\\?\C:\...\a` instead of `a`, which matches what Node v26 returns on Windows.

### Verification (Windows x64)

- The script from the issue now prints the expected output and exits 0, and the literal names round-trip.
- New tests in `test/js/node/fs/fs-windows-special-names.test.ts`: 7/7 pass with the fix, 5/7 fail on the unfixed build. The other two pin behaviors the rewrite must not change (`Dirent.parentPath`, alternate data streams, explicit `\\?\` input).
- `test/js/node/fs`, `test/js/node/watch`, and `Bun.write` suites: no new failures. The only failures (four 200-iteration recursive readdir stress tests and one large-file read) are 10s test-timeout exceedances of the debug build and fail identically with the src changes reverted on the same machine.
- UNC paths (`\\localhost\c$\...`, `\\?\UNC\...`), forward slashes, `.` and `..`, trailing separators, and ENOENT `error.path` / `error.message` are byte-identical before and after.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs-windows-special-names.test.ts

<!-- robobun:evidence:end -->