### PR TITLE
Fix panic when require "paths" entries are not absolute paths

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -376,6 +376,7 @@ pub struct Bufs {
     pub dir_info_uncached_path: PathBuffer,
     pub tsconfig_base_url: PathBuffer,
     pub relative_abs_path: PathBuffer,
+    pub custom_dir_path_abs: PathBuffer,
     pub load_as_file_or_directory_via_tsconfig_base_path: PathBuffer,
     pub node_modules_check: PathBuffer,
     pub field_abs_path: PathBuffer,
@@ -2097,12 +2098,15 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8_without_ref();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    // Entries of `options.paths` come from JavaScript. Like Node's
+                    // `path.resolve`, treat relative entries as relative to cwd.
+                    let custom_dir = if bun_paths::is_absolute(custom_utf8.slice()) {
+                        custom_utf8.slice()
+                    } else {
+                        self.fs_ref()
+                            .abs_buf(&[custom_utf8.slice()], bufs!(custom_dir_path_abs))
+                    };
+                    match self.check_package_path(custom_dir, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -79,3 +79,55 @@ describe("require(specifier)", () => {
     });
   });
 });
+
+describe("require(specifier, { paths })", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = tempDirWithFiles("bun-test-require-paths", {
+      "package.json": JSON.stringify({ name: "require-paths-option" }),
+      "node_modules/installed-pkg/package.json": JSON.stringify({ name: "installed-pkg", main: "index.js" }),
+      "node_modules/installed-pkg/index.js": "module.exports = 'installed';",
+      "vendor/node_modules/vendored-pkg/package.json": JSON.stringify({ name: "vendored-pkg", main: "index.js" }),
+      "vendor/node_modules/vendored-pkg/index.js": "module.exports = 'from-vendor';",
+      "non-absolute.js": /* js */ `
+        const assert = require("node:assert");
+        const Module = require("node:module");
+        const request = "package-that-does-not-exist";
+        const pathsValues = [[2.2250738585072014e-308, -1000, Infinity], ["relative"], ["./relative"], [""]];
+        for (const paths of pathsValues) {
+          assert.throws(() => require.resolve(request, { paths }), { code: "MODULE_NOT_FOUND" });
+          assert.throws(() => require(request, { paths }), { code: "MODULE_NOT_FOUND" });
+          assert.throws(() => Module._resolveFilename(request, null, false, { paths }), { code: "MODULE_NOT_FOUND" });
+        }
+        console.log("ok");
+      `,
+      "relative.js": /* js */ `
+        const assert = require("node:assert");
+        const path = require("node:path");
+        const results = ["vendor", "./vendor", path.join(__dirname, "vendor")].map(entry =>
+          require.resolve("vendored-pkg", { paths: [entry] }),
+        );
+        assert.strictEqual(results[1], results[0]);
+        assert.strictEqual(results[2], results[0]);
+        assert(results[0].endsWith(path.join("vendor", "node_modules", "vendored-pkg", "index.js")), results[0]);
+        assert.strictEqual(require("vendored-pkg", { paths: ["vendor"] }), "from-vendor");
+        console.log("ok");
+      `,
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("throws MODULE_NOT_FOUND instead of crashing when paths entries are not absolute", () => {
+    const { stdout } = bunRun(path.join(dir, "non-absolute.js"));
+    expect(stdout).toBe("ok");
+  });
+
+  it("resolves relative paths entries against the current working directory", () => {
+    const { stdout } = bunRun(path.join(dir, "relative.js"));
+    expect(stdout).toBe("ok");
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a panic in the module resolver when the `paths` option of `require()`, `require.resolve()`, or `Module._resolveFilename()` contains an entry that is not an absolute path:

```js
require.resolve("anything", { paths: ["relative"] });
```

```
panic: cannot resolve DirInfo for non-absolute path: relative
```

Any non-absolute entry hits this: a relative directory name, an empty string, or a non-string value (the array elements are stringified, so `paths: [2.2250738585072014e-308]` becomes the "path" `"2.2250738585072014e-308"`, which is how the fuzzer found it). The assert is a plain `assert!`, so release builds abort too.

### How did you verify your code works?

The `custom_dir_paths` loop in `resolve_without_symlinks` handed the raw user string to `check_package_path`, which requires an absolute directory (`dir_info_cached` asserts it). That assert is a real invariant of the directory cache, so it stays. Instead, non-absolute entries are now joined against the top-level directory (cwd) before use. That is what Node does: `Module._nodeModulePaths` runs each `options.paths` entry through `path.resolve()`, so relative entries mean "relative to the current working directory". The sibling loop for relative specifiers already behaved this way via `abs_buf_checked`.

With this change, `require.resolve("pkg", { paths: ["vendor"] })` resolves through `$CWD/vendor/node_modules` like Node instead of panicking, and garbage entries produce a normal `MODULE_NOT_FOUND` error.

Added two tests to `test/js/bun/resolve/require.test.ts`. Both fail with the panic above on an unfixed build (checked against the release build via `USE_SYSTEM_BUN=1`) and pass with this change:

- non-absolute `paths` entries (numbers, `"relative"`, `"./relative"`, `""`) throw `MODULE_NOT_FOUND` across `require`, `require.resolve`, and `Module._resolveFilename`
- a relative `paths` entry resolves the same module as its absolute spelling
