### PR TITLE
inspect: don't probe every hole when printing a sparse array

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4494,12 +4494,19 @@ pub mod formatter {
                         if empty_start.is_none() {
                             empty_start = Some(i);
                         }
-                        // Skip the whole run of holes at once: probing every
-                        // index would take O(length), and a sparse array's
-                        // length can be up to 2^32 - 1 with no elements at all.
-                        match value.next_present_index(i + 1) {
-                            Some(next) if (next as u64) < len => i = next,
-                            _ => break,
+                        if js_type.is_array() {
+                            // Skip the whole run of holes at once: probing each
+                            // index is O(length), and a sparse array's length
+                            // can be 2^32 - 1 with no elements at all.
+                            match value.next_present_index(i + 1) {
+                                Some(next) if (next as u64) < len => i = next,
+                                _ => break,
+                            }
+                        } else {
+                            // Arguments objects store their elements outside
+                            // the butterfly; their length is small, so probe
+                            // each index like before.
+                            i += 1;
                         }
                         continue;
                     }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4494,7 +4494,13 @@ pub mod formatter {
                         if empty_start.is_none() {
                             empty_start = Some(i);
                         }
-                        i += 1;
+                        // Skip the whole run of holes at once: probing every
+                        // index would take O(length), and a sparse array's
+                        // length can be up to 2^32 - 1 with no elements at all.
+                        match value.next_present_index(i + 1) {
+                            Some(next) if (next as u64) < len => i = next,
+                            _ => break,
+                        }
                         continue;
                     }
                     if nonempty_count >= 100 {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2558,6 +2558,20 @@ impl JSValue {
         }
         JSC__JSValue__getDirectIndex(self, global, i)
     }
+    /// Smallest own present index of a `JSArray` that is `>= start`, or
+    /// `None` when every index from `start` to the end of the array is a
+    /// hole. Walks the array's backing storage (and sparse map) so a run of
+    /// holes is skipped in one call instead of probing each index.
+    /// Returns `Some(start)` when `self` is not a `JSArray`.
+    pub fn next_present_index(self, start: u32) -> Option<u32> {
+        unsafe extern "C" {
+            safe fn Bun__JSArray__nextPresentIndex(this: JSValue, start: u32) -> u64;
+        }
+        match Bun__JSArray__nextPresentIndex(self, start) {
+            u64::MAX => None,
+            index => Some(index as u32),
+        }
+    }
     /// `JSValue.getNameProperty` — write the value's
     /// `.name` (function/class name) into `ret`. No-op for empty/`undefined`/`null`.
     pub fn get_name_property(

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2562,8 +2562,9 @@ impl JSValue {
     /// `None` when every index from `start` to the end of the array is a
     /// hole. Walks the array's backing storage (and sparse map) so a run of
     /// holes is skipped in one call instead of probing each index.
-    /// Returns `Some(start)` when `self` is not a `JSArray`.
+    /// Asserts `self` is a `JSArray` (`Array` or `DerivedArray`).
     pub fn next_present_index(self, start: u32) -> Option<u32> {
+        debug_assert!(self.is_cell() && self.js_type().is_array());
         unsafe extern "C" {
             safe fn Bun__JSArray__nextPresentIndex(this: JSValue, start: u32) -> u64;
         }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -33,6 +33,8 @@
 
 #include "JavaScriptCore/AggregateError.h"
 #include "JavaScriptCore/ArrayBufferView.h"
+#include "JavaScriptCore/ArrayStorage.h"
+#include "JavaScriptCore/SparseArrayValueMap.h"
 #include "JavaScriptCore/BytecodeIndex.h"
 #include "JavaScriptCore/CodeBlock.h"
 #include "JavaScriptCore/Completion.h"
@@ -6717,6 +6719,72 @@ extern "C" bool Bun__JSArray__contiguousVectorIsStillValid(
     if (butterfly->publicLength() != expectedLength) [[unlikely]]
         return false;
     return reinterpret_cast<const JSC::EncodedJSValue*>(butterfly->contiguous().data()) == expected;
+}
+
+// Smallest own present index of a JSArray that is >= `start`, or UINT64_MAX
+// when every index from `start` to the end of the array is a hole. Mirrors the
+// butterfly walk in JSObject::getOwnIndexedPropertyNames so the caller can skip
+// a run of holes without probing each index of a huge sparse array.
+// Returns `start` when the value is not a JSArray (caller probes as usual).
+extern "C" uint64_t Bun__JSArray__nextPresentIndex(
+    JSC::EncodedJSValue encodedValue,
+    uint32_t start)
+{
+    static constexpr uint64_t notFound = std::numeric_limits<uint64_t>::max();
+
+    JSC::JSArray* array = dynamicDowncast<JSC::JSArray>(JSC::JSValue::decode(encodedValue));
+    if (!array) [[unlikely]]
+        return start;
+
+    switch (array->indexingType()) {
+    case ALL_BLANK_INDEXING_TYPES:
+    case ALL_UNDECIDED_INDEXING_TYPES:
+        return notFound;
+
+    case ALL_INT32_INDEXING_TYPES:
+    case ALL_CONTIGUOUS_INDEXING_TYPES: {
+        JSC::Butterfly* butterfly = array->butterfly();
+        unsigned usedLength = butterfly->publicLength();
+        for (unsigned i = start; i < usedLength; ++i) {
+            if (butterfly->contiguous().at(array, i))
+                return i;
+        }
+        return notFound;
+    }
+
+    case ALL_DOUBLE_INDEXING_TYPES: {
+        JSC::Butterfly* butterfly = array->butterfly();
+        unsigned usedLength = butterfly->publicLength();
+        for (unsigned i = start; i < usedLength; ++i) {
+            double value = butterfly->contiguousDouble().at(array, i);
+            // A hole in a double array is stored as NaN.
+            if (value == value)
+                return i;
+        }
+        return notFound;
+    }
+
+    case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
+        JSC::ArrayStorage* storage = array->butterfly()->arrayStorage();
+        unsigned usedVectorLength = std::min(storage->length(), storage->vectorLength());
+        for (unsigned i = start; i < usedVectorLength; ++i) {
+            if (storage->m_vector[i])
+                return i;
+        }
+
+        uint64_t result = notFound;
+        if (JSC::SparseArrayValueMap* map = storage->m_sparseMap.get()) {
+            for (const auto& entry : *map) {
+                if (entry.key >= start && entry.key < result)
+                    result = entry.key;
+            }
+        }
+        return result;
+    }
+
+    default:
+        return start;
+    }
 }
 
 extern "C" void JSC__ArrayBuffer__ref(JSC::ArrayBuffer* self) { self->ref(); }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6757,7 +6757,9 @@ extern "C" uint64_t Bun__JSArray__nextPresentIndex(
         unsigned usedLength = butterfly->publicLength();
         for (unsigned i = start; i < usedLength; ++i) {
             double value = butterfly->contiguousDouble().at(array, i);
-            // A hole in a double array is stored as NaN.
+            // In DoubleShape storage the hole is NaN. A real NaN element can
+            // never be stored there: JSObject::putByIndex / putDirectIndex
+            // convert the array to ContiguousShape first.
             if (value == value)
                 return i;
         }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6725,16 +6725,13 @@ extern "C" bool Bun__JSArray__contiguousVectorIsStillValid(
 // when every index from `start` to the end of the array is a hole. Mirrors the
 // butterfly walk in JSObject::getOwnIndexedPropertyNames so the caller can skip
 // a run of holes without probing each index of a huge sparse array.
-// Returns `start` when the value is not a JSArray (caller probes as usual).
 extern "C" uint64_t Bun__JSArray__nextPresentIndex(
     JSC::EncodedJSValue encodedValue,
     uint32_t start)
 {
     static constexpr uint64_t notFound = std::numeric_limits<uint64_t>::max();
 
-    JSC::JSArray* array = dynamicDowncast<JSC::JSArray>(JSC::JSValue::decode(encodedValue));
-    if (!array) [[unlikely]]
-        return start;
+    JSC::JSArray* array = uncheckedDowncast<JSC::JSArray>(JSC::JSValue::decode(encodedValue).asCell());
 
     switch (array->indexingType()) {
     case ALL_BLANK_INDEXING_TYPES:
@@ -6785,6 +6782,7 @@ extern "C" uint64_t Bun__JSArray__nextPresentIndex(
     }
 
     default:
+        ASSERT_NOT_REACHED();
         return start;
     }
 }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -569,11 +569,12 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({
+  expect({ stdout, stderr, exitCode }).toEqual({
     stdout:
       "[\n  4294967294 x empty items\n]\n" +
       '[\n  4294967292 x empty items, "x"\n]\n' +
       "[\n  1, 2, 3, 4294967291 x empty items\n]\n",
+    stderr: "",
     exitCode: 0,
   });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -546,6 +546,36 @@ it("Bun.inspect array with non-indexed properties", () => {
   expect(Bun.inspect(a)).toBe(`[
   1, 2, 3, 15 x empty items, 24, 23 x empty items, potato: "hello"
 ]`);
+});
+
+// Printing a sparse array must never iterate index-by-index over the holes:
+// `length` can be up to 2^32 - 1 with no elements in the array at all.
+// Run it in a child so a regression times this test out instead of hanging the runner.
+it("Bun.inspect huge sparse array summarizes holes without iterating them", async () => {
+  const code = `
+    const a = new Array(4_294_967_294);
+    console.log(Bun.inspect(a));
+    const b = [];
+    b[4_294_967_292] = "x";
+    console.log(Bun.inspect(b));
+    const c = [1, 2, 3];
+    c.length = 4_294_967_294;
+    console.log(c);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({
+    stdout:
+      "[\n  4294967294 x empty items\n]\n" +
+      '[\n  4294967292 x empty items, "x"\n]\n' +
+      "[\n  1, 2, 3, 4294967291 x empty items\n]\n",
+    exitCode: 0,
+  });
 });
 
 describe("console.logging function displays async and generator names", async () => {


### PR DESCRIPTION
### Problem

Printing a large sparse array never returns:

```js
const a = new Array(4_294_967_294); // sparse: zero elements, huge length
console.log(a);    // bun: pegs a core, never returns. node: "[ <4294967294 empty items> ]" in ~0ms
Bun.inspect(a);    // same hang
```

Any large holey array does it (`new Array(n)`, `arr.length = big`, `a[4_294_967_292] = "x"`), which makes the logging call itself freeze the process. `util.inspect` is not affected (it is the ported Node implementation, which already summarizes holes).

### Cause

`print_array` in `src/jsc/ConsoleObject.rs` walks `i = 0..length` and calls `getDirectIndex(i)` over FFI for every index, relying on holes coming back as the empty value. The hole-run summarization ("N x empty items") already exists, but reaching it costs one FFI probe per hole, so a `length` of 4,294,967,294 means ~4.3 billion calls.

### Fix

Add `Bun__JSArray__nextPresentIndex(array, start)`: the smallest own present index `>= start`, or none. It mirrors the butterfly walk in JSC's `JSObject::getOwnIndexedPropertyNames` (Int32/Contiguous/Double shapes plus ArrayStorage and its sparse map), so it never touches more memory than the array actually allocated. The formatter now jumps from the first hole of a run to the next present index in one call instead of probing each index. Non-`JSArray` array-likes (arguments objects) keep the previous per-index probing.

Output is byte-identical to before on every sparse/holey shape I could construct (holey literals, `delete`, `length` growth, double arrays with holes, frozen arrays in dictionary indexing mode, sparse-map arrays, derived arrays, arguments objects); the only change is that huge ones now finish:

```
❯ bun -e 'console.time("log"); console.log(new Array(4_294_967_294)); console.timeEnd("log")'
[
  4294967294 x empty items
]
[2.21ms] log
```

### Verification

New test in `test/js/bun/util/inspect.test.js` spawns a child that prints `new Array(4_294_967_294)`, `b[4_294_967_292] = "x"`, and `c = [1,2,3]; c.length = 4_294_967_294`, and asserts the exact output. On an unfixed build the child never exits and the test times out; with the fix it completes in milliseconds. Existing console/inspect suites (`test/js/web/console`, `test/js/bun/util/inspect.test.js`) pass unchanged.
