### PR TITLE
util: do not throw from util.inspect when a value's getters throw

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1660,11 +1660,19 @@ function getStackString(ctx, error) {
     if (typeof stack === "string") {
       return stack;
     }
+    // Restore `ctx` even if formatting the non-string stack throws, so that a
+    // later occurrence of `error` in the same call is not reported as circular.
+    const seenLength = ctx.seen.length;
+    const indentationLvl = ctx.indentationLvl;
     ctx.seen.push(error);
     ctx.indentationLvl += 4;
-    const result = formatValue(ctx, stack);
-    ctx.indentationLvl -= 4;
-    ctx.seen.pop();
+    let result;
+    try {
+      result = formatValue(ctx, stack);
+    } finally {
+      ctx.seen.length = seenLength;
+      ctx.indentationLvl = indentationLvl;
+    }
     return `${ErrorPrototypeToString(error)}\n    ${result}`;
   }
   return ErrorPrototypeToString(error);
@@ -1803,11 +1811,13 @@ function formatError(err, constructor, tag, ctx, keys) {
   }
   let nameIsGetterThatThrows = false;
   try {
-    name = err.name;
+    // Unlike V8, JSC's lazy `Error#stack` does not re-read the live `name`, so
+    // a `name` whose coercion throws (e.g. `[Symbol()]`) reaches this `String()`.
+    name = err.name != null ? String(err.name) : "Error";
   } catch {
     nameIsGetterThatThrows = true;
+    name = "Error";
   }
-  name = name != null ? String(name) : "Error";
 
   //! temp fix for Bun losing the error name from inherited errors + extraneous ": " with no message
   stack = RegExpPrototypeSymbolReplace(/^Error: /, stack, `${name}${message ? ": " : ""}`);
@@ -1850,8 +1860,9 @@ function formatError(err, constructor, tag, ctx, keys) {
 
   stack = improveStack(stack, constructor, name, tag);
 
-  // Ignore the error message if it's contained in the stack.
-  let pos = (message && StringPrototypeIndexOf(stack, message)) || -1;
+  // Ignore the error message if it's contained in the stack. Skip non-string
+  // messages: `indexOf` would coerce them and can throw (e.g. `[Symbol()]`).
+  let pos = (typeof message === "string" && StringPrototypeIndexOf(stack, message)) || -1;
   if (pos !== -1) pos += message.length;
   // Wrap the error in brackets in case it has no stack trace.
   const stackStart = StringPrototypeIndexOf(stack, "\n    at", pos);

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1660,12 +1660,12 @@ function getStackString(ctx, error) {
     if (typeof stack === "string") {
       return stack;
     }
-    // Restore `ctx` even if formatting the non-string stack throws. Otherwise a
-    // later occurrence of `error` is misreported as circular, and a `<ref *N>`
-    // emitted into the discarded result leaves `ctx.seenRefs` dangling.
+    // Restore `ctx` even if formatting the non-string stack throws. Otherwise a later
+    // occurrence of `error` is misreported as circular, and a `<ref *N>` emitted into
+    // the discarded result dangles. `seenRefs` is copied: the render mutates it in place.
     const seenLength = ctx.seen.length;
     const indentationLvl = ctx.indentationLvl;
-    const seenRefs = ctx.seenRefs;
+    const seenRefs = ctx.seenRefs && new Set(ctx.seenRefs);
     ctx.seen.push(error);
     ctx.indentationLvl += 4;
     let result;

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1660,10 +1660,12 @@ function getStackString(ctx, error) {
     if (typeof stack === "string") {
       return stack;
     }
-    // Restore `ctx` even if formatting the non-string stack throws, so that a
-    // later occurrence of `error` in the same call is not reported as circular.
+    // Restore `ctx` even if formatting the non-string stack throws. Otherwise a
+    // later occurrence of `error` is misreported as circular, and a `<ref *N>`
+    // emitted into the discarded result leaves `ctx.seenRefs` dangling.
     const seenLength = ctx.seen.length;
     const indentationLvl = ctx.indentationLvl;
+    const seenRefs = ctx.seenRefs;
     ctx.seen.push(error);
     ctx.indentationLvl += 4;
     let result;
@@ -1672,6 +1674,7 @@ function getStackString(ctx, error) {
     } finally {
       ctx.seen.length = seenLength;
       ctx.indentationLvl = indentationLvl;
+      ctx.seenRefs = seenRefs;
     }
     return `${ErrorPrototypeToString(error)}\n    ${result}`;
   }
@@ -1803,6 +1806,16 @@ function safeGetCWD() {
 }
 
 function formatError(err, constructor, tag, ctx, keys) {
+  // The `stack` is rendered as the error itself, never as a `stack:` property.
+  // Hide it before reading it, so the early return below cannot leave an
+  // enumerable `stack` in `keys` to be formatted a second time as a property.
+  if (!ctx.showHidden) {
+    const index = ArrayPrototypeIndexOf(keys, "stack");
+    if (index !== -1) {
+      ArrayPrototypeSplice(keys, index, 1);
+    }
+  }
+
   let message, name, stack;
   try {
     stack = getStackString(ctx, err);
@@ -1832,11 +1845,6 @@ function formatError(err, constructor, tag, ctx, keys) {
   stack = RegExpPrototypeSymbolReplace(/^Error: /, stack, `${name}${message ? ": " : ""}`);
 
   if (!ctx.showHidden && keys.length !== 0) {
-    const index = ArrayPrototypeIndexOf(keys, "stack");
-    if (index !== -1) {
-      ArrayPrototypeSplice(keys, index, 1);
-    }
-
     if (!messageIsGetterThatThrows) {
       const index = ArrayPrototypeIndexOf(keys, "message");
       // Only hide the property if it's a string and if it's part of the original stack

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1253,7 +1253,12 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
     protoProps = undefined;
   }
 
-  let tag = value[SymbolToStringTag];
+  let tag = "";
+  try {
+    tag = value[SymbolToStringTag];
+  } catch {
+    // If `Symbol.toStringTag` is a getter that throws, ignore it.
+  }
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.
   if (
@@ -1445,16 +1450,14 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       ArrayPrototypePush.$apply(output, protoProps);
     }
   } catch (err) {
-    if (err instanceof RangeError && err.message === ERROR_STACK_OVERFLOW_MSG) {
-      const constructorName = StringPrototypeSlice(getCtxStyle(value, constructor, tag), 0, -1);
-      ctx.seen.pop();
-      ctx.indentationLvl = indentationLvl;
-      return ctx.stylize(
-        `[${constructorName}: Inspection interrupted prematurely. Maximum call stack size exceeded.]`,
-        "special",
-      );
-    }
-    throw new AssertionError("handleMaxCallStackSize assertion failed: " + String(err), true);
+    if (!(err instanceof RangeError && err.message === ERROR_STACK_OVERFLOW_MSG)) throw err;
+    const constructorName = StringPrototypeSlice(getCtxStyle(value, constructor, tag), 0, -1);
+    ctx.seen.pop();
+    ctx.indentationLvl = indentationLvl;
+    return ctx.stylize(
+      `[${constructorName}: Inspection interrupted prematurely. Maximum call stack size exceeded.]`,
+      "special",
+    );
   }
   const circular = ctx.circular;
   if (circular !== undefined) {
@@ -1646,8 +1649,25 @@ function identicalSequenceRange(a, b) {
   return { len: 0, offset: 0 };
 }
 
-function getStackString(error) {
-  return error.stack ? String(error.stack) : ErrorPrototypeToString(error);
+function getStackString(ctx, error) {
+  let stack;
+  try {
+    stack = error.stack;
+  } catch {
+    // If `stack` is a getter that throws, ignore it.
+  }
+  if (stack) {
+    if (typeof stack === "string") {
+      return stack;
+    }
+    ctx.seen.push(error);
+    ctx.indentationLvl += 4;
+    const result = formatValue(ctx, stack);
+    ctx.indentationLvl -= 4;
+    ctx.seen.pop();
+    return `${ErrorPrototypeToString(error)}\n    ${result}`;
+  }
+  return ErrorPrototypeToString(error);
 }
 
 function getStackFrames(ctx, err, stack) {
@@ -1662,7 +1682,7 @@ function getStackFrames(ctx, err, stack) {
 
   // Remove stack frames identical to frames in cause.
   if (cause != null && cause instanceof Error) {
-    const causeStack = getStackString(cause);
+    const causeStack = getStackString(ctx, cause);
     const causeStackStart = StringPrototypeIndexOf(causeStack, "\n    at");
     if (causeStackStart !== -1) {
       const causeFrames = StringPrototypeSplit(StringPrototypeSlice(causeStack, causeStackStart + 1), "\n");
@@ -1711,18 +1731,6 @@ function improveStack(stack, constructor, name, tag) {
     }
   }
   return stack;
-}
-
-function removeDuplicateErrorKeys(ctx, keys, err, stack) {
-  if (!ctx.showHidden && keys.length !== 0) {
-    for (const name of ["name", "message", "stack"]) {
-      const index = ArrayPrototypeIndexOf(keys, name);
-      // Only hide the property in case it's part of the original stack
-      if (index !== -1 && StringPrototypeIncludes(stack, err[name])) {
-        ArrayPrototypeSplice(keys, index, 1);
-      }
-    }
-  }
 }
 
 function markNodeModules(ctx, line) {
@@ -1778,28 +1786,73 @@ function safeGetCWD() {
 }
 
 function formatError(err, constructor, tag, ctx, keys) {
-  const name = err.name != null ? String(err.name) : "Error";
-  let stack = getStackString(err);
+  let message, name, stack;
+  try {
+    stack = getStackString(ctx, err);
+  } catch {
+    // The `stack` getter threw and `Error.prototype.toString()` threw as well,
+    // e.g. because the `name` or `message` getters also throw.
+    return ObjectPrototypeToString(err);
+  }
+
+  let messageIsGetterThatThrows = false;
+  try {
+    message = err.message;
+  } catch {
+    messageIsGetterThatThrows = true;
+  }
+  let nameIsGetterThatThrows = false;
+  try {
+    name = err.name;
+  } catch {
+    nameIsGetterThatThrows = true;
+  }
+  name = name != null ? String(name) : "Error";
 
   //! temp fix for Bun losing the error name from inherited errors + extraneous ": " with no message
-  stack = stack.replace(/^Error: /, `${name}${err.message ? ": " : ""}`);
+  stack = stack.replace(/^Error: /, `${name}${message ? ": " : ""}`);
 
-  removeDuplicateErrorKeys(ctx, keys, err, stack);
+  if (!ctx.showHidden && keys.length !== 0) {
+    const index = ArrayPrototypeIndexOf(keys, "stack");
+    if (index !== -1) {
+      ArrayPrototypeSplice(keys, index, 1);
+    }
+
+    if (!messageIsGetterThatThrows) {
+      const index = ArrayPrototypeIndexOf(keys, "message");
+      // Only hide the property if it's a string and if it's part of the original stack
+      if (index !== -1 && (typeof message !== "string" || StringPrototypeIncludes(stack, message))) {
+        ArrayPrototypeSplice(keys, index, 1);
+      }
+    }
+
+    if (!nameIsGetterThatThrows) {
+      const index = ArrayPrototypeIndexOf(keys, "name");
+      // Only hide the property in case it's part of the original stack
+      if (index !== -1 && StringPrototypeIncludes(stack, name)) {
+        ArrayPrototypeSplice(keys, index, 1);
+      }
+    }
+  }
 
   if ("cause" in err && (keys.length === 0 || !ArrayPrototypeIncludes(keys, "cause"))) {
     ArrayPrototypePush.$call(keys, "cause");
   }
 
   // Print errors aggregated into AggregateError
-  if ($isJSArray(err.errors) && (keys.length === 0 || !ArrayPrototypeIncludes(keys, "errors"))) {
-    ArrayPrototypePush.$call(keys, "errors");
+  try {
+    if ($isJSArray(err.errors) && (keys.length === 0 || !ArrayPrototypeIncludes(keys, "errors"))) {
+      ArrayPrototypePush.$call(keys, "errors");
+    }
+  } catch {
+    // If `errors` is a getter that throws, ignore it.
   }
 
   stack = improveStack(stack, constructor, name, tag);
 
   // Ignore the error message if it's contained in the stack.
-  let pos = (err.message && StringPrototypeIndexOf(stack, err.message)) || -1;
-  if (pos !== -1) pos += err.message.length;
+  let pos = (message && StringPrototypeIndexOf(stack, message)) || -1;
+  if (pos !== -1) pos += message.length;
   // Wrap the error in brackets in case it has no stack trace.
   const stackStart = StringPrototypeIndexOf(stack, "\n    at", pos);
   if (stackStart === -1) {

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -210,14 +210,14 @@ const isBoxedPrimitive = val => isBigIntObject(val) || isSymbolObject(val) || _n
 
 // We need this duplicate here to avoid a circular dependency between node:assert and node:util.
 class AssertionError extends Error {
-  constructor(message, isForced = false) {
+  constructor(message) {
     super(message);
     this.name = "AssertionError";
     this.code = "ERR_ASSERTION";
     this.operator = "==";
-    this.generatedMessage = !isForced;
-    this.actual = isForced && undefined;
-    this.expected = !isForced || undefined;
+    this.generatedMessage = true;
+    this.actual = false;
+    this.expected = true;
   }
 }
 function assert(p, message) {
@@ -1690,7 +1690,16 @@ function getStackFrames(ctx, err, stack) {
 
   // Remove stack frames identical to frames in cause.
   if (cause != null && cause instanceof Error) {
-    const causeStack = getStackString(ctx, cause);
+    // Only a string `cause.stack` has frames to deduplicate. Recursively formatting
+    // a non-string one (via `getStackString`) runs before `err` is on `ctx.seen`,
+    // so `cause.stack === err` would recurse without ever hitting the cycle check.
+    let causeStack = "";
+    try {
+      const causeStackValue = cause.stack;
+      if (typeof causeStackValue === "string") causeStack = causeStackValue;
+    } catch {
+      // A `stack` getter that throws leaves nothing to deduplicate.
+    }
     const causeStackStart = StringPrototypeIndexOf(causeStack, "\n    at");
     if (causeStackStart !== -1) {
       const causeFrames = StringPrototypeSplit(StringPrototypeSlice(causeStack, causeStackStart + 1), "\n");

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1810,7 +1810,7 @@ function formatError(err, constructor, tag, ctx, keys) {
   name = name != null ? String(name) : "Error";
 
   //! temp fix for Bun losing the error name from inherited errors + extraneous ": " with no message
-  stack = stack.replace(/^Error: /, `${name}${message ? ": " : ""}`);
+  stack = RegExpPrototypeSymbolReplace(/^Error: /, stack, `${name}${message ? ": " : ""}`);
 
   if (!ctx.showHidden && keys.length !== 0) {
     const index = ArrayPrototypeIndexOf(keys, "stack");

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1837,8 +1837,8 @@ test("util.inspect stack overflow handling", () => {
   assert(longList.includes("[Object: Inspection interrupted prematurely. Maximum call stack size exceeded.]"));
 });
 
-// `util.inspect` must never throw because of the value being inspected. Expected
-// outputs here are what Node.js produces for the same inputs.
+// `util.inspect` must never throw because of the value being inspected. Unless a
+// case notes otherwise, the expected output matches what Node.js produces.
 test("util.inspect does not throw on values with throwing getters", () => {
   const throwingGetter = key => ({
     get() {
@@ -1900,6 +1900,35 @@ test("util.inspect does not throw on values with throwing getters", () => {
     const err = new Error("foo");
     err.stack = err;
     assert.strictEqual(util.inspect(err), "[Error: foo\n    [Circular *1]]");
+  }
+
+  // A non-string `stack` whose own formatting throws must leave `ctx` intact, so
+  // a second occurrence of the error is not misreported as circular. (Node leaks
+  // the error onto `ctx.seen` here and prints `[Circular *1]` for the second one.)
+  {
+    const err = new Error("x");
+    err.stack = {
+      [Symbol.for("nodejs.util.inspect.custom")]() {
+        throw new Error("boom");
+      },
+    };
+    assert.strictEqual(util.inspect([err, err]), "[ [object Error], [object Error] ]");
+  }
+
+  // `name` / `message` values whose coercion throws (such as an array holding a
+  // Symbol) must not escape either. Node never reaches the coercions because
+  // V8's lazy `Error#stack` fails first; Bun gets here with a valid stack.
+  {
+    const err = new Error("hostile");
+    err.name = [Symbol("foo")];
+    const out = util.inspect(err);
+    assert.match(out, /^Error: hostile\n {4}at /);
+    assert.match(out, /\{\n {2}name: \[ Symbol\(foo\) \]\n\}$/);
+  }
+  {
+    const err = new Error("hostile");
+    err.message = [Symbol("foo")];
+    assert.match(util.inspect(err), /^Error\n {4}at /);
   }
 
   // A throwing `Symbol.toStringTag` getter on any value is ignored.

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1957,6 +1957,28 @@ test("util.inspect does not throw on values with throwing getters", () => {
     assert.strictEqual(util.inspect([err, shared]), "[ [object Error], <ref *1> { self: [Circular *1] } ]");
   }
 
+  // Same, when `ctx.seenRefs` already holds an index from an earlier value: the
+  // restore must not alias the set that the discarded render then mutates in place.
+  {
+    const a = {};
+    a.self = a;
+    const b = {};
+    b.self = b;
+    const err = new Error("x");
+    err.stack = [
+      b,
+      {
+        [Symbol.for("nodejs.util.inspect.custom")]() {
+          throw new Error("boom");
+        },
+      },
+    ];
+    assert.strictEqual(
+      util.inspect([a, err, b]),
+      "[\n  <ref *1> { self: [Circular *1] },\n  [object Error],\n  <ref *2> { self: [Circular *2] }\n]",
+    );
+  }
+
   // An enumerable unformattable `stack` must be hidden from `keys` before it is
   // read, or the early `[object Error]` return leaves it to be formatted a second
   // time as a plain property, which rethrows. (Node throws on this input.)

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1902,6 +1902,30 @@ test("util.inspect does not throw on values with throwing getters", () => {
     assert.strictEqual(util.inspect(err), "[Error: foo\n    [Circular *1]]");
   }
 
+  // The cause frame dedup must not recursively format a non-string `cause.stack`:
+  // the outer error is not on `ctx.seen` at that point, so `cause.stack === err`
+  // never terminates. (Node throws a stack-overflow RangeError on this input.)
+  {
+    const err = new Error("outer");
+    const cause = new Error("c");
+    Object.defineProperty(cause, "stack", { value: err });
+    err.cause = cause;
+    const out = util.inspect(err);
+    assert.match(out, /^<ref \*1> Error: outer\n {4}at /);
+    assert.match(out, /\{\n {2}cause: \[Error: c\n {6}\[Circular \*1\]\]\n\}$/);
+  }
+
+  // A `cause` whose `stack` and `name` getters both throw. (Node throws here.)
+  {
+    const cause = new Error("c");
+    for (const key of ["stack", "name"]) {
+      Object.defineProperty(cause, key, throwingGetter(key));
+    }
+    const out = util.inspect(new Error("outer", { cause }));
+    assert.match(out, /^Error: outer\n {4}at /);
+    assert.match(out, /\{\n {2}\[cause\]: \[object Error\]\n\}$/);
+  }
+
   // A non-string `stack` whose own formatting throws must leave `ctx` intact, so
   // a second occurrence of the error is not misreported as circular. (Node leaks
   // the error onto `ctx.seen` here and prints `[Circular *1]` for the second one.)

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1939,6 +1939,41 @@ test("util.inspect does not throw on values with throwing getters", () => {
     assert.strictEqual(util.inspect([err, err]), "[ [object Error], [object Error] ]");
   }
 
+  // Same for `ctx.seenRefs`: the `<ref *1>` here was emitted into the discarded
+  // result, so a later occurrence of the same object must re-emit it instead of
+  // producing a `[Circular *1]` that points at nothing.
+  {
+    const shared = {};
+    shared.self = shared;
+    const err = new Error("x");
+    err.stack = [
+      shared,
+      {
+        [Symbol.for("nodejs.util.inspect.custom")]() {
+          throw new Error("boom");
+        },
+      },
+    ];
+    assert.strictEqual(util.inspect([err, shared]), "[ [object Error], <ref *1> { self: [Circular *1] } ]");
+  }
+
+  // An enumerable unformattable `stack` must be hidden from `keys` before it is
+  // read, or the early `[object Error]` return leaves it to be formatted a second
+  // time as a plain property, which rethrows. (Node throws on this input.)
+  {
+    const err = new Error("x");
+    Object.defineProperty(err, "stack", {
+      value: {
+        [Symbol.for("nodejs.util.inspect.custom")]() {
+          throw new Error("boom");
+        },
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    assert.strictEqual(util.inspect(err), "[object Error]");
+  }
+
   // `name` / `message` values whose coercion throws (such as an array holding a
   // Symbol) must not escape either. Node never reaches the coercions because
   // V8's lazy `Error#stack` fails first; Bun gets here with a valid stack.

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -20,10 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import assert from "assert";
+import { setDefaultTimeout, test } from "bun:test";
 import { isWindows } from "harness";
 import util, { inspect } from "util";
 import vm from "vm";
 import { MessageChannel } from "worker_threads";
+
+// Several of the `test()` blocks below bundle hundreds of ported Node.js
+// assertions; the slowest of them exceeds the 5s default under a debug build.
+setDefaultTimeout(60_000);
+
 const noop = () => {};
 const mustCallChecks = [];
 
@@ -693,7 +699,7 @@ test("no assertion failures 2", () => {
   // TODO: Node 20+ changed how it handles the these cases, we should update to match such behavior.
   // It should now preserve the original name and display the user-defined one as an extra property.
   [
-    [404, "404: foo", "[404]"],
+    [404, "404: foo", "[RangeError: foo\n    404]"],
     [0, "0: foo", "[RangeError: foo]"],
     [0n, "0: foo", "[RangeError: foo]"],
     [null, "null: foo", "[RangeError: foo]"],
@@ -1471,7 +1477,7 @@ test("no assertion failures 2", () => {
       }
     }
 
-    assert.throws(() => util.inspect(new ThrowingClass()), /toStringTag error/);
+    assert.strictEqual(util.inspect(new ThrowingClass()), "ThrowingClass {}");
 
     class NotStringClass {
       get [Symbol.toStringTag]() {
@@ -1829,6 +1835,79 @@ test("util.inspect stack overflow handling", () => {
   //? Node will generally cutoff with a stack overflow at around 900.
   assert(match.length > 500 && match.length < 10000);
   assert(longList.includes("[Object: Inspection interrupted prematurely. Maximum call stack size exceeded.]"));
+});
+
+// `util.inspect` must never throw because of the value being inspected. Expected
+// outputs here are what Node.js produces for the same inputs.
+test("util.inspect does not throw on values with throwing getters", () => {
+  const throwingGetter = key => ({
+    get() {
+      throw new Error(`no ${key}`);
+    },
+  });
+
+  // A throwing `stack` getter falls back to `Error.prototype.toString()`.
+  {
+    const err = new Error("hostile");
+    Object.defineProperty(err, "stack", throwingGetter("stack"));
+    assert.strictEqual(util.inspect(err), "[Error: hostile]");
+    assert.strictEqual(util.inspect([err]), "[ [Error: hostile] ]");
+    assert.strictEqual(util.inspect({ err }), "{ err: [Error: hostile] }");
+  }
+
+  // Same, with the `stack` key enumerable so that it shows up in the key list.
+  {
+    const err = new Error("hostile");
+    Object.defineProperty(err, "stack", { ...throwingGetter("stack"), enumerable: true, configurable: true });
+    assert.strictEqual(util.inspect(err), "[Error: hostile]");
+  }
+
+  // Throwing `message`, `name` or `errors` getters must not escape either.
+  for (const key of ["message", "name", "errors"]) {
+    const err = new Error("hostile");
+    Object.defineProperty(err, key, throwingGetter(key));
+    assert.match(util.inspect(err), /^Error(: hostile)?\n {4}at /);
+    assert.match(util.inspect([err]), /^\[\n {2}Error(: hostile)?\n/);
+  }
+
+  // Every accessor throws, so `Error.prototype.toString()` throws as well.
+  {
+    const err = new Error("hostile");
+    for (const key of ["stack", "message", "name"]) {
+      Object.defineProperty(err, key, throwingGetter(key));
+    }
+    assert.strictEqual(util.inspect(err), "[object Error]");
+    assert.strictEqual(util.inspect([err]), "[ [object Error] ]");
+  }
+
+  // Non-string `stack` values are formatted recursively instead of being
+  // coerced with `String()`, which would invoke a user-provided `toString`.
+  {
+    const err = new Error("x");
+    err.stack = {
+      toString() {
+        throw new Error("bad toString");
+      },
+    };
+    assert.strictEqual(util.inspect(err), "[Error: x\n    {\n      toString: [Function: toString]\n    }]");
+  }
+  {
+    const err = new Error();
+    err.stack = [Symbol("foo")];
+    assert.strictEqual(util.inspect(err), "[Error\n    [\n      Symbol(foo)\n    ]]");
+  }
+  {
+    const err = new Error("foo");
+    err.stack = err;
+    assert.strictEqual(util.inspect(err), "[Error: foo\n    [Circular *1]]");
+  }
+
+  // A throwing `Symbol.toStringTag` getter on any value is ignored.
+  {
+    const obj = Object.defineProperty({}, Symbol.toStringTag, throwingGetter("toStringTag"));
+    assert.strictEqual(util.inspect(obj), "{}");
+    assert.strictEqual(util.inspect([obj]), "[ {} ]");
+  }
 });
 
 test("no assertion failures 3", () => {


### PR DESCRIPTION
### What

`util.inspect` must never throw because of the value it is printing; that is the contract every `catch (e) { log(e) }` relies on. Bun's `util.inspect` (and everything built on it: `util.format`, the `node:console` `Console` class, `assert` diff rendering) violates it for any value carrying a throwing getter.

### Repro

```js
const util = require("util");
const e = new Error("hostile");
Object.defineProperty(e, "stack", { get() { throw new Error("no stack"); } });
util.inspect(e);   // bun: throws `Error: no stack`              node: "[Error: hostile]"
util.inspect([e]); // bun: throws `AssertionError: ...`           node: "[ [Error: hostile] ]"
```

On 1.4.0 and current `main`:

```
util.inspect(e)   THREW -> Error: no stack
util.inspect([e]) THREW -> AssertionError: handleMaxCallStackSize assertion failed: Error: no stack
```

So a logger that was asked to print `e` instead throws, and if `e` sits inside any container the real error is replaced by an unrelated internal `AssertionError`.

### Cause

Two bugs in `src/js/internal/util/inspect.js`:

1. The `Error` formatter read `err.stack`, `err.name`, `err.message` and `err.errors` directly, with no guards. Node.js wraps each of these in its own `try`/`catch` ([`getStackString`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/util/inspect.js), `formatError`). A throwing `Symbol.toStringTag` getter escaped `formatRaw` the same way, and non-string `stack` values were coerced with `String()`, which invokes a user `toString` (and throws a `TypeError` outright for values such as `[Symbol()]`).
2. `formatRaw`'s `catch` treats every exception that is not its synthetic stack-overflow `RangeError` as an internal invariant violation and throws a fabricated `AssertionError("handleMaxCallStackSize assertion failed: " + err)`, destroying the original error. Node re-throws the original (`if (!isStackOverflowError(err)) throw err;`).

### Fix

Port Node's guards, keeping Bun's surrounding structure:

- `getStackString(ctx, error)` catches the `stack` getter and falls back to `Error.prototype.toString()`. Non-string stacks are rendered recursively via `formatValue()` instead of `String()`, which also matches Node's output for `err.stack = 404`, circular stacks, etc.
- `formatError()` wraps `getStackString()` (falling back to `"[object Error]"` when `Error.prototype.toString()` throws too, i.e. hostile `name`/`message`), and reads `message`, `name` and `errors` each under their own `try`/`catch`. The duplicate-key hiding is inlined from Node so it reuses the already-read values instead of invoking the getters a second time; `removeDuplicateErrorKeys` is deleted since that was its only caller.
- The `value[Symbol.toStringTag]` read in `formatRaw()` is guarded the same way Node guards it.
- `formatRaw()`'s catch re-throws the original error instead of manufacturing the `AssertionError`.

### Verification

New test `util.inspect does not throw on values with throwing getters` in `test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js` covers throwing `stack` / `message` / `name` / `errors` / `Symbol.toStringTag` getters (alone, enumerable, all-at-once, and nested in containers) plus the non-string-stack shapes. Every exact expected string was captured from Node.js v26.3.0.

<details>
<summary>Before / after for the full matrix</summary>

```
case                            bun (before)                                                          bun (after) == node
------------------------------  --------------------------------------------------------------------  --------------------------
inspect(e)   stack throws       THREW Error: no stack                                                 [Error: hostile]
inspect([e]) stack throws       THREW AssertionError: handleMaxCallStackSize assertion failed: ...    [ [Error: hostile] ]
inspect({e}) stack throws       THREW AssertionError: handleMaxCallStackSize assertion failed: ...    { e: [Error: hostile] }
Console#log([e]) stack throws   THREW AssertionError: handleMaxCallStackSize assertion failed: ...    [ [Error: hostile] ]
inspect(e)   message throws     THREW Error: no message                                               (no throw)
inspect(e)   name throws        THREW Error: no name                                                  (no throw)
inspect(e)   errors throws      THREW Error: no errors                                                (no throw)
inspect(e)   all three throw    THREW Error: no name                                                  [object Error]
e.stack = {toString: throws}    THREW Error: bad toString                                             [Error: x\n    { toString: [Function: toString] }]
e.stack = [Symbol("foo")]       THREW TypeError                                                       [Error\n    [\n      Symbol(foo)\n    ]]
e.stack = e (circular)          [Circular *1]  (whole output)                                         [Error: foo\n    [Circular *1]]
o[Symbol.toStringTag] throws    THREW Error                                                           {}
```

The `message`/`name`/`errors` rows print the full stack in Bun rather than Node's `[object Error]`, because JSC's lazy `Error#stack` does not invoke those getters while V8's does. That difference is pre-existing and benign; the contract (never throw) now matches.

</details>

Three pre-existing assertions in `util-inspect.test.js` locked in the old behavior and are updated to Node's current expectations (Node's own `test-util-inspect.js` was updated the same way upstream):

- `err.stack = 404` now renders `[RangeError: foo\n    404]` instead of `[404]`. The test already carried a `TODO: Node 20+ changed how it handles these cases`.
- `util.inspect(new ThrowingClass())` (throwing `Symbol.toStringTag` getter) now returns `"ThrowingClass {}"` instead of throwing; Node's test asserts exactly that string.
- A `setDefaultTimeout(60_000)` was added to the file. This is unrelated to the fix: on unmodified `main`, `bun bd test` of this file already fails because the ported `no assertion failures 2` block takes 8.8s under a debug + ASAN build and exceeds the 5s default (CI passes an explicit `--timeout`, which is why it is green there). Without it the file cannot be run locally with a debug build at all.
