### PR TITLE
install: honor --recursive and --filter in non-interactive bun update

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -406,6 +406,11 @@ pub struct PackageManager {
     // (catalog name, dependency name) -> original version literal
     pub updating_catalogs: Vec<CatalogUpdateInfo>,
 
+    // When `bun update` is run with `--recursive` or `--filter`, this holds the
+    // name hashes of the workspaces whose dependencies should be updated. `None`
+    // means the default behavior: only the current (root/cwd) workspace updates.
+    pub(crate) update_workspace_name_hashes: Option<Box<[PackageNameHash]>>,
+
     pub(crate) patched_dependencies_to_remove:
         ArrayHashMap<PackageNameAndVersionHash, () /* , ArrayIdentityContext::U64, false */>,
 
@@ -1954,6 +1959,7 @@ pub fn init(
         wr!(any_failed_to_install, false);
         wr!(updating_packages, StringArrayHashMap::default());
         wr!(updating_catalogs, Vec::new());
+        wr!(update_workspace_name_hashes, None);
         wr!(patched_dependencies_to_remove, ArrayHashMap::default());
         wr!(last_reported_slow_lifecycle_script_at, 0);
         wr!(cached_tick_for_slow_lifecycle_script_logging, 0);
@@ -2392,6 +2398,7 @@ fn init_with_runtime_once(
         );
         wr!(updating_packages, StringArrayHashMap::default());
         wr!(updating_catalogs, Vec::new());
+        wr!(update_workspace_name_hashes, None);
         wr!(patched_dependencies_to_remove, ArrayHashMap::default());
         wr!(last_reported_slow_lifecycle_script_at, 0);
         wr!(cached_tick_for_slow_lifecycle_script_logging, 0);

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -242,10 +242,9 @@ pub fn edit_trusted_dependencies(
 /// versions.
 pub(crate) fn edit_update_no_args(
     manager: &mut PackageManager,
-    // Per-workspace scratch so each workspace's original version literals stay
-    // separate (two workspaces can pin the same dependency differently). The
-    // root/cwd passes `manager.updating_packages`; fanned-out members pass a
-    // fresh map each.
+    // Per-workspace scratch so two workspaces can pin the same dep differently.
+    // The root/cwd passes `manager.updating_packages`; fanned-out members each
+    // pass a fresh map.
     updating_packages: &mut StringArrayHashMap<PackageUpdateInfo>,
     // Which workspace's resolved versions to read back in the post-install pass.
     // `None` means the root workspace.

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1,4 +1,4 @@
-use bun_collections::VecExt;
+use bun_collections::{StringArrayHashMap, VecExt};
 use std::io::Write as _;
 
 use bun_ast as js_ast;
@@ -9,7 +9,7 @@ use bun_semver as semver;
 use bun_install::dependency::{self, TagExt as _};
 use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::{Dependency, INVALID_PACKAGE_ID, resolution};
-use bun_install_types::DependencyGroup;
+use bun_install_types::{DependencyGroup, PackageNameHash};
 
 use super::package_manager_options::{Do, Enable};
 use super::{CatalogUpdateInfo, PackageManager, PackageUpdateInfo, Subcommand, UpdateRequest};
@@ -242,6 +242,14 @@ pub fn edit_trusted_dependencies(
 /// versions.
 pub(crate) fn edit_update_no_args(
     manager: &mut PackageManager,
+    // Per-workspace scratch so each workspace's original version literals stay
+    // separate (two workspaces can pin the same dependency differently). The
+    // root/cwd passes `manager.updating_packages`; fanned-out members pass a
+    // fresh map each.
+    updating_packages: &mut StringArrayHashMap<PackageUpdateInfo>,
+    // Which workspace's resolved versions to read back in the post-install pass.
+    // `None` means the root workspace.
+    workspace_name_hash: Option<PackageNameHash>,
     current_package_json: &mut Expr,
     options: EditOptions,
 ) -> Result<(), bun_alloc::AllocError> {
@@ -252,8 +260,6 @@ pub(crate) fn edit_update_no_args(
 
     // Process-lifetime arena for AST
     // nodes that must outlive `Expr.Data.Store.reset()`. See `PackageManager.ast_arena`.
-    // `arena` is a disjoint-field borrow held across
-    // the `&mut manager.updating_packages` accesses below.
     let arena = &manager.ast_arena;
 
     for group in DEPENDENCY_GROUPS {
@@ -315,9 +321,9 @@ pub(crate) fn edit_update_no_args(
 
                         let key_str = key.as_utf8_string_literal().expect("unreachable");
                         // Capture the literal as an owned
-                        // copy before borrowing `manager.updating_packages` mutably.
+                        // copy before borrowing `updating_packages` mutably.
                         let version_literal_owned = Box::<[u8]>::from(version_literal);
-                        let entry = manager.updating_packages.get_or_put(key_str)?;
+                        let entry = updating_packages.get_or_put(key_str)?;
 
                         // If a dependency is present in more than one dependency group, only one of it's versions
                         // will be updated. The group is determined by the order of `dependency_groups`, the same
@@ -359,7 +365,7 @@ pub(crate) fn edit_update_no_args(
                     let lockfile = &*manager.lockfile;
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
                     let workspace_package_id =
-                        lockfile.get_workspace_package_id(manager.workspace_name_hash);
+                        lockfile.get_workspace_package_id(workspace_name_hash);
                     let packages = lockfile.packages.slice();
                     let resolutions = packages.items_resolution();
                     let deps = packages.items_dependencies()[workspace_package_id as usize];
@@ -402,9 +408,7 @@ pub(crate) fn edit_update_no_args(
                         'updated: {
                             // fetchSwapRemove because we want to update the first dependency with a matching
                             // name, or none at all
-                            if let Some(entry) =
-                                manager.updating_packages.fetch_swap_remove(key_str)
-                            {
+                            if let Some(entry) = updating_packages.fetch_swap_remove(key_str) {
                                 let is_alias = entry.value.is_alias;
                                 let dep_name = &*entry.key;
                                 debug_assert_eq!(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1964,18 +1964,20 @@ fn get_or_put_resolved_package_with_find_result(
     install_peer: bool,
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
-    // reshaped for borrowck — `is_root_dependency(&self, &mut PackageManager, …)`
+    // reshaped for borrowck — `is_update_target_dependency(&self, &mut PackageManager, …)`
     // borrows `this.lockfile` and `this` at once. Split via raw root.
     let should_update = {
         let this_ptr: *mut PackageManager = this;
-        // SAFETY: `is_root_dependency` reads `manager.root_dependency_list` /
-        // `manager.workspace_package_json_cache` only — disjoint from
+        // SAFETY: `is_update_target_dependency` reads `manager.root_package_id` /
+        // `manager.update_workspace_name_hashes` only — disjoint from
         // `manager.lockfile`.
         this.to_update
-            // Update direct deps of the current workspace; catalogs are root-scoped.
+            // Update direct deps of the targeted workspace(s): the cwd by
+            // default, or the `--recursive`/`--filter` set when one was
+            // selected. Catalogs are root-scoped.
             && (dependency.version.tag == dependency::version::Tag::Catalog
                 || unsafe { &*(*this_ptr).lockfile }
-                    .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id))
+                    .is_update_target_dependency(unsafe { &mut *this_ptr }, dependency_id))
             // no need to do a look up if update requests are empty (`bun update` with no args)
             && (this.update_requests.is_empty()
                 || this.updating_packages.contains(

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -677,10 +677,9 @@ fn update_package_json_and_install_with_manager_with_updates(
             .to_vec();
     }
 
-    // Commit the fanned-out workspace members: read back the versions the
-    // install step resolved, write each member's package.json, and refresh its
-    // cache entry. This runs before the catalog pass below, which re-reads the
-    // root from the cache and must compose on top of these dependency edits.
+    // Commit the fanned-out members: write each package.json and refresh its
+    // cache entry. Runs before the catalog pass, which re-reads the root from
+    // the cache and must compose on top of these dependency edits.
     if subcommand == Subcommand::Update && manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
         for member in plan.members.iter_mut() {
             commit_workspace_member_update(manager, member)?;

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -1,5 +1,5 @@
 use crate::lockfile::package::PackageColumns as _;
-use bun_collections::VecExt;
+use bun_collections::{StringArrayHashMap, VecExt};
 use core::fmt;
 use std::borrow::Cow;
 
@@ -9,8 +9,12 @@ use crate::Error;
 use crate::ShellCompletions;
 use crate::bun_fs::FileSystem;
 use crate::bun_json as json;
+use crate::package_manager::WorkspaceFilter;
+use crate::{PackageID, PackageNameHash, lockfile, resolution};
+use bun_ast::Indentation;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
+use bun_glob as glob;
 use bun_js_printer as js_printer;
 use bun_paths::{self, PathBuffer};
 use bun_sys::{self, Fd, File};
@@ -19,7 +23,7 @@ use super::command_line_arguments::CommandLineArguments;
 use super::package_json_editor as PackageJSONEditor;
 use super::update_request::Array as UpdateRequestArray;
 use super::{
-    Command, PackageManager, PatchCommitResult, Subcommand, UpdateRequest,
+    Command, PackageManager, PackageUpdateInfo, PatchCommitResult, Subcommand, UpdateRequest,
     attempt_to_create_package_json, install_with_manager, patch_package,
 };
 
@@ -151,6 +155,19 @@ fn update_package_json_and_install_with_manager_with_updates(
         }
         Global::crash();
     }
+
+    // `bun update --recursive` / `--filter` (with no package names) fan the
+    // update out to workspace members. This resolves the target workspace set,
+    // sets the install-time update gate (`manager.update_workspace_name_hashes`),
+    // and runs the pre-install edit pass on each member. The cwd/root
+    // package.json is still handled by the flow below (guarded by
+    // `plan.cwd_in_target`), and members are committed after install. Named
+    // updates (`bun update <pkg> --recursive`) keep the existing behavior.
+    let mut plan = if subcommand == Subcommand::Update && updates.is_empty() {
+        prepare_workspace_update_plan(manager, original_cwd)?
+    } else {
+        WorkspaceUpdatePlan::cwd_only()
+    };
 
     // reshaped for borrowck — `get_with_path` returns `&mut MapEntry`
     // borrowed from `manager.workspace_package_json_cache`, but we then need
@@ -344,16 +361,22 @@ fn update_package_json_and_install_with_manager_with_updates(
                 // `edit` may shrink the slice.
                 let new_len = updates_slice.len();
                 updates.truncate(new_len);
-            } else if subcommand == Subcommand::Update {
-                PackageJSONEditor::edit_update_no_args(
+            } else if subcommand == Subcommand::Update && plan.cwd_in_target {
+                let mut updating = core::mem::take(&mut manager.updating_packages);
+                let ws_hash = manager.workspace_name_hash;
+                let res = PackageJSONEditor::edit_update_no_args(
                     manager,
+                    &mut updating,
+                    ws_hash,
                     &mut current_package_json_root,
                     EditOptions {
                         exact_versions: true,
                         before_install: true,
                         ..Default::default()
                     },
-                )?;
+                );
+                manager.updating_packages = updating;
+                res?;
             }
         }
         _ => {
@@ -600,14 +623,22 @@ fn update_package_json_and_install_with_manager_with_updates(
             };
 
         if updates.is_empty() {
-            PackageJSONEditor::edit_update_no_args(
-                manager,
-                &mut new_package_json,
-                EditOptions {
-                    exact_versions: manager.options.enable.exact_versions(),
-                    ..Default::default()
-                },
-            )?;
+            if plan.cwd_in_target {
+                let mut updating = core::mem::take(&mut manager.updating_packages);
+                let ws_hash = manager.workspace_name_hash;
+                let res = PackageJSONEditor::edit_update_no_args(
+                    manager,
+                    &mut updating,
+                    ws_hash,
+                    &mut new_package_json,
+                    EditOptions {
+                        exact_versions: manager.options.enable.exact_versions(),
+                        ..Default::default()
+                    },
+                );
+                manager.updating_packages = updating;
+                res?;
+            }
 
             if editing_catalogs && manager.workspace_name_hash.is_none() {
                 // running from root: catalogs live in this file.
@@ -734,7 +765,12 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     let _ = written;
 
-    if manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
+    // When `--filter` selects workspaces that don't include the cwd/root, the
+    // cwd package.json is not a target and must not be rewritten here. For the
+    // default and `--recursive` cases `cwd_in_target` is always true.
+    if manager.options.do_.contains(Do::WRITE_PACKAGE_JSON)
+        && (plan.cwd_in_target || subcommand != Subcommand::Update)
+    {
         let (source, path): (&[u8], &ZStr) =
             if matches!(manager.options.patch_features, PatchFeatures::Commit { .. }) {
                 'source_and_path: {
@@ -860,7 +896,362 @@ fn update_package_json_and_install_with_manager_with_updates(
         }
     }
 
+    // Commit the fanned-out workspace members: read back the versions the
+    // install step resolved and write each member's package.json to disk.
+    if subcommand == Subcommand::Update && manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
+        for member in plan.members.iter_mut() {
+            commit_workspace_member_update(manager, member)?;
+        }
+    }
+
     Ok(())
+}
+
+/// Plan for fanning `bun update` out to workspace members under
+/// `--recursive`/`--filter`.
+struct WorkspaceUpdatePlan {
+    /// Members other than the cwd/root workspace (which the main flow edits).
+    members: Vec<MemberUpdate>,
+    /// Whether the cwd/root workspace is itself a target of this update.
+    cwd_in_target: bool,
+}
+
+impl WorkspaceUpdatePlan {
+    fn cwd_only() -> Self {
+        Self {
+            members: Vec::new(),
+            cwd_in_target: true,
+        }
+    }
+}
+
+/// A workspace member to update, captured before install so its resolved
+/// versions can be written back afterwards.
+struct MemberUpdate {
+    /// Absolute path to the member's package.json.
+    package_json_path: Box<[u8]>,
+    /// Stable across `clean_with_logger`; selects the member post-install.
+    name_hash: Option<PackageNameHash>,
+    /// The member package.json printed after the pre-install pass.
+    source_before_install: Vec<u8>,
+    /// The member package.json exactly as it was on disk, so an unchanged
+    /// member is not rewritten.
+    original_contents: Vec<u8>,
+    /// Per-member original version literals captured in the pre-install pass.
+    updating_packages: StringArrayHashMap<PackageUpdateInfo>,
+    indentation: Indentation,
+    preserve_trailing_newline: bool,
+}
+
+fn prepare_workspace_update_plan(
+    manager: &mut PackageManager,
+    original_cwd: &[u8],
+) -> Result<WorkspaceUpdatePlan, Error> {
+    let recursive = manager.options.do_.recursive();
+    let has_filter = !manager.options.filter_patterns.is_empty();
+    if !recursive && !has_filter {
+        return Ok(WorkspaceUpdatePlan::cwd_only());
+    }
+
+    // Enumerating workspace members needs a lockfile. Without one there is no
+    // prior resolution to update against, so fall back to the default flow.
+    if !matches!(
+        manager.load_lockfile_from_cwd::<true>(),
+        lockfile::LoadResult::Ok(_)
+    ) {
+        return Ok(WorkspaceUpdatePlan::cwd_only());
+    }
+
+    let selected: Vec<PackageID> = if has_filter {
+        select_filtered_workspaces(manager, original_cwd)
+    } else {
+        select_all_workspaces(manager)
+    };
+
+    let cwd_pkg_id = manager
+        .lockfile
+        .get_workspace_package_id(manager.workspace_name_hash);
+
+    // The install-time update gate: a dependency updates iff it belongs to one
+    // of these workspaces. Name hashes are stable across `clean_with_logger`.
+    {
+        let col = manager.lockfile.packages.items_name_hash();
+        let name_hashes: Box<[PackageNameHash]> =
+            selected.iter().map(|&id| col[id as usize]).collect();
+        manager.update_workspace_name_hashes = Some(name_hashes);
+    }
+
+    let top_level_dir: Box<[u8]> =
+        Box::from(strings::without_trailing_slash(FileSystem::instance().top_level_dir()));
+
+    let mut cwd_in_target = false;
+    let mut members: Vec<MemberUpdate> = Vec::new();
+    for &pkg_id in &selected {
+        if pkg_id == cwd_pkg_id {
+            // The cwd/root package.json is edited by the main flow.
+            cwd_in_target = true;
+            continue;
+        }
+
+        let name_hash = manager.lockfile.packages.items_name_hash()[pkg_id as usize];
+        let rel: Box<[u8]> = {
+            let res = manager.lockfile.packages.items_resolution()[pkg_id as usize];
+            if res.tag == resolution::Tag::Workspace {
+                Box::from(
+                    res.workspace()
+                        .slice(manager.lockfile.buffers.string_bytes.as_slice()),
+                )
+            } else {
+                Box::default()
+            }
+        };
+
+        let mut path_buf = PathBuffer::uninit();
+        let abs_path: &[u8] = if rel.is_empty() {
+            bun_paths::resolve_path::join_abs_string_buf::<bun_paths::resolve_path::platform::Auto>(
+                &top_level_dir,
+                &mut path_buf.0,
+                &[b"package.json"],
+            )
+        } else {
+            bun_paths::resolve_path::join_abs_string_buf::<bun_paths::resolve_path::platform::Auto>(
+                &top_level_dir,
+                &mut path_buf.0,
+                &[&rel, b"package.json"],
+            )
+        };
+
+        if let Some(member) = prepare_member_before_install(manager, abs_path, name_hash)? {
+            members.push(member);
+        }
+    }
+
+    Ok(WorkspaceUpdatePlan {
+        members,
+        cwd_in_target,
+    })
+}
+
+fn select_all_workspaces(manager: &PackageManager) -> Vec<PackageID> {
+    let resolutions = manager.lockfile.packages.items_resolution();
+    let mut ids = Vec::new();
+    for (pkg_id, res) in resolutions.iter().enumerate() {
+        if res.tag == resolution::Tag::Workspace || res.tag == resolution::Tag::Root {
+            ids.push(pkg_id as PackageID);
+        }
+    }
+    ids
+}
+
+fn select_filtered_workspaces(manager: &PackageManager, original_cwd: &[u8]) -> Vec<PackageID> {
+    let lockfile = &manager.lockfile;
+    let packages = lockfile.packages.slice();
+    let pkg_names = packages.items_name();
+    let pkg_resolutions = packages.items_resolution();
+    let string_buf = lockfile.buffers.string_bytes.as_slice();
+
+    let mut ids: Vec<PackageID> = Vec::new();
+    for (pkg_id, res) in pkg_resolutions.iter().enumerate() {
+        if res.tag == resolution::Tag::Workspace || res.tag == resolution::Tag::Root {
+            ids.push(pkg_id as PackageID);
+        }
+    }
+
+    let mut path_buf = PathBuffer::uninit();
+    let converted_filters: Vec<WorkspaceFilter> = manager
+        .options
+        .filter_patterns
+        .iter()
+        .map(|filter| {
+            bun_core::handle_oom(WorkspaceFilter::init(filter, original_cwd, &mut path_buf.0))
+        })
+        .collect();
+
+    let top_level_dir = FileSystem::instance().top_level_dir();
+
+    // Keep only workspaces matching every filter (mirrors `outdated`/`update
+    // --interactive`).
+    let mut i = 0;
+    while i < ids.len() {
+        let pkg_id = ids[i];
+        let matched = 'matched: {
+            for filter in &converted_filters {
+                match filter {
+                    WorkspaceFilter::Path(pattern) => {
+                        if pattern.is_empty() {
+                            continue;
+                        }
+                        let res = &pkg_resolutions[pkg_id as usize];
+                        let res_path: &[u8] = match res.tag {
+                            resolution::Tag::Workspace => res.workspace().slice(string_buf),
+                            resolution::Tag::Root => top_level_dir,
+                            _ => continue,
+                        };
+                        let abs = bun_paths::resolve_path::join_abs_string_buf::<
+                            bun_paths::resolve_path::platform::Posix,
+                        >(
+                            top_level_dir, &mut path_buf.0, &[res_path]
+                        );
+                        if !glob::r#match(pattern, strings::without_trailing_slash(abs)).matches() {
+                            break 'matched false;
+                        }
+                    }
+                    WorkspaceFilter::Name(pattern) => {
+                        let name = pkg_names[pkg_id as usize].slice(string_buf);
+                        if !glob::r#match(pattern, name).matches() {
+                            break 'matched false;
+                        }
+                    }
+                    WorkspaceFilter::All => {}
+                }
+            }
+            true
+        };
+        if matched {
+            i += 1;
+        } else {
+            ids.swap_remove(i);
+        }
+    }
+
+    ids
+}
+
+fn prepare_member_before_install(
+    manager: &mut PackageManager,
+    abs_path: &[u8],
+    name_hash: PackageNameHash,
+) -> Result<Option<MemberUpdate>, Error> {
+    // Demote to a raw pointer so the edit pass can take `&mut manager`.
+    let entry_ptr: *mut MapEntry = match manager.workspace_package_json_cache.get_with_path(
+        manager.log_mut(),
+        abs_path,
+        GetJSONOptions {
+            guess_indentation: true,
+            ..Default::default()
+        },
+    ) {
+        GetResult::Entry(entry) => core::ptr::from_mut(entry),
+        // A member we can't read/parse is skipped rather than aborting the whole update.
+        GetResult::ParseErr(_) | GetResult::ReadErr(_) => return Ok(None),
+    };
+
+    // SAFETY: pointer into `manager.workspace_package_json_cache`, valid until the
+    // next `get_with_path`. The edit pass touches only disjoint manager fields.
+    let (mut member_root, indentation, preserve_trailing_newline, original_contents) = {
+        let entry = unsafe { &*entry_ptr };
+        (
+            entry.root,
+            entry.indentation,
+            entry.source.contents.last() == Some(&b'\n'),
+            entry.source.contents.to_vec(),
+        )
+    };
+
+    let mut updating_packages: StringArrayHashMap<PackageUpdateInfo> = StringArrayHashMap::default();
+    PackageJSONEditor::edit_update_no_args(
+        manager,
+        &mut updating_packages,
+        Some(name_hash),
+        &mut member_root,
+        EditOptions {
+            exact_versions: true,
+            before_install: true,
+            ..Default::default()
+        },
+    )?;
+
+    // SAFETY: see above.
+    let entry: &mut MapEntry = unsafe { &mut *entry_ptr };
+    let source_before_install =
+        print_package_json(&entry.source, member_root, indentation, preserve_trailing_newline);
+    // Push the pre-install edit into the cache so install resolves the updated
+    // (possibly `latest`) versions for this member.
+    entry.source.contents = Cow::Owned(source_before_install.clone());
+    if let Err(err) = entry.reparse_root(manager.log_mut()) {
+        bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
+        Global::crash();
+    }
+
+    Ok(Some(MemberUpdate {
+        package_json_path: Box::from(abs_path),
+        name_hash: Some(name_hash),
+        source_before_install,
+        original_contents,
+        updating_packages,
+        indentation,
+        preserve_trailing_newline,
+    }))
+}
+
+fn commit_workspace_member_update(
+    manager: &mut PackageManager,
+    member: &mut MemberUpdate,
+) -> Result<(), Error> {
+    let source =
+        bun_ast::Source::init_path_string(&b"package.json"[..], &member.source_before_install[..]);
+    let json_arena = bun_alloc::Arena::new();
+    let mut ast: bun_ast::Expr =
+        match json::parse_package_json_utf8(&source, manager.log_mut(), &json_arena) {
+            Ok(v) => v,
+            Err(err) => {
+                bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
+                Global::crash();
+            }
+        };
+
+    PackageJSONEditor::edit_update_no_args(
+        manager,
+        &mut member.updating_packages,
+        member.name_hash,
+        &mut ast,
+        EditOptions {
+            exact_versions: manager.options.enable.exact_versions(),
+            ..Default::default()
+        },
+    )?;
+
+    let new_source =
+        print_package_json(&source, ast, member.indentation, member.preserve_trailing_newline);
+
+    // Don't rewrite a member the update left unchanged.
+    if new_source == member.original_contents {
+        return Ok(());
+    }
+
+    let mut path_zbuf = PathBuffer::uninit();
+    let path_z = bun_paths::resolve_path::z(&member.package_json_path, &mut path_zbuf);
+    File::write_file(Fd::cwd(), path_z, &new_source).map_err(Error::from)?;
+    Ok(())
+}
+
+fn print_package_json(
+    source: &bun_ast::Source,
+    root: bun_ast::Expr,
+    indent: Indentation,
+    preserve_newline: bool,
+) -> Vec<u8> {
+    let mut buffer_writer = js_printer::BufferWriter::init();
+    buffer_writer
+        .buffer
+        .list
+        .reserve((source.contents.len() + 1).saturating_sub(buffer_writer.buffer.list.len()));
+    buffer_writer.append_newline = preserve_newline;
+    let mut writer = js_printer::BufferPrinter::init(buffer_writer);
+    if let Err(e) = js_printer::print_json(
+        &mut writer,
+        root,
+        source,
+        js_printer::PrintJsonOptions {
+            indent,
+            mangled_props: None,
+            ..Default::default()
+        },
+    ) {
+        bun_core::pretty_errorln!("package.json failed to write due to error {}", e.name());
+        Global::crash();
+    }
+    writer.ctx.written_without_trailing_zero().to_vec()
 }
 
 pub fn update_package_json_and_install_and_cli(

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -156,13 +156,9 @@ fn update_package_json_and_install_with_manager_with_updates(
         Global::crash();
     }
 
-    // `bun update --recursive` / `--filter` (with no package names) fan the
-    // update out to workspace members. This resolves the target workspace set,
-    // sets the install-time update gate (`manager.update_workspace_name_hashes`),
-    // and runs the pre-install edit pass on each member. The cwd/root
-    // package.json is still handled by the flow below (guarded by
-    // `plan.cwd_in_target`), and members are committed after install. Named
-    // updates (`bun update <pkg> --recursive`) keep the existing behavior.
+    // For `bun update --recursive`/`--filter` with no named packages, fan the
+    // update out to workspace members: set the install-time gate and edit each
+    // member before install (the cwd is still handled below via `cwd_in_target`).
     let mut plan = if subcommand == Subcommand::Update && updates.is_empty() {
         prepare_workspace_update_plan(manager, original_cwd)?
     } else {
@@ -953,11 +949,9 @@ fn prepare_workspace_update_plan(
         return Ok(WorkspaceUpdatePlan::cwd_only());
     }
 
-    // Enumerating workspace members needs a lockfile, but the plan only needs
-    // the workspace list, not migration, so probe without it (`<false>`).
-    // `install_with_manager` performs the real (migrating) load right after and
-    // owns the lockfile-error policy, so a missing/foreign/corrupt lockfile
-    // here just falls back to the default flow rather than migrating twice.
+    // Probe the lockfile without migration (planning only needs the workspace
+    // list). `install_with_manager` does the real migrating load and owns the
+    // error policy, so a missing/foreign/corrupt lockfile just falls back here.
     if !manager.options.do_.load_lockfile()
         || !matches!(
             manager.load_lockfile_from_cwd::<false>(),

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -953,12 +953,17 @@ fn prepare_workspace_update_plan(
         return Ok(WorkspaceUpdatePlan::cwd_only());
     }
 
-    // Enumerating workspace members needs a lockfile. Without one there is no
-    // prior resolution to update against, so fall back to the default flow.
-    if !matches!(
-        manager.load_lockfile_from_cwd::<true>(),
-        lockfile::LoadResult::Ok(_)
-    ) {
+    // Enumerating workspace members needs a lockfile, but the plan only needs
+    // the workspace list, not migration, so probe without it (`<false>`).
+    // `install_with_manager` performs the real (migrating) load right after and
+    // owns the lockfile-error policy, so a missing/foreign/corrupt lockfile
+    // here just falls back to the default flow rather than migrating twice.
+    if !manager.options.do_.load_lockfile()
+        || !matches!(
+            manager.load_lockfile_from_cwd::<false>(),
+            lockfile::LoadResult::Ok(_)
+        )
+    {
         return Ok(WorkspaceUpdatePlan::cwd_only());
     }
 
@@ -994,17 +999,22 @@ fn prepare_workspace_update_plan(
             continue;
         }
 
-        let name_hash = manager.lockfile.packages.items_name_hash()[pkg_id as usize];
-        let rel: Box<[u8]> = {
+        let res_tag = manager.lockfile.packages.items_resolution()[pkg_id as usize].tag;
+        // `None` means the root workspace (the codebase convention
+        // `get_workspace_package_id` honors); only real workspaces carry a hash.
+        let name_hash: Option<PackageNameHash> = if res_tag == resolution::Tag::Workspace {
+            Some(manager.lockfile.packages.items_name_hash()[pkg_id as usize])
+        } else {
+            None
+        };
+        let rel: Box<[u8]> = if res_tag == resolution::Tag::Workspace {
             let res = manager.lockfile.packages.items_resolution()[pkg_id as usize];
-            if res.tag == resolution::Tag::Workspace {
-                Box::from(
-                    res.workspace()
-                        .slice(manager.lockfile.buffers.string_bytes.as_slice()),
-                )
-            } else {
-                Box::default()
-            }
+            Box::from(
+                res.workspace()
+                    .slice(manager.lockfile.buffers.string_bytes.as_slice()),
+            )
+        } else {
+            Box::default()
         };
 
         let mut path_buf = PathBuffer::uninit();
@@ -1116,7 +1126,7 @@ fn select_filtered_workspaces(manager: &PackageManager, original_cwd: &[u8]) -> 
 fn prepare_member_before_install(
     manager: &mut PackageManager,
     abs_path: &[u8],
-    name_hash: PackageNameHash,
+    name_hash: Option<PackageNameHash>,
 ) -> Result<MemberUpdate, Error> {
     // Demote to a raw pointer so the edit pass can take `&mut manager`. A
     // selected workspace that can't be read/parsed is a hard failure (its
@@ -1166,7 +1176,7 @@ fn prepare_member_before_install(
     PackageJSONEditor::edit_update_no_args(
         manager,
         &mut updating_packages,
-        Some(name_hash),
+        name_hash,
         &mut member_root,
         EditOptions {
             exact_versions: true,
@@ -1193,7 +1203,7 @@ fn prepare_member_before_install(
 
     Ok(MemberUpdate {
         package_json_path: Box::from(abs_path),
-        name_hash: Some(name_hash),
+        name_hash,
         source_before_install,
         original_contents,
         updating_packages,

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -573,8 +573,6 @@ fn update_package_json_and_install_with_manager_with_updates(
     // here, so taking it back yields exactly the slice assigned above.
     let mut updates: Box<[UpdateRequest]> = core::mem::take(&mut manager.update_requests);
 
-    // Catalogs are root-scoped: a filtered update that excludes the cwd/root
-    // can still move catalog entries, and that must reach disk (see below).
     let mut cwd_catalogs_changed = false;
 
     if subcommand == Subcommand::Update
@@ -757,9 +755,8 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     let _ = written;
 
-    // When `--filter` excludes the cwd/root, the cwd package.json is not a
-    // target and is not rewritten, except when root-scoped catalog entries
-    // moved: those live in this file and must stay in sync with the lockfile.
+    // A filter excluding the cwd/root skips this write, unless root-scoped
+    // catalog entries moved: those must stay in sync with the lockfile.
     if manager.options.do_.contains(Do::WRITE_PACKAGE_JSON)
         && (plan.cwd_in_target || subcommand != Subcommand::Update || cwd_catalogs_changed)
     {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -981,8 +981,9 @@ fn prepare_workspace_update_plan(
         manager.update_workspace_name_hashes = Some(name_hashes);
     }
 
-    let top_level_dir: Box<[u8]> =
-        Box::from(strings::without_trailing_slash(FileSystem::instance().top_level_dir()));
+    let top_level_dir: Box<[u8]> = Box::from(strings::without_trailing_slash(
+        FileSystem::instance().top_level_dir(),
+    ));
 
     let mut cwd_in_target = false;
     let mut members: Vec<MemberUpdate> = Vec::new();
@@ -1007,19 +1008,16 @@ fn prepare_workspace_update_plan(
         };
 
         let mut path_buf = PathBuffer::uninit();
-        let abs_path: &[u8] = if rel.is_empty() {
-            bun_paths::resolve_path::join_abs_string_buf::<bun_paths::resolve_path::platform::Auto>(
-                &top_level_dir,
-                &mut path_buf.0,
-                &[b"package.json"],
-            )
-        } else {
-            bun_paths::resolve_path::join_abs_string_buf::<bun_paths::resolve_path::platform::Auto>(
-                &top_level_dir,
-                &mut path_buf.0,
-                &[&rel, b"package.json"],
-            )
-        };
+        let abs_path: &[u8] =
+            if rel.is_empty() {
+                bun_paths::resolve_path::join_abs_string_buf::<
+                    bun_paths::resolve_path::platform::Auto,
+                >(&top_level_dir, &mut path_buf.0, &[b"package.json"])
+            } else {
+                bun_paths::resolve_path::join_abs_string_buf::<
+                    bun_paths::resolve_path::platform::Auto,
+                >(&top_level_dir, &mut path_buf.0, &[&rel, b"package.json"])
+            };
 
         if let Some(member) = prepare_member_before_install(manager, abs_path, name_hash)? {
             members.push(member);
@@ -1148,7 +1146,8 @@ fn prepare_member_before_install(
         )
     };
 
-    let mut updating_packages: StringArrayHashMap<PackageUpdateInfo> = StringArrayHashMap::default();
+    let mut updating_packages: StringArrayHashMap<PackageUpdateInfo> =
+        StringArrayHashMap::default();
     PackageJSONEditor::edit_update_no_args(
         manager,
         &mut updating_packages,
@@ -1163,8 +1162,12 @@ fn prepare_member_before_install(
 
     // SAFETY: see above.
     let entry: &mut MapEntry = unsafe { &mut *entry_ptr };
-    let source_before_install =
-        print_package_json(&entry.source, member_root, indentation, preserve_trailing_newline);
+    let source_before_install = print_package_json(
+        &entry.source,
+        member_root,
+        indentation,
+        preserve_trailing_newline,
+    );
     // Push the pre-install edit into the cache so install resolves the updated
     // (possibly `latest`) versions for this member.
     entry.source.contents = Cow::Owned(source_before_install.clone());
@@ -1195,7 +1198,10 @@ fn commit_workspace_member_update(
         match json::parse_package_json_utf8(&source, manager.log_mut(), &json_arena) {
             Ok(v) => v,
             Err(err) => {
-                bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
+                bun_core::pretty_errorln!(
+                    "package.json failed to parse due to error {}",
+                    err.name()
+                );
                 Global::crash();
             }
         };
@@ -1211,8 +1217,12 @@ fn commit_workspace_member_update(
         },
     )?;
 
-    let new_source =
-        print_package_json(&source, ast, member.indentation, member.preserve_trailing_newline);
+    let new_source = print_package_json(
+        &source,
+        ast,
+        member.indentation,
+        member.preserve_trailing_newline,
+    );
 
     // Don't rewrite a member the update left unchanged.
     if new_source == member.original_contents {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -573,6 +573,10 @@ fn update_package_json_and_install_with_manager_with_updates(
     // here, so taking it back yields exactly the slice assigned above.
     let mut updates: Box<[UpdateRequest]> = core::mem::take(&mut manager.update_requests);
 
+    // Catalogs are root-scoped: a filtered update that excludes the cwd/root
+    // can still move catalog entries, and that must reach disk (see below).
+    let mut cwd_catalogs_changed = false;
+
     if subcommand == Subcommand::Update
         || subcommand == Subcommand::Add
         || subcommand == Subcommand::Link
@@ -621,7 +625,7 @@ fn update_package_json_and_install_with_manager_with_updates(
 
             if editing_catalogs && manager.workspace_name_hash.is_none() {
                 // running from root: catalogs live in this file.
-                let _ = PackageJSONEditor::edit_catalogs_after_update(
+                cwd_catalogs_changed = PackageJSONEditor::edit_catalogs_after_update(
                     manager,
                     &new_package_json,
                     EditOptions {
@@ -753,11 +757,11 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     let _ = written;
 
-    // When `--filter` selects workspaces that don't include the cwd/root, the
-    // cwd package.json is not a target and must not be rewritten here. For the
-    // default and `--recursive` cases `cwd_in_target` is always true.
+    // When `--filter` excludes the cwd/root, the cwd package.json is not a
+    // target and is not rewritten, except when root-scoped catalog entries
+    // moved: those live in this file and must stay in sync with the lockfile.
     if manager.options.do_.contains(Do::WRITE_PACKAGE_JSON)
-        && (plan.cwd_in_target || subcommand != Subcommand::Update)
+        && (plan.cwd_in_target || subcommand != Subcommand::Update || cwd_catalogs_changed)
     {
         let (source, path): (&[u8], &ZStr) =
             if matches!(manager.options.patch_features, PatchFeatures::Commit { .. }) {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -29,31 +29,14 @@ use super::{
 
 fn print_package_json_into_cache_entry(entry: &mut MapEntry, root: bun_ast::Expr) {
     let preserve_trailing_newline = entry.source.contents.last() == Some(&b'\n');
-    let mut buffer_writer = js_printer::BufferWriter::init();
-    buffer_writer
-        .buffer
-        .list
-        .reserve((entry.source.contents.len() + 1).saturating_sub(buffer_writer.buffer.list.len()));
-    buffer_writer.append_newline = preserve_trailing_newline;
-    let mut writer = js_printer::BufferPrinter::init(buffer_writer);
-
-    if let Err(e) = js_printer::print_json(
-        &mut writer,
-        root,
+    let printed = print_package_json(
         &entry.source,
-        js_printer::PrintJsonOptions {
-            indent: entry.indentation,
-            mangled_props: None,
-            ..Default::default()
-        },
-    ) {
-        bun_core::pretty_errorln!("package.json failed to write due to error {}", e.name(),);
-        Global::crash();
-    }
-    let old = core::mem::replace(
-        &mut entry.source.contents,
-        Cow::Owned(writer.ctx.written_without_trailing_zero().to_vec()),
+        root,
+        entry.indentation,
+        preserve_trailing_newline,
     );
+    // Cached `root` AST slices borrow the old buffer; pin it instead of freeing.
+    let old = core::mem::replace(&mut entry.source.contents, Cow::Owned(printed));
     entry.stale_contents.push(old);
 }
 
@@ -694,6 +677,16 @@ fn update_package_json_and_install_with_manager_with_updates(
             .to_vec();
     }
 
+    // Commit the fanned-out workspace members: read back the versions the
+    // install step resolved, write each member's package.json, and refresh its
+    // cache entry. This runs before the catalog pass below, which re-reads the
+    // root from the cache and must compose on top of these dependency edits.
+    if subcommand == Subcommand::Update && manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
+        for member in plan.members.iter_mut() {
+            commit_workspace_member_update(manager, member)?;
+        }
+    }
+
     if editing_catalogs
         && manager.workspace_name_hash.is_some()
         && manager.options.do_.contains(Do::WRITE_PACKAGE_JSON)
@@ -889,14 +882,6 @@ fn update_package_json_and_install_with_manager_with_updates(
                     }
                 }
             }
-        }
-    }
-
-    // Commit the fanned-out workspace members: read back the versions the
-    // install step resolved and write each member's package.json to disk.
-    if subcommand == Subcommand::Update && manager.options.do_.contains(Do::WRITE_PACKAGE_JSON) {
-        for member in plan.members.iter_mut() {
-            commit_workspace_member_update(manager, member)?;
         }
     }
 
@@ -1210,6 +1195,15 @@ fn commit_workspace_member_update(
     manager: &mut PackageManager,
     member: &mut MemberUpdate,
 ) -> Result<(), Error> {
+    // A stale lockfile can select a workspace that install's re-resolve drops
+    // (for `Some(hash)`, `get_workspace_package_id` returning the root id means
+    // a miss); don't rewrite it against the root's resolutions.
+    if member.name_hash.is_some()
+        && manager.lockfile.get_workspace_package_id(member.name_hash) == 0
+    {
+        return Ok(());
+    }
+
     let source =
         bun_ast::Source::init_path_string(&b"package.json"[..], &member.source_before_install[..]);
     let json_arena = bun_alloc::Arena::new();
@@ -1251,6 +1245,29 @@ fn commit_workspace_member_update(
     let mut path_zbuf = PathBuffer::uninit();
     let path_z = bun_paths::resolve_path::z(&member.package_json_path, &mut path_zbuf);
     File::write_file(Fd::cwd(), path_z, &new_source).map_err(Error::from)?;
+
+    // Refresh the cache so later readers (the root catalog pass) compose on
+    // top of this write instead of a stale snapshot.
+    if let GetResult::Entry(entry) = manager.workspace_package_json_cache.get_with_path(
+        manager.log_mut(),
+        &member.package_json_path,
+        GetJSONOptions {
+            guess_indentation: true,
+            ..Default::default()
+        },
+    ) {
+        let old = core::mem::replace(&mut entry.source.contents, Cow::Owned(new_source));
+        entry.stale_contents.push(old);
+        // reshaped for borrowck — `entry` borrows the cache; reparse needs the
+        // log. Demote like the other cache-entry sites in this file.
+        let entry_ptr: *mut MapEntry = core::ptr::from_mut(entry);
+        // SAFETY: pointer into `manager.workspace_package_json_cache`, valid
+        // until the next `get_with_path`; `log_mut` is a disjoint field.
+        if let Err(err) = unsafe { &mut *entry_ptr }.reparse_root(manager.log_mut()) {
+            bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
+            Global::crash();
+        }
+    }
     Ok(())
 }
 

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -1019,9 +1019,7 @@ fn prepare_workspace_update_plan(
                 >(&top_level_dir, &mut path_buf.0, &[&rel, b"package.json"])
             };
 
-        if let Some(member) = prepare_member_before_install(manager, abs_path, name_hash)? {
-            members.push(member);
-        }
+        members.push(prepare_member_before_install(manager, abs_path, name_hash)?);
     }
 
     Ok(WorkspaceUpdatePlan {
@@ -1119,8 +1117,10 @@ fn prepare_member_before_install(
     manager: &mut PackageManager,
     abs_path: &[u8],
     name_hash: PackageNameHash,
-) -> Result<Option<MemberUpdate>, Error> {
-    // Demote to a raw pointer so the edit pass can take `&mut manager`.
+) -> Result<MemberUpdate, Error> {
+    // Demote to a raw pointer so the edit pass can take `&mut manager`. A
+    // selected workspace that can't be read/parsed is a hard failure (its
+    // dependencies are already in the update gate), matching the cwd path above.
     let entry_ptr: *mut MapEntry = match manager.workspace_package_json_cache.get_with_path(
         manager.log_mut(),
         abs_path,
@@ -1130,8 +1130,23 @@ fn prepare_member_before_install(
         },
     ) {
         GetResult::Entry(entry) => core::ptr::from_mut(entry),
-        // A member we can't read/parse is skipped rather than aborting the whole update.
-        GetResult::ParseErr(_) | GetResult::ReadErr(_) => return Ok(None),
+        GetResult::ParseErr(err) => {
+            let _ = manager
+                .log_mut()
+                .print(std::ptr::from_mut(Output::error_writer()));
+            Output::err_generic(
+                "failed to parse package.json \"{s}\": {s}",
+                (BStr::new(abs_path), err.name()),
+            );
+            Global::crash();
+        }
+        GetResult::ReadErr(err) => {
+            Output::err_generic(
+                "failed to read package.json \"{s}\": {s}",
+                (BStr::new(abs_path), err.name()),
+            );
+            Global::crash();
+        }
     };
 
     // SAFETY: pointer into `manager.workspace_package_json_cache`, valid until the
@@ -1176,7 +1191,7 @@ fn prepare_member_before_install(
         Global::crash();
     }
 
-    Ok(Some(MemberUpdate {
+    Ok(MemberUpdate {
         package_json_path: Box::from(abs_path),
         name_hash: Some(name_hash),
         source_before_install,
@@ -1184,7 +1199,7 @@ fn prepare_member_before_install(
         updating_packages,
         indentation,
         preserve_trailing_newline,
-    }))
+    })
 }
 
 fn commit_workspace_member_update(

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -863,6 +863,28 @@ impl Lockfile {
         self.packages.items_dependencies()[root_id as usize].contains(id)
     }
 
+    /// Whether `id` is a direct dependency of a workspace that the current
+    /// `bun update` targets. Without `--recursive`/`--filter` this is just the
+    /// root/cwd workspace; with them it is any workspace whose name hash was
+    /// selected (see `PackageManager.update_workspace_name_hashes`). Name hashes
+    /// are stable across `clean_with_logger`, so the check stays valid after the
+    /// lockfile is remapped during install.
+    pub fn is_update_target_dependency(
+        &self,
+        manager: &mut PackageManager,
+        id: DependencyID,
+    ) -> bool {
+        let Some(name_hashes) = manager.update_workspace_name_hashes.as_deref() else {
+            return self.is_root_dependency(manager, id);
+        };
+        let pkg_id = self.get_workspace_pkg_if_workspace_dep(id);
+        if pkg_id == invalid_package_id {
+            return false;
+        }
+        let name_hash = self.packages.items_name_hash()[pkg_id as usize];
+        name_hashes.contains(&name_hash)
+    }
+
     /// Is this a direct dependency of any workspace (including workspace root)?
     /// TODO make this faster by caching the workspace package ids
     pub(crate) fn is_workspace_dependency(&self, id: DependencyID) -> bool {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -863,12 +863,9 @@ impl Lockfile {
         self.packages.items_dependencies()[root_id as usize].contains(id)
     }
 
-    /// Whether `id` is a direct dependency of a workspace that the current
-    /// `bun update` targets. Without `--recursive`/`--filter` this is just the
-    /// root/cwd workspace; with them it is any workspace whose name hash was
-    /// selected (see `PackageManager.update_workspace_name_hashes`). Name hashes
-    /// are stable across `clean_with_logger`, so the check stays valid after the
-    /// lockfile is remapped during install.
+    /// Whether `id` is a dependency of a workspace targeted by the current
+    /// `bun update` (cwd by default; the `--recursive`/`--filter` set via
+    /// `update_workspace_name_hashes`). Keyed on name hashes (stable across clean).
     pub fn is_update_target_dependency(
         &self,
         manager: &mut PackageManager,

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -633,6 +633,57 @@ it("--filter updates only matching workspaces, leaving siblings and root untouch
   expect(root.dependencies.baz).toBe("~0.0.3");
 });
 
+// https://github.com/oven-sh/bun/issues/33176
+// A named update with --recursive keeps the existing (cwd-scoped) behavior: it
+// does not fan out to workspace members.
+it("named update with --recursive only updates the named package in the cwd", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "baz", "--recursive", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  expect(root.dependencies.baz).toBe("~0.0.5");
+  // Named updates do not fan out to members.
+  expect(a.dependencies.baz).toBe("~0.0.3");
+});
+
 it("should print UTF-8 arrows correctly with colors enabled", async () => {
   const urls: string[] = [];
   const registry = {

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -684,6 +684,168 @@ it("named update with --recursive only updates the named package in the cwd", as
   expect(a.dependencies.baz).toBe("~0.0.3");
 });
 
+// https://github.com/oven-sh/bun/issues/33176
+// A workspace member's `catalog:` reference must survive `bun update`: the
+// version lives in the root catalog, not inline in the member.
+it("--recursive preserves a workspace member's catalog: reference", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      catalog: { baz: "^0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "catalog:" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--recursive", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  // The member keeps the catalog reference; the catalog definition is unchanged.
+  expect(a.dependencies.baz).toBe("catalog:");
+  expect(root.catalog.baz).toBe("^0.0.3");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+it("--filter with a path targets only the matching workspace", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "pkg-b"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "pkg-b", "package.json"),
+    JSON.stringify({ name: "pkg-b", dependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "./packages/pkg-a", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
+  expect(a.dependencies.baz).toBe("~0.0.5");
+  expect(b.dependencies.baz).toBe("~0.0.3");
+  expect(root.dependencies.baz).toBe("~0.0.3");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+it("--filter with a negated pattern updates everything except the excluded workspace", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "pkg-b"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "pkg-b", "package.json"),
+    JSON.stringify({ name: "pkg-b", dependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "!pkg-a", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
+  // `!pkg-a` excludes pkg-a but keeps the root and sibling members.
+  expect(a.dependencies.baz).toBe("~0.0.3");
+  expect(b.dependencies.baz).toBe("~0.0.5");
+  expect(root.dependencies.baz).toBe("~0.0.5");
+});
+
 it("should print UTF-8 arrows correctly with colors enabled", async () => {
   const urls: string[] = [];
   const registry = {

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -483,6 +483,156 @@ it("should support --recursive flag", async () => {
   expect(out + err).toMatch(/bun update|missing lockfile|nothing to update/);
 });
 
+// https://github.com/oven-sh/bun/issues/33176
+it("--recursive updates dependencies and peerDependencies in workspace members", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "pkg-b"), { recursive: true });
+  // Same dependency name in two workspaces, one as a regular dep and one as a
+  // peer dep, so the update must fan out to both members and handle each
+  // workspace's dependency groups independently.
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "pkg-b", "package.json"),
+    JSON.stringify({ name: "pkg-b", peerDependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--recursive", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
+  expect(a.dependencies.baz).toBe("~0.0.5");
+  expect(b.peerDependencies.baz).toBe("~0.0.5");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+it("--recursive --latest updates workspace members to the latest version", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  // Exact pin below latest: only `--latest` moves it, so this also proves the
+  // member goes through the `--latest` path rather than range-constrained update.
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--recursive", "--latest", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  expect(a.dependencies.baz).toBe("0.0.5");
+});
+
+// https://github.com/oven-sh/bun/issues/33176
+it("--filter updates only matching workspaces, leaving siblings and root untouched", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "pkg-b"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "~0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "pkg-b", "package.json"),
+    JSON.stringify({ name: "pkg-b", dependencies: { baz: "~0.0.3" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "pkg-a", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
+  expect(a.dependencies.baz).toBe("~0.0.5");
+  // Unmatched workspace and the root are left untouched.
+  expect(b.dependencies.baz).toBe("~0.0.3");
+  expect(root.dependencies.baz).toBe("~0.0.3");
+});
+
 it("should print UTF-8 arrows correctly with colors enabled", async () => {
   const urls: string[] = [];
   const registry = {

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -787,6 +787,56 @@ it("--recursive from a workspace keeps both root dependency and catalog updates"
   expect(a.dependencies.baz).toBe("catalog:");
 });
 
+// A filtered update that excludes the root can still move root-scoped catalog
+// entries; the root package.json must be rewritten or it diverges from the
+// lockfile.
+it("--filter with --latest keeps the root catalog in sync", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      catalog: { baz: "^0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "catalog:" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--filter", "pkg-a", "--latest", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  expect(root.catalog.baz).toBe("^0.0.5");
+  expect(a.dependencies.baz).toBe("catalog:");
+});
+
 // https://github.com/oven-sh/bun/issues/33176
 it("--filter with a path targets only the matching workspace", async () => {
   const urls: string[] = [];

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -735,6 +735,58 @@ it("--recursive preserves a workspace member's catalog: reference", async () => 
   expect(root.catalog.baz).toBe("^0.0.3");
 });
 
+// Running --recursive from inside a workspace makes the root a fanned-out
+// member. Its dependency rewrite must not clobber the catalog update that the
+// catalog pass writes into the same root package.json.
+it("--recursive from a workspace keeps both root dependency and catalog updates", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "~0.0.3" },
+      catalog: { baz: "~0.0.3" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", dependencies: { baz: "catalog:" } }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    expect(await new Response(stderr).text()).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--recursive", "--linker=hoisted"],
+    cwd: join(package_dir, "packages", "pkg-a"),
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await new Response(stderr).text()).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  const root = await file(join(package_dir, "package.json")).json();
+  const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
+  expect(root.dependencies.baz).toBe("~0.0.5");
+  expect(root.catalog.baz).toBe("~0.0.5");
+  expect(a.dependencies.baz).toBe("catalog:");
+});
+
 // https://github.com/oven-sh/bun/issues/33176
 it("--filter with a path targets only the matching workspace", async () => {
   const urls: string[] = [];


### PR DESCRIPTION
## What

`bun update --recursive` (and `bun update --filter <pattern>`) only rewrote the root/cwd `package.json`. Workspace members, including their `peerDependencies`, were left untouched: the flags were effectively ignored by the non-interactive update path.

Closes #33176.

Also implements the `--recursive`/`--filter` portion of #23507. Catalog-definition updates for workspace members are out of scope here and remain a follow-up, so that issue is linked rather than auto-closed.

## Repro (before this PR)

```jsonc
// package.json
{ "name": "root", "private": true, "workspaces": ["packages/*"] }
// packages/pkg-a/package.json
{ "name": "pkg-a", "dependencies": { "dep": "^1.0.0" }, "peerDependencies": { "peer": "^1.0.0" } }
```

```console
$ bun install
$ bun update --recursive
# packages/pkg-a/package.json unchanged: dep and peer still ^1.0.0
```

Only the root updated; every workspace member was skipped.

## Cause

`--recursive` set `Do::RECURSIVE` and `--filter` populated `filter_patterns`, but only `update --interactive` and `outdated` ever read them. The non-interactive update path (`updatePackageJSONAndInstall.rs`) edited a single package.json (the cwd's), and the installer's update gate (`PackageManagerEnqueue.rs`) re-resolved dependencies only when they belonged to the root workspace (`is_root_dependency`). Nothing fanned the update out to the other workspaces.

## Fix

When `bun update` is run with `--recursive` or `--filter` and no package names:

- Resolve the target workspace set from the lockfile (all workspaces for `--recursive`, matched workspaces for `--filter`), mirroring how `update --interactive` / `outdated` already resolve it.
- Set an install-time update gate (`is_update_target_dependency`, keyed on stable workspace name hashes so it survives the lockfile remap during install) so the resolver re-resolves dependencies of every selected workspace, not just the root.
- Run the same pre-install / post-install package.json edit pass on each selected member, so all four dependency groups (including `peerDependencies`) are rewritten with the resolved versions and original pin style preserved.

Each member gets its own scratch map, so two workspaces can pin the same dependency differently, and a member the update didn't change is not rewritten. Named updates (`bun update <pkg> --recursive`) are intentionally left on the existing path and unchanged. The default `bun update` (no flags) takes an early return and is byte-for-byte unchanged.

## Tests

`test/cli/install/bun-update.test.ts` (in-process registry):

- `--recursive` updates a member's `dependencies` and another member's `peerDependencies` (same dependency name in both, exercising the per-workspace maps).
- `--recursive --latest` bumps a member's exact-pinned dependency to the latest version.
- `--filter <name>` updates only the matched workspace and leaves sibling workspaces and the root untouched.

Verified fail-before / pass-after: with `src/` reverted the new tests fail (member stays `~0.0.3`); with the fix they pass. Existing update tests and the non-network workspace tests continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3be51a23e)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [490.92ms]
(pass) should update to latest versions of dependencies (~) [420.72ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [1282.98ms]
(pass) should support catalog versions in update [263.81ms]
(pass) should support --recursive flag [337.76ms]
528 |   expect(await new Response(stderr).text()).not.toContain("error:");
529 |   expect(await exited).toBe(0);
530 | 
531 |   const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
532 |   const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
533 |   expect(a.dependencies.baz).toBe
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [28.05ms]
(pass) should update to latest versions of dependencies (~) [12.08ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [32.45ms]
(pass) should support catalog versions in update [5.68ms]
(pass) should support --recursive flag [7.16ms]
528 |   expect(await new Response(stderr).text()).not.toContain("error:");
529 |   expect(await exited).toBe(0);
530 | 
531 |   const a = await file(join(package_dir, "packages", "pkg-a", "package.json")).json();
532 |   const b = await file(join(package_dir, "packages", "pkg-b", "package.json")).json();
533 |   expect(a.dependencies.baz).toBe("~0.0.5");
                                   ^
error: expect(received).toBe(expected)

Expected: "~0.0.5"
Received: "~0.0.3"

      at <anonymous> (/workspace/bun/test/cli/install/bun-update.test.ts:533:30)
(fail) --recursive updates dependencies and peerDependencies in workspace members [10.79ms]
572 |   });
573 |   expect(await new Response(stderr).text()).not.toContain("error:");
574 |   expect(await exited).toBe(0);

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-update.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3be51a23e)

test/cli/install/bun-update.test.ts:
(pass) should update to latest version of dependency (~) [482.42ms]
(pass) should update to latest versions of dependencies (~) [501.22ms]
(pass) lockfile should not be modified when there are no version changes, issue#5888 [1301.17ms]
(pass) should support catalog versions in update [260.26ms]
(pass) should support --recursive flag [268.16ms]
(pass) --recursive updates dependencies and peerDependencies in workspace members [378.64ms]
(pass) --recursive --latest updates workspace members to the latest version [439.88ms]
(pass) --filter updates only matching workspaces, leaving siblings and root untouched [440.13ms]
(pass) named update with --recursive only updates the named package 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3be51a23e8
  features     (none)

22 deps, 106 codegen, 1168 objects in 787ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[4/1231] gen ErrorCode+*.h
[5/1231] gen bindgenv2
[6/1231] fetch picohttpparser
[picohttpparser] up to date
[7/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      |   7 +
 src/install/PackageManager/PackageJSONEditor.rs    |  33 +-
 .../PackageManager/PackageManagerEnqueue.rs        |  12 +-
 .../PackageManager/updatePackageJSONAndInstall.rs  | 448 ++++++++++++++++++++-
 src/install/lockfile.rs                            |  19 +
 test/cli/install/bun-update.test.ts                | 363 +++++++++++++++++
 6 files changed, 850 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/install/PackageManager.rs                                 3      2      0
src/install/PackageManager/PackageJSONEditor.rs               7      9      0
src/install/PackageManager/PackageManagerEnqueue.rs           3      2      0
…c/install/PackageManager/updatePackageJSONAndInstall.rs     19     23      0
src/install/lockfile.rs                                       3      3      0
test/cli/install/bun-update.test.ts                           5      4      0
```

</details>

**root cause** · written by the author bot

The root cause was that non-interactive `bun update` only applied version updates to the root package.json, so with `--recursive` or `--filter` the manifests of workspace members, including their peerDependencies, were never rewritten. The fix makes the update path fan out across all matched workspace packages, editing each member's package.json alongside the root. It also preserves `catalog:` protocol specifiers during that rewrite so catalog references are not clobbered with concrete versions.

<!-- robobun:evidence:end -->