### PR TITLE
Fail `bun run` on a malformed bunfig.toml; detect tsconfig `extends` cycles

### DIFF
--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -121,10 +121,13 @@ pub fn load_config_path(
     load_bunfig(cmd, auto_loaded, config_path, ctx)
 }
 
+/// Print the accumulated parse log (the concrete TOML error and its location)
+/// followed by the "failed to load bunfig" error, then exit 1. The shared
+/// user-facing presentation of a malformed `bunfig.toml`.
 #[cold]
-fn report_bunfig_load_failure(log: *mut bun_ast::Log, err: crate::Error) -> ! {
+pub fn report_bunfig_load_failure(ctx: Context<'_>, err: crate::Error) -> ! {
     // SAFETY: process-global Log; see `load_bunfig` note.
-    let log = unsafe { &mut *log };
+    let log = unsafe { &mut *ctx.log };
     if log.has_any() {
         let _ = log.print(std::ptr::from_mut(Output::error_writer()));
         Output::print_error("\n");
@@ -158,7 +161,7 @@ pub fn load_config(
 
             if let Some(path) = get_home_config_path(&mut config_buf) {
                 if let Err(err) = load_config_path(cmd, true, path, ctx) {
-                    report_bunfig_load_failure(ctx.log, err);
+                    report_bunfig_load_failure(ctx, err);
                 }
             }
         }
@@ -221,7 +224,7 @@ pub fn load_config(
     let config_path = ZStr::from_buf(&config_buf[..], config_path_len);
 
     if let Err(err) = load_config_path(cmd, auto_loaded, config_path, ctx) {
-        report_bunfig_load_failure(ctx.log, err);
+        report_bunfig_load_failure(ctx, err);
     }
     Ok(())
 }

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -126,6 +126,7 @@ pub fn load_config_path(
 /// user-facing presentation of a malformed `bunfig.toml`.
 #[cold]
 pub fn report_bunfig_load_failure(ctx: Context<'_>, err: crate::Error) -> ! {
+    debug_assert!(!ctx.log.is_null());
     // SAFETY: process-global Log; see `load_bunfig` note.
     let log = unsafe { &mut *ctx.log };
     if log.has_any() {

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -121,9 +121,7 @@ pub fn load_config_path(
     load_bunfig(cmd, auto_loaded, config_path, ctx)
 }
 
-/// Print the accumulated parse log (the concrete TOML error and its location)
-/// followed by the "failed to load bunfig" error, then exit 1. The shared
-/// user-facing presentation of a malformed `bunfig.toml`.
+/// Print the parse log and the `failed to load bunfig` error, then exit 1.
 #[cold]
 pub fn report_bunfig_load_failure(ctx: Context<'_>, err: crate::Error) -> ! {
     debug_assert!(!ctx.log.is_null());

--- a/src/bunfig/lib.rs
+++ b/src/bunfig/lib.rs
@@ -12,6 +12,8 @@ pub mod arguments;
 pub mod bunfig;
 pub mod error;
 
-pub use arguments::{load_config, load_config_path, load_config_with_cmd_args};
+pub use arguments::{
+    load_config, load_config_path, load_config_with_cmd_args, report_bunfig_load_failure,
+};
 pub use bunfig::Bunfig;
 pub use error::{Error, Result};

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6366,20 +6366,14 @@ impl<'a> Resolver<'a> {
                     );
                     while !current.extends.is_empty() {
                         let ts_dir_name = Dirname::dirname(&current.abs_path);
-                        // `Platform::Loose` so the joined path uses the same
-                        // separator normalization as `abs_buf` (which built
-                        // `parent_configs[0].abs_path`); the cycle check below
-                        // compares the two byte-for-byte.
+                        // Loose: same normalization as `abs_buf` so the cycle check can byte-compare.
                         let abs_path = ResolvePath::join_abs_string_buf(
                             ts_dir_name,
                             bufs!(tsconfig_path_abs),
                             &[ts_dir_name, &current.extends],
                             bun_paths::Platform::Loose,
                         );
-                        // An `extends` that resolves back into the chain would
-                        // otherwise re-parse forever until `parent_configs`
-                        // overflows, surfacing `error.Overflow` to the user.
-                        // Match esbuild: warn and stop following.
+                        // Match esbuild: stop following a cyclic `extends` with a warning.
                         if parent_configs.iter().any(|&visited| {
                             // SAFETY: see loop-wide note above; every pointer in
                             // `parent_configs` stays live until the merge loop below.
@@ -6395,9 +6389,7 @@ impl<'a> Resolver<'a> {
                             );
                             break;
                         }
-                        // Reserve the slot before parsing so a chain deeper than
-                        // the array's capacity stops cleanly instead of leaking the
-                        // freshly parsed config and propagating `error.Overflow`.
+                        // Reserve before parsing: a full array would leak the fresh alloc.
                         if parent_configs.ensure_unused_capacity(1).is_err() {
                             let _ = self.log_mut().add_warning_fmt(
                                 None,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6366,12 +6366,49 @@ impl<'a> Resolver<'a> {
                     );
                     while !current.extends.is_empty() {
                         let ts_dir_name = Dirname::dirname(&current.abs_path);
+                        // `Platform::Loose` so the joined path uses the same
+                        // separator normalization as `abs_buf` (which built
+                        // `parent_configs[0].abs_path`); the cycle check below
+                        // compares the two byte-for-byte.
                         let abs_path = ResolvePath::join_abs_string_buf(
                             ts_dir_name,
                             bufs!(tsconfig_path_abs),
                             &[ts_dir_name, &current.extends],
-                            bun_paths::Platform::AUTO,
+                            bun_paths::Platform::Loose,
                         );
+                        // An `extends` that resolves back into the chain would
+                        // otherwise re-parse forever until `parent_configs`
+                        // overflows, surfacing `error.Overflow` to the user.
+                        // Match esbuild: warn and stop following.
+                        if parent_configs.iter().any(|&visited| {
+                            // SAFETY: see loop-wide note above; every pointer in
+                            // `parent_configs` stays live until the merge loop below.
+                            strings::eql(unsafe { &(*visited).abs_path }, abs_path)
+                        }) {
+                            let _ = self.log_mut().add_warning_fmt(
+                                None,
+                                bun_ast::Loc::EMPTY,
+                                format_args!(
+                                    "Base config file {} forms cycle",
+                                    bun_core::fmt::quote(&current.extends)
+                                ),
+                            );
+                            break;
+                        }
+                        // Reserve the slot before parsing so a chain deeper than
+                        // the array's capacity stops cleanly instead of leaking the
+                        // freshly parsed config and propagating `error.Overflow`.
+                        if parent_configs.ensure_unused_capacity(1).is_err() {
+                            let _ = self.log_mut().add_warning_fmt(
+                                None,
+                                bun_ast::Loc::EMPTY,
+                                format_args!(
+                                    "tsconfig \"extends\" chain is too long; ignoring {} and the rest of the chain",
+                                    bun_core::fmt::quote(&current.extends)
+                                ),
+                            );
+                            break;
+                        }
                         let parent_config_maybe: Option<*mut TSConfigJSON> =
                             match self.parse_tsconfig(abs_path, FD::INVALID) {
                                 Ok(v) => v.map(bun_core::heap::into_raw),
@@ -6389,7 +6426,7 @@ impl<'a> Resolver<'a> {
                                 }
                             };
                         if let Some(parent_config) = parent_config_maybe {
-                            parent_configs.append(parent_config)?;
+                            parent_configs.append_assume_capacity(parent_config);
                             current = bun_ptr::BackRef::from(
                                 core::ptr::NonNull::new(parent_config).expect("heap alloc"),
                             );

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -705,7 +705,9 @@ pub(crate) static Bun__Node__UseSystemCA: core::sync::atomic::AtomicBool =
 // their private helpers moved to `bun_bunfig::arguments` so `bun_install` can
 // call them without a tier-6 dependency. Re-export here so existing
 // `crate::cli::arguments::load_config*` callers are unaffected.
-pub use bun_bunfig::arguments::{load_config, load_config_path, load_config_with_cmd_args};
+pub use bun_bunfig::arguments::{
+    load_config, load_config_path, load_config_with_cmd_args, report_bunfig_load_failure,
+};
 
 /// Parse `argv` into `api::TransformOptions` for the given subcommand.
 ///

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2380,12 +2380,17 @@ impl RunCommand {
         if !ctx.debug.loaded_bunfig {
             // `Arguments::load_config_path` — loads global bunfig (if the
             // command opts in via `read_global_config`) then `bunfig.toml`.
-            let _ = arguments::load_config_path(
+            // A malformed bunfig is a hard error, matching every other entry
+            // point (`bun <file>`, `bun -e`, `bun install`); dropping it here
+            // silently ran the script with default config.
+            if let Err(err) = arguments::load_config_path(
                 CommandTag::RunCommand,
                 true,
                 bun_core::zstr!("bunfig.toml"),
                 ctx,
-            );
+            ) {
+                arguments::report_bunfig_load_failure(ctx, err);
+            }
         }
 
         // ── try fast run (file exists & not a dir → boot VM) ────────────────

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2380,9 +2380,7 @@ impl RunCommand {
         if !ctx.debug.loaded_bunfig {
             // `Arguments::load_config_path` — loads global bunfig (if the
             // command opts in via `read_global_config`) then `bunfig.toml`.
-            // A malformed bunfig is a hard error, matching every other entry
-            // point (`bun <file>`, `bun -e`, `bun install`); dropping it here
-            // silently ran the script with default config.
+            // A malformed bunfig is a hard error, matching every other entry point.
             if let Err(err) = arguments::load_config_path(
                 CommandTag::RunCommand,
                 true,

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -19,6 +19,35 @@ describe("bun", () => {
     expect(exitCode).toBe(1);
   });
 
+  // `bun run` used to discard the bunfig parse error and proceed with default
+  // config, while `bun <file>`, `bun -e`, and `bun install` already exited 1.
+  test.each(["start", "./index.ts"])("a malformed bunfig.toml fails `bun run %s`", async target => {
+    using dir = tempDir("run-bad-bunfig", {
+      "bunfig.toml": "[install]\nregistry = \n",
+      "index.ts": `console.log("RAN_THE_SCRIPT");`,
+      "package.json": JSON.stringify({
+        name: "bad-bunfig",
+        version: "1.0.0",
+        scripts: { start: "echo RAN_THE_SCRIPT" },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", target],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stdout).not.toContain("RAN_THE_SCRIPT");
+    expect(stderr).toContain("failed to load bunfig");
+    expect(exitCode).toBe(1);
+  });
+
   test("an empty-string script value is not a runnable script", () => {
     using dir = tempDir("empty-script", {
       "package.json": JSON.stringify({ scripts: { build: "" } }),

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -38,11 +38,7 @@ describe("bun", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).not.toContain("RAN_THE_SCRIPT");
     expect(stderr).toContain("failed to load bunfig");
     expect(exitCode).toBe(1);

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -191,10 +191,11 @@ describe("tsconfig 'extends' cycle", () => {
 
 // A non-cyclic chain deeper than the resolver's bounded parent array must
 // also stop with a warning instead of an internal `Overflow` error.
-test("tsconfig 'extends' chain deeper than the resolver's capacity does not abort `bun run`", async () => {
+test("tsconfig 'extends' chain deeper than the resolver's capacity does not abort", async () => {
   const chainDepth = 80;
   const files: Record<string, string> = {
     "tsconfig.json": JSON.stringify({ extends: "./tsconfig.1.json" }),
+    "index.js": `console.log("RAN_THE_SCRIPT");`,
     "package.json": JSON.stringify({
       name: "x",
       version: "1.0.0",
@@ -206,16 +207,29 @@ test("tsconfig 'extends' chain deeper than the resolver's capacity does not abor
   }
   using dir = tempDir("tsconfig-extends-too-deep", files);
 
-  await using proc = Bun.spawn({
+  await using run = Bun.spawn({
     cmd: [bunExe(), "run", "start"],
     env: bunEnv,
     cwd: String(dir),
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+  expect(runErr).not.toContain("Overflow");
+  expect(runOut).toContain("RAN_THE_SCRIPT");
+  expect(runExit).toBe(0);
 
-  expect(stderr).not.toContain("Overflow");
-  expect(stdout).toContain("RAN_THE_SCRIPT");
-  expect(exitCode).toBe(0);
+  // The diagnostic surfaces through the transpiler log, which `bun <file>`
+  // flushes; `bun run <script>` shells out and never does.
+  await using file = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [fileOut, fileErr, fileExit] = await Promise.all([file.stdout.text(), file.stderr.text(), file.exited]);
+  expect(fileErr).toContain(`"extends" chain is too long`);
+  expect(fileOut).toContain("RAN_THE_SCRIPT");
+  expect(fileExit).toBe(0);
 });

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -12,7 +12,7 @@
 // the debug-build `BUN_DEBUG_alloc=1` instrumentation which logs every
 // bun.new()/bun.destroy() call, and count TSConfigJSON lifetimes directly.
 
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import path from "path";
 
@@ -120,5 +120,102 @@ test("tsconfig 'extends' merge still works after freeing intermediates", async (
 
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("leaf");
+  expect(exitCode).toBe(0);
+});
+
+// An "extends" cycle must be detected and stopped with a warning. It must
+// never abort the directory load with `error: Overflow loading directory`.
+describe("tsconfig 'extends' cycle", () => {
+  const cycles: Record<string, Record<string, string>> = {
+    "two-file": {
+      "tsconfig.json": JSON.stringify({ extends: "./tsconfig.base.json" }),
+      "tsconfig.base.json": JSON.stringify({ extends: "./tsconfig.json" }),
+    },
+    "self-extend": {
+      "tsconfig.json": JSON.stringify({ extends: "./tsconfig.json" }),
+    },
+  };
+
+  test.each(Object.keys(cycles))("does not abort `bun run <script>` (%s)", async kind => {
+    using dir = tempDir(`tsconfig-extends-cycle-${kind}`, {
+      ...cycles[kind],
+      "package.json": JSON.stringify({
+        name: "x",
+        version: "1.0.0",
+        scripts: { start: "echo RAN_THE_SCRIPT" },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "start"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Overflow");
+    expect(stdout).toContain("RAN_THE_SCRIPT");
+    expect(exitCode).toBe(0);
+  });
+
+  // A cycle must not discard the tsconfig wholesale: everything merged up to
+  // the point the cycle is detected (here, `paths`) still applies.
+  test("keeps the config merged up to the cycle", async () => {
+    using dir = tempDir("tsconfig-extends-cycle-paths", {
+      "tsconfig.json": JSON.stringify({
+        extends: "./tsconfig.base.json",
+        compilerOptions: { paths: { "@leaf/*": ["./lib/*"] } },
+      }),
+      "tsconfig.base.json": JSON.stringify({ extends: "./tsconfig.json" }),
+      "lib/thing.ts": `export const who = "resolved";`,
+      "index.ts": `import { who } from "@leaf/thing"; console.log(who);`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Cannot find module");
+    expect(stderr).toContain(`Base config file "./tsconfig.json" forms cycle`);
+    expect(stdout.trim()).toBe("resolved");
+    expect(exitCode).toBe(0);
+  });
+});
+
+// A non-cyclic chain deeper than the resolver's bounded parent array must
+// also stop with a warning instead of an internal `Overflow` error.
+test("tsconfig 'extends' chain deeper than the resolver's capacity does not abort `bun run`", async () => {
+  const chainDepth = 80;
+  const files: Record<string, string> = {
+    "tsconfig.json": JSON.stringify({ extends: "./tsconfig.1.json" }),
+    "package.json": JSON.stringify({
+      name: "x",
+      version: "1.0.0",
+      scripts: { start: "echo RAN_THE_SCRIPT" },
+    }),
+  };
+  for (let i = 1; i <= chainDepth; i++) {
+    files[`tsconfig.${i}.json`] = JSON.stringify(i < chainDepth ? { extends: `./tsconfig.${i + 1}.json` } : {});
+  }
+  using dir = tempDir("tsconfig-extends-too-deep", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "start"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Overflow");
+  expect(stdout).toContain("RAN_THE_SCRIPT");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/highlighter.test.ts
+++ b/test/js/bun/util/highlighter.test.ts
@@ -69,7 +69,10 @@ test("bunfig error on a line ending in `${}` does not crash", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The highlighter printed the source line without panicking. A malformed
+  // bunfig is a hard startup error for `bun run`, so the script never runs.
   expect(stderr).toContain("expected string");
-  expect(stdout).toContain("hi");
-  expect(exitCode).toBe(0);
+  expect(stderr).toContain("failed to load bunfig");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
Two config parse failures that surfaced in the wrong shape, both found by fuzzing entry-point consistency.

### 1. `bun run <script>` silently ignores a malformed `bunfig.toml`

```sh
printf '[install]\nregistry = \n' > bunfig.toml   # any syntax error
bun run start   # exit 0: the script runs with DEFAULT config
bun -e '1'      # exit 1: "SyntaxError: failed to load bunfig"
bun install     # exit 1
```

The dangerous half is the silent one: a typo (or merge artifact) in `bunfig.toml` means your registry, `[run]` settings, and defines just stop applying for `bun run`, with no message, while `bun install` in the same directory errors.

**Cause:** `RunCommand::exec_with_cfg` loads the bunfig lazily (`RunCommand` is deliberately absent from `ALWAYS_LOADS_CONFIG`, so the eager path in `Arguments::parse` skips it) and then discards the result:

```rust
// src/runtime/cli/run_command.rs
let _ = arguments::load_config_path(CommandTag::RunCommand, true, zstr!("bunfig.toml"), ctx);
```

Every other entry point goes through `Arguments::load_config`, which routes a failure to `report_bunfig_load_failure` (print the TOML error, print `failed to load bunfig`, exit 1).

**Fix:** route the `bun run` load through that same `report_bunfig_load_failure`, now `pub` (and taking `Context<'_>` instead of a raw `*mut Log`, so it can be public without clippy's `not_unsafe_ptr_arg_deref`). `bun run <script>` and `bun run <file>` now behave like `bun <file>`:

```
$ bun run start
2 | registry =
               ^
error: Unexpected end of file
    at bunfig.toml:2:12

SyntaxError: failed to load bunfig
$ echo $?
1
```

A missing `bunfig.toml` is unaffected; only a present and malformed one errors, exactly as on the eager path.

### 2. A `tsconfig.json` `extends` cycle kills every `bun run` in the tree

```sh
printf '{"extends":"./tsconfig.base.json"}\n' > tsconfig.json
printf '{"extends":"./tsconfig.json"}\n'      > tsconfig.base.json
bun run start
# error: Overflow loading directory "/tmp/x"
# error: An internal error occurred (Overflow)
```

**Cause:** the `extends` chain walk in `Resolver::dir_info_uncached` has no cycle detection. It re-parses the cycle until the `BoundedArray<*mut TSConfigJSON, 64>` overflows, and the internal `error.Overflow` propagates out of `read_dir_info` as a fatal error.

On the `bun <file>` and bundler path the same overflow is *swallowed* (`if let Ok(Some(..)) = read_dir_info(..)` in `configure_linker_with_auto_jsx`), which is arguably worse: a cyclic chain silently discards the entire tsconfig, `paths` included.

```sh
# tsconfig.json also has "paths": {"@leaf/*": ["./lib/*"]}
bun index.ts
# error: Cannot find module '@leaf/thing'
```

**Fix:** before following an `extends`, check whether the resolved absolute path is already in the chain. If so, emit esbuild's warning and stop:

```
$ bun index.ts
resolved
warn: Base config file "./tsconfig.json" forms cycle
```

Both cycle shapes (A extends B extends A, and a self-extend) are handled, everything merged up to the cycle point still applies, and `bun build`/`bun run` no longer abort. A non-cyclic chain deeper than the array's capacity also stops with a warning instead of the internal `Overflow`.

The chain is now joined with `Platform::Loose`, matching `abs_buf` (which builds `parent_configs[0].abs_path` with `Loose`). They previously used different platforms, so on Windows the root's `abs_path` was `/`-separated while the children's were `\`-separated; the cycle check compares byte-for-byte, so they have to agree.

esbuild detects this with a visited set and emits the same warning; Bun already has that scenario ported as `itBundled("tsconfig/JsonExtendsLoop")`, whose `expectedScanLog` is a `TODO FIX` because that fixture also relies on `extends` extension probing (`./tsconfig` resolving to `./tsconfig.json`), which Bun does not implement. That test is unchanged and still passes.

### Verification

- `test/cli/run/run_command.test.ts`: `bun run start` and `bun run ./index.ts` with a malformed bunfig must exit 1 with `failed to load bunfig` and must not run the script.
- `test/js/bun/resolve/tsconfig-extends-leak.test.ts`: two-file cycle, self-extend, a cycle with `paths` (asserts the alias resolves and the `forms cycle` warning is emitted), and an 80-deep non-cyclic chain.

One existing test asserted the old `bun run` behavior and is updated rather than deleted: the end-to-end case in `test/js/bun/util/highlighter.test.ts` feeds a malformed `bunfig.toml` (``logLevel = 3 # `${}``) through `bun run` and expected the script to still run (`stdout` contains `hi`, exit 0). That was the bug. The property it was written to protect, that the error's source line is printed through the redacting highlighter without panicking (`stderr` contains `expected string`), is kept; the assertions on the script running are flipped to the new hard-error semantics.

All six new tests fail on `main` with the exact reported symptoms and pass with the fix. `test/bundler/esbuild/tsconfig.test.ts`, `test/cli/run/tsconfig-override.test.ts`, `test/config/bunfig/preload.test.ts`, and `test/cli/bunfig-test-options.test.ts` are unaffected.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run_command.test.ts

<!-- robobun:evidence:end -->