### PR TITLE
Match Node bounds handling in Buffer.from(arrayBuffer, byteOffset, length)

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -3283,23 +3283,35 @@ EncodedJSValue constructBufferFromArrayBuffer(JSC::ThrowScope& throwScope, JSGlo
         double offsetD = offsetValue.toNumber(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
         if (std::isnan(offsetD)) offsetD = 0;
+        // Node range-checks the offset before truncating it, so a fractional
+        // offset past the end is out of bounds. Offsets at or below -1 must be
+        // rejected here: truncateDoubleToUint64 would wrap them.
+        if (offsetD > static_cast<double>(byteLength) || std::trunc(offsetD) < 0)
+            return Bun::ERR::BUFFER_OUT_OF_BOUNDS(throwScope, lexicalGlobalObject, "offset"_s);
         offset = truncateDoubleToUint64(offsetD);
-        if (offset > byteLength) return Bun::ERR::BUFFER_OUT_OF_BOUNDS(throwScope, lexicalGlobalObject, "offset"_s);
         length -= offset;
     }
 
     if (!lengthValue.isUndefined()) {
         double lengthD = lengthValue.toNumber(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
-        if (std::isnan(lengthD)) lengthD = 0;
-        length = truncateDoubleToUint64(lengthD);
-        if (length > byteLength - offset) return Bun::ERR::BUFFER_OUT_OF_BOUNDS(throwScope, lexicalGlobalObject, "length"_s);
+        // Node range-checks a positive length before truncating it and clamps
+        // everything else (NaN, -0, negative) to an empty view.
+        if (lengthD > 0) {
+            if (lengthD > static_cast<double>(byteLength - offset)) return Bun::ERR::BUFFER_OUT_OF_BOUNDS(throwScope, lexicalGlobalObject, "length"_s);
+            length = truncateDoubleToUint64(lengthD);
+        } else {
+            length = 0;
+        }
     }
 
     auto isResizableOrGrowableShared = jsBuffer->isResizableOrGrowableShared();
     if (isResizableOrGrowableShared) {
         auto* subclassStructure = globalObject->JSResizableOrGrowableSharedBufferSubclassStructure();
-        auto* uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, WTF::move(buffer), offset, std::nullopt);
+        // Node only returns a length-tracking Buffer when no explicit length is given.
+        std::optional<size_t> viewLength;
+        if (!lengthValue.isUndefined()) viewLength = length;
+        auto* uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, WTF::move(buffer), offset, viewLength);
         RETURN_IF_EXCEPTION(throwScope, {});
         if (!uint8Array) [[unlikely]] {
             throwOutOfMemoryError(globalObject, throwScope);

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -3278,9 +3278,10 @@ EncodedJSValue constructBufferFromArrayBuffer(JSC::ThrowScope& throwScope, JSGlo
     size_t byteLength = buffer->byteLength();
     size_t offset = 0;
     size_t length = byteLength;
+    double offsetD = 0;
 
     if (!offsetValue.isUndefined()) {
-        double offsetD = offsetValue.toNumber(lexicalGlobalObject);
+        offsetD = offsetValue.toNumber(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
         if (std::isnan(offsetD)) offsetD = 0;
         // Node range-checks the offset before truncating it, so a fractional
@@ -3295,10 +3296,11 @@ EncodedJSValue constructBufferFromArrayBuffer(JSC::ThrowScope& throwScope, JSGlo
     if (!lengthValue.isUndefined()) {
         double lengthD = lengthValue.toNumber(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
-        // Node range-checks a positive length before truncating it and clamps
-        // everything else (NaN, -0, negative) to an empty view.
+        // Node range-checks a positive length, before truncating it, against the
+        // capacity left by the un-truncated offset, and clamps everything else
+        // (NaN, -0, negative) to an empty view.
         if (lengthD > 0) {
-            if (lengthD > static_cast<double>(byteLength - offset)) return Bun::ERR::BUFFER_OUT_OF_BOUNDS(throwScope, lexicalGlobalObject, "length"_s);
+            if (lengthD > static_cast<double>(byteLength) - offsetD) return Bun::ERR::BUFFER_OUT_OF_BOUNDS(throwScope, lexicalGlobalObject, "length"_s);
             length = truncateDoubleToUint64(lengthD);
         } else {
             length = 0;

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3730,6 +3730,79 @@ it("Buffer.from(arrayBuffer, byteOffset, length)", () => {
   expect(buf[Symbol.iterator]().toArray()).toEqual([13, 14, 15, 16, 17]);
 });
 
+describe("Buffer.from(arrayBuffer, byteOffset, length) bounds", () => {
+  it("clamps NaN and non-positive lengths to 0", () => {
+    const ab = new ArrayBuffer(16);
+    const cases = [
+      [ab, 4, -1],
+      [ab, 4, -100],
+      [ab, 0, -Infinity],
+      [ab, 0, -0],
+      [ab, 0, "-5"],
+      [ab, 0, NaN],
+      [ab, 16, -1],
+      [ab, undefined, -1],
+      [ab, 4, { valueOf: () => -1 }],
+      [new SharedArrayBuffer(16), 4, -1],
+    ];
+    const lengths = cases.map(args => {
+      try {
+        return Buffer.from(...args).length;
+      } catch (e) {
+        return e.code;
+      }
+    });
+    expect(lengths).toEqual(cases.map(() => 0));
+    // the byteOffset is still respected
+    expect(Buffer.from(ab, 4, -1).byteOffset).toBe(4);
+    // deprecated constructor form takes the same path
+    expect(new Buffer(ab, 4, -1).length).toBe(0);
+  });
+
+  it("throws ERR_BUFFER_OUT_OF_BOUNDS for positive lengths past the end", () => {
+    const ab = new ArrayBuffer(16);
+    expect(() => Buffer.from(ab, 0, 17)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    expect(() => Buffer.from(ab, 8, 9)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    expect(() => Buffer.from(ab, 0, Infinity)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    // Node compares the un-truncated length against the remaining capacity
+    expect(() => Buffer.from(ab, 0, 16.5)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    expect(Buffer.from(ab, 0, 16).length).toBe(16);
+    expect(Buffer.from(ab, 0, 15.5).length).toBe(15);
+    expect(Buffer.from(ab, 8, 8).length).toBe(8);
+  });
+
+  it("throws ERR_BUFFER_OUT_OF_BOUNDS for offsets past the end", () => {
+    const ab = new ArrayBuffer(16);
+    expect(() => Buffer.from(ab, 17)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    expect(() => Buffer.from(ab, Infinity)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    // Node compares the un-truncated offset against byteLength
+    expect(() => Buffer.from(ab, 16.5)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    expect(() => Buffer.from(ab, -1)).toThrow(RangeError);
+    expect(Buffer.from(ab, 16).length).toBe(0);
+    // (-1, 0] truncates to a zero offset
+    expect(Buffer.from(ab, -0.5).length).toBe(16);
+  });
+
+  it("honors an explicit length on a resizable ArrayBuffer", () => {
+    const rab = new ArrayBuffer(8, { maxByteLength: 32 });
+    const fixed = Buffer.from(rab, 0, 4);
+    const clamped = Buffer.from(rab, 4, -1);
+    const tracking = Buffer.from(rab, 4);
+    expect([fixed.length, clamped.length, clamped.byteOffset, tracking.length]).toEqual([4, 0, 4, 4]);
+    rab.resize(32);
+    // only the no-length form is a length-tracking view
+    expect([fixed.length, clamped.length, tracking.length]).toEqual([4, 0, 28]);
+  });
+
+  it("honors an explicit length on a growable SharedArrayBuffer", () => {
+    const gsab = new SharedArrayBuffer(8, { maxByteLength: 32 });
+    const fixed = Buffer.from(gsab, 0, 4);
+    const tracking = Buffer.from(gsab);
+    gsab.grow(32);
+    expect([fixed.length, tracking.length]).toEqual([4, 32]);
+  });
+});
+
 describe("ERR_BUFFER_OUT_OF_BOUNDS", () => {
   for (const method of ["writeBigInt64BE", "writeBigInt64LE", "writeBigUInt64BE", "writeBigUInt64LE"]) {
     for (const bufferLength of [0, 1, 2, 3, 4, 5, 6]) {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3769,6 +3769,12 @@ describe("Buffer.from(arrayBuffer, byteOffset, length) bounds", () => {
     expect(Buffer.from(ab, 0, 16).length).toBe(16);
     expect(Buffer.from(ab, 0, 15.5).length).toBe(15);
     expect(Buffer.from(ab, 8, 8).length).toBe(8);
+    // ... and that capacity is computed from the un-truncated offset
+    expect(() => Buffer.from(ab, 0.5, 16)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    expect(() => Buffer.from(ab, 15.5, 1)).toThrowWithCode(RangeError, "ERR_BUFFER_OUT_OF_BOUNDS");
+    expect(Buffer.from(ab, 0.5, 15).length).toBe(15);
+    const fractional = Buffer.from(ab, 3.5, 12);
+    expect([fractional.byteOffset, fractional.length]).toEqual([3, 12]);
   });
 
   it("throws ERR_BUFFER_OUT_OF_BOUNDS for offsets past the end", () => {


### PR DESCRIPTION
### Problem

`Buffer.from(arrayBuffer, byteOffset, length)` throws for any negative length:

```js
const ab = new ArrayBuffer(16);
Buffer.from(ab, 4, -1);
// Bun:  RangeError: "length" is outside of buffer bounds  (ERR_BUFFER_OUT_OF_BOUNDS)
// Node: <Buffer >  (length 0)
```

Node clamps NaN and non-positive lengths to 0 (`lib/internal/buffer.js`, `fromArrayBuffer`), so code that computes a length defensively (`min(remaining, n) - k` going negative) gets an empty view there and an exception here.

### Cause

`constructBufferFromArrayBuffer` ran `truncateDoubleToUint64(lengthD)` before validating, so `-1` wrapped to `2^64 - 1` and tripped the bounds check. Two adjacent problems in the same function:

- the `byteOffset` argument was also compared after truncation, so a fractional offset past the end (`Buffer.from(ab16, 16.5)`) was accepted where Node throws;
- when the source is a resizable `ArrayBuffer` or growable `SharedArrayBuffer`, an explicit length was ignored and a length-tracking view was returned. Node only returns a length-tracking Buffer when no length argument is given.

### Fix

Follow Node's order of operations: validate the un-truncated double (positive lengths against the remaining capacity, offsets against `byteLength`), clamp NaN and non-positive lengths to 0, and only then truncate. For resizable/growable-shared buffers, pass the explicit length through to the view instead of always creating an auto-length one.

With the fix, every `Buffer.from(arrayBuffer, ...)` argument combination I checked (negative/NaN/fractional/Infinity lengths and offsets, string and `valueOf` coercion, `SharedArrayBuffer`, resizable and growable-shared buffers, the deprecated `new Buffer(ab, o, l)` form) now behaves identically to Node 26.

### Tests

`test/js/node/buffer.test.js`, `describe("Buffer.from(arrayBuffer, byteOffset, length) bounds")`. All five fail on the released Bun and pass with this change; the ported Node suites (`test-buffer-arraybuffer`, `test-buffer-from`, `test-buffer-sharedarraybuffer`, `test-buffer-backing-arraybuffer`, `test-buffer-alloc`, `test-buffer-over-max-length`, `test-buffer-new`) and the full `buffer.test.js` still pass.
