### PR TITLE
worker_threads: make postMessage on an exited worker a silent no-op

### DIFF
--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -205,8 +205,11 @@ bool Worker::postTaskToParent(Function<void(ScriptExecutionContext&)>&& task)
 
 ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
-    if (m_state.load() == State::Closed)
-        return Exception { InvalidStateError, "Worker has been terminated"_s };
+    // Posting to a worker that has exited (or been terminated) is a silent
+    // no-op, like Node and the HTML spec. Return before serializing so the
+    // undeliverable message cannot detach transferList entries or throw.
+    if (m_state.load() >= State::Closing)
+        return {};
 
     Vector<RefPtr<MessagePort>> ports;
     auto serialized = SerializedScriptValue::create(state, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
@@ -227,13 +230,12 @@ void Worker::enqueueToWorker(MessageWithMessagePorts&& message)
     {
         Locker locker { m_toWorker.lock };
         m_toWorker.queue.append(WTF::move(message));
-        // If the worker isn't Running yet, just buffer; fireEarlyMessages()
-        // drains the inbox on the worker thread once it is. If Closing/
-        // Closed, also buffer (dropped with the Worker) — postMessage()
-        // already rejects on Closed, so only the close-handler window lands
-        // here. If a drain is already scheduled, don't double-schedule.
-        // drainScheduled is only set/cleared under the lock so the
-        // load/store pair is not a race.
+        // Pending: buffer here; fireEarlyMessages() drains the inbox on the
+        // worker thread once it's Running. postMessage() no-ops at Closing/
+        // Closed, so nothing lands here after the worker exits. If a drain
+        // is already scheduled, don't double-schedule. drainScheduled is
+        // only set/cleared under the lock so the load/store pair is not a
+        // race.
         if (m_state.load() != State::Running || m_toWorker.drainScheduled.load(std::memory_order_relaxed))
             return;
         m_toWorker.drainScheduled.store(true, std::memory_order_relaxed);
@@ -603,10 +605,9 @@ bool Worker::dispatchExit(int32_t exitCode)
         m_parentContextId,
         [this] { this->deref(); },
         [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext&) {
-            // Closing → dispatch 'close' → Closed. The split lets 'close'/'exit'
-            // handlers observe threadId == -1 and isOnline() == false while
-            // postMessage() (gated only on Closed) still accepts and drops the
-            // message, matching browser/Node and pre-refactor behaviour.
+            // Closing -> dispatch 'close' -> Closed. The split lets 'close'/
+            // 'exit' handlers observe threadId == -1 and isOnline() == false
+            // while hasPendingActivity() still holds for the close dispatch.
             //
             // Drop any tasks queued while the worker was Pending and never
             // reached Running (m_pendingCrossVMRequests / rejectAllCrossVMRequests

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -84,9 +84,9 @@ struct WorkerOptions;
 ///                 └────────┘  dispatched      └────────┘
 ///
 /// Closing exists so that inside the 'close'/'exit' handler threadId reads
-/// -1 and isOnline() is false (old ClosingFlag behaviour) while postMessage()
-/// — which only gates on Closed (old TerminatedFlag behaviour) — still
-/// accepts and silently drops the message, matching browser/Node semantics.
+/// -1 and isOnline() is false while hasPendingActivity() still holds for the
+/// close dispatch. postMessage() silently drops from Closing onward,
+/// matching browser/Node semantics.
 ///
 /// m_terminateRequested is orthogonal: set once by terminate(), gates
 /// dispatchEvent()/setKeepAlive(), and is mirrored into the native side via

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
@@ -21,6 +22,10 @@ import wt, {
   Worker,
   workerData,
 } from "worker_threads";
+
+// Most tests here spawn a subprocess that starts a worker JSC VM; under a
+// debug+ASAN build several of them exceed the 5s default timeout.
+setDefaultTimeout(1000 * 60 * 5);
 
 test("support eval in worker", async () => {
   const worker = new Worker(`postMessage(1 + 1)`, {
@@ -201,6 +206,42 @@ test("threadId module and worker property is consistent", async () => {
   expect(() => worker2.postMessage({ workerId: worker2.threadId })).not.toThrow();
   await worker1.terminate();
   await worker2.terminate();
+});
+
+// Node's worker.postMessage() is a silent no-op once the worker has exited
+// or been terminated; it never throws for a dead worker.
+test("postMessage after the worker has exited is a no-op", async () => {
+  const worker = new Worker("", { eval: true });
+  const exitCode = await new Promise<number>(resolve => worker.on("exit", resolve));
+  expect(exitCode).toBe(0);
+  expect(() => worker.postMessage("after exit")).not.toThrow();
+});
+
+test("postMessage after terminate() resolves is a no-op", async () => {
+  const worker = new Worker("setInterval(() => {}, 100000)", { eval: true });
+  await new Promise(resolve => worker.on("online", resolve));
+  await worker.terminate();
+  expect(() => worker.postMessage("after terminate")).not.toThrow();
+});
+
+// Node returns before serializing, so a message to a dead worker can neither
+// throw a DataCloneError nor detach its transferList entries. This holds
+// from inside the 'exit' handler itself onward.
+test("postMessage to an exited worker does not serialize the message", async () => {
+  const worker = new Worker("", { eval: true });
+  await new Promise<void>((resolve, reject) => {
+    worker.on("exit", () => {
+      try {
+        worker.postMessage(() => {});
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+  const buffer = new ArrayBuffer(8);
+  expect(() => worker.postMessage(buffer, [buffer])).not.toThrow();
+  expect(buffer.byteLength).toBe(8);
 });
 
 test("receiveMessageOnPort works across threads", async () => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -246,7 +246,8 @@ describe("web worker", () => {
 
   // The bug under test makes the parent's event loop exit before the worker
   // message exchange finishes, so the child exits 0 without ever printing
-  // "done". A true hang is caught by the per-test timeout.
+  // "done". A true hang is bounded by the 30s explicit timeout below; the
+  // fixture itself takes about a second under a debug+ASAN build.
   async function expectEventLoopSurvivesManyMessages(fixture: string) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), fixture],
@@ -258,11 +259,17 @@ describe("web worker", () => {
     expect(exitCode).toBe(0);
   }
 
-  test("worker with event listeners doesn't close event loop", () =>
-    expectEventLoopSurvivesManyMessages("worker-fixture-many-messages.js"));
+  test(
+    "worker with event listeners doesn't close event loop",
+    () => expectEventLoopSurvivesManyMessages("worker-fixture-many-messages.js"),
+    30_000,
+  );
 
-  test("worker with event listeners doesn't close event loop 2", () =>
-    expectEventLoopSurvivesManyMessages("worker-fixture-many-messages2.js"));
+  test(
+    "worker with event listeners doesn't close event loop 2",
+    () => expectEventLoopSurvivesManyMessages("worker-fixture-many-messages2.js"),
+    30_000,
+  );
 
   test("worker with process.exit", done => {
     const worker = new Worker(new URL("worker-fixture-process-exit.js", import.meta.url), {
@@ -288,9 +295,32 @@ describe("web worker", () => {
     await closed;
     expect(() => terminated.postMessage("after terminate")).not.toThrow();
 
+    // Inside the 'close' handler the worker is still in the Closing state.
+    // The message must be dropped before serialization even there, so a
+    // non-cloneable value cannot reach structured clone and throw.
     const exited = new Worker("data:text/javascript,");
-    await new Promise(resolve => exited.addEventListener("close", resolve, { once: true }));
+    await new Promise<void>((resolve, reject) => {
+      exited.addEventListener(
+        "close",
+        () => {
+          try {
+            exited.postMessage(() => {});
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        { once: true },
+      );
+    });
     expect(() => exited.postMessage("after exit")).not.toThrow();
+
+    // One tick later (Closed) the same holds: no DataCloneError for a
+    // non-cloneable value, and a transferList entry is not detached.
+    expect(() => exited.postMessage(() => {})).not.toThrow();
+    const buffer = new ArrayBuffer(8);
+    expect(() => exited.postMessage(buffer, [buffer])).not.toThrow();
+    expect(buffer.byteLength).toBe(8);
   });
 
   describe("worker event", () => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { once } from "events";
 import { bunEnv, bunExe } from "harness";
 import path from "path";
 import wt from "worker_threads";
+
+// Most tests here spawn a subprocess that starts a worker JSC VM; under a
+// debug+ASAN build several of them exceed the 5s default timeout.
+setDefaultTimeout(1000 * 60 * 5);
 
 describe("web worker", () => {
   async function waitForWorkerResult(worker: Worker, message: any): Promise<any> {
@@ -240,61 +244,25 @@ describe("web worker", () => {
     });
   });
 
-  test("worker with event listeners doesn't close event loop", done => {
-    const x = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), "worker-fixture-many-messages.js"],
+  // The bug under test makes the parent's event loop exit before the worker
+  // message exchange finishes, so the child exits 0 without ever printing
+  // "done". A true hang is caught by the per-test timeout.
+  async function expectEventLoopSurvivesManyMessages(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), fixture],
       env: bunEnv,
       stdio: ["inherit", "pipe", "inherit"],
     });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("done\n");
+    expect(exitCode).toBe(0);
+  }
 
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
+  test("worker with event listeners doesn't close event loop", () =>
+    expectEventLoopSurvivesManyMessages("worker-fixture-many-messages.js"));
 
-    x.exited.then(async code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        done(new Error("exited with non-zero code"));
-      } else {
-        const text = await new Response(x.stdout).text();
-        if (!text.includes("done")) {
-          console.log({ text });
-          done(new Error("event loop killed early"));
-        } else {
-          done();
-        }
-      }
-    });
-  });
-
-  test("worker with event listeners doesn't close event loop 2", done => {
-    const x = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "many-messages-event-loop.js"), "worker-fixture-many-messages2.js"],
-      env: bunEnv,
-      stdio: ["inherit", "pipe", "inherit"],
-    });
-
-    const timer = setTimeout(() => {
-      x.kill();
-      done(new Error("timeout"));
-    }, 1000);
-
-    x.exited.then(async code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        done(new Error("exited with non-zero code"));
-      } else {
-        const text = await new Response(x.stdout).text();
-        if (!text.includes("done")) {
-          console.log({ text });
-          done(new Error("event loop killed early"));
-        } else {
-          done();
-        }
-      }
-    });
-  });
+  test("worker with event listeners doesn't close event loop 2", () =>
+    expectEventLoopSurvivesManyMessages("worker-fixture-many-messages2.js"));
 
   test("worker with process.exit", done => {
     const worker = new Worker(new URL("worker-fixture-process-exit.js", import.meta.url), {
@@ -308,6 +276,21 @@ describe("web worker", () => {
       }
       done();
     });
+  });
+
+  // terminate() never disentangles the implicit port, so posting to a dead
+  // Worker is a silent no-op (per the HTML spec, and Chrome/Firefox/Node).
+  test("postMessage after terminate() or exit is a no-op", async () => {
+    const terminated = new Worker("data:text/javascript,setInterval(() => {}, 100000)");
+    await new Promise(resolve => terminated.addEventListener("open", resolve, { once: true }));
+    const closed = new Promise(resolve => terminated.addEventListener("close", resolve, { once: true }));
+    terminated.terminate();
+    await closed;
+    expect(() => terminated.postMessage("after terminate")).not.toThrow();
+
+    const exited = new Worker("data:text/javascript,");
+    await new Promise(resolve => exited.addEventListener("close", resolve, { once: true }));
+    expect(() => exited.postMessage("after exit")).not.toThrow();
   });
 
   describe("worker event", () => {


### PR DESCRIPTION
Fixes #20425

### What does this PR do?

`worker.postMessage()` throws once a worker has exited or been terminated:

```
InvalidStateError: Worker has been terminated
```

```js
import { Worker } from "node:worker_threads";
const w = new Worker("", { eval: true });
await new Promise(r => w.on("exit", r));
w.postMessage("x"); // bun: throws InvalidStateError. node: no-op
```

The same happens after `await worker.terminate()`, and for the Web `Worker` global. Node implements a silent no-op; that is what lets a worker pool post to a worker without guarding against it having just died, while under Bun the same code throws in whatever context did the post. This is what breaks `pgmock` in #20425: its embedded x86 emulator posts to a worker that has exited, and `postMessage@[native code]` surfaces the `InvalidStateError` as an unhandled error.

The throw comes from WebKit's terminated check in `Worker::postMessage` (`src/jsc/bindings/webcore/Worker.cpp`):

```cpp
if (m_state.load() == State::Closed)
    return Exception { InvalidStateError, "Worker has been terminated"_s };
```

The `Closing` state was added precisely so the in-handler window silently drops ("matching browser/Node semantics", per the comment in `Worker.h`), but `Closed` kept the throw. The throw is a Safari-only behavior: the HTML spec's "terminate a worker" never disentangles the implicit port, so Chrome, Firefox, and Node all no-op. Node's `Worker.prototype.postMessage` returns before serializing once the port is gone (`lib/internal/worker.js`: `if (this[kPublicPort] === null) return;`), and it nulls that port before emitting `exit`.

The fix: return early from `Worker::postMessage`, before serializing, once the worker has exited (`m_state >= State::Closing`). That matches Node in all three windows: inside the exit handler, after the exit event, and after `terminate()`. Returning before serialization also means a message to a dead worker can no longer throw `DataCloneError` or detach its transferList entries, which the previous `Closing` path did while serializing into a queue that could only be dropped.

### How did you verify your code works?

- `test/js/node/worker_threads/worker_threads.test.ts`: `postMessage` after the `exit` event, after `terminate()` resolves, and with a non-cloneable message plus a transferList from inside the exit handler onward.
- `test/js/web/workers/worker.test.ts`: the Web `Worker` after `terminate()` (`Closed`), from inside the `close` handler with a non-cloneable value (`Closing`), and after a natural exit with a non-cloneable value and a transferList.

Every one fails on an unmodified build and passes with this change (`bun bd test <file>` both ways). Behavior checked against node v26.3.0. The error string `"Worker has been terminated"` exists at exactly one line in the source, the one changed here, and running the pgmock reproduction from #20425 on an unmodified build reproduces it at the expected `postMessage@[native code]` frame.

`bun bd test <file>` was already red on unmodified main for both files, independent of this change, so the following is included to get them reliably green:

- The two "worker with event listeners doesn't close event loop" tests raced a spawned debug build against a hardcoded 1s `setTimeout`. Replaced the timer with awaiting the process and asserting the same output exactly, with an explicit 30s per-test timeout so a real hang is still bounded tightly (the fixture itself takes about a second under debug+ASAN). Also deduplicated the two copy-pasted bodies into a helper.
- Several tests in these files only pass because the CI runner injects `--timeout=90000`. Set the same file-level `setDefaultTimeout` the shell test suites use. The precedence is explicit per-test timeout, then `setDefaultTimeout()`, then `--timeout` (verified empirically in a comment below), so this only raises the default for these two files and never tightens a CI budget.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (683555b1d)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [11.23ms]
(pass) web worker > preload > string [137.90ms]
(pass) web worker > preload > array of 2 strings [147.45ms]
(pass) web worker > preload > array of string [130.95ms]
(pass) web worker > preload > error in preload doesn't crash parent [156.39ms]
(pass) web worker > worker [128.59ms]
(pass) web worker > worker-env [134.57ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1067.25ms]
(pass) web worker > worker-env with a lot of properties [331.94ms]
(pass) web worker > argv / execArgv defaults [147.86ms]
(pass) web worker > argv / execArgv options [148.6
... (truncated)

release without fix: 4 failed, 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [0.21ms]
(pass) web worker > preload > string [5.09ms]
(pass) web worker > preload > array of 2 strings [3.52ms]
(pass) web worker > preload > array of string [4.23ms]
(pass) web worker > preload > error in preload doesn't crash parent [2.58ms]
(pass) web worker > worker [3.63ms]
(pass) web worker > worker-env [2.73ms]
166 |       ],
167 |       env: bunEnv,
168 |       stderr: "pipe",
169 |     });
170 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
171 |     expect(JSON.parse(stdout)).toEqual({ seen: "from-parent", parentSees: "from-worker" });
                      ^
SyntaxError: JSON Parse error: Unexpected EOF
      at <anonymous> (/workspace/bun/test/js/web/workers/worker.test.ts:171:17)
(fail) web worker > worker-env: SHARE_ENV via the global Worker constructor [22.24ms]
(pass) web worker > worker-env with a lot of properties [5.95ms]
(pass) web worker > argv / execArgv defaults [3.46ms]
(pass) web worker > argv / execArgv options [3.25ms]
(pass) web worker > sending 50 mess
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (683555b1d)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [12.42ms]
(pass) web worker > preload > string [147.89ms]
(pass) web worker > preload > array of 2 strings [158.26ms]
(pass) web worker > preload > array of string [138.09ms]
(pass) web worker > preload > error in preload doesn't crash parent [167.95ms]
(pass) web worker > worker [133.82ms]
(pass) web worker > worker-env [139.41ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1099.77ms]
(pass) web worker > worker-env with a lot of properties [335.87ms]
(pass) web worker > argv / execArgv defaults [147.42ms]
(pass) web worker > argv / execArgv options [144.9
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     683555b1d7
  features     (none)

22 deps, 106 codegen, 1168 objects in 844ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [9.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1231] gen ErrorCode+*.h
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] fetch zlib
[zlib] up to date
[8/1230] fetch picohttpparser
[picoh
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/Worker.cpp                |  27 ++---
 src/jsc/bindings/webcore/Worker.h                  |   6 +-
 test/js/node/worker_threads/worker_threads.test.ts |  41 ++++++++
 test/js/web/workers/worker.test.ts                 | 115 ++++++++++++---------
 4 files changed, 122 insertions(+), 67 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/Worker.cpp                     2      4      0
src/jsc/bindings/webcore/Worker.h                       1      1      0
test/js/node/worker_threads/worker_threads.test.ts      3      7      0
test/js/web/workers/worker.test.ts                      5      8      0
```

</details>

<!-- robobun:evidence:end -->