### PR TITLE
bake: pin the react experimental build the test harness installs

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1439,8 +1439,21 @@ if (!fs.existsSync(tempDir)) {
   fs.mkdirSync(tempDir, { recursive: true });
 }
 
-// Create a cache directory for React dependencies
-const reactCacheDir = path.join(tempDir, ".react-cache");
+// react-server-dom-bun's only published build was compiled against this react build. RSC
+// packages only pair with the exact react they were built for, so pin all three instead of
+// tracking the daily-moving `experimental` dist-tag (whose 2026-07-01 build broke the suite).
+const REACT_EXPERIMENTAL_VERSION = "0.0.0-experimental-603e6108-20241029";
+// Bun.$ expands an array into separate escaped arguments, so both install sites share it.
+const REACT_INSTALL_PACKAGES = [
+  `react@${REACT_EXPERIMENTAL_VERSION}`,
+  `react-dom@${REACT_EXPERIMENTAL_VERSION}`,
+  "react-server-dom-bun",
+  `react-refresh@${REACT_EXPERIMENTAL_VERSION}`,
+];
+
+// Cache the installed React packages, keyed on the pinned build so a stale cache under a
+// persistent BUN_DEV_SERVER_TEST_TEMP is repopulated whenever the pin changes.
+const reactCacheDir = path.join(tempDir, `.react-cache-${REACT_EXPERIMENTAL_VERSION}`);
 if (!fs.existsSync(reactCacheDir)) {
   fs.mkdirSync(reactCacheDir, { recursive: true });
 }
@@ -1453,11 +1466,6 @@ function cleanTestDir(dir: string) {
     fs.rmSync(filePath, { recursive: true, force: true });
   }
 }
-
-// react-server-dom-bun's only published build was compiled against this react build. RSC
-// packages only pair with the exact react they were built for, so pin all three instead of
-// tracking the daily-moving `experimental` dist-tag (whose 2026-07-01 build broke the suite).
-const REACT_EXPERIMENTAL_VERSION = "0.0.0-experimental-603e6108-20241029";
 
 async function installReactWithCache(root: string) {
   const cacheFiles = ["node_modules", "package.json", "bun.lock"];
@@ -1476,7 +1484,7 @@ async function installReactWithCache(root: string) {
     }
   } else {
     // Install fresh and populate cache
-    await Bun.$`${bunExe()} i --linker=hoisted react@${REACT_EXPERIMENTAL_VERSION} react-dom@${REACT_EXPERIMENTAL_VERSION} react-server-dom-bun react-refresh@${REACT_EXPERIMENTAL_VERSION} && ${bunExe()} install --linker=hoisted`
+    await Bun.$`${bunExe()} i --linker=hoisted ${REACT_INSTALL_PACKAGES} && ${bunExe()} install --linker=hoisted`
       .cwd(root)
       .env({ ...bunEnv })
       .throws(true);
@@ -1525,7 +1533,7 @@ export async function ensureReactCache(): Promise<void> {
 
         try {
           // Install React packages
-          await Bun.$`${bunExe()} i --linker=hoisted react@${REACT_EXPERIMENTAL_VERSION} react-dom@${REACT_EXPERIMENTAL_VERSION} react-server-dom-bun react-refresh@${REACT_EXPERIMENTAL_VERSION} && ${bunExe()} install --linker=hoisted`
+          await Bun.$`${bunExe()} i --linker=hoisted ${REACT_INSTALL_PACKAGES} && ${bunExe()} install --linker=hoisted`
             .cwd(tempInstallDir)
             .env({ ...bunEnv })
             .throws(true);

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1454,6 +1454,11 @@ function cleanTestDir(dir: string) {
   }
 }
 
+// react-server-dom-bun's only published build was compiled against this react build. RSC
+// packages only pair with the exact react they were built for, so pin all three instead of
+// tracking the daily-moving `experimental` dist-tag (whose 2026-07-01 build broke the suite).
+const REACT_EXPERIMENTAL_VERSION = "0.0.0-experimental-603e6108-20241029";
+
 async function installReactWithCache(root: string) {
   const cacheFiles = ["node_modules", "package.json", "bun.lock"];
   const cacheValid = cacheFiles.every(file => fs.existsSync(path.join(reactCacheDir, file)));
@@ -1471,7 +1476,7 @@ async function installReactWithCache(root: string) {
     }
   } else {
     // Install fresh and populate cache
-    await Bun.$`${bunExe()} i --linker=hoisted react@experimental react-dom@experimental react-server-dom-bun react-refresh@experimental && ${bunExe()} install --linker=hoisted`
+    await Bun.$`${bunExe()} i --linker=hoisted react@${REACT_EXPERIMENTAL_VERSION} react-dom@${REACT_EXPERIMENTAL_VERSION} react-server-dom-bun react-refresh@${REACT_EXPERIMENTAL_VERSION} && ${bunExe()} install --linker=hoisted`
       .cwd(root)
       .env({ ...bunEnv })
       .throws(true);
@@ -1520,7 +1525,7 @@ export async function ensureReactCache(): Promise<void> {
 
         try {
           // Install React packages
-          await Bun.$`${bunExe()} i --linker=hoisted react@experimental react-dom@experimental react-server-dom-bun react-refresh@experimental && ${bunExe()} install --linker=hoisted`
+          await Bun.$`${bunExe()} i --linker=hoisted react@${REACT_EXPERIMENTAL_VERSION} react-dom@${REACT_EXPERIMENTAL_VERSION} react-server-dom-bun react-refresh@${REACT_EXPERIMENTAL_VERSION} && ${bunExe()} install --linker=hoisted`
             .cwd(tempInstallDir)
             .env({ ...bunEnv })
             .throws(true);


### PR DESCRIPTION
### What this does

Pins the react packages the bake test harness installs (`react`, `react-dom`, `react-refresh`) to `0.0.0-experimental-603e6108-20241029` — the exact build `react-server-dom-bun` (installed by the same harness) was compiled against — instead of following the moving `experimental` dist-tag.

### Why now

react republished the `experimental` tag on 2026-07-01 at ~17:00 UTC (`0.0.0-experimental-ec0fca31-20260701`). Paired with the frozen `react-server-dom-bun`, `bun build --app` now hangs after an SSG render error, so `test/bake/dev/production.test.ts` ("works with sourcemaps - error thrown in React component") times out on **every platform**, for **every branch** built after that publish (seen across many of today's Buildkite builds, e.g. #67594, #67606, #67626). Agents whose react cache predates the publish still pass, which made it look platform-specific at first.

RSC bindings are only supported against the exact react build they were compiled with. `react-server-dom-bun`'s only published version targets `603e6108-20241029`, so installing it next to whatever `react@experimental` resolves to today breaks whenever react publishes an incompatible build — this is just the day it finally did.

### How this was verified

- Reproduced locally with a fresh install of today's `react@experimental`: `bun bd test test/bake/dev/production.test.ts -t "works with sourcemaps"` hangs and times out exactly like CI.
- With this pin as the only change, the same file passes 8/8 locally.
- `react@0.0.0-experimental-603e6108-20241029`, `react-dom@…`, and `react-refresh@…` all exist on npm (react publishes every experimental build under its hash-dated version).

### After merge

bake CI stops depending on react's daily experimental publishes. Branches need a rebase/merge to pick the harness change up. If `react-server-dom-bun` is ever republished against a newer react, the constant should move with it.

The separate `bun build --app` hang itself (the process not exiting after the RSC render error with the newer react) is left for the bake owners — this PR only removes the version skew from the test harness.
