### PR TITLE
node: deliver the buffered stdin remainder at EOF in paused mode

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -169,7 +169,7 @@ export function getStdinStream(
   const originalOn = stream.on;
 
   let stream_destroyed = false;
-  let stream_endEmitted = false;
+  let stream_reachedEof = false;
   stream.addListener = stream.on = function (event, listener) {
     // Streams don't generally required to present any data when only
     // `readable` events are present, i.e. `readableFlowing === false`
@@ -215,6 +215,17 @@ export function getStdinStream(
     return originalResume.$call(this);
   };
 
+  const originalRead = stream.read;
+  stream.read = function (size) {
+    // An explicit read() must acquire the native reader, otherwise _read() has
+    // no source and never produces data. Internal read(0) kicks (maybeReadMore,
+    // nReadingNextTick) must not re-own a reader that pause() released.
+    if (size !== 0 && reader === undefined && !stream_destroyed && !stream_reachedEof) {
+      own();
+    }
+    return originalRead.$call(this, size);
+  };
+
   async function internalRead(stream) {
     $debug("internalRead();");
     try {
@@ -226,15 +237,14 @@ export function getStdinStream(
 
         if (shouldDisown) disown();
       } else {
-        if (!stream_endEmitted) {
-          stream_endEmitted = true;
-          stream.emit("end");
-        }
-        if (!stream_destroyed) {
-          stream_destroyed = true;
-          stream.destroy();
-          disown();
-        }
+        // EOF. Route it through push(null) so read(n) can still return the
+        // buffered < n byte remainder and 'end'/'readableEnded' come from the
+        // stream machinery instead of firing while data is still buffered.
+        stream_reachedEof = true;
+        stream.push(null);
+        // Nothing is left to read, so the process must be able to exit even
+        // if the consumer never drains the buffer.
+        disown();
       }
     } catch (err) {
       if (err?.code === "ERR_STREAM_RELEASE_LOCK") {
@@ -279,6 +289,17 @@ export function getStdinStream(
         disown();
       }
     });
+  });
+
+  // The stream is created with autoClose: false so autoDestroy is off; match
+  // Node by destroying stdin once 'end' has emitted ('close' follows 'end').
+  stream.on("end", () => {
+    if (!stream_destroyed) {
+      stream_destroyed = true;
+      process.nextTick(() => {
+        stream.destroy();
+      });
+    }
   });
 
   stream.on("close", () => {

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -217,13 +217,14 @@ export function getStdinStream(
 
   const originalRead = stream.read;
   stream.read = function (size) {
-    // An explicit read() must acquire the native reader, otherwise _read() has
-    // no source and never produces data. Internal read(0) kicks (maybeReadMore,
-    // nReadingNextTick) must not re-own a reader that pause() released.
+    const ret = originalRead.$call(this, size);
+    // An explicit read() must acquire the native reader: _read() without one only
+    // records needsInternalReadRefresh, which own() replays. Owning afterwards so a
+    // throwing size never refs stdin; read(0) kicks never own (pause() relies on it).
     if (size !== 0 && reader === undefined && !stream_destroyed && !stream_reachedEof) {
       own();
     }
-    return originalRead.$call(this, size);
+    return ret;
   };
 
   async function internalRead(stream) {

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -128,6 +128,9 @@ export function getStdinStream(
   let forceUnref = false;
 
   function own() {
+    // After EOF there is nothing left to read: no acquisition path ('readable'
+    // listeners, resume(), ref(), an explicit read()) may take the reader back.
+    if (stream_reachedEof) return;
     $debug("ref();", reader ? "already has reader" : "getting reader");
     reader ??= native.getReader();
     source.updateRef(forceUnref ? false : true);
@@ -221,7 +224,7 @@ export function getStdinStream(
     // An explicit read() must acquire the native reader: _read() without one only
     // records needsInternalReadRefresh, which own() replays. Owning afterwards so a
     // throwing size never refs stdin; read(0) kicks never own (pause() relies on it).
-    if (size !== 0 && reader === undefined && !stream_destroyed && !stream_reachedEof) {
+    if (size !== 0 && reader === undefined && !stream_destroyed) {
       own();
     }
     return ret;

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -241,14 +241,15 @@ export function getStdinStream(
 
         if (shouldDisown) disown();
       } else {
-        // EOF. Route it through push(null) so read(n) can still return the
-        // buffered < n byte remainder and 'end'/'readableEnded' come from the
-        // stream machinery instead of firing while data is still buffered.
+        // EOF. Nothing is left to read, so release the native reader before
+        // push(null) runs user 'readable' listeners; the process must be able
+        // to exit even if one of them throws or never drains the buffer.
         stream_reachedEof = true;
-        stream.push(null);
-        // Nothing is left to read, so the process must be able to exit even
-        // if the consumer never drains the buffer.
         disown();
+        // push(null) instead of emitting 'end' by hand so read(n) can still
+        // return the buffered < n byte remainder and 'end'/'readableEnded'
+        // come from the stream machinery once the buffer drains.
+        stream.push(null);
       }
     } catch (err) {
       if (err?.code === "ERR_STREAM_RELEASE_LOCK") {

--- a/test/js/bun/util/fuzzy-wuzzy.test.ts
+++ b/test/js/bun/util/fuzzy-wuzzy.test.ts
@@ -106,7 +106,6 @@ const banned = [
   "pipe",
   "_start",
   "wait",
-  "wait",
   "sleep",
   "exit",
   "kill",
@@ -182,14 +181,9 @@ function allThePropertyNames(object, banned) {
     pro = Object.getPrototypeOf(pro);
   }
 
-  for (const ban of banned) {
-    const index = names.indexOf(ban);
-    if (index !== -1) {
-      names.splice(index, 1);
-    }
-  }
-
-  return names;
+  // A name can appear once per prototype that defines it (process.stdin sees
+  // "pipe" from ReadStream, Readable and Stream), so drop every occurrence.
+  return names.filter(name => !banned.includes(name));
 }
 
 if (ENABLE_LOGGING) {

--- a/test/js/bun/util/fuzzy-wuzzy.test.ts
+++ b/test/js/bun/util/fuzzy-wuzzy.test.ts
@@ -100,6 +100,10 @@ const banned = [
   "close",
   "connect",
   "listen",
+  // Readable#pipe() with no destination throws, but first registers an 'end'
+  // listener that later throws an uncatchable TypeError (dest.end() with dest
+  // undefined) once process.stdin ends. Node leaves the same listener behind.
+  "pipe",
   "_start",
   "wait",
   "wait",

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -109,6 +109,14 @@ test("stdin with 'data' event handler should NOT receive data when paused", asyn
   expect(proc.exitCode).toBe(1);
 });
 
+// Drains the child; its stderr joins the comparison only when it failed, so a
+// crash shows up in the diff without asserting stderr empty on success (debug
+// builds write benign noise there).
+async function stdioResult(proc: Bun.Subprocess<"pipe", "pipe", "pipe">) {
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, exitCode, stderr: exitCode === 0 ? undefined : stderr };
+}
+
 test("paused mode read(n) returns the buffered remainder at EOF", async () => {
   // 8 bytes pulled 3 at a time: the final read(3) must return the 2 byte tail
   // once EOF is reached, and 'end' must mark readableEnded.
@@ -133,9 +141,8 @@ test("paused mode read(n) returns the buffered remainder at EOF", async () => {
   proc.stdin.write("abcdefgh");
   proc.stdin.end();
 
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: JSON.parse(stdout), exitCode }).toEqual({
-    stdout: { chunks: ["abc", "def", "gh"], readableEnded: true },
+  expect(await stdioResult(proc)).toEqual({
+    stdout: JSON.stringify({ chunks: ["abc", "def", "gh"], readableEnded: true }) + "\n",
     exitCode: 0,
   });
 });
@@ -173,9 +180,8 @@ test("explicit read(n) with no 'readable' listener still pulls from stdin", asyn
   proc.stdin.write("abcdefgh");
   proc.stdin.end();
 
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: JSON.parse(stdout), exitCode }).toEqual({
-    stdout: { chunks: ["abc", "def", "gh"], readableEnded: true },
+  expect(await stdioResult(proc)).toEqual({
+    stdout: JSON.stringify({ chunks: ["abc", "def", "gh"], readableEnded: true }) + "\n",
     exitCode: 0,
   });
 });
@@ -201,9 +207,9 @@ test("a read() that throws does not keep the process alive", async () => {
     env: bunEnv,
   });
 
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = await stdioResult(proc);
   proc.stdin.end();
-  expect({ stdout, exitCode }).toEqual({ stdout: "ERR_OUT_OF_RANGE\n", exitCode: 0 });
+  expect(result).toEqual({ stdout: "ERR_OUT_OF_RANGE\n", exitCode: 0 });
 });
 
 test("touching stdin again after 'end' does not keep the process alive", async () => {
@@ -228,8 +234,7 @@ test("touching stdin again after 'end' does not keep the process alive", async (
   proc.stdin.write("abcdefgh");
   proc.stdin.end();
 
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "END\nEXIT\n", exitCode: 0 });
+  expect(await stdioResult(proc)).toEqual({ stdout: "END\nEXIT\n", exitCode: 0 });
 });
 
 test("'end' is not emitted when the buffer is never drained, and the process still exits", async () => {
@@ -249,8 +254,7 @@ test("'end' is not emitted when the buffer is never drained, and the process sti
   proc.stdin.write("abcdefgh");
   proc.stdin.end();
 
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "EXIT 8\n", exitCode: 0 });
+  expect(await stdioResult(proc)).toEqual({ stdout: "EXIT 8\n", exitCode: 0 });
 });
 
 test("stdin should allow process to exit when paused", async () => {

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -109,6 +109,98 @@ test("stdin with 'data' event handler should NOT receive data when paused", asyn
   expect(proc.exitCode).toBe(1);
 });
 
+test("paused mode read(n) returns the buffered remainder at EOF", async () => {
+  // 8 bytes pulled 3 at a time: the final read(3) must return the 2 byte tail
+  // once EOF is reached, and 'end' must mark readableEnded.
+  const proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const chunks = [];
+      process.stdin.on("readable", () => {
+        let chunk;
+        while ((chunk = process.stdin.read(3)) !== null) chunks.push(chunk.toString());
+      });
+      process.stdin.on("end", () => {
+        console.log(JSON.stringify({ chunks, readableEnded: process.stdin.readableEnded }));
+      });`,
+    ],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  proc.stdin.write("abcdefgh");
+  proc.stdin.end();
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: JSON.parse(stdout), exitCode }).toEqual({
+    stdout: { chunks: ["abc", "def", "gh"], readableEnded: true },
+    exitCode: 0,
+  });
+});
+
+test("explicit read(n) with no 'readable' listener still pulls from stdin", async () => {
+  // read() must start the underlying stdin reader even when no 'readable'
+  // listener or resume() ever ran.
+  const proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const chunks = [];
+      process.stdin.on("end", () => {
+        console.log(JSON.stringify({ chunks, readableEnded: process.stdin.readableEnded }));
+      });
+      let spins = 0;
+      function poll() {
+        let chunk;
+        while ((chunk = process.stdin.read(3)) !== null) chunks.push(chunk.toString());
+        if (process.stdin.readableEnded) return;
+        // Bounded so a regression fails with output instead of spinning forever.
+        if (++spins > 20000) {
+          console.log(JSON.stringify({ chunks, readableEnded: false }));
+          process.exit(1);
+        }
+        setImmediate(poll);
+      }
+      poll();`,
+    ],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  proc.stdin.write("abcdefgh");
+  proc.stdin.end();
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: JSON.parse(stdout), exitCode }).toEqual({
+    stdout: { chunks: ["abc", "def", "gh"], readableEnded: true },
+    exitCode: 0,
+  });
+});
+
+test("'end' is not emitted when the buffer is never drained, and the process still exits", async () => {
+  const proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.stdin.on("readable", () => {});
+      process.stdin.on("end", () => console.log("END"));
+      process.on("exit", () => console.log("EXIT " + process.stdin.readableLength));`,
+    ],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  proc.stdin.write("abcdefgh");
+  proc.stdin.end();
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({ stdout: "EXIT 8\n", exitCode: 0 });
+});
+
 test("stdin should allow process to exit when paused", async () => {
   const proc = Bun.spawn({
     cmd: [

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -206,6 +206,32 @@ test("a read() that throws does not keep the process alive", async () => {
   expect({ stdout, exitCode }).toEqual({ stdout: "ERR_OUT_OF_RANGE\n", exitCode: 0 });
 });
 
+test("touching stdin again after 'end' does not keep the process alive", async () => {
+  const proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.stdin.on("data", () => {});
+      process.stdin.on("end", () => {
+        console.log("END");
+        process.stdin.resume();
+        process.stdin.ref();
+        process.stdin.on("readable", () => {});
+      });
+      process.on("exit", () => console.log("EXIT"));`,
+    ],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  proc.stdin.write("abcdefgh");
+  proc.stdin.end();
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({ stdout: "END\nEXIT\n", exitCode: 0 });
+});
+
 test("'end' is not emitted when the buffer is never drained, and the process still exits", async () => {
   const proc = Bun.spawn({
     cmd: [

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -180,6 +180,32 @@ test("explicit read(n) with no 'readable' listener still pulls from stdin", asyn
   });
 });
 
+test("a read() that throws does not keep the process alive", async () => {
+  // stdin stays open for the child's whole lifetime: it only exits if the
+  // failed read did not start (and ref) the native stdin reader.
+  const proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let code = "";
+      try {
+        process.stdin.read(2 ** 31);
+      } catch (err) {
+        code = err.code;
+      }
+      process.on("exit", () => console.log(code));`,
+    ],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  proc.stdin.end();
+  expect({ stdout, exitCode }).toEqual({ stdout: "ERR_OUT_OF_RANGE\n", exitCode: 0 });
+});
+
 test("'end' is not emitted when the buffer is never drained, and the process still exits", async () => {
   const proc = Bun.spawn({
     cmd: [


### PR DESCRIPTION
### What

`process.stdin` in paused (pull) mode loses the final partial chunk of piped input at EOF, and a bare `process.stdin.read()` with no `'readable'` listener never delivers anything.

```js
// echo -n "abcdefgh" | bun app.js
const chunks = [];
process.stdin.on("readable", () => {
  let c;
  while ((c = process.stdin.read(3)) !== null) chunks.push(c.toString());
});
process.stdin.on("end", () => console.log(chunks, process.stdin.readableEnded));
// node: [ 'abc', 'def', 'gh' ] true
// bun:  [ 'abc', 'def' ]       false
```

`read(n)` returning the remaining `< n` bytes once the stream has ended is core `stream.Readable` behavior, so anything pulling fixed-size records from stdin (length-prefixed protocols, fixed-width formats, block decoders) silently drops the last record.

### Why

`getStdinStream`'s EOF path in `ProcessObjectInternals.ts` did `stream.emit("end")` + `stream.destroy()` by hand instead of `stream.push(null)`. Without `push(null)` the readable state never reaches `ended`, so `howMuchToRead(n)` keeps returning 0 for the `< n` remainder, `readableEnded` never becomes true, and `'end'` fires even while data is still buffered (Node only emits `'end'` after the buffer is drained).

Separately, only `on('readable')`, `resume()` and `ref()` acquired the native reader. A consumer that just calls `process.stdin.read()` (no `'readable'` listener) hit `_read()` with no source, so it never produced data and `'end'` never fired.

### How

In `getStdinStream`:

- On EOF, call `stream.push(null)` so the buffered remainder stays readable and `'end'`/`readableEnded` come from the stream machinery, then release the native reader right away so the process can still exit even if the consumer never drains the buffer.
- The stream is created with `autoClose: false` (so `autoDestroy` is off); destroy it once `'end'` has emitted, which keeps Node's `'end'` then `'close'` ordering.
- An explicit `read()` now acquires the native reader. Internal `read(0)` kicks (`maybeReadMore`, `nReadingNextTick`) deliberately don't, so `pause()` still lets the process exit.

### Verification

New tests in `test/js/node/process/process-stdin.test.ts` (the first three fail on `bun` 1.4.0 and all pass with this change; output matches `node` v26.3.0):

- `read(3)` over 8 piped bytes yields `["abc","def","gh"]` and `readableEnded === true`
- polling `read(3)` with no `'readable'` listener drains stdin and reaches `'end'`
- `'end'` is not emitted when the buffer is never drained, and the process still exits
- a `read()` that throws while validating its argument (`read(2 ** 31)`) does not leave stdin holding the process open

Existing stdin suites (`test/js/node/process/`, `test/js/node/process/stdin/`, `test/regression/issue/{stdin,tty}-*`, and the vendored `test/js/node/test/parallel/test-stdin-*.js`) pass unchanged, except five `stdin-fixtures.test.ts` cases and `test-stdin-from-file-spawn.js`, which fail identically on an unmodified debug build (1s fixture auto-kill vs debug startup time, and a pre-existing debug-only assertion).



### Note on `test/js/bun/util/fuzzy-wuzzy.test.ts`

CI caught the fuzzer failing on Windows after this change: it calls `process.stdin.pipe()` with no arguments, and `Readable#pipe()` registers its `once('end', onend)` handler before it ever touches `dest`, so the call throws synchronously but leaves an `'end'` listener whose `dest` is `undefined`. Node does the same thing:

```bash
node -e "try { process.stdin.pipe() } catch {} process.stdin.resume()" < /dev/null
# TypeError: Cannot read properties of undefined (reading 'end')  at onend
```

The fuzzer only survived that listener before because the old EOF path emitted `'end'` from inside `internalRead`'s try/catch, whose error sink is `stream.destroy()`, which the fuzzer replaces with a no-op, so the listener's throw was silently swallowed. Now that `process.stdin` ends through the normal stream machinery, the throw surfaces as an uncaught exception, exactly as it does in Node. `pipe` is now in the fuzzer's banned list (its no-argument call always threw, so no coverage is lost).
