### PR TITLE
Re-resolve through updated package.json files under --hot

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -30,10 +30,9 @@ pub enum ImportWatcher {
     Watch(Box<Watcher>),
 }
 
-// Drift guard for the bun_watcher CYCLEBREAK `Loader` newtype: its constants
-// must mirror `bun_ast::Loader` (`File` for auto-watched directories, `Json`
-// for resolved package.json files). This crate sees both types, so the
-// compile-time check lives here.
+// Drift guard for the bun_watcher CYCLEBREAK `Loader` newtype: its `File` and
+// `Json` constants must mirror `bun_ast::Loader`. This crate sees both types,
+// so the compile-time check lives here.
 const _: () = assert!(bun_watcher::Loader::File.0 == bun_ast::Loader::File as u8);
 const _: () = assert!(bun_watcher::Loader::Json.0 == bun_ast::Loader::Json as u8);
 

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -30,11 +30,12 @@ pub enum ImportWatcher {
     Watch(Box<Watcher>),
 }
 
-// Drift guard for the bun_watcher CYCLEBREAK `Loader` newtype: its `File`
-// constant must mirror `bun_ast::Loader::File` —
-// the watcher stores that value for auto-watched directories. This crate sees
-// both types, so the compile-time check lives here.
+// Drift guard for the bun_watcher CYCLEBREAK `Loader` newtype: its constants
+// must mirror `bun_ast::Loader` (`File` for auto-watched directories, `Json`
+// for resolved package.json files). This crate sees both types, so the
+// compile-time check lives here.
 const _: () = assert!(bun_watcher::Loader::File.0 == bun_ast::Loader::File as u8);
+const _: () = assert!(bun_watcher::Loader::Json.0 == bun_ast::Loader::Json as u8);
 
 impl ImportWatcher {
     pub fn start(&mut self) -> Result<(), crate::CrateError> {
@@ -954,6 +955,15 @@ where
                         .op
                         .intersects(WatchOp::WRITE | WatchOp::DELETE | WatchOp::RENAME)
                     {
+                        // A changed package.json must also bust the resolver's
+                        // per-directory manifest cache, or the reload keeps
+                        // resolving through the stale exports/imports maps.
+                        if bun_paths::basename(file_path) == b"package.json" {
+                            if let Some(dir) = bun_paths::dirname(file_path) {
+                                let _ = self.ctx_mut().bust_dir_cache(dir);
+                            }
+                        }
+
                         record_changed_path(file_path);
                         if IS_KQUEUE {
                             if event.op.contains(WatchOp::RENAME) {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -497,6 +497,7 @@ impl<C> ResolveWatcher<C> {
             callback: unsafe {
                 bun_ptr::cast_fn_ptr::<fn(*mut C, &[u8], FD), fn(*mut (), &[u8], FD)>(self.on_watch)
             },
+            package_json_callback: None,
         }
     }
 }
@@ -1810,6 +1811,21 @@ impl<'a> Resolver<'a> {
         if !kind.is_from_css() && module_type == options::ModuleType::Unknown {
             if let Some(pkg) = result.package_json_ref() {
                 module_type = pkg.module_type;
+            }
+        }
+
+        // Register the package.json this module resolved through so the hot
+        // reloader can bust its directory cache when it changes. Gated like
+        // the module watch in `maybe_watch_file`: `node_modules` is excluded.
+        if let Some(watcher) = self.watcher {
+            if let Some(package_json) = result.package_json_ref() {
+                let manifest_path = package_json.source.path.text;
+                if result.path().is_some_and(|path| {
+                    bun_paths::is_absolute(path.text)
+                        && !strings::contains(path.text, b"node_modules")
+                }) {
+                    watcher.watch_package_json(manifest_path);
+                }
             }
         }
 

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -808,6 +808,15 @@ impl Watcher {
     /// - true if the file is successfully added to the watchlist or already watched
     /// - false if the file cannot be opened or added to the watchlist
     pub fn add_file_by_path_slow(&mut self, file_path: &[u8], loader: Loader) -> bool {
+        self.add_file_by_path(file_path, loader, WATCH_OPEN_FLAGS)
+    }
+
+    /// [`Self::add_file_by_path_slow`] with an explicit macOS/FreeBSD open
+    /// mode. `snapshot_fd_and_package_json` hands the stored fd back to the
+    /// transpiler whenever the same path is later fetched as a module, so a
+    /// caller registering a path before it is loaded must pass a readable
+    /// mode: `read()` on a macOS `O_EVTONLY` descriptor fails with `EBADF`.
+    pub fn add_file_by_path(&mut self, file_path: &[u8], loader: Loader, open_flags: i32) -> bool {
         if file_path.is_empty() {
             return false;
         }
@@ -836,13 +845,16 @@ impl Watcher {
             // `path_z[file_path.len()] == 0` written above; `from_buf` borrows
             // `path_z[..len]` as a `&ZStr` with the NUL debug-asserted in-bounds.
             let z = ZStr::from_buf(&path_z[..], file_path.len());
-            match bun_sys::open(z, WATCH_OPEN_FLAGS, 0) {
+            match bun_sys::open(z, open_flags, 0) {
                 Ok(opened) => opened,
                 Err(_) => return false,
             }
         };
         #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
-        let fd: Fd = Fd::INVALID;
+        let fd: Fd = {
+            let _ = open_flags;
+            Fd::INVALID
+        };
 
         let res = self.add_file::<true>(fd, file_path, hash, loader, Fd::INVALID, None);
         match res {
@@ -961,7 +973,10 @@ impl Watcher {
         fn wrap_package_json(ctx: *mut (), path: &[u8]) {
             // SAFETY: same pairing invariant as `wrap` above.
             let this = unsafe { &mut *ctx.cast::<Watcher>() };
-            let _ = this.add_file_by_path_slow(path, Loader::Json);
+            // `O_RDONLY`, not `WATCH_OPEN_FLAGS`: this runs at resolve time,
+            // so a later `import './package.json'` reuses the stored fd, and
+            // the transpiler cannot `read()` a macOS `O_EVTONLY` descriptor.
+            let _ = this.add_file_by_path(path, Loader::Json, bun_sys::O::RDONLY);
         }
         AnyResolveWatcher {
             context: std::ptr::from_mut::<Self>(self).cast::<()>(),

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -895,10 +895,12 @@ impl Watcher {
         self.mutex.lock();
 
         if let Some(index) = self.index_of(hash) {
-            if feature_flags::ATOMIC_FILE_WATCHER {
-                // On Linux, the file descriptor might be out of date.
-                if fd.is_valid() {
-                    let fds = self.watchlist.items_fd_mut();
+            // The caller has transferred ownership of `fd`. Adopt it when the
+            // stored slot is empty so Windows does not leak the transpiler's
+            // handle into a slot pre-seeded by `wrap_package_json`.
+            if fd.is_valid() {
+                let fds = self.watchlist.items_fd_mut();
+                if feature_flags::ATOMIC_FILE_WATCHER || !fds[index as usize].is_valid() {
                     fds[index as usize] = fd;
                 }
             }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -73,12 +73,23 @@ pub struct AnyResolveWatcher {
     // closure-style invariant upheld by this struct), and the body discharges
     // its own type-recovery `unsafe` internally.
     pub callback: fn(*mut (), dir_path: &[u8], dir_fd: Fd),
+    /// Registers a package.json the resolver read so `--hot`/`--watch` observe
+    /// edits to its exports/imports maps, "main", and "type". `None` when the
+    /// producer has no file watcher to register it with.
+    pub package_json_callback: Option<fn(*mut (), path: &[u8])>,
 }
 
 impl AnyResolveWatcher {
     #[inline]
     pub fn watch(self, dir_path: &[u8], dir_fd: Fd) {
         (self.callback)(self.context, dir_path, dir_fd)
+    }
+
+    #[inline]
+    pub fn watch_package_json(self, path: &[u8]) {
+        if let Some(callback) = self.package_json_callback {
+            callback(self.context, path);
+        }
     }
 }
 
@@ -947,9 +958,15 @@ impl Watcher {
             let this = unsafe { &mut *ctx.cast::<Watcher>() };
             Watcher::on_maybe_watch_directory(this, dir_path, dir_fd);
         }
+        fn wrap_package_json(ctx: *mut (), path: &[u8]) {
+            // SAFETY: same pairing invariant as `wrap` above.
+            let this = unsafe { &mut *ctx.cast::<Watcher>() };
+            let _ = this.add_file_by_path_slow(path, Loader::Json);
+        }
         AnyResolveWatcher {
             context: std::ptr::from_mut::<Self>(self).cast::<()>(),
             callback: wrap,
+            package_json_callback: Some(wrap_package_json),
         }
     }
 

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -812,10 +812,8 @@ impl Watcher {
     }
 
     /// [`Self::add_file_by_path_slow`] with an explicit macOS/FreeBSD open
-    /// mode. `snapshot_fd_and_package_json` hands the stored fd back to the
-    /// transpiler whenever the same path is later fetched as a module, so a
-    /// caller registering a path before it is loaded must pass a readable
-    /// mode: `read()` on a macOS `O_EVTONLY` descriptor fails with `EBADF`.
+    /// mode. The stored fd is handed to the transpiler if the same path is
+    /// later fetched as a module, so pre-load callers need a readable mode.
     pub fn add_file_by_path(&mut self, file_path: &[u8], loader: Loader, open_flags: i32) -> bool {
         if file_path.is_empty() {
             return false;

--- a/src/watcher/lib.rs
+++ b/src/watcher/lib.rs
@@ -57,4 +57,6 @@ impl Loader {
     /// drift guard lives in `src/jsc/hot_reloader.rs` (a crate that sees both
     /// types).
     pub const File: Loader = Loader(5);
+    /// Mirrors `bun_ast::Loader::Json as u8`; same drift guard as [`Self::File`].
+    pub const Json: Loader = Loader(6);
 }

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -826,6 +826,8 @@ it(
       "package.json": JSON.stringify({ name: "app", imports: { "#impl": "./a.js" } }),
       "a.js": `export default "FROM-A";\n`,
       "b.js": `export default "FROM-B";\n`,
+      // The manifest must not be imported here: that alone puts it in the
+      // watch set, which is exactly what this test proves is no longer needed.
       "entry.js": `import v from "#impl";\nconsole.log("gen1 " + v);\n`,
     });
 
@@ -855,12 +857,18 @@ it(
 it.skipIf(isWindows)(
   'should hot reload when a linked dependency\'s "exports" map changes',
   async () => {
+    // The `./package.json` import is load-bearing on macOS: resolving any
+    // sibling import registers the root manifest in the watch set first, so
+    // the manifest's own fetch reuses the watcher's cached fd, which must
+    // therefore be readable (`O_EVTONLY` descriptors cannot be `read()`).
+    const entry = (gen: number) =>
+      `import v from "dep";\nimport pkg from "./package.json";\nconsole.log("gen${gen} " + v + " " + pkg.name);\n`;
     using dir = tempDir("hot-exports-map", {
       "package.json": JSON.stringify({ name: "app" }),
       "packages/dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0", exports: { ".": "./a.js" } }),
       "packages/dep/a.js": `export default "FROM-A";\n`,
       "packages/dep/b.js": `export default "FROM-B";\n`,
-      "entry.js": `import v from "dep";\nconsole.log("gen1 " + v);\n`,
+      "entry.js": entry(1),
     });
     // `bun install` links a workspace/`file:` dependency into node_modules as
     // a symlink, which is what aliases the resolver's cache key.
@@ -877,7 +885,7 @@ it.skipIf(isWindows)(
     });
     const next = stdoutLineReader(runner);
 
-    expect(await next("gen1 ")).toBe("gen1 FROM-A");
+    expect(await next("gen1 ")).toBe("gen1 FROM-A app");
 
     writeFileSync(
       join(String(dir), "packages", "dep", "package.json"),
@@ -890,12 +898,12 @@ it.skipIf(isWindows)(
     // final assertion fails with the stale value instead of hanging.
     let gen = 1;
     let line = "";
-    while (gen < 6 && !line.endsWith(" FROM-B")) {
+    while (gen < 6 && !line.endsWith(" FROM-B app")) {
       gen += 1;
-      writeFileSync(join(String(dir), "entry.js"), `import v from "dep";\nconsole.log("gen${gen} " + v);\n`);
+      writeFileSync(join(String(dir), "entry.js"), entry(gen));
       line = await next(`gen${gen} `);
     }
-    expect(line).toBe(`gen${gen} FROM-B`);
+    expect(line).toBe(`gen${gen} FROM-B app`);
   },
   boundedTimeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,11 +1,25 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import {
+  copyFileSync,
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
 const longTimeout = isDebug ? Infinity : 30_000;
+// Finite even in debug builds: the package.json tests below use it where the
+// unfixed failure mode is "no reload ever happens", which must fail instead
+// of hanging forever.
+const boundedTimeout = isDebug ? 60_000 : 10_000;
 
 /**
  * Helper to parse stderr from a --hot process that throws errors.
@@ -775,4 +789,113 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+/**
+ * Buffers a --hot runner's stdout into lines and returns the next line
+ * starting with `prefix`, skipping unrelated ones. If the process exits
+ * first, resolves to a marker the caller's assertion surfaces; resolving
+ * (instead of throwing) keeps a timed-out test from leaving an unhandled
+ * rejection behind when the runner's pipe is torn down.
+ */
+function stdoutLineReader(runner: ReturnType<typeof spawn>) {
+  const reader = (runner.stdout as ReadableStream<Uint8Array>).getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  const lines: string[] = [];
+  return async (prefix: string): Promise<string> => {
+    while (true) {
+      const i = lines.findIndex(l => l.startsWith(prefix));
+      if (i !== -1) return lines.splice(0, i + 1)[i];
+      const { value, done } = await reader.read();
+      if (done) {
+        return `<--hot child exited before printing "${prefix}"; stdout so far: ${JSON.stringify(lines)}>`;
+      }
+      buffered += decoder.decode(value);
+      const parts = buffered.split("\n");
+      buffered = parts.pop()!;
+      lines.push(...parts);
+    }
+  };
+}
+
+it(
+  'should hot reload when the enclosing package.json\'s "imports" map changes',
+  async () => {
+    using dir = tempDir("hot-imports-map", {
+      "package.json": JSON.stringify({ name: "app", imports: { "#impl": "./a.js" } }),
+      "a.js": `export default "FROM-A";\n`,
+      "b.js": `export default "FROM-B";\n`,
+      "entry.js": `import v from "#impl";\nconsole.log("gen1 " + v);\n`,
+    });
+
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+    const next = stdoutLineReader(runner);
+
+    expect(await next("gen1 ")).toBe("gen1 FROM-A");
+
+    // Rewriting the package.json must trigger a reload by itself, and that
+    // reload must resolve "#impl" through the rewritten map.
+    writeFileSync(join(String(dir), "package.json"), JSON.stringify({ name: "app", imports: { "#impl": "./b.js" } }));
+    expect(await next("gen1 ")).toBe("gen1 FROM-B");
+  },
+  boundedTimeout,
+);
+
+// Windows is excluded: ReadDirectoryChangesW reports changes by physical path
+// (packages\dep\package.json), but the manifest is registered under its
+// node_modules link alias, so the per-file watch never matches there.
+it.skipIf(isWindows)(
+  'should hot reload when a linked dependency\'s "exports" map changes',
+  async () => {
+    using dir = tempDir("hot-exports-map", {
+      "package.json": JSON.stringify({ name: "app" }),
+      "packages/dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0", exports: { ".": "./a.js" } }),
+      "packages/dep/a.js": `export default "FROM-A";\n`,
+      "packages/dep/b.js": `export default "FROM-B";\n`,
+      "entry.js": `import v from "dep";\nconsole.log("gen1 " + v);\n`,
+    });
+    // `bun install` links a workspace/`file:` dependency into node_modules as
+    // a symlink, which is what aliases the resolver's cache key.
+    mkdirSync(join(String(dir), "node_modules"));
+    symlinkSync(join(String(dir), "packages", "dep"), join(String(dir), "node_modules", "dep"));
+
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+    const next = stdoutLineReader(runner);
+
+    expect(await next("gen1 ")).toBe("gen1 FROM-A");
+
+    writeFileSync(
+      join(String(dir), "packages", "dep", "package.json"),
+      JSON.stringify({ name: "dep", version: "1.0.0", exports: { ".": "./b.js" } }),
+    );
+
+    // Force reloads via the (always-watched) entry until one resolves "dep"
+    // through the rewritten exports map. A stale resolver cache never reaches
+    // FROM-B no matter how many reloads happen, so the loop is bounded and the
+    // final assertion fails with the stale value instead of hanging.
+    let gen = 1;
+    let line = "";
+    while (gen < 6 && !line.endsWith(" FROM-B")) {
+      gen += 1;
+      writeFileSync(join(String(dir), "entry.js"), `import v from "dep";\nconsole.log("gen${gen} " + v);\n`);
+      line = await next(`gen${gen} `);
+    }
+    expect(line).toBe(`gen${gen} FROM-B`);
+  },
+  boundedTimeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -791,13 +791,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   longTimeout,
 );
 
-/**
- * Buffers a --hot runner's stdout into lines and returns the next line
- * starting with `prefix`, skipping unrelated ones. If the process exits
- * first, resolves to a marker the caller's assertion surfaces; resolving
- * (instead of throwing) keeps a timed-out test from leaving an unhandled
- * rejection behind when the runner's pipe is torn down.
- */
+// Buffers a --hot runner's stdout and returns the next line starting with
+// `prefix`. On exit it resolves to a marker (rather than throwing) so a
+// timed-out test does not leave an unhandled rejection behind.
 function stdoutLineReader(runner: ReturnType<typeof spawn>) {
   const reader = (runner.stdout as ReadableStream<Uint8Array>).getReader();
   const decoder = new TextDecoder();
@@ -857,10 +853,9 @@ it(
 it.skipIf(isWindows)(
   'should hot reload when a linked dependency\'s "exports" map changes',
   async () => {
-    // The `./package.json` import is load-bearing on macOS: resolving any
-    // sibling import registers the root manifest in the watch set first, so
-    // the manifest's own fetch reuses the watcher's cached fd, which must
-    // therefore be readable (`O_EVTONLY` descriptors cannot be `read()`).
+    // The `./package.json` import is load-bearing on macOS: resolving "dep"
+    // registers the root manifest first, so the manifest's own fetch reuses
+    // the watcher's cached fd, which must therefore be readable.
     const entry = (gen: number) =>
       `import v from "dep";\nimport pkg from "./package.json";\nconsole.log("gen${gen} " + v + " " + pkg.name);\n`;
     using dir = tempDir("hot-exports-map", {
@@ -893,9 +888,8 @@ it.skipIf(isWindows)(
     );
 
     // Force reloads via the (always-watched) entry until one resolves "dep"
-    // through the rewritten exports map. A stale resolver cache never reaches
-    // FROM-B no matter how many reloads happen, so the loop is bounded and the
-    // final assertion fails with the stale value instead of hanging.
+    // through the rewritten exports map: a stale resolver cache never reaches
+    // FROM-B, so the bounded loop fails with the stale value, not a hang.
     let gen = 1;
     let line = "";
     while (gen < 6 && !line.endsWith(" FROM-B app")) {


### PR DESCRIPTION
Under `bun --hot`, editing a resolved package's `package.json` (for example flipping an `"exports"` target, or a subpath `"imports"` entry) never took effect. The resolver caches the parsed manifest per directory for the lifetime of the process, and nothing invalidated it:

1. package.json files were never added to the watch set, so the edit did not trigger a reload at all.
2. Even when a reload was forced by editing a source file, the import kept resolving through the stale exports map. For a linked (symlinked) workspace package this is unrecoverable without a full restart: the cache key is the `node_modules/dep` alias, while the directory watch only ever busts the symlink target's directory (`packages/dep`).

### Repro

```sh
# packages/dep/package.json: {"exports": {".": "./a.js"}}
# node_modules/dep -> ../packages/dep
# entry.js: import v from "dep"; console.log(v)
bun --hot entry.js     # prints the a.js value
# flip exports to "./b.js": nothing reloads
# edit packages/dep/a.js: reloads, but still serves a.js, not b.js
```

### Fix

- `Resolver::finalize_result` registers the package.json each resolution went through with the hot reload watcher, via a new callback on the existing `AnyResolveWatcher` vtable. It uses the same gate as the module watch in `maybe_watch_file` (absolute path, resolved module not under `node_modules`), so a plain installed dependency's manifest is never watched and the watch list does not grow with `node_modules`.
- `on_file_update` (`Kind::File`) busts the resolver's directory cache for the changed file's directory when that file is a `package.json`, before enqueuing the reload.
- On macOS the registration opens the manifest with `O_RDONLY`, not the watch-only `O_EVTONLY` that `add_file_by_path_slow` normally uses. The transpiler reuses a watchlist fd for any path it later fetches as a module (`snapshot_fd_and_package_json`), and since this registration happens at resolve time, `import './package.json'` would otherwise hit an `O_EVTONLY` descriptor that `read()` rejects with `EBADF`. Caught in review; `test_command.rs` documents the same hazard for its `--changed --watch` seeding.
- On Windows the registration seeds the watchlist slot with `fd = Fd::INVALID`. When the transpiler later opens a HANDLE for `import './package.json'`, `maybe_watch_file` hands it to `add_file`, which now adopts it into the empty slot instead of early-returning (the overwrite was gated on the Linux-only `ATOMIC_FILE_WATCHER`). Without this, the caller's close guard was already disarmed and the HANDLE leaked once per reload. Caught in review; verified on Windows x64 by measuring `(Get-Process).HandleCount` across 60 reloads (+1/reload before, 0 after).

Registering the alias path (`node_modules/dep/package.json`) is what makes the symlinked case work: inotify and kqueue resolve it to the real inode, so the edit comes back keyed to the alias, which is exactly the directory-cache key that needs busting.

`tsconfig.json` has the same class of staleness but lives in a separate cache and is not carried on the resolve result, so it is intentionally out of scope here.

### Known limitation

The Windows watcher matches events by the physical path `ReadDirectoryChangesW` reports, so the symlinked case still does not fire there (the manifest is registered under its `node_modules` alias). The non-linked cases (the project's own package.json, `"imports"` maps) do work on Windows, and that is what the first test covers.

### Tests

Added to `test/cli/hot/hot.test.ts`; both fail on unpatched main:

- `should hot reload when the enclosing package.json's "imports" map changes`: the reload that the manifest edit should produce never arrives.
- `should hot reload when a linked dependency's "exports" map changes`: after flipping the exports target and forcing 5 more reloads, the import still resolves the old file.

```
Expected: "gen6 FROM-B app"
Received: "gen6 FROM-A app"
```

The exports test's entry also imports `./package.json` directly so the macOS lanes cover the readable-fd requirement above.

Both pass with the fix. `hot.test.ts` (14 tests), `watch.test.ts`, `watch-many-dirs.test.ts`, and `watcher-trace.test.ts` are green under `bun bd test`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->
