### PR TITLE
Bun.Archive: support per-entry file modes when creating archives

### DIFF
--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -60,6 +60,7 @@ File contents can be:
 - **Blobs** - Binary data
 - **ArrayBufferViews** (such as `Uint8Array`) - Raw bytes
 - **ArrayBuffers** - Raw binary data
+- **`{ data, mode }`** - Any of the above plus a Unix file mode (default `0o644`)
 
 ```ts
 const data = "binary data";
@@ -72,6 +73,19 @@ const archive = new Bun.Archive({
   "buffer.bin": arrayBuffer,
 });
 ```
+
+### Setting file modes
+
+Pass `{ data, mode }` to set a per-entry Unix file mode. This is how you ship an executable binary inside a tarball (e.g. an npm platform package), since otherwise every entry defaults to `0o644`:
+
+```ts
+const archive = new Bun.Archive({
+  "bin/mytool": { data: await Bun.file("./mytool").bytes(), mode: 0o755 },
+  "README.md": "hello",
+});
+```
+
+The mode is masked to `0o777`, so passing a full `fs.stat()` mode such as `0o100755` resolves to `0o755`.
 
 ### Writing Archives to Disk
 
@@ -397,8 +411,10 @@ await Bun.write("my-project.tar.gz", archive);
 > **Note**: The following type signatures are simplified. See [`packages/bun-types/bun.d.ts`](https://github.com/oven-sh/bun/blob/main/packages/bun-types/bun.d.ts) for the full type definitions.
 
 ```ts
+type ArchiveEntry = string | Blob | Bun.ArrayBufferView | ArrayBufferLike | { data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike; mode?: number };
+
 type ArchiveInput =
-  | Record<string, string | Blob | Bun.ArrayBufferView | ArrayBufferLike>
+  | Record<string, ArchiveEntry>
   | Blob
   | Bun.ArrayBufferView
   | ArrayBufferLike;

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -85,7 +85,7 @@ const archive = new Bun.Archive({
 });
 ```
 
-The mode is masked to `0o777`, so passing a full `fs.stat()` mode such as `0o100755` resolves to `0o755`. A descriptor must include `data`, and `mode` (when present) must be a non-negative integer; anything else throws a `TypeError`.
+`mode` is validated like the `node:fs` mode argument: a non-negative integer or an octal string such as `"755"`. It is masked to `0o777`, so a full `fs.stat()` mode such as `0o100755` resolves to `0o755`. A descriptor must include `data`, and an invalid `mode` is rejected with an error.
 
 ### Writing Archives to Disk
 
@@ -416,7 +416,7 @@ type ArchiveEntry =
   | Blob
   | Bun.ArrayBufferView
   | ArrayBufferLike
-  | { data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike; mode?: number };
+  | { data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike; mode?: number | string };
 
 type ArchiveInput = Record<string, ArchiveEntry> | Blob | Bun.ArrayBufferView | ArrayBufferLike;
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -85,7 +85,7 @@ const archive = new Bun.Archive({
 });
 ```
 
-The mode is masked to `0o777`, so passing a full `fs.stat()` mode such as `0o100755` resolves to `0o755`.
+The mode is masked to `0o777`, so passing a full `fs.stat()` mode such as `0o100755` resolves to `0o755`. A descriptor must include `data`, and `mode` (when present) must be a non-negative integer; anything else throws a `TypeError`.
 
 ### Writing Archives to Disk
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -411,13 +411,14 @@ await Bun.write("my-project.tar.gz", archive);
 > **Note**: The following type signatures are simplified. See [`packages/bun-types/bun.d.ts`](https://github.com/oven-sh/bun/blob/main/packages/bun-types/bun.d.ts) for the full type definitions.
 
 ```ts
-type ArchiveEntry = string | Blob | Bun.ArrayBufferView | ArrayBufferLike | { data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike; mode?: number };
-
-type ArchiveInput =
-  | Record<string, ArchiveEntry>
+type ArchiveEntry =
+  | string
   | Blob
   | Bun.ArrayBufferView
-  | ArrayBufferLike;
+  | ArrayBufferLike
+  | { data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike; mode?: number };
+
+type ArchiveInput = Record<string, ArchiveEntry> | Blob | Bun.ArrayBufferView | ArrayBufferLike;
 
 type ArchiveOptions = {
   /** Compression algorithm. Currently only "gzip" is supported. */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8978,7 +8978,8 @@ declare module "bun" {
 
   /**
    * A single archive entry. Either the file contents directly, or an object
-   * carrying the contents plus an optional Unix file mode.
+   * carrying the contents plus an optional Unix file mode. `mode` is validated
+   * like the `node:fs` mode argument: a non-negative integer or an octal string.
    *
    * @example
    * ```ts
@@ -8988,7 +8989,7 @@ declare module "bun" {
    * });
    * ```
    */
-  type ArchiveEntry = BlobPart | { data: BlobPart; mode?: number };
+  type ArchiveEntry = BlobPart | { data: BlobPart; mode?: number | string };
 
   /**
    * Input data for creating an archive. Can be:

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8977,12 +8977,27 @@ declare module "bun" {
   }
 
   /**
+   * A single archive entry. Either the file contents directly, or an object
+   * carrying the contents plus an optional Unix file mode.
+   *
+   * @example
+   * ```ts
+   * new Bun.Archive({
+   *   "bin/mytool": { data: bytes, mode: 0o755 },
+   *   "README.md": "hello",
+   * });
+   * ```
+   */
+  type ArchiveEntry = BlobPart | { data: BlobPart; mode?: number };
+
+  /**
    * Input data for creating an archive. Can be:
-   * - An object mapping paths to file contents (string, Blob, TypedArray, or ArrayBuffer)
+   * - An object mapping paths to file contents (string, Blob, TypedArray, or ArrayBuffer),
+   *   or to `{ data, mode }` entries to set a per-entry Unix file mode (default `0o644`)
    * - A Blob containing existing archive data
    * - A TypedArray or ArrayBuffer containing existing archive data
    */
-  type ArchiveInput = Record<string, BlobPart> | Blob | ArrayBufferView | ArrayBufferLike;
+  type ArchiveInput = Record<string, ArchiveEntry> | Blob | ArrayBufferView | ArrayBufferLike;
 
   /**
    * Compression format for archive output.
@@ -9132,6 +9147,15 @@ declare module "bun" {
      * const archive = new Bun.Archive({
      *   "hello.txt": "Hello, World!",
      *   "nested/file.txt": "Nested content",
+     * });
+     * ```
+     *
+     * @example
+     * **Set a per-entry Unix file mode (e.g. mark a binary executable):**
+     * ```ts
+     * const archive = new Bun.Archive({
+     *   "bin/mytool": { data: bytes, mode: 0o755 },
+     *   "README.md": "hello",
      * });
      * ```
      *

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -453,25 +453,14 @@ fn get_entry_data_and_perm(
     Ok((get_entry_data(global, value)?, DEFAULT_ENTRY_PERM))
 }
 
-/// Reads the optional `mode` of a `{ data, mode }` entry descriptor. Missing or
-/// undefined → default perm; present must be a non-negative integer and is
-/// masked to `0o777`, matching the bits the extraction path preserves.
+/// Reads the optional `mode` of a `{ data, mode }` entry descriptor through the
+/// same validator as the `node:fs` mode argument (a non-negative integer or an
+/// octal string, masked to `0o777`). Missing/undefined/null → default perm.
 fn resolve_entry_perm(global: &JSGlobalObject, descriptor: JSValue) -> JsResult<u32> {
     let Some(mode_val) = descriptor.get(global, "mode")? else {
         return Ok(DEFAULT_ENTRY_PERM);
     };
-    if !mode_val.is_number() {
-        return Err(
-            global.throw_invalid_arguments(format_args!("Archive: entry mode must be a number"))
-        );
-    }
-    let mode = mode_val.as_number();
-    if !mode.is_finite() || mode < 0.0 || mode.fract() != 0.0 {
-        return Err(global.throw_invalid_arguments(format_args!(
-            "Archive: entry mode must be a non-negative integer"
-        )));
-    }
-    Ok((mode as u32) & 0o777)
+    Ok(crate::node::types::mode_from_js(global, mode_val)?.unwrap_or(DEFAULT_ENTRY_PERM))
 }
 
 /// Static method: Archive.write(path, data, options?)

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -24,6 +24,10 @@ use bun_sys::{self, Fd, FdDirExt as _, FdExt as _, Mode};
 /// does not yet expose `FileType`, so mirror the constant locally.
 const FILETYPE_REGULAR: u32 = 0o100000;
 
+/// Default Unix permission for a created entry, matching the fallback the
+/// extraction path uses when an entry carries no perm bits.
+const DEFAULT_ENTRY_PERM: u32 = 0o644;
+
 /// Compression options for the archive
 #[derive(Clone, Copy, Default)]
 pub(crate) enum Compression {
@@ -353,8 +357,9 @@ fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<
         let key_str = ZBox::from_vec_with_nul(key_slice.slice().to_vec());
         // defer free(key_str)/key_slice.deinit() — handled by Drop
 
-        // Get data - use view for Blob/ArrayBuffer, convert for strings
-        let data_slice = get_entry_data(global, value)?;
+        // Resolve bytes and Unix perm. A plain object is the `{ data, mode }`
+        // descriptor form; Blob/ArrayBuffer/TypedArray/string keep the default perm.
+        let (data_slice, perm) = get_entry_data_and_perm(global, value)?;
         // defer data_slice.deinit() — handled by Drop
 
         // Write entry to archive
@@ -369,7 +374,7 @@ fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<
         entry_ref.set_pathname(key_str.as_zstr());
         entry_ref.set_size(i64::try_from(data.len()).expect("int cast"));
         entry_ref.set_filetype(FILETYPE_REGULAR);
-        entry_ref.set_perm(0o644);
+        entry_ref.set_perm(perm);
         entry_ref.set_mtime(now_secs, 0);
 
         // `Warn` means the header was still written (libarchive fell back to a
@@ -421,6 +426,52 @@ fn get_entry_data(global: &JSGlobalObject, value: JSValue) -> JsResult<ZigString
 
     // For strings, convert (allocates)
     value.to_slice(global)
+}
+
+/// Resolves an object-property value to `(bytes, unix_perm)` for one tarball
+/// entry. A plain object is the `{ data, mode? }` descriptor; a
+/// Blob/ArrayBuffer/TypedArray/string keeps the default perm. Blob and
+/// ArrayBuffer/TypedArray are themselves objects, so they are matched before
+/// the descriptor branch.
+fn get_entry_data_and_perm(
+    global: &JSGlobalObject,
+    value: JSValue,
+) -> JsResult<(ZigStringSlice, u32)> {
+    if value.is_object() && blob_from_js(value).is_none() && value.as_array_buffer(global).is_none()
+    {
+        let Some(data_val) = value.get(global, "data")? else {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Archive: entry object must have a \"data\" property"
+            )));
+        };
+        // Read and validate the perm (a fully-owned u32) before resolving the
+        // bytes, so no borrowed data view is held across the property reads.
+        let perm = resolve_entry_perm(global, value)?;
+        return Ok((get_entry_data(global, data_val)?, perm));
+    }
+
+    Ok((get_entry_data(global, value)?, DEFAULT_ENTRY_PERM))
+}
+
+/// Reads the optional `mode` of a `{ data, mode }` entry descriptor. Missing or
+/// undefined → default perm; present must be a non-negative integer and is
+/// masked to `0o777`, matching the bits the extraction path preserves.
+fn resolve_entry_perm(global: &JSGlobalObject, descriptor: JSValue) -> JsResult<u32> {
+    let Some(mode_val) = descriptor.get(global, "mode")? else {
+        return Ok(DEFAULT_ENTRY_PERM);
+    };
+    if !mode_val.is_number() {
+        return Err(
+            global.throw_invalid_arguments(format_args!("Archive: entry mode must be a number"))
+        );
+    }
+    let mode = mode_val.as_number();
+    if !mode.is_finite() || mode < 0.0 || mode.fract() != 0.0 {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "Archive: entry mode must be a non-negative integer"
+        )));
+    }
+    Ok((mode as u32) & 0o777)
 }
 
 /// Static method: Archive.write(path, data, options?)

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -305,8 +305,13 @@ describe("Bun.Archive", () => {
       expect(statSync(join(String(dir), "plain.txt")).mode & 0o100).toBe(0);
     });
 
+    test("mode accepts an octal string, matching node:fs", async () => {
+      const archive = new Bun.Archive({ "bin/tool": { data: "x", mode: "755" } });
+      expect(parseTarModes(await archive.bytes()).get("bin/tool")).toBe(0o755);
+    });
+
     test.each([
-      ["a string", "0755"],
+      ["a non-octal string", "not-a-mode"],
       ["a negative number", -1],
       ["a non-integer", 0o755 + 0.5],
       ["NaN", NaN],

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { existsSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import { join } from "path";
 
 // Minimal ustar tarball builder (pathnames must be <100 bytes). `name` accepts
@@ -61,6 +61,30 @@ function buildPaxTarball(entries: Array<{ name: string; data: Buffer | string }>
   const parts = entries.map((e, i) => paxEntry(e.name, e.data, i));
   parts.push(Buffer.alloc(1024));
   return new Uint8Array(Buffer.concat(parts));
+}
+
+// Reads the permission bits (masked to 0o777) of every regular-file header in a
+// tar stream, keyed by entry name. Octal mode lives at offset 100 (8 bytes),
+// size at 124 (12 bytes), typeflag at 156; each entry is a 512-byte header plus
+// size rounded up to 512-byte data blocks.
+function parseTarModes(bytes: Uint8Array): Map<string, number> {
+  const modes = new Map<string, number>();
+  const td = new TextDecoder("latin1");
+  const octal = (field: Uint8Array) => parseInt(td.decode(field).replace(/[\0 ]/g, ""), 8) || 0;
+  let off = 0;
+  while (off + 512 <= bytes.length) {
+    const block = bytes.subarray(off, off + 512);
+    if (block.every(b => b === 0)) break; // end-of-archive marker
+    const nameField = block.subarray(0, 100);
+    const nul = nameField.indexOf(0);
+    const name = td.decode(nameField.subarray(0, nul === -1 ? 100 : nul));
+    const typeflag = block[156];
+    if (name && (typeflag === 0x30 || typeflag === 0x00)) {
+      modes.set(name, octal(block.subarray(100, 108)) & 0o777);
+    }
+    off += 512 + Math.ceil(octal(block.subarray(124, 136)) / 512) * 512;
+  }
+  return modes;
 }
 
 describe("Bun.Archive", () => {
@@ -200,6 +224,100 @@ describe("Bun.Archive", () => {
       const bytes = await archive.bytes();
       // Should contain "123" somewhere in the tarball (use {} to get uncompressed tar)
       expect(new TextDecoder().decode(bytes)).toContain("123");
+    });
+  });
+
+  describe("per-entry file mode", () => {
+    test("{ data, mode } sets the stored Unix mode; plain values default to 0o644", async () => {
+      const archive = new Bun.Archive({
+        "bin/tool": { data: "#!/bin/sh\necho hi\n", mode: 0o755 },
+        "README.md": "hello",
+      });
+
+      const modes = parseTarModes(await archive.bytes());
+      expect(modes.get("bin/tool")).toBe(0o755);
+      expect(modes.get("README.md")).toBe(0o644);
+    });
+
+    test("descriptor data accepts string, Blob, Uint8Array, and ArrayBuffer", async () => {
+      const archive = new Bun.Archive({
+        "a": { data: "from-string", mode: 0o755 },
+        "b": { data: new Blob(["from-blob"]), mode: 0o700 },
+        "c": { data: new TextEncoder().encode("from-u8"), mode: 0o644 },
+        "d": { data: new TextEncoder().encode("from-ab").buffer, mode: 0o600 },
+      });
+
+      const modes = parseTarModes(await archive.bytes());
+      expect(modes.get("a")).toBe(0o755);
+      expect(modes.get("b")).toBe(0o700);
+      expect(modes.get("c")).toBe(0o644);
+      expect(modes.get("d")).toBe(0o600);
+
+      using dir = tempDir("archive-mode-data", {});
+      await archive.extract(String(dir));
+      expect(await Bun.file(join(String(dir), "a")).text()).toBe("from-string");
+      expect(await Bun.file(join(String(dir), "b")).text()).toBe("from-blob");
+      expect(await Bun.file(join(String(dir), "c")).text()).toBe("from-u8");
+      expect(await Bun.file(join(String(dir), "d")).text()).toBe("from-ab");
+    });
+
+    test("mode defaults to 0o644 when the descriptor omits it", async () => {
+      const archive = new Bun.Archive({
+        "no-mode": { data: "content" },
+      });
+      expect(parseTarModes(await archive.bytes()).get("no-mode")).toBe(0o644);
+    });
+
+    test("high mode bits (e.g. a full stat() mode) are masked to 0o777", async () => {
+      const archive = new Bun.Archive({
+        // 0o100755 is S_IFREG | 0o755, the shape fs.stat() returns.
+        "bin/tool": { data: "x", mode: 0o100755 },
+      });
+      expect(parseTarModes(await archive.bytes()).get("bin/tool")).toBe(0o755);
+    });
+
+    test("Archive.write preserves per-entry modes on disk", async () => {
+      using dir = tempDir("archive-write-mode", {});
+      const archivePath = join(String(dir), "out.tar");
+
+      await Bun.Archive.write(archivePath, {
+        "bin/tool": { data: "x", mode: 0o755 },
+        "plain.txt": "y",
+      });
+
+      const modes = parseTarModes(await Bun.file(archivePath).bytes());
+      expect(modes.get("bin/tool")).toBe(0o755);
+      expect(modes.get("plain.txt")).toBe(0o644);
+    });
+
+    test.skipIf(isWindows)("extracted file carries the executable bit", async () => {
+      using dir = tempDir("archive-extract-mode", {});
+      const archive = new Bun.Archive({
+        "bin/tool": { data: "#!/bin/sh\n", mode: 0o755 },
+        "plain.txt": "hi",
+      });
+
+      await archive.extract(String(dir));
+
+      // Owner-exec bit is set for 0o755 and clear for 0o644; owner bits survive
+      // the usual process umask.
+      expect(statSync(join(String(dir), "bin/tool")).mode & 0o100).toBe(0o100);
+      expect(statSync(join(String(dir), "plain.txt")).mode & 0o100).toBe(0);
+    });
+
+    test.each([
+      ["a string", "0755"],
+      ["a negative number", -1],
+      ["a non-integer", 0o755 + 0.5],
+      ["NaN", NaN],
+      ["Infinity", Infinity],
+    ])("rejects mode that is %s", (_label, mode) => {
+      expect(() => new Bun.Archive({ "bin/tool": { data: "x", mode: mode as number } })).toThrow();
+    });
+
+    test("rejects a descriptor object with no data property", () => {
+      // @ts-expect-error - data is required on the descriptor form
+      expect(() => new Bun.Archive({ "bin/tool": { mode: 0o755 } })).toThrow();
     });
   });
 


### PR DESCRIPTION
## What

`Bun.Archive` hardcoded `0o644` for every entry when creating a tarball (`entry_ref.set_perm(0o644)` in `build_tarball_from_object`), so there was no way to mark a file executable. That made it unusable for building npm tarballs that ship precompiled binaries (esbuild-style platform packages), where the binary must carry `0o755` inside the tarball.

Closes #33212.

## API

Entry values may now be a `{ data, mode }` descriptor in addition to the existing string / Blob / TypedArray / ArrayBuffer forms:

```ts
new Bun.Archive({
  "bin/mytool": { data: bytes, mode: 0o755 },
  "README.md": "hello",
});
```

- `mode` is optional; missing/undefined falls back to `0o644`.
- `mode` is masked to `0o777`, matching the bits the extraction path already preserves (so a full `fs.stat()` mode like `0o100755` resolves to `0o755`).
- Non-integer, negative, `NaN`, `Infinity`, and non-number modes throw a clear `TypeError`; a descriptor missing `data` throws.
- Both `new Bun.Archive({...})` and `Bun.Archive.write(path, {...})` go through the same build path, so both gain the feature.

Blob / ArrayBuffer / TypedArray are matched before the descriptor branch because they are objects too. Plain-object entry values were never part of the typed input (`Record<string, BlobPart>`), so treating them as descriptors is not a change to any typed usage; extraction already preserved modes, so this only closes the creation-side gap.

## Verification

New tests in `test/js/bun/archive.test.ts` (a `per-entry file mode` block) verify the stored mode by parsing the tar header bytes (umask-independent, cross-platform) and by extracting on POSIX and checking the owner-exec bit:

- `{ data, mode: 0o755 }` round-trips to `0o755`; plain values stay `0o644`.
- descriptor `data` accepts string / Blob / Uint8Array / ArrayBuffer and the content round-trips.
- mode defaults to `0o644` when omitted; high bits mask to `0o777`.
- `Bun.Archive.write(...)` preserves modes on disk.
- invalid mode values and a descriptor without `data` are rejected.

```
 12 pass  0 fail   (per-entry file mode block, bun bd test)
117 pass  1 skip  0 fail   (full archive.test.ts, bun bd test)
```

11 of the 12 new tests fail on the released binary (the 12th asserts the `0o644` default, which matches the old hardcoded value); all pass with the change. The `bun-types` type test passes with the updated `ArchiveInput` / new `ArchiveEntry` types.
