### PR TITLE
resolver: fix panic on non-absolute require.resolve paths entries

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -376,6 +376,7 @@ pub struct Bufs {
     pub dir_info_uncached_path: PathBuffer,
     pub tsconfig_base_url: PathBuffer,
     pub relative_abs_path: PathBuffer,
+    pub custom_dir_path_abs: PathBuffer,
     pub load_as_file_or_directory_via_tsconfig_base_path: PathBuffer,
     pub node_modules_check: PathBuffer,
     pub field_abs_path: PathBuffer,
@@ -2097,12 +2098,16 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8_without_ref();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    // Node resolves each `paths` entry against cwd before walking
+                    // node_modules: "Guarantee that 'from' is absolute." in
+                    // Module._nodeModulePaths. `check_package_path` requires this.
+                    let Some(custom_abs) = self
+                        .fs_ref()
+                        .abs_buf_checked(&[custom_utf8.slice()], bufs!(custom_dir_path_abs))
+                    else {
+                        continue;
+                    };
+                    match self.check_package_path(custom_abs, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -203,6 +203,54 @@ describe.concurrent("node-module-module", () => {
   test("builtin resolution", () => {
     expect(require.resolve("fs")).toBe("fs");
     expect(require.resolve("node:fs")).toBe("node:fs");
+  });
+  // A relative `options.paths` entry must be resolved against cwd, like
+  // Module._nodeModulePaths -> path.resolve(from). It previously panicked
+  // with "cannot resolve DirInfo for non-absolute path".
+  test("require.resolve resolves relative `paths` entries against cwd", async () => {
+    using dir = tempDir("require-resolve-relative-paths", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0" }),
+      "rel/node_modules/pkg/package.json": JSON.stringify({ name: "pkg", version: "1.0.0", main: "index.js" }),
+      "rel/node_modules/pkg/index.js": "module.exports = 1;",
+    });
+    const code = /* js */ `
+      const path = require("path");
+      const resolved = require.resolve("pkg", { paths: ["rel"] });
+      console.log(path.relative(process.cwd(), resolved));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe(ospath("rel/node_modules/pkg/index.js"));
+    expect(exitCode).toBe(0);
+  });
+  test("require.resolve does not crash on non-string `paths` entries", async () => {
+    using dir = tempDir("require-resolve-nonstring-paths", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0" }),
+    });
+    const code = /* js */ `
+      function f2() { return 15; }
+      try {
+        require.resolve("pkg-that-does-not-exist", { paths: [9n, f2] });
+      } catch (e) {
+        console.log("threw");
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("threw");
+    expect(exitCode).toBe(0);
   });
   test("require cache node builtins specifier", () => {
     // as js builtin


### PR DESCRIPTION
### What

`require.resolve(id, { paths })` panicked whenever a `paths` entry was not an absolute directory, killing the process:

```js
require.resolve("pkg", { paths: ["relative/dir"] });
```

```
panic: cannot resolve DirInfo for non-absolute path: relative/dir
```

The same panic fires for non-string entries (a bigint, a function) because the binding stringifies them and the result is never absolute. Found by fuzzing.

### Why

The resolver's `custom_dir_paths` loop forwarded each user-provided entry to `check_package_path` as the source directory. `check_package_path` requires an absolute directory: it feeds `dir_info_cached`, which asserts on it.

Node resolves each entry against cwd first. `Module._nodeModulePaths` in `lib/internal/modules/cjs/loader.js` begins with:

```js
// Guarantee that 'from' is absolute.
from = path.resolve(from);
```

Bun never did that step.

### Fix

Join each `paths` entry against the top-level dir (cwd) with `abs_buf_checked` before calling `check_package_path`, using a dedicated scratch buffer so the slice survives the call. Already-absolute entries are unchanged by the join. The sibling `custom_dir_paths` site that feeds `check_relative_path` already joins against cwd internally, so it did not need a change.

With the fix Bun matches Node:

```
$ node -e 'console.log(require.resolve("pkg", { paths: ["rel"] }))'
/tmp/nodpos/rel/node_modules/pkg/index.js
$ bun  -e 'console.log(require.resolve("pkg", { paths: ["rel"] }))'
/tmp/nodpos/rel/node_modules/pkg/index.js
```

### Out of scope

Node also throws `ERR_INVALID_ARG_TYPE` for non-string `paths` entries on the bare-specifier path, and Bun still stringifies them. I left that alone on purpose: Node validates lazily for relative specifiers (`require.resolve("./x", { paths: ["/good", 9n] })` succeeds in Node when the first entry wins), so an eager type check here would reject input Node accepts. With this change those entries produce a normal resolution error instead of a crash. Happy to do the full validation as a follow-up.

### Test plan

Added two subprocess tests to `test/js/node/module/node-module-module.test.js`:

- a relative `paths` entry resolves against cwd and returns the expected absolute path, matching Node byte for byte
- non-string `paths` entries throw a catchable error instead of crashing the process

Both fail on the unfixed build (the child panics, stdout is empty, nonzero exit) and pass with the fix. `test/js/node/test/parallel/test-require-resolve.js` (the ported upstream suite, which covers absolute `paths` entries) and `test/js/node/module/module-resolve-filename-paths.test.js` still pass.
