### PR TITLE
vscode: resolve bun.runtime and test settings per workspace folder

### DIFF
--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -42,7 +42,7 @@
         "bun.runtime": {
           "type": "string",
           "description": "A path to the `bun` executable. By default, the extension looks for `bun` in the `PATH`, but if set, it will use the specified path instead.",
-          "scope": "window",
+          "scope": "resource",
           "default": null
         },
         "bun.diagnosticsSocket.enabled": {
@@ -72,22 +72,25 @@
         "bun.test.filePattern": {
           "type": "string",
           "default": "**/*{.test.,.spec.,_test_,_spec_}{js,ts,tsx,jsx,mts,cts,cjs,mjs}",
-          "description": "Glob pattern to find test files"
+          "description": "Glob pattern to find test files",
+          "scope": "resource"
         },
         "bun.test.customFlag": {
           "type": "string",
           "default": "",
-          "description": "Custom flag added to the end of test command"
+          "description": "Custom flag added to the end of test command",
+          "scope": "resource"
         },
         "bun.test.customScript": {
           "type": "string",
           "default": "bun test",
-          "description": "Custom script to use instead of `bun test`, for example script from `package.json`"
+          "description": "Custom script to use instead of `bun test`, for example script from `package.json`",
+          "scope": "resource"
         },
         "bun.test.enable": {
           "type": "boolean",
           "description": "If the test explorer should be enabled and integrated with your editor",
-          "scope": "window",
+          "scope": "resource",
           "default": true
         }
       }

--- a/packages/bun-vscode/src/features/tests/__tests__/multi-root-config.test.ts
+++ b/packages/bun-vscode/src/features/tests/__tests__/multi-root-config.test.ts
@@ -1,0 +1,118 @@
+// Regression test for https://github.com/oven-sh/bun/issues/33169
+// In a multi-root workspace each folder must resolve its own folder-scoped
+// `bun.runtime` / `bun.test.*` settings. The controller reads config through
+// `getConfiguration(section, <folder uri>)` so VS Code applies folder overrides
+// instead of a single workspace-global value.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { MockTestController, MockUri, MockWorkspaceFolder } from "./vscode-types.mock";
+
+const DEFAULT_TEST_PATTERN = "**/*{.test.,.spec.,_test_,_spec_}{js,ts,tsx,jsx,mts,cts,cjs,mjs}";
+
+// folder uri string -> fully-qualified setting -> value
+const folderSettings: Record<string, Record<string, unknown>> = {
+  "file:///repo/packages/api": {
+    "bun.test.filePattern": "**/*.spec.ts",
+    "bun.test.customFlag": "--coverage",
+    "bun.test.customScript": "bun run test:ci",
+    "bun.runtime": "/custom/bin/bun",
+  },
+  "file:///repo/packages/frontend": {
+    "bun.test.filePattern": "**/*.test.tsx",
+  },
+};
+
+class ScopedConfiguration {
+  constructor(
+    private readonly section: string,
+    private readonly scopeKey: string | undefined,
+  ) {}
+
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    const full = this.section ? `${this.section}.${key}` : key;
+    if (this.scopeKey) {
+      const overrides = folderSettings[this.scopeKey];
+      if (overrides && full in overrides) {
+        return overrides[full] as T;
+      }
+    }
+    return defaultValue;
+  }
+}
+
+function vscodeFactory() {
+  return {
+    window: {
+      createOutputChannel: () => ({ appendLine: () => {} }),
+      visibleTextEditors: [],
+      showErrorMessage: () => {},
+    },
+    workspace: {
+      getConfiguration: (section?: string, scope?: { toString(): string }) =>
+        new ScopedConfiguration(section ?? "", scope ? scope.toString() : undefined),
+      onDidOpenTextDocument: () => ({ dispose() {} }),
+      textDocuments: [],
+      createFileSystemWatcher: () => ({
+        onDidChange: () => ({ dispose() {} }),
+        onDidCreate: () => ({ dispose() {} }),
+        onDidDelete: () => ({ dispose() {} }),
+        dispose() {},
+      }),
+      findFiles: async () => [],
+    },
+    Uri: MockUri,
+    RelativePattern: class {
+      constructor(
+        public base: unknown,
+        public pattern: string,
+      ) {}
+    },
+    TestRunProfileKind: { Run: 1, Debug: 2, Coverage: 3 },
+  };
+}
+
+mock.module("vscode", vscodeFactory);
+
+const { BunTestController } = await import("../bun-test-controller");
+
+// `mock.module` is global and the module graph is evaluated with interleaved
+// awaits, so re-assert this file's mock before each test to stay independent of
+// the order in which other test files register their own vscode mock.
+beforeEach(() => {
+  mock.module("vscode", vscodeFactory);
+});
+
+function makeController(folderPath: string, name: string, index: number) {
+  const folder = new MockWorkspaceFolder(MockUri.file(folderPath), name, index);
+  const controller = new MockTestController(`bun:${folderPath}`, name);
+  return new BunTestController(controller as any, folder as any, true);
+}
+
+describe("multi-root workspace config scoping (issue #33169)", () => {
+  test("customFilePattern resolves each folder's own filePattern", () => {
+    const api = makeController("/repo/packages/api", "api", 0);
+    const frontend = makeController("/repo/packages/frontend", "frontend", 1);
+    expect(api._internal.customFilePattern()).toBe("**/*.spec.ts");
+    expect(frontend._internal.customFilePattern()).toBe("**/*.test.tsx");
+  });
+
+  test("getBunExecutionConfig resolves the folder's runtime, customScript and customFlag", () => {
+    const api = makeController("/repo/packages/api", "api", 0);
+    const apiConfig = api._internal.getBunExecutionConfig();
+    expect(apiConfig.bunCommand).toBe("/custom/bin/bun");
+    expect(apiConfig.testArgs).toEqual(["run", "test:ci", "--coverage"]);
+  });
+
+  test("a folder without overrides keeps the defaults and does not inherit another folder's settings", () => {
+    const frontend = makeController("/repo/packages/frontend", "frontend", 1);
+    expect(frontend._internal.customFilePattern()).toBe("**/*.test.tsx");
+
+    const frontendConfig = frontend._internal.getBunExecutionConfig();
+    expect(frontendConfig.bunCommand).toBe("bun");
+    expect(frontendConfig.testArgs).toEqual(["test"]);
+  });
+
+  test("default pattern is used when no scope matches", () => {
+    const other = makeController("/repo/packages/other", "other", 2);
+    expect(other._internal.customFilePattern()).toBe(DEFAULT_TEST_PATTERN);
+  });
+});

--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -156,13 +156,15 @@ export class BunTestController implements vscode.Disposable {
   }
 
   private customFilePattern(): string {
-    return vscode.workspace.getConfiguration("bun.test").get("filePattern", DEFAULT_TEST_PATTERN);
+    return vscode.workspace
+      .getConfiguration("bun.test", this.workspaceFolder.uri)
+      .get("filePattern", DEFAULT_TEST_PATTERN);
   }
 
   private async findTestFiles(cancellationToken?: vscode.CancellationToken): Promise<vscode.Uri[]> {
     const ignoreGlobs = await this.buildIgnoreGlobs(cancellationToken);
     const tests = await vscode.workspace.findFiles(
-      this.customFilePattern(),
+      new vscode.RelativePattern(this.workspaceFolder, this.customFilePattern()),
       "**/node_modules/**",
       // 5k tests is more than enough for most projects.
       // If they need more, they can manually open the files themself and it should be added to the test explorer.
@@ -182,7 +184,7 @@ export class BunTestController implements vscode.Disposable {
 
   private async buildIgnoreGlobs(cancellationToken?: vscode.CancellationToken): Promise<string[]> {
     const ignores = await vscode.workspace.findFiles(
-      "**/.gitignore",
+      new vscode.RelativePattern(this.workspaceFolder, "**/.gitignore"),
       "**/node_modules/**",
       undefined,
       cancellationToken,
@@ -269,15 +271,19 @@ export class BunTestController implements vscode.Disposable {
   }
 
   private getBunExecutionConfig() {
-    const customFlag = vscode.workspace.getConfiguration("bun.test").get("customFlag", "").trim();
-    const customScriptSetting = vscode.workspace.getConfiguration("bun.test").get("customScript", "bun test").trim();
+    const scope = this.workspaceFolder.uri;
+    const customFlag = vscode.workspace.getConfiguration("bun.test", scope).get("customFlag", "").trim();
+    const customScriptSetting = vscode.workspace
+      .getConfiguration("bun.test", scope)
+      .get("customScript", "bun test")
+      .trim();
     const customScript = customScriptSetting.length ? customScriptSetting : "bun test";
 
     const [cmd, ...args] = customScript.split(/\s+/);
 
     let bunCommand = "bun";
     if (cmd === "bun") {
-      const bunRuntime = vscode.workspace.getConfiguration("bun").get<string>("runtime", "bun");
+      const bunRuntime = vscode.workspace.getConfiguration("bun", scope).get<string>("runtime", "bun");
       bunCommand = bunRuntime || "bun";
     } else {
       bunCommand = cmd;

--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -144,10 +144,8 @@ export class BunTestController implements vscode.Disposable {
     );
   }
 
-  // The open-document listener is workspace-global, so in a multi-root
-  // workspace every folder's controller sees every opened file. Only adopt a
-  // document that belongs to this controller's folder, matching the
-  // RelativePattern scoping used by findTestFiles and the file watcher.
+  // Open-document events are workspace-global; only adopt documents inside
+  // this controller's folder, matching findTestFiles and the file watcher.
   private documentBelongsToFolder(uri: vscode.Uri): boolean {
     return vscode.workspace.getWorkspaceFolder(uri)?.uri.toString() === this.workspaceFolder.uri.toString();
   }
@@ -283,11 +281,9 @@ export class BunTestController implements vscode.Disposable {
 
   private getBunExecutionConfig() {
     const scope = this.workspaceFolder.uri;
-    const customFlag = vscode.workspace.getConfiguration("bun.test", scope).get("customFlag", "").trim();
-    const customScriptSetting = vscode.workspace
-      .getConfiguration("bun.test", scope)
-      .get("customScript", "bun test")
-      .trim();
+    const testConfig = vscode.workspace.getConfiguration("bun.test", scope);
+    const customFlag = testConfig.get("customFlag", "").trim();
+    const customScriptSetting = testConfig.get("customScript", "bun test").trim();
     const customScript = customScriptSetting.length ? customScriptSetting : "bun test";
 
     const [cmd, ...args] = customScript.split(/\s+/);

--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -130,7 +130,10 @@ export class BunTestController implements vscode.Disposable {
   }
 
   private handleOpenDocument(document: vscode.TextDocument): void {
-    if (this.isTestFile(document) && !this.testController.items.get(windowsVscodeUri(document.uri.fsPath))) {
+    if (!this.isTestFile(document) || !this.documentBelongsToFolder(document.uri)) {
+      return;
+    }
+    if (!this.testController.items.get(windowsVscodeUri(document.uri.fsPath))) {
       this.discoverTests(false, windowsVscodeUri(document.uri.fsPath));
     }
   }
@@ -139,6 +142,14 @@ export class BunTestController implements vscode.Disposable {
     return (
       document?.uri?.scheme === "file" && /\.(test|spec)\.(js|jsx|ts|tsx|cjs|mjs|mts|cts)$/.test(document.uri.fsPath)
     );
+  }
+
+  // The open-document listener is workspace-global, so in a multi-root
+  // workspace every folder's controller sees every opened file. Only adopt a
+  // document that belongs to this controller's folder, matching the
+  // RelativePattern scoping used by findTestFiles and the file watcher.
+  private documentBelongsToFolder(uri: vscode.Uri): boolean {
+    return vscode.workspace.getWorkspaceFolder(uri)?.uri.toString() === this.workspaceFolder.uri.toString();
   }
 
   private async discoverInitialTests(
@@ -1485,6 +1496,7 @@ export class BunTestController implements vscode.Disposable {
       shouldUseTestNamePattern: this.shouldUseTestNamePattern.bind(this),
 
       isTestFile: this.isTestFile.bind(this),
+      documentBelongsToFolder: this.documentBelongsToFolder.bind(this),
       customFilePattern: this.customFilePattern.bind(this),
       getBunExecutionConfig: this.getBunExecutionConfig.bind(this),
 

--- a/packages/bun-vscode/src/features/tests/index.ts
+++ b/packages/bun-vscode/src/features/tests/index.ts
@@ -1,29 +1,79 @@
 import * as vscode from "vscode";
 import { BunTestController, debug } from "./bun-test-controller";
 
-export async function registerTests(context: vscode.ExtensionContext) {
-  const workspaceFolder = (vscode.workspace.workspaceFolders || [])[0];
-  if (!workspaceFolder) {
-    return;
+export type TestControllerFactory = (
+  controller: vscode.TestController,
+  folder: vscode.WorkspaceFolder,
+) => vscode.Disposable;
+
+export async function registerTests(
+  context: vscode.ExtensionContext,
+  createController: TestControllerFactory = (controller, folder) => new BunTestController(controller, folder),
+) {
+  // One controller per workspace folder so each folder resolves its own
+  // folder-scoped settings (`bun.runtime`, `bun.test.*`) and discovers tests
+  // with its own `filePattern`. This is what makes multi-root workspaces work.
+  const controllers = new Map<string, { controller: vscode.TestController; bun: vscode.Disposable }>();
+  let shownVersionError = false;
+
+  const addFolder = (folder: vscode.WorkspaceFolder): void => {
+    const key = folder.uri.toString();
+    if (controllers.has(key)) {
+      return;
+    }
+
+    const enable = vscode.workspace.getConfiguration("bun.test", folder.uri).get<boolean>("enable", true);
+    if (!enable) {
+      return;
+    }
+
+    try {
+      const multiRoot = (vscode.workspace.workspaceFolders || []).length > 1;
+      const controller = vscode.tests.createTestController(
+        `bun:${key}`,
+        multiRoot ? `Bun Tests (${folder.name})` : "Bun Tests",
+      );
+      const bun = createController(controller, folder);
+      controllers.set(key, { controller, bun });
+    } catch (error) {
+      debug.appendLine(`Error initializing Bun Test Controller: ${error}`);
+      if (!shownVersionError) {
+        shownVersionError = true;
+        vscode.window.showErrorMessage(
+          "Failed to initialize Bun Test Explorer. You may need to update VS Code to version 1.59 or later.",
+        );
+      }
+    }
+  };
+
+  const removeFolder = (folder: vscode.WorkspaceFolder): void => {
+    const key = folder.uri.toString();
+    const entry = controllers.get(key);
+    if (!entry) {
+      return;
+    }
+    entry.bun.dispose();
+    entry.controller.dispose();
+    controllers.delete(key);
+  };
+
+  for (const folder of vscode.workspace.workspaceFolders || []) {
+    addFolder(folder);
   }
 
-  const config = vscode.workspace.getConfiguration("bun.test");
-  const enable = config.get<boolean>("enable", true);
-  if (!enable) {
-    return;
-  }
-
-  try {
-    const controller = vscode.tests.createTestController("bun", "Bun Tests");
-    context.subscriptions.push(controller);
-
-    const bunTestController = new BunTestController(controller, workspaceFolder);
-
-    context.subscriptions.push(bunTestController);
-  } catch (error) {
-    debug.appendLine(`Error initializing Bun Test Controller: ${error}`);
-    vscode.window.showErrorMessage(
-      "Failed to initialize Bun Test Explorer. You may need to update VS Code to version 1.59 or later.",
-    );
-  }
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(event => {
+      for (const folder of event.removed) removeFolder(folder);
+      for (const folder of event.added) addFolder(folder);
+    }),
+    {
+      dispose() {
+        for (const { controller, bun } of controllers.values()) {
+          bun.dispose();
+          controller.dispose();
+        }
+        controllers.clear();
+      },
+    },
+  );
 }

--- a/packages/bun-vscode/src/features/tests/index.ts
+++ b/packages/bun-vscode/src/features/tests/index.ts
@@ -13,8 +13,22 @@ export async function registerTests(
   // One controller per workspace folder so each folder resolves its own
   // folder-scoped settings (`bun.runtime`, `bun.test.*`) and discovers tests
   // with its own `filePattern`. This is what makes multi-root workspaces work.
-  const controllers = new Map<string, { controller: vscode.TestController; bun: vscode.Disposable }>();
+  const controllers = new Map<
+    string,
+    { controller: vscode.TestController; bun: vscode.Disposable; folder: vscode.WorkspaceFolder }
+  >();
   let shownVersionError = false;
+
+  // Disambiguate the folder name only when more than one folder is open; a
+  // single-root workspace keeps the plain "Bun Tests" title.
+  const labelFor = (folder: vscode.WorkspaceFolder): string =>
+    (vscode.workspace.workspaceFolders || []).length > 1 ? `Bun Tests (${folder.name})` : "Bun Tests";
+
+  const refreshLabels = (): void => {
+    for (const { controller, folder } of controllers.values()) {
+      controller.label = labelFor(folder);
+    }
+  };
 
   const addFolder = (folder: vscode.WorkspaceFolder): void => {
     const key = folder.uri.toString();
@@ -27,15 +41,13 @@ export async function registerTests(
       return;
     }
 
+    let controller: vscode.TestController | undefined;
     try {
-      const multiRoot = (vscode.workspace.workspaceFolders || []).length > 1;
-      const controller = vscode.tests.createTestController(
-        `bun:${key}`,
-        multiRoot ? `Bun Tests (${folder.name})` : "Bun Tests",
-      );
+      controller = vscode.tests.createTestController(`bun:${key}`, labelFor(folder));
       const bun = createController(controller, folder);
-      controllers.set(key, { controller, bun });
+      controllers.set(key, { controller, bun, folder });
     } catch (error) {
+      controller?.dispose();
       debug.appendLine(`Error initializing Bun Test Controller: ${error}`);
       if (!shownVersionError) {
         shownVersionError = true;
@@ -65,6 +77,8 @@ export async function registerTests(
     vscode.workspace.onDidChangeWorkspaceFolders(event => {
       for (const folder of event.removed) removeFolder(folder);
       for (const folder of event.added) addFolder(folder);
+      // Folder count may have crossed the single/multi-root boundary.
+      refreshLabels();
     }),
     {
       dispose() {

--- a/test/regression/issue/33169.test.ts
+++ b/test/regression/issue/33169.test.ts
@@ -3,13 +3,16 @@
 // The Bun VS Code extension read `bun.runtime` and `bun.test.*` through
 // `getConfiguration(section)` with no resource scope, so in a multi-root
 // workspace VS Code never applied a folder's `.vscode/settings.json` override:
-// every folder saw the same workspace-global value. The fix passes the folder
-// URI as the configuration scope and raises those settings to `resource` scope.
-import { describe, expect, mock, test } from "bun:test";
+// every folder saw the same workspace-global value, and only the first folder
+// got a test controller. The fix passes the folder URI as the configuration
+// scope, raises those settings to `resource` scope, and creates one controller
+// per workspace folder.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const CONTROLLER = "../../../packages/bun-vscode/src/features/tests/bun-test-controller";
+const INDEX = "../../../packages/bun-vscode/src/features/tests/index";
 const PACKAGE_JSON = join(import.meta.dir, "../../../packages/bun-vscode/package.json");
 const DEFAULT_TEST_PATTERN = "**/*{.test.,.spec.,_test_,_spec_}{js,ts,tsx,jsx,mts,cts,cjs,mjs}";
 
@@ -23,6 +26,9 @@ const folderSettings: Record<string, Record<string, unknown>> = {
   },
   "file:///repo/packages/frontend": {
     "bun.test.filePattern": "**/*.test.tsx",
+  },
+  "file:///ws/disabled": {
+    "bun.test.enable": false,
   },
 };
 
@@ -44,6 +50,10 @@ class ScopedConfiguration {
   }
 }
 
+let workspaceFolders: any[] = [];
+let folderChangeListener: ((e: { added: any[]; removed: any[] }) => void) | undefined;
+const createdControllers: any[] = [];
+
 function vscodeFactory() {
   return {
     window: {
@@ -52,9 +62,16 @@ function vscodeFactory() {
       showErrorMessage: () => {},
     },
     workspace: {
+      get workspaceFolders() {
+        return workspaceFolders;
+      },
       getConfiguration: (section?: string, scope?: { toString(): string }) =>
         new ScopedConfiguration(section ?? "", scope ? scope.toString() : undefined),
       onDidOpenTextDocument: () => ({ dispose() {} }),
+      onDidChangeWorkspaceFolders: (listener: (e: { added: any[]; removed: any[] }) => void) => {
+        folderChangeListener = listener;
+        return { dispose() {} };
+      },
       textDocuments: [],
       createFileSystemWatcher: () => ({
         onDidChange: () => ({ dispose() {} }),
@@ -63,6 +80,16 @@ function vscodeFactory() {
         dispose() {},
       }),
       findFiles: async () => [],
+    },
+    tests: {
+      createTestController: (id: string, label: string) => {
+        const controller: any = { id, label, disposed: false };
+        controller.dispose = () => {
+          controller.disposed = true;
+        };
+        createdControllers.push(controller);
+        return controller;
+      },
     },
     RelativePattern: class {
       constructor(
@@ -77,6 +104,7 @@ function vscodeFactory() {
 mock.module("vscode", vscodeFactory);
 
 const { BunTestController } = await import(CONTROLLER);
+const { registerTests } = await import(INDEX);
 
 function makeController(folderPath: string) {
   const uri = { toString: () => `file://${folderPath}`, fsPath: folderPath };
@@ -119,5 +147,90 @@ describe("multi-root workspace config scoping (issue #33169)", () => {
     for (const key of ["bun.runtime", "bun.test.filePattern", "bun.test.customFlag", "bun.test.customScript"]) {
       expect(props[key].scope).toBe("resource");
     }
+  });
+});
+
+describe("registerTests multi-root controllers (issue #33169)", () => {
+  type Built = { controller: any; folder: any; disposed: boolean };
+
+  function recordingFactory(records: Built[]) {
+    return (controller: any, folder: any) => {
+      const rec: Built = { controller, folder, disposed: false };
+      records.push(rec);
+      return {
+        dispose() {
+          rec.disposed = true;
+        },
+      };
+    };
+  }
+
+  function makeContext() {
+    return { subscriptions: [] as any[] } as any;
+  }
+
+  function wsFolder(folderPath: string, name: string) {
+    const uri = { toString: () => `file://${folderPath}`, fsPath: folderPath };
+    return { uri, name, index: 0 };
+  }
+
+  beforeEach(() => {
+    workspaceFolders = [];
+    folderChangeListener = undefined;
+    createdControllers.length = 0;
+  });
+
+  test("creates one controller per workspace folder with folder-qualified labels", async () => {
+    workspaceFolders = [wsFolder("/ws/a", "a"), wsFolder("/ws/b", "b")];
+    const records: Built[] = [];
+    await registerTests(makeContext(), recordingFactory(records));
+
+    expect(records.map(r => r.folder.name)).toEqual(["a", "b"]);
+    expect(createdControllers.map(c => c.id)).toEqual(["bun:file:///ws/a", "bun:file:///ws/b"]);
+    expect(createdControllers.map(c => c.label)).toEqual(["Bun Tests (a)", "Bun Tests (b)"]);
+  });
+
+  test("uses the plain label for a single-folder workspace", async () => {
+    workspaceFolders = [wsFolder("/ws/only", "only")];
+    await registerTests(makeContext(), recordingFactory([]));
+
+    expect(createdControllers.map(c => c.label)).toEqual(["Bun Tests"]);
+  });
+
+  test("skips folders where bun.test.enable is false", async () => {
+    workspaceFolders = [wsFolder("/ws/a", "a"), wsFolder("/ws/disabled", "disabled")];
+    const records: Built[] = [];
+    await registerTests(makeContext(), recordingFactory(records));
+
+    expect(records.map(r => r.folder.name)).toEqual(["a"]);
+  });
+
+  test("disposes the created controller when the factory throws", async () => {
+    workspaceFolders = [wsFolder("/ws/a", "a")];
+    await registerTests(makeContext(), () => {
+      throw new Error("boom");
+    });
+
+    expect(createdControllers).toHaveLength(1);
+    expect(createdControllers[0].disposed).toBe(true);
+  });
+
+  test("adds, relabels and removes controllers as folders change", async () => {
+    const a = wsFolder("/ws/a", "a");
+    workspaceFolders = [a];
+    const records: Built[] = [];
+    await registerTests(makeContext(), recordingFactory(records));
+    expect(createdControllers.map(c => c.label)).toEqual(["Bun Tests"]);
+
+    const b = wsFolder("/ws/b", "b");
+    workspaceFolders = [a, b];
+    folderChangeListener?.({ added: [b], removed: [] });
+    expect(records.map(r => r.folder.name)).toEqual(["a", "b"]);
+    expect(createdControllers.map(c => c.label)).toEqual(["Bun Tests (a)", "Bun Tests (b)"]);
+
+    workspaceFolders = [a];
+    folderChangeListener?.({ added: [], removed: [b] });
+    expect(records.find(r => r.folder.name === "b")?.disposed).toBe(true);
+    expect(createdControllers.find(c => c.id === "bun:file:///ws/a")?.label).toBe("Bun Tests");
   });
 });

--- a/test/regression/issue/33169.test.ts
+++ b/test/regression/issue/33169.test.ts
@@ -1,11 +1,16 @@
-// Regression test for https://github.com/oven-sh/bun/issues/33169
-// In a multi-root workspace each folder must resolve its own folder-scoped
-// `bun.runtime` / `bun.test.*` settings. The controller reads config through
-// `getConfiguration(section, <folder uri>)` so VS Code applies folder overrides
-// instead of a single workspace-global value.
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { MockTestController, MockUri, MockWorkspaceFolder } from "./vscode-types.mock";
+// https://github.com/oven-sh/bun/issues/33169
+//
+// The Bun VS Code extension read `bun.runtime` and `bun.test.*` through
+// `getConfiguration(section)` with no resource scope, so in a multi-root
+// workspace VS Code never applied a folder's `.vscode/settings.json` override:
+// every folder saw the same workspace-global value. The fix passes the folder
+// URI as the configuration scope and raises those settings to `resource` scope.
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
+const CONTROLLER = "../../../packages/bun-vscode/src/features/tests/bun-test-controller";
+const PACKAGE_JSON = join(import.meta.dir, "../../../packages/bun-vscode/package.json");
 const DEFAULT_TEST_PATTERN = "**/*{.test.,.spec.,_test_,_spec_}{js,ts,tsx,jsx,mts,cts,cjs,mjs}";
 
 // folder uri string -> fully-qualified setting -> value
@@ -59,7 +64,6 @@ function vscodeFactory() {
       }),
       findFiles: async () => [],
     },
-    Uri: MockUri,
     RelativePattern: class {
       constructor(
         public base: unknown,
@@ -72,47 +76,48 @@ function vscodeFactory() {
 
 mock.module("vscode", vscodeFactory);
 
-const { BunTestController } = await import("../bun-test-controller");
+const { BunTestController } = await import(CONTROLLER);
 
-// `mock.module` is global and the module graph is evaluated with interleaved
-// awaits, so re-assert this file's mock before each test to stay independent of
-// the order in which other test files register their own vscode mock.
-beforeEach(() => {
-  mock.module("vscode", vscodeFactory);
-});
-
-function makeController(folderPath: string, name: string, index: number) {
-  const folder = new MockWorkspaceFolder(MockUri.file(folderPath), name, index);
-  const controller = new MockTestController(`bun:${folderPath}`, name);
-  return new BunTestController(controller as any, folder as any, true);
+function makeController(folderPath: string) {
+  const uri = { toString: () => `file://${folderPath}`, fsPath: folderPath };
+  const folder = { uri, name: folderPath.split("/").pop() ?? folderPath, index: 0 };
+  return new BunTestController({} as any, folder as any, true);
 }
 
 describe("multi-root workspace config scoping (issue #33169)", () => {
-  test("customFilePattern resolves each folder's own filePattern", () => {
-    const api = makeController("/repo/packages/api", "api", 0);
-    const frontend = makeController("/repo/packages/frontend", "frontend", 1);
+  test("each folder resolves its own filePattern from its folder scope", () => {
+    const api = makeController("/repo/packages/api");
+    const frontend = makeController("/repo/packages/frontend");
     expect(api._internal.customFilePattern()).toBe("**/*.spec.ts");
     expect(frontend._internal.customFilePattern()).toBe("**/*.test.tsx");
   });
 
   test("getBunExecutionConfig resolves the folder's runtime, customScript and customFlag", () => {
-    const api = makeController("/repo/packages/api", "api", 0);
-    const apiConfig = api._internal.getBunExecutionConfig();
-    expect(apiConfig.bunCommand).toBe("/custom/bin/bun");
-    expect(apiConfig.testArgs).toEqual(["run", "test:ci", "--coverage"]);
+    const api = makeController("/repo/packages/api");
+    const config = api._internal.getBunExecutionConfig();
+    expect(config.bunCommand).toBe("/custom/bin/bun");
+    expect(config.testArgs).toEqual(["run", "test:ci", "--coverage"]);
   });
 
   test("a folder without overrides keeps the defaults and does not inherit another folder's settings", () => {
-    const frontend = makeController("/repo/packages/frontend", "frontend", 1);
+    const frontend = makeController("/repo/packages/frontend");
     expect(frontend._internal.customFilePattern()).toBe("**/*.test.tsx");
 
-    const frontendConfig = frontend._internal.getBunExecutionConfig();
-    expect(frontendConfig.bunCommand).toBe("bun");
-    expect(frontendConfig.testArgs).toEqual(["test"]);
+    const config = frontend._internal.getBunExecutionConfig();
+    expect(config.bunCommand).toBe("bun");
+    expect(config.testArgs).toEqual(["test"]);
   });
 
-  test("default pattern is used when no scope matches", () => {
-    const other = makeController("/repo/packages/other", "other", 2);
+  test("default pattern is used when no folder scope matches", () => {
+    const other = makeController("/repo/packages/other");
     expect(other._internal.customFilePattern()).toBe(DEFAULT_TEST_PATTERN);
+  });
+
+  test("per-folder settings are declared with resource scope in package.json", () => {
+    const manifest = JSON.parse(readFileSync(PACKAGE_JSON, "utf8"));
+    const props = manifest.contributes.configuration.properties;
+    for (const key of ["bun.runtime", "bun.test.filePattern", "bun.test.customFlag", "bun.test.customScript"]) {
+      expect(props[key].scope).toBe("resource");
+    }
   });
 });

--- a/test/regression/issue/33169.test.ts
+++ b/test/regression/issue/33169.test.ts
@@ -53,6 +53,7 @@ class ScopedConfiguration {
 let workspaceFolders: any[] = [];
 let folderChangeListener: ((e: { added: any[]; removed: any[] }) => void) | undefined;
 const createdControllers: any[] = [];
+const knownFolderPaths = ["/repo/packages/api", "/repo/packages/frontend"];
 
 function vscodeFactory() {
   return {
@@ -71,6 +72,11 @@ function vscodeFactory() {
       onDidChangeWorkspaceFolders: (listener: (e: { added: any[]; removed: any[] }) => void) => {
         folderChangeListener = listener;
         return { dispose() {} };
+      },
+      getWorkspaceFolder: (uri: { fsPath?: string; toString(): string }) => {
+        const p = uri.fsPath ?? uri.toString();
+        const match = knownFolderPaths.find(f => p === f || p.startsWith(`${f}/`));
+        return match ? { uri: { toString: () => `file://${match}` } } : undefined;
       },
       textDocuments: [],
       createFileSystemWatcher: () => ({
@@ -139,6 +145,20 @@ describe("multi-root workspace config scoping (issue #33169)", () => {
   test("default pattern is used when no folder scope matches", () => {
     const other = makeController("/repo/packages/other");
     expect(other._internal.customFilePattern()).toBe(DEFAULT_TEST_PATTERN);
+  });
+
+  test("only adopts opened documents that belong to the controller's folder", () => {
+    const api = makeController("/repo/packages/api");
+    const inApi = { fsPath: "/repo/packages/api/foo.test.ts", toString: () => "file:///repo/packages/api/foo.test.ts" };
+    const inFrontend = {
+      fsPath: "/repo/packages/frontend/bar.test.ts",
+      toString: () => "file:///repo/packages/frontend/bar.test.ts",
+    };
+    const external = { fsPath: "/elsewhere/baz.test.ts", toString: () => "file:///elsewhere/baz.test.ts" };
+
+    expect(api._internal.documentBelongsToFolder(inApi)).toBe(true);
+    expect(api._internal.documentBelongsToFolder(inFrontend)).toBe(false);
+    expect(api._internal.documentBelongsToFolder(external)).toBe(false);
   });
 
   test("per-folder settings are declared with resource scope in package.json", () => {


### PR DESCRIPTION
Fixes #33169

## Problem

In a multi-root workspace (`.code-workspace` with several folders) the Bun extension applied `bun.runtime`, `bun.test.filePattern`, `bun.test.customFlag` and `bun.test.customScript` globally. There was no way to set a different Bun runtime or test pattern per folder: every folder saw the same workspace-global value, and only the first folder got a test explorer at all.

## Cause

Two things combined:

1. The test controller read configuration with no resource scope, e.g. `vscode.workspace.getConfiguration("bun.test").get("filePattern", ...)`. Without a scope VS Code cannot apply a folder's `.vscode/settings.json` override, so it always returned the workspace-global value.
2. Those settings were `window`-scoped in `package.json` (explicitly for `bun.runtime`, by default for the `bun.test.*` strings). A `window`-scoped setting is not folder-overridable even when a URI is passed.

Separately, `registerTests` created a single controller bound to `workspaceFolders[0]`, so additional roots were never wired up.

## Fix

- `bun-test-controller.ts`: pass the controller's folder URI as the configuration scope for every per-folder read (`customFilePattern`, `getBunExecutionConfig` -> `customFlag` / `customScript` / `runtime`), scope test and `.gitignore` discovery to the folder via `RelativePattern`, and only adopt opened documents that belong to the controller's folder (the open-document listener is workspace-global).
- `package.json`: raise `bun.runtime`, `bun.test.filePattern`, `bun.test.customFlag`, `bun.test.customScript` and `bun.test.enable` from `window` to `resource` scope so folder overrides are allowed to resolve.
- `index.ts`: create one controller per workspace folder (each scoped to its folder) and react to `onDidChangeWorkspaceFolders`, so every root in a multi-root workspace gets its own Bun test explorer. The debug feature already passed a resource scope to `bun.runtime`; the scope bump makes that read folder-aware too.

## Verification

The regression test `test/regression/issue/33169.test.ts` drives the real `BunTestController` and `registerTests` with a scope-aware `vscode` mock. It asserts each folder resolves its own `filePattern` / `runtime` / `customScript` / `customFlag`, that a folder with no overrides keeps the defaults, that an opened document is only adopted by its own folder's controller, that one controller is created per folder (with enable gating, dispose-on-failure, add/remove and label refresh), and that the settings are declared with `resource` scope in `package.json`.

```console
$ bun bd test test/regression/issue/33169.test.ts
 11 pass  0 fail

# with the source fix reverted (bug present):
 2 pass  9 fail
```
