### PR TITLE
streams: reject instead of throwing when consuming an already-errored ReadableStream

### DIFF
--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -207,10 +207,11 @@ export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>)
   }
 
   if ($isPromise(result)) {
-    const completedResult = Bun.peek(result);
-    if (completedResult !== result) {
-      result = completedResult;
+    if ($isPromiseFulfilled(result)) {
+      result = $peekPromiseSettledValue(result);
     } else {
+      // Pending, or already rejected (the stream was errored): the returned
+      // promise must settle the same way.
       return result.then(toArrayBuffer);
     }
   }
@@ -285,10 +286,11 @@ export function readableStreamToBytes(stream: ReadableStream<ArrayBuffer>): Prom
   }
 
   if ($isPromise(result)) {
-    const completedResult = Bun.peek(result);
-    if (completedResult !== result) {
-      result = completedResult;
+    if ($isPromiseFulfilled(result)) {
+      result = $peekPromiseSettledValue(result);
     } else {
+      // Pending, or already rejected (the stream was errored): the returned
+      // promise must settle the same way.
       return result.then(toBytes);
     }
   }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2423,7 +2423,13 @@ export async function readableStreamIntoArrayProcessManyResult(this: ReadableStr
 
 export function readableStreamIntoArray(stream) {
   var reader = stream.getReader();
-  var manyResult = reader.readMany();
+  var manyResult;
+  try {
+    // readMany() throws synchronously when the stream is already errored.
+    manyResult = reader.readMany();
+  } catch (e) {
+    return Promise.$reject(e);
+  }
 
   if (manyResult && $isPromise(manyResult)) {
     return manyResult.$then($readableStreamIntoArrayProcessManyResult.bind(reader));

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -665,6 +665,61 @@ it("readableStreamToBytes (default)", async () => {
   expect(new TextDecoder().decode(new Uint8Array(buffer))).toBe("abdefgh");
 });
 
+describe("consuming an already-errored stream rejects instead of throwing", () => {
+  const erroredStream = error =>
+    new ReadableStream({
+      start(controller) {
+        controller.error(error);
+      },
+    });
+
+  test.each([
+    "readableStreamToArrayBuffer",
+    "readableStreamToBytes",
+    "readableStreamToBlob",
+    "readableStreamToArray",
+    "readableStreamToFormData",
+    "readableStreamToText",
+    "readableStreamToJSON",
+  ])("Bun.%s", async name => {
+    const error = new Error("boom");
+    let promise;
+    expect(() => {
+      promise = Bun[name](erroredStream(error));
+    }).not.toThrow();
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).rejects.toBe(error);
+  });
+
+  test.each(["arrayBuffer", "bytes", "blob", "formData", "text", "json"])("Response.prototype.%s", async name => {
+    const error = new Error("boom");
+    const response = new Response(erroredStream(error), {
+      headers: { "content-type": "multipart/form-data; boundary=x" },
+    });
+    let promise;
+    expect(() => {
+      promise = response[name]();
+    }).not.toThrow();
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).rejects.toBe(error);
+  });
+
+  test.each(["arrayBuffer", "bytes", "blob", "formData", "text", "json"])("Request.prototype.%s", async name => {
+    const error = new Error("boom");
+    const request = new Request("http://localhost/", {
+      method: "POST",
+      body: erroredStream(error),
+      headers: { "content-type": "multipart/form-data; boundary=x" },
+    });
+    let promise;
+    expect(() => {
+      promise = request[name]();
+    }).not.toThrow();
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).rejects.toBe(error);
+  });
+});
+
 it("ReadableStream for Blob", async () => {
   var blob = new Blob(["abdefgh", "ijklmnop"]);
   expect(await blob.text()).toBe("abdefghijklmnop");


### PR DESCRIPTION
### Problem

Five of the seven `Bun.readableStreamTo*` helpers throw synchronously when handed an already-errored `ReadableStream`, instead of returning a rejected promise like `readableStreamToText` and `readableStreamToJSON` do:

```js
const stream = new ReadableStream({ start(c) { c.error(new Error("boom")) } });
Bun.readableStreamToArrayBuffer(stream).catch(e => console.log("caught", e.message));
// uncaught Error: boom  (readableStreamToArrayBuffer threw synchronously, .catch never runs)
```

On 1.4.0, `readableStreamToArrayBuffer`, `readableStreamToBytes`, `readableStreamToBlob`, `readableStreamToArray`, and `readableStreamToFormData` all throw synchronously; `readableStreamToText` and `readableStreamToJSON` reject.

The same divergence surfaces through the body mixin, which is required by the fetch spec to return a promise: `new Response(erroredStream).arrayBuffer()` (and `.bytes()`, `.blob()`, `.formData()`) throw synchronously while `.text()` and `.json()` reject. Same for `Request`.

### Cause

`ReadableStreamDefaultReader.readMany()` throws synchronously when the stream state is already errored. `readableStreamIntoArray`, which the array, arrayBuffer, bytes, blob, and formData consumers all funnel through, called it with nothing to turn that throw into a rejection, so it escaped from a function that is supposed to return a promise. The text and json consumers read through `readStreamIntoSink`, an async function, so the same throw becomes a rejection there.

### Fix

- `readableStreamIntoArray` catches the synchronous throw from `reader.readMany()` and returns `Promise.$reject(e)`. `readMany()` itself is unchanged: it is allowed to return a result synchronously, other callers handle the throw correctly, and changing it would affect the text path too.
- `readableStreamToArrayBuffer` and `readableStreamToBytes` peek the internal array promise to skip a microtask when it settled synchronously, but `Bun.peek` returns the rejection reason of a rejected promise the same way it returns a fulfillment value, so the now-possible synchronously rejected promise would have been passed to `toArrayBuffer`/`toBytes` as if it were the chunk array. They now check `$isPromiseFulfilled` and otherwise return `result.then(...)`, which forwards a rejection.

### Verification

New tests in `test/js/web/streams/streams.test.js` ("consuming an already-errored stream rejects instead of throwing") cover all seven `Bun.readableStreamTo*` helpers plus `arrayBuffer`/`bytes`/`blob`/`formData`/`text`/`json` on both `Response` and `Request`. Each asserts the call does not throw, returns a promise, and rejects with the original error object.

13 of the 19 cases fail with `USE_SYSTEM_BUN=1` (bun 1.4.0); all 19 pass with this change. Also ran the existing stream and body suites (`streams.test.js`, `readablestreamtoarraybuffer.test.ts`, `body.test.ts`, `body-mixin-errors.test.ts`, `body-stream.test.ts`, `body-async-iterator.test.ts`, `body-clone.test.ts`, `stream-fast-path.test.ts`, `direct-readable-stream.test.tsx`, `console-iterator.test.ts`, node's `test-stream-consumers.js`): no regressions.
