### PR TITLE
Response.redirect: parse and serialize the url into the Location header

### DIFF
--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -3,7 +3,7 @@ use core::ptr::NonNull;
 
 use crate::virtual_machine::VirtualMachine;
 use crate::{JSGlobalObject, JSValue, JsResult, VM, host_fn};
-use bun_core::{StringPointer, ZigString};
+use bun_core::{String as BunString, StringPointer, ZigString};
 use bun_uws::ResponseKind;
 
 bun_opaque::opaque_ffi! {
@@ -14,8 +14,9 @@ bun_opaque::opaque_ffi! {
 // `FetchHeaders`/`JSGlobalObject`/`VM` are opaque `UnsafeCell`-backed ZST
 // handles, so `&T` is ABI-identical to a non-null `*const T` and C++ mutating
 // header storage / VM state through them is interior mutation invisible to
-// Rust. `ZigString` is a plain `#[repr(C)]` POD; `&ZigString`/`&mut ZigString`
-// at the FFI boundary are sound (C++ reads/writes only the named struct).
+// Rust. `ZigString` and `String` (`BunString`) are plain `#[repr(C)]` PODs;
+// `&`/`&mut` refs to them at the FFI boundary are sound (C++ reads/writes
+// only the named struct).
 // Shims that traffic only in such refs + scalars are declared `safe fn`; those
 // that take raw `*mut c_void` / unsized `*mut StringPointer` arrays / `deref`
 // (which may free) keep their `unsafe fn` body.
@@ -102,7 +103,7 @@ unsafe extern "C" {
     safe fn WebCore__FetchHeaders__put(
         this: &FetchHeaders,
         name_: HTTPHeaderName,
-        value: &ZigString,
+        value: &BunString,
         global: &JSGlobalObject,
     );
 }
@@ -151,7 +152,7 @@ impl FetchHeaders {
     pub fn put_default(
         &mut self,
         name_: HTTPHeaderName,
-        value: &ZigString,
+        value: &BunString,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
         if self.fast_has(name_) {
@@ -231,12 +232,12 @@ impl FetchHeaders {
         WebCore__FetchHeaders__append(self, name_, value, global)
     }
 
-    /// `value`'s pointer tag carries its encoding (Latin-1 / UTF-16 / UTF-8); a
-    /// raw `&[u8]` parameter would force every caller into a Latin-1 read.
+    /// `value`'s tag carries its encoding, and a `WTFStringImpl`-tagged value
+    /// is ref'd by the C++ side instead of copied character-by-character.
     pub fn put(
         &mut self,
         name_: HTTPHeaderName,
-        value: &ZigString,
+        value: &BunString,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
         host_fn::from_js_host_call_generic(global, || {

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -151,7 +151,7 @@ impl FetchHeaders {
     pub fn put_default(
         &mut self,
         name_: HTTPHeaderName,
-        value: &[u8],
+        value: &ZigString,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
         if self.fast_has(name_) {
@@ -231,15 +231,16 @@ impl FetchHeaders {
         WebCore__FetchHeaders__append(self, name_, value, global)
     }
 
+    /// `value`'s pointer tag carries its encoding (Latin-1 / UTF-16 / UTF-8); a
+    /// raw `&[u8]` parameter would force every caller into a Latin-1 read.
     pub fn put(
         &mut self,
         name_: HTTPHeaderName,
-        value: &[u8],
+        value: &ZigString,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
         host_fn::from_js_host_call_generic(global, || {
-            let zs = ZigString::init(value);
-            WebCore__FetchHeaders__put(self, name_, &zs, global)
+            WebCore__FetchHeaders__put(self, name_, value, global)
         })
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2103,11 +2103,12 @@ bool WebCore__FetchHeaders__has(WebCore::FetchHeaders* headers, const ZigString*
     } else
         return result.releaseReturnValue();
 }
-extern "C" void WebCore__FetchHeaders__put(WebCore::FetchHeaders* headers, HTTPHeaderName name, const ZigString* arg2, JSC::JSGlobalObject* global)
+extern "C" void WebCore__FetchHeaders__put(WebCore::FetchHeaders* headers, HTTPHeaderName name, const BunString* arg2, JSC::JSGlobalObject* global)
 {
     auto throwScope = DECLARE_THROW_SCOPE(global->vm());
     throwScope.assertNoException(); // can't throw an exception when there's already one.
-    WebCore::propagateException(*global, throwScope, headers->set(name, Zig::toStringCopy(*arg2)));
+    // `toWTFString()` refs a `WTFStringImpl`-tagged value instead of copying it.
+    WebCore::propagateException(*global, throwScope, headers->set(name, arg2->toWTFString()));
 }
 void WebCore__FetchHeaders__remove(WebCore::FetchHeaders* headers, const ZigString* arg1, JSC::JSGlobalObject* global)
 {

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -71,7 +71,7 @@ static ExceptionOr<bool> canWriteHeader(const HTTPHeaderName name, const String&
 {
     ASSERT(value.isEmpty() || (!isHTTPSpace(value[0]) && !isHTTPSpace(value[value.length() - 1])));
     if (!isValidHTTPHeaderValue((value)))
-        return Exception { TypeError, makeString("Header '"_s, name, "' has invalid value: '"_s, value, "'"_s) };
+        return Exception { TypeError, makeString("Header '"_s, httpHeaderNameString(name), "' has invalid value: '"_s, value, "'"_s) };
     if (guard == FetchHeaders::Guard::Immutable)
         return Exception { TypeError, "Headers object's guard is 'immutable'"_s };
     return true;

--- a/src/runtime/webcore/BakeResponse.rs
+++ b/src/runtime/webcore/BakeResponse.rs
@@ -2,7 +2,7 @@ use core::ffi::{c_int, c_void};
 
 use crate::webcore::Response;
 use crate::webcore::response::{HeadersRef, Init};
-use bun_core::String as BunString;
+use bun_core::{String as BunString, ZigString};
 use bun_jsc::{CallFrame, HTTPHeaderName, JSGlobalObject, JSValue, JsError, JsResult};
 
 pub fn fix_dead_code_elimination() {
@@ -200,7 +200,11 @@ pub(crate) fn construct_render(
             status_code: 200,
             headers: {
                 let mut headers = HeadersRef::create_empty();
-                headers.put(HTTPHeaderName::Location, path_utf8.slice(), global_this)?;
+                headers.put(
+                    HTTPHeaderName::Location,
+                    &ZigString::init(path_utf8.slice()),
+                    global_this,
+                )?;
                 Some(headers)
             },
             ..Default::default()

--- a/src/runtime/webcore/BakeResponse.rs
+++ b/src/runtime/webcore/BakeResponse.rs
@@ -188,8 +188,8 @@ pub(crate) fn construct_render(
             .throw_invalid_arguments(format_args!("Response.render() path must be a string")));
     }
 
-    // The path string in its native encoding, same as `Headers.prototype.set`.
-    let path = path_arg.get_zig_string(global_this)?;
+    // Get the path string
+    let path_str = bun_core::OwnedString::new(path_arg.to_bun_string(global_this)?);
 
     // Create a Response with Render body
     let response = Box::new(Response::init(
@@ -197,7 +197,7 @@ pub(crate) fn construct_render(
             status_code: 200,
             headers: {
                 let mut headers = HeadersRef::create_empty();
-                headers.put(HTTPHeaderName::Location, &path, global_this)?;
+                headers.put(HTTPHeaderName::Location, &path_str, global_this)?;
                 Some(headers)
             },
             ..Default::default()

--- a/src/runtime/webcore/BakeResponse.rs
+++ b/src/runtime/webcore/BakeResponse.rs
@@ -2,7 +2,7 @@ use core::ffi::{c_int, c_void};
 
 use crate::webcore::Response;
 use crate::webcore::response::{HeadersRef, Init};
-use bun_core::{String as BunString, ZigString};
+use bun_core::String as BunString;
 use bun_jsc::{CallFrame, HTTPHeaderName, JSGlobalObject, JSValue, JsError, JsResult};
 
 pub fn fix_dead_code_elimination() {
@@ -188,11 +188,8 @@ pub(crate) fn construct_render(
             .throw_invalid_arguments(format_args!("Response.render() path must be a string")));
     }
 
-    // Get the path string
-    let path_str = bun_core::OwnedString::new(path_arg.to_bun_string(global_this)?);
-
-    let path_utf8 = path_str.to_utf8();
-    // `defer path_utf8.deinit()` → handled by Drop on the UTF-8 slice guard
+    // The path string in its native encoding, same as `Headers.prototype.set`.
+    let path = path_arg.get_zig_string(global_this)?;
 
     // Create a Response with Render body
     let response = Box::new(Response::init(
@@ -200,11 +197,7 @@ pub(crate) fn construct_render(
             status_code: 200,
             headers: {
                 let mut headers = HeadersRef::create_empty();
-                headers.put(
-                    HTTPHeaderName::Location,
-                    &ZigString::init(path_utf8.slice()),
-                    global_this,
-                )?;
+                headers.put(HTTPHeaderName::Location, &path, global_this)?;
                 Some(headers)
             },
             ..Default::default()

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -288,7 +288,7 @@ impl Request {
                 if !content_type_.is_empty() {
                     self.headers_mut().as_mut().unwrap().put(
                         HTTPHeaderName::ContentType,
-                        &ZigString::init(content_type_),
+                        &BunString::ascii(content_type_),
                         global_this,
                     )?;
                 }
@@ -1481,7 +1481,7 @@ impl Request {
                     match req.headers_mut().as_mut().unwrap().put(
                         HTTPHeaderName::ContentType,
                         // SAFETY: ct_ptr borrows req.body which is not mutated here.
-                        &ZigString::init(unsafe { &*ct_ptr }),
+                        &BunString::ascii(unsafe { &*ct_ptr }),
                         global_this,
                     ) {
                         Ok(()) => {}

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -288,7 +288,7 @@ impl Request {
                 if !content_type_.is_empty() {
                     self.headers_mut().as_mut().unwrap().put(
                         HTTPHeaderName::ContentType,
-                        content_type_,
+                        &ZigString::init(content_type_),
                         global_this,
                     )?;
                 }
@@ -1481,7 +1481,7 @@ impl Request {
                     match req.headers_mut().as_mut().unwrap().put(
                         HTTPHeaderName::ContentType,
                         // SAFETY: ct_ptr borrows req.body which is not mutated here.
-                        unsafe { &*ct_ptr },
+                        &ZigString::init(unsafe { &*ct_ptr }),
                         global_this,
                     ) {
                         Ok(()) => {}

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -631,7 +631,7 @@ impl Response {
                 if !content_type.is_empty() {
                     init.headers.as_mut().unwrap().put(
                         HTTPHeaderName::ContentType,
-                        &ZigString::init(content_type),
+                        &BunString::ascii(content_type),
                         global_this,
                     )?;
                 }
@@ -1027,7 +1027,7 @@ impl Response {
         let json_mime = bun_http_types::MimeType::JSON;
         headers_ref.put_default(
             HTTPHeaderName::ContentType,
-            &ZigString::init(json_mime.value.as_ref()),
+            &BunString::ascii(json_mime.value.as_ref()),
             global_this,
         )?;
         // Disarm the body-reset guard: all fallible ops have succeeded.
@@ -1074,9 +1074,8 @@ impl Response {
         let mut args =
             bun_jsc::ArgumentsSlice::init(global_this.bun_vm(), &args_list.ptr[0..args_list.len]);
 
-        let url_string;
-        let url_string_slice;
-        // url_string_slice drops at scope exit
+        // url_string drops (derefs the WTF string) at scope exit
+        let url_string: OwnedString;
         let response: Response = 'brk: {
             let response = Response {
                 init: JsCell::new(Init {
@@ -1088,12 +1087,11 @@ impl Response {
             };
 
             let url_string_value = args.next_eat().unwrap_or(JSValue::ZERO);
-            url_string = if url_string_value.is_empty() {
-                ZigString::init(b"")
+            url_string = OwnedString::new(if url_string_value.is_empty() {
+                BunString::empty()
             } else {
-                url_string_value.get_zig_string(global_this)?
-            };
-            url_string_slice = url_string.to_slice();
+                url_string_value.to_bun_string(global_this)?
+            });
             // `Init`'s drop glue (HeadersRef + OwnedString)
             // handles cleanup on `?`.
 
@@ -1128,18 +1126,10 @@ impl Response {
         // https://fetch.spec.whatwg.org/#dom-response-redirect steps 1 & 6: `Location`
         // gets the serialization of the parsed url, not the raw input. Non-absolute
         // input keeps the raw string: relative redirects are documented Bun behavior.
-        let href = OwnedString::new(bun_url::href_from_string(&BunString::from_bytes(
-            url_string_slice.slice(),
-        )));
-        let href_slice;
-        let location: ZigString = if href.is_empty() {
-            // The JS string in its native encoding, same as `Headers.prototype.set`.
-            url_string
-        } else {
-            href_slice = href.to_utf8();
-            ZigString::init(href_slice.slice())
-        };
-        headers.put(HTTPHeaderName::Location, &location, global_this)?;
+        let href = OwnedString::new(bun_url::href_from_string(&url_string));
+        // The JS string's own WTF string (no re-encode), same as `Headers.prototype.set`.
+        let location = if href.is_empty() { &url_string } else { &href };
+        headers.put(HTTPHeaderName::Location, location, global_this)?;
         Ok(response)
     }
 
@@ -1226,7 +1216,7 @@ impl Response {
                     let headers = response.get_or_create_headers(global_this)?;
                     headers.put(
                         HTTPHeaderName::Location,
-                        &ZigString::init(&result.url),
+                        &BunString::ascii(&result.url),
                         global_this,
                     )?;
                     return Ok(bun_core::heap::into_raw(Box::new(response)));
@@ -1282,7 +1272,7 @@ impl Response {
                 if !content_type.is_empty() && !headers.fast_has(HTTPHeaderName::ContentType) {
                     headers.put(
                         HTTPHeaderName::ContentType,
-                        &ZigString::init(content_type),
+                        &BunString::ascii(content_type),
                         global_this,
                     )?;
                 }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -631,7 +631,7 @@ impl Response {
                 if !content_type.is_empty() {
                     init.headers.as_mut().unwrap().put(
                         HTTPHeaderName::ContentType,
-                        content_type,
+                        &ZigString::init(content_type),
                         global_this,
                     )?;
                 }
@@ -1027,7 +1027,7 @@ impl Response {
         let json_mime = bun_http_types::MimeType::JSON;
         headers_ref.put_default(
             HTTPHeaderName::ContentType,
-            json_mime.value.as_ref(),
+            &ZigString::init(json_mime.value.as_ref()),
             global_this,
         )?;
         // Disarm the body-reset guard: all fallible ops have succeeded.
@@ -1074,6 +1074,7 @@ impl Response {
         let mut args =
             bun_jsc::ArgumentsSlice::init(global_this.bun_vm(), &args_list.ptr[0..args_list.len]);
 
+        let url_string;
         let url_string_slice;
         // url_string_slice drops at scope exit
         let response: Response = 'brk: {
@@ -1087,11 +1088,11 @@ impl Response {
             };
 
             let url_string_value = args.next_eat().unwrap_or(JSValue::ZERO);
-            let mut url_string = ZigString::init(b"");
-
-            if !url_string_value.is_empty() {
-                url_string = url_string_value.get_zig_string(global_this)?;
-            }
+            url_string = if url_string_value.is_empty() {
+                ZigString::init(b"")
+            } else {
+                url_string_value.get_zig_string(global_this)?
+            };
             url_string_slice = url_string.to_slice();
             // `Init`'s drop glue (HeadersRef + OwnedString)
             // handles cleanup on `?`.
@@ -1122,13 +1123,23 @@ impl Response {
             break 'brk response;
         };
 
-        let headers = response.get_or_create_headers(global_this)?;
         // `get_or_create_headers` already populated init.headers.
-        headers.put(
-            HTTPHeaderName::Location,
+        let headers = response.get_or_create_headers(global_this)?;
+        // https://fetch.spec.whatwg.org/#dom-response-redirect steps 1 & 6: `Location`
+        // gets the serialization of the parsed url, not the raw input. Non-absolute
+        // input keeps the raw string: relative redirects are documented Bun behavior.
+        let href = OwnedString::new(bun_url::href_from_string(&BunString::from_bytes(
             url_string_slice.slice(),
-            global_this,
-        )?;
+        )));
+        let href_slice;
+        let location: ZigString = if href.is_empty() {
+            // The JS string in its native encoding, same as `Headers.prototype.set`.
+            url_string
+        } else {
+            href_slice = href.to_utf8();
+            ZigString::init(href_slice.slice())
+        };
+        headers.put(HTTPHeaderName::Location, &location, global_this)?;
         Ok(response)
     }
 
@@ -1213,7 +1224,11 @@ impl Response {
                     // `defer result.deinit()` — SignResult: Drop frees owned buffers at scope exit.
                     response.redirected.set(true);
                     let headers = response.get_or_create_headers(global_this)?;
-                    headers.put(HTTPHeaderName::Location, &result.url, global_this)?;
+                    headers.put(
+                        HTTPHeaderName::Location,
+                        &ZigString::init(&result.url),
+                        global_this,
+                    )?;
                     return Ok(bun_core::heap::into_raw(Box::new(response)));
                 }
             }
@@ -1265,7 +1280,11 @@ impl Response {
             if let Some(headers) = init.headers.as_deref_mut() {
                 let content_type = blob.content_type_slice();
                 if !content_type.is_empty() && !headers.fast_has(HTTPHeaderName::ContentType) {
-                    headers.put(HTTPHeaderName::ContentType, content_type, global_this)?;
+                    headers.put(
+                        HTTPHeaderName::ContentType,
+                        &ZigString::init(content_type),
+                        global_this,
+                    )?;
                 }
             }
         }

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1216,16 +1216,18 @@ describe("Response", () => {
   });
   describe("Response.redirect", () => {
     it("works", () => {
+      // Location is the serialization of the parsed url, so an empty path
+      // gains a trailing "/". https://fetch.spec.whatwg.org/#dom-response-redirect
       const inputs = [
-        "http://example.com",
-        "http://example.com/",
-        "http://example.com/hello",
-        "http://example.com/hello/",
-        "http://example.com/hello/world",
-        "http://example.com/hello/world/",
+        ["http://example.com", "http://example.com/"],
+        ["http://example.com/", "http://example.com/"],
+        ["http://example.com/hello", "http://example.com/hello"],
+        ["http://example.com/hello/", "http://example.com/hello/"],
+        ["http://example.com/hello/world", "http://example.com/hello/world"],
+        ["http://example.com/hello/world/", "http://example.com/hello/world/"],
       ];
-      for (let input of inputs) {
-        expect(Response.redirect(input).headers.get("Location")).toBe(input);
+      for (const [input, expected] of inputs) {
+        expect(Response.redirect(input).headers.get("Location")).toBe(expected);
       }
     });
 
@@ -1239,7 +1241,7 @@ describe("Response", () => {
         status: 307,
       });
       expect(response.headers.get("x-hello")).toBe("world");
-      expect(response.headers.get("Location")).toBe("https://example.com");
+      expect(response.headers.get("Location")).toBe("https://example.com/");
       expect(response.status).toBe(307);
       expect(response.type).toBe("default");
       expect(response.ok).toBe(false);

--- a/test/js/web/fetch/fetch_headers.test.js
+++ b/test/js/web/fetch/fetch_headers.test.js
@@ -32,6 +32,13 @@ describe("Headers", async () => {
     expect(() => fetch(url, { headers: { "x-test": "❤️" } })).toThrow("Header 'x-test' has invalid value: '❤️'");
   });
 
+  it("Invalid values for well-known headers name the header, not its index", () => {
+    // The HTTPHeaderName fast path must report the header's name (e.g. 'Location'),
+    // not its numeric enum value (e.g. '51').
+    expect(() => new Headers({ location: "a\nb" })).toThrow("Header 'Location' has invalid value: 'a\nb'");
+    expect(() => new Headers({ "content-type": "\0" })).toThrow("Header 'Content-Type' has invalid value: '\0'");
+  });
+
   it("repro 1602", async () => {
     const origString = "😂1234".slice(3);
 

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (5.83 KB) {
+    "Response (7.50 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -98,6 +98,37 @@ test("Response.redirect status code validation", () => {
   // Check that the correct status is set
   expect(Response.redirect("url", 301).status).toBe(301);
   expect(Response.redirect("url", { status: 308 }).status).toBe(308);
+});
+
+// https://fetch.spec.whatwg.org/#dom-response-redirect
+// `Location` gets the serialization of the parsed url, not the raw input string.
+test.each([
+  // percent-encoding
+  ["http://example.com/a b", "http://example.com/a%20b"],
+  ["http://x/é", "http://x/%C3%A9"],
+  // ASCII tab and newline are stripped by the URL parser instead of
+  // surfacing as a header-validation TypeError
+  ["http://x/a\nb", "http://x/ab"],
+  ["http://x/a\tb", "http://x/ab"],
+  // scheme/host lowercased, default port removed, dot-segments resolved
+  ["HTTP://U:P@EX.COM:80/p/../q", "http://U:P@ex.com/q"],
+  // empty path serializes as "/"
+  ["http://example.com", "http://example.com/"],
+  // IDN host is punycode-encoded
+  ["http://bücher.example/", "http://xn--bcher-kva.example/"],
+])("Response.redirect(%j) serializes the url into Location", (input, expected) => {
+  expect(Response.redirect(input).headers.get("location")).toBe(expected);
+  // every arity takes the same path into the Location header
+  expect(Response.redirect(input, 307).headers.get("location")).toBe(expected);
+  expect(Response.redirect(input, { status: 308 }).headers.get("location")).toBe(expected);
+});
+
+test("Response.redirect keeps a non-absolute url as-is in Location", () => {
+  // Relative redirect targets are documented Bun behavior (see docs/runtime/http).
+  expect(Response.redirect("/login").headers.get("location")).toBe("/login");
+  expect(Response.redirect("/login?next=1#a").headers.get("location")).toBe("/login?next=1#a");
+  // non-ASCII must round-trip, not come back as a latin-1 view of the UTF-8 bytes
+  expect(Response.redirect("/café").headers.get("location")).toBe("/café");
 });
 
 test("new Response(123, { statusText: 123 }) does not throw", () => {

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (7.50 KB) {
+    "Response (8.0 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -129,6 +129,14 @@ test("Response.redirect keeps a non-absolute url as-is in Location", () => {
   expect(Response.redirect("/login?next=1#a").headers.get("location")).toBe("/login?next=1#a");
   // non-ASCII must round-trip, not come back as a latin-1 view of the UTF-8 bytes
   expect(Response.redirect("/café").headers.get("location")).toBe("/café");
+});
+
+test("Response.redirect rejects a non-absolute url that is not a valid header value", () => {
+  // A code point above U+00FF cannot be a header value, so this throws the same
+  // TypeError that `new Headers({ location: "/€" })` does, instead of silently
+  // writing a latin-1-corrupted Location ("/â¬").
+  expect(() => Response.redirect("/€")).toThrow("Header 'Location' has invalid value: '/€'");
+  expect(() => Response.redirect("/搜索")).toThrow("Header 'Location' has invalid value: '/搜索'");
 });
 
 test("new Response(123, { statusText: 123 }) does not throw", () => {

--- a/test/vendor.json
+++ b/test/vendor.json
@@ -4,7 +4,9 @@
     "repository": "https://github.com/elysiajs/elysia",
     "tag": "1.4.28",
     "skipTests": {
-      "ws*connection.test.ts": "TEMPORARY: elysia 1.4.28 asserts wasClean=false for a server-initiated ws.close(), but that's a clean Close handshake — Bun now reports wasClean=true to match Node/WHATWG (oven-sh/bun#31518). Fixed upstream in elysiajs/elysia#1908; remove this skip on the next elysia bump. (glob * = path separator, so it also matches Windows backslash paths)"
+      "ws*connection.test.ts": "TEMPORARY: elysia 1.4.28 asserts wasClean=false for a server-initiated ws.close(), but that's a clean Close handshake — Bun now reports wasClean=true to match Node/WHATWG (oven-sh/bun#31518). Fixed upstream in elysiajs/elysia#1908; remove this skip on the next elysia bump. (glob * = path separator, so it also matches Windows backslash paths)",
+      "adapter*web-standard*map-response.test.ts": "TEMPORARY: Bun's Response.redirect now puts the WHATWG serialization of the url into Location (oven-sh/bun#33126), matching Node and https://fetch.spec.whatwg.org/#dom-response-redirect, so Response.redirect('https://cunny.school') yields 'https://cunny.school/'. elysia 1.4.28's 'map redirect' test asserts the unserialized string; remove this skip once the upstream assertion expects the trailing slash.",
+      "adapter*web-standard*map-early-response.test.ts": "TEMPORARY: same as adapter*web-standard*map-response.test.ts; its 'map redirect' test asserts the unserialized Response.redirect Location value."
     }
   }
 ]


### PR DESCRIPTION
`Response.redirect(url)` placed its argument into the `Location` header verbatim instead of parsing and serializing it, as https://fetch.spec.whatwg.org/#dom-response-redirect steps 1 and 6 require.

### Reproduction

```js
Response.redirect("http://example.com/a b").headers.get("location");
// expected (Node, spec): "http://example.com/a%20b"     bun: "http://example.com/a b"

Response.redirect("http://x/é").headers.get("location");
// expected: "http://x/%C3%A9"                           bun: "http://x/Ã©"

Response.redirect("HTTP://U:P@EX.COM:80/p/../q").headers.get("location");
// expected: "http://U:P@ex.com/q"                       bun: the raw string

Response.redirect("http://x/a\nb").headers.get("location");
// expected: "http://x/ab" (the URL parser strips ASCII tab and newline)
// bun: TypeError: Header '51' has invalid value: 'http://x/a\nb'
```

### Cause

`Response::construct_redirect_impl` never ran its argument through a URL parser. It converted the JS string to UTF-8 bytes and put those bytes into `Location` as Latin-1, so

- the spec's parse + serialize step (percent-encoding, tab/newline stripping, scheme and host lowercasing, default-port removal, dot-segment resolution, punycode) never happened, and
- any non-ASCII input came back corrupted, because `FetchHeaders::put` wrapped its `&[u8]` argument in a Latin-1-tagged `ZigString`.

Separately, `canWriteHeader`'s `HTTPHeaderName` overload in `FetchHeaders.cpp` formatted the enum's numeric value into the error message (`Location` is 51). That is reachable from any well-known header name, for example `new Headers({ location: "a\nb" })`.

### Fix

- `construct_redirect_impl` now runs the argument through `bun_url::href_from_string` (the same WHATWG parser `new Request(url)` already uses) and puts the serialized href into `Location`.

  A non-absolute input keeps the raw string. The spec would throw a `TypeError` there, but `Response.redirect("/login")` is documented Bun behavior (`docs/runtime/http/server.mdx`, `docs/guides/http/server.mdx`) and widely used, so it is preserved; this is called out in a code comment.

- `FetchHeaders::put` takes a `&BunString` instead of `&[u8]`. A `WTFStringImpl`-tagged value carries its encoding and gets ref'd by the C++ side (`BunString::toWTFString`) instead of having its characters copied, exactly as `Headers.prototype.set` does. `Response.redirect("/café")` previously produced `Location: /cafÃ©` because that path went through a Latin-1 read of the JS string's UTF-8 bytes; `Response.render(path)` (the bake dev server) had the same round-trip and now hands the JS string straight to `put`, and `construct_redirect_impl` hands it the parsed href (already a `BunString`) with no re-encode. The remaining byte-slice callers (the content-type sites, the presigned S3 url, the JSON mime) wrap in `BunString::ascii`, which is the same `ZigString::init` that `put` built internally before, so they are unchanged.

  One deliberate consequence: a relative target containing a code point above U+00FF, which cannot be a header value, now throws `TypeError: Header 'Location' has invalid value`. That is exactly what `headers.set("location", "/€")`, `new Headers({ location: "/€" })`, and `new Response(null, { headers: { location: "/€" } })` already do for the same input; `Response.redirect` was the one path that instead silently wrote a Latin-1-corrupted value (`Response.redirect("/€")` produced `Location: /â¬`). A test covers both sides of the boundary (`/café` passes, `/€` throws).

- `canWriteHeader(HTTPHeaderName, ...)` uses `httpHeaderNameString(name)` in its error message, so the example above now reports `Header 'Location' has invalid value`.

Two existing tests asserted the unserialized `Location` value and were updated: `http://example.com` serializes as `http://example.com/`, matching Node and the spec.

Two elysia vendor tests (`adapter/web-standard/map-response.test.ts` and `map-early-response.test.ts`) pin the unserialized `Location` and are skipped in `test/vendor.json` with a TEMPORARY note, following the existing `ws*connection.test.ts` entry; they are the only `Response.redirect` assertions in elysia 1.4.28's test tree.

### Not in this PR

The same statics also have a non-null `.body` where the spec says `null`. #33125 already fixes that, so this PR does not touch those lines.

### Verification

```
bun bd test test/js/web/fetch/response.test.ts \
            test/js/web/fetch/fetch_headers.test.js
```

Both fail without the `src/` change and pass with it. Also ran the headers, serve-static, serve-if-none-match, cookie, proxy, client-fetch, and bake response regression suites against the fixed build with no new failures.


