### PR TITLE
shell: add ShellPromise.terminal() to attach a Bun.Terminal (PTY)

### DIFF
--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -246,6 +246,48 @@ const result = await $`cat < ${response} | wc -w`.text();
 console.log(result); // 6\n
 ```
 
+## Terminals (PTY)
+
+By default, the commands Bun Shell spawns get pipes for stdout and stderr, so anything that checks `isatty()` behaves as if it were piped: `ls` and `git` turn colors off, pagers act like `cat`, and full-screen programs like `vim` or `htop` refuse to start.
+
+`.terminal()` attaches a [`Bun.Terminal`](/runtime/child-process#terminal-pty-support) (a pseudo-terminal) to the shell. Every command the script spawns receives the terminal's slave on stdin, stdout, and stderr, so `isatty()` is `true` on all three. Builtins like `echo` write to the terminal too.
+
+```js
+import { $ } from "bun";
+
+await using terminal = new Bun.Terminal({
+  cols: process.stdout.columns,
+  rows: process.stdout.rows,
+  data(_terminal, chunk) {
+    process.stdout.write(chunk);
+  },
+});
+
+await $`git log --oneline | head -5`.terminal(terminal);
+```
+
+Output goes to the terminal's `data` callback instead of the shell's buffered `stdout`/`stderr` (which stay empty), mirroring how `Bun.spawn({ terminal })` returns `null` for `proc.stdout`/`proc.stderr`. Use `terminal.write()` to send input to whatever is currently reading the terminal.
+
+The shell never closes the terminal, so one terminal can back many invocations, which is useful for an interactive shell that evaluates each line the user types:
+
+```js
+import { $ } from "bun";
+
+await using terminal = new Bun.Terminal({
+  data(_terminal, chunk) {
+    process.stdout.write(chunk);
+  },
+});
+
+for await (const line of console) {
+  await $`${{ raw: line }}`.terminal(terminal).nothrow();
+}
+```
+
+Redirects still take precedence over the terminal. With `cmd > out.txt`, stdout goes to the file and only stderr reaches the terminal. In a pipeline, only the last stage's stdout is the terminal; the intermediate stages still get pipes.
+
+`.terminal()` requires an existing `Bun.Terminal` instance and is not supported on Windows.
+
 ## Command substitution (`$(...)`)
 
 Command substitution inserts the output of another command into the current script:

--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -109,6 +109,38 @@ declare module "bun" {
       env(newEnv: Record<string, string | undefined> | NodeJS.Dict<string> | undefined): this;
 
       /**
+       * Attach a pseudo-terminal (PTY) to the shell.
+       *
+       * The commands the shell spawns receive the terminal's slave on stdin,
+       * stdout, and stderr, so they see `isatty() === true` on all three
+       * (colors, pagers, and full-screen programs work). Builtins like `echo`
+       * write to the terminal too.
+       *
+       * Output goes to the terminal's `data` callback instead of the shell's
+       * buffered `stdout`/`stderr` (which stay empty), mirroring how
+       * `Bun.spawn({ terminal })` returns `null` for `stdout`/`stderr`.
+       * Use `terminal.write()` to send input.
+       *
+       * The terminal is not closed when the shell finishes, so it can be
+       * reused across invocations. Not supported on Windows.
+       *
+       * @param terminal The `Bun.Terminal` to attach
+       *
+       * @example
+       * ```ts
+       * await using terminal = new Bun.Terminal({
+       *   cols: 80,
+       *   rows: 24,
+       *   data(_term, chunk) {
+       *     process.stdout.write(chunk);
+       *   },
+       * });
+       * await $`ls --color=auto`.terminal(terminal);
+       * ```
+       */
+      terminal(terminal: Terminal): this;
+
+      /**
        * By default, the shell writes to the current process's stdout and stderr while also buffering that output.
        *
        * `quiet()` configures the shell to only buffer the output.

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -165,6 +165,12 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
       return this;
     }
 
+    terminal(terminal: Bun.Terminal): this {
+      this.#throwIfRunning();
+      this.#args!.setTerminal(terminal);
+      return this;
+    }
+
     #run() {
       if (!this.#hasRun) {
         this.#hasRun = true;

--- a/src/jsc/bindings/ShellBindings.cpp
+++ b/src/jsc/bindings/ShellBindings.cpp
@@ -12,17 +12,22 @@ using namespace WTF;
 extern "C" SYSV_ABI EncodedJSValue Bun__createShellInterpreter(Zig::GlobalObject* _Nonnull globalObject, void* _Nonnull ptr, EncodedJSValue parsed_shell_script, EncodedJSValue resolve, EncodedJSValue reject)
 {
     auto& vm = globalObject->vm();
-    const auto& existingArgs = uncheckedDowncast<WebCore::JSParsedShellScript>(JSValue::decode(parsed_shell_script))->values();
+    auto* parsedScript = uncheckedDowncast<WebCore::JSParsedShellScript>(JSValue::decode(parsed_shell_script));
+    const auto& existingArgs = parsedScript->values();
     WTF::FixedVector<WriteBarrier<Unknown>> args = WTF::FixedVector<WriteBarrier<Unknown>>(existingArgs.size());
     for (size_t i = 0; i < existingArgs.size(); i++) {
         args[i].setWithoutWriteBarrier(existingArgs[i].get());
     }
     JSValue resolveFn = JSValue::decode(resolve);
     JSValue rejectFn = JSValue::decode(reject);
+    // Re-root the `Bun.Terminal` attached via `setTerminal` on the interpreter
+    // wrapper: the `ParsedShellScript` that was rooting it becomes unreachable
+    // as soon as JS drops its reference. Empty when no terminal is attached.
+    JSValue terminal = parsedScript->m_terminal.get();
     auto* structure = globalObject->JSShellInterpreterStructure();
     ASSERT(structure);
 
-    auto* result = WebCore::JSShellInterpreter::create(vm, globalObject, structure, ptr, WTF::move(args), resolveFn, rejectFn);
+    auto* result = WebCore::JSShellInterpreter::create(vm, globalObject, structure, ptr, WTF::move(args), resolveFn, rejectFn, terminal);
 
     size_t size = ShellInterpreter__estimatedSize(ptr);
     vm.heap.reportExtraMemoryAllocated(result, size);

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -1119,8 +1119,8 @@ js_class_module!(JSRequest   = "Request"   { body, headers, url, signal, stream 
 // `values: ["ondrain", "oncancel", "stream"]` in src/runtime/api/ResumableSink.classes.ts.
 js_class_module!(JSResumableFetchSink    = "ResumableFetchSink"    { ondrain, oncancel, stream });
 js_class_module!(JSResumableS3UploadSink = "ResumableS3UploadSink" { ondrain, oncancel, stream });
-// `values: ["resolve", "reject"]` in src/runtime/api/Shell.classes.ts.
-js_class_module!(JSShellInterpreter      = "ShellInterpreter"      { resolve, reject });
+// `values: ["resolve", "reject", "terminal"]` in src/runtime/api/Shell.classes.ts.
+js_class_module!(JSShellInterpreter      = "ShellInterpreter"      { resolve, reject, terminal });
 // `src/runtime/crypto/crypto.classes.ts` — one entry per `StaticCryptoHasher`
 // monomorphization. Payload erased;
 // the native struct lives in `bun_runtime::crypto`.

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -1120,7 +1120,9 @@ js_class_module!(JSRequest   = "Request"   { body, headers, url, signal, stream 
 js_class_module!(JSResumableFetchSink    = "ResumableFetchSink"    { ondrain, oncancel, stream });
 js_class_module!(JSResumableS3UploadSink = "ResumableS3UploadSink" { ondrain, oncancel, stream });
 // `values: ["resolve", "reject", "terminal"]` in src/runtime/api/Shell.classes.ts.
-js_class_module!(JSShellInterpreter      = "ShellInterpreter"      { resolve, reject, terminal });
+// `terminal` is seeded by `Bun__createShellInterpreter` (ShellBindings.cpp) and
+// only read by the generated GC visitor, so it has no Rust-side accessor here.
+js_class_module!(JSShellInterpreter      = "ShellInterpreter"      { resolve, reject });
 // `src/runtime/crypto/crypto.classes.ts` — one entry per `StaticCryptoHasher`
 // monomorphization. Payload erased;
 // the native struct lives in `bun_runtime::crypto`.

--- a/src/runtime/api/ParsedShellScript.classes.ts
+++ b/src/runtime/api/ParsedShellScript.classes.ts
@@ -9,6 +9,8 @@ export default [
     hasPendingActivity: false,
     configurable: false,
     valuesArray: true,
+    // GC root for the `Bun.Terminal` wrapper attached via `setTerminal`.
+    values: ["terminal"],
     memoryCost: true,
     estimatedSize: true,
     klass: {},
@@ -23,6 +25,10 @@ export default [
       },
       setQuiet: {
         fn: "setQuiet",
+        length: 1,
+      },
+      setTerminal: {
+        fn: "setTerminal",
         length: 1,
       },
     },

--- a/src/runtime/api/Shell.classes.ts
+++ b/src/runtime/api/Shell.classes.ts
@@ -10,7 +10,8 @@ export default [
     hasPendingActivity: true,
     configurable: false,
     klass: {},
-    values: ["resolve", "reject"],
+    // `terminal` roots the `Bun.Terminal` wrapper for the lifetime of the run.
+    values: ["resolve", "reject", "terminal"],
     valuesArray: true,
     memoryCost: true,
     estimatedSize: true,

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -31,9 +31,8 @@ pub struct ParsedShellScript {
     pub quiet: Cell<bool>,
     pub cwd: Cell<Option<BunString>>,
     /// `Bun.Terminal` attached via `setTerminal`. Non-owning backref: the
-    /// terminal's JS wrapper holds the intrusive ref and is GC-rooted on this
-    /// wrapper's `terminal` cached-value slot (`values: ["terminal"]` in
-    /// ParsedShellScript.classes.ts), so the pointee outlives the holder.
+    /// terminal's JS wrapper holds the intrusive ref, and `setTerminal` roots
+    /// that wrapper on this wrapper's `terminal` cached-value slot.
     pub terminal: Cell<Option<core::ptr::NonNull<Terminal>>>,
     /// Self-wrapper backref. `.classes.ts` has `finalize: true`, so the weak arm is
     /// sound: codegen calls `finalize()` which flips this to `.Finalized` before sweep.

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -8,6 +8,8 @@ use bun_jsc::{
     JsRef, JsResult, MarkedArgumentBuffer, StringJsc as _,
 };
 
+use crate::api::bun_terminal_body::{self as terminal_body, Terminal};
+
 use super::interpreter::ShellArgs;
 use super::shell_body::{JsStrings, shell_cmd_from_js};
 use super::{EnvMap, EnvStr, Interpreter};
@@ -28,6 +30,11 @@ pub struct ParsedShellScript {
     pub export_env: JsCell<Option<EnvMap>>,
     pub quiet: Cell<bool>,
     pub cwd: Cell<Option<BunString>>,
+    /// `Bun.Terminal` attached via `setTerminal`. Non-owning backref: the
+    /// terminal's JS wrapper holds the intrusive ref and is GC-rooted on this
+    /// wrapper's `terminal` cached-value slot (`values: ["terminal"]` in
+    /// ParsedShellScript.classes.ts), so the pointee outlives the holder.
+    pub terminal: Cell<Option<core::ptr::NonNull<Terminal>>>,
     /// Self-wrapper backref. `.classes.ts` has `finalize: true`, so the weak arm is
     /// sound: codegen calls `finalize()` which flips this to `.Finalized` before sweep.
     /// Read-only after construction; mutated only in `finalize(mut self: Box<Self>)`.
@@ -44,6 +51,7 @@ impl Default for ParsedShellScript {
             export_env: JsCell::new(None),
             quiet: Cell::new(false),
             cwd: Cell::new(None),
+            terminal: Cell::new(None),
             this_jsvalue: JsRef::empty(),
             estimated_size_for_gc: 0,
         }
@@ -84,13 +92,18 @@ impl ParsedShellScript {
         bool,
         Option<BunString>,
         Option<EnvMap>,
+        Option<core::ptr::NonNull<Terminal>>,
     ) {
         let args = self.args.replace(None).expect("args already taken");
         let jsobjs = self.jsobjs.replace(Vec::new());
         let quiet = self.quiet.get();
         let cwd = self.cwd.take();
         let export_env = self.export_env.replace(None);
-        (args, jsobjs, quiet, cwd, export_env)
+        // The terminal's JS wrapper stays rooted on this wrapper's `terminal`
+        // cached-value slot until `create_shell_interpreter` re-roots it on
+        // the `ShellInterpreter` wrapper.
+        let terminal = self.terminal.take();
+        (args, jsobjs, quiet, cwd, export_env, terminal)
     }
 
     /// Called from the generated C++ wrapper's `finalize()`. Runs on the mutator
@@ -131,6 +144,58 @@ impl ParsedShellScript {
     pub fn set_quiet(&self, _global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arg = callframe.argument(0);
         self.quiet.set(arg.to_boolean());
+        Ok(JSValue::UNDEFINED)
+    }
+
+    /// Attach a `Bun.Terminal` whose PTY slave becomes the interpreter's root
+    /// stdin/stdout/stderr, so spawned commands see `isatty() == true`.
+    #[bun_jsc::host_fn(method)]
+    pub fn set_terminal(
+        &self,
+        global: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        // On Windows the shell's root IO cannot be backed by a ConPTY (there
+        // is no slave fd to dup and builtins cannot write into the conhost
+        // stream), so fail loudly instead of silently ignoring the option.
+        if cfg!(windows) {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "$`...`.terminal() is not supported on Windows"
+            )));
+        }
+        let value = callframe.argument(0);
+        let Some(terminal) = terminal_body::js::from_js(value) else {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "$`...`.terminal(): expected a Bun.Terminal (create one with `new Bun.Terminal(options)`)"
+            )));
+        };
+        // Same validation `Bun.spawn` applies to an existing terminal.
+        {
+            let term = bun_ptr::BackRef::from(terminal);
+            if term.is_closed() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "$`...`.terminal(): terminal is closed"
+                )));
+            }
+            if term.is_inline_spawned() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "$`...`.terminal(): terminal was created inline by Bun.spawn and cannot be reused"
+                )));
+            }
+            if term.get_slave_fd() == bun_sys::Fd::INVALID {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "$`...`.terminal(): terminal slave fd is no longer valid"
+                )));
+            }
+        }
+        // Root the terminal's JS wrapper on this wrapper so the raw pointer in
+        // `self.terminal` stays valid until `take()` hands it to the interpreter.
+        crate::generated_classes::js_ParsedShellScript::terminal_set_cached(
+            callframe.this(),
+            global,
+            value,
+        );
+        self.terminal.set(Some(terminal));
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -316,15 +316,9 @@ pub struct Interpreter {
     pub root_shell: JsCell<ShellExecEnv>,
     pub root_io: JsCell<IO>,
 
-    /// `Bun.Terminal` attached via `$`...`.terminal()`. When set,
-    /// [`setup_io_before_run`](Self::setup_io_before_run) replaces `root_io`
-    /// with dups of the PTY slave so spawned commands and builtins see a tty.
-    ///
-    /// Non-owning backref, same model as `Subprocess.terminal`: the terminal's
-    /// JS wrapper holds the intrusive ref and is GC-rooted on the
-    /// `ShellInterpreter` wrapper's `terminal` cached-value slot
-    /// (`values: [..., "terminal"]` in Shell.classes.ts) for the run's lifetime.
-    /// Always `None` on the mini event loop (`bun exec`, `.sh` files).
+    /// `Bun.Terminal` attached via `$`...`.terminal()`: `setup_io_before_run`
+    /// replaces `root_io` with dups of its PTY slave. Non-owning backref (same
+    /// model as `Subprocess.terminal`); the `ShellInterpreter` wrapper roots it.
     pub terminal: Cell<Option<core::ptr::NonNull<Terminal>>>,
 
     pub has_pending_activity: AtomicU32,
@@ -1264,19 +1258,12 @@ impl Interpreter {
         Ok(())
     }
 
-    /// Replace `root_io`'s stdin/stdout/stderr with dups of the attached
-    /// terminal's PTY slave, so external commands receive the slave on
-    /// fds 0/1/2 (`Stdio::Fd` → `dup2` in the child) and builtins write into
-    /// the PTY. `captured` stays `None`: output reaches the terminal's `data`
-    /// callback, not the JS-side buffers — the same contract as
-    /// `Bun.spawn({ terminal })`, whose `proc.stdout` is `null`.
-    ///
-    /// The interpreter works on its own dups so tearing down `root_io` never
-    /// closes the terminal's `slave_fd` (and vice versa).
+    /// Replace `root_io`'s stdin/stdout/stderr with the interpreter's own dups
+    /// of the attached terminal's PTY slave, so spawned commands and builtins
+    /// see a tty. Own dups: teardown must not close the terminal's `slave_fd`.
     fn setup_terminal_io(&self, terminal: core::ptr::NonNull<Terminal>) -> bun_sys::Result<()> {
-        // SAFETY: `terminal` was validated and stored by
-        // `create_shell_interpreter`; its JS wrapper is rooted on the
-        // `ShellInterpreter` wrapper for the lifetime of this run.
+        // `terminal` stays live for the run: the `ShellInterpreter` wrapper
+        // roots its JS wrapper, which holds the +1 on the Rust struct.
         let slave_fd = bun_ptr::BackRef::from(terminal).get_slave_fd();
         // `setTerminal` rejected closed terminals, but the user can still
         // `close()` it between `.terminal(t)` and the first await.
@@ -1311,10 +1298,9 @@ impl Interpreter {
         let stdin_reader = IOReader::init(stdin_fd, event_loop);
         // SAFETY: `interp_ptr` is the live `Interpreter` being set up.
         stdin_reader.set_interp(interp_ptr);
-        // A PTY slave is a tty, so this matches the existing "parent stdout is
-        // a terminal" path: pollable, blocking (IOWriter never flips
-        // O_NONBLOCK, which the children would inherit through the shared
-        // open-file description).
+        // A pty slave is a tty (pollable), same as the existing "parent stdout
+        // is a terminal" path. `IOWriter` never flips O_NONBLOCK, which the
+        // children would inherit through the shared open-file description.
         let stdout_writer = IOWriter::init(
             stdout_fd,
             crate::shell::io_writer::Flags {
@@ -1340,6 +1326,8 @@ impl Interpreter {
         // taken in `init`.
         self.root_io.with_mut(|io| {
             io.stdin = crate::shell::io::InKind::Fd(stdin_reader);
+            // `captured: None`: children get `Stdio::Fd(slave)`, not a relayed
+            // capture pipe; output reaches the terminal's `data` callback.
             io.stdout = crate::shell::io::OutKind::Fd(crate::shell::io::OutFd {
                 writer: stdout_writer,
                 captured: None,

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -3217,22 +3217,6 @@ pub fn create_shell_interpreter(
             reject,
         );
         it.this_jsvalue.set(js_value);
-        // Re-root the terminal's JS wrapper on the `ShellInterpreter` wrapper:
-        // the `ParsedShellScript` that was rooting it becomes unreachable as
-        // soon as JS drops its reference (`this.#args = undefined`).
-        if terminal.is_some() {
-            if let Some(terminal_js) =
-                crate::generated_classes::js_ParsedShellScript::terminal_get_cached(
-                    parsed_shell_script_js,
-                )
-            {
-                crate::jsc::generated::JSShellInterpreter::terminal_set_cached(
-                    js_value,
-                    global,
-                    terminal_js,
-                );
-            }
-        }
         it.keep_alive.with_mut(|k| {
             // `bun_vm_ptr()` is the live per-thread VM singleton.
             k.ref_(crate::jsc::VirtualMachineRef::event_loop_ctx(

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1436,6 +1436,10 @@ impl Interpreter {
         );
 
         if let Err(e) = self.setup_io_before_run() {
+            // Mirror `finish()`'s release ordering: `create_shell_interpreter`
+            // took an event-loop keep-alive ref that nothing else releases
+            // before the GC finalizer, so the loop would idle at +1 forever.
+            self.keep_alive.with_mut(|k| k.disable());
             self.deref_root_shell_and_io_if_needed(true);
             let shellerr = ShellErr::new_sys(&e);
             return Err(throw_shell_err(

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -34,6 +34,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use bun_sys::{self, Fd};
 
+use crate::api::bun_terminal_body::Terminal;
 pub use crate::shell::env_map::EnvMap;
 use crate::shell::io::IO;
 use crate::shell::states::assigns::Assigns;
@@ -314,6 +315,17 @@ pub struct Interpreter {
 
     pub root_shell: JsCell<ShellExecEnv>,
     pub root_io: JsCell<IO>,
+
+    /// `Bun.Terminal` attached via `$`...`.terminal()`. When set,
+    /// [`setup_io_before_run`](Self::setup_io_before_run) replaces `root_io`
+    /// with dups of the PTY slave so spawned commands and builtins see a tty.
+    ///
+    /// Non-owning backref, same model as `Subprocess.terminal`: the terminal's
+    /// JS wrapper holds the intrusive ref and is GC-rooted on the
+    /// `ShellInterpreter` wrapper's `terminal` cached-value slot
+    /// (`values: [..., "terminal"]` in Shell.classes.ts) for the run's lifetime.
+    /// Always `None` on the mini event loop (`bun exec`, `.sh` files).
+    pub terminal: Cell<Option<core::ptr::NonNull<Terminal>>>,
 
     pub has_pending_activity: AtomicU32,
     pub started: AtomicBool,
@@ -598,6 +610,9 @@ impl Interpreter {
                 stdout: crate::shell::io::OutKind::Pipe,
                 stderr: crate::shell::io::OutKind::Pipe,
             }),
+            // Set (on the JS event-loop path only) by `create_shell_interpreter`,
+            // alongside `quiet`, before `run()`.
+            terminal: Cell::new(None),
             has_pending_activity: AtomicU32::new(0),
             started: AtomicBool::new(false),
             keep_alive: JsCell::new(bun_io::KeepAlive::default()),
@@ -1168,7 +1183,13 @@ impl Interpreter {
     /// so command output reaches the terminal. On the JS event loop the
     /// `captured` slot is also wired to `_buffered_stdout/err` so
     /// `Bun.$` callers can read it back.
+    ///
+    /// An attached `Bun.Terminal` takes precedence over `quiet`: the PTY slave
+    /// must reach the children's fds regardless of whether output is echoed.
     fn setup_io_before_run(&self) -> bun_sys::Result<()> {
+        if let Some(terminal) = self.terminal.get() {
+            return self.setup_terminal_io(terminal);
+        }
         if self.flags.get().quiet() {
             return Ok(());
         }
@@ -1237,6 +1258,95 @@ impl Interpreter {
             io.stderr = crate::shell::io::OutKind::Fd(crate::shell::io::OutFd {
                 writer: stderr_writer,
                 captured: cap_err,
+            });
+        });
+
+        Ok(())
+    }
+
+    /// Replace `root_io`'s stdin/stdout/stderr with dups of the attached
+    /// terminal's PTY slave, so external commands receive the slave on
+    /// fds 0/1/2 (`Stdio::Fd` → `dup2` in the child) and builtins write into
+    /// the PTY. `captured` stays `None`: output reaches the terminal's `data`
+    /// callback, not the JS-side buffers — the same contract as
+    /// `Bun.spawn({ terminal })`, whose `proc.stdout` is `null`.
+    ///
+    /// The interpreter works on its own dups so tearing down `root_io` never
+    /// closes the terminal's `slave_fd` (and vice versa).
+    fn setup_terminal_io(&self, terminal: core::ptr::NonNull<Terminal>) -> bun_sys::Result<()> {
+        // SAFETY: `terminal` was validated and stored by
+        // `create_shell_interpreter`; its JS wrapper is rooted on the
+        // `ShellInterpreter` wrapper for the lifetime of this run.
+        let slave_fd = bun_ptr::BackRef::from(terminal).get_slave_fd();
+        // `setTerminal` rejected closed terminals, but the user can still
+        // `close()` it between `.terminal(t)` and the first await.
+        if slave_fd == Fd::INVALID {
+            return Err(bun_sys::Error::from_code(
+                bun_sys::E::EBADF,
+                bun_sys::Tag::dup,
+            ));
+        }
+
+        let event_loop = self.event_loop;
+        let interp_ptr: *mut Interpreter = self.as_ctx_ptr();
+
+        log!("Duping terminal slave for stdin/stdout/stderr");
+        let stdin_fd = shell_dup(slave_fd)?;
+        let stdout_fd = match shell_dup(slave_fd) {
+            Ok(fd) => fd,
+            Err(e) => {
+                closefd(stdin_fd);
+                return Err(e);
+            }
+        };
+        let stderr_fd = match shell_dup(slave_fd) {
+            Ok(fd) => fd,
+            Err(e) => {
+                closefd(stdin_fd);
+                closefd(stdout_fd);
+                return Err(e);
+            }
+        };
+
+        let stdin_reader = IOReader::init(stdin_fd, event_loop);
+        // SAFETY: `interp_ptr` is the live `Interpreter` being set up.
+        stdin_reader.set_interp(interp_ptr);
+        // A PTY slave is a tty, so this matches the existing "parent stdout is
+        // a terminal" path: pollable, blocking (IOWriter never flips
+        // O_NONBLOCK, which the children would inherit through the shared
+        // open-file description).
+        let stdout_writer = IOWriter::init(
+            stdout_fd,
+            crate::shell::io_writer::Flags {
+                pollable: is_pollable(stdout_fd),
+                ..Default::default()
+            },
+            event_loop,
+        );
+        // SAFETY: `interp_ptr` is the live `Interpreter` being set up.
+        stdout_writer.set_interp(interp_ptr);
+        let stderr_writer = IOWriter::init(
+            stderr_fd,
+            crate::shell::io_writer::Flags {
+                pollable: is_pollable(stderr_fd),
+                ..Default::default()
+            },
+            event_loop,
+        );
+        // SAFETY: `interp_ptr` is the live `Interpreter` being set up.
+        stderr_writer.set_interp(interp_ptr);
+
+        // Dropping the previous `root_io.stdin` releases the parent-stdin dup
+        // taken in `init`.
+        self.root_io.with_mut(|io| {
+            io.stdin = crate::shell::io::InKind::Fd(stdin_reader);
+            io.stdout = crate::shell::io::OutKind::Fd(crate::shell::io::OutFd {
+                writer: stdout_writer,
+                captured: None,
+            });
+            io.stderr = crate::shell::io::OutKind::Fd(crate::shell::io::OutFd {
+                writer: stderr_writer,
+                captured: None,
             });
         });
 
@@ -3054,7 +3164,7 @@ pub fn create_shell_interpreter(
         )));
     }
 
-    let (shargs, jsobjs, quiet, cwd, export_env) = parsed_shell_script.take(global);
+    let (shargs, jsobjs, quiet, cwd, export_env, terminal) = parsed_shell_script.take(global);
 
     let cwd = cwd.map(bun_core::OwnedString::new);
     let cwd_slice = cwd.as_deref().map(|c| c.to_utf8());
@@ -3094,6 +3204,7 @@ pub fn create_shell_interpreter(
     let js_value = unsafe {
         let it = &*interpreter;
         it.update_flags(|f| f.set_quiet(quiet));
+        it.terminal.set(terminal);
         it.global_this
             .set(std::ptr::from_ref::<crate::jsc::JSGlobalObject>(global).cast_mut());
         it.estimated_size_for_gc
@@ -3106,6 +3217,22 @@ pub fn create_shell_interpreter(
             reject,
         );
         it.this_jsvalue.set(js_value);
+        // Re-root the terminal's JS wrapper on the `ShellInterpreter` wrapper:
+        // the `ParsedShellScript` that was rooting it becomes unreachable as
+        // soon as JS drops its reference (`this.#args = undefined`).
+        if terminal.is_some() {
+            if let Some(terminal_js) =
+                crate::generated_classes::js_ParsedShellScript::terminal_get_cached(
+                    parsed_shell_script_js,
+                )
+            {
+                crate::jsc::generated::JSShellInterpreter::terminal_set_cached(
+                    js_value,
+                    global,
+                    terminal_js,
+                );
+            }
+        }
         it.keep_alive.with_mut(|k| {
             // `bun_vm_ptr()` is the live per-thread VM singleton.
             k.ref_(crate::jsc::VirtualMachineRef::event_loop_ctx(

--- a/test/js/bun/shell/bunshell-terminal.test.ts
+++ b/test/js/bun/shell/bunshell-terminal.test.ts
@@ -1,0 +1,181 @@
+// https://github.com/oven-sh/bun/issues/33234
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
+
+// Reports whether each of the child's std streams is a tty.
+const TTY_PROBE =
+  "process.stdout.write('in=' + !!process.stdin.isTTY + ' out=' + !!process.stdout.isTTY + ' err=' + !!process.stderr.isTTY)";
+
+/**
+ * A `Bun.Terminal` whose `data` callback accumulates PTY output into
+ * `output()`. `finished` resolves once `done(output, terminal)` returns true.
+ */
+function pty(done: (output: string, terminal: Bun.Terminal) => boolean) {
+  let output = "";
+  const decoder = new TextDecoder();
+  const finished = Promise.withResolvers<void>();
+  const terminal = new Bun.Terminal({
+    cols: 80,
+    rows: 24,
+    data(term, chunk: Uint8Array) {
+      output += decoder.decode(chunk, { stream: true });
+      if (done(output, term)) finished.resolve();
+    },
+  });
+  return { terminal, finished: finished.promise, output: () => output };
+}
+
+describe.skipIf(isWindows)("ShellPromise.terminal", () => {
+  test.concurrent("spawned commands see a tty on stdin, stdout, and stderr", async () => {
+    const h = pty(o => o.includes("err="));
+    await using terminal = h.terminal;
+
+    await $`${bunExe()} -e ${TTY_PROBE}`.env(bunEnv).terminal(terminal);
+    await h.finished;
+
+    expect(h.output()).toContain("in=true");
+    expect(h.output()).toContain("out=true");
+    expect(h.output()).toContain("err=true");
+  });
+
+  test.concurrent("works with a raw interpolation, like an interactive shell executor", async () => {
+    const h = pty(o => o.includes("err="));
+    await using terminal = h.terminal;
+
+    const line = `${bunExe()} -e ${$.escape(TTY_PROBE)}`;
+    await $`${{ raw: line }}`.env(bunEnv).terminal(terminal);
+    await h.finished;
+
+    expect(h.output()).toContain("in=true out=true err=true");
+  });
+
+  test.concurrent("builtin output goes to the terminal, not the buffered stdout", async () => {
+    const h = pty(o => o.includes("builtin-via-pty"));
+    await using terminal = h.terminal;
+
+    const result = await $`echo builtin-via-pty`.terminal(terminal);
+    await h.finished;
+
+    expect(h.output()).toContain("builtin-via-pty");
+    expect(result.stdout.length).toBe(0);
+    expect(result.stderr.length).toBe(0);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test.concurrent(".text() is empty: output goes to the terminal even when quiet", async () => {
+    const h = pty(o => o.includes("to-the-pty"));
+    await using terminal = h.terminal;
+
+    // `.text()` implies `.quiet()`; the terminal must still reach the child.
+    const text = await $`${bunExe()} -e ${"process.stdout.write('to-the-pty out=' + !!process.stdout.isTTY)"}`
+      .env(bunEnv)
+      .terminal(terminal)
+      .text();
+    await h.finished;
+
+    expect(h.output()).toContain("to-the-pty out=true");
+    expect(text).toBe("");
+  });
+
+  test.concurrent("terminal.write() reaches the command's stdin", async () => {
+    let wrote = false;
+    const h = pty((o, term) => {
+      if (!wrote && o.includes("READY")) {
+        wrote = true;
+        term.write("ping\n");
+      }
+      return o.includes("got:ping");
+    });
+    await using terminal = h.terminal;
+
+    const script =
+      "process.stdout.write('READY'); process.stdin.once('data', d => { process.stdout.write('got:' + d.toString().trim()); process.exit(0); });";
+    await $`${bunExe()} -e ${script}`.env(bunEnv).terminal(terminal);
+    await h.finished;
+
+    expect(h.output()).toContain("got:ping");
+  });
+
+  test.concurrent("a terminal can be reused across shell invocations", async () => {
+    const h = pty(o => o.includes("first-run") && o.includes("second-run"));
+    await using terminal = h.terminal;
+
+    await $`echo first-run`.terminal(terminal);
+    await $`echo second-run`.terminal(terminal);
+    await h.finished;
+
+    expect(h.output()).toContain("first-run");
+    expect(h.output()).toContain("second-run");
+  });
+
+  test.concurrent("in a pipeline, only the last stage's stdout is the tty", async () => {
+    const h = pty(o => o.includes("a-out=") && o.includes("b-out="));
+    await using terminal = h.terminal;
+
+    // Each stage reports over stderr, which is the terminal for every stage.
+    const a = "process.stderr.write('a-out=' + !!process.stdout.isTTY + ' ')";
+    const b = "process.stderr.write('b-out=' + !!process.stdout.isTTY + ' ')";
+    await $`${bunExe()} -e ${a} | ${bunExe()} -e ${b}`.env(bunEnv).terminal(terminal);
+    await h.finished;
+
+    expect(h.output()).toContain("a-out=false");
+    expect(h.output()).toContain("b-out=true");
+  });
+
+  test.concurrent("a file redirect overrides the terminal for that fd", async () => {
+    using dir = tempDir("shell-terminal-redirect", {});
+    const h = pty(o => o.includes("on-stderr"));
+    await using terminal = h.terminal;
+
+    const script = "process.stdout.write('to-file'); process.stderr.write('on-stderr')";
+    await $`${bunExe()} -e ${script} > out.txt`.env(bunEnv).cwd(String(dir)).terminal(terminal);
+    await h.finished;
+
+    expect(await Bun.file(join(String(dir), "out.txt")).text()).toBe("to-file");
+    expect(h.output()).toContain("on-stderr");
+    expect(h.output()).not.toContain("to-file");
+  });
+
+  test.concurrent(".terminal() throws once the shell is running", async () => {
+    const h = pty(() => false);
+    await using terminal = h.terminal;
+
+    const promise = $`true`.terminal(terminal);
+    promise.run();
+    expect(() => promise.terminal(terminal)).toThrow("Shell is already running");
+    await promise;
+  });
+
+  test(".terminal() rejects a non-Terminal argument", () => {
+    // An options object must be rejected: the shell needs an existing handle
+    // whose lifecycle the caller owns.
+    expect(() => ($`true` as any).terminal({ cols: 80, rows: 24 })).toThrow("expected a Bun.Terminal");
+    expect(() => ($`true` as any).terminal(null)).toThrow("expected a Bun.Terminal");
+    expect(() => ($`true` as any).terminal(42)).toThrow("expected a Bun.Terminal");
+  });
+
+  test(".terminal() rejects a closed terminal", () => {
+    const terminal = new Bun.Terminal({ cols: 80, rows: 24 });
+    terminal.close();
+    expect(() => $`true`.terminal(terminal)).toThrow("terminal is closed");
+  });
+
+  test.concurrent(".terminal() rejects a terminal created inline by Bun.spawn", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", ""],
+      env: bunEnv,
+      terminal: { cols: 80, rows: 24 },
+    });
+    await using terminal = proc.terminal!;
+    await proc.exited;
+
+    expect(() => $`true`.terminal(terminal)).toThrow("cannot be reused");
+  });
+});
+
+test.skipIf(!isWindows)(".terminal() throws on Windows", async () => {
+  await using terminal = new Bun.Terminal({ cols: 80, rows: 24 });
+  expect(() => $`true`.terminal(terminal)).toThrow("not supported on Windows");
+});

--- a/test/js/bun/shell/bunshell-terminal.test.ts
+++ b/test/js/bun/shell/bunshell-terminal.test.ts
@@ -162,6 +162,29 @@ describe.skipIf(isWindows)("ShellPromise.terminal", () => {
     expect(() => $`true`.terminal(terminal)).toThrow("terminal is closed");
   });
 
+  test.concurrent("closing the terminal after .terminal() but before await rejects and exits", async () => {
+    const script = [
+      "const t = new Bun.Terminal({ cols: 80, rows: 24 });",
+      "const p = Bun.$`echo hi`.terminal(t);",
+      "t.close();",
+      "let caught = false;",
+      "try { await p } catch { caught = true }",
+      'console.log("caught=" + caught);',
+    ].join("\n");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, signalCode: proc.signalCode, exitCode }).toEqual({
+      stdout: "caught=true\n",
+      signalCode: null,
+      exitCode: 0,
+    });
+  });
+
   test.concurrent(".terminal() rejects a terminal created inline by Bun.spawn", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", ""],


### PR DESCRIPTION
Fixes #33234

### What

Bun Shell always gives spawned commands pipes for stdout and stderr (it relays them into the parent's stdout so it can also capture them). Anything that checks `isatty()` degrades: `ls`/`git` turn colors off, pagers act like `cat`, full-screen programs refuse to start. `ShellPromise` has no escape hatch.

```ts
await Bun.$`python3 -c "import sys;print(sys.stdin.isatty(),sys.stdout.isatty(),sys.stderr.isatty())"`;
// True False False
```

This adds `$`...`.terminal(terminal)`, taking an existing `Bun.Terminal`:

```ts
await using terminal = new Bun.Terminal({ cols, rows, data: (t, d) => process.stdout.write(d) });
await $`${{ raw: line }}`.terminal(terminal);
// the spawned commands see isatty() === true on stdin, stdout, and stderr
```

### How

When a terminal is attached, `Interpreter::setup_io_before_run` replaces `root_io`'s stdin/stdout/stderr with the interpreter's own dups of the PTY slave instead of dups of the parent's stdio. Everything downstream composes unchanged:

- External commands get the slave on fds 0/1/2 (`Stdio::Fd` -> `dup2` in the child), the same mechanism `Bun.spawn({ terminal })` uses.
- Builtins (`echo`, ...) write into the PTY too.
- Redirects (`> file`) and pipelines layer on top exactly as they do today: a redirect wins for that fd, and only the last pipeline stage's stdout is the terminal.

Semantics mirror `Bun.spawn({ terminal })`:

- Output goes to the terminal's `data` callback, not the captured `stdout`/`stderr` buffers (which stay empty), like `proc.stdout`/`proc.stderr` being `null`. The terminal takes precedence over `.quiet()`, so `.text()` still gives children a tty.
- The shell never closes the terminal, so one terminal can back many invocations.
- `setTerminal` applies the same validation `Bun.spawn` does: rejects a closed terminal and a terminal created inline by a previous `Bun.spawn`.

Ownership follows `Subprocess.terminal`: the interpreter holds a non-owning pointer and the terminal's JS wrapper is rooted on the `JSShellInterpreter` wrapper (a `values:` slot seeded in `Bun__createShellInterpreter`) for the lifetime of the run.

### Scope decisions

- **Existing `Bun.Terminal` only, not an inline options object.** Bun Shell runs lazily and one script can spawn many commands, so a shell-owned inline PTY would have no retrievable handle (there is no `Subprocess` object to hang `.terminal` off) and would leak if the promise were never awaited. An explicit `Bun.Terminal` is one extra line and its lifecycle is the caller's. The options-object form throws with a message pointing at `new Bun.Terminal(options)`.
- **No per-child `setsid`/`TIOCSCTTY`.** A script spawns N children and only one process can be the session leader, and bun itself keeps running. This matches `Bun.spawn({ terminal: existingTerminal })`, and `isatty()` being true on all three fds is the entirety of what's needed for colors, pagers, and full-screen rendering.
- **Not supported on Windows.** The shell's root IO cannot be backed by a ConPTY (there is no slave fd to dup, and builtins cannot write into the conhost stream). `.terminal()` throws a clear error there instead of silently doing nothing.

### Verification

New tests in `test/js/bun/shell/bunshell-terminal.test.ts`: all 12 fail on the unpatched build (`.terminal is not a function`) and pass with this change. They cover isatty on all three fds, a raw-interpolation line, builtin output, `.text()`/`.quiet()`, `terminal.write()` reaching the child's stdin, terminal reuse, pipelines, file redirects, `throwIfRunning`, and the argument/closed/inline-spawned rejections.

The existing `test/js/bun/shell/`, `test/js/bun/terminal/` suites were also run against a baseline built with `src/` and `packages/` reverted to `main` in the same container.

<details>
<summary>Baseline comparison (A/B against main, same container)</summary>

A handful of pre-existing shell tests time out here because their hardcoded budgets (700ms in `shell-hang.test.ts`, 5s/100s in `leak.test.ts`) assume more headroom than a debug+ASAN build gets on a resource-capped box. All of them fail identically with `src/` reverted to `main`:

| file | with this change | `src/` reverted to `main` |
|---|---|---|
| `shell/leak.test.ts` | 33 pass / 9 fail | 33 pass / 9 fail (same 9) |
| `shell/shell-hang.test.ts` | 0 pass / 6 fail | 0 pass / 6 fail (same 6) |
| `shell/{exec,file-io,shelloutput}.test.ts` + `terminal/` | 170 pass / 0 fail | - |

`leak.test.ts`'s `#11816` leak assertions pass when given a timeout this container can meet (`--timeout 120000`: `external` needs 7.9s against a 5s budget; `builtin` then sees a clean heap).

</details>
