### PR TITLE
module loader: fix false "require() async module" for a module racing a concurrent import

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -766,6 +766,43 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(ns);
         }
+
+        // A concurrent static import of this same module may have created the
+        // registry entry and kicked off an async (transpiler-thread) fetch that
+        // is still in flight. loadModuleSync's top-level path reuses that pending
+        // fetch promise instead of forcing a synchronous fetch, so the graph
+        // never completes synchronously and require() wrongly reports a plain
+        // (non-TLA) module as an unsupported async module. Drive the fetch
+        // synchronously here so the entry reaches Fetched before loadModuleSync
+        // links and evaluates it, mirroring the dependency-load handling in
+        // JSModuleLoader::hostLoadImportedModule. A module that genuinely can't
+        // complete synchronously (real top-level await, async onLoad plugin)
+        // leaves the fetch promise pending and correctly reaches the throw below.
+        if (entry->status() == JSC::ModuleRegistryEntry::Status::Fetching && !entry->record()) {
+            JSPromise* fetchPromise = entry->ensureFetchPromise(globalObject);
+            JSPromise* modulePromise = entry->ensureModulePromise(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (modulePromise->status() == JSPromise::Status::Pending && fetchPromise->status() == JSPromise::Status::Pending) {
+                JSC::VM::SynchronousModuleQueue queue;
+                queue.prev = vm.m_synchronousModuleQueue;
+                vm.m_synchronousModuleQueue = &queue;
+                JSPromise* src = loader->fetch(globalObject, keyValue, nullptr, nullptr);
+                bool settled = false;
+                if (!scope.exception()) {
+                    if (src->status() == JSPromise::Status::Fulfilled) {
+                        fetchPromise->fulfillPromise(vm, src->result());
+                        settled = true;
+                    } else if (src->status() == JSPromise::Status::Rejected) {
+                        fetchPromise->rejectPromise(vm, src->result());
+                        settled = true;
+                    }
+                    if (settled && !scope.exception())
+                        JSC::JSModuleLoader::drainSynchronousModuleQueue(globalObject);
+                }
+                vm.m_synchronousModuleQueue = queue.prev;
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        }
     }
 
     JSPromise* promise = loader->loadModuleSync(globalObject, key, nullptr, nullptr);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -767,17 +767,9 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
             return JSValue::encode(ns);
         }
 
-        // A concurrent static import of this same module may have created the
-        // registry entry and kicked off an async (transpiler-thread) fetch that
-        // is still in flight. loadModuleSync's top-level path reuses that pending
-        // fetch promise instead of forcing a synchronous fetch, so the graph
-        // never completes synchronously and require() wrongly reports a plain
-        // (non-TLA) module as an unsupported async module. Drive the fetch
-        // synchronously here so the entry reaches Fetched before loadModuleSync
-        // links and evaluates it, mirroring the dependency-load handling in
-        // JSModuleLoader::hostLoadImportedModule. A module that genuinely can't
-        // complete synchronously (real top-level await, async onLoad plugin)
-        // leaves the fetch promise pending and correctly reaches the throw below.
+        // A concurrent import may leave this entry Fetching with no record; drive
+        // the fetch synchronously so a sync-completable module reaches Fetched
+        // before loadModuleSync links it. Async fetches (TLA, plugin) stay pending.
         if (entry->status() == JSC::ModuleRegistryEntry::Status::Fetching && !entry->record()) {
             JSPromise* fetchPromise = entry->ensureFetchPromise(globalObject);
             JSPromise* modulePromise = entry->ensureModulePromise(globalObject);

--- a/test/regression/issue/33180.test.ts
+++ b/test/regression/issue/33180.test.ts
@@ -31,10 +31,11 @@ const files = {
   `,
 };
 
-// Repeat as independent tests; without the fix the race throws the false
-// "async module" error on essentially every debug run, so any attempt suffices.
+// Independent attempts (separate temp dirs + child processes, nothing shared);
+// without the fix the race throws the false "async module" error on essentially
+// every debug run, so any attempt suffices.
 for (let attempt = 0; attempt < 4; attempt++) {
-  test(`require(esm) racing a concurrent static import loads synchronously (attempt ${attempt})`, async () => {
+  test.concurrent(`require(esm) racing a concurrent static import loads synchronously (attempt ${attempt})`, async () => {
     using dir = tempDir("issue-33180", files);
     await using proc = Bun.spawn({
       cmd: [bunExe(), "entry.mjs"],

--- a/test/regression/issue/33180.test.ts
+++ b/test/regression/issue/33180.test.ts
@@ -35,19 +35,22 @@ const files = {
 // without the fix the race throws the false "async module" error on essentially
 // every debug run, so any attempt suffices.
 for (let attempt = 0; attempt < 4; attempt++) {
-  test.concurrent(`require(esm) racing a concurrent static import loads synchronously (attempt ${attempt})`, async () => {
-    using dir = tempDir("issue-33180", files);
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "entry.mjs"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("async module");
-    expect(stdout).toContain("required-ok");
-    expect(stdout).toContain("entry-done");
-    expect(exitCode).toBe(0);
-  });
+  test.concurrent(
+    `require(esm) racing a concurrent static import loads synchronously (attempt ${attempt})`,
+    async () => {
+      using dir = tempDir("issue-33180", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("async module");
+      expect(stdout).toContain("required-ok");
+      expect(stdout).toContain("entry-done");
+      expect(exitCode).toBe(0);
+    },
+  );
 }

--- a/test/regression/issue/33180.test.ts
+++ b/test/regression/issue/33180.test.ts
@@ -2,14 +2,9 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// A plain ESM module (no top-level await) that is statically imported while a
-// sibling CommonJS module require()s it must load successfully. The static
-// import kicks off a concurrent transpiler-thread fetch; the require() lands
-// while that fetch is still in flight. loadModuleSync used to reuse the pending
-// async fetch promise instead of forcing a synchronous fetch, so require()
-// wrongly reported the plain module as an unsupported async module. The module
-// body here is large enough that its off-thread transpile is reliably still
-// running when the tiny CommonJS sibling evaluates.
+// A plain (no top-level await) ESM module must stay require()-able while a
+// concurrent static import is still fetching it off-thread. The target is large
+// so its transpile reliably overlaps the tiny CommonJS sibling's require().
 function makeTarget() {
   let src = "";
   for (let i = 0; i < 1000; i++) src += `export const v${i} = ${i};\n`;
@@ -36,10 +31,8 @@ const files = {
   `,
 };
 
-// Several independent attempts: without the fix the race reports the false
-// "async module" error on essentially every run of a debug build, so any one
-// attempt failing is enough. Each attempt is its own test so a single spawn
-// stays well under the default timeout.
+// Repeat as independent tests; without the fix the race throws the false
+// "async module" error on essentially every debug run, so any attempt suffices.
 for (let attempt = 0; attempt < 4; attempt++) {
   test(`require(esm) racing a concurrent static import loads synchronously (attempt ${attempt})`, async () => {
     using dir = tempDir("issue-33180", files);

--- a/test/regression/issue/33180.test.ts
+++ b/test/regression/issue/33180.test.ts
@@ -1,0 +1,59 @@
+// https://github.com/oven-sh/bun/issues/33180
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// A plain ESM module (no top-level await) that is statically imported while a
+// sibling CommonJS module require()s it must load successfully. The static
+// import kicks off a concurrent transpiler-thread fetch; the require() lands
+// while that fetch is still in flight. loadModuleSync used to reuse the pending
+// async fetch promise instead of forcing a synchronous fetch, so require()
+// wrongly reported the plain module as an unsupported async module. The module
+// body here is large enough that its off-thread transpile is reliably still
+// running when the tiny CommonJS sibling evaluates.
+function makeTarget() {
+  let src = "";
+  for (let i = 0; i < 1000; i++) src += `export const v${i} = ${i};\n`;
+  src += `export const val = 42;\n`;
+  src += `export function getVal() { return val; }\n`;
+  return src;
+}
+
+const files = {
+  "target.mjs": makeTarget(),
+  "cjs-req.cjs": `
+    const t = require("./target.mjs");
+    if (t.val !== 42 || t.getVal() !== 42) {
+      console.error("half-initialized namespace: val=" + t.val);
+      process.exit(3);
+    }
+    console.log("required-ok");
+    module.exports = {};
+  `,
+  "entry.mjs": `
+    import "./target.mjs";
+    import "./cjs-req.cjs";
+    console.log("entry-done");
+  `,
+};
+
+// Several independent attempts: without the fix the race reports the false
+// "async module" error on essentially every run of a debug build, so any one
+// attempt failing is enough. Each attempt is its own test so a single spawn
+// stays well under the default timeout.
+for (let attempt = 0; attempt < 4; attempt++) {
+  test(`require(esm) racing a concurrent static import loads synchronously (attempt ${attempt})`, async () => {
+    using dir = tempDir("issue-33180", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("async module");
+    expect(stdout).toContain("required-ok");
+    expect(stdout).toContain("entry-done");
+    expect(exitCode).toBe(0);
+  });
+}


### PR DESCRIPTION
Fixes #33180

## Problem

Under Bun 1.3.14+, `require()` of a plain ESM module (no top-level await) throws a false positive when that module is concurrently loaded by a static `import`:

```
TypeError: require() async module ".../node_modules/jose/dist/webapi/index.js" is unsupported. use "await import()" instead.
      at <anonymous> (.../node_modules/jwks-rsa/src/utils.js:1:7)
```

The reporter hits this on startup with `firebase-admin` (whose `jwks-rsa` does `require('jose')`) while the app also `import`s `jose` directly. `jose`'s webapi entry has zero top-level await, so Node and Bun 1.3.11 both return it; 1.3.14+ throws. It regressed in the module-loader rewrite (#29393).

## Cause

When the `require()` lands, a concurrent static import has already created the registry entry and kicked off an async fetch on the transpiler thread, so the entry is at status `Fetching` with no module record yet. `require(esm)` calls `JSModuleLoader::loadModuleSync`, whose top-level `loadModule` reuses the existing **pending async** fetch promise (`status != New`) instead of forcing a synchronous fetch. The synchronous-fetch handling only exists in the dependency path (`hostLoadImportedModule`), not this top-level path, so the drain completes nothing and the load stays pending, which `functionEsmLoadSync` reports as an unsupported async module.

Instrumented state at the throw (releases, synthetic repro): the entry is `Fetching`, record `null`, and fetch/module/load promises are all still pending both before and after `loadModuleSync`, i.e. the call advances nothing.

## Fix

`functionEsmLoadSync` now detects an entry that is still `Fetching` with no record and drives the fetch synchronously (set up the synchronous module queue, re-issue `loader->fetch` which routes to `fetchESMSourceCodeSync`, fulfill the entry's fetch promise, drain the queue), mirroring the dependency-load handling in `hostLoadImportedModule`. The entry then reaches `Fetched` and the existing `loadModuleSync` path links and evaluates it.

A module that genuinely cannot complete synchronously (real top-level await, async `onLoad` plugin) leaves the fetch promise pending and still reaches the async-module throw, so the existing guardrail behavior is preserved.

## Verification

- New regression test `test/regression/issue/33180.test.ts`: a plain ESM module statically imported alongside a CJS sibling that `require()`s it. Fails on the unfixed debug build with the exact issue error on every attempt; passes with the fix.
- Guardrails stay green: `require-esm-transitive-tla`, `require-esm-microtask-order`, `issue/24387` (TLA still throws `ERR_REQUIRE_ASYNC_MODULE`), plus `require`, `concurrent-dynamic-import`, `esModule`.
- Manual: a large synthetically-slow (sync-completable, no TLA) target went from 20/20 throws to 0/20 on a release build; a macro-task-TLA target still throws 5/5.