### PR TITLE
child_process: honor uid and gid spawn options

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6792,6 +6792,20 @@ declare module "bun" {
       detached?: boolean;
 
       /**
+       * Sets the user identity of the child process (see setuid(2)).
+       *
+       * POSIX only. On Windows the spawn fails with `ENOTSUP`.
+       */
+      uid?: number;
+
+      /**
+       * Sets the group identity of the child process (see setgid(2)).
+       *
+       * POSIX only. On Windows the spawn fails with `ENOTSUP`.
+       */
+      gid?: number;
+
+      /**
        * The environment variables of the process
        *
        * Defaults to `process.env` as it was when the current Bun process launched.

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4804,6 +4804,12 @@ pub mod spawn_ffi {
         pub actions: ActionsList,
         pub pty_slave_fd: c_int,
         pub linux_pdeathsig: c_int,
+        /// `setuid(uid)` in the child before exec when `set_uid` is true.
+        pub uid: u32,
+        /// `setgid(gid)` in the child before exec when `set_gid` is true.
+        pub gid: u32,
+        pub set_uid: bool,
+        pub set_gid: bool,
     }
 
     impl Default for BunSpawnRequest {
@@ -4815,6 +4821,10 @@ pub mod spawn_ffi {
                 actions: ActionsList::default(),
                 pty_slave_fd: -1,
                 linux_pdeathsig: 0,
+                uid: 0,
+                gid: 0,
+                set_uid: false,
+                set_gid: false,
             }
         }
     }

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -567,6 +567,8 @@ function spawnSync(file, args, options) {
       cwd: options.cwd || undefined,
       stdio: bunStdio,
       detached: options.detached,
+      uid: options.uid,
+      gid: options.gid,
       windowsVerbatimArguments: options.windowsVerbatimArguments,
       windowsHide: options.windowsHide,
       argv0: options.args[0],
@@ -1407,6 +1409,8 @@ class ChildProcess extends EventEmitter {
         cwd: options.cwd || undefined,
         env: env,
         detached: typeof detachedOption !== "undefined" ? !!detachedOption : false,
+        uid: options.uid,
+        gid: options.gid,
         onExit: (handle, exitCode, signalCode, err) => {
           this.#handle = handle;
           this.pid = this.#handle.pid;
@@ -1486,6 +1490,11 @@ class ChildProcess extends EventEmitter {
           this.#stdioOptions[2] = "undefined";
         }
       } else {
+        if (exCode !== undefined) {
+          // Node throws errors that are not in the deferred list above
+          // synchronously, with `syscall: "spawn"` (no file appended).
+          ex.syscall = "spawn";
+        }
         throw ex;
       }
     }

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -69,10 +69,6 @@ if ($debug) {
 // ------------------------------
 // TODO: Look at Pipe to see if we can support passing Node Pipe objects to stdio param
 
-// TODO: Add these params after support added in Bun.spawn
-// uid <number> Sets the user identity of the process (see setuid(2)).
-// gid <number> Sets the group identity of the process (see setgid(2)).
-
 // stdio <Array> | <string> Child's stdio configuration (see options.stdio).
 // Support wrapped ipc types (e.g. net.Socket, dgram.Socket, TTY, etc.)
 // IPC FD passing support

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -12,6 +12,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/resource.h>
+#include <grp.h>
 
 #if OS(LINUX)
 #include <sys/syscall.h>
@@ -102,6 +103,10 @@ typedef struct bun_spawn_request_t {
     bun_spawn_file_action_list_t actions;
     int pty_slave_fd; // -1 if not using PTY, otherwise the slave fd to set as controlling terminal
     int linux_pdeathsig; // 0 = unset; otherwise signal delivered to child when parent thread dies
+    uint32_t uid; // setuid(uid) in the child before exec when set_uid is true
+    uint32_t gid; // setgid(gid) in the child before exec when set_gid is true
+    bool set_uid;
+    bool set_gid;
 } bun_spawn_request_t;
 
 // Raw exit syscall that doesn't go through libc.
@@ -292,6 +297,35 @@ extern "C" ssize_t posix_spawn_bun(
             }
             }
         }
+
+        // libuv order: setgroups (best-effort) -> setgid -> setuid, just before exec.
+        // Linux MUST use raw syscalls here: this is a vfork child sharing the parent's
+        // memory, and glibc's set*id wrappers broadcast SIGSETXID to every (parent) thread.
+        if (request->set_uid || request->set_gid) {
+            int savedErrno = errno;
+#if OS(LINUX)
+            (void)syscall(SYS_setgroups, 0, (const gid_t*)NULL);
+#else
+            (void)setgroups(0, NULL);
+#endif
+            errno = savedErrno;
+        }
+
+#if OS(LINUX)
+        if (request->set_gid && syscall(SYS_setgid, (gid_t)request->gid) != 0) {
+            return childFailed();
+        }
+        if (request->set_uid && syscall(SYS_setuid, (uid_t)request->uid) != 0) {
+            return childFailed();
+        }
+#else
+        if (request->set_gid && setgid((gid_t)request->gid) != 0) {
+            return childFailed();
+        }
+        if (request->set_uid && setuid((uid_t)request->uid) != 0) {
+            return childFailed();
+        }
+#endif
 
         sigprocmask(SIG_SETMASK, &childmask, 0);
         if (!envp)

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -158,6 +158,11 @@ extern "C" ssize_t posix_spawn_bun(
     // Linux's vfork() is more permissive and allows the setup we need
     // (setsid, ioctl, dup2, etc.) before exec.
     volatile int child_errno = 0;
+    // The vfork child shares this mm, and set*id in the child resets the
+    // mm-wide "dumpable" flag to /proc/sys/fs/suid_dumpable (commit_creds).
+    // Save it so the parent can restore it once vfork returns, like Go's
+    // forkAndExecInChild1 and systemd's safe_fork_full do.
+    int saved_dumpable = (request->set_uid || request->set_gid) ? prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) : -1;
     pid_t child = vfork();
 #else
     // On macOS, we must use fork() because vfork() is more strictly enforced.
@@ -318,6 +323,11 @@ extern "C" ssize_t posix_spawn_bun(
         if (request->set_uid && syscall(SYS_setuid, (uid_t)request->uid) != 0) {
             return childFailed();
         }
+        // The kernel clears PR_SET_PDEATHSIG when the effective uid/gid changes
+        // (prctl(2)), so re-arm it after dropping credentials.
+        if (request->linux_pdeathsig != 0 && (request->set_uid || request->set_gid)) {
+            prctl(PR_SET_PDEATHSIG, request->linux_pdeathsig, 0, 0, 0);
+        }
 #else
         if (request->set_gid && setgid((gid_t)request->gid) != 0) {
             return childFailed();
@@ -412,6 +422,12 @@ extern "C" ssize_t posix_spawn_bun(
     } else {
         // vfork() failed
         res = errno;
+    }
+
+    // PR_SET_DUMPABLE only accepts SUID_DUMP_DISABLE (0) / SUID_DUMP_USER (1);
+    // a saved value of 2 (suid_dumpable=2) means it was already the reset value.
+    if (saved_dumpable == 0 || saved_dumpable == 1) {
+        (void)prctl(PR_SET_DUMPABLE, saved_dumpable, 0, 0, 0);
     }
 #endif
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -397,6 +397,8 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut argv0: Option<*const c_char> = None;
     let mut ipc_channel: i32 = -1;
     let mut timeout: Option<i32> = None;
+    let mut uid: Option<u32> = None;
+    let mut gid: Option<u32> = None;
     let mut kill_signal: SignalCode = SignalCode::DEFAULT;
     let mut max_buffer: Option<i64> = None;
 
@@ -664,6 +666,40 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
             if let Some(detached_val) = args.get(global_this, "detached")? {
                 if detached_val.is_boolean() {
                     detached = detached_val.to_boolean();
+                }
+            }
+
+            // Node semantics: uid/gid are int32s passed through to the OS
+            // (negative values are cast to uid_t/gid_t, matching libuv).
+            if let Some(uid_value) = args.get(global_this, "uid")? {
+                if uid_value != JSValue::NULL {
+                    let uid_int = global_this.validate_integer_range::<i32>(
+                        uid_value,
+                        0,
+                        bun_sql_jsc::jsc::IntegerRange {
+                            min: i128::from(i32::MIN),
+                            max: i128::from(i32::MAX),
+                            field_name: b"uid",
+                            ..Default::default()
+                        },
+                    )?;
+                    uid = Some(uid_int as u32);
+                }
+            }
+
+            if let Some(gid_value) = args.get(global_this, "gid")? {
+                if gid_value != JSValue::NULL {
+                    let gid_int = global_this.validate_integer_range::<i32>(
+                        gid_value,
+                        0,
+                        bun_sql_jsc::jsc::IntegerRange {
+                            min: i128::from(i32::MIN),
+                            max: i128::from(i32::MAX),
+                            field_name: b"gid",
+                            ..Default::default()
+                        },
+                    )?;
+                    gid = Some(gid_int as u32);
                 }
             }
 
@@ -1052,6 +1088,8 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut spawn_options = SpawnOptions {
         cwd: cwd.to_vec().into_boxed_slice(),
         detached,
+        uid,
+        gid,
         stdin: match stdio[0].as_spawn_option(0) {
             stdio::ResultT::Result(opt) => opt,
             stdio::ResultT::Err(e) => return Err(e.throw_js(global_this)),

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1566,6 +1566,12 @@ pub struct WindowsSpawnOptions {
     pub extra_fds: Box<[WindowsStdio]>,
     pub cwd: Box<[u8]>,
     pub detached: bool,
+    /// `uv_process_options_t.uid` + `UV_PROCESS_SETUID`; libuv returns
+    /// `UV_ENOTSUP` on Windows, exactly like Node.
+    pub uid: Option<u32>,
+    /// `uv_process_options_t.gid` + `UV_PROCESS_SETGID`; libuv returns
+    /// `UV_ENOTSUP` on Windows, exactly like Node.
+    pub gid: Option<u32>,
     pub windows: WindowsOptions,
     pub argv0: Option<*const c_char>,
     pub stream: bool,
@@ -1593,6 +1599,8 @@ impl Default for WindowsSpawnOptions {
             extra_fds: Box::new([]),
             cwd: Box::new([]),
             detached: false,
+            uid: None,
+            gid: None,
             windows: WindowsOptions::default(),
             argv0: None,
             stream: true,
@@ -1862,6 +1870,17 @@ mod spawn_process_body {
 
         if options.detached {
             uv_process_options.flags |= uv::UV_PROCESS_DETACHED;
+        }
+
+        // libuv's uv_spawn rejects UV_PROCESS_SETUID/SETGID with UV_ENOTSUP on
+        // Windows — the same error Node reports for uid/gid there.
+        if let Some(uid) = options.uid {
+            uv_process_options.uid = uid as uv::uv_uid_t;
+            uv_process_options.flags |= uv::UV_PROCESS_SETUID;
+        }
+        if let Some(gid) = options.gid {
+            uv_process_options.gid = gid as uv::uv_gid_t;
+            uv_process_options.flags |= uv::UV_PROCESS_SETGID;
         }
 
         let mut stdio_containers: Vec<uv::uv_stdio_container_t> =

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -218,6 +218,8 @@ pub mod bun_spawn {
         pub flags: u16,
         pub reset_signals: bool,
         pub linux_pdeathsig: i32,
+        pub uid: Option<u32>,
+        pub gid: Option<u32>,
     }
 
     impl Default for Attr {
@@ -232,6 +234,8 @@ pub mod bun_spawn {
                 flags: 0,
                 reset_signals: false,
                 linux_pdeathsig: 0,
+                uid: None,
+                gid: None,
             }
         }
     }
@@ -601,16 +605,20 @@ pub mod posix_spawn {
     ) -> sys::Result<pid_t> {
         let pty_slave_fd = attr.map_or(-1, |a| a.pty_slave_fd);
         let detached = attr.is_some_and(|a| a.detached);
+        let uid = attr.and_then(|a| a.uid);
+        let gid = attr.and_then(|a| a.gid);
 
         // Use posix_spawn_bun when:
         // - Linux: always (uses vfork which is fast and safe)
-        // - macOS: only for PTY spawns (pty_slave_fd >= 0) because PTY setup requires
-        //   setsid() + ioctl(TIOCSCTTY) before exec, which system posix_spawn can't do.
-        //   For non-PTY spawns on macOS, we use system posix_spawn which is safer
+        // - macOS: for PTY spawns (pty_slave_fd >= 0) because PTY setup requires
+        //   setsid() + ioctl(TIOCSCTTY) before exec, which system posix_spawn can't do,
+        //   and for uid/gid spawns because Darwin's posix_spawn cannot change ids
+        //   (libuv makes the same fork() fallback for UV_PROCESS_SETUID/SETGID).
+        //   For other spawns on macOS, we use system posix_spawn which is safer
         //   (Apple's posix_spawn uses a kernel fast-path that avoids fork() entirely).
         let use_bun_spawn = cfg!(any(target_os = "linux", target_os = "android"))
             || cfg!(target_os = "freebsd")
-            || (cfg!(target_os = "macos") && pty_slave_fd >= 0);
+            || (cfg!(target_os = "macos") && (pty_slave_fd >= 0 || uid.is_some() || gid.is_some()));
 
         #[cfg(unix)]
         if use_bun_spawn {
@@ -634,6 +642,10 @@ pub mod posix_spawn {
                     new_process_group: attr.is_some_and(|a| a.new_process_group),
                     pty_slave_fd,
                     linux_pdeathsig: attr.map_or(0, |a| a.linux_pdeathsig),
+                    uid: uid.unwrap_or(0),
+                    gid: gid.unwrap_or(0),
+                    set_uid: uid.is_some(),
+                    set_gid: gid.is_some(),
                 },
                 argv,
                 envp,

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -308,6 +308,10 @@ pub struct PosixSpawnOptions {
     pub extra_fds: Box<[PosixStdio]>,
     pub cwd: Box<[u8]>,
     pub detached: bool,
+    /// Run the child as this user id (`setuid` after fork, like libuv/Node).
+    pub uid: Option<u32>,
+    /// Run the child as this group id (`setgid` after fork, like libuv/Node).
+    pub gid: Option<u32>,
     pub windows: (),
     pub argv0: Option<*const c_char>,
     pub stream: bool,
@@ -351,6 +355,8 @@ impl Default for PosixSpawnOptions {
             extra_fds: Box::default(),
             cwd: Box::default(),
             detached: false,
+            uid: None,
+            gid: None,
             windows: (),
             argv0: None,
             stream: true,
@@ -690,6 +696,8 @@ pub unsafe fn spawn_process_posix(
     // Pass PTY slave fd to attr for controlling terminal setup
     attr.pty_slave_fd = options.pty_slave_fd;
     attr.new_process_group = options.new_process_group;
+    attr.uid = options.uid;
+    attr.gid = options.gid;
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -52,6 +52,20 @@ const fixture = tempDir("no-orphans", {
     console.log(process.pid, process.ppid, gc.pid);
     setInterval(()=>{}, 1000);
   `,
+  // Same as child-nonbun.js but the grandchild drops to nobody. On Linux the
+  // kernel clears PR_SET_PDEATHSIG when the child's effective ids change
+  // (prctl(2)), so the spawn must re-arm it after setgid/setuid.
+  "child-nonbun-uid.js": `
+    const gc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", "echo r; while :; do sleep 1; done"],
+      uid: 65534,
+      gid: 65534,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    await gc.stdout.getReader().read();
+    console.log(process.pid, process.ppid, gc.pid);
+    setInterval(()=>{}, 1000);
+  `,
 });
 
 async function spawnTree(noOrphans: string | undefined, childScript = "child.js") {
@@ -172,6 +186,24 @@ test.skipIf(!isSupported)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: non-Bun grandchildren are reaped when bun dies with its parent",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun.js");
+    expect(isAlive(grandchildPid)).toBe(true);
+    process.kill(sh.pid!, "SIGKILL");
+    await sh.exited;
+    const bunDied = await waitUntilDead(bunPid, 10000);
+    const grandchildDied = await waitUntilDead(grandchildPid, 10000);
+    reap(bunPid, grandchildPid);
+    expect(bunDied).toBe(true);
+    expect(grandchildDied).toBe(true);
+  },
+);
+
+// Same as above but the grandchild is spawned with uid/gid. The credential
+// change clears the pdeathsig the spawn armed (prctl(2)), so this proves it
+// gets re-armed after setgid/setuid. Needs root to setuid.
+test.skipIf(!isSupported || process.getuid?.() !== 0)(
+  "BUN_FEATURE_FLAG_NO_ORPHANS=1: a non-Bun grandchild spawned with uid/gid is reaped",
+  async () => {
+    const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun-uid.js");
     expect(isAlive(grandchildPid)).toBe(true);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1227,3 +1227,31 @@ describe("option combinations", () => {
     expect(await proc.exited).toBe(0);
   });
 });
+
+describe("uid/gid", () => {
+  const isRoot = process.getuid?.() === 0;
+
+  it.if(isPosix && isRoot)("applies uid and gid to the child", async () => {
+    await using proc = spawn({ cmd: ["id", "-u"], uid: 65534, gid: 65534, stdout: "pipe" });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("65534");
+    expect(exitCode).toBe(0);
+  });
+
+  it.if(isPosix && isRoot)("omitting uid/gid leaves the child's ids unchanged", async () => {
+    await using proc = spawn({ cmd: ["id", "-u"], stdout: "pipe" });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("0");
+    expect(exitCode).toBe(0);
+  });
+
+  it.if(isPosix && !isRoot)("throws EPERM for a uid the process cannot set", () => {
+    let thrown: any;
+    try {
+      spawn({ cmd: ["id"], uid: 0 });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown?.code).toBe("EPERM");
+  });
+});

--- a/test/js/bun/spawn/spawnSync.test.ts
+++ b/test/js/bun/spawn/spawnSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isPosix } from "harness";
+import { bunEnv, bunExe, isLinux, isMusl, isPosix } from "harness";
 import { join } from "path";
 describe("spawnSync", () => {
   it("should throw a RangeError if timeout is less than 0", () => {
@@ -59,6 +59,29 @@ describe("uid/gid", () => {
 
     const groups = Bun.spawnSync({ cmd: ["id", "-G"], uid: 65534, gid: 65534 });
     expect(groups.stdout.toString().trim()).toBe("65534");
+  });
+
+  // The vfork child shares the parent's mm, and set*id resets the mm-wide
+  // "dumpable" flag (prctl(2)); the spawn must restore it in the parent.
+  it.if(isLinux && isRoot)("does not clear the parent's dumpable flag", async () => {
+    const libc = isMusl ? (process.arch === "arm64" ? "libc.musl-aarch64.so.1" : "libc.musl-x86_64.so.1") : "libc.so.6";
+    const fixture = `
+      const { dlopen, FFIType } = require("bun:ffi");
+      const { prctl } = dlopen(${JSON.stringify(libc)}, {
+        prctl: { args: [FFIType.i32, FFIType.u64, FFIType.u64, FFIType.u64, FFIType.u64], returns: FFIType.i32 },
+      }).symbols;
+      const PR_GET_DUMPABLE = 3;
+      const before = prctl(PR_GET_DUMPABLE, 0, 0, 0, 0);
+      const child = Bun.spawnSync({ cmd: ["id", "-u"], uid: 65534, gid: 65534 });
+      const after = prctl(PR_GET_DUMPABLE, 0, 0, 0, 0);
+      console.log(JSON.stringify({ before, after, childUid: child.stdout.toString().trim() }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: { before: 1, after: 1, childUid: "65534" },
+      exitCode: 0,
+    });
   });
 
   it.if(isPosix && !isRoot)("throws EPERM for a uid the process cannot set", () => {

--- a/test/js/bun/spawn/spawnSync.test.ts
+++ b/test/js/bun/spawn/spawnSync.test.ts
@@ -41,3 +41,33 @@ describe("spawnSync", () => {
     expect([join(import.meta.dir, "spawnSync-counters-fixture.ts")]).toRun();
   });
 });
+
+describe("uid/gid", () => {
+  const isRoot = process.getuid?.() === 0;
+
+  it("rejects a non-integer uid", () => {
+    expect(() => Bun.spawnSync({ cmd: [bunExe()], env: bunEnv, uid: 1.5 })).toThrow();
+    expect(() => Bun.spawnSync({ cmd: [bunExe()], env: bunEnv, gid: 1.5 })).toThrow();
+  });
+
+  it.if(isPosix && isRoot)("applies uid/gid and drops supplementary groups", () => {
+    const result = Bun.spawnSync({ cmd: ["id"], uid: 65534, gid: 65534 });
+    const out = result.stdout.toString();
+    expect(out).toContain("uid=65534");
+    expect(out).toContain("gid=65534");
+    expect(result.exitCode).toBe(0);
+
+    const groups = Bun.spawnSync({ cmd: ["id", "-G"], uid: 65534, gid: 65534 });
+    expect(groups.stdout.toString().trim()).toBe("65534");
+  });
+
+  it.if(isPosix && !isRoot)("throws EPERM for a uid the process cannot set", () => {
+    let thrown: any;
+    try {
+      Bun.spawnSync({ cmd: ["id"], uid: 0 });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown?.code).toBe("EPERM");
+  });
+});

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -728,3 +728,103 @@ done
   const asyncOut = await promise;
   expect(asyncOut.trim().split("\n")).toEqual(expected);
 });
+
+describe("uid/gid options", () => {
+  const isRoot = process.getuid?.() === 0;
+  // 65534 is "nobody" on every Linux distro and on macOS.
+  const NOBODY = 65534;
+
+  it.skipIf(isWindows || !isRoot)("spawnSync applies uid/gid and drops supplementary groups", () => {
+    const both = spawnSync("id", [], { uid: NOBODY, gid: NOBODY, encoding: "utf8" });
+    expect(both.error).toBeUndefined();
+    expect(both.stdout).toContain(`uid=${NOBODY}`);
+    expect(both.stdout).toContain(`gid=${NOBODY}`);
+
+    // libuv (and Node) call setgroups(0, NULL) before setgid/setuid, so the
+    // child must not retain root's supplementary group 0.
+    const groups = spawnSync("id", ["-G"], { uid: NOBODY, gid: NOBODY, encoding: "utf8" });
+    expect(groups.error).toBeUndefined();
+    expect(groups.stdout.trim()).toBe(`${NOBODY}`);
+
+    const gidOnly = spawnSync("id", [], { gid: NOBODY, encoding: "utf8" });
+    expect(gidOnly.error).toBeUndefined();
+    expect(gidOnly.stdout).toContain("uid=0");
+    expect(gidOnly.stdout).toContain(`gid=${NOBODY}`);
+  });
+
+  it.skipIf(isWindows || !isRoot)("spawn applies uid/gid (async)", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{ out: string; code: number | null }>();
+    const child = spawn("id", ["-u"], { uid: NOBODY, gid: NOBODY });
+    let out = "";
+    child.stdout.on("data", d => (out += d));
+    child.on("error", reject);
+    child.on("close", code => resolve({ out, code }));
+    const { out: stdout, code } = await promise;
+    expect(stdout.trim()).toBe(`${NOBODY}`);
+    expect(code).toBe(0);
+  });
+
+  it.skipIf(isWindows || isRoot)("spawn with a uid the process cannot set throws EPERM synchronously", () => {
+    // Node defers only EACCES/EAGAIN/EMFILE/ENFILE/ENOENT to the 'error'
+    // event; EPERM is thrown synchronously from spawn().
+    let thrown: any;
+    try {
+      spawn("id", [], { uid: 0 });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown?.code).toBe("EPERM");
+    expect(thrown?.errno).toBe(-1);
+    expect(thrown?.syscall).toBe("spawn");
+
+    const r = spawnSync("id", [], { uid: 0, encoding: "utf8" });
+    expect(r.error?.code).toBe("EPERM");
+    expect(r.error?.errno).toBe(-1);
+    expect(r.error?.syscall).toBe("spawnSync id");
+    expect(r.stdout == null).toBe(true);
+  });
+
+  it.skipIf(isWindows || !isRoot)("spawn reports EPERM after dropping privileges", async () => {
+    const fixture = `const cp = require("node:child_process");
+let thrown = null;
+try { cp.spawn("id", [], { uid: 0 }); } catch (e) { thrown = e; }
+const r = cp.spawnSync("id", [], { uid: 0 });
+console.log(JSON.stringify({ uid: process.getuid(), threwCode: thrown?.code, threwErrno: thrown?.errno, threwSyscall: thrown?.syscall, syncCode: r.error?.code, gotStdout: r.stdout != null }));`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      // The de-privileged child re-spawns from its cwd, so the cwd must be
+      // traversable by uid 65534 (the harness tmpdir is mode 0700, root-owned).
+      cwd: "/",
+      uid: NOBODY,
+      gid: NOBODY,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: {
+        uid: NOBODY,
+        threwCode: "EPERM",
+        threwErrno: -1,
+        threwSyscall: "spawn",
+        syncCode: "EPERM",
+        gotStdout: false,
+      },
+      exitCode: 0,
+    });
+  });
+
+  it.if(isWindows)("spawn with uid/gid fails with ENOTSUP on Windows", () => {
+    let thrown: any;
+    try {
+      spawn("cmd.exe", ["/c", "exit 0"], { uid: 0 });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown?.code).toBe("ENOTSUP");
+
+    const r = spawnSync("cmd.exe", ["/c", "exit 0"], { gid: 0 });
+    expect(r.error?.code).toBe("ENOTSUP");
+  });
+});


### PR DESCRIPTION
### What does this PR do?

`node:child_process` validates the `uid`/`gid` options but never forwarded them to the underlying spawn, so the child always ran with the parent's user/group ids. This implements them end-to-end for `Bun.spawn`, `Bun.spawnSync`, and `node:child_process` (`spawn`, `spawnSync`, and the `exec*`/`fork` wrappers that build on them), following libuv's behavior so it matches Node:

- **POSIX**: in the child, after `chdir` and the fd actions and immediately before `exec`: best-effort `setgroups(0, NULL)`, then `setgid`, then `setuid`. An id-set failure surfaces through the existing child-errno channel, so `cp.spawn` throws `EPERM` synchronously and `cp.spawnSync` returns it on `result.error` — the same dispatch as Node (EPERM is not in Node's deferred-to-`'error'`-event list).
  - On Linux the child is a `vfork` child sharing the parent's address space, so the id changes use raw `syscall(SYS_setgroups/SYS_setgid/SYS_setuid, ...)` rather than the glibc wrappers, which run the NPTL `SIGSETXID` broadcast over the (shared) parent thread list. glibc's own `posix_spawn` does the same for `POSIX_SPAWN_RESETIDS`.
- **macOS**: uid/gid spawns are routed through the fork-based `posix_spawn_bun` path (already used for PTY spawns), because Darwin's system `posix_spawn` cannot change ids — the same fallback libuv makes.
- **Windows**: `uv_process_options_t.uid/.gid` + `UV_PROCESS_SETUID/SETGID` are passed to `uv_spawn`, which returns `UV_ENOTSUP` — exactly what Node reports on Windows.

Also: errors that `cp.spawn` throws synchronously (i.e. not in the deferred list) now get `syscall: "spawn"`, matching Node.

`packages/bun-types/bun.d.ts` documents the new `uid`/`gid` options on `Bun.spawn`.

### Behavior verified against real Node (v26.3.0, Linux)

Outputs compared side by side with `node`:

- as root, `{uid: 65534, gid: 65534}` → child reports `uid=65534 gid=65534 groups=65534` (supplementary group 0 dropped); `{gid: 65534}` alone → `uid=0 gid=65534`; `id -G` prints only `65534`. `spawn`/`spawnSync`/`execFile` all match.
- as a non-root user, `{uid: 0}` → `spawnSync(...).error` is `{code: "EPERM", errno: -1, syscall: "spawnSync id", spawnargs: []}` and `spawn()` throws synchronously with `{code: "EPERM", errno: -1, syscall: "spawn"}` — identical fields to Node.
- `test-child-process-spawnsync-validation-errors.js` passes both as root and as a non-root user.

One intentional deviation: the EPERM error's `message` string keeps Bun's existing native wording (`"EPERM: operation not permitted, posix_spawn 'id'"`) instead of Node's `"spawn EPERM"`, consistent with how Bun already reports `ENOENT` from spawn. `code`/`errno`/`syscall`/throw-vs-event dispatch all match Node; the new tests assert those, not the message text.

### Tests

Added to the existing `test/js/node/child_process/child_process.test.ts`, `test/js/bun/spawn/spawn.test.ts`, and `test/js/bun/spawn/spawnSync.test.ts`:

- root-gated (`test.skipIf(!isRoot)`) success-path tests: uid+gid applied, supplementary groups dropped, gid-only leaves uid unchanged, async `spawn` variant.
- non-root EPERM tests (synchronous throw from `spawn`, `result.error` from `spawnSync`, `Bun.spawn`/`Bun.spawnSync`).
- a root-gated fixture that uses the new option to drop to uid 65534 and then asserts the real EPERM path inside the de-privileged child, so the EPERM path is exercised on root CI runners too.
- a Windows test asserting `ENOTSUP`.
- a validation test (`uid: 1.5` rejected) that runs everywhere regardless of privileges.

All of the new tests (except the deliberate negative-contract one) fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`. Full runs of `child_process.test.ts`, `spawn.test.ts`, `spawnSync.test.ts`, the other `test/js/node/child_process/*` suites, and a sweep of `test/js/node/test/parallel/test-child-process-*` show no new failures.