### PR TITLE
perf_hooks: emit 'dns' observer entries, stop advertising 'resource'

### DIFF
--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -288,10 +288,13 @@ function observeLookup(hostname, options, promise) {
   });
   return promise.then(res => {
     // An empty result reaches the caller as ENODATA (see throwIfEmpty), so it
-    // records nothing, like every other failed lookup. The recorded addresses
-    // are ordered the way the caller will receive them.
-    if (res.length)
-      stopPerf(ctx, kPerfEntry, { detail: { addresses: sortByOrder(res, options.order).map(mapResolveX) } });
+    // records nothing, like every other failed lookup. The addresses are
+    // recorded in the shape and order the caller receives them.
+    if (res.length) {
+      sortByOrder(res, options.order);
+      const addresses = options.all ? res.map(mapLookupAll) : res.map(mapResolveX);
+      stopPerf(ctx, kPerfEntry, { detail: { addresses } });
+    }
     return res;
   });
 }

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -944,7 +944,8 @@ const promises = {
           query = query.then(promisifyResolveX(false));
           break;
       }
-      return translateErrorCode(observeQuery(queryNameFor(rrtype), hostname, query));
+      // The native resolver treats the null rrtype above as an A query.
+      return translateErrorCode(observeQuery(queryNameFor(rrtype ?? "A"), hostname, query));
     }
 
     resolve4(hostname, options) {

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -313,8 +313,7 @@ function observeLookupService(host, port, promise) {
 
 // `name` is Node's c-ares binding (and entry) name for the operation, e.g.
 // resolve4 -> "queryA", reverse -> "getHostByAddr". `detail.result` records
-// the promise's value, so callers pass the promise the user will observe:
-// https://github.com/nodejs/node/blob/v25.2.1/lib/internal/dns/promises.js#L288-L330
+// the wrapped promise's value, so callers pass the one the user observes.
 function observeQuery(name, host, promise, ttl?) {
   if (!hasObserver("dns")) return promise;
   const ctx = {};

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -287,7 +287,9 @@ function observeLookup(hostname, options, promise) {
     },
   });
   return promise.then(res => {
-    stopPerf(ctx, kPerfEntry, { detail: { addresses: res.map(mapResolveX) } });
+    // An empty result reaches the caller as ENODATA (see throwIfEmpty), so it
+    // records nothing, like every other failed lookup.
+    if (res.length) stopPerf(ctx, kPerfEntry, { detail: { addresses: res.map(mapResolveX) } });
     return res;
   });
 }
@@ -304,9 +306,10 @@ function observeLookupService(host, port, promise) {
   });
 }
 
-// `name` is the c-ares binding Node uses for the operation, which is also the
-// entry name Node reports: resolve4 -> "queryA", reverse -> "getHostByAddr".
-// https://github.com/nodejs/node/blob/v25.2.1/lib/internal/dns/promises.js#L306-L330
+// `name` is Node's c-ares binding (and entry) name for the operation, e.g.
+// resolve4 -> "queryA", reverse -> "getHostByAddr". `detail.result` records
+// the promise's value, so callers pass the promise the user will observe:
+// https://github.com/nodejs/node/blob/v25.2.1/lib/internal/dns/promises.js#L288-L330
 function observeQuery(name, host, promise, ttl?) {
   if (!hasObserver("dns")) return promise;
   const ctx = {};
@@ -470,17 +473,16 @@ var InternalResolver = class Resolver {
 
     validateResolve(hostname, callback);
 
-    observeQuery(queryNameFor(rrtype), hostname, Resolver.#getResolver(this).resolve(hostname, rrtype)).then(
+    let query = Resolver.#getResolver(this).resolve(hostname, rrtype);
+    switch (rrtype?.toLowerCase()) {
+      case "a":
+      case "aaaa":
+        query = query.then(promisifyResolveX(false));
+        break;
+    }
+    observeQuery(queryNameFor(rrtype), hostname, query).then(
       results => {
-        switch (rrtype?.toLowerCase()) {
-          case "a":
-          case "aaaa":
-            callback(null, results.map(mapResolveX));
-            break;
-          default:
-            callback(null, results);
-            break;
-        }
+        callback(null, results);
       },
       error => {
         callback(withTranslatedError(error));
@@ -496,9 +498,14 @@ var InternalResolver = class Resolver {
 
     validateResolve(hostname, callback);
 
-    observeQuery("queryA", hostname, Resolver.#getResolver(this).resolve(hostname, "A"), options?.ttl).then(
+    observeQuery(
+      "queryA",
+      hostname,
+      Resolver.#getResolver(this).resolve(hostname, "A").then(promisifyResolveX(options?.ttl)),
+      options?.ttl,
+    ).then(
       addresses => {
-        callback(null, options?.ttl ? addresses : addresses.map(mapResolveX));
+        callback(null, addresses);
       },
       error => {
         callback(withTranslatedError(error));
@@ -514,9 +521,14 @@ var InternalResolver = class Resolver {
 
     validateResolve(hostname, callback);
 
-    observeQuery("queryAaaa", hostname, Resolver.#getResolver(this).resolve(hostname, "AAAA"), options?.ttl).then(
+    observeQuery(
+      "queryAaaa",
+      hostname,
+      Resolver.#getResolver(this).resolve(hostname, "AAAA").then(promisifyResolveX(options?.ttl)),
+      options?.ttl,
+    ).then(
       addresses => {
-        callback(null, options?.ttl ? addresses : addresses.map(mapResolveX));
+        callback(null, addresses);
       },
       error => {
         callback(withTranslatedError(error));
@@ -834,26 +846,29 @@ const promises = {
       throw $ERR_INVALID_ARG_TYPE("rrtype", "string", rrtype);
     }
 
-    const res = observeQuery(queryNameFor(rrtype), hostname, dns.resolve(hostname, rrtype));
+    let query = dns.resolve(hostname, rrtype);
     switch (rrtype?.toLowerCase()) {
       case "a":
       case "aaaa":
-        return translateErrorCode(res.then(promisifyResolveX(false)));
-      default:
-        return translateErrorCode(res);
+        query = query.then(promisifyResolveX(false));
+        break;
     }
+    return translateErrorCode(observeQuery(queryNameFor(rrtype), hostname, query));
   },
 
   resolve4(hostname, options) {
     return translateErrorCode(
-      observeQuery("queryA", hostname, dns.resolve(hostname, "A"), options?.ttl).then(promisifyResolveX(options?.ttl)),
+      observeQuery("queryA", hostname, dns.resolve(hostname, "A").then(promisifyResolveX(options?.ttl)), options?.ttl),
     );
   },
 
   resolve6(hostname, options) {
     return translateErrorCode(
-      observeQuery("queryAaaa", hostname, dns.resolve(hostname, "AAAA"), options?.ttl).then(
-        promisifyResolveX(options?.ttl),
+      observeQuery(
+        "queryAaaa",
+        hostname,
+        dns.resolve(hostname, "AAAA").then(promisifyResolveX(options?.ttl)),
+        options?.ttl,
       ),
     );
   },
@@ -918,28 +933,34 @@ const promises = {
       } else if (typeof rrtype !== "string") {
         rrtype = null;
       }
-      const res = observeQuery(queryNameFor(rrtype), hostname, Resolver.#getResolver(this).resolve(hostname, rrtype));
+      let query = Resolver.#getResolver(this).resolve(hostname, rrtype);
       switch (rrtype?.toLowerCase()) {
         case "a":
         case "aaaa":
-          return translateErrorCode(res.then(promisifyResolveX(false)));
-        default:
-          return translateErrorCode(res);
+          query = query.then(promisifyResolveX(false));
+          break;
       }
+      return translateErrorCode(observeQuery(queryNameFor(rrtype), hostname, query));
     }
 
     resolve4(hostname, options) {
       return translateErrorCode(
-        observeQuery("queryA", hostname, Resolver.#getResolver(this).resolve(hostname, "A"), options?.ttl).then(
-          promisifyResolveX(options?.ttl),
+        observeQuery(
+          "queryA",
+          hostname,
+          Resolver.#getResolver(this).resolve(hostname, "A").then(promisifyResolveX(options?.ttl)),
+          options?.ttl,
         ),
       );
     }
 
     resolve6(hostname, options) {
       return translateErrorCode(
-        observeQuery("queryAaaa", hostname, Resolver.#getResolver(this).resolve(hostname, "AAAA"), options?.ttl).then(
-          promisifyResolveX(options?.ttl),
+        observeQuery(
+          "queryAaaa",
+          hostname,
+          Resolver.#getResolver(this).resolve(hostname, "AAAA").then(promisifyResolveX(options?.ttl)),
+          options?.ttl,
         ),
       );
     }

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -282,14 +282,16 @@ function observeLookup(hostname, options, promise) {
       hostname,
       family: options.family ?? 0,
       hints: options.flags ?? 0,
-      verbatim: options.order !== "ipv4first",
+      verbatim: options.order === "verbatim",
       order: options.order,
     },
   });
   return promise.then(res => {
     // An empty result reaches the caller as ENODATA (see throwIfEmpty), so it
-    // records nothing, like every other failed lookup.
-    if (res.length) stopPerf(ctx, kPerfEntry, { detail: { addresses: res.map(mapResolveX) } });
+    // records nothing, like every other failed lookup. The recorded addresses
+    // are ordered the way the caller will receive them.
+    if (res.length)
+      stopPerf(ctx, kPerfEntry, { detail: { addresses: sortByOrder(res, options.order).map(mapResolveX) } });
     return res;
   });
 }
@@ -325,6 +327,17 @@ function observeQuery(name, host, promise, ttl?) {
 function queryNameFor(rrtype) {
   rrtype = "" + rrtype;
   return "query" + rrtype.charAt(0).toUpperCase() + rrtype.slice(1).toLowerCase();
+}
+
+// Applies the requested result order to `res` in place and returns it.
+// Re-applying it is a no-op, so observeLookup may run it before the caller.
+function sortByOrder(res, order) {
+  if (order == "ipv4first") {
+    res.sort((a, b) => a.family - b.family);
+  } else if (order == "ipv6first") {
+    res.sort((a, b) => b.family - a.family);
+  }
+  return res;
 }
 
 function lookup(hostname, options, callback) {
@@ -373,11 +386,7 @@ function lookup(hostname, options, callback) {
     .then(res => {
       throwIfEmpty(res);
 
-      if (options.order == "ipv4first") {
-        res.sort((a, b) => a.family - b.family);
-      } else if (options.order == "ipv6first") {
-        res.sort((a, b) => b.family - a.family);
-      }
+      sortByOrder(res, options.order);
 
       if (options?.all) {
         callback(null, res.map(mapLookupAll));
@@ -738,22 +747,14 @@ Object.defineProperty(throwIfEmpty, "name", { value: "::bunternal::" });
 
 const promisifyLookup = order => res => {
   throwIfEmpty(res);
-  if (order == "ipv4first") {
-    res.sort((a, b) => a.family - b.family);
-  } else if (order == "ipv6first") {
-    res.sort((a, b) => b.family - a.family);
-  }
+  sortByOrder(res, order);
   const [{ address, family }] = res;
   return { address, family };
 };
 
 const promisifyLookupAll = order => res => {
   throwIfEmpty(res);
-  if (order == "ipv4first") {
-    res.sort((a, b) => a.family - b.family);
-  } else if (order == "ipv6first") {
-    res.sort((a, b) => b.family - a.family);
-  }
+  sortByOrder(res, order);
   return res.map(mapLookupAll);
 };
 

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -2,6 +2,7 @@
 const dns = Bun.dns;
 const utilPromisifyCustomSymbol = Symbol.for("nodejs.util.promisify.custom");
 const { isIP } = require("internal/net/isIP");
+const { hasObserver, startPerf, stopPerf } = require("internal/shared");
 const {
   validateFunction,
   validateArray,
@@ -264,6 +265,65 @@ function validateLookupOptions(options) {
   validateOrderOption(options);
 }
 
+// node:perf_hooks 'dns' entries. As in Node, an entry is recorded only when
+// the resolver operation was dispatched and completed successfully; each
+// helper wraps the native promise and is free when nothing observes 'dns'.
+const kPerfEntry = Symbol("kPerfEntry");
+
+// Detail fields mirror lib/dns.js `lookup`:
+// https://github.com/nodejs/node/blob/v25.2.1/lib/dns.js#L229-L248
+function observeLookup(hostname, options, promise) {
+  if (!hasObserver("dns")) return promise;
+  const ctx = {};
+  startPerf(ctx, kPerfEntry, {
+    type: "dns",
+    name: "lookup",
+    detail: {
+      hostname,
+      family: options.family ?? 0,
+      hints: options.flags ?? 0,
+      verbatim: options.order !== "ipv4first",
+      order: options.order,
+    },
+  });
+  return promise.then(res => {
+    stopPerf(ctx, kPerfEntry, { detail: { addresses: res.map(mapResolveX) } });
+    return res;
+  });
+}
+
+// https://github.com/nodejs/node/blob/v25.2.1/lib/dns.js#L255-L296
+function observeLookupService(host, port, promise) {
+  if (!hasObserver("dns")) return promise;
+  const ctx = {};
+  startPerf(ctx, kPerfEntry, { type: "dns", name: "lookupService", detail: { host, port } });
+  return promise.then(res => {
+    // The native lookupService promise resolves with a [hostname, service] pair.
+    stopPerf(ctx, kPerfEntry, { detail: { hostname: res[0], service: res[1] } });
+    return res;
+  });
+}
+
+// `name` is the c-ares binding Node uses for the operation, which is also the
+// entry name Node reports: resolve4 -> "queryA", reverse -> "getHostByAddr".
+// https://github.com/nodejs/node/blob/v25.2.1/lib/internal/dns/promises.js#L306-L330
+function observeQuery(name, host, promise, ttl?) {
+  if (!hasObserver("dns")) return promise;
+  const ctx = {};
+  startPerf(ctx, kPerfEntry, { type: "dns", name, detail: { host, ttl: !!ttl } });
+  return promise.then(result => {
+    stopPerf(ctx, kPerfEntry, { detail: { result } });
+    return result;
+  });
+}
+
+// resolve(hostname, "MX") records the same entry name as resolveMx():
+// https://github.com/nodejs/node/blob/v25.2.1/lib/internal/dns/utils.js#L293-L307
+function queryNameFor(rrtype) {
+  rrtype = "" + rrtype;
+  return "query" + rrtype.charAt(0).toUpperCase() + rrtype.slice(1).toLowerCase();
+}
+
 function lookup(hostname, options, callback) {
   if (typeof hostname !== "string" && hostname) {
     throw $ERR_INVALID_ARG_TYPE("hostname", "string", hostname);
@@ -306,8 +366,7 @@ function lookup(hostname, options, callback) {
     return;
   }
 
-  dns
-    .lookup(hostname, options)
+  observeLookup(hostname, options, dns.lookup(hostname, options))
     .then(res => {
       throwIfEmpty(res);
 
@@ -348,7 +407,7 @@ function lookupService(address, port, callback) {
 
   validateString(address);
 
-  dns.lookupService(address, port).then(
+  observeLookupService(address, port, dns.lookupService(address, port)).then(
     results => {
       callback(null, ...results);
     },
@@ -411,24 +470,22 @@ var InternalResolver = class Resolver {
 
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolve(hostname, rrtype)
-      .then(
-        results => {
-          switch (rrtype?.toLowerCase()) {
-            case "a":
-            case "aaaa":
-              callback(null, results.map(mapResolveX));
-              break;
-            default:
-              callback(null, results);
-              break;
-          }
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery(queryNameFor(rrtype), hostname, Resolver.#getResolver(this).resolve(hostname, rrtype)).then(
+      results => {
+        switch (rrtype?.toLowerCase()) {
+          case "a":
+          case "aaaa":
+            callback(null, results.map(mapResolveX));
+            break;
+          default:
+            callback(null, results);
+            break;
+        }
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolve4(hostname, options, callback) {
@@ -439,16 +496,14 @@ var InternalResolver = class Resolver {
 
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolve(hostname, "A")
-      .then(
-        addresses => {
-          callback(null, options?.ttl ? addresses : addresses.map(mapResolveX));
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryA", hostname, Resolver.#getResolver(this).resolve(hostname, "A"), options?.ttl).then(
+      addresses => {
+        callback(null, options?.ttl ? addresses : addresses.map(mapResolveX));
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolve6(hostname, options, callback) {
@@ -459,121 +514,105 @@ var InternalResolver = class Resolver {
 
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolve(hostname, "AAAA")
-      .then(
-        addresses => {
-          callback(null, options?.ttl ? addresses : addresses.map(mapResolveX));
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryAaaa", hostname, Resolver.#getResolver(this).resolve(hostname, "AAAA"), options?.ttl).then(
+      addresses => {
+        callback(null, options?.ttl ? addresses : addresses.map(mapResolveX));
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolveAny(hostname, callback) {
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolveAny(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryAny", hostname, Resolver.#getResolver(this).resolveAny(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolveCname(hostname, callback) {
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolveCname(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryCname", hostname, Resolver.#getResolver(this).resolveCname(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolveMx(hostname, callback) {
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolveMx(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryMx", hostname, Resolver.#getResolver(this).resolveMx(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolveNaptr(hostname, callback) {
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolveNaptr(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryNaptr", hostname, Resolver.#getResolver(this).resolveNaptr(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolveNs(hostname, callback) {
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolveNs(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryNs", hostname, Resolver.#getResolver(this).resolveNs(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolvePtr(hostname, callback) {
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolvePtr(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryPtr", hostname, Resolver.#getResolver(this).resolvePtr(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolveSrv(hostname, callback) {
     validateResolve(hostname, callback);
 
-    Resolver.#getResolver(this)
-      .resolveSrv(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("querySrv", hostname, Resolver.#getResolver(this).resolveSrv(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolveCaa(hostname, callback) {
@@ -581,16 +620,14 @@ var InternalResolver = class Resolver {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
     }
 
-    Resolver.#getResolver(this)
-      .resolveCaa(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryCaa", hostname, Resolver.#getResolver(this).resolveCaa(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   resolveTxt(hostname, callback) {
@@ -598,32 +635,28 @@ var InternalResolver = class Resolver {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
     }
 
-    Resolver.#getResolver(this)
-      .resolveTxt(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("queryTxt", hostname, Resolver.#getResolver(this).resolveTxt(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
   resolveSoa(hostname, callback) {
     if (typeof callback !== "function") {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
     }
 
-    Resolver.#getResolver(this)
-      .resolveSoa(hostname)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("querySoa", hostname, Resolver.#getResolver(this).resolveSoa(hostname)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   reverse(ip, callback) {
@@ -631,16 +664,14 @@ var InternalResolver = class Resolver {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
     }
 
-    Resolver.#getResolver(this)
-      .reverse(ip)
-      .then(
-        results => {
-          callback(null, results);
-        },
-        error => {
-          callback(withTranslatedError(error));
-        },
-      );
+    observeQuery("getHostByAddr", ip, Resolver.#getResolver(this).reverse(ip)).then(
+      results => {
+        callback(null, results);
+      },
+      error => {
+        callback(withTranslatedError(error));
+      },
+    );
   }
 
   setLocalAddress(first, second) {
@@ -763,10 +794,11 @@ const promises = {
       return Promise.$resolve(options.all ? [obj] : obj);
     }
 
+    const res = observeLookup(hostname, options, dns.lookup(hostname, options));
     if (options.all) {
-      return translateErrorCode(dns.lookup(hostname, options).then(promisifyLookupAll(options.order)));
+      return translateErrorCode(res.then(promisifyLookupAll(options.order)));
     }
-    return translateErrorCode(dns.lookup(hostname, options).then(promisifyLookup(options.order)));
+    return translateErrorCode(res.then(promisifyLookup(options.order)));
   },
 
   lookupService(address, port) {
@@ -777,10 +809,12 @@ const promises = {
     validateString(address);
 
     try {
-      return translateErrorCode(dns.lookupService(address, port)).then(([hostname, service]) => ({
-        hostname,
-        service,
-      }));
+      return translateErrorCode(observeLookupService(address, port, dns.lookupService(address, port))).then(
+        ([hostname, service]) => ({
+          hostname,
+          service,
+        }),
+      );
     } catch (err) {
       if (err.name === "TypeError" || err.name === "RangeError") {
         throw err;
@@ -800,55 +834,62 @@ const promises = {
       throw $ERR_INVALID_ARG_TYPE("rrtype", "string", rrtype);
     }
 
+    const res = observeQuery(queryNameFor(rrtype), hostname, dns.resolve(hostname, rrtype));
     switch (rrtype?.toLowerCase()) {
       case "a":
       case "aaaa":
-        return translateErrorCode(dns.resolve(hostname, rrtype).then(promisifyResolveX(false)));
+        return translateErrorCode(res.then(promisifyResolveX(false)));
       default:
-        return translateErrorCode(dns.resolve(hostname, rrtype));
+        return translateErrorCode(res);
     }
   },
 
   resolve4(hostname, options) {
-    return translateErrorCode(dns.resolve(hostname, "A").then(promisifyResolveX(options?.ttl)));
+    return translateErrorCode(
+      observeQuery("queryA", hostname, dns.resolve(hostname, "A"), options?.ttl).then(promisifyResolveX(options?.ttl)),
+    );
   },
 
   resolve6(hostname, options) {
-    return translateErrorCode(dns.resolve(hostname, "AAAA").then(promisifyResolveX(options?.ttl)));
+    return translateErrorCode(
+      observeQuery("queryAaaa", hostname, dns.resolve(hostname, "AAAA"), options?.ttl).then(
+        promisifyResolveX(options?.ttl),
+      ),
+    );
   },
 
   resolveAny(hostname) {
-    return translateErrorCode(dns.resolveAny(hostname));
+    return translateErrorCode(observeQuery("queryAny", hostname, dns.resolveAny(hostname)));
   },
   resolveSrv(hostname) {
-    return translateErrorCode(dns.resolveSrv(hostname));
+    return translateErrorCode(observeQuery("querySrv", hostname, dns.resolveSrv(hostname)));
   },
   resolveTxt(hostname) {
-    return translateErrorCode(dns.resolveTxt(hostname));
+    return translateErrorCode(observeQuery("queryTxt", hostname, dns.resolveTxt(hostname)));
   },
   resolveSoa(hostname) {
-    return translateErrorCode(dns.resolveSoa(hostname));
+    return translateErrorCode(observeQuery("querySoa", hostname, dns.resolveSoa(hostname)));
   },
   resolveNaptr(hostname) {
-    return translateErrorCode(dns.resolveNaptr(hostname));
+    return translateErrorCode(observeQuery("queryNaptr", hostname, dns.resolveNaptr(hostname)));
   },
   resolveMx(hostname) {
-    return translateErrorCode(dns.resolveMx(hostname));
+    return translateErrorCode(observeQuery("queryMx", hostname, dns.resolveMx(hostname)));
   },
   resolveCaa(hostname) {
-    return translateErrorCode(dns.resolveCaa(hostname));
+    return translateErrorCode(observeQuery("queryCaa", hostname, dns.resolveCaa(hostname)));
   },
   resolveNs(hostname) {
-    return translateErrorCode(dns.resolveNs(hostname));
+    return translateErrorCode(observeQuery("queryNs", hostname, dns.resolveNs(hostname)));
   },
   resolvePtr(hostname) {
-    return translateErrorCode(dns.resolvePtr(hostname));
+    return translateErrorCode(observeQuery("queryPtr", hostname, dns.resolvePtr(hostname)));
   },
   resolveCname(hostname) {
-    return translateErrorCode(dns.resolveCname(hostname));
+    return translateErrorCode(observeQuery("queryCname", hostname, dns.resolveCname(hostname)));
   },
   reverse(ip) {
-    return translateErrorCode(dns.reverse(ip));
+    return translateErrorCode(observeQuery("getHostByAddr", ip, dns.reverse(ip)));
   },
 
   Resolver: class Resolver {
@@ -877,71 +918,78 @@ const promises = {
       } else if (typeof rrtype !== "string") {
         rrtype = null;
       }
+      const res = observeQuery(queryNameFor(rrtype), hostname, Resolver.#getResolver(this).resolve(hostname, rrtype));
       switch (rrtype?.toLowerCase()) {
         case "a":
         case "aaaa":
-          return translateErrorCode(
-            Resolver.#getResolver(this).resolve(hostname, rrtype).then(promisifyResolveX(false)),
-          );
+          return translateErrorCode(res.then(promisifyResolveX(false)));
         default:
-          return translateErrorCode(Resolver.#getResolver(this).resolve(hostname, rrtype));
+          return translateErrorCode(res);
       }
     }
 
     resolve4(hostname, options) {
       return translateErrorCode(
-        Resolver.#getResolver(this).resolve(hostname, "A").then(promisifyResolveX(options?.ttl)),
+        observeQuery("queryA", hostname, Resolver.#getResolver(this).resolve(hostname, "A"), options?.ttl).then(
+          promisifyResolveX(options?.ttl),
+        ),
       );
     }
 
     resolve6(hostname, options) {
       return translateErrorCode(
-        Resolver.#getResolver(this).resolve(hostname, "AAAA").then(promisifyResolveX(options?.ttl)),
+        observeQuery("queryAaaa", hostname, Resolver.#getResolver(this).resolve(hostname, "AAAA"), options?.ttl).then(
+          promisifyResolveX(options?.ttl),
+        ),
       );
     }
 
     resolveAny(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveAny(hostname));
+      return translateErrorCode(observeQuery("queryAny", hostname, Resolver.#getResolver(this).resolveAny(hostname)));
     }
 
     resolveCname(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveCname(hostname));
+      return translateErrorCode(
+        observeQuery("queryCname", hostname, Resolver.#getResolver(this).resolveCname(hostname)),
+      );
     }
 
     resolveMx(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveMx(hostname));
+      return translateErrorCode(observeQuery("queryMx", hostname, Resolver.#getResolver(this).resolveMx(hostname)));
     }
 
     resolveNaptr(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveNaptr(hostname));
+      return translateErrorCode(
+        observeQuery("queryNaptr", hostname, Resolver.#getResolver(this).resolveNaptr(hostname)),
+      );
     }
 
     resolveNs(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveNs(hostname));
+      return translateErrorCode(observeQuery("queryNs", hostname, Resolver.#getResolver(this).resolveNs(hostname)));
     }
 
     resolvePtr(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolvePtr(hostname));
+      return translateErrorCode(observeQuery("queryPtr", hostname, Resolver.#getResolver(this).resolvePtr(hostname)));
     }
 
     resolveSoa(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveSoa(hostname));
+      return translateErrorCode(observeQuery("querySoa", hostname, Resolver.#getResolver(this).resolveSoa(hostname)));
     }
 
     resolveSrv(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveSrv(hostname));
+      return translateErrorCode(observeQuery("querySrv", hostname, Resolver.#getResolver(this).resolveSrv(hostname)));
     }
 
     resolveCaa(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveCaa(hostname));
+      return translateErrorCode(observeQuery("queryCaa", hostname, Resolver.#getResolver(this).resolveCaa(hostname)));
     }
 
     resolveTxt(hostname) {
-      return translateErrorCode(Resolver.#getResolver(this).resolveTxt(hostname));
+      return translateErrorCode(observeQuery("queryTxt", hostname, Resolver.#getResolver(this).resolveTxt(hostname)));
     }
 
     reverse(ip) {
-      return translateErrorCode(Resolver.#getResolver(this).reverse(ip));
+      return translateErrorCode(observeQuery("getHostByAddr", ip, Resolver.#getResolver(this).reverse(ip)));
     }
 
     setLocalAddress(first, second) {

--- a/src/jsc/bindings/webcore/PerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/PerformanceObserver.cpp
@@ -147,10 +147,12 @@ void PerformanceObserver::deliver()
 
 Vector<String> PerformanceObserver::supportedEntryTypes(ScriptExecutionContext& context)
 {
+    // This list is the feature-detection surface: a type belongs here only if
+    // an entry of that type can exist. Nothing in Bun calls
+    // Performance::addResourceTiming, so "resource" is not advertised.
     Vector<String> entryTypes = {
         "mark"_s,
-        "measure"_s,
-        "resource"_s
+        "measure"_s
     };
 
     // if (context.settingsValues().performanceNavigationTimingAPIEnabled)

--- a/test/js/node/perf_hooks/dns-entries-fixture.ts
+++ b/test/js/node/perf_hooks/dns-entries-fixture.ts
@@ -56,7 +56,7 @@ observer.observe({ entryTypes: ["dns", "resource"] });
 
 // Each operation is awaited so the entries are recorded in a fixed order.
 await new Promise((resolve, reject) => dns.lookup("localhost", error => (error ? reject(error) : resolve(undefined))));
-await dns.promises.lookup("localhost");
+await dns.promises.lookup("localhost", { order: "ipv6first" });
 await new Promise((resolve, reject) =>
   dns.lookupService("127.0.0.1", 80, error => (error ? reject(error) : resolve(undefined))),
 );

--- a/test/js/node/perf_hooks/dns-entries-fixture.ts
+++ b/test/js/node/perf_hooks/dns-entries-fixture.ts
@@ -1,8 +1,6 @@
-// Fixture for perf_hooks.test.ts ("node:dns operations are observable ...").
-// A local UDP DNS server answers every A/TXT/PTR query so the 'dns'
-// performance entries asserted by the parent test are produced without a real
-// resolver. Runs in its own process because it repoints the default resolver
-// at the local server with dns.setServers().
+// Fixture for perf_hooks.test.ts: a local UDP DNS server answers the A/TXT/PTR
+// queries so the asserted 'dns' entries are produced without a real resolver.
+// Runs in its own process because dns.setServers() repoints the default resolver.
 import dgram from "node:dgram";
 import dns from "node:dns";
 import { once } from "node:events";

--- a/test/js/node/perf_hooks/dns-entries-fixture.ts
+++ b/test/js/node/perf_hooks/dns-entries-fixture.ts
@@ -57,6 +57,7 @@ observer.observe({ entryTypes: ["dns", "resource"] });
 // Each operation is awaited so the entries are recorded in a fixed order.
 await new Promise((resolve, reject) => dns.lookup("localhost", error => (error ? reject(error) : resolve(undefined))));
 await dns.promises.lookup("localhost", { order: "ipv6first" });
+await dns.promises.lookup("localhost", { all: true });
 await new Promise((resolve, reject) =>
   dns.lookupService("127.0.0.1", 80, error => (error ? reject(error) : resolve(undefined))),
 );

--- a/test/js/node/perf_hooks/dns-entries-fixture.ts
+++ b/test/js/node/perf_hooks/dns-entries-fixture.ts
@@ -63,6 +63,7 @@ await new Promise((resolve, reject) =>
 await dns.promises.lookupService("127.0.0.1", 80);
 await new Promise((resolve, reject) => dns.resolve4("a.test", error => (error ? reject(error) : resolve(undefined))));
 await dns.promises.resolve4("a.test");
+await dns.promises.resolve4("a.test", { ttl: true });
 await new Promise((resolve, reject) =>
   dns.resolve("a.test", "TXT", error => (error ? reject(error) : resolve(undefined))),
 );

--- a/test/js/node/perf_hooks/dns-entries-fixture.ts
+++ b/test/js/node/perf_hooks/dns-entries-fixture.ts
@@ -1,8 +1,8 @@
 // Fixture for perf_hooks.test.ts ("node:dns operations are observable ...").
-// A local UDP DNS server answers every A/TXT query so the 'dns' performance
-// entries asserted by the parent test are produced without a real resolver.
-// Runs in its own process because it repoints the default resolver at the
-// local server with dns.setServers().
+// A local UDP DNS server answers every A/TXT/PTR query so the 'dns'
+// performance entries asserted by the parent test are produced without a real
+// resolver. Runs in its own process because it repoints the default resolver
+// at the local server with dns.setServers().
 import dgram from "node:dgram";
 import dns from "node:dns";
 import { once } from "node:events";
@@ -18,9 +18,14 @@ function readName(message: Buffer, offset: number) {
 }
 
 // One resource record per supported QTYPE, each using the 0xc00c compression
-// pointer back to the question name at offset 12.
+// pointer back to the question name at offset 12. The PTR target is
+// "host.test"; lookupService resolves a reverse name through it.
 const A_RECORD = Buffer.from([0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 0, 60, 0, 4, 127, 0, 0, 1]);
 const TXT_RECORD = Buffer.from([0xc0, 0x0c, 0, 16, 0, 1, 0, 0, 0, 60, 0, 6, 5, 0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+const PTR_RECORD = Buffer.from([
+  ...[0xc0, 0x0c, 0, 12, 0, 1, 0, 0, 0, 60, 0, 11],
+  ...[4, 0x68, 0x6f, 0x73, 0x74, 4, 0x74, 0x65, 0x73, 0x74, 0],
+]);
 
 // Echo the question and append one record of the requested type. Names under
 // "nx." are answered with RCODE=3 (NXDOMAIN) so the query fails.
@@ -28,7 +33,15 @@ function respond(query: Buffer): Buffer {
   const { name, end } = readName(query, 12);
   const qtype = query.readUInt16BE(end);
   const notFound = name.startsWith("nx.");
-  const answer = notFound ? undefined : qtype === 1 ? A_RECORD : qtype === 16 ? TXT_RECORD : undefined;
+  const answer = notFound
+    ? undefined
+    : qtype === 1
+      ? A_RECORD
+      : qtype === 16
+        ? TXT_RECORD
+        : qtype === 12
+          ? PTR_RECORD
+          : undefined;
   const header = Buffer.alloc(12);
   header[0] = query[0];
   header[1] = query[1];
@@ -58,10 +71,13 @@ observer.observe({ entryTypes: ["dns", "resource"] });
 await new Promise((resolve, reject) => dns.lookup("localhost", error => (error ? reject(error) : resolve(undefined))));
 await dns.promises.lookup("localhost", { order: "ipv6first" });
 await dns.promises.lookup("localhost", { all: true });
+// 192.0.2.1 (TEST-NET-1) is in nobody's hosts file, so getnameinfo reverses
+// it with a PTR query to the local server on every platform. (127.0.0.1 is
+// in Linux's hosts file but not Windows's, so its reverse is host-dependent.)
 await new Promise((resolve, reject) =>
-  dns.lookupService("127.0.0.1", 80, error => (error ? reject(error) : resolve(undefined))),
+  dns.lookupService("192.0.2.1", 80, error => (error ? reject(error) : resolve(undefined))),
 );
-await dns.promises.lookupService("127.0.0.1", 80);
+await dns.promises.lookupService("192.0.2.1", 80);
 await new Promise((resolve, reject) => dns.resolve4("a.test", error => (error ? reject(error) : resolve(undefined))));
 await dns.promises.resolve4("a.test");
 await dns.promises.resolve4("a.test", { ttl: true });

--- a/test/js/node/perf_hooks/dns-entries-fixture.ts
+++ b/test/js/node/perf_hooks/dns-entries-fixture.ts
@@ -1,0 +1,99 @@
+// Fixture for perf_hooks.test.ts ("node:dns operations are observable ...").
+// A local UDP DNS server answers every A/TXT query so the 'dns' performance
+// entries asserted by the parent test are produced without a real resolver.
+// Runs in its own process because it repoints the default resolver at the
+// local server with dns.setServers().
+import dgram from "node:dgram";
+import dns from "node:dns";
+import { once } from "node:events";
+import { PerformanceObserver } from "node:perf_hooks";
+
+function readName(message: Buffer, offset: number) {
+  const labels: string[] = [];
+  while (message[offset] !== 0) {
+    labels.push(message.subarray(offset + 1, offset + 1 + message[offset]).toString("ascii"));
+    offset += 1 + message[offset];
+  }
+  return { name: labels.join("."), end: offset + 1 };
+}
+
+// One resource record per supported QTYPE, each using the 0xc00c compression
+// pointer back to the question name at offset 12.
+const A_RECORD = Buffer.from([0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 0, 60, 0, 4, 127, 0, 0, 1]);
+const TXT_RECORD = Buffer.from([0xc0, 0x0c, 0, 16, 0, 1, 0, 0, 0, 60, 0, 6, 5, 0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+
+// Echo the question and append one record of the requested type. Names under
+// "nx." are answered with RCODE=3 (NXDOMAIN) so the query fails.
+function respond(query: Buffer): Buffer {
+  const { name, end } = readName(query, 12);
+  const qtype = query.readUInt16BE(end);
+  const notFound = name.startsWith("nx.");
+  const answer = notFound ? undefined : qtype === 1 ? A_RECORD : qtype === 16 ? TXT_RECORD : undefined;
+  const header = Buffer.alloc(12);
+  header[0] = query[0];
+  header[1] = query[1];
+  header[2] = 0x81; // QR=1 RD=1
+  header[3] = notFound ? 0x83 : 0x80; // RA=1, RCODE
+  header[5] = 1; // QDCOUNT
+  header[7] = answer ? 1 : 0; // ANCOUNT
+  const question = query.subarray(12, end + 4);
+  return answer ? Buffer.concat([header, question, answer]) : Buffer.concat([header, question]);
+}
+
+const server = dgram.createSocket("udp4");
+server.on("message", (message, rinfo) => server.send(respond(message), rinfo.port, rinfo.address));
+server.bind(0, "127.0.0.1");
+await once(server, "listening");
+const nameserver = `127.0.0.1:${(server.address() as { port: number }).port}`;
+dns.setServers([nameserver]);
+
+const entries: unknown[] = [];
+const observer = new PerformanceObserver(list => {
+  entries.push(...list.getEntries());
+});
+// "resource" is accepted but never delivered; only the "dns" entries arrive.
+observer.observe({ entryTypes: ["dns", "resource"] });
+
+// Each operation is awaited so the entries are recorded in a fixed order.
+await new Promise((resolve, reject) => dns.lookup("localhost", error => (error ? reject(error) : resolve(undefined))));
+await dns.promises.lookup("localhost");
+await new Promise((resolve, reject) =>
+  dns.lookupService("127.0.0.1", 80, error => (error ? reject(error) : resolve(undefined))),
+);
+await dns.promises.lookupService("127.0.0.1", 80);
+await new Promise((resolve, reject) => dns.resolve4("a.test", error => (error ? reject(error) : resolve(undefined))));
+await dns.promises.resolve4("a.test");
+await new Promise((resolve, reject) =>
+  dns.resolve("a.test", "TXT", error => (error ? reject(error) : resolve(undefined))),
+);
+await dns.promises.resolve("a.test", "TXT");
+const resolver = new dns.Resolver();
+resolver.setServers([nameserver]);
+await new Promise((resolve, reject) =>
+  resolver.resolveTxt("a.test", error => (error ? reject(error) : resolve(undefined))),
+);
+const promisesResolver = new dns.promises.Resolver();
+promisesResolver.setServers([nameserver]);
+await promisesResolver.resolveTxt("a.test");
+
+// Neither of these may record an entry: an IP-literal lookup never reaches
+// the resolver, and a failed query is skipped, both matching Node.
+await new Promise(resolve => dns.lookup("127.0.0.1", resolve));
+const notFoundError = await dns.promises.resolve4("nx.test").then(
+  () => null,
+  error => error,
+);
+if (!notFoundError) throw new Error("nx.test unexpectedly resolved");
+
+// Entries are handed to observers on a setImmediate scheduled by the
+// operation that produced them, so one turn after the last awaited operation
+// every pending delivery has run.
+await new Promise(resolve => setImmediate(resolve));
+
+// Nothing recorded after disconnect() may be delivered.
+observer.disconnect();
+await dns.promises.resolveTxt("a.test");
+await new Promise(resolve => setImmediate(resolve));
+
+server.close();
+console.log(JSON.stringify(entries));

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -95,10 +95,12 @@ test("node:dns operations are observable as 'dns' performance entries", async ()
     addresses: expect.any(Array),
   });
   expect(entries[2].detail.addresses[0]).toEqual({ address: expect.any(String), family: expect.any(Number) });
+  // The fixture's DNS server answers the PTR query for the reversed address
+  // with "host.test".
   expect(entries[3].detail).toEqual({
-    host: "127.0.0.1",
+    host: "192.0.2.1",
     port: 80,
-    hostname: expect.any(String),
+    hostname: "host.test",
     service: expect.any(String),
   });
   expect(entries[5].detail).toEqual({ host: "a.test", ttl: false, result: ["127.0.0.1"] });

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -50,7 +50,8 @@ test("node:dns operations are observable as 'dns' performance entries", async ()
     exitCode: 0,
     entries: [
       "dns:lookup", // dns.lookup()
-      "dns:lookup", // dns.promises.lookup()
+      "dns:lookup", // dns.promises.lookup(hostname, { order: "ipv6first" })
+      "dns:lookup", // dns.promises.lookup(hostname, { all: true })
       "dns:lookupService", // dns.lookupService()
       "dns:lookupService", // dns.promises.lookupService()
       "dns:queryA", // dns.resolve4()
@@ -72,8 +73,8 @@ test("node:dns operations are observable as 'dns' performance entries", async ()
   }
 
   // detail carries the same fields and values Node records for each operation
-  // kind, including the caller-visible result (strings without {ttl: true},
-  // {address, ttl} objects with it).
+  // kind, always in the shape the caller receives: address strings unless
+  // {all: true} or {ttl: true} asked for objects.
   expect(entries[0].detail).toEqual({
     hostname: "localhost",
     family: 0,
@@ -93,13 +94,14 @@ test("node:dns operations are observable as 'dns' performance entries", async ()
     order: "ipv6first",
     addresses: expect.any(Array),
   });
-  expect(entries[2].detail).toEqual({
+  expect(entries[2].detail.addresses[0]).toEqual({ address: expect.any(String), family: expect.any(Number) });
+  expect(entries[3].detail).toEqual({
     host: "127.0.0.1",
     port: 80,
     hostname: expect.any(String),
     service: expect.any(String),
   });
-  expect(entries[4].detail).toEqual({ host: "a.test", ttl: false, result: ["127.0.0.1"] });
-  expect(entries[6].detail).toEqual({ host: "a.test", ttl: true, result: [{ address: "127.0.0.1", ttl: 60 }] });
-  expect(entries[7].detail).toEqual({ host: "a.test", ttl: false, result: [["hello"]] });
+  expect(entries[5].detail).toEqual({ host: "a.test", ttl: false, result: ["127.0.0.1"] });
+  expect(entries[7].detail).toEqual({ host: "a.test", ttl: true, result: [{ address: "127.0.0.1", ttl: 60 }] });
+  expect(entries[8].detail).toEqual({ host: "a.test", ttl: false, result: [["hello"]] });
 });

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -83,6 +83,16 @@ test("node:dns operations are observable as 'dns' performance entries", async ()
     addresses: expect.any(Array),
   });
   expect(typeof entries[0].detail.addresses[0]).toBe("string");
+  // An explicit order is reported as Node reports it: verbatim means exactly
+  // order === "verbatim".
+  expect(entries[1].detail).toEqual({
+    hostname: "localhost",
+    family: 0,
+    hints: 0,
+    verbatim: false,
+    order: "ipv6first",
+    addresses: expect.any(Array),
+  });
   expect(entries[2].detail).toEqual({
     host: "127.0.0.1",
     port: 80,

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
 import perf from "perf_hooks";
 
 test("stubs", () => {
@@ -20,4 +22,73 @@ test("doesn't throw", () => {
   expect(() => performance.now()).not.toThrow();
   expect(() => performance.timeOrigin).not.toThrow();
   expect(() => performance.markResourceTiming()).not.toThrow();
+});
+
+// supportedEntryTypes is the feature-detection surface: only types that can
+// actually be delivered to an observer belong in it.
+test("PerformanceObserver.supportedEntryTypes only lists deliverable types", () => {
+  expect(globalThis.PerformanceObserver.supportedEntryTypes).toEqual(["mark", "measure"]);
+  expect(perf.PerformanceObserver.supportedEntryTypes).toEqual(["dns", "http", "mark", "measure", "net"]);
+});
+
+test("node:dns operations are observable as 'dns' performance entries", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "dns-entries-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The fixture prints the delivered entries as one JSON array. If it failed
+  // to do so, compare against its stderr instead so the failure is readable.
+  const entries = stdout.trimStart().startsWith("[") ? JSON.parse(stdout) : null;
+  expect({
+    exitCode,
+    entries: entries ? entries.map(entry => `${entry.entryType}:${entry.name}`) : stderr,
+  }).toEqual({
+    exitCode: 0,
+    entries: [
+      "dns:lookup", // dns.lookup()
+      "dns:lookup", // dns.promises.lookup()
+      "dns:lookupService", // dns.lookupService()
+      "dns:lookupService", // dns.promises.lookupService()
+      "dns:queryA", // dns.resolve4()
+      "dns:queryA", // dns.promises.resolve4()
+      "dns:queryTxt", // dns.resolve(hostname, "TXT")
+      "dns:queryTxt", // dns.promises.resolve(hostname, "TXT")
+      "dns:queryTxt", // new dns.Resolver().resolveTxt()
+      "dns:queryTxt", // new dns.promises.Resolver().resolveTxt()
+    ],
+  });
+
+  // Entries are delivered in dispatch order with sane timings.
+  let previousStartTime = -Infinity;
+  for (const entry of entries) {
+    expect(entry.startTime).toBeGreaterThanOrEqual(previousStartTime);
+    expect(entry.duration).toBeGreaterThanOrEqual(0);
+    previousStartTime = entry.startTime;
+  }
+
+  // detail carries the same fields Node records for each operation kind.
+  expect(entries[0].detail).toEqual({
+    hostname: "localhost",
+    family: 0,
+    hints: 0,
+    verbatim: expect.any(Boolean),
+    order: expect.any(String),
+    addresses: expect.any(Array),
+  });
+  expect(typeof entries[0].detail.addresses[0]).toBe("string");
+  expect(entries[2].detail).toEqual({
+    host: "127.0.0.1",
+    port: 80,
+    hostname: expect.any(String),
+    service: expect.any(String),
+  });
+  expect(entries[4].detail).toEqual({
+    host: "a.test",
+    ttl: false,
+    result: expect.any(Array),
+  });
 });

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -55,6 +55,7 @@ test("node:dns operations are observable as 'dns' performance entries", async ()
       "dns:lookupService", // dns.promises.lookupService()
       "dns:queryA", // dns.resolve4()
       "dns:queryA", // dns.promises.resolve4()
+      "dns:queryA", // dns.promises.resolve4(hostname, { ttl: true })
       "dns:queryTxt", // dns.resolve(hostname, "TXT")
       "dns:queryTxt", // dns.promises.resolve(hostname, "TXT")
       "dns:queryTxt", // new dns.Resolver().resolveTxt()
@@ -70,7 +71,9 @@ test("node:dns operations are observable as 'dns' performance entries", async ()
     previousStartTime = entry.startTime;
   }
 
-  // detail carries the same fields Node records for each operation kind.
+  // detail carries the same fields and values Node records for each operation
+  // kind, including the caller-visible result (strings without {ttl: true},
+  // {address, ttl} objects with it).
   expect(entries[0].detail).toEqual({
     hostname: "localhost",
     family: 0,
@@ -86,9 +89,7 @@ test("node:dns operations are observable as 'dns' performance entries", async ()
     hostname: expect.any(String),
     service: expect.any(String),
   });
-  expect(entries[4].detail).toEqual({
-    host: "a.test",
-    ttl: false,
-    result: expect.any(Array),
-  });
+  expect(entries[4].detail).toEqual({ host: "a.test", ttl: false, result: ["127.0.0.1"] });
+  expect(entries[6].detail).toEqual({ host: "a.test", ttl: true, result: [{ address: "127.0.0.1", ttl: 60 }] });
+  expect(entries[7].detail).toEqual({ host: "a.test", ttl: false, result: [["hello"]] });
 });

--- a/test/js/node/test/parallel/test-dns-perf_hooks.js
+++ b/test/js/node/test/parallel/test-dns-perf_hooks.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const dns = require('dns');
+const { PerformanceObserver } = require('perf_hooks');
+
+const entries = [];
+const obs = new PerformanceObserver((items) => {
+  entries.push(...items.getEntries());
+});
+
+obs.observe({ type: 'dns' });
+
+let count = 0;
+
+function inc() {
+  count++;
+}
+
+// If DNS resolution fails, skip it
+// https://github.com/nodejs/node/issues/44003
+dns.lookup('localhost', common.mustCall((err) => { !err && inc(); }));
+dns.lookupService('127.0.0.1', 80, common.mustCall((err) => { !err && inc(); }));
+dns.resolveAny('localhost', common.mustCall((err) => { !err && inc(); }));
+
+dns.promises.lookup('localhost').then(inc).catch(() => {});
+dns.promises.lookupService('127.0.0.1', 80).then(inc).catch(() => {});
+dns.promises.resolveAny('localhost').then(inc).catch(() => {});
+
+process.on('exit', () => {
+  assert.strictEqual(entries.length, count);
+  entries.forEach((entry) => {
+    assert.strictEqual(!!entry.name, true);
+    assert.strictEqual(entry.entryType, 'dns');
+    assert.strictEqual(typeof entry.startTime, 'number');
+    assert.strictEqual(typeof entry.duration, 'number');
+    assert.strictEqual(typeof entry.detail, 'object');
+    switch (entry.name) {
+      case 'lookup':
+        assert.strictEqual(typeof entry.detail.hostname, 'string');
+        assert.strictEqual(typeof entry.detail.family, 'number');
+        assert.strictEqual(typeof entry.detail.hints, 'number');
+        assert.strictEqual(typeof entry.detail.verbatim, 'boolean');
+        assert.strictEqual(typeof entry.detail.order, 'string');
+        assert.strictEqual(Array.isArray(entry.detail.addresses), true);
+        break;
+      case 'lookupService':
+        assert.strictEqual(typeof entry.detail.host, 'string');
+        assert.strictEqual(typeof entry.detail.port, 'number');
+        assert.strictEqual(typeof entry.detail.hostname, 'string');
+        assert.strictEqual(typeof entry.detail.service, 'string');
+        break;
+      case 'queryAny':
+        assert.strictEqual(typeof entry.detail.host, 'string');
+        assert.strictEqual(typeof entry.detail.ttl, 'boolean');
+        assert.strictEqual(Array.isArray(entry.detail.result), true);
+        break;
+    }
+  });
+});


### PR DESCRIPTION
### What

`PerformanceObserver.supportedEntryTypes` advertises `dns` and `resource`, and `observe()` accepts them, but neither type is ever delivered. That is the worst outcome for feature detection, which is the one job `supportedEntryTypes` has: code checks the list, sees support, registers an observer, and silently collects nothing.

```js
const seen = [];
new PerformanceObserver(l => l.getEntries().forEach(e => seen.push(`${e.entryType}:${e.name}`)))
  .observe({ entryTypes: ["dns", "resource"] });
await require("node:dns").promises.lookup("localhost");
// Node: ["dns:lookup"]
// Bun:  []
```

### `dns`: deliver the entries

`node:net` and `node:http` already record their `net` and `http` entries through `internal/shared`'s `hasObserver`/`startPerf`/`stopPerf`, but `node:dns` never called into it, so `dns` was advertised (it is in `kNodeEntryTypes`) with no producer.

This wires every `node:dns` operation into that machinery: `lookup`, `lookupService`, every `resolve*`, `resolve(hostname, rrtype)`, and `reverse`, across the callback API, the promises API, and `Resolver` / `promises.Resolver` instances. Three small helpers wrap the native promise so each call site stays a single expression and costs nothing when no `dns` observer is registered. Semantics match Node (`lib/dns.js`, `lib/internal/dns/{promises,callback_resolver}.js`):

- an entry is recorded only when the operation was dispatched and completed successfully; failures and the IP-literal / empty-hostname early returns in `lookup` record nothing
- entries are named after the c-ares binding Node uses: `lookup`, `lookupService`, `queryA`, `queryAaaa`, `queryTxt`, ..., `getHostByAddr` for `reverse`
- `detail` carries the same fields Node records (`{hostname, family, hints, verbatim, order, addresses}` for lookup, `{host, port, hostname, service}` for lookupService, `{host, ttl, result}` for resolvers)

Since `node:net` resolves hostnames through `dns.lookup`, `net.connect("example.com", ...)` now also produces a `dns:lookup` entry, as it does in Node.

Most of the `dns.ts` diff is Prettier re-indenting the call sites it touches; reviewing with whitespace hidden shows the real change.

### `resource`: stop advertising it

Nothing in Bun can produce a resource entry. `Performance::addResourceTiming` has zero callers, `performance.markResourceTiming` is a no-op stub, and the HTTP client collects no per-request timing for `fetch()` to report. Per the Performance Timeline spec, `supportedEntryTypes` lists the types for which an entry could exist in the global, so `resource` is removed. This is a one-line hunk, independent of the `dns` change, and should be reverted by whichever change implements resource timing.

Actually implementing resource timing is a separate feature, not a one-liner: the `PerformanceResourceTiming` consumer side in WebCore is real and compiled, but the producer side needs new per-phase instrumentation in the HTTP client's connection callbacks, plumbing through `HTTPClientResult`, and a conversion into the synthetic clock domain `Performance::m_timeOrigin` uses. Happy to write that up as a tracking issue.

### Verification

New tests, both failing without the fix:

- `test/js/node/perf_hooks/perf_hooks.test.ts`
  - asserts the exact `supportedEntryTypes` lists for the web global (`["mark", "measure"]`) and for `node:perf_hooks` (`["dns", "http", "mark", "measure", "net"]`)
  - spawns `dns-entries-fixture.ts`, which runs a local UDP DNS responder and points `dns.setServers()` at it in its own process, so all twelve expected entries (covering every structurally distinct call-site shape) are produced hermetically and in a deterministic order, with exact `detail` values. Also covers the negatives: an IP-literal lookup, an NXDOMAIN, and an operation after `disconnect()` record nothing.
- `test/js/node/test/parallel/test-dns-perf_hooks.js`: Node's own test for this, ported verbatim from nodejs/node. Previously failed with `0 !== 4`; now exits 0.

Existing `test-net-perf_hooks.js`, `test-http-perf_hooks.js`, the performance observer leak test, and the `node:dns` suites are unaffected (`bun bd test test/js/node/dns/ test/js/bun/dns/` reports the same set of failures as stock, all of which need direct network access).

Reported by bun-sys-fuzz.


