### PR TITLE
fs.watch: emit null-filename change on Windows watcher overflow

### DIFF
--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -352,6 +352,9 @@ impl Default for FSWatchTaskWindows {
 pub enum StringOrBytesToDecode {
     String(bun_core::String),
     BytesToFree(Box<[u8]>),
+    /// ReadDirectoryChangesW overflow: events were lost and no filename is
+    /// available. JS receives a null filename (matches node).
+    NoFilename,
 }
 
 // The `String` arm wraps `bun_core::String`, which is `#[derive(Copy)]` and
@@ -367,9 +370,8 @@ impl Drop for StringOrBytesToDecode {
     }
 }
 
-// `PathWatcher::emit` and `Event::dupe` take a borrowed `&[u8]` rel-path and box
-// it into the owned `bytes_to_free` arm so the Windows task can carry it across
-// the thread hop.
+// `fs_events.rs` is compiled (not run) on Windows, where its platform-generic
+// `to_event(path.into())` needs `EventPathString: From<&[u8]>` to type-check.
 impl From<&[u8]> for StringOrBytesToDecode {
     #[inline]
     fn from(bytes: &[u8]) -> Self {
@@ -384,6 +386,7 @@ impl core::fmt::Display for StringOrBytesToDecode {
             StringOrBytesToDecode::BytesToFree(utf8) => {
                 write!(f, "{}", bstr::BStr::new(utf8))
             }
+            StringOrBytesToDecode::NoFilename => f.write_str("(null)"),
         }
     }
 }
@@ -435,27 +438,29 @@ impl FSWatchTaskWindows {
     #[cfg(windows)]
     fn run_path<const EVENT_TYPE: EventType>(ctx: &FSWatcher, path: &mut StringOrBytesToDecode) {
         use bun_jsc::StringJsc;
-        if ctx.encoding == Encoding::Utf8 {
-            let StringOrBytesToDecode::String(s) = path else {
-                // Producer invariant (win_watcher::on_path_update_windows): when
-                // `ctx.encoding == Utf8` the payload is always the `String`
-                // variant, and `encoding` is immutable after init.
-                unreachable!()
-            };
-            // Returning from this helper on `transferToJS` failure lets
-            // `run()` fall through to `unref_task()`, so
-            // `pending_activity_count` is never left permanently elevated.
-            let Ok(js) = s.transfer_to_js(&ctx.global_this) else {
-                return;
-            };
-            ctx.emit_with_filename::<EVENT_TYPE>(js);
-        } else {
-            let StringOrBytesToDecode::BytesToFree(bytes_ref) = path else {
-                unreachable!()
-            };
-            let bytes = core::mem::take(bytes_ref);
-            ctx.emit::<EVENT_TYPE>(&bytes);
-            drop(bytes);
+        // Producer invariant (win_watcher::emit): `String` is built only when
+        // `ctx.encoding == Utf8`, `BytesToFree` only otherwise, `NoFilename`
+        // for either; `encoding` is immutable after init.
+        match path {
+            StringOrBytesToDecode::NoFilename => {
+                ctx.emit_with_filename::<EVENT_TYPE>(JSValue::NULL);
+            }
+            StringOrBytesToDecode::String(s) => {
+                debug_assert!(ctx.encoding == Encoding::Utf8);
+                // Returning from this helper on `transferToJS` failure lets
+                // `run()` fall through to `unref_task()`, so
+                // `pending_activity_count` is never left permanently elevated.
+                let Ok(js) = s.transfer_to_js(&ctx.global_this) else {
+                    return;
+                };
+                ctx.emit_with_filename::<EVENT_TYPE>(js);
+            }
+            StringOrBytesToDecode::BytesToFree(bytes_ref) => {
+                debug_assert!(ctx.encoding != Encoding::Utf8);
+                let bytes = core::mem::take(bytes_ref);
+                ctx.emit::<EVENT_TYPE>(&bytes);
+                drop(bytes);
+            }
         }
     }
 

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -352,8 +352,9 @@ impl Default for FSWatchTaskWindows {
 pub enum StringOrBytesToDecode {
     String(bun_core::String),
     BytesToFree(Box<[u8]>),
-    /// ReadDirectoryChangesW overflow: events were lost and no filename is
-    /// available. JS receives a null filename (matches node).
+    /// libuv passed a NULL filename: a ReadDirectoryChangesW overflow (events
+    /// were lost) or a name whose UTF-16 to UTF-8 conversion failed. JS
+    /// receives a null filename either way (matches node).
     NoFilename,
 }
 

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -234,9 +234,9 @@ impl PathWatcher {
             return;
         }
 
-        // A NULL filename with status 0 is libuv's ReadDirectoryChangesW
-        // buffer-overflow notification (win/fs-event.c): events were lost.
-        // Match node: deliver 'change' with a null filename so callers can rescan.
+        // libuv (win/fs-event.c) passes a NULL filename with status 0 both for a
+        // ReadDirectoryChangesW buffer overflow (events were lost) and for a name
+        // whose UTF-16 to UTF-8 conversion failed; node delivers null for both.
         let path: Option<&[u8]> = if filename.is_null() {
             None
         } else {
@@ -277,10 +277,17 @@ impl PathWatcher {
 
         for i in 0..self.handlers.len() {
             let event = &mut self.handlers.values_mut()[i];
-            // An overflow notification is never a suppressible duplicate — node
-            // delivers every one — so it bypasses dedup, like the posix
-            // `emit_unsuppressed`.
-            if path.is_none() || event.emit(hash, timestamp, event_type) {
+            // An overflow is never a suppressible duplicate (node delivers every
+            // one), so it bypasses dedup and resets it: the next path event is
+            // not consecutive with the one that preceded the overflow.
+            let should_emit = match path {
+                None => {
+                    *event = ChangeEvent::default();
+                    true
+                }
+                Some(_) => event.emit(hash, timestamp, event_type),
+            };
+            if should_emit {
                 let ctx: *mut FSWatcher = self.handlers.keys()[i].cast::<FSWatcher>();
                 // SAFETY: handlers keys are `*mut FSWatcher` erased to `*mut c_void` in `watch()`.
                 let encoding = unsafe { (*ctx).encoding };

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -246,8 +246,9 @@ impl PathWatcher {
 
         // Intentional wrap to bun_watcher::HashType. Overflow events bypass
         // dedup in `emit`, so they carry no hash.
-        let hash =
-            path.map_or(0, |p| this.handle.hash(p, events, status) as bun_watcher::HashType);
+        let hash = path.map_or(0, |p| {
+            this.handle.hash(p, events, status) as bun_watcher::HashType
+        });
         let is_file = !this.handle.is_dir();
         this.emit(
             path,

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -234,22 +234,23 @@ impl PathWatcher {
             return;
         }
 
-        let Some(path) = (if filename.is_null() {
+        // A NULL filename with status 0 is libuv's ReadDirectoryChangesW
+        // buffer-overflow notification (win/fs-event.c): events were lost.
+        // Match node: deliver 'change' with a null filename so callers can rescan.
+        let path: Option<&[u8]> = if filename.is_null() {
             None
         } else {
             // SAFETY: libuv passes a valid NUL-terminated string when non-null.
-            Some(ZStr::from_cstr(unsafe {
-                core::ffi::CStr::from_ptr(filename)
-            }))
-        }) else {
-            return;
+            Some(unsafe { core::ffi::CStr::from_ptr(filename) }.to_bytes())
         };
 
-        // Intentional wrap to bun_watcher::HashType
-        let hash = this.handle.hash(path.as_bytes(), events, status) as bun_watcher::HashType;
+        // Intentional wrap to bun_watcher::HashType. Overflow events bypass
+        // dedup in `emit`, so they carry no hash.
+        let hash =
+            path.map_or(0, |p| this.handle.hash(p, events, status) as bun_watcher::HashType);
         let is_file = !this.handle.is_dir();
         this.emit(
-            path.as_bytes(),
+            path,
             hash,
             timestamp,
             is_file,
@@ -263,7 +264,7 @@ impl PathWatcher {
 
     pub(crate) fn emit(
         &mut self,
-        path: &[u8],
+        path: Option<&[u8]>,
         hash: bun_watcher::HashType,
         timestamp: u64,
         is_file: bool,
@@ -275,16 +276,23 @@ impl PathWatcher {
 
         for i in 0..self.handlers.len() {
             let event = &mut self.handlers.values_mut()[i];
-            if event.emit(hash, timestamp, event_type) {
+            // An overflow notification is never a suppressible duplicate — node
+            // delivers every one — so it bypasses dedup, like the posix
+            // `emit_unsuppressed`.
+            if path.is_none() || event.emit(hash, timestamp, event_type) {
                 let ctx: *mut FSWatcher = self.handlers.keys()[i].cast::<FSWatcher>();
                 // SAFETY: handlers keys are `*mut FSWatcher` erased to `*mut c_void` in `watch()`.
                 let encoding = unsafe { (*ctx).encoding };
                 // `EventPathString` on Windows is `StringOrBytesToDecode`.
-                let payload = match encoding {
-                    crate::node::Encoding::Utf8 => {
-                        StringOrBytesToDecode::String(BunString::clone_utf8(path))
-                    }
-                    _ => StringOrBytesToDecode::BytesToFree(Box::<[u8]>::from(path)),
+                let payload = match path {
+                    // Overflow: no filename available; JS receives null (node parity).
+                    None => StringOrBytesToDecode::NoFilename,
+                    Some(path) => match encoding {
+                        crate::node::Encoding::Utf8 => {
+                            StringOrBytesToDecode::String(BunString::clone_utf8(path))
+                        }
+                        _ => StringOrBytesToDecode::BytesToFree(Box::<[u8]>::from(path)),
+                    },
                 };
                 on_path_update_fn(Some(ctx.cast()), event_type.to_event(payload), is_file);
                 #[cfg(debug_assertions)]
@@ -299,7 +307,7 @@ impl PathWatcher {
         bun_output::scoped_log!(
             fs_watch,
             "emit({}, {}, {}, at {}) x {}",
-            bstr::BStr::new(path),
+            bstr::BStr::new(path.unwrap_or(b"(null)")),
             if is_file { "file" } else { "dir" },
             <&'static str>::from(event_type),
             timestamp,

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -955,6 +955,120 @@ test.skipIf(!isWindows)("retrying a failed fs.watch does not crash (windows)", a
   expect(exitCode).toBe(0); // unpatched: exitCode is 3 (Windows segfault)
 });
 
+// libuv signals a ReadDirectoryChangesW buffer overflow (events were lost) by
+// invoking the fs_event callback with a NULL filename; node surfaces it as a
+// 'change' event with a null filename, for every encoding, so callers can rescan.
+test.skipIf(!isWindows)(
+  "fs.watch delivers a null-filename 'change' event when ReadDirectoryChangesW overflows (windows)",
+  async () => {
+    using dir = tempDir("fswatch-overflow", {});
+    const watchDir = String(dir);
+    // ~100-char names make ~210-byte FILE_NOTIFY_INFORMATION entries, so ~19
+    // fill libuv's 4KB buffer; 100 blocked-loop writes overflow it ~5x over.
+    const N = 100;
+
+    const fixture = /* js */ `
+      const fs = require("node:fs");
+      const path = require("node:path");
+
+      const dir = ${JSON.stringify(watchDir)};
+      const N = ${N};
+
+      const stats = {
+        utf8: { names: new Set(), nulls: 0, nullEventTypes: new Set() },
+        buffer: { names: new Set(), nulls: 0, nullEventTypes: new Set() },
+      };
+      const { promise, resolve, reject } = Promise.withResolvers();
+      let settled = false;
+      const settle = fn => { if (!settled) { settled = true; fn(); } };
+
+      // Per watcher, the contract is: every created file is observed, or the
+      // overflow notification (strictly-null filename) arrives.
+      const done = s => s.nulls > 0 || s.names.size >= N;
+      const seen = (slot, eventType, filename) => {
+        if (filename === null) {
+          slot.nulls++;
+          slot.nullEventTypes.add(eventType);
+        } else {
+          slot.names.add(String(filename));
+        }
+        if (done(stats.utf8) && done(stats.buffer)) settle(resolve);
+      };
+
+      const watchers = [
+        fs.watch(dir, { encoding: "utf8" }, (e, f) => seen(stats.utf8, e, f)),
+        fs.watch(dir, { encoding: "buffer" }, (e, f) => seen(stats.buffer, e, f)),
+      ];
+      for (const w of watchers) {
+        w.on("error", err => settle(() => reject(err)));
+        w.on("close", () => settle(() => reject(new Error("watcher closed before overflow or full delivery"))));
+      }
+
+      // The watch is armed synchronously, so sync-writing N files now blocks
+      // the event loop while the kernel-side 4KB notification buffer fills,
+      // overflows, and discards — forcing the lost-events notification.
+      const pad = Buffer.alloc(90, "x").toString();
+      for (let i = 0; i < N; i++) {
+        fs.writeFileSync(path.join(dir, "f" + pad + String(i).padStart(3, "0") + ".txt"), "");
+      }
+
+      // Bounded window: on a build that drops the overflow notification the
+      // condition never becomes true, so give up and report what arrived.
+      const giveUp = setTimeout(() => settle(resolve), 3_000);
+
+      promise
+        .finally(() => {
+          clearTimeout(giveUp);
+          for (const w of watchers) w.close();
+          console.log(JSON.stringify({
+            utf8: { names: stats.utf8.names.size, nulls: stats.utf8.nulls, nullEventTypes: [...stats.utf8.nullEventTypes] },
+            buffer: { names: stats.buffer.names.size, nulls: stats.buffer.nulls, nullEventTypes: [...stats.buffer.nullEventTypes] },
+          }));
+        })
+        .catch(err => {
+          console.error(err);
+          process.exitCode = 1;
+        });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    type Slot = { names: number; nulls: number; nullEventTypes: string[] };
+    let result: { utf8: Slot; buffer: Slot };
+    try {
+      result = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`fixture produced no JSON\nstdout: ${stdout}\nstderr: ${stderr}`);
+    }
+
+    const summarize = (s: Slot) =>
+      s.names >= N
+        ? "all events delivered"
+        : s.nulls > 0
+          ? `overflow signaled via ${JSON.stringify(s.nullEventTypes)}`
+          : `silent loss: ${JSON.stringify(s)}`;
+
+    const okDelivery = expect.stringMatching(/^(all events delivered|overflow signaled via \["change"\])$/);
+    expect({
+      utf8: summarize(result.utf8),
+      buffer: summarize(result.buffer),
+      signalCode: proc.signalCode, // the fixture must exit on its own
+      exitCode,
+    }).toEqual({
+      utf8: okDelivery,
+      buffer: okDelivery,
+      signalCode: null,
+      exitCode: 0,
+    });
+  },
+);
+
 // The FSEvents path in PathWatcher.init() dupeZ's the resolved directory path
 // into `resolved_path`, but then immediately overwrote `this.*` with a struct
 // literal that did not include `.resolved_path`, resetting it to its default

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1055,12 +1055,16 @@ test.skipIf(!isWindows)(
           : `silent loss: ${JSON.stringify(s)}`;
 
     const okDelivery = expect.stringMatching(/^(all events delivered|overflow signaled via \["change"\])$/);
+    // stderr is in the asserted object so a watcher 'error'/'close' rejection
+    // (whose message the fixture writes to stderr) shows up in the diff.
     expect({
+      stderr,
       utf8: summarize(result.utf8),
       buffer: summarize(result.buffer),
       signalCode: proc.signalCode, // the fixture must exit on its own
       exitCode,
     }).toEqual({
+      stderr: "",
       utf8: okDelivery,
       buffer: okDelivery,
       signalCode: null,


### PR DESCRIPTION
## Summary

When a burst of file changes overflows the 4KB `ReadDirectoryChangesW` buffer on Windows, the kernel discards every pending notification and libuv reports the loss by invoking the fs_event callback with a NULL filename (`win/fs-event.c`). Bun's watcher dropped that callback entirely, so `fs.watch` consumers received a tiny fraction of the events — measured: **1 named event out of 1000** when the event loop is busy — with zero indication anything was lost.

Node surfaces this as a `'change'` event with a `null` filename so callers can rescan (verified empirically on node v25.8.1 on Windows: one named event, then exactly `('change', null)`). This PR makes Bun do the same:

- `win_watcher.rs`: a NULL filename with status 0 now flows through `emit` as `path: Option<&[u8]> = None` instead of returning early. Overflow notifications bypass the per-handler duplicate suppression — they are never duplicates worth folding, and node delivers every one (same rationale as the posix `emit_unsuppressed` path); without the bypass, two overflows landing in one uv-loop iteration share a constant hash and the cached loop timestamp, so the second would be swallowed.
- `node_fs_watcher.rs`: new `StringOrBytesToDecode::NoFilename` payload variant, delivered to JS as `JSValue::NULL` before any encoding handling, so `utf8`, `buffer`, and other encodings all receive exactly `null` (not `undefined`, not an empty string/Buffer). The JS wrapper already guards its ignore-matcher with `filenameOrError != null`, so `null` passes through untouched, including via the `fs.promises.watch` async iterator.
- Corrects the stale comment on the `From<&[u8]> for StringOrBytesToDecode` impl: its actual consumer is `fs_events.rs`, which is compiled (not run) on Windows and needs the impl to type-check.

One deliberate semantic note: rewriting `run_path` as a match over the payload replaces the old `unreachable!()`s on a payload/encoding mismatch with `debug_assert!`s. The invariant is enforced by construction at the single producer (the variant is derived from the same immutable `encoding` field the consumer reads), and a mismatch cannot corrupt memory, so a release-build abort is not warranted.

## Test plan

- [x] New Windows test in `test/js/node/watch/fs.watch.test.ts`: bursts 100 long-named files while the event loop is blocked (forcing kernel-buffer overflow), with `utf8` and `buffer` watchers on the same directory, and asserts the contract "either every created file is observed or a strictly-null-filename `'change'` arrives" — never silence. Watcher `error`/`close` reject the awaited condition; the fixture must exit on its own (`signalCode === null`).
- [x] Test fails on the previous build with `silent loss: {"names":1,"nulls":0}` and passes deterministically (3/3 runs) with this change.
- [x] All 64 tests across the 5 `test/js/node/watch/` files pass.
- [x] Behavior compared side-by-side with node v25.8.1 on Windows: identical output for the overflow burst, the `fs.promises.watch` iterator, `watcher.close()` from inside the overflow callback, `encoding: "buffer"`, and watcher liveness after an overflow.
- [x] `BUN_JSC_validateExceptionChecks=1` run clean; cross-target `cargo check` (linux/macos/windows × x64/aarch64) green.