### PR TITLE
sql(mysql): fix caching_sha2_password fast authentication

### DIFF
--- a/src/sql/mysql/protocol/Auth.rs
+++ b/src/sql/mysql/protocol/Auth.rs
@@ -82,10 +82,12 @@ pub mod caching_sha2_password {
         // SAFETY: engine is null (default).
         unsafe { SHA256::hash(&digest1, &mut digest2, core::ptr::null_mut()) };
 
-        // SHA256(SHA256(SHA256(password)) + nonce)
-        let mut combined = vec![0u8; nonce.len() + digest2.len()];
-        combined[0..nonce.len()].copy_from_slice(nonce);
-        combined[nonce.len()..].copy_from_slice(&digest2);
+        // SHA256(SHA256(SHA256(password)) + nonce): the double hash comes FIRST.
+        // mysql_native_password concatenates the other way around; the server's
+        // Generate_scramble (sha2_password_common.cc) updates digest_stage2 then m_rnd.
+        let mut combined = vec![0u8; digest2.len() + nonce.len()];
+        combined[0..digest2.len()].copy_from_slice(&digest2);
+        combined[digest2.len()..].copy_from_slice(nonce);
         // SAFETY: engine is null (default).
         unsafe { SHA256::hash(&combined, &mut digest3, core::ptr::null_mut()) };
         // `defer bun.default_allocator.free(combined)` → Vec drops at scope exit

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -816,12 +816,10 @@ impl MySQLConnection {
 
                             match response.status {
                                 Auth::caching_sha2_password::FastAuthStatus::SUCCESS => {
-                                    debug!("success auth");
-                                    self.set_status(ConnectionState::Connected);
-
-                                    self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
-                                    self.queue.mark_as_ready_for_query();
-                                    self.advance();
+                                    // fast_auth_success only acknowledges the cached scramble; the
+                                    // server always follows it with the OK/ERR packet that concludes
+                                    // auth, so stay in Authenticating and let the arms above consume it.
+                                    debug!("fast auth success, awaiting OK");
                                 }
                                 Auth::caching_sha2_password::FastAuthStatus::CONTINUE_AUTH => {
                                     bun_core::scoped_log!(MySQLConnection, "continue auth");

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -69,14 +69,9 @@ describeWithContainer(
       await sql.end();
     });
 
-    // MySQL 8's steady state for a passworded caching_sha2_password user: any
-    // successful full authentication warms the server's per-user auth cache, and
-    // every later connection takes the fast path (AuthMoreData 0x03
-    // fast_auth_success followed by the OK packet that concludes authentication).
-    // The client used to enter the command phase on the 0x03 marker alone, so the
-    // trailing OK was handed to the command handler and the second connection
-    // failed with ERR_MYSQL_UNEXPECTED_PACKET (or, if a query was already in
-    // flight, silently became that query's empty result).
+    // A passworded caching_sha2_password user's second and later connections take
+    // the fast path: AuthMoreData(0x03 fast_auth_success) followed by the OK packet
+    // that concludes authentication. Any prior full auth warms the server's cache.
     test("caching_sha2_password fast auth (warm server-side auth cache)", async () => {
       {
         await using admin = new SQL({ url: getUrl(), max: 1 });
@@ -93,33 +88,18 @@ describeWithContainer(
         expect(await cold`select 1 as x`).toEqual([{ x: 1 }]);
       }
 
-      // Connection #2: warm cache -> the server takes the fast path.
-      // allowPublicKeyRetrieval stays enabled only so that a concurrent test's
-      // FLUSH PRIVILEGES (which drops the whole auth cache) degrades this to
-      // full auth instead of flaking; the fast path is the overwhelmingly
-      // common outcome and is what the unfixed client fails on.
+      // Connection #2: warm cache -> the server takes the fast path. Keep
+      // allowPublicKeyRetrieval on so a concurrent test's FLUSH PRIVILEGES (which
+      // drops the whole auth cache) degrades this to full auth instead of flaking.
       await using fast = new SQL({ url: userUrl, max: 1, allowPublicKeyRetrieval: true });
       expect(await fast`select 'REAL-ROW' as v`).toEqual([{ v: "REAL-ROW" }]);
     });
   },
 );
 
-// ---------------------------------------------------------------------------
-// caching_sha2_password fast authentication, byte-scripted.
-//
-// Covers the same exchange as the container test above, but against a scripted
-// server so that (a) it runs without Docker and (b) both TCP framings of the
-// AuthMoreData(0x03) + OK pair can be forced: a real server coalesces or splits
-// them at its own discretion. All frames come from wire-frames.ts.
-//
+// The caching_sha2_password "Fast path succeeds" exchange, byte-scripted (rather
+// than containerized) so both TCP framings of the AuthMoreData(0x03) + OK pair can be forced:
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html
-// "Fast path succeeds": the server responds to HandshakeResponse41 with an
-// AuthMoreData containing fast_auth_success (0x03), then sends an OK_Packet to
-// conclude authentication. Bun used to enter the command phase on the 0x03
-// marker alone; the trailing OK then either killed the connection
-// (ERR_MYSQL_UNEXPECTED_PACKET, no query in flight yet) or was mis-attributed
-// to the first query, which resolved with [] instead of its real rows.
-// ---------------------------------------------------------------------------
 
 const COM_QUERY = 0x03;
 const MYSQL_TYPE_VAR_STRING = 0xfd;
@@ -168,8 +148,8 @@ test.each(["split", "coalesced"] as const)(
         rows => ({ rows }),
         (e: { code?: string }) => ({ code: e?.code ?? String(e) }),
       );
-      // `commands` proves the client did not send COM_QUERY until authentication
-      // actually completed (before the fix it never got to send one at all).
+      // `commands` proves the client only sends COM_QUERY once authentication
+      // has actually completed.
       expect({ result, commands }).toEqual({
         result: { rows: [{ v: "REAL-ROW" }] },
         commands: [COM_QUERY],

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -1,6 +1,15 @@
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
+import {
+  listeningServer,
+  MYSQL_FAST_AUTH_SUCCESS,
+  mysqlAuthMoreData,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  mysqlTextResultSet,
+} from "./wire-frames";
 
 describeWithContainer(
   "mysql",
@@ -59,5 +68,114 @@ describeWithContainer(
       expect(result).toEqual([{ x: 1 }]);
       await sql.end();
     });
+
+    // MySQL 8's steady state for a passworded caching_sha2_password user: any
+    // successful full authentication warms the server's per-user auth cache, and
+    // every later connection takes the fast path (AuthMoreData 0x03
+    // fast_auth_success followed by the OK packet that concludes authentication).
+    // The client used to enter the command phase on the 0x03 marker alone, so the
+    // trailing OK was handed to the command handler and the second connection
+    // failed with ERR_MYSQL_UNEXPECTED_PACKET (or, if a query was already in
+    // flight, silently became that query's empty result).
+    test("caching_sha2_password fast auth (warm server-side auth cache)", async () => {
+      {
+        await using admin = new SQL({ url: getUrl(), max: 1 });
+        await admin`DROP USER IF EXISTS fastauth@'%';`.simple();
+        await admin`CREATE USER fastauth@'%' IDENTIFIED WITH caching_sha2_password BY 'bunbun';
+              GRANT ALL PRIVILEGES ON bun_sql_test.* TO fastauth@'%';`.simple();
+      }
+      const userUrl = `mysql://fastauth:bunbun@${container.host}:${container.port}/bun_sql_test`;
+
+      // Connection #1: cold cache -> full authentication (RSA public-key
+      // exchange). Its success is what warms the auth cache for `fastauth`.
+      {
+        await using cold = new SQL({ url: userUrl, max: 1, allowPublicKeyRetrieval: true });
+        expect(await cold`select 1 as x`).toEqual([{ x: 1 }]);
+      }
+
+      // Connection #2: warm cache -> the server takes the fast path.
+      // allowPublicKeyRetrieval stays enabled only so that a concurrent test's
+      // FLUSH PRIVILEGES (which drops the whole auth cache) degrades this to
+      // full auth instead of flaking; the fast path is the overwhelmingly
+      // common outcome and is what the unfixed client fails on.
+      await using fast = new SQL({ url: userUrl, max: 1, allowPublicKeyRetrieval: true });
+      expect(await fast`select 'REAL-ROW' as v`).toEqual([{ v: "REAL-ROW" }]);
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// caching_sha2_password fast authentication, byte-scripted.
+//
+// Covers the same exchange as the container test above, but against a scripted
+// server so that (a) it runs without Docker and (b) both TCP framings of the
+// AuthMoreData(0x03) + OK pair can be forced: a real server coalesces or splits
+// them at its own discretion. All frames come from wire-frames.ts.
+//
+// https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html
+// "Fast path succeeds": the server responds to HandshakeResponse41 with an
+// AuthMoreData containing fast_auth_success (0x03), then sends an OK_Packet to
+// conclude authentication. Bun used to enter the command phase on the 0x03
+// marker alone; the trailing OK then either killed the connection
+// (ERR_MYSQL_UNEXPECTED_PACKET, no query in flight yet) or was mis-attributed
+// to the first query, which resolved with [] instead of its real rows.
+// ---------------------------------------------------------------------------
+
+const COM_QUERY = 0x03;
+const MYSQL_TYPE_VAR_STRING = 0xfd;
+
+test.each(["split", "coalesced"] as const)(
+  "caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (%s framing)",
+  async framing => {
+    const commands: number[] = [];
+    const { server, port } = await listeningServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let authed = false;
+      socket.write(mysqlHandshakeV10({ authPlugin: "caching_sha2_password" }));
+      socket.on("data", chunk => {
+        buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+          if (!authed) {
+            // HandshakeResponse41 -> warm auth cache: fast_auth_success then OK.
+            authed = true;
+            const fastAuthSuccess = mysqlAuthMoreData(seq + 1, Buffer.from([MYSQL_FAST_AUTH_SUCCESS]));
+            const authOk = mysqlOkPacket(seq + 2);
+            if (framing === "coalesced") {
+              socket.write(Buffer.concat([fastAuthSuccess, authOk]));
+            } else {
+              socket.write(fastAuthSuccess);
+              setImmediate(() => socket.write(authOk));
+            }
+            return;
+          }
+          commands.push(payload[0]);
+          if (payload[0] === COM_QUERY) {
+            socket.write(mysqlTextResultSet(1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["REAL-ROW"]]));
+          } else {
+            // COM_QUIT from `await using sql` below: a real server just closes.
+            socket.end();
+          }
+        });
+      });
+      socket.on("error", () => {});
+    });
+
+    try {
+      await using sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
+      // .simple() -> COM_QUERY / text protocol, which is exactly the result set
+      // the scripted server answers with. Settle to a value so a rejection shows
+      // up in the toEqual diff below instead of failing the test opaquely.
+      const result = await sql`SELECT 'REAL-ROW' AS v`.simple().then(
+        rows => ({ rows }),
+        (e: { code?: string }) => ({ code: e?.code ?? String(e) }),
+      );
+      // `commands` proves the client did not send COM_QUERY until authentication
+      // actually completed (before the fix it never got to send one at all).
+      expect({ result, commands }).toEqual({
+        result: { rows: [{ v: "REAL-ROW" }] },
+        commands: [COM_QUERY],
+      });
+    } finally {
+      server.close();
+    }
   },
 );

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -1,12 +1,16 @@
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
+import { createHash } from "node:crypto";
 import {
   listeningServer,
   MYSQL_FAST_AUTH_SUCCESS,
+  MYSQL_MOCK_AUTH_DATA_PART_1,
+  MYSQL_MOCK_AUTH_DATA_PART_2,
   mysqlAuthMoreData,
   mysqlHandshakeV10,
   mysqlOkPacket,
+  mysqlParseHandshakeResponse41,
   mysqlReadPackets,
   mysqlTextResultSet,
 } from "./wire-frames";
@@ -69,9 +73,9 @@ describeWithContainer(
       await sql.end();
     });
 
-    // A passworded caching_sha2_password user's second and later connections take
-    // the fast path: AuthMoreData(0x03 fast_auth_success) followed by the OK packet
-    // that concludes authentication. Any prior full auth warms the server's cache.
+    // A passworded caching_sha2_password user's second and later connections take the
+    // fast path (AuthMoreData 0x03 then the concluding OK) once the server accepts the
+    // client's scramble; any prior successful full auth is what warms the server cache.
     test("caching_sha2_password fast auth (warm server-side auth cache)", async () => {
       {
         await using admin = new SQL({ url: getUrl(), max: 1 });
@@ -88,17 +92,17 @@ describeWithContainer(
         expect(await cold`select 1 as x`).toEqual([{ x: 1 }]);
       }
 
-      // Connection #2: warm cache -> the server takes the fast path. Keep
-      // allowPublicKeyRetrieval on so a concurrent test's FLUSH PRIVILEGES (which
-      // drops the whole auth cache) degrades this to full auth instead of flaking.
+      // Connection #2: warm cache -> the server should take the fast path. Until the
+      // 21-byte-nonce bug (#26195 / #28161) also lands, it degrades to full auth via
+      // allowPublicKeyRetrieval. The scripted tests below carry the fast-auth proof.
       await using fast = new SQL({ url: userUrl, max: 1, allowPublicKeyRetrieval: true });
       expect(await fast`select 'REAL-ROW' as v`).toEqual([{ v: "REAL-ROW" }]);
     });
   },
 );
 
-// The caching_sha2_password "Fast path succeeds" exchange, byte-scripted (rather
-// than containerized) so both TCP framings of the AuthMoreData(0x03) + OK pair can be forced:
+// The caching_sha2_password "Fast path succeeds" exchange, byte-scripted so the scramble
+// bytes can be read back off the wire and both TCP framings of AuthMoreData(0x03) + OK forced:
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html
 
 const COM_QUERY = 0x03;
@@ -159,3 +163,58 @@ test.each(["split", "coalesced"] as const)(
     }
   },
 );
+
+// The scramble is XOR(SHA256(pw), SHA256(SHA256(SHA256(pw)) || nonce)) with the double
+// hash hashed FIRST: MySQL's Generate_scramble, mysql2, go-sql-driver, and Connector/J all
+// agree. mysql_native_password concatenates the other way around, which is NOT correct here.
+test("caching_sha2_password scramble hashes the double-SHA256 before the nonce", async () => {
+  const password = "pw";
+  const scrambleSent = Promise.withResolvers<Buffer>();
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10({ authPlugin: "caching_sha2_password" }));
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          try {
+            scrambleSent.resolve(mysqlParseHandshakeResponse41(payload).authResponse);
+          } catch (e) {
+            scrambleSent.reject(e);
+          }
+          // Accept the auth so the query below completes and `await using sql` can
+          // tear down over the normal COM_QUIT path; the scramble is the subject.
+          socket.write(mysqlOkPacket(seq + 1));
+        } else if (payload[0] === COM_QUERY) {
+          socket.write(mysqlTextResultSet(1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["REAL-ROW"]]));
+        } else {
+          socket.end();
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({ url: `mysql://root:${password}@127.0.0.1:${port}/db`, max: 1 });
+    const [sent, rows] = await Promise.all([scrambleSent.promise, sql`SELECT 'REAL-ROW' AS v`.simple()]);
+
+    const sha256 = (b: Buffer) => createHash("sha256").update(b).digest();
+    const digest1 = sha256(Buffer.from(password));
+    const digest2 = sha256(digest1);
+    const expected = (nonce: Buffer) => {
+      const digest3 = sha256(Buffer.concat([digest2, nonce]));
+      return Buffer.from(digest1.map((byte, i) => byte ^ digest3[i])).toString("hex");
+    };
+    // The spec nonce is 20 bytes (part1 + the first 12 bytes of part2). Bun currently
+    // also keeps part2's trailing filler byte (#26195, fixed separately in #28161), so
+    // accept either nonce length: this test pins only the concatenation order.
+    const nonce20 = Buffer.concat([MYSQL_MOCK_AUTH_DATA_PART_1, MYSQL_MOCK_AUTH_DATA_PART_2.subarray(0, 12)]);
+    const nonce21 = Buffer.concat([MYSQL_MOCK_AUTH_DATA_PART_1, MYSQL_MOCK_AUTH_DATA_PART_2]);
+    expect([expected(nonce20), expected(nonce21)]).toContain(sent.toString("hex"));
+    expect(rows).toEqual([{ v: "REAL-ROW" }]);
+  } finally {
+    server.close();
+  }
+});

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -333,9 +333,8 @@ export function mysqlTextResultSetRow(seq: number, cols: (string | Buffer)[]): B
 }
 
 // MySQL Textual Resultset — page_protocol_com_query_response_text_resultset.html, in the
-// CLIENT_DEPRECATE_EOF framing mysqlHandshakeV10's default capabilities negotiate:
-//   lenenc(column_count) packet, one ColumnDefinition41 per column, one row packet per row,
-//   then an OK packet with the 0xFE header as the terminator (no intermediate EOF).
+// CLIENT_DEPRECATE_EOF framing: lenenc(column_count) packet, one ColumnDefinition41 per
+// column, one row packet per row, then an OK packet with the 0xFE header as the terminator.
 export function mysqlTextResultSet(
   startSeq: number,
   columns: { name: string; type: number }[],

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -217,6 +217,12 @@ export function mysqlRawPacket(seq: number, payload: Buffer): Buffer {
   return Buffer.concat([header, payload]);
 }
 
+// The auth-plugin-data (scramble seed) mysqlHandshakeV10 advertises. The 20-byte
+// nonce every auth plugin scrambles against is PART_1 + the first 12 bytes of
+// PART_2; PART_2's 13th byte is the protocol's trailing NUL filler, not nonce data.
+export const MYSQL_MOCK_AUTH_DATA_PART_1: Buffer = Buffer.alloc(8, 0x61);
+export const MYSQL_MOCK_AUTH_DATA_PART_2: Buffer = Buffer.concat([Buffer.alloc(12, 0x62), Buffer.from([0])]);
+
 // MySQL Protocol::HandshakeV10 — page_protocol_connection_phase_packets_protocol_handshake_v10.html
 // Int<1>(10) NulString(server_version) Int<4>(thread_id) String<8>(auth1) Int<1>(0) Int<2>(cap_lo)
 // Int<1>(charset) Int<2>(status) Int<2>(cap_hi) Int<1>(auth_len) String<10>(reserved) String<13>(auth2) NulString(plugin)
@@ -224,14 +230,11 @@ export function mysqlHandshakeV10(
   opts: { authPlugin?: string; capabilities?: number; serverVersion?: string } = {},
 ): Buffer {
   const caps = opts.capabilities ?? MYSQL_DEFAULT_CAPABILITIES;
-  const authData1 = Buffer.alloc(8, 0x61);
-  const authData2 = Buffer.alloc(13, 0x62);
-  authData2[12] = 0;
   const payload = Buffer.concat([
     Buffer.from([10]),
     Buffer.from(`${opts.serverVersion ?? "mock-5.7.0"}\0`),
     Buffer.from([1, 0, 0, 0]), // thread_id
-    authData1,
+    MYSQL_MOCK_AUTH_DATA_PART_1,
     Buffer.from([0]), // filler
     Buffer.from([caps & 0xff, (caps >> 8) & 0xff]), // capability_flags_1
     Buffer.from([0x2d]), // character_set (utf8mb4_general_ci)
@@ -239,7 +242,7 @@ export function mysqlHandshakeV10(
     Buffer.from([(caps >> 16) & 0xff, (caps >>> 24) & 0xff]), // capability_flags_2
     Buffer.from([21]), // auth_plugin_data_len
     Buffer.alloc(10, 0), // reserved
-    authData2,
+    MYSQL_MOCK_AUTH_DATA_PART_2,
     Buffer.from(`${opts.authPlugin ?? "mysql_native_password"}\0`),
   ]);
   return mysqlRawPacket(0, payload);
@@ -284,6 +287,32 @@ export function mysqlLenencInt(n: number | bigint): Buffer {
 export function mysqlLenencStr(s: string | Buffer): Buffer {
   const buf = typeof s === "string" ? Buffer.from(s, "utf-8") : s;
   return Buffer.concat([mysqlLenencInt(buf.length), buf]);
+}
+
+// Decode a length-encoded integer at `offset` (inverse of mysqlLenencInt); returns the value and the encoded width.
+export function mysqlReadLenencInt(buf: Buffer, offset: number): { value: number; width: number } {
+  const first = buf[offset];
+  if (first < 0xfb) return { value: first, width: 1 };
+  if (first === 0xfc) return { value: buf.readUInt16LE(offset + 1), width: 3 };
+  if (first === 0xfd) return { value: buf.readUIntLE(offset + 1, 3), width: 4 };
+  if (first === 0xfe) return { value: Number(buf.readBigUInt64LE(offset + 1)), width: 9 };
+  throw new Error(`0x${first.toString(16)} is not a lenenc-int prefix`);
+}
+
+// MySQL Protocol::HandshakeResponse41 — page_protocol_connection_phase_packets_protocol_handshake_response.html:
+//   Int<4>(client_flag) Int<4>(max_packet) Int<1>(charset) String<23>(filler) NulString(username)
+//   then the auth_response as a string<lenenc> (CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA) or Int<1>-prefixed string.
+export function mysqlParseHandshakeResponse41(payload: Buffer): { username: string; authResponse: Buffer } {
+  let offset = 4 + 4 + 1 + 23;
+  const usernameEnd = payload.indexOf(0, offset);
+  if (usernameEnd < 0) throw new Error("HandshakeResponse41: unterminated username");
+  const username = payload.subarray(offset, usernameEnd).toString("utf-8");
+  offset = usernameEnd + 1;
+  // MYSQL_DEFAULT_CAPABILITIES always includes CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA, and for the
+  // <=250-byte responses every plugin produces, the lenenc and Int<1>-length encodings are identical.
+  const { value: authLen, width } = mysqlReadLenencInt(payload, offset);
+  offset += width;
+  return { username, authResponse: payload.subarray(offset, offset + authLen) };
 }
 
 // MySQL Protocol::ColumnDefinition41 — page_protocol_com_query_response_text_resultset_column_definition.html:

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -245,10 +245,21 @@ export function mysqlHandshakeV10(
   return mysqlRawPacket(0, payload);
 }
 
-// MySQL Protocol::OK_Packet — page_protocol_basic_ok_packet.html: Int<1>(0x00) lenenc(affected_rows) lenenc(last_insert_id) Int<2>(status) Int<2>(warnings)
-export function mysqlOkPacket(seq: number): Buffer {
-  return mysqlRawPacket(seq, Buffer.from([0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+// MySQL Protocol::OK_Packet — page_protocol_basic_ok_packet.html: Int<1>(header) lenenc(affected_rows) lenenc(last_insert_id) Int<2>(status) Int<2>(warnings)
+// The header is 0x00, except for the CLIENT_DEPRECATE_EOF result-set terminator, which is an OK packet with a 0xFE header.
+export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00): Buffer {
+  return mysqlRawPacket(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
 }
+
+// MySQL Protocol::AuthMoreData — page_protocol_connection_phase_packets_protocol_auth_more_data.html:
+//   Int<1>(0x01) String<EOF>(plugin-specific payload)
+export function mysqlAuthMoreData(seq: number, data: Buffer): Buffer {
+  return mysqlRawPacket(seq, Buffer.concat([Buffer.from([0x01]), data]));
+}
+
+// caching_sha2_password fast_auth_success marker carried in an AuthMoreData payload —
+// page_caching_sha2_authentication_exchanges.html (its sibling, 0x04, is perform_full_authentication).
+export const MYSQL_FAST_AUTH_SUCCESS = 0x03;
 
 // MySQL Protocol::AuthSwitchRequest — page_protocol_connection_phase_packets_protocol_auth_switch_request.html:
 //   Int<1>(0xfe) NulString(plugin_name) String<EOF>(plugin_provided_data)
@@ -313,6 +324,29 @@ export function mysqlColumnDefinition(
       fixed,
     ]),
   );
+}
+
+// MySQL text-protocol resultset row — page_protocol_com_query_response_text_resultset_row.html:
+//   one string<lenenc> per column. (SQL NULL is the single byte 0xfb; not needed by any mock yet.)
+export function mysqlTextResultSetRow(seq: number, cols: (string | Buffer)[]): Buffer {
+  return mysqlRawPacket(seq, Buffer.concat(cols.map(c => mysqlLenencStr(c))));
+}
+
+// MySQL Textual Resultset — page_protocol_com_query_response_text_resultset.html, in the
+// CLIENT_DEPRECATE_EOF framing mysqlHandshakeV10's default capabilities negotiate:
+//   lenenc(column_count) packet, one ColumnDefinition41 per column, one row packet per row,
+//   then an OK packet with the 0xFE header as the terminator (no intermediate EOF).
+export function mysqlTextResultSet(
+  startSeq: number,
+  columns: { name: string; type: number }[],
+  rows: string[][],
+): Buffer {
+  let seq = startSeq;
+  const parts: Buffer[] = [mysqlRawPacket(seq++, mysqlLenencInt(columns.length))];
+  for (const column of columns) parts.push(mysqlColumnDefinition(seq++, column));
+  for (const row of rows) parts.push(mysqlTextResultSetRow(seq++, row));
+  parts.push(mysqlOkPacket(seq, 0xfe));
+  return Buffer.concat(parts);
 }
 
 // MySQL COM_STMT_PREPARE_OK — page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response_ok:


### PR DESCRIPTION
### What does this PR do?

Fixes two bugs in MySQL 8's `caching_sha2_password` fast authentication, the exchange a passworded user's second and later connections take once the server's auth cache is warm.

**1. The scramble concatenated its operands in the wrong order** (`src/sql/mysql/protocol/Auth.rs`).

The client proves cache membership by sending `XOR(SHA256(password), SHA256(SHA256(SHA256(password)) || nonce))`. Bun hashed `SHA256(nonce || SHA256(SHA256(password)))` instead, likely copied from `mysql_native_password`, which genuinely puts the nonce first. MySQL's own `Generate_scramble` (`sha2_password_common.cc`), mysql2, go-sql-driver/mysql, Connector/J, and Connector/Python all hash the double SHA-256 first, as did the comment on the line itself.

Because the scramble never matched, a real MySQL 8 with a warm cache rejected every fast-auth attempt and fell back to `perform_full_authentication` (0x04) instead of answering `fast_auth_success` (0x03). So the fast path was dead code: every Bun connection to MySQL 8 did the slow full authentication (RSA key exchange or plaintext over TLS), warm cache or not. Credit to the review below for catching this.

**2. The fast-auth success marker was treated as the end of authentication** (`src/sql_jsc/mysql/MySQLConnection.rs`).

Per the ["Fast path succeeds" exchange](https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html), the server answers the handshake response with an `AuthMoreData` packet carrying `fast_auth_success` (0x03) and then sends the `OK` packet that actually concludes authentication. `handle_auth` entered the command phase on the 0x03 marker alone, so that trailing OK was routed to `handle_command`: with no query in flight it killed the connection with `ERR_MYSQL_UNEXPECTED_PACKET`, and with one racing ahead it became that query's (empty) result.

These two have to land together. Fixing only the scramble makes the 0x03 path reachable and turns the second bug into a regression that breaks every warm-cache connection; fixing only the 0x03 handling leaves it on a path the scramble bug keeps unreachable.

### Deliberately excluded: the nonce length

`auth_data` also keeps the handshake's trailing filler byte, so the nonce Bun scrambles against is 21 bytes where the server uses 20. That is a third defect in the same path, but it is #26195 with an open fix in #28161, so it is not duplicated here. Until #28161 also lands, a real server still rejects the (now correctly ordered) scramble and falls back to full authentication, which is exactly today's behavior and is harmless.

### Reproduction

Scripted server replaying the warm-cache exchange (handshake advertising `caching_sha2_password`, then `AuthMoreData(0x03)` followed by `OK`, then answering `COM_QUERY` with a one-row result set):

```ts
const sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
const rows = await sql`SELECT 'REAL-ROW' AS v`.simple();
// expected: [{ v: "REAL-ROW" }]
// before:   rejects with ERR_MYSQL_UNEXPECTED_PACKET (the server never even receives COM_QUERY)
```

Reproduces on 1.4.0 and current main for both TCP framings (marker and OK in separate segments, or coalesced into one). The scramble bug reproduces by reading the `auth_response` bytes off the `HandshakeResponse41` the client sends and comparing them to the spec computation.

### Tests

All in `test/js/sql/sql-mysql.auth.test.ts`; every frame comes from `test/js/sql/wire-frames.ts`.

- Scripted server, both TCP framings of the `0x03` + `OK` pair: the query must return its real rows, and `COM_QUERY` must only be sent once authentication has completed.
- Scripted server reading the `HandshakeResponse41` off the wire: the scramble must be `XOR(SHA256(pw), SHA256(SHA256(SHA256(pw)) || nonce))`. The assertion accepts both the 20- and 21-byte nonce so that it pins the concatenation order and keeps passing once #28161 lands.
- Container suite: creates a `caching_sha2_password` user, connects once with full auth to warm the server's cache, then reconnects and queries. This becomes fully load-bearing for the fast path once #28161 also lands; until then it degrades to full authentication.
- Helpers added to `wire-frames.ts`: `mysqlAuthMoreData`, `mysqlParseHandshakeResponse41`, `mysqlReadLenencInt`, `mysqlTextResultSet`/`Row`, and an optional `0xFE` header on `mysqlOkPacket`.

```
bun bd test test/js/sql/sql-mysql.auth.test.ts
3 pass, 0 fail
```

### Correction on related issues

An earlier revision of this description linked #27102 and #26235 as likely explained by the 0x03 bug. That was wrong: because of the scramble bug above, the 0x03 path has never been reachable against a real server, so neither issue can have been caused by it. Both links are withdrawn.
