### PR TITLE
Bun.serve: invoke error() when the returned Response body is already used

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3033,6 +3033,24 @@ where
                 this.run_error_handler(js_err);
                 return;
             }
+            // The handler returned a Response whose body was already used,
+            // usually the same Response object returned for a second request.
+            // A disturbed body is an error, not a silent empty 200.
+            Body::Value::Used => {
+                if this.is_aborted_or_ended() {
+                    return;
+                }
+                let js_err = global_this
+                    .err(
+                        jsc::ErrorCode::BODY_ALREADY_USED,
+                        format_args!(
+                            "Response body already used. A Response body can only be sent once; create a new Response for each request."
+                        ),
+                    )
+                    .to_js();
+                this.run_error_handler(js_err);
+                return;
+            }
             // .InlineBlob,
             Body::Value::WTFStringImpl(_) | Body::Value::InternalBlob(_) | Body::Value::Blob(_) => {
                 // toBlobIfPossible checks for WTFString needing a conversion.

--- a/test/js/bun/http/serve-reused-response.test.ts
+++ b/test/js/bun/http/serve-reused-response.test.ts
@@ -1,0 +1,152 @@
+import { serve } from "bun";
+import { describe, expect, it, jest } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A fetch handler that returns a Response whose body has already been used
+// (most often the same Response object returned for every request) must invoke
+// the error handler instead of silently sending a 200 with an empty body.
+describe("returning a Response with an already-used body", () => {
+  const alreadyUsedError = {
+    code: "ERR_BODY_ALREADY_USED",
+    name: "TypeError",
+    message:
+      "Response body already used. A Response body can only be sent once; create a new Response for each request.",
+  };
+
+  const reusedBodies = {
+    string: () => new Response("cached-route-body"),
+    "Uint8Array": () => new Response(new TextEncoder().encode("cached-route-body")),
+    stream: () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("cached-route-body"));
+            controller.close();
+          },
+        }),
+      ),
+  };
+
+  it.each(Object.keys(reusedBodies) as (keyof typeof reusedBodies)[])(
+    "returning the same %s-bodied Response twice calls the error handler",
+    async kind => {
+      const cached = reusedBodies[kind]();
+      const errors: unknown[] = [];
+      await using server = serve({
+        port: 0,
+        fetch() {
+          return cached;
+        },
+        error(err: any) {
+          errors.push({ code: err.code, name: err.constructor.name, message: err.message });
+          return new Response("handled", { status: 500 });
+        },
+      });
+
+      // The first response sends the body and disturbs it.
+      const first = await fetch(server.url);
+      expect(await first.text()).toBe("cached-route-body");
+      expect(first.status).toBe(200);
+      expect(cached.bodyUsed).toBe(true);
+
+      // Returning the disturbed Response again must surface an error, not an empty 200.
+      const second = await fetch(server.url);
+      expect(await second.text()).toBe("handled");
+      expect(second.status).toBe(500);
+      const third = await fetch(server.url);
+      expect(await third.text()).toBe("handled");
+      expect(third.status).toBe(500);
+
+      expect(errors).toEqual([alreadyUsedError, alreadyUsedError]);
+    },
+  );
+
+  it("returning a Response whose body was consumed before returning calls the error handler", async () => {
+    const errors: unknown[] = [];
+    await using server = serve({
+      port: 0,
+      async fetch() {
+        const response = new Response("consumed before returning");
+        await response.text();
+        return response;
+      },
+      error(err: any) {
+        errors.push({ code: err.code, name: err.constructor.name, message: err.message });
+        return new Response("handled", { status: 500 });
+      },
+    });
+
+    const response = await fetch(server.url);
+    expect(await response.text()).toBe("handled");
+    expect(response.status).toBe(500);
+    expect(errors).toEqual([alreadyUsedError]);
+  });
+
+  it("a Response that is not reused keeps working", async () => {
+    const error = jest.fn();
+    await using server = serve({
+      port: 0,
+      fetch() {
+        return new Response("fresh");
+      },
+      error,
+    });
+
+    for (let i = 0; i < 3; i++) {
+      const response = await fetch(server.url);
+      expect(await response.text()).toBe("fresh");
+      expect(response.status).toBe(200);
+    }
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("a Response reused through a static route keeps working", async () => {
+    // Static routes snapshot the body at registration, so reuse is allowed there.
+    await using server = serve({
+      port: 0,
+      routes: {
+        "/static": new Response("static-body"),
+      },
+      fetch() {
+        return new Response("fallback");
+      },
+    });
+
+    for (let i = 0; i < 3; i++) {
+      const response = await fetch(new URL("/static", server.url));
+      expect(await response.text()).toBe("static-body");
+      expect(response.status).toBe(200);
+    }
+  });
+
+  it("without an error handler, logs the error and responds with 500", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const cached = new Response("cached-route-body");
+        const server = Bun.serve({
+          port: 0,
+          development: false,
+          fetch() {
+            return cached;
+          },
+        });
+        const first = await fetch(server.url);
+        console.log(first.status, JSON.stringify(await first.text()));
+        const second = await fetch(server.url);
+        console.log(second.status, JSON.stringify(await second.text()));
+        server.stop(true);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe('200 "cached-route-body"\n500 "Something went wrong!"\n');
+    expect(stderr).toContain("Response body already used");
+    // The error is reported like any other unhandled error thrown from the fetch handler.
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a silent failure in `Bun.serve`: when the `fetch` handler returns a `Response` whose body has already been used (most commonly the same `Response` object returned for more than one request), the request is answered with a `200` and `Content-Length: 0`. Nothing is thrown, nothing is logged, and `error()` is never invoked.

```js
const cached = new Response("cached-route-body");
Bun.serve({ fetch() { return cached; } });
// request #1: 200, body "cached-route-body"
// request #2+: 200, Content-Length: 0, empty body, error() never fires
```

Per the fetch model a disturbed body is an error, and Deno and workerd both reject it loudly. Bun's static routes (`routes: { "/x": new Response(...) }`) already throw "Response body has already been used" for a used body at registration time; the dynamic path was the only place a disturbed body got silently dropped.

Cause: `RequestContext::do_render_with_body` has explicit arms for `Error` bodies, in-memory bodies, and `Locked` streams, but `Body::Value::Used` fell into the catch-all `_ => {}` arm, which renders the never-assigned context blob: a 200 with `Content-Length: 0`. This affected string, `Uint8Array`, stream, and file bodied Responses alike, and also a Response whose body the handler consumed (`await response.text()`) before returning it.

Fix: add a `Body::Value::Used` arm that builds a `TypeError` (`code: "ERR_BODY_ALREADY_USED"`, message `Response body already used. A Response body can only be sent once; create a new Response for each request.`) and routes it through `run_error_handler`, exactly like the existing body-error and locked-stream arms. With an `error()` handler, the handler receives the TypeError and its Response is sent. Without one, the error is logged and the request gets the standard 500, the same as any other error thrown from `fetch`. The existing `has_called_error_handler` guard keeps an `error()` handler that itself returns a used Response from recursing.

Static routes, fresh Responses per request, bodiless Responses, and HEAD rendering are unchanged; only the `Used` (disturbed) body state is affected.

### How did you verify your code works?

`test/js/bun/http/serve-reused-response.test.ts`:

- the same string, `Uint8Array`, and stream bodied Response returned twice: the first request gets the body, later ones invoke `error()` with the TypeError (`code: "ERR_BODY_ALREADY_USED"`) and receive its response
- a Response consumed with `.text()` before being returned from an async handler: same error
- no `error()` handler (`development: false`): the client gets 500 `"Something went wrong!"`, the error is printed to stderr, and the process exit code matches other unhandled fetch errors
- fresh Responses and a static-route Response reused across requests keep working and never call `error()`

The already-used cases fail on current `bun test` (they observe the empty 200s and zero `error()` calls) and pass with this change; the two no-reuse tests pass both ways by design.
