### PR TITLE
sql(mysql): retry a failed prepare instead of caching the error forever

### DIFF
--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -147,9 +147,6 @@ impl JSMySQLQuery {
         }
         this.set_target(target);
         if let Err(err) = this.run(connection) {
-            // The thrown exception propagates out of this host function and
-            // internal/sql/query.ts rejects the promise, so the native query is
-            // marked terminal here rather than in run()'s errguard (see there).
             this.mark_as_failed();
             if !global_object.has_exception() {
                 return Err(global_object.throw_value(mysql_error_to_js(
@@ -382,9 +379,6 @@ impl JSMySQLQuery {
         // value, mutation is `JsCell`-backed, and `into_inner` disarms on the
         // success path below.
         let errguard = scopeguard::guard(self, |s| {
-            // `query.fail()` is deliberately not here (PostgresSQLQuery::run
-            // matches): the advance()-driven caller settles the promise via
-            // `reject_with_js_value`, whose once-guard no-ops on a failed query.
             s.this_value.with_mut(|v| v.downgrade());
         });
 

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -147,6 +147,10 @@ impl JSMySQLQuery {
         }
         this.set_target(target);
         if let Err(err) = this.run(connection) {
+            // The thrown exception propagates out of this host function and
+            // internal/sql/query.ts rejects the promise, so the native query is
+            // marked terminal here rather than in run()'s errguard (see there).
+            this.mark_as_failed();
             if !global_object.has_exception() {
                 return Err(global_object.throw_value(mysql_error_to_js(
                     global_object,
@@ -378,8 +382,10 @@ impl JSMySQLQuery {
         // value, mutation is `JsCell`-backed, and `into_inner` disarms on the
         // success path below.
         let errguard = scopeguard::guard(self, |s| {
+            // `query.fail()` is deliberately not here (PostgresSQLQuery::run
+            // matches): the advance()-driven caller settles the promise via
+            // `reject_with_js_value`, whose once-guard no-ops on a failed query.
             s.this_value.with_mut(|v| v.downgrade());
-            let _ = s.query.with_mut(|q| q.fail());
         });
 
         let columns_value = self.get_columns().unwrap_or(JSValue::UNDEFINED);

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1359,12 +1359,8 @@ impl MySQLConnection {
                 // `on_error_packet` below.
                 self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
                 statement.status = mysql_statement::Status::Failed;
-                // err.error_message is a temporary slice into the socket read buffer that
-                // the next packet overwrites, and queries that attached to this statement
-                // before the failure read stmt.error_response later, so own a copy of it.
-                // ErrorPacket lacks Clone in bun_sql (Data is not Clone), so rebuild it
-                // field-by-field with an owned dupe of the message; the scalar fields
-                // (header / error_code / sql_state) are all Copy.
+                // err.error_message borrows the socket read buffer, which the next packet
+                // overwrites; queries attached to this statement read error_response later.
                 statement.error_response = ErrorPacket {
                     header: err.header,
                     error_code: err.error_code,
@@ -1373,9 +1369,6 @@ impl MySQLConnection {
                     error_message: Data::create(err.error_message.slice())
                         .map_err(|_| AnyMySQLError::OutOfMemory)?,
                 };
-                // Evict the failed prepare from the statement cache so the next query with
-                // this text re-prepares instead of rethrowing the stale server error forever
-                // (mirrors PostgresSQLConnection's ErrorResponse handler).
                 // The request still holds its own ref, so dropping the map's RefPtr
                 // cannot free the statement.
                 let stmt_ptr: *const MySQLStatement = core::ptr::from_ref(&*statement);

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1359,8 +1359,6 @@ impl MySQLConnection {
                 // `on_error_packet` below.
                 self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
                 statement.status = mysql_statement::Status::Failed;
-                // err.error_message borrows the socket read buffer, which the next packet
-                // overwrites; queries attached to this statement read error_response later.
                 statement.error_response = ErrorPacket {
                     header: err.header,
                     error_code: err.error_code,

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1359,14 +1359,12 @@ impl MySQLConnection {
                 // `on_error_packet` below.
                 self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
                 statement.status = mysql_statement::Status::Failed;
-                // err.error_message is a Data{ .temporary = ... } slice into the socket read
-                // buffer which will be overwritten by the next packet. Queries that attached
-                // to this statement before the failure read stmt.error_response later, so we
-                // must own a copy of the message bytes.
-                // ErrorPacket lacks Clone in bun_sql (Data is not Clone), so
-                // reconstruct field-by-field with an owned dupe of the message
-                // — the scalar fields (header / error_code / sql_state) are
-                // all Copy.
+                // err.error_message is a temporary slice into the socket read buffer that
+                // the next packet overwrites, and queries that attached to this statement
+                // before the failure read stmt.error_response later, so own a copy of it.
+                // ErrorPacket lacks Clone in bun_sql (Data is not Clone), so rebuild it
+                // field-by-field with an owned dupe of the message; the scalar fields
+                // (header / error_code / sql_state) are all Copy.
                 statement.error_response = ErrorPacket {
                     header: err.header,
                     error_code: err.error_code,

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1360,9 +1360,9 @@ impl MySQLConnection {
                 self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
                 statement.status = mysql_statement::Status::Failed;
                 // err.error_message is a Data{ .temporary = ... } slice into the socket read
-                // buffer which will be overwritten by the next packet. The statement is cached
-                // in this.statements and its error_response may be read later via
-                // stmt.error_response.toJS(), so we must own a copy of the message bytes.
+                // buffer which will be overwritten by the next packet. Queries that attached
+                // to this statement before the failure read stmt.error_response later, so we
+                // must own a copy of the message bytes.
                 // ErrorPacket lacks Clone in bun_sql (Data is not Clone), so
                 // reconstruct field-by-field with an owned dupe of the message
                 // — the scalar fields (header / error_code / sql_state) are
@@ -1375,6 +1375,21 @@ impl MySQLConnection {
                     error_message: Data::create(err.error_message.slice())
                         .map_err(|_| AnyMySQLError::OutOfMemory)?,
                 };
+                // Evict the failed prepare from the statement cache so the next query with
+                // this text re-prepares instead of rethrowing the stale server error forever
+                // (mirrors PostgresSQLConnection's ErrorResponse handler).
+                // The request still holds its own ref, so dropping the map's RefPtr
+                // cannot free the statement.
+                let stmt_ptr: *const MySQLStatement = core::ptr::from_ref(&*statement);
+                let name = &statement.signature.name[..];
+                if self.statements.get(name).is_some_and(|p| {
+                    core::ptr::eq(
+                        p.as_ref().map_or(core::ptr::null(), |p| p.as_ptr()),
+                        stmt_ptr,
+                    )
+                }) {
+                    self.statements.remove(name);
+                }
                 self.queue.mark_as_ready_for_query();
                 self.queue.mark_current_request_as_finished(request);
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1367,8 +1367,7 @@ impl MySQLConnection {
                     error_message: Data::create(err.error_message.slice())
                         .map_err(|_| AnyMySQLError::OutOfMemory)?,
                 };
-                // The request still holds its own ref, so dropping the map's RefPtr
-                // cannot free the statement.
+                // The request still holds another ref; this cannot drop to 0.
                 let stmt_ptr: *const MySQLStatement = core::ptr::from_ref(&*statement);
                 let name = &statement.signature.name[..];
                 if self.statements.get(name).is_some_and(|p| {

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -307,12 +307,6 @@ impl MySQLQuery {
 
             match entry.value_ptr {
                 Some(stmt) => {
-                    if stmt.status == my_sql_statement::Status::Failed {
-                        let error_response = stmt.error_response.to_js(global_object);
-                        // If the statement failed, we need to throw the error
-                        let _ = global_object.throw_value(error_response);
-                        return Err(crate::Error::JSError);
-                    }
                     self.statement = Some(stmt.clone());
                 }
                 slot @ None => {

--- a/test/js/sql/sql-mysql-cached-error.test.ts
+++ b/test/js/sql/sql-mysql-cached-error.test.ts
@@ -1,73 +1,77 @@
-// Regression test: MySQLConnection.handlePreparedStatement stored an ErrorPacket whose
-// error_message was a Data{ .temporary = ... } slice pointing into the socket read buffer.
-// The statement is cached in the connection's statements map with status = .failed, so
-// re-running the same failing query would read the stale slice after subsequent packets
-// overwrote the buffer.
+// Regression test: MySQLConnection cached a prepared statement whose
+// COM_STMT_PREPARE failed (status = .failed) in the per-connection statement map
+// and never evicted it, so every later execution of the same query text on that
+// connection rethrew the stale ErrorPacket without ever re-preparing. A
+// transient prepare-time error (a table created by a concurrent migration, a
+// deadlock, ER_TOO_MANY_CONCURRENT_STMTS) therefore poisoned the connection for
+// the process lifetime. handlePreparedStatement now evicts the failed statement
+// from the map (as the Postgres driver already did) so the prepare is retried on
+// the next use of that text.
+//
+// This file previously asserted the opposite (Com_stmt_prepare must NOT
+// increment across an identical re-run) to pin a dangling-slice read in the
+// cached ErrorPacket's error_message; that cache-hit path no longer exists.
+// test/js/sql/sql-mysql-failed-prepare-retry.test.ts is the wire-level
+// counterpart that runs without a container.
 
-import { SQL } from "bun";
+import { SQL, randomUUIDv7 } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer, isDockerEnabled } from "harness";
 
 if (isDockerEnabled()) {
   describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    test("MySQL: cached failed prepared statement error_message is not a dangling slice", async () => {
+    test("MySQL: a failed prepare is re-prepared instead of served from the statement cache", async () => {
       await container.ready;
+      // max: 1 so every query runs on the same connection / same statement map,
+      // and Com_stmt_prepare (a SESSION counter) observes exactly that session.
       await using sql = new SQL({
         url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
         max: 1,
       });
 
-      // Long bogus identifiers so the server's echoed error_message exceeds the 15-byte
-      // inline-string threshold and is heap-backed, and so the two messages differ at
-      // bytes the second packet would overwrite in the read buffer. MySQL truncates the
-      // "near '...'" clause to ~80 chars, so keep these short enough to appear in full.
-      const longA = Buffer.alloc(50, "A").toString();
-      const longZ = Buffer.alloc(50, "Z").toString();
+      const table = "t_retry_" + randomUUIDv7("hex").replaceAll("-", "");
+      // .simple() = COM_QUERY (text protocol), so the counter read itself never
+      // sends a COM_STMT_PREPARE.
+      const prepares = async () =>
+        Number((await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple())[0].Value);
 
-      // First failing query → statement cached as .failed with error_message.
-      const err1 = await sql`wat ${1} ${sql.unsafe(longA)}`.catch((x: any) => x);
-      expect(err1).toBeInstanceOf(Error);
-      expect(err1.code).toBe("ERR_MYSQL_SYNTAX_ERROR");
-      expect(err1.errno).toBe(1064);
-      expect(err1.message).toContain(longA);
+      try {
+        // 1. The table does not exist yet: the prepare fails (ER_NO_SUCH_TABLE).
+        const err1 = await sql`SELECT n FROM ${sql(table)}`.catch((x: any) => x);
+        expect(err1).toBeInstanceOf(Error);
+        expect(err1.errno).toBe(1146);
+        const afterFirst = await prepares();
+        expect(afterFirst).toBeGreaterThan(0);
 
-      // Different failing query → server sends a different ERROR packet that overwrites
-      // the connection read buffer where err1's message slice used to point.
-      const errOverwrite = await sql`other ${1} ${sql.unsafe(longZ)}`.catch((x: any) => x);
-      expect(errOverwrite).toBeInstanceOf(Error);
-      expect(errOverwrite.message).toContain(longZ);
-      expect(errOverwrite.message).not.toBe(err1.message);
+        // 2. Same text, table still missing. Before the fix the stale cached
+        //    ErrorPacket was replayed and the server never saw a second
+        //    COM_STMT_PREPARE; now Bun re-prepares and the server answers the
+        //    same (still true) error.
+        const err2 = await sql`SELECT n FROM ${sql(table)}`.catch((x: any) => x);
+        expect({ errno: err2.errno, message: err2.message, prepares: await prepares() }).toEqual({
+          errno: 1146,
+          message: err1.message,
+          prepares: afterFirst + 1,
+        });
 
-      // Same as the first failing query → hits the cached .failed statement and calls
-      // stmt.error_response.toJS(). Before the fix this read the overwritten buffer and
-      // returned bytes from errOverwrite's packet; after the fix it returns the original.
-      // Com_stmt_prepare (read via .simple() so the status query itself does not prepare)
-      // must not increment across this call — proving the third query was served from
-      // Bun's failed-statement cache, not re-prepared on the server. A fresh prepare
-      // would return an identical error for identical SQL and silently satisfy every
-      // assertion below without exercising the cached-slice path.
-      const [{ Value: preparesBefore }] = await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple();
-      // err1 and errOverwrite each reached COM_STMT_PREPARE, so the counter is
-      // already non-zero here; if it were 0 the "no increment" check below would
-      // be vacuous because the prepared path was never taken.
-      expect(Number(preparesBefore)).toBeGreaterThan(0);
-      const err2 = await sql`wat ${1} ${sql.unsafe(longA)}`.catch((x: any) => x);
-      const [{ Value: preparesAfter }] = await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple();
-      expect({
-        code: err2.code,
-        errno: err2.errno,
-        sqlState: err2.sqlState,
-        message: err2.message,
-        preparesAfter: Number(preparesAfter),
-      }).toEqual({
-        code: err1.code,
-        errno: err1.errno,
-        sqlState: err1.sqlState,
-        message: err1.message,
-        preparesAfter: Number(preparesBefore),
-      });
-      expect(err2.message).toContain(longA);
-      expect(err2.message).not.toContain(longZ);
+        // 3. The migration lands. The same text on the same connection must now
+        //    prepare successfully and return rows.
+        await sql.unsafe(`CREATE TABLE \`${table}\` (n INT)`).simple();
+        await sql.unsafe(`INSERT INTO \`${table}\` VALUES (42)`).simple();
+        const beforeThird = await prepares();
+        expect(await sql`SELECT n FROM ${sql(table)}`).toEqual([{ n: 42 }]);
+        expect(await prepares()).toBe(beforeThird + 1);
+
+        // 4. Only Failed entries are evicted: the now-Prepared statement is
+        //    served from the cache, so the counter does not move.
+        expect(await sql`SELECT n FROM ${sql(table)}`).toEqual([{ n: 42 }]);
+        expect(await prepares()).toBe(beforeThird + 1);
+      } finally {
+        await sql
+          .unsafe(`DROP TABLE IF EXISTS \`${table}\``)
+          .simple()
+          .catch(() => {});
+      }
     });
   });
 }

--- a/test/js/sql/sql-mysql-failed-prepare-retry.test.ts
+++ b/test/js/sql/sql-mysql-failed-prepare-retry.test.ts
@@ -1,0 +1,117 @@
+// Regression test: MySQLConnection cached a prepared statement whose
+// COM_STMT_PREPARE failed (status = .failed) in the per-connection statement
+// map and never evicted it, so every later execution of the same query text on
+// that connection rethrew the stale ErrorPacket without ever re-preparing.
+// Transient prepare failures are normal (a table that appears after a
+// migration, deadlocks, ER_TOO_MANY_CONCURRENT_STMTS); with pooling this
+// poisons a connection for the process lifetime.
+//
+// The oracle is the number of COM_STMT_PREPARE frames the client emits for one
+// query text, so the server here is a scripted mock that observes the client's
+// outbound frames directly: the first prepare of the text fails, every later
+// prepare of it succeeds. A real container cannot make the same prepare fail
+// once and then succeed without an out-of-band DDL racing the client.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import type { Socket } from "node:net";
+import {
+  listeningServer,
+  mysqlErrorPacket,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  mysqlStmtPrepareOk,
+} from "./wire-frames";
+
+const COM_QUIT = 0x01;
+const COM_STMT_PREPARE = 0x16;
+const COM_STMT_EXECUTE = 0x17;
+const COM_STMT_CLOSE = 0x19;
+
+test("MySQL: a failed prepare is evicted from the statement cache and retried", async () => {
+  // First COM_STMT_PREPARE for a given text answers ERR 1146 (table missing),
+  // every later one answers OK. COM_STMT_EXECUTE always answers OK.
+  const preparesByText = new Map<string, number>();
+  let connections = 0;
+  let stmtId = 0;
+  const sockets = new Set<Socket>();
+  const { server, port } = await listeningServer(socket => {
+    connections++;
+    sockets.add(socket);
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        const cmd = payload[0];
+        if (cmd === COM_STMT_PREPARE) {
+          const text = payload.subarray(1).toString("utf-8");
+          const n = (preparesByText.get(text) ?? 0) + 1;
+          preparesByText.set(text, n);
+          if (n === 1) {
+            socket.write(mysqlErrorPacket(1, 1146, "42S02", "Table 'db.t' doesn't exist"));
+          } else {
+            socket.write(mysqlStmtPrepareOk(1, ++stmtId, 0, 0));
+          }
+        } else if (cmd === COM_STMT_EXECUTE) {
+          socket.write(mysqlOkPacket(1));
+        } else if (cmd === COM_STMT_CLOSE) {
+          // COM_STMT_CLOSE expects no response.
+        } else if (cmd === COM_QUIT) {
+          socket.end();
+        } else {
+          socket.end();
+        }
+      });
+    });
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+    const settled = (q: Promise<any>) =>
+      q.then(
+        value => ({ status: "fulfilled", value }) as const,
+        reason => ({ status: "rejected", reason }) as const,
+      );
+
+    // 1. The prepare fails with a transient server error.
+    const first = await settled(sql`SELECT * FROM t`);
+    expect(first.status).toBe("rejected");
+    expect((first as any).reason).toMatchObject({ errno: 1146, code: "ERR_MYSQL_SERVER_ERROR" });
+
+    // 2. The same text again on the same connection. Before the fix the stale
+    //    ErrorPacket was replayed from the statement cache and the server never
+    //    saw a second COM_STMT_PREPARE; after the fix it re-prepares and runs.
+    const second = await settled(sql`SELECT * FROM t`);
+
+    // 3. Same text a third time: the now-Prepared statement IS served from the
+    //    cache, proving only Failed entries are evicted, not the cache itself.
+    const third = await settled(sql`SELECT * FROM t`);
+
+    expect({
+      connections,
+      prepares: preparesByText.get("SELECT * FROM t"),
+      second: second.status,
+      third: third.status,
+    }).toEqual({
+      connections: 1,
+      prepares: 2,
+      second: "fulfilled",
+      third: "fulfilled",
+    });
+  } finally {
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});

--- a/test/js/sql/sql-mysql-failed-prepare-retry.test.ts
+++ b/test/js/sql/sql-mysql-failed-prepare-retry.test.ts
@@ -1,18 +1,22 @@
-// Regression test: MySQLConnection cached a prepared statement whose
-// COM_STMT_PREPARE failed (status = .failed) in the per-connection statement
-// map and never evicted it, so every later execution of the same query text on
-// that connection rethrew the stale ErrorPacket without ever re-preparing.
-// Transient prepare failures are normal (a table that appears after a
-// migration, deadlocks, ER_TOO_MANY_CONCURRENT_STMTS); with pooling this
-// poisons a connection for the process lifetime.
+// Regression tests for how a failed COM_STMT_PREPARE is handled, against a
+// scripted MySQL server. All wire-protocol bytes come from
+// test/js/sql/wire-frames.ts; do not inline Buffer.alloc frame construction.
+//
+// 1. MySQLConnection cached a prepared statement whose prepare failed
+//    (status = .failed) in the per-connection statement map and never evicted
+//    it, so every later execution of the same query text on that connection
+//    rethrew the stale ErrorPacket without ever re-preparing. Transient
+//    prepare failures are normal (a table that appears after a migration,
+//    deadlocks, ER_TOO_MANY_CONCURRENT_STMTS); with pooling this poisons a
+//    connection for the process lifetime.
+// 2. A second identical query started in the same synchronous turn attaches to
+//    the first's in-flight statement. When the shared prepare failed, the
+//    second query's promise was never settled (see the second test).
 //
 // The oracle is the number of COM_STMT_PREPARE frames the client emits for one
-// query text, so the server here is a scripted mock that observes the client's
-// outbound frames directly: the first prepare of the text fails, every later
-// prepare of it succeeds. A real container cannot make the same prepare fail
-// once and then succeed without an out-of-band DDL racing the client.
-// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
-// Buffer.alloc frame construction here.
+// query text, so the server is a mock that observes the client's outbound
+// frames directly: a real container cannot make the same prepare fail once and
+// then succeed without an out-of-band DDL racing the client.
 
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
@@ -31,12 +35,15 @@ const COM_STMT_PREPARE = 0x16;
 const COM_STMT_EXECUTE = 0x17;
 const COM_STMT_CLOSE = 0x19;
 
-test("MySQL: a failed prepare is evicted from the statement cache and retried", async () => {
-  // First COM_STMT_PREPARE for a given text answers ERR 1146 (table missing),
-  // every later one answers OK. COM_STMT_EXECUTE always answers OK.
+/**
+ * A scripted MySQL server: handshake, OK for the auth response, then routes
+ * each COM_STMT_PREPARE through `onPrepare(text, nth)` (nth is 1-based per
+ * distinct query text) and answers every COM_STMT_EXECUTE with an OK packet.
+ * Call `stop()` in a `finally`.
+ */
+async function mockMySQLServer(onPrepare: (text: string, nth: number) => Buffer) {
   const preparesByText = new Map<string, number>();
   let connections = 0;
-  let stmtId = 0;
   const sockets = new Set<Socket>();
   const { server, port } = await listeningServer(socket => {
     connections++;
@@ -56,11 +63,7 @@ test("MySQL: a failed prepare is evicted from the statement cache and retried", 
           const text = payload.subarray(1).toString("utf-8");
           const n = (preparesByText.get(text) ?? 0) + 1;
           preparesByText.set(text, n);
-          if (n === 1) {
-            socket.write(mysqlErrorPacket(1, 1146, "42S02", "Table 'db.t' doesn't exist"));
-          } else {
-            socket.write(mysqlStmtPrepareOk(1, ++stmtId, 0, 0));
-          }
+          socket.write(onPrepare(text, n));
         } else if (cmd === COM_STMT_EXECUTE) {
           socket.write(mysqlOkPacket(1));
         } else if (cmd === COM_STMT_CLOSE) {
@@ -75,15 +78,35 @@ test("MySQL: a failed prepare is evicted from the statement cache and retried", 
     socket.on("error", () => {});
     socket.on("close", () => sockets.delete(socket));
   });
+  return {
+    port,
+    preparesByText,
+    connections: () => connections,
+    async stop() {
+      for (const s of sockets) s.destroy();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    },
+  };
+}
+
+const tableMissing = () => mysqlErrorPacket(1, 1146, "42S02", "Table 'db.t' doesn't exist");
+
+const settled = (q: Promise<any>) =>
+  q.then(
+    value => ({ status: "fulfilled", value }),
+    reason => ({ status: "rejected", reason }),
+  );
+
+test("MySQL: a failed prepare is evicted from the statement cache and retried", async () => {
+  // First COM_STMT_PREPARE for a given text answers ERR 1146 (table missing),
+  // every later one answers OK.
+  let stmtId = 0;
+  const mock = await mockMySQLServer((_text, nth) =>
+    nth === 1 ? tableMissing() : mysqlStmtPrepareOk(1, ++stmtId, 0, 0),
+  );
 
   try {
-    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
-
-    const settled = (q: Promise<any>) =>
-      q.then(
-        value => ({ status: "fulfilled", value }) as const,
-        reason => ({ status: "rejected", reason }) as const,
-      );
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${mock.port}/db`, max: 1 });
 
     // 1. The prepare fails with a transient server error.
     const first = await settled(sql`SELECT * FROM t`);
@@ -100,8 +123,8 @@ test("MySQL: a failed prepare is evicted from the statement cache and retried", 
     const third = await settled(sql`SELECT * FROM t`);
 
     expect({
-      connections,
-      prepares: preparesByText.get("SELECT * FROM t"),
+      connections: mock.connections(),
+      prepares: mock.preparesByText.get("SELECT * FROM t"),
       second: second.status,
       third: third.status,
     }).toEqual({
@@ -111,7 +134,43 @@ test("MySQL: a failed prepare is evicted from the statement cache and retried", 
       third: "fulfilled",
     });
   } finally {
-    for (const s of sockets) s.destroy();
-    await new Promise<void>(resolve => server.close(() => resolve()));
+    await mock.stop();
+  }
+});
+
+// Two identical queries started in the same synchronous turn share one prepare:
+// the second attaches to the first's in-flight (Parsing) statement before the
+// server answers. When that shared prepare failed, advance() re-ran the second
+// query, JSMySQLQuery::run's errguard marked it failed on unwind, and
+// reject_with_js_value's settle-once guard then returned without ever invoking
+// the reject callback, leaving the second query's promise pending forever.
+test("MySQL: a concurrent query sharing a failed prepare is rejected, not left pending", async () => {
+  // Every COM_STMT_PREPARE for the text answers ERR 1146, so the only correct
+  // outcome for BOTH queries is a rejection carrying that error.
+  const mock = await mockMySQLServer(() => tableMissing());
+
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${mock.port}/db`, max: 1 });
+
+    const results = await Promise.all(
+      [sql`SELECT * FROM t`, sql`SELECT * FROM t`].map(q =>
+        q.then(
+          () => ({ status: "fulfilled" }),
+          (e: any) => ({ status: "rejected", isError: e instanceof Error, errno: e?.errno }),
+        ),
+      ),
+    );
+
+    // `prepares: 1` proves the second query shared the first's prepare attempt
+    // instead of issuing its own COM_STMT_PREPARE.
+    expect({ results, prepares: mock.preparesByText.get("SELECT * FROM t") }).toEqual({
+      results: [
+        { status: "rejected", isError: true, errno: 1146 },
+        { status: "rejected", isError: true, errno: 1146 },
+      ],
+      prepares: 1,
+    });
+  } finally {
+    await mock.stop();
   }
 });

--- a/test/js/sql/sql-mysql-failed-prepare-retry.test.ts
+++ b/test/js/sql/sql-mysql-failed-prepare-retry.test.ts
@@ -97,7 +97,7 @@ const settled = (q: Promise<any>) =>
     reason => ({ status: "rejected", reason }),
   );
 
-test("MySQL: a failed prepare is evicted from the statement cache and retried", async () => {
+test.concurrent("MySQL: a failed prepare is evicted from the statement cache and retried", async () => {
   // First COM_STMT_PREPARE for a given text answers ERR 1146 (table missing),
   // every later one answers OK.
   let stmtId = 0;
@@ -138,13 +138,10 @@ test("MySQL: a failed prepare is evicted from the statement cache and retried", 
   }
 });
 
-// Two identical queries started in the same synchronous turn share one prepare:
-// the second attaches to the first's in-flight (Parsing) statement before the
-// server answers. When that shared prepare failed, advance() re-ran the second
-// query, JSMySQLQuery::run's errguard marked it failed on unwind, and
-// reject_with_js_value's settle-once guard then returned without ever invoking
-// the reject callback, leaving the second query's promise pending forever.
-test("MySQL: a concurrent query sharing a failed prepare is rejected, not left pending", async () => {
+// Two identical queries started in the same synchronous turn share one prepare
+// (the second attaches to the first's in-flight statement); a shared failure
+// must reject both, not leave one pending forever.
+test.concurrent("MySQL: a concurrent query sharing a failed prepare is rejected, not left pending", async () => {
   // Every COM_STMT_PREPARE for the text answers ERR 1146, so the only correct
   // outcome for BOTH queries is a rejection carrying that error.
   const mock = await mockMySQLServer(() => tableMissing());

--- a/test/js/sql/sql-mysql-failed-prepare-retry.test.ts
+++ b/test/js/sql/sql-mysql-failed-prepare-retry.test.ts
@@ -23,7 +23,8 @@ import { expect, test } from "bun:test";
 import type { Socket } from "node:net";
 import {
   listeningServer,
-  mysqlErrorPacket,
+  mysqlAckSessionSetup,
+  mysqlErrPacket,
   mysqlHandshakeV10,
   mysqlOkPacket,
   mysqlReadPackets,
@@ -36,10 +37,10 @@ const COM_STMT_EXECUTE = 0x17;
 const COM_STMT_CLOSE = 0x19;
 
 /**
- * A scripted MySQL server: handshake, OK for the auth response, then routes
- * each COM_STMT_PREPARE through `onPrepare(text, nth)` (nth is 1-based per
- * distinct query text) and answers every COM_STMT_EXECUTE with an OK packet.
- * Call `stop()` in a `finally`.
+ * A scripted MySQL server: handshake, OK for the auth response and for the
+ * driver's session-setup query, then routes each COM_STMT_PREPARE through
+ * `onPrepare(text, nth)` (nth is 1-based per distinct query text) and answers
+ * every COM_STMT_EXECUTE with an OK packet. Call `stop()` in a `finally`.
  */
 async function mockMySQLServer(onPrepare: (text: string, nth: number) => Buffer) {
   const preparesByText = new Map<string, number>();
@@ -58,6 +59,7 @@ async function mockMySQLServer(onPrepare: (text: string, nth: number) => Buffer)
           socket.write(mysqlOkPacket(seq + 1));
           return;
         }
+        if (mysqlAckSessionSetup(socket, payload)) return;
         const cmd = payload[0];
         if (cmd === COM_STMT_PREPARE) {
           const text = payload.subarray(1).toString("utf-8");
@@ -89,7 +91,7 @@ async function mockMySQLServer(onPrepare: (text: string, nth: number) => Buffer)
   };
 }
 
-const tableMissing = () => mysqlErrorPacket(1, 1146, "42S02", "Table 'db.t' doesn't exist");
+const tableMissing = () => mysqlErrPacket(1, 1146, "42S02", "Table 'db.t' doesn't exist");
 
 const settled = (q: Promise<any>) =>
   q.then(

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -798,13 +798,15 @@ if (isDockerEnabled()) {
           expect(err.code).toBe("ERR_MYSQL_SYNTAX_ERROR");
         });
 
-        // Regression: the error_message stored on a cached failed prepared statement
-        // was a .temporary slice into the socket read buffer. Re-running the same
-        // failing query after other queries overwrote the buffer would read garbage
-        // (or crash under ASAN) when constructing the error from the cached statement.
-        test("Cached failed prepared statement returns stable error message", async () => {
+        // Regression: the error_message held on a failed prepared statement was a
+        // .temporary slice into the socket read buffer, so re-running the same
+        // failing query after other traffic overwrote the buffer returned garbage
+        // (or crashed under ASAN). A failed prepare is now also evicted from the
+        // statement cache, so the second attempt re-prepares; the server must
+        // answer with the same error either way.
+        test("Re-running a failing prepared statement returns a stable error message", async () => {
           await using sql = new SQL({ ...getOptions(), max: 1 });
-          // Need a parameter so it goes through the prepared-statement cache path.
+          // Need a parameter so it goes through the prepared-statement path.
           const err1 = await sql`wat ${1}`.catch(x => x);
           expect(err1.code).toBe("ERR_MYSQL_SYNTAX_ERROR");
           expect(typeof err1.message).toBe("string");
@@ -818,7 +820,7 @@ if (isDockerEnabled()) {
             expect(rows[0].x).toBe(filler);
           }
 
-          // Hitting the cached .failed statement must reproduce the same error.
+          // The re-prepare of the same text must reproduce the same error.
           const err2 = await sql`wat ${1}`.catch(x => x);
           expect({
             code: err2.code,

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -397,6 +397,18 @@ export function mysqlAuthSwitchRequest(seq: number, pluginName: string, pluginDa
   return mysqlRawPacket(seq, Buffer.concat([Buffer.from([0xfe]), Buffer.from(pluginName + "\0"), pluginData]));
 }
 
+// MySQL ERR_Packet (CLIENT_PROTOCOL_41) — page_protocol_basic_err_packet.html:
+//   Int<1>(0xff) Int<2>(error_code) Byte1('#') String<5>(sql_state) String<EOF>(error_message)
+export function mysqlErrorPacket(seq: number, errorCode: number, sqlState: string, message: string): Buffer {
+  const fixed = Buffer.alloc(3);
+  fixed[0] = 0xff;
+  fixed.writeUInt16LE(errorCode, 1);
+  return mysqlRawPacket(
+    seq,
+    Buffer.concat([fixed, Buffer.from("#"), Buffer.from(sqlState, "latin1"), Buffer.from(message, "utf-8")]),
+  );
+}
+
 // MySQL length-encoded integer — page_protocol_basic_dt_integers.html#sect_protocol_basic_dt_int_le:
 //   <0xfb 1B; 0xfc + Int<2>; 0xfd + Int<3>; 0xfe + Int<8>.
 export function mysqlLenencInt(n: number | bigint): Buffer {

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -397,18 +397,6 @@ export function mysqlAuthSwitchRequest(seq: number, pluginName: string, pluginDa
   return mysqlRawPacket(seq, Buffer.concat([Buffer.from([0xfe]), Buffer.from(pluginName + "\0"), pluginData]));
 }
 
-// MySQL ERR_Packet (CLIENT_PROTOCOL_41) — page_protocol_basic_err_packet.html:
-//   Int<1>(0xff) Int<2>(error_code) Byte1('#') String<5>(sql_state) String<EOF>(error_message)
-export function mysqlErrorPacket(seq: number, errorCode: number, sqlState: string, message: string): Buffer {
-  const fixed = Buffer.alloc(3);
-  fixed[0] = 0xff;
-  fixed.writeUInt16LE(errorCode, 1);
-  return mysqlRawPacket(
-    seq,
-    Buffer.concat([fixed, Buffer.from("#"), Buffer.from(sqlState, "latin1"), Buffer.from(message, "utf-8")]),
-  );
-}
-
 // MySQL length-encoded integer — page_protocol_basic_dt_integers.html#sect_protocol_basic_dt_int_le:
 //   <0xfb 1B; 0xfc + Int<2>; 0xfd + Int<3>; 0xfe + Int<8>.
 export function mysqlLenencInt(n: number | bigint): Buffer {


### PR DESCRIPTION
### Problem

In `Bun.SQL` (MySQL), a prepared statement whose `COM_STMT_PREPARE` the server answers with an ERR packet is stored in the per-connection statement cache with `Status::Failed`. Every later execution of the same query text on that connection finds the cached entry and replays its stored `ErrorPacket` without ever re-preparing, so a transient prepare-time error (a table created by a concurrent migration, a deadlock, `ER_TOO_MANY_CONCURRENT_STMTS`) poisons the connection for the process lifetime. With a pool this looks like "the same query works on some requests and permanently fails on others". `mysql2` and other clients re-prepare on the next use.

Against a scripted server whose first `COM_STMT_PREPARE` for a text answers `ERR 1146` and every later one answers OK:

```
query 1: rejected errno=1146 Table 'db.t' doesn't exist
query 2: rejected errno=1146 Table 'db.t' doesn't exist   <- replayed from cache
query 3: rejected errno=1146 Table 'db.t' doesn't exist   <- replayed from cache
server saw COM_STMT_PREPARE for the text: 1
```

A second, related problem surfaced during review (thanks, claude-bot): if two identical queries start in the same synchronous turn, the second attaches to the first's in-flight statement instead of issuing its own prepare. When that shared prepare fails, the second query's promise is **never settled**:

```
Promise.all([sql`SELECT * FROM t`, sql`SELECT * FROM t`])   // table missing
// first:  rejected errno=1146
// second: pending forever
```

### Cause

1. `handle_prepared_statement`'s `PacketType::ERROR` arm sets `statement.status = Failed` and stores the error packet but never removes the statement from `self.statements`, so `run_prepared_query` serves the entry on every later lookup of the same signature hash. The Postgres driver already does this correctly: `PostgresSQLConnection`'s `ErrorResponse` arm removes the failed statement from the map and drops the map's ref.
2. `advance()` re-runs the attached second query, which hits the `Failed` status arm and returns an error. `JSMySQLQuery::run`'s errguard set the query's status to `Fail` on unwind, and `reject_with_js_value`'s settle-once guard (`if !q.fail() { return }`) then returned before ever invoking the JS reject callback. `PostgresSQLQuery::run`'s equivalent guard already only rolls back the `this_value` upgrade.

### Fix

- `MySQLConnection::handle_prepared_statement` (`ERROR` arm): remove the failed statement from `self.statements`, mirroring the Postgres handler. The map holds an `Option<RefPtr<MySQLStatement>>`, so `remove()` drops the map's ref with no `unsafe`; queries that attached to the statement before the failure hold their own `RefPtr` and still observe the error, and the next query with the same text gets a fresh prepare.
- `MySQLQuery::run_prepared_query`: delete the `found_existing && Failed` guard. The only place that sets `Status::Failed` now also removes the entry, so a cached entry is never `Failed`; the status `match` a few lines below already rejects on `Failed` for statements a query attached to before the failure.
- `JSMySQLQuery::run`: the errguard no longer calls `query.fail()`; it only rolls back the `this_value` upgrade, matching Postgres. The `advance()`-driven caller settles through `reject_with_js_value`, which owns the `fail()` transition; the `do_run` caller propagates the exception into JS (`internal/sql/query.ts` rejects the promise) and marks the native query terminal itself. This also makes that rejection a real `MySQLError` (via `onRejectMySQLQuery`'s `wrapError`) instead of the raw error-options object.

Only `Failed` entries are affected by the eviction. A successfully prepared statement is still cached and reused without re-preparing.

### Tests

`test/js/sql/sql-mysql-failed-prepare-retry.test.ts` (new, scripted wire server):

- *eviction and retry*: the first `COM_STMT_PREPARE` for a text answers `ERR 1146`, every later one OK. Asserts the second identical query fulfills, the server saw exactly 2 prepares on 1 connection, and a third identical query reuses the now-prepared statement (still 2 prepares). Fails on the unfixed build with `prepares: 1, second: rejected, third: rejected`.
- *concurrent siblings*: two identical queries in the same `Promise.all`, every prepare answers `ERR 1146`. Asserts both reject with a real `Error` carrying `errno: 1146` and that exactly one prepare reached the wire. On the unfixed build the test times out because the second promise never settles.

`test/js/sql/sql-mysql-cached-error.test.ts` (rewritten, `describeWithContainer`): queries a missing table twice on one connection (both prepares fail, `Com_stmt_prepare` increments both times), creates the table, and the same text succeeds. This file previously asserted the opposite (`Com_stmt_prepare` must not increment across an identical re-run) to pin a dangling-slice read on the cache-hit path added in #29847; that path no longer exists.

`test/js/sql/sql-mysql.test.ts`: the "Cached failed prepared statement returns stable error message" case still passes (a fresh prepare of the same text returns the identical error); its comments are updated since the cache-hit path is gone.

Both tests in `sql-mysql-failed-prepare-retry.test.ts` were verified to fail on a build from `main`'s `src/` and pass with the fix, and the rest of the `test/js/sql` wire-frame suites still pass. The `describeWithContainer` test needs a docker daemon, which this environment does not have; it runs on CI's docker-enabled lanes.

### Rebase notes

Rebased onto main twice after it moved under the MySQL driver. Three adaptations, no change in what the fix does:

- The per-connection statement map is now `StringHashMap<Option<RefPtr<MySQLStatement>>>` (keyed by the signature bytes, owning a `RefPtr`) instead of a wyhash-keyed map of raw `*mut` pointers with a hand-managed intrusive ref. The eviction is now plain Rust: `statements.get(name)` with a pointer-identity check, then `statements.remove(name)`, which drops the map's `RefPtr`. This is the same shape the Postgres `ErrorResponse` handler on main uses, and the original `unsafe { MySQLStatement::deref(..) }` release is gone with the raw-pointer model (#40516).
- The driver now sends `SET time_zone = '+00:00'` after authentication and waits for its OK before reporting connected, so the scripted server in `sql-mysql-failed-prepare-retry.test.ts` acknowledges it through the new `mysqlAckSessionSetup` helper. `wire-frames.ts` also gained an identical `ERR_Packet` builder (`mysqlErrPacket`) in the meantime, so this PR no longer adds one.

Both wire-level tests were re-verified on each new base: they fail on a build from main's `src/` and pass with the fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-cached-error.test.ts test/js/sql/sql-mysql-failed-prepare-retry.test.ts test/js/sql/sql-mysql.test.ts
bun test v1.4.1 (65362b53b)

test/js/sql/sql-mysql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) MySQL: binary TIME with a very large days field formats without integer wraparound [1720.49ms]
(pass) MySQL: a row split across several maximum-size wire packets is reassembled into one value [1740.44ms]

test/js/sql/sql-mysql-cached-error.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory

test/js/sql/sql-mysql-failed-prepare-retry.test.ts:
127 |     expect({
128 |       connections: mock.connections(),
129 |       prepares: mock.preparesByText.get("SELECT * FROM t"),
130 |       second: second.status,
131 |
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/sql/sql-mysql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) MySQL: binary TIME with a very large days field formats without integer wraparound [22.64ms]
(pass) MySQL: a row split across several maximum-size wire packets is reassembled into one value [425.75ms]

test/js/sql/sql-mysql-cached-error.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory

test/js/sql/sql-mysql-failed-prepare-retry.test.ts:
127 |     expect({
128 |       connections: mock.connections(),
129 |       prepares: mock.preparesByText.get("SELECT * FROM t"),
130 |       second: second.status,
131 |       third: third.status,
132 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
    "connections": 1,
-   "prepares": 2,
-   "second": "fulfilled",
-   "third": "fulfilled",
+   "prepares": 1,
+   "second": "rejected",
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-cached-error.test.ts test/js/sql/sql-mysql-failed-prepare-retry.test.ts test/js/sql/sql-mysql.test.ts
bun test v1.4.1 (65362b53b)

test/js/sql/sql-mysql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) MySQL: binary TIME with a very large days field formats without integer wraparound [1273.64ms]
(pass) MySQL: a row split across several maximum-size wire packets is reassembled into one value [1474.09ms]

test/js/sql/sql-mysql-cached-error.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory

test/js/sql/sql-mysql-failed-prepare-retry.test.ts:
(pass) MySQL: a concurrent query sharing a failed prepare is rejected, not left pending [171.27ms]
(pass) MySQL: a failed prepare is evicted from the statement cache and 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     afb4ffb69f
  features     baseline

23 deps, 131 codegen, 1172 objects in 1046ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1244] gen bindgenv2
[3/1244] fetch zlib
[zlib] up to date
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] gen ErrorCode+*.h
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/mysql/JSMySQLQuery.rs                  |   2 +-
 src/sql_jsc/mysql/MySQLConnection.rs               |  19 ++-
 src/sql_jsc/mysql/MySQLQuery.rs                    |   6 -
 test/js/sql/sql-mysql-cached-error.test.ts         | 114 +++++++-------
 test/js/sql/sql-mysql-failed-prepare-retry.test.ts | 175 +++++++++++++++++++++
 test/js/sql/sql-mysql.test.ts                      |  16 +-
 6 files changed, 255 insertions(+), 77 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/sql_jsc/mysql/JSMySQLQuery.rs                       7      7      0
src/sql_jsc/mysql/MySQLConnection.rs                   11      8      0
src/sql_jsc/mysql/MySQLQuery.rs                         7      4      0
test/js/sql/sql-mysql-cached-error.test.ts              1      1      0
test/js/sql/sql-mysql-failed-prepare-retry.test.ts      2     10      0
test/js/sql/sql-mysql.test.ts                           1      2      0
```

</details>

<!-- robobun:evidence:end -->

