### PR TITLE
sql(mysql): cap the prepared-statement cache and send COM_STMT_CLOSE on eviction

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1224,7 +1224,7 @@ const [users, orders, products] = await Promise.all([
 ]);
 ```
 
-Each connection caches up to 256 prepared statements. Past that, the least recently used statement that no query still references is deallocated on the server (`COM_STMT_CLOSE`) to make room, so long-lived pooled connections running many distinct query strings don't exhaust the server-wide `max_prepared_stmt_count` limit.
+Each connection keeps up to 256 idle prepared statements cached; statements referenced by in-flight queries are never evicted, so the count can temporarily exceed that. Past the limit, the least recently used idle statement is deallocated on the server with `COM_STMT_CLOSE` to make room. Without the cap, a long-lived pooled connection running many distinct query strings (for example, an ORM interpolating identifiers) would keep growing the server's prepared-statement table, which is limited server-wide by `max_prepared_stmt_count`.
 
 #### Multiple Result Sets
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1224,6 +1224,8 @@ const [users, orders, products] = await Promise.all([
 ]);
 ```
 
+Each connection caches up to 256 prepared statements. Past that, the least recently used statement that no query still references is deallocated on the server (`COM_STMT_CLOSE`) to make room, so long-lived pooled connections running many distinct query strings don't exhaust the server-wide `max_prepared_stmt_count` limit.
+
 #### Multiple Result Sets
 
 MySQL can return multiple result sets from multi-statement queries:

--- a/src/sql/mysql/MySQLRequest.rs
+++ b/src/sql/mysql/MySQLRequest.rs
@@ -34,3 +34,21 @@ pub fn prepare_request<Context: WriterContext>(
     packet.end()?;
     Ok(())
 }
+
+/// COM_STMT_CLOSE deallocates a prepared statement on the server. The server
+/// never replies to it, so it is not queued as a request and does not shift
+/// response ordering for the commands around it.
+/// https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_close.html
+pub fn close_request<Context: WriterContext>(
+    statement_id: u32,
+    writer: NewWriter<Context>,
+) -> Result<(), bun_core::Error> {
+    bun_core::scoped_log!(MySQLRequest, "closeRequest {}", statement_id);
+    // resets the sequence id to zero every time we send a command
+    let mut packet = writer.start(0)?;
+    writer.int1(CommandType::COM_STMT_CLOSE as u8)?;
+    writer.int4(statement_id)?;
+
+    packet.end()?;
+    Ok(())
+}

--- a/src/sql/mysql/MySQLRequest.rs
+++ b/src/sql/mysql/MySQLRequest.rs
@@ -35,10 +35,9 @@ pub fn prepare_request<Context: WriterContext>(
     Ok(())
 }
 
-/// COM_STMT_CLOSE deallocates a prepared statement on the server. The server
-/// never replies to it, so it is not queued as a request and does not shift
-/// response ordering for the commands around it.
-/// https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_close.html
+/// COM_STMT_CLOSE deallocates a prepared statement on the server. It gets no
+/// response, so it is not queued as a request and does not shift response
+/// ordering for the commands around it.
 pub fn close_request<Context: WriterContext>(
     statement_id: u32,
     writer: NewWriter<Context>,

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -936,7 +936,9 @@ impl JSMySQLConnection {
         signature_name: &[u8],
     ) -> Result<my_sql_connection::PreparedStatementsMapGetOrPutResult<'_>, bun_core::AllocError>
     {
-        self.connection_mut().statements.get_or_put(signature_name)
+        // `get_or_put_statement` enforces the statement-cache cap (evicting +
+        // closing LRU idle statements) and stamps the LRU clock on a hit.
+        self.connection_mut().get_or_put_statement(signature_name)
     }
 }
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -6,6 +6,7 @@ use bun_sql::mysql::Capabilities;
 use bun_sql::mysql::MySQLQueryResult;
 use bun_sql::mysql::auth_method::AuthMethod;
 use bun_sql::mysql::connection_state::ConnectionState;
+use bun_sql::mysql::mysql_request;
 use bun_sql::mysql::mysql_types::FieldType;
 use bun_sql::mysql::protocol::any_mysql_error::{self as any_mysql_error, Error as AnyMySQLError};
 use bun_sql::mysql::protocol::auth as Auth;
@@ -61,6 +62,9 @@ pub struct MySQLConnection {
     pub queue: MySQLRequestQueue,
     // TODO: move it to JSMySQLConnection
     pub statements: PreparedStatementsMap,
+    /// Monotonic clock for the statement cache's LRU order; bumped on every
+    /// cache lookup and stamped into `MySQLStatement::last_used` on reuse.
+    statement_lru_clock: u64,
 
     server_version: Vec<u8>,
     connection_id: u32,
@@ -101,6 +105,7 @@ impl Default for MySQLConnection {
             sequence_id: 0,
             queue: MySQLRequestQueue::init(),
             statements: PreparedStatementsMap::default(),
+            statement_lru_clock: 0,
             server_version: Vec::<u8>::default(),
             connection_id: 0,
             capabilities: Capabilities::default(),
@@ -315,6 +320,76 @@ impl MySQLConnection {
             unsafe { bun_boringssl_sys::SSL_CTX_free(s) };
         }
         // _options_buf dropped at scope exit (Box<[u8]> frees via Drop)
+    }
+
+    /// Cache lookup for a prepared-statement signature name. Inserting a new
+    /// entry first evicts LRU idle statements so the cache never exceeds
+    /// [`MAX_CACHED_PREPARED_STATEMENTS`]; a hit re-stamps the entry's LRU clock.
+    pub(crate) fn get_or_put_statement(
+        &mut self,
+        signature_name: &[u8],
+    ) -> Result<PreparedStatementsMapGetOrPutResult<'_>, bun_core::AllocError> {
+        if !self.statements.contains_key(signature_name) {
+            self.evict_lru_statements();
+        }
+        self.statement_lru_clock += 1;
+        let lru_tick = self.statement_lru_clock;
+        let entry = self.statements.get_or_put(signature_name)?;
+        if entry.found_existing {
+            // Shared borrow through `ParentRef`: map values are live boxed
+            // statements (the map owns one intrusive ref on each) and
+            // `last_used` is a `Cell`.
+            let stmt = bun_ptr::ParentRef::from(
+                core::ptr::NonNull::new(*entry.value_ptr)
+                    .expect("found_existing ⇒ non-null map entry"),
+            );
+            stmt.last_used.set(lru_tick);
+        }
+        Ok(entry)
+    }
+
+    /// Evict idle least-recently-used cached statements until the cache is
+    /// under [`MAX_CACHED_PREPARED_STATEMENTS`], writing a COM_STMT_CLOSE for
+    /// each so the server frees its side of the statement.
+    fn evict_lru_statements(&mut self) {
+        while self.statements.count() >= MAX_CACHED_PREPARED_STATEMENTS {
+            let mut victim: Option<core::ptr::NonNull<MySQLStatement>> = None;
+            let mut oldest = u64::MAX;
+            for value in self.statements.values() {
+                let ptr = core::ptr::NonNull::new(*value).expect("map entries are non-null");
+                // Shared borrow; every field read below is `Cell`/`Copy`.
+                let stmt = bun_ptr::ParentRef::from(ptr);
+                // A `MySQLQuery` still holds this statement (pending, running,
+                // or not yet finalized): its statement_id must stay valid.
+                if !stmt.has_one_ref() {
+                    continue;
+                }
+                if victim.is_none() || stmt.last_used.get() < oldest {
+                    oldest = stmt.last_used.get();
+                    victim = Some(ptr);
+                }
+            }
+            // Every cached statement is still referenced by a query; nothing
+            // can be released right now. The next insert tries again.
+            let Some(ptr) = victim else { return };
+            let stmt = bun_ptr::ParentRef::from(ptr);
+            // Statements that never finished preparing (or failed to) own no
+            // server-side handle; there is nothing to close for id 0.
+            if stmt.statement_id != 0
+                && mysql_request::close_request(stmt.statement_id, self.writer()).is_err()
+            {
+                // The close packet could not be written (OOM): keep the cache
+                // entry so the server-side statement is not orphaned.
+                return;
+            }
+            // The statement owns the signature whose name keyed this entry
+            // (`get_or_put_statement`); the map's key is a separate copy, so
+            // removing it leaves these bytes live for the deref below.
+            self.statements.remove(&*stmt.signature.name);
+            // SAFETY: `has_one_ref` above ⇒ the map owned the last ref;
+            // removing the entry transfers it to us to release here.
+            unsafe { MySQLStatement::deref(ptr.as_ptr()) };
+        }
     }
 
     pub fn upgrade_to_tls(&mut self) -> Result<(), FlushQueueError> {
@@ -1730,3 +1805,12 @@ pub(crate) type PreparedStatementsMapGetOrPutResult<'a> =
     bun_collections::hash_map::GetOrPutResult<'a, *mut MySQLStatement>;
 
 const MAX_PIPELINE_SIZE: usize = u16::MAX as usize; // about 64KB per connection
+
+/// Upper bound on server-side prepared statements a connection keeps cached.
+/// They are allocated on the server until COM_STMT_CLOSE or disconnect, and
+/// the server-wide budget (`max_prepared_stmt_count`, default 16382) is shared
+/// by every connection of every client, so an uncapped cache on a long-lived
+/// pooled connection running distinct query texts eventually makes the whole
+/// server reject prepares. Statements still referenced by a query are never
+/// evicted, so the cache can temporarily exceed this while queries are alive.
+const MAX_CACHED_PREPARED_STATEMENTS: usize = 256;

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1806,11 +1806,7 @@ pub(crate) type PreparedStatementsMapGetOrPutResult<'a> =
 
 const MAX_PIPELINE_SIZE: usize = u16::MAX as usize; // about 64KB per connection
 
-/// Upper bound on server-side prepared statements a connection keeps cached.
-/// They are allocated on the server until COM_STMT_CLOSE or disconnect, and
-/// the server-wide budget (`max_prepared_stmt_count`, default 16382) is shared
-/// by every connection of every client, so an uncapped cache on a long-lived
-/// pooled connection running distinct query texts eventually makes the whole
-/// server reject prepares. Statements still referenced by a query are never
-/// evicted, so the cache can temporarily exceed this while queries are alive.
+/// Per-connection cap on cached server-side prepared statements: they stay
+/// allocated on the server until COM_STMT_CLOSE (or disconnect) and count
+/// against the server-wide `max_prepared_stmt_count` budget (default 16382).
 const MAX_CACHED_PREPARED_STATEMENTS: usize = 256;

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -352,6 +352,12 @@ impl MySQLConnection {
     /// under [`MAX_CACHED_PREPARED_STATEMENTS`], writing a COM_STMT_CLOSE for
     /// each so the server frees its side of the statement.
     fn evict_lru_statements(&mut self) {
+        // Packet framing assumes the write buffer has no flushed prefix;
+        // every other packet writer guarantees that through this same gate.
+        // A deferred eviction (backpressure) happens on the next insert.
+        if !self.is_able_to_write() {
+            return;
+        }
         while self.statements.count() >= MAX_CACHED_PREPARED_STATEMENTS {
             let mut victim: Option<core::ptr::NonNull<MySQLStatement>> = None;
             let mut oldest = u64::MAX;

--- a/src/sql_jsc/mysql/MySQLStatement.rs
+++ b/src/sql_jsc/mysql/MySQLStatement.rs
@@ -36,6 +36,10 @@ pub struct MySQLStatement {
     pub execution_flags: ExecutionFlags,
     pub fields_flags: DataCellFlags,
     pub result_count: u64,
+    /// LRU stamp from the owning connection's statement clock, bumped each
+    /// time a later query reuses this cached statement; never-reused
+    /// statements keep 0 and are evicted first.
+    pub last_used: Cell<u64>,
 }
 
 impl MySQLStatement {
@@ -55,6 +59,7 @@ impl MySQLStatement {
             execution_flags: ExecutionFlags::default(),
             fields_flags: DataCellFlags::default(),
             result_count: 0,
+            last_used: Cell::new(0),
         }
     }
 }
@@ -98,6 +103,14 @@ impl MySQLStatement {
     pub(crate) fn init_exact_refs(&mut self, n: u32) {
         debug_assert!(n > 0);
         self.ref_count.set(n);
+    }
+
+    /// Whether the caller holds the only outstanding ref. The statement cache
+    /// only evicts statements it is the sole owner of (no `MySQLQuery` left
+    /// that could still execute the server-side statement id).
+    #[inline]
+    pub(crate) fn has_one_ref(&self) -> bool {
+        bun_ptr::CellRefCounted::ref_count(self).get() == 1
     }
 
     pub(crate) fn reset(&mut self) {

--- a/test/js/sql/sql-mysql-statement-cache.test.ts
+++ b/test/js/sql/sql-mysql-statement-cache.test.ts
@@ -123,23 +123,18 @@ test("MySQL: the prepared-statement cache is capped and evicted statements are c
   try {
     await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
 
-    // More distinct parameterized query texts than the cache cap (distinct
-    // texts are what an ORM interpolating table/column names produces), all
-    // in flight at once on the single pooled connection. While a query still
-    // references its statement nothing may be evicted or closed: the mock
-    // rejects any execute of a closed id, which would reject the Promise.all.
+    // More distinct query texts than the cap, all in flight at once on one
+    // connection: none may be evicted or closed while a query references it
+    // (the mock rejects executes of closed ids, failing the Promise.all).
     const DISTINCT = MAX_CACHED_PREPARED_STATEMENTS + 8;
     const results = await Promise.all(Array.from({ length: DISTINCT }, (_, i) => sql.unsafe(`select ? as c${i}`, [i])));
     expect(results).toHaveLength(DISTINCT);
     expect(counters.prepares).toBe(DISTINCT);
     expect(counters.closed.size).toBe(0);
 
-    // A cached statement only becomes evictable once no query object
-    // references it anymore, and a query releases its statement when its
-    // wrapper is collected. Collect, then keep issuing new distinct texts:
-    // every insert past the cap must now evict + COM_STMT_CLOSE
-    // least-recently-used statements. Poll the condition (GC decides how many
-    // rounds the finalizers take) instead of assuming a fixed iteration count.
+    // Statements become evictable once their (collected) query wrappers stop
+    // referencing them. Collect, then keep inserting distinct texts: each one
+    // past the cap must evict + COM_STMT_CLOSE. Poll, since GC sets the pace.
     let extra = 0;
     while (counters.prepares - counters.closed.size > MAX_CACHED_PREPARED_STATEMENTS && extra < 64) {
       Bun.gc(true);

--- a/test/js/sql/sql-mysql-statement-cache.test.ts
+++ b/test/js/sql/sql-mysql-statement-cache.test.ts
@@ -115,26 +115,31 @@ async function statementCountingServer() {
   return { server, port, counters };
 }
 
+// Exceeding the cache cap takes MAX_CACHED_PREPARED_STATEMENTS + 1 prepare +
+// execute round trips by definition, which outgrows the 5s default per-test
+// timeout on debug + ASAN builds, so this test declares its real budget.
 test("MySQL: the prepared-statement cache is capped and evicted statements are closed with COM_STMT_CLOSE", async () => {
   const { server, port, counters } = await statementCountingServer();
   try {
     await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
 
-    // Distinct parameterized query texts on one pooled connection, which is
-    // what an ORM interpolating table/column names produces. Each text is a
-    // new server-side prepared statement.
-    const DISTINCT = MAX_CACHED_PREPARED_STATEMENTS + 44;
-    for (let i = 0; i < DISTINCT; i++) {
-      await sql.unsafe(`select ? as c${i}`, [i]);
-    }
+    // More distinct parameterized query texts than the cache cap (distinct
+    // texts are what an ORM interpolating table/column names produces), all
+    // in flight at once on the single pooled connection. While a query still
+    // references its statement nothing may be evicted or closed: the mock
+    // rejects any execute of a closed id, which would reject the Promise.all.
+    const DISTINCT = MAX_CACHED_PREPARED_STATEMENTS + 8;
+    const results = await Promise.all(Array.from({ length: DISTINCT }, (_, i) => sql.unsafe(`select ? as c${i}`, [i])));
+    expect(results).toHaveLength(DISTINCT);
     expect(counters.prepares).toBe(DISTINCT);
+    expect(counters.closed.size).toBe(0);
 
-    // A cached statement is only evictable once no query object references it
-    // anymore, and a query releases its statement when its wrapper is
-    // collected. Collect, then keep issuing new distinct texts: every insert
-    // past the cap must now evict + COM_STMT_CLOSE least-recently-used
-    // statements. Poll the condition (GC decides how many rounds the
-    // finalizers take) instead of assuming a fixed iteration count.
+    // A cached statement only becomes evictable once no query object
+    // references it anymore, and a query releases its statement when its
+    // wrapper is collected. Collect, then keep issuing new distinct texts:
+    // every insert past the cap must now evict + COM_STMT_CLOSE
+    // least-recently-used statements. Poll the condition (GC decides how many
+    // rounds the finalizers take) instead of assuming a fixed iteration count.
     let extra = 0;
     while (counters.prepares - counters.closed.size > MAX_CACHED_PREPARED_STATEMENTS && extra < 64) {
       Bun.gc(true);
@@ -150,14 +155,14 @@ test("MySQL: the prepared-statement cache is capped and evicted statements are c
     expect(counters.prepares - counters.closed.size).toBeLessThanOrEqual(MAX_CACHED_PREPARED_STATEMENTS);
     // Only ids the server actually handed out may be closed.
     expect([...counters.closed].every(id => counters.prepared.has(id))).toBe(true);
-    // Every query text was prepared and executed exactly once (an execute of a
-    // closed id would have been rejected by the mock and thrown above).
+    // Every query text was prepared and executed exactly once (an execute of
+    // a closed id would have been rejected by the mock and thrown above).
     expect(counters.prepares).toBe(DISTINCT + extra);
     expect(counters.executes).toBe(DISTINCT + extra);
   } finally {
     await new Promise<void>(r => server.close(() => r()));
   }
-});
+}, 30_000);
 
 test("MySQL: an identical query text keeps reusing one prepared statement and is never closed", async () => {
   const { server, port, counters } = await statementCountingServer();
@@ -182,37 +187,6 @@ test("MySQL: an identical query text keeps reusing one prepared statement and is
     }).toEqual({
       prepares: 1,
       executes: 50,
-      closed: 0,
-    });
-  } finally {
-    await new Promise<void>(r => server.close(() => r()));
-  }
-});
-
-test("MySQL: statements referenced by in-flight queries are never evicted or closed", async () => {
-  const { server, port, counters } = await statementCountingServer();
-  try {
-    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
-
-    // More distinct texts than the cache cap, all in flight at once on a
-    // single connection, so every cached statement is referenced by a live
-    // query while the burst runs. None may be evicted (the mock rejects any
-    // execute of a closed id, which would reject the Promise.all).
-    const BURST = MAX_CACHED_PREPARED_STATEMENTS + 20;
-    const results = await Promise.all(
-      Array.from({ length: BURST }, (_, i) => sql.unsafe(`select ? as burst${i}`, [i])),
-    );
-    expect(results).toHaveLength(BURST);
-
-    expect({
-      prepares: counters.prepares,
-      executes: counters.executes,
-      closed: counters.closed.size,
-    }).toEqual({
-      prepares: BURST,
-      executes: BURST,
-      // Nothing was evictable: the cache only evicts statements no query
-      // holds anymore, so it defers past the cap instead of breaking queries.
       closed: 0,
     });
   } finally {

--- a/test/js/sql/sql-mysql-statement-cache.test.ts
+++ b/test/js/sql/sql-mysql-statement-cache.test.ts
@@ -1,0 +1,221 @@
+// This test counts the exact commands Bun's MySQL client puts on the wire
+// (COM_STMT_PREPARE / COM_STMT_CLOSE), which needs a scripted server; a real
+// server only exposes those as status counters shared with every other
+// connection. All wire-protocol bytes come from test/js/sql/wire-frames.ts.
+//
+// Regression test: the client never sent COM_STMT_CLOSE and kept an unbounded
+// per-connection prepared-statement cache. Server-side prepared statements
+// survive until they are closed or the connection ends, and they count against
+// the server-wide `max_prepared_stmt_count` budget (default 16382, shared by
+// every client of that server), so one long-lived pooled connection running
+// many distinct query texts (what ORMs produce) eventually makes the whole
+// server reject prepares for everyone. The client now caps the per-connection
+// cache (MAX_CACHED_PREPARED_STATEMENTS in src/sql_jsc/mysql/MySQLConnection.rs)
+// and sends COM_STMT_CLOSE for what it evicts.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import {
+  listeningServer,
+  mysqlColumnDefinition,
+  mysqlErrPacket,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  mysqlStmtPrepareOk,
+} from "./wire-frames";
+
+const COM_QUIT = 0x01;
+const COM_STMT_PREPARE = 0x16;
+const COM_STMT_EXECUTE = 0x17;
+const COM_STMT_CLOSE = 0x19;
+const MYSQL_TYPE_LONGLONG = 0x08;
+const ER_UNKNOWN_STMT_HANDLER = 1243;
+
+// Keep in sync with MAX_CACHED_PREPARED_STATEMENTS in
+// src/sql_jsc/mysql/MySQLConnection.rs.
+const MAX_CACHED_PREPARED_STATEMENTS = 256;
+
+/**
+ * Minimal MySQL server: accepts any auth, answers COM_STMT_PREPARE with a
+ * fresh statement id (one `?` parameter, no result columns), COM_STMT_EXECUTE
+ * with an empty OK, and records every COM_STMT_CLOSE (which, per protocol, has
+ * no response). Executing an id that was closed (or never prepared) answers
+ * with ER_UNKNOWN_STMT_HANDLER exactly like a real server, so a client that
+ * closes a statement another query still needs fails that query loudly.
+ */
+async function statementCountingServer() {
+  const counters = {
+    prepares: 0,
+    executes: 0,
+    /** statement ids handed out to the client */
+    prepared: new Set<number>(),
+    /** statement ids the client sent COM_STMT_CLOSE for */
+    closed: new Set<number>(),
+  };
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    let nextStatementId = 1;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        switch (payload[0]) {
+          case COM_STMT_PREPARE: {
+            counters.prepares++;
+            const id = nextStatementId++;
+            counters.prepared.add(id);
+            // COM_STMT_PREPARE_OK(num_columns = 0, num_params = 1) followed by
+            // the single parameter definition. CLIENT_DEPRECATE_EOF is
+            // negotiated by the handshake above, so no trailing EOF packet.
+            socket.write(
+              Buffer.concat([
+                mysqlStmtPrepareOk(1, id, 0, 1),
+                mysqlColumnDefinition(2, { name: "?", type: MYSQL_TYPE_LONGLONG }),
+              ]),
+            );
+            break;
+          }
+          case COM_STMT_EXECUTE: {
+            // Int<1> command, Int<4> statement_id.
+            const id = payload.readUInt32LE(1);
+            if (!counters.prepared.has(id) || counters.closed.has(id)) {
+              socket.write(
+                mysqlErrPacket(
+                  1,
+                  ER_UNKNOWN_STMT_HANDLER,
+                  `Unknown prepared statement handler (${id}) given to mysqld_stmt_execute`,
+                ),
+              );
+              break;
+            }
+            counters.executes++;
+            socket.write(mysqlOkPacket(1));
+            break;
+          }
+          case COM_STMT_CLOSE: {
+            // Int<1> command, Int<4> statement_id.
+            counters.closed.add(payload.readUInt32LE(1));
+            break;
+          }
+          case COM_QUIT: {
+            socket.end();
+            break;
+          }
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+  return { server, port, counters };
+}
+
+test("MySQL: the prepared-statement cache is capped and evicted statements are closed with COM_STMT_CLOSE", async () => {
+  const { server, port, counters } = await statementCountingServer();
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+    // Distinct parameterized query texts on one pooled connection, which is
+    // what an ORM interpolating table/column names produces. Each text is a
+    // new server-side prepared statement.
+    const DISTINCT = MAX_CACHED_PREPARED_STATEMENTS + 44;
+    for (let i = 0; i < DISTINCT; i++) {
+      await sql.unsafe(`select ? as c${i}`, [i]);
+    }
+    expect(counters.prepares).toBe(DISTINCT);
+
+    // A cached statement is only evictable once no query object references it
+    // anymore, and a query releases its statement when its wrapper is
+    // collected. Collect, then keep issuing new distinct texts: every insert
+    // past the cap must now evict + COM_STMT_CLOSE least-recently-used
+    // statements. Poll the condition (GC decides how many rounds the
+    // finalizers take) instead of assuming a fixed iteration count.
+    let extra = 0;
+    while (counters.prepares - counters.closed.size > MAX_CACHED_PREPARED_STATEMENTS && extra < 64) {
+      Bun.gc(true);
+      await Bun.sleep(0);
+      await sql.unsafe(`select ? as extra${extra}`, [extra]);
+      extra++;
+    }
+
+    // Without COM_STMT_CLOSE the server-side statement count
+    // (prepares - closes) grows monotonically with every distinct query text;
+    // the loop above then exhausts its budget with closed.size still 0.
+    expect(counters.closed.size).toBeGreaterThan(0);
+    expect(counters.prepares - counters.closed.size).toBeLessThanOrEqual(MAX_CACHED_PREPARED_STATEMENTS);
+    // Only ids the server actually handed out may be closed.
+    expect([...counters.closed].every(id => counters.prepared.has(id))).toBe(true);
+    // Every query text was prepared and executed exactly once (an execute of a
+    // closed id would have been rejected by the mock and thrown above).
+    expect(counters.prepares).toBe(DISTINCT + extra);
+    expect(counters.executes).toBe(DISTINCT + extra);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test("MySQL: an identical query text keeps reusing one prepared statement and is never closed", async () => {
+  const { server, port, counters } = await statementCountingServer();
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+    // Same text + same parameter type = same statement-cache entry. Collect in
+    // between so finalized query wrappers can't take the cached statement (or
+    // its server-side id) with them.
+    for (let i = 0; i < 50; i++) {
+      await sql.unsafe("select ? as reused", [i]);
+      if (i % 10 === 0) {
+        Bun.gc(true);
+        await Bun.sleep(0);
+      }
+    }
+
+    expect({
+      prepares: counters.prepares,
+      executes: counters.executes,
+      closed: counters.closed.size,
+    }).toEqual({
+      prepares: 1,
+      executes: 50,
+      closed: 0,
+    });
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test("MySQL: statements referenced by in-flight queries are never evicted or closed", async () => {
+  const { server, port, counters } = await statementCountingServer();
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+    // More distinct texts than the cache cap, all in flight at once on a
+    // single connection, so every cached statement is referenced by a live
+    // query while the burst runs. None may be evicted (the mock rejects any
+    // execute of a closed id, which would reject the Promise.all).
+    const BURST = MAX_CACHED_PREPARED_STATEMENTS + 20;
+    const results = await Promise.all(
+      Array.from({ length: BURST }, (_, i) => sql.unsafe(`select ? as burst${i}`, [i])),
+    );
+    expect(results).toHaveLength(BURST);
+
+    expect({
+      prepares: counters.prepares,
+      executes: counters.executes,
+      closed: counters.closed.size,
+    }).toEqual({
+      prepares: BURST,
+      executes: BURST,
+      // Nothing was evictable: the cache only evicts statements no query
+      // holds anymore, so it defers past the cap instead of breaking queries.
+      closed: 0,
+    });
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});

--- a/test/js/sql/sql-mysql-statement-cache.test.ts
+++ b/test/js/sql/sql-mysql-statement-cache.test.ts
@@ -75,10 +75,9 @@ async function statementCountingServer(opts: { resultColumn?: boolean } = {}) {
             counters.prepares++;
             const id = nextStatementId++;
             counters.prepared.add(id);
-            // COM_STMT_PREPARE_OK(num_columns, num_params = 1) followed by the
-            // parameter definition and, when advertised, the result column
-            // definition. CLIENT_DEPRECATE_EOF is negotiated by the handshake
-            // above, so no trailing EOF packets.
+            // COM_STMT_PREPARE_OK(num_columns, num_params = 1), then the param
+            // definition and (when advertised) the result column definition; no
+            // trailing EOF packets since CLIENT_DEPRECATE_EOF is negotiated.
             const columns = opts.resultColumn ? [mysqlColumnDefinition(3, { name: "c", type: MYSQL_TYPE_LONG })] : [];
             socket.write(
               Buffer.concat([
@@ -209,10 +208,9 @@ test("MySQL: evicting cached statements releases their rooted row Structures (cl
     await Bun.sleep(0);
 
     expect(counters.closed.size).toBeGreaterThan(0);
-    // Post-GC, only statements still cached may root a Structure (the slack
-    // absorbs unrelated Strong handles created while the test runs). Without
-    // eviction every one of the DISTINCT + extra texts roots its Structure
-    // (and retains its statement) until the connection closes.
+    // Post-GC, only still-cached statements may root a Structure (the slack
+    // absorbs unrelated Strong handles). Without eviction, every one of the
+    // DISTINCT + extra texts roots its Structure until the connection closes.
     expect(protectedStructures() - baseline).toBeLessThanOrEqual(MAX_CACHED_PREPARED_STATEMENTS + 16);
   } finally {
     await new Promise<void>(r => server.close(() => r()));

--- a/test/js/sql/sql-mysql-statement-cache.test.ts
+++ b/test/js/sql/sql-mysql-statement-cache.test.ts
@@ -14,9 +14,11 @@
 // and sends COM_STMT_CLOSE for what it evicts.
 
 import { SQL } from "bun";
+import { heapStats } from "bun:jsc";
 import { expect, test } from "bun:test";
 import {
   listeningServer,
+  mysqlBinaryResultSet,
   mysqlColumnDefinition,
   mysqlErrPacket,
   mysqlHandshakeV10,
@@ -29,6 +31,7 @@ const COM_QUIT = 0x01;
 const COM_STMT_PREPARE = 0x16;
 const COM_STMT_EXECUTE = 0x17;
 const COM_STMT_CLOSE = 0x19;
+const MYSQL_TYPE_LONG = 0x03;
 const MYSQL_TYPE_LONGLONG = 0x08;
 const ER_UNKNOWN_STMT_HANDLER = 1243;
 
@@ -38,13 +41,15 @@ const MAX_CACHED_PREPARED_STATEMENTS = 256;
 
 /**
  * Minimal MySQL server: accepts any auth, answers COM_STMT_PREPARE with a
- * fresh statement id (one `?` parameter, no result columns), COM_STMT_EXECUTE
- * with an empty OK, and records every COM_STMT_CLOSE (which, per protocol, has
- * no response). Executing an id that was closed (or never prepared) answers
- * with ER_UNKNOWN_STMT_HANDLER exactly like a real server, so a client that
- * closes a statement another query still needs fails that query loudly.
+ * fresh statement id (one `?` parameter; one INT result column "c" when
+ * `resultColumn`, none otherwise), COM_STMT_EXECUTE with a one-row binary
+ * resultset (`resultColumn`) or an empty OK, and records every COM_STMT_CLOSE
+ * (which, per protocol, has no response). Executing an id that was closed (or
+ * never prepared) answers with ER_UNKNOWN_STMT_HANDLER exactly like a real
+ * server, so a client that closes a statement another query still needs fails
+ * that query loudly.
  */
-async function statementCountingServer() {
+async function statementCountingServer(opts: { resultColumn?: boolean } = {}) {
   const counters = {
     prepares: 0,
     executes: 0,
@@ -70,13 +75,16 @@ async function statementCountingServer() {
             counters.prepares++;
             const id = nextStatementId++;
             counters.prepared.add(id);
-            // COM_STMT_PREPARE_OK(num_columns = 0, num_params = 1) followed by
-            // the single parameter definition. CLIENT_DEPRECATE_EOF is
-            // negotiated by the handshake above, so no trailing EOF packet.
+            // COM_STMT_PREPARE_OK(num_columns, num_params = 1) followed by the
+            // parameter definition and, when advertised, the result column
+            // definition. CLIENT_DEPRECATE_EOF is negotiated by the handshake
+            // above, so no trailing EOF packets.
+            const columns = opts.resultColumn ? [mysqlColumnDefinition(3, { name: "c", type: MYSQL_TYPE_LONG })] : [];
             socket.write(
               Buffer.concat([
-                mysqlStmtPrepareOk(1, id, 0, 1),
+                mysqlStmtPrepareOk(1, id, columns.length, 1),
                 mysqlColumnDefinition(2, { name: "?", type: MYSQL_TYPE_LONGLONG }),
+                ...columns,
               ]),
             );
             break;
@@ -95,7 +103,15 @@ async function statementCountingServer() {
               break;
             }
             counters.executes++;
-            socket.write(mysqlOkPacket(1));
+            if (opts.resultColumn) {
+              // One INT row ("c" = statement id) so the client materializes a
+              // row object (and caches its JSC Structure on the statement).
+              const value = Buffer.alloc(4);
+              value.writeInt32LE(id, 0);
+              socket.write(mysqlBinaryResultSet(1, [{ name: "c", type: MYSQL_TYPE_LONG }], [[value]]));
+            } else {
+              socket.write(mysqlOkPacket(1));
+            }
             break;
           }
           case COM_STMT_CLOSE: {
@@ -154,6 +170,50 @@ test("MySQL: the prepared-statement cache is capped and evicted statements are c
     // a closed id would have been rejected by the mock and thrown above).
     expect(counters.prepares).toBe(DISTINCT + extra);
     expect(counters.executes).toBe(DISTINCT + extra);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}, 30_000);
+
+// The same unbounded cache also leaked client memory: every cached statement
+// roots one JSC Structure (its row shape) through a Strong handle, plus its
+// own metadata, for the connection's lifetime. Eviction must release both.
+test("MySQL: evicting cached statements releases their rooted row Structures (client memory)", async () => {
+  const protectedStructures = () => heapStats().protectedObjectTypeCounts.Structure ?? 0;
+  const { server, port, counters } = await statementCountingServer({ resultColumn: true });
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+    // The mock names every result column "c" and returns the statement id (the
+    // warmup's is 1), which also proves the binary row framing is consumed.
+    expect(await sql.unsafe("select ? as warmup", [0])).toEqual([{ c: 1 }]);
+    Bun.gc(true);
+    await Bun.sleep(0);
+    const baseline = protectedStructures();
+
+    const DISTINCT = MAX_CACHED_PREPARED_STATEMENTS + 8;
+    for (let i = 0; i < DISTINCT; i++) {
+      await sql.unsafe(`select ? as c${i}`, [i]);
+    }
+
+    // Statements become evictable once their collected query wrappers drop
+    // them (same convergence loop as the capped-eviction test above).
+    let extra = 0;
+    while (counters.prepares - counters.closed.size > MAX_CACHED_PREPARED_STATEMENTS && extra < 64) {
+      Bun.gc(true);
+      await Bun.sleep(0);
+      await sql.unsafe(`select ? as extra${extra}`, [extra]);
+      extra++;
+    }
+    Bun.gc(true);
+    await Bun.sleep(0);
+
+    expect(counters.closed.size).toBeGreaterThan(0);
+    // Post-GC, only statements still cached may root a Structure (the slack
+    // absorbs unrelated Strong handles created while the test runs). Without
+    // eviction every one of the DISTINCT + extra texts roots its Structure
+    // (and retains its statement) until the connection closes.
+    expect(protectedStructures() - baseline).toBeLessThanOrEqual(MAX_CACHED_PREPARED_STATEMENTS + 16);
   } finally {
     await new Promise<void>(r => server.close(() => r()));
   }

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -409,6 +409,34 @@ export function mysqlTextResultSet(
   return Buffer.concat(parts);
 }
 
+// MySQL Binary Protocol Resultset Row (page_protocol_binary_resultset.html#sect_protocol_binary_resultset_row):
+//   Int<1>(0x00 header) String<(column_count + 7 + 2) / 8>(NULL bitmap, bit offset 2)
+//   then each non-NULL value in its column type's binary encoding (callers pass values pre-encoded).
+export function mysqlBinaryResultSetRow(seq: number, values: (Buffer | null)[]): Buffer {
+  const bitmap = Buffer.alloc(Math.floor((values.length + 7 + 2) / 8));
+  values.forEach((value, i) => {
+    if (value === null) bitmap[(i + 2) >> 3] |= 1 << ((i + 2) & 7);
+  });
+  const nonNull = values.filter((value): value is Buffer => value !== null);
+  return mysqlRawPacket(seq, Buffer.concat([Buffer.from([0x00]), bitmap, ...nonNull]));
+}
+
+// MySQL Binary Protocol Resultset (page_protocol_binary_resultset.html), in the CLIENT_DEPRECATE_EOF
+// framing (same shape as the textual resultset): lenenc(column_count) packet, one ColumnDefinition41
+// per column, one binary row packet per row, then an OK packet with the 0xFE header as the terminator.
+export function mysqlBinaryResultSet(
+  startSeq: number,
+  columns: { name: string; type: number }[],
+  rows: (Buffer | null)[][],
+): Buffer {
+  let seq = startSeq;
+  const parts: Buffer[] = [mysqlRawPacket(seq++, mysqlLenencInt(columns.length))];
+  for (const column of columns) parts.push(mysqlColumnDefinition(seq++, column));
+  for (const row of rows) parts.push(mysqlBinaryResultSetRow(seq++, row));
+  parts.push(mysqlOkPacket(seq, 0xfe));
+  return Buffer.concat(parts);
+}
+
 // MySQL COM_STMT_PREPARE_OK — page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response_ok:
 //   Int<1>(0x00) Int<4>(statement_id) Int<2>(num_columns) Int<2>(num_params) Int<1>(0x00) Int<2>(warning_count)
 export function mysqlStmtPrepareOk(seq: number, stmtId: number, numColumns: number, numParams: number): Buffer {

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -285,6 +285,17 @@ export function mysqlAuthMoreData(seq: number, data: Buffer): Buffer {
 // page_caching_sha2_authentication_exchanges.html (its sibling, 0x04, is perform_full_authentication).
 export const MYSQL_FAST_AUTH_SUCCESS = 0x03;
 
+// MySQL Protocol::ERR_Packet — page_protocol_basic_err_packet.html (CLIENT_PROTOCOL_41):
+//   Int<1>(0xff) Int<2>(error_code) String<1>("#") String<5>(sql_state) String<EOF>(message)
+export function mysqlErrPacket(seq: number, code: number, message: string, sqlState = "HY000"): Buffer {
+  const head = Buffer.alloc(9);
+  head[0] = 0xff;
+  head.writeUInt16LE(code, 1);
+  head.write("#", 3);
+  head.write(sqlState, 4);
+  return mysqlRawPacket(seq, Buffer.concat([head, Buffer.from(message, "utf-8")]));
+}
+
 // MySQL Protocol::AuthSwitchRequest — page_protocol_connection_phase_packets_protocol_auth_switch_request.html:
 //   Int<1>(0xfe) NulString(plugin_name) String<EOF>(plugin_provided_data)
 export function mysqlAuthSwitchRequest(seq: number, pluginName: string, pluginData: Buffer): Buffer {


### PR DESCRIPTION
### Problem

The MySQL client caches one server-side prepared statement per distinct query text and never sends `COM_STMT_CLOSE`: the `statements` map on `MySQLConnection` is insert-only, and the `COM_STMT_CLOSE` opcode had no users. Server-side prepared statements stay allocated until they are closed or the connection ends, and they count against the server-wide `max_prepared_stmt_count` budget (default 16382, shared by every connection of every client).

So one long-lived pooled connection running many distinct query texts (ORMs interpolate table/column names into SQL constantly) grows the server's prepared-statement table monotonically until every client of that server starts failing with `Can't create more than max_prepared_stmt_count statements`. Nothing crashes in the Bun process; the damage lands on the shared server, hours or days in.

The unbounded cache leaks on the client side too: each cached `MySQLStatement` keeps its metadata and roots one JSC `Structure` (its row shape) through a `Strong` handle until the connection closes. Measured on Bun 1.4.0 against an in-process scripted server (one connection, distinct parameterized texts, `Bun.gc(true)` between samples), `bun:jsc` `heapStats().protectedObjectTypeCounts.Structure` grows by exactly one per distinct text (5001 rooted Structures after 5000 texts) and RSS by roughly 8 KB per text; nothing is released until `sql.close()`. A repeated-text control stays flat. So the same defect exhausts memory on both ends of the connection.

Reproduced against a scripted MySQL server that counts commands (Bun 1.4.0, one pooled connection, distinct parameterized texts):

```
COM_STMT_PREPARE: 264   COM_STMT_CLOSE: 0
```

mysql2 and Connector/J both bound their per-connection statement caches with an LRU and close what they evict; Bun kept everything forever.

### Fix

- `src/sql_jsc/mysql/MySQLConnection.rs`: cap the per-connection cache at `MAX_CACHED_PREPARED_STATEMENTS` (256). Inserting a new entry past the cap evicts the least recently used statement whose only remaining owner is the cache, removes it from the map, and writes `COM_STMT_CLOSE` for its server id. A statement still referenced by any query object (pending, running, or simply not yet collected) is never evicted, so an id can never be closed out from under a query that will still execute it; the cache defers past the cap instead.
- Eviction only runs when `is_able_to_write()`, the same gate every other packet writer uses, so the close packet is never framed while the write buffer still has a flushed-but-unreleased prefix from a partial socket write (backpressure). A deferred eviction happens on the next statement insert.
- Evicting releases the client side of the statement as well: the map drops its (sole) ref, which frees the `MySQLStatement` and the `Strong` rooting its cached row `Structure`, so client memory is bounded by the cap instead of growing with every distinct query text.
- `src/sql_jsc/mysql/MySQLStatement.rs`: add the `last_used` LRU stamp, bumped each time a later query reuses a cached statement. Never-reused statements keep 0 and are evicted first; they are exactly the one-shot texts that cause the overflow.
- `src/sql/mysql/MySQLRequest.rs`: add the `COM_STMT_CLOSE` writer. The server never replies to it, so it is not queued as a request and does not shift response ordering.

Postgres is left alone deliberately: its named prepared statements are session-scoped with no server-global counterpart to `max_prepared_stmt_count`, and `prepare: false` already exists there.

### Verification

`test/js/sql/sql-mysql-statement-cache.test.ts` drives a scripted MySQL server (helpers in `test/js/sql/wire-frames.ts`) that counts `COM_STMT_PREPARE` / `COM_STMT_CLOSE` and, like a real server, answers any execute of a closed (or never prepared) statement id with `ER_UNKNOWN_STMT_HANDLER`, so closing a statement another query still needed would fail that query loudly.

- 264 distinct texts in flight at once on one connection (past the 256 cap): all resolve, nothing is evicted or closed while referenced. After the query wrappers are collected, further distinct texts trigger eviction: `COM_STMT_CLOSE` is sent and the number of live server statements (prepares minus closes) converges back under the cap. On `bun-v1.4.0` and current `main` this fails with 0 closes ever sent.
- client memory: the same flow against a mock that returns a one-row binary resultset (so each statement caches a row `Structure`), asserting the rooted `Structure` count (`heapStats().protectedObjectTypeCounts.Structure`) stays within the cap after exceeding it. Unfixed, it grows by one per distinct text and only `sql.close()` releases it.
- the same text re-run 50 times across GC cycles: 1 prepare, 0 closes (the cache still reuses).

```
bun test test/js/sql/sql-mysql-statement-cache.test.ts    # USE_SYSTEM_BUN=1 / main: 2 fail (0 closes, unbounded client memory)
bun bd test test/js/sql/sql-mysql-statement-cache.test.ts # with the fix: 3 pass
```

The other non-container SQL mock tests (`sql-mysql-auth-short-nonce`, `sql-mysql-columns-realloc-oom`, `sql-mysql-tls-plaintext-injection`, `wire-frames`, `sql-connect-error-reporting`, `sql-close-pending-connection`, `postgres-invalid-message-length`, `sql-mysql-cached-error`) still pass with the debug build.


### Rebase note

Rebased onto current `main` after #33072 landed. That change replaced the prepared-statement cache's `u64` signature hash key with the signature name bytes (`StringHashMap<*mut MySQLStatement>`), which conflicted with this PR's cache helpers. Resolved by porting `get_or_put_statement` / `evict_lru_statements` to the byte key: the eviction scan now walks `values()` and removes the victim by its own `signature.name` (the statement owns the bytes that keyed its entry, and the map's key is a separate copy, so it stays valid for the deref that follows). `wire-frames.ts` also took both sides' new helpers. All three statement-cache tests plus the neighbouring SQL mock tests pass on the rebased build, and the capped-eviction and client-memory tests still fail on an unfixed build.
