### PR TITLE
bundler: keep a "__proto__" export name an own property in generated exports

### DIFF
--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -486,7 +486,7 @@ impl LinkerContext<'_> {
                 stmts: stmts_eat1!(Stmt::allocate(arena, S::Return { value: Some(value) }, loc,)),
                 loc,
             };
-            properties.push(G::Property {
+            let mut prop = G::Property {
                 key: Some(Expr::allocate(
                     arena,
                     // TODO: test emoji work as expected (relevant for WASM exports)
@@ -506,7 +506,13 @@ impl LinkerContext<'_> {
                     loc,
                 )),
                 ..Default::default()
-            });
+            };
+            // An alias named `__proto__` must print as a computed key: a bare
+            // `__proto__:` sets this descriptor object's prototype, and
+            // `__export`'s `for..in` would never install that getter.
+            prop.flags =
+                E::own_key_property_flags(prop.key.as_ref().expect("infallible: prop has key"));
+            properties.push(prop);
             ns_export_symbol_uses
                 .put_assume_capacity(exp_data.import_ref, SymbolUse { count_estimate: 1 });
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -447,6 +447,10 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                             // empty" invariant makes that drop a no-op today, but
                             // `ptr::write` enforces it structurally.
                             let key = prop.key;
+                            // Keep IsComputed: a data key named `__proto__` must
+                            // keep printing as `["__proto__"]:`, not as the
+                            // prototype-setter `__proto__:`.
+                            let flags = prop.flags;
                             let value_loc =
                                 prop.value.as_ref().expect("infallible: prop has value").loc;
                             // SAFETY: `prop` is a valid `&mut G::Property` slot;
@@ -457,6 +461,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                                     prop,
                                     G::Property {
                                         key,
+                                        flags,
                                         value: Some(Expr::init_identifier(export_ref, value_loc)),
                                         ..Default::default()
                                     },

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -77,12 +77,14 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                             // if the symbol is not used, we don't need to preserve
                             // a binding in this scope. we can move it to the exports object.
                             if symbol.use_count_estimate == 0 && value.can_be_moved() {
+                                let key = Expr::init(
+                                    // SAFETY: arena-owned name slice valid for the parse.
+                                    E::EString::init(symbol.original_name.slice()),
+                                    binding.loc,
+                                );
                                 self.export_props.push(G::Property {
-                                    key: Some(Expr::init(
-                                        // SAFETY: arena-owned name slice valid for the parse.
-                                        E::EString::init(symbol.original_name.slice()),
-                                        binding.loc,
-                                    )),
+                                    flags: E::own_key_property_flags(&key),
+                                    key: Some(key),
                                     value: Some(value),
                                     ..Default::default()
                                 });
@@ -257,16 +259,18 @@ impl<'a> ConvertESMExportsForHmr<'a> {
 
                 let class_name_ref = st.class.class_name.unwrap().ref_;
                 // Export as CommonJS
+                let key = Expr::init(
+                    // SAFETY: arena-owned name slice valid for the parse.
+                    E::EString::init(
+                        p.symbols[class_name_ref.inner_index() as usize]
+                            .original_name
+                            .slice(),
+                    ),
+                    stmt.loc,
+                );
                 self.export_props.push(G::Property {
-                    key: Some(Expr::init(
-                        // SAFETY: arena-owned name slice valid for the parse.
-                        E::EString::init(
-                            p.symbols[class_name_ref.inner_index() as usize]
-                                .original_name
-                                .slice(),
-                        ),
-                        stmt.loc,
-                    )),
+                    flags: E::own_key_property_flags(&key),
+                    key: Some(key),
                     value: Some(Expr::init_identifier(class_name_ref, stmt.loc)),
                     ..Default::default()
                 });
@@ -350,12 +354,11 @@ impl<'a> ConvertESMExportsForHmr<'a> {
 
                 if let Some(alias) = &st.alias {
                     // 'export * as ns from' creates one named property.
+                    // SAFETY: arena-owned name slice valid for the parse.
+                    let key = Expr::init(E::EString::init(alias.original_name.slice()), stmt.loc);
                     self.export_props.push(G::Property {
-                        // SAFETY: arena-owned name slice valid for the parse.
-                        key: Some(Expr::init(
-                            E::EString::init(alias.original_name.slice()),
-                            stmt.loc,
-                        )),
+                        flags: E::own_key_property_flags(&key),
+                        key: Some(key),
                         value: Some(Expr::init_identifier(deduped.namespace_ref, stmt.loc)),
                         ..Default::default()
                     });
@@ -621,11 +624,13 @@ impl<'a> ConvertESMExportsForHmr<'a> {
             // no setter is added since live bindings are read-only
         } else {
             // 'abc,'
+            let key = Expr::init(
+                E::EString::init(export_symbol_name.unwrap_or(original_name).slice()),
+                loc,
+            );
             self.export_props.push(G::Property {
-                key: Some(Expr::init(
-                    E::EString::init(export_symbol_name.unwrap_or(original_name).slice()),
-                    loc,
-                )),
+                flags: E::own_key_property_flags(&key),
+                key: Some(key),
                 value: Some(id),
                 ..Default::default()
             });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -369,6 +369,52 @@ describe("bundler", () => {
       stdout: '{"default":234}',
     },
   });
+  // A module namespace object is materialized via
+  // `__export(exports, { alias: () => var })`. A bare `__proto__:` key there is
+  // a prototype setter, so that named export would silently vanish.
+  itBundled("edgecase/ExportNamedProtoThroughNamespace", {
+    files: {
+      "/entry.ts": /* js */ `
+        import * as ns from './dep';
+        const get = (k: string) => (ns as any)[k];
+        console.log(JSON.stringify([Object.keys(ns).sort(), get("__proto__"), get("a")]));
+      `,
+      "/dep.ts": /* js */ `
+        export const a = 1;
+        const x = { own: true };
+        export { x as __proto__ };
+      `,
+    },
+    run: { stdout: '[["__proto__","a"],{"own":true},1]' },
+  });
+  // The HMR (internal_bake_dev) format emits each module's exports as an
+  // `hmr.exports = { ... }` object literal; an export named `__proto__` must
+  // use the computed key form or it becomes a prototype setter and vanishes.
+  itBundled("edgecase/ExportNamedProtoThroughHmrExports", {
+    format: "internal_bake_dev",
+    files: {
+      "/entry.ts": /* js */ `
+        import * as a from './a';
+        import * as b from './b';
+        import * as c from './c';
+        import * as d from './d';
+        console.log(a, b, c, d);
+      `,
+      "/a.ts": `const x = { own: true }; export { x as __proto__ };`,
+      "/b.ts": `export const __proto__ = 1;`,
+      "/c.ts": `export class __proto__ {}`,
+      "/d.ts": `export * as __proto__ from './other';`,
+      "/other.ts": `export const y = 1;`,
+    },
+    onAfterBundle(api) {
+      const output = api.readFile("/out.js");
+      const withProto = (output.match(/hmr\.exports = \{[^}]*\}/g) ?? []).filter(o => o.includes("__proto__"));
+      // Four modules export `__proto__` (alias, moved const, class declaration,
+      // and `export * as`); every one must use the computed own-property key.
+      expect(withProto.length).toBeGreaterThanOrEqual(4);
+      for (const o of withProto) expect(o).toContain('["__proto__"]:');
+    },
+  });
   itBundled("edgecase/RequireUnknownExtension", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -251,6 +251,42 @@ describe("bundler", async () => {
     run: { stdout: "[true,true,true]" },
   });
 
+  // The linker rewrites a lazy export's properties to reference the generated
+  // named-export variables. Dropping the property flags there undoes the
+  // parser's computed key, and renaming makes it a prototype setter again.
+  itBundled("bun/loader-json-proto-key-named-import-minified", {
+    target: "bun",
+    minifyIdentifiers: true,
+    files: {
+      "/entry.ts": /* js */ `
+    import data, { __proto__ as p } from './data.json';
+    console.write(JSON.stringify([
+      p,
+      Object.hasOwn(data, "__proto__"),
+      Object.getPrototypeOf(data) === Object.prototype,
+    ]));
+  `,
+      "/data.json": `{"__proto__": {"polluted": true}, "a": 1}`,
+    },
+    run: { stdout: '[{"polluted":true},true,true]' },
+  });
+
+  // When the namespace escapes, the linker materializes it with
+  // `__export(exports, { alias: () => var })`. A bare `__proto__:` key there is
+  // a prototype setter too, which drops that named export entirely.
+  itBundled("bun/loader-json-proto-key-namespace", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+    import * as ns from './data.json';
+    const get = (k: string) => (ns as any)[k];
+    console.write(JSON.stringify([Object.keys(ns).sort(), get("__proto__"), get("a")]));
+  `,
+      "/data.json": `{"__proto__": {"polluted": true}, "a": 1}`,
+    },
+    run: { stdout: '[["__proto__","a","default"],{"polluted":true},1]' },
+  });
+
   itBundled("bun/wasm-is-copied-to-outdir", {
     target: "bun",
     outdir: "/out",


### PR DESCRIPTION
> **Rescoped after #33072.** This PR originally fixed the `__proto__` key bug in the data-file parsers. #33072 ("Hardening round 11") landed that same fix on `main` while this was open, so the parser half has been dropped and this now contains only the part that is still broken: three sites later in the bundler pipeline that rebuild object literals and reintroduce the bare key. One of them silently undoes #33072's own fix. The original parser fix, the exhaustive audit, and the review discussion are preserved in this PR's history.

### What does this PR do?

A non-computed `__proto__` key in a JS object literal sets the object's `[[Prototype]]` instead of defining an own property. #33072 handles this at the data-file parsers by marking such keys computed (`["__proto__"]:`) via `E::own_key_property_flags`. Three places that construct object literals *after* parsing still emit the bare form, so the key is dropped and the prototype is replaced.

All three reproduce on `main` today, at `a8d0692` (which includes #33072).

**1. `generateCodeForFileInChunkJS.rs` drops the flags, defeating #33072.** The linker rewrites a lazy export's property values to reference the generated named-export variables, and rebuilds each `G::Property` with `..Default::default()`, discarding `IsComputed`. Under `--minify-identifiers` the generated variable is renamed, so the key and value names differ and the result is a real prototype setter:

```js
// data.json: {"__proto__": {"polluted": true}, "a": 1}
// entry.ts:  import data, { __proto__ as p } from './data.json';
```

```
$ bun build entry.ts --minify-identifiers
var t = { polluted: 1 };
var o = { __proto__: t, a: 1 };            // ← the computed key is gone

Object.hasOwn(o, "__proto__")              // false
Object.getPrototypeOf(o)                   // { polluted: 1 }
```

**2. `doStep5.rs` builds the `__export` namespace descriptor with a bare key.** `create_exports_for_file` emits `__export(exports, { alias: () => var })`. A `__proto__` alias sets that descriptor object's prototype, so `__export`'s `for..in` loop never sees the entry and never installs the getter. The named export vanishes from the namespace object:

```js
import * as ns from "./data.json";
const get = k => ns[k];
console.log(Object.keys(ns), get("__proto__"));
// main: [ 'a', 'default' ] {}       ← the export is gone
```

This is not specific to data files: plain JS `export { x as __proto__ }` hits the same path.

**3. `lower_esm_exports_hmr.rs` builds `hmr.exports` with a bare key.** The `internal_bake_dev` (dev server) lowering emits each module's exports as `hmr.exports = { name: value }`. Four of its arms use a user-derived key, and all four print the setter form:

```js
"a.ts"(hmr) { var x = { own: true }; hmr.exports = { __proto__: x }; }        // export { x as __proto__ }
"b.ts"(hmr) { hmr.exports = { __proto__: 1 }; }                               // export const __proto__ = 1
"c.ts"(hmr) { class __proto__2 {} hmr.exports = { __proto__: __proto__2 }; }  // export class __proto__
"d.ts"(hmr) { ... hmr.exports = { __proto__: exports4 }; }                    // export * as __proto__ from
```

**The fix** routes all three through the existing `E::own_key_property_flags` helper from #33072, and preserves `prop.flags` across the lazy-export rewrite. No new helper is introduced.

Two sibling sites that also key object literals by export aliases are already correct and are deliberately left alone, because accessors and spreads are not subject to the `__proto__` prototype-setter rule: the synthetic-getter object in `postProcessJSChunk.rs`, and the live-binding getter and export-star spread arms in `lower_esm_exports_hmr.rs`.

### How did you verify your code works?

Four new tests, each of which fails on `main` at `a8d0692` and passes with this change:

- `bun/loader-json-proto-key-named-import-minified` and `bun/loader-json-proto-key-namespace` in `bundler_loader.test.ts`, alongside #33072's parser tests.
- `edgecase/ExportNamedProtoThroughNamespace` (plain JS `export { x as __proto__ }` through `__export`) and `edgecase/ExportNamedProtoThroughHmrExports` (all four HMR arms) in `bundler_edgecase.test.ts`.

Failing output on `main`:

```
Expected: "[{"polluted":true},true,true]"
Received: "[{"polluted":true},false,false]"      # the minified case

Expected: "[["__proto__","a","default"],{"polluted":true},1]"
Received: "[["a","default"],{},1]"               # the namespace case
```

Regression runs with `bun bd test`: `bundler_loader.test.ts` + `bundler_edgecase.test.ts` (156 pass, 0 fail), including #33072's nine parser tests, which confirms this composes with that fix rather than conflicting with it. `test/bake/dev/esm.test.ts` (17 dev-server tests covering the HMR lowering) also passes.

Each of the three reproductions above was run against a build of `main` at `a8d0692` before the fix and against this branch after it.

### Out of scope: known sibling sites

An exhaustive audit of every `G::Property` construction in `src/` found three other places that key an object literal by a user-derived name, deliberately not changed here:

- `AstBuilder.rs:401` and `bundle_v2.rs:3381` key the Bake RSC client-reference proxy and the `ssrManifest` by a `"use client"` module's export names. Neither is reachable today: `bun build --server-components` panics (`called Option::unwrap() on a None value`) on an unmodified Bun whenever a `"use client"` module is present, before either object is emitted, and the code beside the second site is a `todo_panic!("use server")`. A fail-before test is impossible until that separate crash is fixed. The fix at each is the same one-line swap.
- The JSX transform turns `<div __proto__={x} />` into `jsx("div", { __proto__: x })`. esbuild, whose JSX lowering Bun's is ported from, emits the identical form, so this is ecosystem parity rather than a Bun bug, and the parse-site properties round-trip back to JSX under `--jsx=preserve`, where a computed key would be invalid.

Everything else in the audit is a fixed literal key, an accessor or spread, a faithful round-trip of the user's JS source, or `print_json` output.