### PR TITLE
Test: a failed dynamic import must not strand later importers of the same file

### DIFF
--- a/test/js/bun/resolve/concurrent-dynamic-import.test.ts
+++ b/test/js/bun/resolve/concurrent-dynamic-import.test.ts
@@ -6,7 +6,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // each call gets its own embedder fetch promise (the registry entry is created
 // only after the first fetch settles), so the loser of that race must still be
 // resolved by Bun__onFulfillAsyncModule rather than left pending forever.
-test("concurrent dynamic imports of the same module both resolve", async () => {
+test.concurrent("concurrent dynamic imports of the same module both resolve", async () => {
   using dir = tempDir("concurrent-dyn-import", {
     "shared.ts": `export const heavy = "H";`,
     "modules.ts": `import { heavy } from "./shared";\nexport const lazy = heavy + "-lazy";`,
@@ -29,4 +29,42 @@ test("concurrent dynamic imports of the same module both resolve", async () => {
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("ok");
   expect(exitCode).toBe(0);
+});
+
+// A top-level dynamic import whose fetch rejects with a non-Error value (a
+// single-message transpile failure is a BuildMessage, not an ErrorInstance)
+// must record a fetch failure on its registry entry. If it is recorded as an
+// evaluation error instead, the entry is left with no fetch/module/load
+// promise, and every later importer of the same file that goes through
+// hostLoadImportedModule parks forever on a promise nothing settles.
+test.concurrent("a failed dynamic import does not strand later static importers of the same file", async () => {
+  using dir = tempDir("dyn-import-fetch-error", {
+    // Exactly one parser error so the rejection value is a BuildMessage
+    // rather than an AggregateError (which is an ErrorInstance).
+    "bad.ts": `import {\n`,
+    "other.ts": `import "./bad.ts";\nconsole.log("other loaded");\n`,
+    "entry.mjs": `
+      const d = import.meta.dir;
+      const names = [];
+      try { await import(d + "/bad.ts"); names.push("resolved"); } catch (e) { names.push(e?.name); }
+      try { await import(d + "/other.ts"); names.push("resolved"); } catch (e) { names.push(e?.name); }
+      console.log(JSON.stringify(names));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  // Without the fix the second import() never settles, so the child never
+  // exits and this test times out.
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: JSON.stringify(["BuildMessage", "BuildMessage"]),
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
 });


### PR DESCRIPTION
Adds a regression test for a module-loader hang whose fix, oven-sh/WebKit#262, is already in the `WEBKIT_VERSION` on `main`. No code changes.

### Reproduction (Bun <= 1.4.0)

```js
// bad.ts contains `import {`  (exactly one parser error)
// other.ts contains `import "./bad.ts"`
await import("./bad.ts").catch(() => {});
await import("./other.ts"); // never settles
```

The second `import()` neither resolves nor rejects and the process never exits (`timeout 10 bun run.mjs` exits 124). Any module that imports such a file statically, or dynamically inside another module's graph load, is stranded, not just the direct importer. A test runner that `import()`s each file and catches errors hits this routinely.

### Cause

A top-level dynamic `import()` whose transpile fails with a single parser error rejects with a `BuildMessage`, which is not an `ErrorInstance`. JSC's `moduleLoadTopSettled` gated its entire fetch-vs-evaluation error classification on `dynamicDowncast<ErrorInstance>`, so the rejection was never recorded as a fetch failure and `moduleLoadTopRejected` recorded it as an evaluation error instead. That left the module registry entry at `EvaluationFailed` with no fetch, module, or load promise. The next `hostLoadImportedModule` of the same key found a non-`New` entry with no `fetchError()` and no `loadPromise()`, skipped the re-fetch because the status was not `New`, and parked on a freshly created pending `fetchPromise` that nothing ever settles.

oven-sh/WebKit#262 records a non-Error fetch rejection with `setFetchError` (matching what the sibling nested-import path, `moduleRegistryFetchSettled`, already does), so later importers take `hostLoadImportedModule`'s `fetchError()` short circuit and reject instead of hanging.

That misclassification is also what trips `ASSERTION FAILED: m_status == Status::Fetching` in `ModuleRegistryEntry::fetchComplete` on an asserts build when a failing and a succeeding loader of one path race (for example `import(p, { with: { type: "toml" } })` of a file with a TOML syntax error concurrently with `import(p, { with: { type: "text" } })`): `setEvaluationError` leaves the entry in a state `fetchComplete` does not guard, while `setFetchError` lands it at `FetchFailed`, which `fetchComplete` already early-returns on. Independent of the import-attribute module map key in #32999 / oven-sh/WebKit#258; the hang needs no import attributes at all.

### Test

`test/js/bun/resolve/concurrent-dynamic-import.test.ts`, "a failed dynamic import does not strand later static importers of the same file". Plain TypeScript, no import attributes.

### Verification

- `USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/concurrent-dynamic-import.test.ts`: the new test fails with a 5000ms timeout on released Bun 1.4.0 (the hang); the existing test passes.
- `bun bd test test/js/bun/resolve/concurrent-dynamic-import.test.ts` against `main`'s `WEBKIT_VERSION` (`c9ad5813fd`, which contains oven-sh/WebKit#262): both tests pass.