### PR TITLE
install: resolve overrides that point at a tarball with a mismatched internal name

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1949,7 +1949,8 @@ fn update_name_and_name_hash_from_version_replacement(
     new_version: &dependency::Version,
 ) -> (SemverString, PackageNameHash) {
     match new_version.tag {
-        // only get name hash for npm and dist_tag. git, github, tarball don't have names until after extracting tarball
+        // npm and dist_tag carry their name up front; git/github/tarball only
+        // learn it post-extract (see name_and_hash_from_extracted_package_name).
         dependency::version::Tag::DistTag => (
             new_version.dist_tag().name,
             Semver::string::Builder::string_hash(lockfile.str(&new_version.dist_tag().name)),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1958,12 +1958,40 @@ fn update_name_and_name_hash_from_version_replacement(
             new_version.npm().name,
             Semver::string::Builder::string_hash(lockfile.str(&new_version.npm().name)),
         ),
-        dependency::version::Tag::Git => (new_version.git().package_name, original_name_hash),
-        dependency::version::Tag::Github => (new_version.github().package_name, original_name_hash),
-        dependency::version::Tag::Tarball => {
-            (new_version.tarball().package_name, original_name_hash)
-        }
+        dependency::version::Tag::Git => name_and_hash_from_extracted_package_name(
+            lockfile,
+            new_version.git().package_name,
+            original_name_hash,
+        ),
+        dependency::version::Tag::Github => name_and_hash_from_extracted_package_name(
+            lockfile,
+            new_version.github().package_name,
+            original_name_hash,
+        ),
+        dependency::version::Tag::Tarball => name_and_hash_from_extracted_package_name(
+            lockfile,
+            new_version.tarball().package_name,
+            original_name_hash,
+        ),
         _ => (original_name, original_name_hash),
+    }
+}
+
+/// A git/github/tarball replacement (e.g. from `overrides`) has no package name
+/// until its tarball is extracted; until then keep the original name hash so the
+/// override stays keyed by its original name. Once the extracted name has been
+/// recorded on the version, hash it so resolution finds the package the index
+/// stored under the tarball's own name.
+fn name_and_hash_from_extracted_package_name(
+    lockfile: &Lockfile::Lockfile,
+    package_name: SemverString,
+    original_name_hash: PackageNameHash,
+) -> (SemverString, PackageNameHash) {
+    if package_name.is_empty() {
+        (package_name, original_name_hash)
+    } else {
+        let name_hash = Semver::string::Builder::string_hash(lockfile.str(&package_name));
+        (package_name, name_hash)
     }
 }
 

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1193,23 +1193,45 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             match dep {
                                 bun_install::TaskCallbackContext::Dependency(id)
                                 | bun_install::TaskCallbackContext::RootDependency(id) => {
-                                    let version = &mut manager.lockfile.buffers.dependencies
-                                        [id as usize]
-                                        .version;
-                                    match version.tag {
-                                        bun_install::DependencyVersionTag::Git => {
-                                            version.git_mut().package_name = pkg.name;
+                                    // Record the extracted package's real name so the
+                                    // re-enqueue below computes a matching name hash
+                                    // (tarball/git/github names are only known post-extract).
+                                    // When the dependency was redirected here by
+                                    // `overrides`/`resolutions`, its stored version keeps the
+                                    // original tag, so the name is recorded on the override
+                                    // entry instead (keyed by the original name hash).
+                                    let (dep_tag, dep_name_hash) = {
+                                        let dep_row =
+                                            &manager.lockfile.buffers.dependencies[id as usize];
+                                        (dep_row.version.tag, dep_row.name_hash)
+                                    };
+                                    let target = match dep_tag {
+                                        bun_install::DependencyVersionTag::Git
+                                        | bun_install::DependencyVersionTag::Github
+                                        | bun_install::DependencyVersionTag::Tarball => Some(
+                                            &mut manager.lockfile.buffers.dependencies[id as usize]
+                                                .version,
+                                        ),
+                                        _ => manager
+                                            .lockfile
+                                            .overrides
+                                            .map
+                                            .get_mut(&dep_name_hash)
+                                            .map(|over| &mut over.version),
+                                    };
+                                    if let Some(version) = target {
+                                        match version.tag {
+                                            bun_install::DependencyVersionTag::Git => {
+                                                version.git_mut().package_name = pkg.name;
+                                            }
+                                            bun_install::DependencyVersionTag::Github => {
+                                                version.github_mut().package_name = pkg.name;
+                                            }
+                                            bun_install::DependencyVersionTag::Tarball => {
+                                                version.tarball_mut().package_name = pkg.name;
+                                            }
+                                            _ => {}
                                         }
-                                        bun_install::DependencyVersionTag::Github => {
-                                            version.github_mut().package_name = pkg.name;
-                                        }
-                                        bun_install::DependencyVersionTag::Tarball => {
-                                            version.tarball_mut().package_name = pkg.name;
-                                        }
-
-                                        // `else` is reachable if this package is from `overrides`. Version in `lockfile.buffer.dependencies`
-                                        // will still have the original.
-                                        _ => {}
                                     }
                                     manager.process_dependency_list_item(
                                         &dep,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10021,7 +10021,7 @@ it.each([
 });
 
 // https://github.com/oven-sh/bun/issues/33192
-describe("override to a tarball whose internal name differs from the key", () => {
+describe.concurrent("override to a tarball whose internal name differs from the key", () => {
   // A dependency or `overrides` entry that points a name at an HTTP(S) or local
   // tarball must install that tarball under the dependency key even when the
   // tarball's own `package.json` `name` differs, matching npm and pnpm. Bun keyed

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10091,6 +10091,37 @@ describe("override to a tarball whose internal name differs from the key", () =>
     });
   });
 
+  test("direct dependency resolved through a remote-tarball `resolutions` entry with a mismatched name", async () => {
+    // `resolutions` feeds the same override map as `overrides`, so it must honor
+    // a mismatched internal name too.
+    await using server = serveTarballs({
+      "/vite-core.tgz": npmTarball({ name: "@scope/vite-core", version: "0.2.1" }),
+    });
+    const base = `http://localhost:${server.port}`;
+    using dir = tempDir("issue-33192-resolutions", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        devDependencies: { vite: "^5.0.0" },
+        resolutions: { vite: `${base}/vite-core.tgz` },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), npm_config_registry: `${base}/` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("failed to resolve");
+    expect(exitCode).toBe(0);
+    expect(await file(join(String(dir), "node_modules", "vite", "package.json")).json()).toEqual({
+      name: "@scope/vite-core",
+      version: "0.2.1",
+    });
+  });
+
   test("transitive peer satisfied by a remote-tarball override with a mismatched name", async () => {
     // The real-world shape from the issue: a dependency (testrunner) declares a
     // transitive peer on `vite`, and `overrides` points `vite` at a tarball whose

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10019,3 +10019,179 @@ it.each([
     expect(exitCode).not.toBe(0);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/33192
+describe("override to a tarball whose internal name differs from the key", () => {
+  // A dependency or `overrides` entry that points a name at an HTTP(S) or local
+  // tarball must install that tarball under the dependency key even when the
+  // tarball's own `package.json` `name` differs, matching npm and pnpm. Bun keyed
+  // the override's resolution on the tarball's internal name, so the extracted
+  // package (indexed under its own name) could not be found for the overridden
+  // key and `node_modules/<key>` was never created:
+  //   error: vite@^5.0.0 failed to resolve
+
+  // Minimal npm-style .tgz: a single gzipped `package/package.json` entry.
+  function npmTarball(pkg: Record<string, unknown>): Buffer {
+    const body = Buffer.from(JSON.stringify(pkg) + "\n", "utf8");
+    const block = Buffer.alloc(Math.ceil((body.length + 512) / 512) * 512);
+    block.write("package/package.json", 0, 100, "utf8");
+    block.write("0000644\0", 100); // mode
+    block.write("0000000\0", 108); // uid
+    block.write("0000000\0", 116); // gid
+    block.write(body.length.toString(8).padStart(11, "0") + "\0", 124); // size
+    block.write("00000000000\0", 136); // mtime
+    block.write("        ", 148, 8); // checksum placeholder
+    block.write("0", 156); // typeflag: regular file
+    block.write("ustar\0", 257);
+    block.write("00", 263);
+    body.copy(block, 512);
+    let checksum = 0;
+    for (let i = 0; i < 512; i++) checksum += i >= 148 && i < 156 ? 32 : block[i];
+    block.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8);
+    // trailing 1024 zero bytes = end-of-archive marker
+    return Bun.gzipSync(Buffer.concat([block, Buffer.alloc(1024)]));
+  }
+
+  function serveTarballs(tgz: Record<string, Buffer>) {
+    return Bun.serve({
+      port: 0,
+      fetch(req) {
+        const body = tgz[new URL(req.url).pathname];
+        return body ? new Response(body) : new Response("not found", { status: 404 });
+      },
+    });
+  }
+
+  test("direct dependency resolved through a remote-tarball override with a mismatched name", async () => {
+    await using server = serveTarballs({
+      "/vite-core.tgz": npmTarball({ name: "@scope/vite-core", version: "0.2.1" }),
+    });
+    const base = `http://localhost:${server.port}`;
+    using dir = tempDir("issue-33192-remote", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        devDependencies: { vite: "^5.0.0" },
+        overrides: { vite: `${base}/vite-core.tgz` },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), npm_config_registry: `${base}/` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("failed to resolve");
+    expect(exitCode).toBe(0);
+    expect(await file(join(String(dir), "node_modules", "vite", "package.json")).json()).toEqual({
+      name: "@scope/vite-core",
+      version: "0.2.1",
+    });
+  });
+
+  test("transitive peer satisfied by a remote-tarball override with a mismatched name", async () => {
+    // The real-world shape from the issue: a dependency (testrunner) declares a
+    // transitive peer on `vite`, and `overrides` points `vite` at a tarball whose
+    // internal name is `@scope/vite-core`.
+    const tgz: Record<string, Buffer> = {};
+    await using server = serveTarballs(tgz);
+    const base = `http://localhost:${server.port}`;
+    tgz["/vite-core.tgz"] = npmTarball({ name: "@scope/vite-core", version: "0.2.1" });
+    tgz["/mocker.tgz"] = npmTarball({
+      name: "mocker",
+      version: "1.0.0",
+      peerDependencies: { vite: "^5.0.0 || ^6.0.0 || ^7.0.0-0" },
+    });
+    tgz["/testrunner.tgz"] = npmTarball({
+      name: "testrunner",
+      version: "3.2.4",
+      dependencies: { mocker: `${base}/mocker.tgz` },
+    });
+    using dir = tempDir("issue-33192-peer", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        devDependencies: { testrunner: `${base}/testrunner.tgz` },
+        overrides: { vite: `${base}/vite-core.tgz` },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), npm_config_registry: `${base}/` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("failed to resolve");
+    expect(exitCode).toBe(0);
+    expect(await file(join(String(dir), "node_modules", "vite", "package.json")).json()).toEqual({
+      name: "@scope/vite-core",
+      version: "0.2.1",
+    });
+  });
+
+  test("direct dependency resolved through a local-tarball override with a mismatched name", async () => {
+    using dir = tempDir("issue-33192-local", {
+      "package.json": "{}",
+    });
+    const tarballPath = join(String(dir), "vite-core.tgz");
+    await write(tarballPath, npmTarball({ name: "@scope/vite-core", version: "0.2.1" }));
+    await write(
+      join(String(dir), "package.json"),
+      JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        devDependencies: { vite: "^5.0.0" },
+        overrides: { vite: tarballPath },
+      }),
+    );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("failed to resolve");
+    expect(exitCode).toBe(0);
+    expect(await file(join(String(dir), "node_modules", "vite", "package.json")).json()).toEqual({
+      name: "@scope/vite-core",
+      version: "0.2.1",
+    });
+  });
+
+  test("override tarball whose internal name matches the key still installs", async () => {
+    // Guard against over-correcting: when the tarball's internal name equals the
+    // overridden key, resolution must keep working exactly as before.
+    await using server = serveTarballs({
+      "/vite.tgz": npmTarball({ name: "vite", version: "5.4.0" }),
+    });
+    const base = `http://localhost:${server.port}`;
+    using dir = tempDir("issue-33192-match", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        devDependencies: { vite: "^5.0.0" },
+        overrides: { vite: `${base}/vite.tgz` },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), npm_config_registry: `${base}/` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("failed to resolve");
+    expect(exitCode).toBe(0);
+    expect(await file(join(String(dir), "node_modules", "vite", "package.json")).json()).toEqual({
+      name: "vite",
+      version: "5.4.0",
+    });
+  });
+});


### PR DESCRIPTION
## What

Fixes #33192. A dependency or `overrides`/`resolutions` entry that points a name at an HTTP(S) or local tarball is now installed under the dependency key even when the tarball's own `package.json` `name` field differs, matching npm and pnpm.

## Repro

```jsonc
// package.json
{
  "name": "app",
  "devDependencies": { "vite": "^5.0.0" },
  "overrides": { "vite": "https://example.com/vite-core.tgz" } // tarball's internal name is "@scope/vite-core"
}
```

```
$ bun install
error: vite@^5.0.0 failed to resolve
node_modules/vite: NOT INSTALLED
```

In graphs where the only `vite` edge is a transitive peer (vitest -> @vitest/mocker), `bun install` instead exits 0 and silently drops `vite` rather than erroring.

## Cause

When a tarball is extracted, the resulting package is indexed in the lockfile's package index under the tarball's **own** `package.json` name (`@scope/vite-core`). Resolution then looks the package up by name hash.

- The direct-dependency path works because after extraction it back-propagates the extracted name onto the dependency's stored tarball version, so the re-enqueue computes `hash("@scope/vite-core")` and finds the package.
- The override path skipped that step: the dependency's stored version keeps its original tag (e.g. an npm range), so the back-propagation branch fell through (`_ => {}`), and `update_name_and_name_hash_from_version_replacement` returned the original name hash (`hash("vite")`). `get_package_id(hash("vite"), ...)` could not find the package indexed under `hash("@scope/vite-core")`, so the edge never resolved.

## Fix

Two changes, both in the hoisted installer's tarball-extract path:

1. `runTasks.rs`: when the completed tarball's waiting dependency edge keeps its original (non-tarball) tag, it was redirected by `overrides`/`resolutions`, so record the extracted name on the override entry (keyed by the original name hash) instead of the stored version.
2. `PackageManagerEnqueue.rs`: once a git/github/tarball replacement's package name is known, derive the replacement's name hash from that name so resolution finds the package under the tarball's own name. While the name is still unknown (pre-extract), the original name hash is kept so the override stays keyed by its original name.

The directory name stays the overridden key (`node_modules/vite`), since `assign_resolution` only overwrites a dependency's name when it is empty or equals the version literal.

Catalog replacements are unchanged: their package name is never back-propagated, so the new helper returns the original hash (its existing behavior).

## Scope

`overrides` that resolve to a **git** URL (`git+...`, cloned rather than tarball-extracted) are intentionally left out of this PR. They take a different completion path (`Task::Tag::GitCheckout`) with a pre-existing wrong-union-arm write for override edges, and git clones cannot be reproduced hermetically in the test harness, so that sibling is a follow-up. GitHub URLs are covered here because they download as tarballs through the same extract path.

## Tests

`test/cli/install/bun-install.test.ts`, serving in-process tarballs over HTTP and from a local path:

- direct dependency resolved through a remote-tarball override with a mismatched name
- transitive peer satisfied by a remote-tarball override with a mismatched name (the issue's real-world shape)
- direct dependency resolved through a local-tarball override with a mismatched name
- override tarball whose internal name matches the key still installs (guard)

The three mismatched-name tests fail on the current binary (two with `vite@^5.0.0 failed to resolve`, the transitive-peer one by silently not installing `vite`) and pass with the fix; the matching-name guard passes both ways.

