### PR TITLE
node: fix tty.WriteStream#getColorDepth reporting 256 colors for every TERM

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -810,8 +810,9 @@ fn compute_color_depth() -> ColorDepth {
         return ColorDepth::None;
     }
 
+    // tmux supports 24-bit color since 2.2 (2016); Node also reports 16m here.
     if env_var::TMUX.get().is_some() {
-        return ColorDepth::C256;
+        return ColorDepth::C16m;
     }
 
     if env_var::CI.get().is_some() {

--- a/src/js/internal/tty.ts
+++ b/src/js/internal/tty.ts
@@ -27,20 +27,43 @@ const TERM_ENVS = {
   "mosh": COLORS_16m,
   "putty": COLORS_16,
   "st": COLORS_16,
-  // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color
+  // http://lists.schmorp.de/pipermail/rxvt-unicode/2016q2/002261.html
   "rxvt-unicode-24bit": COLORS_16m,
-  // https://gist.github.com/XVilka/8346728#gistcomment-2823421
+  // https://bugs.launchpad.net/terminator/+bug/1030562
   "terminator": COLORS_16m,
+  "xterm-kitty": COLORS_16m,
 };
 
-const TERM_ENVS_REG_EXP = [/ansi/, /color/, /linux/, /^con[0-9]*x[0-9]/, /^rxvt/, /^screen/, /^xterm/, /^vt100/];
+const CI_ENVS = {
+  APPVEYOR: COLORS_256,
+  BUILDKITE: COLORS_256,
+  CIRCLECI: COLORS_16m,
+  DRONE: COLORS_256,
+  GITEA_ACTIONS: COLORS_16m,
+  GITHUB_ACTIONS: COLORS_16m,
+  GITLAB_CI: COLORS_256,
+  TRAVIS: COLORS_256,
+};
+
+const TERM_ENVS_REG_EXP = [
+  /ansi/,
+  /color/,
+  /linux/,
+  /direct/,
+  /^con[0-9]*x[0-9]/,
+  /^rxvt/,
+  /^screen/,
+  /^xterm/,
+  /^vt100/,
+  /^vt220/,
+];
 
 let warned = false;
 function warnOnDeactivatedColors(env) {
   if (warned) return;
   let name = "";
-  if (env.NODE_DISABLE_COLORS !== undefined) name = "NODE_DISABLE_COLORS";
-  if (env.NO_COLOR !== undefined) {
+  if (env.NODE_DISABLE_COLORS !== undefined && env.NODE_DISABLE_COLORS !== "") name = "NODE_DISABLE_COLORS";
+  if (env.NO_COLOR !== undefined && env.NO_COLOR !== "") {
     if (name !== "") {
       name += "' and '";
     }
@@ -76,9 +99,9 @@ function getColorDepth(env: NodeJS.ProcessEnv) {
   }
 
   if (
-    env.NODE_DISABLE_COLORS !== undefined ||
+    (env.NODE_DISABLE_COLORS !== undefined && env.NODE_DISABLE_COLORS !== "") ||
     // See https://no-color.org/
-    env.NO_COLOR !== undefined ||
+    (env.NO_COLOR !== undefined && env.NO_COLOR !== "") ||
     // The "dumb" special terminal, as defined by terminfo, doesn't support
     // ANSI color control codes.
     // See https://invisible-island.net/ncurses/terminfo.ti.html#toc-_Specials
@@ -106,24 +129,28 @@ function getColorDepth(env: NodeJS.ProcessEnv) {
   }
 
   if (env.TMUX) {
-    return COLORS_256;
+    return COLORS_16m;
   }
 
-  if (env.CI) {
-    if (
-      ["APPVEYOR", "BUILDKITE", "CIRCLECI", "DRONE", "GITHUB_ACTIONS", "GITLAB_CI", "TRAVIS"].some(
-        sign => sign in env,
-      ) ||
-      env.CI_NAME === "codeship"
-    ) {
+  // Azure DevOps
+  if ("TF_BUILD" in env && "AGENT_NAME" in env) {
+    return COLORS_16;
+  }
+
+  if ("CI" in env) {
+    for (const name in CI_ENVS) {
+      if (name in env) {
+        return CI_ENVS[name];
+      }
+    }
+    if (env.CI_NAME === "codeship") {
       return COLORS_256;
     }
     return COLORS_2;
   }
 
-  const TEAMCITY_VERSION = env.TEAMCITY_VERSION;
-  if (TEAMCITY_VERSION) {
-    return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(TEAMCITY_VERSION) ? COLORS_16 : COLORS_2;
+  if ("TEAMCITY_VERSION" in env) {
+    return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? COLORS_16 : COLORS_2;
   }
 
   switch (env.TERM_PROGRAM) {
@@ -150,7 +177,11 @@ function getColorDepth(env: NodeJS.ProcessEnv) {
   const TERM = env.TERM;
 
   if (TERM) {
-    if (TERM.startsWith("xterm-256") !== null) {
+    if (/truecolor/.test(TERM)) {
+      return COLORS_16m;
+    }
+
+    if (/^xterm-256/.test(TERM)) {
       return COLORS_256;
     }
 

--- a/src/js/internal/tty.ts
+++ b/src/js/internal/tty.ts
@@ -181,7 +181,7 @@ function getColorDepth(env: NodeJS.ProcessEnv) {
       return COLORS_16m;
     }
 
-    if (/^xterm-256/.test(TERM)) {
+    if (TERM.startsWith("xterm-256")) {
       return COLORS_256;
     }
 

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -237,7 +237,7 @@ test("0 args", () => {
   );
 });
 
-describe('color(input, "ansi") picks the escape for the detected color depth', () => {
+describe.concurrent('color(input, "ansi") picks the escape for the detected color depth', () => {
   // The "ansi" format resolves against the terminal color depth derived from
   // the environment, so it has to be observed from a child process.
   async function autoAnsi(env: Record<string, string | undefined>) {
@@ -256,26 +256,31 @@ describe('color(input, "ansi") picks the escape for the detected color depth', (
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    return JSON.parse(stdout);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr is only part of the comparison when the child failed, so the
+    // failure diff shows why without asserting it empty on success.
+    return { stdout, exitCode, stderr: exitCode === 0 ? undefined : stderr };
+  }
+
+  function ansi(format: "ansi-24bit" | "ansi-256") {
+    return { stdout: JSON.stringify(color("#ff0000", format)), exitCode: 0 };
   }
 
   test("TMUX is 24-bit color", async () => {
     // https://github.com/oven-sh/bun/issues/28463
-    expect(await autoAnsi({ TMUX: "1", TERM: "screen-256color" })).toBe(color("#ff0000", "ansi-24bit"));
+    expect(await autoAnsi({ TMUX: "1", TERM: "screen-256color" })).toEqual(ansi("ansi-24bit"));
   });
 
   test("COLORTERM=truecolor is 24-bit color", async () => {
-    expect(await autoAnsi({ COLORTERM: "truecolor" })).toBe(color("#ff0000", "ansi-24bit"));
+    expect(await autoAnsi({ COLORTERM: "truecolor" })).toEqual(ansi("ansi-24bit"));
   });
 
   test("FORCE_COLOR=2 is 256 colors", async () => {
-    expect(await autoAnsi({ FORCE_COLOR: "2" })).toBe(color("#ff0000", "ansi-256"));
+    expect(await autoAnsi({ FORCE_COLOR: "2" })).toEqual(ansi("ansi-256"));
   });
 
   test("TERM=dumb is no color", async () => {
-    expect(await autoAnsi({ TERM: "dumb" })).toBe("");
+    expect(await autoAnsi({ TERM: "dumb" })).toEqual({ stdout: JSON.stringify(""), exitCode: 0 });
   });
 });
 

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -1,6 +1,6 @@
 import { color } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isDebug, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isDebug, withoutAggressiveGC } from "harness";
 
 const namedColors = ["red", "green", "blue", "yellow", "purple", "orange", "pink", "brown", "gray"];
 
@@ -235,6 +235,48 @@ test("0 args", () => {
       code: "ERR_INVALID_ARG_TYPE",
     }),
   );
+});
+
+describe('color(input, "ansi") picks the escape for the detected color depth', () => {
+  // The "ansi" format resolves against the terminal color depth derived from
+  // the environment, so it has to be observed from a child process.
+  async function autoAnsi(env: Record<string, string | undefined>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `process.stdout.write(JSON.stringify(Bun.color("#ff0000", "ansi")))`],
+      env: {
+        ...bunEnv,
+        NO_COLOR: undefined,
+        FORCE_COLOR: undefined,
+        CI: undefined,
+        TMUX: undefined,
+        COLORTERM: undefined,
+        TERM: "xterm-256color",
+        ...env,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  test("TMUX is 24-bit color", async () => {
+    // https://github.com/oven-sh/bun/issues/28463
+    expect(await autoAnsi({ TMUX: "1", TERM: "screen-256color" })).toBe(color("#ff0000", "ansi-24bit"));
+  });
+
+  test("COLORTERM=truecolor is 24-bit color", async () => {
+    expect(await autoAnsi({ COLORTERM: "truecolor" })).toBe(color("#ff0000", "ansi-24bit"));
+  });
+
+  test("FORCE_COLOR=2 is 256 colors", async () => {
+    expect(await autoAnsi({ FORCE_COLOR: "2" })).toBe(color("#ff0000", "ansi-256"));
+  });
+
+  test("TERM=dumb is no color", async () => {
+    expect(await autoAnsi({ TERM: "dumb" })).toBe("");
+  });
 });
 
 // 2^24 color() calls take minutes on debug builds, past the per-test timeout.

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -84,6 +84,93 @@ describe("ReadStream.prototype.setRawMode", () => {
 });
 
 describe("WriteStream.prototype.getColorDepth", () => {
+  const getColorDepth = (env: Record<string, string>) => WriteStream.prototype.getColorDepth.call(undefined, env);
+
+  // Expected values come from running the same env objects through Node
+  // v26.3.0. On Windows the OS build number decides instead of TERM/CI/
+  // COLORTERM, so the env matrix is only meaningful on POSIX.
+  const cases: [env: Record<string, string>, depth: number][] = [
+    [{ TERM: "dumb" }, 1],
+    [{ TERM: "dumb", COLORTERM: "truecolor" }, 1],
+    [{ NO_COLOR: "1", COLORTERM: "24bit" }, 1],
+    [{ NO_COLOR: "", COLORTERM: "24bit" }, 24],
+    [{ NO_COLOR: "", TERM: "xterm-256color" }, 8],
+    [{ NODE_DISABLE_COLORS: "1", TERM: "color" }, 1],
+    [{ NODE_DISABLE_COLORS: "", TERM: "xterm" }, 4],
+    [{ FORCE_COLOR: "" }, 4],
+    [{ FORCE_COLOR: "1" }, 4],
+    [{ FORCE_COLOR: "true" }, 4],
+    [{ FORCE_COLOR: "2" }, 8],
+    [{ FORCE_COLOR: "3" }, 24],
+    [{ FORCE_COLOR: "0" }, 1],
+    [{ FORCE_COLOR: "junk" }, 1],
+    [{ NO_COLOR: "1", FORCE_COLOR: "2" }, 8],
+    [{ NODE_DISABLE_COLORS: "1", FORCE_COLOR: "3" }, 24],
+    [{ COLORTERM: "24bit", FORCE_COLOR: "" }, 4],
+    [{ TMUX: "1" }, 24],
+    [{ TMUX: "1", COLORTERM: "truecolor" }, 24],
+    [{ TMUX: "1", TERM: "tmux-256color" }, 24],
+    [{ TF_BUILD: "1", AGENT_NAME: "x" }, 4],
+    [{ TF_BUILD: "1" }, 1],
+    [{ CI: "1" }, 1],
+    [{ CI: "" }, 1],
+    [{ CI: "1", APPVEYOR: "1" }, 8],
+    [{ CI: "1", BUILDKITE: "1" }, 8],
+    [{ CI: "1", CIRCLECI: "1" }, 24],
+    [{ CI: "1", DRONE: "1" }, 8],
+    [{ CI: "1", GITEA_ACTIONS: "1" }, 24],
+    [{ CI: "1", GITHUB_ACTIONS: "1" }, 24],
+    [{ CI: "1", GITLAB_CI: "1" }, 8],
+    [{ CI: "1", TRAVIS: "1" }, 8],
+    [{ CI: "1", CI_NAME: "codeship" }, 8],
+    [{ TEAMCITY_VERSION: "9.0.5 (build 32523)" }, 1],
+    [{ TEAMCITY_VERSION: "9.1.0 (build 32523)" }, 4],
+    [{ TERM_PROGRAM: "iTerm.app" }, 8],
+    [{ TERM_PROGRAM: "iTerm.app", TERM_PROGRAM_VERSION: "2.1" }, 8],
+    [{ TERM_PROGRAM: "iTerm.app", TERM_PROGRAM_VERSION: "3.2" }, 24],
+    [{ TERM_PROGRAM: "HyperTerm" }, 24],
+    [{ TERM_PROGRAM: "MacTerm" }, 24],
+    [{ TERM_PROGRAM: "Apple_Terminal" }, 8],
+    [{ COLORTERM: "truecolor" }, 24],
+    [{ COLORTERM: "24bit" }, 24],
+    [{ COLORTERM: "1" }, 4],
+    [{ TERM: "xterm" }, 4],
+    [{ TERM: "xterm", COLORTERM: "truecolor" }, 24],
+    [{ TERM: "xterm-256" }, 8],
+    [{ TERM: "xterm-256color" }, 8],
+    [{ TERM: "xterm-kitty" }, 24],
+    [{ TERM: "xterm-direct" }, 4],
+    [{ TERM: "screen.xterm-truecolor" }, 24],
+    [{ TERM: "rxvt-unicode-24bit" }, 24],
+    [{ TERM: "rxvt" }, 4],
+    [{ TERM: "vt100" }, 4],
+    [{ TERM: "vt220" }, 4],
+    [{ TERM: "konsole" }, 4],
+    [{ TERM: "KONSOLE" }, 4],
+    [{ TERM: "mosh" }, 24],
+    [{ TERM: "terminator" }, 24],
+    [{ TERM: "st" }, 4],
+    [{ TERM: "linux" }, 4],
+    [{ TERM: "ansi" }, 4],
+    [{ TERM: "ANSI" }, 4],
+    [{ TERM: "color" }, 4],
+    [{ TERM: "con132x25" }, 4],
+    [{ TERM: "fail" }, 1],
+    [{ TERM: "" }, 1],
+    [{ COLORTERM: "ansi256" }, 4],
+  ];
+
+  it.skipIf(isWindows)("matches Node across the TERM/COLORTERM/CI env matrix", () => {
+    const results = cases.map(([env, expected]) => ({ env, expected, actual: getColorDepth(env) }));
+    expect(results.filter(r => r.actual !== r.expected)).toEqual([]);
+  });
+
+  // Bun recognizes these truecolor terminals on top of Node's list.
+  it.skipIf(isWindows)("reports 24-bit color for ghostty and WezTerm", () => {
+    expect(getColorDepth({ TERM_PROGRAM: "ghostty" })).toBe(24);
+    expect(getColorDepth({ TERM_PROGRAM: "WezTerm" })).toBe(24);
+  });
+
   it("iTerm ancient", () => {
     expect(
       WriteStream.prototype.getColorDepth.call(undefined, {


### PR DESCRIPTION
### What

`tty.WriteStream#getColorDepth()` reports 256 colors for every terminal that gets past the `dumb`/`NO_COLOR`/`FORCE_COLOR` checks, because of an always-true condition:

```js
if (TERM.startsWith("xterm-256") !== null) {   // startsWith returns a boolean, never null
  return COLORS_256;
}
```

Both `false !== null` and `true !== null` are true, so the `TERM_ENVS` table, the `TERM` regexes, and the 2-color fallback below it are unreachable. The bug is as old as the file: it started as `/^xterm-256/.test(TERM) !== null`, the same always-true shape, when the `RegExpPrototypeExec(...) !== null` from Node was ported to `.test()`.

Observed (`node` v26.3.0 vs `bun` 1.4.0):

| env | node | bun |
|---|---|---|
| `TERM=xterm` | 4 | 8 |
| `TERM=vt100` | 4 | 8 |
| `TERM=xterm-kitty` | 24 | 8 |
| `TERM=mosh` | 24 | 8 |
| `TERM=unknownterm` | 1 | 8 |
| `TMUX=1` | 24 | 8 |
| `CI=1 GITHUB_ACTIONS=1` | 24 | 8 |

### How

Fix the condition and sync the rest of `getColorDepth` with Node v26.3.0, which it had drifted from:

- `TERM` containing `truecolor` reports 24-bit
- `TMUX` reports 24-bit (fixes #28463)
- per-CI color depths (CircleCI, GitHub Actions and Gitea Actions are 24-bit) and the check is on `CI` being present, not non-empty
- Azure DevOps (`TF_BUILD` + `AGENT_NAME`) reports 16 colors
- `xterm-kitty`, `/direct/`, `/^vt220/` entries
- empty `NO_COLOR` / `NODE_DISABLE_COLORS` are ignored, per <https://no-color.org>

Bun's extra `TERM_PROGRAM` entries (ghostty, WezTerm; both truecolor terminals Node does not know about) are kept.

#28463 also points at the native copy of this detector (`compute_color_depth` in `src/bun_core/output.rs`), which backs `Bun.color(input, "ansi")`: it had the same `TMUX` cap, so its `TMUX` branch now answers 24-bit too.

### Verification

`test/js/node/tty.test.ts` gets a 68-entry env matrix whose expected values come from running the same objects through Node v26.3.0 (the fixed function matches Node on every row, verified against the real binary), plus a case for Bun's ghostty/WezTerm extras. `test/js/bun/css/color.test.ts` covers `Bun.color(x, "ansi")` depth resolution for `TMUX`, `COLORTERM`, `FORCE_COLOR` and `TERM=dumb`. The matrix test and the `TMUX` color test fail on the current build.
