### PR TITLE
docker: install ca-certificates in Debian image final stages

### DIFF
--- a/dockerhub/debian-slim/Dockerfile
+++ b/dockerhub/debian-slim/Dockerfile
@@ -57,6 +57,13 @@ RUN apt-get update -qq \
 
 FROM debian:trixie-slim
 
+# Install CA certificates so tools that verify TLS (e.g. apt over HTTPS on
+# Debian 13) have a trust store. The base image ships none.
+RUN apt-get update -qq \
+    && apt-get install -qq --no-install-recommends ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Disable the runtime transpiler cache by default inside Docker containers.
 # On ephemeral containers, the cache is not useful
 ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0

--- a/dockerhub/debian/Dockerfile
+++ b/dockerhub/debian/Dockerfile
@@ -58,6 +58,13 @@ RUN apt-get update -qq \
 
 FROM debian:trixie
 
+# Install CA certificates so tools that verify TLS (e.g. apt over HTTPS on
+# Debian 13) have a trust store. The base image ships none.
+RUN apt-get update -qq \
+    && apt-get install -qq --no-install-recommends ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY docker-entrypoint.sh /usr/local/bin
 COPY --from=build /usr/local/bin/bun /usr/local/bin/bun
 RUN mkdir -p /usr/local/bun-node-fallback-bin && ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/node

--- a/test/js/bun/test/parallel/test-docker-build-debian-slim.ts
+++ b/test/js/bun/test/parallel/test-docker-build-debian-slim.ts
@@ -1,17 +1,34 @@
 import { expect } from "bun:test";
+import { randomUUID } from "node:crypto";
 import { bunEnv, dockerExe, isDockerEnabled } from "harness";
 import { resolve } from "path";
 
 if (isDockerEnabled()) {
   const docker = dockerExe()!;
   const cwd = resolve(import.meta.dir, "..", "..", "..", "..", "..", "dockerhub", "debian-slim");
-  const proc = Bun.spawn({
-    cmd: [docker, "build", "--progress=plain", "--no-cache", "--rm", "."],
-    stdio: ["ignore", "inherit", "inherit"],
-    cwd,
-    env: bunEnv,
-  });
-  await proc.exited;
-  expect(proc.signalCode).toBeNull();
-  expect(proc.exitCode).toBe(0);
+  const tag = `bun-docker-build-debian-slim-${randomUUID()}`;
+
+  try {
+    const build = Bun.spawn({
+      cmd: [docker, "build", "--progress=plain", "--no-cache", "--rm", "-t", tag, "."],
+      stdio: ["ignore", "inherit", "inherit"],
+      cwd,
+      env: bunEnv,
+    });
+    await build.exited;
+    expect(build.signalCode).toBeNull();
+    expect(build.exitCode).toBe(0);
+
+    // https://github.com/oven-sh/bun/issues/33135
+    const check = Bun.spawn({
+      cmd: [docker, "run", "--rm", tag, "sh", "-c", "test -s /etc/ssl/certs/ca-certificates.crt && echo HAS_CA_CERTS"],
+      stdio: ["ignore", "pipe", "inherit"],
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([check.stdout.text(), check.exited]);
+    expect(stdout.trim()).toBe("HAS_CA_CERTS");
+    expect(exitCode).toBe(0);
+  } finally {
+    Bun.spawnSync({ cmd: [docker, "rmi", "-f", tag], stdio: ["ignore", "ignore", "ignore"], env: bunEnv });
+  }
 }

--- a/test/js/bun/test/parallel/test-docker-build-debian.ts
+++ b/test/js/bun/test/parallel/test-docker-build-debian.ts
@@ -1,17 +1,34 @@
 import { expect } from "bun:test";
+import { randomUUID } from "node:crypto";
 import { bunEnv, dockerExe, isDockerEnabled } from "harness";
 import { resolve } from "path";
 
 if (isDockerEnabled()) {
   const docker = dockerExe()!;
   const cwd = resolve(import.meta.dir, "..", "..", "..", "..", "..", "dockerhub", "debian");
-  const proc = Bun.spawn({
-    cmd: [docker, "build", "--progress=plain", "--no-cache", "--rm", "."],
-    stdio: ["ignore", "inherit", "inherit"],
-    cwd,
-    env: bunEnv,
-  });
-  await proc.exited;
-  expect(proc.signalCode).toBeNull();
-  expect(proc.exitCode).toBe(0);
+  const tag = `bun-docker-build-debian-${randomUUID()}`;
+
+  try {
+    const build = Bun.spawn({
+      cmd: [docker, "build", "--progress=plain", "--no-cache", "--rm", "-t", tag, "."],
+      stdio: ["ignore", "inherit", "inherit"],
+      cwd,
+      env: bunEnv,
+    });
+    await build.exited;
+    expect(build.signalCode).toBeNull();
+    expect(build.exitCode).toBe(0);
+
+    // https://github.com/oven-sh/bun/issues/33135
+    const check = Bun.spawn({
+      cmd: [docker, "run", "--rm", tag, "sh", "-c", "test -s /etc/ssl/certs/ca-certificates.crt && echo HAS_CA_CERTS"],
+      stdio: ["ignore", "pipe", "inherit"],
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([check.stdout.text(), check.exited]);
+    expect(stdout.trim()).toBe("HAS_CA_CERTS");
+    expect(exitCode).toBe(0);
+  } finally {
+    Bun.spawnSync({ cmd: [docker, "rmi", "-f", tag], stdio: ["ignore", "ignore", "ignore"], env: bunEnv });
+  }
 }


### PR DESCRIPTION
## Summary

`oven/bun:latest` stopped being able to `apt-get install` over HTTPS in 1.3.14. apt fails with:

```
SSL connection failed: error:0A000086:SSL routines::certificate verify failed
```

Downgrading to `oven/bun:1.3.13` fixes it.

Fixes #33135.

## Reproduction

```dockerfile
FROM oven/bun:1.3.14        # or :latest, or :1.3.14-slim
RUN apt-get update -y && apt-get install -y --no-install-recommends procps openssl
```

```
Err:1 https://deb.debian.org/debian trixie InRelease
  SSL connection failed: error:0A000086:SSL routines::certificate verify failed
E: Unable to locate package procps
```

`oven/bun:1.3.13` builds the same Dockerfile successfully.

## Root cause

1.3.14 moved the images from Debian 12 (bookworm) to Debian 13 (trixie) in 5bdb8ec0cb. The tag mapping (`.github/workflows/release.yml`) is:

- `oven/bun:latest`, `oven/bun:<version>`, `oven/bun:debian` build from `dockerhub/debian` (`FROM debian:trixie`)
- `oven/bun:<version>-slim`, `oven/bun:slim` build from `dockerhub/debian-slim` (`FROM debian:trixie-slim`)

Neither `debian:trixie` nor `debian:trixie-slim` ships the `ca-certificates` package, so the final image has no system CA trust store (`/etc/ssl/certs/ca-certificates.crt`). The `build` stage installs `ca-certificates`, but that stage is thrown away; the runtime stage starts from a fresh base and never installs it.

On the bookworm images this was invisible because apt reached its mirror over HTTP, which needs no TLS verification. On trixie the mirror is reached over HTTPS (the reporter's log), and with no CA store the handshake fails with `certificate verify failed`.

bun itself is unaffected because it bundles its own root certificates (`getBundledRootCertificates`), so `fetch` and `bun install` over HTTPS keep working. The breakage is limited to system tools that use the system trust store, such as apt, curl, and wget.

## Fix

Install `ca-certificates` in the final stage of both Debian images:

```dockerfile
RUN apt-get update -qq \
    && apt-get install -qq --no-install-recommends ca-certificates \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*
```

The alpine image uses apk over HTTP mirrors, and the distroless image has no package manager (and relies on bun's bundled roots), so neither is affected and both are left unchanged.

## Tests

Extended the existing `docker build` smoke tests for the two Debian images (`test/js/bun/test/parallel/test-docker-build-debian.ts` and `test-docker-build-debian-slim.ts`) to build the image, then run it and assert the final image contains a non-empty `/etc/ssl/certs/ca-certificates.crt`. Without this change the file is absent and the assertion fails; with it the assertion passes. These run on the Docker CI lane.

## Verification note

This is a Dockerfile-only change, so the automated fail-before/pass-after harness can't exercise it: it strips `src/`/`packages/` (this diff touches neither), and building the image requires pulling `debian:trixie` from Docker Hub, which the CI sandbox firewalls off. The root cause is confirmed from the official Debian rootfs manifests (no `ca-certificates` in `trixie` or `trixie-slim`, both using the same mirror scheme as bookworm which does not), the regressing commit, and the reporter's log. The added tests verify the fix on the Docker CI lane, where image pulls are allowed.
