### PR TITLE
Fix a spurious unhandledRejection when an async iterable Response body throws

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -488,7 +488,9 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject)
             if (abrupt)
                 handleError(globalObject, abrupt);
         } else if (auto* pullPromise = dynamicDowncast<JSPromise>(result)) {
-            // The un-handled result promise is load-bearing: a rejected pull must still unhandledReject.
+            // Nothing reads the result promise, but it must be a real one: onFulfilled is undefined,
+            // so a fulfilled pull forwards through PromiseResolveWithoutHandlerJob, which needs a
+            // promise to forward into. onDirectPullRejected returns normally, so it stays fulfilled.
             auto* runtime = JSStreamsRuntime::from(globalObject);
             auto* rejectionResult = JSPromise::create(vm, globalObject->promiseStructure());
             pullPromise->performPromiseThenWithContext(vm, globalObject, jsUndefined(), runtime->onDirectPullRejected(), rejectionResult, this);
@@ -703,9 +705,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullRejected, (JSGlobalObje
     JSValue error = callFrame->argument(0);
     controller->handleError(globalObject, error);
     RETURN_IF_EXCEPTION(scope, {});
-    // Re-throw so the (deliberately un-handled) result promise rejects with the pull error.
-    throwException(globalObject, scope, error);
-    return {};
+    return JSValue::encode(jsUndefined());
 }
 
 // The FIVE public own methods are JSBoundFunctions over these [bound-convention] targets.

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -173,8 +173,6 @@ class JSDirectStreamController;
     V(onResumableSinkEndMicrotask)
 
 // owner: JSDirectStreamController.cpp. context = the JSDirectStreamController.
-// onDirectPullRejected is THE one reaction registered WITH a real (fresh, unhandled) result
-// promise — the unhandledRejection is load-bearing.
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_DIRECT_CONTROLLER(V) \
     V(onDirectPullRejected)
 

--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -38,20 +38,46 @@ describe.concurrent("Streaming body via", () => {
     expect(text).toBe("a");
   });
 
-  // An erroring async-iterable body also emits an internal unhandled rejection (pre-existing,
-  // matches the previous implementation), so these two assert in a subprocess.
+  // An erroring async-iterable body delivers the error to the consumer exactly once. These assert
+  // in a subprocess because a second, internal rejection would surface as an unhandledRejection.
   test("an iterator whose next() rejects and has no throw() rejects the body", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
-        `await new Response({ [Symbol.asyncIterator]: () => ({ next: () => Promise.reject(new Error("nrej")), return: () => Promise.resolve({ done: true }) }) }).text().then(() => console.log("resolved"), e => console.log("rejected", e.constructor.name, e.message)); process.exit(0);`,
+        `await new Response({ [Symbol.asyncIterator]: () => ({ next: () => Promise.reject(new Error("nrej")), return: () => Promise.resolve({ done: true }) }) }).text().then(() => console.log("resolved"), e => console.log("rejected", e.constructor.name, e.message));`,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout.trim()).toBe("rejected Error nrej");
+    expect(stderr).not.toContain("nrej");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a throwing async generator body does not leak an unhandled rejection", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `async function* gen() {
+          yield new Uint8Array([1, 2, 3]);
+          throw new Error("gen boom");
+        }
+        await new Response(gen()).text().then(
+          () => { throw new Error("should have rejected"); },
+          e => console.log("caught:", e.message),
+        );`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("caught: gen boom\n");
+    // A second, internal rejection would print the error again and exit nonzero.
+    expect(stderr).not.toContain("gen boom");
     expect(exitCode).toBe(0);
   });
 
@@ -77,13 +103,14 @@ describe.concurrent("Streaming body via", () => {
       cmd: [
         bunExe(),
         "-e",
-        `await new Response({ [Symbol.asyncIterator]: () => ({ next: async () => undefined }) }).text().then(() => console.log("resolved"), e => console.log("rejected", e.constructor.name)); process.exit(0);`,
+        `await new Response({ [Symbol.asyncIterator]: () => ({ next: async () => undefined }) }).text().then(() => console.log("resolved"), e => console.log("rejected", e.constructor.name));`,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout.trim()).toBe("rejected TypeError");
+    expect(stderr).not.toContain("TypeError");
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### What does this PR do?

Consuming a `Response` (or `Request`) whose body is an async iterable that throws delivers the error to the consumer correctly, but also reports it a second time as an unhandled rejection. With no `unhandledRejection` listener, the error is printed again and the process exits nonzero even though the rejection was handled:

```js
async function* gen() {
  yield new Uint8Array([1, 2, 3]);
  throw new Error("gen boom");
}
await new Response(gen()).text().catch(e => console.log("caught:", e.message));
```

```
caught: gen boom
error: gen boom
      at gen (repro.ts:3:13)
      at next (33:82)
```

exit code 1. The same happens for `for await (const chunk of response.body)`.

The cause is in `JSDirectStreamController`. `onPull` registers `onDirectPullRejected` as the rejection reaction for the underlying source's `pull()` promise, passing a freshly created result promise that nothing ever reads. The handler then calls `handleError` and **re-throws**, so that result promise rejects with no reactions attached to it, which is the spurious report. `handleError` has already delivered the error everywhere it needs to go: it rejects `m_pendingRead` (the promise the reader is awaiting) and errors the stream.

The fix is for `onDirectPullRejected` to return normally instead of re-throwing. The result promise then settles fulfilled and is simply ignored.

It stays a real promise rather than `jsUndefined()`: `onFulfilled` is undefined, so a *fulfilled* pull forwards through `PromiseResolveWithoutHandlerJob`, which needs a promise to forward into. Passing `jsUndefined()` there sends every successful pull into `promiseResolveWithoutHandlerJobSlow`, which reads `.resolve` off `undefined` and throws `TypeError: undefined is not an object` (51 of them across this test file, which is how I caught it).

### History of this PR

It was originally a one-line change to `onPullDirectStream` in `src/js/builtins/ReadableStreamInternals.ts`, where the same defect existed as `result.catch($handleDirectStreamErrorReject)` with the derived promise discarded and the handler ending in `return Promise.$reject(e)`. #33193 then rewrote streams in C++ and deleted that file, transcribing the defect faithfully, down to a comment asserting that the unhandled rejection was intentional:

```cpp
// The un-handled result promise is load-bearing: a rejected pull must still unhandledReject.
```

and in `JSStreamsRuntime.h`:

```
// onDirectPullRejected is THE one reaction registered WITH a real (fresh, unhandled) result
// promise — the unhandledRejection is load-bearing.
```

It is not load-bearing: the consumer is served entirely by `handleError`. Both comments are removed, and this PR is rebased onto the rewrite with the fix ported to C++.

### How did you verify your code works?

Added a regression test to `test/js/bun/http/async-iterator-stream.test.ts` that spawns the repro with no `unhandledRejection` listener and asserts the error reaches the consumer exactly once: stdout is the caught message, stderr does not contain it a second time, and the process exits 0.

#33193 added two tests for erroring async-iterable bodies that worked around this defect, masking the duplicate with a trailing `process.exit(0)` and never asserting stderr, under a comment reading "also emits an internal unhandled rejection (pre-existing, matches the previous implementation)". The workaround is no longer needed, so both now exit naturally and assert stderr stays clean.

```
bun bd test test/js/bun/http/async-iterator-stream.test.ts   # 91 pass, 0 fail
bun bd test test/js/third_party/wpt-streams/                 # 1175 pass, 0 fail
bun bd test test/js/web/streams/ test/js/web/fetch/body.test.ts
bun bd test test/js/bun/spawn/spawn-stdin-readable-stream.test.ts test/js/bun/http/serve-stream-body-error.test.ts  # 34 pass, 0 fail
```

The three failures in `test/js/web/streams/` + `body.test.ts` are pre-existing and reproduce with `src/` reverted: two are ASAN-slow tests that pass with `--timeout 90000` (the stack-overflow and large-file cases), and the pipe leak test is already listed in `test/expectations.txt`.

With `src/` reverted, the three new/strengthened assertions fail; with it, the file passes.
