### PR TITLE
bake: fail the build when a component throws during static prerender

### DIFF
--- a/src/js/builtins/Bake.ts
+++ b/src/js/builtins/Bake.ts
@@ -152,9 +152,7 @@ export async function renderRoutesForProdStatic(
           }
         } else {
           await Promise.all(
-            paramGetter.pages.map(params =>
-              callRouteGenerator(type, noClient, i, layouts, pageModule, params),
-            ),
+            paramGetter.pages.map(params => callRouteGenerator(type, noClient, i, layouts, pageModule, params)),
           );
         }
       } else {

--- a/src/js/builtins/Bake.ts
+++ b/src/js/builtins/Bake.ts
@@ -152,9 +152,9 @@ export async function renderRoutesForProdStatic(
           }
         } else {
           await Promise.all(
-            paramGetter.pages.map(params => {
-              callRouteGenerator(type, noClient, i, layouts, pageModule, params);
-            }),
+            paramGetter.pages.map(params =>
+              callRouteGenerator(type, noClient, i, layouts, pageModule, params),
+            ),
           );
         }
       } else {

--- a/src/runtime/bake/bun-framework-react/server.tsx
+++ b/src/runtime/bake/bun-framework-react/server.tsx
@@ -175,6 +175,7 @@ export async function prerender(meta: Bake.RouteMetadata) {
     onError: err => {
       if (signal.aborted) return;
       signal.aborted = err;
+      // @ts-expect-error the real abort accepts a reason
       signal.abort(err);
       rscPayload.destroy(err);
     },

--- a/src/runtime/bake/bun-framework-react/server.tsx
+++ b/src/runtime/bake/bun-framework-react/server.tsx
@@ -163,22 +163,33 @@ export async function render(
 export async function prerender(meta: Bake.RouteMetadata) {
   const page = getPage(meta, meta.styles);
 
-  const rscPayload = renderToPipeableStream(page, serverManifest)
-    // TODO: write a lightweight version of PassThrough
-    .pipe(new PassThrough());
+  // TODO: write a lightweight version of PassThrough
+  const rscPayload = new PassThrough();
+
+  // Mirror `render`: a render error must abort both the flight and HTML
+  // renderers. Without this, a throw during static generation never settles
+  // the render promise and the build hangs instead of failing.
+  const signal: MiniAbortSignal = { aborted: undefined, abort: null! };
+  let pipe: (stream: any) => void;
+  ({ pipe, abort: signal.abort } = renderToPipeableStream(page, serverManifest, {
+    onError: err => {
+      if (signal.aborted) return;
+      signal.aborted = err;
+      signal.abort(err);
+      rscPayload.destroy(err);
+    },
+    filterStackFrame: () => false,
+  }));
+  pipe(rscPayload);
 
   const int = new Uint32Array(1);
   int[0] = meta.styles.length;
   let rscChunks: Array<BlobPart> = [int.buffer as ArrayBuffer, meta.styles.join("\n")];
   rscPayload.on("data", chunk => rscChunks.push(chunk));
 
-  let html;
-  try {
-    html = await renderToStaticHtml(rscPayload, meta.modules);
-  } catch (err) {
-    //console.error("ah fuck");
-    return undefined;
-  }
+  // A render error rejects this promise; let it propagate so the build fails
+  // with the underlying error instead of reporting the route as non-static.
+  const html = await renderToStaticHtml(rscPayload, meta.modules, signal);
   const rsc = new Blob(rscChunks, { type: "text/x-component" });
 
   return {

--- a/src/runtime/bake/bun-framework-react/server.tsx
+++ b/src/runtime/bake/bun-framework-react/server.tsx
@@ -104,7 +104,6 @@ export async function render(
 
       // Mark as aborted and call the abort function
       signal.aborted = err;
-      // @ts-expect-error
       signal.abort(err);
       rscPayload.destroy(err);
     },
@@ -174,7 +173,6 @@ export async function prerender(meta: Bake.RouteMetadata) {
     onError: err => {
       if (signal.aborted) return;
       signal.aborted = err;
-      // @ts-expect-error the real abort accepts a reason
       signal.abort(err);
       rscPayload.destroy(err);
     },
@@ -247,5 +245,5 @@ export const contentTypeToStaticFile = {
 export interface MiniAbortSignal {
   aborted: Error | undefined;
   /** Caller must set `aborted` to true before calling. */
-  abort: () => void;
+  abort: (reason?: Error) => void;
 }

--- a/src/runtime/bake/bun-framework-react/server.tsx
+++ b/src/runtime/bake/bun-framework-react/server.tsx
@@ -163,7 +163,6 @@ export async function render(
 export async function prerender(meta: Bake.RouteMetadata) {
   const page = getPage(meta, meta.styles);
 
-  // TODO: write a lightweight version of PassThrough
   const rscPayload = new PassThrough();
 
   // Mirror `render`: a render error must abort both the flight and HTML

--- a/src/runtime/bake/bun-framework-react/ssr.tsx
+++ b/src/runtime/bake/bun-framework-react/ssr.tsx
@@ -97,16 +97,32 @@ export function renderToHtml(
 
 // Static builds can not stream suspense boundaries as they finish, but instead
 // produce a single HTML blob. The approach is otherwise similar to `renderToHtml`.
-export function renderToStaticHtml(rscPayload: Readable, bootstrapModules: readonly string[]): Promise<Blob> {
-  const stream = new StaticRscInjectionStream(rscPayload);
+export function renderToStaticHtml(
+  rscPayload: Readable,
+  bootstrapModules: readonly string[],
+  signal: MiniAbortSignal,
+): Promise<Blob> {
+  const stream = new StaticRscInjectionStream(rscPayload, signal);
   const promise = createFromNodeStream(rscPayload, createFromNodeStreamOptions);
   const Root = () => React.use(promise);
-  const { pipe } = renderToPipeableStream(<Root />, {
+  let pipe: (stream: any) => void;
+  let abort: ((reason?: any) => void) | undefined;
+  ({ pipe, abort } = renderToPipeableStream(<Root />, {
     bootstrapModules,
     // Only begin flowing HTML once all of it is ready. This tells React
     // to not emit the flight chunks, just the entire HTML.
     onAllReady: () => pipe(stream),
-  });
+    // On error `onAllReady` never fires, so the render must be aborted and the
+    // result promise rejected here or the build would hang forever.
+    onError(error) {
+      if (!signal.aborted) {
+        signal.aborted = error;
+        signal.abort?.();
+      }
+      abort?.();
+      stream.destroy(signal.aborted ?? error);
+    },
+  }));
   return stream.result;
 }
 
@@ -266,7 +282,7 @@ class StaticRscInjectionStream extends EventEmitter {
   finalize: (blob: Blob) => void;
   reject: (error: Error) => void;
 
-  constructor(rscPayload: Readable) {
+  constructor(rscPayload: Readable, signal?: MiniAbortSignal) {
     super();
     const { resolve, promise, reject } = Promise.withResolvers<Blob>();
     this.result = promise;
@@ -274,6 +290,9 @@ class StaticRscInjectionStream extends EventEmitter {
     this.reject = reject;
 
     rscPayload.on("data", chunk => this.rscPayloadChunks.push(chunk));
+    // If the flight payload errors, the HTML can never be produced. Reject the
+    // result (preferring the original error) instead of leaving it pending.
+    rscPayload.on("error", err => this.reject(signal?.aborted ?? err));
   }
 
   write(chunk) {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -11,39 +11,43 @@ const platformPath = (path: string) => (process.platform === "win32" ? path.repl
  * Production build tests
  */
 describe("production", () => {
-  test("works with sourcemaps - error thrown in React component", async () => {
-    const dir = await tempDirWithBakeDeps("bake-production-sourcemap", {
-      "src/index.tsx": `export default { app: { framework: "react" } };`,
-      "pages/index.tsx": `export default function IndexPage() {
+  test(
+    "works with sourcemaps - error thrown in React component",
+    async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-sourcemap", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "pages/index.tsx": `export default function IndexPage() {
   throw new Error("oh no!");
   return <div>Hello World</div>;
 }`,
-      "package.json": JSON.stringify({
-        "name": "test-app",
-        "version": "1.0.0",
-        "devDependencies": {
-          "react": "^18.0.0",
-          "react-dom": "^18.0.0",
-        },
-      }),
-    });
+        "package.json": JSON.stringify({
+          "name": "test-app",
+          "version": "1.0.0",
+          "devDependencies": {
+            "react": "^18.0.0",
+            "react-dom": "^18.0.0",
+          },
+        }),
+      });
 
-    // Run the build command
-    const {
-      exitCode: buildExitCode,
-      stdout: buildStdout,
-      stderr: buildStderr,
-    } = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).throws(false);
+      // Run the build command
+      const {
+        exitCode: buildExitCode,
+        stdout: buildStdout,
+        stderr: buildStderr,
+      } = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).throws(false);
 
-    // The build should fail due to the runtime error during SSG
-    expect(buildExitCode).toBe(1);
+      // The build should fail due to the runtime error during SSG
+      expect(buildExitCode).toBe(1);
 
-    // Check that the error message shows the proper source location
-    expect(buildStderr.toString()).toContain("throw new Error");
-    expect(buildStderr.toString()).toContain("oh no!");
-    // https://github.com/oven-sh/bun/issues/33214: the build must surface the
-    // thrown error and exit rather than hang on a render promise that never settles.
-  }, isASAN ? 60_000 : 30_000);
+      // Check that the error message shows the proper source location
+      expect(buildStderr.toString()).toContain("throw new Error");
+      expect(buildStderr.toString()).toContain("oh no!");
+      // https://github.com/oven-sh/bun/issues/33214: the build must surface the
+      // thrown error and exit rather than hang on a render promise that never settles.
+    },
+    isASAN ? 60_000 : 30_000,
+  );
 
   test("import.meta properties are inlined in production build", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-import-meta", {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -49,6 +49,39 @@ describe("production", () => {
     isASAN ? 60_000 : 30_000,
   );
 
+  test(
+    "fails the build when a parameterized route throws during SSG",
+    async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-param-throw", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "pages/blog/[slug].tsx": `export default function BlogPost({ params }) {
+  throw new Error("param boom");
+  return <div>{params.slug}</div>;
+}
+export function getStaticPaths() {
+  return { paths: [{ params: { slug: "hello" } }], fallback: false };
+}`,
+        "package.json": JSON.stringify({
+          "name": "test-app",
+          "version": "1.0.0",
+          "devDependencies": {
+            "react": "^18.0.0",
+            "react-dom": "^18.0.0",
+          },
+        }),
+      });
+
+      // A render error on a route generated from `getStaticPaths` must fail the
+      // build. Previously the render promise was dropped by the caller, so the
+      // error became an unhandled rejection and the build still exited 0.
+      const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).throws(false);
+
+      expect(stderr.toString()).toContain("param boom");
+      expect(exitCode).toBe(1);
+    },
+    isASAN ? 60_000 : 30_000,
+  );
+
   test("import.meta properties are inlined in production build", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-import-meta", {
       "src/index.tsx": `export default { 

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -41,7 +41,9 @@ describe("production", () => {
     // Check that the error message shows the proper source location
     expect(buildStderr.toString()).toContain("throw new Error");
     expect(buildStderr.toString()).toContain("oh no!");
-  });
+    // https://github.com/oven-sh/bun/issues/33214: the build must surface the
+    // thrown error and exit rather than hang on a render promise that never settles.
+  }, isASAN ? 60_000 : 30_000);
 
   test("import.meta properties are inlined in production build", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-import-meta", {


### PR DESCRIPTION
## Problem

`test/bake/dev/production.test.ts > "works with sourcemaps - error thrown in React component"` times out on every POSIX CI build. The test runs `bun build --app` on an app whose page throws during static generation and expects the build to print the sourcemapped error and exit 1. Instead the build prints the error and then spins at 100% CPU forever.

Reproduction (fresh fixture; stock release `bun` and a debug build both hang):

```
// pages/index.tsx
export default function IndexPage() {
  throw new Error("oh no!");
  return <div>Hello World</div>;
}
```
```
$ timeout -s KILL 40 bun build --app ./src/index.tsx; echo "exit=$?"
Rendering routes
error: oh no!
      at r (pages/index.tsx:2:13)
error: An error occurred in the Server Components render. ...
exit=137   # still running, SIGKILL at timeout
```

## Cause

The static prerender path in `bun-framework-react` has no error handling, unlike the streaming path used by the dev server:

- `renderToStaticHtml` (`ssr.tsx`) passes only `onAllReady` to react-dom's `renderToPipeableStream`. On a render error `onAllReady` never fires, so `pipe(stream)` is never called and `StaticRscInjectionStream.result` never settles. There is no `onError` and no `rscPayload.on("error")` listener.
- `prerender` (`server.tsx`) calls the flight `renderToPipeableStream` with no `onError` and no abort, so the renderer is never stopped.

Because the result promise never settles and the renderers keep the loop busy, `vm.wait_for_promise` in `production.rs` loops forever. The streaming sibling (`render` + `renderToHtml` + `RscInjectionStream`) already handles all of this.

It went red fleet-wide with no Bun change because the bake harness installs `react`/`react-dom` on a floating `@experimental` range while `react-server-dom-bun` is pinned older; a newly published React stopped settling the error-path render on its own. The missing error handling was always latent.

## Fix

Mirror the streaming path in the static path:

- `prerender` wires a `MiniAbortSignal` + `onError` into the flight renderer that records the error, aborts the flight render, and destroys the RSC stream.
- `renderToStaticHtml` takes the signal, passes `onError` to react-dom (abort the HTML render + reject the result), and `StaticRscInjectionStream` rejects when the RSC stream errors.
- The error propagates out of `prerender`, so the build fails with the underlying sourcemapped error instead of hanging.

This also uncovered a sibling gap in the caller: for routes generated from `getStaticPaths` (the `{ paths: [...] }` form), `renderRoutesForProdStatic` in `src/js/builtins/Bake.ts` mapped with a block-body arrow that dropped the `callRouteGenerator` promise, so the rejection became an unhandled rejection and the build still exited 0. The arrow now returns the promise so `Promise.all` awaits the render (and the per-page writes).

With the fix `bun build --app` exits 1 and prints:

```
2 |   throw new Error("oh no!");
            ^
error: oh no!
      at pages/index.tsx:2:13
```

## Verification

- `bun bd test test/bake/dev/production.test.ts` -> 9 pass, 0 fail (includes a new test for a `getStaticPaths` route that throws -> exit 1).
- Reverting only the `src/` change makes the target tests hang/exit 0 and fail (fail-before holds).

The test gets an explicit ASAN-aware timeout because a debug+ASAN `bun build --app` takes several seconds and the default 5s test timeout is too tight.
