### PR TITLE
terminal: drain the PTY master on subprocess exit before closing the slave

### DIFF
--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -662,11 +662,40 @@ impl Terminal {
         self.hpcon.get()
     }
 
-    /// Close the parent's copy of slave_fd after fork
-    /// The child process has its own copy - closing the parent's ensures
-    /// EOF is received on the master side when the child exits
-    pub(crate) fn close_slave_fd(&self) {
+    /// Mark an inline-created terminal as attached to a subprocess, so it can't
+    /// be reused for a second spawn. The parent keeps its slave fd (POSIX) /
+    /// pseudoconsole (Windows) open for the child's lifetime; the read side is
+    /// released from the subprocess's exit handler (`on_owning_subprocess_exit`
+    /// on POSIX, `close_pseudoconsole` on Windows).
+    pub(crate) fn mark_inline_spawned(&self) {
         self.update_flags(|f| f.insert(Flags::INLINE_SPAWNED));
+    }
+
+    /// POSIX: called from the owning subprocess's exit handler. The parent kept
+    /// its copy of the slave fd open across the child's lifetime, so the child
+    /// exiting did not make the master return EIO. That matters on macOS, where
+    /// reading the master after the last slave closes returns EIO and can
+    /// discard buffered output that was never read. While a slave is still open
+    /// the master returns buffered data then EAGAIN (never EIO), so drain it
+    /// now, then close the parent's slave so the next read observes EOF and the
+    /// exit callback fires.
+    #[cfg(not(windows))]
+    pub(crate) fn on_owning_subprocess_exit(&self) {
+        if self
+            .flags
+            .get()
+            .intersects(Flags::CLOSED | Flags::READER_DONE | Flags::FINALIZED)
+        {
+            return;
+        }
+        if self.slave_fd.get() == Fd::INVALID {
+            return;
+        }
+        if self.flags.get().contains(Flags::READER_STARTED) {
+            self.reader.with_mut(|r| r.read());
+        }
+        // Re-read: a reentrant close() from the drain's data callback may have
+        // already invalidated the slave fd.
         let fd = self.slave_fd.get();
         if fd != Fd::INVALID {
             fd.close();

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1413,15 +1413,17 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         IS_SYNC,
     ));
 
-    // For inline terminal options: close parent's slave_fd so EOF is received when child exits
-    // For existing terminal: keep slave_fd open so terminal can be reused for more spawns
+    // Inline terminal: keep the parent's slave fd open for the child's lifetime
+    // so its exit doesn't make the master return EIO (on macOS that can discard
+    // unread output). The slave is drained and closed from the subprocess exit
+    // handler instead (Subprocess::on_process_exit).
+    // Existing terminal: leave it alone - the user manages lifecycle and reuse.
     if let Some(info) = terminal_info.take() {
         terminal_js_value = info.js_value;
         // Spawn succeeded so the child holds its own copy of the slave fd.
-        info.term().close_slave_fd();
+        info.term().mark_inline_spawned();
         subprocess.update_flags(|f| f.insert(Subprocess::Flags::OWNS_TERMINAL));
     }
-    // existing_terminal: don't close slave_fd - user manages lifecycle and can reuse
 
     // SAFETY: `subprocess_ptr` is the live JSC-allocated Subprocess that owns
     // `process` and outlives it (handler ctx invariant).

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -909,8 +909,7 @@ impl Subprocess<'_> {
 
         #[cfg(windows)]
         if self.flags.get().contains(Flags::OWNS_TERMINAL) {
-            // POSIX gets EOF on the master when the child (last slave_fd holder)
-            // exits. ConPTY's conhost stays alive after the child exits, so close
+            // ConPTY's conhost stays alive after the child exits, so close
             // the pseudoconsole now to deliver EOF and fire the terminal's exit
             // callback. Leaves the Terminal itself open to match POSIX.
             if let Some(terminal) = self.terminal.get() {
@@ -918,6 +917,22 @@ impl Subprocess<'_> {
                 // borrowed from a JS wrapper kept live by) this subprocess and
                 // outlives this scope; single JS thread.
                 bun_ptr::BackRef::from(terminal).close_pseudoconsole();
+            }
+        }
+
+        #[cfg(not(windows))]
+        if self.flags.get().contains(Flags::OWNS_TERMINAL) {
+            // The parent kept its slave fd open for the child's lifetime, so the
+            // child's exit did not make the master return EIO (which on macOS
+            // can discard unread output). Drain the master while a slave is
+            // still open, then close the parent's slave so the master observes
+            // EOF and the terminal's exit callback fires. Mirrors the Windows
+            // pseudoconsole close above.
+            if let Some(terminal) = self.terminal.get() {
+                // `BackRef` invariant holds: the terminal is owned by (or
+                // borrowed from a JS wrapper kept live by) this subprocess and
+                // outlives this scope; single JS thread.
+                bun_ptr::BackRef::from(terminal).on_owning_subprocess_exit();
             }
         }
 

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -998,6 +998,7 @@ describe.concurrent("Bun.spawn with terminal option", () => {
   test("creates subprocess with terminal attached", async () => {
     const dataChunks: Uint8Array[] = [];
     const gotMarker = Promise.withResolvers<void>();
+    const gotEof = Promise.withResolvers<void>();
 
     const proc = Bun.spawn([bunExe(), "-e", "console.log('hello from terminal')"], {
       env: bunEnv,
@@ -1008,13 +1009,17 @@ describe.concurrent("Bun.spawn with terminal option", () => {
           dataChunks.push(data);
           if (Buffer.concat(dataChunks).toString().includes("hello from terminal")) gotMarker.resolve();
         },
+        exit: () => gotEof.resolve(),
       },
     });
 
     expect(proc.terminal).toBeDefined();
     expect(proc.terminal).toBeInstanceOf(Object);
 
-    await gotMarker.promise;
+    // The child's output must reach the data callback before the PTY reaches
+    // EOF. Racing against EOF makes a dropped-output regression fail fast
+    // (https://github.com/oven-sh/bun/issues/33187) instead of hanging 90s.
+    await Promise.race([gotMarker.promise, gotEof.promise]);
     await proc.exited;
 
     // Should have received data through the terminal


### PR DESCRIPTION
Fixes #33187.

## Symptom

`test/js/bun/terminal/terminal.test.ts > Bun.spawn with terminal option > creates subprocess with terminal attached` times out after 90000ms on the `darwin 14 x64 - test-bun` lane, on ~13% of builds, across unrelated branches. Only that lane fails; the other darwin lanes pass the same file in the same builds.

```
✗ Bun.spawn with terminal option > creates subprocess with terminal attached [90000.00ms]
  ^ this test timed out after 90000ms.
```

The test spawns `bun -e "console.log('hello from terminal')"` with an inline `terminal:` option and awaits the PTY `data` callback delivering that line. When the line never arrives, it blocks to the timeout.

## Cause

For an inline terminal, `Bun.spawn` closed the parent's copy of the PTY slave fd immediately after spawn (`js_bun_spawn_bindings.rs`), so the child process held the last open slave. The child's exit then closed that last slave, which is what delivered EOF on the master.

On Linux the kernel returns any buffered output before EOF, so the bytes always arrive. On macOS, reading the master after the last slave closes returns `EIO`, and output the reader had not drained yet can be discarded. The child's stdout is lost, the `data` callback never fires, `gotMarker` never resolves, and the test hangs. The heavier `describe.concurrent` load on a slower Intel agent widens the window between "child writes + exits" and "master is read", which is why it only shows up on `darwin 14 x64`.

Windows already avoids this: it keeps the pseudoconsole open for the child's lifetime and closes it on subprocess exit (`subprocess.rs`). POSIX was the odd one out.

## Fix

Make POSIX mirror Windows. Keep the parent's slave fd open for the child's lifetime, and release it from the subprocess exit handler:

1. While a slave fd is still open, a read on the master returns buffered data then `EAGAIN`, never `EIO`. Drain the master fully there.
2. Then close the parent's slave so the next read observes EOF and the terminal's exit callback fires.

Because the drain happens while a slave is guaranteed open, it cannot hit the `EIO`-discard path, so no output is lost regardless of how the read and the process-exit events are ordered within an event-loop turn.

The test now races the data marker against the PTY EOF (`exit` callback) so a future dropped-output regression fails in ~1s instead of hanging to the timeout.

## Verification

On linux-x64 (debug build, ASAN), the full terminal suite is green and stable:

- `terminal.test.ts`: 89 pass / 0 fail, 5/5 repeat runs stable.
- `terminal-spawn.test.ts` + `terminal-platform-gaps.test.ts`: 34 pass / 0 fail, including "exit callback fires after child exits (inline terminal)", "terminal can be reused across sequential spawns", and "can create many terminals with FD cleanup".
- spawn exit tests unaffected (the new branch is gated on `OWNS_TERMINAL`).

The change is behavior-preserving on Linux and now closes the slave from the exit handler there too, so the new code path is exercised on every lane.

Note: the race is macOS-specific and does not reproduce on Linux (Linux preserves buffered PTY data before EOF), so it is not fail-before reproducible on a Linux-only check. Confirmation belongs on the `darwin 14 x64` lane; re-running CI a few times on this PR should show the flake gone.