### PR TITLE
url: reject an empty string base in the URL constructor

### DIFF
--- a/src/jsc/bindings/webcore/JSDOMURL.cpp
+++ b/src/jsc/bindings/webcore/JSDOMURL.cpp
@@ -162,7 +162,9 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMURLDOMConstructor::const
     EnsureStillAliveScope argument1 = callFrame->argument(1);
     auto base = argument1.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    auto object = base.isEmpty() ? DOMURL::create(WTF::move(url)) : DOMURL::create(WTF::move(url), WTF::move(base));
+    // A null base means no base argument. An empty string is a real base and must be
+    // parsed (and rejected) like DOMURL::parse/canParse do, per the URL spec.
+    auto object = base.isNull() ? DOMURL::create(WTF::move(url)) : DOMURL::create(WTF::move(url), WTF::move(base));
     if constexpr (IsExceptionOr<decltype(object)>)
         RETURN_IF_EXCEPTION(throwScope, {});
     static_assert(TypeOrExceptionOrUnderlyingType<decltype(object)>::isRef);

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -25,9 +25,7 @@ describe("url", () => {
     expect(() => new URL("http://example.com/", "")).toThrow(
       '"http://example.com/" cannot be parsed as a URL against ""',
     );
-    expect(() => new URL("http://example.com/", "")).toThrow(
-      expect.objectContaining({ code: "ERR_INVALID_URL" }),
-    );
+    expect(() => new URL("http://example.com/", "")).toThrow(expect.objectContaining({ code: "ERR_INVALID_URL" }));
     // The constructor must agree with the static validators.
     expect(URL.canParse("http://example.com/", "")).toBe(false);
     expect(URL.parse("http://example.com/", "")).toBeNull();

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -38,6 +38,19 @@ describe("url", () => {
     expect(URL.parse("http://example.com/", undefined)?.href).toBe("http://example.com/");
   });
 
+  // An explicit null base is coerced to the string "null" by WebIDL, which is not a
+  // valid URL, so it is a real (and invalid) base rather than no base.
+  it("treats an explicit null base as an invalid base, not as no base", () => {
+    // @ts-expect-error
+    expect(() => new URL("http://example.com/", null)).toThrow(
+      '"http://example.com/" cannot be parsed as a URL against "null"',
+    );
+    // @ts-expect-error
+    expect(URL.canParse("http://example.com/", null)).toBe(false);
+    // @ts-expect-error
+    expect(URL.parse("http://example.com/", null)).toBeNull();
+  });
+
   it("should have correct origin and protocol", () => {
     var url = new URL("https://example.com");
     expect(url.protocol).toBe("https:");

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -19,6 +19,27 @@ describe("url", () => {
     );
   });
 
+  // https://url.spec.whatwg.org/#url-class: a provided base is always parsed, and an
+  // empty string is not a valid URL, so it must be rejected even if the input is absolute.
+  it("rejects an empty string base", () => {
+    expect(() => new URL("http://example.com/", "")).toThrow(
+      '"http://example.com/" cannot be parsed as a URL against ""',
+    );
+    expect(() => new URL("http://example.com/", "")).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_URL" }),
+    );
+    // The constructor must agree with the static validators.
+    expect(URL.canParse("http://example.com/", "")).toBe(false);
+    expect(URL.parse("http://example.com/", "")).toBeNull();
+  });
+
+  it("treats only an undefined base as no base", () => {
+    expect(new URL("http://example.com/", undefined).href).toBe("http://example.com/");
+    expect(new URL("http://example.com/").href).toBe("http://example.com/");
+    expect(URL.canParse("http://example.com/", undefined)).toBe(true);
+    expect(URL.parse("http://example.com/", undefined)?.href).toBe("http://example.com/");
+  });
+
   it("should have correct origin and protocol", () => {
     var url = new URL("https://example.com");
     expect(url.protocol).toBe("https:");


### PR DESCRIPTION
### Problem

`new URL(absolute, "")` succeeds when it should throw, and it disagrees with Bun's own `URL.parse` and `URL.canParse` on the same input:

```js
new URL("http://x/", "").href    // Bun: "http://x/"   Node, Chrome, Safari: TypeError
URL.canParse("http://x/", "")    // false
URL.parse("http://x/", "")       // null
```

Per the [URL spec](https://url.spec.whatwg.org/#url-class), a provided base is always run through the URL parser, and an empty string is not a valid URL, so the constructor must throw even when the input is absolute. This breaks the `canParse(x, base) && new URL(x, base)` validation pattern: the guard says invalid and the constructor then accepts the construction anyway.

### Cause

`JSDOMURLDOMConstructor::construct` dispatched on `base.isEmpty()` to decide whether a base was supplied:

```cpp
auto object = base.isEmpty() ? DOMURL::create(url) : DOMURL::create(url, base);
```

A WTF null `String` (the base argument was `undefined`) and a real `""` are both `isEmpty()`, so an empty string base was silently treated as no base. `DOMURL::parse` and `DOMURL::canParse` already use the correct `isNull()` predicate, which is why the statics disagreed with the constructor. The `isEmpty()` dispatch was introduced in #10129; before that the binding always called the two argument `DOMURL::create(url, base)`, which checks `base.isNull()` itself.

### Fix

Use `isNull()`, matching `DOMURL::parse`/`canParse` and the null `String()` sentinel the other in-tree `DOMURL::create` callers already pass for "no base".

```js
new URL("http://x/", "")
// TypeError: "http://x/" cannot be parsed as a URL against ""  (code: ERR_INVALID_URL)
```

`new URL(x)` and `new URL(x, undefined)` keep the single argument path and its shorter error message, so the existing error message assertions are unchanged.

### Verification

Tests added to `test/js/web/url/url.test.ts`:
- `rejects an empty string base` covers the constructor, `URL.parse`, and `URL.canParse` agreeing on the same input. It fails on the unfixed build (the constructor returns a `URL` instead of throwing) and passes with the fix.
- `treats only an undefined base as no base` guards the missing / `undefined` base paths that must keep working.
- `treats an explicit null base as an invalid base, not as no base` documents the WebIDL coercion of a JS `null` to the string `"null"`, a real (and invalid) base that all three entry points reject. This path was already correct and is unchanged by the fix; it pins down the remaining spelling of the base argument.

All existing tests in `test/js/web/url/` and `test/js/node/url/` pass. The only failures in those directories are two pre-existing 5s timeouts on loop tests that are slow under the debug + ASAN build (`pathToFileURL doesn't leak memory`, `URL.canParse repeatedly called produces same result`); they time out identically with and without this change and never reach the constructor's base dispatch.

