### PR TITLE
Quarantine test-net-connect-memleak on linux-x64-musl

### DIFF
--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -12,20 +12,23 @@ test/cli/run/run-crash-handler.test.ts [ FAIL ] # automatic crash reporter > seg
 # the spawned child needs process.binding('inspector'), which is not implemented
 test/js/node/test/parallel/test-inspector-enabled.js [ FAIL ]
 
-# Verbatim node v26.3.0 test asserting a FinalizationRegistry callback fires
+# Verbatim node v26.3.0 tests asserting a FinalizationRegistry callback fires
 # within ONE globalThis.gc() + ONE setImmediate after the connect callback's
 # closure is unreferenced. The FinalizationRegistry spec gives no timing
 # guarantee for cleanup callbacks; JSC schedules them via DeferredWorkTimer
 # with no defined ordering relative to the immediate queue. The connect
-# listener IS removed (verified: listenerCount("secureConnect") === 0 in
-# done()) and the object IS collected (test passes 70/70 on darwin and
-# glibc Linux); on alpine x64 the FR callback delivery slips past the single
-# setImmediate after this PR's added module loads at process startup shift
-# the heap layout. The robust fix is gcUntil() rather than a single tick,
-# but the file is a verbatim upstream port. Quarantined on the failing
-# linux-x64-musl matrix only; still runs everywhere else (build 63145:
-# alpine 3.23 x64 + x64-baseline only).
+# listener IS removed (verified listenerCount 0 in done(): "secureConnect"
+# for tls, "connect" for net) and the object IS collected (both pass on
+# darwin and glibc Linux); on alpine x64 the FR callback delivery slips past
+# the single setImmediate, so the assertion reds the lane on ~half of PR
+# builds. The robust fix is gcUntil() rather than a single tick, but these
+# are verbatim upstream ports we do not edit. Quarantined on the failing
+# linux-x64-musl matrix only (alpine 3.23 x64 + x64-baseline); still runs
+# everywhere else. Both twins share the identical onGC + gc() + setImmediate
+# pattern: the tls one was quarantined first (build 63145), the net one has
+# been failing intermittently since ~2026-06-28 (e.g. builds 66653, 66657).
 [ LINUX-X64-MUSL ] test/js/node/test/parallel/test-tls-connect-memleak.js [ FLAKY ] # JSC FinalizationRegistry callback delivery vs setImmediate timing on musl x64
+[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-net-connect-memleak.js [ FLAKY ] # JSC FinalizationRegistry callback delivery vs setImmediate timing on musl x64
 
 # Vendored node v26.3.0 stream tests blocked on missing native subsystems (see PR #31826)
 test/js/node/test/parallel/test-stream-pipeline.js [ SKIP ] # block at L271 hangs: pipeline(rs, req) writes 11x'hello' raw after a never-ended GET's \r\n\r\n; node's llhttp rejects lowercase 'h' as a method char (HPE_INVALID_METHOD -> clientError -> 400+close -> req 'close' -> pipeline callback fires), but bun's uWS HttpParser buffers any incomplete run of valid tchars waiting for the request-line, so the connection stays open and the callback never fires. Pre-existing server-parser leniency; needs uWS HttpParser to reject non-uppercase method bytes like llhttp.


### PR DESCRIPTION
Fixes #33044

## What

`test/js/node/test/parallel/test-net-connect-memleak.js` fails on roughly half of PR builds on the two musl test lanes (`:alpine: 3.23 x64 - test-bun` and `:alpine: 3.23 x64-baseline - test-bun`). The per-file retry also fails, so the lane goes red. The glibc linux x64 / x64-baseline / ASAN / darwin / Windows lanes do not hit it.

```
51 | function done(sock) {
52 |   globalThis.gc();
53 |   setImmediate(common.mustCall(() => {
54 |     assert.strictEqual(collected, true);
                ^
AssertionError: Expected values to be strictly equal:

false !== true

      at <anonymous> (/var/lib/buildkite-agent/build/test/js/node/test/parallel/test-net-connect-memleak.js:54:12)
```

Examples: [build 66653](https://buildkite.com/bun/bun/builds/66653), [build 66657](https://buildkite.com/bun/bun/builds/66657). These are unrelated PRs, so this is not caused by any one change.

## Cause

The test registers an object in a `FinalizationRegistry` (via `common/gc.js` `onGC`), then asserts the cleanup callback has fired within one `globalThis.gc()` plus one `setImmediate`. The FinalizationRegistry spec gives no timing guarantee for cleanup callbacks; JSC schedules them through `DeferredWorkTimer` with no defined ordering relative to the immediate queue. On musl x64 that delivery intermittently slips past the single `setImmediate`, so `collected` is still `false` when the assertion runs. The object is collected and the listener is removed; only the delivery timing is racy.

This is the same mechanism already on record for the test's TLS sibling, `test-tls-connect-memleak.js`, which was quarantined on this exact matrix (`test/expectations.txt`). Both tests use the identical `onGC` + `gc()` + `setImmediate` pattern.

## Fix

These are verbatim upstream Node ports that we do not edit (`test/js/node/test/parallel/CLAUDE.md`), so the robust in-test fix (`gcUntil()` instead of a single tick) is not available here. Mark the `net` twin `[ FLAKY ]` on `[ LINUX-X64-MUSL ]` next to its `tls` sibling and fold both under one comment. The `LINUX-X64-MUSL` modifier covers both the regular and baseline musl x64 lanes; the test keeps running everywhere else.

## Verification

Parsing `test/expectations.txt` with the runner's own logic (`scripts/runner.node.mjs` `getTestExpectations`) and simulating each lane's modifiers:

- musl x64 lane modifiers -> both `test-tls-connect-memleak.js` and `test-net-connect-memleak.js` are quarantined.
- glibc x64 lane modifiers -> neither is quarantined; both still run.

The failure is musl-x64 only and does not reproduce on glibc, so there is no local fail-before to capture off that platform; the change is test-infra only (no source change).