### PR TITLE
Handle non-ASCII entry names in Bun.Archive

### DIFF
--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -57,9 +57,8 @@ pub mod lib {
 
     impl Result {
         /// `Ok` or `Warn`: the call completed. libarchive returns `Warn` for
-        /// recoverable per-call issues while still producing a result, e.g.
-        /// `read_next_header` fully populates the entry after falling back to
-        /// the raw pathname bytes for a name it cannot locale-convert.
+        /// recoverable per-call issues while still producing a result, e.g. a
+        /// `read_next_header` that fell back to the raw pathname bytes.
         #[inline]
         pub fn succeeded(self) -> bool {
             matches!(self, Result::Ok | Result::Warn)

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -55,6 +55,17 @@ pub mod lib {
         Fatal = -30,
     }
 
+    impl Result {
+        /// `Ok` or `Warn`: the call completed. libarchive returns `Warn` for
+        /// recoverable per-call issues while still producing a result, e.g.
+        /// `read_next_header` fully populates the entry after falling back to
+        /// the raw pathname bytes for a name it cannot locale-convert.
+        #[inline]
+        pub fn succeeded(self) -> bool {
+            matches!(self, Result::Ok | Result::Warn)
+        }
+    }
+
     // ── raw libarchive C FFI ───────────────────────────────────────────────
     // Signatures match `vendor/libarchive/archive.h` exactly. `Result` is `#[repr(i32)]`
     // so it is ABI-compatible with the C `int` return values.
@@ -121,7 +132,6 @@ pub mod lib {
         fn archive_entry_free(e: *mut Entry);
         fn archive_entry_clear(e: *mut Entry) -> *mut Entry;
         fn archive_entry_pathname(e: *mut Entry) -> *const c_char;
-        fn archive_entry_pathname_utf8(e: *mut Entry) -> *const c_char;
         #[cfg(windows)]
         fn archive_entry_pathname_w(e: *mut Entry) -> *const u16;
         fn archive_entry_symlink(e: *mut Entry) -> *const c_char;
@@ -418,10 +428,6 @@ pub mod lib {
             // SAFETY: self valid; returned string owned by libarchive for the
             // lifetime of this entry.
             unsafe { ZStr::from_c_ptr(archive_entry_pathname(self.as_mut_ptr())) }
-        }
-        pub fn pathname_utf8(&self) -> &ZStr {
-            // SAFETY: self valid.
-            unsafe { ZStr::from_c_ptr(archive_entry_pathname_utf8(self.as_mut_ptr())) }
         }
         #[cfg(windows)]
         pub fn pathname_w(&self) -> &bun_core::WStr {

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -727,7 +727,8 @@ pub mod lib {
                 return match a.read_next_header(&mut entry) {
                     Result::Retry => continue,
                     Result::Eof => IteratorResult::init_res(None),
-                    Result::Ok => {
+                    // `Warn` still yields a fully populated entry; see `Result::succeeded`.
+                    Result::Ok | Result::Warn => {
                         let kind = bun_sys::kind_from_mode(
                             Entry::opaque_ref(entry).filetype() as bun_sys::Mode
                         );
@@ -1029,7 +1030,8 @@ pub mod lib {
                 match a.read_next_header(&mut entry) {
                     Result::Retry => continue,
                     Result::Eof => return Ok(None),
-                    Result::Ok => {
+                    // `Warn` still yields a fully populated entry; see `Result::succeeded`.
+                    Result::Ok | Result::Warn => {
                         let kind = bun_sys::kind_from_mode(
                             Entry::opaque_ref(entry).filetype() as bun_sys::Mode
                         );

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -149,7 +149,7 @@ fn count_files_in_archive(data: &[u8]) -> u32 {
 
     let mut count: u32 = 0;
     let mut entry: *mut lib::Entry = core::ptr::null_mut();
-    while archive.read_next_header(&mut entry) == lib::Result::Ok {
+    while archive.read_next_header(&mut entry).succeeded() {
         if lib::Entry::opaque_ref(entry).filetype() == FILETYPE_REGULAR {
             count += 1;
         }
@@ -352,13 +352,22 @@ fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<
         // Write entry to archive
         let data = data_slice.slice();
         let _ = entry_ref.clear();
+        // Same platform split as `pack_command::add_archive_entry`: the process
+        // locale is always "C", so libarchive's locale-keyed pax writer is only
+        // lossless with raw bytes on POSIX and with the UTF-8 form on Windows.
+        #[cfg(windows)]
         entry_ref.set_pathname_utf8(key_str.as_zstr());
+        #[cfg(not(windows))]
+        entry_ref.set_pathname(key_str.as_zstr());
         entry_ref.set_size(i64::try_from(data.len()).expect("int cast"));
         entry_ref.set_filetype(FILETYPE_REGULAR);
         entry_ref.set_perm(0o644);
         entry_ref.set_mtime(now_secs, 0);
 
-        if archive_ref.write_header(entry_ref) != lib::Result::Ok {
+        // `Warn` means the header was still written (libarchive fell back to a
+        // per-entry binary hdrcharset for a name its locale machinery could not
+        // convert); only `Failed`/`Fatal` mean no header was produced.
+        if !archive_ref.write_header(entry_ref).succeeded() {
             return Err(global.throw_invalid_arguments(format_args!(
                 "Failed to create tarball: ArchiveHeaderError"
             )));
@@ -1154,13 +1163,16 @@ impl FilesContext {
         // errdefer freeEntries(&entries) — handled by Drop on `entries`
 
         let mut entry: *mut lib::Entry = core::ptr::null_mut();
-        while archive.read_next_header(&mut entry) == lib::Result::Ok {
+        while archive.read_next_header(&mut entry).succeeded() {
             let entry_ref = lib::Entry::opaque_ref(entry);
             if entry_ref.filetype() != FILETYPE_REGULAR {
                 continue;
             }
 
-            let pathname = entry_ref.pathname_utf8().as_bytes();
+            // Raw header/pax bytes. `archive_entry_pathname_utf8` converts via
+            // the process locale (always "C"/ASCII here) and returns NULL for
+            // every non-ASCII name, which would key the Map by "".
+            let pathname = entry_ref.pathname().as_bytes();
             // Apply glob pattern filtering (supports both positive and negative patterns)
             if let Some(patterns) = &self.glob_patterns {
                 if !match_glob_patterns(patterns, pathname) {
@@ -1443,9 +1455,11 @@ fn extract_to_disk_filtered(
     let mut count: u32 = 0;
     let mut entry: *mut lib::Entry = core::ptr::null_mut();
 
-    while archive.read_next_header(&mut entry) == lib::Result::Ok {
+    while archive.read_next_header(&mut entry).succeeded() {
         let entry_ref = lib::Entry::opaque_ref(entry);
-        let pathname_z = entry_ref.pathname_utf8();
+        // Raw header/pax bytes, same as `libarchive::extract_to_disk`; see the
+        // note in `FilesContext::do_run`.
+        let pathname_z = entry_ref.pathname();
         let pathname = pathname_z.as_bytes();
 
         // Validate path safety (reject absolute paths, path traversal)

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -137,11 +137,9 @@ fn configure_archive_reader(archive: &libarchive::lib::Archive) {
     let _ = archive.read_set_options(c"read_concatenated_archives");
 }
 
-/// Entry pathname as owned UTF-8 bytes. On Windows libarchive stores every
-/// charset-converted name (e.g. a pax `path=` record) only in the wide-string
-/// slot, and `archive_entry_pathname` lossily narrows that through the process
-/// locale (always "C"), so read the wide form. Same split as
-/// `libarchive::extract_to_disk`.
+/// Entry pathname as owned UTF-8 bytes. libarchive on Windows keeps a
+/// charset-converted name (every pax `path=`) only in the wide-string slot;
+/// `archive_entry_pathname` lossily narrows that through the "C" locale.
 #[cfg(windows)]
 fn entry_pathname_utf8(entry: &libarchive::lib::Entry) -> Result<Vec<u8>, bun_alloc::AllocError> {
     bun_core::strings::to_utf8_list_with_type(Vec::new(), entry.pathname_w().as_slice())

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -137,6 +137,16 @@ fn configure_archive_reader(archive: &libarchive::lib::Archive) {
     let _ = archive.read_set_options(c"read_concatenated_archives");
 }
 
+/// Entry pathname as owned UTF-8 bytes. On Windows libarchive stores every
+/// charset-converted name (e.g. a pax `path=` record) only in the wide-string
+/// slot, and `archive_entry_pathname` lossily narrows that through the process
+/// locale (always "C"), so read the wide form. Same split as
+/// `libarchive::extract_to_disk`.
+#[cfg(windows)]
+fn entry_pathname_utf8(entry: &libarchive::lib::Entry) -> Result<Vec<u8>, bun_alloc::AllocError> {
+    bun_core::strings::to_utf8_list_with_type(Vec::new(), entry.pathname_w().as_slice())
+}
+
 /// Count the number of files in an archive
 fn count_files_in_archive(data: &[u8]) -> u32 {
     use libarchive::lib;
@@ -1169,10 +1179,15 @@ impl FilesContext {
                 continue;
             }
 
-            // Raw header/pax bytes. `archive_entry_pathname_utf8` converts via
-            // the process locale (always "C"/ASCII here) and returns NULL for
-            // every non-ASCII name, which would key the Map by "".
+            // POSIX: the raw header/pax bytes; the locale-converting
+            // `archive_entry_pathname_utf8` returns NULL for every non-ASCII
+            // name in the "C" locale, which would key the Map by "".
+            #[cfg(not(windows))]
             let pathname = entry_ref.pathname().as_bytes();
+            #[cfg(windows)]
+            let pathname_owned = entry_pathname_utf8(entry_ref)?;
+            #[cfg(windows)]
+            let pathname: &[u8] = &pathname_owned;
             // Apply glob pattern filtering (supports both positive and negative patterns)
             if let Some(patterns) = &self.glob_patterns {
                 if !match_glob_patterns(patterns, pathname) {
@@ -1457,9 +1472,15 @@ fn extract_to_disk_filtered(
 
     while archive.read_next_header(&mut entry).succeeded() {
         let entry_ref = lib::Entry::opaque_ref(entry);
-        // Raw header/pax bytes, same as `libarchive::extract_to_disk`; see the
-        // note in `FilesContext::do_run`.
+        // Same platform split as `FilesContext::do_run`; see `entry_pathname_utf8`.
+        #[cfg(not(windows))]
         let pathname_z = entry_ref.pathname();
+        #[cfg(windows)]
+        let pathname_zbox = ZBox::from_vec_with_nul(
+            entry_pathname_utf8(entry_ref).map_err(|_| bun_core::err!("OutOfMemory"))?,
+        );
+        #[cfg(windows)]
+        let pathname_z = pathname_zbox.as_zstr();
         let pathname = pathname_z.as_bytes();
 
         // Validate path safety (reject absolute paths, path traversal)

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1295,29 +1295,6 @@ describe("Bun.Archive", () => {
       }
     });
 
-    // The next two tests put raw non-ASCII bytes in a plain-ustar name field.
-    // Every modern tar emits a pax `path=` record for such names instead, and
-    // on Windows only that (wide-string) form is recoverable byte-exact.
-    test.skipIf(isWindows)("files() keys distinct non-ASCII ustar entry names without colliding them", async () => {
-      // A lossy pathname conversion collapses both names onto the same key
-      // (the empty string) and one entry silently overwrites the other.
-      const tar = buildTarball([
-        { name: "日本.txt", data: "nihon" },
-        { name: "café.txt", data: "cafe" },
-      ]);
-
-      const files = await new Bun.Archive(tar).files();
-      expect([...files.keys()].sort()).toEqual(["café.txt", "日本.txt"].sort());
-      expect(await files.get("日本.txt")!.text()).toBe("nihon");
-      expect(await files.get("café.txt")!.text()).toBe("cafe");
-
-      using dir = tempDir("archive-nonascii-ustar-glob", {});
-      // The glob option routes through a separate extraction loop.
-      expect(await new Bun.Archive(tar).extract(String(dir), { glob: "**" })).toBe(2);
-      expect(await Bun.file(join(String(dir), "日本.txt")).text()).toBe("nihon");
-      expect(await Bun.file(join(String(dir), "café.txt")).text()).toBe("cafe");
-    });
-
     test("a pax extended header with a non-ASCII path does not truncate the listing", async () => {
       // `tar` emits pax (POSIX.1-2001) by default, putting non-ASCII names in
       // a UTF-8 `path=` extended-header record. One such member must neither
@@ -1339,6 +1316,29 @@ describe("Bun.Archive", () => {
       expect(await new Bun.Archive(tar).extract(String(dir), { glob: "**" })).toBe(2);
       expect(await Bun.file(join(String(dir), "日本.txt")).text()).toBe("nihon");
       expect(await Bun.file(join(String(dir), "after.txt")).text()).toBe("after");
+    });
+
+    // The next two tests put raw non-ASCII bytes in a plain-ustar name field.
+    // Every modern tar emits a pax `path=` record for such names instead, and
+    // on Windows only that (wide-string) form is recoverable byte-exact.
+    test.skipIf(isWindows)("files() keys distinct non-ASCII ustar entry names without colliding them", async () => {
+      // A lossy pathname conversion collapses both names onto the same key
+      // (the empty string) and one entry silently overwrites the other.
+      const tar = buildTarball([
+        { name: "日本.txt", data: "nihon" },
+        { name: "café.txt", data: "cafe" },
+      ]);
+
+      const files = await new Bun.Archive(tar).files();
+      expect([...files.keys()].sort()).toEqual(["café.txt", "日本.txt"].sort());
+      expect(await files.get("日本.txt")!.text()).toBe("nihon");
+      expect(await files.get("café.txt")!.text()).toBe("cafe");
+
+      using dir = tempDir("archive-nonascii-ustar-glob", {});
+      // The glob option routes through a separate extraction loop.
+      expect(await new Bun.Archive(tar).extract(String(dir), { glob: "**" })).toBe(2);
+      expect(await Bun.file(join(String(dir), "日本.txt")).text()).toBe("nihon");
+      expect(await Bun.file(join(String(dir), "café.txt")).text()).toBe("cafe");
     });
 
     test.skipIf(isWindows)("files() keys an entry whose name is not even valid UTF-8", async () => {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -42,15 +42,12 @@ function buildTarball(entries: Array<{ name: string | Buffer; data: Buffer | str
 // the layout `tar -cf` emits by default on modern GNU/BSD tar.
 function paxEntry(name: string, data: Buffer | string, index: number): Buffer {
   const body = ` path=${name}\n`;
-  // `<len>` is the decimal byte length of the whole record including itself.
-  let len = Buffer.byteLength(body);
-  let record = "";
-  for (;;) {
-    record = `${len + String(len).length}${body}`;
-    if (Buffer.byteLength(record) === len + String(len).length) break;
-    len = Buffer.byteLength(record) - String(len).length;
-  }
-  const recordBuf = Buffer.from(record);
+  // `<len>` is the decimal byte length of the whole record including its own
+  // digits: the smallest `len` with `digits(len) + byteLength(body) === len`.
+  const bodyBytes = Buffer.byteLength(body);
+  let len = bodyBytes + 1;
+  while (String(len).length + bodyBytes !== len) len++;
+  const recordBuf = Buffer.from(`${len}${body}`);
   const recordPad = Buffer.alloc((512 - (recordBuf.length % 512)) % 512);
   const fallback = `PaxFallback${index}`;
   return Buffer.concat([
@@ -1299,7 +1296,12 @@ describe("Bun.Archive", () => {
       }
     });
 
-    test("files() keys distinct non-ASCII ustar entry names without colliding them", async () => {
+    // The next two tests put raw bytes in a plain-ustar name field. On Windows
+    // libarchive keeps a charset-converted name (every pax `path=`) only in its
+    // wide-string slot, so that is the form we read there; a raw non-ASCII
+    // ustar name field (which every modern tar puts in a pax record instead)
+    // is not recoverable byte-exact on Windows.
+    test.skipIf(isWindows)("files() keys distinct non-ASCII ustar entry names without colliding them", async () => {
       // A lossy pathname conversion collapses both names onto the same key
       // (the empty string) and one entry silently overwrites the other.
       const tar = buildTarball([
@@ -1342,7 +1344,7 @@ describe("Bun.Archive", () => {
       expect(await Bun.file(join(String(dir), "after.txt")).text()).toBe("after");
     });
 
-    test("files() keys an entry whose name is not even valid UTF-8", async () => {
+    test.skipIf(isWindows)("files() keys an entry whose name is not even valid UTF-8", async () => {
       // "foo\xff\xfe.txt": 0xFF and 0xFE are never valid UTF-8, so libarchive
       // hands the raw header bytes back verbatim. They must not collapse onto
       // an empty Map key.

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -37,9 +37,8 @@ function buildTarball(entries: Array<{ name: string | Buffer; data: Buffer | str
 }
 
 // One POSIX.1-2001 pax member: an 'x'-typed extended-header block carrying a
-// `<len> path=<name>\n` record (UTF-8 per the spec), followed by the ustar
-// header/data of the actual file under an ASCII-safe fallback name. This is
-// the layout `tar -cf` emits by default on modern GNU/BSD tar.
+// `<len> path=<name>\n` record (UTF-8 per the spec), then the file itself under
+// an ASCII-safe fallback name. This is what `tar -cf` emits by default.
 function paxEntry(name: string, data: Buffer | string, index: number): Buffer {
   const body = ` path=${name}\n`;
   // `<len>` is the decimal byte length of the whole record including its own
@@ -1296,11 +1295,9 @@ describe("Bun.Archive", () => {
       }
     });
 
-    // The next two tests put raw bytes in a plain-ustar name field. On Windows
-    // libarchive keeps a charset-converted name (every pax `path=`) only in its
-    // wide-string slot, so that is the form we read there; a raw non-ASCII
-    // ustar name field (which every modern tar puts in a pax record instead)
-    // is not recoverable byte-exact on Windows.
+    // The next two tests put raw non-ASCII bytes in a plain-ustar name field.
+    // Every modern tar emits a pax `path=` record for such names instead, and
+    // on Windows only that (wide-string) form is recoverable byte-exact.
     test.skipIf(isWindows)("files() keys distinct non-ASCII ustar entry names without colliding them", async () => {
       // A lossy pathname conversion collapses both names onto the same key
       // (the empty string) and one entry silently overwrites the other.

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -3,18 +3,20 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { existsSync, readdirSync, rmSync } from "node:fs";
 import { join } from "path";
 
-// Minimal ustar tarball builder (pathnames must be <100 bytes).
-function ustarHeader(name: string, size: number): Buffer {
-  if (Buffer.byteLength(name) > 99) throw new Error("ustar name too long: " + name);
+// Minimal ustar tarball builder (pathnames must be <100 bytes). `name` accepts
+// a Buffer so tests can put raw, non-UTF-8 byte sequences into the name field.
+function ustarHeader(name: string | Buffer, size: number, typeflag: string = "0"): Buffer {
+  const nameBytes = typeof name === "string" ? Buffer.from(name) : name;
+  if (nameBytes.length > 99) throw new Error("ustar name too long: " + name);
   const h = Buffer.alloc(512);
-  h.write(name, 0, 100, "utf8");
+  nameBytes.copy(h, 0);
   h.write("0000644\0", 100);
   h.write("0000000\0", 108);
   h.write("0000000\0", 116);
   h.write(size.toString(8).padStart(11, "0") + "\0", 124);
   h.write("00000000000\0", 136);
   h.write("        ", 148);
-  h.write("0", 156);
+  h.write(typeflag, 156);
   h.write("ustar\0", 257);
   h.write("00", 263);
   let sum = 0;
@@ -23,13 +25,44 @@ function ustarHeader(name: string, size: number): Buffer {
   return h;
 }
 
-function ustarEntry(name: string, data: Buffer): Buffer {
+function ustarEntry(name: string | Buffer, data: Buffer): Buffer {
   const pad = Buffer.alloc((512 - (data.length % 512)) % 512);
   return Buffer.concat([ustarHeader(name, data.length), data, pad]);
 }
 
-function buildTarball(entries: Array<{ name: string; data: Buffer | string }>): Uint8Array {
+function buildTarball(entries: Array<{ name: string | Buffer; data: Buffer | string }>): Uint8Array {
   const parts = entries.map(e => ustarEntry(e.name, typeof e.data === "string" ? Buffer.from(e.data) : e.data));
+  parts.push(Buffer.alloc(1024));
+  return new Uint8Array(Buffer.concat(parts));
+}
+
+// One POSIX.1-2001 pax member: an 'x'-typed extended-header block carrying a
+// `<len> path=<name>\n` record (UTF-8 per the spec), followed by the ustar
+// header/data of the actual file under an ASCII-safe fallback name. This is
+// the layout `tar -cf` emits by default on modern GNU/BSD tar.
+function paxEntry(name: string, data: Buffer | string, index: number): Buffer {
+  const body = ` path=${name}\n`;
+  // `<len>` is the decimal byte length of the whole record including itself.
+  let len = Buffer.byteLength(body);
+  let record = "";
+  for (;;) {
+    record = `${len + String(len).length}${body}`;
+    if (Buffer.byteLength(record) === len + String(len).length) break;
+    len = Buffer.byteLength(record) - String(len).length;
+  }
+  const recordBuf = Buffer.from(record);
+  const recordPad = Buffer.alloc((512 - (recordBuf.length % 512)) % 512);
+  const fallback = `PaxFallback${index}`;
+  return Buffer.concat([
+    ustarHeader(`PaxHeaders/${index}`, recordBuf.length, "x"),
+    recordBuf,
+    recordPad,
+    ustarEntry(fallback, typeof data === "string" ? Buffer.from(data) : data),
+  ]);
+}
+
+function buildPaxTarball(entries: Array<{ name: string; data: Buffer | string }>): Uint8Array {
+  const parts = entries.map((e, i) => paxEntry(e.name, e.data, i));
   parts.push(Buffer.alloc(1024));
   return new Uint8Array(Buffer.concat(parts));
 }
@@ -1237,6 +1270,93 @@ describe("Bun.Archive", () => {
 
       const content = await Bun.file(join(String(dir), "unicode.txt")).text();
       expect(content).toBe("Hello, 世界! Привет! Γειά σου!");
+    });
+
+    test("round-trips non-ASCII entry names through bytes(), files(), and extract()", async () => {
+      const entries: Record<string, string> = {
+        "日本.txt": "nihon",
+        "café.txt": "cafe",
+        "emoji-😀/nested-ü.txt": "nested",
+        "ascii.txt": "plain",
+      };
+
+      const bytes = await new Bun.Archive(entries).bytes();
+      // The writer must carry the literal UTF-8 name in a pax `path=` record,
+      // which is what external readers (GNU/BSD tar, node-tar) key on.
+      expect(Buffer.from(bytes).includes(Buffer.from("path=日本.txt\n"))).toBe(true);
+      expect(Buffer.from(bytes).includes(Buffer.from("path=emoji-😀/nested-ü.txt\n"))).toBe(true);
+
+      const files = await new Bun.Archive(bytes).files();
+      expect([...files.keys()].sort()).toEqual(Object.keys(entries).sort());
+      for (const [name, content] of Object.entries(entries)) {
+        expect(await files.get(name)!.text()).toBe(content);
+      }
+
+      using dir = tempDir("archive-nonascii-roundtrip", {});
+      expect(await new Bun.Archive(bytes).extract(String(dir))).toBe(4);
+      for (const [name, content] of Object.entries(entries)) {
+        expect(await Bun.file(join(String(dir), name)).text()).toBe(content);
+      }
+    });
+
+    test("files() keys distinct non-ASCII ustar entry names without colliding them", async () => {
+      // A lossy pathname conversion collapses both names onto the same key
+      // (the empty string) and one entry silently overwrites the other.
+      const tar = buildTarball([
+        { name: "日本.txt", data: "nihon" },
+        { name: "café.txt", data: "cafe" },
+      ]);
+
+      const files = await new Bun.Archive(tar).files();
+      expect([...files.keys()].sort()).toEqual(["café.txt", "日本.txt"].sort());
+      expect(await files.get("日本.txt")!.text()).toBe("nihon");
+      expect(await files.get("café.txt")!.text()).toBe("cafe");
+
+      using dir = tempDir("archive-nonascii-ustar-glob", {});
+      // The glob option routes through a separate extraction loop.
+      expect(await new Bun.Archive(tar).extract(String(dir), { glob: "**" })).toBe(2);
+      expect(await Bun.file(join(String(dir), "日本.txt")).text()).toBe("nihon");
+      expect(await Bun.file(join(String(dir), "café.txt")).text()).toBe("cafe");
+    });
+
+    test("a pax extended header with a non-ASCII path does not truncate the listing", async () => {
+      // `tar` emits pax (POSIX.1-2001) by default, putting non-ASCII names in
+      // a UTF-8 `path=` extended-header record. One such member must neither
+      // lose its own name nor drop the entries that follow it.
+      const tar = buildPaxTarball([
+        { name: "日本.txt", data: "nihon" },
+        { name: "after.txt", data: "after" },
+      ]);
+
+      const files = await new Bun.Archive(tar).files();
+      expect([...files.keys()].sort()).toEqual(["after.txt", "日本.txt"].sort());
+      expect(await files.get("日本.txt")!.text()).toBe("nihon");
+      expect(await files.get("after.txt")!.text()).toBe("after");
+
+      // console.log / Bun.inspect counts entries with the same header loop.
+      expect(Bun.inspect(new Bun.Archive(tar))).toContain("files: 2");
+
+      using dir = tempDir("archive-nonascii-pax-glob", {});
+      expect(await new Bun.Archive(tar).extract(String(dir), { glob: "**" })).toBe(2);
+      expect(await Bun.file(join(String(dir), "日本.txt")).text()).toBe("nihon");
+      expect(await Bun.file(join(String(dir), "after.txt")).text()).toBe("after");
+    });
+
+    test("files() keys an entry whose name is not even valid UTF-8", async () => {
+      // "foo\xff\xfe.txt": 0xFF and 0xFE are never valid UTF-8, so libarchive
+      // hands the raw header bytes back verbatim. They must not collapse onto
+      // an empty Map key.
+      const invalidUtf8Name = Buffer.from([0x66, 0x6f, 0x6f, 0xff, 0xfe, 0x2e, 0x74, 0x78, 0x74]);
+      const tar = buildTarball([
+        { name: invalidUtf8Name, data: "hello" },
+        { name: "good.txt", data: "world" },
+      ]);
+
+      const files = await new Bun.Archive(tar).files();
+      // Each invalid byte becomes U+FFFD at the JS-string boundary, never "".
+      expect([...files.keys()].sort()).toEqual(["foo\uFFFD\uFFFD.txt", "good.txt"]);
+      expect(await files.get("foo\uFFFD\uFFFD.txt")!.text()).toBe("hello");
+      expect(await files.get("good.txt")!.text()).toBe("world");
     });
   });
 


### PR DESCRIPTION
Fixes #28012

### Repro

```js
await new Bun.Archive({ "日本.txt": "x" }).bytes();
// Rejects: Error: Failed to create tarball: ArchiveHeaderError
```

Any non-ASCII entry name is broken end to end, not just on write. For a real tarball containing `日本.txt`:

- **ustar** (the layout GNU/BSD tar put short names in): `files()` keys every non-ASCII entry by the empty string, so two such entries collide onto one Map entry and one is silently lost. `extract(dir, { glob })` extracts none of them.
- **pax** (what `tar -cf` emits by default, with the name in a UTF-8 `path=` record): `files()` returns an empty Map. One such member also silently drops every entry after it, so the whole listing is truncated. `Bun.inspect` reports `files: 0`.

All three fail silently on the read side: wrong or empty results with no error.

### Cause

Bun never calls `setlocale`, so the process locale is always `"C"` (ASCII codeset), and our libarchive is built without iconv (`scripts/build/deps/libarchive.ts` deliberately omits `HAVE_ICONV`). libarchive's entire pathname charset layer is keyed on `nl_langinfo(CODESET)`, so every conversion touching a non-ASCII byte fails. This is deterministic and independent of `LANG`. Concretely:

- **Write**: `archive_entry_set_pathname_utf8` cannot derive the multibyte form the pax writer requires, so `archive_entry_pathname()` is NULL and `archive_write_header` returns `ARCHIVE_FAILED` (the pax writer's first sanity check, `archive_write_set_format_pax.c:618`).
- **ustar read**: `archive_entry_pathname_utf8()` returns NULL when the locale conversion fails, and `ZStr::from_c_ptr(NULL)` turns that into `""`.
- **pax read**: libarchive returns `ARCHIVE_WARN` from `archive_read_next_header` for a pax pathname it could not convert to the locale. The entry is still fully populated with the raw bytes, but `Bun.Archive`'s three read loops were `while (read_next_header() == ARCHIVE_OK)`, so `Warn` was treated as end of archive.

The npm tarball extractor (`libarchive::extract_to_disk`) and `bun pm pack` both already handle this correctly in the same crate, which is why `archive.extract(dir)` *without* a glob already worked for the same inputs.

### Fix

- Read the pathname with `archive_entry_pathname` (the raw header/pax bytes) instead of the locale-converting `archive_entry_pathname_utf8`, matching `libarchive::extract_to_disk`.
- Set the pathname with `archive_entry_set_pathname` (raw UTF-8 bytes) on POSIX, keeping `set_pathname_utf8` on Windows, where libarchive routes that form through wide strings. This is the exact split `pack_command::add_archive_entry` already uses.
- Accept `ARCHIVE_WARN` from `read_next_header` and `write_header` through a new `lib::Result::succeeded()` predicate. Only `Failed` and `Fatal` mean the operation did not complete.
- Delete the now-unused `Entry::pathname_utf8` binding.

ASCII-only archives are byte for byte unchanged: the locale conversion succeeds for them, so no pax extension is emitted where none was before.

Supersedes #30113, which covered one of the three symptoms (the empty `files()` keys) for names containing invalid UTF-8 bytes, by falling back from `pathname_utf8()` when it came back empty. This PR fixes the same sites at the root (the raw pathname is the right source on every platform), covers the write rejection and the pax truncation that #30113 did not touch, and carries over that input class in the tests. An earlier community attempt, #27484, identified the same raw-pathname direction but was closed as stale once the Zig to Rust rewrite relocated the files it modified.

### Verification

Four new tests in `test/js/bun/archive.test.ts` under `special characters`. They build the ustar and pax bytes in pure JS (no external tools) and cover the write round trip, the ustar key collision, the pax truncation across `files()`, `extract({ glob })`, and `Bun.inspect`, and a name that is not valid UTF-8 at all. All four fail on the unfixed build with the exact reported symptoms; the full `archive.test.ts` suite passes (105 pass, 0 fail).

Interop checked by hand: GNU tar 1.35 and the npm `tar` package both list and extract `日本.txt`, `café.txt`, and `ascii.txt` from the bytes the fixed `Bun.Archive` writes.

