### PR TITLE
Fix panics on oversized and path-less Worker specifiers

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -493,20 +493,17 @@ impl<'a> Transpiler<'a> {
                 // disjoint mutable borrows of `cache_bust_buf` across `break`,
                 // so compute `busted` directly instead.
                 let busted: bool = 'name: {
-                    // An entry point longer than a path buffer can't name a real
-                    // file; skip the bust rather than overflow `cache_bust_buf`
-                    // in the unchecked joins below.
-                    if self.fs().top_level_dir.len() + entry_point.len() + b"/../".len()
-                        >= cache_bust_buf.len()
-                    {
-                        break 'name false;
-                    }
-
                     if bun_paths::is_absolute(entry_point) {
                         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
                             entry_point,
                         );
                         if !dir.is_empty() {
+                            // A dirname longer than the path buffer can't name a
+                            // cached directory; skip the bust rather than overflow
+                            // `cache_bust_buf` in `normalize_slashes_only`.
+                            if dir.len() > cache_bust_buf.len() {
+                                break 'name false;
+                            }
                             // Normalized with trailing slash
                             let buster_name = bun_paths::string_paths::normalize_slashes_only(
                                 &mut cache_bust_buf[..],
@@ -524,6 +521,15 @@ impl<'a> Transpiler<'a> {
                     // `".."` needs no platform separator rewrite.
                     let parts: [&[u8]; 2] = [entry_point, b".."];
                     let top_level_dir = self.fs().top_level_dir;
+
+                    // An entry point too long to join onto `top_level_dir` can't
+                    // name a real file; skip the bust rather than overflow
+                    // `cache_bust_buf` in the unchecked join below.
+                    if top_level_dir.len() + entry_point.len() + b"/../".len()
+                        >= cache_bust_buf.len()
+                    {
+                        break 'name false;
+                    }
 
                     let buster_name = bun_paths::resolve_path::join_abs_string_buf_z::<
                         bun_paths::platform::Auto,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -493,6 +493,15 @@ impl<'a> Transpiler<'a> {
                 // disjoint mutable borrows of `cache_bust_buf` across `break`,
                 // so compute `busted` directly instead.
                 let busted: bool = 'name: {
+                    // An entry point longer than a path buffer can't name a real
+                    // file; skip the bust rather than overflow `cache_bust_buf`
+                    // in the unchecked joins below.
+                    if self.fs().top_level_dir.len() + entry_point.len() + b"/../".len()
+                        >= cache_bust_buf.len()
+                    {
+                        break 'name false;
+                    }
+
                     if bun_paths::is_absolute(entry_point) {
                         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
                             entry_point,

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1561,11 +1561,15 @@ unsafe fn resolve_entry_point_specifier<'s>(
             'try_from_extension: {
                 let mut pathbuf = bun_paths::path_buffer_pool::get();
                 let base_path = graph.base_public_path_with_default_suffix();
-                let base = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Loose>(
-                    base_path,
-                    &mut pathbuf[..],
-                    &[str],
-                );
+                // A specifier too long to join into a path buffer can't name an
+                // embedded file; `usable_len` keeps room for the `.js` the
+                // `./foo` arm appends in place below.
+                let usable_len = pathbuf.len() - b".js".len();
+                let Some(base) = bun_paths::resolve_path::join_abs_string_buf_checked::<
+                    bun_paths::platform::Loose,
+                >(base_path, &mut pathbuf[..usable_len], &[str]) else {
+                    break 'try_from_extension;
+                };
                 let base_len = base.len();
                 let extname_len = bun_paths::extension(base).len();
                 // `extname` cannot be held as a sub-slice of `pathbuf` while

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2743,16 +2743,18 @@ fn transpile_source_code_inner(
                                     .cast::<bun_resolver::package_json::PackageJSON>()
                             })
                             .or_else(|| {
+                                // Path-less sources (eval, `blob:` URLs) have no
+                                // directory; `read_dir_info` requires an absolute
+                                // path (same guard as the non-cached branch below).
+                                let dir = source.path.name().dir;
+                                if !bun_paths::is_absolute(dir) {
+                                    return None;
+                                }
                                 // SAFETY: per fn contract — `transpiler.
                                 // resolver` is a value field of the VM;
                                 // `read_dir_info` is re-entrant on the JS
                                 // thread and returns a stable cache slot.
-                                match unsafe {
-                                    (*jsc_vm)
-                                        .transpiler
-                                        .resolver
-                                        .read_dir_info(source.path.name().dir)
-                                } {
+                                match unsafe { (*jsc_vm).transpiler.resolver.read_dir_info(dir) } {
                                     Ok(Some(dir_info)) => {
                                         dir_info.package_json().or(dir_info.enclosing_package_json)
                                     }

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -261,6 +261,38 @@ describe("transpiler cache", () => {
     expect(run(["--feature=OTHER", "--feature=SUPER_SECRET"])).toBe("enabled");
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
+  test("cache hit for a source with no filesystem path", () => {
+    // A worker created from an `eval: true` source string loads from a `blob:`
+    // object URL, which has no directory. The source is cache-eligible (it is
+    // above MINIMUM_CACHE_SIZE and CommonJS), so the second identical worker
+    // takes the cache-hit path, which must not walk a package.json directory
+    // for the path-less specifier.
+    writeFileSync(
+      join(temp_dir, "eval-worker.js"),
+      `import { Worker } from "node:worker_threads";
+const src = 'module.exports = "' + Buffer.alloc(6000, "x").toString() + '";';
+const run = () =>
+  new Promise((resolve, reject) => {
+    const w = new Worker(src, { eval: true });
+    w.on("error", reject);
+    w.on("exit", code => (code === 0 ? resolve() : reject(new Error("worker exited with " + code))));
+  });
+await run();
+await run();
+console.log("ok");
+`,
+    );
+    const result = Bun.spawnSync({
+      cmd: [bunExe(), "eval-worker.js"],
+      cwd: temp_dir,
+      env,
+    });
+    expect(result.stdout.toString()).toBe("ok\n");
+    expect(result.exitCode).toBe(0);
+    // The first worker's source was written to the cache; the second hit it.
+    expect(existsSync(cache_dir)).toBeTrue();
+    expect(newCacheCount()).toBe(1);
+  });
 });
 
 test("rejects cached module records containing out-of-range string indices", () => {

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -262,6 +262,7 @@ describe("transpiler cache", () => {
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
   test("cache hit for a source with no filesystem path", () => {
+    // https://github.com/oven-sh/bun/issues/30429
     // A worker created from an `eval: true` source string loads from a `blob:`
     // object URL, which has no directory. The source is cache-eligible (it is
     // above MINIMUM_CACHE_SIZE and CommonJS), so the second identical worker

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -288,8 +288,16 @@ console.log("ok");
       cwd: temp_dir,
       env,
     });
-    expect(result.stdout.toString()).toBe("ok\n");
-    expect(result.exitCode).toBe(0);
+    // Asserted as one object so a crash surfaces the panic text from stderr.
+    expect({
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+      exitCode: result.exitCode,
+    }).toEqual({
+      stdout: "ok\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
     // The first worker's source was written to the cache; the second hit it.
     expect(existsSync(cache_dir)).toBeTrue();
     expect(newCacheCount()).toBe(1);

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -201,60 +201,31 @@ describe("web worker", () => {
     });
   });
 
-  test("worker with event listeners doesn't close event loop", done => {
-    const x = Bun.spawn({
+  // A torn-down event loop makes the child exit without printing "done"; a
+  // hang is bounded by the per-test timeout (no wall-clock race: the fixture
+  // alone takes over a second on debug builds).
+  test("worker with event listeners doesn't close event loop", async () => {
+    await using x = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), "worker-fixture-many-messages.js"],
       env: bunEnv,
       stdio: ["inherit", "pipe", "inherit"],
     });
 
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
-    x.exited.then(async code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        done(new Error("exited with non-zero code"));
-      } else {
-        const text = await new Response(x.stdout).text();
-        if (!text.includes("done")) {
-          console.log({ text });
-          done(new Error("event loop killed early"));
-        } else {
-          done();
-        }
-      }
-    });
+    const [text, exitCode] = await Promise.all([x.stdout.text(), x.exited]);
+    expect(text).toBe("done\n");
+    expect(exitCode).toBe(0);
   });
 
-  test("worker with event listeners doesn't close event loop 2", done => {
-    const x = Bun.spawn({
+  test("worker with event listeners doesn't close event loop 2", async () => {
+    await using x = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), "worker-fixture-many-messages2.js"],
       env: bunEnv,
       stdio: ["inherit", "pipe", "inherit"],
     });
 
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
-    x.exited.then(async code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        done(new Error("exited with non-zero code"));
-      } else {
-        const text = await new Response(x.stdout).text();
-        if (!text.includes("done")) {
-          console.log({ text });
-          done(new Error("event loop killed early"));
-        } else {
-          done();
-        }
-      }
-    });
+    const [text, exitCode] = await Promise.all([x.stdout.text(), x.exited]);
+    expect(text).toBe("done\n");
+    expect(exitCode).toBe(0);
   });
 
   test("worker with process.exit", done => {
@@ -294,6 +265,24 @@ describe("web worker", () => {
       expect(err.type).toBe("error");
       expect(err.message).toBe("5");
       expect(err.error).toBe(null);
+    });
+
+    // A specifier longer than a path buffer used to overflow the entry-point
+    // resolver's directory-cache-bust retry and abort the whole process.
+    test("is fired for a specifier longer than a path buffer", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const w = new Worker(Buffer.alloc(8192, "x").toString());
+w.onerror = e => console.log("worker error:", e.message.includes("ModuleNotFound"));`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("worker error: true\n");
+      expect(exitCode).toBe(0);
     });
   });
 });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "path";
 import wt from "worker_threads";
 
@@ -292,8 +292,46 @@ console.log("absolute errored:", typeof absolute === "string");`,
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stdout).toBe("relative: true\nabsolute errored: true\n");
-      expect(exitCode).toBe(0);
+      // Asserted as one object so a crash surfaces the panic text from stderr.
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "relative: true\nabsolute errored: true\n",
+        stderr: expect.any(String),
+        exitCode: 0,
+      });
+    });
+
+    // In a compiled binary the specifier is first matched against the embedded
+    // standalone module graph, which joins `./`-relative specifiers into a path
+    // buffer before the resolver sees them.
+    test("is fired for a specifier longer than a path buffer in a compiled binary", async () => {
+      using dir = tempDir("worker-compile-long-specifier", {
+        "entry.ts": `const w = new Worker("./" + Buffer.alloc(8192, "x").toString());
+w.onerror = () => console.log("worker error");`,
+      });
+
+      const out = path.join(String(dir), "compiled");
+      const build = Bun.spawnSync({
+        cmd: [bunExe(), "build", "--compile", path.join(String(dir), "entry.ts"), "--outfile", out],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      expect(build.stderr.toString()).not.toContain("error:");
+      expect(build.exitCode).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [isWindows ? `${out}.exe` : out],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "worker error\n",
+        stderr: expect.any(String),
+        exitCode: 0,
+      });
     });
   });
 });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -268,20 +268,31 @@ describe("web worker", () => {
     });
 
     // A specifier longer than a path buffer used to overflow the entry-point
-    // resolver's directory-cache-bust retry and abort the whole process.
+    // resolver's directory-cache-bust retry and abort the whole process. The
+    // relative spelling overflows the join with the working directory, and the
+    // absolute one (with backslashes) overflows the dirname normalization.
     test("is fired for a specifier longer than a path buffer", async () => {
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),
           "-e",
-          `const w = new Worker(Buffer.alloc(8192, "x").toString());
-w.onerror = e => console.log("worker error:", e.message.includes("ModuleNotFound"));`,
+          `function spawn(specifier) {
+  return new Promise(resolve => {
+    const w = new Worker(specifier);
+    w.onerror = e => resolve(e.message);
+  });
+}
+const sep = String.fromCharCode(92);
+const relative = await spawn(Buffer.alloc(8192, "x").toString());
+console.log("relative:", relative.includes("ModuleNotFound"));
+const absolute = await spawn("/" + Buffer.alloc(8192, "a" + sep + "b/").toString() + "x");
+console.log("absolute errored:", typeof absolute === "string");`,
         ],
         env: bunEnv,
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stdout).toBe("worker error: true\n");
+      expect(stdout).toBe("relative: true\nabsolute errored: true\n");
       expect(exitCode).toBe(0);
     });
   });


### PR DESCRIPTION
Fixes #30429

### Problem

Two ways to abort the whole process through the public `Worker` API, both found while reproducing the same fuzz report.

**1. A specifier longer than a path buffer**

```js
new Worker(Buffer.alloc(8192, "x").toString());
```

```
panic: range end index 5014 out of range for slice of length 4095
bun_paths::resolve_path::normalize_string_generic_tz
bun_paths::resolve_path::join_abs_string_buf_z
bun_bundler::transpiler::Transpiler::resolve_entry_point   src/bundler/transpiler.rs:519
bun_jsc::web_worker::resolve_entry_point_specifier
```

When the first resolve fails, `Transpiler::resolve_entry_point` retries after busting the directory cache, and that retry joins `top_level_dir + entry_point + ".."` into a fixed-size `PathBuffer` with no length check. Any entry specifier longer than the buffer aborts the process. `bun build <long-arg>` hits the same line, an absolute specifier with a long dirname overflows the same buffer in `normalize_slashes_only`, and in a compiled (`bun build --compile`) binary the standalone-module-graph branch of `resolve_entry_point_specifier` does the same unchecked join on `./`-relative specifiers before the resolver is ever reached.

**2. A transpiler cache hit for a source with no filesystem path**

```js
import { Worker } from "node:worker_threads";
const src = 'module.exports = "' + Buffer.alloc(6000, "x").toString() + '";';
new Worker(src, { eval: true }); // cache miss: fine
new Worker(src, { eval: true }); // cache hit: aborts
```

```
panic: cannot resolve DirInfo for non-absolute path:
bun_resolver::resolver::Resolver::dir_info_cached_maybe_log   src/resolver/resolver.rs:4200
bun_resolver::resolver::Resolver::read_dir_info
bun_runtime::jsc_hooks::transpile_source_code_inner           src/runtime/jsc_hooks.rs:2754
```

An `eval: true` worker loads its source from a `blob:` object URL, which has no directory. Once the source crosses `MINIMUM_CACHE_SIZE` (4 KiB) it is eligible for the runtime transpiler cache, and the cache-hit arm re-derives the enclosing package.json by calling `read_dir_info` on the source's dirname, which is empty for a `blob:` specifier. The resolver asserts the path is absolute. The non-cached arm at `jsc_hooks.rs:3021` already guards this with `is_absolute(dir)`; the cache-hit arm is missing the same guard, so only the second transpile of the same source crashes.

This is the crash in #30429 (`transpileSourceCode -> readDirInfo` with an empty path, `transpiler_cache` and `workers_spawned` active). The earlier attempt at that issue, #30432, patched `resolver.zig` and was closed when the Zig sources were removed.

### Fix

- `src/bundler/transpiler.rs`: guard each cache-bust branch by what it writes into `cache_bust_buf` (the dirname length for absolute entry points, the joined length for the fall-through), mirroring the per-branch guards in `VirtualMachine`'s resolve path. The original `ModuleNotFound` is reported instead.
- `src/jsc/web_worker.rs`: the standalone-module-graph extension remapping now uses `join_abs_string_buf_checked` (leaving room for the `.js` it appends in place) and falls through to the resolver when the specifier does not fit.
- `src/runtime/jsc_hooks.rs`: in the cache-hit arm, only call `read_dir_info` when the source's directory is absolute, matching the non-cached arm.

### Tests

- `test/js/web/workers/worker.test.ts`: a Worker with an 8 KiB specifier (relative, absolute-with-backslashes, and `./`-relative inside a `bun build --compile` binary) fires `error` and the process exits 0.
- `test/cli/run/transpiler-cache.test.ts`: two `eval: true` workers from the same cache-eligible source both run, and exactly one cache entry is written (proving the second was a hit).

All of them fail on the unmodified source (the child is killed by SIGABRT) and pass with the fix.

Two neighboring tests in `worker.test.ts` ("worker with event listeners doesn't close event loop" 1 and 2) raced a hardcoded 1s `setTimeout` against a spawned child that takes over a second on a debug build, so they could never pass there. The racing timer is removed; the per-test timeout already bounds a hang and the exit-code and stdout assertions are kept.
