### PR TITLE
webcore: make Request/Response clone() throw on a disturbed or locked body

### DIFF
--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1837,26 +1837,53 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         self.get_body_value().to_readable_stream(global_this)
     }
 
-    fn get_body_used(&self, global_object: &JSGlobalObject) -> JSValue {
+    /// `Used` / in-flight-read bodies are unconditionally `true`; otherwise
+    /// `check` decides from the body's ReadableStream (JS `stream` cache
+    /// first, then `Locked.readable`). Bodies with no stream yet are `false`.
+    fn body_stream_check(
+        &self,
+        global_object: &JSGlobalObject,
+        check: fn(&ReadableStream, &JSGlobalObject) -> bool,
+    ) -> bool {
         // reshaped for borrowck — `get_body_readable_stream` needs `&self`,
         // so we can't hold a `match` borrow on `get_body_value()` across it.
-        let used = match self.get_body_value() {
+        match self.get_body_value() {
             Value::Used => true,
             Value::Locked(pending) if !pending.action.is_none() => true,
             Value::Locked(_) => 'brk: {
                 if let Some(readable) = self.get_body_readable_stream(global_object) {
-                    break 'brk readable.is_disturbed(global_object);
+                    break 'brk check(&readable, global_object);
                 }
                 if let Value::Locked(pending) = self.get_body_value() {
                     if let Some(stream) = pending.readable.get(global_object) {
-                        break 'brk stream.is_disturbed(global_object);
+                        break 'brk check(&stream, global_object);
                     }
                 }
                 false
             }
             _ => false,
-        };
-        JSValue::from(used)
+        }
+    }
+
+    fn get_body_used(&self, global_object: &JSGlobalObject) -> JSValue {
+        JSValue::from(self.body_stream_check(global_object, ReadableStream::is_disturbed))
+    }
+
+    /// Fetch spec step 1 of both `clone()` algorithms: throw a `TypeError`
+    /// when "this is unusable", i.e. the body is non-null and its stream is
+    /// disturbed or locked. <https://fetch.spec.whatwg.org/#body-unusable>
+    fn throw_if_body_unusable(&self, global_object: &JSGlobalObject) -> JsResult<()> {
+        let unusable =
+            self.body_stream_check(global_object, |s, g| s.is_disturbed(g) || s.is_locked(g));
+        if unusable {
+            return Err(global_object
+                .err(
+                    jsc::ErrorCode::BODY_ALREADY_USED,
+                    format_args!("Body is disturbed or locked"),
+                )
+                .throw());
+        }
+        Ok(())
     }
 
     fn get_json(&self, global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1516,6 +1516,7 @@ impl Request {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
+        self.throw_if_body_unusable(global_this)?;
         let this_value = callframe.this();
         let cloned = self.clone(global_this)?;
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -411,8 +411,12 @@ impl Request {
         self.set_timeout(seconds.to_u32() as c_uint);
     }
 
+    /// `BunRequest.prototype.clone` (the `Bun.serve` `routes:` subclass) goes
+    /// through `JSBunRequest::clone` -> here, not through [`Self::do_clone`],
+    /// so it needs the same fetch-spec step-1 usability check.
     #[bun_uws::uws_callback(export = "Request__clone")]
     pub fn ffi_clone(&self, global_this: &JSGlobalObject) -> Option<Box<Request>> {
+        self.throw_if_body_unusable(global_this).ok()?;
         self.clone(global_this).ok()
     }
 }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -803,6 +803,7 @@ impl Response {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
+        this.throw_if_body_unusable(global_this)?;
         let this_value = callframe.this();
         let cloned = this.clone(global_this)?;
 

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -554,11 +554,11 @@ test.each(["Request", "Response"])(
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+    expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
       stdout: ["caught TypeError: Body is disturbed or locked", "done"],
+      stderr: "",
       exitCode: 0,
     });
-    expect(stderr).not.toContain("Body is disturbed or locked");
   },
 );
 
@@ -592,11 +592,11 @@ test("new Request(request) with a locked stream body throws a catchable TypeErro
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+  expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
     stdout: ["caught TypeError: ReadableStream is locked", "done"],
+    stderr: "",
     exitCode: 0,
   });
-  expect(stderr).not.toContain("ReadableStream is locked");
 });
 
 // https://fetch.spec.whatwg.org/#dom-request-clone (step 1)

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -741,6 +741,46 @@ describe("clone() throws when the body is disturbed or locked", () => {
     expect(await promise).toEqual(["hello", "hello"]);
   });
 
+  // `routes:` handlers receive a BunRequest subclass whose own `clone` is a
+  // separate native entry point (JSBunRequest::clone -> Request__clone) from
+  // Request.prototype.clone; it must run the same usability check.
+  test("Bun.serve routes: clone() of an already-read BunRequest throws", async () => {
+    const results: string[] = [];
+    const handler = async (req: Request) => {
+      await req.text();
+      try {
+        const cloned = req.clone();
+        results.push(`no throw, clone.text()=${JSON.stringify(await cloned.text())}`);
+      } catch (e) {
+        results.push(`${(e as Error).constructor.name}: ${(e as Error).message}`);
+      }
+      return new Response("ok");
+    };
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/param/:id": handler, "/static": handler },
+    });
+    await fetch(new URL("/param/1", server.url), { method: "POST", body: "hello" });
+    await fetch(new URL("/static", server.url), { method: "POST", body: "hello" });
+    expect(results).toEqual(["TypeError: Body is disturbed or locked", "TypeError: Body is disturbed or locked"]);
+  });
+
+  test("Bun.serve routes: clone() of an unread BunRequest still works", async () => {
+    const results: string[][] = [];
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/param/:id": async (req: Request) => {
+          const cloned = req.clone();
+          results.push(await Promise.all([req.text(), cloned.text()]));
+          return new Response("ok");
+        },
+      },
+    });
+    await fetch(new URL("/param/1", server.url), { method: "POST", body: "hello" });
+    expect(results).toEqual([["hello", "hello"]]);
+  });
+
   test("clone() still succeeds on a null body", () => {
     expect(new Request("http://example.com/").clone().body).toBeNull();
     expect(new Response(null).clone().body).toBeNull();

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("Request with streaming body can be cloned", async () => {
@@ -555,12 +555,205 @@ test.each(["Request", "Response"])(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
-      stdout: ["caught TypeError: ReadableStream is locked", "done"],
+      stdout: ["caught TypeError: Body is disturbed or locked", "done"],
       exitCode: 0,
     });
-    expect(stderr).not.toContain("ReadableStream is locked");
+    expect(stderr).not.toContain("Body is disturbed or locked");
   },
 );
+
+// clone()'s usability check now fires before the stream is teed, so the
+// readableStreamTee C++ bridge's exception propagation (which used to be
+// covered by the test above) is exercised via `new Request(lockedRequest)`,
+// which still tees. It must throw a single catchable TypeError, not also
+// report it as uncaught (exit code 1) or surface a bogus follow-up error.
+test("new Request(request) with a locked stream body throws a catchable TypeError from the tee and does not fail the process", async () => {
+  const script = `
+    const stream = new ReadableStream({ start() {} });
+    const source = new Request("http://example.com/", { method: "POST", body: stream, duplex: "half" });
+    source.body.getReader(); // lock the body stream
+    try {
+      new Request(source);
+      console.log("no throw");
+    } catch (e) {
+      console.log("caught " + e.constructor.name + ": " + e.message);
+    }
+    // Give the event loop a turn so a deferred error report would surface.
+    await new Promise(resolve => setImmediate(resolve));
+    console.log("done");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+    stdout: ["caught TypeError: ReadableStream is locked", "done"],
+    exitCode: 0,
+  });
+  expect(stderr).not.toContain("ReadableStream is locked");
+});
+
+// https://fetch.spec.whatwg.org/#dom-request-clone (step 1)
+// https://fetch.spec.whatwg.org/#dom-response-clone (step 1)
+// clone() must throw a TypeError when "this is unusable": the body is non-null
+// and its stream is disturbed or locked. Without the check, the clone of a
+// consumed body "succeeds" and silently carries an empty body.
+describe("clone() throws when the body is disturbed or locked", () => {
+  function expectUnusable(target: Request | Response) {
+    expect(() => target.clone()).toThrow(TypeError);
+    expect(() => target.clone()).toThrow("Body is disturbed or locked");
+  }
+
+  test("Request: consumed string body", async () => {
+    const request = new Request("http://example.com/", { method: "POST", body: "hello world" });
+    await request.text();
+    expectUnusable(request);
+  });
+
+  test("Request: consumed user ReadableStream body", async () => {
+    const request = new Request("http://example.com/", {
+      method: "POST",
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("hello"));
+          controller.close();
+        },
+      }),
+    });
+    await request.text();
+    expectUnusable(request);
+  });
+
+  test("Request: consumed FormData body", async () => {
+    const form = new FormData();
+    form.append("name", "value");
+    const request = new Request("http://example.com/", { method: "POST", body: form });
+    await request.text();
+    expectUnusable(request);
+  });
+
+  test("Request: locked body (reader acquired, never read)", () => {
+    const request = new Request("http://example.com/", { method: "POST", body: "hello world" });
+    request.body!.getReader();
+    expectUnusable(request);
+  });
+
+  test("Request: read in flight on a stream body", async () => {
+    let controller!: ReadableStreamDefaultController;
+    const request = new Request("http://example.com/", {
+      method: "POST",
+      body: new ReadableStream({
+        start(c) {
+          controller = c;
+        },
+      }),
+    });
+    const pending = request.text();
+    expectUnusable(request);
+    // The original read must still complete after the rejected clone.
+    controller.enqueue(new TextEncoder().encode("hello"));
+    controller.close();
+    expect(await pending).toBe("hello");
+  });
+
+  test("Response: consumed string body", async () => {
+    const response = new Response("hello world");
+    await response.text();
+    expectUnusable(response);
+  });
+
+  test("Response: consumed Blob body", async () => {
+    const response = new Response(new Blob(["hello world"]));
+    await response.arrayBuffer();
+    expectUnusable(response);
+  });
+
+  test("Response: consumed user ReadableStream body", async () => {
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("hello"));
+          controller.close();
+        },
+      }),
+    );
+    await response.text();
+    expectUnusable(response);
+  });
+
+  test("Response: locked body (reader acquired, never read)", () => {
+    const response = new Response("hello world");
+    response.body!.getReader();
+    expectUnusable(response);
+  });
+
+  test("Response: fetch() response disturbed by a reader", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("hello from server"),
+    });
+    const response = await fetch(server.url);
+    const reader = response.body!.getReader();
+    await reader.read();
+    expectUnusable(response);
+  });
+
+  test("Bun.serve: clone() of an already-read incoming request throws", async () => {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const original = await req.text();
+        try {
+          req.clone();
+          resolve(`no throw (original=${JSON.stringify(original)})`);
+        } catch (e) {
+          resolve(`${(e as Error).constructor.name}: ${(e as Error).message}`);
+        }
+        return new Response("ok");
+      },
+    });
+    await fetch(server.url, { method: "POST", body: "hello" });
+    expect(await promise).toBe("TypeError: Body is disturbed or locked");
+  });
+
+  test("Bun.serve: clone() of an unread incoming request still works", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        try {
+          const cloned = req.clone();
+          resolve(await Promise.all([req.text(), cloned.text()]));
+        } catch (e) {
+          reject(e);
+        }
+        return new Response("ok");
+      },
+    });
+    await fetch(server.url, { method: "POST", body: "hello" });
+    expect(await promise).toEqual(["hello", "hello"]);
+  });
+
+  test("clone() still succeeds on a null body", () => {
+    expect(new Request("http://example.com/").clone().body).toBeNull();
+    expect(new Response(null).clone().body).toBeNull();
+  });
+
+  test("clone() still succeeds after the body getter materialized a stream", async () => {
+    // Accessing .body locks nothing and disturbs nothing; clone must work.
+    const response = new Response("hello world");
+    expect(response.body!.locked).toBe(false);
+    const cloned = response.clone();
+    expect(await Promise.all([response.text(), cloned.text()])).toEqual(["hello world", "hello world"]);
+  });
+});
 
 test("Blob type from a consumed Response keeps the original content-type after clones with different content-types are consumed", async () => {
   // The Response and its clones share one underlying body store. Consuming a clone


### PR DESCRIPTION
### Problem

`Request.prototype.clone()` and `Response.prototype.clone()` never perform step 1 of the fetch spec's clone algorithms: "If this is unusable, then throw a `TypeError`", where unusable means the body is non-null and its stream is disturbed or locked (https://fetch.spec.whatwg.org/#body-unusable).

```js
const q = new Request("http://x/", { method: "POST", body: "hello world" });
await q.text();       // body consumed
const c = q.clone();  // node, Deno, browsers: TypeError. Bun: succeeds
await c.text();       // "" (silent empty body)
```

What Bun does instead depends on the body's internal representation:

- Consumed string, Blob, and FormData bodies: `clone()` succeeds and the clone resolves to an empty body.
- Consumed or locked stream bodies: `clone()` succeeds and an error surfaces later, from the clone's own read or from the internal tee, never from `clone()` itself.

The check exists so that clone-after-read, which is always a bug in the caller, fails loudly in development. Without it, proxy and retry middleware that does `clone()` then forwards the request silently forwards an empty body whenever the order of operations is wrong.

Node (undici) throws a `TypeError` synchronously from `clone()` in each case:

```
$ node repro.mjs
1 req-consumed-string:   clone() THREW TypeError: unusable
2 req-consumed-stream:   clone() THREW TypeError: unusable
3 req-locked(unread):    clone() THREW TypeError: unusable
4 res-consumed-string:   clone() THREW TypeError: Response.clone: Body has already been consumed.
5 res-locked(unread):    clone() THREW TypeError: Response.clone: Body has already been consumed.
6 res-consumed-blob:     clone() THREW TypeError: Response.clone: Body has already been consumed.
7 req-consumed-formdata: clone() THREW TypeError: unusable

$ bun repro.mjs   # 1.4.0 and main
1 req-consumed-string:   clone() OK, clone.text() -> ""
2 req-consumed-stream:   clone() OK, clone.text() THREW TypeError: Body already used
3 req-locked(unread):    clone() OK, clone.text() THREW TypeError: Body already used
4 res-consumed-string:   clone() OK, clone.text() -> ""
5 res-locked(unread):    clone() OK, clone.text() THREW TypeError: Body already used
6 res-consumed-blob:     clone() OK, clone.text() -> ""
7 req-consumed-formdata: clone() OK, clone.text() -> ""
```

### Fix

Add `BodyMixin::throw_if_body_unusable` and call it at the top of both `do_clone` entry points (`src/runtime/webcore/Request.rs`, `src/runtime/webcore/Response.rs`).

Request has a third JS entry point: `BunRequest.prototype.clone`, the subclass that `Bun.serve` `routes:` handlers receive. It dispatches through `JSBunRequest::clone` -> `Request__clone` -> `Request::ffi_clone` rather than `do_clone`, so it gets the same check at the top of `ffi_clone`. Response has no such subclass. `Request::clone` and `Response::clone` have no other callers, so every JS-visible `clone()` is covered and no internal clone path changes.

The unusable predicate is the existing `bodyUsed` walk with `ReadableStream::is_locked` OR'd in, so `get_body_used` is refactored to share a parameterized helper (`body_stream_check`) instead of duplicating the match.

The error is `ERR_BODY_ALREADY_USED`, an instance of `TypeError` like node and browsers, with the message `Body is disturbed or locked` (WebKit's wording, which covers both halves of the predicate).

Only the two `clone()` entry points are guarded. `new Request(usedRequest)` has the same spec check (Request constructor step 36.1) and is also missing in Bun, but it is a separate algorithm with a much wider blast radius in `Bun.serve` middleware, so it is intentionally not part of this PR. `fetch(usedRequest)` already throws.

### Tests

`test/js/web/fetch/body-clone.test.ts`:

- New `describe("clone() throws when the body is disturbed or locked")`: consumed string / user-stream / Blob / FormData bodies, locked bodies, an in-flight read, a `fetch()` response disturbed by a reader, a consumed `Bun.serve` incoming request (catch-all `fetch` handler), and a consumed `BunRequest` from a `routes:` handler (both a `/:param` route and a static one). All fail on `main`.
- Negative coverage: null bodies, an unread `Bun.serve` request (both handler kinds), and a body materialized by the `body` getter still clone.
- The existing "`clone()` on a locked stream body throws a catchable TypeError" subprocess test now asserts the new message. Since the usability check fires before the stream is teed, that test no longer reaches the `readableStreamTee` exception-propagation path it was added for in #32786, so a sibling test drives the same path through `new Request(lockedRequest)`, which still tees, and keeps that coverage.

With the fix, `bun bd test test/js/web/fetch/body-clone.test.ts` passes 44/44. The surrounding `body.test.ts`, `response.test.ts`, `body-stream.test.ts`, `blob.test.ts`, and `test/js/web/request/` suites are unchanged.

