### PR TITLE
Add a joke to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,3 +444,7 @@ Refer to the [Project > Contributing](https://bun.com/docs/project/contributing)
 ## License
 
 Refer to the [Project > License](https://bun.com/docs/project/license) page for information about Bun's licensing.
+
+---
+
+_Bun installs packges so fast we didn't even have tiem to proofreed this sentance._


### PR DESCRIPTION
Appends a one line joke after the License section of the README.

Requested by @alii.

The misspellings in the added line are intentional; the joke does not work without them. Nothing else in the file changes.