### PR TITLE
link: don't chdir into the global dir for `bun link -g` / `bun unlink -g`

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1428,7 +1428,11 @@ pub fn init(
     cli: CommandLineArguments,
     subcommand: Subcommand,
 ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
-    if cli.global {
+    // `bun link` with no package name registers the current package globally;
+    // `-g` is redundant there, and fchdir'ing into the global install dir would
+    // read that dir's package.json and symlink it instead of the user's package.
+    let link_current_package = subcommand == Subcommand::Link && cli.positionals.len() == 1;
+    if cli.global && !link_current_package {
         // Non-consuming peek: `ctx.install` is
         // `Option<Box<BunInstall>>` borrowed via `&mut ContextData`; reborrow with
         // `as_deref()` so the boxed config remains in `ctx` for the

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1428,10 +1428,11 @@ pub fn init(
     cli: CommandLineArguments,
     subcommand: Subcommand,
 ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
-    // `bun link` with no package name registers the current package globally;
-    // `-g` is redundant there, and fchdir'ing into the global install dir would
-    // read that dir's package.json and symlink it instead of the user's package.
-    let link_current_package = subcommand == Subcommand::Link && cli.positionals.len() == 1;
+    // `bun link`/`bun unlink` with no package name act on the current package
+    // via its package.json; `-g` is redundant there, and fchdir'ing into the
+    // global install dir would read that dir's package.json instead of the user's.
+    let link_current_package =
+        matches!(subcommand, Subcommand::Link | Subcommand::Unlink) && cli.positionals.len() == 1;
     if cli.global && !link_current_package {
         // Non-consuming peek: `ctx.install` is
         // `Option<Box<BunInstall>>` borrowed via `&mut ContextData`; reborrow with

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -8,6 +8,7 @@ import {
   readdirSorted,
   runBunInstall,
   stderrForInstall,
+  tempDir,
   tmpdirSync,
   toBeValidBin,
   toHaveBins,
@@ -357,6 +358,48 @@ it("should link scoped package", async () => {
   expect(err4).toContain(`error: Package "${link_name}" is not linked`);
   expect((await new Response(stdout4).text()).split(/\r?\n/)).toEqual([expect.stringContaining("bun link v1."), ""]);
   expect(await exited4).toBe(1);
+});
+
+// https://github.com/oven-sh/bun/issues/33141
+it("registers the current package with `bun link -g`", async () => {
+  const name = "my-link-global-pkg";
+  using projectDir = tempDir("bun-link-global", {
+    "package.json": JSON.stringify({
+      name,
+      version: "1.0.0",
+      bin: { [name]: "./cli.js" },
+    }),
+    "cli.js": "#!/usr/bin/env node\nconsole.log('hello');\n",
+  });
+  using installDir = tempDir("bun-link-global-install", {});
+
+  await using proc = spawn({
+    cmd: [bunExe(), "link", "-g"],
+    cwd: String(projectDir),
+    env: { ...env, BUN_INSTALL: String(installDir), BUN_INSTALL_GLOBAL_DIR: undefined, BUN_INSTALL_BIN: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain(`Success! Registered "${name}"`);
+  expect(stderr).not.toContain(`missing "name"`);
+
+  // The global node_modules entry must resolve to the user's package, not Bun's
+  // internal global dir that the `-g` chdir used to target.
+  const linked = await file(join(String(installDir), "install", "global", "node_modules", name, "package.json")).json();
+  expect(linked.name).toBe(name);
+
+  const bins = await readdirSorted(join(String(installDir), "bin"));
+  expect(bins.some(b => b.includes(name))).toBe(true);
+  if (!isWindows) {
+    expect(join(String(installDir), "bin", name)).toBeValidBin(
+      join("..", "install", "global", "node_modules", name, "cli.js"),
+    );
+  }
+
+  expect(exitCode).toBe(0);
 });
 
 it("should link dependency without crashing", async () => {

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -402,6 +402,62 @@ it("registers the current package with `bun link -g`", async () => {
   expect(exitCode).toBe(0);
 });
 
+// https://github.com/oven-sh/bun/issues/33141
+it("unregisters the current package with `bun unlink -g`", async () => {
+  const name = "my-unlink-global-pkg";
+  using projectDir = tempDir("bun-unlink-global", {
+    "package.json": JSON.stringify({
+      name,
+      version: "1.0.0",
+      bin: { [name]: "./cli.js" },
+    }),
+    "cli.js": "#!/usr/bin/env node\nconsole.log('hello');\n",
+  });
+  using installDir = tempDir("bun-unlink-global-install", {});
+  const spawnEnv = {
+    ...env,
+    BUN_INSTALL: String(installDir),
+    BUN_INSTALL_GLOBAL_DIR: undefined,
+    BUN_INSTALL_BIN: undefined,
+  };
+
+  // Register with plain `bun link` (works regardless of the fix) so the
+  // `bun unlink -g` step below is what this test actually exercises.
+  await using register = spawn({
+    cmd: [bunExe(), "link"],
+    cwd: String(projectDir),
+    env: spawnEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [registerOut, , registerExit] = await Promise.all([
+    register.stdout.text(),
+    register.stderr.text(),
+    register.exited,
+  ]);
+  expect(registerOut).toContain(`Success! Registered "${name}"`);
+  expect(registerExit).toBe(0);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "unlink", "-g"],
+    cwd: String(projectDir),
+    env: spawnEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain(`success: unlinked package "${name}"`);
+  expect(stderr).not.toContain(`missing "name"`);
+
+  // The global registration must be removed, not left behind.
+  const entries = await readdirSorted(join(String(installDir), "install", "global", "node_modules"));
+  expect(entries).not.toContain(name);
+
+  expect(exitCode).toBe(0);
+});
+
 it("should link dependency without crashing", async () => {
   const link_name = basename(link_dir).slice("bun-link.".length) + "-really-long-name";
   await writeFile(


### PR DESCRIPTION
## Summary

`bun link -g` (no package name) crashes with an error pointing at Bun's internal global `package.json`:

```
error: package.json missing "name" in "/root/.bun/install/global/package.json"
```

Plain `bun link` already registers the current package globally and creates the `~/.bun/bin/<name>` binary, so a user coming from npm (`npm link` is implicitly global) naturally types `bun link -g` and hits the error. `bun unlink -g` has the identical crash. Fixes #33141. Fixes #21397 (same root cause, reported as circular self-linking of the global dir into its own node_modules).

## Reproduction

```console
$ mkdir /tmp/linktest && cd /tmp/linktest
$ echo '{ "name": "my-pkg", "version": "1.0.0", "bin": { "my-pkg": "./cli.js" } }' > package.json
$ echo 'console.log("hi")' > cli.js

$ bun link -g
bun link v1.4.0-canary.1
error: package.json missing "name" in "/root/.bun/install/global/package.json"
# exit 1
```

## Cause

`bun link` with no positional package name takes the "register the current package" branch, which reads `manager.original_package_json_path`. That path is derived from the cwd in `pm::init`. When `cli.global` is set, `pm::init` first `fchdir`s into the global install dir (correct for `bun add -g` / `bun install -g`):

```rust
if cli.global {
    let global_dir = package_manager_options::open_global_dir(explicit_global_dir)?;
    bun_sys::fchdir(global_dir)?;
}
```

So the cwd becomes `~/.bun/install/global`, `original_package_json_path` points at Bun's internal global manifest (no `"name"`), and the missing-name guard crashes. The same chdir would also have made the `node_modules/<name>` symlink target the global dir instead of the user's package. `bun unlink -g` (no package name) unregisters the current package through the same structure and crashes identically.

## Fix

Skip the `fchdir` for the `bun link` / `bun unlink`-current-package case (`Subcommand::Link` or `Subcommand::Unlink` with no package-name positional). The `-g` flag is redundant there, so `bun link -g` / `bun unlink -g` now behave identically to the flagless forms. Every other subcommand and `bun link <name> -g` are unchanged (the chdir still happens).

## Verification

New tests in `test/cli/install/bun-link.test.ts` run `bun link -g` and `bun unlink -g` in an isolated `BUN_INSTALL`. The link test asserts the global `node_modules/<name>` entry resolves to the user's package (not the internal global dir) and that the global bin is created; the unlink test registers with plain `bun link` and asserts `bun unlink -g` removes the registration.

- Fail before the fix: the commands crash (`Received: "bun link v1.4.0-canary.1\n"` / `"bun unlink v1.4.0-canary.1\n"`).
- Pass after the fix.