### PR TITLE
Fix type confusion in BuildArtifact.prototype.stream

### DIFF
--- a/src/runtime/api/JSBundler.classes.ts
+++ b/src/runtime/api/JSBundler.classes.ts
@@ -37,6 +37,9 @@ export default [
     configurable: false,
     klass: {},
     JSType: "0b11101110",
+    // Per-class cached-stream slot. `Blob::get_stream` reads/writes the
+    // receiver's slot; it must never reach through JSBlob's layout here.
+    values: ["stream"],
     proto: {
       text: { fn: "getText" },
       json: { fn: "getJSON" },

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1939,13 +1939,21 @@ impl BuildArtifact {
         BlobExt::get_type(&this.blob, global_this)
     }
 
+    /// `callframe.this()` is a `JSBuildArtifact`, not a `JSBlob`, so the
+    /// cached-stream slot must be BuildArtifact's own (`values: ["stream"]` in
+    /// JSBundler.classes.ts); `Blob::get_stream` would poke `JSBlob::m_stream`.
     #[bun_jsc::host_fn(method)]
     pub fn get_stream(
         this: &Self,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        this.blob.get_stream(global_this, callframe)
+        this.blob.get_stream_with_cache(
+            global_this,
+            callframe,
+            crate::generated_classes::js_BuildArtifact::stream_get_cached,
+            crate::generated_classes::js_BuildArtifact::stream_set_cached,
+        )
     }
 
     #[bun_jsc::host_fn(getter)]

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -203,6 +203,13 @@ pub trait BlobExt {
         F: jsc::ConsoleFormatter,
         W: core::fmt::Write;
     fn get_stream(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
+    fn get_stream_with_cache(
+        &self,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+        get_cached: fn(JSValue) -> Option<JSValue>,
+        set_cached: fn(JSValue, &JSGlobalObject, JSValue),
+    ) -> JsResult<JSValue>;
     fn get_text(&self, global_this: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue>;
     fn get_text_clone(&self, global_object: &JSGlobalObject) -> Result<JSValue, jsc::JsTerminated>;
     fn get_text_transfer(
@@ -1177,8 +1184,26 @@ impl BlobExt for Blob {
         Ok(())
     }
     fn get_stream(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        self.get_stream_with_cache(
+            global_this,
+            callframe,
+            bun_jsc::generated::JSBlob::stream_get_cached,
+            bun_jsc::generated::JSBlob::stream_set_cached,
+        )
+    }
+
+    /// Shared body of `.stream()` for every class whose receiver wraps a
+    /// `Blob` (`Blob` itself and `BuildArtifact`). `callframe.this()` is that
+    /// receiver, so its cached-stream slot accessors must come from the caller.
+    fn get_stream_with_cache(
+        &self,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+        get_cached: fn(JSValue) -> Option<JSValue>,
+        set_cached: fn(JSValue, &JSGlobalObject, JSValue),
+    ) -> JsResult<JSValue> {
         let this_value = callframe.this();
-        if let Some(cached) = bun_jsc::generated::JSBlob::stream_get_cached(this_value) {
+        if let Some(cached) = get_cached(this_value) {
             return Ok(cached);
         }
         let mut recommended_chunk_size: SizeType = 0;
@@ -1203,7 +1228,7 @@ impl BlobExt for Blob {
                     // in the case we have a file descriptor store, we want to de-duplicate
                     // readable streams. in every other case we want `.stream()` to be its
                     // own stream.
-                    bun_jsc::generated::JSBlob::stream_set_cached(this_value, global_this, stream);
+                    set_cached(this_value, global_this, stream);
                 }
             }
         }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -370,6 +370,7 @@ describe("Bun.build", () => {
     expect(response.headers.get("etag")).toMatchSnapshot("content-etag");
   });
 
+  // https://github.com/oven-sh/bun/issues/10004
   // `.stream()` must use BuildArtifact's own cached-stream slot, not JSBlob's
   // (the JSBlob slot offset aliases the cached `.kind` getter on a BuildArtifact).
   describe("BuildArtifact.stream()", () => {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -370,37 +370,6 @@ describe("Bun.build", () => {
     expect(response.headers.get("etag")).toMatchSnapshot("content-etag");
   });
 
-  // https://github.com/oven-sh/bun/issues/10004
-  // `.stream()` must use BuildArtifact's own cached-stream slot, not JSBlob's
-  // (the JSBlob slot offset aliases the cached `.kind` getter on a BuildArtifact).
-  describe("BuildArtifact.stream()", () => {
-    test("streams the artifact's own contents", async () => {
-      const x = await Bun.build({
-        entrypoints: [join(import.meta.dir, "./fixtures/trivial/index.js")],
-      });
-      expect(x.success).toBe(true);
-      const artifact = x.outputs[0];
-      const stream = artifact.stream();
-      expect(stream).toBeInstanceOf(ReadableStream);
-      expect(await new Response(stream).text()).toBe(await artifact.text());
-    });
-
-    test("is unaffected by reading cached getters first", async () => {
-      const x = await Bun.build({
-        entrypoints: [join(import.meta.dir, "./fixtures/trivial/index.js")],
-      });
-      expect(x.success).toBe(true);
-      const artifact = x.outputs[0];
-      // Populate the cached `.kind` getter slot before the first `.stream()`.
-      expect(artifact.kind).toBe("entry-point");
-      const stream = artifact.stream();
-      expect(stream).toBeInstanceOf(ReadableStream);
-      expect(await new Response(stream).text()).toBe(await artifact.text());
-      // And `.stream()` must not have clobbered the cached `.kind` slot.
-      expect(artifact.kind).toBe("entry-point");
-    });
-  });
-
   // test("BuildArtifact with assets", async () => {
   //   const x = await Bun.build({
   //     entrypoints: [join(import.meta.dir, "./fixtures/with-assets/index.js")],

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -370,6 +370,36 @@ describe("Bun.build", () => {
     expect(response.headers.get("etag")).toMatchSnapshot("content-etag");
   });
 
+  // `.stream()` must use BuildArtifact's own cached-stream slot, not JSBlob's
+  // (the JSBlob slot offset aliases the cached `.kind` getter on a BuildArtifact).
+  describe("BuildArtifact.stream()", () => {
+    test("streams the artifact's own contents", async () => {
+      const x = await Bun.build({
+        entrypoints: [join(import.meta.dir, "./fixtures/trivial/index.js")],
+      });
+      expect(x.success).toBe(true);
+      const artifact = x.outputs[0];
+      const stream = artifact.stream();
+      expect(stream).toBeInstanceOf(ReadableStream);
+      expect(await new Response(stream).text()).toBe(await artifact.text());
+    });
+
+    test("is unaffected by reading cached getters first", async () => {
+      const x = await Bun.build({
+        entrypoints: [join(import.meta.dir, "./fixtures/trivial/index.js")],
+      });
+      expect(x.success).toBe(true);
+      const artifact = x.outputs[0];
+      // Populate the cached `.kind` getter slot before the first `.stream()`.
+      expect(artifact.kind).toBe("entry-point");
+      const stream = artifact.stream();
+      expect(stream).toBeInstanceOf(ReadableStream);
+      expect(await new Response(stream).text()).toBe(await artifact.text());
+      // And `.stream()` must not have clobbered the cached `.kind` slot.
+      expect(artifact.kind).toBe("entry-point");
+    });
+  });
+
   // test("BuildArtifact with assets", async () => {
   //   const x = await Bun.build({
   //     entrypoints: [join(import.meta.dir, "./fixtures/with-assets/index.js")],

--- a/test/regression/issue/10004.test.ts
+++ b/test/regression/issue/10004.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/10004
+describe("BuildArtifact.stream()", () => {
+  test("streams the artifact's own contents", async () => {
+    using dir = tempDir("issue-10004", {
+      "entry.ts": "export const hello = 'BuildArtifact.stream() regression test';\n",
+    });
+    const x = await Bun.build({ entrypoints: [join(String(dir), "entry.ts")] });
+    expect(x.success).toBe(true);
+    const artifact = x.outputs[0];
+    const stream = artifact.stream();
+    expect(stream).toBeInstanceOf(ReadableStream);
+    expect(await new Response(stream).text()).toBe(await artifact.text());
+  });
+
+  test("is unaffected by reading cached getters like .kind first", async () => {
+    using dir = tempDir("issue-10004-kind", {
+      "entry.ts": "export const hello = 'BuildArtifact.stream() regression test';\n",
+    });
+    const x = await Bun.build({ entrypoints: [join(String(dir), "entry.ts")] });
+    expect(x.success).toBe(true);
+    const artifact = x.outputs[0];
+    expect(artifact.kind).toBe("entry-point");
+    const stream = artifact.stream();
+    expect(stream).toBeInstanceOf(ReadableStream);
+    expect(await new Response(stream).text()).toBe(await artifact.text());
+    expect(artifact.kind).toBe("entry-point");
+  });
+});


### PR DESCRIPTION
Fixes #10004

### Problem

`BuildArtifact.prototype.stream()` reads and writes a cached-value `WriteBarrier` slot through `JSBlob`'s class layout, but the receiver there is a `JSBuildArtifact`.

On builds with assertions enabled, the first `.stream()` call on any `BuildArtifact` aborts deterministically (100%):

```js
const r = await Bun.build({ entrypoints: ["./e.css"], throw: false });
const s = r.outputs[0].stream();
await new Response(s).text(); // SIGABRT
```

```
JSC::reportZappedCellAndCrash(const JSCell *) at JSCell.cpp:371
```

The cell is not actually zapped. It is a live `JSBuildArtifact`, and `uncheckedDowncast<JSBlob>` raises that crash whenever the `inherits()` check fails under `ASSERT_ENABLED`.

On release builds the cast is unchecked and silently reads or writes the wrong slot. Reading any cached getter before the first `.stream()` call makes `.stream()` return that getter's cached string instead of a `ReadableStream`:

```js
const r = await Bun.build({ entrypoints: ["./e.css"], throw: false });
r.outputs[0].kind;                                // "asset"
await new Response(r.outputs[0].stream()).text(); // "asset"  (should be the CSS)
```

This is exactly the behavior reported in #10004 ("build output.stream() returns output.kind instead of the file contents"), including the observation that touching `output.kind` first is what triggers it.

### Cause

`BuildArtifact::get_stream` delegates to `Blob::get_stream`, which calls the generated `JSBlob` cached-slot accessor on `callframe.this()`:

```cpp
auto* thisObject = uncheckedDowncast<JSBlob>(JSValue::decode(thisValue));
return JSValue::encode(thisObject->m_stream.get());
```

`JSBlob` and `JSBuildArtifact` are sibling classes, and their generated `WriteBarrier` members happen to line up at the offset `JSBlob::m_stream` lives at:

| offset | `JSBlob` | `JSBuildArtifact` |
|---|---|---|
| 16 | `m_ctx` | `m_ctx` |
| 24 | `m_name` | `m_hash` |
| 32 | `m_stream` | `m_kind` |

So on a `BuildArtifact`, the "cached stream" slot is really the cached `.kind` getter slot. Once `.kind` has been read, `.stream()` returns that string; on an fd-backed artifact, the cache write would overwrite `.kind` with the stream.

### When it broke

This is a true regression. `BuildArtifact.stream()` worked from its introduction in 982dc0b441 (May 2023) until #7650 (c8305df5c2, Dec 2023), which added the `stream` cache slot to `Blob` and the `streamGetCached(callframe.this())` fast path to `Blob.getStream` to de-duplicate `process.stdin`'s fd-backed blob stream. That change did not account for `BuildArtifact` delegating to the same function with a non-`JSBlob` receiver. #10004 was filed four months later.

### Fix

- `JSBundler.classes.ts`: give `BuildArtifact` its own cached-stream slot (`values: ["stream"]`). Codegen emits the per-class accessor pair and wires `m_stream` into `JSBuildArtifact::visitChildrenImpl`.
- `Blob.rs`: factor the body of `get_stream` into `get_stream_with_cache`, which takes the receiver class's cached-slot accessor pair instead of hardcoding `JSBlob`'s. `Blob::get_stream` still passes `JSBlob`'s, unchanged.
- `JSBundler.rs`: `BuildArtifact::get_stream` passes `js_BuildArtifact`'s accessors.

`BuildArtifact` is the only class that delegated to `Blob::get_stream` with a non-`JSBlob` receiver; I audited every other `*_get_cached` / `*_set_cached` call site in `src/runtime/` and each one uses its own class's accessor.

### Verification

Two tests in `test/regression/issue/10004.test.ts` (it is a true regression with an issue number, so it goes under `test/regression/issue/` rather than `bun-build-api.test.ts`).

Without the fix:

```
# debug / assertions build
$ bun bd test test/regression/issue/10004.test.ts
error: script "bd" was terminated by signal SIGABRT (Abort)

# release build
$ bun test test/regression/issue/10004.test.ts
error: expect(received).toBeInstanceOf(expected)
Received value: "entry-point"
1 pass, 1 fail
```

With the fix, both pass on both builds and the reproductions above return the artifact's actual contents.
