### PR TITLE
node:tls: give the exported SecureContext constructor its own SSL_CTX

### DIFF
--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -789,7 +789,9 @@ var InternalSecureContext = class SecureContext {
 };
 
 function SecureContext(options): void {
-  return new InternalSecureContext(options) as never;
+  // Same contract as createSecureContext(): user-constructed contexts own
+  // their SSL_CTX exclusively (see the note there), so delegate to it.
+  return createSecureContext(options) as never;
 }
 
 function createSecureContext(options) {
@@ -914,8 +916,8 @@ function TLSSocket(socket?, options?) {
     // server-upgrade method below; leaving it unset until then means a synchronous
     // teardown during upgradeTLS won't call close() on the bare net.Socket.
   }
-  // Internal path: keep the per-digest cache (only the user-facing
-  // tls.createSecureContext() owns its SSL_CTX exclusively).
+  // Internal path: keep the per-digest cache (the user-facing constructors,
+  // createSecureContext() and new tls.SecureContext(), own theirs exclusively).
   this[ksecureContext] = options.secureContext || new InternalSecureContext(options);
   this.authorized = false;
   this.secureConnecting = true;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -653,7 +653,10 @@ function normalizePemKeyOption(key, ctxPassphrase) {
   });
 }
 
-function newNativeSecureContext(options, cached = true) {
+// The digest cache is opt-in: the internal connect/listen paths pass
+// `cached = true` explicitly. A forgotten opt-in on a future entry point is a
+// perf regression, not a shared trust store.
+function newNativeSecureContext(options, cached = false) {
   maybeWarnAboutExtraCACerts();
   // tls.createSecureContext() with no options still goes through the version
   // translation below so the module-level DEFAULT_MIN/MAX_VERSION apply.
@@ -737,7 +740,7 @@ var InternalSecureContext = class SecureContext {
   context;
   servername;
 
-  constructor(options, cached = true) {
+  constructor(options, cached = false) {
     // When tls.setDefaultCACertificates() has installed an override and no
     // explicit `ca` was given, use the override as the default CA set so the
     // process-wide default applies on every construction path (the public
@@ -803,7 +806,7 @@ function createSecureContext(options) {
   // is built fresh because it carries the per-call `servername`.
   // The user-facing constructor owns its SSL_CTX exclusively so addCACert
   // cannot leak across contexts; internal connect/listen paths stay cached.
-  return new InternalSecureContext(options, false);
+  return new InternalSecureContext(options);
 }
 
 // Translate some fields from the handle's C-friendly format into more idiomatic
@@ -918,7 +921,7 @@ function TLSSocket(socket?, options?) {
   }
   // Internal path: keep the per-digest cache (the user-facing constructors,
   // createSecureContext() and new tls.SecureContext(), own theirs exclusively).
-  this[ksecureContext] = options.secureContext || new InternalSecureContext(options);
+  this[ksecureContext] = options.secureContext || new InternalSecureContext(options, true);
   this.authorized = false;
   this.secureConnecting = true;
   this._secureEstablished = false;
@@ -1108,7 +1111,7 @@ TLSSocket.prototype.setKeyCert = function setKeyCert(context) {
   // Serve this connection's identity from the given context (Node calls this
   // from ALPNCallback/SNICallback before the certificate is sent). Accepts a
   // SecureContext or the same options object createSecureContext takes.
-  const ctx = context?.context ? context : new InternalSecureContext(context);
+  const ctx = context?.context ? context : new InternalSecureContext(context, true);
   this._handle?.setKeyCert?.(ctx.context);
 };
 
@@ -1296,7 +1299,7 @@ function Server(options, secureConnectionListener): void {
       throw new TypeError("hostname must be a string");
     }
     if (!(context instanceof InternalSecureContext)) {
-      context = new InternalSecureContext(context);
+      context = new InternalSecureContext(context, true);
     }
     const handle = this._handle;
     if (handle) {

--- a/src/runtime/api/SecureContext.classes.ts
+++ b/src/runtime/api/SecureContext.classes.ts
@@ -12,9 +12,10 @@ export default [
       // digest so identical configs return the same JS cell. Replaces the
       // old SHA-256/WeakRef cache that lived in `tls.ts`.
       intern: { fn: "intern", length: 1 },
-      // `tls.createSecureContext()` — exclusive-ownership variant: no digest
-      // memoisation at either cache level, so addCACert on one context can
-      // never affect another. The connect/listen paths keep using `intern`.
+      // The user-facing constructors (`tls.createSecureContext()` and
+      // `new tls.SecureContext()`) — exclusive ownership: no digest memoisation
+      // at either cache level, so addCACert on one context can never affect
+      // another. The internal connect/listen paths keep using `intern`.
       createPrivate: { fn: "create_private", length: 1 },
       // Parses a PKCS#12 (`pfx`) blob into { key, cert, ca } PEM strings so
       // the regular key/cert/ca option plumbing can consume it.

--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -186,7 +186,7 @@ impl SecureContext {
         Ok(result)
     }
 
-    /// `tls.createSecureContext()` entry - builds a context that owns its
+    /// `tls.createSecureContext()` / `new tls.SecureContext()` entry - builds a context that owns its
     /// SSL_CTX exclusively: no digest memoisation at either the JS-wrapper
     /// cache or the native SSLContextCache level, so prototype mutators like
     /// `addCACert` can never affect another context (or the cached

--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -41,6 +41,12 @@ pub struct SecureContext {
     /// Approximate cert/key/CA byte length plus the BoringSSL `SSL_CTX` floor
     /// (~50 KB), so the GC can account for the off-heap allocation.
     pub extra_memory: usize,
+    /// Whether `ctx` is a digest-interned `SSL_CTX*` that other consumers may
+    /// also hold. Set for every path through `intern`/`create_with_digest`;
+    /// only `create_private` builds an exclusively-owned context. Prototype
+    /// mutators (`add_ca_cert`) refuse to touch a shared context so a stray
+    /// user-reachable interned handle can never poison the cache.
+    pub shared: bool,
 }
 
 /// Exposed via `bun:internal-for-testing` so churn tests can assert
@@ -227,6 +233,7 @@ impl SecureContext {
             ctx,
             digest: d,
             extra_memory: ctx_opts.approx_cert_bytes() + SSL_CTX_BASE_COST,
+            shared: false,
         });
         Ok(Self::to_js_boxed(sc, global))
     }
@@ -325,6 +332,7 @@ impl SecureContext {
             ctx,
             digest: d,
             extra_memory: ctx_opts.approx_cert_bytes() + SSL_CTX_BASE_COST,
+            shared: true,
         }))
     }
 
@@ -348,6 +356,11 @@ impl SecureContext {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
+        if this.shared {
+            return Err(global.throw(format_args!(
+                "cannot mutate a shared SecureContext; use tls.createSecureContext()"
+            )));
+        }
         let args = frame.arguments();
         if args.is_empty() {
             return Err(

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -220,6 +220,40 @@ test("addCACert on one user-facing context does not affect another with identica
   expect(a.context).not.toBe(b.context);
 });
 
+// The exported constructor is user-facing too: it must never hand out the
+// digest-interned SSL_CTX, or addCACert on one instance would silently extend
+// the trust store of every context sharing that digest.
+test("new tls.SecureContext() owns its native handle exclusively, like createSecureContext()", () => {
+  const a = new (tls as any).SecureContext({ ca: tlsCerts.cert });
+  const b = new (tls as any).SecureContext({ ca: tlsCerts.cert });
+  // The interned cache would hand both the same native cell.
+  expect(a.context).not.toBe(b.context);
+});
+
+test("addCACert on one exported SecureContext instance does not change what another verifies", async () => {
+  // agent6's chain roots at ca1, which is not in the default roots: a client
+  // using `b` must keep rejecting it after `a` starts trusting ca1 (Node
+  // isolates the contexts and fails this connection closed).
+  const fx = (n: string) => readFileSync(join(import.meta.dir, "fixtures", n), "utf8");
+  const server = tls.createServer({ key: fx("agent6-key.pem"), cert: fx("agent6-cert.pem") }, s => s.end());
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as import("net").AddressInfo;
+  const a = new (tls as any).SecureContext({ ca: fx("ca2-cert.pem") });
+  const b = new (tls as any).SecureContext({ ca: fx("ca2-cert.pem") });
+  a.context.addCACert(fx("ca1-cert.pem"));
+  const outcome = Promise.withResolvers<string>();
+  const socket = tls.connect({ port, secureContext: b, checkServerIdentity: () => undefined });
+  socket.on("secureConnect", () => outcome.resolve(`secureConnect authorized=${socket.authorized}`));
+  socket.on("error", error => outcome.resolve(`error ${(error as NodeJS.ErrnoException).code}`));
+  try {
+    expect(await outcome.promise).toBe("error UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+});
+
 test("setDefaultCACertificates() override applies to plain tls.connect (no explicit ca)", async () => {
   const keys = (f: string) => readFileSync(join(import.meta.dir, "../test/fixtures/keys", f));
   const prev = tls.getCACertificates("default");

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -220,6 +220,17 @@ test("addCACert on one user-facing context does not affect another with identica
   expect(a.context).not.toBe(b.context);
 });
 
+// The digest-interned cache is deliberately reachable only through internal
+// paths, but if one leaks (Symbol.for constructor, TLSSocket internals) the
+// mutator itself must refuse rather than silently poison every consumer.
+test("addCACert on a digest-interned context throws instead of poisoning the cache", () => {
+  const NativeSecureContext = tls.Server.prototype[Symbol.for("::buntlsnativesecurecontextctor::")];
+  const a = NativeSecureContext.intern({ ca: tlsCerts.cert });
+  const b = NativeSecureContext.intern({ ca: tlsCerts.cert });
+  expect(a).toBe(b);
+  expect(() => a.addCACert(tlsCerts.ca)).toThrow("cannot mutate a shared SecureContext");
+});
+
 // The exported constructor is user-facing too: it must never hand out the
 // digest-interned SSL_CTX, or addCACert on one instance would silently extend
 // the trust store of every context sharing that digest.
@@ -243,7 +254,12 @@ test("addCACert on one exported SecureContext instance does not change what anot
   const b = new (tls as any).SecureContext({ ca: fx("ca2-cert.pem") });
   a.context.addCACert(fx("ca1-cert.pem"));
   const outcome = Promise.withResolvers<string>();
-  const socket = tls.connect({ port, secureContext: b, checkServerIdentity: () => undefined });
+  const socket = tls.connect({
+    port,
+    secureContext: b,
+    rejectUnauthorized: true,
+    checkServerIdentity: () => undefined,
+  });
   socket.on("secureConnect", () => outcome.resolve(`secureConnect authorized=${socket.authorized}`));
   socket.on("error", error => outcome.resolve(`error ${(error as NodeJS.ErrnoException).code}`));
   try {


### PR DESCRIPTION
### What

`new tls.SecureContext(options)` (the exported constructor) returned a wrapper around the **digest-interned, shared** native `SSL_CTX`. Mutating it therefore mutated every other context with the same configuration digest:

```js
const a = new tls.SecureContext({ ca: ca2 });
const b = new tls.SecureContext({ ca: ca2 }); // independent object, same interned SSL_CTX
a.context.addCACert(ca1);
tls.connect({ secureContext: b, ... }); // b now trusts ca1 too
```

Against a server whose chain roots in `ca1` (not in the default roots), **node v26.3.0 fails closed** (`UNABLE_TO_GET_ISSUER_CERT_LOCALLY`) while Bun completed the handshake with `authorized=true` — an extra CA silently trusted by connections that never asked for it. (Surfaced by a security scan of this branch; reproduced end-to-end against both runtimes before fixing.)

`createSecureContext()` already builds a **private** context for exactly this reason ("a user-constructed context owns its SSL_CTX exclusively, so addCACert can never leak across contexts"); the exported constructor was the one user-constructible path that missed the invariant. It now passes `cached: false` too. Internal paths (`tls.connect`/`Server`/`fetch`) keep the shared cache: their contexts are never exposed for mutation, and that sharing is the cache's purpose.

Regression tests (both in `ssl-ctx-cache.test.ts`, next to their `createSecureContext` siblings): (1) two `new tls.SecureContext()` instances with identical options get **distinct native handles** — the interned cache handed both the same cell before the fix; (2) the end-to-end scenario above — after `a.context.addCACert(ca1)`, a connection using `b` still fails with node's exact `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` (on the unfixed code it completed with `authorized=true`).

### The other scan findings that touch this PR stack's files (triaged, not fixed here)

Each was verified against the sources before deciding:

- **`upgradeTLS` `initialData` used after re-entrant JS can free the backing store** (`socket_body.rs`): real, pre-existing on `main` — and since fixed upstream by #33388, so nothing is owed here anymore.
- **TLS 1.3 session resumption marks certificate-less clients as verified** (`openssl.c`): the resumption arm pre-exists on `main` and is a faithful port of Node's own `VerifyPeerCertificate` (`src/crypto/crypto_common.cc`), which Node's server path also uses — so Bun matches Node here by construction. Hardening beyond Node would be a deliberate divergence decision.
- **TLS socket reports `authorized=true` despite failed chain verification** (two findings, `socket_body.rs` `on_handshake`): the scan itself notes the computation is byte-identical to upstream Bun; it concerns the Bun-native `Bun.connect`/`Bun.listen` socket API (node:tls and fetch enforce verification in their own layers). Changing a Bun-native API contract needs a maintainer decision, not a drive-by in a node:tls compat stack.

### Notes from the pre-PR review pass

- The exported constructor now simply delegates to `createSecureContext()` (one source of truth for the ownership contract), and the three comments that enumerated `createSecureContext` as the *only* exclusively-owned constructor were updated so the enumeration cannot rot into a regression.
- Informational, unchanged: a digest-cached native context with a callable `addCACert` is still reachable if code deliberately digs out the registered internal symbol (`::buntlsnativesecurecontextctor::`); that is outside the public API surface.

---

Rebased onto the updated base branch (which itself was rebased onto current `main`).
