### PR TITLE
Bun.serve: invoke error() and respond 500 when fetch returns a non-Response value

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -742,6 +742,12 @@ where
             // is always true when `server` is None, so there is nothing to render.
             return;
         };
+        // Mirror `on_response`: a returned `Error` instance reaches `error()`
+        // as itself, not wrapped, so the synchronous and asynchronous paths
+        // hand the handler the same object.
+        if let Some(err) = value.to_error() {
+            return self.run_error_handler(err);
+        }
         // server is a BACKREF — valid while this RequestContext is alive
         let global_this: &JSGlobalObject = server.global_this();
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -690,99 +690,62 @@ where
     }
 
     fn render_missing_invalid_response(&mut self, value: JSValue) {
-        // `undefined`/`null` mean the handler produced no response: keep the
-        // diagnostic plus the 204 (production) / welcome page (development).
-        if value.is_empty_or_undefined_or_null() {
-            if let Some(server) = self.server {
-                // server is a BACKREF — valid while this RequestContext is alive
-                let global_this: &JSGlobalObject = server.global_this();
-
-                Output::enable_buffering();
-                let writer = Output::error_writer();
-
-                if !value.is_empty() && !global_this.has_exception() {
-                    let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
-                    formatter.quote_strings = true;
-                    bun_core::err_generic!(
-                        "Expected a Response object, but received '{}'",
-                        jsc::console_object::formatter::ZigFormatter::new(&mut formatter, value),
-                    );
-                    // `formatter` drops here.
-                } else {
-                    bun_core::err_generic!("Expected a Response object");
-                }
-
-                Output::flush();
-                if !global_this.has_exception() {
-                    jsc::ConsoleObject::write_trace(writer, global_this);
-                }
-                Output::flush();
-            }
-            // The formatter and `write_trace` above re-enter JS (getters, proxy
-            // traps, Error.prepareStackTrace), which can synchronously abort,
-            // end, or upgrade this request (e.g. AbortController.abort()
-            // inside a getter).
-            // We hold `&mut self` for the whole call, matching the rest of this
-            // promise-resolve path (`on_resolve` → `handle_resolve` also re-enter
-            // JS through `&mut`).
-            // The `RequestContextRef` guard taken in `on_resolve` keeps the
-            // allocation alive across the re-entry; re-check the request state so
-            // we never render onto a response that was ended underneath us.
-            if self.is_aborted_or_ended() || self.did_upgrade_web_socket() {
-                return;
-            }
-            return self.render_missing();
-        }
-
-        // Anything else is an invalid return value, not a missing one: surface
-        // it through `error()` as a 500, the same as a thrown error or a
-        // returned Response whose body was already used.
         let Some(server) = self.server else {
             // The server was stopped while the handler ran; `is_aborted_or_ended()`
-            // is always true when `server` is None, so there is nothing to render.
+            // is already true, so there is nothing left to render onto.
             return;
         };
-        // Mirror `on_response`: a returned `Error` instance reaches `error()`
-        // as itself, not wrapped, so the synchronous and asynchronous paths
-        // hand the handler the same object.
+        // A returned `Error` instance reaches `error()` as itself, not wrapped,
+        // mirroring the synchronous path in `on_response`.
         if let Some(err) = value.to_error() {
             return self.run_error_handler(err);
         }
         // server is a BACKREF — valid while this RequestContext is alive
         let global_this: &JSGlobalObject = server.global_this();
 
-        let js_err = if value.get_class_info_name().unwrap_or(b"") == b"Response" {
-            global_this
-                .err(
-                    jsc::ErrorCode::INVALID_RETURN_VALUE,
-                    format_args!(
-                        "Expected a native Response object, but received a polyfilled Response object. Bun.serve() only supports native Response objects."
-                    ),
-                )
-                .to_js()
-        } else if !global_this.has_exception() {
+        // Formatting `value` re-enters JS (getters, proxy traps); the
+        // `RequestContextRef` taken in `on_resolve` keeps `self` alive, and
+        // the request state is re-validated below before rendering onto it.
+        let message: String = if value.get_class_info_name().unwrap_or(b"") == b"Response" {
+            "Expected a native Response object, but received a polyfilled Response object. Bun.serve() only supports native Response objects.".into()
+        } else if !value.is_empty() && !global_this.has_exception() {
             let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
             formatter.quote_strings = true;
-            global_this
-                .err(
-                    jsc::ErrorCode::INVALID_RETURN_VALUE,
-                    format_args!(
-                        "Expected a Response object, but received '{}'",
-                        jsc::console_object::formatter::ZigFormatter::new(&mut formatter, value)
-                    ),
-                )
-                .to_js()
+            format!(
+                "Expected a Response object, but received '{}'",
+                jsc::console_object::formatter::ZigFormatter::new(&mut formatter, value)
+            )
         } else {
-            global_this
-                .err(
-                    jsc::ErrorCode::INVALID_RETURN_VALUE,
-                    format_args!("Expected a Response object"),
-                )
-                .to_js()
+            "Expected a Response object".into()
         };
-        // Formatting `value` re-enters JS (getters, proxy traps, toString) and
-        // can synchronously abort, end, or upgrade this request; re-check
-        // before rendering anything onto it.
+
+        // `undefined`/`null` mean the handler produced no response: log the
+        // diagnostic and render the 204 (production) / welcome page (development).
+        if value.is_empty_or_undefined_or_null() {
+            Output::enable_buffering();
+            let writer = Output::error_writer();
+            bun_core::err_generic!("{}", message);
+            Output::flush();
+            if !global_this.has_exception() {
+                // write_trace re-enters JS through `Error.prepareStackTrace`.
+                jsc::ConsoleObject::write_trace(writer, global_this);
+            }
+            Output::flush();
+            if self.is_aborted_or_ended() || self.did_upgrade_web_socket() {
+                return;
+            }
+            return self.render_missing();
+        }
+
+        // Anything else is an invalid return value: report it through `error()`
+        // as a 500, the same as a thrown error or a returned Response whose
+        // body was already used.
+        let js_err = global_this
+            .err(
+                jsc::ErrorCode::INVALID_RETURN_VALUE,
+                format_args!("{}", message),
+            )
+            .to_js();
         if self.is_aborted_or_ended() || self.did_upgrade_web_socket() {
             return;
         }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -719,15 +719,16 @@ where
                 Output::flush();
             }
             // The formatter and `write_trace` above re-enter JS (getters, proxy
-            // traps, Error.prepareStackTrace), which can synchronously abort or
-            // end this request (e.g. AbortController.abort() inside a getter).
+            // traps, Error.prepareStackTrace), which can synchronously abort,
+            // end, or upgrade this request (e.g. AbortController.abort()
+            // inside a getter).
             // We hold `&mut self` for the whole call, matching the rest of this
             // promise-resolve path (`on_resolve` → `handle_resolve` also re-enter
             // JS through `&mut`).
             // The `RequestContextRef` guard taken in `on_resolve` keeps the
             // allocation alive across the re-entry; re-check the request state so
             // we never render onto a response that was ended underneath us.
-            if self.is_aborted_or_ended() {
+            if self.is_aborted_or_ended() || self.did_upgrade_web_socket() {
                 return;
             }
             return self.render_missing();
@@ -737,12 +738,9 @@ where
         // it through `error()` as a 500, the same as a thrown error or a
         // returned Response whose body was already used.
         let Some(server) = self.server else {
-            // The server was stopped while the handler ran; there is no
-            // `error()` handler left to invoke.
-            if self.is_aborted_or_ended() {
-                return;
-            }
-            return self.render_missing();
+            // The server was stopped while the handler ran; `is_aborted_or_ended()`
+            // is always true when `server` is None, so there is nothing to render.
+            return;
         };
         // server is a BACKREF — valid while this RequestContext is alive
         let global_this: &JSGlobalObject = server.global_this();
@@ -777,9 +775,9 @@ where
                 .to_js()
         };
         // Formatting `value` re-enters JS (getters, proxy traps, toString) and
-        // can synchronously abort or end this request; re-check before
-        // rendering anything onto it.
-        if self.is_aborted_or_ended() {
+        // can synchronously abort, end, or upgrade this request; re-check
+        // before rendering anything onto it.
+        if self.is_aborted_or_ended() || self.did_upgrade_web_socket() {
             return;
         }
         self.run_error_handler(js_err);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -690,50 +690,99 @@ where
     }
 
     fn render_missing_invalid_response(&mut self, value: JSValue) {
-        let class_name = value.get_class_info_name().unwrap_or(b"");
+        // `undefined`/`null` mean the handler produced no response: keep the
+        // diagnostic plus the 204 (production) / welcome page (development).
+        if value.is_empty_or_undefined_or_null() {
+            if let Some(server) = self.server {
+                // server is a BACKREF — valid while this RequestContext is alive
+                let global_this: &JSGlobalObject = server.global_this();
 
-        if let Some(server) = self.server {
-            // server is a BACKREF — valid while this RequestContext is alive
-            let global_this: &JSGlobalObject = server.global_this();
+                Output::enable_buffering();
+                let writer = Output::error_writer();
 
-            Output::enable_buffering();
-            let writer = Output::error_writer();
+                if !value.is_empty() && !global_this.has_exception() {
+                    let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
+                    formatter.quote_strings = true;
+                    bun_core::err_generic!(
+                        "Expected a Response object, but received '{}'",
+                        jsc::console_object::formatter::ZigFormatter::new(&mut formatter, value),
+                    );
+                    // `formatter` drops here.
+                } else {
+                    bun_core::err_generic!("Expected a Response object");
+                }
 
-            if class_name == b"Response" {
-                bun_core::err_generic!(
-                    "Expected a native Response object, but received a polyfilled Response object. Bun.serve() only supports native Response objects.",
-                );
-            } else if !value.is_empty() && !global_this.has_exception() {
-                let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
-                formatter.quote_strings = true;
-                bun_core::err_generic!(
-                    "Expected a Response object, but received '{}'",
-                    jsc::console_object::formatter::ZigFormatter::new(&mut formatter, value),
-                );
-                // `formatter` drops here.
-            } else {
-                bun_core::err_generic!("Expected a Response object");
+                Output::flush();
+                if !global_this.has_exception() {
+                    jsc::ConsoleObject::write_trace(writer, global_this);
+                }
+                Output::flush();
             }
-
-            Output::flush();
-            if !global_this.has_exception() {
-                jsc::ConsoleObject::write_trace(writer, global_this);
+            // The formatter and `write_trace` above re-enter JS (getters, proxy
+            // traps, Error.prepareStackTrace), which can synchronously abort or
+            // end this request (e.g. AbortController.abort() inside a getter).
+            // We hold `&mut self` for the whole call, matching the rest of this
+            // promise-resolve path (`on_resolve` → `handle_resolve` also re-enter
+            // JS through `&mut`).
+            // The `RequestContextRef` guard taken in `on_resolve` keeps the
+            // allocation alive across the re-entry; re-check the request state so
+            // we never render onto a response that was ended underneath us.
+            if self.is_aborted_or_ended() {
+                return;
             }
-            Output::flush();
+            return self.render_missing();
         }
-        // The formatter and `write_trace` above re-enter JS (getters, proxy
-        // traps, Error.prepareStackTrace), which can synchronously abort or
-        // end this request (e.g. AbortController.abort() inside a getter).
-        // We hold `&mut self` for the whole call, matching the rest of this
-        // promise-resolve path (`on_resolve` → `handle_resolve` also re-enter
-        // JS through `&mut`).
-        // The `RequestContextRef` guard taken in `on_resolve` keeps the
-        // allocation alive across the re-entry; re-check the request state so
-        // we never render onto a response that was ended underneath us.
+
+        // Anything else is an invalid return value, not a missing one: surface
+        // it through `error()` as a 500, the same as a thrown error or a
+        // returned Response whose body was already used.
+        let Some(server) = self.server else {
+            // The server was stopped while the handler ran; there is no
+            // `error()` handler left to invoke.
+            if self.is_aborted_or_ended() {
+                return;
+            }
+            return self.render_missing();
+        };
+        // server is a BACKREF — valid while this RequestContext is alive
+        let global_this: &JSGlobalObject = server.global_this();
+
+        let js_err = if value.get_class_info_name().unwrap_or(b"") == b"Response" {
+            global_this
+                .err(
+                    jsc::ErrorCode::INVALID_RETURN_VALUE,
+                    format_args!(
+                        "Expected a native Response object, but received a polyfilled Response object. Bun.serve() only supports native Response objects."
+                    ),
+                )
+                .to_js()
+        } else if !global_this.has_exception() {
+            let mut formatter = jsc::ConsoleObject::Formatter::new(global_this);
+            formatter.quote_strings = true;
+            global_this
+                .err(
+                    jsc::ErrorCode::INVALID_RETURN_VALUE,
+                    format_args!(
+                        "Expected a Response object, but received '{}'",
+                        jsc::console_object::formatter::ZigFormatter::new(&mut formatter, value)
+                    ),
+                )
+                .to_js()
+        } else {
+            global_this
+                .err(
+                    jsc::ErrorCode::INVALID_RETURN_VALUE,
+                    format_args!("Expected a Response object"),
+                )
+                .to_js()
+        };
+        // Formatting `value` re-enters JS (getters, proxy traps, toString) and
+        // can synchronously abort or end this request; re-check before
+        // rendering anything onto it.
         if self.is_aborted_or_ended() {
             return;
         }
-        self.render_missing();
+        self.run_error_handler(js_err);
     }
 
     fn handle_resolve(ctx: &mut Self, value: JSValue) {

--- a/test/js/bun/http/serve-invalid-return.test.ts
+++ b/test/js/bun/http/serve-invalid-return.test.ts
@@ -1,0 +1,124 @@
+import { serve } from "bun";
+import { describe, expect, it, jest } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A fetch handler that returns a truthy value that is not a `Response` (a
+// plain object, a string, a number, ...) must invoke the error handler and
+// respond 500, the same as a thrown error, instead of silently sending a
+// cacheable 2xx with an empty body.
+describe("returning a non-Response value from fetch", () => {
+  const invalidReturnError = {
+    code: "ERR_INVALID_RETURN_VALUE",
+    name: "TypeError",
+  };
+
+  const invalidValues = {
+    "plain object": () => ({ forgot: "new Response" }),
+    "string": () => "plain string",
+    "number": () => 42,
+    "symbol": () => Symbol("invalid response type"),
+  };
+
+  it.each(Object.keys(invalidValues) as (keyof typeof invalidValues)[])(
+    "returning a %s calls the error handler and responds with its Response",
+    async kind => {
+      const make = invalidValues[kind];
+      // The same value goes down three distinct native paths: a synchronous
+      // return, an already-fulfilled promise, and a promise resolved later.
+      const handlers = {
+        "sync": () => make(),
+        "fulfilled": () => Promise.resolve(make()),
+        "pending": async () => make(),
+      };
+
+      const results: unknown[] = [];
+      for (const [path, fetchImpl] of Object.entries(handlers)) {
+        let error: unknown = null;
+        await using server = serve({
+          port: 0,
+          // @ts-ignore the invalid return value is the point
+          fetch: fetchImpl,
+          error(err: any) {
+            error = { code: err.code, name: err.constructor.name };
+            return new Response("handled", { status: 500 });
+          },
+        });
+        const response = await fetch(server.url);
+        results.push({ path, status: response.status, body: await response.text(), error });
+      }
+
+      const handled = { status: 500, body: "handled", error: invalidReturnError };
+      expect(results).toEqual([
+        { path: "sync", ...handled },
+        { path: "fulfilled", ...handled },
+        { path: "pending", ...handled },
+      ]);
+    },
+  );
+
+  it("the error names the value that was returned", async () => {
+    let error: any;
+    await using server = serve({
+      port: 0,
+      // @ts-ignore
+      fetch: () => 42,
+      error(err: any) {
+        error = err;
+        return new Response("handled", { status: 500 });
+      },
+    });
+    await (await fetch(server.url)).text();
+    expect(error.message).toBe("Expected a Response object, but received '42'");
+  });
+
+  // `undefined` and `null` mean the handler produced no response; that is not
+  // an error, and production still renders an empty 204.
+  it.each([
+    ["undefined", () => undefined],
+    ["null", () => null],
+    ["undefined from an async handler", async () => undefined],
+  ])("returning %s does not call the error handler", async (_name, fetchImpl) => {
+    const error = jest.fn();
+    await using server = serve({
+      port: 0,
+      development: false,
+      // @ts-ignore
+      fetch: fetchImpl,
+      error,
+    });
+
+    const response = await fetch(server.url);
+    expect(await response.text()).toBe("");
+    expect(response.status).toBe(204);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("without an error handler, logs the error and responds with 500", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const server = Bun.serve({
+          port: 0,
+          development: false,
+          fetch() {
+            return { forgot: "new Response" };
+          },
+        });
+        const res = await fetch(server.url);
+        console.log(res.status, JSON.stringify(await res.text()));
+        server.stop(true);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe('500 "Something went wrong!"\n');
+    expect(stderr).toContain("Expected a Response object, but received");
+    // The invalid return is reported like any other unhandled error thrown
+    // from the fetch handler.
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/js/bun/http/serve-invalid-return.test.ts
+++ b/test/js/bun/http/serve-invalid-return.test.ts
@@ -74,6 +74,47 @@ describe("returning a non-Response value from fetch", () => {
     expect(error.message).toBe("Expected a Response object, but received '42'");
   });
 
+  // A returned `Error` instance reaches `error()` as itself on every path,
+  // the same as the synchronous return already did, instead of being
+  // wrapped in an ERR_INVALID_RETURN_VALUE TypeError.
+  it("returning an Error instance passes it to the error handler unwrapped", async () => {
+    class ReturnedError extends Error {
+      code = "RETURNED_ERROR";
+    }
+    const handlers = {
+      "sync": () => new ReturnedError("boom"),
+      "fulfilled": () => Promise.resolve(new ReturnedError("boom")),
+      "deferred": () => new Promise(resolve => setImmediate(() => resolve(new ReturnedError("boom")))),
+    };
+
+    const results: unknown[] = [];
+    for (const [path, fetchImpl] of Object.entries(handlers)) {
+      let error: unknown = null;
+      await using server = serve({
+        port: 0,
+        // @ts-ignore the invalid return value is the point
+        fetch: fetchImpl,
+        error(err: any) {
+          error = { code: err.code, name: err.constructor.name, message: err.message };
+          return new Response("handled", { status: 500 });
+        },
+      });
+      const response = await fetch(server.url);
+      results.push({ path, status: response.status, body: await response.text(), error });
+    }
+
+    const handled = {
+      status: 500,
+      body: "handled",
+      error: { code: "RETURNED_ERROR", name: "ReturnedError", message: "boom" },
+    };
+    expect(results).toEqual([
+      { path: "sync", ...handled },
+      { path: "fulfilled", ...handled },
+      { path: "deferred", ...handled },
+    ]);
+  });
+
   // `undefined` and `null` mean the handler produced no response; that is not
   // an error, and production still renders an empty 204.
   it.each([

--- a/test/js/bun/http/serve-invalid-return.test.ts
+++ b/test/js/bun/http/serve-invalid-return.test.ts
@@ -28,7 +28,10 @@ describe("returning a non-Response value from fetch", () => {
       const handlers = {
         "sync": () => make(),
         "fulfilled": () => Promise.resolve(make()),
-        "pending": async () => make(),
+        // The server drains microtasks before unwrapping the returned promise,
+        // so a microtask-resolved promise collapses into "fulfilled". Only a
+        // macrotask keeps it pending long enough to reach the deferred path.
+        "deferred": () => new Promise(resolve => setImmediate(() => resolve(make()))),
       };
 
       const results: unknown[] = [];
@@ -51,7 +54,7 @@ describe("returning a non-Response value from fetch", () => {
       expect(results).toEqual([
         { path: "sync", ...handled },
         { path: "fulfilled", ...handled },
-        { path: "pending", ...handled },
+        { path: "deferred", ...handled },
       ]);
     },
   );

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -355,13 +355,14 @@ describe.todoIf(isBroken && isIntelMacOS)(
   });
 });
 
-it("should display a welcome message when the response value type is incorrect", async () => {
+// A truthy non-Response return now goes through `error()` as a 500 (covered
+// in serve-invalid-return.test.ts). The welcome page is only for handlers
+// that produce no response at all.
+it("should display a welcome message when the fetch handler returns no Response", async () => {
   await runTest(
     {
       // @ts-ignore
-      fetch(req) {
-        return Symbol("invalid response type");
-      },
+      fetch(req) {},
     },
     async server => {
       const response = await fetch(server.url.origin);
@@ -371,9 +372,10 @@ it("should display a welcome message when the response value type is incorrect",
   );
 });
 
-// The async handler path already reported non-Response returns to stderr; the
-// synchronous path must emit the same diagnostic instead of staying silent.
-it("logs the invalid-response diagnostic when a synchronous fetch handler returns a non-Response value", async () => {
+// Without an `error` handler, a non-Response return is reported to stderr and
+// the client receives a 500, the same as a thrown error, on both the
+// synchronous and asynchronous paths.
+it("logs the invalid-response diagnostic and responds 500 when a fetch handler returns a non-Response value", async () => {
   const script = `
     const statuses = [];
     async function hit(fetchImpl) {
@@ -399,15 +401,15 @@ it("logs the invalid-response diagnostic when a synchronous fetch handler return
 
   const diagnostics = stderr.match(/Expected a Response object, but received/g) ?? [];
   expect({
-    // Returning a non-Response still renders 204 in production mode; only the
-    // missing stderr diagnostic on the synchronous path changes.
     statuses: JSON.parse(stdout.trim()),
     diagnosticCount: diagnostics.length,
     exitCode,
   }).toEqual({
-    statuses: [204, 204, 204, 204],
+    statuses: [500, 500, 500, 500],
     diagnosticCount: 4,
-    exitCode: 0,
+    // The invalid return is reported like any other unhandled error thrown
+    // from the fetch handler.
+    exitCode: 1,
   });
   expect(stderr).toContain(`received '"plain string"'`);
   expect(stderr).toContain("received '42'");


### PR DESCRIPTION
### Summary

A `fetch` handler that returns a truthy non-`Response` value (a plain object, a string, a number, ...) sends the client an empty, cacheable 2xx: 204 in production, 200 plus the welcome page in development. `error()` is never invoked.

```js
Bun.serve({
  development: false,
  fetch(req) {
    return { ok: true }; // forgot `new Response(JSON.stringify(...))`
  },
  error(err) {
    // never called
  },
});
// client: HTTP 204, empty body
```

That is a silent failure: an intermediary cache stores the empty 2xx, and an `error()` handler, if configured, never hears about it. #33120 added the missing stderr diagnostic but deliberately left the response alone. Since then #33118 made the adjacent case, returning a `Response` whose body is already used, invoke `error()` and respond 500, so the two now disagree:

| handler | status | `error()` |
| --- | --- | --- |
| `fetch() { throw new Error(...) }` | 500 | invoked |
| `fetch() { return usedResponse }` | 500 | invoked (`ERR_BODY_ALREADY_USED`) |
| `fetch() { return { ok: true } }` | 204 | never |

### Cause

`RequestContext::render_missing_invalid_response` handles every non-`Response` return value. It logs the `Expected a Response object, but received '...'` diagnostic and then unconditionally calls `render_missing()`, which writes `204 No Content` in production and the welcome page in development.

### Fix

Split `render_missing_invalid_response` on the value:

- `undefined` / `null` / empty still mean "the handler produced no response" and keep the existing diagnostic plus `render_missing()`. `undefined` is part of the documented return type, and `return;` after `server.upgrade()` relies on it.
- Anything else builds a `TypeError` with code `ERR_INVALID_RETURN_VALUE` carrying the same message the diagnostic used, and routes it through `run_error_handler`, exactly like the used-body arm. `error()` is invoked; without one, the client receives a 500 and the error is reported.
- A returned `Error` instance is handed to `error()` as itself, not wrapped, which is what `on_response` already did for a synchronous return.

No call sites change, so the fix covers all three native paths a return value can take: a synchronous return (`on_response`), an already-fulfilled promise (`on_response`'s `Fulfilled` arm), and a promise that resolves later (`handle_resolve`). Thrown values, including non-`Error` throws, never reach this function and are unchanged: they already went to `run_error_handler` with the raw thrown value.

### Verification

New file `test/js/bun/http/serve-invalid-return.test.ts`, modeled on `serve-reused-response.test.ts` from #33118:

- {plain object, string, number, symbol} x {synchronous return, already-fulfilled promise, deferred promise}: `error()` receives a `TypeError` with code `ERR_INVALID_RETURN_VALUE`, and the `Response` it returns is served. The deferred variant is gated on `setImmediate` because the server drains microtasks before unwrapping the returned promise, so only a macrotask reaches `handle_resolve`.
- The error message names the rejected value: `Expected a Response object, but received '42'`.
- A returned `Error` instance reaches `error()` as the original object (own `code`, constructor, message) on all three paths, not wrapped.
- `undefined` and `null` still render an empty 204 and never call `error()`.
- Without an `error()` handler in production: `500 "Something went wrong!"`, the diagnostic on stderr, and the process exits 1, the same as a thrown error.

On the unmodified build, 7 of the 10 fail (the client gets `204 ""` and `error()` never fires); all 10 pass with the fix. The existing `serve-reused-response.test.ts` still passes.

Two tests in `serve.test.ts` asserted the old behavior and are updated:

- "should display a welcome message when the response value type is incorrect" returned a `Symbol` and asserted the welcome page. The `Symbol` fixture moves into the new file with the corrected expectation, and the welcome-page assertion is kept for a handler that returns nothing, the only case that still renders it.
- The #33120 diagnostic test keeps its four diagnostics but now expects `[500, 500, 500, 500]` instead of `[204, 204, 204, 204]`, and exit code 1 instead of 0.