### PR TITLE
watcher: do not leak a file descriptor of the entrypoint on every `bun --hot` reload

### DIFF
--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -833,10 +833,25 @@ impl Watcher {
         #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
         let fd: Fd = Fd::INVALID;
 
-        // `add_file` owns `fd` on success (stored or closed there), so only
-        // the error path still has to release it here.
-        match self.add_file::<true>(fd, file_path, hash, loader, Fd::INVALID, None) {
-            Ok(()) => true,
+        let res = self.add_file::<true>(fd, file_path, hash, loader, Fd::INVALID, None);
+        match res {
+            Ok(()) => {
+                #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+                if fd.is_valid() {
+                    self.mutex.lock();
+                    let maybe_idx = self.index_of(hash);
+                    let stored_fd = if let Some(idx) = maybe_idx {
+                        self.watchlist.items_fd()[idx as usize]
+                    } else {
+                        Fd::INVALID
+                    };
+                    self.mutex.unlock();
+                    if maybe_idx.is_some() && stored_fd.native() != fd.native() {
+                        let _ = bun_sys::close(fd);
+                    }
+                }
+                true
+            }
             Err(_) => {
                 if fd.is_valid() {
                     let _ = bun_sys::close(fd);
@@ -846,9 +861,6 @@ impl Watcher {
         }
     }
 
-    /// Registers `file_path` in the watchlist. Ownership of `fd` transfers to
-    /// the watcher on success: it is either stored on the watch item or closed
-    /// here. On error the caller keeps ownership and must close it.
     pub fn add_file<const CLONE_FILE_PATH: bool>(
         &mut self,
         fd: Fd,
@@ -862,25 +874,20 @@ impl Watcher {
         self.mutex.lock();
 
         if let Some(index) = self.index_of(hash) {
-            // Already watched: exactly one descriptor may stay open for the item.
-            if fd.is_valid() {
-                let fds = self.watchlist.items_fd_mut();
-                let previous = fds[index as usize];
-                if previous != fd {
-                    if feature_flags::ATOMIC_FILE_WATCHER {
-                        // On Linux, the file descriptor might be out of date.
-                        fds[index as usize] = fd;
-                        // Releasing the last reference to an unlinked inode delivers
-                        // IN_DELETE_SELF on this item's still-registered inotify watch (a
-                        // spurious change event), so only close while the inode is linked.
-                        if previous.is_valid()
-                            && matches!(bun_sys::fstat(previous), Ok(st) if st.st_nlink > 0)
-                        {
-                            let _ = bun_sys::close(previous);
-                        }
-                    } else {
-                        // kqueue stays registered on the stored descriptor.
-                        let _ = bun_sys::close(fd);
+            if feature_flags::ATOMIC_FILE_WATCHER {
+                // On Linux, the file descriptor might be out of date.
+                if fd.is_valid() {
+                    let fds = self.watchlist.items_fd_mut();
+                    let previous = fds[index as usize];
+                    fds[index as usize] = fd;
+                    // Close the replaced descriptor so it isn't orphaned, but only while
+                    // its inode is still linked: releasing the last reference to an unlinked
+                    // inode delivers IN_DELETE_SELF on this item's still-registered watch.
+                    if previous.is_valid()
+                        && previous != fd
+                        && matches!(bun_sys::fstat(previous), Ok(st) if st.st_nlink > 0)
+                    {
+                        let _ = bun_sys::close(previous);
                     }
                 }
             }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -870,7 +870,12 @@ impl Watcher {
                     if feature_flags::ATOMIC_FILE_WATCHER {
                         // On Linux, the file descriptor might be out of date.
                         fds[index as usize] = fd;
-                        if previous.is_valid() {
+                        // Releasing the last reference to an unlinked inode delivers
+                        // IN_DELETE_SELF on this item's still-registered inotify watch (a
+                        // spurious change event), so only close while the inode is linked.
+                        if previous.is_valid()
+                            && matches!(bun_sys::fstat(previous), Ok(st) if st.st_nlink > 0)
+                        {
                             let _ = bun_sys::close(previous);
                         }
                     } else {

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -833,25 +833,10 @@ impl Watcher {
         #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
         let fd: Fd = Fd::INVALID;
 
-        let res = self.add_file::<true>(fd, file_path, hash, loader, Fd::INVALID, None);
-        match res {
-            Ok(()) => {
-                #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-                if fd.is_valid() {
-                    self.mutex.lock();
-                    let maybe_idx = self.index_of(hash);
-                    let stored_fd = if let Some(idx) = maybe_idx {
-                        self.watchlist.items_fd()[idx as usize]
-                    } else {
-                        Fd::INVALID
-                    };
-                    self.mutex.unlock();
-                    if maybe_idx.is_some() && stored_fd.native() != fd.native() {
-                        let _ = bun_sys::close(fd);
-                    }
-                }
-                true
-            }
+        // `add_file` owns `fd` on success (stored or closed there), so only
+        // the error path still has to release it here.
+        match self.add_file::<true>(fd, file_path, hash, loader, Fd::INVALID, None) {
+            Ok(()) => true,
             Err(_) => {
                 if fd.is_valid() {
                     let _ = bun_sys::close(fd);
@@ -861,6 +846,9 @@ impl Watcher {
         }
     }
 
+    /// Registers `file_path` in the watchlist. Ownership of `fd` transfers to
+    /// the watcher on success: it is either stored on the watch item or closed
+    /// here. On error the caller keeps ownership and must close it.
     pub fn add_file<const CLONE_FILE_PATH: bool>(
         &mut self,
         fd: Fd,
@@ -874,11 +862,21 @@ impl Watcher {
         self.mutex.lock();
 
         if let Some(index) = self.index_of(hash) {
-            if feature_flags::ATOMIC_FILE_WATCHER {
-                // On Linux, the file descriptor might be out of date.
-                if fd.is_valid() {
-                    let fds = self.watchlist.items_fd_mut();
-                    fds[index as usize] = fd;
+            // Already watched: exactly one descriptor may stay open for the item.
+            if fd.is_valid() {
+                let fds = self.watchlist.items_fd_mut();
+                let previous = fds[index as usize];
+                if previous != fd {
+                    if feature_flags::ATOMIC_FILE_WATCHER {
+                        // On Linux, the file descriptor might be out of date.
+                        fds[index as usize] = fd;
+                        if previous.is_valid() {
+                            let _ = bun_sys::close(previous);
+                        }
+                    } else {
+                        // kqueue stays registered on the stored descriptor.
+                        let _ = bun_sys::close(fd);
+                    }
                 }
             }
             self.mutex.unlock();

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -863,8 +863,10 @@ it.skipIf(!isLinux)(
     }
     const after = countEntrypointFds();
 
+    // `kill()` can abort the stream readers; the teardown must never mask
+    // the assertion below, so settle instead of propagating.
     runner.kill();
-    await Promise.all([pump, stderrText, runner.exited]);
+    await Promise.allSettled([pump, stderrText, runner.exited]);
 
     // Every rebuild re-opens the entrypoint; the watcher must close the
     // descriptor it replaces instead of accumulating one per reload.

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,18 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import {
+  copyFileSync,
+  cpSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { bunEnv, bunExe, isDebug, isLinux, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -775,4 +786,89 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+// /proc/<pid>/fd only exists on Linux.
+it.skipIf(!isLinux)(
+  "does not leak a file descriptor of the entrypoint on each reload",
+  async () => {
+    using dir = tempDir("hot-fd-leak", {
+      "dep.ts": "export const value = 0;\n",
+      "entry.ts": 'import { value } from "./dep.ts";\nconsole.log("RELOAD", value);\n',
+    });
+    const entryReal = realpathSync(join(String(dir), "entry.ts"));
+    const depPath = join(String(dir), "dep.ts");
+
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    // Drain stderr concurrently so the pipe never fills up and blocks the child.
+    const stderrText = runner.stderr.text();
+
+    // Resolve once stdout has printed `RELOAD <n>`; the entrypoint logs that
+    // line every time the module graph is re-evaluated.
+    const seen = new Set<number>();
+    let pending: { n: number; resolve: () => void } | null = null;
+    const pump = (async () => {
+      const decoder = new TextDecoder();
+      let buffered = "";
+      for await (const chunk of runner.stdout) {
+        buffered += decoder.decode(chunk, { stream: true });
+        let newline: number;
+        while ((newline = buffered.indexOf("\n")) !== -1) {
+          const line = buffered.slice(0, newline);
+          buffered = buffered.slice(newline + 1);
+          const match = /^RELOAD (\d+)$/.exec(line);
+          if (!match) continue;
+          const n = Number(match[1]);
+          seen.add(n);
+          if (pending?.n === n) {
+            pending.resolve();
+            pending = null;
+          }
+        }
+      }
+    })();
+    const waitForReload = (n: number) =>
+      new Promise<void>((resolve, reject) => {
+        if (seen.has(n)) return resolve();
+        pending = { n, resolve };
+        runner.exited.then(code => reject(new Error(`--hot exited early with code ${code}`)));
+      });
+
+    const countEntrypointFds = () => {
+      let count = 0;
+      for (const fd of readdirSync(`/proc/${runner.pid}/fd`)) {
+        try {
+          if (readlinkSync(`/proc/${runner.pid}/fd/${fd}`) === entryReal) count++;
+        } catch {}
+      }
+      return count;
+    };
+
+    await waitForReload(0);
+    const before = countEntrypointFds();
+    expect(before).toBeGreaterThan(0);
+
+    const reloads = 20;
+    for (let i = 1; i <= reloads; i++) {
+      const reloaded = waitForReload(i);
+      writeFileSync(depPath, `export const value = ${i};\n`);
+      await reloaded;
+    }
+    const after = countEntrypointFds();
+
+    runner.kill();
+    await Promise.all([pump, stderrText, runner.exited]);
+
+    // Every rebuild re-opens the entrypoint; the watcher must close the
+    // descriptor it replaces instead of accumulating one per reload.
+    expect({ before, after }).toEqual({ before, after: before });
+  },
+  timeout,
 );


### PR DESCRIPTION
## What

Every incremental rebuild under `bun --hot` leaked one open file descriptor of the entrypoint. A long editing session eventually exhausts the fd limit and every later `open`/`socket`/`accept` in the process starts failing with `EMFILE`.

## Repro

```js
// entry.ts
import { value } from "./dep.ts";
console.log("RELOAD", value);
```

```sh
bun --hot entry.ts &
for i in $(seq 1 200); do echo "export const value = $i;" > dep.ts; sleep 0.05; done
ls -l /proc/$(pgrep -f 'bun --hot')/fd | grep -c entry.ts
```

On 1.4.0 the count of open descriptors pointing at `entry.ts` grows by exactly one per reload (201 after 200 saves).

## Cause

A `--hot` reload re-transpiles the entrypoint. The module loader deliberately does not reuse the watcher's cached descriptor for the entrypoint (an atomic save can replace its inode, see the note above `is_main` in `jsc_hooks.rs`), so it opens the file again and hands the fresh descriptor to `Watcher::add_file`. The entrypoint is already in the watchlist, and the dedup branch there did this:

```rust
if let Some(index) = self.index_of(hash) {
    if feature_flags::ATOMIC_FILE_WATCHER {   // Linux only
        if fd.is_valid() {
            fds[index as usize] = fd;         // previous fd orphaned
        }
    }
    return Ok(());
}
```

The stored descriptor is overwritten and the previous one is never closed. Once overwritten it has no owner, so `flush_evictions`/`shutdown` can never close it either: one descriptor per reload, forever.

## Fix

On Linux, `add_file`'s already-watched branch closes the descriptor it just replaced, guarded by `fstat(previous).st_nlink > 0`. The whole `src/watcher/Watcher.rs` diff is those 10 lines.

Two things shaped that exact form:

1. **Why the `st_nlink` guard.** A first revision of this PR closed `previous` unconditionally and deterministically broke `test/bake/dev/hot.test.ts` (`DEV:hot-9`). The leaked descriptor was load bearing: `IN_DELETE_SELF` for a per-file inotify watch is deferred until the watched inode is actually destroyed, and the watcher's descriptor was the last open reference keeping a renamed-over inode alive. Closing it made the kernel deliver that deferred event for the item's still-registered watch, and the dev server turned it into a duplicate HMR reload. (`flush_evictions` only gets away with the same close because it `swap_remove`s the item before the event is read back.) `st_nlink > 0` is exactly the condition under which the close cannot generate an fsnotify event, and it is the one the `--hot` entrypoint case always satisfies: every reload re-opens the same, still-linked inode.

2. **Why only the replaced descriptor, and why only Linux.** Callers can hand `add_file` a descriptor they do not exclusively own: the bundler passes a descriptor that may be borrowed from the resolver's entry cache (the ownership #33102 fixed), so closing the *incoming* `fd` has no proof it is not someone else's. Closing the *replaced* one does: at that instant it is `fds[index]`, i.e. exactly the descriptor `flush_evictions` was already authorized to close for this item, and the `st_nlink` guard only narrows that further. An earlier revision also closed the incoming `fd` on macOS/FreeBSD (where the dedup branch just drops it); that is reverted and left as-is, for the same "no ownership proof" reason.

## Verification

New test in `test/cli/hot/hot.test.ts` runs `bun --hot`, triggers 20 reloads, and counts the `/proc/<pid>/fd` entries that resolve to the entrypoint.

Without the fix:

```
expect(received).toEqual(expected)
  {
-   "after": 1,
+   "after": 21,
    "before": 1,
  }
```

With the fix it passes, along with the rest of `test/cli/hot/hot.test.ts` (13 pass) and all of `test/bake/dev/hot.test.ts` (9 pass) on a debug (ASAN) build.

The `DEV:hot-9` regression the first revision introduced was verified directly, all on the same ASAN debug configuration:

| build | `DEV:hot-9` |
| --- | --- |
| unpatched | 20/20 pass |
| unconditional close (first revision) | 0/20 pass |
| close gated on `st_nlink > 0` | 10/10 pass |

`cargo check -p bun_watcher` passes for `x86_64-apple-darwin`, `x86_64-unknown-freebsd`, `x86_64-pc-windows-msvc`, and `x86_64-unknown-linux-gnu`.

## Not fixed here

- An entrypoint that is atomically renamed over on each save (vim/emacs style `rename(tmp, target)`) still leaks one descriptor per save on Linux, for the `IN_DELETE_SELF` reason above. A proper fix has to also re-register the item's inotify watch on the new inode so the old descriptor can be released without the spurious event; that interacts with the existing directory-watch recovery path and is deliberately out of scope.
- On macOS/FreeBSD the already-watched branch still drops the incoming descriptor (one leak per `--hot` entrypoint reload there too). Closing it needs a proof that the caller owned it exclusively, which the bundler call sites do not provide.
- `bun --hot` also leaks a second descriptor per reload: the `O_DIRECTORY` handle the resolver keeps in the cached `DirEntry` under `store_fd`, orphaned because `bust_entries_cache` removes only the hash-to-index mapping. Its raw value is also copied into queued bundler `ParseTask`s, the bake dev server's directory watch store, and sometimes the watcher's own watchlist, so a plain close at eviction risks a use-after-close on another thread. #29919 already reworks `bust_entries_cache` to reuse the `DirEntry` in place instead of orphaning it, which is the right shape for that half.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->