### PR TITLE
node:v8: round-trip Buffer as Buffer through serialize and deserialize

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -149,7 +149,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:v8`](https://nodejs.org/api/v8.html)
 
-🟡 `writeHeapSnapshot` and `getHeapSnapshot` are implemented. `serialize` and `deserialize` use JavaScriptCore's wire format instead of V8's. Other methods are not implemented. For profiling, use [`bun:jsc`](/project/benchmarking#javascript-heap-stats) instead.
+🟡 `writeHeapSnapshot` and `getHeapSnapshot` are implemented. `serialize` and `deserialize` are implemented (`Buffer` round-trips as `Buffer`, like Node.js), but they use JavaScriptCore's wire format instead of V8's: data serialized by Node.js cannot be deserialized by Bun, or vice versa. Other methods, including the `Serializer` and `Deserializer` classes, are not implemented. For profiling, use [`bun:jsc`](/project/benchmarking#javascript-heap-stats) instead.
 
 ### [`node:vm`](https://nodejs.org/api/vm.html)
 

--- a/src/js/node/v8.ts
+++ b/src/js/node/v8.ts
@@ -4,6 +4,14 @@
 const { hideFromStack, throwNotImplemented } = require("internal/shared");
 const jsc: typeof import("bun:jsc") = require("bun:jsc");
 
+// Like jsc.serialize(value, { binaryType: "nodebuffer" }), except Buffer instances
+// round-trip as Buffer instead of Uint8Array, matching Node's DefaultSerializer.
+const serializeImpl: (value: unknown) => Buffer = $newCppFunction(
+  "StructuredClone.cpp",
+  "jsFunctionNodeV8Serialize",
+  1,
+);
+
 function notimpl(message) {
   throwNotImplemented("node:v8 " + message);
 }
@@ -104,7 +112,7 @@ function stopCoverage() {
   notimpl("stopCoverage");
 }
 function serialize(arg1) {
-  return jsc.serialize(arg1, { binaryType: "nodebuffer" });
+  return serializeImpl(arg1);
 }
 
 function getDefaultHeapSnapshotPath() {

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -110,6 +110,7 @@
 #include "ZigGlobalObject.h"
 #include "blob.h"
 #include "ZigGeneratedClasses.h"
+#include "JSBuffer.h"
 #include "JSX509Certificate.h"
 #include "ncrypto.h"
 #include "JSKeyObject.h"
@@ -276,6 +277,11 @@ enum ArrayBufferViewSubtag {
     BigInt64ArrayTag = 10,
     BigUint64ArrayTag = 11,
     Float16ArrayTag = 12,
+
+    // Bun subtags start at 254 and decrease with each addition, so they can't
+    // collide with future WebKit subtags. A Uint8Array that is a Node.js Buffer;
+    // only written under SerializationContext::NodeV8Serialize.
+    Bun__NodeBufferTag = 254,
 };
 
 // static bool isTypeExposedToGlobalObject(JSC::JSGlobalObject& globalObject, SerializationTag tag)
@@ -374,6 +380,7 @@ static unsigned typedArrayElementSize(ArrayBufferViewSubtag tag)
     case Int8ArrayTag:
     case Uint8ArrayTag:
     case Uint8ClampedArrayTag:
+    case Bun__NodeBufferTag:
         return 1;
     case Int16ArrayTag:
     case Uint16ArrayTag:
@@ -1350,9 +1357,15 @@ private:
             write(Uint8ClampedArrayTag);
         else if (obj->inherits<JSInt8Array>())
             write(Int8ArrayTag);
-        else if (obj->inherits<JSUint8Array>())
-            write(Uint8ArrayTag);
-        else if (obj->inherits<JSInt16Array>())
+        else if (obj->inherits<JSUint8Array>()) {
+            // Node's v8.serialize() round-trips Buffer as Buffer (it writes a host
+            // object tag for it); structuredClone()/postMessage() produce a plain
+            // Uint8Array in Node, so only NodeV8Serialize writes the Buffer subtag.
+            if (m_context == SerializationContext::NodeV8Serialize && JSBuffer__isBuffer(m_lexicalGlobalObject, JSValue::encode(JSValue(obj))))
+                write(Bun__NodeBufferTag);
+            else
+                write(Uint8ArrayTag);
+        } else if (obj->inherits<JSInt16Array>())
             write(Int16ArrayTag);
         else if (obj->inherits<JSUint16Array>())
             write(Uint16ArrayTag);
@@ -3812,6 +3825,23 @@ private:
         case BigUint64ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, BigUint64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
             return true;
+        case Bun__NodeBufferTag: {
+            // Written by node:v8's serialize() for Node.js Buffers: reconstruct with
+            // a Buffer structure so Buffer.isBuffer() is true after the round trip.
+            auto* globalObject = defaultGlobalObject(m_globalObject);
+            // Buffers over resizable/growable ArrayBuffers use a distinct structure;
+            // see constructFromArrayBuffer in JSBuffer.cpp.
+            JSC::Structure* structure = arrayBuffer->isResizableOrGrowableShared()
+                ? globalObject->JSResizableOrGrowableSharedBufferSubclassStructure()
+                : globalObject->JSBufferSubclassStructure();
+            RefPtr<Uint8Array> impl = Uint8Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length);
+            if (!impl) [[unlikely]] {
+                arrayBufferView = jsNull();
+                return true;
+            }
+            arrayBufferView = JSC::JSUint8Array::create(structure, m_lexicalGlobalObject, WTF::move(impl));
+            return true;
+        }
         default:
             return false;
         }

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3830,7 +3830,7 @@ private:
             // a Buffer structure so Buffer.isBuffer() is true after the round trip.
             auto* globalObject = defaultGlobalObject(m_globalObject);
             // Buffers over resizable/growable ArrayBuffers use a distinct structure;
-            // see constructFromArrayBuffer in JSBuffer.cpp.
+            // see constructBufferFromArrayBuffer in JSBuffer.cpp.
             JSC::Structure* structure = arrayBuffer->isResizableOrGrowableShared()
                 ? globalObject->JSResizableOrGrowableSharedBufferSubclassStructure()
                 : globalObject->JSBufferSubclassStructure();

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -103,7 +103,10 @@ enum class SerializationErrorMode { NonThrowing,
     Throwing };
 enum class SerializationContext { Default,
     WorkerPostMessage,
-    WindowPostMessage };
+    WindowPostMessage,
+    // Bun: node:v8's serialize(). Writes Node.js Buffers with their own subtag so
+    // they deserialize as Buffer, matching Node's DefaultSerializer.
+    NodeV8Serialize };
 enum class SerializationForStorage : bool { No,
     Yes };
 enum class SerializationForCrossProcessTransfer : bool { No,

--- a/src/jsc/bindings/webcore/StructuredClone.cpp
+++ b/src/jsc/bindings/webcore/StructuredClone.cpp
@@ -33,6 +33,7 @@
 #include "SerializedScriptValue.h"
 #include "MessagePort.h"
 #include "JSStructuredSerializeOptions.h"
+#include "ZigGlobalObject.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -211,6 +212,33 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredCloneAdvanced, (JSC::JSGlobalObject
     RETURN_IF_EXCEPTION(throwScope, {});
 
     return JSValue::encode(deserialized);
+}
+
+// node:v8's serialize(). Unlike the structured clone entry points above, Node.js
+// Buffers are tagged so they deserialize as Buffer rather than Uint8Array
+// (Node's DefaultSerializer writes them as host objects). Returns a Buffer.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeV8Serialize, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSValue value = callFrame->argument(0);
+
+    Vector<JSC::Strong<JSC::JSObject>> transferList;
+    Vector<RefPtr<MessagePort>> dummyPorts;
+    ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTF::move(transferList), dummyPorts,
+        SerializationForStorage::Yes, SerializationContext::NodeV8Serialize);
+    if (serialized.hasException()) {
+        WebCore::propagateException(*globalObject, throwScope, serialized.releaseException());
+        RELEASE_AND_RETURN(throwScope, {});
+    }
+    throwScope.assertNoException();
+
+    auto arrayBuffer = serialized.releaseReturnValue()->toArrayBuffer();
+    size_t byteLength = arrayBuffer->byteLength();
+    auto* result = JSC::JSUint8Array::create(globalObject, defaultGlobalObject(globalObject)->JSBufferSubclassStructure(), WTF::move(arrayBuffer), 0, byteLength);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    return JSValue::encode(result);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/StructuredClone.h
+++ b/src/jsc/bindings/webcore/StructuredClone.h
@@ -38,4 +38,5 @@ JSC_DECLARE_HOST_FUNCTION(cloneArrayBuffer);
 JSC_DECLARE_HOST_FUNCTION(structuredCloneForStream);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionStructuredClone);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionStructuredCloneAdvanced);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeV8Serialize);
 } // namespace WebCore

--- a/test/js/node/v8/v8-serialize.test.ts
+++ b/test/js/node/v8/v8-serialize.test.ts
@@ -1,0 +1,127 @@
+import { serialize as jscSerialize } from "bun:jsc";
+import { describe, expect, test } from "bun:test";
+import v8 from "node:v8";
+
+function roundTrip(value: any): any {
+  return v8.deserialize(v8.serialize(value));
+}
+
+// Node's v8.serialize()/deserialize() (DefaultSerializer) round-trips Buffer as
+// Buffer. structuredClone()/postMessage() deserialize Buffer as a plain
+// Uint8Array in Node, so those must keep doing that.
+describe("v8.serialize + v8.deserialize", () => {
+  test("serialize returns a Buffer", () => {
+    const serialized = v8.serialize(123);
+    expect(Buffer.isBuffer(serialized)).toBe(true);
+    expect(v8.deserialize(serialized)).toBe(123);
+  });
+
+  test("Buffer round-trips as Buffer", () => {
+    const input = Buffer.from("hello");
+    const output = roundTrip(input);
+    expect(Buffer.isBuffer(output)).toBe(true);
+    expect(output).toBeInstanceOf(Buffer);
+    expect(output.constructor.name).toBe("Buffer");
+    expect(output.toString("utf8")).toBe("hello");
+    expect(output.equals(input)).toBe(true);
+    expect(output).not.toBe(input);
+  });
+
+  test("empty Buffer round-trips as Buffer", () => {
+    const output = roundTrip(Buffer.alloc(0));
+    expect(Buffer.isBuffer(output)).toBe(true);
+    expect(output.byteLength).toBe(0);
+  });
+
+  test("Buffers nested in objects, arrays, Maps and Sets round-trip as Buffer", () => {
+    const output = roundTrip({
+      b: Buffer.from("hello"),
+      arr: [Buffer.from("y")],
+      m: new Map([["k", Buffer.from("x")]]),
+      s: new Set([Buffer.from("z")]),
+    });
+    expect(Buffer.isBuffer(output.b)).toBe(true);
+    expect(Buffer.isBuffer(output.arr[0])).toBe(true);
+    expect(Buffer.isBuffer(output.m.get("k"))).toBe(true);
+    expect(Buffer.isBuffer([...output.s][0])).toBe(true);
+    expect(output.b.toString("utf8")).toBe("hello");
+    expect(output.m.get("k").toString("utf8")).toBe("x");
+  });
+
+  test("Buffer with a non-zero byteOffset keeps its contents", () => {
+    const output = roundTrip(Buffer.from("abcdefgh").subarray(2, 5));
+    expect(Buffer.isBuffer(output)).toBe(true);
+    expect(output.byteLength).toBe(3);
+    expect(output.toString("utf8")).toBe("cde");
+  });
+
+  test("deserialized Buffer supports Buffer methods", () => {
+    const output = roundTrip(Buffer.from([0xde, 0xad, 0xbe, 0xef]));
+    expect(output.toString("hex")).toBe("deadbeef");
+    expect(output.readUInt32BE(0)).toBe(0xdeadbeef);
+  });
+
+  test("the same Buffer referenced twice deserializes to the same Buffer", () => {
+    const buf = Buffer.from("dup");
+    const output = roundTrip({ a: buf, b: buf });
+    expect(Buffer.isBuffer(output.a)).toBe(true);
+    expect(output.a).toBe(output.b);
+  });
+
+  test("Buffer backed by a resizable ArrayBuffer round-trips as Buffer", () => {
+    const resizable = new ArrayBuffer(8, { maxByteLength: 16 });
+    const input = Buffer.from(resizable, 0, 8);
+    input.fill(7);
+    const output = roundTrip(input);
+    expect(Buffer.isBuffer(output)).toBe(true);
+    expect([...output]).toEqual([7, 7, 7, 7, 7, 7, 7, 7]);
+  });
+
+  test("Uint8Array and other ArrayBufferViews do not become Buffers", () => {
+    const output = roundTrip({
+      u8: new Uint8Array([1, 2, 3]),
+      u8c: new Uint8ClampedArray([4]),
+      i32: new Int32Array([5, 6]),
+      dv: new DataView(new ArrayBuffer(4)),
+    });
+    expect(Buffer.isBuffer(output.u8)).toBe(false);
+    expect(output.u8.constructor.name).toBe("Uint8Array");
+    expect(output.u8).toEqual(new Uint8Array([1, 2, 3]));
+    expect(output.u8c.constructor.name).toBe("Uint8ClampedArray");
+    expect(output.i32).toEqual(new Int32Array([5, 6]));
+    expect(output.dv.constructor.name).toBe("DataView");
+  });
+
+  test("blobs without the Buffer tag still deserialize as Uint8Array", () => {
+    // bun:jsc's serialize uses structured clone semantics: no Buffer tag.
+    const output = v8.deserialize(jscSerialize({ b: Buffer.from("x") }, { binaryType: "nodebuffer" }));
+    expect(Buffer.isBuffer(output.b)).toBe(false);
+    expect(output.b.constructor.name).toBe("Uint8Array");
+    expect(output.b).toEqual(new Uint8Array([120]));
+  });
+
+  test("structuredClone still produces Uint8Array, not Buffer", () => {
+    const cloned = structuredClone({ b: Buffer.from("sc") });
+    expect(Buffer.isBuffer(cloned.b)).toBe(false);
+    expect(cloned.b.constructor.name).toBe("Uint8Array");
+    expect(cloned.b).toEqual(new Uint8Array([115, 99]));
+  });
+
+  test("MessagePort.postMessage still delivers Uint8Array, not Buffer", async () => {
+    const { port1, port2 } = new MessageChannel();
+    try {
+      const received = new Promise<any>((resolve, reject) => {
+        port2.onmessage = event => resolve(event.data);
+        port2.onmessageerror = reject;
+      });
+      port1.postMessage({ b: Buffer.from("pm") });
+      const data = await received;
+      expect(Buffer.isBuffer(data.b)).toBe(false);
+      expect(data.b.constructor.name).toBe("Uint8Array");
+      expect(data.b).toEqual(new Uint8Array([112, 109]));
+    } finally {
+      port1.close();
+      port2.close();
+    }
+  });
+});


### PR DESCRIPTION
### Problem

`v8.deserialize(v8.serialize(buf))` returns a plain `Uint8Array` instead of a `Buffer`, top-level and nested:

```js
const v8 = require("node:v8");
const back = v8.deserialize(v8.serialize({ b: Buffer.from("hello"), m: new Map([["k", Buffer.from("x")]]) }));
back.b.constructor.name;          // node: "Buffer"   bun: "Uint8Array"
Buffer.isBuffer(back.m.get("k")); // node: true       bun: false
```

Every consumer that gates on `Buffer.isBuffer()` or calls Buffer methods (`.toString("hex")`, `.readUInt32BE(...)`) on a deserialized value misbehaves. Node's `v8.serialize` (DefaultSerializer) writes Buffers as host objects and reconstructs them as Buffers.

### Cause

`node:v8`'s `serialize` goes through the structured clone serializer (`SerializedScriptValue`), which encodes every `Uint8Array` view, including Buffers, with the `Uint8ArrayTag` subtag. Deserialization always rebuilds a plain `Uint8Array`, so the Buffer prototype is lost.

### Fix

- `node:v8`'s `serialize()` now uses its own native entry point (`jsFunctionNodeV8Serialize`) that serializes under a new `SerializationContext::NodeV8Serialize`.
- In that context only, the serializer writes a Bun-specific ArrayBufferView subtag (`Bun__NodeBufferTag = 254`, counting down from 254 so it can't collide with future WebKit subtags) for views that are Buffers.
- The deserializer rebuilds views with that subtag using the Buffer structure (or the resizable-backed Buffer structure, mirroring `constructBufferFromArrayBuffer` in JSBuffer.cpp), so `Buffer.isBuffer()`, `instanceof Buffer`, and Buffer methods work after `deserialize`.

`structuredClone()` and `postMessage()` are intentionally unchanged: Node also delivers plain `Uint8Array`s there, and blobs that contain no Buffers are byte-for-byte identical to before. Blobs produced by older versions of Bun still deserialize (the subtag is additive). `child_process` advanced IPC (which also preserves Buffers in Node) is a separate entry point with cross-version wire-compat implications between Bun processes, so it is not changed here.

Also makes the existing `node:v8` compat note in `docs/runtime/nodejs-compat.mdx` explicit that the wire format is JavaScriptCore's, so blobs are not interchangeable with Node.js.

### Verification

New tests in `test/js/node/v8/v8-serialize.test.ts` cover top-level/nested/Map/Set Buffers, byteOffset views, resizable-backed Buffers, duplicate references, Buffer methods on the result, and the negative contracts (plain `Uint8Array` and other views stay what they are; `structuredClone`/`postMessage` still produce `Uint8Array`; old-format blobs still deserialize).

```
bun bd test test/js/node/v8/v8-serialize.test.ts   # 12 pass
USE_SYSTEM_BUN=1 bun test test/.../v8-serialize.test.ts  # 7 fail on 1.4.0 (Buffer-ness lost), 5 pass
```

