### PR TITLE
spawn: give existing Bun.Terminal children the PTY as controlling terminal

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7081,6 +7081,11 @@ declare module "bun" {
        * await proc2.exited;
        * terminal.close();
        * ```
+       *
+       * Reuse is sequential. Each child becomes the session leader with the PTY as its
+       * controlling terminal (like `forkpty(3)`), and a PTY can only be the controlling
+       * terminal of one session at a time, so `await` the previous child's `exited`
+       * before spawning the next one.
        */
       terminal?: TerminalOptions | Terminal;
     }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -644,11 +644,14 @@ impl Terminal {
     /// True when a session-leader child's exit made the BSD/macOS kernel
     /// revoke every fd on the pts (xnu `proc_exit` -> `VNOP_REVOKE` on
     /// `s_ttyvp`), so the held slave fd is no longer a tty. Never true on
-    /// Linux, whose `disassociate_ctty` skips the hangup for PTY drivers.
+    /// Linux, whose `disassociate_ctty` skips the hangup for PTY drivers,
+    /// nor for an inline terminal, where that same EOF is the terminal exit.
     #[cfg(unix)]
     fn slave_was_revoked(&self) -> bool {
+        let flags = self.flags.get();
         let slave = self.slave_fd.get();
-        !self.flags.get().contains(Flags::CLOSED)
+        !flags.contains(Flags::CLOSED)
+            && !flags.contains(Flags::INLINE_SPAWNED)
             && slave != Fd::INVALID
             && get_termios(slave).is_none()
     }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -10,8 +10,6 @@
 //! - Callbacks are stored via `values` in classes.ts, accessed via js.gc
 
 use core::cell::Cell;
-#[cfg(unix)]
-use core::ffi::c_ulong;
 use core::ffi::{c_int, c_void};
 #[cfg(windows)]
 use core::sync::atomic::{AtomicU32, Ordering};
@@ -126,6 +124,12 @@ pub struct Terminal {
     /// The slave side of the PTY (used by child processes). Unused on Windows.
     slave_fd: Cell<Fd>,
 
+    /// NUL-terminated pts device path from openpty. Read-only after
+    /// construction; used to re-open the slave after a macOS/BSD revoke
+    /// (see `slave_was_revoked`).
+    #[cfg(unix)]
+    slave_path: [u8; SLAVE_PATH_BUF_LEN],
+
     /// Windows ConPTY handle. Used for resize and passed to uv_spawn via
     /// uv_process_options_t.pseudoconsole.
     #[cfg(windows)]
@@ -165,7 +169,7 @@ pub struct Terminal {
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, Default)]
-    pub struct Flags: u8 {
+    pub struct Flags: u16 {
         const CLOSED         = 1 << 0;
         const FINALIZED      = 1 << 1;
         const RAW_MODE       = 1 << 2;
@@ -177,6 +181,10 @@ bitflags::bitflags! {
         /// reuse. Windows: first exit's ClosePseudoConsole would kill a second
         /// child. POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
         const INLINE_SPAWNED = 1 << 7;
+        /// The user called `unref()`. The keepalive bit otherwise lives only on
+        /// the reader's `FilePoll`, which a macOS/BSD revoke destroys, so
+        /// `restart_reader_if_done` re-applies this to the fresh poll.
+        const UNREFED        = 1 << 8;
     }
 }
 
@@ -437,6 +445,8 @@ impl Terminal {
             read_fd: Cell::new(pty_result.read_fd),
             write_fd: Cell::new(pty_result.write_fd),
             slave_fd: Cell::new(pty_result.slave),
+            #[cfg(unix)]
+            slave_path: pty_result.slave_path,
             #[cfg(windows)]
             hpcon: Cell::new(Some(pty_result.hpcon)),
             cols: Cell::new(if cfg!(windows) {
@@ -631,6 +641,154 @@ impl Terminal {
         self.slave_fd.get()
     }
 
+    /// True when a session-leader child's exit made the BSD/macOS kernel
+    /// revoke every fd on the pts (xnu `proc_exit` -> `VNOP_REVOKE` on
+    /// `s_ttyvp`), so the held slave fd is no longer a tty. Never true on
+    /// Linux, whose `disassociate_ctty` skips the hangup for PTY drivers.
+    #[cfg(unix)]
+    fn slave_was_revoked(&self) -> bool {
+        let slave = self.slave_fd.get();
+        !self.flags.get().contains(Flags::CLOSED)
+            && slave != Fd::INVALID
+            && get_termios(slave).is_none()
+    }
+
+    #[cfg(not(unix))]
+    fn slave_was_revoked(&self) -> bool {
+        false
+    }
+
+    /// Make the terminal usable for another spawn after a macOS/BSD revoke
+    /// (see `slave_was_revoked`): re-open the slave and, if the master reader
+    /// already observed the resulting hangup, re-arm it. No-op on Linux and
+    /// whenever the held slave fd is still a live tty.
+    #[cfg(unix)]
+    pub(crate) fn ensure_slave_open(&self) {
+        if self.slave_was_revoked() {
+            self.reopen_slave();
+        }
+        // Only re-arm the reader for a terminal that has a slave to read from.
+        // A failed re-open leaves `Fd::INVALID` with the master still hung up;
+        // re-arming there would turn its instant EOF into a spurious exit(0).
+        if self.slave_fd.get() != Fd::INVALID {
+            self.restart_reader_if_done();
+        }
+    }
+
+    /// Re-open the pts slave by path. The fresh slave open resets the line
+    /// discipline to kernel defaults, so termios is snapshotted through the
+    /// master first and written back afterwards; on xnu that same `tcsetattr`
+    /// also restores the master's `TS_CONNECTED`, un-hanging the read side.
+    #[cfg(unix)]
+    fn reopen_slave(&self) {
+        // The held fd is provably dead (the caller's `slave_was_revoked` saw
+        // its tcgetattr fail). Release it first so every exit below, including
+        // a failed `open`, leaves `Fd::INVALID` and the spawn path rejects
+        // this terminal loudly instead of handing the dead fd to a child.
+        let old = self.slave_fd.get();
+        if old != Fd::INVALID {
+            old.close();
+        }
+        self.slave_fd.set(Fd::INVALID);
+
+        let master = self.master_fd.get();
+        // `create_pty_posix` zero-initializes the buffer and forces a trailing
+        // NUL, so a leading NUL means the libc never filled it in and there is
+        // no path to re-open from.
+        let Some(nul) = self.slave_path.iter().position(|&b| b == 0) else {
+            return;
+        };
+        if nul == 0 || master == Fd::INVALID {
+            return;
+        }
+        let path = bun_core::ZStr::from_buf(&self.slave_path, nul);
+        let saved_termios = get_termios(master);
+        let new_fd = match sys::open(path, sys::O::RDWR | sys::O::NOCTTY, 0) {
+            sys::Result::Ok(fd) => fd,
+            sys::Result::Err(_) => return,
+        };
+        self.slave_fd.set(new_fd);
+        if let Some(t) = saved_termios {
+            let _ = set_termios(master, &t);
+        }
+        // xnu zeroes (then defaults to 80x24) the winsize on the slave re-open.
+        let _ = self.set_winsize(self.cols.get(), self.rows.get());
+    }
+
+    /// Re-arm the master reader after it observed the pts hangup caused by a
+    /// revoke. Mirrors the reader start in `init_terminal`: a fresh
+    /// non-blocking CLOEXEC dup of the master, `start` with the PTY poll
+    /// flags, and the reader's ref on `self`.
+    #[cfg(unix)]
+    fn restart_reader_if_done(&self) {
+        let flags = self.flags.get();
+        if !flags.contains(Flags::READER_STARTED) || !flags.contains(Flags::READER_DONE) {
+            return;
+        }
+        let master = self.master_fd.get();
+        if master == Fd::INVALID {
+            return;
+        }
+        let sys::Result::Ok(read_fd) = sys::dup(master) else {
+            return;
+        };
+        let _ = sys::update_nonblocking(read_fd, true);
+        let _ = crate::api::bun_process::spawn_sys::set_close_on_exec(read_fd);
+        let started = self.reader.with_mut(|r| {
+            // The reader torched its previous handle on EOF; clear the
+            // terminal-state flags so `finish()` accepts a future done.
+            r.flags.remove(
+                PosixFlags::IS_DONE
+                    | PosixFlags::RECEIVED_EOF
+                    | PosixFlags::CLOSED_WITHOUT_REPORTING
+                    | PosixFlags::IS_PAUSED,
+            );
+            if r.start(read_fd, true).is_err() {
+                return false;
+            }
+            // PTY behaves like a pipe, not a socket (same as init_terminal).
+            r.flags
+                .insert(PosixFlags::NONBLOCKING | PosixFlags::POLLABLE);
+            if let Some(poll) = r.handle.get_poll() {
+                poll.set_flag(bun_io::FilePollFlag::Nonblocking);
+            }
+            true
+        });
+        if !started {
+            read_fd.close();
+            return;
+        }
+        self.read_fd.set(read_fd);
+        // The reader's ref was released when READER_DONE was set; re-acquire
+        // it so the refcount balances on the next on_reader_finished.
+        self.ref_();
+        self.update_flags(|f| f.remove(Flags::READER_DONE));
+        // `register_poll` keeps a brand-new poll alive unconditionally; carry
+        // the user's earlier `unref()` over to it.
+        if self.flags.get().contains(Flags::UNREFED) {
+            self.reader.with_mut(|r| r.update_ref(false));
+        }
+    }
+
+    /// `ioctl(master, TIOCSWINSZ)`. Returns false on failure.
+    #[cfg(unix)]
+    fn set_winsize(&self, cols: u16, rows: u16) -> bool {
+        let winsize = Winsize {
+            row: rows,
+            col: cols,
+            xpixel: 0,
+            ypixel: 0,
+        };
+        // SAFETY: master_fd is a live PTY master; TIOCSWINSZ takes *const winsize.
+        unsafe {
+            libc::ioctl(
+                self.master_fd.get().native(),
+                libc::TIOCSWINSZ,
+                &raw const winsize,
+            ) == 0
+        }
+    }
+
     /// `flags.closed` — read by `Bun.spawn` arg validation.
     #[inline]
     pub(crate) fn is_closed(&self) -> bool {
@@ -767,11 +925,21 @@ impl Terminal {
     }
 }
 
+/// Size of the stored pts device path. No real pts path is longer: macOS's
+/// `ioctl(TIOCPTYGNAME)`, which its `openpty` fills the `name` out-param with,
+/// is defined to write at most this many bytes.
+#[cfg(unix)]
+pub const SLAVE_PATH_BUF_LEN: usize = 128;
+
 pub struct PtyResult {
     pub master: Fd,
     pub read_fd: Fd,
     pub write_fd: Fd,
     pub slave: Fd,
+    /// NUL-terminated pts device path (e.g. `/dev/pts/3`); all-zero if the
+    /// libc's openpty did not fill it. Used to re-open the slave on macOS/BSD.
+    #[cfg(unix)]
+    pub slave_path: [u8; SLAVE_PATH_BUF_LEN],
     #[cfg(windows)]
     pub hpcon: windows::HPCON,
     #[cfg(not(windows))]
@@ -912,6 +1080,11 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
 
     let mut master_fd: c_int = -1;
     let mut slave_fd: c_int = -1;
+    // openpty(3)'s `name` out-param has no length, but it receives a device
+    // path, so PATH_MAX is a hard upper bound on what any libc can write.
+    // The (much shorter) result is bounds-copied into `slave_path` below.
+    const NAME_SCRATCH_LEN: usize = libc::PATH_MAX as usize;
+    let mut name_scratch = [0u8; NAME_SCRATCH_LEN];
 
     let winsize = Winsize {
         row: rows,
@@ -920,18 +1093,29 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
         ypixel: 0,
     };
 
-    // SAFETY: openpty writes to master_fd/slave_fd; name/termp are null (allowed).
+    // SAFETY: openpty writes to master_fd/slave_fd and a NUL-terminated device
+    // path into `name_scratch` (bounded by PATH_MAX); termp is null (allowed).
     let result = unsafe {
         openpty_fn(
             &raw mut master_fd,
             &raw mut slave_fd,
-            core::ptr::null_mut(),
+            name_scratch.as_mut_ptr(),
             core::ptr::null(),
             &raw const winsize,
         )
     };
     if result != 0 {
         return Err(CreatePtyError::OpenPtyFailed);
+    }
+    // Never rely on the libc having kept the terminator in-bounds.
+    name_scratch[NAME_SCRATCH_LEN - 1] = 0;
+    // A real pts path always fits (macOS's TIOCPTYGNAME writes at most
+    // `SLAVE_PATH_BUF_LEN`); a longer one leaves `slave_path` all-zero and
+    // `reopen_slave` simply has no path to re-open from.
+    let mut slave_path = [0u8; SLAVE_PATH_BUF_LEN];
+    let nul = name_scratch.iter().position(|&b| b == 0).unwrap_or(0);
+    if nul < SLAVE_PATH_BUF_LEN {
+        slave_path[..=nul].copy_from_slice(&name_scratch[..=nul]);
     }
 
     let master_fd_desc = Fd::from_native(master_fd);
@@ -1046,6 +1230,7 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
         read_fd,
         write_fd,
         slave: slave_fd_desc,
+        slave_path,
         hpcon: (),
     })
 }
@@ -1485,31 +1670,8 @@ impl Terminal {
         };
 
         #[cfg(unix)]
-        {
-            #[cfg(target_os = "macos")]
-            const TIOCSWINSZ: c_ulong = 0x80087467;
-            #[cfg(not(target_os = "macos"))]
-            const TIOCSWINSZ: c_ulong = 0x5414;
-
-            let winsize = bun_core::Winsize {
-                row: new_rows,
-                col: new_cols,
-                xpixel: 0,
-                ypixel: 0,
-            };
-
-            // SAFETY: master_fd is open (closed flag checked above), TIOCSWINSZ
-            // takes a *const winsize.
-            let ioctl_result = unsafe {
-                libc::ioctl(
-                    self.master_fd.get().native(),
-                    TIOCSWINSZ as _,
-                    &raw const winsize,
-                )
-            };
-            if ioctl_result != 0 {
-                return Err(global_object.throw(format_args!("Failed to resize terminal")));
-            }
+        if !self.set_winsize(new_cols, new_rows) {
+            return Err(global_object.throw(format_args!("Failed to resize terminal")));
         }
 
         #[cfg(windows)]
@@ -1596,6 +1758,9 @@ impl Terminal {
     /// Reference the terminal to keep the event loop alive
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_ref(&self, _g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
+        // The user's intent is remembered here (see `Flags::UNREFED`), not in
+        // `update_ref`: `drain_and_close_slave_fd` also calls `update_ref(false)`.
+        self.update_flags(|f| f.remove(Flags::UNREFED));
         self.update_ref(true);
         Ok(JSValue::UNDEFINED)
     }
@@ -1603,6 +1768,7 @@ impl Terminal {
     /// Unreference the terminal
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_unref(&self, _g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
+        self.update_flags(|f| f.insert(Flags::UNREFED));
         self.update_ref(false);
         Ok(JSValue::UNDEFINED)
     }
@@ -1646,6 +1812,14 @@ impl Terminal {
         if self.flags.get().contains(Flags::CLOSED) {
             return;
         }
+        // A swallowed macOS/BSD revoke left the reader already done without
+        // ever delivering the exit callback, so `reader.close()` below is a
+        // no-op that cannot re-deliver it. Capture that now, before `CLOSED`
+        // makes `slave_was_revoked` unconditionally false, and fire it after
+        // the reader is torn down so `close()` keeps its exit-callback contract.
+        #[cfg(unix)]
+        let exit_was_deferred =
+            self.flags.get().contains(Flags::READER_DONE) && self.slave_was_revoked();
         self.update_flags(|f| f.insert(Flags::CLOSED));
 
         // Close writer (closes write_fd). R-2: `with_mut` borrow is held across
@@ -1676,6 +1850,12 @@ impl Terminal {
             self.reader.with_mut(|r| r.close());
         }
         self.read_fd.set(Fd::INVALID);
+
+        #[cfg(unix)]
+        if exit_was_deferred && !self.flags.get().contains(Flags::FINALIZED) {
+            // exit_code 0 = clean EOF on PTY stream (not subprocess exit code)
+            self.call_exit_callback(0, None);
+        }
 
         // Close master fd
         let master = self.master_fd.get();
@@ -1762,7 +1942,12 @@ impl Terminal {
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
         if !self.flags.get().contains(Flags::FINALIZED) {
             self.this_value.with_mut(|v| v.downgrade());
-            self.call_exit_callback(exit_code, None);
+            // A macOS/BSD revoke hung up the master, but the user still holds
+            // an open Terminal: not a terminal exit. `ensure_slave_open` on
+            // the next spawn re-opens the slave and re-arms this reader.
+            if !self.slave_was_revoked() {
+                self.call_exit_callback(exit_code, None);
+            }
         }
         self.deref_();
     }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -808,6 +808,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                                 "terminal was created inline by a previous spawn and cannot be reused",
                             )));
                         }
+                        // On macOS/BSD, a previous session-leader child's exit
+                        // revoked the pts; re-open the slave and re-arm the
+                        // reader so the terminal stays reusable.
+                        #[cfg(unix)]
+                        term.ensure_slave_open();
                         #[cfg(unix)]
                         if term.get_slave_fd() == Fd::INVALID {
                             return Err(global_this.throw_invalid_arguments(format_args!(
@@ -1152,13 +1157,14 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         },
         argv0,
         can_block_entire_thread_to_reduce_cpu_usage_in_fast_path,
-        // Only pass pty_slave_fd for newly created terminals (for setsid+TIOCSCTTY setup).
-        // For existing terminals, the session is already set up - child just uses the fd as stdio.
+        // The child calls setsid() + ioctl(TIOCSCTTY) on this fd so the PTY becomes
+        // its controlling terminal (forkpty semantics); required for both existing
+        // Terminal objects and terminals created inline by this spawn.
         #[cfg(unix)]
-        pty_slave_fd: match terminal_info.as_ref() {
-            Some(ti) => ti.term().get_slave_fd().native(),
-            None => -1,
-        },
+        pty_slave_fd: existing_terminal
+            .as_deref()
+            .or_else(|| terminal_info.as_ref().map(TerminalCreateResult::term))
+            .map_or(-1, |t| t.get_slave_fd().native()),
         #[cfg(windows)]
         pseudoconsole: existing_terminal
             .as_deref()

--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -11,12 +11,18 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 
 /** Spawn a child attached to a fresh terminal, collect all PTY output until
- *  `done()` returns true or the child exits, then close the terminal. */
+ *  `done()` returns true or the child exits, then close the terminal.
+ *
+ *  On POSIX the child becomes the session leader with the PTY as its
+ *  controlling terminal (setsid + TIOCSCTTY) whether the terminal is created
+ *  inline by the spawn or passed as a pre-constructed `Bun.Terminal`; set
+ *  `existing: true` to exercise the latter (oven-sh/bun#33237). */
 async function runInTerminal(
   childScript: string,
   opts: {
     cols?: number;
     rows?: number;
+    existing?: boolean;
     done: (output: string) => boolean;
     afterReady?: (terminal: Bun.Terminal, output: () => string) => void | Promise<void>;
     readyMarker?: string;
@@ -29,23 +35,23 @@ async function runInTerminal(
   const readyMarker = opts.readyMarker ?? "READY";
   const decoder = new TextDecoder();
 
-  // Use an inline terminal so the child becomes the session leader on POSIX
-  // (setsid + TIOCSCTTY), which is required for SIGINT/SIGWINCH delivery.
+  const terminalOptions: Bun.TerminalOptions = {
+    cols: opts.cols ?? 80,
+    rows: opts.rows ?? 24,
+    data(_t, chunk: Uint8Array) {
+      output += decoder.decode(chunk, { stream: true });
+      if (output.includes(readyMarker)) ready.resolve();
+      if (opts.done(output)) finished.resolve();
+    },
+    exit() {
+      eof.resolve();
+    },
+  };
+
   const proc = Bun.spawn({
     cmd: [bunExe(), "-e", childScript],
     env: bunEnv,
-    terminal: {
-      cols: opts.cols ?? 80,
-      rows: opts.rows ?? 24,
-      data(_t, chunk: Uint8Array) {
-        output += decoder.decode(chunk, { stream: true });
-        if (output.includes(readyMarker)) ready.resolve();
-        if (opts.done(output)) finished.resolve();
-      },
-      exit() {
-        eof.resolve();
-      },
-    },
+    terminal: opts.existing ? new Bun.Terminal(terminalOptions) : terminalOptions,
   });
 
   if (opts.afterReady) {
@@ -143,6 +149,36 @@ describe("Bun.Terminal platform behaviour", () => {
     expect(output).toContain("rows=19");
   });
 
+  // POSIX only: /dev/tty (the controlling terminal) has no Windows equivalent,
+  // so these are skipped rather than todo'd there. The child opens /dev/tty
+  // and writes a marker; that marker only reaches the PTY's data callback if
+  // the PTY is the child's controlling terminal (setsid + TIOCSCTTY). Before
+  // https://github.com/oven-sh/bun/issues/33237 an existing-Terminal child
+  // kept the parent's controlling terminal (or none), so the open failed with
+  // ENXIO or the write went to the wrong tty.
+  const DEV_TTY_CHILD = `
+    const fs = require("fs");
+    process.stdout.write("READY");
+    let r;
+    try { fs.writeSync(fs.openSync("/dev/tty", "w"), "VIA_DEV_TTY"); r = "ok"; }
+    catch (e) { r = String(e.code || e); }
+    process.stdout.write(" DONE:" + r);`;
+
+  test.skipIf(isWindows)("POSIX: /dev/tty inside the child is the PTY (inline terminal)", async () => {
+    const { output } = await runInTerminal(DEV_TTY_CHILD, { done: o => o.includes("DONE:") });
+    expect(output).toContain("VIA_DEV_TTY");
+    expect(output).toContain("DONE:ok");
+  });
+
+  test.skipIf(isWindows)("POSIX: /dev/tty inside the child is the PTY (existing Terminal)", async () => {
+    const { output } = await runInTerminal(DEV_TTY_CHILD, {
+      existing: true,
+      done: o => o.includes("DONE:"),
+    });
+    expect(output).toContain("VIA_DEV_TTY");
+    expect(output).toContain("DONE:ok");
+  });
+
   // (Bun.Terminal stores `name` but does not inject TERM= into the child env
   // on either platform; that's inheritance from the caller's env, not a gap.)
 
@@ -188,6 +224,23 @@ describe("Bun.Terminal platform behaviour", () => {
        setInterval(() => {}, 1000);
        process.stdout.write('READY');`,
       {
+        done: o => o.includes("SIGINT"),
+        afterReady: t => void t.write("\x03"),
+      },
+    );
+    expect(output).toContain("SIGINT");
+  });
+
+  // https://github.com/oven-sh/bun/issues/33237: a pre-constructed Bun.Terminal
+  // must also become the child's controlling terminal, or the line discipline
+  // has no foreground process group to deliver SIGINT to and \x03 is only echoed.
+  test.todoIf(isWindows)("SAME: Ctrl+C input interrupts a child on an existing Terminal", async () => {
+    const { output } = await runInTerminal(
+      `process.on('SIGINT', () => { process.stdout.write('SIGINT'); process.exit(0); });
+       setInterval(() => {}, 1000);
+       process.stdout.write('READY');`,
+      {
+        existing: true,
         done: o => o.includes("SIGINT"),
         afterReady: t => void t.write("\x03"),
       },
@@ -335,6 +388,23 @@ describe("Bun.Terminal platform behaviour", () => {
     terminal.close();
   });
 
+  // Companion to the test above: the exit callback that a child's exit must NOT
+  // fire must still fire on close(). On macOS/BSD the session leader's exit
+  // revokes the pts and finishes the master reader early; the exit callback is
+  // deferred through that, not lost (https://github.com/oven-sh/bun/issues/33237).
+  test("SAME: exit callback fires on close() after an existing terminal's child exited", async () => {
+    const exitFired = Promise.withResolvers<void>();
+    const terminal = new Bun.Terminal({
+      exit() {
+        exitFired.resolve();
+      },
+    });
+    const proc = Bun.spawn({ cmd: [bunExe(), "-e", ""], env: bunEnv, terminal });
+    await proc.exited;
+    terminal.close();
+    await exitFired.promise;
+  });
+
   test("SAME: terminal can be reused across sequential spawns", async () => {
     let output = "";
     const first = Promise.withResolvers<void>();
@@ -358,6 +428,49 @@ describe("Bun.Terminal platform behaviour", () => {
     terminal.close();
     expect(output).toContain("FIRST");
     expect(output).toContain("SECOND");
+  });
+
+  // https://github.com/oven-sh/bun/issues/33237: sequential children on a
+  // reused Terminal must each get the PTY as their controlling terminal. On
+  // macOS/BSD the first session leader's exit revokes every fd on the pts, so
+  // the Terminal must transparently re-acquire a live slave (and re-arm its
+  // master reader) before the second spawn. POSIX only: /dev/tty has no
+  // Windows equivalent.
+  test.skipIf(isWindows)("POSIX: sequential children on a reused Terminal each get it as the ctty", async () => {
+    let output = "";
+    const first = Promise.withResolvers<void>();
+    const second = Promise.withResolvers<void>();
+    const terminal = new Bun.Terminal({
+      data(_t, chunk) {
+        output += Buffer.from(chunk).toString("latin1");
+        if (output.includes("DONE1:")) first.resolve();
+        if (output.includes("DONE2:")) second.resolve();
+      },
+    });
+    // Writes a marker to /dev/tty (only visible on the PTY when it is the
+    // child's ctty), then always reports DONE on stdout so the test never hangs.
+    const writeToDevTty = (n: number) =>
+      `const fs = require("fs");
+       let r;
+       try { fs.writeSync(fs.openSync("/dev/tty", "w"), "CTTY:${n} "); r = "ok"; }
+       catch (e) { r = String(e.code || e); }
+       process.stdout.write("DONE${n}:" + r + " ");`;
+
+    try {
+      const p1 = Bun.spawn({ cmd: [bunExe(), "-e", writeToDevTty(1)], env: bunEnv, terminal });
+      await first.promise;
+      await p1.exited;
+
+      const p2 = Bun.spawn({ cmd: [bunExe(), "-e", writeToDevTty(2)], env: bunEnv, terminal });
+      await second.promise;
+      await p2.exited;
+    } finally {
+      terminal.close();
+    }
+    expect(output).toContain("CTTY:1");
+    expect(output).toContain("CTTY:2");
+    expect(output).toContain("DONE1:ok");
+    expect(output).toContain("DONE2:ok");
   });
 
   // ClosePseudoConsole on Windows < 11 24H2 may not terminate a still-running


### PR DESCRIPTION
Fixes #33237

### Repro

```ts
const term = new Bun.Terminal({ cols: 80, rows: 24, data: (_t, d) => process.stdout.write(d) });
const proc = Bun.spawn(["sh", "-c", 'ps -o pid,pgid,sid,tty,args -p "$$"; sleep 500'], { terminal: term });
setTimeout(() => term.write("\x03"), 500); // ^C into the PTY (slave has ISIG on)
console.log(await Promise.race([proc.exited, new Promise(r => setTimeout(() => r("still alive"), 3000))]));
```

With an existing `Bun.Terminal` object the child keeps the parent's session (`SID` unchanged, `TTY ?`), the `^C` is only echoed, and the race reports `still alive`. The inline form, `terminal: { cols, rows, data }`, already prints `PID == PGID == SID` on a `pts/N` and exits `130`.

### Cause

The terminal option parser in `js_bun_spawn_bindings.rs` only populated `pty_slave_fd` from `terminal_info` (a terminal created inline by the spawn), never from `existing_terminal`. That field is what gates the child's `setsid()` + `ioctl(TIOCSCTTY)` in `bun-spawn.cpp`, and on macOS it also selects the fork-based spawn over Apple's `posix_spawn` (which cannot do either). The sibling Windows `pseudoconsole` field in the same initializer already falls back to the existing terminal; the Unix field was the only one that did not.

### Fix

- `src/runtime/api/bun/js_bun_spawn_bindings.rs`: populate `pty_slave_fd` from the existing terminal too, mirroring the Windows `pseudoconsole` expression just below it.

- `src/runtime/api/bun/Terminal.rs`: handle the macOS/BSD consequence. Once a session-leader child exits with the pts as its controlling terminal, xnu revokes every fd on the slave vnode (`proc_exit` -> `VNOP_REVOKE` on the session's `s_ttyvp`) and the resulting `ttyclose` clears the master's `TS_CONNECTED`. That kills the Terminal's long-lived slave fd and hangs up the master, which breaks the documented reuse of one `Bun.Terminal` across sequential spawns. This is exactly why the earlier attempt (#25834) failed all four darwin test lanes, with `echo second` exiting 1 (EIO on the dead slave) in the reuse tests. Now:
  - `openpty` captures the pts device path (previously passed `NULL`).
  - On the next spawn with that Terminal, the revoked slave is detected (`tcgetattr` fails on it), re-opened by path, and the master reader re-armed. The `tcsetattr` that restores the user's termios through the master also restores the master's `TS_CONNECTED` on xnu (`ttioctl` re-derives it from `TS_CARR_ON`), un-hanging the read side.
  - The master reader's EOF handler does not fire the Terminal's `exit()` callback when the cause is a revoke on a still-open, user-held Terminal; that is not a terminal exit.

  Linux's `disassociate_ctty` deliberately skips the hangup for PTY drivers, so every one of these paths is a no-op there: `tcgetattr` on the held slave never fails. Inline terminals are excluded from `slave_was_revoked()` by `INLINE_SPAWNED`: after #33882 they hold `slave_fd` until `on_process_exit` runs `drain_and_close_slave_fd`, so on macOS their own master EOF would otherwise trip the check, but an inline terminal is one-shot and its master EOF is its exit.

### Verification

`test/js/bun/terminal/terminal-platform-gaps.test.ts` gains three tests that fail on the unpatched build and pass with the fix, alongside the existing inline siblings:

- `SAME: Ctrl+C input interrupts a child on an existing Terminal`
- `POSIX: /dev/tty inside the child is the PTY (existing Terminal)`, with the inline variant as the already-passing control
- `POSIX: sequential children on a reused Terminal each get it as the ctty`: each child writes a marker to `/dev/tty`, which only reaches the PTY's data callback when the PTY is that child's controlling terminal, so one test exercises the one-line fix, the macOS slave re-open, and the reader re-arm

All 129 existing terminal tests still pass on Linux x64, including `exit callback does NOT fire on child exit for existing terminal` and both sequential-reuse tests (the ones #25834 regressed on darwin). `cargo check -p bun_runtime` passes for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`.

<details>
<summary>Before / after (Linux x64)</summary>

```console
$ USE_SYSTEM_BUN=1 bun repro-existing.ts
    PID    PGID     SID TT       COMMAND
   1324    1314    1308 ?        sh -c ps -o pid,pgid,sid,tty,args -p "$$"; slee
^C
RESULT: child still alive 3s after ^C

$ bun bd repro-existing.ts
    PID    PGID     SID TT       COMMAND
  17104   17104   17104 pts/0    sh -c ps -o pid,pgid,sid,tty,args -p "$$"; slee
^C
RESULT: 130
```

</details>


### Rebase onto main (d2e54c00b9)

Main merged #33882 and #34225 while this PR was open, which refactored `on_reader_done` / `on_reader_error` into a shared `on_reader_finished` and added `drain_and_close_slave_fd` for inline terminals; #33909 replaced `bun_core::Error` with per-crate `thiserror` enums. The seven review-iteration commits were squashed and re-applied on top of that, with the following semantic reconciliation:

- The `slave_was_revoked()` suppression of the exit callback moved into main's new `on_reader_finished`. Its `READER_DONE` early-return already subsumes this PR's previous `on_reader_error` gate (a `register_poll` failure dispatched from inside `restart_reader_if_done` now no-ops because `READER_DONE` is still set at that point), so that edit was dropped.
- `Flags::UNREFED` is now recorded only in the JS-exposed `do_ref` / `do_unref`, not in `update_ref`: main's `drain_and_close_slave_fd` calls `update_ref(false)` internally for inline terminals, which is not user intent.
- `Flags` keeps main's updated `INLINE_SPAWNED` comment and widens to `u16` for the new `UNREFED` bit.
- `slave_was_revoked()` gains `!INLINE_SPAWNED`: #33882 moved the inline `close_slave_fd()` to `on_process_exit`, so an inline session-leader child's exit would have tripped the check on macOS and suppressed its exit callback. The revoke suppression only exists for reusable existing terminals.

The pre-rebase darwin CI evidence above is for commits c42c5563..dca2e4f4 and does not cover the rebased head; the darwin lanes of the rebased build do.

All 130 terminal tests (132 with the two #33882/#34225 added) pass on Linux x64 after the rebase, the fail-before proof is unchanged (the three existing-Terminal tests), and `cargo check -p bun_runtime` is clean for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal-platform-gaps.test.ts

<!-- robobun:evidence:end -->
