### PR TITLE
install: fix resolution union type confusion in the auto-install name lookup

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -3177,9 +3177,15 @@ impl Lockfile {
         match version.tag {
             dependency::Tag::Npm => {
                 // SAFETY: tag checked == .npm above; `npm` is the active
-                // `dependency::Value` union field. Same for `Resolution.value`
-                // below — `.npm` is read unconditionally on this path.
+                // `dependency::Value` union field.
                 let npm_group = &version.npm().version;
+                // Only a resolution whose own tag is npm may be read through
+                // `Resolution::npm()`: the root package, workspace members, and
+                // folder/symlink deps share the name index with other variants.
+                let satisfies = |resolution: &Resolution| -> bool {
+                    resolution.tag == ResolutionTag::Npm
+                        && npm_group.satisfies(resolution.npm().version, buf, buf)
+                };
                 match entry {
                     PackageIndexEntry::Id(id) => {
                         let resolutions = self.packages.items_resolution();
@@ -3187,8 +3193,7 @@ impl Lockfile {
                         if cfg!(debug_assertions) {
                             debug_assert!((*id as usize) < resolutions.len());
                         }
-                        let res_ver = resolutions[*id as usize].npm().version;
-                        if npm_group.satisfies(res_ver, buf, buf) {
+                        if satisfies(&resolutions[*id as usize]) {
                             return Some(*id);
                         }
                     }
@@ -3199,8 +3204,7 @@ impl Lockfile {
                             if cfg!(debug_assertions) {
                                 debug_assert!((id as usize) < resolutions.len());
                             }
-                            let res_ver = resolutions[id as usize].npm().version;
-                            if npm_group.satisfies(res_ver, buf, buf) {
+                            if satisfies(&resolutions[id as usize]) {
                                 return Some(id);
                             }
                         }

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 //   --install=<val>                 Configure auto-install behavior. One of "auto" (default, auto-installs when no node_modules), "fallback" (missing packages only), "force" (always).
@@ -46,6 +46,43 @@ describe("basic autoinstall", () => {
       });
     }
   }
+});
+
+// In auto-install mode the project's own package.json is the lockfile's root
+// package (resolution tag `root`, not `npm`). With a name and an exact version
+// present, resolving any missing bare specifier used to read that resolution
+// through the npm union accessor: "assertion failed: self.tag == Tag::Npm".
+test("auto-install in a project whose package.json has a name and version", async () => {
+  const requests: string[] = [];
+  using registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      requests.push(new URL(req.url).pathname);
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  using dir = tempDir("autoinstall-root-name-version", {
+    "package.json": JSON.stringify({ name: "myapp", version: "1.0.0" }),
+    "index.js": `import "pkg-that-does-not-exist-anywhere";\n`,
+    "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The resolver must get as far as asking the (local) registry for the
+  // missing package, then report it as missing instead of dying while
+  // re-parsing the project's own package.json.
+  expect(requests).toContain("/pkg-that-does-not-exist-anywhere");
+  expect(stderr).toContain("Cannot find package 'pkg-that-does-not-exist-anywhere'");
+  expect(exitCode).toBe(1);
 });
 
 test("--install=fallback to install missing packages", async () => {


### PR DESCRIPTION
### Problem

In a project whose `package.json` has a `name` and an exact `version`, with no `node_modules` anywhere up the directory tree (a fresh checkout before the first `bun install`), resolving any missing bare specifier (static `import`, `import()`, `require()`, `Bun.resolveSync`) crashes builds with assertions enabled:

```
panic: assertion failed: self.tag == Tag::Npm
bun_install::resolution::ResolutionType<u64>::npm
bun_install::lockfile_real::Lockfile::resolve_package_from_name_and_version  src/install/lockfile.rs:3190
PackageManager::lockfile_resolve  src/install/auto_installer.rs:175
bun_resolver::package_json::PackageJSON::parse  src/resolver/package_json.rs:1466
bun_resolver::resolver::Resolver::dir_info_uncached
```

```sh
mkdir fresh && cd fresh
echo '{ "name": "myapp", "version": "1.0.0" }' > package.json
echo 'import "some-missing-package";' > index.js
bun run index.js
```

Release builds compile the assertion out and read the wrong union variant instead.

### Cause

In auto-install mode the project's own `package.json` is appended to the in-memory lockfile as the root package, whose `Resolution` is tagged `Root`. While building the directory's `DirInfo`, `PackageJSON::parse` looks that `name`/`version` pair up with `Lockfile::resolve_package_from_name_and_version`. The lookup checked the tag of the requested dependency version, but not the tag of each candidate package's `Resolution`, before reading it through the `Npm` union accessor, so the root package's `Root`-tagged resolution was read as `Npm`.

The same applies to any non-npm package sharing the name index entry (workspace members, `folder:`/`link:` dependencies). On release builds the reinterpreted bytes feed the semver comparison, which can spuriously match and return a package whose resolution is not npm at all.

### Fix

Skip candidates whose resolution tag is not `Npm`, the same check the sibling lookup `Lockfile::get_package_id` already performs. A non-npm resolution is never a valid match for an npm version range.

### Verification

New test in `test/cli/run/run-autoinstall.test.ts`: runs `bun index.js` in a fresh project (`package.json` with `name` and `version`, no `node_modules`) importing a missing package, with the registry pointed at a local server that returns 404. On a debug build before the fix the child dies on the assertion above; after, it exits 1 with `error: Cannot find package 'pkg-that-does-not-exist-anywhere'`. The release build before the fix performs the wrong-variant read silently, so the regression test is only able to catch this on builds with assertions enabled.
