### PR TITLE
Surface ENOMEM instead of aborting when a whole-file read cannot allocate st_size

### DIFF
--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -212,9 +212,22 @@ impl File {
     /// `size+16`.
     pub fn read_to_end_with_array_list(&self, list: &mut Vec<u8>, hint: SizeHint) -> Maybe<usize> {
         match hint {
-            SizeHint::ProbablySmall => list.reserve(64),
+            SizeHint::ProbablySmall => {
+                if list.try_reserve(64).is_err() {
+                    return Err(Error::oom());
+                }
+            }
             SizeHint::UnknownSize => {
-                list.reserve_exact((self.get_end_pos()? + 16).saturating_sub(list.len()));
+                // `st_size` is only a hint (sparse files, racing writers, /proc):
+                // reserve fallibly so an absurd size surfaces as ENOMEM to the
+                // caller instead of aborting the process in `handle_alloc_error`.
+                let want = self
+                    .get_end_pos()?
+                    .saturating_add(16)
+                    .saturating_sub(list.len());
+                if list.try_reserve_exact(want).is_err() {
+                    return Err(Error::oom());
+                }
             }
         }
         read_fill_vec(list, 16, |dst, off| {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4471,7 +4471,11 @@ fn read_fill_vec(
     let mut total: i64 = 0;
     loop {
         if buf.capacity() == buf.len() {
-            buf.reserve(grow_by);
+            // Fallible (amortized) growth: OOM propagates as ENOMEM instead of
+            // aborting, matching the fallible pre-reservation in the callers.
+            if buf.try_reserve(grow_by).is_err() {
+                return Err(Error::oom());
+            }
         }
         // SAFETY: `read_chunk` writes initialized bytes; we commit exactly what was written.
         let n = read_chunk(unsafe { bun_core::vec::spare_bytes_mut(buf) }, total)?;

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1,6 +1,17 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, bunRun, bunRunAsScript, bunTest, isLinux, isWindows, tempDirWithFiles } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  bunRun,
+  bunRunAsScript,
+  bunTest,
+  isASAN,
+  isDebug,
+  isLinux,
+  isWindows,
+  tempDirWithFiles,
+} from "harness";
 import path from "path";
 
 function bunRunWithoutTrim(file: string, env?: Record<string, string>) {
@@ -327,13 +338,15 @@ test(".env doesnt crash with 159 bytes", () => {
   );
 });
 
-test(".env with 50000 entries", () => {
-  const dir = tempDirWithFiles("dotenv-many-entries", {
-    ".env": new Array(50000)
-      .fill(null)
-      .map((_, i) => `TEST_VAR${i}=TEST_VAL${i}`)
-      .join("\n"),
-    "index.ts": /* ts */ `
+test(
+  ".env with 50000 entries",
+  () => {
+    const dir = tempDirWithFiles("dotenv-many-entries", {
+      ".env": new Array(50000)
+        .fill(null)
+        .map((_, i) => `TEST_VAR${i}=TEST_VAL${i}`)
+        .join("\n"),
+      "index.ts": /* ts */ `
       for (let i = 0; i < 50000; i++) {
         if(process.env['TEST_VAR' + i] !== 'TEST_VAL' + i) {
           throw new Error('TEST_VAR' + i + ' !== TEST_VAL' + i);
@@ -341,10 +354,14 @@ test(".env with 50000 entries", () => {
       }
       console.log('OK');
     `,
-  });
-  const { stdout } = bunRun(`${dir}/index.ts`);
-  expect(stdout).toBe("OK");
-});
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("OK");
+  },
+  // The spawned debug+ASAN child alone needs ~8s for this; the default 5s
+  // budget only fits release-ish builds.
+  isDebug ? 90_000 : 5_000,
+);
 
 test(".env space edgecase (issue #411)", () => {
   const dir = tempDirWithFiles("dotenv-issue-411", {
@@ -929,4 +946,35 @@ test.skipIf(!canUseRunuser)("process.env is preserved when cwd lacks read permis
     // Restore permissions so tempDir cleanup can remove the directory.
     fs.chmodSync(noreadDir, 0o755);
   }
+});
+
+// `st_size` is only a hint (sparse file, writer racing the loader): the env
+// loader's whole-file read used to `reserve_exact` it and abort the process in
+// `handle_alloc_error` before any user code ran. It must surface as a
+// recoverable error. ASAN-only: ASAN rejects the 1 TiB request deterministically.
+test.skipIf(!isASAN || isWindows)(".env with a huge lying st_size does not abort the process", async () => {
+  const dir = tempDirWithFiles("dotenv-huge-sparse", {
+    ".env": "",
+    "app.js": `console.log("reached user code");`,
+  });
+  // 1 TiB sparse `.env`: fstat reports 2**40 bytes, nothing is actually stored.
+  fs.truncateSync(path.join(dir, ".env"), 2 ** 40);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "app.js"],
+    cwd: dir,
+    env: {
+      ...bunEnv,
+      // Let ASAN return null for the oversized request (instead of hard-erroring
+      // itself) so Bun's own allocation-failure path is what gets exercised.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Unfixed, startup died in `handle_alloc_error` ("memory allocation of
+  // 1099511627792 bytes failed", SIGABRT) without ever reaching app.js.
+  expect({ stdout, exitCode }).toEqual({ stdout: "reached user code\n", exitCode: 0 });
 });


### PR DESCRIPTION
### Problem

`bun_sys::File::read_to_end` presizes its destination with `list.reserve_exact(get_end_pos()? + 16)` (`src/sys/file.rs:217`), where `get_end_pos()` is a fresh `fstat`. `st_size` is only a hint: sparse files, files truncated or grown by a racing writer, and unusual filesystems can report sizes that have nothing to do with what is readable or allocatable. `reserve_exact` is infallible, so when the allocator refuses the request, Rust's `handle_alloc_error` aborts the whole process. No JS code can catch it.

The cheapest reproduction is the automatic `.env` loader, which runs before any user code:

```sh
truncate -s 1T .env   # sparse: 0 bytes of real data
bun app.js
# memory allocation of 1099511627792 bytes failed
# SIGABRT (exit 134), app.js never runs
```

1099511627792 is exactly `st_size + 16`. Verified on bun 1.4.0 (release, under an 8 GB address space limit) and on a debug ASAN build (ASAN caps a single request at 1 TiB). Without a memory limit the release build instead commits the lying size and reads sparse zeros until the OOM killer ends it, still before user code.

The `.env` loader has an explicit branch that treats `ENOMEM` while reading an env file as recoverable (`src/dotenv/env_loader.rs`, `read_env_file_contents`), but it was unreachable: the abort happened in the reservation, before `read()` could return anything. The same `read_to_end` is reached from `bunx`'s `package.json` read, `bun pack`, the lockfile reader, the standalone module graph, and `Bun.Image(path)`, where a second `fstat` inside `read_to_end` can also disagree with the `st_size` the caller just validated against `MAX_INPUT_FILE_BYTES`.

### Fix

Treat the fstat-derived size as a hint and make every reservation in the read path fallible:

- `read_to_end_with_array_list`: `try_reserve_exact` the saturating `st_size + 16` hint and return the existing `bun_sys::Error::oom()` (ENOMEM) on failure.
- `read_fill_vec`: the incremental `reserve(grow_by)` in the read loop becomes `try_reserve` with the same error.

No signatures change and every caller already handles `Err` from these functions (the `fstat` itself could fail before). With the fix, the `.env` case takes the already-designed recoverable path and startup reaches user code; the other callers report a normal `ENOMEM` error.

Files whose content really is that large still cost that much memory to read, same as `node --env-file`; this change only guarantees that allocation failure surfaces as `ENOMEM` instead of `SIGABRT`.

### Tests

`test/cli/run/env.test.ts`:

- New: `.env with a huge lying st_size does not abort the process`. Creates a 1 TiB sparse `.env`, runs `bun app.js`, asserts user code runs and the process exits 0. Gated to ASAN builds (`skipIf(!isASAN || isWindows)`): ASAN deterministically refuses the 1 TiB request (`allocator_may_return_null=1`), so the test does not depend on machine memory. On the unfixed build the child dies with exit 134 and empty stdout; on the fixed build it prints `reached user code` and exits 0. A release build would treat the sparse file as a genuinely huge one, so there is nothing deterministic to assert there.
- Existing `.env with 50000 entries` now has an explicit debug-build timeout. The spawned debug ASAN child alone takes about 8 seconds on a slower machine (measured the same, 8.2s, with and without this change), which cannot fit the default 5s budget. Workload and assertions are unchanged.

<details>
<summary>fail before / pass after</summary>

```
# src stashed (unfixed), bun bd test test/cli/run/env.test.ts -t "huge lying"
  {
-   "exitCode": 0,
-   "stdout": "reached user code\n",
+   "exitCode": 134,
+   "stdout": "",
  }
(fail) .env with a huge lying st_size does not abort the process

# with the fix
 81 pass, 0 fail  (full test/cli/run/env.test.ts)
```

</details>
