### PR TITLE
crypto: port upstream ncrypto correctness fixes

### DIFF
--- a/src/jsc/bindings/JSX509Certificate.cpp
+++ b/src/jsc/bindings/JSX509Certificate.cpp
@@ -778,13 +778,18 @@ JSC::JSObject* JSX509Certificate::toLegacyObject(ncrypto::X509View view, JSGloba
                     RETURN_IF_EXCEPTION(scope, nullptr);
                 }
 
-                // Convert exponent to string
-                uint64_t exponent_word = static_cast<uint64_t>(ncrypto::BignumPointer::GetWord(e));
-                auto bio_e = ncrypto::BIOPointer::NewMem();
-                if (bio_e) {
-                    BIO_printf(bio_e.get(), "0x%" PRIx64, exponent_word);
-                    object->putDirect(vm, Identifier::fromString(vm, "exponent"_s), jsString(vm, toWTFString(bio_e)));
-                    RETURN_IF_EXCEPTION(scope, nullptr);
+                // Convert exponent to string. Node.js reports null when the
+                // exponent is too wide for a BIGNUM word.
+                auto exponent_word = ncrypto::BignumPointer::GetWord(e);
+                if (!exponent_word.has_value()) {
+                    object->putDirect(vm, Identifier::fromString(vm, "exponent"_s), jsNull());
+                } else {
+                    auto bio_e = ncrypto::BIOPointer::NewMem();
+                    if (bio_e) {
+                        BIO_printf(bio_e.get(), "0x%" PRIx64, static_cast<uint64_t>(*exponent_word));
+                        object->putDirect(vm, Identifier::fromString(vm, "exponent"_s), jsString(vm, toWTFString(bio_e)));
+                        RETURN_IF_EXCEPTION(scope, nullptr);
+                    }
                 }
 
                 // Set bits
@@ -947,13 +952,18 @@ JSC::JSObject* JSX509Certificate::toLegacyObject(JSGlobalObject* globalObject)
                     RETURN_IF_EXCEPTION(scope, nullptr);
                 }
 
-                // Convert exponent to string
-                uint64_t exponent_word = static_cast<uint64_t>(ncrypto::BignumPointer::GetWord(e));
-                auto bio_e = ncrypto::BIOPointer::NewMem();
-                if (bio_e) {
-                    BIO_printf(bio_e.get(), "0x%" PRIx64, exponent_word);
-                    object->putDirect(vm, Identifier::fromString(vm, "exponent"_s), jsString(vm, toWTFString(bio_e)));
-                    RETURN_IF_EXCEPTION(scope, nullptr);
+                // Convert exponent to string. Node.js reports null when the
+                // exponent is too wide for a BIGNUM word.
+                auto exponent_word = ncrypto::BignumPointer::GetWord(e);
+                if (!exponent_word.has_value()) {
+                    object->putDirect(vm, Identifier::fromString(vm, "exponent"_s), jsNull());
+                } else {
+                    auto bio_e = ncrypto::BIOPointer::NewMem();
+                    if (bio_e) {
+                        BIO_printf(bio_e.get(), "0x%" PRIx64, static_cast<uint64_t>(*exponent_word));
+                        object->putDirect(vm, Identifier::fromString(vm, "exponent"_s), jsString(vm, toWTFString(bio_e)));
+                        RETURN_IF_EXCEPTION(scope, nullptr);
+                    }
                 }
 
                 // Set bits

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -254,7 +254,12 @@ DataPointer DataPointer::resize(size_t len)
     size_t actual_len = std::min(len_, len);
     auto buf = release();
     if (actual_len == len_) return DataPointer(buf.data, actual_len);
-    buf.data = OPENSSL_realloc(buf.data, actual_len);
+    void* new_data = OPENSSL_realloc(buf.data, actual_len);
+    if (new_data == nullptr) {
+        OPENSSL_clear_free(buf.data, buf.len);
+        return {};
+    }
+    buf.data = new_data;
     buf.len = actual_len;
     return DataPointer(buf);
 }
@@ -399,14 +404,16 @@ bool BignumPointer::setWord(unsigned long w)
     return BN_set_word(bn_.get(), w) == 1;
 }
 
-unsigned long BignumPointer::GetWord(const BIGNUM* bn)
+std::optional<unsigned long> BignumPointer::GetWord(const BIGNUM* bn)
 { // NOLINT(runtime/int)
-    return BN_get_word(bn);
+    BN_ULONG ret = BN_get_word(bn);
+    if (ret == static_cast<BN_ULONG>(-1)) return std::nullopt;
+    return ret;
 }
 
-unsigned long BignumPointer::getWord() const
+std::optional<unsigned long> BignumPointer::getWord() const
 { // NOLINT(runtime/int)
-    if (!bn_) return 0;
+    if (!bn_) return std::nullopt;
     return GetWord(bn_.get());
 }
 
@@ -1578,6 +1585,7 @@ BIOPointer BIOPointer::NewSecMem()
 
 BIOPointer BIOPointer::New(const BIO_METHOD* method)
 {
+    if (method == nullptr) return {};
     return BIOPointer(BIO_new(method));
 }
 
@@ -3134,7 +3142,7 @@ bool SSLCtxPointer::setCipherSuites(WTF::StringView ciphers)
 #ifndef OPENSSL_IS_BORINGSSL
     if (!ctx_) return false;
     auto ciphersUtf8 = ciphers.utf8();
-    return SSL_CTX_set_ciphersuites(ctx_.get(), ciphers.length());
+    return SSL_CTX_set_ciphersuites(ctx_.get(), ciphersUtf8.data());
 #else
     // BoringSSL does not allow API config of TLS 1.3 cipher suites.
     // We treat this as a non-op.
@@ -3427,22 +3435,19 @@ bool CipherCtxPointer::setKeyLength(size_t length)
 bool CipherCtxPointer::setIvLength(size_t length)
 {
     if (!ctx_) return false;
-    return EVP_CIPHER_CTX_ctrl(
-        ctx_.get(), EVP_CTRL_AEAD_SET_IVLEN, length, nullptr);
+    return EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_SET_IVLEN, length, nullptr) > 0;
 }
 
 bool CipherCtxPointer::setAeadTag(const Buffer<const char>& tag)
 {
     if (!ctx_) return false;
-    return EVP_CIPHER_CTX_ctrl(
-        ctx_.get(), EVP_CTRL_AEAD_SET_TAG, tag.len, const_cast<char*>(tag.data));
+    return EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_SET_TAG, tag.len, const_cast<char*>(tag.data)) > 0;
 }
 
 bool CipherCtxPointer::setAeadTagLength(size_t length)
 {
     if (!ctx_) return false;
-    return EVP_CIPHER_CTX_ctrl(
-        ctx_.get(), EVP_CTRL_AEAD_SET_TAG, length, nullptr);
+    return EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_SET_TAG, length, nullptr) > 0;
 }
 
 bool CipherCtxPointer::setPadding(bool padding)
@@ -3519,7 +3524,7 @@ bool CipherCtxPointer::update(const Buffer<const unsigned char>& in,
 bool CipherCtxPointer::getAeadTag(size_t len, unsigned char* out)
 {
     if (!ctx_) return false;
-    return EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_GET_TAG, len, out);
+    return EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_GET_TAG, len, out) > 0;
 }
 
 // ============================================================================
@@ -4097,7 +4102,6 @@ bool EVPKeyCtxPointer::publicCheck() const
 {
     if (!ctx_) return false;
 #ifndef OPENSSL_IS_BORINGSSL
-    return EVP_PKEY_public_check(ctx_.get()) == 1;
 #if OPENSSL_VERSION_MAJOR >= 3
     return EVP_PKEY_public_check_quick(ctx_.get()) == 1;
 #else
@@ -4875,12 +4879,17 @@ std::pair<WTF::String, WTF::String> X509Name::Iterator::operator*() const
         name_str = WTF::String::fromUTF8(buf);
     }
 
-    unsigned char* value_str;
+    unsigned char* value_str = nullptr;
     int value_str_size = ASN1_STRING_to_UTF8(&value_str, value);
+    if (value_str_size < 0) [[unlikely]] {
+        return { {}, {} };
+    }
+    // ASN1_STRING_to_UTF8 allocates; fromUTF8 copies, so release it here.
+    DataPointer free_value_str(value_str, static_cast<size_t>(value_str_size));
 
     return {
         WTF::move(name_str),
-        WTF::String::fromUTF8(std::span(value_str, value_str_size)),
+        WTF::String::fromUTF8(std::span(value_str, static_cast<size_t>(value_str_size))),
     };
 }
 

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -404,15 +404,15 @@ bool BignumPointer::setWord(unsigned long w)
     return BN_set_word(bn_.get(), w) == 1;
 }
 
-std::optional<unsigned long> BignumPointer::GetWord(const BIGNUM* bn)
-{ // NOLINT(runtime/int)
+std::optional<BN_ULONG> BignumPointer::GetWord(const BIGNUM* bn)
+{
     BN_ULONG ret = BN_get_word(bn);
     if (ret == static_cast<BN_ULONG>(-1)) return std::nullopt;
     return ret;
 }
 
-std::optional<unsigned long> BignumPointer::getWord() const
-{ // NOLINT(runtime/int)
+std::optional<BN_ULONG> BignumPointer::getWord() const
+{
     if (!bn_) return std::nullopt;
     return GetWord(bn_.get());
 }

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -660,7 +660,10 @@ public:
     bool isOne() const;
 
     bool setWord(unsigned long w); // NOLINT(runtime/int)
-    unsigned long getWord() const; // NOLINT(runtime/int)
+    // Returns std::nullopt if the value does not fit in an unsigned long
+    // (BN_get_word signals overflow by returning ULONG_MAX, which is
+    // otherwise indistinguishable from the real value ULONG_MAX).
+    std::optional<unsigned long> getWord() const; // NOLINT(runtime/int)
 
     size_t byteLength() const;
 
@@ -700,7 +703,7 @@ public:
         size_t size);
     static int GetBitCount(const BIGNUM* bn);
     static int GetByteCount(const BIGNUM* bn);
-    static unsigned long GetWord(const BIGNUM* bn); // NOLINT(runtime/int)
+    static std::optional<unsigned long> GetWord(const BIGNUM* bn); // NOLINT(runtime/int)
     static const BIGNUM* One();
 
     BignumPointer clone();

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -660,10 +660,10 @@ public:
     bool isOne() const;
 
     bool setWord(unsigned long w); // NOLINT(runtime/int)
-    // Returns std::nullopt if the value does not fit in an unsigned long
-    // (BN_get_word signals overflow by returning ULONG_MAX, which is
-    // otherwise indistinguishable from the real value ULONG_MAX).
-    std::optional<unsigned long> getWord() const; // NOLINT(runtime/int)
+    // std::nullopt when the value does not fit in a single BN_ULONG, which
+    // BN_get_word reports as the all-ones word (otherwise a real value).
+    // BN_ULONG, not unsigned long: the latter is only 32 bits on LLP64.
+    std::optional<BN_ULONG> getWord() const;
 
     size_t byteLength() const;
 
@@ -703,7 +703,7 @@ public:
         size_t size);
     static int GetBitCount(const BIGNUM* bn);
     static int GetByteCount(const BIGNUM* bn);
-    static std::optional<unsigned long> GetWord(const BIGNUM* bn); // NOLINT(runtime/int)
+    static std::optional<BN_ULONG> GetWord(const BIGNUM* bn);
     static const BIGNUM* One();
 
     BignumPointer clone();

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
@@ -153,7 +153,10 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
                 return JSValue::encode(createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, "Invalid generator"_s));
             }
 
-            if (bn_g.getWord() < 2) {
+            // A generator too wide for BN_get_word is necessarily >= 2, so only
+            // reject when the value actually fits and is below 2.
+            auto generatorWord = bn_g.getWord();
+            if (generatorWord.has_value() && *generatorWord < 2) {
                 ERR_put_error(ERR_LIB_DH, 0, DH_R_BAD_GENERATOR, __FILE__, __LINE__);
                 throwCryptoError(globalObject, scope, ERR_get_error(), "Invalid generator"_s);
                 return {};

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -608,6 +608,30 @@ describe("DiffieHellman", () => {
     expect(dh.setPublicKey.name).toBe("setPublicKey");
     expect(dh.setPrivateKey.name).toBe("setPrivateKey");
   });
+
+  it("accepts a buffer generator wider than a BIGNUM word", () => {
+    // A 72-bit generator overflows BN_get_word (which reports the overflow as
+    // ULONG_MAX). The generator-below-2 check must not misread that as a
+    // small value, nor reject it outright: any generator too wide for a word
+    // is necessarily >= 2.
+    const p = crypto.getDiffieHellman("modp5").getPrime();
+    const g = Buffer.from("020000000000000001", "hex");
+
+    const alice = crypto.createDiffieHellman(p, g);
+    const bob = crypto.createDiffieHellman(p, g);
+    alice.generateKeys();
+    bob.generateKeys();
+
+    expect(alice.getGenerator()).toEqual(g);
+    expect(alice.computeSecret(bob.getPublicKey())).toEqual(bob.computeSecret(alice.getPublicKey()));
+  });
+
+  it("rejects a buffer generator below 2 and accepts exactly 2", () => {
+    const p = crypto.getDiffieHellman("modp5").getPrime();
+    expect(() => crypto.createDiffieHellman(p, Buffer.from([0x00]))).toThrow(/bad.generator/i);
+    expect(() => crypto.createDiffieHellman(p, Buffer.from([0x01]))).toThrow(/bad.generator/i);
+    expect(() => crypto.createDiffieHellman(p, Buffer.from([0x02]))).not.toThrow();
+  });
 });
 
 describe("ECDH", () => {

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -609,13 +609,16 @@ describe("DiffieHellman", () => {
     expect(dh.setPrivateKey.name).toBe("setPrivateKey");
   });
 
-  it("accepts a buffer generator wider than a BIGNUM word", () => {
-    // A 72-bit generator overflows BN_get_word (which reports the overflow as
-    // ULONG_MAX). The generator-below-2 check must not misread that as a
-    // small value, nor reject it outright: any generator too wide for a word
-    // is necessarily >= 2.
+  // BN_get_word reports a BIGNUM too wide for a single BN_ULONG by returning
+  // the all-ones word. The generator-below-2 check must not misread that (or a
+  // truncation of a 33-to-64-bit value on LLP64, where unsigned long is 32
+  // bits) as a small value: any generator that wide is necessarily >= 2.
+  it.each([
+    ["33 bits (wider than a 32-bit unsigned long)", "0100000000"],
+    ["72 bits (wider than any BN_ULONG)", "020000000000000001"],
+  ])("accepts a buffer generator of %s", (_label, hex) => {
     const p = crypto.getDiffieHellman("modp5").getPrime();
-    const g = Buffer.from("020000000000000001", "hex");
+    const g = Buffer.from(hex, "hex");
 
     const alice = crypto.createDiffieHellman(p, g);
     const bob = crypto.createDiffieHellman(p, g);


### PR DESCRIPTION
Bun's `src/jsc/bindings/ncrypto.{cpp,h}` is a port of [nodejs/ncrypto@134ac40](https://github.com/nodejs/ncrypto/commit/134ac4073148b16cee564eb7a883b72f6d699a0d) (February 2025), which maps to Node's `deps/ncrypto` from late January 2025. This ports the upstream correctness fixes made since then that apply to code Bun already has, plus one Bun-local typo found while auditing the drift.

### Upstream fixes

| Change | Upstream |
| --- | --- |
| `DataPointer::resize()`: handle `OPENSSL_realloc` failure instead of returning a `DataPointer` with a null pointer and a nonzero length. Also frees the old block on failure. Upstream's version calls a `free()` helper after `release()` has already nulled `data_`, which is a no-op, so the old block leaks; this keeps the intent without that. | [nodejs/ncrypto#37](https://github.com/nodejs/ncrypto/pull/37) |
| `CipherCtxPointer::{setIvLength, setAeadTag, setAeadTagLength, getAeadTag}`: compare the `EVP_CIPHER_CTX_ctrl` return against `> 0`. The raw `int` can be negative, which converts to `true`. BoringSSL normalizes `-1` to `0`, so this is masked in Bun's build today, but it is still the wrong check. | [nodejs/ncrypto#36](https://github.com/nodejs/ncrypto/pull/36) |
| `BignumPointer::{GetWord, getWord}` return `std::optional` so a `BN_get_word` overflow (reported as the all-ones word) is distinguishable from the real all-ones value. The optional wraps `BN_ULONG`, not upstream's `unsigned long`: BoringSSL's `BN_ULONG` is `uint64_t` on every 64-bit target, so `unsigned long` would still silently truncate 33-to-64-bit values on LLP64 (Windows x64). | [nodejs/node#63895](https://github.com/nodejs/node/pull/63895) |
| `BIOPointer::New(method)`: return an empty pointer for a null method. | [nodejs/node#61788](https://github.com/nodejs/node/pull/61788) |
| `EVPKeyCtxPointer::publicCheck()`: remove an unconditional return that made the `EVP_PKEY_public_check_quick` branch unreachable. The whole block is non-BoringSSL, so it is dead in Bun's build. | [nodejs/node#59471](https://github.com/nodejs/node/pull/59471) |
| `X509Name::Iterator::operator*()`: free the buffer allocated by `ASN1_STRING_to_UTF8`, and return early on a negative size (the out-pointer is never written on failure). Dead code today: `JSX509Certificate.cpp` has its own correct loop. | [nodejs/node#60609](https://github.com/nodejs/node/pull/60609) |

### `GetWord` callers updated

- `JSDiffieHellmanConstructor.cpp`: the generator-below-2 check becomes `has_value() && *word < 2`. This is the one spot that needed care: `std::optional<T> < 2` compiles and evaluates `nullopt < 2` as `true`, so a naive translation would have started rejecting any generator wider than a word.
- `JSX509Certificate.cpp` (both legacy-object sites): `exponent` is reported as `null` when the RSA public exponent does not fit in a word, matching Node. This branch is unreachable under BoringSSL, which rejects RSA public exponents wider than 33 bits at SPKI parse time.

### Bun-local typo

`SSLCtxPointer::setCipherSuites` passed `ciphers.length()` where `SSL_CTX_set_ciphersuites` expects the string. It is in the non-BoringSSL `#ifndef` branch so it never compiles in Bun's build; introduced by the original `WTF::StringView` port of the file.

### Testing

No test here can fail against the unmodified source on a Linux machine, because nothing in this diff changes observable behavior on Linux. I checked each one: `DataPointer::resize` only diverges under `OPENSSL_realloc` failure, the `EVP_CIPHER_CTX_ctrl` returns are already normalized to `0` or `1` by BoringSSL, `publicCheck` and `setCipherSuites` are inside non-BoringSSL `#ifndef` branches, `BIOPointer::New(method)` and `X509Name::Iterator` have no callers, and `BN_ULONG` and `unsigned long` are the same 64-bit type on LP64. The one real before-and-after is the `BN_ULONG` truncation, and it only exists on Windows x64 (LLP64).

So the new tests pin invariants rather than prove a failure. `node-crypto.test.js` gains three `DiffieHellman` cases:

- A 72-bit buffer generator is accepted. This is what a naive `optional < 2` translation would have broken on every platform.
- A 33-bit (5-byte) buffer generator is accepted. Equivalent on platforms with a 64-bit `unsigned long`; on Windows x64 the `unsigned long` version of this change truncates it to `0` and wrongly rejects it as below 2, so this is the real regression test for the `BN_ULONG` return type on that platform.
- Generators below 2 are still rejected and exactly 2 is still accepted.

Node v26 agrees on all three.

<details>
<summary>Local verification against the debug build</summary>

- `test/js/node/crypto/{crypto,node-crypto,crypto.key-objects,crypto-rsa,x509-subclass}.test.*`: 677 pass, 0 fail
- `test/js/node/test/parallel/test-crypto-{x509,dh,dh-errors,dh-constructor,dh-odd-key,dh-generate-keys,dh-shared,dh-padding,cipheriv-decipheriv,gcm-explicit-short-tag,gcm-implicit-short-tag,aes-wrap,padding-aes256,getcipherinfo,rsa-dsa}.js`, `test-webcrypto-encrypt-decrypt-aes.js`, `test-crypto-webcrypto-aes-decrypt-tag-too-small.js`: all pass

</details>

### Deliberately not included

- `Cipher::MAX_AUTH_TAG_LENGTH` ([nodejs/node#57803](https://github.com/nodejs/node/pull/57803)): of the three macros upstream's `static_assert` uses, BoringSSL only defines `EVP_GCM_TLS_TAG_LEN`, so the assert degenerates to `16 <= 16`.
- `ECKeyPointer::setPublicKeyRaw` ([nodejs/node#62396](https://github.com/nodejs/node/pull/62396)): the expensive check that rewrite avoids (the `order * Q == infinity` step of `EC_KEY_check_key`) does not exist in BoringSSL's `EC_KEY_check_key`, so there is no perf win for Bun.
- The BoringSSL build guards the standalone repo added (`NCRYPTO_NO_DSA_KEYGEN`, `NCRYPTO_NO_EVP_DH`, rejecting DSA in `NewFromID`, ...): those exist for vanilla BoringSSL CI, and Bun's DSA and DH paths work today against its BoringSSL.
