### PR TITLE
Diagnose terminal spawn test timeout on darwin x64

### DIFF
--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -662,9 +662,14 @@ impl Terminal {
         self.hpcon.get()
     }
 
-    /// Close the parent's copy of slave_fd after fork
-    /// The child process has its own copy - closing the parent's ensures
-    /// EOF is received on the master side when the child exits
+    /// Mark a terminal created inline by `Bun.spawn` so it can't be reused
+    /// by a later spawn.
+    pub(crate) fn mark_inline_spawned(&self) {
+        self.update_flags(|f| f.insert(Flags::INLINE_SPAWNED));
+    }
+
+    /// Close the parent's copy of slave_fd. The child holds its own copy;
+    /// once every slave fd is closed the master reader observes EOF.
     pub(crate) fn close_slave_fd(&self) {
         self.update_flags(|f| f.insert(Flags::INLINE_SPAWNED));
         let fd = self.slave_fd.get();
@@ -672,6 +677,28 @@ impl Terminal {
             fd.close();
             self.slave_fd.set(Fd::INVALID);
         }
+    }
+
+    /// Called when the owned subprocess exits. BSD/macOS discards any data
+    /// still buffered in the PTY output queue when the last slave fd closes,
+    /// so the parent must keep its slave copy open until the child has exited
+    /// and the master has been drained; only then may it close the slave to
+    /// let the reader observe EOF.
+    #[cfg(unix)]
+    pub(crate) fn drain_and_close_slave(&self) {
+        let flags = self.flags.get();
+        if flags.contains(Flags::CLOSED) {
+            return;
+        }
+        if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
+            // Streams pending chunks to the JS data callback until EAGAIN.
+            // Re-check state after: user JS may have closed the terminal.
+            self.reader.with_mut(|r| r.read());
+            if self.flags.get().contains(Flags::CLOSED) {
+                return;
+            }
+        }
+        self.close_slave_fd();
     }
 
     /// Windows: close only the ConPTY handle so conhost releases its pipe ends and

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1413,11 +1413,18 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         IS_SYNC,
     ));
 
-    // For inline terminal options: close parent's slave_fd so EOF is received when child exits
+    // For inline terminal options: keep the parent's slave_fd open until the
+    // subprocess exits — BSD/macOS discards unread PTY output when the last
+    // slave fd closes, so closing it now can race the child's final writes.
+    // Subprocess::on_process_exit drains the master and closes it then.
     // For existing terminal: keep slave_fd open so terminal can be reused for more spawns
     if let Some(info) = terminal_info.take() {
         terminal_js_value = info.js_value;
-        // Spawn succeeded so the child holds its own copy of the slave fd.
+        #[cfg(unix)]
+        info.term().mark_inline_spawned();
+        // Windows: ConPTY's conhost buffers output, so the client pipe end can
+        // close immediately; EOF is delivered via close_pseudoconsole on exit.
+        #[cfg(windows)]
         info.term().close_slave_fd();
         subprocess.update_flags(|f| f.insert(Subprocess::Flags::OWNS_TERMINAL));
     }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -921,6 +921,18 @@ impl Subprocess<'_> {
             }
         }
 
+        #[cfg(unix)]
+        if self.flags.get().contains(Flags::OWNS_TERMINAL) {
+            // The parent kept its slave fd open across the child's lifetime
+            // (BSD/macOS discards unread PTY output at last slave close).
+            // Drain the master now and close the slave so EOF fires the
+            // terminal's exit callback.
+            if let Some(terminal) = self.terminal.get() {
+                // `BackRef` invariant: see the Windows arm above.
+                bun_ptr::BackRef::from(terminal).drain_and_close_slave();
+            }
+        }
+
         let mut stdin: Option<NonNull<FileSink>> = if matches!(self.stdin.get(), Writable::Pipe(_))
             && self.flags.get().contains(Flags::IS_STDIN_A_READABLE_STREAM)
         {

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -995,37 +995,77 @@ describe("Bun.Terminal", () => {
 });
 
 describe.concurrent("Bun.spawn with terminal option", () => {
-  test("creates subprocess with terminal attached", async () => {
-    const dataChunks: Uint8Array[] = [];
-    const gotMarker = Promise.withResolvers<void>();
+  // Instrumented while investigating a timeout on the darwin x64 CI runner:
+  // dumps where the test is stuck (child state, received bytes) every 15s.
+  const spawnWithTerminalAttached = (label: string) =>
+    test(label, async () => {
+      const dataChunks: Uint8Array[] = [];
+      const gotMarker = Promise.withResolvers<void>();
+      let stage = "spawning";
+      const events: string[] = [];
+      const t0 = Date.now();
+      const mark = (e: string) => events.push(`${Date.now() - t0}ms ${e}`);
 
-    const proc = Bun.spawn([bunExe(), "-e", "console.log('hello from terminal')"], {
-      env: bunEnv,
-      terminal: {
-        cols: 80,
-        rows: 24,
-        data: (terminal: Bun.Terminal, data: Uint8Array) => {
-          dataChunks.push(data);
-          if (Buffer.concat(dataChunks).toString().includes("hello from terminal")) gotMarker.resolve();
+      const proc = Bun.spawn([bunExe(), "-e", "console.log('hello from terminal')"], {
+        env: bunEnv,
+        terminal: {
+          cols: 80,
+          rows: 24,
+          data: (terminal: Bun.Terminal, data: Uint8Array) => {
+            dataChunks.push(data);
+            mark(`data +${data.length}b`);
+            if (Buffer.concat(dataChunks).toString().includes("hello from terminal")) gotMarker.resolve();
+          },
+          exit: () => mark("terminal exit cb"),
         },
-      },
+      });
+      mark(`spawned pid=${proc.pid}`);
+      proc.exited.then(code => mark(`proc.exited resolved code=${code}`));
+
+      const watchdog = setInterval(() => {
+        let ps = "";
+        try {
+          ps = require("node:child_process")
+            .execSync(`ps -o pid,stat,command -p ${proc.pid} || true`, { shell: "/bin/sh" })
+            .toString()
+            .trim();
+        } catch (e: any) {
+          ps = `ps failed: ${e?.message ?? e}`;
+        }
+        console.error(
+          `[${label}] WATCHDOG stage=${stage} pid=${proc.pid} exitCode=${proc.exitCode} signalCode=${proc.signalCode} ` +
+            `killed=${proc.killed} terminalClosed=${proc.terminal?.closed} bytes=${Buffer.concat(dataChunks).length} ` +
+            `out=${JSON.stringify(Buffer.concat(dataChunks).toString())}\n  events: ${events.join(" | ")}\n  ps: ${ps}`,
+        );
+      }, 15_000);
+
+      try {
+        expect(proc.terminal).toBeDefined();
+        expect(proc.terminal).toBeInstanceOf(Object);
+
+        stage = "awaiting-marker";
+        await gotMarker.promise;
+        stage = "awaiting-exited";
+        await proc.exited;
+        stage = "done-awaiting";
+
+        // Should have received data through the terminal
+        const combinedOutput = Buffer.concat(dataChunks).toString();
+        expect(combinedOutput).toContain("hello from terminal");
+
+        // Terminal should still be accessible after process exit
+        expect(proc.terminal!.closed).toBe(false);
+        proc.terminal!.close();
+        expect(proc.terminal!.closed).toBe(true);
+      } finally {
+        clearInterval(watchdog);
+      }
     });
 
-    expect(proc.terminal).toBeDefined();
-    expect(proc.terminal).toBeInstanceOf(Object);
-
-    await gotMarker.promise;
-    await proc.exited;
-
-    // Should have received data through the terminal
-    const combinedOutput = Buffer.concat(dataChunks).toString();
-    expect(combinedOutput).toContain("hello from terminal");
-
-    // Terminal should still be accessible after process exit
-    expect(proc.terminal!.closed).toBe(false);
-    proc.terminal!.close();
-    expect(proc.terminal!.closed).toBe(true);
-  });
+  spawnWithTerminalAttached("creates subprocess with terminal attached");
+  spawnWithTerminalAttached("creates subprocess with terminal attached (copy 2)");
+  spawnWithTerminalAttached("creates subprocess with terminal attached (copy 3)");
+  spawnWithTerminalAttached("creates subprocess with terminal attached (copy 4)");
 
   test("terminal option creates proper PTY for interactive programs", async () => {
     const dataChunks: Uint8Array[] = [];

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 // Helper to enable echo on a terminal (echo is disabled by default to avoid duplication)
 function enableEcho(terminal: Bun.Terminal) {
@@ -1239,6 +1241,96 @@ describe.concurrent("Bun.spawn with terminal option", () => {
     expect(proc.stderr).toBeNull();
 
     await proc.exited;
+    proc.terminal!.close();
+  });
+
+  // BSD/macOS discards unread PTY output when the last slave fd closes. If the
+  // parent dropped its slave copy at spawn and the event loop stalls until the
+  // child writes and closes its slave fds, the output was lost and the data
+  // callback never fired. The child (sh, which holds the tty only as stdio)
+  // closes its stdio and then signals via a sentinel file, so the only
+  // remaining slave fd is the parent's.
+  test.skipIf(isWindows)(
+    "output written before the parent reads is not lost when the child drops the pty",
+    async () => {
+      using dir = tempDir("terminal-drain", {});
+      const sentinel = join(String(dir), "closed-tty-fds");
+      const dataChunks: Uint8Array[] = [];
+      const gotMarker = Promise.withResolvers<void>();
+
+      const proc = Bun.spawn(
+        [
+          "sh",
+          "-c",
+          `echo marker-before-drain
+           exec 0<&- 1>&- 2>&-
+           echo done > "$0"
+           exec sleep 1000`,
+          sentinel,
+        ],
+        {
+          env: bunEnv,
+          terminal: {
+            data: (_terminal: Bun.Terminal, data: Uint8Array) => {
+              dataChunks.push(data);
+              if (Buffer.concat(dataChunks).toString().includes("marker-before-drain")) gotMarker.resolve();
+            },
+          },
+        },
+      );
+
+      // Block the event loop until the child has written the marker and closed
+      // its tty fds, so the first master read can only happen afterwards.
+      while (!existsSync(sentinel)) {
+        Bun.sleepSync(10);
+      }
+
+      await gotMarker.promise;
+      proc.kill();
+      await proc.exited;
+      expect(Buffer.concat(dataChunks).toString()).toContain("marker-before-drain");
+      proc.terminal!.close();
+    },
+  );
+
+  // Same kernel hazard, exit flavor: when the child (the session leader) dies,
+  // older macOS flushes the PTY output queue during exit instead of letting
+  // the master drain first. Block the event loop until the child has entered
+  // exit, then expect its output to still be readable.
+  test.skipIf(isWindows)("output written before the parent reads is not lost when the child exits", async () => {
+    using dir = tempDir("terminal-exit-drain", {});
+    const sentinel = join(String(dir), "wrote-marker");
+    const dataChunks: Uint8Array[] = [];
+    const gotMarker = Promise.withResolvers<void>();
+
+    const proc = Bun.spawn(["sh", "-c", `echo marker-before-exit; echo done > "$0"; exit 0`, sentinel], {
+      env: bunEnv,
+      terminal: {
+        data: (_terminal: Bun.Terminal, data: Uint8Array) => {
+          dataChunks.push(data);
+          if (Buffer.concat(dataChunks).toString().includes("marker-before-exit")) gotMarker.resolve();
+        },
+      },
+    });
+
+    // Block the event loop until the child has written the marker and
+    // reached exit. "Z" = fully exited; "E" = exiting — a session leader
+    // with unread PTY output may park in exit until the master drains,
+    // which cannot happen while we hold the loop. spawnSync runs on its own
+    // isolated loop, so the terminal reader cannot run during this wait.
+    while (!existsSync(sentinel)) {
+      Bun.sleepSync(10);
+    }
+    while (true) {
+      const ps = Bun.spawnSync({ cmd: ["ps", "-p", String(proc.pid), "-o", "stat="] });
+      const stat = ps.stdout.toString().trim();
+      if (!ps.success || stat === "" || stat.includes("Z") || stat.includes("E")) break;
+      Bun.sleepSync(10);
+    }
+
+    await gotMarker.promise;
+    await proc.exited;
+    expect(Buffer.concat(dataChunks).toString()).toContain("marker-before-exit");
     proc.terminal!.close();
   });
 


### PR DESCRIPTION
The `creates subprocess with terminal attached` test intermittently times out after 90s on the darwin 14 x64 CI runner (all retries fail while the condition persists, then passes again).

**Root cause (confirmed via watchdog diagnostics in build 67461):** the child exits code 0 and the terminal EOF arrives, but zero bytes are ever delivered — the child's output is discarded in the kernel. BSD/macOS flushes the PTY output queue when the last slave fd closes (and on macOS 14, when the session leader exits before the master drains). Bun closed the parent's slave copy immediately after spawn, so when the event loop stalls past the child's write+exit (e.g. while serially fork+exec'ing the other concurrent spawns), the data is gone before the first master read. Newer macOS preserves the data / parks the exiting leader until the master drains, which is why this only reproduces on the macOS 14 agents.

**Fix:** keep the parent's slave fd open for inline-spawned terminals until the owned subprocess exits; then drain the master and close the slave so EOF still fires the terminal exit callback. Windows unchanged (ConPTY buffers in conhost; EOF via ClosePseudoConsole).

Includes two regression tests that block the event loop past the child's write + slave-close/exit before allowing the first master read, plus (temporary, this branch only) watchdog instrumentation on the original test.

Draft until the darwin 14 x64 jobs validate the fix; the instrumentation commit will be dropped before merge.