### PR TITLE
bun:ffi: propagate exceptions from viewSource callback descriptor getters

### DIFF
--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1275,11 +1275,7 @@ impl FFI {
         let mut function = Function::default();
         let func = &mut function;
 
-        if let Some(val) = generate_symbol_for_function(global_this, interface, func)
-            .unwrap_or_else(|_| {
-                Some(ZigString::init(b"Out of memory").to_error_instance(global_this))
-            })
-        {
+        if let Some(val) = generate_symbol_for_function(global_this, interface, func)? {
             return Ok(val);
         }
 
@@ -1384,9 +1380,7 @@ impl FFI {
         let mut symbols = StringArrayHashMap::<Function>::default();
         // SAFETY: `get_object()` returned a non-null `*mut JSObject`; `object` keeps it alive.
         let obj = unsafe { &*obj };
-        if let Some(val) =
-            generate_symbols(global, &mut symbols, obj).unwrap_or(Some(JSValue::ZERO))
-        {
+        if let Some(val) = generate_symbols(global, &mut symbols, obj)? {
             // an error while validating symbols
             // keys/arg_types freed by Drop
             return Ok(val);

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1338,18 +1338,16 @@ impl FFI {
         Ok(JSValue::UNDEFINED)
     }
 
-    pub fn print_callback(global: &JSGlobalObject, object: JSValue) -> JSValue {
+    pub fn print_callback(global: &JSGlobalObject, object: JSValue) -> JsResult<JSValue> {
         jsc::mark_binding();
 
         if object.is_empty_or_undefined_or_null() || !object.is_object() {
-            return global.to_invalid_arguments(format_args!("Expected an object"));
+            return Ok(global.to_invalid_arguments(format_args!("Expected an object")));
         }
 
         let mut function = Function::default();
-        if let Some(val) = generate_symbol_for_function(global, object, &mut function)
-            .unwrap_or_else(|_| Some(ZigString::init(b"Out of memory").to_error_instance(global)))
-        {
-            return val;
+        if let Some(val) = generate_symbol_for_function(global, object, &mut function)? {
+            return Ok(val);
         }
 
         let mut arraylist: Vec<u8> = Vec::new();
@@ -1360,9 +1358,9 @@ impl FFI {
             .print_callback_source_code(None, None, &mut arraylist)
             .is_err()
         {
-            return ZigString::init(b"Error while printing code").to_error_instance(global);
+            return Ok(ZigString::init(b"Error while printing code").to_error_instance(global));
         }
-        jsc::bun_string_jsc::create_utf8_for_js(global, &arraylist).unwrap_or(JSValue::ZERO)
+        jsc::bun_string_jsc::create_utf8_for_js(global, &arraylist)
     }
 
     pub fn print(
@@ -1372,7 +1370,7 @@ impl FFI {
     ) -> JsResult<JSValue> {
         if let Some(is_callback) = is_callback_val {
             if is_callback.to_boolean() {
-                return Ok(Self::print_callback(global, object));
+                return Self::print_callback(global, object);
             }
         }
 

--- a/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
+++ b/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
@@ -78,4 +78,21 @@ describe.skipIf(isFFIUnavailable)("FFI JSCallback", () => {
     expect(typeof cb.ptr).toBe("number");
     expect(cb.ptr).not.toBe(0);
   });
+
+  // print_callback swallowed a pending exception from the descriptor's getters
+  // and returned a non-empty "Out of memory" error instance instead, tripping
+  // "host fn return/exception state mismatch". The getter's error must propagate.
+  test.each(["args", "threadsafe", "returns"])("propagates a throwing %s getter in the callback descriptor", prop => {
+    const message = `boom from ${prop} getter`;
+    expect(() =>
+      Bun.FFI.viewSource(
+        {
+          get [prop]() {
+            throw new Error(message);
+          },
+        },
+        true,
+      ),
+    ).toThrow(message);
+  });
 });

--- a/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
+++ b/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
@@ -42,6 +42,43 @@ describe.skipIf(isFFIUnavailable)("FFI viewSource", () => {
     expect((err as TypeError).message).toContain("Expected an object");
   });
 
+  // print_callback swallowed a pending exception from the descriptor's getters
+  // and returned a non-empty "Out of memory" error instance instead, tripping
+  // "host fn return/exception state mismatch". The getter's error must propagate.
+  test.each(["args", "threadsafe", "returns", "ptr"])(
+    "propagates a throwing %s getter in the callback descriptor",
+    prop => {
+      const message = `boom from ${prop} getter`;
+      const err = thrown(() =>
+        viewSource(
+          {
+            get [prop]() {
+              throw new Error(message);
+            },
+          },
+          true,
+        ),
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe(message);
+    },
+  );
+
+  // Sibling path through generate_symbols (the non-callback form of viewSource).
+  test("propagates a throwing getter in a symbol descriptor", () => {
+    const err = thrown(() =>
+      viewSource({
+        sym: {
+          get args() {
+            throw new Error("boom from symbol args getter");
+          },
+        },
+      }),
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("boom from symbol args getter");
+  });
+
   test("returns the generated source for a valid descriptor", () => {
     const src = viewSource({ foo: { args: ["i32"], returns: "i32" } });
     expect(src).toBeArray();
@@ -73,26 +110,25 @@ describe.skipIf(isFFIUnavailable)("FFI JSCallback", () => {
     expect((err as TypeError).message).toContain("bogus_type");
   });
 
+  // FFI::callback had the same bug as print_callback: a descriptor getter that
+  // throws left the exception pending while callback() returned an error value.
+  test.each(["args", "threadsafe", "returns", "ptr"])("propagates a throwing %s getter in the descriptor", prop => {
+    const message = `boom from ${prop} getter`;
+    const err = thrown(
+      () =>
+        new JSCallback(() => {}, {
+          get [prop]() {
+            throw new Error(message);
+          },
+        }),
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe(message);
+  });
+
   test("constructs with a valid descriptor", () => {
     using cb = new JSCallback(() => {}, { args: ["i32"], returns: "void" });
     expect(typeof cb.ptr).toBe("number");
     expect(cb.ptr).not.toBe(0);
-  });
-
-  // print_callback swallowed a pending exception from the descriptor's getters
-  // and returned a non-empty "Out of memory" error instance instead, tripping
-  // "host fn return/exception state mismatch". The getter's error must propagate.
-  test.each(["args", "threadsafe", "returns"])("propagates a throwing %s getter in the callback descriptor", prop => {
-    const message = `boom from ${prop} getter`;
-    expect(() =>
-      Bun.FFI.viewSource(
-        {
-          get [prop]() {
-            throw new Error(message);
-          },
-        },
-        true,
-      ),
-    ).toThrow(message);
   });
 });


### PR DESCRIPTION
Two `bun:ffi` entry points convert a pending JS exception from the symbol descriptor's getters into a non-empty "Out of memory" error value, leaving the real exception set on the VM. A host function must not return a non-empty value while an exception is pending, so this trips the assertion:

```
Assertion failed: Native function returned a non-zero JSValue while an exception is pending
panic: host fn return/exception state mismatch
```

Both repros:

```js
Bun.FFI.viewSource({ get args() { throw new Error("boom") } }, true);
new JSCallback(() => {}, { get args() { throw new Error("boom") } });
```

Cause: `print_callback` and `FFI::callback` both handled the error arm of `generate_symbol_for_function` (a `JsResult<Option<JSValue>>` that reads the descriptor's `args`, `threadsafe`, `returns`, and `ptr` properties) with `.unwrap_or_else(|_| Some(<"Out of memory" error instance>))`. `Err(JsError::Thrown)` means a JS exception is already pending on the VM, so substituting a non-empty return value violates the host function contract (the return value must be empty iff an exception is pending) and also mislabels the user's exception as "Out of memory".

Fix: `?`-propagate at both sites so the getter's exception is thrown to JS. `print_callback` is widened to `JsResult<JSValue>` (its only caller, `print`, already returns that), which also drops the `create_utf8_for_js(...).unwrap_or(JSValue::ZERO)` on its return path. `print()`'s own `generate_symbols(...).unwrap_or(Some(JSValue::ZERO))` is switched to `?` as well; it was correct for `Err(Thrown)` but not for a future `Err(OutOfMemory)`.

Not changed: `open()` and `link_symbols()` use the same `unwrap_or(Some(JSValue::ZERO))`. That form is correct there: `JSValue::ZERO` with the exception left pending is exactly how a host function signals it, and I verified `dlopen` and `linkSymbols` with a throwing `args` getter already propagate the getter's error on an unfixed build. Widening those two to `JsResult` would ripple through every bare `JSValue` return in both for an `OutOfMemory` variant no callee can currently produce.

Test: `test/js/bun/ffi/ffi-viewSource-non-object.test.ts` covers `viewSource(descriptor, true)` and `new JSCallback(fn, descriptor)` for each of the four getter-readable properties, plus the non-callback `viewSource` path. Before the fix the file aborts with the panic above; after, the getter's error propagates as a normal throw.

Found while auditing for the bug class from #28786 (returning the "exception pending" sentinel without an exception actually pending). This is the same assertion, in the opposite direction.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/ffi-viewSource-non-object.test.ts

<!-- robobun:evidence:end -->