### PR TITLE
docs: say Bun is written in Rust, not Zig

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,25 +11,6 @@
       },
       "problemMatcher": [
         {
-          "owner": "zig",
-          "fileLocation": ["relative", "${workspaceFolder}"],
-          "pattern": [
-            {
-              "regexp": "^(.+?):(\\d+):(\\d+): (error|warning|note): (.+)$",
-              "file": 1,
-              "line": 2,
-              "column": 3,
-              "severity": 4,
-              "message": 5,
-            },
-            {
-              "regexp": "^\\s+(.+)$",
-              "message": 1,
-              "loop": true,
-            },
-          ],
-        },
-        {
           "owner": "clang",
           "fileLocation": ["relative", "${workspaceFolder}"],
           "pattern": [

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,9 +8,9 @@ Bun statically links JavaScriptCore (and WebKit) which is LGPL-2 licensed. WebCo
 
 You can find the patched version of WebKit used by Bun here: <https://github.com/oven-sh/webkit>. If you would like to relink Bun with changes:
 
-- `git submodule update --init --recursive`
-- `make jsc`
-- `zig build`
+- `git clone https://github.com/oven-sh/WebKit vendor/WebKit`
+- `git -C vendor/WebKit checkout <commit>` (the commit hash in `WEBKIT_VERSION` in `scripts/build/deps/webkit.ts`)
+- `bun run build:local`
 
 This compiles JavaScriptCore, compiles Bun’s `.cpp` bindings for JavaScriptCore (which are the object files using JavaScriptCore) and outputs a new `bun` binary with your changes.
 
@@ -78,5 +78,5 @@ For compatibility reasons, the following packages are embedded into Bun's binary
 
 ## Additional credits
 
-- Bun's JS transpiler, CSS lexer, and Node.js module resolver source code is a Zig port of [@evanw](https://github.com/evanw)’s [esbuild](https://github.com/evanw/esbuild) project.
+- Bun's JS transpiler, CSS lexer, and Node.js module resolver source code is a port of [@evanw](https://github.com/evanw)’s [esbuild](https://github.com/evanw/esbuild) project.
 - Credit to [@kipply](https://github.com/kipply) for the name "Bun"!

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 Bun is an all-in-one toolkit for JavaScript and TypeScript apps. It ships as a single executable called `bun`.
 
-At its core is the _Bun runtime_, a fast JavaScript runtime designed as **a drop-in replacement for Node.js**. It's written in Zig and powered by JavaScriptCore under the hood, dramatically reducing startup times and memory usage.
+At its core is the _Bun runtime_, a fast JavaScript runtime designed as **a drop-in replacement for Node.js**. It's written in Rust and powered by JavaScriptCore under the hood, dramatically reducing startup times and memory usage.
 
 ```bash
 bun run index.tsx             # TS and JSX supported out-of-the-box

--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -14,7 +14,7 @@ Bun's bundler has built-in support for CSS with the following features:
 
 Bun's CSS bundler lets you use modern/future CSS features without having to worry about browser compatibility — all thanks to its transpiling and vendor prefixing features which are enabled by default.
 
-Bun's CSS parser and bundler is a direct Rust → Zig port of LightningCSS, with a bundling approach inspired by esbuild. The transpiler converts modern CSS syntax into backwards-compatible equivalents that work across browsers.
+Bun's CSS parser and bundler is a direct port of LightningCSS, with a bundling approach inspired by esbuild. The transpiler converts modern CSS syntax into backwards-compatible equivalents that work across browsers.
 
 <Note>A huge thanks goes to the amazing work from the authors of LightningCSS and esbuild.</Note>
 

--- a/docs/bundler/esbuild.mdx
+++ b/docs/bundler/esbuild.mdx
@@ -20,7 +20,7 @@ There are a few behavioral differences to note.
 
 ## Performance
 
-With a performance-minded API coupled with the extensively optimized Zig-based JS/TS parser, Bun's bundler is 1.75x faster than esbuild on esbuild's three.js benchmark.
+With a performance-minded API coupled with the extensively optimized Rust-based JS/TS parser, Bun's bundler is 1.75x faster than esbuild on esbuild's three.js benchmark.
 
 <Info>Bundling 10 copies of three.js from scratch, with sourcemaps and minification</Info>
 

--- a/docs/bundler/html-static.mdx
+++ b/docs/bundler/html-static.mdx
@@ -148,7 +148,7 @@ Learn more about module resolution in Bun.
 
 ## CSS
 
-Bun's CSS parser is also natively implemented (clocking in around 58,000 lines of Zig).
+Bun's CSS parser is also natively implemented (clocking in around 70,000 lines of Rust).
 
 It's also a CSS bundler. You can use `@import` in your CSS files to import other CSS files.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -87,7 +87,7 @@ Explore each area using the cards above. Each section is structured with an over
 
 Bun is an all-in-one toolkit for JavaScript and TypeScript apps. It ships as a single executable called `bun`.
 
-At its core is the _Bun runtime_, a fast JavaScript runtime designed as **a drop-in replacement for Node.js**. It's written in Zig and powered by JavaScriptCore under the hood, dramatically reducing startup times and memory usage.
+At its core is the _Bun runtime_, a fast JavaScript runtime designed as **a drop-in replacement for Node.js**. It's written in Rust and powered by JavaScriptCore under the hood, dramatically reducing startup times and memory usage.
 
 ```bash terminal icon="terminal"
 bun run index.tsx  # TS and JSX supported out of the box

--- a/docs/project/license.mdx
+++ b/docs/project/license.mdx
@@ -13,9 +13,9 @@ Bun statically links JavaScriptCore (and WebKit) which is LGPL-2 licensed. WebCo
 
 You can find the patched version of WebKit used by Bun here: https://github.com/oven-sh/webkit. If you would like to relink Bun with changes:
 
-- `git submodule update --init --recursive`
-- `make jsc`
-- `zig build`
+- `git clone https://github.com/oven-sh/WebKit vendor/WebKit`
+- `git -C vendor/WebKit checkout <commit>` (the commit hash in `WEBKIT_VERSION` in `scripts/build/deps/webkit.ts`)
+- `bun run build:local`
 
 This compiles JavaScriptCore, compiles Bun's `.cpp` bindings for JavaScriptCore (which are the object files using JavaScriptCore) and outputs a new `bun` binary with your changes.
 
@@ -74,5 +74,5 @@ For compatibility reasons, the following packages are embedded into Bun's binary
 
 ## Additional credits
 
-- Bun's JS transpiler, CSS lexer, and Node.js module resolver source code is a Zig port of [@evanw](https://github.com/evanw)’s [esbuild](https://github.com/evanw/esbuild) project.
+- Bun's JS transpiler, CSS lexer, and Node.js module resolver source code is a port of [@evanw](https://github.com/evanw)’s [esbuild](https://github.com/evanw/esbuild) project.
 - Credit to [@kipply](https://github.com/kipply) for the name "Bun"!

--- a/docs/runtime/ffi.mdx
+++ b/docs/runtime/ffi.mdx
@@ -116,7 +116,7 @@ extern "C" int32_t add(int32_t a, int32_t b) {
 To compile:
 
 ```bash
-zig build-lib add.cpp -dynamic -lc -lc++
+clang++ -shared -fPIC add.cpp -o libadd.so
 ```
 
 ---

--- a/docs/runtime/ffi.mdx
+++ b/docs/runtime/ffi.mdx
@@ -116,7 +116,11 @@ extern "C" int32_t add(int32_t a, int32_t b) {
 To compile:
 
 ```bash
+# Linux
 clang++ -shared -fPIC add.cpp -o libadd.so
+
+# macOS
+clang++ -dynamiclib add.cpp -o libadd.dylib
 ```
 
 ---

--- a/docs/runtime/index.mdx
+++ b/docs/runtime/index.mdx
@@ -7,7 +7,7 @@ import Run from "/snippets/cli/run.mdx";
 
 The Bun Runtime is designed to start fast and run fast.
 
-Under the hood, Bun uses the [JavaScriptCore engine](https://developer.apple.com/documentation/javascriptcore), which is developed by Apple for Safari. In most cases, the startup and running performance is faster than V8, the engine used by Node.js and Chromium-based browsers. Its transpiler and runtime are written in Zig, a modern, high-performance language. On Linux, this translates into startup times [4x faster](https://twitter.com/jarredsumner/status/1499225725492076544) than Node.js.
+Under the hood, Bun uses the [JavaScriptCore engine](https://developer.apple.com/documentation/javascriptcore), which is developed by Apple for Safari. In most cases, the startup and running performance is faster than V8, the engine used by Node.js and Chromium-based browsers. Its transpiler and runtime are written in Rust, a modern, high-performance language. On Linux, this translates into startup times [4x faster](https://twitter.com/jarredsumner/status/1499225725492076544) than Node.js.
 
 | Command         | Time     |
 | --------------- | -------- |

--- a/docs/runtime/json5.mdx
+++ b/docs/runtime/json5.mdx
@@ -13,7 +13,7 @@ In Bun, JSON5 is a first-class citizen alongside JSON, TOML, and YAML. You can:
 
 ## Conformance
 
-Bun's JSON5 parser passes 100% of the [official JSON5 test suite](https://github.com/json5/json5-tests). The parser is written in Zig for optimal performance. You can view our [translated test suite](https://github.com/oven-sh/bun/blob/main/test/js/bun/json5/json5-test-suite.test.ts) to see every test case.
+Bun's JSON5 parser passes 100% of the [official JSON5 test suite](https://github.com/json5/json5-tests). The parser is written in Rust for optimal performance. You can view our [translated test suite](https://github.com/oven-sh/bun/blob/main/test/js/bun/json5/json5-test-suite.test.ts) to see every test case.
 
 ---
 

--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -7,7 +7,7 @@ description: Parse and render Markdown with Bun's built-in Markdown API, support
   **Unstable API** — This API is under active development and may change in future versions of Bun.
 </Callout>
 
-Bun includes a fast, built-in Markdown parser written in Zig. It supports GitHub Flavored Markdown (GFM) extensions and provides three APIs:
+Bun includes a fast, built-in Markdown parser written in Rust. It supports GitHub Flavored Markdown (GFM) extensions and provides three APIs:
 
 - `Bun.markdown.html()` — render Markdown to an HTML string
 - `Bun.markdown.render()` — render Markdown with custom callbacks for each element

--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -567,7 +567,7 @@ async function getSession(sessionId) {
 
 ## Implementation Notes
 
-Bun's Redis client is implemented in Zig and uses the Redis Serialization Protocol (RESP3). It manages connections efficiently and provides automatic reconnection with exponential backoff.
+Bun's Redis client is implemented in Rust and uses the Redis Serialization Protocol (RESP3). It manages connections efficiently and provides automatic reconnection with exponential backoff.
 
 The client supports pipelining commands, meaning multiple commands can be sent without waiting for the replies to previous commands. This significantly improves performance when sending multiple commands in succession.
 

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -27,7 +27,7 @@ await $`cat < ${response} | wc -c`; // 1256
 - **Safety**: Bun Shell escapes all strings by default, preventing shell injection attacks.
 - **JavaScript interop**: Use `Response`, `ArrayBuffer`, `Blob`, `Bun.file(path)` and other JavaScript objects as stdin, stdout, and stderr.
 - **Shell scripting**: Bun Shell can be used to run shell scripts (`.bun.sh` files).
-- **Custom interpreter**: Bun Shell is written in Zig, along with its lexer, parser, and interpreter. Bun Shell is a small programming language.
+- **Custom interpreter**: Bun Shell is written in Rust, along with its lexer, parser, and interpreter. Bun Shell is a small programming language.
 
 ---
 
@@ -559,7 +559,7 @@ Hello World! pwd=C:\Users\Demo
 
 ## Implementation notes
 
-Bun Shell is a small programming language in Bun that is implemented in Zig. It includes a handwritten lexer, parser, and interpreter. Unlike bash, zsh, and other shells, Bun Shell runs operations concurrently.
+Bun Shell is a small programming language in Bun that is implemented in Rust. It includes a handwritten lexer, parser, and interpreter. Unlike bash, zsh, and other shells, Bun Shell runs operations concurrently.
 
 ---
 

--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -349,7 +349,7 @@ benchmark                                          time (avg)             (min â
 npm/string-width    500 chars ascii             249,710 ns/iter (239,970 ns â€¦ 293,180 ns) 250,930 ns  276,700 ns 281,450 ns
 ```
 
-To make `Bun.stringWidth` fast, we've implemented it in Zig using optimized SIMD instructions, accounting for Latin1, UTF-16, and UTF-8 encodings. It passes `string-width`'s tests.
+To make `Bun.stringWidth` fast, we've implemented it in native code using optimized SIMD instructions, accounting for Latin1, UTF-16, and UTF-8 encodings. It passes `string-width`'s tests.
 
 <Accordion title="View full benchmark">
 

--- a/docs/runtime/yaml.mdx
+++ b/docs/runtime/yaml.mdx
@@ -13,7 +13,7 @@ In Bun, YAML is a first-class citizen alongside JSON and TOML. You can:
 
 ## Conformance
 
-Bun's YAML parser currently passes over 90% of the official YAML test suite. While we're actively working on reaching 100% conformance, the current implementation covers the vast majority of real-world use cases. The parser is written in Zig for optimal performance and is continuously being improved.
+Bun's YAML parser currently passes over 90% of the official YAML test suite. While we're actively working on reaching 100% conformance, the current implementation covers the vast majority of real-world use cases. The parser is written in Rust for optimal performance and is continuously being improved.
 
 ---
 

--- a/misctools/lldb/README.md
+++ b/misctools/lldb/README.md
@@ -13,7 +13,7 @@ This directory contains LLDB pretty printers for various Bun data structures to 
 ### bun.String Types
 - `bun.String` (or just `String`) - The main Bun string type
 - `WTFStringImpl` - WebKit string implementation (Latin1/UTF16)
-- `ZigString` - Zig string type (UTF8/Latin1/UTF16 with pointer tagging)
+- `ZigString` - Tagged string type used at the FFI boundary (UTF8/Latin1/UTF16 with pointer tagging)
 
 ### Display Format
 
@@ -92,7 +92,7 @@ WTFStringImpl uses flags in `m_hashAndFlags`:
 bun.String is a tagged union with these variants:
 - Dead (0): Invalid/freed string
 - WTFStringImpl (1): WebKit string
-- ZigString (2): Regular Zig string
+- ZigString (2): Regular ZigString
 - StaticZigString (3): Static/immortal string
 - Empty (4): Empty string ""
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3160,9 +3160,8 @@ declare module "bun" {
    *
    * @see [Bun.password API docs](https://bun.com/guides/util/hash-a-password)
    *
-   * The underlying implementation of these functions are provided by the Zig
-   * Standard Library. Thanks to \@jedisct1 and other Zig contributors for their
-   * work on this.
+   * The underlying implementation of these functions is provided by the
+   * `rust-argon2` and `bcrypt` Rust crates.
    *
    * @example
    * **Example with argon2**
@@ -3267,9 +3266,8 @@ declare module "bun" {
      * Warning: password hashing is slow, consider using {@link Bun.password.verify}
      * instead which runs in a worker thread.
      *
-     * The underlying implementation of these functions are provided by the Zig
-     * Standard Library. Thanks to \@jedisct1 and other Zig contributors for their
-     * work on this.
+     * The underlying implementation of these functions is provided by the
+     * `rust-argon2` and `bcrypt` Rust crates.
      *
      * @example
      * **Example with argon2**
@@ -3312,9 +3310,8 @@ declare module "bun" {
      * Warning: password hashing is slow, consider using {@link Bun.password.hash}
      * instead which runs in a worker thread.
      *
-     * The underlying implementation of these functions are provided by the Zig
-     * Standard Library. Thanks to \@jedisct1 and other Zig contributors for their
-     * work on this.
+     * The underlying implementation of these functions is provided by the
+     * `rust-argon2` and `bcrypt` Rust crates.
      *
      * @example
      * **Example with argon2**

--- a/packages/bun-vscode/README.md
+++ b/packages/bun-vscode/README.md
@@ -6,7 +6,7 @@
 
 This extension adds support for using [Bun](https://bun.com/) with Visual Studio Code. Bun is an all-in-one toolkit for JavaScript and TypeScript apps.
 
-At its core is the _Bun runtime_, a fast JavaScript runtime designed as a drop-in replacement for Node.js. It's written in Zig and powered by JavaScriptCore under the hood, dramatically reducing startup times and memory usage.
+At its core is the _Bun runtime_, a fast JavaScript runtime designed as a drop-in replacement for Node.js. It's written in Rust and powered by JavaScriptCore under the hood, dramatically reducing startup times and memory usage.
 
 <div align="center">
   <a href="https://bun.com/docs">Documentation</a>

--- a/scripts/build/deps/nodejs-headers.ts
+++ b/scripts/build/deps/nodejs-headers.ts
@@ -10,8 +10,8 @@ import { resolve } from "node:path";
 import type { Dependency } from "../source.ts";
 
 /**
- * Node.js compat version — reported via process.version, used for headers
- * download URL, and passed to zig as -Dreported_nodejs_version.
+ * Node.js compat version — reported via process.version and used for the
+ * headers download URL.
  * Override via `--nodejs-version=X.Y.Z` to test a bump.
  */
 export const NODEJS_VERSION = "26.3.0";

--- a/test/js/web/fetch/H2_TEST_PORT_PLAN.md
+++ b/test/js/web/fetch/H2_TEST_PORT_PLAN.md
@@ -111,7 +111,7 @@ function rawH2Server(onStream: (write: (type, flags, sid, payload) => void, hpac
 }
 ```
 
-Or piggy-back on `src/http/H2FrameParser.zig` exposed via `bun:internal-for-testing` for encode helpers.
+Or piggy-back on `src/runtime/api/bun/h2_frame_parser.rs` exposed via `bun:internal-for-testing` for encode helpers.
 
 ---
 


### PR DESCRIPTION
Fixes #31233

### What does this PR do?

#32621 removed the Zig sources; the Rust port is the only implementation. The README, the docs site, and a couple of published packages still describe Bun as written in Zig (#31233 reports the README one). This updates them. Nothing in this PR reaches the compiler: it is markdown, mdx, JSDoc, editor config, and a build-script comment.

**User-facing**

- `README.md`, `docs/index.mdx`, `packages/bun-vscode/README.md`: "It's written in Zig and powered by JavaScriptCore" now says Rust.
- `docs/runtime/index.mdx`, `docs/bundler/esbuild.mdx`, `docs/runtime/{shell,redis,json5,yaml,markdown}.mdx`: "written in Zig" and "Zig-based" claims, each checked against the actual implementation (`src/runtime/shell/`, `src/runtime/valkey_jsc/`, `src/parsers/{json5,yaml}.rs`, `src/md/`).
- `docs/bundler/css.mdx`: the CSS bundler was described as "a direct Rust → Zig port of LightningCSS", now "a direct port of LightningCSS".
- `docs/bundler/html-static.mdx`: "58,000 lines of Zig" becomes "70,000 lines of Rust" (`src/css/**/*.rs` is 71.7k lines today).
- `docs/runtime/utils.mdx`: the `Bun.stringWidth` SIMD implementation lives in `src/jsc/bindings/stringWidth.cpp`, so this one says "native code" rather than claiming Rust.
- `docs/runtime/ffi.mdx`: the C++ example was compiled with `zig build-lib add.cpp`; it now shows `clang++` for Linux and macOS. The Zig FFI example itself stays, since calling a Zig shared library through `bun:ffi` is unrelated to Bun's implementation language.
- `packages/bun-types/bun.d.ts`: the `Bun.password` JSDoc credited the Zig standard library. The implementation routes to the `rust-argon2` and `bcrypt` crates (`src/runtime/crypto/pwhash.rs`), so it now says that.
- `LICENSE.md` and `docs/project/license.mdx` still told people to relink WebKit with `git submodule update`, `make jsc`, and `zig build`, none of which exist anymore. The steps now match `docs/project/contributing.mdx`: clone the WebKit fork into `vendor/WebKit`, check out `WEBKIT_VERSION`, run `bun run build:local`. The esbuild credit is now "a port of esbuild".

**Developer-facing**

- `.vscode/tasks.json`: the "Build Bun" task had a zig-owner problemMatcher for `file:line:col: error:` output. There is no Zig compiler in the build, and the clang matcher next to it handles the same single-line format, so the dead matcher is removed.
- `misctools/lldb/README.md`, `scripts/build/deps/nodejs-headers.ts`, `test/js/web/fetch/H2_TEST_PORT_PLAN.md`: internal docs that described `ZigString` as "the Zig string type", a Zig build flag that no longer exists, and a deleted `.zig` path.

**Intentionally not changed**

- Identifiers that still exist in the code (`Zig::GlobalObject`, `ZigString`, `$ZigGeneratedClasses`, `zig_mutex_t`). #31822 is the rename pass for those.
- Comments inside compiled sources (the `src/codegen/*.ts` "written in Zig" docblocks, the `packages/bun-usockets` header, a few `src/js` notes). Those are code changes, not docs, and they fit better with the identifier rename than with this prose pass.
- The `bun:ffi` docs listing Zig among the C ABI languages, and the Zig FFI example.
- Comments that are deliberately historical: Cargo.toml rationale notes, `bench/snippets/escapeHTML.mjs`, tests that explain a Zig-era bug.
- External links into other projects' `.zig` files, such as the Tigerbeetle row in the license table.
- `process.versions.zig` is still exposed at runtime with a pinned historical hash (`BunProcess.cpp` and `scripts/build/depVersionsHeader.ts`). Removing a `process.versions` key is a behavior change, not a docs fix, so it is left for a separate decision.

### How did you verify your code works?

- This PR changes prose only; no compiled source is touched, so there is no runtime behavior to regression-test.
- Every "written in Rust" claim was checked against the implementation it describes before editing (paths above).
- `bun test test/integration/bun-types/bun-types.test.ts` passes with the `bun.d.ts` edit.
- The docs preview deployment renders the changed pages.
