### PR TITLE
Make CLI flags override their [run] counterparts in bunfig.toml

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -773,10 +773,15 @@ impl<'a> Parser<'a> {
                 self.parse_install(&install_obj)?;
             }
 
+            // CLI flags take precedence over their `[run]` keys. bunfig.toml can
+            // be loaded after the CLI flags were applied (`bun run` defers it to
+            // `RunCommand::exec`), so skip any key the CLI already set.
             if let Some(run_expr) = json.get(b"run") {
                 if let Some(silent) = run_expr.get(b"silent") {
                     if let Some(value) = silent.as_bool() {
-                        self.ctx.debug.silent = value;
+                        if !self.ctx.debug.silent_from_cli {
+                            self.ctx.debug.silent = value;
+                        }
                     } else {
                         self.add_error(silent.loc, b"Expected boolean")?;
                     }
@@ -784,8 +789,10 @@ impl<'a> Parser<'a> {
 
                 if let Some(elide_lines) = run_expr.get(b"elide-lines") {
                     if let Some(n) = elide_lines.as_number() {
-                        // Note: Rust `as` saturates on overflow/NaN
-                        self.ctx.bundler_options.elide_lines = Some(n as usize);
+                        if !self.ctx.bundler_options.elide_lines_from_cli {
+                            // Note: Rust `as` saturates on overflow/NaN
+                            self.ctx.bundler_options.elide_lines = Some(n as usize);
+                        }
                     } else {
                         self.add_error(elide_lines.loc, b"Expected number")?;
                     }
@@ -793,10 +800,10 @@ impl<'a> Parser<'a> {
 
                 if let Some(shell) = run_expr.get(b"shell") {
                     if let Some(value) = shell.as_string(self.bump) {
-                        if value == b"bun" {
-                            self.ctx.debug.use_system_shell = false;
-                        } else if value == b"system" {
-                            self.ctx.debug.use_system_shell = true;
+                        if value == b"bun" || value == b"system" {
+                            if !self.ctx.debug.use_system_shell_from_cli {
+                                self.ctx.debug.use_system_shell = value == b"system";
+                            }
                         } else {
                             self.add_error(
                                 shell.loc,
@@ -810,7 +817,9 @@ impl<'a> Parser<'a> {
 
                 if let Some(bun_flag) = run_expr.get(b"bun") {
                     if let Some(value) = bun_flag.as_bool() {
-                        self.ctx.debug.run_in_bun = value;
+                        if !self.ctx.debug.run_in_bun_from_cli {
+                            self.ctx.debug.run_in_bun = value;
+                        }
                     } else {
                         self.add_error(bun_flag.loc, b"Expected boolean")?;
                     }

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -219,6 +219,8 @@ pub struct BundlerOptions {
     pub env_behavior: api::DotEnvBehavior,
     pub env_prefix: Box<[u8]>,
     pub elide_lines: Option<usize>,
+    /// `--elide-lines` was passed, so `run.elide-lines` in bunfig.toml must not override it.
+    pub elide_lines_from_cli: bool,
     // Compile options
     pub compile: bool,
     pub compile_target: CompileTarget,
@@ -270,6 +272,7 @@ impl Default for BundlerOptions {
             env_behavior: api::DotEnvBehavior::disable,
             env_prefix: Box::default(),
             elide_lines: None,
+            elide_lines_from_cli: false,
             compile: false,
             compile_target: CompileTarget::default(),
             compile_exec_argv: None,
@@ -333,13 +336,20 @@ pub struct DebugOptions {
     pub dump_limits: bool,
     pub fallback_only: bool,
     pub silent: bool,
+    /// `--silent` was passed, so `run.silent` in bunfig.toml must not override it.
+    /// (bunfig.toml can be loaded after CLI flags are applied, e.g. for `bun run`.)
+    pub silent_from_cli: bool,
     pub hot_reload: HotReload,
     pub global_cache: GlobalCache,
     pub offline_mode_setting: Option<OfflineMode>,
     pub run_in_bun: bool,
+    /// `--bun` was passed, so `run.bun` in bunfig.toml must not override it.
+    pub run_in_bun_from_cli: bool,
     pub loaded_bunfig: bool,
     /// Disables using bun.shell.Interpreter for `bun run`, instead spawning cmd.exe
     pub use_system_shell: bool,
+    /// `--shell` was passed, so `run.shell` in bunfig.toml must not override it.
+    pub use_system_shell_from_cli: bool,
 
     // technical debt
     pub macros: MacroOptions,
@@ -359,12 +369,15 @@ impl Default for DebugOptions {
             dump_limits: false,
             fallback_only: false,
             silent: false,
+            silent_from_cli: false,
             hot_reload: HotReload::None,
             global_cache: GlobalCache::auto,
             offline_mode_setting: None,
             run_in_bun: false,
+            run_in_bun_from_cli: false,
             loaded_bunfig: false,
             use_system_shell: !cfg!(windows),
+            use_system_shell_from_cli: false,
             macros: MacroOptions::Unspecified,
             editor: Box::default(),
             package_bundle_map: ArrayHashMap::default(),

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -811,6 +811,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> Result<api::TransformOptions,
                         Global::exit(1);
                     }
                 };
+                ctx.bundler_options.elide_lines_from_cli = true;
             }
         }
     }
@@ -1367,6 +1368,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> Result<api::TransformOptions,
         // "run.silent" in bunfig.toml
         if args.flag(b"--silent") {
             ctx.debug.silent = true;
+            ctx.debug.silent_from_cli = true;
         }
 
         if let Some(elide_lines) = args.option(b"--elide-lines") {
@@ -1382,6 +1384,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> Result<api::TransformOptions,
                         Global::exit(1);
                     }
                 };
+                ctx.bundler_options.elide_lines_from_cli = true;
             }
         }
 
@@ -1400,6 +1403,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> Result<api::TransformOptions,
         // "run.bun" in bunfig.toml
         if args.flag(b"--bun") {
             ctx.debug.run_in_bun = true;
+            ctx.debug.run_in_bun_from_cli = true;
         }
     }
 
@@ -1505,8 +1509,10 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> Result<api::TransformOptions,
         if let Some(shell) = args.option(b"--shell") {
             if shell == b"bun" {
                 ctx.debug.use_system_shell = false;
+                ctx.debug.use_system_shell_from_cli = true;
             } else if shell == b"system" {
                 ctx.debug.use_system_shell = true;
+                ctx.debug.use_system_shell_from_cli = true;
             } else {
                 Output::err_generic(
                     "Expected --shell to be one of 'bun' or 'system'. Received: \"{}\"",

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -316,7 +316,7 @@ describe.concurrent.each(["bun run", "bun"])("%s: CLI flags take precedence over
       env: bunEnv,
       cwd,
       stdin: "ignore",
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -248,3 +248,81 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
     expect(result.success).toBeTrue();
   });
 });
+
+// CLI flags must take precedence over the corresponding `[run]` keys in bunfig.toml.
+// `bun run <script>` (and `bun <script>`) load bunfig.toml after CLI flags are parsed,
+// which used to let the bunfig value overwrite the flag.
+describe.concurrent.each(["bun run", "bun"])("%s: CLI flags take precedence over [run] in bunfig.toml", baseCmd => {
+  const runArg = baseCmd === "bun run" ? ["run"] : [];
+
+  test("--bun overrides run.bun = false", async () => {
+    const cwd = tempDirWithFiles("bunfig-precedence-bun", {
+      "bunfig.toml": toTOMLString({ run: { bun: false } }),
+      "package.json": JSON.stringify({ scripts: { "where-node": "which node" } }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--silent", "--bun", ...runArg, "where-node"],
+      env: bunEnv,
+      cwd,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // `node` must resolve to the temporary `bun-node-*` shim, not the real node.
+    const nodeBin = stdout.trim();
+    expect(nodeBin).not.toBe("");
+    if (isWindows) {
+      expect(realpathSync(nodeBin)).toContain("\\bun-node-");
+    } else {
+      expect(realpathSync(nodeBin)).toBe(realpathSync(process.execPath));
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test("--silent overrides run.silent = false", async () => {
+    const cwd = tempDirWithFiles("bunfig-precedence-silent", {
+      "bunfig.toml": toTOMLString({ run: { silent: false } }),
+      "package.json": JSON.stringify({ scripts: { startScript: "echo 1" } }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--silent", ...runArg, "startScript"],
+      env: bunEnv,
+      cwd,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // --silent suppresses the "$ echo 1" command echo.
+    expect(stderr).not.toContain("$ echo 1");
+    expect(stdout).toContain("1");
+    expect(exitCode).toBe(0);
+  });
+
+  // The existing tests above skip `shell = "system"` on Windows: scripts always use the bun shell there.
+  test.skipIf(isWindows)('--shell=bun overrides run.shell = "system"', async () => {
+    const cwd = tempDirWithFiles("bunfig-precedence-shell", {
+      "bunfig.toml": toTOMLString({ run: { shell: "system" } }),
+      "package.json": JSON.stringify({ scripts: { start: "cli-precedence-command-not-found" } }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--silent", "--shell=bun", ...runArg, "start"],
+      env: bunEnv,
+      cwd,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // Bun's shell prefixes command-not-found errors with "bun:"; the system shell does not.
+    expect(stderr).toContain("bun: command not found: cli-precedence-command-not-found");
+    expect(exitCode).not.toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem

The `[run]` section in bunfig.toml silently overrides explicit CLI flags for `bun run <script>` and `bun <script>`, inverting the documented precedence ("CLI flags override `bunfig` settings where applicable").

```toml
# bunfig.toml
[run]
bun = false
```

```sh
bun run --bun where-node   # runs the real node: the --bun flag is ignored
```

Reproduced on 1.4.0 and current main with `--bun` vs `run.bun`, `--silent` vs `run.silent`, and `--shell` vs `run.shell`:

```
$ cat bunfig.toml
[run]
shell = "system"
$ bun run --shell=bun start
/usr/bin/bash: line 1: cli-precedence-command-not-found: command not found
```

### Cause

`Arguments::parse` applies `--silent` / `--bun` / `--shell` / `--elide-lines` to the context after `load_config`, which is correct when bunfig.toml is loaded during argument parsing (`-c=...`, `bun file.ts`, `bun test`, ...). But for `bun run <script>` and `bun <script-name>` the local bunfig.toml is only loaded later, inside `RunCommand::exec` (#16664), and its `[run]` keys overwrote the values the CLI flags had already set. That is why `bun run -c=bunfig.toml --bun x` behaved correctly while `bun run --bun x` did not.

### Fix

Record which of the four `[run]`-related CLI flags were explicitly passed (`*_from_cli`, the same pattern `test.pathIgnorePatterns` already uses) and have the bunfig `[run]` parser skip a key whose flag was passed. This keeps the deferred bunfig load for `bun run` (so `[run]` settings still apply when no flag is given) while restoring CLI > bunfig precedence in both load orders.

`run.elide-lines` gets the same guard for consistency; its only consumer is the `--filter` runner, which re-applies the CLI value today, so it is not observable in a test without a PTY.

### Verification

New tests in `test/cli/install/bun-run-bunfig.test.ts`, for both `bun run <script>` and `bun <script>`:

- `--bun` overrides `run.bun = false` (node resolves to the `bun-node-*` shim)
- `--silent` overrides `run.silent = false` (no `$ echo 1` echo)
- `--shell=bun` overrides `run.shell = "system"` (bun shell error message)

All 6 fail on the unfixed build and pass with this change; the 28 pre-existing tests in the file (including `run.bun`/`run.silent`/`run.shell` without flags, and the bunfig autoload tests) still pass, as do `test/cli/run/filter-workspace.test.ts`, `test/cli/run/run_command.test.ts`, and `test/cli/bunfig-test-options.test.ts`.
