### PR TITLE
Upgrade lsquic to 4.6.3 and fix HTTP/3 100-continue on cold connections

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -981,9 +981,8 @@ int us_quic_stream_send_headers(us_quic_stream_t *s,
     /* Mark the context dirty so drainQuicIfNecessary picks up header-only
      * responses (204/304) that never call us_quic_stream_write. */
     if (r == 0) s->ctx->pending_write_bytes += (unsigned int) total + 1;
-    /* lsquic rejects a send while a previous header block (e.g. an auto-sent
-     * 100-continue) is still draining, with errno EBADMSG. Report it as a
-     * distinct retryable code so the caller can resend once it flushes. */
+    /* lsquic refuses a send while a prior header block (e.g. a 100-continue)
+     * is still draining (errno EBADMSG); map it to a retryable code. */
     if (r != 0 && send_errno == EBADMSG) return US_QUIC_SEND_HEADERS_PENDING;
     return r;
 }

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -972,13 +972,19 @@ int us_quic_stream_send_headers(us_quic_stream_t *s,
     }
 
     lsquic_http_headers_t lh = { .count = (int) count, .headers = xh };
+    errno = 0;
     int r = lsquic_stream_send_headers(s->stream, &lh, end_stream);
+    int send_errno = errno;
     if (buf != stackbuf) free(buf);
     if (xh != stackh) free(xh);
     if (end_stream && r == 0) lsquic_stream_shutdown(s->stream, 1);
     /* Mark the context dirty so drainQuicIfNecessary picks up header-only
      * responses (204/304) that never call us_quic_stream_write. */
     if (r == 0) s->ctx->pending_write_bytes += (unsigned int) total + 1;
+    /* lsquic rejects a send while a previous header block (e.g. an auto-sent
+     * 100-continue) is still draining, with errno EBADMSG. Report it as a
+     * distinct retryable code so the caller can resend once it flushes. */
+    if (r != 0 && send_errno == EBADMSG) return US_QUIC_SEND_HEADERS_PENDING;
     return r;
 }
 

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -134,6 +134,11 @@ void us_quic_socket_context_on_stream_close(us_quic_socket_context_t *ctx,
 int us_quic_stream_write(us_quic_stream_t *s, const char *data, unsigned int len);
 void us_quic_stream_want_read(us_quic_stream_t *s, int want);
 void us_quic_stream_want_write(us_quic_stream_t *s, int want);
+/* Returned by us_quic_stream_send_headers when the send was refused because a
+ * previous header block (e.g. an auto-sent 100-continue) is still draining;
+ * the caller should resend once the stream is writable. Distinct from 0 (sent)
+ * and -1 (fatal). */
+#define US_QUIC_SEND_HEADERS_PENDING 1
 int us_quic_stream_send_headers(us_quic_stream_t *s,
     const struct us_quic_header_t *headers, unsigned int count, int end_stream);
 /* Send a 1xx interim HEADERS frame (`:status` only); the final response

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -134,10 +134,9 @@ void us_quic_socket_context_on_stream_close(us_quic_socket_context_t *ctx,
 int us_quic_stream_write(us_quic_stream_t *s, const char *data, unsigned int len);
 void us_quic_stream_want_read(us_quic_stream_t *s, int want);
 void us_quic_stream_want_write(us_quic_stream_t *s, int want);
-/* Returned by us_quic_stream_send_headers when the send was refused because a
- * previous header block (e.g. an auto-sent 100-continue) is still draining;
- * the caller should resend once the stream is writable. Distinct from 0 (sent)
- * and -1 (fatal). */
+/* us_quic_stream_send_headers returns this when the send was refused because a
+ * prior header block (e.g. a 100-continue) is still draining; resend when
+ * writable. Distinct from 0 (sent) and -1 (fatal). */
 #define US_QUIC_SEND_HEADERS_PENDING 1
 int us_quic_stream_send_headers(us_quic_stream_t *s,
     const struct us_quic_header_t *headers, unsigned int count, int end_stream);

--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -70,7 +70,7 @@ struct Http3Response {
     bool write(std::string_view data, size_t *writtenPtr = nullptr) {
         Http3ResponseData *d = getHttpResponseData();
         flushHeaders();
-        if (d->backpressure.length() != 0) {
+        if (d->headersDeferred || d->backpressure.length() != 0) {
             d->backpressure.append(data.data(), data.length());
             if (writtenPtr) *writtenPtr = 0;
             us_quic_stream_want_write((us_quic_stream_t *) this, 1);
@@ -108,6 +108,9 @@ struct Http3Response {
         } else {
             writeStatus("200 OK");
             sendBufferedHeaders(d, true);
+            /* Deferred behind a draining interim block: drain() resends the
+             * header block (with FIN) and calls markDone then. */
+            if (d->headersDeferred) return;
         }
         markDone(d);
     }
@@ -115,7 +118,7 @@ struct Http3Response {
     bool sendTerminatingChunk(bool /*closeConnection*/ = false) {
         Http3ResponseData *d = getHttpResponseData();
         flushHeaders();
-        if (d->backpressure.length() != 0) {
+        if (d->headersDeferred || d->backpressure.length() != 0) {
             d->endAfterDrain = true;
             us_quic_stream_want_write((us_quic_stream_t *) this, 1);
             return false;
@@ -185,6 +188,19 @@ struct Http3Response {
     /* Called from Http3Context's on_stream_writable. */
     bool drain() {
         Http3ResponseData *d = getHttpResponseData();
+        if (d->headersDeferred) {
+            d->headersDeferred = false;
+            bool endStream = d->deferredEndStream;
+            /* The interim block has drained (this callback only fires once it
+             * has), so the resend now succeeds; sendBufferedHeaders re-arms
+             * headersDeferred only if it is somehow still pending. */
+            sendBufferedHeaders(d, endStream);
+            if (d->headersDeferred) return false;
+            if (endStream) {
+                markDone(d);
+                return true;
+            }
+        }
         while (d->backpressure.length() != 0) {
             int w = us_quic_stream_write((us_quic_stream_t *) this,
                 d->backpressure.data(), (unsigned) d->backpressure.length());
@@ -210,13 +226,26 @@ private:
     }
 
     void sendBufferedHeaders(Http3ResponseData *d, bool endStream) {
+        /* Resolve the stored byte offsets into absolute pointers in a local
+         * copy so hdrs/hdrBuf stay untouched and can be resent as-is if the
+         * send is deferred below. */
         const char *base = d->hdrBuf.span().data();
+        WTF::Vector<us_quic_header_t, 16> resolved;
+        resolved.reserveInitialCapacity(d->hdrs.size());
         for (auto &h : d->hdrs) {
-            h.name = base + (uintptr_t) h.name;
-            h.value = base + (uintptr_t) h.value;
+            resolved.append({base + (uintptr_t) h.name, h.name_len,
+                             base + (uintptr_t) h.value, h.value_len, h.qpack_index});
         }
-        us_quic_stream_send_headers((us_quic_stream_t *) this,
-            d->hdrs.mutableSpan().data(), (unsigned) d->hdrs.size(), endStream);
+        int r = us_quic_stream_send_headers((us_quic_stream_t *) this,
+            resolved.mutableSpan().data(), (unsigned) resolved.size(), endStream);
+        if (r == US_QUIC_SEND_HEADERS_PENDING) {
+            /* An auto-sent 100-continue block is still draining; lsquic refused
+             * this block (#33082). Keep it buffered and resend from drain(). */
+            d->headersDeferred = true;
+            d->deferredEndStream = endStream;
+            us_quic_stream_want_write((us_quic_stream_t *) this, 1);
+            return;
+        }
         d->hdrBuf.shrink(0);
         d->hdrs.shrink(0);
     }
@@ -234,6 +263,9 @@ private:
             }
             if (data.empty() && d->offset == totalSize) {
                 sendBufferedHeaders(d, true);
+                /* Deferred behind a draining interim block: drain() resends
+                 * the header block (with FIN) and calls markDone then. */
+                if (d->headersDeferred) return false;
                 markDone(d);
                 return true;
             }
@@ -241,7 +273,7 @@ private:
             d->state |= Http3ResponseData::HTTP_WRITE_CALLED;
         }
 
-        if (d->backpressure.length() != 0) {
+        if (d->headersDeferred || d->backpressure.length() != 0) {
             if (optional) return false;
             d->backpressure.append(data.data(), data.length());
             d->endAfterDrain = true;

--- a/packages/bun-uws/src/Http3ResponseData.h
+++ b/packages/bun-uws/src/Http3ResponseData.h
@@ -59,6 +59,13 @@ struct Http3ResponseData {
     BackPressure backpressure;
     bool endAfterDrain = false;
 
+    /* Set when the final response header block was refused because an interim
+     * (100-continue) block is still draining in lsquic (#33082). The buffered
+     * headers stay in hdrs/hdrBuf and body bytes route to backpressure until
+     * the writable event resends them in order. */
+    bool headersDeferred = false;
+    bool deferredEndStream = false;
+
     uint64_t offset = 0;
     uint64_t totalSize = 0;
     uint8_t state = 0;
@@ -87,6 +94,8 @@ struct Http3ResponseData {
         hdrs.shrink(0);
         backpressure.clear();
         endAfterDrain = false;
+        headersDeferred = false;
+        deferredEndStream = false;
         offset = 0;
         totalSize = 0;
         state = HTTP_RESPONSE_PENDING;

--- a/packages/bun-uws/src/Http3ResponseData.h
+++ b/packages/bun-uws/src/Http3ResponseData.h
@@ -59,10 +59,9 @@ struct Http3ResponseData {
     BackPressure backpressure;
     bool endAfterDrain = false;
 
-    /* Set when the final response header block was refused because an interim
-     * (100-continue) block is still draining in lsquic (#33082). The buffered
-     * headers stay in hdrs/hdrBuf and body bytes route to backpressure until
-     * the writable event resends them in order. */
+    /* Final header block refused while an interim (100-continue) block is still
+     * draining in lsquic (#33082); headers stay buffered and body routes to
+     * backpressure until drain() resends them. */
     bool headersDeferred = false;
     bool deferredEndStream = false;
 

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -14,7 +14,7 @@
 import type { Dependency, DirectBuild } from "../source.ts";
 import { depBuildDir, depSourceDir } from "../source.ts";
 
-const LSQUIC_COMMIT = "3181911301b1aa4f54c1ed690901abc674ee08fb";
+const LSQUIC_COMMIT = "0fa4f361094c1899b7bd664e5ee96e82e0af7e18";
 
 // gQUIC (Google QUIC, pre-IETF) sources are excluded — Bun only negotiates
 // IETF QUIC. The unconditional engine/global references to gQUIC vtables are

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1077,14 +1077,8 @@ describe("Bun.serve HTTP/3 production", () => {
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
 
-  // https://github.com/oven-sh/bun/issues/33082: the server auto-answers
-  // `Expect: 100-continue` with an interim HEADERS(:status 100) before the
-  // handler runs. On the first stream of a fresh QUIC connection that interim
-  // block is stashed inside lsquic (QPACK/flow-control still settling), and the
-  // final response's header block used to clobber it, resetting the stream
-  // (HTTP3StreamReset). Fixed upstream in lsquic 4.6.3 (litespeedtech/lsquic#637).
-  // The connection must be cold: a dedicated server whose very first request
-  // carries the Expect header, with no warm-up.
+  // https://github.com/oven-sh/bun/issues/33082
+  // Must stay a cold connection (no warm-up request) or the bug is masked.
   test("Expect: 100-continue delivers the final response on a cold connection", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1076,4 +1076,34 @@ describe("Bun.serve HTTP/3 production", () => {
   // Expect: 100-continue is handled at the uWS layer for both transports
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
+
+  // https://github.com/oven-sh/bun/issues/33082: the server auto-answers
+  // `Expect: 100-continue` with an interim HEADERS(:status 100) before the
+  // handler runs. On the first stream of a fresh QUIC connection that interim
+  // block is stashed inside lsquic (QPACK/flow-control still settling), and the
+  // final response's header block used to clobber it, resetting the stream
+  // (HTTP3StreamReset). Fixed upstream in lsquic 4.6.3 (litespeedtech/lsquic#637).
+  // The connection must be cold: a dedicated server whose very first request
+  // carries the Expect header, with no warm-up.
+  test("Expect: 100-continue delivers the final response on a cold connection", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls,
+      http3: true,
+      http1: false,
+      async fetch(req) {
+        const body = await req.bytes();
+        return new Response("body:" + body.length);
+      },
+    });
+    const res = await fetch(`https://127.0.0.1:${server.port}/`, {
+      protocol: "http3",
+      tls: { rejectUnauthorized: false },
+      method: "POST",
+      body: "request-content",
+      headers: { expect: "100-continue" },
+    } as RequestInit);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("body:15");
+  });
 });


### PR DESCRIPTION
Fixes #33082. Supersedes #33083 (per @Jarred-Sumner's request to upgrade lsquic instead of carrying a custom patch).

## Background

`Bun.serve({ http3: true })` auto-answers `Expect: 100-continue` with an interim `HEADERS(:status 100)` before running the handler. On the first stream of a fresh QUIC connection the final `HEADERS(:status 200)` never reaches the client and the fetch rejects with `HTTP3StreamReset`. Warming the connection first makes it work. Deterministic.

## What the lsquic upgrade does

@dtikhonov fixed the underlying memory bug in [litespeedtech/lsquic#637](https://github.com/litespeedtech/lsquic/pull/637), released in **lsquic 4.6.3**. In 4.6.2 the second `lsquic_stream_send_headers()` reallocated the stashed interim block and clobbered it. 4.6.3 rejects a send while a header block is still pending:

```c
if (stream->sm_send_headers_state != SSHS_BEGIN || stream->sm_header_block) {
    LSQ_INFO("cannot send headers while previous header block is pending");
    errno = EBADMSG;
    return -1;
}
```

This PR bumps `LSQUIC_COMMIT` from v4.6.2 to v4.6.3. The four existing lsquic patches still apply cleanly, and no custom lsquic patch is needed.

## Why the upgrade alone is not enough

The 4.6.3 guard removes the corruption, but by itself the response is still not delivered. I verified this: building with only the version bump, the cold test still rejects with `HTTP3StreamReset`. The reason is that Bun's H3 writer issues the second (final) header send, lsquic now refuses it with `EBADMSG`, the writer ignores the refusal and writes the body after the interim 100, and the peer resets the stream.

So the writer has to serialize the two header blocks. `us_quic_stream_send_headers` now reports the `EBADMSG` refusal as a distinct retryable code (`US_QUIC_SEND_HEADERS_PENDING`), and `Http3Response` keeps the final block buffered, routes any body bytes through the existing backpressure buffer, and resends the block from the stream's writable event once the interim block has drained. The warm path (interim written inline) is unchanged.

## Verification

- `test/js/bun/http/serve-http3.test.ts` ("Expect: 100-continue delivers the final response on a cold connection"): fails with only the version bump (`HTTP3StreamReset`) and passes with the writer change. The version bump lives in `scripts/`/`vendor/` and the writer change in `packages/`, so the gate's `git stash push -- src/ packages/` reproduces exactly that fail-before/pass-after split.
- Full `serve-http3.test.ts` (46) and `fetch-http3-adversarial.test.ts` (27) suites pass, including the `204 then 200 on the same connection` multi-block path.
