### PR TITLE
fs.watch: report watcher queue overflow as ('change', null)

### DIFF
--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -194,6 +194,7 @@ impl FSWatchTaskPosix {
                 Event::Rename(file_path) => self.ctx().emit::<{ EventType::Rename }>(file_path),
                 Event::Change(file_path) => self.ctx().emit::<{ EventType::Change }>(file_path),
                 Event::Error(err) => self.ctx().emit_error(err),
+                Event::NoFilename(event_type) => self.ctx().emit_null_filename(*event_type),
                 Event::Abort => self.ctx().emit_if_aborted(),
                 Event::Close => self.ctx().emit::<{ EventType::Close }>(b""),
             }
@@ -290,6 +291,10 @@ pub enum Event {
     Rename(EventPathString),
     Change(EventPathString),
     Error(bun_sys::Error),
+    /// An event with no filename, surfaced to JS with `null`, matching node:
+    /// `Change` when the OS event queue overflowed and changes were lost,
+    /// `Rename` when libuv could not convert a name to UTF-8 (Windows).
+    NoFilename(path_watcher::EventType),
     Abort,
     Close,
 }
@@ -301,6 +306,7 @@ impl Event {
             Event::Rename(path) => Event::Rename(Box::<[u8]>::from(&path[..])),
             Event::Change(path) => Event::Change(Box::<[u8]>::from(&path[..])),
             Event::Error(err) => Event::Error(err.clone()),
+            Event::NoFilename(event_type) => Event::NoFilename(*event_type),
             Event::Abort => Event::Abort,
             Event::Close => Event::Close,
         }
@@ -425,6 +431,7 @@ impl FSWatchTaskWindows {
             Event::Rename(path) => Self::run_path::<{ EventType::Rename }>(ctx, path),
             Event::Change(path) => Self::run_path::<{ EventType::Change }>(ctx, path),
             Event::Error(err) => ctx.emit_error(err),
+            Event::NoFilename(event_type) => ctx.emit_null_filename(*event_type),
             Event::Abort => ctx.emit_if_aborted(),
             Event::Close => ctx.emit::<{ EventType::Close }>(b""),
         }
@@ -840,6 +847,18 @@ impl FSWatcher {
             return;
         };
         emit_js::<EVENT_TYPE>(listener, &self.global_this, file_name);
+    }
+
+    /// `Event::NoFilename`: deliver `(event, null)` regardless of encoding.
+    fn emit_null_filename(&self, event_type: path_watcher::EventType) {
+        match event_type {
+            path_watcher::EventType::Rename => {
+                self.emit_with_filename::<{ EventType::Rename }>(JSValue::NULL);
+            }
+            path_watcher::EventType::Change => {
+                self.emit_with_filename::<{ EventType::Change }>(JSValue::NULL);
+            }
+        }
     }
 
     pub fn emit<const EVENT_TYPE: EventType>(&self, file_name: &[u8]) {

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -317,6 +317,16 @@ impl PathWatcher {
         }
     }
 
+    /// The shared inotify queue overflowed and events were lost; every handler
+    /// gets `('change', null)`. No duplicate suppression — a loss signal must
+    /// always be delivered. Caller holds `manager.mutex`.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn emit_overflow(&mut self) {
+        for &ctx in self.handlers.keys() {
+            (FSWatcher::ON_PATH_UPDATE)(Some(ctx), Event::NoFilename(EventType::Change), false);
+        }
+    }
+
     #[cfg(not(any(windows, target_os = "freebsd")))]
     fn emit_error(&mut self, err: &sys::Error) {
         for &ctx in self.handlers.keys() {
@@ -933,6 +943,20 @@ impl Linux {
                 };
                 i += core::mem::size_of::<InotifyEvent>() + ev.name_len as usize;
                 let wd = ev.watch_descriptor;
+
+                // Queue hit fs.inotify.max_queued_events and the kernel dropped
+                // events (wd == -1 matches no watch). Every watcher on this fd
+                // is affected — notify all, like node on Windows does.
+                if ev.mask & IN::Q_OVERFLOW != 0 {
+                    // SAFETY: holding manager.mutex.
+                    let watchers = unsafe { &*manager.watchers.get() };
+                    for &w in watchers.values() {
+                        // SAFETY: w live under manager.mutex.
+                        unsafe { (*w).emit_overflow() };
+                        let _ = handle_oom(touched.get_or_put(w));
+                    }
+                    continue;
+                }
 
                 // Kernel retired this wd: `remove_watch` issued an explicit
                 // `inotify_rm_watch` (it deletes the `wd_map` entry first, so no

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -15,7 +15,9 @@ use bun_sys::windows::libuv as uv;
 use bun_sys::windows::libuv::UvHandle as _;
 use bun_threading::Mutex;
 
-use super::path_watcher::EventType;
+// `pub(crate)`: node_fs_watcher's `path_watcher` alias resolves to this module
+// on Windows, so `path_watcher::EventType` must re-export the real one.
+pub(crate) use super::path_watcher::EventType;
 // The callbacks are *associated functions* on `FSWatcher`, not free fns.
 use crate::node::node_fs_watcher::{Event, FSWatcher, StringOrBytesToDecode};
 #[allow(non_upper_case_globals)]
@@ -234,31 +236,32 @@ impl PathWatcher {
             return;
         }
 
-        let Some(path) = (if filename.is_null() {
-            None
+        let event_type = if events & uv::UV_RENAME != 0 {
+            EventType::Rename
         } else {
-            // SAFETY: libuv passes a valid NUL-terminated string when non-null.
-            Some(ZStr::from_cstr(unsafe {
-                core::ffi::CStr::from_ptr(filename)
-            }))
-        }) else {
-            return;
+            EventType::Change
         };
+
+        if filename.is_null() {
+            // ReadDirectoryChangesW overflowed and changes were lost (always
+            // UV_CHANGE), or libuv could not convert the name to UTF-8.
+            // Forward `(event, null)` to every handler like node, unsuppressed.
+            this.emit_in_progress = true;
+            for &ctx in this.handlers.keys() {
+                on_path_update_fn(Some(ctx), Event::NoFilename(event_type), false);
+                on_update_end_fn(Some(ctx));
+            }
+            this.emit_in_progress = false;
+            this.maybe_deinit();
+            return;
+        }
+        // SAFETY: libuv passes a valid NUL-terminated string when non-null.
+        let path = ZStr::from_cstr(unsafe { core::ffi::CStr::from_ptr(filename) });
 
         // Intentional wrap to bun_watcher::HashType
         let hash = this.handle.hash(path.as_bytes(), events, status) as bun_watcher::HashType;
         let is_file = !this.handle.is_dir();
-        this.emit(
-            path.as_bytes(),
-            hash,
-            timestamp,
-            is_file,
-            if events & uv::UV_RENAME != 0 {
-                EventType::Rename
-            } else {
-                EventType::Change
-            },
-        );
+        this.emit(path.as_bytes(), hash, timestamp, is_file, event_type);
     }
 
     pub(crate) fn emit(

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -5506,6 +5506,7 @@ pub mod linux {
         pub const ISDIR: u32 = libc::IN_ISDIR;
         pub const ONESHOT: u32 = libc::IN_ONESHOT;
         pub const IGNORED: u32 = libc::IN_IGNORED;
+        pub const Q_OVERFLOW: u32 = libc::IN_Q_OVERFLOW;
         pub const CLOEXEC: c_int = libc::IN_CLOEXEC;
         pub const NONBLOCK: c_int = libc::IN_NONBLOCK;
         use core::ffi::c_int;

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -591,6 +591,65 @@ describe("fs.watch", () => {
       ["rename", "sub"],
     ]);
   });
+
+  // Past fs.inotify.max_queued_events the kernel drops events and queues one
+  // IN_Q_OVERFLOW; Bun reports it as ('change', null) on every watcher sharing
+  // the inotify fd, the same shape node uses for overflow on Windows.
+  const inotifySysctl = (name: string) => {
+    try {
+      return Number(fs.readFileSync(`/proc/sys/fs/inotify/${name}`, "utf8").trim());
+    } catch {
+      return 0;
+    }
+  };
+  const maxQueuedEvents = isLinux ? inotifySysctl("max_queued_events") : 0;
+  // Enough directories that unregistering one watch per directory overflows
+  // the queue even if the reader thread drains a full 64KB read (4096 events).
+  const overflowDirCount = maxQueuedEvents + 6144;
+  // 16384 is the kernel default; a host tuned above that would need an
+  // impractically large directory tree, so skip there.
+  const canOverflowInotify =
+    isLinux &&
+    maxQueuedEvents > 0 &&
+    maxQueuedEvents <= 16384 &&
+    inotifySysctl("max_user_watches") >= overflowDirCount + 1024;
+
+  test.skipIf(!canOverflowInotify)("inotify queue overflow is delivered as ('change', null)", async () => {
+    using dir = tempDir("fs-watch-overflow", { "observed": {} });
+    const root = String(dir);
+    const observedDir = path.join(root, "observed");
+    const treeDir = path.join(root, "tree");
+    fs.mkdirSync(treeDir);
+    for (let i = 0; i < overflowDirCount; i++) fs.mkdirSync(path.join(treeDir, "d" + i));
+
+    const overflow = Promise.withResolvers<[string, string | null]>();
+    const bufferOverflow = Promise.withResolvers<[string, Buffer | null]>();
+    const survived = Promise.withResolvers<[string, string | null]>();
+    const watcher = fs.watch(observedDir, (eventType, filename) => {
+      if (filename === null) overflow.resolve([eventType, filename]);
+      else if (filename === "f.txt") survived.resolve([eventType, filename]);
+    });
+    watcher.on("error", overflow.reject);
+    // The overflow event carries no name to encode, so every encoding gets null.
+    const bufferWatcher = fs.watch(observedDir, { encoding: "buffer" }, (eventType, filename) => {
+      if (filename === null) bufferOverflow.resolve([eventType, filename]);
+    });
+    bufferWatcher.on("error", bufferOverflow.reject);
+    try {
+      // Closing the recursive watcher unregisters one inotify watch per
+      // directory in a single critical section; each unregister queues an
+      // IN_IGNORED the blocked reader can't drain, overflowing the queue.
+      fs.watch(treeDir, { recursive: true }, () => {}).close();
+      expect(await overflow.promise).toEqual(["change", null]);
+      expect(await bufferOverflow.promise).toEqual(["change", null]);
+      // Overflow signals lost events; the watcher itself must keep working.
+      fs.writeFileSync(path.join(observedDir, "f.txt"), "x");
+      expect(await survived.promise).toEqual(["rename", "f.txt"]);
+    } finally {
+      watcher.close();
+      bufferWatcher.close();
+    }
+  });
 });
 
 describe("fs.promises.watch", () => {

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -508,7 +508,11 @@ describe("fs.watch", () => {
   });
 
   // on windows 0o200 will be readable (match nodejs behavior)
-  test.skipIf(isWindows)("should throw if no permission to watch the directory", async () => {
+  // Root has CAP_DAC_OVERRIDE, so the chmod 0o200 below never yields the
+  // EACCES these two tests expect; they only make sense as a non-root user.
+  const isRoot = process.getuid?.() === 0;
+
+  test.skipIf(isWindows || isRoot)("should throw if no permission to watch the directory", async () => {
     const filepath = path.join(testDir, "permission-dir");
     fs.mkdirSync(filepath, { recursive: true });
     fs.chmodSync(filepath, 0o200);
@@ -524,7 +528,7 @@ describe("fs.watch", () => {
     }
   });
 
-  test.skipIf(isWindows)("should throw if no permission to watch the file", async () => {
+  test.skipIf(isWindows || isRoot)("should throw if no permission to watch the file", async () => {
     const filepath = path.join(testDir, "permission-file.txt");
 
     fs.writeFileSync(filepath, "hello.txt");
@@ -614,42 +618,61 @@ describe("fs.watch", () => {
     maxQueuedEvents <= 16384 &&
     inotifySysctl("max_user_watches") >= overflowDirCount + 1024;
 
-  test.skipIf(!canOverflowInotify)("inotify queue overflow is delivered as ('change', null)", async () => {
-    using dir = tempDir("fs-watch-overflow", { "observed": {} });
-    const root = String(dir);
-    const observedDir = path.join(root, "observed");
-    const treeDir = path.join(root, "tree");
-    fs.mkdirSync(treeDir);
-    for (let i = 0; i < overflowDirCount; i++) fs.mkdirSync(path.join(treeDir, "d" + i));
+  // The directory count is fixed by the kernel (the overflow needs more watch
+  // removals than max_queued_events=16384 plus one 64KB read the reader may
+  // drain), so setup is ~22k syscalls: well past the 5s default under ASAN.
+  test.skipIf(!canOverflowInotify)(
+    "inotify queue overflow is delivered as ('change', null)",
+    async () => {
+      using dir = tempDir("fs-watch-overflow", { "observed": {} });
+      const root = String(dir);
+      const observedDir = path.join(root, "observed");
+      const treeDir = path.join(root, "tree");
+      fs.mkdirSync(treeDir);
+      for (let i = 0; i < overflowDirCount; i++) fs.mkdirSync(path.join(treeDir, "d" + i));
 
-    const overflow = Promise.withResolvers<[string, string | null]>();
-    const bufferOverflow = Promise.withResolvers<[string, Buffer | null]>();
-    const survived = Promise.withResolvers<[string, string | null]>();
-    const watcher = fs.watch(observedDir, (eventType, filename) => {
-      if (filename === null) overflow.resolve([eventType, filename]);
-      else if (filename === "f.txt") survived.resolve([eventType, filename]);
-    });
-    watcher.on("error", overflow.reject);
-    // The overflow event carries no name to encode, so every encoding gets null.
-    const bufferWatcher = fs.watch(observedDir, { encoding: "buffer" }, (eventType, filename) => {
-      if (filename === null) bufferOverflow.resolve([eventType, filename]);
-    });
-    bufferWatcher.on("error", bufferOverflow.reject);
-    try {
-      // Closing the recursive watcher unregisters one inotify watch per
-      // directory in a single critical section; each unregister queues an
-      // IN_IGNORED the blocked reader can't drain, overflowing the queue.
-      fs.watch(treeDir, { recursive: true }, () => {}).close();
-      expect(await overflow.promise).toEqual(["change", null]);
-      expect(await bufferOverflow.promise).toEqual(["change", null]);
-      // Overflow signals lost events; the watcher itself must keep working.
-      fs.writeFileSync(path.join(observedDir, "f.txt"), "x");
-      expect(await survived.promise).toEqual(["rename", "f.txt"]);
-    } finally {
-      watcher.close();
-      bufferWatcher.close();
-    }
-  });
+      const overflow = Promise.withResolvers<[string, string | null]>();
+      const bufferOverflow = Promise.withResolvers<[string, Buffer | null]>();
+      const survived = Promise.withResolvers<[string, string | null]>();
+      // An error or unexpected close on either watcher must reject every pending
+      // promise so the test reports the failure instead of hanging to the
+      // timeout. The no-op catch keeps the not-yet-awaited ones handled.
+      const pending = [overflow, bufferOverflow, survived];
+      for (const p of pending) p.promise.catch(() => {});
+      const fail = (err: unknown) => pending.forEach(p => p.reject(err));
+      const watcher = fs.watch(observedDir, (eventType, filename) => {
+        if (filename === null) overflow.resolve([eventType, filename]);
+        else if (filename === "f.txt") survived.resolve([eventType, filename]);
+      });
+      // The overflow event carries no name to encode, so every encoding gets null.
+      const bufferWatcher = fs.watch(observedDir, { encoding: "buffer" }, (eventType, filename) => {
+        if (filename === null) bufferOverflow.resolve([eventType, filename]);
+      });
+      let closing = false;
+      for (const w of [watcher, bufferWatcher]) {
+        w.once("error", fail);
+        w.once("close", () => {
+          if (!closing) fail(new Error("watcher closed unexpectedly"));
+        });
+      }
+      try {
+        // Closing the recursive watcher unregisters one inotify watch per
+        // directory in a single critical section; each unregister queues an
+        // IN_IGNORED the blocked reader can't drain, overflowing the queue.
+        fs.watch(treeDir, { recursive: true }, () => {}).close();
+        expect(await overflow.promise).toEqual(["change", null]);
+        expect(await bufferOverflow.promise).toEqual(["change", null]);
+        // Overflow signals lost events; the watcher itself must keep working.
+        fs.writeFileSync(path.join(observedDir, "f.txt"), "x");
+        expect(await survived.promise).toEqual(["rename", "f.txt"]);
+      } finally {
+        closing = true;
+        watcher.close();
+        bufferWatcher.close();
+      }
+    },
+    90_000,
+  );
 });
 
 describe("fs.promises.watch", () => {
@@ -1013,6 +1036,120 @@ test.skipIf(!isWindows)("retrying a failed fs.watch does not crash (windows)", a
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0); // unpatched: exitCode is 3 (Windows segfault)
 });
+
+// libuv signals a ReadDirectoryChangesW buffer overflow (events were lost) by
+// invoking the fs_event callback with a NULL filename; node surfaces it as a
+// 'change' event with a null filename, for every encoding, so callers can rescan.
+test.skipIf(!isWindows)(
+  "fs.watch delivers a null-filename 'change' event when ReadDirectoryChangesW overflows (windows)",
+  async () => {
+    using dir = tempDir("fswatch-overflow-win", {});
+    const watchDir = String(dir);
+    // ~100-char names make ~210-byte FILE_NOTIFY_INFORMATION entries, so ~19
+    // fill libuv's 4KB buffer; 100 blocked-loop writes overflow it ~5x over.
+    const N = 100;
+
+    const fixture = /* js */ `
+      const fs = require("node:fs");
+      const path = require("node:path");
+
+      const dir = ${JSON.stringify(watchDir)};
+      const N = ${N};
+
+      const stats = {
+        utf8: { names: new Set(), nulls: 0, nullEventTypes: new Set() },
+        buffer: { names: new Set(), nulls: 0, nullEventTypes: new Set() },
+      };
+      const { promise, resolve, reject } = Promise.withResolvers();
+      let settled = false;
+      const settle = fn => { if (!settled) { settled = true; fn(); } };
+
+      // Per watcher, the contract is: every created file is observed, or the
+      // overflow notification (strictly-null filename) arrives.
+      const done = s => s.nulls > 0 || s.names.size >= N;
+      const seen = (slot, eventType, filename) => {
+        if (filename === null) {
+          slot.nulls++;
+          slot.nullEventTypes.add(eventType);
+        } else {
+          slot.names.add(String(filename));
+        }
+        if (done(stats.utf8) && done(stats.buffer)) settle(resolve);
+      };
+
+      const watchers = [
+        fs.watch(dir, { encoding: "utf8" }, (e, f) => seen(stats.utf8, e, f)),
+        fs.watch(dir, { encoding: "buffer" }, (e, f) => seen(stats.buffer, e, f)),
+      ];
+      for (const w of watchers) {
+        w.on("error", err => settle(() => reject(err)));
+        w.on("close", () => settle(() => reject(new Error("watcher closed before overflow or full delivery"))));
+      }
+
+      // The watch is armed synchronously, so sync-writing N files now blocks
+      // the event loop while libuv's 4KB ReadDirectoryChangesW buffer fills
+      // and overflows, forcing the lost-events notification.
+      const pad = Buffer.alloc(90, "x").toString();
+      for (let i = 0; i < N; i++) {
+        fs.writeFileSync(path.join(dir, "f" + pad + String(i).padStart(3, "0") + ".txt"), "");
+      }
+
+      // Bounded window: on a build that drops the overflow notification the
+      // condition never becomes true, so give up and report what arrived.
+      const giveUp = setTimeout(() => settle(resolve), 3_000);
+
+      promise
+        .finally(() => {
+          clearTimeout(giveUp);
+          for (const w of watchers) w.close();
+          console.log(JSON.stringify({
+            utf8: { names: stats.utf8.names.size, nulls: stats.utf8.nulls, nullEventTypes: [...stats.utf8.nullEventTypes] },
+            buffer: { names: stats.buffer.names.size, nulls: stats.buffer.nulls, nullEventTypes: [...stats.buffer.nullEventTypes] },
+          }));
+        })
+        .catch(err => {
+          console.error(err);
+          process.exitCode = 1;
+        });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    type Slot = { names: number; nulls: number; nullEventTypes: string[] };
+    let result: { utf8: Slot; buffer: Slot };
+    try {
+      result = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`fixture produced no JSON\nstdout: ${stdout}\nstderr: ${stderr}`);
+    }
+
+    const summarize = (s: Slot) =>
+      s.names >= N
+        ? "all events delivered"
+        : s.nulls > 0
+          ? `overflow signaled via ${JSON.stringify(s.nullEventTypes)}`
+          : `silent loss: ${JSON.stringify(s)}`;
+
+    const okDelivery = expect.stringMatching(/^(all events delivered|overflow signaled via \["change"\])$/);
+    expect({
+      utf8: summarize(result.utf8),
+      buffer: summarize(result.buffer),
+      signalCode: proc.signalCode, // the fixture must exit on its own
+      exitCode,
+    }).toEqual({
+      utf8: okDelivery,
+      buffer: okDelivery,
+      signalCode: null,
+      exitCode: 0,
+    });
+  },
+);
 
 // The FSEvents path in PathWatcher.init() dupeZ's the resolved directory path
 // into `resolved_path`, but then immediately overwrote `this.*` with a struct


### PR DESCRIPTION
## Summary

`fs.watch` on Linux silently dropped the kernel's queue-overflow signal: once more than `fs.inotify.max_queued_events` (default 16384) events pile up, the kernel discards events and queues a single `IN_Q_OVERFLOW` record with `wd == -1`. The reader thread's `wd_map` lookup found no watch for `wd == -1`, so consumers got no signal that events were lost. Windows had the same gap: libuv reports a `ReadDirectoryChangesW` overflow by invoking the callback with a NULL filename (`uv__fs_event_process`, `src/win/fs-event.c:562`), which `uv_event_callback` discarded with an early return.

Both backends now deliver the loss signal the way node does on Windows: a `'change'` event with a `null` filename, sent to every live watcher (the inotify queue is shared by all watchers on the fd). Node on Linux drops the overflow (libuv cannot map `wd == -1` to a handle), so on Linux this is deliberately better than node rather than node parity.

- New `Event::NoFilename(EventType)` variant flows through both task pipelines and reaches JS as `(eventType, null)` for every `encoding`, including `'buffer'`.
- On Windows a NULL filename is not exclusively overflow: libuv also passes NULL with `UV_RENAME` when a filename fails UTF-16 to UTF-8 conversion (the conversion result is unchecked in `uv__fs_event_process`). The branch keys the event type off `events & UV_RENAME`, so that case now surfaces as `('rename', null)` exactly like node, instead of being dropped.
- Overflow delivery bypasses per-handler duplicate suppression, since a loss signal must always be delivered.

Supersedes #33109, which is the Windows-only half of the same fix; its Windows overflow test is folded in here.

Deliberately excluded:

- `src/watcher/INotifyWatcher.rs` (the bundler / `--watch` / `--hot` watcher) still drops `IN_Q_OVERFLOW`; the right response there is a rescan or reload decision in the hot reloader, not a JS event, so it needs its own change.
- macOS FSEvents `kFSEventStreamEventFlagKernelDropped` / `UserDropped` are not surfaced. libuv and node do not surface them either.

## Test plan

- [x] New Linux test in `test/js/node/watch/fs.watch.test.ts` triggers a real `IN_Q_OVERFLOW` deterministically without root: closing a recursive watcher over `max_queued_events + 6144` directories unregisters one watch per directory inside a single reader-lock critical section, and each `inotify_rm_watch` queues an `IN_IGNORED` the blocked reader cannot drain (it gets at most one 64KB read, 4096 events). Asserts `('change', null)` on a default-encoding watcher and an `encoding: 'buffer'` watcher, then that the watcher still delivers normal events afterwards. Self-skips when `/proc/sys/fs/inotify` limits make the setup impractical.
- [x] The Linux test fails without the fix (the overflow event is never delivered, so it times out) and passes with it.
- [x] New Windows test (from #33109): 100 synchronous writes of ~100-char names while the event loop is blocked overflow libuv's 4KB `ReadDirectoryChangesW` buffer, which libuv reports by calling back with a NULL filename. Asserts a null-filename `'change'` reaches both a utf8 and a buffer watcher, or that every write was observed.
- [x] Full `test/js/node/watch/` suite (56 pass, 0 fail) and all 33 `test/js/node/test/parallel/test-fs-watch*.js` pass under a debug ASAN build.
- [x] All four `build-rust` lanes (linux-x64, windows-x64, windows-x64-baseline, windows-aarch64) pass on this diff, covering the `#[cfg(windows)]` path.
- [ ] The Windows UTF-16 to UTF-8 conversion-failure path (`('rename', null)`) has no test: a filename libuv cannot convert is not creatable from JS. It compiles for both Windows targets and shares the delivery code the overflow test exercises.

Two test changes beyond the new coverage:

- The Linux overflow test carries an explicit 90s budget. Its directory count is dictated by the kernel constant (overflowing needs more watch removals than `max_queued_events` plus one 64KB read), so its ~22k syscalls of setup cannot fit the 5s default under a debug ASAN build (6s measured). A `cpSync`-based setup was measured 6x slower, so the flat `mkdirSync` loop is already the cheapest form.
- The two pre-existing `EACCES` permission tests in the same file now skip when running as root: root has `CAP_DAC_OVERRIDE`, so the `chmod 0o200` they rely on never produces the error they assert. They fail identically on an unpatched build, so this is environmental, not a regression.