### PR TITLE
install: parse a file: dependency on a workspace member as a workspace dependency

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -352,26 +352,29 @@ fn dep_sort_cmp(buf: &[u8], a: &Dependency, b: &Dependency) -> core::cmp::Orderi
 }
 
 /// The workspace member registered at `folder_path` (relative to the top-level dir),
-/// if any. Matched by path (not dependency name) so `"alias": "file:../member"` is
-/// found too. Workspace paths are stored posix, `folder_path` is platform-separated.
+/// matched by path so `"alias": "file:../member"` is found too. Declined when a
+/// different member owns the alias as its name: the `Tag::Workspace` resolver
+/// (`enqueue_dependency`) looks the path up by name first and would link that member.
 fn find_workspace_by_path(
     workspace_paths: &lockfile::NameHashMap,
     buf: &[u8],
+    alias_hash: PackageNameHash,
     folder_path: &[u8],
 ) -> Option<String> {
     if folder_path.is_empty() {
         return None;
     }
-    workspace_paths
-        .values()
-        .iter()
-        .find(|workspace_path| {
-            let workspace_path = workspace_path.slice(buf);
-            workspace_path.len() == folder_path.len()
-                && core::iter::zip(workspace_path, folder_path)
-                    .all(|(&a, &b)| a == b || (path::is_sep_any(a) && path::is_sep_any(b)))
-        })
-        .copied()
+    let (&name_hash, workspace_path) = workspace_paths.iter().find(|(_, workspace_path)| {
+        // workspace paths are stored posix; `folder_path` uses the platform separator
+        let workspace_path = workspace_path.slice(buf);
+        workspace_path.len() == folder_path.len()
+            && core::iter::zip(workspace_path, folder_path)
+                .all(|(&a, &b)| a == b || (path::is_sep_any(a) && path::is_sep_any(b)))
+    })?;
+    if name_hash != alias_hash && workspace_paths.get(&alias_hash).is_some() {
+        return None;
+    }
+    Some(*workspace_path)
 }
 
 /// Field tags for the binary lockfile serializer (`bun.lockb`). The
@@ -1896,7 +1899,9 @@ impl Package<u64> {
                 // The bun.lock parser rewrites a dependency that resolved to a workspace
                 // package to `Tag::Workspace` (`map_dep_to_pkg`). Do the same here so a
                 // freshly parsed package.json compares equal to its loaded lockfile entry.
-                if let Some(workspace) = find_workspace_by_path(workspace_paths, buf, relative) {
+                if let Some(workspace) =
+                    find_workspace_by_path(workspace_paths, buf, external_alias.hash, relative)
+                {
                     let path = workspace.sliced(buf);
                     if let Some(mut dep) = dependency::parse_with_tag(
                         external_alias.value,

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -368,9 +368,8 @@ fn find_workspace_by_path(
         .find(|workspace_path| {
             let workspace_path = workspace_path.slice(buf);
             workspace_path.len() == folder_path.len()
-                && core::iter::zip(workspace_path, folder_path).all(|(&a, &b)| {
-                    a == b || (path::is_sep_any(a) && path::is_sep_any(b))
-                })
+                && core::iter::zip(workspace_path, folder_path)
+                    .all(|(&a, &b)| a == b || (path::is_sep_any(a) && path::is_sep_any(b)))
         })
         .copied()
 }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -351,6 +351,30 @@ fn dep_sort_cmp(buf: &[u8], a: &Dependency, b: &Dependency) -> core::cmp::Orderi
     }
 }
 
+/// The workspace member registered at `folder_path` (relative to the top-level dir),
+/// if any. Matched by path (not dependency name) so `"alias": "file:../member"` is
+/// found too. Workspace paths are stored posix, `folder_path` is platform-separated.
+fn find_workspace_by_path(
+    workspace_paths: &lockfile::NameHashMap,
+    buf: &[u8],
+    folder_path: &[u8],
+) -> Option<String> {
+    if folder_path.is_empty() {
+        return None;
+    }
+    workspace_paths
+        .values()
+        .iter()
+        .find(|workspace_path| {
+            let workspace_path = workspace_path.slice(buf);
+            workspace_path.len() == folder_path.len()
+                && core::iter::zip(workspace_path, folder_path).all(|(&a, &b)| {
+                    a == b || (path::is_sep_any(a) && path::is_sep_any(b))
+                })
+        })
+        .copied()
+}
+
 /// Field tags for the binary lockfile serializer (`bun.lockb`). The
 /// reflection-backed `MultiArrayList` no longer needs an enum, but the
 /// serializer iterates fields by tag to write column blobs in a fixed order.
@@ -1870,9 +1894,30 @@ impl Package<u64> {
                 };
                 let relative =
                     resolve_path::relative(FileSystem::instance().top_level_dir(), joined);
-                // if relative is empty, we are linking the package to itself
-                dependency_version.value.folder = string_builder
-                    .append::<String>(if relative.is_empty() { b"." } else { relative });
+                // The bun.lock parser rewrites a dependency that resolved to a workspace
+                // package to `Tag::Workspace` (`map_dep_to_pkg`). Do the same here so a
+                // freshly parsed package.json compares equal to its loaded lockfile entry.
+                if let Some(workspace) = find_workspace_by_path(workspace_paths, buf, relative) {
+                    let path = workspace.sliced(buf);
+                    if let Some(mut dep) = dependency::parse_with_tag(
+                        external_alias.value,
+                        Some(external_alias.hash),
+                        path.slice,
+                        dependency::version::Tag::Workspace,
+                        &path,
+                        Some(&mut *log),
+                        Some(&mut *pm),
+                    ) {
+                        // Whole-struct move so `Drop` frees the old value;
+                        // keep the user's `file:` literal.
+                        dep.literal = dependency_version.literal;
+                        dependency_version = dep;
+                    }
+                } else {
+                    // if relative is empty, we are linking the package to itself
+                    dependency_version.value.folder = string_builder
+                        .append::<String>(if relative.is_empty() { b"." } else { relative });
+                }
             }
             dependency::version::Tag::Npm => {
                 if let Some(workspace_version) = workspace_version {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -197,7 +197,12 @@ test("dependency on workspace without version in package.json", async () => {
 // to the workspace package, including when the lockfile is loaded rather than
 // resolved fresh; otherwise every install re-registers the folder and rewrites bun.lock.
 describe("file: dependency on a workspace member", () => {
-  async function writeWorkspace(appDependencies: Record<string, string>, rootDependencies?: Record<string, string>) {
+  async function writeWorkspace(
+    ctx: TestCtx,
+    appDependencies: Record<string, string>,
+    rootDependencies?: Record<string, string>,
+  ) {
+    const { packageDir, packageJson } = ctx;
     await Promise.all([
       write(
         packageJson,
@@ -216,7 +221,8 @@ describe("file: dependency on a workspace member", () => {
     ]);
   }
 
-  async function expectStableLockfile() {
+  async function expectStableLockfile(ctx: TestCtx) {
+    const { packageDir, env } = ctx;
     await runBunInstall(env, packageDir, { saveTextLockfile: true });
     const first = await file(join(packageDir, "bun.lock")).text();
 
@@ -237,26 +243,31 @@ describe("file: dependency on a workspace member", () => {
     await runBunInstall(env, packageDir, { frozenLockfile: true, savesLockfile: false });
   }
 
-  test("declared by a sibling member", async () => {
-    await writeWorkspace({ lib: "file:../lib" });
-    await expectStableLockfile();
+  test.concurrent("declared by a sibling member", async () => {
+    using ctx = await setupTest();
+    await writeWorkspace(ctx, { lib: "file:../lib" });
+    await expectStableLockfile(ctx);
   });
 
-  test("declared by a sibling member under an alias", async () => {
-    await writeWorkspace({ "lib-alias": "file:../lib" });
-    await expectStableLockfile();
+  test.concurrent("declared by a sibling member under an alias", async () => {
+    using ctx = await setupTest();
+    await writeWorkspace(ctx, { "lib-alias": "file:../lib" });
+    await expectStableLockfile(ctx);
   });
 
-  test("declared by the root next to the workspaces array", async () => {
-    await writeWorkspace({}, { lib: "file:./packages/lib" });
-    await expectStableLockfile();
+  test.concurrent("declared by the root next to the workspaces array", async () => {
+    using ctx = await setupTest();
+    await writeWorkspace(ctx, {}, { lib: "file:./packages/lib" });
+    await expectStableLockfile(ctx);
   });
 
   // Negative contract: the rewrite keys on the folder path, not the dependency
   // name. A `file:` path outside the workspaces stays a plain folder dependency
   // even when its alias collides with a workspace member's name.
-  test("a colliding name pointing at a non-workspace folder stays a folder dependency", async () => {
-    await writeWorkspace({ lib: "file:../../vendor/other" });
+  test.concurrent("a colliding name pointing at a non-workspace folder stays a folder dependency", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await writeWorkspace(ctx, { lib: "file:../../vendor/other" });
     await write(
       join(packageDir, "vendor", "other", "package.json"),
       JSON.stringify({ name: "other", version: "2.0.0" }),
@@ -275,7 +286,8 @@ describe("file: dependency on a workspace member", () => {
   // `app` aliases the contents of packages/legacy-utils under the name of the
   // unrelated `utils` member, so the rewrite must decline (see
   // `find_workspace_by_path`) and the alias must link the folder it names.
-  async function writeAliasCollision() {
+  async function writeAliasCollision(ctx: TestCtx) {
+    const { packageDir, packageJson } = ctx;
     await Promise.all([
       write(packageJson, JSON.stringify({ name: "root", version: "1.0.0", workspaces: ["packages/*"] })),
       write(join(packageDir, "packages", "utils", "package.json"), JSON.stringify({ name: "utils", version: "1.0.0" })),
@@ -290,8 +302,10 @@ describe("file: dependency on a workspace member", () => {
     ]);
   }
 
-  test("an alias colliding with another member's name still links the folder it names", async () => {
-    await writeAliasCollision();
+  test.concurrent("an alias colliding with another member's name still links the folder it names", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await writeAliasCollision(ctx);
     await runBunInstall(env, packageDir, { saveTextLockfile: true });
     const lockfile = await file(join(packageDir, "bun.lock")).text();
     expect(lockfile).toContain('"app/utils": ["legacy@workspace:packages/legacy-utils"]');
@@ -305,7 +319,9 @@ describe("file: dependency on a workspace member", () => {
   // pre-existing second-install lockfile rewrite. It needs the `Tag::Workspace`
   // resolver to prefer a dependency's stored path over its name-keyed lookup.
   test.todo("an alias colliding with another member's name also produces a stable lockfile", async () => {
-    await writeAliasCollision();
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await writeAliasCollision(ctx);
     await runBunInstall(env, packageDir, { saveTextLockfile: true });
     const first = await file(join(packageDir, "bun.lock")).text();
 

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -271,6 +271,34 @@ describe("file: dependency on a workspace member", () => {
     expect(err).not.toContain("Saved lockfile");
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(first);
   });
+
+  // Negative contract: the rewrite must not fire for an alias owned by a DIFFERENT
+  // member as its name, because the workspace resolver looks the path up by name
+  // first and would link that member instead of the folder the `file:` path names.
+  test("an alias colliding with another member's name still links the folder it names", async () => {
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "root", version: "1.0.0", workspaces: ["packages/*"] })),
+      write(join(packageDir, "packages", "utils", "package.json"), JSON.stringify({ name: "utils", version: "1.0.0" })),
+      write(
+        join(packageDir, "packages", "legacy-utils", "package.json"),
+        JSON.stringify({ name: "legacy", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "app", "package.json"),
+        JSON.stringify({ name: "app", version: "1.0.0", dependencies: { utils: "file:../legacy-utils" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir, { saveTextLockfile: true });
+    // `app` named the contents of packages/legacy-utils; the `utils` member it
+    // happens to be aliased as must not win.
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain('"app/utils": ["legacy@workspace:packages/legacy-utils"]');
+    expect(await file(join(packageDir, "packages", "app", "node_modules", "utils", "package.json")).json()).toEqual({
+      name: "legacy",
+      version: "1.0.0",
+    });
+  });
 });
 
 test.concurrent("allowing negative workspace patterns", async () => {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -193,6 +193,89 @@ test("dependency on workspace without version in package.json", async () => {
   }
 });
 
+// A `file:` dependency that points at a workspace member's folder must resolve
+// to the workspace package, including when the lockfile is loaded rather than
+// resolved fresh; otherwise every install re-registers the folder and rewrites bun.lock.
+describe("file: dependency on a workspace member", () => {
+  async function writeWorkspace(
+    appDependencies: Record<string, string>,
+    rootDependencies?: Record<string, string>,
+  ) {
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "root",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          ...(rootDependencies ? { dependencies: rootDependencies } : {}),
+        }),
+      ),
+      write(join(packageDir, "packages", "lib", "package.json"), JSON.stringify({ name: "lib", version: "1.0.0" })),
+      write(
+        join(packageDir, "packages", "app", "package.json"),
+        JSON.stringify({ name: "app", version: "1.0.0", dependencies: appDependencies }),
+      ),
+    ]);
+  }
+
+  async function expectStableLockfile() {
+    await runBunInstall(env, packageDir, { saveTextLockfile: true });
+    const first = await file(join(packageDir, "bun.lock")).text();
+
+    // the member folder resolves to the workspace package exactly once
+    expect([...new Set(first.match(/"lib@[^"]*"/g))]).toEqual(['"lib@workspace:packages/lib"']);
+
+    // nothing changed, so the second install (which loads bun.lock rather than
+    // resolving from scratch) must be a no-op
+    const { err } = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(err).not.toContain("Saved lockfile");
+    const second = await file(join(packageDir, "bun.lock")).text();
+    const packagePaths = [...second.matchAll(/^    ("[^"]*"): \[/gm)].map(m => m[1]);
+    expect(packagePaths).toEqual([...new Set(packagePaths)]);
+    expect(second).toBe(first);
+
+    // the lockfile the first install produced satisfies --frozen-lockfile
+    await write(join(packageDir, "bun.lock"), first);
+    await runBunInstall(env, packageDir, { frozenLockfile: true, savesLockfile: false });
+  }
+
+  test("declared by a sibling member", async () => {
+    await writeWorkspace({ lib: "file:../lib" });
+    await expectStableLockfile();
+  });
+
+  test("declared by a sibling member under an alias", async () => {
+    await writeWorkspace({ "lib-alias": "file:../lib" });
+    await expectStableLockfile();
+  });
+
+  test("declared by the root next to the workspaces array", async () => {
+    await writeWorkspace({}, { lib: "file:./packages/lib" });
+    await expectStableLockfile();
+  });
+
+  // Negative contract: the rewrite keys on the folder path, not the dependency
+  // name. A `file:` path outside the workspaces stays a plain folder dependency
+  // even when its alias collides with a workspace member's name.
+  test("a colliding name pointing at a non-workspace folder stays a folder dependency", async () => {
+    await writeWorkspace({ lib: "file:../../vendor/other" });
+    await write(
+      join(packageDir, "vendor", "other", "package.json"),
+      JSON.stringify({ name: "other", version: "2.0.0" }),
+    );
+
+    await runBunInstall(env, packageDir, { saveTextLockfile: true });
+    const first = await file(join(packageDir, "bun.lock")).text();
+    expect([...new Set(first.match(/"lib@[^"]*"/g))]).toEqual(['"lib@workspace:packages/lib"']);
+    expect(first).toContain('"other@file:vendor/other"');
+
+    const { err } = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(first);
+  });
+});
+
 test.concurrent("allowing negative workspace patterns", async () => {
   using ctx = await setupTest();
   const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -197,10 +197,7 @@ test("dependency on workspace without version in package.json", async () => {
 // to the workspace package, including when the lockfile is loaded rather than
 // resolved fresh; otherwise every install re-registers the folder and rewrites bun.lock.
 describe("file: dependency on a workspace member", () => {
-  async function writeWorkspace(
-    appDependencies: Record<string, string>,
-    rootDependencies?: Record<string, string>,
-  ) {
+  async function writeWorkspace(appDependencies: Record<string, string>, rootDependencies?: Record<string, string>) {
     await Promise.all([
       write(
         packageJson,

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -272,10 +272,10 @@ describe("file: dependency on a workspace member", () => {
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(first);
   });
 
-  // Negative contract: the rewrite must not fire for an alias owned by a DIFFERENT
-  // member as its name, because the workspace resolver looks the path up by name
-  // first and would link that member instead of the folder the `file:` path names.
-  test("an alias colliding with another member's name still links the folder it names", async () => {
+  // `app` aliases the contents of packages/legacy-utils under the name of the
+  // unrelated `utils` member, so the rewrite must decline (see
+  // `find_workspace_by_path`) and the alias must link the folder it names.
+  async function writeAliasCollision() {
     await Promise.all([
       write(packageJson, JSON.stringify({ name: "root", version: "1.0.0", workspaces: ["packages/*"] })),
       write(join(packageDir, "packages", "utils", "package.json"), JSON.stringify({ name: "utils", version: "1.0.0" })),
@@ -288,16 +288,32 @@ describe("file: dependency on a workspace member", () => {
         JSON.stringify({ name: "app", version: "1.0.0", dependencies: { utils: "file:../legacy-utils" } }),
       ),
     ]);
+  }
 
+  test("an alias colliding with another member's name still links the folder it names", async () => {
+    await writeAliasCollision();
     await runBunInstall(env, packageDir, { saveTextLockfile: true });
-    // `app` named the contents of packages/legacy-utils; the `utils` member it
-    // happens to be aliased as must not win.
     const lockfile = await file(join(packageDir, "bun.lock")).text();
     expect(lockfile).toContain('"app/utils": ["legacy@workspace:packages/legacy-utils"]');
     expect(await file(join(packageDir, "packages", "app", "node_modules", "utils", "package.json")).json()).toEqual({
       name: "legacy",
       version: "1.0.0",
     });
+  });
+
+  // Because the rewrite declines for the colliding alias, that shape keeps the
+  // pre-existing second-install lockfile rewrite. It needs the `Tag::Workspace`
+  // resolver to prefer a dependency's stored path over its name-keyed lookup.
+  test.todo("an alias colliding with another member's name also produces a stable lockfile", async () => {
+    await writeAliasCollision();
+    await runBunInstall(env, packageDir, { saveTextLockfile: true });
+    const first = await file(join(packageDir, "bun.lock")).text();
+
+    const { err } = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(first);
+    await write(join(packageDir, "bun.lock"), first);
+    await runBunInstall(env, packageDir, { frozenLockfile: true, savesLockfile: false });
   });
 });
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1828,7 +1828,11 @@ export class VerdaccioRegistry {
 
   async start(silent: boolean = true) {
     await rm(join(dirname(this.configPath), "htpasswd"), { force: true });
-    this.process = fork(require.resolve("verdaccio/bin/verdaccio"), ["-c", this.configPath, "-l", `${this.port}`], {
+    // Bind the IPv4 loopback explicitly: a bare port makes verdaccio listen on
+    // whatever `localhost` resolves to, which is `::1` on hosts that list it first,
+    // while the clients connect to 127.0.0.1. That mismatch refuses every request.
+    const listen = `127.0.0.1:${this.port}`;
+    this.process = fork(require.resolve("verdaccio/bin/verdaccio"), ["-c", this.configPath, "-l", listen], {
       silent,
       // Prefer using a release build of Bun since it's faster
       execPath: isCI ? bunExe() : Bun.which("bun") || bunExe(),


### PR DESCRIPTION
### Reproduction

A workspace member that references a sibling member with a `file:` path (the usual shape in a monorepo migrated from npm or yarn):

```
# package.json              { "name": "root", "workspaces": ["packages/*"] }
# packages/lib/package.json { "name": "lib", "version": "1.0.0" }
# packages/app/package.json { "name": "app", "version": "1.0.0",
#                             "dependencies": { "lib": "file:../lib" } }

bun install   # Saved lockfile
bun install   # Saved lockfile (again, with nothing changed)
```

The second install loads `bun.lock` instead of resolving from scratch, registers the member's folder a second time as a `Folder`-resolved package next to its existing `Workspace` entry, and rewrites the lockfile:

```diff
 "packages": {
   "app": ["app@workspace:packages/app"],
   "lib": ["lib@workspace:packages/lib"],
+  "app/lib": ["lib@file:packages/lib", {}],
 }
```

Consequences:

- `bun install` never reaches a fixed point, so `bun install --frozen-lockfile` in CI against the lockfile the first install wrote fails with `error: lockfile had changes, but lockfile is frozen`.
- When the root itself declares both `"workspaces": ["packages/*"]` and `"lib": "file:./packages/lib"`, the second entry serializes as a duplicate `"lib"` key that bun's own parser then rejects (`warn: Duplicate key "lib" in object literal`, `warn: Ignoring lockfile`), so every other install does a full fresh resolve and the lockfile oscillates between the two states forever.
- The aliased form (`"lib-alias": "file:../lib"`) is unstable the same way.

### Cause

The two sides that produce a `Dependency` for the same `file:` literal disagree on its tag:

- The bun.lock parser normalizes a dependency that resolved to a `Workspace` package to `Tag::Workspace` (`map_dep_to_pkg` in `src/install/lockfile/bun.lock.rs`).
- `Package::parse_dependency` leaves it on `Tag::Folder` when it parses `packages/app/package.json` from disk.

`Version::eql` compares tags first, so `Diff::generate` always sees the workspace member's dependency list as changed and re-enqueues it. Re-resolving the `Folder`-tagged dependency cannot reuse the existing `Workspace("packages/lib")` package: `Resolution::eql` is tag strict, and `PackageManager.folders` (the absolute-path cache that makes the two share one package on a fresh resolve) is never seeded from a loaded lockfile. `Lockfile::append_package` therefore adds a second package for the same folder.

The `Tag::Npm` arm of the same match already performs this exact rewrite for `"lib": "1.0.0"` next to a workspace named `lib`; the `Tag::Folder` arm never got it.

### Fix

In `Package::parse_dependency`'s `Tag::Folder` arm, after normalizing the path relative to the top-level dir, if that path is a registered workspace member's path, produce the same `Tag::Workspace` dependency the Npm arm and the loader produce, keeping the user's `file:` literal. The lookup is keyed on the path rather than the dependency's name, so an aliased `file:` reference to a member is covered, and a name that merely collides with a workspace member but points at a different folder is left alone.

One guard, added from review: the rewrite also declines when a *different* member already owns the dependency's alias as its name (for example `"utils": "file:../legacy-utils"` where both `utils` and `legacy-utils` are members). The workspace resolver (`enqueue_dependency`'s `Tag::Workspace` arm) looks the path up by the dependency's name first and would have linked that member instead of the folder the path names. Such a dependency stays a plain folder dependency and resolves by path, as before.

Because that name-collision shape is excluded from the rewrite, it keeps the pre-existing second-install lockfile rewrite this PR fixes for the non-colliding shapes (verified identical on an unmodified build, so not a regression). Removing it too requires the workspace resolver above to prefer the dependency's stored path over its name-keyed lookup, a change to a lookup that also serves `workspace:other@range` aliases and is intentionally left out of this PR. A `test.todo` asserts the missing stability property so the trade-off is visible; bun:test flags a todo whose body starts passing, so it retires itself once that resolver change lands.

The lockfile a fresh install writes is unchanged by this (the `file:` dependency already resolved to the workspace package there, via `PackageManager.folders`); the loaded lockfile now diffs clean against it.

### Verification

Five tests and one `test.todo` in `test/cli/install/bun-workspaces.test.ts` under `file: dependency on a workspace member`. The first three run `bun install` twice and assert the second install does not print `Saved lockfile`, the two lockfiles are byte-identical with no duplicate package paths, exactly one `lib@workspace:packages/lib` package entry exists, and `--frozen-lockfile` against the first install's lockfile succeeds.

- `declared by a sibling member`, `declared by a sibling member under an alias`, and `declared by the root next to the workspaces array` fail on bun 1.4.0 and pass with this change.
- `a colliding name pointing at a non-workspace folder stays a folder dependency` guards the negative contract for a path outside the workspaces; it passes on both.
- `an alias colliding with another member's name still links the folder it names` guards the review finding above: it passes on an unmodified build, failed on the first commit of this PR, and passes with the guard.
- `... also produces a stable lockfile` is the `test.todo` for the intentionally excluded residual described above.

With this branch the whole file is 68 pass, 1 todo, 0 fail; against an unmodified build it is 65 pass, 1 todo, and exactly the 3 fixed tests failing. `bun-install.test.ts` (the `folder` and `file:` cases and the full file), `bun-link.test.ts`, and the rest of `bun-workspaces.test.ts` show no new failures relative to an unmodified debug build.

One test-infra change rides along because every registry-backed install test depends on it: `VerdaccioRegistry.start` now passes verdaccio `127.0.0.1:<port>` instead of a bare port. With a bare port verdaccio listens on whatever `localhost` resolves to, which is `::1` on a host whose `/etc/hosts` lists it, while bun's install client and `fetch` connect to `127.0.0.1`; on such a host every verdaccio-backed test (12 in this file alone) failed with `error: ConnectionRefused downloading package manifest`.

