### PR TITLE
shell: separate multiple parse errors with newlines in ShellError.message

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2092,24 +2092,7 @@ impl<'bump> Parser<'bump> {
     }
 
     pub fn combine_errors(&self) -> &'bump [u8] {
-        let errors = &self.errors[..];
-
-        ({
-            let size = {
-                let mut i = 0usize;
-                for e in errors {
-                    i += e.msg.len();
-                }
-                i
-            };
-            let buf = self.alloc.alloc_slice_fill_copy(size, 0u8);
-            let mut i = 0usize;
-            for e in errors {
-                buf[i..i + e.msg.len()].copy_from_slice(e.msg);
-                i += e.msg.len();
-            }
-            buf
-        }) as _
+        join_error_msgs(self.alloc, self.errors[..].iter().map(|e| e.msg))
     }
 
     fn add_error(&mut self, args: fmt::Arguments<'_>) -> ParseResult<()> {
@@ -2128,6 +2111,26 @@ impl<'bump> Parser<'bump> {
             <&'static str>::from(kind)
         ))
     }
+}
+
+/// Join error messages with a newline so each one renders on its own line in
+/// `ShellError.message` and in the CLI error output.
+fn join_error_msgs<'bump>(
+    bump: &'bump Bump,
+    msgs: impl ExactSizeIterator<Item = &'bump [u8]> + Clone,
+) -> &'bump [u8] {
+    let size = msgs.clone().map(|m| m.len()).sum::<usize>() + msgs.len().saturating_sub(1);
+    let buf = bump.alloc_slice_fill_copy(size, 0u8);
+    let mut i = 0usize;
+    for (n, msg) in msgs.enumerate() {
+        if n > 0 {
+            buf[i] = b'\n';
+            i += 1;
+        }
+        buf[i..i + msg.len()].copy_from_slice(msg);
+        i += msg.len();
+    }
+    buf
 }
 
 #[derive(Default)]
@@ -2356,25 +2359,8 @@ pub struct LexResult<'bump> {
 
 impl<'bump> LexResult<'bump> {
     pub fn combine_errors(&self, bump: &'bump Bump) -> &'bump [u8] {
-        let errors = self.errors;
-
-        ({
-            let size = {
-                let mut i = 0usize;
-                for e in errors {
-                    i += e.msg.len() as usize;
-                }
-                i
-            };
-            let buf = bump.alloc_slice_fill_copy(size, 0u8);
-            let mut i = 0usize;
-            for e in errors {
-                let s = e.msg.slice(self.strpool);
-                buf[i..i + s.len()].copy_from_slice(s);
-                i += s.len();
-            }
-            buf
-        }) as _
+        let strpool = self.strpool;
+        join_error_msgs(bump, self.errors.iter().map(move |e| e.msg.slice(strpool)))
     }
 }
 

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -744,5 +744,10 @@ describe("lex shell", () => {
 
       await TestBuilder.command`echo hi && (echo uh oh`.error("Unclosed subshell").run();
     });
+
+    // https://github.com/oven-sh/bun/issues/33235
+    TestBuilder.command`(((( |||`
+      .error("Unexpected EOF\nUnclosed subshell\nUnclosed subshell\nUnclosed subshell")
+      .runAsTest("multiple errors are newline separated");
   });
 });


### PR DESCRIPTION
Fixes #33235

### Problem

When Bun Shell hits several parse errors in one script, `ShellError.message` is all of them concatenated with no separator:

```ts
try {
  await Bun.$`(((( |||`;
} catch (e) {
  console.log(JSON.stringify(e.message));
  // "Unexpected EOFUnclosed subshellUnclosed subshellUnclosed subshell"
}
```

### Cause

Both `combine_errors` implementations in `src/shell_parser/parse.rs` (`Parser::combine_errors` and `LexResult::combine_errors`) sum the message lengths and copy each one back to back into the arena buffer, with nothing in between. The `(((( |||` repro goes through the lexer path, which accumulates four errors before it bails.

### Fix

Route both through a shared `join_error_msgs` helper that inserts a newline between messages. Single-error output is byte for byte unchanged, so the existing exact-match assertions on `"Unexpected EOF"`, `"Unclosed subshell"`, etc. are unaffected.

The message now reads:

```
Unexpected EOF
Unclosed subshell
Unclosed subshell
Unclosed subshell
```

### Verification

New test in `test/js/bun/shell/lex.test.ts` asserts the exact newline-joined message. It fails on `bun-1.4.0` (gets the concatenated string) and passes with this change. Also ran `parse.test.ts`, `shelloutput.test.ts`, `bunshell-default.test.ts`, and `bunshell.test.ts` (376 pass, 0 fail), and grepped the suite for any assertion on the old concatenated form (none exist).
