### PR TITLE
Stop Response.clone() from retaining ~2x the body for an unread clone

### DIFF
--- a/src/jsc/bindings/webcore/StructuredClone.cpp
+++ b/src/jsc/bindings/webcore/StructuredClone.cpp
@@ -96,13 +96,17 @@ JSC_DEFINE_HOST_FUNCTION(structuredCloneForStream, (JSGlobalObject * globalObjec
             throwDataCloneError(*globalObject, scope);
             return {};
         }
-        auto bufferClone = buffer->slice(0);
+        // Copy only the bytes the view covers. Chunks are often narrow windows into a
+        // much larger shared buffer (e.g. a fetch body's read buffer); cloning the whole
+        // backing buffer per chunk retains every neighboring chunk's bytes again.
+        size_t byteOffset = bufferView->byteOffset();
+        auto bufferClone = buffer->slice(byteOffset, byteOffset + bufferView->byteLength());
         Structure* structure = bufferView->structure();
 
-#define CLONE_TYPED_ARRAY(name)                                                                                                                                                   \
-    do {                                                                                                                                                                          \
-        if (bufferView->inherits<JS##name##Array>())                                                                                                                              \
-            RELEASE_AND_RETURN(scope, JSValue::encode(JS##name##Array::create(globalObject, structure, WTF::move(bufferClone), bufferView->byteOffset(), bufferView->length()))); \
+#define CLONE_TYPED_ARRAY(name)                                                                                                                            \
+    do {                                                                                                                                                   \
+        if (bufferView->inherits<JS##name##Array>())                                                                                                       \
+            RELEASE_AND_RETURN(scope, JSValue::encode(JS##name##Array::create(globalObject, structure, WTF::move(bufferClone), 0, bufferView->length()))); \
     } while (0);
 
         FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(CLONE_TYPED_ARRAY)
@@ -110,7 +114,7 @@ JSC_DEFINE_HOST_FUNCTION(structuredCloneForStream, (JSGlobalObject * globalObjec
 #undef CLONE_TYPED_ARRAY
 
         if (value.inherits<JSDataView>())
-            RELEASE_AND_RETURN(scope, JSValue::encode(JSDataView::create(globalObject, structure, WTF::move(bufferClone), bufferView->byteOffset(), bufferView->length())));
+            RELEASE_AND_RETURN(scope, JSValue::encode(JSDataView::create(globalObject, structure, WTF::move(bufferClone), 0, bufferView->length())));
     }
 
     throwTypeError(globalObject, scope, "structuredClone not implemented for non-ArrayBuffer / non-ArrayBufferView"_s);

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -520,6 +520,75 @@ test("ReadableStream with mixed content (starting with ArrayBuffer) can be conve
   expect(text).toContain("Здравствуй, мир!");
 });
 
+// The tee behind Request/Response.clone() structured-clones every chunk for the
+// second branch. For a typed array view that must copy only the bytes the view
+// covers: cloning the whole backing ArrayBuffer retains (per chunk!) the entire
+// shared receive buffer that fetch()'s body stream slices its chunks out of,
+// which roughly doubles the memory held by an unread clone.
+test.each(["Request", "Response"])(
+  "%s.clone() chunk clones do not retain the chunk's whole backing buffer",
+  async kind => {
+    const backing = new Uint8Array(1 << 20);
+    const chunk = backing.subarray(17, 17 + 64);
+    chunk.fill(7);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+
+    const target =
+      kind === "Request" ? new Request("https://example.com", { method: "POST", body: stream }) : new Response(stream);
+    const clone = target.clone();
+
+    const [originalBytes, clonedRead] = await Promise.all([target.bytes(), clone.body!.getReader().read()]);
+    const clonedChunk = clonedRead.value as Uint8Array<ArrayBuffer>;
+
+    expect(originalBytes).toEqual(chunk);
+    expect(clonedChunk).toEqual(chunk);
+    expect(clonedChunk.buffer.byteLength).toBe(64);
+  },
+);
+
+test("fetch().clone(): chunks buffered for the unread clone own exactly their bytes", async () => {
+  const total = 8 * 1024 * 1024;
+  const chunk = new Uint8Array(64 * 1024).fill(42);
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      let sent = 0;
+      return new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (sent >= total) return controller.close();
+            controller.enqueue(chunk);
+            sent += chunk.byteLength;
+          },
+        }),
+      );
+    },
+  });
+
+  const response = await fetch(server.url);
+  const clone = response.clone();
+
+  // Read the original to completion: the cache-a-copy pattern. Everything the
+  // clone will ever emit is now sitting in its queue.
+  const original = await response.bytes();
+  expect(original.byteLength).toBe(total);
+
+  let bytes = 0;
+  let backing = 0;
+  for await (const teed of clone.body!) {
+    bytes += teed.byteLength;
+    backing += teed.buffer.byteLength;
+  }
+  // fetch() delivers chunks as views into a larger shared receive buffer; the
+  // clones queued for the second branch must not each retain a copy of it.
+  expect({ bytes, backing }).toEqual({ bytes: total, backing: total });
+});
+
 // clone() on a locked-stream body must throw a single catchable TypeError.
 // It must not also report the error as uncaught: that sets exit code 1 and
 // clears the pending exception even though the user handled the throw.

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -521,10 +521,8 @@ test("ReadableStream with mixed content (starting with ArrayBuffer) can be conve
 });
 
 // The tee behind Request/Response.clone() structured-clones every chunk for the
-// second branch. For a typed array view that must copy only the bytes the view
-// covers: cloning the whole backing ArrayBuffer retains (per chunk!) the entire
-// shared receive buffer that fetch()'s body stream slices its chunks out of,
-// which roughly doubles the memory held by an unread clone.
+// second branch. That clone must copy only the bytes the view covers: cloning the
+// whole backing ArrayBuffer retains the larger shared buffer fetch() slices from.
 test.each(["Request", "Response"])(
   "%s.clone() chunk clones do not retain the chunk's whole backing buffer",
   async kind => {


### PR DESCRIPTION
### What

`Response.clone()` / `Request.clone()` tee the body stream and structured-clone every chunk for the second branch. The cloner, `structuredCloneForStream`, copied each chunk's entire backing ArrayBuffer (`buffer->slice(0)`) rather than the range the view covers.

Chunks produced by Bun's native body streams are subarray views into a shared 256KB-2MB receive buffer (several chunks per buffer, see `#handleNumberResult` in `ReadableStreamInternals.ts`), so every clone queued for the second branch dragged along a full copy of that shared buffer. The standard "cache a copy" middleware pattern paid for the body about twice:

```js
const res = await fetch(bigUrl);
const cached = res.clone();
await res.arrayBuffer(); // cached not read yet: its queue buffers the whole body
```

Measured on 1.4.0 with a 256 MB body: 608 MB RSS without the clone, 1068 MB with it, and the unread clone's queue held 2.2x the body in ArrayBuffers. Node holds ~1x for the same code. Smallest repro of the underlying bug:

```js
const backing = new Uint8Array(1 << 20);
const chunk = backing.subarray(17, 17 + 64);
const res = new Response(new ReadableStream({ start(c) { c.enqueue(chunk); c.close(); } }));
const clone = res.clone();
await res.arrayBuffer();
const { value } = await clone.body.getReader().read();
console.log(value.byteLength, value.buffer.byteLength); // 64, 1048576
```

### Fix

`structuredCloneForStream` now slices `[byteOffset, byteOffset + byteLength)` and creates the cloned view at offset 0, so a cloned chunk costs exactly its own bytes. This is what the streams spec's byte stream tee does (`CloneAsUint8Array`), which is the path other engines take for fetch bodies because their body streams are byte streams.

The function is only reachable from `Request.clone()` / `Response.clone()` (`ReadableStream.prototype.tee()` passes `shouldClone = false`), so nothing else observes the change. The producer side (the shared receive buffer) is intentional and stays as is; normal reads of a body always cost 1x, only the clone path over-copied.

### Verification

Three tests added to `test/js/web/fetch/body-clone.test.ts`, all failing on the released 1.4.0 and passing with this change:

- `Request.clone()` / `Response.clone()` chunk clones do not retain the chunk's whole backing buffer (before: a cloned 64 byte chunk held a 1 MiB buffer)
- `fetch().clone()`: chunks buffered for the unread clone own exactly their bytes (before: 16.6 MB of ArrayBuffers retained for 8.4 MB of data)

With the fix, the 32 MB fetch scenario retains exactly 32 MB in the unread clone's queue (was 71 MB).
