### PR TITLE
install: link a transitive file: dependency of a local file: package

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1989,7 +1989,7 @@ impl<'a> PackageInstaller<'a> {
                         bun_core::pretty_errorln!(
                             "<r><red>error<r>: Could not find folder \"file:{}\" for dependency \"{}\"",
                             bstr::BStr::new(resolution.folder().slice(string_buf!())),
-                            bstr::BStr::new(self.names[package_id as usize].slice(string_buf!())),
+                            bstr::BStr::new(alias.slice(string_buf!())),
                         );
                         self.summary.fail += 1;
                     } else if cause.err == bun_core::err!("AccessDenied") {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1376,7 +1376,7 @@ impl<'a> PackageInstaller<'a> {
                     }
                     installer.cache_dir = Fd::cwd();
                 } else {
-                    // transitive folder dependencies are relative to their parent. they are not hoisted
+                    // transitive folder dependencies are not hoisted
                     if folder.len() >= self.folder_path_buf.len()
                         || (bin::bin_target_escapes_package_dir(folder) && {
                             // overrides/resolutions are only ever parsed from the root
@@ -1717,6 +1717,24 @@ impl<'a> PackageInstaller<'a> {
                     {
                         // This is a transitive folder dependency. It is installed with a single symlink to the target folder/file,
                         // and is not hoisted.
+                        //
+                        // A transitive `Resolution::Folder` declared by a local `file:` package
+                        // is relative to the top-level dir (`Package::parse` normalized it), so
+                        // install it from `installer.cache_dir` (the cwd, set in the switch above).
+                        if resolution.tag == resolution::Tag::Folder
+                            && self.lockfile().is_folder_tree_id(self.current_tree_id)
+                        {
+                            break 'result installer.install(
+                                self.skip_delete,
+                                &destination_dir,
+                                installer.get_install_method(),
+                                resolution.tag,
+                            );
+                        }
+
+                        // One declared by an npm manifest (`Package::from_npm`) is verbatim,
+                        // i.e. relative to the declaring package, which installs at
+                        // `dirname(node_modules.path)` because transitive folders never hoist.
                         let dir_name = {
                             let d = dirname::<platform::Auto>(self.node_modules.path.as_slice());
                             if d.is_empty() {
@@ -1755,6 +1773,8 @@ impl<'a> PackageInstaller<'a> {
                             )
                         };
 
+                        // npm packages can declare `file:` paths missing from the published
+                        // tarball (e.g. excluded by `files`); nothing to link is not a failure.
                         if let package_install::InstallResult::Failure(f) = &result {
                             if f.err == bun_core::err!("ENOENT")
                                 || f.err == bun_core::err!("FileNotFound")
@@ -1960,6 +1980,15 @@ impl<'a> PackageInstaller<'a> {
                         bun_core::pretty_errorln!(
                             "<r><red>error<r>: <b>{}<r> \"link:{}\" not found (try running 'bun link' in the intended package's folder)<r>",
                             cause.err.name(),
+                            bstr::BStr::new(self.names[package_id as usize].slice(string_buf!())),
+                        );
+                        self.summary.fail += 1;
+                    } else if resolution.tag == resolution::Tag::Folder
+                        && cause.is_package_missing_from_cache()
+                    {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r>: Could not find folder \"file:{}\" for dependency \"{}\"",
+                            bstr::BStr::new(resolution.folder().slice(string_buf!())),
                             bstr::BStr::new(self.names[package_id as usize].slice(string_buf!())),
                         );
                         self.summary.fail += 1;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -998,6 +998,20 @@ impl Lockfile {
                 .is_workspace()
     }
 
+    /// Is the package whose `node_modules` this tree represents resolved from a
+    /// local `file:` folder? Its `Resolution::Folder` dependencies were normalized
+    /// relative to the top-level dir (`Package::parse`), unlike npm's (`Package::from_npm`).
+    pub fn is_folder_tree_id(&self, id: tree::Id) -> bool {
+        if id == 0 {
+            return false;
+        }
+        let dependency_id = self.buffers.trees[id as usize].dependency_id;
+        let package_id = self.buffers.resolutions[dependency_id as usize];
+        package_id != invalid_package_id
+            && self.packages.slice().items_resolution()[package_id as usize].tag
+                == ResolutionTag::Folder
+    }
+
     /// Returns the package id of the workspace the install is taking place in.
     pub fn get_workspace_package_id(
         &self,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9546,6 +9546,100 @@ for (const field of ["resolutions", "overrides"]) {
   });
 }
 
+it("installs the transitive file: dependency of a file: dependency", async () => {
+  using dir = tempDir("transitive-file-dep", {
+    "package.json": JSON.stringify({
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: {
+        lib: "file:./vendor/lib",
+      },
+    }),
+    "vendor/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      main: "index.js",
+      dependencies: {
+        nested: "file:../nested",
+      },
+    }),
+    "vendor/lib/index.js": `module.exports = require("nested");`,
+    "vendor/nested/package.json": JSON.stringify({
+      name: "nested",
+      version: "1.0.0",
+      main: "index.js",
+    }),
+    "vendor/nested/index.js": `module.exports = "it worked";`,
+  });
+
+  // The first pass resolves from package.json; the second installs from the
+  // lockfile the first pass wrote.
+  for (const args of [["install"], ["install", "--frozen-lockfile"]]) {
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("error:");
+    expect(out).toContain("2 packages installed");
+    expect(exitCode).toBe(0);
+
+    expect(await exists(join(String(dir), "node_modules", "lib", "node_modules", "nested", "package.json"))).toBe(true);
+
+    await using runProc = spawn({
+      cmd: [bunExe(), "-e", `console.log(require("lib"))`],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+    expect(runErr).toBe("");
+    expect(runOut.trim()).toBe("it worked");
+    expect(runExit).toBe(0);
+  }
+});
+
+it("fails when a transitive file: dependency's folder does not exist", async () => {
+  using dir = tempDir("transitive-file-dep-missing", {
+    "package.json": JSON.stringify({
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: {
+        lib: "file:./vendor/lib",
+      },
+    }),
+    "vendor/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: {
+        nested: "file:../nested",
+      },
+    }),
+    "vendor/lib/index.js": `module.exports = require("nested");`,
+  });
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+  expect(err).toContain('Could not find folder "file:vendor/nested" for dependency "nested"');
+  expect(await exists(join(String(dir), "node_modules", "lib", "node_modules", "nested"))).toBe(false);
+  expect(out).not.toContain("2 packages installed");
+  expect(exitCode).toBe(1);
+});
+
 it("does not extract a local file: tarball outside the temp dir for a dependency alias containing '..' path segments", async () => {
   // For `file:` tarball dependencies, the dependency alias (the key in
   // `dependencies`) is used to derive the temporary extraction folder name.

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9600,7 +9600,7 @@ it("installs the transitive file: dependency of a file: dependency", async () =>
       stderr: "pipe",
     });
     const [runOut, runErr, runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
-    expect(runErr).toBe("");
+    expect(runErr).not.toContain("error:");
     expect(runOut.trim()).toBe("it worked");
     expect(runExit).toBe(0);
   }
@@ -9634,7 +9634,8 @@ it("fails when a transitive file: dependency's folder does not exist", async () 
   });
   const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
 
-  expect(err).toContain('Could not find folder "file:vendor/nested" for dependency "nested"');
+  // The printed folder path uses the platform separator on Windows.
+  expect(err.replaceAll(sep, "/")).toContain('Could not find folder "file:vendor/nested" for dependency "nested"');
   expect(out).not.toContain("2 packages installed");
   expect(exitCode).toBe(1);
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9590,8 +9590,8 @@ it("installs the transitive file: dependency of a file: dependency", async () =>
     expect(out).toContain("2 packages installed");
     expect(exitCode).toBe(0);
 
-    expect(await exists(join(String(dir), "node_modules", "lib", "node_modules", "nested", "package.json"))).toBe(true);
-
+    // `lib/index.js` requires "nested", so this only passes when the
+    // transitive file: dependency is materialized under node_modules.
     await using runProc = spawn({
       cmd: [bunExe(), "-e", `console.log(require("lib"))`],
       cwd: String(dir),
@@ -9635,7 +9635,6 @@ it("fails when a transitive file: dependency's folder does not exist", async () 
   const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
 
   expect(err).toContain('Could not find folder "file:vendor/nested" for dependency "nested"');
-  expect(await exists(join(String(dir), "node_modules", "lib", "node_modules", "nested"))).toBe(false);
   expect(out).not.toContain("2 packages installed");
   expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
### Repro

A three-package, all-local project where a `file:` dependency has its own `file:` dependency (the standard vendored-monorepo shape):

```
# package.json            depends on  file:./vendor/lib
# vendor/lib/package.json depends on  file:../util
mkdir -p vendor/lib vendor/util
echo '{"name":"app","dependencies":{"lib":"file:./vendor/lib"}}' > package.json
echo '{"name":"lib","version":"1.0.0","main":"index.js","dependencies":{"util2":"file:../util"}}' > vendor/lib/package.json
echo 'module.exports = require("util2")' > vendor/lib/index.js
echo '{"name":"util2","version":"1.0.0","main":"index.js"}' > vendor/util/package.json
echo 'module.exports = "ok"' > vendor/util/index.js

bun install                         # "2 packages installed", exit 0
node -e 'require("lib")'            # Cannot find module 'util2'
```

The lockfile records the resolution (`"lib/util2": ["util2@file:vendor/util", {}]`), but `node_modules/lib/node_modules` is left empty. The install reports success, and every downstream consumer (runtime `require`, `--frozen-lockfile` reinstalls, lifecycle scripts for that package) fails in confusing ways. The isolated linker handles the same project correctly; only the hoisted (default) linker is affected.

### Cause

`Resolution::Folder` paths are produced by two parsers with different bases, and the hoisted installer only handles one of them:

- `Lockfile::Package::parse` (used for the root, workspace members, and local `file:` packages) normalizes each `file:` dependency relative to the top-level dir. A `file:../util` declared in `vendor/lib/package.json` is stored as `vendor/util`.
- `Package::from_npm` (registry manifests) stores the `file:` path verbatim, so it stays relative to the declaring package (for example `./the-files` inside `file-dep`).

`PackageInstaller` (`src/install/PackageInstaller.rs`) sourced every transitive folder dependency from `dirname(node_modules.path)`, the declaring package's install directory. That is only correct for the npm case. For a local `file:` parent it looked for `node_modules/lib/vendor/util`, which never exists, and the `ENOENT -> InstallResult::Success` rewrite on the next lines turned the failure into a successful, counted install.

### Fix

- `Lockfile::is_folder_tree_id(tree_id)`: the package whose `node_modules` a tree represents is resolved from a local `file:` folder.
- In the installer's transitive-folder branch, when the declaring package is a `Folder` resolution, install from `Fd::cwd()` (the top-level dir, which `bun install` chdirs to) instead of the parent's install dir, and do not swallow the error. A genuinely missing source folder now fails the install with

  ```
  error: Could not find folder "file:vendor/util" for dependency "util2"
  ```

  instead of exiting 0 with the package missing.
- npm-declared transitive folder dependencies keep the existing behavior, including treating a `file:` path absent from the published tarball as nothing to link. `test/cli/install/bun-install-registry.test.ts` (`transitive file dependencies`, the `missing-file-dep` / `self-file-dep` / `file-dep` fixtures) depends on both.

Related: #33106 lifts the `..`-escape rejection for transitive `file:` dependencies declared by local packages. That PR and this one address different halves of the same user story (resolve-time rejection vs install-time materialization) and do not depend on each other; they conflict on one comment line.

### Tests

`test/cli/install/bun-install.test.ts`:

- `installs the transitive file: dependency of a file: dependency`: asserts `node_modules/lib/node_modules/nested/package.json` exists and `require("lib")` works, for both a fresh resolve and a `--frozen-lockfile` install from the saved lockfile.
- `fails when a transitive file: dependency's folder does not exist`: the source folder is deleted; asserts the new error message and a nonzero exit instead of a silent success.

Both fail on the released build and pass with this change. Verified no regression in the npm path by diffing `bun.lock` and the `node_modules` tree produced by the released build vs this build for all seven `*file-dep` registry fixtures: byte-identical. `bun-install.test.ts` (`file:` and `folder`), the full `bun-install-registry.test.ts`, `isolated-install.test.ts`, and `bun-workspaces.test.ts` pass (the only failures are pre-existing tests that need network access).
