### PR TITLE
Preserve AsyncLocalStorage context in WebSocket client event handlers

### DIFF
--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -2,6 +2,7 @@
 #include "ZigGlobalObject.h"
 #include "AsyncContextFrame.h"
 #include "BunClientData.h"
+#include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/InternalFieldTuple.h>
 
 #if ASSERT_ENABLED
@@ -33,6 +34,32 @@ AsyncContextFrame* AsyncContextFrame::create(JSGlobalObject* global, JSValue cal
 JSC::Structure* AsyncContextFrame::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     return Structure::create(vm, globalObject, jsNull(), TypeInfo(ObjectType, StructureFlags), info());
+}
+
+void AsyncContextFrame::captureCurrentContext(JSGlobalObject* globalObject, WebCore::JSValueInWrappedObject& slot)
+{
+    JSValue context = globalObject->m_asyncContextData.get()->getInternalField(0);
+    // If there is no async context, do not snapshot it.
+    if (context.isUndefined())
+        return;
+    slot.setWeakly(context);
+}
+
+AsyncContextFrameScope::AsyncContextFrameScope(JSGlobalObject* globalObject, JSValue context)
+{
+    if (!globalObject || !context || context.isUndefined())
+        return;
+    m_globalObject = globalObject;
+    auto* asyncContextData = globalObject->m_asyncContextData.get();
+    m_previousContext = asyncContextData->getInternalField(0);
+    asyncContextData->putInternalField(globalObject->vm(), 0, context);
+}
+
+AsyncContextFrameScope::~AsyncContextFrameScope()
+{
+    if (!m_globalObject)
+        return;
+    m_globalObject->m_asyncContextData.get()->putInternalField(m_globalObject->vm(), 0, m_previousContext);
 }
 
 JSValue AsyncContextFrame::withAsyncContextIfNeeded(JSGlobalObject* globalObject, JSValue callback)

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -22,9 +22,7 @@ public:
     // When given a JSFunction that you want to call later, wrap it with this function
     static JSC::JSValue withAsyncContextIfNeeded(JSC::JSGlobalObject* globalObject, JSC::JSValue callback);
 
-    // Snapshots the active async context (what AsyncLocalStorage.getStore() reads)
-    // into `slot` for AsyncContextFrameScope to restore later. No-op when there is
-    // none. `slot` must be GC-visited by the owning object's JS wrapper.
+    // Snapshots the active async context into `slot`, which the owner's JS wrapper must GC-visit.
     static void captureCurrentContext(JSC::JSGlobalObject* globalObject, WebCore::JSValueInWrappedObject& slot);
 
     // The following is JSC::call but
@@ -57,9 +55,7 @@ public:
     }
 };
 
-// RAII: installs `context` as the active async context and restores the previous
-// one on exit. Use it around an event dispatch that runs asynchronously on behalf
-// of a resource created earlier. A no-op when `context` is empty or undefined.
+// Makes `context` the active async context for its lifetime. No-op if `context` is empty.
 class AsyncContextFrameScope {
     WTF_MAKE_NONCOPYABLE(AsyncContextFrameScope);
 

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -3,6 +3,11 @@
 #include "root.h"
 #include "BunClientData.h"
 #include <JavaScriptCore/CallData.h>
+#include <wtf/Noncopyable.h>
+
+namespace WebCore {
+class JSValueInWrappedObject;
+}
 
 class AsyncContextFrame : public JSC::JSNonFinalObject {
 public:
@@ -16,6 +21,11 @@ public:
 
     // When given a JSFunction that you want to call later, wrap it with this function
     static JSC::JSValue withAsyncContextIfNeeded(JSC::JSGlobalObject* globalObject, JSC::JSValue callback);
+
+    // Snapshots the active async context (what AsyncLocalStorage.getStore() reads)
+    // into `slot` for AsyncContextFrameScope to restore later. No-op when there is
+    // none. `slot` must be GC-visited by the owning object's JS wrapper.
+    static void captureCurrentContext(JSC::JSGlobalObject* globalObject, WebCore::JSValueInWrappedObject& slot);
 
     // The following is JSC::call but
     // - it unwraps AsyncContextFrame
@@ -45,4 +55,19 @@ public:
         , context(context_, JSC::WriteBarrierEarlyInit)
     {
     }
+};
+
+// RAII: installs `context` as the active async context and restores the previous
+// one on exit. Use it around an event dispatch that runs asynchronously on behalf
+// of a resource created earlier. A no-op when `context` is empty or undefined.
+class AsyncContextFrameScope {
+    WTF_MAKE_NONCOPYABLE(AsyncContextFrameScope);
+
+public:
+    AsyncContextFrameScope(JSC::JSGlobalObject*, JSC::JSValue context);
+    ~AsyncContextFrameScope();
+
+private:
+    JSC::JSGlobalObject* m_globalObject { nullptr };
+    JSC::JSValue m_previousContext;
 };

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -998,6 +998,20 @@ size_t JSWebSocket::estimatedSize(JSCell* cell, JSC::VM& vm)
     return Base::estimatedSize(cell, vm) + thisObject->wrapped().memoryCost();
 }
 
+template<typename Visitor>
+void JSWebSocket::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSWebSocket>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    // Set once in the WebSocket constructor (before this wrapper exists) and
+    // only ever cleared afterwards, so it cannot acquire a new value
+    // post-marking: no output constraint is needed.
+    thisObject->wrapped().creationAsyncContext().visit(visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSWebSocket);
+
 void JSWebSocket::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     auto* thisObject = uncheckedDowncast<JSWebSocket>(cell);

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -1004,9 +1004,7 @@ void JSWebSocket::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSWebSocket>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    // Set once in the WebSocket constructor (before this wrapper exists) and
-    // only ever cleared afterwards, so it cannot acquire a new value
-    // post-marking: no output constraint is needed.
+    // Only ever set before this wrapper exists, then cleared: no output constraint needed.
     thisObject->wrapped().creationAsyncContext().visit(visitor);
 }
 

--- a/src/jsc/bindings/webcore/JSWebSocket.h
+++ b/src/jsc/bindings/webcore/JSWebSocket.h
@@ -43,6 +43,7 @@ public:
     static WebSocket* toWrapped(JSC::VM&, JSC::JSValue);
 
     DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -31,6 +31,7 @@
 
 #include "config.h"
 #include "WebSocket.h"
+#include "AsyncContextFrame.h"
 #include "WebSocketDeflate.h"
 #include "headers.h"
 #include "blob.h"
@@ -179,6 +180,19 @@ WebSocket::WebSocket(ScriptExecutionContext& context)
     , m_extensions(emptyString())
 {
     m_rejectUnauthorized = Bun__getTLSRejectUnauthorizedValue() != 0;
+    // Events are dispatched from the network, not from a JS caller, so snapshot
+    // the creator's async context now (Node's AsyncWrap does the same).
+    if (auto* globalObject = context.jsGlobalObject())
+        AsyncContextFrame::captureCurrentContext(globalObject, m_creationAsyncContext);
+}
+
+// Listeners observe the async context that was active when the WebSocket was
+// constructed, matching Node.js.
+void WebSocket::dispatchEventInCreationContext(Event& event)
+{
+    auto* context = scriptExecutionContext();
+    AsyncContextFrameScope asyncContextScope(context ? context->jsGlobalObject() : nullptr, m_creationAsyncContext.getValue());
+    dispatchEvent(event);
 }
 
 WebSocket::~WebSocket()
@@ -652,8 +666,9 @@ __attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url,
             queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [](WebSocket& ws) {
                 auto eventInit = createErrorEventInit(ws, "Failed to connect"_s, ws.scriptExecutionContext()->jsGlobalObject());
                 auto message = eventInit.message;
-                ws.dispatchEvent(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
-                ws.dispatchEvent(CloseEvent::create(false, 1006, WTF::move(message)));
+                ws.dispatchEventInCreationContext(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
+                ws.dispatchEventInCreationContext(CloseEvent::create(false, 1006, WTF::move(message)));
+                ws.m_creationAsyncContext.clear();
             });
         }
         // create() still holds a Ref, so releasing connect()'s claim here cannot destroy `this`.
@@ -818,8 +833,9 @@ void WebSocket::failConnectingWebSocket()
         // an error event before the close event. Matches Chrome/Firefox and npm ws.
         auto reason = "WebSocket is closed before the connection is established"_s;
         auto eventInit = createErrorEventInit(ws, reason, ws.scriptExecutionContext()->jsGlobalObject());
-        ws.dispatchEvent(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
-        ws.dispatchEvent(CloseEvent::create(false, 1006, reason));
+        ws.dispatchEventInCreationContext(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
+        ws.dispatchEventInCreationContext(CloseEvent::create(false, 1006, reason));
+        ws.m_creationAsyncContext.clear();
     });
     // The queued task now holds its own claim; connect()'s is over.
     m_pendingActivity = nullptr;
@@ -958,6 +974,7 @@ void WebSocket::stop()
     case ConnectedWebSocketKind::None:
         break;
     }
+    m_creationAsyncContext.clear();
     m_pendingActivity = nullptr;
 }
 
@@ -1228,10 +1245,10 @@ void WebSocket::didConnect()
 
         if (this->hasEventListeners("open"_s)) {
             // the main reason for dispatching on a separate tick is to handle when you haven't yet attached an event listener
-            dispatchEvent(Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No));
+            dispatchEventInCreationContext(Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No));
         } else {
             queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [](WebSocket& ws) mutable {
-                ws.dispatchEvent(Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No));
+                ws.dispatchEventInCreationContext(Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No));
             });
         }
     }
@@ -1258,13 +1275,13 @@ void WebSocket::didReceiveMessage(String&& message)
 
     if (this->hasEventListeners("message"_s)) {
         // the main reason for dispatching on a separate tick is to handle when you haven't yet attached an event listener
-        dispatchEvent(MessageEvent::create(WTF::move(message), m_url.string()));
+        dispatchEventInCreationContext(MessageEvent::create(WTF::move(message), m_url.string()));
         return;
     }
 
     if (scriptExecutionContext()) {
         queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [message_ = WTF::move(message)](WebSocket& ws) mutable {
-            ws.dispatchEvent(MessageEvent::create(message_, ws.m_url.string()));
+            ws.dispatchEventInCreationContext(MessageEvent::create(message_, ws.m_url.string()));
         });
     }
 
@@ -1283,14 +1300,14 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
         if (this->hasEventListeners(eventName)) {
             // the main reason for dispatching on a separate tick is to handle when you haven't yet attached an event listener
             RefPtr<Blob> blob = Blob::create(binaryData, scriptExecutionContext()->jsGlobalObject());
-            dispatchEvent(MessageEvent::create(eventName, blob.releaseNonNull(), m_url.string()));
+            dispatchEventInCreationContext(MessageEvent::create(eventName, blob.releaseNonNull(), m_url.string()));
             return;
         }
 
         if (auto* context = scriptExecutionContext()) {
             RefPtr<Blob> blob = Blob::create(binaryData, context->jsGlobalObject());
             queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [name = eventName, blob = blob.releaseNonNull()](WebSocket& ws) mutable {
-                ws.dispatchEvent(MessageEvent::create(name, blob, ws.m_url.string()));
+                ws.dispatchEventInCreationContext(MessageEvent::create(name, blob, ws.m_url.string()));
             });
         }
 
@@ -1298,14 +1315,14 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
     case BinaryType::ArrayBuffer: {
         if (this->hasEventListeners(eventName)) {
             // the main reason for dispatching on a separate tick is to handle when you haven't yet attached an event listener
-            dispatchEvent(MessageEvent::create(eventName, ArrayBuffer::create(binaryData), m_url.string()));
+            dispatchEventInCreationContext(MessageEvent::create(eventName, ArrayBuffer::create(binaryData), m_url.string()));
             return;
         }
 
         if (scriptExecutionContext()) {
             auto arrayBuffer = JSC::ArrayBuffer::create(binaryData);
             queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [name = eventName, buffer = WTF::move(arrayBuffer)](WebSocket& ws) mutable {
-                ws.dispatchEvent(MessageEvent::create(name, buffer, ws.m_url.string()));
+                ws.dispatchEventInCreationContext(MessageEvent::create(name, buffer, ws.m_url.string()));
             });
         }
 
@@ -1322,7 +1339,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
 
                 ErrorEvent::Init errorInit;
                 errorInit.message = "Failed to allocate memory for binary data"_s;
-                dispatchEvent(ErrorEvent::create(eventNames().errorEvent, errorInit));
+                dispatchEventInCreationContext(ErrorEvent::create(eventNames().errorEvent, errorInit));
                 return;
             }
 
@@ -1331,7 +1348,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
             init.data = buffer;
             init.origin = this->m_url.string();
 
-            dispatchEvent(MessageEvent::create(eventName, WTF::move(init), EventIsTrusted::Yes));
+            dispatchEventInCreationContext(MessageEvent::create(eventName, WTF::move(init), EventIsTrusted::Yes));
             return;
         }
 
@@ -1346,7 +1363,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
                 MessageEvent::Init init;
                 init.data = uint8array;
                 init.origin = ws.m_url.string();
-                ws.dispatchEvent(MessageEvent::create(name, WTF::move(init), EventIsTrusted::Yes));
+                ws.dispatchEventInCreationContext(MessageEvent::create(name, WTF::move(init), EventIsTrusted::Yes));
             });
         }
 
@@ -1403,7 +1420,7 @@ void WebSocket::didReceiveHandshakeResponse(uint16_t statusCode, std::span<const
     init.data = obj;
     init.origin = m_url.string();
 
-    dispatchEvent(MessageEvent::create(eventNames().handshakeEvent, WTF::move(init), EventIsTrusted::Yes));
+    dispatchEventInCreationContext(MessageEvent::create(eventNames().handshakeEvent, WTF::move(init), EventIsTrusted::Yes));
 }
 
 void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError)
@@ -1437,9 +1454,11 @@ void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::
             ws.m_state = CLOSED;
             if (dispatchError) {
                 auto eventInit = createErrorEventInit(ws, reason, ws.scriptExecutionContext()->jsGlobalObject());
-                ws.dispatchEvent(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
+                ws.dispatchEventInCreationContext(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
             }
-            ws.dispatchEvent(CloseEvent::create(clean, code, reason));
+            ws.dispatchEventInCreationContext(CloseEvent::create(clean, code, reason));
+            // The close event is the last one this socket can dispatch.
+            ws.m_creationAsyncContext.clear();
         });
     } else {
         m_state = CLOSED;
@@ -1492,7 +1511,9 @@ void WebSocket::didClose(unsigned unhandledBufferedAmount, unsigned short code, 
                 return;
             }
             protectedThis->m_state = CLOSED;
-            protectedThis->dispatchEvent(CloseEvent::create(wasClean, code, reason));
+            protectedThis->dispatchEventInCreationContext(CloseEvent::create(wasClean, code, reason));
+            // The close event is the last one this socket can dispatch.
+            protectedThis->m_creationAsyncContext.clear();
             protectedThis->m_pendingActivity = nullptr;
         });
         return;

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -180,14 +180,11 @@ WebSocket::WebSocket(ScriptExecutionContext& context)
     , m_extensions(emptyString())
 {
     m_rejectUnauthorized = Bun__getTLSRejectUnauthorizedValue() != 0;
-    // Events are dispatched from the network, not from a JS caller, so snapshot
-    // the creator's async context now (Node's AsyncWrap does the same).
+    // Node's AsyncWrap captures here too: the events come from the network, not a JS caller.
     if (auto* globalObject = context.jsGlobalObject())
         AsyncContextFrame::captureCurrentContext(globalObject, m_creationAsyncContext);
 }
 
-// Listeners observe the async context that was active when the WebSocket was
-// constructed, matching Node.js.
 void WebSocket::dispatchEventInCreationContext(Event& event)
 {
     auto* context = scriptExecutionContext();

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -316,8 +316,7 @@ private:
     void didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError = false);
     void failConnectingWebSocket();
 
-    // All open/message/error/close events originate from the network, not from a
-    // JS caller: dispatch them in the async context captured at construction.
+    // Every network-originated event goes through here, never plain dispatchEvent().
     void dispatchEventInCreationContext(Event&);
 
     void sendWebSocketString(const String& message, const Opcode opcode);
@@ -359,9 +358,7 @@ private:
     // upgrade client in connect(); freed by ~WebSocketSSLConfigPtr otherwise).
     WebSocketSSLConfigPtr m_sslConfig;
 
-    // The async context active when the WebSocket was constructed, restored
-    // around event dispatch. Visited by JSWebSocket::visitChildrenImpl and
-    // released once the close event (the last one possible) has fired.
+    // Cleared after the close event. Visited by JSWebSocket::visitChildrenImpl.
     JSValueInWrappedObject m_creationAsyncContext;
 
     NativeCallbacks m_native;

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -34,6 +34,7 @@
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObject.h"
 #include <wtf/URL.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
@@ -287,6 +288,8 @@ public:
 
     size_t memoryCost() const;
 
+    const JSValueInWrappedObject& creationAsyncContext() const { return m_creationAsyncContext; }
+
 private:
     typedef union AnyWebSocket {
         WebSocketClient* client;
@@ -312,6 +315,10 @@ private:
 
     void didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError = false);
     void failConnectingWebSocket();
+
+    // All open/message/error/close events originate from the network, not from a
+    // JS caller: dispatch them in the async context captured at construction.
+    void dispatchEventInCreationContext(Event&);
 
     void sendWebSocketString(const String& message, const Opcode opcode);
     void sendWebSocketData(const char* data, size_t length, const Opcode opcode);
@@ -351,6 +358,11 @@ private:
     // TLS options (native heap SSLConfig — ownership is released to the
     // upgrade client in connect(); freed by ~WebSocketSSLConfigPtr otherwise).
     WebSocketSSLConfigPtr m_sslConfig;
+
+    // The async context active when the WebSocket was constructed, restored
+    // around event dispatch. Visited by JSWebSocket::visitChildrenImpl and
+    // released once the close event (the last one possible) has fired.
+    JSValueInWrappedObject m_creationAsyncContext;
 
     NativeCallbacks m_native;
 };

--- a/test/js/node/async_hooks/async-context/async-context-websocket.js
+++ b/test/js/node/async_hooks/async-context/async-context-websocket.js
@@ -1,0 +1,69 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+const net = require("net");
+const { createHash } = require("crypto");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+let failed = false;
+const seen = new Set();
+
+function check(name) {
+  const store = asyncLocalStorage.getStore();
+  seen.add(name);
+  if (store?.test !== "WebSocket") {
+    console.error(`FAIL: WebSocket ${name} handler lost context, got`, store);
+    failed = true;
+  }
+}
+
+// Minimal RFC 6455 server: completes the upgrade, sends one text frame,
+// then starts the closing handshake.
+const server = net.createServer(socket => {
+  // The upgrade request may be split across TCP chunks: buffer until the
+  // header block is complete before parsing it.
+  let request = Buffer.alloc(0);
+  socket.on("data", function onHandshakeData(chunk) {
+    request = Buffer.concat([request, chunk]);
+    if (!request.includes("\r\n\r\n")) return;
+    socket.off("data", onHandshakeData);
+
+    const key = /Sec-WebSocket-Key: (.*)\r\n/i.exec(request.toString())[1].trim();
+    const accept = createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    socket.write(Buffer.from([0x81, 0x02, 0x68, 0x69])); // text frame "hi"
+    socket.write(Buffer.from([0x88, 0x02, 0x03, 0xe8])); // close frame, code 1000
+    // The next bytes are the client's close frame reply: finish the TCP close.
+    socket.once("data", () => socket.end());
+  });
+  socket.on("error", () => {});
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+
+  // Event handlers observe the async context that was active when the
+  // WebSocket was constructed, whether assigned as onX or via addEventListener.
+  asyncLocalStorage.run({ test: "WebSocket" }, () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    ws.onopen = () => check("open");
+    ws.onmessage = () => check("message");
+    ws.addEventListener("close", () => check("close (addEventListener)"));
+    ws.onclose = () => {
+      check("close");
+      server.close(() => {
+        for (const name of ["open", "message", "close", "close (addEventListener)"]) {
+          if (!seen.has(name)) {
+            console.error(`FAIL: WebSocket ${name} handler never ran`);
+            failed = true;
+          }
+        }
+        process.exit(failed ? 1 : 0);
+      });
+    };
+  });
+});

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -2,8 +2,10 @@ import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, nodeExe } from "harness";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
+import type { AddressInfo } from "node:net";
 import { createServer } from "node:net";
 import * as path from "node:path";
 import { WebSocket as NodeWS, WebSocketServer } from "ws";
@@ -659,6 +661,146 @@ describe("WebSocket handshake Connection header token list", () => {
       ws.terminate();
     } finally {
       server.close();
+    }
+  });
+});
+
+describe("WebSocket AsyncLocalStorage context", () => {
+  it("dispatches events in the context active at construction", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("Upgrade failed", { status: 500 });
+      },
+      websocket: {
+        open(ws) {
+          ws.send("hello");
+        },
+        message(ws) {
+          ws.close(1000, "done");
+        },
+      },
+    });
+
+    const als = new AsyncLocalStorage<string>();
+    const contexts: Record<string, string | undefined> = {};
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+    als.run("creation-context", () => {
+      const ws = new WebSocket(`ws://${server.hostname}:${server.port}`);
+      ws.onopen = () => {
+        contexts.open = als.getStore();
+        ws.send("x");
+      };
+      ws.onmessage = () => {
+        contexts.message = als.getStore();
+      };
+      ws.addEventListener("close", () => {
+        contexts.closeListener = als.getStore();
+      });
+      ws.onclose = () => {
+        contexts.close = als.getStore();
+        resolve();
+      };
+      ws.onerror = () => reject(new Error("unexpected error event"));
+    });
+
+    await promise;
+    expect(contexts).toEqual({
+      open: "creation-context",
+      message: "creation-context",
+      closeListener: "creation-context",
+      close: "creation-context",
+    });
+  });
+
+  it("keeps the captured context alive across garbage collection", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("Upgrade failed", { status: 500 });
+      },
+      websocket: {
+        open() {},
+        message(ws) {
+          ws.send("pong");
+          ws.close(1000, "done");
+        },
+      },
+    });
+
+    const als = new AsyncLocalStorage<{ id: string }>();
+    const contexts: Record<string, unknown> = {};
+    const opened = Promise.withResolvers<WebSocket>();
+    const closed = Promise.withResolvers<void>();
+
+    // Once this IIFE returns, the captured async context is only reachable
+    // through the WebSocket, so it must be visited from the JS wrapper.
+    (function create() {
+      als.run({ id: "creation-context" }, () => {
+        const ws = new WebSocket(`ws://${server.hostname}:${server.port}`);
+        ws.onopen = () => {
+          contexts.open = als.getStore();
+          opened.resolve(ws);
+        };
+        ws.onmessage = () => {
+          contexts.message = als.getStore();
+        };
+        ws.onclose = () => {
+          contexts.close = als.getStore();
+          closed.resolve();
+        };
+        ws.onerror = () => closed.reject(new Error("unexpected error event"));
+      });
+    })();
+
+    const ws = await opened.promise;
+    Bun.gc(true);
+    Bun.gc(true);
+    ws.send("ping");
+    await closed.promise;
+    expect(contexts).toEqual({
+      open: { id: "creation-context" },
+      message: { id: "creation-context" },
+      close: { id: "creation-context" },
+    });
+  });
+
+  it("dispatches error and close events in the context active at construction", async () => {
+    // The upgrade never completes: the server destroys the socket, so the
+    // client goes down the connection-error path (error + close events).
+    const tcpServer = createServer(socket => socket.destroy());
+    const listening = Promise.withResolvers<void>();
+    tcpServer.once("error", listening.reject);
+    tcpServer.listen(0, "127.0.0.1", listening.resolve);
+    await listening.promise;
+    const { port } = tcpServer.address() as AddressInfo;
+
+    try {
+      const als = new AsyncLocalStorage<string>();
+      const contexts: Record<string, string | undefined> = {};
+      const { promise, resolve } = Promise.withResolvers<void>();
+
+      als.run("creation-context", () => {
+        const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+        ws.onerror = () => {
+          contexts.error = als.getStore();
+        };
+        ws.onclose = () => {
+          contexts.close = als.getStore();
+          resolve();
+        };
+      });
+
+      await promise;
+      expect(contexts).toEqual({
+        error: "creation-context",
+        close: "creation-context",
+      });
+    } finally {
+      tcpServer.close();
     }
   });
 });

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -752,7 +752,11 @@ describe("WebSocket AsyncLocalStorage context", () => {
           contexts.close = als.getStore();
           closed.resolve();
         };
-        ws.onerror = () => closed.reject(new Error("unexpected error event"));
+        ws.onerror = () => {
+          const error = new Error("unexpected error event");
+          opened.reject(error);
+          closed.reject(error);
+        };
       });
     })();
 


### PR DESCRIPTION
### Problem

Client `WebSocket` event handlers lose the `AsyncLocalStorage` context that was active when the socket was constructed. This affects `onopen`, `onmessage`, `onerror`, `onclose` and their `addEventListener` equivalents, so the usual APM pattern (open an outbound WebSocket inside a request, tag its messages with the request's trace id) silently loses the request context.

```js
als.run("request-7", () => {
  const ws = new WebSocket(url);
  ws.onopen = () => console.log(als.getStore());    // node: "request-7"   bun: undefined
  ws.onmessage = () => console.log(als.getStore()); // node: "request-7"   bun: undefined
  ws.addEventListener("close", () => console.log(als.getStore())); // same
});
```

Node reports `"request-7"` in all of them, Bun reports `undefined` in all of them.

### Cause

The client WebSocket's events are dispatched from the native socket callbacks (`didConnect`, `didReceiveMessage`, `didReceiveBinaryData`, `didReceiveClose`, `didClose`) and from the event-loop tasks those queue. None of them enter an `AsyncContextFrame`, so listeners run with whatever async context the event loop last had (none). Node treats the WebSocket as an async resource created at construction, so its handlers observe the construction context.

### Fix

- `AsyncContextFrame::captureCurrentContext()` snapshots the active async context into a `JSValueInWrappedObject`, and the new `AsyncContextFrameScope` RAII type installs a captured context for the duration of a block, restoring the previous one afterwards.
- `WebSocket` captures the context in its constructor into `m_creationAsyncContext` and routes every network-originated event (open, text/binary message, ping, pong, handshake, error, close, including the queued-task variants and the connect-failure paths) through `dispatchEventInCreationContext()`.
- The snapshot is GC-visited from `JSWebSocket::visitChildrenImpl` (it is set before the wrapper exists and only cleared afterwards, so no output constraint is needed) and released after the close event, the last event a socket can dispatch, so a long-lived `ws` object does not pin the store.

Synchronous user-initiated dispatches (`ws.dispatchEvent(...)`) are not affected.

### Verification

- `test/js/web/websocket/websocket-client.test.ts`: three new tests, the normal open/message/close flow, a GC stress case, and the connection-error path (error + close). On an unfixed build every captured store is `undefined` and all three fail; with the fix the file is green (40 tests).
- The GC test is the guard for the marking path: it builds the socket in a scope that returns, runs `Bun.gc(true)` twice, then exercises a late message and the close. Removing the `creationAsyncContext().visit(visitor)` line makes exactly that test fail. All three also pass under `BUN_JSC_collectContinuously=1` on the ASAN debug build.
- `test/js/node/async_hooks/async-context/async-context-websocket.js`: new fixture in the AsyncLocalStorage tracking suite, which runs every fixture under both `bun` and `node` and requires exit code 0 from both (76 fixtures green).

<details><summary>Notes</summary>

Rebased onto current main on 2026-09-07. The conflicts came from main's WebSocket refactor and were resolved by re-applying the change onto the new shapes:

- `WebSocket` moved from `ContextDestructionObserver` plus manual pending-activity counting to `ActiveDOMObject`, and deferred dispatches moved from `context->postTask([this, protectedThis = Ref { *this }] ...)` to `queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [](WebSocket& ws) ...)`. Every dispatch site moved with it, so each one now calls `ws.dispatchEventInCreationContext(...)`.
- Main added a `handshake` event (`didReceiveHandshakeResponse`, used by the `ws` shim). It is network-originated too, so it goes through the same helper.
- Main added `ActiveDOMObject::stop()`. It is a terminal path, so it clears the snapshot.
- The earlier branch also carried a commit that ran prettier over two docs pages. Main is clean there now, so that commit is dropped.

Also addressed in review: the comments on the new code are one line each, and the GC test's error handler rejects both of its promises so an early error fails the test instead of hanging.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:36707/
(pass) WebSocket > url [8.26ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [2.29ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [3.76ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:36707',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'RRi8aZSKaHQjOgcw
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:34397/
(pass) WebSocket > url [0.43ms]
(pass) WebSocket > binaryType > (default) [0.08ms]
(pass) WebSocket > binaryType > (invalid) [0.11ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:34397',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'c02/pzRcAus8dPJn5/1SEg=='
}
(pass) WebSocket > readyState [4.99ms]
Received connection: 127.0.0.1
Received bytes: <Buffer 88 82 38 a7 34 fa 3b 4f>
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received close: 1000 <Buffer >
Received
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:39135/
(pass) WebSocket > url [8.41ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [2.18ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [3.89ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:39135',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'U3cogCBKL7IRXR5a
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b4d46961c4
  features     baseline

23 deps, 131 codegen, 1172 objects in 650ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [13.00ms]
[6/1243] gen bindgenv2
[7/1243] fetch zlib
[zlib] up to date
[8/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4.81 KB  (entry point)

[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/AsyncContextFrame.cpp             |  27 ++++
 src/jsc/bindings/AsyncContextFrame.h               |  21 +++
 src/jsc/bindings/webcore/JSWebSocket.cpp           |  12 ++
 src/jsc/bindings/webcore/JSWebSocket.h             |   1 +
 src/jsc/bindings/webcore/WebSocket.cpp             |  56 +++++---
 src/jsc/bindings/webcore/WebSocket.h               |   9 ++
 .../async-context/async-context-websocket.js       |  69 ++++++++++
 test/js/web/websocket/websocket-client.test.ts     | 146 +++++++++++++++++++++
 8 files changed, 322 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/AsyncContextFrame.cpp                        2      4     35
src/jsc/bindings/AsyncContextFrame.h                          3      7     35
src/jsc/bindings/webcore/JSWebSocket.cpp                      3      8     35
src/jsc/bindings/webcore/JSWebSocket.h                        2      2     35
src/jsc/bindings/webcore/WebSocket.cpp                       11     27     35
src/jsc/bindings/webcore/WebSocket.h                          6     10     35
…de/async_hooks/async-context/async-context-websocket.js      1      2     37
test/js/web/websocket/websocket-client.test.ts                6      6     35
```

</details>

<!-- robobun:evidence:end -->