### PR TITLE
Keep the process alive while a streaming WebAssembly compilation is pending

### DIFF
--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/DeferredWorkTimerInlines.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 
@@ -52,6 +53,24 @@ void JSCTaskScheduler::onScheduleWorkSoon(WebCore::JSVMClientData* clientData, T
 {
     auto* job = new JSCDeferredWorkTask(*ticket, WTF::move(task));
     Bun__queueJSCDeferredWorkTaskConcurrently(clientData->bunVM, job);
+}
+
+void JSCTaskScheduler::refEventLoopForPendingWork(WebCore::JSVMClientData* clientData, JSC::JSObject* target)
+{
+    auto& scheduler = clientData->deferredWorkTimer;
+    Locker<Lock> holder { scheduler.m_lock };
+
+    Vector<Ref<TicketData>, 1> ticketsToPromote;
+    for (auto& pendingTicket : scheduler.m_pendingTicketsOther) {
+        if (!pendingTicket->isCancelled() && pendingTicket->target() == target)
+            ticketsToPromote.append(pendingTicket.copyRef());
+    }
+
+    for (auto& pendingTicket : ticketsToPromote) {
+        scheduler.m_pendingTicketsOther.remove(pendingTicket);
+        Bun__eventLoop__incrementRefConcurrently(clientData->bunVM, 1);
+        scheduler.m_pendingTicketsKeepingEventLoopAlive.add(WTF::move(pendingTicket));
+    }
 }
 
 void JSCTaskScheduler::onCancelPendingWork(WebCore::JSVMClientData* clientData, Ticket ticket)

--- a/src/jsc/bindings/JSCTaskScheduler.h
+++ b/src/jsc/bindings/JSCTaskScheduler.h
@@ -20,6 +20,13 @@ public:
     static void onScheduleWorkSoon(WebCore::JSVMClientData* clientData, JSC::DeferredWorkTimer::Ticket ticket, JSC::DeferredWorkTimer::Task&& task);
     static void onCancelPendingWork(WebCore::JSVMClientData* clientData, JSC::DeferredWorkTimer::Ticket ticket);
 
+    // Pending work added with WorkType::AtSomePoint does not hold an event loop
+    // ref because it may never be scheduled (e.g. Atomics.waitAsync). Call this
+    // once such work is guaranteed to get scheduled (the wasm streaming compiler
+    // received its last byte): the ticket targeting `target` then keeps the
+    // event loop alive until it is scheduled or cancelled.
+    static void refEventLoopForPendingWork(WebCore::JSVMClientData* clientData, JSC::JSObject* target);
+
 public:
     Lock m_lock;
     UncheckedKeyHashSet<Ref<JSC::DeferredWorkTimer::TicketData>> m_pendingTicketsKeepingEventLoopAlive;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3832,6 +3832,10 @@ static void handleResponseOnStreamingAction(JSGlobalObject* lexicalGlobalObject,
 
     // We were able to get the slice synchronously.
     if (readableStreamMaybe.isNull()) {
+        // The compiler got every byte, so its pending work ticket (added as
+        // WorkType::AtSomePoint, which holds no event loop ref) is now
+        // guaranteed to be scheduled: keep the event loop alive until then.
+        Bun::JSCTaskScheduler::refEventLoopForPendingWork(WebCore::clientData(vm), promise);
         compiler->finalize(globalObject);
         if (scope.exception()) [[unlikely]]
             promise->rejectWithCaughtException(vm, scope);
@@ -3839,6 +3843,7 @@ static void handleResponseOnStreamingAction(JSGlobalObject* lexicalGlobalObject,
     }
 
     auto wrapper = WebCore::toJSNewlyCreated(globalObject, globalObject, WTF::move(compiler));
+    uncheckedDowncast<WebCore::JSWasmStreamingCompiler>(wrapper)->setPromise(vm, promise);
     auto builtin = globalObject->wasmStreamingConsumeStreamFunction();
     auto callData = JSC::getCallData(builtin);
     MarkedArgumentBuffer arguments;

--- a/src/jsc/bindings/webcore/JSWasmStreamingCompiler.cpp
+++ b/src/jsc/bindings/webcore/JSWasmStreamingCompiler.cpp
@@ -1,8 +1,10 @@
 #include "config.h"
 #include "JSWasmStreamingCompiler.h"
 
+#include "BunClientData.h"
 #include "DOMClientIsoSubspaces.h"
 #include "DOMIsoSubspaces.h"
+#include "JSCTaskScheduler.h"
 #include "JSDOMBinding.h"
 #include "JSDOMOperation.h"
 #include <JavaScriptCore/HeapAnalyzer.h>
@@ -156,6 +158,12 @@ JSC_DEFINE_HOST_FUNCTION(jsWasmStreamingCompilerPrototypeFunction_addBytes, (JSG
 
 static inline EncodedJSValue jsWasmStreamingCompilerPrototypeFunction_finalizeBody(JSGlobalObject* lexicalGlobalObject, CallFrame*, typename IDLOperation<JSWasmStreamingCompiler>::ClassParameter castedThis)
 {
+    // The last byte was delivered, so compilation is guaranteed to schedule the
+    // promise's pending work ticket. That ticket was registered as
+    // WorkType::AtSomePoint (no event loop ref); from now on it must keep the
+    // process alive until the compile threads settle the promise.
+    if (auto* promise = castedThis->promise())
+        Bun::JSCTaskScheduler::refEventLoopForPendingWork(WebCore::clientData(JSC::getVM(lexicalGlobalObject)), promise);
     castedThis->wrapped().finalize(lexicalGlobalObject);
     return encodedJSUndefined();
 }
@@ -198,6 +206,17 @@ GCClient::IsoSubspace* JSWasmStreamingCompiler::subspaceForImpl(VM& vm)
         [](auto& spaces) { return spaces.m_subspaceForWasmStreamingCompiler.get(); },
         [](auto& spaces, auto&& space) { spaces.m_subspaceForWasmStreamingCompiler = std::forward<decltype(space)>(space); });
 }
+
+template<typename Visitor>
+void JSWasmStreamingCompiler::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSWasmStreamingCompiler>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_promise);
+}
+
+DEFINE_VISIT_CHILDREN(JSWasmStreamingCompiler);
 
 void JSWasmStreamingCompiler::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {

--- a/src/jsc/bindings/webcore/JSWasmStreamingCompiler.h
+++ b/src/jsc/bindings/webcore/JSWasmStreamingCompiler.h
@@ -2,6 +2,7 @@
 
 #include "JSDOMWrapper.h"
 #include "JavaScriptCore/WasmStreamingCompiler.h"
+#include <JavaScriptCore/JSPromise.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
@@ -22,11 +23,18 @@ public:
     static void destroy(JSC::JSCell*);
 
     DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
     }
+
+    // The promise WebAssembly.{compile,instantiate}Streaming() returned. It is
+    // the target of the compiler's DeferredWorkTimer ticket; finalize() uses it
+    // to make that ticket keep the event loop alive while compilation finishes.
+    JSC::JSPromise* promise() const { return m_promise.get(); }
+    void setPromise(JSC::VM& vm, JSC::JSPromise* promise) { m_promise.set(vm, this, promise); }
 
     // static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
@@ -42,6 +50,9 @@ protected:
     JSWasmStreamingCompiler(JSC::Structure*, JSDOMGlobalObject&, Ref<JSC::Wasm::StreamingCompiler>&&);
 
     void finishCreation(JSC::VM&);
+
+private:
+    JSC::WriteBarrier<JSC::JSPromise> m_promise;
 };
 class JSWasmStreamingCompilerOwner final : public JSC::WeakHandleOwner {
 public:

--- a/test/js/web/fetch/wasm-streaming-keeps-alive-fixture.ts
+++ b/test/js/web/fetch/wasm-streaming-keeps-alive-fixture.ts
@@ -1,0 +1,80 @@
+// Fixture for "pending streaming compilation keeps the process alive".
+//
+// Builds a wasm module whose compilation outlives the main script, starts a
+// streaming compile of it, and prints "settled" once the promise settles. If
+// the pending compilation does not hold an event loop ref, the process exits 0
+// before anything is printed.
+//
+// argv[2]: "compileStreaming" | "instantiateStreaming"
+// argv[3]: "buffered" (Response over bytes) | "stream" (Response over a ReadableStream)
+
+function uleb(value: number): number[] {
+  const out: number[] = [];
+  do {
+    let byte = value & 0x7f;
+    value >>>= 7;
+    if (value !== 0) byte |= 0x80;
+    out.push(byte);
+  } while (value !== 0);
+  return out;
+}
+
+function section(id: number, contents: number[]): number[] {
+  return [id, ...uleb(contents.length), ...contents];
+}
+
+// `funcs` copies of `(func (result i32) i32.const 0 (i32.const 1 i32.add)*addsPerFunc)`.
+function makeWasm(funcs: number, addsPerFunc: number): Uint8Array {
+  const typeSection = section(1, [1, 0x60, 0, 1, 0x7f]);
+  const funcSection = section(3, [...uleb(funcs), ...new Array(funcs).fill(0)]);
+
+  const body: number[] = [0, 0x41, 0x00];
+  for (let i = 0; i < addsPerFunc; i++) body.push(0x41, 0x01, 0x6a);
+  body.push(0x0b);
+  const oneBody = new Uint8Array([...uleb(body.length), ...body]);
+
+  const funcCount = uleb(funcs);
+  const codeSectionSize = funcCount.length + oneBody.length * funcs;
+  const header = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    ...typeSection,
+    ...funcSection,
+    10, ...uleb(codeSectionSize), ...funcCount,
+  ]);
+
+  const bytes = new Uint8Array(header.length + oneBody.length * funcs);
+  bytes.set(header, 0);
+  for (let i = 0; i < funcs; i++) bytes.set(oneBody, header.length + i * oneBody.length);
+  return bytes;
+}
+
+const wasm = makeWasm(2000, 1000);
+const headers = { "Content-Type": "application/wasm" };
+
+// "buffered" feeds the compiler synchronously in C++; "stream" goes through the
+// consumeStream builtin, which finalizes the compiler from JavaScript.
+const response =
+  process.argv[3] === "stream"
+    ? new Response(
+        new ReadableStream({
+          pull(controller) {
+            controller.enqueue(wasm);
+            controller.close();
+          },
+        }),
+        { headers },
+      )
+    : new Response(wasm, { headers });
+
+const promise =
+  process.argv[2] === "instantiateStreaming"
+    ? WebAssembly.instantiateStreaming(response)
+    : WebAssembly.compileStreaming(response);
+
+promise.then(
+  () => console.log("settled"),
+  error => {
+    console.error(error);
+    process.exit(1);
+  },
+);

--- a/test/js/web/fetch/wasm-streaming.test.ts
+++ b/test/js/web/fetch/wasm-streaming.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 
 import { ok } from "node:assert/strict";
+import { join } from "node:path";
 
 const wasmDataUriPrefix = "data:application/wasm;base64,";
 
@@ -236,4 +237,42 @@ describe("WebAssembly.instantiateStreaming", () => {
       "can't make WebAssembly.Instance because there is no imports Object and the WebAssembly.Module requires imports",
     );
   });
+});
+
+// The streaming compiler registers its pending work as work that may never get
+// scheduled (the response body could stall forever), which by itself does not
+// keep the event loop alive. Once the last byte is in, compilation is running
+// on the wasm worklist threads and the process must wait for it to settle the
+// promise instead of exiting with it forever pending.
+// https://github.com/oven-sh/bun/issues/25145
+describe("pending streaming compilation keeps the process alive", () => {
+  const fixture = join(import.meta.dir, "wasm-streaming-keeps-alive-fixture.ts");
+
+  test.concurrent.each([
+    ["compileStreaming", "buffered"],
+    ["compileStreaming", "stream"],
+    ["instantiateStreaming", "buffered"],
+    ["instantiateStreaming", "stream"],
+  ] as const)(
+    "%s settles with a %s response body",
+    async (api, body) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture, api, body],
+        // A single compiler thread keeps the whole compilation pending when the
+        // main script finishes, on any machine.
+        env: { ...bunEnv, BUN_JSC_numberOfWasmCompilerThreads: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      // stderr is drained concurrently (debug builds write benign warnings there).
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, exitCode, rejection: exitCode === 1 ? stderr : "" }).toEqual({
+        stdout: "settled\n",
+        exitCode: 0,
+        rejection: "",
+      });
+    },
+    60_000,
+  );
 });

--- a/test/js/web/fetch/wasm-streaming.test.ts
+++ b/test/js/web/fetch/wasm-streaming.test.ts
@@ -265,12 +265,14 @@ describe("pending streaming compilation keeps the process alive", () => {
         stderr: "pipe",
       });
 
-      // stderr is drained concurrently (debug builds write benign warnings there).
+      // stderr is drained concurrently (debug builds write benign warnings
+      // there) and only included in the assertion when the child did not exit
+      // cleanly, so failures show what went wrong.
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, exitCode, rejection: exitCode === 1 ? stderr : "" }).toEqual({
+      expect({ stdout, exitCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
         stdout: "settled\n",
         exitCode: 0,
-        rejection: "",
+        stderr: "",
       });
     },
     60_000,


### PR DESCRIPTION
Fixes #25145

### Problem

A pending `WebAssembly.compileStreaming()` / `instantiateStreaming()` promise does not keep the process alive. With a module that takes long enough to compile, Bun exits 0 with the promise forever pending, so the code waiting on the module never runs:

```js
const p = WebAssembly.instantiateStreaming(new Response(bigWasm, { headers: { "Content-Type": "application/wasm" } }));
p.then(() => console.log("ready")); // never prints, the process exits 0 first
```

`WebAssembly.compile()` / `instantiate()` on the same bytes do keep the process alive, and Node keeps it alive for all four forms. Smaller modules make it a race instead of a guaranteed loss, which is worse: whether "ready" runs depends on how fast the wasm compiler threads happen to be. That race is what #25145 reports: `zxing-wasm` loads its module with `instantiateStreaming()`, and `readBarcodes()` sometimes completes and sometimes the process silently exits.

### Cause

JSC's `Wasm::StreamingCompiler` registers its pending work ticket as `DeferredWorkTimer::WorkType::AtSomePoint`, because at creation time the response body may never finish arriving. Bun's `JSCTaskScheduler` only holds an event loop ref for `ImminentlyScheduled` tickets, so after the body was fully delivered and compilation moved to the wasm worklist threads, nothing kept the event loop alive and Bun exited before the completion task could run. The non-streaming paths in `JSWebAssembly.cpp` register `ImminentlyScheduled` work, which is why they were unaffected.

### Fix

At the moment the streaming compiler receives its last byte, compilation is guaranteed to schedule the ticket's completion task, so `JSCTaskScheduler::refEventLoopForPendingWork()` now moves that ticket into the scheduler's keep-alive set (taking an event loop ref). Both finalize sites do this: the buffered `Response` path in `handleResponseOnStreamingAction`, and the `consumeStream` builtin's `finalize()` for `ReadableStream` bodies (the wrapper now remembers the promise the ticket targets). The scheduler's existing schedule/cancel paths already release the ref on every exit: completion, compile error, and cancellation.

The ref is only taken once the whole module has been received, not for the lifetime of the stream, so a body that never finishes behaves as before, and `AtSomePoint` work that may legitimately never be scheduled (`Atomics.waitAsync`) is unaffected.

### Verification

New tests in `test/js/web/fetch/wasm-streaming.test.ts` spawn a bun that streaming-compiles a module too large to finish before the main script ends (pinned to one wasm compiler thread so the whole compilation is still pending at exit time on any machine) and assert that the promise settles. All four variants (`compileStreaming` / `instantiateStreaming` x buffered / `ReadableStream` body) fail without the fix (`USE_SYSTEM_BUN=1`: empty stdout, exit 0) and pass with it. `Atomics.waitAsync` with no notifier still lets the process exit.

The reproduction from #25145 also confirms it: with `zxing-wasm@3.1.0`, awaiting `prepareZXingModule({ fireImmediately: true })` traces a call to `WebAssembly.instantiateStreaming` and the process exits with the promise pending in 5/5 runs on 1.4.0 (Node resolves it); with this change it resolves in 3/3 runs.
