### PR TITLE
Address review nits from #31789 in computeErrorInfoWrapperToString

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -579,8 +579,8 @@ WTF::String computeErrorInfoWrapperToString(JSC::VM& vm, Vector<StackFrame>& sta
 {
     UNUSED_PARAM(bunErrorData);
 
-    // ErrorInstance::finalizeUnconditionally calls this from Heap::runEndPhase, which
-    // nulls the current thread's atom string table (and may run on the collector thread).
+    // ErrorInstance::finalizeUnconditionally calls this from Heap::runEndPhase, which nulls
+    // the current thread's atom string table and runs on whichever thread conducts the GC.
     // Releasing the last ref of an atom string there crashes in AtomStringImpl::remove(),
     // so install the VM's table for the duration; the mutator is suspended for the whole
     // end phase, so this is race-free (same as JSLock::didAcquireLock).
@@ -591,7 +591,7 @@ WTF::String computeErrorInfoWrapperToString(JSC::VM& vm, Vector<StackFrame>& sta
     if (needsVMAtomStringTable) [[unlikely]]
         thread.setCurrentAtomStringTable(vm.atomStringTable());
     auto restoreAtomStringTable = WTF::makeScopeExit([&] {
-        if (needsVMAtomStringTable) [[unlikely]]
+        if (needsVMAtomStringTable)
             thread.setCurrentAtomStringTable(previousAtomStringTable);
     });
 


### PR DESCRIPTION
### What does this PR do?

Follow-up to the review notes on #31789 (merged):

- drop the `[[unlikely]]` inside the scope-exit lambda: it runs once on an already-computed bool, so the annotation buys nothing
- tighten the comment: the finalizer window runs on whichever thread conducts the GC, not only the concurrent collector thread

No behavior change.

### How did you verify your code works?

`bun bd` builds; the GC-window repro from #31789 (errors with dead `new Function` frames plus `Bun.gc(true)` in a transpiled module) ran 10 times on the debug (assertion-enabled, ASAN) build with `BUN_GARBAGE_COLLECTOR_LEVEL=1` with no failures, and the error-stack/sourcemap suites pass.