### PR TITLE
Bun.serve: emit root-relative asset URLs for HTML routes in subdirectories

### DIFF
--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -428,6 +428,23 @@ impl Route {
         // `Config` owns its fields and
         // drops on early-return.
         config.entry_points.insert(&self.bundle.path)?;
+        // Single-entry outbase default, same as `bun build` / `Bun.build()`:
+        // the entry's own directory. Leaving it empty makes a nested HTML's
+        // source path its output `[dir]`, so its asset URLs escape the root.
+        let html_dir = bun_core::dirname(&self.bundle.path).unwrap_or(b".");
+        let mut rootdir_buf = bun_paths::PathBuffer::uninit();
+        let rootdir: &[u8] = match bun_sys::open_dir_at(bun_sys::Fd::cwd(), html_dir) {
+            Ok(fd) => {
+                // `Dir` is the owning RAII handle; its Drop closes the fd.
+                let dir = bun_sys::Dir { fd };
+                match bun_sys::get_fd_path(dir.fd, &mut rootdir_buf) {
+                    Ok(p) => &*p,
+                    Err(_) => html_dir,
+                }
+            }
+            Err(_) => html_dir,
+        };
+        config.rootdir.append_slice_exact(rootdir)?;
         let xform = &vm.transpiler.options.transform_options;
         if let Some(public_path) = xform.serve_public_path.as_deref() {
             if !public_path.is_empty() {

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1093,3 +1093,68 @@ describe("production headers and import.meta.env", () => {
     expect(a).not.toBe(b);
   });
 });
+
+// An HTML route whose source file lives in a subdirectory must emit asset URLs
+// relative to the served root, not to the HTML file's directory on disk.
+test("production HTML route in a subdirectory emits root-relative asset URLs", async () => {
+  const dir = tempDirWithFiles("html-nested-outbase", {
+    "pages/app/index.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <link rel="stylesheet" href="./styles.css">
+          <script type="module" src="./app.ts"></script>
+        </head>
+        <body><img src="./logo.svg"></body>
+      </html>
+    `,
+    "pages/app/styles.css": `body { color: rgb(12, 34, 56); }`,
+    "pages/app/app.ts": `console.log("nested app ran");`,
+    "pages/app/logo.svg": `<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>`,
+    "serve.ts": /*js*/ `
+      import net from "node:net";
+      import page from "./pages/app/index.html";
+      await using server = Bun.serve({ port: 0, development: false, routes: { "/": page } });
+      const html = await (await fetch(server.url)).text();
+      const refs = [...html.matchAll(/(?:src|href)="([^"]+)"/g)].map(m => m[1]);
+
+      // Request each emitted URL by its literal bytes over a raw socket, so no
+      // client normalizes a "/../" away before it reaches Bun's router.
+      function rawStatus(path) {
+        const { promise, resolve, reject } = Promise.withResolvers();
+        const sock = net.connect(server.port, "127.0.0.1", () => {
+          sock.write("GET " + path + " HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n");
+        });
+        let data = "";
+        sock.on("data", chunk => (data += chunk));
+        sock.on("end", () => resolve(Number(data.split(" ")[1])));
+        sock.on("error", reject);
+        return promise;
+      }
+      const statuses = [];
+      for (const ref of refs) statuses.push(await rawStatus(ref));
+      console.log(JSON.stringify({ refs, statuses }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "serve.ts"],
+    env: { ...bunEnv, NODE_ENV: undefined },
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) throw new Error(stdout + "\n" + stderr);
+
+  const out = JSON.parse(stdout.trim());
+  const byExt = Object.fromEntries(out.refs.map((ref: string) => [ref.split(".").pop(), ref]));
+  expect({ byExt, statuses: out.statuses }).toEqual({
+    byExt: {
+      css: expect.stringMatching(/^\/chunk-[a-z0-9]+\.css$/),
+      js: expect.stringMatching(/^\/chunk-[a-z0-9]+\.js$/),
+      svg: expect.stringMatching(/^\/logo-[a-z0-9]+\.svg$/),
+    },
+    statuses: [200, 200, 200],
+  });
+});

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1096,6 +1096,7 @@ describe("production headers and import.meta.env", () => {
 
 // An HTML route whose source file lives in a subdirectory must emit asset URLs
 // relative to the served root, not to the HTML file's directory on disk.
+// pages/shared/* sits outside the HTML's directory (the outbase) on purpose.
 test("production HTML route in a subdirectory emits root-relative asset URLs", async () => {
   const dir = tempDirWithFiles("html-nested-outbase", {
     "pages/app/index.html": /*html*/ `
@@ -1105,12 +1106,13 @@ test("production HTML route in a subdirectory emits root-relative asset URLs", a
           <link rel="stylesheet" href="./styles.css">
           <script type="module" src="./app.ts"></script>
         </head>
-        <body><img src="./logo.svg"></body>
+        <body><img src="../shared/logo.svg"></body>
       </html>
     `,
     "pages/app/styles.css": `body { color: rgb(12, 34, 56); }`,
-    "pages/app/app.ts": `console.log("nested app ran");`,
-    "pages/app/logo.svg": `<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>`,
+    "pages/app/app.ts": `import { util } from "../shared/util";\nconsole.log("nested app ran", util());`,
+    "pages/shared/util.ts": `export function util() { return "from a sibling of the outbase"; }`,
+    "pages/shared/logo.svg": `<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>`,
     "serve.ts": /*js*/ `
       import net from "node:net";
       import page from "./pages/app/index.html";


### PR DESCRIPTION
### Summary

A `Bun.serve` HTML route served in production mode (`development: false`) emits root-escaping asset URLs when the HTML source file lives in a subdirectory, one `../` per directory level.

```js
// serve.ts (cwd), HTML at ./pages/app/index.html
import page from "./pages/app/index.html";
Bun.serve({ development: false, routes: { "/": page } });
```

The served HTML references:

```html
<script type="module" crossorigin src="/../../chunk-0qas0tc8.js"></script>
```

Bun registers the chunk route at `/chunk-0qas0tc8.js`, so the URL it emits 404s when requested literally. It only works in browsers because they collapse `/../` client-side before sending the request; RFC 3986 forbids producing such references, and a non-normalizing proxy, WAF, or scraper in front of the server breaks.

```
raw GET /../../chunk-0qas0tc8.js -> HTTP/1.1 404 Not Found
raw GET /chunk-0qas0tc8.js       -> HTTP/1.1 200 OK
```

The same references come out of `<link href>` and `<img src>`, since CSS chunks and copied assets go through the same substitution.

`bun build ./pages/app/index.html --outdir dist --production` and `Bun.build()` both get this right: the output lands at `dist/index.html` next to `dist/chunk-*.js`, referencing `./chunk-*.js`.

### Cause

The bundler computes each chunk URL relative to the HTML entry chunk's own output directory (`[dir]`), which is the entry's source path relative to the configured output root (`root` / outbase). `bun build` (`build_command.rs`) and `Bun.build()` (`JSBundler.rs`) both default that root to the single entry point's own directory, so the HTML entry's `[dir]` is empty and the chunk URL comes out as `./chunk-*.js`.

`HTMLBundle::on_plugins_resolved`, the `Bun.serve` HTML route path, builds its own bundler config by hand and skips that default, leaving `root_dir` empty. The bundler then falls back to the cwd, the HTML entry's `[dir]` becomes `pages/app`, and the chunk URL relative to that is `../../chunk-*.js`, which the `/` public path turns into `/../../chunk-*.js`. The routes the server registers never included that prefix.

### Fix

Apply the same single-entry outbase default in `HTMLBundle::on_plugins_resolved`: resolve the HTML entry's directory and set it as `config.rootdir`. Each HTML route is its own single-entry bundle, so this cannot conflict with other entry points.

The directory is canonicalized the same way the two existing call sites do (`open_dir_at` + `get_fd_path`), falling back to the lexical dirname if that fails. The failure is not propagated as an `Err` because the caller routes `on_plugins_resolved` errors through `handle_oom`.

### Verification

New test in `test/js/bun/http/bun-serve-html.test.ts`. It serves an HTML file nested two directories deep with a script, a stylesheet, and an image, then requests each emitted URL by its literal bytes over a raw socket so nothing normalizes a `/../` before it reaches Bun's router.

Before the fix:

```
-     "css": StringMatching /^\/chunk-[a-z0-9]+\.css$/,
-     "js": StringMatching /^\/chunk-[a-z0-9]+\.js$/,
-     "svg": StringMatching /^\/logo-[a-z0-9]+\.svg$/,
+     "css": "/../../chunk-pg4z8t5x.css",
+     "js": "/../../chunk-v3xfz2q2.js",
+     "svg": "/../../logo-ydcsf7xs.svg",
    },
    "statuses": [
-     200, 200, 200,
+     404, 404, 404,
```

After the fix it passes. `bun-serve-html.test.ts` otherwise passes the same set of tests as on `main`.
