### PR TITLE
Add regression test for streaming a wasm module with an invalid function body

### DIFF
--- a/test/js/web/fetch/wasm-streaming.test.ts
+++ b/test/js/web/fetch/wasm-streaming.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 
 import { ok } from "node:assert/strict";
 
@@ -212,6 +212,66 @@ describe("WebAssembly.compileStreaming", () => {
   test("doesn't compile a response that isn't valid WebAssembly", async () => {
     const response = await fetch("data:application/wasm,This is not actually Wasm");
     expect(WebAssembly.compileStreaming(response)).rejects.toBeInstanceOf(WebAssembly.CompileError);
+  });
+});
+
+describe("streaming a module whose function body fails validation", () => {
+  // The streaming compiler parses section framing on the main thread and compiles
+  // each function body on a worklist thread, so this error path is distinct from a
+  // malformed header. Fixed in JSC by https://commits.webkit.org/316510@main.
+  test("rejects with CompileError instead of crashing", async () => {
+    const fixture = `
+      // 3 functions of type () -> (); the bytes are framing-valid, but the last
+      // function body leaves an i32 on the stack, so it fails validation.
+      const bytes = Uint8Array.from([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type section: 1 type, () -> ()
+        0x03, 0x04, 0x03, 0x00, 0x00, 0x00, // function section: 3 functions of type 0
+        0x0a, 0x0d, 0x03, // code section: 3 bodies
+        0x02, 0x00, 0x0b, // (func)
+        0x03, 0x00, 0x01, 0x0b, // (func nop)
+        0x04, 0x00, 0x41, 0x00, 0x0b, // (func i32.const 0): invalid
+      ]);
+      console.log("validate:", WebAssembly.validate(bytes));
+      const headers = { "Content-Type": "application/wasm" };
+
+      const compiled = await WebAssembly.compileStreaming(new Response(bytes, { headers })).then(
+        () => "resolved",
+        e => e.constructor.name,
+      );
+      console.log("compileStreaming:", compiled);
+
+      // Deliver the code section in a second chunk so the stream turns invalid late.
+      const response = new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(bytes.slice(0, 20));
+            controller.enqueue(bytes.slice(20));
+            controller.close();
+          },
+        }),
+        { headers },
+      );
+      const instantiated = await WebAssembly.instantiateStreaming(response).then(
+        () => "resolved",
+        e => e.constructor.name,
+      );
+      console.log("instantiateStreaming:", instantiated);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "validate: false
+      compileStreaming: CompileError
+      instantiateStreaming: CompileError"
+    `);
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/web/fetch/wasm-streaming.test.ts
+++ b/test/js/web/fetch/wasm-streaming.test.ts
@@ -264,8 +264,10 @@ describe("streaming a module whose function body fails validation", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    // On a regressed build the JSC assertion text lands here, so check it first.
+    expect(stderr).toBe("");
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
       "validate: false
       compileStreaming: CompileError


### PR DESCRIPTION
### Problem

- `WebAssembly.compileStreaming` / `instantiateStreaming` of a module whose function **body** fails validation (section framing intact, so the streaming parser accepts the bytes) used to move JSC's plan state machine backwards. Assertion-enabled builds aborted, deterministically:

  ```
  ASSERTION FAILED: state >= m_state
  WasmEntryPlan.cpp(78) : void JSC::Wasm::EntryPlan::moveToState(State)
  ```

- Cause (JSC, `WasmIPIntPlan.cpp`): the failing function's worklist thread calls `Plan::fail`, which completes the plan; the last `StreamingPlan` callback then called `didCompileFunctionInStreaming`, which did an unguarded `moveToState(Compiled)`.
- The fix is already in: JSC landed the `hasWork()` guard as https://commits.webkit.org/316510@main, and Bun's current `WEBKIT_VERSION` (7b763944) contains it. My fork PR for the same change (oven-sh/WebKit#265) is closed as superseded.
- What is missing is Bun-side coverage: JSC's own test runs in the `jsc` shell, which does not wire `compileStreaming`, so nothing exercises Bun's `Response` streaming glue for this path. `test/js/web/fetch/wasm-streaming.test.ts` only had a malformed-header case, which never reaches the worklist.

### Fix

- Test only. Adds one test to `test/js/web/fetch/wasm-streaming.test.ts`: a child process streams a framing-valid 3-function module whose last body is invalid through both `compileStreaming` (buffered `Response`) and `instantiateStreaming` (`ReadableStream`, code section in a second chunk), and asserts both reject with `CompileError` and the child exits 0.
- Verified (linux x64, debug + ASAN):
  - against the pre-fix pin: `bun bd --webkit-version=4895f45dfbd0d1226c4d41799887bc0ecb9f341b test test/js/web/fetch/wasm-streaming.test.ts` fails this test (child aborts on the assertion after printing only `validate: false`), 33/34
  - against the current pin: `bun bd test test/js/web/fetch/wasm-streaming.test.ts` 34/34

### Background

- The streaming compiler parses section framing on the main thread and hands each function body to a worklist thread; a validation error in a body is therefore reported from a different thread than a malformed header, which is why the two need separate coverage.
- The module bytes are annotated inline in the test; the invalid body is `(func i32.const 0)` in a `() -> ()` function, which leaves a value on the stack.

<details>
<summary>Earlier form of this PR</summary>

Originally this PR also bumped `WEBKIT_VERSION` to a preview build of oven-sh/WebKit#265 carrying the guard. The identical guard then arrived via the upstream commit above and the regular WebKit bumps on main, so the pin change was dropped during rebase and only the test remains.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 4 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/wasm-streaming.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/wasm-streaming.test.ts
bun test v1.4.0 (d0bf9d4cc)

test/js/web/fetch/wasm-streaming.test.ts:
(pass) WebAssembly.compileStreaming > compiles a non-streaming Response [16.41ms]
(pass) WebAssembly.compileStreaming > compiles a resolved Promise to a non-streaming Response [11.15ms]
(pass) WebAssembly.compileStreaming > compiles a pending Promise to a non-streaming Response [115.05ms]
(pass) WebAssembly.compileStreaming > doesn't compile a rejected Promise [5.94ms]
(pass) WebAssembly.compileStreaming > doesn't compile a non-Response [9.09ms]
(pass) WebAssembly.compileStreaming > doesn't compile a response with the wrong MIME type [9.35ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > accepts Content-Type "application/wasm" [12.35ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > accepts Content-Type "APPLICATION/wasm" [3.78ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > accepts Content-Type "APPLICATION/WASM" [4.26ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > accepts a case-insensitive Content-Type over HTTP [59.36ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > rejects Content-Type "" [10.11ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > rejects Content-Type "application" [2.16ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > rejects Content-Type "application/javascript" [2.47ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > rejects Content-Type "application/octet-stream" [2.00ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > rejects Content-Type "text/wasm" [1.61ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > rejects Content-Type "application/wasm;" [2.13ms]
(pass) WebAssembly.compileStreaming > Content-Type matching > rejects Content-Type "application/wasm;x" [1.78ms]
(pass) WebAssembly.compil
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/fetch/wasm-streaming.test.ts | 64 +++++++++++++++++++++++++++++++-
 1 file changed, 63 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/web/fetch/wasm-streaming.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->