### PR TITLE
bun:ffi: fix f64 argument conversion of NaN, -0.0, and BigInts

### DIFF
--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -255,18 +255,15 @@ ffiWrappers[FFIType.uint16_t] = `{
   return ret <= 0 ? 0 : ret > 0xffff ? 0xffff : ret;
 }`;
 
+// Plain numbers pass through untouched: NaN, -0.0, and every other double are
+// already in the representation the compiled stub reads. Everything else
+// (BigInt included) is converted with Number().
 ffiWrappers[FFIType.double] = `{
-  if (typeof val === "bigint") {
-    if (val.valueOf() < BigInt(Number.MAX_VALUE)) {
-      return Math.abs(Number(val).valueOf()) + (0.00 - 0.00);
-    }
+  if (typeof val === "number") {
+    return val;
   }
 
-  if (!val) {
-    return 0 + (0.00 - 0.00);
-  }
-
-  return val + (0.00 - 0.00);
+  return Number(val);
 }`;
 
 ffiWrappers[FFIType.float] = ffiWrappers[10] = `{

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -650,6 +650,100 @@ describe.skipIf(isFFIUnavailable)("double <-> JSValue conversions", () => {
     });
   });
 
+  // The f64 argument wrapper (ffiWrappers[FFIType.double] in ffi.ts) used
+  // `if (!val) return 0`, which rewrote NaN and -0.0 to +0.0 before C ever
+  // saw them, and its BigInt branch returned Math.abs() of the value. The C
+  // functions report the value they received, so a JS round trip cannot mask
+  // an argument-conversion bug. CFunction goes through the same
+  // FFIBuilder/ffiWrappers path as dlopen; cc() only provides the pointers.
+  it("f64 arguments reach C with NaN, -0.0, and BigInt sign intact", async () => {
+    using dir = tempDir("bun-ffi-f64-args", {
+      "observe.c": /* c */ `
+        union f64bits { double d; unsigned long long u; };
+        int isnan_f64(double x) { return x != x; }
+        int signbit_f64(double x) { union f64bits c; c.d = x; return (int)(c.u >> 63); }
+        double echo_f64(double x) { return x; }
+        void* addr_isnan_f64(void) { return (void*)isnan_f64; }
+        void* addr_signbit_f64(void) { return (void*)signbit_f64; }
+        void* addr_echo_f64(void) { return (void*)echo_f64; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc, CFunction } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "observe.c"),
+          symbols: {
+            addr_isnan_f64: { args: [], returns: "ptr" },
+            addr_signbit_f64: { args: [], returns: "ptr" },
+            addr_echo_f64: { args: [], returns: "ptr" },
+          },
+        });
+
+        const isnan_f64 = new CFunction({ ptr: symbols.addr_isnan_f64(), args: ["f64"], returns: "i32" });
+        const signbit_f64 = new CFunction({ ptr: symbols.addr_signbit_f64(), args: ["f64"], returns: "i32" });
+        const echo_f64 = new CFunction({ ptr: symbols.addr_echo_f64(), args: ["f64"], returns: "f64" });
+
+        // Report a thrown conversion as a value so one failure cannot hide the rest.
+        const show = fn => {
+          try {
+            const value = fn();
+            return [typeof value, String(value)];
+          } catch (err) {
+            return ["threw", err.name];
+          }
+        };
+        const results = {
+          nan_isnan: isnan_f64(NaN),
+          one_point_five_isnan: isnan_f64(1.5),
+          negative_zero_signbit: signbit_f64(-0),
+          positive_zero_signbit: signbit_f64(0),
+          negative_one_signbit: signbit_f64(-1),
+          negative_bigint: show(() => echo_f64(-5n)),
+          positive_bigint: show(() => echo_f64(5n)),
+          huge_bigint: show(() => echo_f64(2n ** 1024n)),
+          negative_huge_bigint: show(() => echo_f64(-(2n ** 1024n))),
+          fractional: show(() => echo_f64(-2.5)),
+          string: show(() => echo_f64("2.5")),
+          null_arg: show(() => echo_f64(null)),
+          undefined_arg: show(() => echo_f64(undefined)),
+        };
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is included in the received object so failures show it, but is not
+    // asserted empty: debug builds emit benign startup warnings.
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        nan_isnan: 1,
+        one_point_five_isnan: 0,
+        negative_zero_signbit: 1,
+        positive_zero_signbit: 0,
+        negative_one_signbit: 1,
+        negative_bigint: ["number", "-5"],
+        positive_bigint: ["number", "5"],
+        huge_bigint: ["number", "Infinity"],
+        negative_huge_bigint: ["number", "-Infinity"],
+        fractional: ["number", "-2.5"],
+        string: ["number", "2.5"],
+        null_arg: ["number", "0"],
+        undefined_arg: ["number", "NaN"],
+      },
+      exitCode: 0,
+    });
+  });
+
   // napi_create_double and napi_create_date take the double from the addon
   // verbatim, so they are the same boundary. cc()-compiled C resolves napi_*
   // from the host process; that lookup is only exercised on POSIX today (see


### PR DESCRIPTION
### What

`f64`/`double` arguments are silently corrupted before the native function sees them. With a C callee that reports what it actually received:

```js
const lib = dlopen(path, {
  isnan_f64:   { args: ["f64"], returns: "i32" },  // x != x
  signbit_f64: { args: ["f64"], returns: "i32" },  // raw sign bit of x
  echo_f64:    { args: ["f64"], returns: "f64" },
});
lib.symbols.isnan_f64(NaN);          // 0: C received 0.0
lib.symbols.signbit_f64(-0.0);       // 0: C received +0.0
lib.symbols.echo_f64(-5n);           // 5: C received the absolute value
lib.symbols.echo_f64(2n ** 1024n);   // TypeError: Cannot mix BigInt and other types
lib.symbols.echo_f64(-(2n ** 1024n)) // +Infinity: wrong sign, no error
```

`f32` arguments and the `f64` return path are correct; the bug is specific to the `f64` argument wrapper. These corrupt silently, and NaN, signed zero, and negative integers are exactly the values numeric C libraries assign meaning to.

### Cause

`ffiWrappers[FFIType.double]` in `src/js/bun/ffi.ts`:

```js
if (typeof val === "bigint") {
  if (val.valueOf() < BigInt(Number.MAX_VALUE)) {
    return Math.abs(Number(val).valueOf()) + (0.00 - 0.00);
  }
}
if (!val) {
  return 0 + (0.00 - 0.00);
}
return val + (0.00 - 0.00);
```

- `!val` is true for `NaN` and `-0.0`, so both become `+0.0`.
- The BigInt branch looks like it meant to range-check `|val| < Number.MAX_VALUE` and return `Number(val)`, but the `Math.abs` ended up on the return value, so every negative BigInt loses its sign.
- A BigInt at or above `Number.MAX_VALUE` falls through to `val + (0.00 - 0.00)`, which throws `TypeError: Cannot mix BigInt and other types`; one at or below `-Number.MAX_VALUE` passes the `<` check and comes out as `+Infinity`.
- A string argument survives the wrapper as a string (`"2.5" + 0` is `"2.50"`), so the compiled stub reinterprets a `JSString` pointer as a double.

The native decoder (`JSVALUE_TO_DOUBLE` in `src/runtime/ffi/FFI.h`) already handles every JS number, including NaN, -0.0, and int32-tagged values (covered by the existing "integral JS numbers reach C as the exact double" test). The wrapper's only job is to guarantee the stub receives a plain number.

### Fix

```js
if (typeof val === "number") {
  return val;
}
return Number(val);
```

Numbers pass through bit-exact. Everything else is converted with `Number()`: BigInt keeps its sign (out-of-range values become +/-Infinity instead of throwing, matching `Number(bigint)` everywhere else), strings and objects go through ToNumber, and `undefined` becomes `NaN` instead of `0.0` (matching the `f32` wrapper, which is `Math.fround(val)`).

### Test

Added to the existing `double <-> JSValue conversions` group in `test/js/bun/ffi/cc.test.ts`. The fixture tinycc-compiles C observers (`x != x`, the raw sign bit via a union, an echo) and calls them through `CFunction`, which uses the same `FFIBuilder`/`ffiWrappers` argument path as `dlopen` (the `dlopen` suite in `ffi.test.js` is gated on a prebuilt library that no longer gets built, and `cc()` symbols currently skip the argument wrappers entirely, so calling them directly would not cover this). Assertions are on the values C reports, so a JS round trip cannot mask an argument bug.

On the unfixed build, the one assertion reports every corruption:

```
nan_isnan:             expected 1, got 0
negative_zero_signbit: expected 1, got 0
negative_bigint:       expected "-5", got "5"
huge_bigint:           expected Infinity, got a thrown TypeError
negative_huge_bigint:  expected "-Infinity", got "Infinity"
string:                expected "2.5", got "NaN" (JSString pointer read as a double)
undefined_arg:         expected "NaN", got "0"
```

With the fix, `bun bd test test/js/bun/ffi/` passes (18 pass, 0 fail, ASAN debug build).

### Out of scope, and overlap with other open PRs

The integer argument wrappers in the same table have their own problems (saturation vs. two's-complement wrapping is inconsistent across widths, and `int16_t`'s clamp bound of `32768` does not fit in int16). That is a behavior decision beyond this bug, and #31449 already proposes changes there.

- #31449 also fixes the BigInt sign half of this wrapper, but keeps the `!val` branch, so NaN and -0.0 arguments are still corrupted with that patch applied.
- #33095 fixes a different bug (JSCallback return values were never coerced). Callback returns reuse the `ffiWrappers` table, so that PR rewrites this same `FFIType.double` entry to an equivalent conversion. The src hunk overlaps; the subjects and most of the coverage do not (that PR asserts what C receives from callback returns, this one asserts what a symbol receives as an `f64` argument, including the sign bit of `-0.0` and out-of-range BigInts). Whichever lands second is a one-hunk rebase, and this test applies unchanged either way.

