### PR TITLE
node:cluster: stop leaking the worker object graph on every cluster.fork()

### DIFF
--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -79,6 +79,16 @@ impl InternalMsgHolder {
         self.worker.has() && self.cb.has()
     }
 
+    /// Release every GC root the holder owns. Idempotent. Must be called when
+    /// the IPC channel closes: no further internal message can arrive or be
+    /// acked, so keeping the roots alive only pins the worker object graph.
+    pub fn deinit(&mut self) {
+        self.callbacks.clear();
+        self.worker.deinit();
+        self.cb.deinit();
+        self.messages.clear();
+    }
+
     pub fn enqueue(&mut self, message: JSValue, global: &JSGlobalObject) {
         self.messages
             .push(crate::StrongOptional::create(message, global));
@@ -988,6 +998,10 @@ impl SendQueue {
             self.windows.windows_write = None; // will be freed by _windowsOnWriteComplete
         }
         self.keep_alive.disable();
+        // The channel is gone: release the cluster-internal GC roots now. They
+        // root the cluster Worker, which references the owning Subprocess, a
+        // cycle the GC can never break (one Subprocess leaked per cluster.fork).
+        self.internal_msg_queue.deinit();
         let was_open = matches!(self.socket, SocketUnion::Open(_));
         self.socket = SocketUnion::Closed;
         // Only enqueue the close notification for the open→closed transition.

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -998,9 +998,9 @@ impl SendQueue {
             self.windows.windows_write = None; // will be freed by _windowsOnWriteComplete
         }
         self.keep_alive.disable();
-        // The channel is gone: release the cluster-internal GC roots now. They
-        // root the cluster Worker, which references the owning Subprocess, a
-        // cycle the GC can never break (one Subprocess leaked per cluster.fork).
+        // The channel is gone: release the cluster-internal GC roots. They root
+        // the Worker, which references the owning Subprocess, so keeping them
+        // past the channel's lifetime pins the whole worker object graph.
         self.internal_msg_queue.deinit();
         let was_open = matches!(self.socket, SocketUnion::Open(_));
         self.socket = SocketUnion::Closed;

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -183,6 +183,13 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
         return Ok(JSValue::FALSE);
     };
 
+    // Node's sendHelper reports false once the channel is gone. Registering the
+    // ack callback on a closed channel would also leak it: the ack can never
+    // arrive, and the callback roots the worker (and this Subprocess) forever.
+    if !ipc_data.is_connected() {
+        return Ok(JSValue::FALSE);
+    }
+
     if message.is_undefined() {
         return Err(global.throw_missing_arguments_value(&["message"]));
     }

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, joinP, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, joinP, tempDir, tempDirWithFiles } from "harness";
 
 test("cloneable and transferable equals", () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -160,6 +160,69 @@ process.send("regular message");
   const { stdout } = bunRun(joinP(dir, "parent.ts"), bunEnv);
   expect(stdout).toContain("P received regular message");
 });
+
+test("primary releases the worker object graph once the worker exits", async () => {
+  using dir = tempDir("cluster-fork-gc", {
+    "primary.fixture.ts": `
+import cluster from "node:cluster";
+import { heapStats } from "bun:jsc";
+
+if (cluster.isPrimary) {
+  const forkOnce = () =>
+    new Promise<void>((resolve, reject) => {
+      const worker = cluster.fork();
+      let pending = 2;
+      const step = () => --pending || resolve();
+      worker.on("error", reject);
+      worker.once("exit", (code, signal) =>
+        code === 0 && signal === null ? step() : reject(new Error(\`worker exited with \${code} \${signal}\`)),
+      );
+      worker.once("disconnect", step);
+    });
+
+  const countSubprocesses = () => {
+    Bun.gc(true);
+    return heapStats().objectTypeCounts.Subprocess ?? 0;
+  };
+
+  // Warm up lazily-initialized state so the measured window is steady-state.
+  for (let i = 0; i < 2; i++) await forkOnce();
+  const before = countSubprocesses();
+
+  const iterations = 6;
+  for (let i = 0; i < iterations; i++) await forkOnce();
+
+  // Bounded poll: deferred finalization may lag a tick, but a real leak
+  // (one Strong-rooted Subprocess per fork) never resolves.
+  let after = countSubprocesses();
+  for (let i = 0; i < 40 && after - before > 1; i++) {
+    await Bun.sleep(25);
+    after = countSubprocesses();
+  }
+
+  console.log(JSON.stringify({ before, after, workers: Object.keys(cluster.workers).length }));
+} else {
+  process.exit(0);
+}
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "primary.fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const summary = stdout.trim().split("\n").at(-1) ?? "";
+  expect(summary, `stderr: ${stderr}`).toStartWith("{");
+  const { before, after, workers } = JSON.parse(summary);
+  expect(workers).toBe(0);
+  // The internal IPC send-queue used to hold jsc.Strong roots on the cluster
+  // Worker, which references the Subprocess that owns the queue, so every
+  // fork leaked one native Subprocess (plus the worker's JS object graph).
+  expect(after - before).toBeLessThanOrEqual(1);
+  expect(exitCode).toBe(0);
+}, 60_000);
 
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {
   // `kHandle` is a private symbol that only `cluster.fork()` sets, so a

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -192,11 +192,12 @@ if (cluster.isPrimary) {
   const iterations = 6;
   for (let i = 0; i < iterations; i++) await forkOnce();
 
-  // Bounded poll: deferred finalization may lag a tick, but a real leak
-  // (one Strong-rooted Subprocess per fork) never resolves.
+  // Bounded poll across event-loop turns: finalization may need a few extra
+  // turns, while a leaked (Strong-rooted) Subprocess never goes away.
+  const nextTurn = () => new Promise<void>(resolve => setImmediate(resolve));
   let after = countSubprocesses();
   for (let i = 0; i < 40 && after - before > 1; i++) {
-    await Bun.sleep(25);
+    await nextTurn();
     after = countSubprocesses();
   }
 
@@ -217,9 +218,6 @@ if (cluster.isPrimary) {
   expect(summary, `stderr: ${stderr}`).toStartWith("{");
   const { before, after, workers } = JSON.parse(summary);
   expect(workers).toBe(0);
-  // The internal IPC send-queue used to hold jsc.Strong roots on the cluster
-  // Worker, which references the Subprocess that owns the queue, so every
-  // fork leaked one native Subprocess (plus the worker's JS object graph).
   expect(after - before).toBeLessThanOrEqual(1);
   expect(exitCode).toBe(0);
 }, 60_000);


### PR DESCRIPTION
### What

Fixes a permanent per-fork memory leak in the `node:cluster` primary: every `cluster.fork()` retained one native `Subprocess` plus the worker's whole JS object graph (~270 KB of post-GC heap per fork) forever, even after the worker exited and `cluster.workers` was empty.

```js
import cluster from "node:cluster";
import { heapStats } from "bun:jsc";

if (cluster.isPrimary) {
  for (let i = 0; i < 70; i++) {
    const w = cluster.fork(); // worker exits immediately
    await new Promise(r => w.on("exit", r));
  }
  Bun.gc(true);
  console.log(heapStats().objectTypeCounts.Subprocess); // bun: +70, node / child_process.fork: flat
} else {
  process.exit(0);
}
```

Any cluster manager that recycles workers (crash respawn, rolling restarts) leaks one process object graph per generation in the long-lived primary.

### Cause

`onInternalMessagePrimary` stores two `jsc.Strong` roots (the cluster `Worker` object and the internal message callback) in `InternalMsgHolder`, which lives inside the subprocess's own `SendQueue` (`src/jsc/ipc.rs`). Pending ack callbacks from `sendHelperPrimary` are stored there too. Those Strongs root the `Worker`, the `Worker` references the `Subprocess` wrapper, and the wrapper owns the `SendQueue` holding the Strongs. The roots were only released by `SendQueue`'s `Drop`, which runs when the `Subprocess` is finalized, which can never happen while the Strongs exist. The cycle goes through a GC root, so `Bun.gc(true)` cannot break it.

### Fix

- `SendQueue::_socket_closed` now calls `InternalMsgHolder::deinit()`, dropping the worker/callback roots and any pending ack callbacks as soon as the IPC channel closes. No internal message can arrive or be acked after that point (`handleInternalMessagePrimary` already early-returns when the holder is not ready).
- `sendHelperPrimary` returns `false` when the channel is no longer connected, matching Node's `sendHelper` (`if (!proc.connected) return false`). Previously it registered the ack callback Strong first, so a send racing with worker death would re-root the worker on a dead channel.

### Verification

New test in `test/js/node/cluster.test.ts` forks 6 workers that exit immediately, then counts live `Subprocess` objects after GC.

- `bun bd test test/js/node/cluster.test.ts`: all 6 tests pass.
- `USE_SYSTEM_BUN=1 bun test test/js/node/cluster.test.ts` (bun 1.4.0): the new test fails with 6 retained Subprocess objects for 6 forks.
- All 54 `test/js/node/test/parallel/test-cluster-*.js` and the `ipc`/`spawn-ipc-gc` suites pass with the fix.
