### PR TITLE
bake: normalize the HTTP request-target before matching framework routes

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5217,7 +5217,11 @@ impl From<framework_router::OpaqueFileIdOptional> for OpaqueFileIdOrOptional {
 
 fn on_request(dev: &mut DevServer, req: &mut Request, mut resp: AnyResponse) {
     let mut params: framework_router::MatchedParams = Default::default();
-    if let Some(route_index) = dev.router.match_slow(req.url(), &mut params) {
+    // The raw request-target includes the query string and may be in
+    // absolute-form (`GET http://host/path`, RFC 9112 section 3.2.2); the
+    // router only understands origin-form pathnames.
+    let pathname = extract_pathname_from_url(req.url());
+    if let Some(route_index) = dev.router.match_slow(pathname, &mut params) {
         let route_bundle_index = dev
             .get_or_put_route_bundle(route_bundle::UnresolvedIndex::Framework(route_index))
             .expect("oom");
@@ -7139,29 +7143,33 @@ fn new_route_params_for_bundle_promise(
     )
 }
 
-// TODO: this is shitty
+/// Extracts the origin-form pathname (no query string or fragment) from either
+/// a full URL (`scheme://host/path?q`) or a raw HTTP request-target. Targets
+/// with no path (`CONNECT host:port`, `OPTIONS *`) are returned unchanged, so
+/// they never start with `/` and never match a route.
 fn extract_pathname_from_url(url: &[u8]) -> &[u8] {
-    // Extract pathname from URL (remove protocol, host, query, hash)
-    let mut pathname = if let Some(proto_end) = strings::index_of(url, b"://") {
-        &url[proto_end + 3..]
-    } else {
+    // An origin-form target is already a pathname; scanning it for "://" would
+    // mangle paths that embed a URL, like "/proxy/https://example.com".
+    let pathname = if url.first() == Some(&b'/') {
         url
+    } else if let Some(scheme_end) = strings::index_of(url, b"://") {
+        match strings::index_of_char_pos(url, b'/', scheme_end + b"://".len()) {
+            Some(path_start) => &url[path_start..],
+            // `http://host` and `http://host?q` name an empty path, meaning "/"
+            None => b"/",
+        }
+    } else {
+        return url;
     };
 
-    if let Some(path_start) = strings::index_of_char(pathname, b'/') {
-        let path_with_query = &pathname[path_start as usize..];
-        // Remove query string and hash
-        let query_index = strings::index_of_char(path_with_query, b'?')
-            .map(|i| i as usize)
-            .unwrap_or(path_with_query.len());
-        let hash_index = strings::index_of_char(path_with_query, b'#')
-            .map(|i| i as usize)
-            .unwrap_or(path_with_query.len());
-        let end = query_index.min(hash_index);
-        pathname = &path_with_query[..end];
-    }
-
-    pathname
+    // Remove query string and hash
+    let query_index = strings::index_of_char(pathname, b'?')
+        .map(|i| i as usize)
+        .unwrap_or(pathname.len());
+    let hash_index = strings::index_of_char(pathname, b'#')
+        .map(|i| i as usize)
+        .unwrap_or(pathname.len());
+    &pathname[..query_index.min(hash_index)]
 }
 
 // Type aliases referenced throughout (Phase B will resolve to real paths)

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -7153,10 +7153,12 @@ fn extract_pathname_from_url(url: &[u8]) -> &[u8] {
     let pathname = if url.first() == Some(&b'/') {
         url
     } else if let Some(scheme_end) = strings::index_of(url, b"://") {
-        match strings::index_of_char_pos(url, b'/', scheme_end + b"://".len()) {
-            Some(path_start) => &url[path_start..],
+        // The authority ends at the first '/', '?' or '#' (RFC 3986 section
+        // 3.2), so a '/' later in the query is not the start of the path.
+        match strings::index_of_any_pos_comptime(url, b"/?#", scheme_end + b"://".len()) {
+            Some(path_start) if url[path_start] == b'/' => &url[path_start..],
             // `http://host` and `http://host?q` name an empty path, meaning "/"
-            None => b"/",
+            _ => b"/",
         }
     } else {
         return url;

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1279,7 +1279,12 @@ impl FrameworkRouter {
     pub fn match_slow(&self, path: &[u8], params: &mut MatchedParams) -> Option<RouteIndex> {
         params.params = BoundedArray::default();
 
-        debug_assert!(path[0] == b'/');
+        // Every route pattern starts with '/', so anything else cannot match.
+        // Callers feed this request-targets and HMR/JS-provided patterns, which
+        // are not guaranteed to be origin-form.
+        if path.first() != Some(&b'/') {
+            return None;
+        }
         if let Some(static_route) = self.static_routes.get(path) {
             return Some(*static_route);
         }

--- a/test/bake/dev/request-target.test.ts
+++ b/test/bake/dev/request-target.test.ts
@@ -1,0 +1,128 @@
+// Tests for how the dev server maps the raw HTTP/1.1 request-target onto
+// framework routes. The request-target is not always an origin-form pathname:
+// it carries the query string, proxies send absolute-form targets
+// (`GET http://host/path HTTP/1.1`, RFC 9112 section 3.2.2), and CONNECT /
+// `OPTIONS *` do not name a path at all.
+import { expect } from "bun:test";
+import { devTest, minimalFramework } from "../bake-harness";
+
+/**
+ * Writes `requestLine` as a raw HTTP/1.1 request over a TCP socket (fetch()
+ * cannot produce these request-targets) and returns the parsed response. The
+ * promise resolves once `Content-Length` bytes of the body arrived, or when
+ * the server closes the socket; a crashed server closes it with no bytes,
+ * which fails the status-line assertion.
+ */
+async function rawRequest(port: number, requestLine: string): Promise<{ status: string; body: string }> {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const chunks: Buffer[] = [];
+  const parse = () => {
+    const response = Buffer.concat(chunks).toString();
+    const headerEnd = response.indexOf("\r\n\r\n");
+    const body = headerEnd === -1 ? "" : response.slice(headerEnd + 4);
+    const contentLength = headerEnd === -1 ? null : /^content-length: *(\d+)/im.exec(response.slice(0, headerEnd));
+    return {
+      status: response.split("\r\n")[0],
+      body,
+      complete: contentLength !== null && body.length >= Number(contentLength[1]),
+    };
+  };
+  await using socket = await Bun.connect({
+    hostname: "127.0.0.1",
+    port,
+    socket: {
+      open(socket) {
+        socket.write(`${requestLine}\r\nHost: 127.0.0.1:${port}\r\nConnection: close\r\n\r\n`);
+      },
+      data(socket, chunk) {
+        chunks.push(chunk);
+        if (parse().complete) resolve();
+      },
+      close() {
+        resolve();
+      },
+      error(socket, error) {
+        reject(error);
+      },
+      connectError(socket, error) {
+        reject(error);
+      },
+    },
+  });
+  await promise;
+  const { status, body } = parse();
+  return { status, body };
+}
+
+const routeFiles = {
+  "routes/index.ts": `
+    export default function (req, meta) {
+      return new Response("index route");
+    }
+  `,
+  "routes/blog/[slug].ts": `
+    export default function (req, meta) {
+      return new Response("slug=" + meta.params.slug);
+    }
+  `,
+  "routes/echo/[...rest].ts": `
+    export default function (req, meta) {
+      return new Response("rest=" + JSON.stringify(meta.params.rest));
+    }
+  `,
+};
+
+devTest("query string is not part of the route path", {
+  framework: minimalFramework,
+  files: routeFiles,
+  async test(dev) {
+    expect(await rawRequest(dev.port, "GET /?foo=bar HTTP/1.1")).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "index route",
+    });
+    expect(await rawRequest(dev.port, "GET /blog/abc?foo=bar#hash HTTP/1.1")).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "slug=abc",
+    });
+    // A pathname that embeds a URL is origin-form, not absolute-form.
+    expect(await rawRequest(dev.port, "GET /echo/https://example.com/a?q=1 HTTP/1.1")).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: 'rest=["https:","example.com","a"]',
+    });
+  },
+});
+
+devTest("absolute-form request-target routes like origin-form", {
+  framework: minimalFramework,
+  files: routeFiles,
+  async test(dev) {
+    // RFC 9112 section 3.2.2: a server MUST accept the absolute-form.
+    expect(await rawRequest(dev.port, `GET http://127.0.0.1:${dev.port}/ HTTP/1.1`)).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "index route",
+    });
+    expect(await rawRequest(dev.port, `GET http://127.0.0.1:${dev.port}/blog/abc?x=1 HTTP/1.1`)).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "slug=abc",
+    });
+    // An absolute-form target with an empty path names the root.
+    expect(await rawRequest(dev.port, `GET http://127.0.0.1:${dev.port} HTTP/1.1`)).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "index route",
+    });
+  },
+});
+
+devTest("authority-form request-target does not match a route and does not abort", {
+  framework: minimalFramework,
+  files: routeFiles,
+  async test(dev) {
+    // A CONNECT target names no path, so it can never match a route. It must
+    // not take the server down either; origin-form requests keep working.
+    expect(await rawRequest(dev.port, `CONNECT 127.0.0.1:${dev.port} HTTP/1.1`)).toEqual({
+      status: "HTTP/1.1 404 Not Found",
+      body: "404 Not Found",
+    });
+    await dev.fetch("/").equals("index route");
+  },
+});

--- a/test/bake/dev/request-target.test.ts
+++ b/test/bake/dev/request-target.test.ts
@@ -110,6 +110,12 @@ devTest("absolute-form request-target routes like origin-form", {
       status: "HTTP/1.1 200 OK",
       body: "index route",
     });
+    // The authority ends at '?' (RFC 3986 section 3.2); a '/' inside the
+    // query of an empty-path target is not the start of the path.
+    expect(await rawRequest(dev.port, `GET http://127.0.0.1:${dev.port}?next=/blog/abc HTTP/1.1`)).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "index route",
+    });
   },
 });
 

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -133,3 +133,17 @@ test("discovers from filesystem paths", () => {
     ],
   });
 });
+
+test("match only accepts origin-form paths", () => {
+  const dir = tempDirWithFiles("fsr-match", {
+    "index.tsx": "1",
+    "blog/[slug].tsx": "1",
+  });
+  const router = new FrameworkRouter({ root: dir, style: "nextjs-pages" });
+  expect(router.match("/blog/abc")).toMatchObject({ params: { slug: "abc" } });
+  // Paths that are not origin-form never match; they must not be treated as
+  // route patterns (which all start with "/").
+  expect(router.match("")).toBeNull();
+  expect(router.match("blog/abc")).toBeNull();
+  expect(router.match("https://example.com/blog/abc")).toBeNull();
+});


### PR DESCRIPTION
### Problem

The bake dev server (`Bun.serve({ app })` with a framework router) matches framework routes against the raw HTTP/1.1 request-target. That value is not an origin-form pathname:

- it still carries the query string, so `GET /?x=1 HTTP/1.1` returns 404 for a `/` route the server owns,
- forward proxies send absolute-form targets (`GET http://host/path HTTP/1.1`), which RFC 9112 section 3.2.2 requires a server to accept; these also 404,
- on a build with debug assertions, any of those requests aborts the whole dev server process:

```
panic: assertion failed: path[0] == b'/'
  <bun_runtime::bake::framework_router_body::FrameworkRouter>::match_slow
  bun_runtime::bake::dev_server_body::on_request
```

Repro: start any dev server that has a framework router, then over a raw TCP socket send one of

```
GET /?x=1 HTTP/1.1
GET http://127.0.0.1:PORT/ HTTP/1.1
CONNECT 127.0.0.1:PORT HTTP/1.1
```

(each followed by `Host: 127.0.0.1:PORT` and a blank line).

### Cause

`on_request` in `src/runtime/bake/DevServer.rs` passed `req.url()` (uWS `getFullUrl()`, the verbatim request-target) to `FrameworkRouter::match_slow`, whose contract is an origin-form path (`debug_assert!(path[0] == b'/')`). Static route keys are exact strings like `/blog`, so `/blog?x=1` or `http://host/blog` never match them, and the dynamic matcher starts at `path[1]`, so a non-origin-form target can even bind garbage params on a catch-all route.

uWS's own router normalizes absolute-form targets before matching (`getUrlForRouting`), which is why plain `Bun.serve` routes are unaffected: only the framework router re-matches from the raw target.

### Fix

- `on_request` routes on `extract_pathname_from_url(req.url())`, the helper the other dev-server route lookups already use.
- `extract_pathname_from_url` knew about absolute-form but had two bugs: it scanned for `://` anywhere, so an origin-form path that embeds a URL (`/proxy/https://example.com/x`) was mangled, and `http://host` with no path produced `host` instead of `/`. It now only strips a scheme when the target does not start with `/`, maps an authority with no path to `/`, and still removes the query string and fragment.
- `FrameworkRouter::match_slow` returns `None` for a path that does not start with `/` instead of asserting. Every route pattern starts with `/`, so no match is the correct answer, and this function's inputs come from the wire (request-targets, including `CONNECT` authority-form, which uWS accepts and routes), the HMR websocket, and JS.

### Verification

`test/bake/dev/request-target.test.ts` (new): raw-socket requests against a dev server using the `nextjs-pages` framework router. Covers query strings and fragments, absolute-form with a path, with a path plus query, and with no path, an origin-form path that embeds a URL, and `CONNECT`, plus a follow-up request proving the server is still alive. On the unfixed build all three tests fail: the query-string case gets a 404 and the absolute-form and CONNECT cases kill the server with the panic above.

`test/bake/framework-router.test.ts`: `FrameworkRouter.match()` (internal testing API) returns `null` for `""` and other non-origin-form paths. On the unfixed build, `match("")` aborts with `panic: index out of bounds: the len is 0 but the index is 0` inside the same assertion.

Also ran with the fix: `test/bake/framework-router.test.ts` (36 pass), `test/bake/dev/bundle.test.ts` (20 pass), `test/bake/dev/ssg-pages-router.test.ts` (9 pass), `test/bake/dev/request-cookies.test.ts` (2 pass).

Related but separate: #33196 fixes HMR websocket frames that reach the same assertion through `route_to_bundle_index_slow`; that path validates at the socket layer and is not covered by (nor does it cover) this change.
