### PR TITLE
node:url: return "" from domainToASCII/domainToUnicode for invalid domains

### DIFF
--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -18,8 +18,13 @@ enum class IDNAMode : bool { ToASCII,
 // valid domain.
 static WTF::String processDomain(const WTF::String& domain, IDNAMode mode)
 {
+    // The basic URL parser removes ASCII tab and newline from its input before
+    // host parsing, but URL::setHost applies UTS #46 to its raw argument first,
+    // which would bake them into a Punycode label. Strip them up front.
+    auto input = domain.removeCharacters([](char16_t c) { return c == '\t' || c == '\n' || c == '\r'; });
+
     WTF::URL url { "ws://x"_str };
-    if (!url.setHost(domain))
+    if (!url.setHost(input))
         return {};
 
     WTF::String host = url.host().toString();

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -1,16 +1,57 @@
 #include "NodeURL.h"
-#include "wtf/URLParser.h"
+#include <wtf/URL.h>
+#include <wtf/URLParser.h>
 #include <unicode/uidna.h>
 
 namespace Bun {
 
-JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+enum class IDNAMode : bool { ToASCII,
+    ToUnicode };
+
+// node defines url.domainToASCII and url.domainToUnicode in terms of the WHATWG
+// host parser: set the input as the host of "ws://x" and report any failure as
+// "". URL::setHost runs that parser, which already percent-decodes, rejects
+// forbidden domain code points, and canonicalizes IPv4. It takes a fast path
+// for all-ASCII hosts that skips UTS #46, so run the real nameTo{ASCII,Unicode}
+// on the parsed host to also reject invalid Punycode in xn-- labels (and, for
+// ToUnicode, produce the decoded form). A null return means the input is not a
+// valid domain.
+static WTF::String processDomain(const WTF::String& domain, IDNAMode mode)
+{
+    WTF::URL url { "ws://x"_str };
+    if (!url.setHost(domain))
+        return {};
+
+    WTF::String host = url.host().toString();
+    // IPv6 literals are not domains. The URL parser only applies IDNA up to
+    // hostnameBufferLength, so longer hosts pass through unvalidated there too.
+    if (host.startsWith('[') || host.length() > WTF::URLParser::hostnameBufferLength)
+        return host;
+
+    if (host.is8Bit())
+        host.convertTo16Bit();
+    const auto span = host.span16();
+
+    char16_t buffer[WTF::URLParser::hostnameBufferLength];
+    UErrorCode error = U_ZERO_ERROR;
+    UIDNAInfo processingDetails = UIDNA_INFO_INITIALIZER;
+    auto* encoder = &WTF::URLParser::internationalDomainNameTranscoder();
+    int32_t numCharactersConverted = mode == IDNAMode::ToASCII
+        ? uidna_nameToASCII(encoder, span.data(), span.size(), buffer, WTF::URLParser::hostnameBufferLength, &processingDetails, &error)
+        : uidna_nameToUnicode(encoder, span.data(), span.size(), buffer, WTF::URLParser::hostnameBufferLength, &processingDetails, &error);
+
+    if (!U_SUCCESS(error) || (processingDetails.errors & ~WTF::URLParser::allowedNameToASCIIErrors) || numCharactersConverted <= 0)
+        return {};
+    return WTF::String(std::span { buffer, static_cast<size_t>(numCharactersConverted) });
+}
+
+static JSC::EncodedJSValue domainTo(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame, IDNAMode mode, ASCIILiteral missingArgumentMessage)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (callFrame->argumentCount() < 1) {
-        throwTypeError(globalObject, scope, "domainToASCII needs 1 argument"_s);
+        throwTypeError(globalObject, scope, missingArgumentMessage);
         return {};
     }
 
@@ -25,120 +66,22 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, J
     }
 
     auto domain = arg0.toWTFString(globalObject);
-    if (domain.isNull())
-        return JSC::JSValue::encode(jsUndefined());
+    RETURN_IF_EXCEPTION(scope, {});
 
-    // https://url.spec.whatwg.org/#forbidden-host-code-point
-    if (
-        domain.contains(0x0000) || // U+0000 NULL
-        domain.contains(0x0009) || // U+0009 TAB
-        domain.contains(0x000A) || // U+000A LF
-        domain.contains(0x000D) || // U+000D CR
-        domain.contains(0x0020) || // U+0020 SPACE
-        domain.contains(0x0023) || // U+0023 (#)
-        domain.contains(0x002F) || // U+002F (/)
-        domain.contains(0x003A) || // U+003A (:)
-        domain.contains(0x003C) || // U+003C (<)
-        domain.contains(0x003E) || // U+003E (>)
-        domain.contains(0x003F) || // U+003F (?)
-        domain.contains(0x0040) || // U+0040 (@)
-        domain.contains(0x005B) || // U+005B ([)
-        domain.contains(0x005C) || // U+005C (\)
-        domain.contains(0x005D) || // U+005D (])
-        domain.contains(0x005E) || // U+005E (^)
-        domain.contains(0x007C) // // U+007C (|).
-    )
+    auto result = processDomain(domain, mode);
+    if (result.isNull())
         return JSC::JSValue::encode(jsEmptyString(vm));
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::move(result)));
+}
 
-    if (domain.containsOnlyASCII())
-        return JSC::JSValue::encode(arg0);
-    if (domain.is8Bit())
-        domain.convertTo16Bit();
-
-    constexpr static int allowedNameToASCIIErrors = UIDNA_ERROR_EMPTY_LABEL | UIDNA_ERROR_LABEL_TOO_LONG | UIDNA_ERROR_DOMAIN_NAME_TOO_LONG | UIDNA_ERROR_LEADING_HYPHEN | UIDNA_ERROR_TRAILING_HYPHEN | UIDNA_ERROR_HYPHEN_3_4;
-    constexpr static size_t hostnameBufferLength = 2048;
-
-    auto encoder = &WTF::URLParser::internationalDomainNameTranscoder();
-    char16_t hostnameBuffer[hostnameBufferLength];
-    UErrorCode error = U_ZERO_ERROR;
-    UIDNAInfo processingDetails = UIDNA_INFO_INITIALIZER;
-    const auto span = domain.span16();
-    int32_t numCharactersConverted = uidna_nameToASCII(encoder, span.data(), span.size(), hostnameBuffer, hostnameBufferLength, &processingDetails, &error);
-
-    if (U_SUCCESS(error) && !(processingDetails.errors & ~allowedNameToASCIIErrors) && numCharactersConverted) {
-        return JSC::JSValue::encode(JSC::jsString(vm, WTF::String(std::span { hostnameBuffer, static_cast<unsigned int>(numCharactersConverted) })));
-    }
-    return JSC::JSValue::encode(jsEmptyString(vm));
+JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    return domainTo(globalObject, callFrame, IDNAMode::ToASCII, "domainToASCII needs 1 argument"_s);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (callFrame->argumentCount() < 1) {
-        throwTypeError(globalObject, scope, "domainToUnicode needs 1 argument"_s);
-        return {};
-    }
-
-    auto arg0 = callFrame->argument(0);
-    if (arg0.isUndefined())
-        return JSC::JSValue::encode(jsUndefined());
-    if (arg0.isNull())
-        return JSC::JSValue::encode(jsNull());
-    if (!arg0.isString()) {
-        throwTypeError(globalObject, scope, "the \"domain\" argument must be a string"_s);
-        return {};
-    }
-
-    auto domain = arg0.toWTFString(globalObject);
-    if (domain.isNull())
-        return JSC::JSValue::encode(jsUndefined());
-
-    // https://url.spec.whatwg.org/#forbidden-host-code-point
-    if (
-        domain.contains(0x0000) || // U+0000 NULL
-        domain.contains(0x0009) || // U+0009 TAB
-        domain.contains(0x000A) || // U+000A LF
-        domain.contains(0x000D) || // U+000D CR
-        domain.contains(0x0020) || // U+0020 SPACE
-        domain.contains(0x0023) || // U+0023 (#)
-        domain.contains(0x002F) || // U+002F (/)
-        domain.contains(0x003A) || // U+003A (:)
-        domain.contains(0x003C) || // U+003C (<)
-        domain.contains(0x003E) || // U+003E (>)
-        domain.contains(0x003F) || // U+003F (?)
-        domain.contains(0x0040) || // U+0040 (@)
-        domain.contains(0x005B) || // U+005B ([)
-        domain.contains(0x005C) || // U+005C (\)
-        domain.contains(0x005D) || // U+005D (])
-        domain.contains(0x005E) || // U+005E (^)
-        domain.contains(0x007C) // // U+007C (|).
-    )
-        return JSC::JSValue::encode(jsEmptyString(vm));
-
-    if (!domain.is8Bit())
-        // this function is only for undoing punycode so its okay if utf-16 text makes it out unchanged.
-        return JSC::JSValue::encode(arg0);
-
-    domain.convertTo16Bit();
-
-    constexpr static int allowedNameToUnicodeErrors = UIDNA_ERROR_EMPTY_LABEL | UIDNA_ERROR_LABEL_TOO_LONG | UIDNA_ERROR_DOMAIN_NAME_TOO_LONG | UIDNA_ERROR_LEADING_HYPHEN | UIDNA_ERROR_TRAILING_HYPHEN | UIDNA_ERROR_HYPHEN_3_4;
-    constexpr static int hostnameBufferLength = 2048;
-
-    auto encoder = &WTF::URLParser::internationalDomainNameTranscoder();
-    char16_t hostnameBuffer[hostnameBufferLength];
-    UErrorCode error = U_ZERO_ERROR;
-    UIDNAInfo processingDetails = UIDNA_INFO_INITIALIZER;
-
-    const auto span = domain.span16();
-
-    int32_t numCharactersConverted = uidna_nameToUnicode(encoder, span.data(), span.size(), hostnameBuffer, hostnameBufferLength, &processingDetails, &error);
-
-    if (U_SUCCESS(error) && !(processingDetails.errors & ~allowedNameToUnicodeErrors) && numCharactersConverted) {
-        return JSC::JSValue::encode(JSC::jsString(vm, WTF::String(std::span { hostnameBuffer, static_cast<unsigned int>(numCharactersConverted) })));
-    }
-    return JSC::JSValue::encode(jsEmptyString(vm));
+    return domainTo(globalObject, callFrame, IDNAMode::ToUnicode, "domainToUnicode needs 1 argument"_s);
 }
 
 JSC::JSValue createNodeURLBinding(Zig::GlobalObject* globalObject)

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -118,9 +118,14 @@ const hostParserParity = [
   ["[::ffff:127.0.0.1]", "[::ffff:7f00:1]", "[::ffff:7f00:1]"],
   ["[", "", ""],
   ["[:", "", ""],
-  // Tab/newline stripping, truncation, and authority characters.
+  // Tab/newline stripping, truncation, and authority characters. Tab/newline
+  // is stripped before UTS #46 runs, so it must not end up inside a Punycode
+  // label.
   ["ex\tample.com", "example.com", "example.com"],
   ["a\r\nb", "ab", "ab"],
+  ["b\t\u00fccher.de", "xn--bcher-kva.de", "b\u00fccher.de"],
+  ["\u00df\nxn", "xn--xn-fia", "\u00dfxn"],
+  ["\u03c2a\nxn--bcher-kva", "xn--axn--bcher-kva-phk", "\u03c2axn--bcher-kva"],
   ["a/b", "a", "a"],
   ["a?b", "a", "a"],
   ["a#b", "a", "a"],

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -72,6 +72,90 @@ const invalids = [
   ["2001:0db8:85a3:0000:0000:8a2e:0370:7334", ""],
 ];
 
+// node defines both functions in terms of the WHATWG host parser: set the
+// input as the hostname of "ws://x" and return "" on failure. Expected values
+// below are [input, domainToASCII(input), domainToUnicode(input)] as produced
+// by node v26.3.0.
+const hostParserParity = [
+  // Invalid Punycode in an all-ASCII xn-- label must fail, not echo the input.
+  ["xn--a-ecp.example", "", ""],
+  ["xn--a-ecp.ss", "", ""],
+  ["xn--a", "", ""],
+  ["xn--a.example", "", ""],
+  ["xn--a.xn--nxa", "", ""],
+  ["xn--zn7c.com", "", ""],
+  ["xn--", "", ""],
+  ["xn--.example", "", ""],
+  ["a.xn--", "", ""],
+  ["xn--1ug.example", "", ""],
+  // Forbidden domain code points: %, C0 controls, DEL, space.
+  ["a%b", "", ""],
+  ["%", "", ""],
+  ["%ZZ", "", ""],
+  ["a\x01b", "", ""],
+  ["a\x0cb", "", ""],
+  ["a\x7fb", "", ""],
+  ["a b", "", ""],
+  [" a ", "", ""],
+  // Percent-decoding happens before IDNA.
+  ["%41", "a", "a"],
+  ["ex%61mple.com", "example.com", "example.com"],
+  ["%e4%bd%a0%e5%a5%bd", "xn--6qq79v", "\u4f60\u597d"],
+  ["%zz%66%a", "", ""],
+  // ASCII lowercasing.
+  ["EXAMPLE.COM", "example.com", "example.com"],
+  ["XN--BCHER-KVA.DE", "xn--bcher-kva.de", "b\u00fccher.de"],
+  // IPv4 canonicalization and rejection.
+  ["0x7f.1", "127.0.0.1", "127.0.0.1"],
+  ["0x7f.0x0.0x0.0x1", "127.0.0.1", "127.0.0.1"],
+  ["192.168.1.1", "192.168.1.1", "192.168.1.1"],
+  ["999.999.999.999", "", ""],
+  ["1.2.3.4.5", "", ""],
+  ["09.1", "", ""],
+  // IPv6.
+  ["[::1]", "[::1]", "[::1]"],
+  ["[0:0:0:0:0:0:0:1]", "[::1]", "[::1]"],
+  ["[::ffff:127.0.0.1]", "[::ffff:7f00:1]", "[::ffff:7f00:1]"],
+  ["[", "", ""],
+  ["[:", "", ""],
+  // Tab/newline stripping, truncation, and authority characters.
+  ["ex\tample.com", "example.com", "example.com"],
+  ["a\r\nb", "ab", "ab"],
+  ["a/b", "a", "a"],
+  ["a?b", "a", "a"],
+  ["a#b", "a", "a"],
+  ["a\\b", "a", "a"],
+  ["a:80", "", ""],
+  // Valid domains are preserved.
+  ["example.com", "example.com", "example.com"],
+  ["b\u00fccher.de", "xn--bcher-kva.de", "b\u00fccher.de"],
+  ["xn--bcher-kva.de", "xn--bcher-kva.de", "b\u00fccher.de"],
+  ["\u00e7.com", "xn--7ca.com", "\u00e7.com"],
+  ["xn--ls8h.example", "xn--ls8h.example", "\u{1f4a9}.example"],
+  ["xn--6qqa088eba", "xn--6qqa088eba", "\u4f60\u597d\u4f60\u597d"],
+  ["a..b", "a..b", "a..b"],
+  [".", ".", "."],
+  ["..", "..", ".."],
+  ["example.com.", "example.com.", "example.com."],
+  ["a_b.example", "a_b.example", "a_b.example"],
+  ["a-.example", "a-.example", "a-.example"],
+  ["-a.example", "-a.example", "-a.example"],
+  ["ab--c.example", "ab--c.example", "ab--c.example"],
+  ["r4---sn-a5mlrn7s.gevideo.com", "r4---sn-a5mlrn7s.gevideo.com", "r4---sn-a5mlrn7s.gevideo.com"],
+  // IDNA mapping, deviation, and context rules.
+  ["x\u200bn--a.example", "", ""],
+  ["xn--te\u0161la", "", ""],
+  ["\ufffd.example", "", ""],
+  ["fa\u00df.de", "xn--fa-hia.de", "fa\u00df.de"],
+  ["\u0130.com", "xn--i-9bb.com", "i\u0307.com"],
+  ["\u03c2.com", "xn--3xa.com", "\u03c2.com"],
+  ["\u0dc1\u0dca\u200d\u0dbb\u0dd3", "xn--10cl1a0b660p", "\u0dc1\u0dca\u200d\u0dbb\u0dd3"],
+  ["\u30c6\u30b9\u30c8.example", "xn--zckzah.example", "\u30c6\u30b9\u30c8.example"],
+  ["\u200d.example", "", ""],
+  ["look\u200cout.net", "", ""],
+  ["", "", ""],
+];
+
 describe("url.domainToASCII", () => {
   for (const [domain, ascii] of pairs) {
     test(`convert from '${domain}' to '${ascii}'`, () => {
@@ -96,6 +180,17 @@ describe("url.domainToUnicode", () => {
   for (const [input, expected] of invalids) {
     test(`-> '${input}' is '${expected}'`, () => {
       expect(url.domainToASCII(input)).toEqual(expected);
+    });
+  }
+});
+
+describe("WHATWG host parser parity", () => {
+  for (const [input, ascii, unicode] of hostParserParity) {
+    test(`${JSON.stringify(input)}`, () => {
+      expect({
+        ascii: url.domainToASCII(input),
+        unicode: url.domainToUnicode(input),
+      }).toEqual({ ascii, unicode });
     });
   }
 });


### PR DESCRIPTION
`node:url`'s `domainToASCII` and `domainToUnicode` never signal failure. Node returns the documented empty string for an invalid domain; Bun echoes the input back as if it were valid.

```js
const { domainToASCII } = require("node:url");
domainToASCII("xn--a-ecp.example"); // node: ""   bun: "xn--a-ecp.example"
domainToASCII("a%b");               // node: ""   bun: "a%b"
```

These two functions are the hostname *validation* API, so "returns `''` on failure" is the whole contract. Under Bun every invalid domain "succeeds", so allowlist and normalization code that checks the return value gets no failure signal.

### Cause

`jsDomainToASCII` in `src/jsc/bindings/NodeURL.cpp` returns any all-ASCII input unchanged without running IDNA at all:

```cpp
if (domain.containsOnlyASCII())
    return JSC::JSValue::encode(arg0);
```

so invalid Punycode in an `xn--` label (`xn--a-ecp` decodes to `a` + U+2488 DIGIT ONE FULL STOP, which UTS-46 disallows) is never rejected. Its forbidden code point check also uses the spec's weaker "forbidden host code point" list rather than the "forbidden domain code point" list, so `%`, C0 controls, and U+007F slip through. `jsDomainToUnicode` additionally returns any non-Latin-1 string unchanged.

The divergence goes past failure signaling. Node defines both functions in terms of the WHATWG host parser (`ws://x` + `set_hostname(input)`, `""` on failure), so it also percent-decodes, lowercases, canonicalizes IPv4, strips ASCII tab and newline, and truncates at `/ ? # \`. Bun does none of that:

| input | node `domainToASCII` | bun `domainToASCII` |
|---|---|---|
| `"xn--a-ecp.example"` | `""` | `"xn--a-ecp.example"` |
| `"a%b"` | `""` | `"a%b"` |
| `"a\x01b"` | `""` | `"a\x01b"` |
| `"%41"` | `"a"` | `"%41"` |
| `"EXAMPLE.COM"` | `"example.com"` | `"EXAMPLE.COM"` |
| `"0x7f.1"` | `"127.0.0.1"` | `"0x7f.1"` |
| `"999.999.999.999"` | `""` | `"999.999.999.999"` |

### Fix

Implement both functions the way Node defines them: run the WHATWG host parser and report its failure.

`WTF::URL::setHost` on a `ws://x` base is exactly that parser, and it already matched Node on every case above except the `xn--` labels (WebKit's `URLParser` takes a fast path for all-ASCII hosts that skips UTS-46 entirely). So `processDomain` now:

1. strips ASCII tab and newline (the basic URL parser's step 3; `setHost` applies IDNA to its raw argument before the parse removes them, which would otherwise bake a tab into a Punycode label),
2. runs `URL::setHost` and returns a null string on failure,
3. runs the real `uidna_nameToASCII` / `uidna_nameToUnicode` on the parsed ASCII host with the same transcoder and allowed-error mask the URL parser uses, which rejects the invalid `xn--` labels the fast path let through and produces the decoded form for `domainToUnicode`.

IPv6 literals are returned as-is (UTS-46 does not apply). `domainToASCII`/`domainToUnicode` of `null`, `undefined`, and a non-string argument are unchanged.

### Verification

Differential against Node v26.3.0:

- a 72-case hand-built matrix (invalid Punycode, forbidden domain code points, percent-decoding, IPv4, IPv6, case folding, tab/newline, truncation, IDNA deviation/joiner/bidi rules) matches Node exactly
- 6,222 + 25,222 pseudo-random inputs over an adversarial alphabet: 25,178 / 25,222 byte-identical. Every one of the 44 residual diffs is the known ICU-vs-ada gap below, and none of them is a verdict difference for `domainToASCII`.

The new cases in `test/js/node/url/url-domain-ascii-unicode.test.js` are a 75-row `[input, domainToASCII, domainToUnicode]` table generated from Node. 45 of the file's 201 tests fail on the released Bun; all 201 pass with this change. The file's pre-existing tests (all the valid conversion pairs, `null`/`undefined`, `@`, a raw IPv6 address) still pass.

### Known remaining divergence

Node (ada) rejects any label that begins with `xn--xn--` (a doubly ACE-prefixed label, a newer UTS-46 rule); the ICU pinned through WebKit accepts it when the decoded label is otherwise valid, e.g. `domainToASCII("xn--xn--4ka")` is `""` in Node and `"xn--xn--4ka"` here. `new URL` behaves the same way in Bun and in Safari, such labels cannot be registered, and closing the gap needs an ICU/WebKit update rather than a special case in `domainToASCII`, so it is left alone here.

### Relationship to #33201

#33201 fixes the sibling bug in the `URL` class (`new URL("http://xn--a-ecp.example/")` should throw). As a rider it also gates `jsDomainToASCII`'s fast path on "the domain has an `xn--` label", which covers the first repro above but not the second (`a%b` has no `xn--` label, so it still takes the fast path there), nor `domainToUnicode`, percent-decoding, IPv4, or case folding. This PR replaces that `NodeURL.cpp` hunk; #33201's `URL`-class changes (`BunIDNA`, `DOMURL`, `URLDecomposition`) are a different surface and are not touched here. The two conflict only on `NodeURL.cpp` and `url-domain-ascii-unicode.test.js`; whichever lands second gets rebased.
