### PR TITLE
node-fallbacks: support base64url in the browser Buffer polyfill

### DIFF
--- a/src/node-fallbacks/buffer.js
+++ b/src/node-fallbacks/buffer.js
@@ -425,6 +425,7 @@ Buffer.isEncoding = function isEncoding(encoding) {
     case "latin1":
     case "binary":
     case "base64":
+    case "base64url":
     case "ucs2":
     case "ucs-2":
     case "utf16le":
@@ -509,6 +510,7 @@ function byteLength(string, encoding) {
       case "hex":
         return len >>> 1;
       case "base64":
+      case "base64url":
         return base64ToBytes(string).length;
       default:
         if (loweredCase) {
@@ -576,6 +578,9 @@ function slowToString(encoding, start, end) {
 
       case "base64":
         return base64Slice(this, start, end);
+
+      case "base64url":
+        return base64urlSlice(this, start, end);
 
       case "ucs2":
       case "ucs-2":
@@ -958,6 +963,7 @@ Buffer.prototype.write = function write(string, offset, length, encoding) {
         return asciiWrite(this, string, offset, length);
 
       case "base64":
+      case "base64url":
         // Warning: maxLength not taken into account in base64Write
         return base64Write(this, string, offset, length);
 
@@ -988,6 +994,12 @@ function base64Slice(buf, start, end) {
   } else {
     return base64.fromByteArray(buf.slice(start, end));
   }
+}
+
+// Like Node: URL-safe alphabet, no padding. Decoding (base64ToBytes) already
+// accepts both alphabets, so only encoding needs a dedicated path.
+function base64urlSlice(buf, start, end) {
+  return base64Slice(buf, start, end).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 function utf8Slice(buf, start, end) {

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -82,6 +82,41 @@ describe("bundler", () => {
       api.expectFile("out.js").not.toInclude("import ");
     },
   });
+  itBundled("browser/NodeBufferBase64Url", {
+    files: {
+      "/entry.js": /* js */ `
+        import { Buffer } from "buffer";
+        const buf = Buffer.from("aGk_-w", "base64url");
+        console.log(buf.toString("hex"));
+        console.log(buf.toString("base64url"));
+        console.log(Buffer.from("aGk/+w==", "base64url").toString("hex"));
+        console.log(Buffer.from("aGk_-w", "BASE64URL").toString("hex"));
+        console.log(Buffer.isEncoding("base64url"));
+        console.log(Buffer.byteLength("aGk_-w", "base64url"));
+        const dst = Buffer.alloc(4);
+        console.log(dst.write("aGk_-w", "base64url"), dst.toString("hex"));
+        console.log(Buffer.from([1, 2]).toString("base64url"), Buffer.from([1, 2, 3]).toString("base64url"));
+        console.log(Buffer.from([0xfb, 0xff, 0xfe]).toString("base64url"));
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: `
+        68693ffb
+        aGk_-w
+        68693ffb
+        68693ffb
+        true
+        4
+        4 68693ffb
+        AQI AQID
+        -__-
+      `,
+    },
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude("import ");
+    },
+  });
   itBundled("browser/NodeFS", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### What

`bun build --target=browser` inlines `src/node-fallbacks/buffer.js` for `buffer` / `node:buffer` imports. That polyfill does not recognize the `base64url` encoding, so code that works under the Bun runtime (and Node) throws once the built artifact runs:

```js
import { Buffer } from "buffer";
console.log(Buffer.from("aGk_-w", "base64url").toString("hex"));
// bun runtime / node:          68693ffb
// bun build --target=browser:  TypeError: Unknown encoding: base64url
```

`base64url` is what JWTs, WebAuthn and URL-safe tokens use, and the failure only shows up in the shipped bundle.

### Why

The polyfill is Bun's fork of feross/buffer, which has no `base64url` support (neither does the latest npm release, 6.0.3), so bumping the package is not a fix.

### How

In `src/node-fallbacks/buffer.js`:

- `Buffer.isEncoding`, `Buffer.byteLength`, `Buffer.prototype.write` and `Buffer.prototype.toString` now accept `base64url`.
- Decoding reuses the existing base64 path: the vendored base64-js already maps `-` and `_`, and Node accepts both alphabets for both encodings.
- Encoding goes through a new `base64urlSlice` helper that switches to the URL-safe alphabet and strips padding, matching Node's output.

### Verification

New test `browser/NodeBufferBase64Url` in `test/bundler/bundler_browser.test.ts` bundles the repro with `--target=browser` and runs the output. It asserts decoding (both alphabets), encoding (URL-safe alphabet, no padding), `isEncoding`, `byteLength`, `write`, and case-insensitive encoding names; the expected values were taken from Node v26 running the same program.

The test fails on current main with `TypeError: Unknown encoding: base64url` and passes with this change. The rest of `test/bundler/bundler_browser.test.ts` still passes.
