### PR TITLE
Fix Bun.spawn on Windows never exiting after the child dies when stdin is an async iterable

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2119,7 +2119,10 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
             Self::r(this).last_write_result = WriteResult::Err(err.clone());
             Self::r_on_error(this, err);
             core::hint::black_box(this);
-            Self::r(this).close_without_reporting();
+            // `close()`, not `close_without_reporting()`: the parent must still
+            // observe `on_close` after `on_error` (the `PosixStreamingWriter`
+            // contract). FileSink's stream teardown only runs from `on_close`.
+            Self::r(this).close();
             return;
         }
 
@@ -2247,11 +2250,10 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         // `Parent::on_error` (re-enters JS via FileSink::on_error → promise
         // reject; user callback may `writer.with_mut(|w| w.end())`/`.close()`
         // forming a fresh aliased `&mut Self`) and then read
-        // `self.{get_fd, closed_without_reporting, is_done}` via
-        // `close_without_reporting()`. With `&mut self` `noalias`, LLVM may
-        // forward pre-`on_error` field loads across the call. Launder this
-        // entry point too — it is reached from `on_write_complete` with a
-        // fresh `&mut`.
+        // `self.{source, is_done, closed_without_reporting}` via `close()`.
+        // With `&mut self` `noalias`, LLVM may forward pre-`on_error` field
+        // loads across the call. Launder this entry point too — it is reached
+        // from `on_write_complete` with a fresh `&mut`.
         let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
         // `this` is the only access path to `*self` for the rest of this
         // function; every `r(this)` reborrow is sole-aliased on the JS thread.
@@ -2278,7 +2280,8 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
                     Self::r(this).last_write_result = WriteResult::Err(err.clone());
                     Self::r_on_error(this, err);
                     core::hint::black_box(this);
-                    Self::r(this).close_without_reporting();
+                    // See `on_write_complete`: the parent must get `on_close`.
+                    Self::r(this).close();
                     return;
                 }
                 Some(Source::SyncFile(_)) => {
@@ -2335,7 +2338,8 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
                 Self::r(this).last_write_result = WriteResult::Err(err.clone());
                 Self::r_on_error(this, err);
                 core::hint::black_box(this);
-                Self::r(this).close_without_reporting();
+                // See `on_write_complete`: the parent must get `on_close`.
+                Self::r(this).close();
                 return;
             }
         } else {
@@ -2357,7 +2361,8 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
                 Self::r(this).last_write_result = WriteResult::Err(err.clone());
                 Self::r_on_error(this, err);
                 core::hint::black_box(this);
-                Self::r(this).close_without_reporting();
+                // See `on_write_complete`: the parent must get `on_close`.
+                Self::r(this).close();
                 return;
             }
         }
@@ -2369,6 +2374,9 @@ impl<Parent: WindowsStreamingWriterParent> WindowsStreamingWriter<Parent> {
         Self::r(this).last_write_result = WriteResult::Pending(0);
     }
 
+    /// Close the source without invoking `Parent::on_close`. Only `Drop` uses
+    /// this (the parent is mid-teardown there). Error paths must use `close()`
+    /// instead so the parent still observes `on_close`.
     fn close_without_reporting(&mut self) {
         if self.get_fd() != Fd::INVALID {
             debug_assert!(!self.closed_without_reporting);

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1955,7 +1955,8 @@ pub struct WindowsStreamingWriter<Parent: WindowsStreamingWriterParent> {
     pub current_payload: StreamBuffer,
     // we preserve the last write result for simplicity
     pub last_write_result: WriteResult,
-    // some error happed? we will not report onClose only onError
+    // Set only by `close_without_reporting()` (i.e. `Drop`) to suppress
+    // `Parent::on_close` while the parent is mid-teardown.
     pub closed_without_reporting: bool,
 }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -464,6 +464,10 @@ impl FileSink {
     /// [`on_attached_process_exit`](Self::on_attached_process_exit)).
     pub unsafe fn on_error(this: *mut FileSink, err: sys::Error) {
         bun_core::scoped_log!(FileSink, "onError({:?})", err);
+        // The streaming writer follows every `onError` with `close()` →
+        // `onClose` (on both platforms), which fires `signal.close()` and
+        // releases the keep-alive ref. Releasing the ref here instead could
+        // drop the last reference and free `this` before that `close()` runs.
         // SAFETY: caller contract — `this` is live with write+dealloc provenance.
         unsafe {
             if (*this).pending.get().state == streams::PendingState::Pending {
@@ -473,27 +477,12 @@ impl FileSink {
                 if let Some(vm) = (*this).js_vm() {
                     if vm.is_inside_deferred_task_queue.get() {
                         (*this).run_pending_later();
-                        #[cfg(windows)]
-                        FileSink::clear_keep_alive_ref(this);
                         return;
                     }
                 }
 
                 FileSink::run_pending(this);
             }
-
-            // On POSIX, the streaming writer always calls `close()` → `onClose`
-            // after `onError`, so `onClose` releases the keep-alive ref. Releasing
-            // it here could drop the last ref and free `this` before the writer's
-            // subsequent `close()` touches its (embedded) fields.
-            //
-            // On Windows, the pipe error paths call `closeWithoutReporting()` which
-            // skips `onClose`, so release here. This is safe because those paths
-            // always hold another ref (the in-flight write's ref via `defer
-            // parent.deref()` in `onWriteComplete`, or the JS caller's ref when
-            // reached synchronously from `write()`) through `closeWithoutReporting`.
-            #[cfg(windows)]
-            FileSink::clear_keep_alive_ref(this);
         }
     }
 

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -452,9 +452,9 @@ describe("spawn stdin ReadableStream", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("EPIPE");
     expect(stdout.trim()).toBe("child exited");
-    expect(exitCode).toBe(0);
     // The parent reached the natural end of its event loop; it was not killed.
     expect(proc.signalCode).toBe(null);
+    expect(exitCode).toBe(0);
   }
 
   test("parent exits after the child dies when stdin is an async iterable", async () => {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -376,11 +376,6 @@ describe("spawn stdin ReadableStream", () => {
         // Unhandled rejections are only reported after a microtask drain; give
         // the tracker a turn so rejections from the last exits are counted.
         await Bun.sleep(0);
-
-        // Exit explicitly: on Windows an async iterable stdin does not tear
-        // down after the child dies and would keep the event loop alive.
-        // https://github.com/oven-sh/bun/issues/33020
-        process.exit(0);
         `,
       ],
       env: bunEnv,
@@ -400,6 +395,74 @@ describe("spawn stdin ReadableStream", () => {
 
   test("in-flight write from an async iterator stdin when the child dies does not surface an unhandled rejection", async () => {
     await expectNoUnhandledRejectionWhenChildDies(true);
+  });
+
+  // When the child dies mid-write the sink's close path must tear down the
+  // ReadableStream feeding it (for an async iterable, return the generator),
+  // or the still-running pull keeps the parent's event loop alive forever.
+  // On Windows the libuv write-error path skipped that close notification.
+  // https://github.com/oven-sh/bun/issues/33020
+  async function expectParentExitsAfterChildDies(useIterator: boolean) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const chunk = Buffer.alloc(256 * 1024, "x");
+        let produced = 0;
+        function producedOne() {
+          if (++produced === 4) child.kill();
+        }
+        async function* iterate() {
+          while (true) {
+            await Bun.sleep(1);
+            producedOne();
+            yield chunk;
+          }
+        }
+        function readable() {
+          return new ReadableStream({
+            async pull(controller) {
+              await Bun.sleep(1);
+              producedOne();
+              controller.enqueue(chunk);
+            },
+          });
+        }
+
+        // The child never reads its stdin, so a 256 KiB write can never finish
+        // and the sink holds an in-flight write when the child is killed.
+        const child = Bun.spawn({
+          cmd: [process.execPath, "-e", "setTimeout(() => {}, 1e9)"],
+          stdin: (${useIterator} ? iterate : readable)(),
+          stdout: "ignore",
+          stderr: "ignore",
+        });
+
+        await child.exited;
+        console.log("child exited");
+        // No process.exit(): the point is that the event loop drains on its own.
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("EPIPE");
+    expect(stdout.trim()).toBe("child exited");
+    expect(exitCode).toBe(0);
+    // The parent reached the natural end of its event loop; it was not killed.
+    expect(proc.signalCode).toBe(null);
+  }
+
+  test("parent exits after the child dies when stdin is an async iterable", async () => {
+    await expectParentExitsAfterChildDies(true);
+  });
+
+  test("parent exits after the child dies when stdin is a ReadableStream", async () => {
+    await expectParentExitsAfterChildDies(false);
   });
 
   test("ReadableStream with process that exits immediately", async () => {


### PR DESCRIPTION
Fixes #33020

### Repro

On Windows the parent prints the message and never exits. On Linux (and on Windows with a plain `ReadableStream` stdin) it exits.

```js
async function* source() {
  const chunk = Buffer.alloc(256 * 1024, "x");
  while (true) {
    await Bun.sleep(1);
    yield chunk;
  }
}
// The child never reads stdin and idles until killed.
const child = Bun.spawn({
  cmd: [process.execPath, "-e", "setTimeout(() => {}, 1e9)"],
  stdin: source(),
  stdout: "ignore",
  stderr: "ignore",
});
setTimeout(() => child.kill(), 100);
await child.exited;
console.log("child exited, parent should exit now"); // prints, then hangs forever
```

### Cause

`Bun.spawn` wraps an async-iterable stdin in a direct `ReadableStream` and assigns it to the child's stdin `FileSink`. Tearing that stream down is `FileSink::on_close`'s job: it fires `signal.close()`, which invokes the stream's close handler, which cancels the underlying source (for an async iterable, calls `iter.return()` on the generator). `ReadableStream__cancel` deliberately no-ops for direct streams for exactly this reason ("their teardown is owned by the controller close/detach path"), so there is no other path.

On Windows the in-flight `uv_write` to the dead child's stdin fails before the process-exit callback runs. `WindowsStreamingWriter::on_write_complete`'s error arm called `close_without_reporting()`, which closes the pipe but suppresses `Parent::on_close`:

```rust
fn on_close_source(&mut self) {
    self.source = None;
    if self.closed_without_reporting {
        self.closed_without_reporting = false;
        return; // Parent::on_close is never called
    }
    unsafe { Parent::on_close(self.parent) };
}
```

When `on_attached_process_exit` later calls `writer.close()`, the source is already gone and `close()` early-returns, so `on_close` still never fires. The generator is never returned, `cancelled` is never set, and the pump loops on `await Bun.sleep(1)` forever, keeping the event loop referenced. An instrumented version of the repro on an unfixed Windows build shows the generator still yielding ~65 chunks/second indefinitely after the child has exited, with its `finally` block never reached.

Both `PosixStreamingWriter::_on_error` and `WindowsBufferedWriter::on_write_complete` still deliver `on_close` to the parent after an error; the Windows streaming writer was the only one that suppressed it (the original Zig had a comment acknowledging it: "some error happed? we will not report onClose only onError"). A plain `ReadableStream` stdin was unaffected only because `on_attached_process_exit` can still cancel it through its real reader.

### Fix

- `WindowsStreamingWriter`'s error paths (the libuv write-completion error and `process_send`'s synchronous errors) now call `close()`, which reports `Parent::on_close`, instead of `close_without_reporting()`. The latter is now only used by `Drop`, where the parent is mid-teardown and must not be re-entered.
- `FileSink::on_error`'s `#[cfg(windows)] clear_keep_alive_ref` is removed. Its own comment says it existed only because "on Windows, the pipe error paths call `closeWithoutReporting()` which skips `onClose`". With `onClose` now delivered on both platforms it is redundant, and releasing the ref there could drop the last reference before the writer's subsequent `close()` touches its embedded fields, which is the exact hazard the same comment warns about for POSIX.

The other two `WindowsStreamingWriterParent` implementors both have idempotent `on_close` handlers (`Flags::WRITER_DONE` and `flags.is_closed()`).

- `Terminal::on_writer_error` already routes through the reporting `writer.close()` re-entrantly (via `close_internal`), so its `on_close` was delivered before this change too; the error arm's trailing `close()` then finds the source already taken and is a no-op. No behavior change.
- `WindowsNamedPipe::on_error` calls `writer.end()`, which returns without closing while a write is still in `current_payload` (the error arm never resets it), so on write errors its `on_close` used to be suppressed and now fires, delivering `handlers.on_close` and `release_resources()`. That is an observable change, but it is the intended one: it matches this parent's own read-error path (`on_read_error` already does `on_error` followed by the reporting `writer.close()`) and the POSIX contract, and it stops a write error from skipping the socket's close delivery and resource release.

### Tests

Two new tests in `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts` spawn a bun that kills its child while a 256 KiB stdin write is in flight and assert the parent reaches the natural end of its event loop, for both an async-iterable and a plain `ReadableStream` stdin. The existing `expectNoUnhandledRejectionWhenChildDies` helper drops the `process.exit(0)` workaround it carried for this bug, so those two tests now also exercise the natural exit.

On Windows x64 (`bun bd test`), before the fix:

```
(fail) spawn stdin ReadableStream > parent exits after the child dies when stdin is an async iterable [5002.09ms]
  ^ this test timed out after 5000ms.
(pass) spawn stdin ReadableStream > parent exits after the child dies when stdin is a ReadableStream [528.83ms]
```

After the fix, the whole file:

```
(pass) spawn stdin ReadableStream > parent exits after the child dies when stdin is an async iterable [456.56ms]
(pass) spawn stdin ReadableStream > parent exits after the child dies when stdin is a ReadableStream [510.34ms]
 25 pass
 2 todo
 0 fail
```

The issue's repro exits 0 on the fixed Windows debug build, and the `FileSink` debug scope now logs the previously missing `onClose()` and `onResolveStream` after the write error:

```
[filesink] onError(Error { errno: 136, ... syscall: Tag(48), ... })
[filesink] onClose()
[filesink] onResolveStream
[subprocess] onProcessExit()
[filesink] onAttachedProcessExit()
```

On Linux the whole file also passes with the fix (25 pass, 0 fail).

Note for reviewers: the bug and the fix live entirely in `#[cfg(windows)]` code, so the new tests cannot be made to fail on a Linux host regardless of whether the fix is applied. They reproduce the hang deterministically on Windows (verified above) and run in CI's Windows lanes.

