### PR TITLE
Fix Headers iteration order with set-cookie and null bodies for Response.error/redirect

### DIFF
--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -336,12 +336,15 @@ void FetchHeaders::filterAndFill(const HTTPHeaderMap& headers, Guard guard)
     }
 }
 
+// https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine
 std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
 {
+    auto& setCookieHeaders = m_headers->m_headers.getSetCookieHeaders();
+
     if (m_keys.isEmpty() || m_updateCounter != m_headers->m_updateCounter) {
-        bool hasSetCookie = !m_headers->getSetCookieHeaders().isEmpty();
+        size_t setCookieCount = setCookieHeaders.size();
         m_keys.resize(0);
-        m_keys.reserveCapacity(m_headers->m_headers.size() + (hasSetCookie ? 1 : 0));
+        m_keys.reserveCapacity(m_headers->m_headers.size());
         if (m_lowerCaseKeys) {
             for (auto& header : m_headers->m_headers)
                 m_keys.unsafeAppendWithoutCapacityCheck(header.asciiLowerCaseName());
@@ -350,39 +353,27 @@ std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
                 m_keys.unsafeAppendWithoutCapacityCheck(header.name());
         }
         std::sort(m_keys.begin(), m_keys.end(), WTF::codePointCompareLessThan);
-        if (hasSetCookie)
-            m_keys.unsafeAppendWithoutCapacityCheck(String());
 
-        m_currentIndex += m_cookieIndex;
-        if (hasSetCookie) {
-            size_t setCookieKeyIndex = m_keys.size() - 1;
-            if (m_currentIndex < setCookieKeyIndex)
-                m_cookieIndex = 0;
-            else {
-                m_cookieIndex = std::min(m_currentIndex - setCookieKeyIndex, m_headers->getSetCookieHeaders().size());
-                m_currentIndex -= m_cookieIndex;
-            }
-        } else
-            m_cookieIndex = 0;
+        // Set-cookie entries are not combined: each value is its own entry at the
+        // name's sorted position. Null strings mark those slots; the loop below
+        // emits setCookieHeaders[slot - m_setCookieKeyIndex] for each of them.
+        m_setCookieKeyIndex = 0;
+        if (setCookieCount) {
+            auto& setCookieName = WTF::httpHeaderNameStringImpl(HTTPHeaderName::SetCookie);
+            m_setCookieKeyIndex = static_cast<size_t>(std::lower_bound(m_keys.begin(), m_keys.end(), setCookieName, WTF::codePointCompareLessThan) - m_keys.begin());
+            m_keys.insertFill(m_setCookieKeyIndex, String(), setCookieCount);
+        }
 
         m_updateCounter = m_headers->m_updateCounter;
     }
 
-    auto& setCookieHeaders = m_headers->m_headers.getSetCookieHeaders();
-
     while (m_currentIndex < m_keys.size()) {
-        auto key = m_keys[m_currentIndex];
+        size_t index = m_currentIndex++;
+        auto key = m_keys[index];
 
-        if (key.isNull()) {
-            if (m_cookieIndex < setCookieHeaders.size()) {
-                String value = setCookieHeaders[m_cookieIndex++];
-                return KeyValuePair<String, String> { WTF::httpHeaderNameStringImpl(HTTPHeaderName::SetCookie), WTF::move(value) };
-            }
-            m_currentIndex++;
-            continue;
-        }
+        if (key.isNull())
+            return KeyValuePair<String, String> { WTF::httpHeaderNameStringImpl(HTTPHeaderName::SetCookie), setCookieHeaders[index - m_setCookieKeyIndex] };
 
-        m_currentIndex++;
         auto value = m_headers->m_headers.get(key);
         if (!value.isNull())
             return KeyValuePair<String, String> { WTF::move(key), WTF::move(value) };
@@ -394,7 +385,6 @@ std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
 FetchHeaders::Iterator::Iterator(FetchHeaders& headers, bool lowerCaseKeys = true)
     : m_headers(headers)
 {
-    m_cookieIndex = 0;
     m_lowerCaseKeys = lowerCaseKeys;
 }
 

--- a/src/jsc/bindings/webcore/FetchHeaders.h
+++ b/src/jsc/bindings/webcore/FetchHeaders.h
@@ -99,7 +99,7 @@ public:
         size_t m_currentIndex { 0 };
         Vector<String> m_keys;
         uint64_t m_updateCounter { 0 };
-        size_t m_cookieIndex { 0 };
+        size_t m_setCookieKeyIndex { 0 };
         bool m_lowerCaseKeys { true };
     };
     Iterator createIterator(bool lowerCaseKeys = true)

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1082,7 +1082,8 @@ impl Response {
                     status_code: 302,
                     ..Default::default()
                 }),
-                body: JsCell::new(Body::new(BodyValue::Empty)),
+                // https://fetch.spec.whatwg.org/#dom-response-redirect: body is null.
+                body: JsCell::new(Body::new(BodyValue::Null)),
                 ..Default::default()
             };
 
@@ -1142,7 +1143,8 @@ impl Response {
                 status_code: 0,
                 ..Default::default()
             }),
-            body: JsCell::new(Body::new(BodyValue::Empty)),
+            // https://fetch.spec.whatwg.org/#dom-response-error: body is null.
+            body: JsCell::new(Body::new(BodyValue::Null)),
             ..Default::default()
         }));
 

--- a/test/js/deno/fetch/headers.test.ts
+++ b/test/js/deno/fetch/headers.test.ts
@@ -312,16 +312,16 @@ test(function headersInitMultiple() {
     ];
     assertEquals(actual, [
         [
-            "x-deno",
-            "foo, bar"
-        ],
-        [
             "set-cookie",
             "foo=bar"
         ],
         [
             "set-cookie",
             "bar=baz"
+        ],
+        [
+            "x-deno",
+            "foo, bar"
         ]
     ]);
 });
@@ -363,16 +363,16 @@ test(function headersAppendMultiple() {
     ];
     assertEquals(actual, [
         [
-            "x-deno",
-            "foo, bar"
-        ],
-        [
             "set-cookie",
             "foo=bar"
         ],
         [
             "set-cookie",
             "bar=baz"
+        ],
+        [
+            "x-deno",
+            "foo, bar"
         ]
     ]);
 });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -458,11 +458,11 @@ describe("Headers", () => {
     ]);
     const actual = [...headers];
     expect(actual).toEqual([
-      ["x-bun", "abc, def"],
       ["set-cookie", "foo=bar"],
       ["set-cookie", "bar=baz"],
+      ["x-bun", "abc, def"],
     ]);
-    expect([...headers.values()]).toEqual(["abc, def", "foo=bar", "bar=baz"]);
+    expect([...headers.values()]).toEqual(["foo=bar", "bar=baz", "abc, def"]);
   });
 
   it("Set-Cookies toJSON", () => {
@@ -487,12 +487,11 @@ describe("Headers", () => {
     headers.append("x-bun", "bar");
     const actual = [...headers];
 
-    // we do not preserve the order
-    // which is kind of bad
+    // entries are sorted by name, not insertion order
     expect(actual).toEqual([
-      ["x-bun", "foo, bar"],
       ["set-cookie", "foo=bar"],
       ["set-cookie", "bar=baz"],
+      ["x-bun", "foo, bar"],
     ]);
   });
 
@@ -1244,12 +1243,32 @@ describe("Response", () => {
       expect(response.type).toBe("default");
       expect(response.ok).toBe(false);
     });
+
+    // https://fetch.spec.whatwg.org/#dom-response-redirect
+    it("has a null body", async () => {
+      const response = Response.redirect("https://example.com/");
+      expect(response.body).toBeNull();
+      expect(response.bodyUsed).toBe(false);
+      expect(await response.text()).toBe("");
+      // a null body is never disturbed
+      expect(response.bodyUsed).toBe(false);
+    });
   });
   describe("Response.error", () => {
     it("works", () => {
       expect(Response.error().type).toBe("error");
       expect(Response.error().ok).toBe(false);
       expect(Response.error().status).toBe(0);
+    });
+
+    // https://fetch.spec.whatwg.org/#dom-response-error
+    it("has a null body", async () => {
+      const response = Response.error();
+      expect(response.body).toBeNull();
+      expect(response.bodyUsed).toBe(false);
+      expect(await response.text()).toBe("");
+      // a null body is never disturbed
+      expect(response.bodyUsed).toBe(false);
     });
   });
   it("clone", async () => {

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -427,6 +427,89 @@ describe("Headers", () => {
       ]);
     });
   });
+  // https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine
+  describe("sort and combine", () => {
+    test("set-cookie entries are not combined and stay at their sorted position", () => {
+      const headers = new Headers();
+      headers.append("zz", "1");
+      headers.append("aa", "2");
+      headers.append("Set-Cookie", "s=1");
+      headers.append("set-cookie", "s=2");
+      headers.append("mm", "3");
+
+      const expected = [
+        ["aa", "2"],
+        ["mm", "3"],
+        ["set-cookie", "s=1"],
+        ["set-cookie", "s=2"],
+        ["zz", "1"],
+      ];
+      expect([...headers]).toEqual(expected);
+      expect([...headers.entries()]).toEqual(expected);
+      expect([...headers.keys()]).toEqual(expected.map(([key]) => key));
+      expect([...headers.values()]).toEqual(expected.map(([, value]) => value));
+
+      const seen: [string, string][] = [];
+      headers.forEach((value, key) => seen.push([key, value]));
+      expect(seen).toEqual(expected);
+    });
+
+    test("set-cookie is sorted among names, duplicates of other names are combined", () => {
+      const headers = new Headers([
+        ["set-d", "4"],
+        ["Set-Cookie", "a=1"],
+        ["set-b", "2"],
+        ["set-cookie2", "legacy"],
+        ["set-b", "3"],
+        ["Set-Cookie", "b=2"],
+      ]);
+      expect([...headers]).toEqual([
+        ["set-b", "2, 3"],
+        ["set-cookie", "a=1"],
+        ["set-cookie", "b=2"],
+        ["set-cookie2", "legacy"],
+        ["set-d", "4"],
+      ]);
+    });
+
+    test("set-cookie can be the first, last, or only entry", () => {
+      expect([
+        ...new Headers([
+          ["zz", "1"],
+          ["set-cookie", "a=1"],
+          ["set-cookie", "b=2"],
+        ]).keys(),
+      ]).toEqual(["set-cookie", "set-cookie", "zz"]);
+      expect([
+        ...new Headers([
+          ["aa", "1"],
+          ["set-cookie", "a=1"],
+        ]).keys(),
+      ]).toEqual(["aa", "set-cookie"]);
+      expect([
+        ...new Headers([
+          ["set-cookie", "a=1"],
+          ["set-cookie", "b=2"],
+        ]),
+      ]).toEqual([
+        ["set-cookie", "a=1"],
+        ["set-cookie", "b=2"],
+      ]);
+    });
+
+    test("iteration order is updated after mutation", () => {
+      const headers = new Headers([
+        ["zz", "1"],
+        ["set-cookie", "a=1"],
+      ]);
+      expect([...headers.keys()]).toEqual(["set-cookie", "zz"]);
+      headers.append("aa", "2");
+      headers.append("set-cookie", "b=2");
+      expect([...headers.keys()]).toEqual(["aa", "set-cookie", "set-cookie", "zz"]);
+      headers.delete("set-cookie");
+      expect([...headers.keys()]).toEqual(["aa", "zz"]);
+    });
+  });
   describe("Bun.inspect()", () => {
     const it = "toJSON" in new Headers() ? test : test.skip;
     it("can convert to json when empty", () => {


### PR DESCRIPTION
Two fetch spec compliance fixes in the same area, both verified against Node (undici) and the spec.

### Headers iteration hoists set-cookie out of the sorted order

```js
const h = new Headers();
h.append("zz", "1");
h.append("aa", "2");
h.append("Set-Cookie", "s=1");
h.append("set-cookie", "s=2");
h.append("mm", "3");
[...h.keys()];
// bun:       ["aa", "mm", "zz", "set-cookie", "set-cookie"]
// node/spec: ["aa", "mm", "set-cookie", "set-cookie", "zz"]
```

The spec's [sort and combine](https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine) algorithm sorts header names lexicographically and keeps `set-cookie` entries uncombined at the name's position in that order. `FetchHeaders::Iterator::next()` (the single source of ordering for `entries`, `keys`, `values`, `forEach`, and spread) sorted the other names and then appended a sentinel for the whole set-cookie block (#4048 introduced this: "append set-cookie after sort"), so set-cookie always came last. Header iteration order is observable: request signing, cache keys, and `[...headers]` snapshots taken on another runtime all diverge.

Fix: after sorting, insert one marker per set-cookie value at the name's sorted position (`std::lower_bound`), and have the consuming loop emit `setCookieHeaders[slot - setCookieKeyIndex]` for marker slots. The iterator index is now a plain index into the sorted-and-combined list, which is what WebIDL prescribes when the list mutates between `next()` calls, so the old sentinel rebasing arithmetic is deleted. Server response serialization (`toUWSResponse`) walks the header map segments directly, not this iterator, so wire output is unchanged.

Existing expectations that encoded the set-cookie-last order are restored to the spec order: "Set-Cookies init" and "Headers append multiple" in `test/js/web/fetch/fetch.test.ts`, and `headersInitMultiple` / `headersAppendMultiple` in the Deno-ported `test/js/deno/fetch/headers.test.ts` (upstream Deno asserts the spec order for these today; #4048 had rewritten them to match the old behavior).

### Response.error() and Response.redirect() carry a non-null body

```js
Response.error().body;                          // bun: ReadableStream, node/spec: null
Response.redirect("https://example.com/").body; // same
```

Consequently `Response.error().bodyUsed` flips to true after `.text()`, which breaks "is there a body" branching on synthesized responses. Per [Response.error()](https://fetch.spec.whatwg.org/#dom-response-error) and [Response.redirect()](https://fetch.spec.whatwg.org/#dom-response-redirect), both statics produce a response with a null body.

Both constructors in `src/runtime/webcore/Response.rs` used `BodyValue::Empty` (a present, zero-length body: `.body` materializes an empty ReadableStream and consuming marks it used) instead of `BodyValue::Null`. `new Response()` already used `Null`, which is why it was already correct. The two variants are handled identically everywhere else (server serialization, cloning, emptiness checks), so the change is limited to `.body` / `.bodyUsed` semantics.

### Verification

New tests, cross-checked against Node v26:

- `test/js/web/fetch/headers.test.ts`, "sort and combine": all five iteration surfaces, set-cookie sorted among close neighbors (`set-b` < `set-cookie` < `set-cookie2` < `set-d`) while other duplicates combine, set-cookie as the first/last/only entry, and re-iteration after mutation.
- `test/js/web/fetch/fetch.test.ts`: "has a null body" for both statics (`body === null`, `bodyUsed` stays false across `text()`).

On an unmodified build the new tests fail (set-cookie entries trail the list; `.body` is a ReadableStream) and the four updated expectations fail the same way; with the fix, `headers.test.ts`, `deno/fetch/headers.test.ts`, `headers.undici.test.ts`, `response.test.ts`, `cookies.test.ts`, and the Headers/Response blocks of `fetch.test.ts` pass.
