### PR TITLE
node:fs: preserve special POSIX mode bits in file modes

### DIFF
--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1636,7 +1636,7 @@ pub fn mode_from_js(ctx: &JSGlobalObject, value: JSValue) -> JsResult<Option<Mod
         }
     };
 
-    Ok(Some((mode_int & 0o777) as Mode))
+    Ok(Some((mode_int & 0o7777) as Mode))
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1733,6 +1733,18 @@ describe("writeFileSync", () => {
     const stat = fs.statSync(path);
     expect(stat.mode).toBe(isWindows ? 33206 : 33188);
   });
+  it.skipIf(isWindows)("write file preserves special POSIX mode bits", () => {
+    for (const mode of [0o107644, "107644"] as const) {
+      const path = `${tmpdirSync()}/writeFileSyncWithSpecialMode.txt`;
+      const oldUmask = process.umask(0);
+      try {
+        writeFileSync(path, "bun", { mode });
+      } finally {
+        process.umask(oldUmask);
+      }
+      expect(fs.statSync(path).mode & 0o7777).toBe(0o7644);
+    }
+  });
   it("returning Buffer works", () => {
     const buffer = new Buffer([
       70, 105, 108, 101, 32, 119, 114, 105, 116, 116, 101, 110, 32, 115, 117, 99, 99, 101, 115, 115, 102, 117, 108, 108,
@@ -1757,6 +1769,58 @@ describe("writeFileSync", () => {
 
     for (let i = 0; i < buffer.length; i++) {
       expect(buffer[i]).toBe(out[i]);
+    }
+  });
+});
+
+describe.skipIf(isWindows)("chmod", () => {
+  const specialMode = 0o7644;
+  const inputMode = 0o100000 | specialMode;
+  const inputs = [inputMode, inputMode.toString(8)];
+
+  it("preserves special POSIX mode bits", async () => {
+    for (const input of inputs) {
+      const path = `${tmpdirSync()}/chmodSpecialMode.txt`;
+      writeFileSync(path, "bun");
+
+      fs.chmodSync(path, input);
+      expect(fs.statSync(path).mode & 0o7777).toBe(specialMode);
+
+      await new Promise<void>((resolve, reject) => {
+        fs.chmod(path, input, err => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      expect(fs.statSync(path).mode & 0o7777).toBe(specialMode);
+    }
+  });
+
+  it("fchmod preserves special POSIX mode bits", async () => {
+    for (const input of inputs) {
+      const path = `${tmpdirSync()}/fchmodSpecialMode.txt`;
+      writeFileSync(path, "bun");
+
+      let fd = openSync(path, "w");
+      try {
+        fs.fchmodSync(fd, input);
+        expect(fstatSync(fd).mode & 0o7777).toBe(specialMode);
+      } finally {
+        closeSync(fd);
+      }
+
+      fd = openSync(path, "w");
+      try {
+        await new Promise<void>((resolve, reject) => {
+          fs.fchmod(fd, input, err => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+        expect(fstatSync(fd).mode & 0o7777).toBe(specialMode);
+      } finally {
+        closeSync(fd);
+      }
     }
   });
 });


### PR DESCRIPTION
### What

Change `node:fs` mode normalization from `mode & 0o777` to `mode & 0o7777`.

### Why

Bun currently masks file modes to `0o777`. That preserves the common rwx permission bits and strips file-type bits from values like `stat.mode`, e.g. `0o100644 -> 0o644`.

However, `0o777` also drops POSIX special mode bits:

- setuid: `0o4000`
- setgid: `0o2000`
- sticky: `0o1000`

Node preserves these bits for `chmod`/`fchmod` and creation modes. Masking to `0o7777` keeps all POSIX permission bits while still stripping file-type bits such as `S_IFREG` (`0o100000`).

This keeps the existing stat-mode compatibility behavior while avoiding accidental loss of special mode bits.

### Note

Node appears to validate file modes as uint32 values and pass them through without applying this permission mask. This PR keeps Bun's existing behavior of stripping higher file-type bits from values like `stat.mode`, but changes the mask from `0o777` to `0o7777` so POSIX special mode bits are preserved.

If exact Node compatibility is preferred, removing the mask entirely is another option.

### Tests

Added Bun-owned coverage for:

- `fs.chmod`
- `fs.chmodSync`
- `fs.fchmod`
- `fs.fchmodSync`
- numeric and octal-string mode inputs
- `fs.writeFileSync({ mode })`

Local verification:

```bash
git diff --check
PATH=/root/.cargo/bin:$PATH bun run build:debug:noasan
./build/debug/bun-debug test test/js/node/fs/fs.test.ts -t 'preserves special POSIX mode bits'
./build/debug/bun-debug test/js/node/test/parallel/test-fs-chmod-mask.js
```
