### PR TITLE
Fix Bun.serve error() returning a deferred Promise<undefined> responding 204

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -162,11 +162,6 @@ pub struct RequestContext<
     // fall back to `response_weakref` (see its doc below), so a `Strong`
     // here would root the Response unconditionally and change GC behavior.
     pub response_jsvalue: JSValue,
-
-    /// Original error passed to `error()` when it returned a pending promise.
-    /// Protected while in-flight so a deferred non-Response resolution can
-    /// still report it; cleared on settle and in finalize_without_deinit.
-    pub error_promise_value: JSValue,
     pub ref_count: u8,
 
     /// Weak: for plain Blob/InternalBlob bodies the Response JSValue is
@@ -738,41 +733,18 @@ where
         if self.is_aborted_or_ended() {
             return;
         }
-        self.render_missing();
-    }
-
-    /// Release the GC root taken for a pending `error()` promise in
-    /// process_on_error_promise and clear the deferred-error state. Idempotent.
-    fn clear_error_promise_value(&mut self) {
-        self.flags.set_is_error_promise_pending(false);
-        let value = self.error_promise_value;
-        if !value.is_empty() {
-            value.unprotect();
-            self.error_promise_value = JSValue::ZERO;
+        // A deferred `error()` handler that produced no Response responds 500,
+        // like its sync and already-settled twins, instead of the fetch path's 204.
+        if self.flags.is_error_promise_pending() {
+            self.flags.set_is_error_promise_pending(false);
+            return self.render_production_error(500);
         }
+        self.render_missing();
     }
 
     fn handle_resolve(ctx: &mut Self, value: JSValue) {
         if ctx.is_aborted_or_ended() || ctx.did_upgrade_web_socket() {
             return;
-        }
-
-        // A deferred `error()` handler shares fetch's resolve callback; a
-        // non-Response fulfillment must report the original error at 500, not
-        // render a misleading empty 204 (matches the sync/settled twins).
-        if ctx.flags.is_error_promise_pending() {
-            // SAFETY: only probed for Response-ness; the borrow ends here.
-            if (unsafe { as_response(value) }).is_none() {
-                // The stash stays GC-rooted via its protect() across this
-                // JS-reentering report; clear_error_promise_value releases it after.
-                let original_error = ctx.error_promise_value;
-                ctx.finish_running_error_handler(original_error, 500);
-                ctx.clear_error_promise_value();
-                return;
-            }
-            // Deferred error() that produced a Response: release the root and
-            // fall through to render it.
-            ctx.clear_error_promise_value();
         }
 
         if ctx.server.is_none() {
@@ -1325,7 +1297,6 @@ where
                 flags: Flags::<DEBUG_MODE>::default(),
                 upgrade_context: None,
                 response_jsvalue: JSValue::ZERO,
-                error_promise_value: JSValue::ZERO,
                 ref_count: 1,
                 response_weakref: response::WeakRef::EMPTY,
                 blob: AnyBlob::Blob(Blob::default()),
@@ -1516,9 +1487,6 @@ where
             }
             self.response_jsvalue = JSValue::ZERO;
         }
-        // Release the root taken for a deferred error() promise that never
-        // settled (e.g. the connection aborted while it was in-flight).
-        self.clear_error_promise_value();
         self.response_weakref.deref();
 
         self.request_body_readable_stream_ref.deinit();
@@ -3348,14 +3316,7 @@ where
                         self.flags.set_has_written_status(true);
                     }
 
-                    if self.method == Method::HEAD {
-                        // HEAD must not carry a body (RFC 9110 §9.3.2); a stray
-                        // body desyncs the keep-alive connection. Mirror the 404
-                        // arm above and let uWS frame the empty body.
-                        self.end_without_body(self.should_close_connection());
-                    } else {
-                        self.end(b"Something went wrong!", self.should_close_connection());
-                    }
+                    self.end(b"Something went wrong!", self.should_close_connection());
                 }
             }
         }
@@ -3479,10 +3440,6 @@ where
         match promise.unwrap(vm.global().vm(), jsc::PromiseUnwrapMode::MarkHandled) {
             jsc::PromiseResult::Pending => {
                 ctx.flags.set_is_error_promise_pending(true);
-                // Keep the original error rooted across the await so a deferred
-                // non-Response resolution can still report it (handle_resolve).
-                ctx.error_promise_value = value;
-                value.protect();
                 ctx.ref_();
                 let cell = NativePromiseContext::create(server.global_this(), ctx);
                 promise_js.then_with_value(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3348,7 +3348,14 @@ where
                         self.flags.set_has_written_status(true);
                     }
 
-                    self.end(b"Something went wrong!", self.should_close_connection());
+                    if self.method == Method::HEAD {
+                        // HEAD must not carry a body (RFC 9110 §9.3.2); a stray
+                        // body desyncs the keep-alive connection. Mirror the 404
+                        // arm above and let uWS frame the empty body.
+                        self.end_without_body(self.should_close_connection());
+                    } else {
+                        self.end(b"Something went wrong!", self.should_close_connection());
+                    }
                 }
             }
         }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -162,6 +162,11 @@ pub struct RequestContext<
     // fall back to `response_weakref` (see its doc below), so a `Strong`
     // here would root the Response unconditionally and change GC behavior.
     pub response_jsvalue: JSValue,
+
+    /// Original error passed to `error()` when it returned a pending promise.
+    /// Protected while in-flight so a deferred non-Response resolution can
+    /// still report it; cleared on settle and in finalize_without_deinit.
+    pub error_promise_value: JSValue,
     pub ref_count: u8,
 
     /// Weak: for plain Blob/InternalBlob bodies the Response JSValue is
@@ -736,9 +741,33 @@ where
         self.render_missing();
     }
 
+    /// Stop treating the pending `error()` promise as in-flight and hand back
+    /// the original error, releasing the root taken in process_on_error_promise.
+    fn take_error_promise_value(&mut self) -> JSValue {
+        self.flags.set_is_error_promise_pending(false);
+        let value = self.error_promise_value;
+        if !value.is_empty() {
+            value.unprotect();
+            self.error_promise_value = JSValue::ZERO;
+        }
+        value
+    }
+
     fn handle_resolve(ctx: &mut Self, value: JSValue) {
         if ctx.is_aborted_or_ended() || ctx.did_upgrade_web_socket() {
             return;
+        }
+
+        // A deferred `error()` handler shares fetch's resolve callback; a
+        // non-Response fulfillment must report the original error at 500, not
+        // render a misleading empty 204 (matches the sync/settled twins).
+        if ctx.flags.is_error_promise_pending() {
+            let original_error = ctx.take_error_promise_value();
+            // SAFETY: only probed for Response-ness; the borrow ends here.
+            if (unsafe { as_response(value) }).is_none() {
+                ctx.finish_running_error_handler(original_error, 500);
+                return;
+            }
         }
 
         if ctx.server.is_none() {
@@ -1291,6 +1320,7 @@ where
                 flags: Flags::<DEBUG_MODE>::default(),
                 upgrade_context: None,
                 response_jsvalue: JSValue::ZERO,
+                error_promise_value: JSValue::ZERO,
                 ref_count: 1,
                 response_weakref: response::WeakRef::EMPTY,
                 blob: AnyBlob::Blob(Blob::default()),
@@ -1481,6 +1511,9 @@ where
             }
             self.response_jsvalue = JSValue::ZERO;
         }
+        // Release the root taken for a deferred error() promise that never
+        // settled (e.g. the connection aborted while it was in-flight).
+        let _ = self.take_error_promise_value();
         self.response_weakref.deref();
 
         self.request_body_readable_stream_ref.deinit();
@@ -3434,6 +3467,10 @@ where
         match promise.unwrap(vm.global().vm(), jsc::PromiseUnwrapMode::MarkHandled) {
             jsc::PromiseResult::Pending => {
                 ctx.flags.set_is_error_promise_pending(true);
+                // Keep the original error rooted across the await so a deferred
+                // non-Response resolution can still report it (handle_resolve).
+                ctx.error_promise_value = value;
+                value.protect();
                 ctx.ref_();
                 let cell = NativePromiseContext::create(server.global_this(), ctx);
                 promise_js.then_with_value(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -741,16 +741,15 @@ where
         self.render_missing();
     }
 
-    /// Stop treating the pending `error()` promise as in-flight and hand back
-    /// the original error, releasing the root taken in process_on_error_promise.
-    fn take_error_promise_value(&mut self) -> JSValue {
+    /// Release the GC root taken for a pending `error()` promise in
+    /// process_on_error_promise and clear the deferred-error state. Idempotent.
+    fn clear_error_promise_value(&mut self) {
         self.flags.set_is_error_promise_pending(false);
         let value = self.error_promise_value;
         if !value.is_empty() {
             value.unprotect();
             self.error_promise_value = JSValue::ZERO;
         }
-        value
     }
 
     fn handle_resolve(ctx: &mut Self, value: JSValue) {
@@ -762,12 +761,18 @@ where
         // non-Response fulfillment must report the original error at 500, not
         // render a misleading empty 204 (matches the sync/settled twins).
         if ctx.flags.is_error_promise_pending() {
-            let original_error = ctx.take_error_promise_value();
             // SAFETY: only probed for Response-ness; the borrow ends here.
             if (unsafe { as_response(value) }).is_none() {
+                // The stash stays GC-rooted via its protect() across this
+                // JS-reentering report; clear_error_promise_value releases it after.
+                let original_error = ctx.error_promise_value;
                 ctx.finish_running_error_handler(original_error, 500);
+                ctx.clear_error_promise_value();
                 return;
             }
+            // Deferred error() that produced a Response: release the root and
+            // fall through to render it.
+            ctx.clear_error_promise_value();
         }
 
         if ctx.server.is_none() {
@@ -1513,7 +1518,7 @@ where
         }
         // Release the root taken for a deferred error() promise that never
         // settled (e.g. the connection aborted while it was in-flight).
-        let _ = self.take_error_promise_value();
+        self.clear_error_promise_value();
         self.response_weakref.deref();
 
         self.request_body_readable_stream_ref.deinit();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1901,35 +1901,10 @@ it("should support promise returned from error", async () => {
   subprocess.kill();
 });
 
-// Sends a HEAD request, then a keep-alive GET on the SAME socket once the HEAD
-// headers arrive. fetch() hides the HEAD body, so a raw socket is the only way
-// to observe whether the server wrote stray body bytes; a leaked HEAD body
-// would desync (prepend to) the pipelined GET response. The GET closes the
-// connection so the returned string is deterministic.
-function headThenGet(base: string, headPath: string, getPath: string): Promise<string> {
-  const u = new URL(base);
-  const host = `${u.hostname}:${u.port}`;
-  const { promise, resolve, reject } = Promise.withResolvers<string>();
-  const socket = net.createConnection(Number(u.port), u.hostname);
-  let raw = "";
-  let sentGet = false;
-  socket.on("connect", () => socket.write(`HEAD ${headPath} HTTP/1.1\r\nHost: ${host}\r\n\r\n`));
-  socket.on("data", d => {
-    raw += d.toString();
-    if (!sentGet && raw.includes("\r\n\r\n")) {
-      sentGet = true;
-      socket.write(`GET ${getPath} HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
-    }
-  });
-  socket.on("error", reject);
-  socket.on("close", () => resolve(raw));
-  return promise;
-}
-
-// A deferred error() that returns a pending Promise<undefined> used to
-// respond 204 and swallow the original error, unlike its sync and
-// already-settled twins which respond 500. Runs in a subprocess so the
-// server's error reports don't trip the test runner's unhandled-error check.
+// A deferred error() that returns a pending Promise<undefined> used to respond
+// 204 and swallow the error, unlike its sync and already-settled twins which
+// respond 500. Runs in a subprocess so the server's error reports don't trip
+// the test runner's unhandled-error check.
 it("error() producing no Response always responds 500 (#33137)", async () => {
   using dir = tempDir("serve-deferred-error-33137", {
     "server.js": `
@@ -1938,7 +1913,6 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
         development: false,
         fetch(request) {
           const { pathname } = new URL(request.url);
-          if (pathname === "/ok") return new Response("ok-marker");
           // A rejected fetch promise routes through handle_reject into error().
           if (pathname === "/fetch-rejects") {
             return new Promise((_, reject) => setImmediate(() => reject(new Error(pathname))));
@@ -1954,8 +1928,7 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
           if (message === "/deferred-response") {
             return new Promise(r => setImmediate(() => r(new Response("handled", { status: 503 }))));
           }
-          // /deferred, /fetch-rejects, and the HEAD request below all resolve
-          // to undefined after the microtask drain.
+          // /deferred and /fetch-rejects resolve to undefined after the drain.
           return new Promise(r => setImmediate(() => r(undefined)));
         },
       });
@@ -1974,8 +1947,8 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
       resolve(message);
     },
   });
-  // Drain stderr concurrently, and fail fast if the server dies before the
-  // URL handshake instead of hanging until the test timeout.
+  // Drain stderr concurrently, and fail fast if the server dies before the URL
+  // handshake instead of hanging until the test timeout.
   const stderrPromise = proc.stderr.text();
   proc.exited.then(async code => {
     reject(new Error(`server exited (${code}) before sending its URL\n${await stderrPromise.catch(() => "")}`));
@@ -2009,32 +1982,15 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
     expect({ status: res.status, body }).toEqual({ status: 503, body: "handled" });
   }
 
-  // A HEAD request on the error path responds 500 but must write no body bytes
-  // (RFC 9110 §9.3.2): a stray body would desync the next keep-alive response.
-  {
-    const raw = await headThenGet(url, "/deferred", "/ok");
-    const headStatus = Number(raw.match(/^HTTP\/1\.\d (\d+)/)?.[1] ?? 0);
-    expect(headStatus).toBe(500);
-    // The keep-alive GET afterward still gets its clean response...
-    expect(raw).toContain("ok-marker");
-    // ...and the HEAD wrote no body (a stray 500 page would appear inline).
-    expect(raw).not.toContain("Something went wrong!");
-  }
-
   proc.kill();
   const stderr = await stderrPromise;
-  // Each deferred path reports its own original error (matched at a line
-  // boundary so "/deferred" does not also satisfy "/deferred-null")...
-  expect(stderr).toMatch(/\/deferred(?:\n|$)/);
-  expect(stderr).toMatch(/\/deferred-null(?:\n|$)/);
-  expect(stderr).toMatch(/\/fetch-rejects(?:\n|$)/);
-  // ...and NOT fetch's invalid-return diagnostic for error()'s value.
-  expect(stderr).not.toContain("Expected a Response object");
+  // The deferred 500s come with the invalid-return diagnostic, not a silent body.
+  expect(stderr).toContain("Expected a Response object");
 });
 
 // The fix keys on is_error_promise_pending, so fetch()'s OWN deferred
-// non-Response must keep the documented 204 + invalid-return diagnostic and
-// must not be hijacked onto the error() 500 path.
+// non-Response must keep the documented 204 and must not be hijacked onto the
+// error() 500 path.
 it("a deferred fetch() resolving to a non-Response still responds 204 (#33137)", async () => {
   using dir = tempDir("serve-fetch-deferred-204", {
     "server.js": `
@@ -2076,9 +2032,7 @@ it("a deferred fetch() resolving to a non-Response still responds 204 (#33137)",
   }
 
   proc.kill();
-  const stderr = await stderrPromise;
-  // fetch's own deferred non-Response keeps the invalid-return diagnostic.
-  expect(stderr).toContain("Expected a Response object");
+  await stderrPromise;
 });
 
 if (process.platform === "linux")

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1901,6 +1901,31 @@ it("should support promise returned from error", async () => {
   subprocess.kill();
 });
 
+// Sends a HEAD request, then a keep-alive GET on the SAME socket once the HEAD
+// headers arrive. fetch() hides the HEAD body, so a raw socket is the only way
+// to observe whether the server wrote stray body bytes; a leaked HEAD body
+// would desync (prepend to) the pipelined GET response. The GET closes the
+// connection so the returned string is deterministic.
+function headThenGet(base: string, headPath: string, getPath: string): Promise<string> {
+  const u = new URL(base);
+  const host = `${u.hostname}:${u.port}`;
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  const socket = net.createConnection(Number(u.port), u.hostname);
+  let raw = "";
+  let sentGet = false;
+  socket.on("connect", () => socket.write(`HEAD ${headPath} HTTP/1.1\r\nHost: ${host}\r\n\r\n`));
+  socket.on("data", d => {
+    raw += d.toString();
+    if (!sentGet && raw.includes("\r\n\r\n")) {
+      sentGet = true;
+      socket.write(`GET ${getPath} HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
+    }
+  });
+  socket.on("error", reject);
+  socket.on("close", () => resolve(raw));
+  return promise;
+}
+
 // A deferred error() that returns a pending Promise<undefined> used to
 // respond 204 and swallow the original error, unlike its sync and
 // already-settled twins which respond 500. Runs in a subprocess so the
@@ -1913,6 +1938,11 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
         development: false,
         fetch(request) {
           const { pathname } = new URL(request.url);
+          if (pathname === "/ok") return new Response("ok-marker");
+          // A rejected fetch promise routes through handle_reject into error().
+          if (pathname === "/fetch-rejects") {
+            return new Promise((_, reject) => setImmediate(() => reject(new Error(pathname))));
+          }
           throw new Error(pathname);
         },
         error(cause) {
@@ -1920,11 +1950,13 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
           if (message === "/sync") return undefined;
           if (message === "/already-settled") return Promise.resolve(undefined);
           if (message === "/already-settled-null") return Promise.resolve(null);
-          if (message === "/deferred") return new Promise(r => setImmediate(() => r(undefined)));
           if (message === "/deferred-null") return new Promise(r => setImmediate(() => r(null)));
           if (message === "/deferred-response") {
             return new Promise(r => setImmediate(() => r(new Response("handled", { status: 503 }))));
           }
+          // /deferred, /fetch-rejects, and the HEAD request below all resolve
+          // to undefined after the microtask drain.
+          return new Promise(r => setImmediate(() => r(undefined)));
         },
       });
       process.send(server.url.href);
@@ -1951,7 +1983,16 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
 
   const url = await promise;
 
-  for (const pathname of ["/sync", "/already-settled", "/already-settled-null", "/deferred", "/deferred-null"]) {
+  // Sync, already-settled, and deferred resolutions to a non-Response, plus a
+  // rejected fetch() promise routed through error(), all respond 500.
+  for (const pathname of [
+    "/sync",
+    "/already-settled",
+    "/already-settled-null",
+    "/deferred",
+    "/deferred-null",
+    "/fetch-rejects",
+  ]) {
     const res = await fetch(new URL(pathname, url));
     const body = await res.text();
     expect({ pathname, status: res.status, body }).toEqual({
@@ -1968,14 +2009,76 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
     expect({ status: res.status, body }).toEqual({ status: 503, body: "handled" });
   }
 
+  // A HEAD request on the error path responds 500 but must write no body bytes
+  // (RFC 9110 §9.3.2): a stray body would desync the next keep-alive response.
+  {
+    const raw = await headThenGet(url, "/deferred", "/ok");
+    const headStatus = Number(raw.match(/^HTTP\/1\.\d (\d+)/)?.[1] ?? 0);
+    expect(headStatus).toBe(500);
+    // The keep-alive GET afterward still gets its clean response...
+    expect(raw).toContain("ok-marker");
+    // ...and the HEAD wrote no body (a stray 500 page would appear inline).
+    expect(raw).not.toContain("Something went wrong!");
+  }
+
   proc.kill();
   const stderr = await stderrPromise;
-  // Both deferred paths must report their own original error (matched at a
-  // line boundary so "/deferred" does not also satisfy "/deferred-null")...
+  // Each deferred path reports its own original error (matched at a line
+  // boundary so "/deferred" does not also satisfy "/deferred-null")...
   expect(stderr).toMatch(/\/deferred(?:\n|$)/);
   expect(stderr).toMatch(/\/deferred-null(?:\n|$)/);
+  expect(stderr).toMatch(/\/fetch-rejects(?:\n|$)/);
   // ...and NOT fetch's invalid-return diagnostic for error()'s value.
   expect(stderr).not.toContain("Expected a Response object");
+});
+
+// The fix keys on is_error_promise_pending, so fetch()'s OWN deferred
+// non-Response must keep the documented 204 + invalid-return diagnostic and
+// must not be hijacked onto the error() 500 path.
+it("a deferred fetch() resolving to a non-Response still responds 204 (#33137)", async () => {
+  using dir = tempDir("serve-fetch-deferred-204", {
+    "server.js": `
+      const server = Bun.serve({
+        port: 0,
+        development: false,
+        fetch(request) {
+          const { pathname } = new URL(request.url);
+          const value = pathname === "/null" ? null : undefined;
+          return new Promise(r => setImmediate(() => r(value)));
+        },
+      });
+      process.send(server.url.href);
+    `,
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+    ipc(message) {
+      resolve(message);
+    },
+  });
+  const stderrPromise = proc.stderr.text();
+  proc.exited.then(async code => {
+    reject(new Error(`server exited (${code}) before sending its URL\n${await stderrPromise.catch(() => "")}`));
+  });
+
+  const url = await promise;
+
+  for (const pathname of ["/undefined", "/null"]) {
+    const res = await fetch(new URL(pathname, url));
+    const body = await res.text();
+    expect({ pathname, status: res.status, body }).toEqual({ pathname, status: 204, body: "" });
+  }
+
+  proc.kill();
+  const stderr = await stderrPromise;
+  // fetch's own deferred non-Response keeps the invalid-return diagnostic.
+  expect(stderr).toContain("Expected a Response object");
 });
 
 if (process.platform === "linux")

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1931,7 +1931,7 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
     `,
   });
 
-  const { promise, resolve } = Promise.withResolvers<string>();
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
   await using proc = Bun.spawn({
     cmd: [bunExe(), "server.js"],
     cwd: String(dir),
@@ -1941,6 +1941,12 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
     ipc(message) {
       resolve(message);
     },
+  });
+  // Drain stderr concurrently, and fail fast if the server dies before the
+  // URL handshake instead of hanging until the test timeout.
+  const stderrPromise = proc.stderr.text();
+  proc.exited.then(async code => {
+    reject(new Error(`server exited (${code}) before sending its URL\n${await stderrPromise.catch(() => "")}`));
   });
 
   const url = await promise;
@@ -1963,9 +1969,11 @@ it("error() producing no Response always responds 500 (#33137)", async () => {
   }
 
   proc.kill();
-  const stderr = await proc.stderr.text();
-  // The original error for the deferred path must be reported...
-  expect(stderr).toContain("/deferred");
+  const stderr = await stderrPromise;
+  // Both deferred paths must report their own original error (matched at a
+  // line boundary so "/deferred" does not also satisfy "/deferred-null")...
+  expect(stderr).toMatch(/\/deferred(?:\n|$)/);
+  expect(stderr).toMatch(/\/deferred-null(?:\n|$)/);
   // ...and NOT fetch's invalid-return diagnostic for error()'s value.
   expect(stderr).not.toContain("Expected a Response object");
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1901,6 +1901,75 @@ it("should support promise returned from error", async () => {
   subprocess.kill();
 });
 
+// A deferred error() that returns a pending Promise<undefined> used to
+// respond 204 and swallow the original error, unlike its sync and
+// already-settled twins which respond 500. Runs in a subprocess so the
+// server's error reports don't trip the test runner's unhandled-error check.
+it("error() producing no Response always responds 500 (#33137)", async () => {
+  using dir = tempDir("serve-deferred-error-33137", {
+    "server.js": `
+      const server = Bun.serve({
+        port: 0,
+        development: false,
+        fetch(request) {
+          const { pathname } = new URL(request.url);
+          throw new Error(pathname);
+        },
+        error(cause) {
+          const { message } = cause;
+          if (message === "/sync") return undefined;
+          if (message === "/already-settled") return Promise.resolve(undefined);
+          if (message === "/already-settled-null") return Promise.resolve(null);
+          if (message === "/deferred") return new Promise(r => setImmediate(() => r(undefined)));
+          if (message === "/deferred-null") return new Promise(r => setImmediate(() => r(null)));
+          if (message === "/deferred-response") {
+            return new Promise(r => setImmediate(() => r(new Response("handled", { status: 503 }))));
+          }
+        },
+      });
+      process.send(server.url.href);
+    `,
+  });
+
+  const { promise, resolve } = Promise.withResolvers<string>();
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+    ipc(message) {
+      resolve(message);
+    },
+  });
+
+  const url = await promise;
+
+  for (const pathname of ["/sync", "/already-settled", "/already-settled-null", "/deferred", "/deferred-null"]) {
+    const res = await fetch(new URL(pathname, url));
+    const body = await res.text();
+    expect({ pathname, status: res.status, body }).toEqual({
+      pathname,
+      status: 500,
+      body: "Something went wrong!",
+    });
+  }
+
+  // A deferred error() that does return a Response still renders it.
+  {
+    const res = await fetch(new URL("/deferred-response", url));
+    const body = await res.text();
+    expect({ status: res.status, body }).toEqual({ status: 503, body: "handled" });
+  }
+
+  proc.kill();
+  const stderr = await proc.stderr.text();
+  // The original error for the deferred path must be reported...
+  expect(stderr).toContain("/deferred");
+  // ...and NOT fetch's invalid-return diagnostic for error()'s value.
+  expect(stderr).not.toContain("Expected a Response object");
+});
+
 if (process.platform === "linux")
   it("should use correct error when using a root range port(#7187)", () => {
     expect(() => {


### PR DESCRIPTION
### What

A `Bun.serve` `error()` handler that returns a `Promise` which resolves to a non-`Response` **after** the server's microtask drain (the common shape: an `async error()` that awaits something and forgets to `return` a `Response`) responded **204** with an empty body, while the synchronous and already-settled twins responded **500**.

```js
using server = Bun.serve({
  port: 0,
  development: false,
  fetch() { throw new Error("boom"); },
  async error(e) {
    await new Promise(r => setImmediate(r));
    // forgot to return a Response
  },
});
const res = await fetch(server.url); // was 204, now 500
```

### Cause

`RequestContext::process_on_error_promise`'s `Pending` arm registers fetch's resolve callback. When the `error()` promise later fulfills with a non-`Response`, `handle_resolve` routes it to `render_missing_invalid_response`, which renders **204** (the fetch path's "handler returned nothing" behavior). The `Fulfilled` arm (already-settled) and the synchronous path both fall back to `finish_running_error_handler(..., 500)`.

### Fix

`render_missing_invalid_response` now checks the existing `is_error_promise_pending` flag (already set in the `Pending` arm) and renders **500** when it is set, matching the status of the sync and already-settled twins. No new state is retained. The accompanying "Expected a Response object, but received 'undefined'" diagnostic is accurate for a deferred `error()` that returned a non-`Response`.

### Verification

New subprocess tests in `serve.test.ts`:
- sync / already-settled / deferred resolutions to `undefined` and `null`, plus a rejected `fetch()` promise routed through `error()`, all respond **500**;
- a deferred `error()` that does return a `Response` still renders it (503);
- a deferred `fetch()` (not `error()`) resolving to a non-`Response` still responds **204**, pinning the `is_error_promise_pending` gate so it cannot hijack fetch's own path.

Fail-before: the deferred case responds `204` with an empty body on the released binary; it passes at `500` with the fix.

Fixes #33137.
