### PR TITLE
bake: write stylesheet byte length into prerender RSC header

### DIFF
--- a/src/runtime/bake/bun-framework-react/server.tsx
+++ b/src/runtime/bake/bun-framework-react/server.tsx
@@ -167,9 +167,10 @@ export async function prerender(meta: Bake.RouteMetadata) {
     // TODO: write a lightweight version of PassThrough
     .pipe(new PassThrough());
 
-  const int = new Uint32Array(1);
-  int[0] = meta.styles.length;
-  let rscChunks: Array<BlobPart> = [int.buffer as ArrayBuffer, meta.styles.join("\n")];
+  const int = Buffer.allocUnsafe(4);
+  const styles = meta.styles.join("\n");
+  int.writeUInt32LE(styles.length, 0);
+  let rscChunks: Array<BlobPart> = [int, styles];
   rscPayload.on("data", chunk => rscChunks.push(chunk));
 
   let html;

--- a/src/runtime/bake/bun-framework-react/server.tsx
+++ b/src/runtime/bake/bun-framework-react/server.tsx
@@ -90,7 +90,7 @@ export async function render(
     // is presented, to avoid a flash of unstyled content.
     const int = Buffer.allocUnsafe(4);
     const str = meta.styles.join("\n");
-    int.writeUInt32LE(str.length, 0);
+    int.writeUInt32LE(Buffer.byteLength(str), 0);
     rscPayload.write(int);
     rscPayload.write(str);
   }
@@ -169,7 +169,7 @@ export async function prerender(meta: Bake.RouteMetadata) {
 
   const int = Buffer.allocUnsafe(4);
   const styles = meta.styles.join("\n");
-  int.writeUInt32LE(styles.length, 0);
+  int.writeUInt32LE(Buffer.byteLength(styles), 0);
   let rscChunks: Array<BlobPart> = [int, styles];
   rscPayload.on("data", chunk => rscChunks.push(chunk));
 

--- a/src/runtime/bake/bun-framework-react/server.tsx
+++ b/src/runtime/bake/bun-framework-react/server.tsx
@@ -37,6 +37,16 @@ function getPage(meta: Bake.RouteMetadata & { request?: Request }, styles: reado
   );
 }
 
+// Prefixes the joined stylesheet string with its UTF-8 byte length (little-endian uint32).
+// client.tsx reads that length to split the CSS metadata from the RSC payload, so render()
+// and prerender() must encode it identically.
+function encodeCssHeader(styles: readonly string[]): [Buffer, string] {
+  const str = styles.join("\n");
+  const int = Buffer.allocUnsafe(4);
+  int.writeUInt32LE(Buffer.byteLength(str), 0);
+  return [int, str];
+}
+
 function component(mod: any, params: Record<string, string> | null, request?: Request) {
   const Page = mod.default;
   let props = {};
@@ -88,9 +98,7 @@ export async function render(
     // "client.tsx" reads the start of the response to determine the
     // CSS files to load. The styles are loaded before the new page
     // is presented, to avoid a flash of unstyled content.
-    const int = Buffer.allocUnsafe(4);
-    const str = meta.styles.join("\n");
-    int.writeUInt32LE(Buffer.byteLength(str), 0);
+    const [int, str] = encodeCssHeader(meta.styles);
     rscPayload.write(int);
     rscPayload.write(str);
   }
@@ -167,10 +175,7 @@ export async function prerender(meta: Bake.RouteMetadata) {
     // TODO: write a lightweight version of PassThrough
     .pipe(new PassThrough());
 
-  const int = Buffer.allocUnsafe(4);
-  const styles = meta.styles.join("\n");
-  int.writeUInt32LE(Buffer.byteLength(styles), 0);
-  let rscChunks: Array<BlobPart> = [int, styles];
+  const rscChunks: Array<BlobPart> = encodeCssHeader(meta.styles);
   rscPayload.on("data", chunk => rscChunks.push(chunk));
 
   let html;

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -588,5 +588,5 @@ export default function IndexPage() {
     // intact (React flight rows start with a numeric id like "0:").
     expect(buf.toString("utf8", 4, 4 + header)).toBe(expectedCss);
     expect(buf.toString("utf8", 4 + header)).toMatch(/^\d+:/);
-  }, 60_000);
+  });
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -540,4 +540,53 @@ export default function IndexPage() {
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
   });
+
+  test("prerendered index.rsc encodes the joined stylesheet byte length in its header", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-rsc-css-header", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "pages/index.tsx": `import "./styles.css";
+export default function IndexPage() {
+  return <div>Hello World</div>;
+}`,
+      "pages/styles.css": `div { color: red; }`,
+      "package.json": JSON.stringify({
+        "name": "test-app",
+        "version": "1.0.0",
+        "devDependencies": {
+          "react": "^18.0.0",
+          "react-dom": "^18.0.0",
+        },
+      }),
+    });
+
+    const { exitCode } = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).env(bunEnv).throws(false);
+    expect(exitCode).toBe(0);
+
+    // The prerendered HTML carries the <link rel="stylesheet"> tags, whose hrefs are exactly
+    // the `meta.styles` list that the RSC header describes. Use them as an independent source
+    // of truth for the expected CSS metadata (a separate code path from the RSC header).
+    const htmlPath = path.join(dir, "dist", "index.html");
+    expect(existsSync(htmlPath)).toBe(true);
+    const html = await Bun.file(htmlPath).text();
+    const hrefs = [...html.matchAll(/<link\b[^>]*\brel="stylesheet"[^>]*>/g)]
+      .map(tag => tag[0].match(/\bhref="([^"]*)"/)?.[1])
+      .filter((href): href is string => !!href);
+    expect(hrefs.length).toBeGreaterThan(0);
+    const expectedCss = hrefs.join("\n");
+
+    // index.rsc layout: [0..4) little-endian uint32 = byte length of the CSS metadata, then
+    // that many bytes of CSS, then the React flight (RSC) payload. The header must be the byte
+    // length of the joined stylesheet string (matching render()), not the number of entries.
+    const rscPath = path.join(dir, "dist", "index.rsc");
+    expect(existsSync(rscPath)).toBe(true);
+    const buf = Buffer.from(await Bun.file(rscPath).arrayBuffer());
+
+    const header = buf.readUInt32LE(0);
+    expect(header).toBe(Buffer.byteLength(expectedCss));
+
+    // The CSS metadata decodes to exactly the stylesheet list, and the RSC payload after it is
+    // intact (React flight rows start with a numeric id like "0:").
+    expect(buf.toString("utf8", 4, 4 + header)).toBe(expectedCss);
+    expect(buf.toString("utf8", 4 + header)).toMatch(/^\d+:/);
+  }, 60_000);
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -559,7 +559,10 @@ export default function IndexPage() {
       }),
     });
 
-    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).env(bunEnv).throws(false);
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
     if (exitCode !== 0) {
       expect(stderr.toString()).toBe("");
     }

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -559,7 +559,10 @@ export default function IndexPage() {
       }),
     });
 
-    const { exitCode } = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).env(bunEnv).throws(false);
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).env(bunEnv).throws(false);
+    if (exitCode !== 0) {
+      expect(stderr.toString()).toBe("");
+    }
     expect(exitCode).toBe(0);
 
     // The prerendered HTML carries the <link rel="stylesheet"> tags, whose hrefs are exactly


### PR DESCRIPTION
Fixes #33217

## Problem

The static `prerender()` path in `bun-framework-react/server.tsx` encoded the wrong value in the 4-byte `index.rsc` header. The client reads that header as a **byte count** and then reads exactly that many bytes as the CSS metadata before handing the rest of the stream to React (`client.tsx`, both the BYOB and fallback readers). `prerender()` instead wrote the **number of stylesheet entries**:

```ts
// prerender() (before)
const int = new Uint32Array(1);
int[0] = meta.styles.length;                 // count of style URLs
let rscChunks = [int.buffer as ArrayBuffer, meta.styles.join("\n")];
```

So whenever a statically built route has styles, `meta.styles.length` (e.g. `1`) does not match the length of the joined URL string (e.g. `18`): the client reads too few CSS bytes and the leftover CSS bytes corrupt the RSC payload that follows during client-side navigation.

## Fix

Both paths now share one helper that writes the byte length of the joined stylesheet string:

```ts
function encodeCssHeader(styles: readonly string[]): [Buffer, string] {
  const str = styles.join("\n");
  const int = Buffer.allocUnsafe(4);
  int.writeUInt32LE(Buffer.byteLength(str), 0);
  return [int, str];
}
```

`int` is handed to the `Blob`/stream directly rather than `int.buffer`, because `Buffer.allocUnsafe` may return a view into a larger pooled buffer.

`encodeCssHeader` uses `Buffer.byteLength()` rather than `String.length`: the string is serialized as UTF-8 and the client reads a UTF-8 byte count, but `String.length` is the UTF-16 code-unit count, which diverges for non-ASCII stylesheet URLs. Extracting the helper also keeps `render()` and `prerender()` from drifting apart again (the drift is what caused the original bug).

## Verification

New regression test in `test/bake/dev/production.test.ts` builds a static route with a stylesheet, then reads the generated `dist/index.rsc`: it asserts the 4-byte LE header equals the byte length of the joined stylesheet string (cross-checked against the `<link rel="stylesheet">` hrefs in `dist/index.html`, an independent code path), that the CSS region decodes to exactly that list, and that the RSC payload after it is intact.

- Without the fix: `expect(header).toBe(18)` fails with `Received: 1`.
- With the fix: passes.

## Follow-up (out of scope)

The `client.tsx` reader of this same 4-byte header has two separate, pre-existing bugs that this writer-side fix does not touch. Both also affect the live `render()` path (which already wrote byte-length headers, so dynamic routes were already exposed), and `client.tsx` is browser code not exercisable from the bun test harness, so they are tracked as a follow-up with browser-level validation:

1. Primary BYOB path (`readCssMetadata`): `reader.read(new Uint8Array(header[0]))` is called without `{ min: header[0] }`. Per the Streams spec a BYOB read may resolve after filling as little as 1 byte, so a CSS region that spans network chunks can short-read, leaving CSS bytes at the head of the stream handed to React.
2. Safari / no-BYOB fallback (`readCssMetadataFallback`): the header is decoded with `new Uint32Array(bytes)[0]`, which element-wise-copies the 4 bytes and yields only the low byte, so headers >= 256 are misread.
