### PR TITLE
Stop HMR websocket frames from aborting or crashing the dev server

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -198,6 +198,9 @@ pub enum TestingBatchEvents {
     /// a message saying that new files have been seen. Once DevServer receives
     /// that signal, or times out, it will "release" this batch.
     Enabled(TestingBatch),
+    /// The harness released this batch while a bundle was already in flight.
+    /// `finalize_bundle_cleanup` releases it once no bundle is running.
+    ReleaseAfterBundle(TestingBatch),
 }
 
 /// There is only ever one bundle executing at the same time, since all bundles
@@ -1151,7 +1154,9 @@ impl Drop for DevServer {
             }
         }
 
-        if let TestingBatchEvents::Enabled(batch) = &mut self.testing_batch_events {
+        if let TestingBatchEvents::Enabled(batch) | TestingBatchEvents::ReleaseAfterBundle(batch) =
+            &mut self.testing_batch_events
+        {
             drop(std::mem::replace(
                 &mut batch.entry_points,
                 EntryPointList::empty(),
@@ -3778,6 +3783,22 @@ fn finalize_bundle_cleanup(dev: &mut DevServer, bv2: &mut BundleV2, had_sent_hmr
 
     dev.start_next_bundle_if_present();
 
+    // A batch released while this bundle was in flight waits for a moment with
+    // no bundle running. `start_next_bundle_if_present` may have started one,
+    // in which case the next cleanup releases the batch.
+    if matches!(
+        dev.testing_batch_events,
+        TestingBatchEvents::ReleaseAfterBundle(_)
+    ) && dev.current_bundle.is_none()
+    {
+        let TestingBatchEvents::ReleaseAfterBundle(batch) =
+            core::mem::replace(&mut dev.testing_batch_events, TestingBatchEvents::Disabled)
+        else {
+            unreachable!()
+        };
+        dev.release_testing_batch(batch);
+    }
+
     // Unref the ref added in `start_async_bundle`
     if let Some(server) = dev.server.as_mut() {
         server.on_static_request_complete();
@@ -4873,6 +4894,24 @@ pub(super) fn finalize_bundle(
 }
 
 impl DevServer {
+    /// Start a bundle for the files a testing batch collected, or tell the
+    /// harness the batch was empty. The caller must have no bundle in flight.
+    pub(crate) fn release_testing_batch(&mut self, batch: TestingBatch) {
+        debug_assert!(self.current_bundle.is_none());
+        if batch.entry_points.set.count() == 0 {
+            self.publish(
+                HmrTopic::TestingWatchSynchronization,
+                &[MessageId::TestingWatchSynchronization.char(), 2],
+                Opcode::BINARY,
+            );
+            return;
+        }
+
+        self.start_async_bundle(batch.entry_points, true, Instant::now())
+            // bun.handleOom(err) — Rust aborts on OOM by default
+            .expect("OOM");
+    }
+
     fn start_next_bundle_if_present(&mut self) {
         debug_assert!(self.magic == Magic::Valid);
         // Clear the current bundle

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -198,8 +198,8 @@ pub enum TestingBatchEvents {
     /// a message saying that new files have been seen. Once DevServer receives
     /// that signal, or times out, it will "release" this batch.
     Enabled(TestingBatch),
-    /// The harness released this batch while a bundle was already in flight.
-    /// `finalize_bundle_cleanup` releases it once no bundle is running.
+    /// Released while a bundle was in flight. `finalize_bundle_cleanup` starts
+    /// it once no bundle is running.
     ReleaseAfterBundle(TestingBatch),
 }
 
@@ -3783,9 +3783,7 @@ fn finalize_bundle_cleanup(dev: &mut DevServer, bv2: &mut BundleV2, had_sent_hmr
 
     dev.start_next_bundle_if_present();
 
-    // A batch released while this bundle was in flight waits for a moment with
-    // no bundle running. `start_next_bundle_if_present` may have started one,
-    // in which case the next cleanup releases the batch.
+    // If the call above started another bundle, its cleanup releases the batch.
     if matches!(
         dev.testing_batch_events,
         TestingBatchEvents::ReleaseAfterBundle(_)
@@ -4894,8 +4892,7 @@ pub(super) fn finalize_bundle(
 }
 
 impl DevServer {
-    /// Start a bundle for the files a testing batch collected, or tell the
-    /// harness the batch was empty. The caller must have no bundle in flight.
+    /// Bundle the files a testing batch collected, or report an empty batch.
     pub(crate) fn release_testing_batch(&mut self, batch: TestingBatch) {
         debug_assert!(self.current_bundle.is_none());
         if batch.entry_points.set.count() == 0 {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -198,8 +198,7 @@ pub enum TestingBatchEvents {
     /// a message saying that new files have been seen. Once DevServer receives
     /// that signal, or times out, it will "release" this batch.
     Enabled(TestingBatch),
-    /// Released while a bundle was in flight. `finalize_bundle_cleanup` starts
-    /// it once no bundle is running.
+    /// Released while a bundle ran; `finalize_bundle_cleanup` starts it after.
     ReleaseAfterBundle(TestingBatch),
 }
 

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -158,6 +158,11 @@ impl HmrSocket {
             }
             x if x == IncomingMessageId::SetUrl as u8 => {
                 let pattern = &msg[1..];
+                // `pattern` is peer bytes; `FrameworkRouter::match_slow` requires
+                // an absolute path (`debug_assert!(path[0] == b'/')`).
+                if pattern.first() != Some(&b'/') {
+                    return ws.close();
+                }
                 // SAFETY: JS-thread only; sole `&mut DevServer` for this scope.
                 let dev = unsafe { self.dev() };
                 let maybe_rbi = dev.route_to_bundle_index_slow(pattern);
@@ -204,36 +209,34 @@ impl HmrSocket {
                             );
                         }
                     }
-                    super::TestingBatchEvents::EnableAfterBundle => {
-                        // do not expose a websocket event that panics a release build
-                        debug_assert!(false);
+                    super::TestingBatchEvents::EnableAfterBundle
+                    | super::TestingBatchEvents::ReleaseAfterBundle(_) => {
+                        // A duplicate `H` before the pending batch activates or
+                        // releases is a peer protocol violation; never assert on
+                        // websocket input.
                         ws.close();
                     }
                     super::TestingBatchEvents::Enabled(_event_const) => {
                         // Replace-and-extract to satisfy borrowck.
-                        let super::TestingBatchEvents::Enabled(mut event) = core::mem::replace(
+                        let super::TestingBatchEvents::Enabled(batch) = core::mem::replace(
                             &mut dev.testing_batch_events,
                             super::TestingBatchEvents::Disabled,
                         ) else {
                             unreachable!()
                         };
-                        let _ = &mut event;
 
-                        if event.entry_points.set.count() == 0 {
-                            dev.publish(
-                                HmrTopic::TestingWatchSynchronization,
-                                &[MessageId::TestingWatchSynchronization.char(), 2],
-                                bun_uws::Opcode::BINARY,
-                            );
+                        // A request for a route that is not bundled yet starts a
+                        // bundle without consulting the batch, and
+                        // `start_async_bundle` requires that no bundle is in
+                        // flight. Hold the batch and release it once that bundle
+                        // finishes.
+                        if dev.current_bundle.is_some() {
+                            dev.testing_batch_events =
+                                super::TestingBatchEvents::ReleaseAfterBundle(batch);
                             return;
                         }
 
-                        let timer = std::time::Instant::now();
-                        dev.start_async_bundle(event.entry_points, true, timer)
-                            // bun.handleOom(err) — Rust aborts on OOM by default
-                            .expect("OOM");
-
-                        // `event.entry_points.deinit(allocator)` → Drop handles this
+                        dev.release_testing_batch(batch);
                     }
                 }
             }
@@ -307,7 +310,7 @@ impl HmrSocket {
             }
             if field.contains(HmrTopic::MemoryVisualizer.as_bit()) {
                 dev.emit_memory_visualizer_events -= 1;
-                if dev.emit_incremental_visualizer_events == 0
+                if dev.emit_memory_visualizer_events == 0
                     && dev.memory_visualizer_timer.state == EventLoopTimerState::ACTIVE
                 {
                     // Note (jsc/runtime crate cycle): `vm.timer` is `()` on the low-tier

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -158,8 +158,7 @@ impl HmrSocket {
             }
             x if x == IncomingMessageId::SetUrl as u8 => {
                 let pattern = &msg[1..];
-                // `pattern` is peer bytes; `FrameworkRouter::match_slow` requires
-                // an absolute path (`debug_assert!(path[0] == b'/')`).
+                // `match_slow` requires an absolute path; these are peer bytes.
                 if pattern.first() != Some(&b'/') {
                     return ws.close();
                 }
@@ -211,9 +210,7 @@ impl HmrSocket {
                     }
                     super::TestingBatchEvents::EnableAfterBundle
                     | super::TestingBatchEvents::ReleaseAfterBundle(_) => {
-                        // A duplicate `H` before the pending batch activates or
-                        // releases is a peer protocol violation; never assert on
-                        // websocket input.
+                        // A duplicate `H` is a protocol violation, not an invariant.
                         ws.close();
                     }
                     super::TestingBatchEvents::Enabled(_event_const) => {
@@ -225,11 +222,9 @@ impl HmrSocket {
                             unreachable!()
                         };
 
-                        // A request for a route that is not bundled yet starts a
-                        // bundle without consulting the batch, and
-                        // `start_async_bundle` requires that no bundle is in
-                        // flight. Hold the batch and release it once that bundle
-                        // finishes.
+                        // A request for an unbundled route starts a bundle
+                        // without consulting the batch; `start_async_bundle`
+                        // requires none in flight.
                         if dev.current_bundle.is_some() {
                             dev.testing_batch_events =
                                 super::TestingBatchEvents::ReleaseAfterBundle(batch);

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -222,9 +222,8 @@ impl HmrSocket {
                             unreachable!()
                         };
 
-                        // A request for an unbundled route starts a bundle
-                        // without consulting the batch; `start_async_bundle`
-                        // requires none in flight.
+                        // An unbundled route's request can start a bundle;
+                        // `start_async_bundle` requires none in flight.
                         if dev.current_bundle.is_some() {
                             dev.testing_batch_events =
                                 super::TestingBatchEvents::ReleaseAfterBundle(batch);

--- a/src/runtime/bake/dev_server/memory_cost.rs
+++ b/src/runtime/bake/dev_server/memory_cost.rs
@@ -234,7 +234,7 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
     // .testing_batch_events
     match &dev.testing_batch_events {
         TestingBatchEvents::Disabled => {}
-        TestingBatchEvents::Enabled(batch) => {
+        TestingBatchEvents::Enabled(batch) | TestingBatchEvents::ReleaseAfterBundle(batch) => {
             other_bytes += memory_cost_array_hash_map(&batch.entry_points.set);
         }
         TestingBatchEvents::EnableAfterBundle => {}

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -676,7 +676,7 @@ impl HotReloadEvent {
 
         match &mut dev_ref.testing_batch_events {
             TestingBatchEvents::Disabled => {}
-            TestingBatchEvents::Enabled(ev) => {
+            TestingBatchEvents::Enabled(ev) | TestingBatchEvents::ReleaseAfterBundle(ev) => {
                 bun_core::handle_oom(ev.append(&entry_points));
                 dev_ref.publish(
                     HmrTopic::TestingWatchSynchronization,

--- a/test/bake/hmr-socket-protocol.test.ts
+++ b/test/bake/hmr-socket-protocol.test.ts
@@ -1,0 +1,341 @@
+// The HMR websocket at `/_bun/hmr` accepts frames from any connected client
+// (a browser tab, an extension, anything on the LAN with `--hostname 0.0.0.0`),
+// so no frame may be able to reach an `assert`/`debug_assert` in the dev
+// server. These tests drive the frames that could:
+//   - a second "H" (testing-batch) frame while a bundle is in flight hit the
+//     `TestingBatchEvents::EnableAfterBundle` arm's `debug_assert!(false)`.
+//   - "n" (SetUrl) with a pattern not starting with "/" reached
+//     `FrameworkRouter::match_slow`'s `debug_assert!(path[0] == b'/')`: an
+//     empty pattern indexes out of bounds inside it, any other fails it.
+//   - releasing a batch with "H" while an unrelated bundle was in flight
+//     reached `start_async_bundle`'s `debug_assert!(current_bundle.is_none())`.
+//     On a release build that assert is compiled out and the second
+//     `start_async_bundle` overwrites the in-flight `CurrentBundle`, freeing
+//     the arena its parse tasks are still reading: a multi-thread segfault.
+import type { Subprocess } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const indexHtml = /* html */ `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body><script type="module" src="./entry.ts"></script></body></html>`;
+
+const serverTs = /* ts */ `
+  import html from "./index.html";
+  const server = Bun.serve({
+    port: 0,
+    development: { hmr: true, console: false },
+    routes: { "/": html },
+    fetch() { return new Response("fallback"); },
+  });
+  console.log("PORT=" + server.port);
+`;
+
+/** Parks any import of `hold.block` on a fetch the test controls. */
+const holdPlugin = /* ts */ `
+  export default {
+    name: "hold-bundle",
+    setup(build) {
+      build.onLoad({ filter: /hold\\.block$/ }, async () => {
+        await fetch(process.env.HMR_TEST_BUNDLE_GATE);
+        return { contents: "export default 1;", loader: "js" };
+      });
+    },
+  };
+`;
+
+/** Drain stdout/stderr concurrently and resolve the port from the PORT= line. */
+function watchDevServer(proc: Subprocess<"ignore", "pipe", "pipe">) {
+  const port = Promise.withResolvers<number>();
+  let stdout = "";
+  let stderr = "";
+  (async () => {
+    for await (const chunk of proc.stdout) {
+      stdout += Buffer.from(chunk).toString();
+      const m = stdout.match(/PORT=(\d+)/);
+      if (m) port.resolve(parseInt(m[1], 10));
+    }
+    port.reject(new Error(`dev server exited before printing its port\n${stdout}${stderr}`));
+  })().catch(() => {});
+  (async () => {
+    for await (const chunk of proc.stderr) stderr += Buffer.from(chunk).toString();
+  })().catch(() => {});
+  return { port: port.promise, stderr: () => stderr };
+}
+
+/**
+ * Connect to `/_bun/hmr`. `onFrame` gets every server frame as its message-id
+ * byte plus the rest of the payload; `onClose` fires on any server-initiated
+ * close (an aborting dev server looks like an abrupt close to the client).
+ */
+async function connectHmr(
+  port: number,
+  onFrame: (id: string, body: Uint8Array) => void,
+  onClose: (err: Error) => void,
+) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/_bun/hmr`);
+  ws.binaryType = "arraybuffer";
+  const received: string[] = [];
+  ws.onmessage = ev => {
+    const bytes = new Uint8Array(ev.data as ArrayBuffer);
+    const id = String.fromCharCode(bytes[0]);
+    received.push(id);
+    onFrame(id, bytes.subarray(1));
+  };
+  const opened = Promise.withResolvers<void>();
+  ws.onopen = () => opened.resolve();
+  ws.onerror = () => opened.reject(new Error("hmr websocket failed to connect"));
+  ws.onclose = ev => onClose(new Error(`hmr websocket closed (code ${ev.code}, reason ${JSON.stringify(ev.reason)})`));
+  await opened.promise;
+  return {
+    ws,
+    received,
+    [Symbol.dispose]() {
+      ws.onclose = null;
+      ws.close();
+    },
+  };
+}
+
+test.concurrent(
+  "a duplicate testing-batch frame (H) during an in-flight bundle closes the socket instead of aborting",
+  async () => {
+    // A bundler plugin parks the bundle on a fetch to this server, so "the
+    // bundle is in flight" is an awaited condition, not a sleep.
+    const bundleEntered = Promise.withResolvers<void>();
+    const bundleRelease = Promise.withResolvers<void>();
+    await using gate = Bun.serve({
+      port: 0,
+      async fetch() {
+        bundleEntered.resolve();
+        await bundleRelease.promise;
+        return new Response("go");
+      },
+    });
+
+    using dir = tempDir("hmr-socket-double-h", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": holdPlugin,
+      "index.html": indexHtml,
+      "entry.ts": `import "./hold.block";\nconsole.log("entry");`,
+      "hold.block": "",
+      "server.ts": serverTs,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "server.ts"],
+      env: { ...bunEnv, HMR_TEST_BUNDLE_GATE: String(gate.url) },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const dev = watchDevServer(proc);
+    const port = await dev.port;
+    // If the bundle never reaches the plugin (so the gate fetch never comes),
+    // fail with the dev server's output instead of hanging on bundleEntered.
+    proc.exited.then(() =>
+      bundleEntered.reject(
+        new Error(`dev server exited before the bundle reached the plugin\n--- dev server stderr ---\n${dev.stderr()}`),
+      ),
+    );
+
+    const closed = Promise.withResolvers<void>();
+    using hmr = await connectHmr(
+      port,
+      () => {},
+      () => closed.resolve(),
+    );
+
+    // Kick off the bundle for `/`; the plugin holds it open on the gate fetch.
+    const pageFetch = fetch(`http://127.0.0.1:${port}/`);
+    pageFetch.catch(() => {});
+    await bundleEntered.promise;
+
+    // 1st "H" with a bundle in flight: Disabled -> EnableAfterBundle.
+    // 2nd "H": the EnableAfterBundle arm must close the socket, not assert.
+    hmr.ws.send("H");
+    hmr.ws.send("H");
+    await closed.promise;
+
+    // Release the held bundle: the deferred `/` request completes only if the
+    // dev server survived the protocol violation.
+    bundleRelease.resolve();
+    let pageStatus: string;
+    try {
+      pageStatus = String((await pageFetch).status);
+    } catch (e) {
+      pageStatus = `${(e as Error).message}\n--- dev server stderr ---\n${dev.stderr()}`;
+    }
+    expect(pageStatus).toBe("200");
+    // And it is still accepting new requests.
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(res.status).toBe(200);
+  },
+);
+
+// "n" is an empty pattern (the out-of-bounds index flavor); "nfoo" is a
+// non-absolute pattern (the failed-assertion flavor).
+test.concurrent.each(["n", "nfoo"])(
+  "a SetUrl frame without a leading slash (%j) closes the socket instead of aborting",
+  async frame => {
+    using dir = tempDir("hmr-socket-seturl", {
+      "index.html": indexHtml,
+      "entry.ts": `console.log("entry");`,
+      "server.ts": serverTs,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "server.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const dev = watchDevServer(proc);
+    const port = await dev.port;
+
+    // An aborting dev server also produces a close event, so the liveness
+    // check below is what distinguishes "closed the socket" from "died".
+    const closed = Promise.withResolvers<void>();
+    using hmr = await connectHmr(
+      port,
+      () => {},
+      () => closed.resolve(),
+    );
+    hmr.ws.send(frame);
+    await closed.promise;
+
+    let status: string;
+    try {
+      status = String((await fetch(`http://127.0.0.1:${port}/`)).status);
+    } catch (e) {
+      status = `${(e as Error).message}\n--- dev server stderr ---\n${dev.stderr()}`;
+    }
+    expect(status).toBe("200");
+  },
+);
+
+test.concurrent("releasing a testing batch while another bundle is in flight defers it", async () => {
+  // `/two` is not bundled at startup, and its entry imports `hold.block`, so
+  // the first request for it parks a bundle in the plugin until this server
+  // answers. That makes "a bundle is in flight" an awaited condition.
+  const bundleEntered = Promise.withResolvers<void>();
+  const bundleRelease = Promise.withResolvers<void>();
+  await using gate = Bun.serve({
+    port: 0,
+    async fetch() {
+      bundleEntered.resolve();
+      await bundleRelease.promise;
+      return new Response("go");
+    },
+  });
+
+  using dir = tempDir("hmr-socket-batch-defer", {
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+    "plugin.ts": holdPlugin,
+    "index.html": indexHtml,
+    "entry.ts": `import { value } from "./dep.ts";\nconsole.log(value);`,
+    "dep.ts": `export const value = 0;`,
+    "two.html": /* html */ `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body><script type="module" src="./two.ts"></script></body></html>`,
+    "two.ts": `import "./hold.block";\nconsole.log("two");`,
+    "hold.block": "",
+    "server.ts": /* ts */ `
+      import one from "./index.html";
+      import two from "./two.html";
+      const server = Bun.serve({
+        port: 0,
+        development: { hmr: true, console: false },
+        routes: { "/": one, "/two": two },
+        fetch() { return new Response("fallback"); },
+      });
+      console.log("PORT=" + server.port);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    env: { ...bunEnv, HMR_TEST_BUNDLE_GATE: String(gate.url) },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const dev = watchDevServer(proc);
+  const port = await dev.port;
+
+  // `r` frames are the testing-synchronization codes: 0 batching started,
+  // 1 the batch saw a file, 2 an empty batch was released, 3/4 a bundle
+  // finished. Waiting on them keeps every step below condition-based.
+  const seen = new Set<number>();
+  const waiters = new Map<number, () => void>();
+  const waitForSync = (code: number) =>
+    new Promise<void>(resolve => {
+      if (seen.delete(code)) return resolve();
+      waiters.set(code, resolve);
+    });
+
+  // Only a process exit means the dev server died; a close is a close.
+  const died = Promise.withResolvers<never>();
+  died.promise.catch(() => {});
+  proc.exited.then(() => died.reject(new Error(`dev server exited\n--- dev server stderr ---\n${dev.stderr()}`)));
+  const socketClosed = Promise.withResolvers<void>();
+  using hmr = await connectHmr(
+    port,
+    (id, body) => {
+      if (id !== "r") return;
+      const code = body[0];
+      const waiter = waiters.get(code);
+      if (waiter) {
+        waiters.delete(code);
+        waiter();
+      } else {
+        seen.add(code);
+      }
+    },
+    () => socketClosed.resolve(),
+  );
+  hmr.ws.send("sr");
+
+  // Bundle `/` so that `dep.ts` is watched and an edit to it reaches the batch.
+  expect((await fetch(`http://127.0.0.1:${port}/`)).status).toBe(200);
+
+  // 1. "H" with no bundle running turns batching on (sync code 0).
+  const batchingOn = waitForSync(0);
+  hmr.ws.send("H");
+  await Promise.race([batchingOn, died.promise]);
+
+  // 2. An edit is parked in the batch instead of starting a bundle (code 1).
+  const sawFile = waitForSync(1);
+  await Bun.write(`${dir}/dep.ts`, `export const value = 1;`);
+  await Promise.race([sawFile, died.promise]);
+
+  // 3. The first request for `/two` starts a bundle that the plugin holds.
+  const twoFetch = fetch(`http://127.0.0.1:${port}/two`);
+  twoFetch.catch(() => {});
+  await Promise.race([bundleEntered.promise, died.promise]);
+
+  // 4. "H" releases the batch while that bundle is still running. Starting a
+  //    second bundle here trips start_async_bundle's assert on a debug build
+  //    and corrupts the in-flight bundle on a release build, so the batch has
+  //    to wait for the running bundle to finish.
+  hmr.ws.send("H");
+  // A further "H" finds the batch pending release and closes the socket.
+  // Receiving that close proves the frame above was handled while the bundle
+  // was still held, which is the state this test is about.
+  hmr.ws.send("H");
+  await Promise.race([socketClosed.promise, died.promise]);
+
+  bundleRelease.resolve();
+  expect(
+    String(
+      await twoFetch.then(
+        r => r.status,
+        e => `${e}\n${dev.stderr()}`,
+      ),
+    ),
+  ).toBe("200");
+
+  // The deferred batch now runs, so both routes still serve and the edit is
+  // live in the bundle for `/`.
+  const reloaded = await fetch(`http://127.0.0.1:${port}/`);
+  expect(reloaded.status).toBe(200);
+  expect(proc.killed).toBe(false);
+});


### PR DESCRIPTION
### Problem

- Three frames on `/_bun/hmr`, which any client that can reach the dev server may send, drove invalid state. A duplicate `H` (testing-batch) frame hit the `TestingBatchEvents::EnableAfterBundle` arm's `debug_assert!(false)`. A `SetUrl` pattern that does not start with `/` reached `FrameworkRouter::match_slow`'s `debug_assert!(path[0] == b'/')`: `ws.send("n")` indexes an empty slice inside that assert, `ws.send("nfoo")` fails it.
- Releasing a batch with `H` while an unrelated bundle was in flight called `start_async_bundle`, whose first line is `debug_assert!(self.current_bundle.is_none())` (`DevServer.rs:3111`). On a release build that assert is compiled out, and the assignment drops the in-flight `CurrentBundle` (its `BundleV2`, and through `Drop for MimallocArena` an `mi_heap_destroy` of its arena) while that bundle's thread-pool tasks are still running. Since 1.4.1 that crashes on several threads at once:

```
panic: Segmentation fault at address 0x1B     # canary 1.4.3, 3/3, addresses vary
oh no: multiple threads are crashing
panic: index out of bounds: the len is 7 but the index is 153309857
```

### Fix

- Duplicate `H`: drop the assert and keep the `ws.close()` that was already there.
- `SetUrl`: close the socket on a pattern that does not start with `/`, like the sibling arms do for their malformed input. `match_slow`'s assert is a correct contract for its HTTP callers, whose request paths always start with `/`; the HMR socket is the one caller feeding it peer bytes.
- Batch release: hold the batch in a new `TestingBatchEvents::ReleaseAfterBundle` state and release it from `finalize_bundle_cleanup` once no bundle is running, so the harness still gets its bundle. A further `H` in that state is a protocol violation and closes the socket.
- Verified: `test/bake/hmr-socket-protocol.test.ts`, 4 tests. All 4 fail against `bun bd` without the `src/` diff and pass with it.

### Background

- `/_bun/hmr` is the dev server's hot-reload websocket. `HmrSocket::on_message` switches on the first byte of each frame, so each arm validates its own payload.
- The `H` frame drives the bake test harness's batching: the first turns batching on, a later one releases the files collected since as a single bundle.
- Only one bundle runs at a time. `CurrentBundle` owns the arena that the bundler's parse tasks, which run on the thread pool, read from.
- A request for a route that is not bundled yet goes through `ensure_route_is_bundled`, which starts a bundle without consulting `testing_batch_events`. That is how a bundle comes to be in flight between two `H` frames.

<details><summary>Notes</summary>

Rebased onto current `main`. The branch was 1983 commits behind and the file had moved from `src/runtime/bake/DevServer/HmrSocket.rs` to `src/runtime/bake/dev_server/hmr_socket.rs`, so the PR had gone conflicting; it is now a clean diff against `main` and all three bugs were re-confirmed present there.

An earlier revision of this PR also gated the visualizer on-subscribe hooks on `cfg!(feature = "bake_debugging_features")` to stop `sM` reaching `emit_memory_visualizer_message`'s `debug_assert!(cfg!(feature = ...))`. That fix is dropped: `main` has since deleted the assert and removed the cargo feature from `src/runtime/Cargo.toml` entirely, so there is nothing left to gate.

While re-checking `sM` against current `main` I found a separate, still-open crash that this PR does not touch: `sM`, then ~1s so the 1-second timer fires, then `s` to unsubscribe gives `panic: assertion failed: self.root == v`, the intrusive timer heap's `remove()` on a node the drain had already popped. The cleanup that emptied `emit_memory_visualizer_message_timer` took away the `state = FIRED` + re-insert that kept the node's bookkeeping honest. It reproduces on unmodified `main` with this diff stashed, and fixing it needs a decision about what remains of the memory-visualizer feature, so it is filed separately rather than folded in here.

The third test keeps every step condition-based rather than timed: a bundler plugin parks the `/two` bundle on a fetch the test controls, the batch steps wait on the `r0`/`r1` synchronization frames, and the release step waits for the socket close that a further `H` triggers, which is what proves the first `H` was handled while the bundle was still held.

The duplicate-`H` and `SetUrl` arms were reported by review on an earlier revision of this PR; the batch-release segfault came with a runnable reproduction from the fuzz lane, and that reproduction now exits 0 with the server still answering, 3/3.

Release dating, from the fuzz lane's runs of the same frames: 1.4.0 keeps serving, while 1.4.1, 1.4.2 and canary segfault 3/3 each. The dev-server side of this did not change in that window. `start_async_bundle` is identical between `bun-v1.4.0` and `bun-v1.4.1` apart from an unrelated inspector string `deref`, and `src/bun_alloc/MimallocArena.rs` is byte-identical, so 1.4.0 already destroys the in-flight bundle's arena and gets away with it: a use-after-free that happens to read intact bytes. Of the two changes first suspected, #40478 only touches `StaticRoute` response refs (neither `CurrentBundle` nor `BundleV2` has a refcounted field for it to affect), and #40640 moves out-of-root path text out of the per-bundle arena into a process-lifetime store, which leaves less dangling, not more. What did change on this path is the allocator: mimalloc moved from `6a14aee2` to `6a64e1ba` in that window, including #40138, which replaced the `mi_heap_delete` and `mi_heap_destroy` teardown with a protocol that detaches, claims and frees a heap's pages even when another thread can still reach them. That is the likeliest reason a silent use-after-free became a reliable fault. It is inferred from the diffs, not bisected; running the reproduction against one Bun commit with the old and the new mimalloc pin would settle it. Either way the defect is the second `start_async_bundle`, which is as old as the `Enabled` arm. 1.4.1 made it visible.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 10 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/hmr-socket-protocol.test.ts
bun test v1.4.3 (4ff919377)

test/bake/hmr-socket-protocol.test.ts:
163 |     try {
164 |       pageStatus = String((await pageFetch).status);
165 |     } catch (e) {
166 |       pageStatus = `${(e as Error).message}\n--- dev server stderr ---\n${dev.stderr()}`;
167 |     }
168 |     expect(pageStatus).toBe("200");
                             ^
error: expect(received).toBe(expected)

- "200"
+ "The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()
+ --- dev server stderr ---
+ ============================================================
+ Bun Debug v1.4.3 (4ff919377) Linux x64
+ Linux Kernel v7.0.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/debug/bun-debug" "server.ts"
+ Features: bunfig fetch http_server jsc dev_server 
+ Builtins: "bun:main" 
+ 
+ 
+ panic: assertion failed: false
+ 
+ "

- Expected  - 1
+ Received  + 14

      at <anonymous> (/workspace/bun/test/bake/hmr-socket-protocol.tes
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/bake/hmr-socket-protocol.test.ts:
(pass) a duplicate testing-batch frame (H) during an in-flight bundle closes the socket instead of aborting [25.15ms]
(fail) a SetUrl frame without a leading slash ("n") closes the socket instead of aborting [5000.12ms]
  ^ this test timed out after 5000ms.
(fail) a SetUrl frame without a leading slash ("nfoo") closes the socket instead of aborting [5000.07ms]
  ^ this test timed out after 5000ms.
(fail) releasing a testing batch while another bundle is in flight defers it [5000.06ms]
  ^ this test timed out after 5000ms.

 1 pass
 3 fail
 3 expect() calls
Ran 4 tests across 1 file. [5.09s]
__F:3:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/hmr-socket-protocol.test.ts
bun test v1.4.3 (4ff919377)

test/bake/hmr-socket-protocol.test.ts:
(pass) a SetUrl frame without a leading slash ("nfoo") closes the socket instead of aborting [587.07ms]
(pass) a duplicate testing-batch frame (H) during an in-flight bundle closes the socket instead of aborting [819.24ms]
(pass) a SetUrl frame without a leading slash ("n") closes the socket instead of aborting [745.62ms]
(pass) releasing a testing batch while another bundle is in flight defers it [897.64ms]

 4 pass
 0 fail
 8 expect() calls
Ran 4 tests across 1 file. [4.13s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 993ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/6] cargo bun_runtime → libbun_runtime.a
^[[1m^[[92m   Compiling^[[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
^[[1m^[[92m    Finished^[[0m `release` profile [optimized + debuginfo] target(s) in 6m 25s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.3-canary.1+03f585b7d
[build] done
bun test v1.4.3-canary.1 (03f585b7d)

test/bake/hmr-socket-protocol.test.ts:
(pass) a SetUrl frame without a leading slash ("n") closes the socket instead of aborting [18.87ms]
(pass) a SetUrl frame without a leading slash ("nfoo") closes the socket instead of aborting [16.56ms]
(pass) a duplicate testing-batch frame (H) during an in-flight bundle closes the socket instead of aborting [28.81ms]
(pass) releasing a testing batch while another bundle is in flight defers it [
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/DevServer.rs              |  37 +++-
 src/runtime/bake/dev_server/hmr_socket.rs  |  33 ++-
 src/runtime/bake/dev_server/memory_cost.rs |   2 +-
 src/runtime/bake/dev_server/mod.rs         |   2 +-
 test/bake/hmr-socket-protocol.test.ts      | 341 +++++++++++++++++++++++++++++
 5 files changed, 394 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/bake/DevServer.rs                   9      6     30
src/runtime/bake/dev_server/hmr_socket.rs       2      7     29
src/runtime/bake/dev_server/memory_cost.rs      1      2     29
src/runtime/bake/dev_server/mod.rs              3      1     29
test/bake/hmr-socket-protocol.test.ts           3      8     29
```

</details>

<!-- robobun:evidence:end -->
