### PR TITLE
bundler: don't cache a module evaluation that threw as a success

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -106,8 +106,18 @@ export var __toCommonJS = from => {
 /*__PURE__*/
 var __moduleCache;
 
-// When you do know the module is CJS
-export var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+// When you do know the module is CJS.
+// Node removes a module from require.cache when its evaluation throws, so a
+// later require() re-evaluates it instead of returning the partial exports.
+export var __commonJS = (cb, mod) => () => {
+  if (!mod)
+    try {
+      cb((mod = { exports: {} }).exports, mod);
+    } catch (e) {
+      throw ((mod = 0), e);
+    }
+  return mod.exports;
+};
 
 export var __name = (target, name) => {
   Object.defineProperty(target, "name", {
@@ -318,7 +328,19 @@ export var __decorateElement = (array, flags, name, decorators, target, extra) =
   );
 };
 
-export var __esm = (fn, res) => () => (fn && (res = fn((fn = 0))), res);
+// Lazily-evaluated ESM module body. ECMA-262 memoizes a failed evaluation:
+// re-importing must re-throw the same error, never succeed with a partial
+// namespace. `err` boxes the value so falsy throws still count as failed.
+export var __esm = (fn, res, err) => () => {
+  if (err) throw err[0];
+  if (fn)
+    try {
+      res = fn((fn = 0));
+    } catch (e) {
+      throw ((err = [e]), e);
+    }
+  return res;
+};
 
 // This is used for JSX inlining with React.
 export var $$typeof = /* @__PURE__ */ Symbol.for("react.element");

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1160,7 +1160,7 @@ describe("bundler", () => {
     snapshotSourceMap: {
       "entry.js.map": {
         files: ["../node_modules/react/index.js", "../entry.js"],
-        mappingsExactMatch: "2lBACA,WAAW,IAAQ,EAAE,ICDrB,eACA,QAAQ,IAAI,CAAK",
+        mappingsExactMatch: "8nBACA,WAAW,IAAQ,EAAE,ICDrB,eACA,QAAQ,IAAI,CAAK",
       },
     },
   });
@@ -2165,6 +2165,56 @@ describe("bundler", () => {
     },
     run: {
       stdout: "Disposing\nCaught error: This function throws",
+    },
+  });
+
+  // ECMA-262 memoizes a module evaluation that threw: every later import of it
+  // must reject with the same error, never succeed with a partial namespace.
+  itBundled("edgecase/ESMEvaluationThrowIsMemoized", {
+    files: {
+      "/entry.js": /* js */ `
+        const errors = [];
+        for (let i = 1; i <= 2; i++)
+          await import("./thrower.js").then(
+            ns => console.log(i, "fulfilled", JSON.stringify(ns)),
+            e => (errors.push(e), console.log(i, "rejected", e.message)),
+          );
+        console.log("same error:", errors.length === 2 && errors[0] === errors[1]);
+        console.log("evaluations:", globalThis.evaluations);
+      `,
+      "/thrower.js": /* js */ `
+        export let v = 1;
+        globalThis.evaluations = (globalThis.evaluations ?? 0) + 1;
+        throw new Error("boom");
+      `,
+    },
+    run: {
+      stdout: "1 rejected boom\n2 rejected boom\nsame error: true\nevaluations: 1",
+    },
+  });
+
+  // Node removes a CJS module from require.cache when its evaluation throws, so
+  // a later require() re-evaluates it instead of seeing the partial exports.
+  itBundled("edgecase/CommonJSEvaluationThrowIsNotCached", {
+    files: {
+      "/entry.cjs": /* js */ `
+        for (let i = 1; i <= 2; i++) {
+          try {
+            console.log(i, "loaded", JSON.stringify(require("./thrower.cjs")));
+          } catch (e) {
+            console.log(i, "threw", e.message);
+          }
+        }
+        console.log("evaluations:", globalThis.evaluations);
+      `,
+      "/thrower.cjs": /* js */ `
+        exports.v = 1;
+        globalThis.evaluations = (globalThis.evaluations ?? 0) + 1;
+        throw new Error("boom");
+      `,
+    },
+    run: {
+      stdout: "1 threw boom\n2 threw boom\nevaluations: 2",
     },
   });
 

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -57,9 +57,9 @@ describe("bundler", () => {
           "../entry.tsx",
         ],
         mappings: [
-          ["react.development.js:524:'getContextName'", "1:5623:nt"],
+          ["react.development.js:524:'getContextName'", "1:5660:nt"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:ar++"],
-          ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
+          ["react.development.js:696:''Component'", '1:7722:\'Component "%s"'],
           ["entry.tsx:6:'\"Content-Type\"'", '100:18808:"Content-Type"'],
           ["entry.tsx:11:'<html>'", "100:19062:void"],
           ["entry.tsx:23:'await'", "100:19161:await"],
@@ -67,7 +67,7 @@ describe("bundler", () => {
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 221969,
+      "out/entry.js": 222006,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -89,7 +89,17 @@ describe("bundler", () => {
               set: __exportSetter.bind(all, name)
             });
         };
-        var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+        var __esm = (fn, res, err) => () => {
+          if (err)
+            throw err[0];
+          if (fn)
+            try {
+              res = fn(fn = 0);
+            } catch (e) {
+              throw err = [e], e;
+            }
+          return res;
+        };
         var __promiseAll = (args) => Promise.all(args);
 
         // StoreDependencyAsync.ts
@@ -164,7 +174,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=42062903F19477CF64756E2164756E21
+        //# debugId=3EF63DB2CB2ED5F664756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -354,7 +364,17 @@ describe("bundler", () => {
               set: __exportSetter.bind(all, name)
             });
         };
-        var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+        var __esm = (fn, res, err) => () => {
+          if (err)
+            throw err[0];
+          if (fn)
+            try {
+              res = fn(fn = 0);
+            } catch (e) {
+              throw err = [e], e;
+            }
+          return res;
+        };
 
         // SecondElementImport.ts
         function SecondElementImport() {
@@ -410,7 +430,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=BF876FBF618133C264756E2164756E21
+        //# debugId=71E152310DE2511464756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
+++ b/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
@@ -122,7 +122,15 @@ var __toESM = (mod, isNodeMode, target) => {
     cache.set(mod, to);
   return to;
 };
-var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+var __commonJS = (cb, mod) => () => {
+  if (!mod)
+    try {
+      cb((mod = { exports: {} }).exports, mod);
+    } catch (e) {
+      throw mod = 0, e;
+    }
+  return mod.exports;
+};
 
 // node_modules/react/index.js
 var require_react = __commonJS(function(exports) {

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -105,7 +105,17 @@ test("cyclic imports with async dependencies should generate async wrappers", as
           set: __exportSetter.bind(all, name)
         });
     };
-    var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+    var __esm = (fn, res, err) => () => {
+      if (err)
+        throw err[0];
+      if (fn)
+        try {
+          res = fn(fn = 0);
+        } catch (e) {
+          throw err = [e], e;
+        }
+      return res;
+    };
     var __promiseAll = (args) => Promise.all(args);
 
     // src/RecursiveDependencies/StoreDependencyAsync.ts
@@ -180,7 +190,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=2020261114B67BB564756E2164756E21
+    //# debugId=D5F43ED7FE060A5564756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
`bun build` without `--splitting` emits a lazy evaluator for dynamically imported ESM modules that clears its init function before calling it:

```js
var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
```

If the module body throws, `fn` is already `0`, so the module is recorded as successfully initialized with `res = undefined`. The next `import()` skips evaluation and resolves with whatever part of the namespace existed at the throw. ECMA-262 memoizes a failed module evaluation, so every later import must reject with the same error. Node, Bun's own runtime on unbundled source, and the `--splitting` output all behave correctly; only the non-splitting bundle is wrong.

```js
// thrower.mjs
export let v = 1;
throw new Error("boom");

// entry.mjs
for (let i = 1; i <= 2; i++)
  await import("./thrower.mjs").then(
    ns => console.log(i, "FULFILLED", JSON.stringify(ns)),
    e => console.log(i, "rejected", e.message));
```

```
$ bun build entry.mjs --outfile o.js && node o.js
1 rejected boom
2 FULFILLED {"v":1}   <- half-initialized namespace; should be "2 rejected boom"
```

`__commonJS` has the same defect: `mod` is installed before the callback runs, so a CJS module that throws during evaluation hands its partial `exports` to the next `require()` as a success. Node removes a module from `require.cache` when its evaluation throws, so a later `require()` must re-evaluate it.

### Fix

Match esbuild, which fixed both helpers in [0.28.1](https://github.com/evanw/esbuild/releases/tag/v0.28.1) (evanw/esbuild#4461):

- `__esm` boxes the thrown value in a third closure-local and re-throws it on every later call. Top-level-await modules were already correct (the rejected promise is memoized in `res`) and are unaffected.
- `__commonJS` resets `mod` to `0` on throw so the next `require()` re-evaluates.

Both helpers are only ever emitted with one argument, so the added closure-local parameters are always `undefined` on the first call. The private `__commonJS` copies inside the vendored single-module bundles in `src/js/` (wasi, querystring, glob's minimatch) are untouched: each runs once at module init and never throws.

Three test files embed the runtime helper source in snapshots and were regenerated. Two tests pin values derived from the minified runtime preamble, which grew with the helper body; the new values were re-derived from the generated output and sourcemap, and in each case the mapped text at the new position is unchanged:

- `bundler_edgecase.test.ts`: the `mappingsExactMatch` string's leading generated-column VLQ.
- `bundler_npm.test.ts` (`npm/ReactSSR`): `expectExactFilesize` (221969 -> 222006) and the two line-1 generated columns in `snapshotSourceMap.mappings` (+37 each). Pins on later output lines are unaffected since a newline resets the column.

### Tests

`edgecase/ESMEvaluationThrowIsMemoized` and `edgecase/CommonJSEvaluationThrowIsNotCached` in `test/bundler/bundler_edgecase.test.ts`. Both fail on the released bun (the second import reports `FULFILLED {"v":1}` / `loaded {"v":1}`) and pass with the fix. With the fix, the bundled output matches node and esbuild for ESM `import()`, CJS `import()`, and CJS `require()`, including under `--minify`.

