### PR TITLE
Scope node:inspector CPU profiles to their own Profiler.start/stop window

### DIFF
--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -57,6 +57,16 @@ void startCPUProfiler(JSC::VM& vm)
 
     JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
     samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
+
+    // ensureSamplingProfiler() reuses the VM's single SamplingProfiler, so other
+    // users (e.g. bun:jsc's startSamplingProfiler) may have left samples in it.
+    // Discard them so this profile only covers its own start..stop window.
+    {
+        auto& lock = samplingProfiler.getLock();
+        WTF::Locker profilerLocker { lock };
+        samplingProfiler.clearData();
+    }
+
     samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();
     samplingProfiler.start();
     s_isProfilerRunning = true;

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import inspector from "node:inspector";
 import inspectorPromises from "node:inspector/promises";
 
@@ -251,6 +252,59 @@ describe("node:inspector", () => {
       // Both profiles should be valid
       expect(result1.profile.nodes.length).toBeGreaterThanOrEqual(1);
       expect(result2.profile.nodes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // The Profiler domain and bun:jsc share the VM's single JSC SamplingProfiler.
+    // Profiler.start must discard samples an earlier user left behind, or an empty
+    // start..stop window reports them with an endTime that precedes its startTime.
+    test("Profiler.start discards samples from a prior sampling-profiler run", async () => {
+      // startSamplingProfiler() is process-global: run it in a subprocess.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const { startSamplingProfiler } = require("bun:jsc");
+          const { Session } = require("node:inspector");
+
+          function burnCpu() {
+            let x = 0;
+            const end = Date.now() + 250;
+            while (Date.now() < end) {
+              for (let i = 0; i < 100000; i++) x += Math.sqrt(i);
+            }
+            return x;
+          }
+
+          startSamplingProfiler();
+          burnCpu();
+
+          const session = new Session();
+          session.connect();
+          session.post("Profiler.enable");
+          session.post("Profiler.start");
+          const { profile } = session.post("Profiler.stop");
+          session.disconnect();
+
+          console.log(
+            JSON.stringify({
+              startTime: profile.startTime,
+              endTime: profile.endTime,
+              functionNames: profile.nodes.map(n => n.callFrame.functionName),
+            }),
+          );
+          `,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const { startTime, endTime, functionNames } = JSON.parse(stdout);
+      expect(functionNames).not.toContain("burnCpu");
+      expect(endTime).toBeGreaterThanOrEqual(startTime);
+      expect(exitCode).toBe(0);
     });
 
     test("disconnect() stops running profiler", () => {


### PR DESCRIPTION
### Problem

`node:inspector`'s Profiler domain, `--cpu-prof`, and `bun:jsc`'s `startSamplingProfiler()`/`profile()` all share the VM's single `JSC::SamplingProfiler`. `Bun::startCPUProfiler` called `vm.ensureSamplingProfiler()` and started sampling without discarding anything a previous user of that profiler had already accumulated.

A `Profiler.start()`/`Profiler.stop()` session therefore absorbs samples recorded before it started. Because those samples' timestamps precede the session's `startTime`, `stopCPUProfiler`'s `endTime = lastTime` lands on the last foreign sample and the profile reports `endTime < startTime`. `.cpuprofile` consumers (Chrome DevTools, speedscope) treat the window as an invariant and reject or misrender such profiles, and the foreign samples silently misattribute cost to the wrong period.

### Repro (bun 1.4.0 and current main)

```js
const { startSamplingProfiler } = require("bun:jsc");
const { Session } = require("node:inspector");

function burnCpu() { /* ~250ms of work */ }
startSamplingProfiler();
burnCpu();

const s = new Session();
s.connect();
s.post("Profiler.enable");
s.post("Profiler.start");
/* do nothing */
const { profile } = s.post("Profiler.stop");
```

```
startTime: 1782888057915024.5
endTime:   1782888057914178.2     <- 846us BEFORE startTime
samples:   191                    <- all from burnCpu, which ran before Profiler.start
nodes:     ["(root)","","burnCpu",...]
```

(The `bun:jsc.profile()` variant does not reproduce this: `profile()` already calls `clearData()` when it finishes. Any prior sampling-profiler user that leaves data behind does, `startSamplingProfiler()` being the simplest.)

### Fix

In `startCPUProfiler`, after `ensureSamplingProfiler()` returns the (possibly reused) profiler, take its lock and `clearData()` before `start()`. `s_profilingStartTime` is captured first, so every sample surviving the clear is `>= startTime` and the session is scoped to its own start..stop window.

`bun:jsc`'s own APIs are intentionally left alone: `startSamplingProfiler()` is the accumulate-until-exit mode, and clearing on entry to `profile()` would discard a concurrent `startSamplingProfiler()` run's data. Only the inspector/`--cpu-prof` path, whose output format has the start/end window invariant, needs the scoping.

### Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/inspector/inspector-profiler.test.ts -t "discards samples"   # FAIL (burnCpu in node list)
bun bd test test/js/node/inspector/inspector-profiler.test.ts                                        # 39 pass
bun bd test test/cli/run/cpu-prof.test.ts                                                            # pass
```

`bun:jsc > profile can be called multiple times` in `test/js/bun/jsc/bun-jsc.test.ts` times out on a debug build, but it does so identically on unmodified `main` (it runs `fib(30)` twice under ASAN); not related to this change.

#32270 fixes a separate bug in this file (process-global profiler state racing across workers, #28472); the two changes are independent.
