### PR TITLE
buffer: normalize the UTF-16LE encoding aliases to utf16le

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1641,6 +1641,13 @@ static int64_t indexOfNumber(JSC::JSGlobalObject* lexicalGlobalObject, bool last
     return result + byteOffset;
 }
 
+// ucs2 and utf16le name the same encoding (the parser normalizes every alias
+// to utf16le); UTF-16 searches operate on whole 16-bit units.
+static inline bool isUTF16Encoding(BufferEncodingType encoding)
+{
+    return encoding == BufferEncodingType::utf16le || encoding == BufferEncodingType::ucs2;
+}
+
 static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, double endD, JSString* str, BufferEncodingType encoding)
 {
     VM& vm = lexicalGlobalObject->vm();
@@ -1654,18 +1661,17 @@ static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last
     auto* arrayValue = uncheckedDowncast<JSC::JSUint8Array>(JSC::JSValue::decode(encodedBuffer));
     size_t needleLength = arrayValue->byteLength();
 
-    // UCS2 searches operate on whole 16-bit units.
-    size_t haystackLength = encoding == BufferEncodingType::ucs2 ? byteLength & ~static_cast<size_t>(1) : byteLength;
+    size_t haystackLength = isUTF16Encoding(encoding) ? byteLength & ~static_cast<size_t>(1) : byteLength;
 
     size_t byteOffset = 0;
     size_t searchEnd = 0;
     int64_t immediateResult = -1;
     if (!computeIndexOfRange(haystackLength, byteOffsetD, endD, needleLength, !last, &byteOffset, &searchEnd, &immediateResult))
         return immediateResult;
-    if (encoding == BufferEncodingType::ucs2) searchEnd &= ~static_cast<size_t>(1);
+    if (isUTF16Encoding(encoding)) searchEnd &= ~static_cast<size_t>(1);
 
     const uint8_t* typedVectorValue = arrayValue->typedVector();
-    if (encoding == BufferEncodingType::ucs2) {
+    if (isUTF16Encoding(encoding)) {
         return last ? lastIndexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset)
                     : indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }
@@ -1676,17 +1682,17 @@ static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last
 static int64_t indexOfBuffer(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, double endD, JSC::JSGenericTypedArrayView<JSC::Uint8Adaptor>* array, BufferEncodingType encoding)
 {
     size_t needleLength = array->byteLength();
-    size_t haystackLength = encoding == BufferEncodingType::ucs2 ? byteLength & ~static_cast<size_t>(1) : byteLength;
+    size_t haystackLength = isUTF16Encoding(encoding) ? byteLength & ~static_cast<size_t>(1) : byteLength;
 
     size_t byteOffset = 0;
     size_t searchEnd = 0;
     int64_t immediateResult = -1;
     if (!computeIndexOfRange(haystackLength, byteOffsetD, endD, needleLength, !last, &byteOffset, &searchEnd, &immediateResult))
         return immediateResult;
-    if (encoding == BufferEncodingType::ucs2) searchEnd &= ~static_cast<size_t>(1);
+    if (isUTF16Encoding(encoding)) searchEnd &= ~static_cast<size_t>(1);
 
     const uint8_t* typedVectorValue = array->typedVector();
-    if (encoding == BufferEncodingType::ucs2) {
+    if (isUTF16Encoding(encoding)) {
         return last ? lastIndexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset)
                     : indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }

--- a/src/jsc/bindings/JSBufferEncodingType.cpp
+++ b/src/jsc/bindings/JSBufferEncodingType.cpp
@@ -120,14 +120,17 @@ template<> std::optional<BufferEncodingType> parseEnumerationFromView<BufferEnco
             return BufferEncodingType::utf8;
         if (WTF::equalIgnoringASCIICase(encoding, "utf-8"_s))
             return BufferEncodingType::utf8;
+        // Node's normalizeEncoding() maps every UTF-16LE alias (including
+        // ucs2/ucs-2) to the canonical name "utf16le", and so does the Rust
+        // parser (ENCODING_MAP in src/runtime/node/types.rs). Match both.
         if (WTF::equalIgnoringASCIICase(encoding, "ucs2"_s))
-            return BufferEncodingType::ucs2;
+            return BufferEncodingType::utf16le;
         if (WTF::equalIgnoringASCIICase(encoding, "ucs-2"_s))
-            return BufferEncodingType::ucs2;
+            return BufferEncodingType::utf16le;
         if (WTF::equalIgnoringASCIICase(encoding, "utf16le"_s))
-            return BufferEncodingType::ucs2;
+            return BufferEncodingType::utf16le;
         if (WTF::equalIgnoringASCIICase(encoding, "utf-16le"_s))
-            return BufferEncodingType::ucs2;
+            return BufferEncodingType::utf16le;
         break;
     }
 

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -242,6 +242,28 @@ for (const StringDecoder of [FakeStringDecoderCall, RealStringDecoder]) {
   });
 }
 
+// Node's normalizeEncoding() maps every UTF-16LE alias (including the legacy
+// ucs2/ucs-2 spellings) to the canonical name "utf16le", and
+// StringDecoder#encoding exposes the normalized name.
+it("normalizes the encoding name like Node", () => {
+  const inputs = ["utf16le", "utf-16le", "ucs2", "ucs-2", "UTF-16LE", "UCS-2", "utf8", "utf-8", "latin1", "binary"];
+  const normalized = Object.fromEntries(inputs.map(name => [name, new RealStringDecoder(name).encoding]));
+  normalized.default = new RealStringDecoder().encoding;
+  expect(normalized).toEqual({
+    "utf16le": "utf16le",
+    "utf-16le": "utf16le",
+    "ucs2": "utf16le",
+    "ucs-2": "utf16le",
+    "UTF-16LE": "utf16le",
+    "UCS-2": "utf16le",
+    "utf8": "utf8",
+    "utf-8": "utf8",
+    "latin1": "latin1",
+    "binary": "latin1",
+    "default": "utf8",
+  });
+});
+
 it("invalid utf-8 input, pr #3562", () => {
   const decoder = new RealStringDecoder("utf-8");
   let output = "";


### PR DESCRIPTION
### What

`new StringDecoder(enc).encoding` (and, via it, `Readable#readableEncoding` after `setEncoding(enc)`) now reports `"utf16le"` for every UTF-16LE alias, matching Node's `normalizeEncoding()`. It previously reported `"ucs2"`.

### Repro

```js
const { StringDecoder } = require("node:string_decoder");
const { Readable } = require("node:stream");
for (const enc of ["utf-16le", "utf16le", "ucs2", "ucs-2"]) {
  const r = new Readable({ read() {} });
  r.setEncoding(enc);
  console.log(enc, new StringDecoder(enc).encoding, r.readableEncoding);
}
```

Node prints `utf16le utf16le` for all four names. Bun printed `ucs2 ucs2`. Code that branches on the normalized encoding name takes the wrong path.

### Cause

`BufferEncodingType` has both a `ucs2` and a `utf16le` variant for what is one encoding. The C++ string parser (`parseEnumerationFromView<BufferEncodingType>` in `JSBufferEncodingType.cpp`) mapped all four aliases (`ucs2`, `ucs-2`, `utf16le`, `utf-16le`) to `ucs2`, while the Rust parser (`ENCODING_MAP` in `src/runtime/node/types.rs`) and Node's `normalizeEncoding()` map them all to `utf16le`. The only place the two variants behave differently is the enum-to-string map, which is exactly what the `StringDecoder#encoding` getter reads, so every StringDecoder constructed with a UTF-16 name reported `"ucs2"`.

### Fix

- `JSBufferEncodingType.cpp`: parse all four aliases to `BufferEncodingType::utf16le`, matching the Rust parser and Node.
- `JSBuffer.cpp`: `indexOfString`/`indexOfBuffer` gated their 16-bit-unit-aligned search on `encoding == BufferEncodingType::ucs2` only (every other consumer already pairs `case ucs2: case utf16le:`). Those comparisons now accept both variants, so `buf.indexOf(x, offset, "ucs2")` keeps matching only at even byte offsets.

Everything else already treats the two variants identically: the Rust `dispatch_encoding!` sites alias `Ucs2` to the `Utf16le` implementation, and the remaining C++ switches list the two cases together. Nothing constructs `BufferEncodingType::ucs2` after this change.

### Tests

`test/js/node/string_decoder/string-decoder.test.js` gains a normalization-table test covering all four aliases (plus case variants, `binary`/`utf-8`, and the default). It fails on the released Bun:

```
-   "ucs-2": "utf16le",
-   "ucs2": "utf16le",
-   "utf-16le": "utf16le",
+   "ucs-2": "ucs2",
+   "ucs2": "ucs2",
+   "utf-16le": "ucs2",
```

The `indexOf` change is behavior-preserving and covered by the existing ported `test/js/node/test/parallel/test-buffer-indexof.js`, whose `ucs2`/`utf16le` alignment assertions (for example `Buffer.from('ff').indexOf(Buffer.from('f'), 1, 'ucs2')` must be `-1`) fail if the 16-bit-aligned search regresses to a byte search. That test, the rest of the ported `test-buffer-*` and `test-string-decoder*` suites (66 files), and `test/js/node/buffer.test.js` (522 tests) all pass with the change.
