### PR TITLE
fetch: abort the request when the response body reader is cancelled

### DIFF
--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1608,8 +1608,7 @@ impl FetchTasklet {
             return;
         }
         // reader.cancel() / body.cancel() aborts the fetch so the server sees the
-        // close (Node/Deno/browsers abort unconditionally). abort_task() is
-        // idempotent and only touches atomics + schedule_shutdown.
+        // close (Node/Deno/browsers abort unconditionally). abort_task() is idempotent.
         this.abort_task();
         this.ignore_remaining_response_body(false);
     }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1622,6 +1622,12 @@ impl FetchTasklet {
         if this.signal_store.body_receive_mode() == BodyReceiveMode::Ignore {
             return;
         }
+        // reader.cancel() on a still-arriving body aborts the fetch so the
+        // connection closes and the server observes the cancellation. A fully
+        // received body is left to drain/cleanup so the socket stays reusable.
+        if this.result.has_more {
+            this.abort_task();
+        }
         this.ignore_remaining_response_body(false);
     }
 
@@ -1772,8 +1778,14 @@ impl FetchTasklet {
         {
             self.schedule_receive_resume();
         }
+        let aborted = self.signal_store.aborted.load(Ordering::Relaxed);
         if let Some(http_) = self.http.as_mut() {
-            http_.enable_response_body_streaming();
+            // An aborted fetch (reader.cancel() on an in-flight body, or an
+            // AbortSignal) is already shutting the connection down; draining
+            // would read the rest of an unbounded body and hold the socket open.
+            if !aborted {
+                http_.enable_response_body_streaming();
+            }
         }
         // we should not keep the process alive if we are ignoring the body
         let _ = self.javascript_vm;

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1607,11 +1607,9 @@ impl FetchTasklet {
         if this.signal_store.body_receive_mode() == BodyReceiveMode::Ignore {
             return;
         }
-        // reader.cancel() on a still-arriving body aborts the fetch so the
-        // connection closes and the server observes the cancellation. A fully
-        // received body is left to drain/cleanup so the socket stays reusable.
-        // `result` is replaced wholesale by the HTTP thread under `mutex`, so
-        // read `has_more` under the lock like the other JS-thread callbacks.
+        // reader.cancel() on a still-arriving body aborts the fetch (server sees
+        // the close); a received body drains/cleans up for reuse. Read `has_more`
+        // under `mutex`: the HTTP thread replaces `result` wholesale.
         this.mutex.lock();
         let has_more = this.result.has_more;
         this.mutex.unlock();
@@ -1762,10 +1760,9 @@ impl FetchTasklet {
         }
         // enabling streaming will make the http thread to drain into the main thread (aka stop buffering)
         // without a stream ref, response body or response instance alive it will just ignore the result
-        // An aborted fetch (reader.cancel() on an in-flight body, or an
-        // AbortSignal) is already shutting the connection down; don't re-arm the
-        // receive or resume draining, which would read the rest of an unbounded
-        // body and hold the socket open (drain_events resumes before shutdowns).
+        // An aborted fetch is already shutting down; don't re-arm receive/resume
+        // draining, which would read the rest of an unbounded body and hold the
+        // socket open (drain_events resumes before shutdowns).
         let aborted = self.signal_store.aborted.load(Ordering::Relaxed);
         if self
             .signal_store

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1152,12 +1152,7 @@ impl FetchTasklet {
                             // mark to wait until deinit
                             self.is_waiting_abort = self.result.has_more;
                             self.abort_reason.set(&global_object, check_result);
-                            self.signal_store.aborted.store(true, Ordering::Relaxed);
-                            self.tracker.did_cancel(&self.global_this);
-                            // we need to abort the request
-                            if let Some(http_) = self.http.as_mut() {
-                                http::http_thread().schedule_shutdown(http_);
-                            }
+                            self.abort_task();
                             self.result.fail = Some(err!("ERR_TLS_CERT_ALTNAME_INVALID"));
                             return false;
                         }
@@ -1177,11 +1172,7 @@ impl FetchTasklet {
                             let hostname_err_result = global_object.try_take_exception().unwrap();
                             self.is_waiting_abort = self.result.has_more;
                             self.abort_reason.set(&global_object, hostname_err_result);
-                            self.signal_store.aborted.store(true, Ordering::Relaxed);
-                            self.tracker.did_cancel(&self.global_this);
-                            if let Some(http_) = self.http.as_mut() {
-                                http::http_thread().schedule_shutdown(http_);
-                            }
+                            self.abort_task();
                             self.result.fail = Some(err!("ERR_TLS_CERT_ALTNAME_INVALID"));
                             return false;
                         }
@@ -1202,13 +1193,7 @@ impl FetchTasklet {
                         // mark to wait until deinit
                         self.is_waiting_abort = self.result.has_more;
                         self.abort_reason.set(&global_object, check_result);
-                        self.signal_store.aborted.store(true, Ordering::Relaxed);
-                        self.tracker.did_cancel(&self.global_this);
-
-                        // we need to abort the request
-                        if let Some(http_) = self.http.as_mut() {
-                            http::http_thread().schedule_shutdown(http_);
-                        }
+                        self.abort_task();
                         self.result.fail = Some(err!("ERR_TLS_CERT_ALTNAME_INVALID"));
                         return false;
                     }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1607,15 +1607,10 @@ impl FetchTasklet {
         if this.signal_store.body_receive_mode() == BodyReceiveMode::Ignore {
             return;
         }
-        // reader.cancel() on a still-arriving body aborts the fetch (server sees
-        // the close); a received body drains/cleans up for reuse. Read `has_more`
-        // under `mutex`: the HTTP thread replaces `result` wholesale.
-        this.mutex.lock();
-        let has_more = this.result.has_more;
-        this.mutex.unlock();
-        if has_more {
-            this.abort_task();
-        }
+        // reader.cancel() / body.cancel() aborts the fetch so the server sees the
+        // close (Node/Deno/browsers abort unconditionally). abort_task() is
+        // idempotent and only touches atomics + schedule_shutdown.
+        this.abort_task();
         this.ignore_remaining_response_body(false);
     }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1625,7 +1625,12 @@ impl FetchTasklet {
         // reader.cancel() on a still-arriving body aborts the fetch so the
         // connection closes and the server observes the cancellation. A fully
         // received body is left to drain/cleanup so the socket stays reusable.
-        if this.result.has_more {
+        // `result` is replaced wholesale by the HTTP thread under `mutex`, so
+        // read `has_more` under the lock like the other JS-thread callbacks.
+        this.mutex.lock();
+        let has_more = this.result.has_more;
+        this.mutex.unlock();
+        if has_more {
             this.abort_task();
         }
         this.ignore_remaining_response_body(false);
@@ -1772,17 +1777,19 @@ impl FetchTasklet {
         }
         // enabling streaming will make the http thread to drain into the main thread (aka stop buffering)
         // without a stream ref, response body or response instance alive it will just ignore the result
+        // An aborted fetch (reader.cancel() on an in-flight body, or an
+        // AbortSignal) is already shutting the connection down; don't re-arm the
+        // receive or resume draining, which would read the rest of an unbounded
+        // body and hold the socket open (drain_events resumes before shutdowns).
+        let aborted = self.signal_store.aborted.load(Ordering::Relaxed);
         if self
             .signal_store
             .set_receive_mode_terminal(BodyReceiveMode::Ignore)
+            && !aborted
         {
             self.schedule_receive_resume();
         }
-        let aborted = self.signal_store.aborted.load(Ordering::Relaxed);
         if let Some(http_) = self.http.as_mut() {
-            // An aborted fetch (reader.cancel() on an in-flight body, or an
-            // AbortSignal) is already shutting the connection down; draining
-            // would read the rest of an unbounded body and hold the socket open.
             if !aborted {
                 http_.enable_response_body_streaming();
             }
@@ -2266,7 +2273,12 @@ impl FetchTasklet {
     }
 
     pub(crate) fn abort_task(&mut self) {
-        self.signal_store.aborted.store(true, Ordering::Relaxed);
+        // Idempotent: reader.cancel() and an AbortSignal can both reach here for
+        // the same fetch. Only the first abort enqueues a shutdown; a second
+        // would append a redundant ShutdownMessage for an already-closing socket.
+        if self.signal_store.aborted.swap(true, Ordering::Relaxed) {
+            return;
+        }
         self.tracker.did_cancel(&self.global_this);
 
         if let Some(http_) = self.http.as_mut() {

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -300,21 +300,21 @@ describe.concurrent("fetch() receive backpressure — buffered consumers are not
 });
 
 describe.concurrent("fetch() receive backpressure — streaming consumer shapes", () => {
-  test("reader.cancel() resumes the socket so the abandoned body drains", async () => {
+  test("reader.cancel() aborts the in-flight request instead of draining the abandoned body", async () => {
     await using server = await serve("h1");
     const r1 = await fetch(server.url, { keepalive: true });
     const reader = r1.body!.getReader();
     await reader.read();
     await Bun.sleep(50);
     await reader.cancel();
-    // The cancelled body must drain before the connection is poolable;
-    // poll server.sent() instead of asserting a connection count.
-    while (server.sent() < TOTAL) await Bun.sleep(5);
+    // Cancelling an in-flight body aborts the request (matching Node/Deno and
+    // browsers, see #33227): the connection closes, so the server never sends
+    // the whole body. A subsequent request still succeeds on a fresh connection.
     const buf = await (await fetch(server.url, { keepalive: true })).arrayBuffer();
-    expect({ byteLength: buf.byteLength, sent: server.sent() }).toEqual({
-      byteLength: TOTAL,
-      sent: 2 * TOTAL,
-    });
+    expect(buf.byteLength).toBe(TOTAL);
+    // Drain-for-keepalive would push the first body to completion too, reaching
+    // 2 * TOTAL; the abort leaves the first response only partially sent.
+    expect(server.sent()).toBeLessThan(2 * TOTAL);
   });
 
   test("res.body.tee() both branches drain", async () => {

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -305,7 +305,6 @@ describe.concurrent("fetch() receive backpressure — streaming consumer shapes"
     const r1 = await fetch(server.url, { keepalive: true });
     const reader = r1.body!.getReader();
     await reader.read();
-    await Bun.sleep(50);
     await reader.cancel();
     // reader.cancel() aborts the in-flight request (#33227), closing the
     // connection; the client must recover so a later request still completes.

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -300,21 +300,18 @@ describe.concurrent("fetch() receive backpressure — buffered consumers are not
 });
 
 describe.concurrent("fetch() receive backpressure — streaming consumer shapes", () => {
-  test("reader.cancel() aborts the in-flight request instead of draining the abandoned body", async () => {
+  test("reader.cancel() mid-stream lets a subsequent request complete", async () => {
     await using server = await serve("h1");
     const r1 = await fetch(server.url, { keepalive: true });
     const reader = r1.body!.getReader();
     await reader.read();
     await Bun.sleep(50);
     await reader.cancel();
-    // Cancelling an in-flight body aborts the request (matching Node/Deno and
-    // browsers, see #33227): the connection closes, so the server never sends
-    // the whole body. A subsequent request still succeeds on a fresh connection.
+    // reader.cancel() aborts the in-flight request (#33227), closing the
+    // connection; the client must recover so a later request still completes.
+    // The abort-vs-drain behavior itself is asserted in regression/issue/33227.
     const buf = await (await fetch(server.url, { keepalive: true })).arrayBuffer();
     expect(buf.byteLength).toBe(TOTAL);
-    // Drain-for-keepalive would push the first body to completion too, reaching
-    // 2 * TOTAL; the abort leaves the first response only partially sent.
-    expect(server.sent()).toBeLessThan(2 * TOTAL);
   });
 
   test("res.body.tee() both branches drain", async () => {

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -1428,4 +1428,49 @@ describe.concurrent("fetch() with streaming", () => {
     expect(new TextDecoder().decode(result.value!)).toBe("hello\n");
     server.kill("SIGTERM");
   });
+
+  it("reader.cancel() aborts the request and triggers the server's stream cancel (#33227)", async () => {
+    const { promise: sawAbort, resolve: onAbort } = Promise.withResolvers<void>();
+    const { promise: sawCancel, resolve: onCancel } = Promise.withResolvers<void>();
+    const { promise: holdOpen } = Promise.withResolvers<void>();
+    const encoder = new TextEncoder();
+
+    using server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        request.signal.addEventListener("abort", () => onAbort());
+        let count = 0;
+        return new Response(
+          new ReadableStream({
+            async pull(controller) {
+              if (count < 8) {
+                controller.enqueue(encoder.encode(`data: ${count++}\n\n`));
+              } else {
+                // Keep the body in-flight (never closes) so the client is
+                // cancelling a response that is still arriving.
+                await holdOpen;
+              }
+            },
+            cancel() {
+              onCancel();
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      },
+    });
+
+    const res = await fetch(`http://localhost:${server.port}`, { method: "POST" });
+    const reader = res.body!.getReader();
+
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(first.value!.byteLength).toBeGreaterThan(0);
+
+    await reader.cancel();
+
+    // Cancelling the reader must abort the fetch and close the connection, so
+    // the server observes request.signal's abort and runs the body stream's cancel().
+    await Promise.all([sawAbort, sawCancel]);
+  });
 });

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -1428,49 +1428,4 @@ describe.concurrent("fetch() with streaming", () => {
     expect(new TextDecoder().decode(result.value!)).toBe("hello\n");
     server.kill("SIGTERM");
   });
-
-  it("reader.cancel() aborts the request and triggers the server's stream cancel (#33227)", async () => {
-    const { promise: sawAbort, resolve: onAbort } = Promise.withResolvers<void>();
-    const { promise: sawCancel, resolve: onCancel } = Promise.withResolvers<void>();
-    const { promise: holdOpen } = Promise.withResolvers<void>();
-    const encoder = new TextEncoder();
-
-    using server = Bun.serve({
-      port: 0,
-      fetch(request) {
-        request.signal.addEventListener("abort", () => onAbort());
-        let count = 0;
-        return new Response(
-          new ReadableStream({
-            async pull(controller) {
-              if (count < 8) {
-                controller.enqueue(encoder.encode(`data: ${count++}\n\n`));
-              } else {
-                // Keep the body in-flight (never closes) so the client is
-                // cancelling a response that is still arriving.
-                await holdOpen;
-              }
-            },
-            cancel() {
-              onCancel();
-            },
-          }),
-          { headers: { "Content-Type": "text/event-stream" } },
-        );
-      },
-    });
-
-    const res = await fetch(`http://localhost:${server.port}`, { method: "POST" });
-    const reader = res.body!.getReader();
-
-    const first = await reader.read();
-    expect(first.done).toBe(false);
-    expect(first.value!.byteLength).toBeGreaterThan(0);
-
-    await reader.cancel();
-
-    // Cancelling the reader must abort the fetch and close the connection, so
-    // the server observes request.signal's abort and runs the body stream's cancel().
-    await Promise.all([sawAbort, sawCancel]);
-  });
 });

--- a/test/regression/issue/33227.test.ts
+++ b/test/regression/issue/33227.test.ts
@@ -1,10 +1,10 @@
+import { sleep } from "bun";
 import { expect, test } from "bun:test";
 
 // https://github.com/oven-sh/bun/issues/33227
 test("reader.cancel() aborts the fetch and triggers the server's stream cancel", async () => {
   const { promise: sawAbort, resolve: onAbort } = Promise.withResolvers<void>();
   const { promise: sawCancel, resolve: onCancel } = Promise.withResolvers<void>();
-  const { promise: holdOpen } = Promise.withResolvers<void>();
   const encoder = new TextEncoder();
 
   using server = Bun.serve({
@@ -14,14 +14,12 @@ test("reader.cancel() aborts the fetch and triggers the server's stream cancel",
       let count = 0;
       return new Response(
         new ReadableStream({
+          // Stream forever (paced) so the body is always in flight: the unfixed
+          // drain path keeps the connection open and actively reading, so the
+          // server never sees a close unless the cancel actually aborts.
           async pull(controller) {
-            if (count < 8) {
-              controller.enqueue(encoder.encode(`data: ${count++}\n\n`));
-            } else {
-              // Keep the body in-flight (never closes) so the client is
-              // cancelling a response that is still arriving.
-              await holdOpen;
-            }
+            controller.enqueue(encoder.encode(`data: ${count++}\n\n`));
+            await sleep(10);
           },
           cancel() {
             onCancel();

--- a/test/regression/issue/33227.test.ts
+++ b/test/regression/issue/33227.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/33227
+test("reader.cancel() aborts the fetch and triggers the server's stream cancel", async () => {
+  const { promise: sawAbort, resolve: onAbort } = Promise.withResolvers<void>();
+  const { promise: sawCancel, resolve: onCancel } = Promise.withResolvers<void>();
+  const { promise: holdOpen } = Promise.withResolvers<void>();
+  const encoder = new TextEncoder();
+
+  using server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      request.signal.addEventListener("abort", () => onAbort());
+      let count = 0;
+      return new Response(
+        new ReadableStream({
+          async pull(controller) {
+            if (count < 8) {
+              controller.enqueue(encoder.encode(`data: ${count++}\n\n`));
+            } else {
+              // Keep the body in-flight (never closes) so the client is
+              // cancelling a response that is still arriving.
+              await holdOpen;
+            }
+          },
+          cancel() {
+            onCancel();
+          },
+        }),
+        { headers: { "Content-Type": "text/event-stream" } },
+      );
+    },
+  });
+
+  const res = await fetch(`http://localhost:${server.port}`, { method: "POST" });
+  const reader = res.body!.getReader();
+
+  const first = await reader.read();
+  expect(first.done).toBe(false);
+  expect(first.value!.byteLength).toBeGreaterThan(0);
+
+  await reader.cancel();
+
+  // Cancelling the reader must abort the fetch and close the connection, so the
+  // server observes request.signal's abort and runs the body stream's cancel().
+  await Promise.all([sawAbort, sawCancel]);
+});


### PR DESCRIPTION
Fixes #33227 (reopen of #19211).

### Repro

```ts
import { sleep } from "bun";

let cancelled = false;
let aborted = false;

const server = Bun.serve({
  fetch(request) {
    let count = 0;
    request.signal.addEventListener("abort", () => { aborted = true; });
    return new Response(new ReadableStream({
      async pull(controller) {
        controller.enqueue(`data: ${count++}\n\n`);
        await sleep(1000);
      },
      async cancel() { cancelled = true; },
    }), { headers: { "Content-Type": "text/event-stream" } });
  },
  port: 0,
});

const res = await fetch(`http://localhost:${server.port}`, { method: "POST" });
const reader = res.body!.getReader();
await reader.read();
await reader.read();

await reader.cancel();          // should abort the fetch / close the connection
await sleep(1000);

console.log("aborted   =", aborted, "(expected true)");
console.log("cancelled =", cancelled, "(expected true)");
```

Before: `aborted = false`, `cancelled = false`. The client kept the
connection open and drained the body, so the server never saw the cancel.

### Cause

Cancelling a fetch response body reader (`reader.cancel()` /
`res.body.cancel()`) routes through the stream source's cancel handler to
`FetchTasklet::on_stream_cancelled_callback`, which called
`ignore_remaining_response_body`. That path sets the receive mode to `Ignore`
and calls `enable_response_body_streaming()`, which keeps reading and
discarding the remaining response body to leave the socket reusable. For an
unbounded or still-streaming response that drain never completes, so the
connection is held open indefinitely and the server never observes a close,
never fires `request.signal`'s `abort`, and never runs the response stream's
`cancel`.

### Fix

When the response body is still arriving at cancel time (`result.has_more`),
abort the fetch via the existing `abort_task()` (sets the aborted flag, cancels
the tracker, and `schedule_shutdown`s the connection) instead of draining, so
the connection closes and the server observes the cancellation. A fully
received body has nothing left to abort and still falls through to the
drain/cleanup path, leaving the socket reusable for keep-alive.
`ignore_remaining_response_body` now skips the drain when the fetch is aborted,
since the connection is already shutting down.

This routes both `reader.cancel()` and `res.body.cancel()`, over HTTP/1 and
HTTP/2, through the same shared path.

### Verification

New regression test in `test/regression/issue/33227.test.ts`: a server streams
an SSE body and records `request.signal` abort + the response stream's `cancel`;
the client reads a chunk then calls `reader.cancel()` and awaits both
server-side callbacks firing.

- With the fix: passes (~260ms).
- Without the fix (`git stash` of `src/`): the callbacks never fire and the
  test times out.

`test/js/web/fetch/fetch-stream-cancel-leak.test.ts` (GC after
`reader.cancel()` / `body.cancel()`) and the abort-path tests
(`fetch-abort-stream-body`, `fetch-abort-queued`, `fetch-abort-socket-close-race`)
still pass.