### PR TITLE
Bun.serve: report non-Response returns from synchronous fetch handlers

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2735,6 +2735,11 @@ where
                 }
             }
         }
+
+        // A truthy non-Response, non-Error, non-Promise value (object, string,
+        // number, ...). The async twin (`handle_resolve`) reports this via
+        // `render_missing_invalid_response`; do the same on the sync path.
+        ctx.render_missing_invalid_response(response_value);
     }
 
     pub fn handle_resolve_stream(req: &mut Self) {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -371,6 +371,48 @@ it("should display a welcome message when the response value type is incorrect",
   );
 });
 
+// The async handler path already reported non-Response returns to stderr; the
+// synchronous path must emit the same diagnostic instead of staying silent.
+it("logs the invalid-response diagnostic when a synchronous fetch handler returns a non-Response value", async () => {
+  const script = `
+    const statuses = [];
+    async function hit(fetchImpl) {
+      await using server = Bun.serve({ port: 0, development: false, fetch: fetchImpl });
+      const res = await fetch(server.url);
+      await res.arrayBuffer();
+      statuses.push(res.status);
+    }
+    await hit(() => ({ forgot: "new Response" }));
+    await hit(() => "plain string");
+    await hit(() => 42);
+    await hit(async () => ({ forgot: "new Response" }));
+    console.log(JSON.stringify(statuses));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const diagnostics = stderr.match(/Expected a Response object, but received/g) ?? [];
+  expect({
+    // Returning a non-Response still renders 204 in production mode; only the
+    // missing stderr diagnostic on the synchronous path changes.
+    statuses: JSON.parse(stdout.trim()),
+    diagnosticCount: diagnostics.length,
+    exitCode,
+  }).toEqual({
+    statuses: [204, 204, 204, 204],
+    diagnosticCount: 4,
+    exitCode: 0,
+  });
+  expect(stderr).toContain(`received '"plain string"'`);
+  expect(stderr).toContain("received '42'");
+});
+
 it("request.signal works in trivial case", async () => {
   var aborty = new AbortController();
   var signaler = Promise.withResolvers();


### PR DESCRIPTION
### Summary

A synchronous `fetch` handler that returns a truthy non-`Response` value (a plain object, a string, a number) produces no diagnostic at all. The async handler path already prints one.

```js
Bun.serve({
  development: false,
  fetch(req) {
    return { ok: true }; // forgot `new Response(JSON.stringify(...))`
  },
});
```

Comparing the two paths on 1.4.0-canary:

| handler | response | stderr |
| --- | --- | --- |
| `async fetch() { return { ok: true } }` | 204 | `error: Expected a Response object, but received '{ ok: true }'` |
| `fetch() { return { ok: true } }` | 204 | nothing |
| `fetch() { return "hello" }` | 204 | nothing |
| `fetch() { return 42 }` | 204 | nothing |

So the one signal that exists for this very common mistake is missing for its most common shape.

### Cause

`RequestContext::on_response` handles the synchronous return value. `undefined`/`null`, `Error`, `Response`, and `Promise` each have a branch that returns; a truthy value of any other type falls off the end of the function without reporting anything, and the request is later finished by `should_render_missing()`. The async twin, `handle_resolve`, already routes this case through `render_missing_invalid_response`, which is what prints the `error: Expected a Response object, but received '...'` line.

### Fix

Call `render_missing_invalid_response(response_value)` on the synchronous fall-through, matching the async path.

The response itself is unchanged: 204 in production, the welcome page in development. `fetch` is typed `MaybePromise<Response | void | undefined>` and `error()` is documented as "called when an error is thrown", and `serve.test.ts` asserts the welcome page for invalid return types, so routing these returns into `error()` / a 500 would be an API behavior change and is deliberately out of scope.

### Verification

New test in `test/js/bun/http/serve.test.ts`. It spawns a server whose handler returns an object, a string, a number, and (as a control) an async object, and counts the diagnostics on stderr.

Before the fix:

```
-   "diagnosticCount": 4,
+   "diagnosticCount": 1,
```

After the fix it passes, and the neighboring "should display a welcome message when the response value type is incorrect" test (which returns a `Symbol` synchronously) still passes.
