### PR TITLE
sql: reject a MySQL prepare-OK carrying statement_id 0

### DIFF
--- a/src/sql/mysql/protocol/PreparedStatement.rs
+++ b/src/sql/mysql/protocol/PreparedStatement.rs
@@ -1,47 +1,11 @@
 use super::any_mysql_error;
 use super::column_definition41::ColumnFlags;
 use super::command_type::CommandType;
-use super::new_reader::{NewReader, ReaderContext};
 use super::new_writer::{NewWriter, WriterContext};
 use crate::mysql::mysql_param::Param;
 use crate::mysql::mysql_types::FieldType;
 
 bun_core::declare_scope!(PreparedStatement, hidden);
-
-#[derive(Default)]
-pub struct PrepareOK {
-    pub status: u8,
-    pub statement_id: u32,
-    pub num_columns: u16,
-    pub num_params: u16,
-    pub warning_count: u16,
-}
-
-impl PrepareOK {
-    pub fn decode_internal<C: ReaderContext>(
-        &mut self,
-        reader: NewReader<C>,
-    ) -> Result<(), any_mysql_error::Error> {
-        self.status = reader.int::<u8>()?;
-        if self.status != 0 {
-            return Err(any_mysql_error::Error::InvalidPrepareOKPacket);
-        }
-
-        self.statement_id = reader.int::<u32>()?;
-        self.num_columns = reader.int::<u16>()?;
-        self.num_params = reader.int::<u16>()?;
-        let _ = reader.int::<u8>()?; // reserved_1
-        self.warning_count = reader.int::<u16>()?;
-        Ok(())
-    }
-
-    pub fn decode<C: ReaderContext>(
-        &mut self,
-        reader: NewReader<C>,
-    ) -> Result<(), any_mysql_error::Error> {
-        self.decode_internal(reader)
-    }
-}
 
 pub struct Execute<'a> {
     /// ID of the prepared statement to execute, returned from COM_STMT_PREPARE

--- a/src/sql/mysql/protocol/StmtPrepareOKPacket.rs
+++ b/src/sql/mysql/protocol/StmtPrepareOKPacket.rs
@@ -22,6 +22,12 @@ impl StmtPrepareOKPacket {
         }
 
         self.statement_id = reader.int::<u32>()?;
+        // The server never issues statement_id 0, and the client keys its own
+        // "prepared" state on statement_id > 0 (see handle_prepared_statement
+        // and bind_and_execute), so a 0 here is a protocol violation.
+        if self.statement_id == 0 {
+            return Err(AnyMySQLError::InvalidPrepareOKPacket);
+        }
         self.num_columns = reader.int::<u16>()?;
         self.num_params = reader.int::<u16>()?;
         let _ = reader.int::<u8>()?; // reserved_1

--- a/test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts
+++ b/test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts
@@ -13,13 +13,7 @@
 // COM_STMT_EXECUTE for statement id 0 on the wire.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
-import {
-  listeningServer,
-  mysqlHandshakeV10,
-  mysqlOkPacket,
-  mysqlReadPackets,
-  mysqlStmtPrepareOk,
-} from "./wire-frames";
+import { listeningServer, mysqlHandshakeV10, mysqlOkPacket, mysqlReadPackets, mysqlStmtPrepareOk } from "./wire-frames";
 
 const COM_STMT_PREPARE = 0x16;
 const COM_STMT_EXECUTE = 0x17;

--- a/test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts
+++ b/test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts
@@ -5,12 +5,7 @@
 // Buffer.alloc frame construction here.
 
 // A COM_STMT_PREPARE response carrying statement_id = 0 must be rejected as a
-// protocol error. The server never issues id 0, and the client keys its own
-// "prepared" state on statement_id > 0 (handle_prepared_statement dispatches
-// on it; bind_and_execute asserts it). Accepting it marks the cached statement
-// Prepared with the "not prepared" sentinel: debug builds abort on the
-// "statement is not prepared" assertion, and release builds send
-// COM_STMT_EXECUTE for statement id 0 on the wire.
+// protocol error; see StmtPrepareOKPacket::decode_internal for the invariant.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { listeningServer, mysqlHandshakeV10, mysqlOkPacket, mysqlReadPackets, mysqlStmtPrepareOk } from "./wire-frames";

--- a/test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts
+++ b/test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts
@@ -1,0 +1,92 @@
+// Fault-injection test: requires a server that sends a protocol-invalid frame,
+// which a healthy container will not do on demand. DO NOT COPY THIS PATTERN —
+// anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+
+// A COM_STMT_PREPARE response carrying statement_id = 0 must be rejected as a
+// protocol error. The server never issues id 0, and the client keys its own
+// "prepared" state on statement_id > 0 (handle_prepared_statement dispatches
+// on it; bind_and_execute asserts it). Accepting it marks the cached statement
+// Prepared with the "not prepared" sentinel: debug builds abort on the
+// "statement is not prepared" assertion, and release builds send
+// COM_STMT_EXECUTE for statement id 0 on the wire.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import {
+  listeningServer,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  mysqlStmtPrepareOk,
+} from "./wire-frames";
+
+const COM_STMT_PREPARE = 0x16;
+const COM_STMT_EXECUTE = 0x17;
+
+test("MySQL: prepare-OK with statement_id 0 is a protocol error and is never executed", async () => {
+  // The mock server runs in the test process (pure node:net, never touches Bun's
+  // MySQL code); only the client runs in a subprocess so that the debug-assert
+  // abort on unfixed builds is observable as a missing result line.
+  const executedStatementIds: number[] = [];
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        if (payload[0] === COM_STMT_PREPARE) {
+          // The hostile frame: a well-formed prepare-OK whose statement_id is 0.
+          socket.write(mysqlStmtPrepareOk(1, 0, 0, 0));
+        } else if (payload[0] === COM_STMT_EXECUTE) {
+          // COM_STMT_EXECUTE: Int<1>(0x17) Int<4>(statement_id) ...
+          executedStatementIds.push(payload.readUInt32LE(1));
+          socket.end();
+        } else {
+          socket.end();
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    const fixture = /* js */ `
+      const { SQL } = require("bun");
+      const sql = new SQL({ url: "mysql://root@127.0.0.1:${port}/db", max: 1 });
+      const err = await sql\`SELECT 1\`.catch(e => e);
+      await sql.close().catch(() => {});
+      console.log(JSON.stringify({ code: err?.code ?? null }));
+      process.exit(0);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 60_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Unfixed debug builds abort inside bind_and_execute before the result line
+    // is printed, so stdout is empty; unfixed release builds accept the id and
+    // the mock records the COM_STMT_EXECUTE it receives for statement id 0.
+    // With the fix the prepare-OK is rejected at decode time, the pending query
+    // rejects with the protocol error, and no execute ever reaches the wire.
+    // stderr is included only so it appears in the toEqual diff on failure.
+    expect({ stderr, stdout: stdout.trim(), executedStatementIds }).toEqual({
+      stderr: expect.any(String),
+      stdout: JSON.stringify({ code: "ERR_MYSQL_INVALID_PREPARE_OK_PACKET" }),
+      executedStatementIds: [],
+    });
+    expect(exitCode).toBe(0);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});


### PR DESCRIPTION
### What

A `COM_STMT_PREPARE` response carrying `statement_id = 0` is accepted without validation. `statement_id == 0` is the client's own "not yet prepared" sentinel: `handle_prepared_statement` keys its packet dispatch on `statement_id > 0`, and `bind_and_execute` asserts it. Accepting a 0 therefore marks the cached statement `Prepared` while leaving it in an impossible state. Only the peer controls this value, so a compromised or desynced MySQL-compatible server or proxy can trigger it with a single frame.

On assert-enabled builds the very next execute aborts the process:

```
panic: statement is not prepared
bind_and_execute                      src/sql_jsc/mysql/MySQLQuery.rs:173
run_prepared_query                    src/sql_jsc/mysql/MySQLQuery.rs:398
check_if_prepared_statement_is_done   src/sql_jsc/mysql/MySQLConnection.rs:1126
handle_prepared_statement             src/sql_jsc/mysql/MySQLConnection.rs:1228
```

On release builds the assertion compiles out and the client sends `COM_STMT_EXECUTE` for statement id 0 on the wire, with the poisoned entry left in the statement cache.

### Repro

`test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts`: a scripted `node:net` MySQL server that completes the handshake and then answers `COM_STMT_PREPARE` with `[00][statement_id = 0 (u32)][columns = 0][params = 0]`. No fault injection; the client runs in a spawned process so the abort is observable, and the mock records the `statement_id` of any `COM_STMT_EXECUTE` it receives.

### Fix

Validate the prepare-OK at the response boundary. `StmtPrepareOKPacket::decode_internal` now rejects `statement_id == 0` with `InvalidPrepareOKPacket`, the same error it already returns for a bad status byte, so the connection fails with `ERR_MYSQL_INVALID_PREPARE_OK_PACKET` before any statement state is mutated and nothing is written to the socket. The execute-time assertion is kept as defense in depth.

Also deletes `PrepareOK` in `src/sql/mysql/protocol/PreparedStatement.rs`: an unused duplicate decoder of the same packet (zero callers) that would otherwise remain as a second, unvalidated parser of it.

The server-reported param count is already cross-checked against the query's placeholder count at bind time and surfaces as a recoverable `WrongNumberOfParametersProvided`, so no change is needed there.

### Verification

| build | result |
| --- | --- |
| release 1.4.0, without fix | test fails: mock records `COM_STMT_EXECUTE` for `statement_id` 0 |
| `bun bd` debug, without fix | test fails: child aborts, `panic: statement is not prepared` |
| `bun bd` debug, with fix | test passes: query rejects with `ERR_MYSQL_INVALID_PREPARE_OK_PACKET`, no execute sent |
