### PR TITLE
node:dgram: throw ERR_SOCKET_ALREADY_BOUND synchronously from bind()

### DIFF
--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -223,8 +223,7 @@ Socket.prototype.bind = function (port_, address_ /* , callback */) {
   const state = this[kStateSymbol];
 
   if (state.bindState !== BIND_STATE_UNBOUND) {
-    this.emit("error", $ERR_SOCKET_ALREADY_BOUND());
-    return;
+    throw $ERR_SOCKET_ALREADY_BOUND();
   }
 
   state.bindState = BIND_STATE_BINDING;

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, jest, test } from "bun:test";
 import { createSocket } from "dgram";
 
 import { disableAggressiveGCScope } from "harness";
@@ -275,5 +275,32 @@ describe("after close()", () => {
   test("Symbol.asyncDispose resolves when the socket is already closed", async () => {
     const { socket } = await boundThenClosed();
     expect(await socket[Symbol.asyncDispose]()).toBeUndefined();
+  });
+});
+
+describe("bind()", () => {
+  // Node throws ERR_SOCKET_ALREADY_BOUND synchronously from bind(); the error
+  // must reach the caller's try/catch, never an attached 'error' listener.
+  test("on an already-bound socket throws ERR_SOCKET_ALREADY_BOUND and does not emit 'error'", async () => {
+    await using socket = createSocket("udp4");
+    const onError = jest.fn();
+    socket.on("error", onError);
+    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+    socket.bind(0, onListening);
+    await listening;
+    expect(() => socket.bind(0)).toThrowWithCode(Error, "ERR_SOCKET_ALREADY_BOUND");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test("while a bind is still in flight throws ERR_SOCKET_ALREADY_BOUND and does not emit 'error'", async () => {
+    await using socket = createSocket("udp4");
+    const onError = jest.fn();
+    socket.on("error", onError);
+    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+    socket.bind(0, onListening);
+    expect(() => socket.bind(0)).toThrowWithCode(Error, "ERR_SOCKET_ALREADY_BOUND");
+    // The in-flight first bind must still complete normally.
+    await listening;
+    expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -283,9 +283,9 @@ describe("bind()", () => {
   // must reach the caller's try/catch, never an attached 'error' listener.
   test("on an already-bound socket throws ERR_SOCKET_ALREADY_BOUND and does not emit 'error'", async () => {
     await using socket = createSocket("udp4");
-    const onError = jest.fn();
+    const { promise: listening, resolve: onListening, reject } = Promise.withResolvers<void>();
+    const onError = jest.fn(reject);
     socket.on("error", onError);
-    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
     socket.bind(0, onListening);
     await listening;
     expect(() => socket.bind(0)).toThrowWithCode(Error, "ERR_SOCKET_ALREADY_BOUND");
@@ -294,9 +294,9 @@ describe("bind()", () => {
 
   test("while a bind is still in flight throws ERR_SOCKET_ALREADY_BOUND and does not emit 'error'", async () => {
     await using socket = createSocket("udp4");
-    const onError = jest.fn();
+    const { promise: listening, resolve: onListening, reject } = Promise.withResolvers<void>();
+    const onError = jest.fn(reject);
     socket.on("error", onError);
-    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
     socket.bind(0, onListening);
     expect(() => socket.bind(0)).toThrowWithCode(Error, "ERR_SOCKET_ALREADY_BOUND");
     // The in-flight first bind must still complete normally.


### PR DESCRIPTION
### What

`dgram.Socket.prototype.bind()` on an already-bound (or still-binding) socket now throws `ERR_SOCKET_ALREADY_BOUND` synchronously, matching Node. It previously did `this.emit("error", ...)` and returned.

### Repro

```js
const dgram = require("node:dgram");
const s = dgram.createSocket("udp4");
s.on("error", e => console.log("error event:", e.code)); // any 'error' listener
s.bind(0, () => {
  try { s.bind(0); } catch (e) { console.log("threw:", e.code); }
  s.close();
});
```

Node prints `threw: ERR_SOCKET_ALREADY_BOUND` and the `'error'` listener never fires. Bun printed `error event: ERR_SOCKET_ALREADY_BOUND` and nothing was thrown.

### Cause

In Node, the misuse-class `bind()` failures throw synchronously (`lib/dgram.js` does `throw new ERR_SOCKET_ALREADY_BOUND()`); only runtime failures such as `EADDRINUSE` are delivered as `'error'` events. Bun's `src/js/node/dgram.ts` emitted this one too. Two consequences:

1. With an `'error'` listener attached (the usual case for a dgram socket), `try/catch` around `bind()` catches nothing, and a programming error gets routed to the generic network-error handler instead.
2. `bind(port, cb)` registers internal `'error'` and `'listening'` listeners to wire up `cb`. A second `bind()` while the first is still in flight triggered them via the emit: the internal `removeListeners` handler tore down the `'listening'` listener, so the first bind completed but its callback never ran and the program hung.

Without any `'error'` listener the two behaviors happened to coincide, because `EventEmitter#emit('error')` with no listener re-throws synchronously from inside `bind()`. That is why the ported `test-dgram-bind.js` (which attaches no `'error'` listener) was already passing.

### Fix

Throw from `bind()` when `bindState !== BIND_STATE_UNBOUND`, like Node. Every other misuse path in the module already throws, and the async/OS failure paths still emit.

### Tests

`test/js/bun/udp/dgram.test.ts` gains two tests (already bound, and bind still in flight) asserting the synchronous throw and that `'error'` is never emitted. Both fail on the released Bun:

```
error: expect(received).toThrowWithCode(cls, code)
Received function did not throw
(fail) bind() > on an already-bound socket throws ERR_SOCKET_ALREADY_BOUND and does not emit 'error'
(fail) bind() > while a bind is still in flight throws ERR_SOCKET_ALREADY_BOUND and does not emit 'error'
```

The ported `test/js/node/test/parallel/test-dgram-bind.js` and the rest of the ported `test-dgram-*` suite still pass with the change.
