### PR TITLE
glob: fix abort when joined absolute paths exceed the join buffer

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -2232,14 +2232,20 @@ fn work_item_logical_path(path: &[u8]) -> &[u8] {
 // const bunJoin = if (!sentinel) ResolvePath.join else ResolvePath.joinZ;
 fn bun_join<const SENTINEL: bool>(parts: &[&[u8]]) -> Box<[u8]> {
     use bun_paths::platform;
+    // Deeply nested trees join to more than the fixed thread-local buffer
+    // holds; the `_spill` variants grow onto the heap instead of writing
+    // past it. Oversized work items still fail with ENAMETOOLONG later.
+    let mut spill: Vec<u8> = Vec::new();
     if SENTINEL {
-        let s = resolve_path::join_z::<platform::Auto>(parts);
+        let s = resolve_path::join_z_spill::<platform::Auto>(&mut spill, parts);
         // include trailing NUL in the owned box
         let mut v = s.as_bytes().to_vec();
         v.push(0);
         v.into_boxed_slice()
     } else {
-        Box::from(resolve_path::join::<platform::Auto>(parts))
+        Box::from(resolve_path::join_spill::<platform::Auto>(
+            &mut spill, parts,
+        ))
     }
 }
 

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1482,6 +1482,19 @@ pub fn join_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -> 
     join_string_buf::<P>(&mut spill[..], parts)
 }
 
+/// [`join_z`] (thread-local buffer) when the result fits, otherwise into
+/// `spill` (grown as needed). `spill` is untouched in the common case.
+pub fn join_z_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -> &'a ZStr {
+    let needed = join_needed(parts);
+    if needed <= JOIN_BUF_LEN {
+        return join_z::<P>(parts);
+    }
+    if spill.len() < needed {
+        spill.resize(needed, 0);
+    }
+    join_z_buf::<P>(&mut spill[..], parts)
+}
+
 pub fn join_z_buf<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a ZStr {
     // reshaped for borrowck — capture buf base ptr before sub-borrow
     let buf_base = buf.as_mut_ptr();

--- a/test/js/bun/glob/path-length.test.ts
+++ b/test/js/bun/glob/path-length.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isMusl, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isMacOS, isMusl, isWindows, tmpdirSync } from "harness";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -19,31 +19,51 @@ const runScanFixture = (pattern: string, opts: Record<string, unknown>) => `
   }
 `;
 
+// Same as runScanFixture but prints the matched paths instead of the count.
+const runScanPathsFixture = (pattern: string, opts: Record<string, unknown>) => `
+  const { Glob } = require("bun");
+  const g = new Glob(${JSON.stringify(pattern)});
+  const opts = ${JSON.stringify(opts)};
+  try {
+    console.log("OK:" + JSON.stringify([...g.scanSync(opts)].sort()));
+  } catch (err) {
+    console.log("ERR:" + (err && err.code ? err.code : String(err)));
+  }
+`;
+
+// Build a deep directory tree using bash cd+mkdir loops so each individual
+// syscall uses a short relative path. The cumulative path length grows past
+// MAX_PATH_BYTES (1024 on macOS, 4096 on Linux) even though the tree is
+// legal on the filesystem. If `fileName` is given, the file is created in
+// the deepest directory.
+async function buildDeepTree(root: string, depth: number, segName: string, fileName?: string) {
+  const touchFile = fileName ? ` && touch "${fileName}"` : "";
+  await using buildProc = Bun.spawn({
+    cmd: [
+      "bash",
+      "-c",
+      `SEG=${segName}; for i in $(seq 1 ${depth}); do mkdir "$SEG" && cd "$SEG" || exit 1; done${touchFile}`,
+    ],
+    env: bunEnv,
+    cwd: root,
+    stderr: "pipe",
+  });
+  const [buildStderr, buildCode] = await Promise.all([buildProc.stderr.text(), buildProc.exited]);
+  // On musl, getcwd(3) fails once the cumulative path exceeds PATH_MAX. bash
+  // prints a cd warning for each subsequent level but mkdir/cd still succeed,
+  // so filter that one known warning out before asserting stderr is clean.
+  const filteredBuildStderr = buildStderr
+    .split("\n")
+    .filter(line => !(isMusl && line.startsWith("cd: error retrieving current directory: getcwd:")))
+    .join("\n");
+  expect(filteredBuildStderr).toBe("");
+  expect(buildCode).toBe(0);
+}
+
 describe.skipIf(isWindows)("Glob path length", () => {
   test("deep directory tree does not overflow path buffer", async () => {
     const root = tmpdirSync("bun-glob-overflow-deep-");
-    // Build a deep directory tree using bash cd+mkdir loops so each
-    // individual syscall uses a short relative path. The cumulative
-    // path length grows past MAX_PATH_BYTES (1024 on macOS, 4096 on
-    // Linux) even though the tree is legal on the filesystem.
-    const depth = 18;
-    const segName = "D".repeat(255);
-    await using buildProc = Bun.spawn({
-      cmd: ["bash", "-c", `SEG=${segName}; for i in $(seq 1 ${depth}); do mkdir "$SEG" && cd "$SEG" || exit 1; done`],
-      env: bunEnv,
-      cwd: root,
-      stderr: "pipe",
-    });
-    const [buildStderr, buildCode] = await Promise.all([buildProc.stderr.text(), buildProc.exited]);
-    // On musl, getcwd(3) fails once the cumulative path exceeds PATH_MAX. bash
-    // prints a cd warning for each subsequent level but mkdir/cd still succeed,
-    // so filter that one known warning out before asserting stderr is clean.
-    const filteredBuildStderr = buildStderr
-      .split("\n")
-      .filter(line => !(isMusl && line.startsWith("cd: error retrieving current directory: getcwd:")))
-      .join("\n");
-    expect(filteredBuildStderr).toBe("");
-    expect(buildCode).toBe(0);
+    await buildDeepTree(root, 18, "D".repeat(255));
 
     await using scanProc = Bun.spawn({
       cmd: [bunExe(), "-e", runScanFixture("**/*", { cwd: root, onlyFiles: false })],
@@ -62,6 +82,55 @@ describe.skipIf(isWindows)("Glob path length", () => {
     // Walker must surface ENAMETOOLONG rather than keep walking past the
     // fixed-size PathBuffer it copies each work item into.
     expect(scanStdout.trim()).toBe("ERR:ENAMETOOLONG");
+  });
+
+  test("deep directory tree with absolute: true does not overflow the join buffer", async () => {
+    const root = tmpdirSync("bun-glob-overflow-abs-");
+    await buildDeepTree(root, 18, "D".repeat(255));
+
+    await using scanProc = Bun.spawn({
+      cmd: [bunExe(), "-e", runScanFixture("**/*", { cwd: root, absolute: true, onlyFiles: false })],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [scanStdout, scanStderr, scanCode] = await Promise.all([
+      scanProc.stdout.text(),
+      scanProc.stderr.text(),
+      scanProc.exited,
+    ]);
+
+    // The absolute walk joins dir + entry through ResolvePath's fixed
+    // thread-local buffer; an over-long directory must surface
+    // ENAMETOOLONG like the relative walk above, not abort the process.
+    expect(scanStdout.trim()).toBe("ERR:ENAMETOOLONG");
+    expect(scanCode).toBe(0);
+  });
+
+  test("matched file whose absolute path exceeds the join buffer is returned", async () => {
+    const root = tmpdirSync("bun-glob-overflow-abs-file-");
+    const segName = "D".repeat(255);
+    const fileName = "F".repeat(255);
+    // Deepest directory stays under MAX_PATH_BYTES (1024 on macOS, 4096 on
+    // Linux) so the walker can open it, while joining the 255-byte file name
+    // onto it produces a path longer than the join buffer.
+    const maxPathBytes = isMacOS ? 1024 : 4096;
+    const depth = Math.floor((maxPathBytes - 1 - root.length) / (segName.length + 1));
+    await buildDeepTree(root, depth, segName, fileName);
+
+    const expected = [root, ...Array(depth).fill(segName), fileName].join("/");
+    await using scanProc = Bun.spawn({
+      cmd: [bunExe(), "-e", runScanPathsFixture("**/*", { cwd: root, absolute: true })],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [scanStdout, scanStderr, scanCode] = await Promise.all([
+      scanProc.stdout.text(),
+      scanProc.stderr.text(),
+      scanProc.exited,
+    ]);
+
+    expect(scanStdout.trim()).toBe("OK:" + JSON.stringify([expected]));
+    expect(scanCode).toBe(0);
   });
 
   test("self-referential symlink does not overflow path buffer", async () => {

--- a/test/js/bun/glob/path-length.test.ts
+++ b/test/js/bun/glob/path-length.test.ts
@@ -106,15 +106,18 @@ describe.skipIf(isWindows)("Glob path length", () => {
     expect(scanCode).toBe(0);
   });
 
-  test("matched file whose absolute path exceeds the join buffer is returned", async () => {
+  // Linux-only: this needs a directory that is still walkable (absolute path
+  // under MAX_PATH_BYTES, 4096 there) while joining one more name onto it
+  // exceeds the 4096-byte join buffer. On macOS MAX_PATH_BYTES is 1024, so a
+  // matched path can never reach the join buffer's size.
+  test.skipIf(isMacOS)("matched file whose absolute path exceeds the join buffer is returned", async () => {
     const root = tmpdirSync("bun-glob-overflow-abs-file-");
     const segName = "D".repeat(255);
     const fileName = "F".repeat(255);
-    // Deepest directory stays under MAX_PATH_BYTES (1024 on macOS, 4096 on
-    // Linux) so the walker can open it, while joining the 255-byte file name
-    // onto it produces a path longer than the join buffer.
-    const maxPathBytes = isMacOS ? 1024 : 4096;
-    const depth = Math.floor((maxPathBytes - 1 - root.length) / (segName.length + 1));
+    // Deepest directory stays under 4096 bytes so the walker can open it,
+    // while joining the 255-byte file name onto it exceeds the join buffer.
+    const joinBufLen = 4096;
+    const depth = Math.floor((joinBufLen - 1 - root.length) / (segName.length + 1));
     await buildDeepTree(root, depth, segName, fileName);
 
     const expected = [root, ...Array(depth).fill(segName), fileName].join("/");

--- a/test/js/bun/glob/path-length.test.ts
+++ b/test/js/bun/glob/path-length.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS, isMusl, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isMusl, isWindows, tmpdirSync } from "harness";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -108,9 +108,9 @@ describe.skipIf(isWindows)("Glob path length", () => {
 
   // Linux-only: this needs a directory that is still walkable (absolute path
   // under MAX_PATH_BYTES, 4096 there) while joining one more name onto it
-  // exceeds the 4096-byte join buffer. On macOS MAX_PATH_BYTES is 1024, so a
-  // matched path can never reach the join buffer's size.
-  test.skipIf(isMacOS)("matched file whose absolute path exceeds the join buffer is returned", async () => {
+  // exceeds the 4096-byte join buffer. Everywhere else MAX_PATH_BYTES is
+  // 1024, so a matched path can never reach the join buffer's size.
+  test.skipIf(!isLinux)("matched file whose absolute path exceeds the join buffer is returned", async () => {
     const root = tmpdirSync("bun-glob-overflow-abs-file-");
     const segName = "D".repeat(255);
     const fileName = "F".repeat(255);


### PR DESCRIPTION
### Problem

Scanning a directory tree whose joined absolute paths exceed 4096 bytes with `Bun.Glob` and `absolute: true` aborts the process:

```
panic: range end index 4209 out of range for slice of length 4095
```

```sh
d=$(mktemp -d); cd "$d"; p="."
for i in $(seq 1 30); do n=$(printf 'd%0148d' $i); p="$p/$n"; mkdir -p "$p"; done
bun -e 'const {Glob} = require("bun");
        console.log([...new Glob("**/*.ts").scanSync({ cwd: ".", absolute: true, onlyFiles: false })].length)'
# bun: panic: range end index 4209 out of range for slice of length 4095   (SIGABRT, exit 134)
```

Such trees are legal on Linux (PATH_MAX limits a single syscall argument, not the depth of a tree), and they show up in practice (nested `node_modules`, generated content stores). `bun run --filter` uses the same walker with `absolute: true`, so a deep workspace tree can abort it too.

### Cause

When `absolute` is set, `GlobWalker::join` goes through `bun_join`, which calls `resolve_path::join` / `join_z`. Those normalize into a fixed 4096-byte thread-local (`JOIN_BUF`) with no bounds check, so `normalize_string_generic_t`'s `buf[buf_i..buf_i + count]` indexes past the end as soon as dir + entry no longer fits (the `4095` in the message is the buffer minus the POSIX leading-separator slot).

The relative branch of the same function uses a growable `Vec` join, and oversized work items are already converted to `ENAMETOOLONG` by the guards added in #28836. The absolute branch panics before those guards can run.

### Fix

- `src/paths/resolve_path.rs`: add `join_z_spill`, the missing sibling of the existing `join_spill` (uses the thread-local buffer when the result fits, otherwise a caller-provided `Vec`).
- `src/glob/GlobWalker.rs`: `bun_join` uses the spill variants, so joined paths of any length are produced without touching memory past the buffer.

With that, the existing work-item guards take over: a directory whose joined path exceeds `MAX_PATH_BYTES` surfaces `ENAMETOOLONG` exactly like the relative walk does today, and a matched entry whose joined path merely exceeds the old buffer is returned instead of crashing. No behavior change for paths that fit.

### Tests

Two new cases in `test/js/bun/glob/path-length.test.ts`, next to the existing deep-tree coverage:

- deep tree scanned with `absolute: true` reports `ENAMETOOLONG` (was: SIGABRT)
- a matched file whose absolute path exceeds the join buffer, inside a directory that is still walkable, is returned (was: SIGABRT)

Both fail on the unfixed build and pass with the fix; the four pre-existing tests in the file are unchanged and still pass.
