### PR TITLE
css: serialize a NaN calc() result as zero instead of the literal NaN

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -6581,10 +6581,9 @@ impl Notation {
 
 /// Writes float with precision. Returns `None` notation if value was not finite.
 pub fn dtoa_short(buf: &mut [u8; 129], value: f32, precision: u8) -> (&[u8], Option<Notation>) {
-    // Only calc() can produce non-finite values, and dtoa_short_impl can't print
-    // them. CSS Values 4 #calc-ieee: NaN escaping a top-level calculation is
-    // censored to zero; infinities clamp to the largest finite value
-    // (https://github.com/oven-sh/bun/issues/18064).
+    // Only calc() yields non-finite values. CSS Values 4 #calc-ieee: a NaN
+    // escaping a top-level calculation is censored to zero; infinities clamp to
+    // the largest finite value (https://github.com/oven-sh/bun/issues/18064).
     if value.is_nan() {
         const S: &[u8] = b"0";
         buf[..S.len()].copy_from_slice(S);

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -6579,11 +6579,17 @@ impl Notation {
     }
 }
 
-/// Writes float with precision. Returns `None` notation if value was infinite.
+/// Writes float with precision. Returns `None` notation if value was not finite.
 pub fn dtoa_short(buf: &mut [u8; 129], value: f32, precision: u8) -> (&[u8], Option<Notation>) {
-    // We can't give Infinity/-Infinity to dtoa_short_impl. We need to print a
-    // valid finite number otherwise browsers like Safari will render certain
-    // things wrong (https://github.com/oven-sh/bun/issues/18064).
+    // Only calc() can produce non-finite values, and dtoa_short_impl can't print
+    // them. CSS Values 4 #calc-ieee: NaN escaping a top-level calculation is
+    // censored to zero; infinities clamp to the largest finite value
+    // (https://github.com/oven-sh/bun/issues/18064).
+    if value.is_nan() {
+        const S: &[u8] = b"0";
+        buf[..S.len()].copy_from_slice(S);
+        return (&buf[..S.len()], None);
+    }
     if value.is_infinite() && value.is_sign_positive() {
         const S: &[u8] = b"3.40282e38";
         buf[..S.len()].copy_from_slice(S);
@@ -6593,8 +6599,6 @@ pub fn dtoa_short(buf: &mut [u8; 129], value: f32, precision: u8) -> (&[u8], Opt
         buf[..S.len()].copy_from_slice(S);
         return (&buf[..S.len()], None);
     }
-    // We shouldn't receive NaN here.
-    debug_assert!(!value.is_nan());
     let (str, notation) = dtoa_short_impl(buf, value, precision);
     (str, Some(notation))
 }

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -138,6 +138,19 @@ describe("css tests", () => {
 }`,
       indoc`.rounded-full{height:infinity;border-radius:3.40282e38px;width:-3.40282e38px}`,
     );
+
+    // NaN is valid inside calc() (CSS Values 4 "Infinities, NaN, and Signed Zero").
+    // A NaN escaping a top-level calculation is censored to zero; it must never be
+    // serialized as the literal `NaNpx`, which browsers reject.
+    minify_test(`a { width: calc(NaN * 1px) }`, `a{width:0px}`);
+    minify_test(`a { width: calc(infinity * 0px) }`, `a{width:0px}`);
+    minify_test(`a { width: calc(infinity * 1px - infinity * 1px) }`, `a{width:0px}`);
+    minify_test(`a { width: min(NaN * 1px, 2px) }`, `a{width:min(0px,2px)}`);
+    minify_test(`a { width: max(NaN * 1px, 2px) }`, `a{width:max(0px,2px)}`);
+    minify_test(`a { width: calc(NaN * 1%) }`, `a{width:0%}`);
+    minify_test(`a { opacity: calc(NaN) }`, `a{opacity:0}`);
+    minify_test(`a { rotate: calc(NaN * 1deg) }`, `a{rotate:0deg}`);
+    minify_test(`a { transition-duration: calc(NaN * 1s) }`, `a{transition-duration:0s}`);
   });
   describe("calc stack overflow", () => {
     // https://github.com/oven-sh/bun/issues/20128


### PR DESCRIPTION
### What

`calc()` math that yields NaN is valid CSS (`calc(NaN * 1px)`, `calc(infinity * 0px)`, `min(NaN * 1px, 2px)`), but Bun serialized the result as the literal text `NaNpx`. That is a CSS parse error, so every browser silently drops the declaration and the bundled stylesheet renders differently from the source. On a debug build the same input aborts:

```
panic: assertion failed: !value.is_nan()
bun_css::css_parser::serializer::serialize_dimension
src/css/css_parser.rs
<bun_css::values::length::LengthValue>::to_css
```

Repro (`e.ts` is `import "./a.css"`):

```css
a { width: calc(NaN * 1px) }
b { width: calc(infinity * 0px) }
c { width: min(NaN * 1px, 2px) }
```

```
bun build e.ts --outdir=o
# before: a{width:NaNpx} b{width:NaNpx} c{width:min(NaNpx,2px)}
# after:  a{width:0px}   b{width:0px}   c{width:min(0px,2px)}
```

### Why

`dtoa_short` in `src/css/css_parser.rs` is the single float printer every serialized CSS number goes through. It already special-cases `+infinity` and `-infinity`, rendering them as the largest finite f32 (added for #18064), but it has no NaN arm, so NaN falls into `dtoa_short_impl`. That function cannot represent NaN: a `debug_assert` fires in debug builds and garbage text comes out of release builds. (lightningcss has the same gap; it prints `5.10424e38px`.)

Non-finite values can only enter the value tree through `calc()` simplification. The tokenizer never produces one, and the color code uses NaN only as an internal sentinel for the `none` channel keyword, which its serializers check for before printing. So the question is just what a NaN calc result should serialize as, and CSS Values 4 answers it directly in "Infinities, NaN, and Signed Zero" (https://drafts.csswg.org/css-values-4/#calc-ieee):

> NaN does not escape a top-level calculation; it's censored into a zero value.

Blink, WebKit, and Gecko all implement that, so `0` is both the spec answer and what a browser would have computed from the original expression.

### How

Add a NaN arm to `dtoa_short` next to the two infinity arms, emitting `0`, and delete the `debug_assert` it makes obsolete.

One approximation, inherited from the existing infinity handling: a NaN leaf inside a math function that could not be fully reduced is censored at the leaf rather than poisoning the whole function, so `max(NaN * 1px, 2px)` serializes as `max(0px, 2px)` where a browser given the original would compute `0`. (`min(NaN * 1px, 2px)` happens to agree either way.) Matching the spec exactly there would mean preserving the unevaluated `calc(NaN * 1px)` expression through serialization, a much larger change; the output here is at least valid CSS that keeps the declaration alive.

### Verification

New cases in the existing `calc edge case` block of `test/js/bun/css/css.test.ts`, next to the #18064 infinity test, covering length, percentage, number, angle, and time contexts plus the `min`/`max` and infinity-arithmetic paths.

Without the `src/` change, `bun bd test test/js/bun/css/css.test.ts` aborts with the assertion above (SIGABRT, exit 134), and the release binary produces `NaNpx`, `min(NaNpx,2px)`, `NaN%`, `NaN`, `NaNdeg`, and `NaNs` for the nine new cases. With it, all 1169 tests in the file pass, the existing `calc(infinity * 1px)` -> `3.40282e38px` behavior is unchanged, and `test/bundler/css/` (including the WPT color tests that rely on the NaN `none` sentinel) is green.
