### PR TITLE
util: honor isDeepStrictEqual skipPrototype third argument

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -23,7 +23,7 @@ function isFunction(value) {
 }
 
 const deepEquals = Bun.deepEquals;
-const isDeepStrictEqual = (a, b) => deepEquals(a, b, true);
+const isDeepStrictEqual = (a, b, skipPrototype) => deepEquals(a, b, true, skipPrototype);
 
 const parseArgs = $newRustFunction("parse_args.rs", "parseArgs", 1);
 

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -698,13 +698,17 @@ JSC_DEFINE_HOST_FUNCTION(functionBunDeepEquals, (JSGlobalObject * globalObject, 
     JSC::JSValue arg1 = callFrame->uncheckedArgument(0);
     JSC::JSValue arg2 = callFrame->uncheckedArgument(1);
     JSC::JSValue strict = callFrame->argument(2);
+    // Node's isDeepStrictEqual third argument: skip the prototype/class comparison.
+    // Only meaningful in strict mode; loose mode never compares prototypes.
+    bool skipPrototype = callFrame->argument(3).toBoolean(globalObject);
 
     Vector<std::pair<JSValue, JSValue>, 16> stack;
     MarkedArgumentBuffer gcBuffer;
 
     if (strict.isBoolean() && strict.asBoolean()) {
-
-        bool isEqual = Bun__deepEquals<true, false>(globalObject, arg1, arg2, gcBuffer, stack, scope, true);
+        bool isEqual = skipPrototype
+            ? Bun__deepEquals<true, false, true>(globalObject, arg1, arg2, gcBuffer, stack, scope, true)
+            : Bun__deepEquals<true, false, false>(globalObject, arg1, arg2, gcBuffer, stack, scope, true);
         RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsBoolean(isEqual));
     } else {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -648,10 +648,10 @@ JSValue getIndexWithoutAccessors(JSGlobalObject* globalObject, JSObject* obj, ui
     return JSValue();
 }
 
-template<bool isStrict, bool enableAsymmetricMatchers>
+template<bool isStrict, bool enableAsymmetricMatchers, bool skipPrototype = false>
 std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSCell* _Nonnull c1, JSCell* _Nonnull c2);
 
-template<bool isStrict, bool enableAsymmetricMatchers>
+template<bool isStrict, bool enableAsymmetricMatchers, bool skipPrototype>
 bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, bool addToStack)
 {
     VM& vm = globalObject->vm();
@@ -730,10 +730,10 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     JSCell* c2 = v2.asCell();
     ASSERT(c1);
     ASSERT(c2);
-    std::optional<bool> isSpecialEqual = specialObjectsDequal<isStrict, enableAsymmetricMatchers>(globalObject, gcBuffer, stack, scope, c1, c2);
+    std::optional<bool> isSpecialEqual = specialObjectsDequal<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, gcBuffer, stack, scope, c1, c2);
     RETURN_IF_EXCEPTION(scope, false);
     if (isSpecialEqual.has_value()) return WTF::move(*isSpecialEqual);
-    isSpecialEqual = specialObjectsDequal<isStrict, enableAsymmetricMatchers>(globalObject, gcBuffer, stack, scope, c2, c1);
+    isSpecialEqual = specialObjectsDequal<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, gcBuffer, stack, scope, c2, c1);
     if (isSpecialEqual.has_value()) return WTF::move(*isSpecialEqual);
     JSObject* o1 = v1.getObject();
     JSObject* o2 = v2.getObject();
@@ -780,7 +780,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 }
             }
 
-            auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, left, right, gcBuffer, stack, scope, true);
+            auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, left, right, gcBuffer, stack, scope, true);
             RETURN_IF_EXCEPTION(scope, false);
             if (!eql) return false;
         }
@@ -835,7 +835,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 return false;
             }
 
-            auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
+            auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
             RETURN_IF_EXCEPTION(scope, false);
             if (!eql) return false;
         }
@@ -845,7 +845,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         return true;
     }
 
-    if constexpr (isStrict) {
+    if constexpr (isStrict && !skipPrototype) {
         if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
             return false;
         }
@@ -883,7 +883,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                     RETURN_IF_EXCEPTION(scope, false);
                     if (same) return true;
 
-                    auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, left, right, gcBuffer, stack, scope, true);
+                    auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, left, right, gcBuffer, stack, scope, true);
                     RETURN_IF_EXCEPTION(scope, false);
                     if (!eql) {
                         result = false;
@@ -919,7 +919,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                     RETURN_IF_EXCEPTION(scope, false);
                     if (same) return true;
 
-                    auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, left, right, gcBuffer, stack, scope, true);
+                    auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, left, right, gcBuffer, stack, scope, true);
                     RETURN_IF_EXCEPTION(scope, false);
                     if (!eql) {
                         result = false;
@@ -1007,7 +1007,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             return false;
         }
 
-        auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
+        auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
         RETURN_IF_EXCEPTION(scope, false);
         if (!eql) return false;
     }
@@ -1028,7 +1028,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     return true;
 }
 
-template<bool isStrict, bool enableAsymmetricMatchers>
+template<bool isStrict, bool enableAsymmetricMatchers, bool skipPrototype>
 std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSCell* _Nonnull c1, JSCell* _Nonnull c2)
 {
     VM& vm = globalObject->vm();
@@ -1065,7 +1065,7 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             JSValue key2;
             bool foundMatchingKey = false;
             while (iter2->next(globalObject, key2)) {
-                bool equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, key1, key2, gcBuffer, stack, scope, false);
+                bool equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, key1, key2, gcBuffer, stack, scope, false);
                 RETURN_IF_EXCEPTION(scope, {});
                 if (equal) {
                     foundMatchingKey = true;
@@ -1108,7 +1108,7 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 JSValue key2;
                 bool foundMatchingKey = false;
                 while (iter2->nextKeyValue(globalObject, key2, value2)) {
-                    bool keysEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, key1, key2, gcBuffer, stack, scope, false);
+                    bool keysEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, key1, key2, gcBuffer, stack, scope, false);
                     RETURN_IF_EXCEPTION(scope, {});
                     if (keysEqual) {
                         foundMatchingKey = true;
@@ -1123,7 +1123,7 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 // Compare both values below.
             }
 
-            bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, value1, value2, gcBuffer, stack, scope, false);
+            bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, value1, value2, gcBuffer, stack, scope, false);
             RETURN_IF_EXCEPTION(scope, {});
             if (!valuesEqual) {
                 return false;
@@ -1255,7 +1255,7 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             RETURN_IF_EXCEPTION(scope, {});
             auto rightCause = right->get(globalObject, cause);
             RETURN_IF_EXCEPTION(scope, {});
-            bool causesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, leftCause, rightCause, gcBuffer, stack, scope, true);
+            bool causesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, leftCause, rightCause, gcBuffer, stack, scope, true);
             RETURN_IF_EXCEPTION(scope, {});
             if (!causesEqual) {
                 return false;
@@ -1305,7 +1305,7 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                     return false;
                 }
 
-                bool propertiesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
+                bool propertiesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
                 RETURN_IF_EXCEPTION(scope, {});
                 if (!propertiesEqual) {
                     return false;
@@ -1421,8 +1421,10 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             return false;
         }
 
-        if (!equal(JSObject::calculatedClassName(c1->getObject()), JSObject::calculatedClassName(c2->getObject()))) {
-            return false;
+        if constexpr (!skipPrototype) {
+            if (!equal(JSObject::calculatedClassName(c1->getObject()), JSObject::calculatedClassName(c2->getObject()))) {
+                return false;
+            }
         }
 
         JSString* s1 = c1->toStringInline(globalObject);
@@ -1584,6 +1586,10 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
     }
     return std::nullopt;
 }
+
+// isDeepStrictEqual's skipPrototype mode (Node's third argument) is only used from
+// BunObject.cpp, so force this instantiation here where the definition is visible.
+template bool Bun__deepEquals<true, false, true>(JSC::JSGlobalObject*, JSValue, JSValue, MarkedArgumentBuffer&, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>&, ThrowScope&, bool);
 
 /**
  * @brief `Bun.deepMatch(a, b)`

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -734,6 +734,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     RETURN_IF_EXCEPTION(scope, false);
     if (isSpecialEqual.has_value()) return WTF::move(*isSpecialEqual);
     isSpecialEqual = specialObjectsDequal<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, gcBuffer, stack, scope, c2, c1);
+    RETURN_IF_EXCEPTION(scope, false);
     if (isSpecialEqual.has_value()) return WTF::move(*isSpecialEqual);
     JSObject* o1 = v1.getObject();
     JSObject* o2 = v2.getObject();

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -429,7 +429,8 @@ extern "C" void Bun__EventLoop__runCallback2(JSC::JSGlobalObject* global, JSC::E
 extern "C" void Bun__EventLoop__runCallback3(JSC::JSGlobalObject* global, JSC::EncodedJSValue callback, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue arg1, JSC::EncodedJSValue arg2, JSC::EncodedJSValue arg3);
 
 /// @note throws a JS exception and returns false if a stack overflow occurs
-template<bool isStrict, bool enableAsymmetricMatchers>
+/// @note skipPrototype skips the prototype/class-name comparison (Node's isDeepStrictEqual third argument)
+template<bool isStrict, bool enableAsymmetricMatchers, bool skipPrototype = false>
 bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSC::JSValue v1, JSC::JSValue v2, JSC::MarkedArgumentBuffer&, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, JSC::ThrowScope& scope, bool addToStack);
 
 /**

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -436,3 +436,82 @@ describe("util.parseEnv", () => {
     expect(util.parseEnv(new String("FOO=bar"))).toEqual({ FOO: "bar" });
   });
 });
+
+describe("isDeepStrictEqual skipPrototype (third argument)", () => {
+  class Foo {
+    constructor(a) {
+      this.a = a;
+    }
+  }
+  class Bar {
+    constructor(a) {
+      this.a = a;
+    }
+  }
+
+  it("has length 3 to match Node", () => {
+    expect(util.isDeepStrictEqual.length).toBe(3);
+  });
+
+  it("skips the prototype check when the third argument is truthy", () => {
+    // https://github.com/oven-sh/bun/issues/33074
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), true)).toBe(true);
+  });
+
+  it("keeps the prototype check without the third argument", () => {
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1))).toBe(false);
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), false)).toBe(false);
+  });
+
+  it("coerces the third argument like Node (truthiness)", () => {
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), 1)).toBe(true);
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), "x")).toBe(true);
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), {})).toBe(true);
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), 0)).toBe(false);
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), "")).toBe(false);
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), null)).toBe(false);
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(1), undefined)).toBe(false);
+  });
+
+  it("still enforces the other strict rules when skipping prototypes", () => {
+    expect(util.isDeepStrictEqual(new Foo(1), new Bar(2), true)).toBe(false);
+    const extra = new Bar(1);
+    extra.b = 2;
+    expect(util.isDeepStrictEqual(new Foo(1), extra, true)).toBe(false);
+    expect(util.isDeepStrictEqual([], {}, true)).toBe(false);
+    expect(util.isDeepStrictEqual(new Date(0), {}, true)).toBe(false);
+  });
+
+  it("treats plain, null-prototype and class objects as equal", () => {
+    expect(util.isDeepStrictEqual({ a: 1 }, new Foo(1), true)).toBe(true);
+    expect(util.isDeepStrictEqual(Object.create(null), {}, true)).toBe(true);
+  });
+
+  it("applies recursively to nested values", () => {
+    expect(util.isDeepStrictEqual({ x: new Foo(1) }, { x: new Bar(1) }, true)).toBe(true);
+    expect(util.isDeepStrictEqual({ a: { b: { c: new Foo(1) } } }, { a: { b: { c: new Bar(1) } } }, true)).toBe(true);
+
+    const g1 = {};
+    Object.defineProperty(g1, "x", { enumerable: true, get: () => new Foo(1) });
+    const g2 = {};
+    Object.defineProperty(g2, "x", { enumerable: true, get: () => new Bar(1) });
+    expect(util.isDeepStrictEqual(g1, g2, true)).toBe(true);
+  });
+
+  it("applies recursively through arrays, Maps and Sets", () => {
+    class MyMap extends Map {}
+    expect(util.isDeepStrictEqual([new Foo(1)], [new Bar(1)], true)).toBe(true);
+    expect(util.isDeepStrictEqual(new MyMap([["a", 1]]), new Map([["a", 1]]), true)).toBe(true);
+    expect(util.isDeepStrictEqual(new Map([["k", new Foo(1)]]), new Map([["k", new Bar(1)]]), true)).toBe(true);
+    expect(util.isDeepStrictEqual(new Map([[new Foo(1), 1]]), new Map([[new Bar(1), 1]]), true)).toBe(true);
+    expect(util.isDeepStrictEqual(new Map([[new Foo(1), 1]]), new Map([[new Bar(1), 2]]), true)).toBe(false);
+    expect(util.isDeepStrictEqual(new Set([new Foo(1)]), new Set([new Bar(1)]), true)).toBe(true);
+  });
+
+  it("skips the prototype check for boxed String objects", () => {
+    class MyStr extends String {}
+    expect(util.isDeepStrictEqual(new String("a"), new MyStr("a"), true)).toBe(true);
+    expect(util.isDeepStrictEqual(new String("a"), new MyStr("a"))).toBe(false);
+    expect(util.isDeepStrictEqual(new String("a"), new MyStr("b"), true)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #33074

### Problem

Node v26 added a third `skipPrototype` argument to `util.isDeepStrictEqual(a, b, skipPrototype)`. When truthy, the prototype/class comparison is skipped (recursively) while every other strict rule still applies, so two instances of different classes with identical own properties compare equal.

Bun hardcoded the two-argument form and dropped the third argument:

```js
import util from "node:util";
class Foo { constructor(a) { this.a = a; } }
class Bar { constructor(a) { this.a = a; } }

util.isDeepStrictEqual(new Foo(1), new Bar(1), true);
// Node: true
// Bun:  false
```

### Cause

`src/js/node/util.ts` defined `isDeepStrictEqual = (a, b) => Bun.deepEquals(a, b, true)`, never forwarding the third argument. The strict-mode prototype check lives in the native comparison (`Bun__deepEquals` / `specialObjectsDequal` in `bindings.cpp`), which compares `JSObject::calculatedClassName` and had no way to be told to skip it.

### Fix

- Thread a compile-time `skipPrototype` flag through `Bun__deepEquals` and `specialObjectsDequal` and bypass the two `calculatedClassName` comparisons (plain objects and boxed `String` objects) when it is set. The flag defaults to `false`, so all existing callers (`expect().toEqual`/`toStrictEqual`, `node:assert`, loose `deepEquals`) are byte-for-byte unchanged.
- The flag is forwarded through every recursive comparison (arrays, object properties, Map keys/values, Set members, Error cause/properties), so the skip applies recursively like Node.
- `util.isDeepStrictEqual` now forwards the third argument; `isDeepStrictEqual.length` is `3`, matching Node. The argument is coerced by truthiness, matching Node.

The third argument stays an internal extension of the native `Bun.deepEquals` entry point; its public `(a, b, strict?)` contract is unchanged.

### Behavior verified against Node v26.3.0

| case | result |
| --- | --- |
| `new Foo(1)` vs `new Bar(1)`, skip | `true` |
| no third argument / `skip=false` | `false` |
| `{ x: new Foo(1) }` vs `{ x: new Bar(1) }`, skip (recurses) | `true` |
| `{ a: 1 }` vs `new Foo(1)`, skip | `true` |
| `Object.create(null)` vs `{}`, skip | `true` |
| `[]` vs `{}`, skip (type tag still checked) | `false` |
| `new Date(0)` vs `{}`, skip (built-in type still distinct) | `false` |
| `new Foo(1)` vs `new Bar(2)`, skip (values differ) | `false` |
| `new Foo(1)` vs `Bar { a: 1, b: 2 }`, skip (prop count differs) | `false` |
| `new MyStr("a")` vs `new String("a")`, skip (boxed String) | `true` |
| class instances inside arrays / Maps / Sets, skip | `true` |

### Test

`test/js/node/util/util.test.js` adds a `describe("isDeepStrictEqual skipPrototype ...")` block covering the matrix above, the recursion paths, and the truthiness coercion.

Without the fix, the released binary returns `false` for the skip cases:

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/util/util.test.js -t "skipPrototype"
 2 pass
 7 fail
```

With the fix the full file passes (201 tests), and the `expect()` matcher suite is unaffected (`test/js/bun/test/expect.test.js`, 406 pass).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/util.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b687664b0)

test/js/node/util/util.test.js:
(pass) util > toUSVString [7.49ms]
(pass) util > inherits [8.06ms]
(pass) util > isArray > all cases [12.14ms]
(pass) util > isRegExp > all cases [6.16ms]
(pass) util > isDate > all cases [5.59ms]
(pass) util > isError > all cases [18.52ms]
(pass) util > isObject > all cases [5.49ms]
(pass) util > isPrimitive > all cases [9.05ms]
(pass) util > isBuffer > all cases [3.92ms]
(pass) util > _extend > all cases [8.01ms]
(pass) util > isBoolean > all cases [2.83ms]
(pass) util > isNull > all cases [3.08ms]
(pass) util > isUndefined > all cases [3.04ms]
(pass) util > isNullOrUndefined > all cases [2.93ms]
(pass) util > isNumber > all cases [2.68ms]
(pass) util > isString > all cases [2.66ms]
(pass) 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b687664b0)

test/js/node/util/util.test.js:
(pass) util > toUSVString [0.08ms]
(pass) util > inherits [0.09ms]
(pass) util > isArray > all cases [0.11ms]
(pass) util > isRegExp > all cases [0.05ms]
(pass) util > isDate > all cases [0.13ms]
(pass) util > isError > all cases [0.20ms]
(pass) util > isObject > all cases [0.07ms]
(pass) util > isPrimitive > all cases [0.12ms]
(pass) util > isBuffer > all cases [0.04ms]
(pass) util > _extend > all cases [0.11ms]
(pass) util > isBoolean > all cases [0.03ms]
(pass) util > isNull > all cases [0.03ms]
(pass) util > isUndefined > all cases [0.02ms]
(pass) util > isNullOrUndefined > all cases [0.02ms]
(pass) util > isNumber > all cases [0.02ms]
(pass) util > isString > all cases [0.02ms]
(pass) util > isSymbol > all cases [0.02ms]
(pass) util > isFunction > all cases [0.03ms]
(pass) util > types.isNativeError > all cases [0.05ms]
(pass) util > TextEncoder > is same as global TextEncoder [0.01ms]
(pass) util > TextDecoder > is same as global TextDecoder
(pass) util > format [0.21ms]
(pass) util > formatWithOptions [1.43ms]
(pass) util > multiplecolors [0.09ms]
(pass) util > styleText [0.63ms]
(pass) uti
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/util.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b687664b0)

test/js/node/util/util.test.js:
(pass) util > toUSVString [7.93ms]
(pass) util > inherits [8.10ms]
(pass) util > isArray > all cases [11.98ms]
(pass) util > isRegExp > all cases [7.11ms]
(pass) util > isDate > all cases [7.60ms]
(pass) util > isError > all cases [20.61ms]
(pass) util > isObject > all cases [6.23ms]
(pass) util > isPrimitive > all cases [14.44ms]
(pass) util > isBuffer > all cases [6.30ms]
(pass) util > _extend > all cases [13.47ms]
(pass) util > isBoolean > all cases [4.64ms]
(pass) util > isNull > all cases [5.23ms]
(pass) util > isUndefined > all cases [5.10ms]
(pass) util > isNullOrUndefined > all cases [3.43ms]
(pass) util > isNumber > all cases [2.68ms]
(pass) util > isString > all cases [2.68ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 734ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/120] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[2/120] gen cpp.rs (cppbind)
[3/120] gen JS modules (bundle-modules)
Preprocess modules (10937ms)
Bundle modules (45ms)
Postprocesss modules (27ms)
Bundle Functions (816ms)
Generate Code (84ms)

[11.93s] Bundled "src/js" for production
  1968 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[4/119] pch pch/root-pch.h.hxx.pch
[5/119] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[6/119] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[7/119] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[8/119] cxx obj/unified/UnifiedSource-src_jsc_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/util.ts                    |  2 +-
 src/jsc/bindings/BunObject.cpp         |  8 +++-
 src/jsc/bindings/bindings.cpp          | 43 ++++++++++--------
 src/jsc/bindings/headers-handwritten.h |  3 +-
 test/js/node/util/util.test.js         | 79 ++++++++++++++++++++++++++++++++++
 5 files changed, 113 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/node/util.ts                         1      1      0
src/jsc/bindings/BunObject.cpp              1      1      0
src/jsc/bindings/bindings.cpp              11      6      0
src/jsc/bindings/headers-handwritten.h      1      1      0
test/js/node/util/util.test.js              3      2      0
```

</details>

**root cause** · written by the author bot

The bug was that `util.isDeepStrictEqual` in Bun ignored Node v26's third `skipPrototype` argument, so objects with identical own properties but different prototypes, such as instances of two structurally identical classes, compared as unequal even when the caller asked for prototypes to be skipped. The native deep equality implementation unconditionally compared the calculated class names of the two values, with no way to opt out. The fix threads a `skipPrototype` template parameter from the JavaScript layer through `Bun__deepEquals` and all of its recursive call sites, gating the class na…

<!-- robobun:evidence:end -->