### PR TITLE
build: fetch and patch rust-argon2 as a vendored cargo path dependency

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,6 +15,8 @@ on:
       - "scripts/build.ts"
       - "Cargo.toml"
       - "Cargo.lock"
+      # Applied onto vendor/rust-argon2 before cargo resolves the workspace.
+      - "patches/rust-argon2/**"
       - "clippy.toml"
       - "rust-toolchain.toml"
       - ".github/workflows/clippy.yml"

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -67,12 +67,14 @@ jobs:
       - name: Generate codegen
         # bun_runtime/bun_jsc/bun_core `include!()` files under
         # build/debug/codegen/; clippy can't lint those crates without them.
-        # `clone-lolhtml` fetches the vendored Rust path-dep
-        # (the root `Cargo.toml` path-deps `lol_html` at `vendor/lolhtml`).
+        # `clone-lolhtml` / `clone-rust-argon2` fetch the vendored Rust path
+        # deps (the root `Cargo.toml` path-deps `lol_html` at `vendor/lolhtml`
+        # and `[patch.crates-io]`es `rust-argon2` at `vendor/rust-argon2`);
+        # cargo can't resolve the workspace until both exist on disk.
         run: |
           bun install --frozen-lockfile
           bun scripts/build.ts --configure-only
-          ninja -C build/debug codegen clone-lolhtml
+          ninja -C build/debug codegen clone-lolhtml clone-rust-argon2
 
       - name: cargo clippy
         env:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -59,8 +59,8 @@ jobs:
 
       - name: Setup system deps
         # cmake/ninja/clang for `--configure-only` (cargo can't resolve the
-        # workspace until vendor/lolhtml exists and bun_core/build.rs has
-        # build_options.rs).
+        # workspace until vendor/lolhtml and vendor/rust-argon2 exist and
+        # bun_core/build.rs has build_options.rs).
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
           echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ env.LLVM_VERSION_MAJOR }} main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
@@ -77,7 +77,7 @@ jobs:
         run: |
           bun install --frozen-lockfile
           bun scripts/build.ts --configure-only
-          ninja -C build/debug clone-lolhtml
+          ninja -C build/debug clone-lolhtml clone-rust-argon2
 
       - name: cargo miri test
         env:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -26,6 +26,8 @@ on:
       - "scripts/rust-miri.ts"
       - "Cargo.toml"
       - "Cargo.lock"
+      # Applied onto vendor/rust-argon2 before cargo resolves the workspace.
+      - "patches/rust-argon2/**"
       - "rust-toolchain.toml"
       - ".github/workflows/miri.yml"
       - ".github/actions/setup-bun/**"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,8 +3163,6 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "rust-argon2"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae76b7506744d254fd0eb2c0ff5c5d108201ccbb083111ac04a44eeda105680"
 dependencies = [
  "base64",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,3 +450,12 @@ bun_transpiler = { path = "src/transpiler" }
 
 [profile.release.package.bun_react_compiler]
 opt-level = "s"
+
+[patch.crates-io]
+# Upstream 3.0.0 fetched at build time by `scripts/build/deps/rust-argon2.ts`
+# into the gitignored `vendor/rust-argon2/`, with
+# `patches/rust-argon2/verify-encoded-legacy-memory.patch` applied: it adds a
+# `verify_encoded_legacy_memory` entry point that accepts `mem_cost < 8 * lanes`
+# so hashes from earlier Bun releases (Zig stdlib argon2 allowed any
+# `memoryCost >= 1`) stay verifiable. Upstream entry points are unchanged.
+rust-argon2 = { path = "vendor/rust-argon2" }

--- a/patches/rust-argon2/verify-encoded-legacy-memory.patch
+++ b/patches/rust-argon2/verify-encoded-legacy-memory.patch
@@ -1,0 +1,130 @@
+--- a/src/context.rs
++++ b/src/context.rs
+@@ -37,6 +37,26 @@
+ impl<'a> Context<'a> {
+     /// Attempts to create a new context.
+     pub fn new(config: Config<'a>, pwd: &'a [u8], salt: &'a [u8]) -> Result<Context<'a>> {
++        Self::new_impl(config, pwd, salt, false)
++    }
++
++    /// Bun patch: `new` with the `mem_cost >= 8 * lanes` floor relaxed to
++    /// `>= 1`, so hashes from earlier Bun releases (Zig stdlib argon2)
++    /// verify. H0 still gets the raw `mem_cost`; the block count is clamped.
++    pub fn new_legacy_memory(
++        config: Config<'a>,
++        pwd: &'a [u8],
++        salt: &'a [u8],
++    ) -> Result<Context<'a>> {
++        Self::new_impl(config, pwd, salt, true)
++    }
++
++    fn new_impl(
++        config: Config<'a>,
++        pwd: &'a [u8],
++        salt: &'a [u8],
++        legacy_memory: bool,
++    ) -> Result<Context<'a>> {
+         if config.lanes < common::MIN_LANES {
+             return Err(Error::LanesTooFew);
+         } else if config.lanes > common::MAX_LANES {
+@@ -44,11 +64,14 @@
+         }
+ 
+         let lanes = config.lanes;
+-        if config.mem_cost < common::MIN_MEMORY {
++        // Bun patch: `new_legacy_memory` lowers the floor from
++        // `MIN_MEMORY` / `8 * lanes` to `1`; `new` keeps upstream's checks.
++        let min_memory = if legacy_memory { 1 } else { common::MIN_MEMORY };
++        if config.mem_cost < min_memory {
+             return Err(Error::MemoryTooLittle);
+         } else if config.mem_cost > common::MAX_MEMORY {
+             return Err(Error::MemoryTooMuch);
+-        } else if config.mem_cost < 8 * lanes {
++        } else if !legacy_memory && config.mem_cost < 8 * lanes {
+             return Err(Error::MemoryTooLittle);
+         }
+ 
+@@ -173,6 +196,33 @@
+             Err(Error::MemoryTooLittle)
+         );
+     }
++
++    // Bun patch: `new_legacy_memory` accepts `1 <= mem_cost < 8 * lanes`
++    // and clamps `memory_blocks` to `2 * SYNC_POINTS * lanes`, just as
++    // `new` already does for in-range values. Only `mem_cost == 0` errors.
++    #[test]
++    fn new_legacy_memory_clamps_low_mem_cost() {
++        let config = Config {
++            lanes: 4,
++            mem_cost: 31,
++            ..Default::default()
++        };
++        let context = Context::new_legacy_memory(config, &[0u8; 8], &[0u8; 8]).unwrap();
++        assert_eq!(context.config.mem_cost, 31);
++        assert_eq!(context.memory_blocks, 32);
++    }
++
++    #[test]
++    fn new_legacy_memory_with_zero_mem_cost_returns_correct_error() {
++        let config = Config {
++            mem_cost: 0,
++            ..Default::default()
++        };
++        assert_eq!(
++            Context::new_legacy_memory(config, &[0u8; 8], &[0u8; 8]),
++            Err(Error::MemoryTooLittle)
++        );
++    }
+ 
+     #[test]
+     fn new_with_too_small_time_cost_returns_correct_error() {
+--- a/src/argon2.rs
++++ b/src/argon2.rs
+@@ -224,6 +224,47 @@
+     Ok(constant_time_eq(hash, &calculated_hash))
+ }
+ 
++/// Bun patch: `verify_encoded`, but accepts `1 <= mem_cost < 8 * lanes`, as
++/// produced by earlier Bun releases (Zig stdlib argon2). Hashing still uses
++/// upstream's `Context::new`. See src/deps/rust-argon2/README.md.
++pub fn verify_encoded_legacy_memory(encoded: &str, pwd: &[u8]) -> Result<bool> {
++    let decoded = encoding::decode_string(encoded)?;
++    let threads = if cfg!(feature = "crossbeam-utils") {
++        decoded.parallelism
++    } else {
++        1
++    };
++    let config = Config {
++        variant: decoded.variant,
++        version: decoded.version,
++        mem_cost: decoded.mem_cost,
++        time_cost: decoded.time_cost,
++        lanes: decoded.parallelism,
++        thread_mode: ThreadMode::from_threads(threads),
++        secret: &[],
++        ad: &[],
++        hash_length: decoded.hash.len() as u32,
++    };
++    verify_raw_legacy_memory(pwd, &decoded.salt, &decoded.hash, &config)
++}
++
++/// Bun patch: `verify_raw` via `Context::new_legacy_memory`, so a
++/// `mem_cost` in `1..8*lanes` is accepted. See `verify_encoded_legacy_memory`.
++pub fn verify_raw_legacy_memory(
++    pwd: &[u8],
++    salt: &[u8],
++    hash: &[u8],
++    config: &Config,
++) -> Result<bool> {
++    let config = Config {
++        hash_length: hash.len() as u32,
++        ..config.clone()
++    };
++    let context = Context::new_legacy_memory(config, pwd, salt)?;
++    let calculated_hash = run(&context);
++    Ok(constant_time_eq(hash, &calculated_hash))
++}
++
+ fn run(context: &Context) -> Vec<u8> {
+     let mut memory = Memory::new(context.config.lanes, context.lane_length);
+     core::initialize(context, &mut memory);

--- a/patches/rust-argon2/verify-encoded-legacy-memory.patch
+++ b/patches/rust-argon2/verify-encoded-legacy-memory.patch
@@ -86,7 +86,7 @@
  
 +/// Bun patch: `verify_encoded`, but accepts `1 <= mem_cost < 8 * lanes`, as
 +/// produced by earlier Bun releases (Zig stdlib argon2). Hashing still uses
-+/// upstream's `Context::new`. See src/deps/rust-argon2/README.md.
++/// upstream's `Context::new`. Applied by patches/rust-argon2/*.patch in bun.
 +pub fn verify_encoded_legacy_memory(encoded: &str, pwd: &[u8]) -> Result<bool> {
 +    let decoded = encoding::decode_string(encoded)?;
 +    let threads = if cfg!(feature = "crossbeam-utils") {
@@ -128,3 +128,23 @@
  fn run(context: &Context) -> Vec<u8> {
      let mut memory = Memory::new(context.config.lanes, context.lane_length);
      core::initialize(context, &mut memory);
+@@ -275,4 +316,19 @@
+         let res = verify_encoded(hash, b"password").unwrap();
+         assert!(res);
+     }
++
++    // Bun patch: a real hash produced by Bun's earlier Zig stdlib argon2 with
++    // `m=5,t=1,p=1`. The upstream entry point must keep rejecting it, and the
++    // legacy entry point must verify it (and still reject a wrong password).
++    #[test]
++    fn verify_encoded_legacy_memory_accepts_low_mem_cost() {
++        let hash = "$argon2id$v=19$m=5,t=1,p=1$JJA3TrXOzpimHbQVvHUgXa412Kmo29q8zBHEWptN2h4$\
++                    GvYy9WOUF64dYFsCjuUcqY90bCKxlV0j4BH/GCzpWa4";
++        assert_eq!(
++            verify_encoded(hash, b"mypw"),
++            Err(crate::Error::MemoryTooLittle)
++        );
++        assert_eq!(verify_encoded_legacy_memory(hash, b"mypw"), Ok(true));
++        assert_eq!(verify_encoded_legacy_memory(hash, b"wrong"), Ok(false));
++    }
+ }

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -164,7 +164,7 @@ For `mode: "full"` (the normal case):
 8. **Post-link** — strip (release only), dsymutil (darwin release only).
 9. **Smoke test** — `<exe> --revision` catches load-time failures.
 
-Split CI modes: `rust-only` (lolhtml+codegen+cargo → libbun_rust.a), `cpp-only` (deps+codegen+compile → archive), `link-only` (download artifacts → link).
+Split CI modes: `rust-only` (lolhtml+rust-argon2+codegen+cargo → libbun_rust.a), `cpp-only` (deps+codegen+compile → archive), `link-only` (download artifacts → link).
 
 ### Phase 3 — Execute
 

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -127,7 +127,7 @@ function systemLibs(cfg: Config): string[] {
  * Optional fields are present only when the mode produces them:
  *   full:      exe, strippedExe?, dsym?, rustObjects, objects, deps, codegen
  *   cpp-only:  archive, objects, deps, codegen
- *   rust-only: rustObjects, deps (lolhtml), codegen
+ *   rust-only: rustObjects, deps (lolhtml, rust-argon2), codegen
  *   link-only: exe, strippedExe?, dsym?
  */
 export interface BunOutput {
@@ -193,7 +193,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   // Outputs of deps that provide headers — used as implicit inputs on PCH/cc/
   // no-PCH cxx so a dep rebuild invalidates compiles that #include its headers
   // (the .a is the signal — see comment at the PCH step). Deps with no provided
-  // includes (tinycc, lolhtml) are skipped: nothing to invalidate, and a tinycc
+  // includes (tinycc, lolhtml, rust-argon2) are skipped: nothing to invalidate, and a tinycc
   // no-op rebuild (ar has no restat) would otherwise cascade to a full PCH+cxx
   // rebuild. Link still gets every dep via depLibs/depObjects.
   const depHeaderSignal: string[] = [];
@@ -443,7 +443,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
     }
 
     // depLibs explicit in the phony: deps with no provided includes (tinycc,
-    // lolhtml) aren't in depHeaderSignal, so the archive doesn't pull them
+    // lolhtml, rust-argon2) aren't in depHeaderSignal, so the archive doesn't pull them
     // transitively — but link-only still needs them uploaded.
     n.phony("bun", [archive, ...depLibs, ...(depUploadStamp ? [depUploadStamp] : [])]);
     n.default(["bun"]);
@@ -533,8 +533,9 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
  *   - cargo build → libbun_rust.a
  *
  * Does NOT need: any C dep built, any cxx, PCH, link. ninja only pulls
- * what's depended on — lolhtml's configure/build rules are emitted but
- * unused (only its `.ref` fetch stamp is depended on by emitRust).
+ * what's depended on — the lolhtml / rust-argon2 configure/build rules are
+ * emitted but unused (only their `.ref` fetch stamps are depended on by
+ * emitRust).
  *
  * Cross-compilation: see `rustCanCrossFromLinux()` in rust.ts for which
  * targets share a linux runner vs need a native agent.

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -230,10 +230,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
       // separate archives — cargo needs both on disk before it resolves the
       // manifest. Each `.ref` stamp's content is the pinned commit (plus
       // patch contents), so a bump or patch edit re-invokes cargo.
-      vendorStamps: [
-        ...(depsByName.get("lolhtml")?.outputs ?? []),
-        ...(depsByName.get("rust-argon2")?.outputs ?? []),
-      ],
+      vendorStamps: [...(depsByName.get("lolhtml")?.outputs ?? []), ...(depsByName.get("rust-argon2")?.outputs ?? [])],
     });
   }
 

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -31,6 +31,7 @@ import { bunExeName, shouldStrip, type Config } from "./config.ts";
 import { generateDepVersionsHeader } from "./depVersionsHeader.ts";
 import { allDeps } from "./deps/index.ts";
 import { lolhtml } from "./deps/lolhtml.ts";
+import { rustArgon2 } from "./deps/rust-argon2.ts";
 import { assert } from "./error.ts";
 import { bunIncludes, computeFlags, extraFlagsFor, linkDepends } from "./flags.ts";
 import { writeIfChanged } from "./fs.ts";
@@ -223,12 +224,16 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
       codegenInputs: codegen.rustInputs,
       codegenOrderOnly: codegen.rustOrderOnly,
       rustSources: sources.rust,
-      // lol-html is a direct path dep of `bun_runtime`/`bun_bundler`
-      // (`lol_html = { path = "vendor/lolhtml" }` in the workspace Cargo.toml),
-      // not built into a separate archive — cargo needs `vendor/lolhtml/` on
-      // disk before it resolves the manifest. The `.ref` stamp's content is
-      // the pinned commit, so a bump re-invokes cargo.
-      vendorStamps: depsByName.get("lolhtml")?.outputs ?? [],
+      // lol-html and rust-argon2 are consumed by cargo as path deps out of
+      // `vendor/` (lol_html directly from `bun_runtime`/`bun_bundler`;
+      // rust-argon2 via the root `[patch.crates-io]`), not built into
+      // separate archives — cargo needs both on disk before it resolves the
+      // manifest. Each `.ref` stamp's content is the pinned commit (plus
+      // patch contents), so a bump or patch edit re-invokes cargo.
+      vendorStamps: [
+        ...(depsByName.get("lolhtml")?.outputs ?? []),
+        ...(depsByName.get("rust-argon2")?.outputs ?? []),
+      ],
     });
   }
 
@@ -526,7 +531,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
  * set via --os/--arch overrides (cargo `--target <triple>`).
  *
  * Needs:
- *   - lolhtml FETCHED (path dep of `bun_runtime`/`bun_bundler`) — not built separately
+ *   - lolhtml + rust-argon2 FETCHED (cargo path deps) — not built separately
  *   - codegen (Rust `include!`s/`include_bytes!`s the same generated set)
  *   - cargo build → libbun_rust.a
  *
@@ -543,10 +548,13 @@ function emitRustOnly(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   n.comment("════════════════════════════════════════════════════════════════");
   n.blank();
 
-  // Only dep: lolhtml, fetched as a cargo path dependency. resolveDep
-  // emits its fetch; emitRust depends on the fetch stamp via vendorStamps.
+  // Only deps: lolhtml and rust-argon2, both fetched as cargo path
+  // dependencies. resolveDep emits each fetch; emitRust depends on the
+  // fetch stamps via vendorStamps.
   const lolhtmlDep = resolveDep(n, cfg, lolhtml, new Map());
   assert(lolhtmlDep !== null, "lolhtml resolveDep returned null — should never be skipped");
+  const rustArgon2Dep = resolveDep(n, cfg, rustArgon2, new Map());
+  assert(rustArgon2Dep !== null, "rust-argon2 resolveDep returned null — should never be skipped");
 
   // Codegen: emitted fully, but only the embed-input subset is pulled.
   // The cpp-related outputs (cppSources, bindgenV2Cpp) have no consumer
@@ -557,13 +565,13 @@ function emitRustOnly(n: Ninja, cfg: Config, sources: Sources): BunOutput {
     codegenInputs: codegen.rustInputs,
     codegenOrderOnly: codegen.rustOrderOnly,
     rustSources: sources.rust,
-    vendorStamps: lolhtmlDep.outputs,
+    vendorStamps: [...lolhtmlDep.outputs, ...rustArgon2Dep.outputs],
   });
 
   n.phony("bun", rustObjects);
   n.default(["bun"]);
 
-  return { deps: [lolhtmlDep], codegen, rustObjects, objects: [] };
+  return { deps: [lolhtmlDep, rustArgon2Dep], codegen, rustObjects, objects: [] };
 }
 
 /**

--- a/scripts/build/deps/index.ts
+++ b/scripts/build/deps/index.ts
@@ -29,6 +29,7 @@ import { lsquic } from "./lsquic.ts";
 import { mimalloc } from "./mimalloc.ts";
 import { nodejsHeaders } from "./nodejs-headers.ts";
 import { picohttpparser } from "./picohttpparser.ts";
+import { rustArgon2 } from "./rust-argon2.ts";
 import { sqlite } from "./sqlite.ts";
 import { tinycc } from "./tinycc.ts";
 import { webkit } from "./webkit.ts";
@@ -61,6 +62,9 @@ export const allDeps: readonly Dependency[] = [
   highway,
   libuv,
   lolhtml,
+  // Like lolhtml: fetch-only, compiled inside the workspace cargo build via
+  // the `[patch.crates-io]` path override in the root Cargo.toml.
+  rustArgon2,
   lshpack,
   lsqpack,
   mimalloc,
@@ -96,6 +100,7 @@ export {
   mimalloc,
   nodejsHeaders,
   picohttpparser,
+  rustArgon2,
   sqlite,
   tinycc,
   webkit,

--- a/scripts/build/deps/rust-argon2.ts
+++ b/scripts/build/deps/rust-argon2.ts
@@ -1,0 +1,48 @@
+/**
+ * rust-argon2 — the Argon2 implementation behind `Bun.password`.
+ *
+ * Like lolhtml, this is NOT built into its own archive: the root Cargo.toml
+ * redirects the published `rust-argon2` crate to `vendor/rust-argon2/` via
+ * `[patch.crates-io]`, so it compiles as an rlib inside the one workspace
+ * cargo build. This dep entry exists only to FETCH the source (plus apply
+ * the patch below) into `vendor/rust-argon2/` — `emitRust` in `rust.ts`
+ * waits on its `.ref` stamp so cargo never sees a missing path dependency.
+ *
+ * Why it is patched at all: upstream's `Context::new` rejects any memory
+ * cost below the RFC 9106 floor of `8 * lanes` before computing. Bun
+ * releases backed by the Zig stdlib argon2 accepted any `memoryCost >= 1`
+ * when hashing, so PHC strings with `m` in 1..7 exist in users' databases
+ * and must stay verifiable. The patch is purely additive: it adds a
+ * `verify_encoded_legacy_memory` entry point and changes no upstream
+ * behavior. See `patches/rust-argon2/verify-encoded-legacy-memory.patch`.
+ */
+
+import type { Dependency } from "../source.ts";
+
+// The `3.0.0` release tag. `src/` at this commit is byte-identical to the
+// `rust-argon2 = "3.0"` sources published on crates.io.
+const RUST_ARGON2_COMMIT = "ed81866f163f0c7026aa6fd8388adf37242eb32a";
+
+export const rustArgon2: Dependency = {
+  name: "rust-argon2",
+
+  source: () => ({
+    kind: "github-archive",
+    repo: "sru-systems/rust-argon2",
+    commit: RUST_ARGON2_COMMIT,
+  }),
+
+  patches: ["patches/rust-argon2/verify-encoded-legacy-memory.patch"],
+
+  // No separate build — compiled as part of the workspace cargo build via
+  // the `[patch.crates-io]` path override in the root Cargo.toml.
+  build: () => ({ kind: "none" }),
+
+  provides: () => ({
+    // No standalone archive on the link line.
+    libs: [],
+    // No includes — it has no C/C++ surface; it's a pure Rust crate cargo
+    // consumes straight out of `vendor/rust-argon2/`.
+    includes: [],
+  }),
+};

--- a/scripts/build/deps/rust-argon2.ts
+++ b/scripts/build/deps/rust-argon2.ts
@@ -2,19 +2,12 @@
  * rust-argon2 — the Argon2 implementation behind `Bun.password`.
  *
  * Like lolhtml, this is NOT built into its own archive: the root Cargo.toml
- * redirects the published `rust-argon2` crate to `vendor/rust-argon2/` via
- * `[patch.crates-io]`, so it compiles as an rlib inside the one workspace
- * cargo build. This dep entry exists only to FETCH the source (plus apply
- * the patch below) into `vendor/rust-argon2/` — `emitRust` in `rust.ts`
- * waits on its `.ref` stamp so cargo never sees a missing path dependency.
- *
- * Why it is patched at all: upstream's `Context::new` rejects any memory
- * cost below the RFC 9106 floor of `8 * lanes` before computing. Bun
- * releases backed by the Zig stdlib argon2 accepted any `memoryCost >= 1`
- * when hashing, so PHC strings with `m` in 1..7 exist in users' databases
- * and must stay verifiable. The patch is purely additive: it adds a
- * `verify_encoded_legacy_memory` entry point and changes no upstream
- * behavior. See `patches/rust-argon2/verify-encoded-legacy-memory.patch`.
+ * redirects the published crate to `vendor/rust-argon2/` via
+ * `[patch.crates-io]`, so it compiles inside the one workspace cargo build.
+ * This dep entry exists only to FETCH the source and apply
+ * `patches/rust-argon2/verify-encoded-legacy-memory.patch` (an additive
+ * `verify_encoded_legacy_memory` entry point; see the patch for why) —
+ * `emitRust` waits on the `.ref` stamp so cargo never sees a missing path.
  */
 
 import type { Dependency } from "../source.ts";

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -339,8 +339,9 @@ export interface RustBuildInputs {
   rustSources: string[];
   /**
    * Fetch stamps for vendored Rust crates the workspace consumes as path
-   * dependencies (currently lol-html). Implicit inputs so cargo never runs
-   * before the source tree exists, and so a commit bump re-invokes cargo.
+   * dependencies (lol-html, and rust-argon2 via the root `[patch.crates-io]`).
+   * Implicit inputs so cargo never runs before the source trees exist, and
+   * so a commit or patch bump re-invokes cargo.
    */
   vendorStamps: string[];
 }
@@ -527,8 +528,8 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   // Path remapping (CI reproducibility) — rustc equivalent of the C/C++
   // `-ffile-prefix-map` entries in flags.ts. Without this, `file!()` /
   // panic locations and the DWARF compilation-dir from every workspace
-  // crate and vendored Rust dep (lol-html) embed the absolute checkout
-  // path into the release binary (`strings bun | grep $PWD` shows them).
+  // crate and vendored Rust dep (lol-html, rust-argon2) embed the absolute
+  // checkout path into the release binary (`strings bun | grep $PWD` shows them).
   // Gated on `cfg.ci` to match the flags.ts entry.
   if (cfg.ci) {
     rustflags.push(`--remap-path-prefix=${cfg.cwd}=.`);
@@ -557,8 +558,8 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     rustflags.push(`-Cprofile-use=${cfg.pgoUse}`);
   }
   // Force lld for any target link rustc itself performs. None exists today
-  // (`bun_bin` is a staticlib with no link step; `lol_html` is a plain rlib
-  // path dep), so this is defensive — see the Windows note below. The
+  // (`bun_bin` is a staticlib with no link step; `lol_html` / `rust-argon2`
+  // are plain rlib path deps), so this is defensive — see the Windows note below. The
   // default `cc` driver picks BFD `/usr/bin/ld`, which doesn't match the
   // semantics the C/C++ object set assumes (and, under `-Clinker-plugin-lto`,
   // doesn't understand `-plugin-opt`). This used to live only behind
@@ -856,9 +857,10 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
       inputs: [],
       // Same staleness signal as the main build (any .rs / Cargo.toml change
       // re-invokes; cargo's own fingerprinting decides what actually
-      // recompiles). vendorStamps order the lol-html fetch first — the shim
-      // crate doesn't depend on lol-html, but cargo refuses to load the
-      // workspace manifest if any path-dep's `Cargo.toml` is missing.
+      // recompiles). vendorStamps order the lol-html / rust-argon2 fetches
+      // first — the shim crate depends on neither, but cargo refuses to load
+      // the workspace manifest if any path dependency's (or `[patch.crates-io]`
+      // override's) `Cargo.toml` is missing.
       // shimDest: rebuilt when a sibling build dir (other arch/profile)
       // overwrote the shared exe.
       implicitInputs: [cfg.cargo, ...inputs.rustSources, ...inputs.vendorStamps, shimDest],
@@ -897,7 +899,7 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     // Codegen `.rs` outputs are side effects of edges in `codegenInputs`,
     // so depending on those orders the codegen step before cargo without
     // ninja needing to know the `.rs` paths. vendorStamps orders the
-    // lol-html source fetch before cargo resolves the path dep.
+    // lol-html / rust-argon2 source fetches before cargo resolves the path deps.
     implicitInputs: [cfg.cargo, ...inputs.rustSources, ...inputs.codegenInputs, ...inputs.vendorStamps, ...shimInputs],
     orderOnlyInputs: inputs.codegenOrderOnly,
     vars: {

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -679,8 +679,9 @@ export function depSourceDir(cfg: Config, name: string): string {
 }
 
 /**
- * Path to a dep's fetch stamp. Used by rust-only mode to depend on lolhtml's
- * source being on disk without resolving the full dep graph.
+ * Path to a dep's fetch stamp. Used by rust-only mode to depend on a vendored
+ * Rust crate's source (lolhtml, rust-argon2) being on disk without resolving
+ * the full dep graph.
  */
 export function depSourceStamp(cfg: Config, name: string): string {
   return resolve(depSourceDir(cfg, name), ".ref");

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -52,14 +52,20 @@ function run(cmd: string, args: string[], opts: Parameters<typeof spawnSync>[2] 
 }
 
 // `bun_core/build.rs` needs `build_options.rs`; cargo can't resolve the
-// workspace until `vendor/lolhtml/` (a path dep) exists. Both come from the
+// workspace until the vendored Rust path deps exist (`vendor/lolhtml/`, and
+// `vendor/rust-argon2/` via the root `[patch.crates-io]`). All come from the
 // configure step, which is a no-op when already done.
 const buildOptionsRs = resolve(repo, "build/debug/codegen/build_options.rs");
 const lolhtmlCargo = resolve(repo, "vendor/lolhtml/Cargo.toml");
-if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo)) {
+const rustArgon2Cargo = resolve(repo, "vendor/rust-argon2/Cargo.toml");
+if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo) || !existsSync(rustArgon2Cargo)) {
   console.log("\x1b[36m[setup]\x1b[0m bun run build --configure-only");
   if (run("bun", ["run", "build", "--configure-only"]).status !== 0) process.exit(1);
-  if (!existsSync(lolhtmlCargo) && run("ninja", ["-C", "build/debug", "clone-lolhtml"]).status !== 0) {
+  const clones = [
+    ...(existsSync(lolhtmlCargo) ? [] : ["clone-lolhtml"]),
+    ...(existsSync(rustArgon2Cargo) ? [] : ["clone-rust-argon2"]),
+  ];
+  if (clones.length > 0 && run("ninja", ["-C", "build/debug", ...clones]).status !== 0) {
     process.exit(1);
   }
   // Re-check: configure can succeed without producing these (e.g. partial
@@ -68,6 +74,7 @@ if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo)) {
   for (const [path, hint] of [
     [buildOptionsRs, "bun run build --configure-only"],
     [lolhtmlCargo, "ninja -C build/debug clone-lolhtml"],
+    [rustArgon2Cargo, "ninja -C build/debug clone-rust-argon2"],
   ] as const) {
     if (!existsSync(path)) {
       console.error(`\x1b[31m[error]\x1b[0m ${path} still missing after setup — try: ${hint}`);


### PR DESCRIPTION
## What

Fetch upstream [`sru-systems/rust-argon2`](https://github.com/sru-systems/rust-argon2) at the 3.0.0 release commit (`ed81866f`) into the gitignored `vendor/rust-argon2/` at build time, apply a checked-in patch, and redirect the published crate there via `[patch.crates-io]`.

This uses machinery the repo already has, nothing new is introduced:
- Eleven existing deps declare a `patches:` list in `scripts/build/deps/*.ts` (libuv, libarchive, webkit, highway, ...). `fetch-cli.ts` applies them with `git apply` after extraction, and the `.ref` stamp's identity hashes the patch contents, so editing the patch correctly invalidates the fetch.
- `lolhtml` is already a Rust crate that cargo consumes as a path dependency straight out of the gitignored `vendor/`; this dep uses the identical fetch-only shape (`build: { kind: "none" }`). The one extra consideration is wiring its `.ref` stamp into both `emitBun` code paths that run cargo, including the `rust-only` CI split mode, which resolves its deps explicitly.

## The patch

`patches/rust-argon2/verify-encoded-legacy-memory.patch` is the only third-party delta and is the thing to review: +87 / -2 across `src/context.rs` and `src/argon2.rs`; the other 13 source files stay byte-identical to upstream. It is purely additive: it adds a `verify_encoded_legacy_memory` entry point (backed by `Context::new_legacy_memory`) that accepts `1 <= mem_cost < 8 * lanes`, and changes no existing behavior. `Context::new` becomes a one-line delegation with its validation preserved verbatim, and upstream's own unit tests (including the two that assert `mem_cost < 8 * lanes` is rejected) still pass unmodified.

The `src/` tree at the pinned commit is byte-identical to the `rust-argon2 = "3.0"` sources published on crates.io, so provenance against the registry release is a one-command diff.

## Why

`Bun.password.verify` throws `WeakParameters` on argon2 hashes with `m < 8*p`, which earlier (Zig-backed) Bun releases produced and accepted, silently locking users out of their own credentials on upgrade. Upstream's `Context::new` is the single choke point for every public entry point and it rejects those before computing, and the `mem_cost` value is an input to H0, so there is no route to the correct digest through the published API of this crate, nor through RustCrypto's `argon2` (verified from its source: `Params::MIN_M_COST = 8`, enforced by every constructor).

Per the review discussion on #32325, this PR carries only the build and vendoring infrastructure so the third-party patch can be reviewed on its own. It is behavior-neutral: nothing calls the new entry point yet. #32325 stacks on top of this and becomes the two-file behavioral fix plus its test.

## Verification

- `bun bd --target=clone-rust-argon2` runs the new ninja fetch edge end to end: downloads the archive, extracts to `vendor/rust-argon2/`, applies the patch (`verify_encoded_legacy_memory` is present in the fetched tree), writes the `.ref` stamp.
- `cargo check -p bun_runtime` resolves `[patch.crates-io]` to `vendor/rust-argon2` and compiles.
- `bunx tsc --noEmit -p scripts/build/tsconfig.json` reports no errors in the changed build scripts.
