### PR TITLE
Fix use-after-free in the Windows buffered pipe writer

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1462,7 +1462,7 @@ impl<Parent: WindowsBufferedWriterParent> Default for WindowsBufferedWriter<Pare
 #[cfg(windows)]
 impl<Parent: WindowsBufferedWriterParent> BaseWindowsPipeWriter for WindowsBufferedWriter<Parent> {
     type Parent = Parent;
-    const HAS_CURRENT_PAYLOAD: bool = false;
+    const HAS_CURRENT_PAYLOAD: bool = true;
 
     fn source(&self) -> &Option<Source> {
         &self.source
@@ -1503,8 +1503,9 @@ impl<Parent: WindowsBufferedWriterParent> BaseWindowsPipeWriter for WindowsBuffe
 
 #[cfg(windows)]
 // SAFETY: libuv write-complete callbacks re-enter via `FileSink::on_write` →
-// JS → `writer.with_mut(|w| w.end())`; writer is intrusive in `Parent`, never
-// freed during the callback; single JS thread.
+// JS → `writer.with_mut(|w| w.end())`; writer is intrusive in `Parent`, kept
+// alive across the callback by the parent ref taken in `write()` (derefed via
+// the callback-end scopeguards); single JS thread.
 unsafe impl<Parent: WindowsBufferedWriterParent> bun_ptr::LaunderedSelf
     for WindowsBufferedWriter<Parent>
 {
@@ -1551,6 +1552,17 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
         unsafe { Parent::on_error(parent, err) }
     }
 
+    /// See [`r_on_error`](Self::r_on_error). Reads `self.parent` at guard
+    /// execution so a re-entrant `set_parent` cannot over-deref a stale
+    /// pointer — mirrors [`WindowsStreamingWriter::r_deref`].
+    #[inline(always)]
+    fn r_deref(this: *mut Self) {
+        let parent = Self::r(this).parent;
+        // SAFETY: type invariant — set-once parent backref; the ref taken in
+        // `write()` keeps parent (and self-as-field) alive until this deref.
+        unsafe { Parent::deref(parent) }
+    }
+
     pub fn memory_cost(&self) -> usize {
         mem::size_of::<Self>() + self.write_buffer.len as usize
     }
@@ -1565,6 +1577,12 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
         // them after the call. Launder so post-`on_write` reads see fresh
         // state.
         let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
+        // Deref the parent at scope end to balance the ref taken in write():
+        // `Parent::on_write` re-entry may drop the last external strong ref,
+        // and the trailing `is_done`/`close()` reads below need parent (and
+        // `self`, intrusive in it) alive. Lazy `.parent` read at guard
+        // execution — see WindowsStreamingWriter::on_write_complete.
+        let _g = scopeguard::guard(this, |s| Self::r_deref(s));
         let written = Self::r(this).pending_payload_size;
         Self::r(this).pending_payload_size = 0;
         if let Some(err) = status.to_error(sys::Tag::write) {
@@ -1615,7 +1633,8 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
         // callback (detach()/close() gates free).
         file.complete(was_canceled);
 
-        // If detached, file may be closing (owned fd) or just stopped (non-owned fd)
+        // If detached, file may be closing (owned fd) or just stopped (non-owned fd).
+        // The deref to balance write()'s ref was already done in close().
         if parent_ptr.is_null() {
             // owns_fd detach() path: complete() already kicked off start_close()
             // (state == Closing) and on_close_complete will heap::take the Box.
@@ -1639,12 +1658,16 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
         let this: *mut Self = core::hint::black_box(parent_ptr.cast::<Self>());
 
         if was_canceled {
-            // Canceled write - clear pending state
+            // Canceled write - clear pending state and balance write()'s ref.
             Self::r(this).pending_payload_size = 0;
+            Self::r_deref(this);
             return;
         }
 
         if let Some(err) = result.to_error(sys::Tag::write) {
+            // Balance write()'s ref — lazy `.parent` read at guard execution
+            // in case close()/on_error re-enter and swap the parent pointer.
+            let _g = scopeguard::guard(this, |s| Self::r_deref(s));
             // close() may re-enter JS.
             Self::r(this).close();
             core::hint::black_box(this);
@@ -1653,7 +1676,7 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
             return;
         }
 
-        // on_write_complete is itself laundered.
+        // on_write_complete handles the deref (and is itself laundered).
         Self::r(this).on_write_complete(uv::ReturnCode::zero());
     }
 
@@ -1715,6 +1738,13 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
                 file.complete(false);
                 self.close();
                 self.parent_on_error(err);
+            } else {
+                // Keep the parent (which owns `self` intrusively) alive while
+                // the write is in flight. The matching deref runs in
+                // on_fs_write_complete/on_write_complete, or in close() if the
+                // writer is torn down mid-flight.
+                // SAFETY: parent BACKREF valid; intrusive refcount bump.
+                unsafe { Parent::ref_(self.parent()) };
             }
         } else {
             // the buffered version should always have a stable ptr
@@ -1732,6 +1762,12 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
             {
                 self.close();
                 self.parent_on_error(write_err);
+            } else {
+                // Keep the parent alive while the stream write is in flight;
+                // the write callback (incl. ECANCELED after close) always
+                // fires, and on_write_complete's guard runs the deref.
+                // SAFETY: parent BACKREF valid; intrusive refcount bump.
+                unsafe { Parent::ref_(self.parent()) };
             }
         }
     }

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1138,9 +1138,6 @@ impl<Parent: PosixStreamingWriterParent> Drop for PosixStreamingWriter<Parent> {
 pub trait BaseWindowsPipeWriter {
     type Parent: WindowsWriterParent;
 
-    /// `true` for WindowsStreamingWriter (has `current_payload`), `false` for buffered.
-    const HAS_CURRENT_PAYLOAD: bool;
-
     fn source(&self) -> &Option<Source>;
     fn source_mut(&mut self) -> &mut Option<Source>;
     fn parent_ptr(&self) -> *mut Self::Parent;
@@ -1181,19 +1178,15 @@ pub trait BaseWindowsPipeWriter {
         let Some(source) = self.source_mut().take() else {
             return;
         };
-        // Check for in-flight file write before detaching. detach()
-        // nulls fs.data so onFsWriteComplete can't recover the writer
-        // to call deref(). We must balance processSend's ref() here.
-        let has_inflight_write = if Self::HAS_CURRENT_PAYLOAD {
-            match &source {
-                Source::SyncFile(file) | Source::File(file) => {
-                    file.state == crate::source::FileState::Operating
-                        || file.state == crate::source::FileState::Canceling
-                }
-                _ => false,
+        // Check for in-flight file write before detaching. detach() nulls
+        // fs.data so on_fs_write_complete can't recover the writer to call
+        // deref(); balance the ref taken when the write was submitted here.
+        let has_inflight_write = match &source {
+            Source::SyncFile(file) | Source::File(file) => {
+                file.state == crate::source::FileState::Operating
+                    || file.state == crate::source::FileState::Canceling
             }
-        } else {
-            false
+            _ => false,
         };
         match source {
             Source::SyncFile(file) | Source::File(file) => {
@@ -1462,7 +1455,6 @@ impl<Parent: WindowsBufferedWriterParent> Default for WindowsBufferedWriter<Pare
 #[cfg(windows)]
 impl<Parent: WindowsBufferedWriterParent> BaseWindowsPipeWriter for WindowsBufferedWriter<Parent> {
     type Parent = Parent;
-    const HAS_CURRENT_PAYLOAD: bool = true;
 
     fn source(&self) -> &Option<Source> {
         &self.source
@@ -1577,11 +1569,9 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
         // them after the call. Launder so post-`on_write` reads see fresh
         // state.
         let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
-        // Deref the parent at scope end to balance the ref taken in write():
-        // `Parent::on_write` re-entry may drop the last external strong ref,
-        // and the trailing `is_done`/`close()` reads below need parent (and
-        // `self`, intrusive in it) alive. Lazy `.parent` read at guard
-        // execution — see WindowsStreamingWriter::on_write_complete.
+        // Scopeguard deref to balance write()'s ref: `Parent::on_write` may
+        // drop the last external strong ref, and the trailing `is_done` /
+        // `close()` reads below need the parent (and `self`, inside it) alive.
         let _g = scopeguard::guard(this, |s| Self::r_deref(s));
         let written = Self::r(this).pending_payload_size;
         Self::r(this).pending_payload_size = 0;
@@ -1739,11 +1729,10 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
                 self.close();
                 self.parent_on_error(err);
             } else {
-                // Keep the parent (which owns `self` intrusively) alive while
-                // the write is in flight. The matching deref runs in
-                // on_fs_write_complete/on_write_complete, or in close() if the
-                // writer is torn down mid-flight.
-                // SAFETY: parent BACKREF valid; intrusive refcount bump.
+                // Ref the parent to prevent it from being freed while the async
+                // write is in flight. The matching deref is in on_write_complete,
+                // on_fs_write_complete, or close() (mid-flight teardown).
+                // SAFETY: parent is BACKREF set via set_parent; valid while writer alive.
                 unsafe { Parent::ref_(self.parent()) };
             }
         } else {
@@ -1993,7 +1982,6 @@ impl<Parent: WindowsStreamingWriterParent> BaseWindowsPipeWriter
     for WindowsStreamingWriter<Parent>
 {
     type Parent = Parent;
-    const HAS_CURRENT_PAYLOAD: bool = true;
 
     fn source(&self) -> &Option<Source> {
         &self.source
@@ -2751,11 +2739,6 @@ macro_rules! impl_streaming_writer_parent {
 
 /// Stamp `PosixBufferedWriterParent` + `WindowsWriterParent` +
 /// `WindowsBufferedWriterParent` for a parent type. See module comment above.
-///
-/// `win_on_write_guard` runs on Windows immediately before forwarding
-/// `on_write`; bind a keepalive there if the callback may drop the last
-/// external strong ref (and the inline `uv_write_t`) mid-re-entry. Pass
-/// `|_this| ()` for none.
 #[macro_export]
 macro_rules! impl_buffered_writer_parent {
     (@borrow mut    $p:expr) => { &mut *$p };
@@ -2773,7 +2756,6 @@ macro_rules! impl_buffered_writer_parent {
         uv_loop    = |$uv_this:ident| $uv:expr,
         ref_       = |$ref_this:ident| $ref_:expr,
         deref      = |$deref_this:ident| $deref:expr,
-        win_on_write_guard = |$guard_this:ident| $guard:expr,
     ) => {
         #[cfg(not(windows))]
         impl $($gen)* $crate::pipe_writer::PosixBufferedWriterParent for $Ty {
@@ -2843,9 +2825,6 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: BACKREF set via `set_parent`; see borrow-mode note.
-                let $guard_this = this;
-                #[allow(unused_unsafe, clippy::let_unit_value)]
-                let _guard = unsafe { $guard };
                 unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_write(amount, status) };
             }
             #[inline]

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -1116,10 +1116,6 @@ bun_io::impl_buffered_writer_parent! {
     // `IOWriter::init` (sole constructor); passing a non-Arc ptr is UB.
     ref_       = |this| std::sync::Arc::increment_strong_count(this as *const Self),
     deref      = |this| std::sync::Arc::decrement_strong_count(this as *const Self),
-    // Hold a keepalive across Windows on_write re-entry: `on_write_pollable` →
-    // `run_yield` → `bump` may fire `on_io_writer_chunk`, which can drop the
-    // last external `Arc<IOWriter>` (and the inline `uv_write_t`) mid-callback.
-    win_on_write_guard = |this| (&*this).keepalive(),
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -78,7 +78,6 @@ bun_io::impl_buffered_writer_parent! {
     uv_loop    = |this| (*this).event_loop.uv_loop(),
     ref_       = |this| RefCount::<Self>::ref_(this),
     deref      = |this| RefCount::<Self>::deref(this),
-    win_on_write_guard = |_this| (),
 }
 
 impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { createTestBuilder } from "./test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -154,5 +155,31 @@ describe("IOWriter file output redirection", () => {
       .runAsTest("builtin echo with &> redirect");
 
     TestBuilder.command`pwd &>> append_output.txt`.exitCode(0).runAsTest("builtin pwd with &>> append redirect");
+  });
+});
+
+// On Windows the uv_fs_write completion callback re-enters JS (resolving the
+// command's promise), which drops the redirect IOWriter's last reference; the
+// rest of that callback must not touch it. https://github.com/oven-sh/bun/pull/33114
+test.concurrent("write completion survives dropping the redirect writer's last reference", async () => {
+  using dir = tempDir("shell-redirect-writer-keepalive", {
+    "redirect-fixture.ts": /* ts */ `
+      import { $ } from "bun";
+      await $\`echo hello > out.txt\`.quiet();
+      process.stdout.write(await Bun.file("out.txt").text());
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "redirect-fixture.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "hello\n",
+    stderr: expect.any(String),
+    exitCode: 0,
   });
 });

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -160,7 +160,7 @@ describe("IOWriter file output redirection", () => {
 
 // On Windows the uv_fs_write completion callback re-enters JS (resolving the
 // command's promise), which drops the redirect IOWriter's last reference; the
-// rest of that callback must not touch it. https://github.com/oven-sh/bun/pull/33114
+// rest of that callback must not touch it. https://github.com/oven-sh/bun/issues/33108
 test.concurrent("write completion survives dropping the redirect writer's last reference", async () => {
   using dir = tempDir("shell-redirect-writer-keepalive", {
     "redirect-fixture.ts": /* ts */ `


### PR DESCRIPTION
## Summary

`WindowsBufferedWriter` (the Windows pipe writer used by the shell's `IOWriter` and the spawn stdin writer) submitted async libuv writes without holding a reference on its parent. A write-completion callback re-enters JS through `Parent::on_write` — for example, a `Bun.$` command's final output flush resolving the command's promise. If that re-entry drops the parent's last external reference, the parent is freed — and the writer, which lives as an intrusive field *inside* the parent, is freed with it while the completion callback is still running. The callback's trailing `is_done` read and `close()` call then operate on freed memory. Debug builds segfault on the poisoned `match source` enum dispatch in `close()` (reported as a fault at address `0xFFFFFFFFFFFFFFFF`); release builds silently read stale memory. The existing `win_on_write_guard` keepalive doesn't cover this: it only spans the `on_write` forwarding shim and drops before the rest of the callback runs.

Reproducible on Windows debug builds with `bun bd test test/cli/install/bun-install.test.ts -t renaming` (two tests that drive installs through `Bun.$`) — it crashed within seconds.

The fix ports the keep-alive protocol that `WindowsStreamingWriter` in the same file already uses:

- `Parent::ref_` after each successful submission in `write()` (both the `uv_fs_write` file path and the stream path); no ref is taken when the submit fails synchronously.
- Exactly one balancing `Parent::deref` per terminal path: a scopeguard at the top of `on_write_complete`, an explicit deref on the canceled arm of `on_fs_write_complete`, a scopeguard on its error arm, and `close()`'s existing `has_inflight_write` deref for mid-flight teardown — enabled by flipping `HAS_CURRENT_PAYLOAD` to true (that flag's only consumer is the `close()` check).
- The deref reads `.parent` lazily at guard execution, matching the streaming writer's handling of re-entrant `set_parent`.

The close-time deref and the callback-time deref are mutually exclusive: `close()` nulls `fs.data`, so a mid-flight teardown's late callback takes the null-parent early return, and a normally-completing callback runs after `complete()` resets the file state so `close()` no longer sees an in-flight write.

## Test plan

- [x] The repro above: instant segfault before, passes 3/3 consecutive runs after.
- [x] `test/js/bun/shell/bunshell.test.ts`: 373 pass / 0 fail on the patched Windows debug build.
- [x] `test/js/bun/spawn/spawn.test.ts`: identical results with and without the patch (116 pass; the one `unref` timeout fails identically on the unpatched binary).
- [x] Refcount balance audited path-by-path for both parent implementations (shell `IOWriter` Arc counts, `StaticPipeWriter` intrusive refcount), including libuv's guarantee that canceled stream write callbacks still fire after `uv_close` (`uv__process_pipe_write_req` invokes the callback unconditionally).
- [x] `cargo check` across all 10 target/platform combinations.

Note: with this crash fixed, the full `bun-install.test.ts` suite on Windows debug builds runs further and surfaces a separate pre-existing failure (a silent `STATUS_BREAKPOINT` exit with no panic output, most likely a C++-side assertion trap). That is a distinct bug and is being tracked separately; the release build runs the full suite fine.


## Minimal repro and regression test

Distilled the repro to a single statement. On a Windows x64 debug build of main this segfaults every time:

```js
await Bun.$`echo hello > out.txt`.quiet();
// panic(main thread): Segmentation fault at address 0xFFFFFFFFFFFFFFFF
```

Not a race. `Builtin::init_redirections` stores the redirect file's only `Arc<IOWriter>` in `Builtin.stdout`, and `Cmd::deinit` drops it synchronously inside the `uv_fs_write` completion chain that resolves the command's promise. The `win_on_write_guard` keepalive is released as soon as the `on_write` forwarding shim returns, so the refcount hits 0 before `on_write_complete`'s trailing `is_done` read and `close()`.

Added a regression test to `test/js/bun/shell/file-io.test.ts` ("write completion survives dropping the redirect writer's last reference"). The fixture is spawned so a regression surfaces as an exit code mismatch instead of a segfaulted test runner.

Verified with Windows x64 debug builds of main (`16a7269639`) with and without this branch's `src/io/PipeWriter.rs`:

- Unfixed: the new test fails with the panic above. Even `bun test bunshell.test.ts -t "lone tilde"` segfaults the runner (no explicit redirect needed: the root stdout `IOWriter` hits the same path when bun's stdout is a pipe).
- Fixed (branch head `162d4aa98a`): `file-io.test.ts` 26/26, `bunshell.test.ts` 373 pass / 0 fail, `spawn.test.ts` 117 pass / 0 fail.

Dead code removed once the fix made it dead (`162d4aa98a`): `HAS_CURRENT_PAYLOAD` is now `true` for both `BaseWindowsPipeWriter` impls, so the constant and `close()`'s conditional on it are gone; and `win_on_write_guard` is redundant now that `on_write_complete` always runs under the ref taken in `write()`, so the hook and both of its users (`IOWriter`, `StaticPipeWriter`) are gone too.


Fixes #33108

