### PR TITLE
zlib: fix streaming-encode test timeouts on Linux CI

### DIFF
--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -254,30 +254,27 @@ describe("zlib.brotli", () => {
         [zlib.constants.BROTLI_PARAM_LGBLOCK]: 16,
       },
     });
-    const firstChunk = Promise.withResolvers();
     const finished = Promise.withResolvers();
-    let inputEnded = false;
     let chunksBeforeEnd = 0;
-    brotliStream.on("data", () => {
-      if (!inputEnded) chunksBeforeEnd++;
-      firstChunk.resolve();
-    });
+    brotliStream.on("data", () => chunksBeforeEnd++);
     brotliStream.on("end", () => finished.resolve());
-    brotliStream.on("error", err => {
-      firstChunk.reject(err);
-      finished.reject(err);
-    });
+    brotliStream.on("error", err => finished.reject(err));
 
-    // Push incompressible data WITHOUT ending the stream. A streaming encoder
-    // emits compressed output from these writes alone; one that waits for the
-    // entire input stays silent until end(), so `firstChunk` never resolves.
-    for (let i = 0; i < 4; i++) brotliStream.write(crypto.randomBytes(512 * 1024));
-    await firstChunk.promise;
+    // Push incompressible data WITHOUT ending the stream, awaiting each write so
+    // the native encoder has processed it. A streaming encoder emits compressed
+    // output from these writes alone; one that waits for the entire input stays
+    // silent until end(), leaving `chunksBeforeEnd` at 0.
+    await Promise.all(
+      Array.from({ length: 4 }, () => {
+        const { promise, resolve } = Promise.withResolvers();
+        brotliStream.write(crypto.randomBytes(512 * 1024), resolve);
+        return promise;
+      }),
+    );
+    expect(chunksBeforeEnd).toBeGreaterThan(0);
 
-    inputEnded = true;
     brotliStream.end();
     await finished.promise;
-    expect(chunksBeforeEnd).toBeGreaterThan(0);
   });
 
   it("should accept params", async () => {
@@ -620,30 +617,27 @@ describe("zlib.zstd", () => {
 
   it("streaming encode doesn't wait for entire input", async () => {
     const zstdStream = zlib.createZstdCompress();
-    const firstChunk = Promise.withResolvers();
     const finished = Promise.withResolvers();
-    let inputEnded = false;
     let chunksBeforeEnd = 0;
-    zstdStream.on("data", () => {
-      if (!inputEnded) chunksBeforeEnd++;
-      firstChunk.resolve();
-    });
+    zstdStream.on("data", () => chunksBeforeEnd++);
     zstdStream.on("end", () => finished.resolve());
-    zstdStream.on("error", err => {
-      firstChunk.reject(err);
-      finished.reject(err);
-    });
+    zstdStream.on("error", err => finished.reject(err));
 
-    // Push incompressible data WITHOUT ending the stream. A streaming encoder
-    // emits compressed output from these writes alone; one that waits for the
-    // entire input stays silent until end(), so `firstChunk` never resolves.
-    for (let i = 0; i < 4; i++) zstdStream.write(crypto.randomBytes(512 * 1024));
-    await firstChunk.promise;
+    // Push incompressible data WITHOUT ending the stream, awaiting each write so
+    // the native encoder has processed it. A streaming encoder emits compressed
+    // output from these writes alone; one that waits for the entire input stays
+    // silent until end(), leaving `chunksBeforeEnd` at 0.
+    await Promise.all(
+      Array.from({ length: 4 }, () => {
+        const { promise, resolve } = Promise.withResolvers();
+        zstdStream.write(crypto.randomBytes(512 * 1024), resolve);
+        return promise;
+      }),
+    );
+    expect(chunksBeforeEnd).toBeGreaterThan(0);
 
-    inputEnded = true;
     zstdStream.end();
     await finished.promise;
-    expect(chunksBeforeEnd).toBeGreaterThan(0);
   });
 });
 

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -2,9 +2,9 @@ import { deflateSync, gunzipSync, gzipSync, inflateSync } from "bun";
 import { describe, expect, it } from "bun:test";
 import { tmpdirSync } from "harness";
 import * as buffer from "node:buffer";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import { resolve } from "node:path";
-import * as stream from "node:stream";
 import * as util from "node:util";
 import * as zlib from "node:zlib";
 
@@ -245,30 +245,40 @@ describe("zlib.brotli", () => {
   });
 
   it("streaming encode doesn't wait for entire input", async () => {
-    const createPRNG = seed => {
-      let state = seed ?? Math.floor(Math.random() * 0x7fffffff);
-      return () => (state = (1103515245 * state + 12345) % 0x80000000) / 0x7fffffff;
-    };
-    const readStream = new stream.Readable();
-    const brotliStream = zlib.createBrotliCompress();
-    const rand = createPRNG(1);
-    let all = [];
+    // Low quality + a small input block so the encoder emits a compressed
+    // chunk after ~1MB instead of buffering several MB of input first; keeps
+    // the test cheap while still exercising incremental output.
+    const brotliStream = zlib.createBrotliCompress({
+      params: {
+        [zlib.constants.BROTLI_PARAM_QUALITY]: 1,
+        [zlib.constants.BROTLI_PARAM_LGBLOCK]: 16,
+      },
+    });
+    const firstChunk = Promise.withResolvers();
+    const finished = Promise.withResolvers();
+    let inputEnded = false;
+    let chunksBeforeEnd = 0;
+    brotliStream.on("data", () => {
+      if (!inputEnded) chunksBeforeEnd++;
+      firstChunk.resolve();
+    });
+    brotliStream.on("end", () => finished.resolve());
+    brotliStream.on("error", err => {
+      firstChunk.reject(err);
+      finished.reject(err);
+    });
 
-    const { promise, resolve, reject } = Promise.withResolvers();
-    brotliStream.on("data", chunk => all.push(chunk.length));
-    brotliStream.on("end", resolve);
-    brotliStream.on("error", reject);
+    // Push incompressible data WITHOUT ending the stream. A streaming encoder
+    // emits compressed output from these writes alone; one that waits for the
+    // entire input stays silent until end(), so `firstChunk` never resolves.
+    for (let i = 0; i < 4; i++) brotliStream.write(crypto.randomBytes(512 * 1024));
+    await firstChunk.promise;
 
-    for (let i = 0; i < 50; i++) {
-      let buf = Buffer.alloc(1024 * 1024);
-      for (let j = 0; j < buf.length; j++) buf[j] = (rand() * 256) | 0;
-      readStream.push(buf);
-    }
-    readStream.push(null);
-    readStream.pipe(brotliStream);
-    await promise;
-    expect(all.length).toBeGreaterThanOrEqual(7);
-  }, 15_000);
+    inputEnded = true;
+    brotliStream.end();
+    await finished.promise;
+    expect(chunksBeforeEnd).toBeGreaterThan(0);
+  });
 
   it("should accept params", async () => {
     const ZLIB = zlib.constants;
@@ -609,30 +619,32 @@ describe("zlib.zstd", () => {
   });
 
   it("streaming encode doesn't wait for entire input", async () => {
-    const createPRNG = seed => {
-      let state = seed ?? Math.floor(Math.random() * 0x7fffffff);
-      return () => (state = (1103515245 * state + 12345) % 0x80000000) / 0x7fffffff;
-    };
-    const readStream = new stream.Readable();
     const zstdStream = zlib.createZstdCompress();
-    const rand = createPRNG(1);
-    let all = [];
+    const firstChunk = Promise.withResolvers();
+    const finished = Promise.withResolvers();
+    let inputEnded = false;
+    let chunksBeforeEnd = 0;
+    zstdStream.on("data", () => {
+      if (!inputEnded) chunksBeforeEnd++;
+      firstChunk.resolve();
+    });
+    zstdStream.on("end", () => finished.resolve());
+    zstdStream.on("error", err => {
+      firstChunk.reject(err);
+      finished.reject(err);
+    });
 
-    const { promise, resolve, reject } = Promise.withResolvers();
-    zstdStream.on("data", chunk => all.push(chunk.length));
-    zstdStream.on("end", resolve);
-    zstdStream.on("error", reject);
+    // Push incompressible data WITHOUT ending the stream. A streaming encoder
+    // emits compressed output from these writes alone; one that waits for the
+    // entire input stays silent until end(), so `firstChunk` never resolves.
+    for (let i = 0; i < 4; i++) zstdStream.write(crypto.randomBytes(512 * 1024));
+    await firstChunk.promise;
 
-    for (let i = 0; i < 50; i++) {
-      let buf = Buffer.alloc(1024 * 1024);
-      for (let j = 0; j < buf.length; j++) buf[j] = (rand() * 256) | 0;
-      readStream.push(buf);
-    }
-    readStream.push(null);
-    readStream.pipe(zstdStream);
-    await promise;
-    expect(all.length).toBeGreaterThanOrEqual(7);
-  }, 15_000);
+    inputEnded = true;
+    zstdStream.end();
+    await finished.promise;
+    expect(chunksBeforeEnd).toBeGreaterThan(0);
+  });
 });
 
 describe("async write buffer lifetime", () => {


### PR DESCRIPTION
The `zlib.brotli` and `zlib.zstd` "streaming encode doesn't wait for entire input" tests time out after 15000ms on the Linux `test-bun` lanes. The failure showed up on 8 of the last 19 `bun` pipeline builds across unrelated branches (for example [67768](https://buildkite.com/bun/bun/builds/67768)), only on Linux, which points at the test's cost rather than any one change.

## Cause

Each test does, serially, inside a 15s budget:

1. generate 50MB of data through a ~52M-iteration JS PRNG loop, then
2. compress it with a brotli/zstd `Transform` at default settings (brotli defaults to quality 11).

On a loaded CI runner that tips past 15s. Under a debug build it is nowhere close:

```
(fail) zlib.brotli > streaming encode doesn't wait for entire input [41195.76ms]
  ^ this test timed out after 15000ms.
(fail) zlib.zstd > streaming encode doesn't wait for entire input [46203.05ms]
  ^ this test timed out after 15000ms.
```

The encoder itself is fine. Streaming works; the test is just doing too much work.

## Fix

The property the test name describes is that the encoder emits output before it has seen the entire input. Assert that directly rather than compressing 50MB:

- push a small incompressible payload (`crypto.randomBytes`) so the encoder cannot hold it all in its internal window, and
- do it without ending the stream, then wait for output and assert at least one chunk arrived before `end()`. A streaming encoder emits output from those writes; one that waits for the whole input stays silent until `end()`.

For brotli, quality 1 plus `BROTLI_PARAM_LGBLOCK` 16 makes it emit after ~1MB instead of buffering several MB, keeping the payload small. This still guards the regression fixed in #10936 (brotli used to withhold all output until the final write), now in a few hundred milliseconds instead of tens of seconds.

## Verification

```
(pass) zlib.brotli > streaming encode doesn't wait for entire input [402.43ms]
(pass) zlib.zstd > streaming encode doesn't wait for entire input [291.47ms]
```

Full `test/js/node/zlib/zlib.test.js`: 378 pass, 2 skip, 0 fail.

Closes #33226
