### PR TITLE
install: fix package-lock.json and pnpm-lock.yaml migration of file: dependencies

### DIFF
--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -1462,6 +1462,20 @@ pub(crate) fn migrate_npm_lockfile<'a>(
         finalize_pkg!();
     }
 
+    // npm records `cpu`/`os` for every lockfile entry, but a fresh resolve only
+    // reads them for the root and npm registry packages (`Package::from_npm`);
+    // workspace, folder, tarball, and git packages install unconditionally.
+    for i in 0..pkg_count {
+        match this.packages.items_resolution()[i].tag {
+            resolution::Tag::Root | resolution::Tag::Npm => {}
+            _ => {
+                let meta = &mut this.packages.items_meta_mut()[i];
+                meta.arch = Npm::Architecture::ALL;
+                meta.os = Npm::OperatingSystem::ALL;
+            }
+        }
+    }
+
     // It is our fault if we hit an error here, making it safe to disable in release.
     #[cfg(debug_assertions)]
     {
@@ -1556,8 +1570,12 @@ fn package_name_from_path(pkg_path: &[u8]) -> &[u8] {
             last_index + b"/node_modules/".len()
         } else if pkg_path.starts_with(b"node_modules/") {
             b"node_modules/".len()
+        } else if let Some(last_index) = strings::last_index_of(pkg_path, b"/") {
+            // Link targets outside `node_modules/` (e.g. `vendor/a`) use the
+            // path's basename; skip past the separator itself.
+            last_index + b"/".len()
         } else {
-            strings::last_index_of(pkg_path, b"/").unwrap_or(0)
+            0
         };
 
     &pkg_path[pkg_name_start..]

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -1572,8 +1572,14 @@ fn package_name_from_path(pkg_path: &[u8]) -> &[u8] {
             b"node_modules/".len()
         } else if let Some(last_index) = strings::last_index_of(pkg_path, b"/") {
             // Link targets outside `node_modules/` (e.g. `vendor/a`) use the
-            // path's basename; skip past the separator itself.
-            last_index + b"/".len()
+            // path's basename; keep the scope (`vendor/@scope/a`) like npm's
+            // `name-from-folder`, which omits `name` when it matches this.
+            let parent = &pkg_path[..last_index];
+            match strings::last_index_of(parent, b"/") {
+                Some(i) if parent[i + 1..].starts_with(b"@") => i + b"/".len(),
+                None if parent.starts_with(b"@") => 0,
+                _ => last_index + b"/".len(),
+            }
         } else {
             0
         };

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -1462,19 +1462,7 @@ pub(crate) fn migrate_npm_lockfile<'a>(
         finalize_pkg!();
     }
 
-    // npm records `cpu`/`os` for every lockfile entry, but a fresh resolve only
-    // reads them for the root and npm registry packages (`Package::from_npm`);
-    // workspace, folder, tarball, and git packages install unconditionally.
-    for i in 0..pkg_count {
-        match this.packages.items_resolution()[i].tag {
-            resolution::Tag::Root | resolution::Tag::Npm => {}
-            _ => {
-                let meta = &mut this.packages.items_meta_mut()[i];
-                meta.arch = Npm::Architecture::ALL;
-                meta.os = Npm::OperatingSystem::ALL;
-            }
-        }
-    }
+    clear_non_registry_platform_constraints(this);
 
     // It is our fault if we hit an error here, making it safe to disable in release.
     #[cfg(debug_assertions)]
@@ -1545,6 +1533,22 @@ pub(crate) fn migrate_npm_lockfile<'a>(
         serializer_result: Default::default(),
         format: LockfileFormat::Binary,
     }))
+}
+
+/// A fresh resolve only records `os`/`cpu` for the root and npm registry
+/// packages (`Package::from_npm`); folder, tarball, git, and workspace packages
+/// install unconditionally, so a migrated lockfile must not constrain them.
+pub(crate) fn clear_non_registry_platform_constraints(lockfile: &mut Lockfile) {
+    for i in 0..lockfile.packages.len() {
+        match lockfile.packages.items_resolution()[i].tag {
+            resolution::Tag::Root | resolution::Tag::Npm => {}
+            _ => {
+                let meta = &mut lockfile.packages.items_meta_mut()[i];
+                meta.arch = Npm::Architecture::ALL;
+                meta.os = Npm::OperatingSystem::ALL;
+            }
+        }
+    }
 }
 
 fn pkg_flag_is_true(pkg: &E::Object, key: &[u8]) -> bool {

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -430,7 +430,16 @@ pub(crate) fn migrate_npm_lockfile<'a>(
 
         if pkg.get(b"resolved").is_none() {
             let version_prop = pkg.get(b"version");
-            let pkg_name = package_name_from_path(pkg_path);
+            // Match the building phase: prefer the entry's explicit "name". npm
+            // writes it whenever it differs from the name its folder path implies,
+            // e.g. a package named `admin` living at `@admin` or `packages/@admin`.
+            let pkg_name: &[u8] = if let Some(set_name) = pkg.get(b"name") {
+                set_name
+                    .as_string(&arena)
+                    .ok_or_else(|| err!("InvalidNPMLockfile"))?
+            } else {
+                package_name_from_path(pkg_path)
+            };
             if let Some(version_prop) = version_prop
                 && !pkg_name.is_empty()
             {

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -1146,6 +1146,10 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
         }
     }
 
+    // pnpm records `os`/`cpu` for every `packages:` entry whose manifest
+    // declares them, including `file:` folders, tarballs, and git packages.
+    crate::migration::clear_non_registry_platform_constraints(lockfile);
+
     lockfile.resolve(log)?;
 
     lockfile.fetch_necessary_package_metadata_after_yarn_or_pnpm_migration::<false>(manager)?;

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -392,3 +392,116 @@ test("package-lock.json migration keeps dependencies declared as arbitrary tarba
   expect(fs.existsSync(join(testDir, "bun.lock"))).toBeTrue();
   expect(exitCode).toBe(0);
 });
+
+// Regular (non-optional) `file:` folder dependency whose package.json declares `os`/`cpu`
+// arrays. npm records those fields in the package-lock.json entry for every package, but
+// Bun only applies platform constraints to npm registry packages; a fresh `bun install`
+// of the same package.json installs the folder regardless. Migrating must not diverge.
+function filePlatformFixture(os: string[], cpu: string[]) {
+  const aPackageJson: Record<string, unknown> = { name: "a", version: "1.0.0" };
+  const aLockEntry: Record<string, unknown> = { version: "1.0.0" };
+  if (os.length) aPackageJson.os = aLockEntry.os = os;
+  if (cpu.length) aPackageJson.cpu = aLockEntry.cpu = cpu;
+  return {
+    "package.json": JSON.stringify({ name: "repro", dependencies: { a: "file:./vendor/a" } }),
+    "vendor/a/package.json": JSON.stringify(aPackageJson),
+    // Exactly what `npm install --package-lock-only` produces for this tree.
+    "package-lock.json": JSON.stringify({
+      name: "repro",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": { name: "repro", dependencies: { a: "file:./vendor/a" } },
+        "node_modules/a": { resolved: "vendor/a", link: true },
+        "vendor/a": aLockEntry,
+      },
+    }),
+  };
+}
+
+async function install(testDir: string, ...args: string[]) {
+  await using proc = Bun.spawn([bunExe(), "install", ...args], {
+    env: bunEnv,
+    cwd: testDir,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  return { stderr, exitCode };
+}
+
+test("package-lock.json migration does not platform-skip a regular file: folder dependency", async () => {
+  const testDir = tempDirWithFiles(
+    "migrate-folder-platform",
+    filePlatformFixture([`!${process.platform}`], [`!${process.arch}`]),
+  );
+
+  const { stderr, exitCode } = await install(testDir);
+  expect(stderr).toContain("migrated lockfile from package-lock.json");
+  expect(stderr).not.toContain("InvalidNPMLockfile");
+  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+  expect(exitCode).toBe(0);
+
+  // The migrated bun.lock matches what a fresh resolve of the same package.json writes:
+  // the folder package keeps its real name and carries no os/cpu constraint.
+  expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
+});
+
+test("package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependencies", async () => {
+  const testDir = tempDirWithFiles("migrate-folder-name", filePlatformFixture([], []));
+
+  const first = await install(testDir);
+  expect(first.stderr).toContain("migrated lockfile from package-lock.json");
+  expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
+  expect(first.exitCode).toBe(0);
+
+  // The second install consumes the bun.lock the migration just wrote. It must parse,
+  // otherwise --frozen-lockfile is permanently broken after an npm migration.
+  const second = await install(testDir, "--frozen-lockfile");
+  expect(second.stderr).not.toContain("Invalid package name");
+  expect(second.stderr).not.toContain("Ignoring lockfile");
+  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+  expect(second.exitCode).toBe(0);
+});
+
+test("package-lock.json migration does not platform-skip a regular file: tarball dependency", async () => {
+  // Same divergence as the folder variant, for a `LocalTarball` resolution. npm records
+  // the packed package's `os`/`cpu` arrays in its lockfile entry, and a fresh resolve of
+  // the same package.json extracts and installs the tarball regardless of them.
+  const nonMatching = { os: [`!${process.platform}`], cpu: [`!${process.arch}`] };
+  const testDir = tempDirWithFiles("migrate-tarball-platform", {
+    "package.json": JSON.stringify({ name: "repro", dependencies: { a: "file:./a-1.0.0.tgz" } }),
+    "src-a/package.json": JSON.stringify({ name: "a", version: "1.0.0", ...nonMatching }),
+  });
+
+  {
+    await using pack = Bun.spawn([bunExe(), "pm", "pack", "--destination", testDir], {
+      env: bunEnv,
+      cwd: join(testDir, "src-a"),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [packErr, packExit] = await Promise.all([pack.stderr.text(), pack.exited]);
+    expect(packExit, packErr).toBe(0);
+    expect(fs.existsSync(join(testDir, "a-1.0.0.tgz"))).toBeTrue();
+  }
+
+  await Bun.write(
+    join(testDir, "package-lock.json"),
+    JSON.stringify({
+      name: "repro",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": { name: "repro", dependencies: { a: "file:./a-1.0.0.tgz" } },
+        "node_modules/a": { version: "1.0.0", resolved: "file:a-1.0.0.tgz", ...nonMatching },
+      },
+    }),
+  );
+
+  const { stderr, exitCode } = await install(testDir);
+  expect(stderr).toContain("migrated lockfile from package-lock.json");
+  expect(stderr).not.toContain("InvalidNPMLockfile");
+  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -397,23 +397,24 @@ test("package-lock.json migration keeps dependencies declared as arbitrary tarba
 // arrays. npm records those fields in the package-lock.json entry for every package, but
 // Bun only applies platform constraints to npm registry packages; a fresh `bun install`
 // of the same package.json installs the folder regardless. Migrating must not diverge.
-function filePlatformFixture(os: string[], cpu: string[]) {
-  const aPackageJson: Record<string, unknown> = { name: "a", version: "1.0.0" };
-  const aLockEntry: Record<string, unknown> = { version: "1.0.0" };
-  if (os.length) aPackageJson.os = aLockEntry.os = os;
-  if (cpu.length) aPackageJson.cpu = aLockEntry.cpu = cpu;
+function filePlatformFixture(name: string, folder: string, os: string[], cpu: string[]) {
+  const folderPackageJson: Record<string, unknown> = { name, version: "1.0.0" };
+  const folderLockEntry: Record<string, unknown> = { version: "1.0.0" };
+  if (os.length) folderPackageJson.os = folderLockEntry.os = os;
+  if (cpu.length) folderPackageJson.cpu = folderLockEntry.cpu = cpu;
   return {
-    "package.json": JSON.stringify({ name: "repro", dependencies: { a: "file:./vendor/a" } }),
-    "vendor/a/package.json": JSON.stringify(aPackageJson),
-    // Exactly what `npm install --package-lock-only` produces for this tree.
+    "package.json": JSON.stringify({ name: "repro", dependencies: { [name]: `file:./${folder}` } }),
+    [`${folder}/package.json`]: JSON.stringify(folderPackageJson),
+    // Exactly what `npm install --package-lock-only` produces for this tree. npm omits the
+    // entry's `name` field whenever it matches the name inferred from the folder path.
     "package-lock.json": JSON.stringify({
       name: "repro",
       lockfileVersion: 3,
       requires: true,
       packages: {
-        "": { name: "repro", dependencies: { a: "file:./vendor/a" } },
-        "node_modules/a": { resolved: "vendor/a", link: true },
-        "vendor/a": aLockEntry,
+        "": { name: "repro", dependencies: { [name]: `file:./${folder}` } },
+        [`node_modules/${name}`]: { resolved: folder, link: true },
+        [folder]: folderLockEntry,
       },
     }),
   };
@@ -433,7 +434,7 @@ async function install(testDir: string, ...args: string[]) {
 test.concurrent("package-lock.json migration does not platform-skip a regular file: folder dependency", async () => {
   const testDir = tempDirWithFiles(
     "migrate-folder-platform",
-    filePlatformFixture([`!${process.platform}`], [`!${process.arch}`]),
+    filePlatformFixture("a", "vendor/a", [`!${process.platform}`], [`!${process.arch}`]),
   );
 
   const { stderr, exitCode } = await install(testDir);
@@ -447,15 +448,18 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
   expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
 });
 
-test.concurrent(
-  "package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependencies",
-  async () => {
-    const testDir = tempDirWithFiles("migrate-folder-name", filePlatformFixture([], []));
+test.concurrent.each([
+  ["a", "vendor/a"],
+  ["@scope/a", "vendor/@scope/a"],
+])(
+  "package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependency %s",
+  async (name, folder) => {
+    const testDir = tempDirWithFiles("migrate-folder-name", filePlatformFixture(name, folder, [], []));
 
     const first = await install(testDir);
     expect(first.stderr).toContain("migrated lockfile from package-lock.json");
     expect(first.exitCode).toBe(0);
-    expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
+    expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"${name}": ["${name}@file:${folder}", {}]`);
 
     // The second install consumes the bun.lock the migration just wrote. It must parse,
     // otherwise --frozen-lockfile is permanently broken after an npm migration.
@@ -463,7 +467,7 @@ test.concurrent(
     expect(second.stderr).not.toContain("Invalid package name");
     expect(second.stderr).not.toContain("Ignoring lockfile");
     expect(second.exitCode).toBe(0);
-    expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+    expect(await Bun.file(join(testDir, "node_modules", name, "package.json")).json()).toHaveProperty("name", name);
   },
 );
 

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -393,6 +393,15 @@ test("package-lock.json migration keeps dependencies declared as arbitrary tarba
   expect(exitCode).toBe(0);
 });
 
+// npm infers a name from a lockfile entry's folder path, keeping an `@scope` parent
+// component, and omits the entry's `name` field whenever that inference matches it.
+function npmNameFromFolder(folder: string) {
+  const parts = folder.split("/");
+  const base = parts[parts.length - 1];
+  const scope = parts[parts.length - 2];
+  return scope?.startsWith("@") ? `${scope}/${base}` : base;
+}
+
 // Regular (non-optional) `file:` folder dependency whose package.json declares `os`/`cpu`
 // arrays. npm records those fields in the package-lock.json entry for every package, but
 // Bun only applies platform constraints to npm registry packages; a fresh `bun install`
@@ -400,13 +409,13 @@ test("package-lock.json migration keeps dependencies declared as arbitrary tarba
 function filePlatformFixture(name: string, folder: string, os: string[], cpu: string[]) {
   const folderPackageJson: Record<string, unknown> = { name, version: "1.0.0" };
   const folderLockEntry: Record<string, unknown> = { version: "1.0.0" };
+  if (npmNameFromFolder(folder) !== name) folderLockEntry.name = name;
   if (os.length) folderPackageJson.os = folderLockEntry.os = os;
   if (cpu.length) folderPackageJson.cpu = folderLockEntry.cpu = cpu;
   return {
     "package.json": JSON.stringify({ name: "repro", dependencies: { [name]: `file:./${folder}` } }),
     [`${folder}/package.json`]: JSON.stringify(folderPackageJson),
-    // Exactly what `npm install --package-lock-only` produces for this tree. npm omits the
-    // entry's `name` field whenever it matches the name inferred from the folder path.
+    // Exactly what `npm install --package-lock-only` produces for this tree.
     "package-lock.json": JSON.stringify({
       name: "repro",
       lockfileVersion: 3,
@@ -451,8 +460,12 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
 test.concurrent.each([
   ["a", "vendor/a"],
   ["@scope/a", "vendor/@scope/a"],
+  // npm writes an explicit `name` for these two, because the name it infers from the
+  // folder path (`@admin`) differs from the manifest's; migration must honor it.
+  ["admin", "@admin"],
+  ["admin", "packages/@admin"],
 ])(
-  "package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependency %s",
+  "package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependency %s at %s",
   async (name, folder) => {
     const testDir = tempDirWithFiles("migrate-folder-name", filePlatformFixture(name, folder, [], []));
 

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -1,6 +1,6 @@
 import { expect, setDefaultTimeout, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, pack, tempDirWithFiles, tmpdirSync } from "harness";
 import { join } from "path";
 
 setDefaultTimeout(1000 * 60 * 5);
@@ -430,7 +430,7 @@ async function install(testDir: string, ...args: string[]) {
   return { stderr, exitCode };
 }
 
-test("package-lock.json migration does not platform-skip a regular file: folder dependency", async () => {
+test.concurrent("package-lock.json migration does not platform-skip a regular file: folder dependency", async () => {
   const testDir = tempDirWithFiles(
     "migrate-folder-platform",
     filePlatformFixture([`!${process.platform}`], [`!${process.arch}`]),
@@ -439,32 +439,35 @@ test("package-lock.json migration does not platform-skip a regular file: folder 
   const { stderr, exitCode } = await install(testDir);
   expect(stderr).toContain("migrated lockfile from package-lock.json");
   expect(stderr).not.toContain("InvalidNPMLockfile");
-  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
   expect(exitCode).toBe(0);
+  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
 
   // The migrated bun.lock matches what a fresh resolve of the same package.json writes:
   // the folder package keeps its real name and carries no os/cpu constraint.
   expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
 });
 
-test("package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependencies", async () => {
-  const testDir = tempDirWithFiles("migrate-folder-name", filePlatformFixture([], []));
+test.concurrent(
+  "package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependencies",
+  async () => {
+    const testDir = tempDirWithFiles("migrate-folder-name", filePlatformFixture([], []));
 
-  const first = await install(testDir);
-  expect(first.stderr).toContain("migrated lockfile from package-lock.json");
-  expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
-  expect(first.exitCode).toBe(0);
+    const first = await install(testDir);
+    expect(first.stderr).toContain("migrated lockfile from package-lock.json");
+    expect(first.exitCode).toBe(0);
+    expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
 
-  // The second install consumes the bun.lock the migration just wrote. It must parse,
-  // otherwise --frozen-lockfile is permanently broken after an npm migration.
-  const second = await install(testDir, "--frozen-lockfile");
-  expect(second.stderr).not.toContain("Invalid package name");
-  expect(second.stderr).not.toContain("Ignoring lockfile");
-  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
-  expect(second.exitCode).toBe(0);
-});
+    // The second install consumes the bun.lock the migration just wrote. It must parse,
+    // otherwise --frozen-lockfile is permanently broken after an npm migration.
+    const second = await install(testDir, "--frozen-lockfile");
+    expect(second.stderr).not.toContain("Invalid package name");
+    expect(second.stderr).not.toContain("Ignoring lockfile");
+    expect(second.exitCode).toBe(0);
+    expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+  },
+);
 
-test("package-lock.json migration does not platform-skip a regular file: tarball dependency", async () => {
+test.concurrent("package-lock.json migration does not platform-skip a regular file: tarball dependency", async () => {
   // Same divergence as the folder variant, for a `LocalTarball` resolution. npm records
   // the packed package's `os`/`cpu` arrays in its lockfile entry, and a fresh resolve of
   // the same package.json extracts and installs the tarball regardless of them.
@@ -474,17 +477,8 @@ test("package-lock.json migration does not platform-skip a regular file: tarball
     "src-a/package.json": JSON.stringify({ name: "a", version: "1.0.0", ...nonMatching }),
   });
 
-  {
-    await using pack = Bun.spawn([bunExe(), "pm", "pack", "--destination", testDir], {
-      env: bunEnv,
-      cwd: join(testDir, "src-a"),
-      stdout: "ignore",
-      stderr: "pipe",
-    });
-    const [packErr, packExit] = await Promise.all([pack.stderr.text(), pack.exited]);
-    expect(packExit, packErr).toBe(0);
-    expect(fs.existsSync(join(testDir, "a-1.0.0.tgz"))).toBeTrue();
-  }
+  await pack(join(testDir, "src-a"), bunEnv, "--destination", testDir);
+  expect(fs.existsSync(join(testDir, "a-1.0.0.tgz"))).toBeTrue();
 
   await Bun.write(
     join(testDir, "package-lock.json"),
@@ -502,6 +496,6 @@ test("package-lock.json migration does not platform-skip a regular file: tarball
   const { stderr, exitCode } = await install(testDir);
   expect(stderr).toContain("migrated lockfile from package-lock.json");
   expect(stderr).not.toContain("InvalidNPMLockfile");
-  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
   expect(exitCode).toBe(0);
+  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
 });

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -503,3 +503,51 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
   expect(exitCode).toBe(0);
   expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
 });
+
+test.concurrent("pnpm-lock.yaml migration does not platform-skip a regular file: folder dependency", async () => {
+  // The pnpm migration copied the lockfile's `os`/`cpu` arrays into every package the
+  // same way the npm one did. pnpm records them for any `packages:` entry whose manifest
+  // declares them, so a `file:` folder dependency was silently dropped on a mismatch.
+  const testDir = tempDirWithFiles("migrate-pnpm-folder-platform", {
+    "package.json": JSON.stringify({ name: "repro", dependencies: { a: "file:./vendor/a" } }),
+    "vendor/a/package.json": JSON.stringify({
+      name: "a",
+      version: "1.0.0",
+      os: [`!${process.platform}`],
+      cpu: [`!${process.arch}`],
+    }),
+    "pnpm-lock.yaml": [
+      "lockfileVersion: '9.0'",
+      "",
+      "settings:",
+      "  autoInstallPeers: true",
+      "  excludeLinksFromLockfile: false",
+      "",
+      "importers:",
+      "",
+      "  .:",
+      "    dependencies:",
+      "      a:",
+      "        specifier: file:./vendor/a",
+      "        version: file:vendor/a",
+      "",
+      "packages:",
+      "",
+      "  a@file:vendor/a:",
+      "    resolution: {directory: vendor/a, type: directory}",
+      `    os: ['!${process.platform}']`,
+      `    cpu: ['!${process.arch}']`,
+      "    version: 1.0.0",
+      "",
+      "snapshots:",
+      "",
+      "  a@file:vendor/a: {}",
+      "",
+    ].join("\n"),
+  });
+
+  const { stderr, exitCode } = await install(testDir);
+  expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+  expect(exitCode).toBe(0);
+  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+});


### PR DESCRIPTION
Migrating an npm `package-lock.json` (or a `pnpm-lock.yaml`) silently changed what `bun install` produces for a regular (non-optional) `file:` dependency, compared to running `bun install` on the identical `package.json` with no foreign lockfile.

### Reproduction

`package.json` depends on a local folder whose `package.json` declares `os`/`cpu` that don't match the host. This is the common shape for a project migrating from npm, because npm records the `cpu`/`os` arrays in the lockfile entry for every package that declares them.

```sh
# package.json:          { "dependencies": { "a": "file:./vendor/a" } }
# vendor/a/package.json: { "name": "a", "version": "1.0.0", "os": ["darwin"] }   # host is linux

bun install                      # no npm lockfile: node_modules/a is installed
npm install --package-lock-only
rm -rf node_modules bun.lock
bun install                      # exit 0, node_modules is EMPTY
```

With `--verbose`, the second install prints:

```
Skip installing /a - cpu & os mismatch
```

That one line shows both of the main bugs.

### Bug 1: the migrations platform-filter packages a fresh resolve never would

Bun only applies `os`/`cpu` platform constraints to npm registry packages (`Package::from_npm`). Folder, tarball, git, and workspace packages are installed regardless of those fields (`parse_with_json_impl` never reads them). This also matches npm, which links `file:` folders without a platform check.

The npm lockfile migration copied the entry's `cpu`/`os` arrays into `meta` for every package regardless of its resolution, so any `file:` folder or local tarball dependency whose declared platform didn't match the host got silently dropped with exit 0. Whatever the migration wrote into `bun.lock` then perpetuated that state.

The pnpm migration (`src/install/pnpm.rs`) had the identical unconditional copy and reproduces the identical drop through a `pnpm-lock.yaml` that records `os`/`cpu` on a `file:` folder entry.

Fix: one shared `clear_non_registry_platform_constraints` that resets `arch`/`os` to `ALL` for every package whose resolution is not `Root` or `Npm` (exactly the set a fresh resolve never platform-filters), called from both the npm and pnpm migrations once resolutions are known.

The yarn migration (`src/install/yarn.rs:1197`) has the same code shape, but `yarn.lock` never records `os`/`cpu`, so there is no user-reachable input; it is intentionally left unchanged.

### Bug 2: the migrated bun.lock is rejected by Bun's own parser

Note the name `/a` in the verbose line above. `package_name_from_path` derives a package name from a lockfile entry path, and for paths outside `node_modules/` (link targets like `vendor/a`) it returned the basename *including* the separator: `strings::last_index_of(pkg_path, b"/")` with no `+ 1`. The migration then wrote

```
"a": ["/a@file:vendor/a", { "os": "linux", "cpu": "x64" }],
```

into `bun.lock`, and every subsequent `bun install` failed to load it:

```
error: Invalid package name
warn: Ignoring lockfile
```

and fell back to a fresh resolve, so `--frozen-lockfile` was permanently broken after any npm migration involving a `file:` folder dependency. The same off-by-one existed in the original Zig source.

The fix is also scope-aware: npm's `name-from-folder` inference keeps the scope and omits the lockfile `name` field whenever the inferred name matches (verified against `npm install --package-lock-only`; the `vendor/@scope/a` entry carries no `name`), so a plain basename would turn `@scope/a` into `a`. When the parent path component begins with `@`, back up one component, so `vendor/@scope/a` yields `@scope/a`.

After both fixes the migrated `bun.lock` entry is byte-identical to the one a fresh resolve writes: `"a": ["a@file:vendor/a", {}]`.

### Bug 3: the counting phase rejects link targets whose folder name starts with `@`

The counting phase builds a fallback registry URL for entries that have a `version` but no `resolved` (which includes every `file:` folder link target) using only the name derived from the entry path, ignoring the entry's explicit `name` field, and hard-fails the whole migration with `InvalidNPMLockfile` if that derived name starts with `@` but contains no `/`.

A package named `admin` living at `@admin` produces exactly that: npm writes `"@admin": { "name": "admin", "version": "1.0.0" }` (it writes `name` whenever it differs from the name it infers from the folder), and `package_name_from_path("@admin")` returns `@admin`. The migration aborts and every subsequent install warns `Ignoring lockfile`.

The `package_name_from_path` rewrite in Bug 2 would have extended the same failure to nested layouts like `packages/@admin` (previously masked by the leading `/`).

Fix: the counting phase prefers the entry's `name` field exactly like the building phase already did. After this, the `@`-without-`/` rejection is only reachable from a malformed lockfile (npm never omits `name` for a folder whose inferred name is not a valid package name).

### Verification

Seven tests added to `test/cli/install/migration/migrate.test.ts`, all offline and concurrent, with hand-verified npm/pnpm lockfile fixtures.

Six of the seven fail on the unfixed build and pass with the fix. The seventh, `admin at packages/@admin`, passes on the base commit by design: it guards the `package_name_from_path` rewrite against the regression described in Bug 3.

<details><summary>fail-before / pass-after</summary>

```
$ USE_SYSTEM_BUN=1 bun test test/cli/install/migration/migrate.test.ts -t "platform-skip|its own parser"
(fail) package-lock.json migration does not platform-skip a regular file: folder dependency
(fail) package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependency a at vendor/a
(fail) package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependency @scope/a at vendor/@scope/a
(fail) package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependency admin at @admin
(fail) pnpm-lock.yaml migration does not platform-skip a regular file: folder dependency
(fail) package-lock.json migration does not platform-skip a regular file: tarball dependency
(pass) package-lock.json migration writes a bun.lock its own parser accepts for file: folder dependency admin at packages/@admin
 1 pass
 6 fail

$ bun bd test test/cli/install/migration/migrate.test.ts
 20 pass
 1 todo
 0 fail
```

</details>

Git/GitHub-resolved packages are covered by the same resolution-tag predicate but have no dedicated test (they would need a git remote). Workspaces already had their meta rebuilt from the on-disk `package.json` at install time, so they were unaffected in practice; the reset covers them anyway for consistency with the invariant.