### PR TITLE
resolver: resolve non-absolute require.resolve paths entries against the cwd

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -376,6 +376,7 @@ pub struct Bufs {
     pub dir_info_uncached_path: PathBuffer,
     pub tsconfig_base_url: PathBuffer,
     pub relative_abs_path: PathBuffer,
+    pub custom_dir_abs_path: PathBuffer,
     pub load_as_file_or_directory_via_tsconfig_base_path: PathBuffer,
     pub node_modules_check: PathBuffer,
     pub field_abs_path: PathBuffer,
@@ -2087,12 +2088,20 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8_without_ref();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    // `paths` comes from JavaScript and may contain relative
+                    // entries; Node resolves those against the cwd.
+                    let custom_dir = if bun_paths::is_absolute(custom_utf8.slice()) {
+                        custom_utf8.slice()
+                    } else {
+                        let Some(joined) = self
+                            .fs_ref()
+                            .abs_buf_checked(&[custom_utf8.slice()], bufs!(custom_dir_abs_path))
+                        else {
+                            continue;
+                        };
+                        joined
+                    };
+                    match self.check_package_path(custom_dir, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -203,6 +203,44 @@ describe.concurrent("node-module-module", () => {
   test("builtin resolution", () => {
     expect(require.resolve("fs")).toBe("fs");
     expect(require.resolve("node:fs")).toBe("node:fs");
+  });
+  test("require.resolve with non-absolute options.paths entries", async () => {
+    using dir = tempDir("resolve-paths-relative", {
+      "node_modules/resolve-paths-relative-pkg/package.json": JSON.stringify({
+        name: "resolve-paths-relative-pkg",
+        main: "index.js",
+      }),
+      "node_modules/resolve-paths-relative-pkg/index.js": "module.exports = 1;",
+    });
+    const code = `
+      const { join } = require("path");
+      const { realpathSync } = require("fs");
+      const root = realpathSync(process.cwd());
+      const out = [
+        require.resolve("resolve-paths-relative-pkg", { paths: ["."] }) ===
+          join(root, "node_modules", "resolve-paths-relative-pkg", "index.js"),
+      ];
+      for (const entry of ["relative-dir-that-does-not-exist", Uint32Array]) {
+        try {
+          out.push(require.resolve("resolve-paths-missing-pkg", { paths: [entry] }));
+        } catch (e) {
+          out.push(e.code);
+        }
+      }
+      process.stdout.write(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({
+      stdout: JSON.stringify([true, "MODULE_NOT_FOUND", "MODULE_NOT_FOUND"]),
+      exitCode: 0,
+    });
   });
   test("require cache node builtins specifier", () => {
     // as js builtin


### PR DESCRIPTION
### What

`require.resolve(id, { paths: [...] })` (and `Module._resolveFilename` with `options.paths`) aborted the whole process when any entry in `paths` was not an absolute path:

```js
require.resolve("total", { paths: ["foo"] });
// panic: cannot resolve DirInfo for non-absolute path: foo
```

Non-string entries hit the same panic because they are stringified first. That is how Fuzzilli found it: `{ paths: [Uint32Array] }` turns into the "path" `function Uint32Array() { [native code] }`. Reproduces on current main and in release builds (the assertion is not debug-only).

### Why

The entries from `paths` are installed as `custom_dir_paths` on the resolver and handed directly to `Resolver::check_package_path` as source directories. That feeds them into `dir_info_cached`, which asserts the path is absolute. The normal source directory is normalized to an absolute path before resolution starts, but the `custom_dir_paths` loop skipped that step.

### How

When a `paths` entry is not absolute, join it against the top level directory (the cwd) before using it, which is what Node does with each entry (`path.resolve(from)` in `Module._nodeModulePaths`). Entries longer than the path buffer are skipped. Absolute entries behave exactly as before, and the relative-specifier branch already resolved entries this way via `check_relative_path`.

Node also rejects non-string `paths` entries with `ERR_INVALID_ARG_TYPE`, while Bun coerces them to strings. That divergence predates this change and is not touched here; such entries now produce `MODULE_NOT_FOUND` instead of a crash.

### Test

`test/js/node/module/node-module-module.test.js` gains a test that spawns a bun subprocess which resolves a real package through a relative `paths` entry (same result as Node) and checks that a relative entry and a non-string entry yield `MODULE_NOT_FOUND`. Before the fix the subprocess dies with exit code 134; with it, the test passes.
