### PR TITLE
MessagePort: don't drop messages when a GC runs during dispatch

### DIFF
--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -150,11 +150,22 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
                 rescheduleCtx = s.ctxId;
                 break;
             }
+            // QueuedOne for this message is released after dispatch, below.
             message = s.inbox.takeFirst();
-            s.state.store(st - QueuedOne, std::memory_order_release);
         }
 
         port->dispatchOneMessage(*context, WTF::move(*message));
+
+        // Decrement only after dispatch: once the peer is closed this count is
+        // all that keeps hasPendingActivity() true, so a GC during the
+        // deserialize would collect the wrapper + listeners and drop the message.
+        {
+            Locker locker { s.lock };
+            uint64_t st = s.state.load(std::memory_order_relaxed);
+            // close() from inside the handler already reset the state word.
+            if (queuedCount(st) > 0)
+                s.state.store(st - QueuedOne, std::memory_order_release);
+        }
 
         // Node's MakeCallback wraps each emit in an InternalCallbackScope,
         // which drains nextTick + microtasks on exit; match that so

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -48,6 +48,9 @@ public:
         QueuedShift = 8,
         QueuedOne = 1ull << QueuedShift,
     };
+    // Count of undelivered messages: the inbox plus the message currently
+    // being dispatched (its unit is released only once dispatch returns, so
+    // hasPendingActivity() keeps the receiving wrapper alive throughout).
     static constexpr uint64_t queuedCount(uint64_t s) { return s >> QueuedShift; }
 
     // Sender-thread operations.

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -274,9 +274,11 @@ describe("MessagePort pipe", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr is reported but not constrained: debug/ASAN lanes may emit
+    // benign diagnostics under the GC pressure this child creates.
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
       stdout: "fired=100/100",
-      stderr: "",
+      stderr: expect.any(String),
       exitCode: 0,
     });
   });

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -228,6 +228,59 @@ describe("MessagePort pipe", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A message popped off the inbox but not yet dispatched must still count
+  // as pending activity: once the peer is closed, that count is all that
+  // keeps the receiving wrapper (and, via it, the listener functions) alive,
+  // and the deserialization inside the dispatch allocates. A GC there used
+  // to collect the wrapper and silently drop the message (on debug builds:
+  // "ASSERTION FAILED: m_wrapper" in JSEventListener::ensureJSFunction).
+  test("in-flight message keeps an otherwise-unreferenced listening port alive across GC", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const N = 100;
+          // Deserializing a large string reports its size as extra GC memory,
+          // so collections trigger inside the dispatch of some of the messages.
+          const big = Buffer.alloc(1 << 20, "x").toString();
+          let fired = 0;
+          for (let i = 0; i < N; i++) {
+            const { port1, port2 } = new MessageChannel();
+            // The handler must not capture port1; nothing but the pipe's
+            // undelivered-message count roots the wrapper once port2 closes.
+            port1.onmessage = () => { fired++; };
+            port2.postMessage(big);
+            port2.close();
+          }
+          // Every postMessage above scheduled its drain task, in order, on this
+          // context's task queue; this channel's drain therefore runs last.
+          await new Promise(resolve => {
+            const { port1, port2 } = new MessageChannel();
+            port1.onmessage = () => { port1.close(); port2.close(); resolve(); };
+            port2.postMessage(null);
+          });
+          console.log("fired=" + fired + "/" + N);
+          process.exit(0);
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        // Keep the JSC heap small so the deserialization inside the dispatch
+        // window reliably triggers a collection.
+        BUN_JSC_forceRAMSize: String(16 * 1024 * 1024),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "fired=100/100",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   // A port transferred through a carrier whose destination is already
   // closed never reaches a new owner. The endpoint must be marked Closed
   // when the in-transit struct is dropped, otherwise the peer's


### PR DESCRIPTION
### Repro

```js
const big = () => ({ a: Array.from({ length: 3000 }, (_, i) => ({ i, s: "x".repeat(8) })) });
let fired = 0;
for (let i = 0; i < 50; i++) {
  const { port1, port2 } = new MessageChannel();
  port1.onmessage = () => { fired++; };  // does not capture port1
  port2.postMessage(big());
  port2.close();
}
await new Promise(r => setTimeout(r, 0));
console.log(`fired=${fired}/50`);  // node: 50/50
```

With a small heap (`BUN_JSC_forceRAMSize=16777216`) this reliably loses a message on bun 1.4.0 (`fired=49/50` on every run here), and a debug build aborts every run:

```
ASSERTION FAILED: m_wrapper
src/jsc/bindings/webcore/JSEventListener.h(157) : JSC::JSObject *WebCore::JSEventListener::ensureJSFunction(ScriptExecutionContext &) const
```

"post a message, then close the sending port" is the normal one-shot pattern, so under memory pressure some fraction of those deliveries silently never happen.

### Cause

`MessagePortPipe::drainAndDispatch()` pops a message and decrements the pipe's queued count under the lock, then deserializes and dispatches it. `MessagePort::hasPendingActivity()` is

```
hasMessageListener && (queuedCount > 0 || isOtherSideOpen)
```

so once the peer is closed and the last message has been popped, nothing reports pending activity for the receiving port. Its `JSMessagePort` wrapper is only kept alive through `JSMessagePortOwner::isReachableFromOpaqueRoots()`, and the listener function is only marked (`JSEventListener::visitJSFunction`) when that wrapper is visited. Deserialization inside `MessageEvent::create()` allocates, so a GC there collects the wrapper and clears the listener's weak `m_jsFunction`; the subsequent `dispatchEvent()` finds no function and does nothing (or trips `ASSERT(m_wrapper)` on debug builds). The message is gone.

Regression from #29937 (v1.3.14): before that, `hasPendingActivity()` returned `m_entangled`, which kept the wrapper alive across dispatch (and also forever after the peer closed, which is the leak that change fixed).

### Fix

Release the message's `QueuedOne` unit only after `dispatchOneMessage()` returns, so `queuedCount > 0` holds for the whole pop to dispatch window and the wrapper (with its listeners) survives any GC in between. The release is skipped when the handler called `close()`, which already reset the state word; subtracting there would underflow the count.

`takeOne()` (used by `receiveMessageOnPort`) still decrements at pop time: there the port is an argument on the JS stack, so its wrapper is already rooted across the deserialize. `BroadcastChannel::hasPendingActivity()` does not depend on a queued count and is unaffected.

### Verification

New test in `test/js/web/workers/message-port-pipe.test.ts`: 100 one-shot channels whose receiving ports are unreferenced, a 1 MiB string payload (its deserialization reports enough extra memory to trigger collections inside the dispatch window), `BUN_JSC_forceRAMSize` to keep the heap small.

Without the `src/` change the test fails every run on a debug build (the `m_wrapper` assertion above, exit 134) and on the released 1.4.0 (`fired=98/100`). With the change it passes, along with the rest of `message-port-pipe.test.ts`, `message-channel.test.ts`, `message-port-closed-leak.test.ts`, `message-port-context-destroy-leak.test.ts`, `message-event.test.ts`, `worker-postmessage-transfer.test.ts`, and `worker_threads.test.ts`.

Independent of the open close-event work (#32564, #32565): neither changes when the queued count is decremented, and a peer torn down without an explicit `close()` never gets a close notification, so this window has to be closed in the drain loop itself. The repro above also never exits on its own because the `onmessage` setter's event-loop ref is not released when the peer closes; that is the separate issue #32564 addresses, and it is why the test child calls `process.exit(0)` after printing its count.
