### PR TITLE
node:fs: faster existsSync/accessSync on Windows via by-name query

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -198,6 +198,10 @@ pub mod feature_flag {
     // EACCES/EFAULT when the syscall returns; this covers environments where
     // it faults instead.
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_EPOLL_PWAIT2, "BUN_FEATURE_FLAG_DISABLE_EPOLL_PWAIT2", {});
+    // Disable the Windows GetFileInformationByName (Win11 23H2+) fast path
+    // for existence/attribute probes; forces the GetFileAttributesW fallback
+    // every pre-23H2 system takes.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_GET_FILE_INFORMATION_BY_NAME, "BUN_FEATURE_FLAG_DISABLE_GET_FILE_INFORMATION_BY_NAME", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX, "BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX", {});
     // Disable streaming tarball extraction in `bun install`. When disabled,
     // the whole .tgz is buffered in memory before being decompressed and

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2737,6 +2737,8 @@ pub mod ffi {
     #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::FILE_BASIC_INFORMATION {}
     #[cfg(windows)]
+    unsafe impl Zeroable for bun_windows_sys::externs::FILE_STAT_BASIC_INFORMATION {}
+    #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::BY_HANDLE_FILE_INFORMATION {}
     #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::WIN32_FILE_ATTRIBUTE_DATA {}

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2983,7 +2983,7 @@ mod posix_impl {
         );
         Ok(())
     }
-    /// Windows uses `GetFileAttributesW`; posix is plain `access`.
+    /// Windows queries file attributes by name; posix is plain `access`.
     pub fn exists_z(path: &ZStr) -> bool {
         // SAFETY: `ZStr::as_ptr()` yields a valid NUL-terminated C string.
         unsafe { libc::access(path.as_ptr(), libc::F_OK) == 0 }
@@ -4163,8 +4163,8 @@ mod windows_impl {
         r
     }
     pub fn access(path: &ZStr, mode: i32) -> Maybe<()> {
-        // GetFileAttributesW, then if
-        // `(mode & W_OK) != 0` AND the file is read-only AND it is NOT a
+        // Attribute query (`queryFileAttributes`, no reparse following), then
+        // if `(mode & W_OK) != 0` AND the file is read-only AND it is NOT a
         // directory, return `.err = EPERM`.
         const W_OK: i32 = 2;
         // Longer than any path NT can address — reject up front instead of
@@ -4182,10 +4182,8 @@ mod windows_impl {
         }
         let mut wbuf = WPathBuffer::default();
         let wpath = bun_paths::string_paths::to_kernel32_path(&mut wbuf, path.as_bytes());
-        let attrs = unsafe { w::kernel32::GetFileAttributesW(wpath.as_ptr()) };
-        if attrs == w::INVALID_FILE_ATTRIBUTES {
-            return Err(Error::new(w::get_last_errno(), Tag::access).with_path(path.as_bytes()));
-        }
+        let attrs = super::query_file_attributes(wpath)
+            .map_err(|errno| Error::new(errno, Tag::access).with_path(path.as_bytes()))?;
         let is_readonly = (attrs & w::FILE_ATTRIBUTE_READONLY) != 0;
         let is_directory = (attrs & w::FILE_ATTRIBUTE_DIRECTORY) != 0;
         if (mode & W_OK) != 0 && is_readonly && !is_directory {
@@ -4273,7 +4271,7 @@ mod windows_impl {
         Ok(())
     }
     pub fn exists_z(path: &ZStr) -> bool {
-        // GetFileAttributesW != INVALID.
+        // Attribute query succeeds (`access(path, F_OK)`).
         access(path, 0).is_ok()
     }
     pub fn exists_at(dir: impl AsFd, sub: &ZStr) -> bool {
@@ -7018,21 +7016,100 @@ pub struct WindowsFileAttributes {
     pub raw: u32,
 }
 
+/// Cached `GetFileInformationByName` — absent on Windows < 11 23H2 (the
+/// api-set module or export is missing; same probe libuv uses in
+/// `src/win/winapi.c`) and when
+/// `BUN_FEATURE_FLAG_DISABLE_GET_FILE_INFORMATION_BY_NAME` is set.
+#[cfg(windows)]
+fn get_file_information_by_name() -> Option<bun_windows_sys::externs::GetFileInformationByNameFn> {
+    if bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_GET_FILE_INFORMATION_BY_NAME
+        .get()
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    crate::dlsym_with_handle!(
+        bun_windows_sys::externs::GetFileInformationByNameFn,
+        "GetFileInformationByName",
+        dlopen(bun_core::zstr!("api-ms-win-core-file-l2-1-4.dll"), RTLD::LAZY)
+    )
+}
+
+/// By-name arm of [`query_file_attributes`]. `None` is inconclusive — the API
+/// is unavailable, the path is not volume-backed (DOS devices like `NUL` fail
+/// with `INVALID_PARAMETER`), or the failure is not a plain miss — and the
+/// caller must re-query with `GetFileAttributesW`, whose exact semantics
+/// (e.g. `NUL` succeeding, `SHARING_VIOLATION` on locked system files) are
+/// the contract.
+#[cfg(windows)]
+fn query_file_attributes_by_name(wpath: &bun_core::WStr) -> Option<core::result::Result<u32, E>> {
+    use bun_windows_sys::externs as w;
+    let get_info = get_file_information_by_name()?;
+    let mut info: w::FILE_STAT_BASIC_INFORMATION = bun_core::ffi::zeroed();
+    // SAFETY: FFI; `wpath` is NUL-terminated UTF-16 and `info` is sized for
+    // the FileStatBasicByNameInfo class.
+    let rc = unsafe {
+        get_info(
+            wpath.as_ptr(),
+            w::FILE_INFO_BY_NAME_CLASS::FileStatBasicByNameInfo,
+            core::ptr::from_mut(&mut info).cast::<c_void>(),
+            core::mem::size_of::<w::FILE_STAT_BASIC_INFORMATION>() as u32,
+        )
+    };
+    if rc == 0 {
+        let err = windows::Win32Error::get();
+        return match err {
+            // Only the plain miss codes (both → ENOENT) are trusted without a
+            // second syscall — they cover the resolver's hot miss probes.
+            windows::Win32Error::FILE_NOT_FOUND | windows::Win32Error::PATH_NOT_FOUND => {
+                Some(Err(err.to_e()))
+            }
+            _ => None,
+        };
+    }
+    match info.DeviceType {
+        w::FILE_DEVICE_CD_ROM
+        | w::FILE_DEVICE_CD_ROM_FILE_SYSTEM
+        | w::FILE_DEVICE_DISK
+        | w::FILE_DEVICE_DISK_FILE_SYSTEM
+        | w::FILE_DEVICE_NETWORK_FILE_SYSTEM
+        | w::FILE_DEVICE_VIRTUAL_DISK
+        | w::FILE_DEVICE_DVD => Some(Ok(info.FileAttributes)),
+        _ => None,
+    }
+}
+
+/// `dwFileAttributes` for `wpath` —
+/// `GetFileInformationByName(FileStatBasicByNameInfo)` where available (the
+/// by-name query class skips the query-open filter-driver tax, ~5x cheaper
+/// than `GetFileAttributesW` with Defender active), `GetFileAttributesW`
+/// otherwise. Reparse points are NOT followed (matching `GetFileAttributesW`);
+/// `Err` is the errno `GetLastError` maps to, identical on both arms.
+#[cfg(windows)]
+fn query_file_attributes(wpath: &bun_core::WStr) -> core::result::Result<u32, E> {
+    use bun_windows_sys::externs as w;
+    if let Some(definitive) = query_file_attributes_by_name(wpath) {
+        return definitive;
+    }
+    // Win32 API does file path normalization, so we do not need the valid path assertion here.
+    // SAFETY: `wpath` is NUL-terminated UTF-16.
+    let dword = unsafe { w::GetFileAttributesW(wpath.as_ptr()) };
+    if dword == windows::INVALID_FILE_ATTRIBUTES {
+        return Err(windows::get_last_errno());
+    }
+    Ok(dword)
+}
+
 /// `getFileAttributes`. Accepts a UTF-8 path (the
-/// resolver only ever calls it with one); the wide-path arm is the
-/// `GetFileAttributesW` body inlined. Returns `None` on
-/// `INVALID_FILE_ATTRIBUTES`.
+/// resolver only ever calls it with one); routes through
+/// [`query_file_attributes`]. Returns `None` when the query fails
+/// (`INVALID_FILE_ATTRIBUTES` class).
 #[cfg(windows)]
 pub fn get_file_attributes(path: &ZStr) -> Option<WindowsFileAttributes> {
     use bun_windows_sys::externs as w;
     let mut wbuf = bun_paths::w_path_buffer_pool::get();
     let wpath = bun_paths::string_paths::to_kernel32_path(&mut wbuf.0[..], path.as_bytes());
-    // Win32 API does file path normalization, so we do not need the valid path assertion here.
-    // SAFETY: `wpath` is NUL-terminated UTF-16 produced by `to_kernel32_path`.
-    let dword = unsafe { w::GetFileAttributesW(wpath.as_ptr()) };
-    if dword == windows::INVALID_FILE_ATTRIBUTES {
-        return None;
-    }
+    let dword = query_file_attributes(wpath).ok()?;
     Some(WindowsFileAttributes {
         is_directory: (dword & w::FILE_ATTRIBUTE_DIRECTORY) != 0,
         is_reparse_point: (dword & w::FILE_ATTRIBUTE_REPARSE_POINT) != 0,
@@ -7051,13 +7128,11 @@ pub fn exists_os_path(path: &bun_paths::OSPathSliceZ, file_only: bool) -> bool {
     #[cfg(windows)]
     {
         use bun_windows_sys::externs as w;
-        // `getFileAttributes(path)`; if `file_only` reject dirs;
+        // Attribute query (no reparse following); if `file_only` reject dirs;
         // if reparse point, open the target with `OPEN_EXISTING` to follow.
-        // SAFETY: path is NUL-terminated UTF-16.
-        let attrs = unsafe { w::GetFileAttributesW(path.as_ptr()) };
-        if attrs == windows::INVALID_FILE_ATTRIBUTES {
+        let Ok(attrs) = query_file_attributes(path) else {
             return false;
-        }
+        };
         if file_only && (attrs & w::FILE_ATTRIBUTE_DIRECTORY) != 0 {
             return false;
         }
@@ -8920,7 +8995,7 @@ pub fn iterate_dir(dir: Fd) -> dir_iterator::WrappedIterator {
 }
 /// `bun.sys.exists`. Non-NUL-terminated convenience over
 /// [`exists_z`]: copies into a stack `PathBuffer`, NUL-terminates, then
-/// `access(path, F_OK)` (POSIX) / `GetFileAttributesW` (Windows).
+/// `access(path, F_OK)` (POSIX) / an attribute query by name (Windows).
 pub fn exists(path: &[u8]) -> bool {
     let mut buf = bun_paths::PathBuffer::default();
     if path.len() >= buf.0.len() {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7031,7 +7031,10 @@ fn get_file_information_by_name() -> Option<bun_windows_sys::externs::GetFileInf
     crate::dlsym_with_handle!(
         bun_windows_sys::externs::GetFileInformationByNameFn,
         "GetFileInformationByName",
-        dlopen(bun_core::zstr!("api-ms-win-core-file-l2-1-4.dll"), RTLD::LAZY)
+        dlopen(
+            bun_core::zstr!("api-ms-win-core-file-l2-1-4.dll"),
+            RTLD::LAZY
+        )
     )
 }
 

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -361,6 +361,64 @@ pub struct FILE_BASIC_INFORMATION {
     pub FileAttributes: ULONG,
 }
 
+/// `FILE_ID_128` (`winnt.h`) — 128-bit file identifier.
+#[repr(C)]
+pub struct FILE_ID_128 {
+    pub Identifier: [u8; 16],
+}
+
+/// `FILE_STAT_BASIC_INFORMATION` (`ntifs.h`, Win11 ≥ 23H2) — output of
+/// `GetFileInformationByName(FileStatBasicByNameInfo)`.
+#[repr(C)]
+pub struct FILE_STAT_BASIC_INFORMATION {
+    pub FileId: LARGE_INTEGER,
+    pub CreationTime: LARGE_INTEGER,
+    pub LastAccessTime: LARGE_INTEGER,
+    pub LastWriteTime: LARGE_INTEGER,
+    pub ChangeTime: LARGE_INTEGER,
+    pub AllocationSize: LARGE_INTEGER,
+    pub EndOfFile: LARGE_INTEGER,
+    pub FileAttributes: ULONG,
+    pub ReparseTag: ULONG,
+    pub NumberOfLinks: ULONG,
+    pub DeviceType: ULONG,
+    pub DeviceCharacteristics: ULONG,
+    pub Reserved: ULONG,
+    pub VolumeSerialNumber: LARGE_INTEGER,
+    pub FileId128: FILE_ID_128,
+}
+
+/// `FILE_INFO_BY_NAME_CLASS` (`winbase.h`) — selector for
+/// `GetFileInformationByName`. Newtype-over-u32 like `FILE_INFORMATION_CLASS`.
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct FILE_INFO_BY_NAME_CLASS(pub u32);
+impl FILE_INFO_BY_NAME_CLASS {
+    pub const FileStatBasicByNameInfo: Self = Self(3);
+}
+
+/// `GetFileInformationByName` (`winbase.h`) — by-name metadata query that
+/// skips the query-open filter-driver tax `GetFileAttributesW` pays. Exported
+/// from `api-ms-win-core-file-l2-1-4.dll` on Win11 ≥ 23H2 only, so it is
+/// resolved at runtime (`bun_sys::dlsym_with_handle!`) instead of `#[link]`,
+/// which would fail to load the binary on older Windows.
+pub type GetFileInformationByNameFn = unsafe extern "system" fn(
+    FileName: LPCWSTR,
+    FileInformationClass: FILE_INFO_BY_NAME_CLASS,
+    FileInfoBuffer: *mut c_void,
+    FileInfoBufferSize: ULONG,
+) -> BOOL;
+
+// `DEVICE_TYPE` values (`winioctl.h`) seen in
+// `FILE_STAT_BASIC_INFORMATION.DeviceType` for volume-backed paths.
+pub const FILE_DEVICE_CD_ROM: ULONG = 0x0002;
+pub const FILE_DEVICE_CD_ROM_FILE_SYSTEM: ULONG = 0x0003;
+pub const FILE_DEVICE_DISK: ULONG = 0x0007;
+pub const FILE_DEVICE_DISK_FILE_SYSTEM: ULONG = 0x0008;
+pub const FILE_DEVICE_NETWORK_FILE_SYSTEM: ULONG = 0x0014;
+pub const FILE_DEVICE_VIRTUAL_DISK: ULONG = 0x0024;
+pub const FILE_DEVICE_DVD: ULONG = 0x0033;
+
 /// `FILE_DIRECTORY_INFORMATION` (`ntifs.h`) — `NtQueryDirectoryFile` record.
 /// `FileName` is a flexible array; declared `[WCHAR; 1]` to match C layout
 /// (read past it via `FileNameLength`).

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2051,15 +2051,18 @@ describe.skipIf(!isWindows)("windows existsSync/accessSync attribute-query seman
     fs.symlinkSync(p("junction-target"), p("junction-dangling"), "junction");
     fs.rmdirSync(p("junction-target"));
 
+    // "code" is a string, or an array when the OS version changes which
+    // errno Windows reports for the same bad input.
     const throws = (fn, code) => {
+      const codes = [].concat(code);
       let threw;
       try {
         fn();
       } catch (err) {
         threw = err;
       }
-      assert.ok(threw, "expected " + code + ", did not throw");
-      assert.strictEqual(threw.code, code);
+      assert.ok(threw, "expected " + codes.join("|") + ", did not throw");
+      assert.ok(codes.includes(threw.code), "expected " + codes.join("|") + ", got " + threw.code);
       assert.strictEqual(threw.syscall, "access");
       return threw;
     };
@@ -2110,7 +2113,10 @@ describe.skipIf(!isWindows)("windows existsSync/accessSync attribute-query seman
       assert.strictEqual(enoent.path, p("missing.txt"));
       throws(() => fs.accessSync(p("missing-dir", "x.txt"), F_OK), "ENOENT");
       throws(() => fs.accessSync(p("ro.txt"), W_OK), "EPERM");
-      throws(() => fs.accessSync(p("file.txt") + "\\", F_OK), "ENOTDIR");
+      // Trailing separator on a file: both arms fall through to
+      // GetFileAttributesW, but the error it reports is OS-version dependent
+      // (ENOTDIR on Windows 11, ENOENT on Windows Server 2019).
+      throws(() => fs.accessSync(p("file.txt") + "\\", F_OK), ["ENOTDIR", "ENOENT"]);
       throws(() => fs.accessSync("", F_OK), "ENOENT");
 
       // The async flavors share the same syscall layer.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1,3 +1,4 @@
+import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, it, spyOn } from "bun:test";
 import {
   bunEnv,
@@ -2017,6 +2018,169 @@ describe("exist", () => {
 
   it("should return false with empty string", () => {
     expect(existsSync("")).toBe(false);
+  });
+});
+
+// existsSync/accessSync on Windows use a by-name attribute query:
+// GetFileInformationByName (Win11 23H2+) with a GetFileAttributesW fallback
+// for older Windows and for paths the fast query cannot answer (DOS devices,
+// locked system files). Both arms must agree on every edge case, so the same
+// matrix runs once per arm; the feature flag forces the fallback arm on
+// machines where the fast API exists.
+describe.skipIf(!isWindows)("windows existsSync/accessSync attribute-query semantics", () => {
+  const matrixFixture = String.raw`
+    import assert from "node:assert";
+    import fs from "node:fs";
+    import path from "node:path";
+    import { dlopen, FFIType } from "bun:ffi";
+
+    const { F_OK, R_OK, W_OK, X_OK } = fs.constants;
+    const p = (...segments) => path.join(process.cwd(), ...segments);
+
+    fs.writeFileSync(p("file.txt"), "hello");
+    fs.mkdirSync(p("dir"));
+    fs.writeFileSync(p("ro.txt"), "ro");
+    fs.mkdirSync(p("ro-dir"));
+    fs.writeFileSync(p("fïlé-中文.txt"), "non-ascii");
+    fs.symlinkSync(p("file.txt"), p("link-file"), "file");
+    fs.symlinkSync(p("dir"), p("link-dir"), "dir");
+    fs.symlinkSync(p("ro.txt"), p("link-ro"), "file");
+    fs.symlinkSync(p("missing-target"), p("link-dangling"), "file");
+    fs.symlinkSync(p("dir"), p("junction-dir"), "junction");
+    fs.mkdirSync(p("junction-target"));
+    fs.symlinkSync(p("junction-target"), p("junction-dangling"), "junction");
+    fs.rmdirSync(p("junction-target"));
+
+    const throws = (fn, code) => {
+      let threw;
+      try {
+        fn();
+      } catch (err) {
+        threw = err;
+      }
+      assert.ok(threw, "expected " + code + ", did not throw");
+      assert.strictEqual(threw.code, code);
+      assert.strictEqual(threw.syscall, "access");
+      return threw;
+    };
+
+    try {
+      // Read-only bits go on last so a setup failure above never leaves the
+      // temp dir undeletable; the finally below clears them.
+      fs.chmodSync(p("ro.txt"), 0o444);
+      fs.chmodSync(p("ro-dir"), 0o444);
+
+      // existsSync resolves reparse points through to their target.
+      assert.strictEqual(fs.existsSync(p("file.txt")), true);
+      assert.strictEqual(fs.existsSync(p("dir")), true);
+      assert.strictEqual(fs.existsSync(p("dir") + "\\"), true);
+      assert.strictEqual(fs.existsSync(p("ro.txt")), true);
+      assert.strictEqual(fs.existsSync(p("missing.txt")), false);
+      assert.strictEqual(fs.existsSync(p("missing-dir", "x.txt")), false);
+      assert.strictEqual(fs.existsSync(p("link-file")), true);
+      assert.strictEqual(fs.existsSync(p("link-dir")), true);
+      assert.strictEqual(fs.existsSync(p("link-dangling")), false);
+      assert.strictEqual(fs.existsSync(p("junction-dir")), true);
+      assert.strictEqual(fs.existsSync(p("junction-dangling")), false);
+      assert.strictEqual(fs.existsSync(p("fïlé-中文.txt")), true);
+      assert.strictEqual(fs.existsSync(p("fïlé-中文-missing.txt")), false);
+      assert.strictEqual(fs.existsSync("file.txt"), true); // relative to cwd
+      assert.strictEqual(fs.existsSync("./file.txt"), true);
+      assert.strictEqual(fs.existsSync("NUL"), true);
+      assert.strictEqual(fs.existsSync(""), false);
+
+      // accessSync reports the reparse point itself (no target resolution),
+      // and W_OK only fails for read-only non-directories.
+      fs.accessSync(p("file.txt"), F_OK);
+      fs.accessSync(p("file.txt"), R_OK | W_OK | X_OK);
+      fs.accessSync(p("dir"), W_OK);
+      fs.accessSync(p("ro-dir"), W_OK); // directories cannot be read-only
+      fs.accessSync(p("ro.txt"), R_OK);
+      fs.accessSync(p("fïlé-中文.txt"), W_OK);
+      fs.accessSync("file.txt", F_OK); // relative to cwd
+      fs.accessSync(p("link-file"), W_OK);
+      // The read-only bit lives on the target, not the link, and access
+      // reports the link itself.
+      fs.accessSync(p("link-ro"), W_OK);
+      fs.accessSync(p("link-dangling"), F_OK);
+      fs.accessSync(p("link-dangling"), W_OK);
+      fs.accessSync("NUL", W_OK);
+
+      const enoent = throws(() => fs.accessSync(p("missing.txt"), F_OK), "ENOENT");
+      assert.strictEqual(enoent.path, p("missing.txt"));
+      throws(() => fs.accessSync(p("missing-dir", "x.txt"), F_OK), "ENOENT");
+      throws(() => fs.accessSync(p("ro.txt"), W_OK), "EPERM");
+      throws(() => fs.accessSync(p("file.txt") + "\\", F_OK), "ENOTDIR");
+      throws(() => fs.accessSync("", F_OK), "ENOENT");
+
+      // The async flavors share the same syscall layer.
+      await fs.promises.access(p("ro.txt"), R_OK);
+      await assert.rejects(fs.promises.access(p("ro.txt"), W_OK), { code: "EPERM", syscall: "access" });
+      await assert.rejects(fs.promises.access(p("missing.txt"), F_OK), { code: "ENOENT", syscall: "access" });
+      {
+        const { promise, resolve, reject } = Promise.withResolvers();
+        fs.access(p("link-dangling"), W_OK, err => (err ? reject(err) : resolve()));
+        await promise;
+      }
+      {
+        const { promise, resolve } = Promise.withResolvers();
+        fs.exists(p("link-dangling"), resolve);
+        assert.strictEqual(await promise, false);
+      }
+    } finally {
+      // Clear read-only bits so the temp dir can be deleted.
+      fs.chmodSync(p("ro.txt"), 0o666);
+      fs.chmodSync(p("ro-dir"), 0o777);
+    }
+
+    // Report whether the Win11 23H2+ API exists so CI logs show which arm
+    // the fast-path run actually exercised on this machine.
+    let fastApiAvailable = false;
+    try {
+      dlopen("api-ms-win-core-file-l2-1-4.dll", {
+        GetFileInformationByName: {
+          args: [FFIType.ptr, FFIType.i32, FFIType.ptr, FFIType.u32],
+          returns: FFIType.i32,
+        },
+      });
+      fastApiAvailable = true;
+    } catch {}
+    console.log("fast-api-available=" + fastApiAvailable);
+    console.log("matrix ok");
+  `;
+
+  it.concurrent.each([
+    ["GetFileInformationByName fast path", {}],
+    ["GetFileAttributesW fallback", { BUN_FEATURE_FLAG_DISABLE_GET_FILE_INFORMATION_BY_NAME: "1" }],
+  ])("edge-case matrix agrees on both arms: %s", async (_label, extraEnv) => {
+    // Independent probe of the same API so the fixture's report is asserted
+    // against this machine's ground truth, not against itself.
+    let fastApiAvailable = false;
+    try {
+      dlopen("api-ms-win-core-file-l2-1-4.dll", {
+        GetFileInformationByName: {
+          args: [FFIType.ptr, FFIType.i32, FFIType.ptr, FFIType.u32],
+          returns: FFIType.i32,
+        },
+      });
+      fastApiAvailable = true;
+    } catch {}
+
+    using dir = tempDir("fs-exists-access-matrix", { "matrix-fixture.mjs": matrixFixture });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "matrix-fixture.mjs"],
+      env: { ...bunEnv, ...extraEnv },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr is surfaced in the diff only on failure (debug builds may log benign warnings).
+    expect({
+      stdout: stdout.trim(),
+      exitCode,
+      ...(exitCode === 0 ? {} : { stderr }),
+    }).toEqual({ stdout: `fast-api-available=${fastApiAvailable}\nmatrix ok`, exitCode: 0 });
   });
 });
 


### PR DESCRIPTION
## Summary

On default-configured Windows (Microsoft Defender's filesystem filter active), `GetFileAttributesW` — the syscall behind `fs.existsSync`, `fs.accessSync`, `Bun.which`, and the resolver's and package manager's existence probes — costs ~20-30µs per call, hit or miss. Windows 11 23H2+ exposes a cheaper "by-name" query class, `GetFileInformationByName(FileStatBasicByNameInfo)`, that returns the same attribute bits for ~4µs. The vendored libuv already uses it for `statSync` (`fs__stat_path` in `src/win/fs.c`), which made `statSync` ~7x faster than `existsSync` in the same bun.exe binary.

This PR routes the three native attribute-probe entry points (`access`, `exists_os_path`, `get_file_attributes` in `src/sys/lib.rs`) through a shared `query_file_attributes()` helper that tries the by-name query first and falls back to `GetFileAttributesW`. The symbol is resolved at runtime from `api-ms-win-core-file-l2-1-4.dll` (the same probe libuv uses), so the binary still loads and behaves identically on Windows 10 and pre-23H2 Windows 11.

Measured on Win11 25H2 with Defender active: raw syscall 13.8µs → 3.4µs per hit; in-process A/B on the same binary (fallback forced via env flag vs fast path) shows existsSync hits ~2x and accessSync hits ~2.5x faster even under debug-build overhead. Misses are unchanged (they were already cheaper). Machines under heavier filter load see proportionally more — the gap this closes is the filter tax, which varies with Defender state.

## Behavior is preserved exactly

The fast call is only trusted in two situations:

- **Failure** with `ERROR_FILE_NOT_FOUND` / `ERROR_PATH_NOT_FOUND` (both map to ENOENT) — this covers the resolver's hot miss probes without a second syscall.
- **Success** on a volume-backed `DeviceType` (disk, network FS, CD/DVD, virtual disk).

Everything else — DOS devices like `NUL` (which fail the by-name call with `ERROR_INVALID_PARAMETER` but succeed under `GetFileAttributesW`), locked system files (`SHARING_VIOLATION` → EBUSY), ACL denials, trailing-separator-on-file (`ERROR_DIRECTORY` → ENOTDIR), not-ready drives, dead UNC shares, empty paths — falls through to `GetFileAttributesW`, so the errno is derived by exactly the same code as before. Reparse points are reported, not followed (matching `GetFileAttributesW`); `existsSync`'s follow-through open for symlink targets is unchanged.

Verified by running a 31-case behavior script (files, dirs, missing leaf/component, valid/dangling symlinks and junctions, readonly files/dirs, `NUL`, `pagefile.sys`, trailing slashes, empty string, R/W/X modes) through the previous release, this build, and this build with the fallback forced: **byte-identical output across all three**.

## Tests

A new matrix in `fs.test.ts` runs an edge-case fixture (dangling and valid symlinks and junctions, readonly file/dir, `NUL`, trailing separators, relative and non-ASCII paths, sync/callback/promises variants, exact error `code`/`syscall`/`path` assertions) once per arm — default, and with `BUN_FEATURE_FLAG_DISABLE_GET_FILE_INFORMATION_BY_NAME=1` forcing the pre-23H2 fallback — so both implementations are held to the same contract on every runner. The fixture also reports whether the fast API exists on the host (asserted against an independent probe), so CI logs show which arm actually executed; on Windows Server images the fast-path arm legitimately degrades to the fallback and says so.

Mutation-checked: adding `ERROR_INVALID_PARAMETER` to the trusted-error set flips `existsSync("NUL")` to false and the matrix fails on exactly that line, on the fast-path arm only.

## Test plan

- [x] `bun bd test test/js/node/fs/fs.test.ts` — new matrix green on both arms; suite failures are pre-existing debug-timeout flakes that reproduce (worse) on an unmodified main build
- [x] `test/js/node/test/parallel/test-fs-access.js`, `test-fs-exists.js`, `test-fs-existssync-false.js`, `test-fs-promises-exists.js`
- [x] `bun install` + module resolution smoke on both arms
- [x] 31-case behavior diff vs previous release: byte-identical (fast path and forced fallback)
- [x] `bun run rust:check-all` — 10/10 targets
- [ ] CI on Windows runners (fallback arm runs natively there; the matrix logs `fast-api-available=false`)

## Not included (deliberately)

- The three one-shot `GetFileAttributesW` reads in `node_fs.rs` copyFile/cpSync paths keep the direct call — copy cost dominates there; they can adopt `query_file_attributes` as a follow-up.
- `exists_at_type_nt` (`directory_exists_at`) still uses `NtQueryAttributesFile` — it needs `OBJECT_ATTRIBUTES.RootDirectory` relative queries, which `GetFileInformationByName` does not take.