### PR TITLE
Move WTFTimer out of the shared timer heap to fix a cross-thread race

### DIFF
--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -189,8 +189,8 @@ pub(crate) mod sql_hooks {
     unsafe fn timer_insert(heap: *mut c_void, timer: *mut EventLoopTimer) {
         // SAFETY: `heap` is `&runtime_state().timer` (live for the VM); `timer`
         // is a live intrusive heap node owned by the caller. Route through
-        // `All::insert` (NOT the raw `.timers` field) so the lock is taken and
-        // `(*timer).state` / `in_heap` bookkeeping is updated.
+        // `All::insert` (NOT the raw `.timers` field) so the fake-timers
+        // routing and the `(*timer).state` / `in_heap` bookkeeping happen.
         unsafe { (*heap.cast::<crate::timer::All>()).insert(timer) };
     }
     unsafe fn timer_remove(heap: *mut c_void, timer: *mut EventLoopTimer) {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -197,10 +197,11 @@ pub(crate) fn global_dns_data() -> &'static core::cell::OnceCell<Box<crate::dns_
 }
 
 /// Recover the [`RuntimeState`] owned by a specific `vm` (not the calling
-/// thread's). `WTFTimer` and the `timer_insert`/`timer_remove` hooks may be
-/// invoked off the VM's JS thread (the `All.lock` mutex exists for exactly
-/// that), so they must reach the heap through `vm.runtime_state` rather than
-/// the thread-local cache.
+/// thread's). `WTFTimer` may be entered off the VM's JS thread (the locked
+/// `All.wtf_timers` heap exists for exactly that), and the
+/// `timer_insert`/`timer_remove` hooks take `vm` from a tier that cannot see
+/// `RuntimeState`; both must reach the heap through `vm.runtime_state`
+/// rather than the thread-local cache.
 ///
 /// # Safety
 /// `vm` must point at a live `VirtualMachine` whose `runtime_state` was set by
@@ -1211,8 +1212,7 @@ unsafe fn timer_insert(
     let state = unsafe { runtime_state_of(vm) };
     debug_assert!(!state.is_null(), "timer_insert before init_runtime_state");
     // SAFETY: this leaf hook runs no JS, so a short-lived `&mut RuntimeState`
-    // does not alias anything. `Timer::All::insert` takes its own lock and
-    // re-derefs `t` per-field.
+    // does not alias anything. `Timer::All::insert` re-derefs `t` per-field.
     unsafe { &mut (*state).timer }.insert(t);
 }
 

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -6,7 +6,7 @@ use bun_core::Environment;
 use bun_core::Timespec;
 use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSValue, JsResult};
 use crate::timer::{
-    self, ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, InHeap,
+    ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, InHeap,
     TimerObjectInternals, TimeoutObject, TimerHeap,
 };
 
@@ -109,91 +109,44 @@ pub(crate) extern "C" fn Bun__FakeTimers__setSystemTime(ms: f64) {
 
 use crate::jsc_hooks::timer_all;
 
-/// RAII `lock()`/`unlock()` for the per-thread `timer::All.lock`. Centralises
-/// the single raw-pointer deref so call sites read `let _g = timers_lock_guard();`
-/// with no `unsafe`. The returned [`bun_threading::MutexGuard`] holds the mutex
-/// by raw pointer (no borrow), so it does not pin a `&timer::All` across the
-/// re-entrant heap accesses documented on `execute_*` below.
-#[inline]
-fn timers_lock_guard() -> bun_threading::MutexGuard {
-    // SAFETY: `timer_all()` returns the boxed per-thread `RuntimeState.timer`,
-    // never null while a VM is installed (asserted above). `lock` is accessed
-    // via shared `&Mutex` only (interior mutability), so this forms no aliased
-    // `&mut` with the surrounding `fake_timers` writes.
-    unsafe { &(*timer_all()).lock }.lock_guard()
-}
-
 #[inline]
 fn from_el_timespec(t: &ElTimespec) -> Timespec {
     Timespec { sec: t.sec, nsec: t.nsec }
 }
 
 impl FakeTimers {
-    fn assert_locked(&self) {
-        if !Environment::CI_ASSERT {
-            return;
-        }
-        // SAFETY: self points to the `fake_timers` field of `timer::All` (always embedded there)
-        let owner: &timer::All = unsafe {
-            &*(bun_core::from_field_ptr!(timer::All, fake_timers, std::ptr::from_ref::<Self>(self)))
-        };
-        debug_assert!(!owner.lock.try_lock());
-    }
-
     pub fn is_active(&self) -> bool {
-        self.assert_locked();
-        // validity re-checked at fn exit
-        let r = self.active;
-        self.assert_locked();
-        r
+        self.active
     }
 
     fn activate(&mut self, js_now: f64, global: &JSGlobalObject) {
-        self.assert_locked();
-
         self.active = true;
         CURRENT_TIME.set(global, &Timespec::EPOCH, Some(js_now));
-
-        self.assert_locked();
     }
 
     fn deactivate(
         &mut self,
         global: &JSGlobalObject,
     ) -> Vec<core::ptr::NonNull<TimerObjectInternals>> {
-        self.assert_locked();
-
         let pinned = self.clear();
         CURRENT_TIME.clear(global);
         self.active = false;
-
-        self.assert_locked();
         pinned
     }
 
-    /// Drain the fake-timer heap. Returns every `TimeoutObject` that was
-    /// linked so the caller can release the heap's `+1` ref and the `Strong`
-    /// JS pin via [`TimerObjectInternals::release_heap_pin`] *after* dropping
-    /// `&mut self` and `All.lock` — that path reaches `&mut All`, which would
-    /// alias `&mut self.fake_timers` here (same hazard `execute_next` notes).
-    ///
     /// Marking `state = CANCELLED` alone strands the `Box<TimeoutObject>`: its
     /// refcount sticks at 2 (wrapper +1 from `init_with`, heap +1 from
     /// `reschedule`) and `internals.this_value` still GC-roots the wrapper, so
     /// neither side ever frees.
     #[must_use]
     fn clear(&mut self) -> Vec<core::ptr::NonNull<TimerObjectInternals>> {
-        self.assert_locked();
-
         let mut pinned = Vec::new();
         while let Some(timer) = self.timers.delete_min() {
-            // SAFETY: `delete_min` returns a live `*mut EventLoopTimer` just
-            // unlinked; for `TimeoutObject` the tag invariant means it IS the
-            // `event_loop_timer` field of a live `Box<TimeoutObject>` whose
-            // refcount is ≥ 1 until the caller's release pass.
+            // SAFETY: `delete_min` returned a live node; the `TimeoutObject`
+            // it belongs to stays live until the caller's release pass.
             unsafe {
-                (*timer).state = EventLoopTimerState::CANCELLED;
                 (*timer).in_heap = InHeap::None;
+                (*timer).state = EventLoopTimerState::CANCELLED;
                 if (*timer).tag == EventLoopTimerTag::TimeoutObject {
                     let parent = TimeoutObject::from_timer_ptr(timer);
                     pinned.push(core::ptr::NonNull::new_unchecked(
@@ -203,34 +156,15 @@ impl FakeTimers {
             }
         }
 
-        self.assert_locked();
         pinned
     }
 
-    // noalias re-entrancy: `execute_*` / `fire` do NOT take
-    // `&mut self`. `EventLoopTimer::fire` dispatches into JS; a `setInterval`
-    // callback's reschedule (`timer::All::update` → `insert_lock_held` →
-    // `(*timer_all()).fake_timers.timers.insert`) writes back into *this
-    // same* `FakeTimers::timers` heap through a fresh raw pointer. With a
-    // live `&mut self` LLVM's `noalias` lets it cache `self.timers.root`
-    // across the (inlined) `fire` body — `peek()` on the next loop iteration
-    // then misses the re-inserted interval, so `advanceTimersByTime` /
-    // `runOnlyPendingTimers` fire each interval at most once per call. Same
-    // bug class as `TimerObjectInternals::fire` (see dc37f2018b34). Access
-    // the heap via the raw `timer_all()` pointer instead so every iteration
-    // reloads from memory.
     fn execute_next(global: &JSGlobalObject) -> bool {
-        let timers = timer_all();
-
-        let next = {
-            let _g = timers_lock_guard();
-            // SAFETY: `timers` is the boxed per-thread `RuntimeState.timer`;
-            // single-threaded JS heap so no concurrent `&mut` to `.fake_timers`.
-            let n = unsafe { (*timers).fake_timers.timers.delete_min() };
-            match n {
-                Some(n) => n,
-                None => return false,
-            }
+        // SAFETY: `timer_all()` is the live per-thread `All`; the borrow ends
+        // at this statement, before `fire` re-enters `All::insert`.
+        let next = match unsafe { (*timer_all()).fake_timers.timers.delete_min() } {
+            Some(n) => n,
+            None => return false,
         };
 
         Self::fire(global, next);
@@ -255,26 +189,22 @@ impl FakeTimers {
     }
 
     fn execute_until(global: &JSGlobalObject, until: Timespec) {
-        let timers = timer_all();
-
+        let all = timer_all();
         'outer: loop {
             let next = 'blk: {
-                let _g = timers_lock_guard();
-
-                // SAFETY: `timers` is the boxed per-thread `RuntimeState.timer`;
-                // single-threaded JS heap. Re-derive each iteration so the
-                // re-entrant `insert` from setInterval rescheduling is observed.
-                let Some(peek) = (unsafe { (*timers).fake_timers.timers.peek() }) else {
+                // SAFETY: `all` is the live per-thread `All`; each borrow
+                // lasts one statement and none spans `fire`.
+                let Some(peek) = (unsafe { (*all).fake_timers.timers.peek() }) else {
                     break 'outer;
                 };
-                // SAFETY: `peek` is the heap root; live while locked.
+                // SAFETY: `peek` is the heap root; live while linked.
                 if from_el_timespec(unsafe { &(*peek).next }).greater(&until) {
                     break 'outer;
                 }
                 // bun.assert always evaluates its arg; debug_assert! does NOT in release.
                 // Hoist the side-effecting delete_min() out so the timer is removed in all builds.
                 // SAFETY: as above.
-                let min = unsafe { (*timers).fake_timers.timers.delete_min() }.expect("unreachable");
+                let min = unsafe { (*all).fake_timers.timers.delete_min() }.expect("unreachable");
                 debug_assert!(core::ptr::eq(min, peek));
                 break 'blk min;
             };
@@ -283,20 +213,11 @@ impl FakeTimers {
     }
 
     fn execute_only_pending_timers(global: &JSGlobalObject) {
-        let timers = timer_all();
-
-        let until = {
-            let _g = timers_lock_guard();
-            // SAFETY: `timers` is the boxed per-thread `RuntimeState.timer`.
-            let target = unsafe { (*timers).fake_timers.timers.find_max() };
-            drop(_g);
-            match target {
-                Some(t) => {
-                    // SAFETY: `t` was reachable in the heap under the lock.
-                    from_el_timespec(unsafe { &(*t).next })
-                }
-                None => return,
-            }
+        // SAFETY: `timer_all()` is the live per-thread `All`.
+        let until = match unsafe { (*timer_all()).fake_timers.timers.find_max() } {
+            // SAFETY: `t` is reachable in the heap and live while linked.
+            Some(t) => from_el_timespec(unsafe { &(*t).next }),
+            None => return,
         };
         Self::execute_until(global, until);
     }
@@ -311,17 +232,9 @@ impl FakeTimers {
 // ===
 
 fn error_unless_fake_timers(global: &JSGlobalObject) -> JsResult<()> {
-    let timers = timer_all();
-    // SAFETY: per-thread `timer::All`.
-    let this = unsafe { &(*timers).fake_timers };
-
-    {
-        let _g = timers_lock_guard();
-        let active = this.is_active();
-        drop(_g);
-        if active {
-            return Ok(());
-        }
+    // SAFETY: per-thread `timer::All`, live for the VM lifetime.
+    if unsafe { (*timer_all()).fake_timers.is_active() } {
+        return Ok(());
     }
     Err(global.throw(format_args!(
         "Fake timers are not active. Call useFakeTimers() first."
@@ -353,10 +266,6 @@ fn set_fake_timer_marker(global: &JSGlobalObject, enabled: bool) {
 
 #[bun_jsc::host_fn]
 fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    let timers = timer_all();
-    // SAFETY: per-thread `timer::All`.
-    let this = unsafe { &mut (*timers).fake_timers };
-
     // SAFETY: FFI call into C++ JSMock
     let mut js_now = JSMock__getCurrentUnixTimeMs();
 
@@ -382,10 +291,8 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
         }
     }
 
-    {
-        let _g = timers_lock_guard();
-        this.activate(js_now, global);
-    }
+    // SAFETY: per-thread `timer::All`; `activate` does not re-enter `All`.
+    unsafe { (*timer_all()).fake_timers.activate(js_now, global) };
 
     // Set setTimeout.clock = true to signal that fake timers are enabled.
     // This is used by testing-library/react to detect if jest.advanceTimersByTime should be called.
@@ -396,14 +303,8 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
 
 #[bun_jsc::host_fn]
 fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    let timers = timer_all();
-
-    let pinned = {
-        // SAFETY: per-thread `timer::All`.
-        let this = unsafe { &mut (*timers).fake_timers };
-        let _g = timers_lock_guard();
-        this.deactivate(global)
-    };
+    // SAFETY: per-thread `timer::All`; the borrow ends before `release_heap_pin`.
+    let pinned = unsafe { (*timer_all()).fake_timers.deactivate(global) };
     let vm = global.bun_vm_ptr();
     for p in pinned {
         TimerObjectInternals::release_heap_pin(p, vm);
@@ -479,30 +380,20 @@ fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValu
 
 #[bun_jsc::host_fn]
 fn get_timer_count(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-    let timers = timer_all();
-    // SAFETY: per-thread `timer::All`.
-    let this = unsafe { &(*timers).fake_timers };
     error_unless_fake_timers(global)?;
 
-    let count = {
-        let _g = timers_lock_guard();
-        this.timers.count()
-    };
+    // SAFETY: per-thread `timer::All`, live for the VM lifetime.
+    let count = unsafe { (*timer_all()).fake_timers.timers.count() };
 
     Ok(JSValue::js_number(count as f64))
 }
 
 #[bun_jsc::host_fn]
 fn clear_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    let timers = timer_all();
     error_unless_fake_timers(global)?;
 
-    let pinned = {
-        // SAFETY: per-thread `timer::All`.
-        let this = unsafe { &mut (*timers).fake_timers };
-        let _g = timers_lock_guard();
-        this.clear()
-    };
+    // SAFETY: per-thread `timer::All`; the borrow ends before `release_heap_pin`.
+    let pinned = unsafe { (*timer_all()).fake_timers.clear() };
     let vm = global.bun_vm_ptr();
     for p in pinned {
         TimerObjectInternals::release_heap_pin(p, vm);
@@ -513,14 +404,8 @@ fn clear_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
 
 #[bun_jsc::host_fn]
 fn is_fake_timers(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-    let timers = timer_all();
-    // SAFETY: per-thread `timer::All`.
-    let this = unsafe { &(*timers).fake_timers };
-
-    let is_active = {
-        let _g = timers_lock_guard();
-        this.is_active()
-    };
+    // SAFETY: per-thread `timer::All`, live for the VM lifetime.
+    let is_active = unsafe { (*timer_all()).fake_timers.is_active() };
 
     Ok(JSValue::from(is_active))
 }

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -482,9 +482,9 @@ impl DateHeaderTimer {
             unsafe { (*(*vm).uws_loop()).update_date() };
 
             let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-            // SAFETY: single JS thread; `All::update` only touches `lock`/`timers`/
-            // `fake_timers`/`epoch`, disjoint from `date_header_timer` which `self`
-            // aliases (raw-ptr-per-field re-entry pattern, see jsc_hooks.rs).
+            // SAFETY: single JS thread; nothing `All::update` touches overlaps
+            // `date_header_timer`, which `self` aliases (raw-ptr-per-field
+            // re-entry pattern, see jsc_hooks.rs).
             unsafe { (*Self::timer_all()).update(elt, &now.add_ms(1000)) };
         } else {
             // The date was updated recently, just reschedule for the next second

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -11,7 +11,6 @@ use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicPtr, Ordering};
 
 use bun_core::{Timespec, TimespecMockMode};
-use bun_threading::Mutex;
 
 use crate::jsc::virtual_machine::{IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE, VirtualMachine};
 use crate::webcore::script_execution_context::Identifier as ScriptExecutionContextIdentifier;
@@ -53,7 +52,6 @@ pub struct WTFTimer {
     // `*mut WTFTimer`).
     imminent: bun_ptr::BackRef<AtomicPtr<()>>,
     repeat: bool,
-    lock: Mutex,
     script_execution_context_id: ScriptExecutionContextIdentifier,
 }
 
@@ -82,17 +80,14 @@ impl WTFTimer {
     pub unsafe fn run(this: *mut Self, vm: *mut VirtualMachine) {
         // SAFETY: per fn contract — `this` is live; `ThisPtr` vends only fresh
         // short-lived `&Self` per Deref so no `&WTFTimer` spans the
-        // `All::remove` raw write to `event_loop_timer`.
+        // `All::wtf_disarm` raw write to `event_loop_timer`.
         let t = unsafe { bun_ptr::ThisPtr::new(this) };
-        if t.event_loop_timer.state == EventLoopTimerState::ACTIVE {
-            // SAFETY: `vm` is the live VM that owns this timer's heap;
-            // `event_loop_timer` is an embedded field of a live allocation.
-            unsafe {
-                let state = crate::jsc_hooks::runtime_state_of(vm);
-                (*state)
-                    .timer
-                    .remove(ptr::addr_of_mut!((*this).event_loop_timer));
-            }
+        // SAFETY: `vm` is the live VM that owns this timer's heap.
+        unsafe {
+            let state = crate::jsc_hooks::runtime_state_of(vm);
+            (*state)
+                .timer
+                .wtf_disarm(ptr::addr_of_mut!((*this).event_loop_timer));
         }
         t.run_without_removing();
     }
@@ -115,7 +110,6 @@ impl WTFTimer {
 
     #[bun_uws::uws_callback(export = "WTFTimer__secondsUntilTimer", no_catch)]
     pub fn seconds_until_timer(&self) -> f64 {
-        let _g = self.lock.lock_guard();
         if self.event_loop_timer.state == EventLoopTimerState::ACTIVE {
             let next = &self.event_loop_timer.next;
             // bun_event_loop carries a local `Timespec` stub; re-pack
@@ -177,16 +171,12 @@ impl WTFTimer {
             interval.nsec -= NS_PER_S;
         }
 
-        // SAFETY: `t.vm` is the VM that owns this timer's heap (captured at
-        // `WTFTimer__create`); `event_loop_timer` is an embedded field of a
-        // live allocation. May be called off the JS thread — `All::update`
-        // takes its own lock. The `repeat` write is the only field write here;
-        // no `&Self` from `t` is live across it.
+        // SAFETY: `t.vm` owns this timer's heap; `wtf_arm` is safe from any thread.
         unsafe {
             let state = crate::jsc_hooks::runtime_state_of(t.vm.as_ptr());
             (*state)
                 .timer
-                .update(ptr::addr_of_mut!((*this).event_loop_timer), &interval);
+                .wtf_arm(ptr::addr_of_mut!((*this).event_loop_timer), &interval);
             (*this).repeat = repeat;
         }
     }
@@ -195,11 +185,8 @@ impl WTFTimer {
     /// `this` must point at a live heap-allocated `WTFTimer`.
     pub unsafe fn cancel(this: *mut Self) {
         // SAFETY: per fn contract — `this` outlives this scope. `ThisPtr` vends
-        // only fresh short-lived `&Self` per Deref; `lock_guard` stores a
-        // `BackRef<Mutex>` (no `&Self` held in `_g`), so the `addr_of_mut!`
-        // below stays legal under Stacked Borrows.
+        // only fresh short-lived `&Self` per Deref.
         let t = unsafe { bun_ptr::ThisPtr::new(this) };
-        let _g = t.lock.lock_guard();
 
         if t.script_execution_context_id.valid() {
             // Only clear imminent if this timer was the one that set it.
@@ -214,17 +201,13 @@ impl WTFTimer {
                 Ordering::SeqCst,
             );
 
-            if t.event_loop_timer.state == EventLoopTimerState::ACTIVE {
-                // SAFETY: `t.vm` is the VM that owns this timer's heap; may be
-                // called off the JS thread — `All::remove` locks.
-                // `addr_of_mut!` through the original `*mut` preserves write
-                // provenance for the heap-node mutation inside `remove`.
-                unsafe {
-                    let state = crate::jsc_hooks::runtime_state_of(t.vm.as_ptr());
-                    (*state)
-                        .timer
-                        .remove(ptr::addr_of_mut!((*this).event_loop_timer));
-                }
+            // SAFETY: `t.vm` owns this timer's heap; `wtf_disarm` is safe from
+            // any thread and is a no-op for a node that is no longer linked.
+            unsafe {
+                let state = crate::jsc_hooks::runtime_state_of(t.vm.as_ptr());
+                (*state)
+                    .timer
+                    .wtf_disarm(ptr::addr_of_mut!((*this).event_loop_timer));
             }
         }
     }
@@ -233,12 +216,8 @@ impl WTFTimer {
     ///
     /// # Safety
     /// `this` is the container of an `EventLoopTimer` just popped from
-    /// `All.timers`; `_vm` is the live per-thread VM.
+    /// `All.wtf_timers`; `_vm` is the live per-thread VM.
     pub unsafe fn fire(this: *mut Self, _now: &ElTimespec, _vm: *mut VirtualMachine) {
-        // SAFETY: per fn contract — `this` is live. Single raw write to
-        // `event_loop_timer.state` precedes the `ThisPtr` borrow; subsequent
-        // field reads via `t` create fresh short-lived `&Self`.
-        unsafe { (*this).event_loop_timer.state = EventLoopTimerState::FIRED };
         // SAFETY: per fn contract — `this` is live; `ThisPtr` vends only fresh
         // short-lived `&Self` per Deref.
         let t = unsafe { bun_ptr::ThisPtr::new(this) };
@@ -302,7 +281,6 @@ pub(crate) unsafe extern "C" fn WTFTimer__create(run_loop_timer: *mut RunLoopTim
             script_execution_context_id: ScriptExecutionContextIdentifier(
                 vm_ref.initial_script_execution_context_identifier as u32,
             ),
-            lock: Mutex::default(),
         })
     };
 

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -7,7 +7,7 @@ use bun_core::{Timespec, TimespecMockMode};
 use bun_libuv_sys::UvHandle as _;
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
-use bun_threading::Mutex;
+use bun_threading::Guarded;
 
 // Low-tier timer node + tag (per §Dispatch hot-path list, the `match tag`
 // dispatch lives in this crate; `bun_event_loop` only stores `(tag, ptr)`).
@@ -419,8 +419,8 @@ impl DateHeaderTimer {
                 nsec: next.nsec,
             };
             let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-            // SAFETY: single JS thread; `All::insert` only touches `lock`/`timers`/
-            // `fake_timers`, disjoint from `date_header_timer` which `self` aliases.
+            // SAFETY: single JS thread; nothing `All::insert` touches
+            // overlaps `date_header_timer`, which `self` aliases.
             unsafe { (*Self::timer_all()).insert(elt) };
         }
     }
@@ -474,8 +474,8 @@ impl EventLoopDelayMonitor {
             nsec: next.nsec,
         };
         let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-        // SAFETY: single JS thread; `All::insert` only touches `lock`/`timers`/
-        // `fake_timers`, disjoint from `event_loop_delay` which `self` aliases.
+        // SAFETY: single JS thread; nothing `All::insert` touches overlaps
+        // `event_loop_delay`, which `self` aliases.
         unsafe { (*Self::timer_all()).insert(elt) };
     }
 
@@ -560,7 +560,7 @@ pub use self::timeout_object::TimeoutObject;
 ///
 /// Returns a raw `NonNull` so the caller decides read vs. write:
 /// [`EventLoopTimer::less`] reads `.epoch()` on the heap-compare hot path;
-/// [`All::update`] writes `.set_epoch()` under the timer lock. The two
+/// [`All::update`] writes `.set_epoch()` on the JS thread. The two
 /// `internals.flags` arms store `Cell<TimerFlags>`; `Cell<T>` is
 /// `#[repr(transparent)]` so the `addr_of!` → `.cast()` is layout-sound.
 ///
@@ -606,7 +606,6 @@ pub use wtf_timer::WTFTimer;
 
 pub struct All {
     pub last_id: i32,
-    pub lock: Mutex,
     pub thread_id: std::thread::ThreadId,
     pub timers: TimerHeap,
     pub active_timer_count: i32,
@@ -626,13 +625,13 @@ pub struct All {
     pub fake_timers: FakeTimers,
     pub maps: Maps,
     pub date_header_timer: DateHeaderTimer,
+    pub wtf_timers: Guarded<TimerHeap>,
 }
 
 impl All {
     pub fn init() -> Self {
         Self {
             last_id: 1,
-            lock: Mutex::default(),
             thread_id: std::thread::current().id(),
             timers: TimerHeap::default(),
             active_timer_count: 0,
@@ -648,25 +647,25 @@ impl All {
             fake_timers: FakeTimers::default(),
             maps: Maps::default(),
             date_header_timer: DateHeaderTimer::default(),
+            wtf_timers: Guarded::init(TimerHeap::default()),
         }
     }
 
-    pub fn insert(&mut self, timer: *mut EventLoopTimer) {
-        self.lock.lock();
-        // Note: bun_threading::Mutex is lock()/unlock(), not RAII.
-        let r = self.insert_lock_held(timer);
-        self.lock.unlock();
-        r
+    #[inline]
+    fn assert_js_thread(&self) {
+        debug_assert!(
+            self.thread_id == std::thread::current().id(),
+            "timer::All: non-WTF timers may only be touched on the owning JS thread",
+        );
     }
 
-    fn insert_lock_held(&mut self, timer: *mut EventLoopTimer) {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub fn insert(&mut self, timer: *mut EventLoopTimer) {
+        self.assert_js_thread();
         // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
-        // Note (§Forbidden aliased-&mut): `TimerHeap::insert` forms a
-        // fresh `&mut EventLoopTimer` via `(*a).heap()` for the same
-        // allocation, so we must NOT hold a `&mut *timer` across that call.
-        // Read `tag` and write `state`/`in_heap` via raw deref instead.
-        let allow_fake = unsafe { (*timer).tag }.allow_fake_timers();
-        if self.fake_timers.is_active() && allow_fake {
+        let tag = unsafe { (*timer).tag };
+        debug_assert!(tag != EventLoopTimerTag::WTFTimer, "use wtf_arm");
+        if self.fake_timers.is_active() && tag.allow_fake_timers() {
             // SAFETY: see fn contract
             unsafe {
                 self.fake_timers.timers.insert(timer);
@@ -686,25 +685,9 @@ impl All {
     }
 
     /// Lazily `uv_timer_init` the
-    /// per-`All` libuv timer, then (re)start it for the soonest heap deadline.
-    /// On Windows there is no epoll/kqueue fallback; this `uv_timer_t` is the
-    /// ONLY thing that wakes `uv_run` for JS timers.
-    ///
-    /// Note (jsc/runtime crate cycle): `All` is a field
-    /// of `RuntimeState` (not `VirtualMachine`) and `RuntimeState` carries no
-    /// back-pointer to the owning VM, so the lazy-init block falls back to the
-    /// calling thread's
-    /// TLS VM/loop. That equivalence holds **only** on the owning JS thread;
-    /// `All.lock` exists precisely because `insert`/`update` may be entered
-    /// cross-thread (WTFTimer), where TLS would resolve to the wrong loop or
-    /// panic. The `debug_assert!` below makes that precondition loud. Once
-    /// initialized, the re-arm path reads the loop back from the handle itself
-    /// (`uv_handle_get_loop`), so the hot path is TLS-free and always targets
-    /// the loop the timer was actually registered on.
-    ///
-    /// TODO: thread `vm: *mut VirtualMachine` through
-    /// `insert`/`insert_lock_held`/`update` once
-    /// the `RuntimeHooks::timer_insert` slot widens — see jsc_hooks.rs.
+    /// per-`All` libuv timer, then (re)start it for the soonest deadline
+    /// across both heaps. On Windows there is no epoll/kqueue fallback; this
+    /// `uv_timer_t` is the ONLY thing that wakes `uv_run` for JS timers.
     #[cfg(windows)]
     fn ensure_uv_timer(&mut self) {
         // `vm` here means the OWNING VM (the one this timer is embedded in),
@@ -722,41 +705,53 @@ impl All {
             self.uv_timer.unref();
         }
 
-        if let Some(timer) = self.timers.peek() {
-            // SAFETY: `uv_timer.data` is non-null past the lazy-init block, so
-            // `uv_timer_init` has run and the handle's `loop` field points at
-            // the owning VM's live `uv_loop_t` (== `vm.uvLoop()` per spec).
-            unsafe { uv::uv_update_time(self.uv_timer.get_loop()) };
-            let now = Timespec::now(TimespecMockMode::ForceRealTime);
+        let reg_next = self.timers.peek().map(|timer| {
             // SAFETY: `peek` returns a live heap node.
             let next = unsafe { &(*timer).next };
-            let next_ts = Timespec {
+            Timespec {
                 sec: next.sec,
                 nsec: next.nsec,
-            };
-            let wait = if next_ts.greater(&now) {
-                next_ts.duration(&now)
-            } else {
-                Timespec { sec: 0, nsec: 0 }
-            };
-
-            // minimum 1ms
-            // https://github.com/nodejs/node/blob/f552c86fecd6c2ba9e832ea129b731dd63abdbe2/src/env.cc#L1512
-            let wait_ms = core::cmp::max(1, wait.ms_unsigned());
-
-            // SAFETY: `uv_timer_init` ran above; the handle is live.
-            let due_in = unsafe { uv::uv_timer_get_due_in(&self.uv_timer) };
-            // Restarting an overdue handle shifts the wakeup out by 1ms. Done
-            // on every insert, the already-due callback never runs.
-            if !(self.uv_timer.is_active() && due_in <= wait_ms) {
-                self.uv_timer.start(wait_ms, 0, Some(Self::on_uv_timer));
             }
-
-            if self.active_timer_count > 0 {
-                self.uv_timer.ref_();
-            } else {
-                self.uv_timer.unref();
+        });
+        let wtf_next = self.wtf_timers.lock().peek().map(|timer| {
+            // SAFETY: `peek` returns a live heap node.
+            let next = unsafe { &(*timer).next };
+            Timespec {
+                sec: next.sec,
+                nsec: next.nsec,
             }
+        });
+        let Some(next_ts) = Self::soonest(reg_next, wtf_next) else {
+            return;
+        };
+
+        // SAFETY: `uv_timer.data` is non-null past the lazy-init block, so
+        // `uv_timer_init` has run and the handle's `loop` field points at
+        // the owning VM's live `uv_loop_t` (== `vm.uvLoop()` per spec).
+        unsafe { uv::uv_update_time(self.uv_timer.get_loop()) };
+        let now = Timespec::now(TimespecMockMode::ForceRealTime);
+        let wait = if next_ts.greater(&now) {
+            next_ts.duration(&now)
+        } else {
+            Timespec { sec: 0, nsec: 0 }
+        };
+
+        // minimum 1ms
+        // https://github.com/nodejs/node/blob/f552c86fecd6c2ba9e832ea129b731dd63abdbe2/src/env.cc#L1512
+        let wait_ms = core::cmp::max(1, wait.ms_unsigned());
+
+        // SAFETY: `uv_timer_init` ran above; the handle is live.
+        let due_in = unsafe { uv::uv_timer_get_due_in(&self.uv_timer) };
+        // Restarting an overdue handle shifts the wakeup out by 1ms. Done
+        // on every insert, the already-due callback never runs.
+        if !(self.uv_timer.is_active() && due_in <= wait_ms) {
+            self.uv_timer.start(wait_ms, 0, Some(Self::on_uv_timer));
+        }
+
+        if self.active_timer_count > 0 {
+            self.uv_timer.ref_();
+        } else {
+            self.uv_timer.unref();
         }
     }
 
@@ -781,13 +776,9 @@ impl All {
         unsafe { (*all).ensure_uv_timer() };
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn remove(&mut self, timer: *mut EventLoopTimer) {
-        self.lock.lock();
-        self.remove_lock_held(timer);
-        self.lock.unlock();
-    }
-
-    fn remove_lock_held(&mut self, timer: *mut EventLoopTimer) {
+        self.assert_js_thread();
         // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
         // Note (§Forbidden aliased-&mut): `TimerHeap::remove` forms a
         // fresh `&mut EventLoopTimer` via `(*v).heap()` for the same
@@ -815,18 +806,15 @@ impl All {
     /// # Safety
     /// `timer` must point to a live `EventLoopTimer` with whole-container
     /// provenance for its tag (see [`js_timer_flags_ptr`]).
-    // `timer` must stay `*mut`: the body forms only short-lived `&mut *timer`
-    // so re-entrant `remove_lock_held` does not alias an outstanding `&mut`
-    // (see Notes below); contract is documented in `# Safety`.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn update(&mut self, timer: *mut EventLoopTimer, time: &Timespec) {
-        self.lock.lock();
+        self.assert_js_thread();
         // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
         // Read `state` via raw deref so we don't hold a `&mut *timer` across
-        // `remove_lock_held` (which also `&mut`-derefs the same pointer);
-        // overlapping `&mut` is UB under Stacked Borrows.
+        // `remove` (which also `&mut`-derefs the same pointer); overlapping
+        // `&mut` is UB under Stacked Borrows.
         if unsafe { (*timer).state } == EventLoopTimerState::ACTIVE {
-            self.remove_lock_held(timer);
+            self.remove(timer);
         }
 
         // SAFETY: `timer` is still a valid live EventLoopTimer; safe to derive
@@ -835,7 +823,7 @@ impl All {
         // while `next` is `ElTimespec` — distinct types, so safe code cannot
         // construct the alias. Re-add a
         // `debug_assert!(!core::ptr::eq(time as *const _ as *const u8, &raw const (*timer).next as *const u8))`
-        // when the Timespec types unify (see the ElTimespec alias TODO at the
+        // when the Timespec types unify (see the ElTimespec alias note at the
         // top of this file).
         let timer_ref = unsafe { &mut *timer };
         timer_ref.next.sec = time.sec;
@@ -848,13 +836,93 @@ impl All {
         // is above so the raw `(*timer).tag` read inside is SB-clean.
         if let Some(flags) = unsafe { js_timer_flags_ptr(timer) } {
             self.epoch = self.epoch.wrapping_add(1) & ((1u32 << 25) - 1);
-            // SAFETY: exclusive under `self.lock`; `flags` points into the
-            // live container recovered above.
+            // SAFETY: `flags` points into the live container recovered above.
             unsafe { (*flags.as_ptr()).set_epoch(self.epoch) };
         }
 
-        self.insert_lock_held(timer);
-        self.lock.unlock();
+        self.insert(timer);
+    }
+
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub(crate) fn wtf_arm(&mut self, timer: *mut EventLoopTimer, time: &Timespec) {
+        // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
+        debug_assert!(unsafe { (*timer).tag } == EventLoopTimerTag::WTFTimer);
+        {
+            let mut wtf = self.wtf_timers.lock();
+            // SAFETY: `timer` is live; its state and heap links only change under this guard.
+            unsafe {
+                if (*timer).state == EventLoopTimerState::ACTIVE {
+                    wtf.remove(timer);
+                }
+                (*timer).next.sec = time.sec;
+                (*timer).next.nsec = time.nsec;
+                wtf.insert(timer);
+                (*timer).state = EventLoopTimerState::ACTIVE;
+            }
+        }
+        #[cfg(windows)]
+        if self.thread_id == std::thread::current().id() {
+            self.ensure_uv_timer();
+        }
+    }
+
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub(crate) fn wtf_disarm(&mut self, timer: *mut EventLoopTimer) {
+        // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
+        debug_assert!(unsafe { (*timer).tag } == EventLoopTimerTag::WTFTimer);
+        let mut wtf = self.wtf_timers.lock();
+        // SAFETY: `timer` is live; its state and heap links only change under this guard.
+        unsafe {
+            if (*timer).state == EventLoopTimerState::ACTIVE {
+                wtf.remove(timer);
+                (*timer).state = EventLoopTimerState::CANCELLED;
+            }
+        }
+    }
+
+    unsafe fn drain_due_wtf_timers(
+        this: *mut Self,
+        maybe_now: &mut Option<Timespec>,
+        vm: *mut (),
+    ) -> Option<Timespec> {
+        loop {
+            let min = {
+                // SAFETY: `this` is live; the guard drops before `fire`.
+                let mut wtf = unsafe { &(*this).wtf_timers }.lock();
+                let min = wtf.peek()?;
+                // SAFETY: `peek` returned a live heap node.
+                let min_next = unsafe {
+                    Timespec {
+                        sec: (*min).next.sec,
+                        nsec: (*min).next.nsec,
+                    }
+                };
+                let now = *maybe_now
+                    .get_or_insert_with(|| Timespec::now(TimespecMockMode::ForceRealTime));
+                if min_next.greater(&now) {
+                    return Some(min_next);
+                }
+                let min = wtf.delete_min().expect("peek succeeded");
+                // SAFETY: `min` is the node `peek` returned above.
+                unsafe { (*min).state = EventLoopTimerState::FIRED };
+                min
+            };
+            let now = maybe_now.expect("set before the pop");
+            let el_now = ElTimespec {
+                sec: now.sec,
+                nsec: now.nsec,
+            };
+            // SAFETY: `min` is live; no guard or borrow of `All` is held here.
+            unsafe { EventLoopTimer::fire(min, &el_now, vm) };
+        }
+    }
+
+    #[inline]
+    fn soonest(a: Option<Timespec>, b: Option<Timespec>) -> Option<Timespec> {
+        match (a, b) {
+            (Some(a), Some(b)) => Some(if a.greater(&b) { b } else { a }),
+            (a, b) => a.or(b),
+        }
     }
 
     /// Called from `EventLoop::auto_tick` to compute the epoll/kqueue timeout.
@@ -888,87 +956,49 @@ impl All {
         #[cfg(not(unix))]
         let _ = has_pending_immediate;
 
-        // Note (§Forbidden aliased-&mut): the WTFTimer arm below calls
-        // `(*min).fire(...)` → `WTFTimer__fire` → C++ may call back into
-        // `WTFTimer__update` → `(*runtime_state()).timer.update(...)`, minting
-        // a fresh `&mut All` to this same allocation while the outer
-        // `&mut self` is live → aliased-`&mut` UB. Mirror `drain_timers`:
-        // convert `self` to a raw pointer up-front and form *short-lived*
-        // `&mut *this` borrows only around `peek()`/`delete_min()`, dropping
-        // them before `fire()` so no `&mut All` is held across the re-entrant
-        // call.
-        //
-        // TODO: same caveat as `drain_timers` — the call-site auto-ref
-        // still creates a `&mut All` for the call frame; switch the signature
-        // to `this: *mut Self` (see the `get_timeout` call sites in jsc_hooks.rs).
         let this: *mut Self = self;
         let maybe_now: &mut Option<Timespec> = now_out;
-        loop {
-            // SAFETY: `this` derived from `&mut self`; short-lived exclusive
-            // borrow scoped to this `peek()` call only.
-            let Some(min) = (unsafe { &mut *this }).timers.peek() else {
-                break;
-            };
-            // SAFETY: peek returns a live heap node.
-            // Note (§Forbidden aliased-&mut): `delete_min()` writes
-            // `(*min).heap` through a fresh `&mut EventLoopTimer`, so we must
-            // NOT hold a `&mut *min` across it. Read `next`/`tag` via raw
-            // deref and fire via raw deref (mirroring `drain_timers`).
-            let (min_next_sec, min_next_nsec, min_tag) =
-                unsafe { ((*min).next.sec, (*min).next.nsec, (*min).tag) };
-            // Real clock: `self.timers` is the opt-out-of-fake-timers set, all
-            // armed in real-time units. Comparing against the mocked clock made
-            // internal pacing (GC, WTFTimer, test timeouts) spin on re-arm.
-            let now =
-                *maybe_now.get_or_insert_with(|| Timespec::now(TimespecMockMode::ForceRealTime));
 
-            // bun_event_loop carries its own Timespec stub; compare field-wise.
-            let min_next = Timespec {
-                sec: min_next_sec,
-                nsec: min_next_nsec,
-            };
-            match now.order(&min_next) {
-                core::cmp::Ordering::Greater | core::cmp::Ordering::Equal => {
-                    // Side-effect: potentially call the StopIfNecessary timer.
-                    if min_tag == EventLoopTimerTag::WTFTimer {
-                        // SAFETY: short-lived `&mut All` scoped to
-                        // `delete_min()`; dropped before `fire()`.
-                        let _ = unsafe { &mut *this }.timers.delete_min();
-                        let el_now = ElTimespec {
-                            sec: now.sec,
-                            nsec: now.nsec,
-                        };
-                        // SAFETY: `min` was just popped and is live; no `&mut`
-                        // to `All` or to `*min` is held across `fire()`, which
-                        // may re-enter `(*runtime_state()).timer`.
-                        unsafe { EventLoopTimer::fire(min, &el_now, vm) };
-                        continue;
-                    }
-                    *spec = Timespec { sec: 0, nsec: 0 };
-                    return true;
-                }
-                core::cmp::Ordering::Less => {
-                    *spec = min_next.duration(&now);
-                    if let Some(us) = quic_next_tick_us {
-                        if us >= 0 {
-                            Self::clamp_to_quic(spec, us);
-                        }
-                    }
+        // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.
+        let wtf_next = unsafe { Self::drain_due_wtf_timers(this, maybe_now, vm) };
+
+        // SAFETY: `this` is live, and only this thread touches the regular heap.
+        let reg_next = (unsafe { &*this }).timers.peek().map(|min| {
+            // SAFETY: `peek` returns a live heap node.
+            let next = unsafe { &(*min).next };
+            Timespec {
+                sec: next.sec,
+                nsec: next.nsec,
+            }
+        });
+
+        let Some(next) = Self::soonest(wtf_next, reg_next) else {
+            if let Some(us) = quic_next_tick_us {
+                if us >= 0 {
+                    *spec = Timespec {
+                        sec: us / US_PER_S,
+                        nsec: (us % US_PER_S) * NS_PER_US,
+                    };
                     return true;
                 }
             }
-        }
+            return false;
+        };
 
-        if let Some(us) = quic_next_tick_us {
-            if us >= 0 {
-                *spec = Timespec {
-                    sec: us / US_PER_S,
-                    nsec: (us % US_PER_S) * NS_PER_US,
-                };
-                return true;
+        // Real clock: both heaps hold opt-out-of-fake-timers nodes armed in
+        // real-time units; the mocked clock made internal pacing spin on re-arm.
+        let now = *maybe_now.get_or_insert_with(|| Timespec::now(TimespecMockMode::ForceRealTime));
+        if next.greater(&now) {
+            *spec = next.duration(&now);
+            if let Some(us) = quic_next_tick_us {
+                if us >= 0 {
+                    Self::clamp_to_quic(spec, us);
+                }
             }
+        } else {
+            *spec = Timespec { sec: 0, nsec: 0 };
         }
-        false
+        true
     }
 
     fn clamp_to_quic(spec: &mut Timespec, us: i64) {
@@ -981,33 +1011,28 @@ impl All {
         }
     }
 
-    /// Pop the next due timer (under lock). `now` is filled lazily on first
-    /// call so we don't pay for `clock_gettime` when the heap is empty.
+    /// Pop the next due timer. `now` is filled lazily on first call so we
+    /// don't pay for `clock_gettime` when the heap is empty.
     fn next(&mut self, has_set_now: &mut bool, now: &mut Timespec) -> Option<*mut EventLoopTimer> {
-        self.lock.lock();
-        let out = (|| {
-            let timer = self.timers.peek()?;
-            if !*has_set_now {
-                // Real clock: this heap is the opt-out-of-fake-timers set.
-                *now = Timespec::now(TimespecMockMode::ForceRealTime);
-                *has_set_now = true;
-            }
-            // SAFETY: peek returns a live heap node
-            let next = unsafe { &(*timer).next };
-            if (Timespec {
-                sec: next.sec,
-                nsec: next.nsec,
-            })
-            .greater(now)
-            {
-                return None;
-            }
-            let deleted = self.timers.delete_min().expect("peek succeeded");
-            debug_assert!(core::ptr::eq(deleted, timer));
-            Some(timer)
-        })();
-        self.lock.unlock();
-        out
+        let timer = self.timers.peek()?;
+        if !*has_set_now {
+            // Real clock: this heap is the opt-out-of-fake-timers set.
+            *now = Timespec::now(TimespecMockMode::ForceRealTime);
+            *has_set_now = true;
+        }
+        // SAFETY: peek returns a live heap node
+        let next = unsafe { &(*timer).next };
+        if (Timespec {
+            sec: next.sec,
+            nsec: next.nsec,
+        })
+        .greater(now)
+        {
+            return None;
+        }
+        let deleted = self.timers.delete_min().expect("peek succeeded");
+        debug_assert!(core::ptr::eq(deleted, timer));
+        Some(timer)
     }
 
     /// # Safety
@@ -1033,6 +1058,11 @@ impl All {
         // itself; switch it to `All::drain_timers(core::ptr::addr_of_mut!(
         // (*state).timer), vm)` and change this signature to `this: *mut Self`.
         let this: *mut Self = self;
+
+        let mut wtf_now: Option<Timespec> = None;
+        // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.
+        let _ = unsafe { Self::drain_due_wtf_timers(this, &mut wtf_now, vm) };
+
         let mut now = Timespec { sec: 0, nsec: 0 };
         let mut has_set_now = false;
         loop {
@@ -1142,11 +1172,6 @@ impl All {
     /// still linked in `timers` / `fake_timers.timers` so the in-heap `+1` ref
     /// and the JS pin (`this_value` Strong) are released before the GC sweep.
     ///
-    /// Snapshots the heap under `lock` (cross-thread `WTFTimer__update` from
-    /// the GC scheduler thread can race the DFS otherwise), then cancels each
-    /// node *outside* the lock — `cancel()` re-enters [`All::remove`] which
-    /// re-acquires `lock` (non-recursive `bun_threading::Mutex`).
-    ///
     /// # Safety
     /// JS thread only, with the TLS `RuntimeState` still installed and `vm`
     /// the live per-thread VM. Must run BEFORE JSC teardown
@@ -1162,55 +1187,50 @@ impl All {
         let mut signal_timeouts: Vec<*mut AbortSignalTimeout> = Vec::new();
         let mut stack: Vec<*mut EventLoopTimer> = Vec::new();
 
-        // SAFETY: `this` is the live per-thread `All`; `lock` guards both heap
-        // roots against concurrent `WTFTimer` insert/remove from off-thread
-        // (GC scheduler thread). Lock/unlock is manual (non-RAII Mutex).
-        unsafe { (*this).lock.lock() };
-        // SAFETY: `this` live; both roots are heap roots or null.
-        let roots = unsafe { [(*this).timers.0.root, (*this).fake_timers.timers.0.root] };
-        for root in roots {
-            if !root.is_null() {
-                stack.push(root);
+        {
+            // SAFETY: `this` is the live per-thread `All` (JS thread only).
+            let roots = unsafe { [(*this).timers.0.root, (*this).fake_timers.timers.0.root] };
+            for root in roots {
+                if !root.is_null() {
+                    stack.push(root);
+                }
+            }
+            while let Some(node) = stack.pop() {
+                // SAFETY: intrusive-heap invariant — every node reachable from a
+                // root is a live `EventLoopTimer` while linked. Read-only walk.
+                let (tag, child, next) =
+                    unsafe { ((*node).tag, (*node).heap.child, (*node).heap.next) };
+                if !child.is_null() {
+                    stack.push(child);
+                }
+                if !next.is_null() {
+                    stack.push(next);
+                }
+                match tag {
+                    EventLoopTimerTag::TimeoutObject => {
+                        // SAFETY: tag invariant — `node` IS the `event_loop_timer`
+                        // field of a live `TimeoutObject`.
+                        let parent = unsafe { TimeoutObject::from_timer_ptr(node) };
+                        // SAFETY: `parent` points at the live `TimeoutObject` recovered
+                        // above; `addr_of!` projects the in-bounds `internals` field.
+                        to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
+                    }
+                    EventLoopTimerTag::ImmediateObject => {
+                        // SAFETY: tag invariant — see above.
+                        let parent = unsafe { ImmediateObject::from_timer_ptr(node) };
+                        // SAFETY: `parent` points at the live `ImmediateObject` recovered
+                        // above; `addr_of!` projects the in-bounds `internals` field.
+                        to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
+                    }
+                    EventLoopTimerTag::AbortSignalTimeout => {
+                        // SAFETY: tag invariant — `node` IS the `event_loop_timer`
+                        // field of a live boxed `abort_signal::Timeout`.
+                        signal_timeouts.push(unsafe { AbortSignalTimeout::from_timer_ptr(node) });
+                    }
+                    _ => {}
+                }
             }
         }
-        while let Some(node) = stack.pop() {
-            // SAFETY: intrusive-heap invariant — every node reachable from a
-            // root is a live `EventLoopTimer` while linked. Read-only walk.
-            let (tag, child, next) =
-                unsafe { ((*node).tag, (*node).heap.child, (*node).heap.next) };
-            if !child.is_null() {
-                stack.push(child);
-            }
-            if !next.is_null() {
-                stack.push(next);
-            }
-            match tag {
-                EventLoopTimerTag::TimeoutObject => {
-                    // SAFETY: tag invariant — `node` IS the `event_loop_timer`
-                    // field of a live `TimeoutObject`.
-                    let parent = unsafe { TimeoutObject::from_timer_ptr(node) };
-                    // SAFETY: `parent` points at the live `TimeoutObject` recovered
-                    // above; `addr_of!` projects the in-bounds `internals` field.
-                    to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
-                }
-                EventLoopTimerTag::ImmediateObject => {
-                    // SAFETY: tag invariant — see above.
-                    let parent = unsafe { ImmediateObject::from_timer_ptr(node) };
-                    // SAFETY: `parent` points at the live `ImmediateObject` recovered
-                    // above; `addr_of!` projects the in-bounds `internals` field.
-                    to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
-                }
-                EventLoopTimerTag::AbortSignalTimeout => {
-                    // SAFETY: tag invariant — `node` IS the `event_loop_timer`
-                    // field of a live boxed `abort_signal::Timeout`.
-                    signal_timeouts.push(unsafe { AbortSignalTimeout::from_timer_ptr(node) });
-                }
-                _ => {}
-            }
-        }
-        // SAFETY: paired with the `lock()` above. Must release before the
-        // cancel loop — `cancel()` re-enters `All::remove` which re-locks.
-        unsafe { (*this).lock.unlock() };
 
         for internals in to_cancel {
             // SAFETY: each pointer was collected from the live heap; the

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1187,48 +1187,46 @@ impl All {
         let mut signal_timeouts: Vec<*mut AbortSignalTimeout> = Vec::new();
         let mut stack: Vec<*mut EventLoopTimer> = Vec::new();
 
-        {
-            // SAFETY: `this` is the live per-thread `All` (JS thread only).
-            let roots = unsafe { [(*this).timers.0.root, (*this).fake_timers.timers.0.root] };
-            for root in roots {
-                if !root.is_null() {
-                    stack.push(root);
-                }
+        // SAFETY: `this` is the live per-thread `All` (JS thread only).
+        let roots = unsafe { [(*this).timers.0.root, (*this).fake_timers.timers.0.root] };
+        for root in roots {
+            if !root.is_null() {
+                stack.push(root);
             }
-            while let Some(node) = stack.pop() {
-                // SAFETY: intrusive-heap invariant — every node reachable from a
-                // root is a live `EventLoopTimer` while linked. Read-only walk.
-                let (tag, child, next) =
-                    unsafe { ((*node).tag, (*node).heap.child, (*node).heap.next) };
-                if !child.is_null() {
-                    stack.push(child);
+        }
+        while let Some(node) = stack.pop() {
+            // SAFETY: intrusive-heap invariant — every node reachable from a
+            // root is a live `EventLoopTimer` while linked. Read-only walk.
+            let (tag, child, next) =
+                unsafe { ((*node).tag, (*node).heap.child, (*node).heap.next) };
+            if !child.is_null() {
+                stack.push(child);
+            }
+            if !next.is_null() {
+                stack.push(next);
+            }
+            match tag {
+                EventLoopTimerTag::TimeoutObject => {
+                    // SAFETY: tag invariant — `node` IS the `event_loop_timer`
+                    // field of a live `TimeoutObject`.
+                    let parent = unsafe { TimeoutObject::from_timer_ptr(node) };
+                    // SAFETY: `parent` points at the live `TimeoutObject` recovered
+                    // above; `addr_of!` projects the in-bounds `internals` field.
+                    to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
                 }
-                if !next.is_null() {
-                    stack.push(next);
+                EventLoopTimerTag::ImmediateObject => {
+                    // SAFETY: tag invariant — see above.
+                    let parent = unsafe { ImmediateObject::from_timer_ptr(node) };
+                    // SAFETY: `parent` points at the live `ImmediateObject` recovered
+                    // above; `addr_of!` projects the in-bounds `internals` field.
+                    to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
                 }
-                match tag {
-                    EventLoopTimerTag::TimeoutObject => {
-                        // SAFETY: tag invariant — `node` IS the `event_loop_timer`
-                        // field of a live `TimeoutObject`.
-                        let parent = unsafe { TimeoutObject::from_timer_ptr(node) };
-                        // SAFETY: `parent` points at the live `TimeoutObject` recovered
-                        // above; `addr_of!` projects the in-bounds `internals` field.
-                        to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
-                    }
-                    EventLoopTimerTag::ImmediateObject => {
-                        // SAFETY: tag invariant — see above.
-                        let parent = unsafe { ImmediateObject::from_timer_ptr(node) };
-                        // SAFETY: `parent` points at the live `ImmediateObject` recovered
-                        // above; `addr_of!` projects the in-bounds `internals` field.
-                        to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
-                    }
-                    EventLoopTimerTag::AbortSignalTimeout => {
-                        // SAFETY: tag invariant — `node` IS the `event_loop_timer`
-                        // field of a live boxed `abort_signal::Timeout`.
-                        signal_timeouts.push(unsafe { AbortSignalTimeout::from_timer_ptr(node) });
-                    }
-                    _ => {}
+                EventLoopTimerTag::AbortSignalTimeout => {
+                    // SAFETY: tag invariant — `node` IS the `event_loop_timer`
+                    // field of a live boxed `abort_signal::Timeout`.
+                    signal_timeouts.push(unsafe { AbortSignalTimeout::from_timer_ptr(node) });
                 }
+                _ => {}
             }
         }
 

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -147,8 +147,9 @@ impl TimerObjectInternals {
     /// `cancel()` skips its own `remove`/`deref` because `state` is already
     /// `CANCELLED`, which is why the explicit `deref` follows.
     ///
-    /// `vm` is the live per-thread VM; `All.lock` must NOT be held (the
-    /// `set_enable_keeping_event_loop_alive` write reaches `&mut All`).
+    /// `vm` is the live per-thread VM; no borrow of `All` may be live across
+    /// this call (`cancel()` reaches `All::remove`, which forms its own
+    /// `&mut All`).
     pub(crate) fn release_heap_pin(this: core::ptr::NonNull<Self>, vm: *mut VirtualMachine) {
         // SAFETY: caller guarantees the parent box is live (refcount ≥ 1).
         let internals = unsafe { this.as_ref() };
@@ -290,8 +291,7 @@ impl TimerObjectInternals {
             flags: {
                 let mut f = Flags::default();
                 f.set_kind(kind);
-                // SAFETY: `state` is the boxed per-thread `RuntimeState`;
-                // single-threaded JS heap so no concurrent `&mut` to `.timer`.
+                // SAFETY: `state` is the boxed per-thread `RuntimeState`.
                 f.set_epoch(unsafe { (*state).timer.epoch });
                 Cell::new(f)
             },

--- a/test/js/web/timers/timer-heap-atomics-fixture.ts
+++ b/test/js/web/timers/timer-heap-atomics-fixture.ts
@@ -1,0 +1,68 @@
+declare var self: Worker;
+
+const DURATION_MS = Number(process.argv[2] ?? 3000);
+const WORKERS = Number(process.argv[3] ?? 3);
+
+function noop() {}
+
+if (!Bun.isMainThread) {
+  self.onmessage = (e: MessageEvent) => {
+    const { sab, durationMs } = e.data as { sab: SharedArrayBuffer; durationMs: number };
+    const i32 = new Int32Array(sab);
+    const deadline = Date.now() + durationMs;
+
+    function pump() {
+      for (let i = 0; i < 48; i++) {
+        const w = Atomics.waitAsync(i32, 0, 0, 1 + (i % 7));
+        if (w.async) w.value.then(noop);
+      }
+      for (let i = 0; i < 8; i++) setTimeout(noop, i % 4);
+      Atomics.notify(i32, 0, 8);
+      if (Date.now() < deadline) {
+        setTimeout(pump, 0);
+      } else {
+        postMessage("done");
+      }
+    }
+    pump();
+  };
+} else {
+  const sab = new SharedArrayBuffer(64);
+  const i32 = new Int32Array(sab);
+  const workers: Worker[] = [];
+  let done = 0;
+
+  for (let w = 0; w < WORKERS; w++) {
+    const worker = new Worker(import.meta.url);
+    worker.onmessage = () => {
+      if (++done === WORKERS) {
+        for (const other of workers) other.terminate();
+        console.log("OK");
+        process.exit(0);
+      }
+    };
+    worker.onerror = (e: ErrorEvent) => {
+      console.error("worker error:", e.message);
+      process.exit(3);
+    };
+    worker.postMessage({ sab, durationMs: DURATION_MS });
+    workers.push(worker);
+  }
+
+  const deadline = Date.now() + DURATION_MS + 1000;
+  function hammer() {
+    for (let i = 0; i < 24; i++) {
+      const w = Atomics.waitAsync(i32, 0, 0, 1 + (i % 5));
+      if (w.async) w.value.then(noop);
+    }
+    const spinUntil = Date.now() + 2;
+    while (Date.now() < spinUntil) {
+      Atomics.notify(i32, 0, 1);
+      Atomics.notify(i32, 0, 1);
+      Atomics.notify(i32, 0, 2);
+    }
+    for (let i = 0; i < 4; i++) setTimeout(noop, i % 3);
+    if (Date.now() < deadline && done < WORKERS) setTimeout(hammer, 0);
+  }
+  hammer();
+}

--- a/test/js/web/timers/timer-heap-gc-fixture.ts
+++ b/test/js/web/timers/timer-heap-gc-fixture.ts
@@ -1,0 +1,17 @@
+const TICKS = 30;
+
+let garbage: unknown[] = [];
+let ticks = 0;
+
+function tick() {
+  garbage = [];
+  for (let i = 0; i < 6000; i++) garbage.push({ i, s: "x" + (i & 255) });
+  Bun.gc(true);
+  if (++ticks < TICKS) {
+    setTimeout(tick, 16);
+  } else {
+    console.log("ok " + ticks);
+  }
+}
+
+tick();

--- a/test/js/web/timers/timer-heap-race.test.ts
+++ b/test/js/web/timers/timer-heap-race.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+import path from "node:path";
+
+async function runFixture(fixture: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, fixture)],
+    env: {
+      ...bunEnv,
+      // These make the debug build an order of magnitude slower; the fixtures need real wall time.
+      BUN_JSC_validateExceptionChecks: undefined,
+      BUN_JSC_dumpSimulatedThrows: undefined,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  return { stdout, stderr, signal: proc.signalCode, exitCode };
+}
+
+it("timer heap survives cross-thread Atomics.waitAsync timeout cancellation", async () => {
+  expect(await runFixture("timer-heap-atomics-fixture.ts")).toEqual({
+    stdout: "OK\n",
+    stderr: expect.any(String),
+    signal: null,
+    exitCode: 0,
+  });
+}, 20_000);
+
+it.skipIf(!isDebug)(
+  "timer heap stays consistent while GC re-arms the RunLoop timer",
+  async () => {
+    expect(await runFixture("timer-heap-gc-fixture.ts")).toEqual({
+      stdout: "ok 30\n",
+      stderr: expect.any(String),
+      signal: null,
+      exitCode: 0,
+    });
+  },
+  20_000,
+);


### PR DESCRIPTION
`WTF::RunLoop::TimerBase` (JSC's GC scheduler timers, and the timer behind an `Atomics.waitAsync` timeout) is started and stopped from threads other than the one that owns its run loop: `Atomics.notify` on thread B re-arms thread A's `JSRunLoopTimer` and cancels thread A's `waitAsync` timeout, and `~ArrayBufferContents` does the same from whichever thread drops the last `SharedArrayBuffer` reference.

Those timers shared one pairing heap (`All.timers`) with `setTimeout` and every other same-thread timer. `All.lock` existed only because of them, and `get_timeout`'s pre-poll pass peeked and popped that shared heap without taking it, racing the locked `Intrusive::remove` from the other threads. In a debug build that trips

```
assertion failed: self.root == v    (src/io/heap.rs:165, Intrusive::remove)
```

and in a release build the check compiles out, so `remove` walks the corrupted links silently.

### Fix

Rather than locking the shared heap, take the one cross-thread client out of it:

- `All.wtf_timers` (a `Guarded<TimerHeap>`) holds only `WTFTimer` nodes, reached through `All::wtf_arm` and `All::wtf_disarm` from any thread.
- `All.lock` is deleted. `insert`, `remove`, `update`, the regular heap, the fake timers, and the epoch are single threaded again, asserted with a `debug_assert!` on the owning thread id, so `setTimeout` no longer takes a mutex per call. The fake-timer lock helper and its `assert_locked` machinery existed only because of that shared lock, so they are deleted too.
- `get_timeout` no longer pops and fires inline. It drains the due `WTFTimer`s through their own mutex (dropping the guard across each `fire`, which can synchronously re-enter it), then returns `min(wtf, regular, quic)`.
- `drain_timers` drains the `WTFTimer` heap first, preserving both existing firing paths: the pre-poll one only runs when the uws loop is active, and on Windows `drain_timers` runs from `on_uv_timer`.
- `WTFTimer.lock` (the per-instance mutex) is deleted; `wtf_timers` owns everything it guarded, and `update` never took it anyway.
- `ensure_uv_timer` folds both heaps into the libuv deadline and is now only reachable from the owning thread, which also removes the cross-thread TLS hazard it had.

`WTFTimer` never enters the fake-timer heap. Its tag already returned `false` from `allow_fake_timers()`, but it can no longer reach that branch at all.

### Reproducer

`test/js/web/timers/timer-heap-race.test.ts` with `timer-heap-atomics-fixture.ts`: four threads each arm batches of short `Atomics.waitAsync` timeouts while the others `Atomics.notify` them, alongside `setTimeout` churn. Under a debug build of `main` this aborts within a few seconds with the assertion above, or with an ASan `heap-use-after-free` in `Intrusive::remove` at `src/io/heap.rs:178`. With this change it runs to completion.

A second fixture drives `Bun.gc(true)` in a `setTimeout` loop so the per-VM `JSRunLoopTimer` is re-armed and popped repeatedly on the owning thread.

### Rebased onto #33359, #33623, #33896, #34009

Squashed to one commit and rebased; the earlier commits in the branch history were the two rejected approaches (locking `get_timeout`, then `Guarded<Heaps>`).

One conflict had semantic content: #33896 switched the regular heap's clock reads in `get_timeout` and `next` from `AllowMockedTime` to `ForceRealTime` because every node that lands there is armed in real-time units. `WTFTimer` is one of those tags, and its new separate heap is the same case, so the `ForceRealTime` change is also applied in `drain_due_wtf_timers`. The #33359 hunk (skip `uv_timer.start` when already due sooner) and the #33623 hunks (`set_wall_ms`, `clear_wall`, `Bun__FakeTimers__setSystemTime`) applied without semantic interaction.

#34009 added a `now_out: &mut Option<Timespec>` out-parameter to `get_timeout` so its caller can reuse the monotonic clock read; the lazy `maybe_now` in the rewritten body becomes a reborrow of that out-parameter, and `drain_due_wtf_timers` fills it the same way the old loop did.

### Verification

```
bun bd test test/js/web/timers/timer-heap-race.test.ts    # 2 pass
bun bd test test/js/bun/test/test-timers.test.ts          # #33896's suite, all pass
bun bd test test/js/bun/test/fake-timers/fake-timers.test.ts   # #33623's suite, all pass
```

Three `setTimeout doesn't leak when X is called inside its own callback` tests in `test/js/web/timers/` fail under debug + ASan on this machine, and did so identically with an unmodified `src/` at the previous merge base: their fixtures widen the RSS threshold only when `process.execPath.includes("bun-asan")`, which is never true for the `bun-debug` binary name.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 11 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/timers/timer-heap-race.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f0fa43421)

test/js/web/timers/timer-heap-race.test.ts:
19 | 
20 |   return { stdout, stderr, signal: proc.signalCode, exitCode };
21 | }
22 | 
23 | it("timer heap survives cross-thread Atomics.waitAsync timeout cancellation", async () => {
24 |   expect(await runFixture("timer-heap-atomics-fixture.ts")).toEqual({
                                                                 ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "signal": null,
-   "stderr": Any<String>,
+   "exitCode": 134,
+   "signal": "SIGABRT",
+   "stderr": 
+ "============================================================
+ Bun Debug v1.4.0 (f0fa43421) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx51
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/timers/timer-heap-race.test.ts:
(pass) timer heap survives cross-thread Atomics.waitAsync timeout cancellation [3036.31ms]
(skip) timer heap stays consistent while GC re-arms the RunLoop timer

 1 pass
 1 skip
 0 fail
 1 expect() calls
Ran 2 tests across 1 file. [3.21s]
__F:0:S:1
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/timers/timer-heap-race.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f0fa43421)

test/js/web/timers/timer-heap-race.test.ts:
(pass) timer heap survives cross-thread Atomics.waitAsync timeout cancellation [3787.70ms]
(pass) timer heap stays consistent while GC re-arms the RunLoop timer [2478.37ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [8.23s]
__F:0:S:0

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
error: could not download file from 'https://static.rust-lang.org/dist/2026-05-06/channel-rust-nightly.toml' to '/root/.rustup/tmp/pg_7uy9hcvyywudd_file.toml': error downloading file: error sending request for url (https://static.rust-lang.org/dist/2026-05-06/channel-rust-nightly.toml): client error (Connect): tls handshake eof
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f0fa43421e
  features     (none)

22 deps, 106 codegen, 1168 objects in 667ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [10.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/hw_exports.rs                        |   4 +-
 src/runtime/jsc_hooks.rs                         |  12 +-
 src/runtime/test_runner/timers/FakeTimers.rs     | 183 ++--------
 src/runtime/timer/Timer.rs                       |   6 +-
 src/runtime/timer/WTFTimer.rs                    |  58 +---
 src/runtime/timer/mod.rs                         | 414 ++++++++++++-----------
 src/runtime/timer/timer_object_internals.rs      |   8 +-
 test/js/web/timers/timer-heap-atomics-fixture.ts |  68 ++++
 test/js/web/timers/timer-heap-gc-fixture.ts      |  17 +
 test/js/web/timers/timer-heap-race.test.ts       |  43 +++
 10 files changed, 411 insertions(+), 402 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/runtime/hw_exports.rs                             2      3      0
src/runtime/jsc_hooks.rs                              2      2      0
src/runtime/test_runner/timers/FakeTimers.rs          9     16      0
src/runtime/timer/Timer.rs                            1      1      0
src/runtime/timer/WTFTimer.rs                         3     13      0
src/runtime/timer/mod.rs                             24     59      0
src/runtime/timer/timer_object_internals.rs           4      3      0
test/js/web/timers/timer-heap-atomics-fixture.ts      2      4      0
test/js/web/timers/timer-heap-gc-fixture.ts           2      3      0
test/js/web/timers/timer-heap-race.test.ts            3      6      0
```

</details>

<!-- robobun:evidence:end -->
