### PR TITLE
bun:test: stop leaking JSC scope objects through mock host functions

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -838,7 +838,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
+    JSValue thisValue = callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -1271,7 +1271,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall, (JSC::JSGlobalObj
 {
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisObject = callframe->thisValue();
+    JSValue thisObject = callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict());
     if (!thisObject.isObject()) [[unlikely]] {
         return JSValue::encode(jsUndefined());
     }
@@ -1444,17 +1444,18 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsNow, (JSC::JSGlobalObject * globalObject, JSC
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
     JSValue argument0 = callframe->argument(0);
+    JSValue thisValue = callframe->thisValue().toThis(globalObject, ECMAMode::strict());
 
     // JSGlobalObject::overridenDateNow's "no override" sentinel is NaN (see
     // JSGlobalObject::jsDateNow()), so every real timestamp, including 0 and
     // pre-epoch negatives, overrides; an omitted arg, NaN, or invalid Date resets.
     if (auto* dateInstance = dynamicDowncast<DateInstance>(argument0)) {
         globalObject->overridenDateNow = dateInstance->internalNumber();
-        return JSValue::encode(callframe->thisValue());
+        return JSValue::encode(thisValue);
     }
     globalObject->overridenDateNow = argument0.isNumber() ? argument0.asNumber() : PNaN;
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(thisValue);
 }
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsRestoreAllMocks, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,31 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  test("this is undefined for a bare call through a closure-captured binding", () => {
+    const fn = jest.fn().mockReturnThis();
+    const captured = 1;
+    // Referencing `fn` from an inner function forces it into the enclosing
+    // lexical environment, so `fn()` below resolves it through that scope.
+    function keepCaptured() {
+      return [fn, captured];
+    }
+    expect(fn()).toBeUndefined();
+    expect(fn.mock.contexts).toEqual([undefined]);
+  });
+
+  test("this seen by the implementation is undefined for a closure-captured bare call", () => {
+    let receivedThis = "not called";
+    const fn = jest.fn(function () {
+      receivedThis = this;
+    });
+    function keepCaptured() {
+      return fn;
+    }
+    fn();
+    expect(receivedThis).toBeUndefined();
+    expect(fn.mock.contexts).toEqual([undefined]);
+  });
 });
 
 describe("spyOn", () => {

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -29,6 +29,16 @@ test("we can go back in time", () => {
   expect(now.toISOString()).toBe(orig.toISOString());
 });
 
+test("setSystemTime returns undefined for a bare call through a closure-captured binding", () => {
+  const { setSystemTime } = jest;
+  // Referencing `setSystemTime` from an inner function forces it into the
+  // enclosing lexical environment, so the bare call resolves through that scope.
+  function keepCaptured() {
+    return setSystemTime;
+  }
+  expect(setSystemTime()).toBeUndefined();
+});
+
 test("setSystemTime accepts pre-epoch and epoch times and resets with no argument", () => {
   const realBefore = Date.now();
   jest.useFakeTimers();


### PR DESCRIPTION
Fixes a deterministic segfault found by fuzzing (fingerprint `f3ce0925415c7f37`).

### What happens

When JavaScript calls a function through a binding that lives in a lexical environment (a `const`/`let` that an inner function also references), JSC's bytecode generator puts the resolved `JSLexicalEnvironment` into the call's implicit `this` slot (`FunctionCallResolveNode::emitBytecode`). Ordinary JS callees run it through `op_to_this`, which maps a `JSScope` to `undefined`. Host functions see the raw value, which is why JSC's own built-ins all start with `callFrame->thisValue().toThis(globalObject, ECMAMode::strict())`.

`jsMockFunctionCall` did not, so for

```js
const fn = mock().mockReturnThis();
function keep() { return [fn, later]; }
const r = fn();     // r is the JSLexicalEnvironment
typeof r.later;     // segfault: `later` is still in its TDZ
const later = 1;
```

the scope object escapes to JavaScript in three places: `fn.mock.contexts`, the `this` passed to the user implementation, and the return value of `mockReturnThis()`. The scope's "own properties" are the enclosing function's captured locals, and the slot of a `const` that has not been initialized yet holds JSC's TDZ marker, the empty `JSValue`. `typeof` on that reads the JSType byte of a cell at address 0:

```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x13a09e93 in llint_op_typeof_is_function ()
=> cmpb $0x21,0x5(%rax)    rax = 0x0
```

### Fix

Run the raw `thisValue` through `JSValue::toThis(globalObject, ECMAMode::strict())`, the same thing `ArrayPrototype`, `ObjectPrototype`, and `ProxyObject::performCall` do in JSC. It is an identity for every value except a `JSScope`, which becomes `undefined`, so the normal `fn()`, `obj.fn()`, and `fn.call(x)` paths are unchanged. `undefined` is also what the spec mandates here (a declarative environment record's `WithBaseObject()` is `undefined`) and what Jest reports, since its `mockConstructor` is a strict JS function.

Two other host functions in the same file read `callframe->thisValue()` without a type check and get the same treatment:

- `JSMock__jsSetSystemTime` returns the raw value, so a destructured `setSystemTime()` called through a captured binding returned the scope.
- `jsMockFunctionGetter_mockGetLastCall` only checks `isObject()`, which a scope passes, then does a `get()` on it. A captured `const calls` still in its TDZ would hand an empty `JSValue` to `jsDynamicCast` and null-deref.

Every other `thisValue()` in the file already goes through `dynamicDowncast<JSMockFunction>`, which rejects a scope.

The same `return JSValue::encode(callFrame->thisValue())` pattern exists in `BunPlugin.cpp`'s three builder methods (`onLoad`, `onResolve`, `module`). That is a different module with its own tests, so it is left for a follow-up.

### Tests

Added regression tests to `mock-fn.test.js` (fail before with `Received: [native code: JSLexicalEnvironment]`, pass after) and `test-timers.test.ts`. The original fuzzer script no longer crashes.