### PR TITLE
http: fix use-after-free of the redirect URL on a retried request

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -769,13 +769,32 @@ impl<'a> AsyncHTTP<'a> {
                 // its `Box<AsyncHTTP>` is reclaimed. Only the state the clone
                 // built up itself during request processing is torn down.
                 {
-                    // After a redirect, `client.url` (and `connected_url`) self-borrow
-                    // `client.redirect`, freed just below. The copy-back into the
-                    // JS-thread original must not hand a retry those dangling slices.
+                    // `handle_response_metadata` rewrites per-hop request state in
+                    // place: `client.url`/`connected_url` become self-borrows into
+                    // `client.redirect` (freed just below), the method may be
+                    // downgraded to GET, and a cross-origin hop strips auth headers
+                    // from `client.header_entries`. The copy-back into the JS-thread
+                    // original must not hand a re-scheduled attempt any of that.
+                    //
+                    // `header_entries` is bitwise-shared with the original (see the
+                    // comment above), so it must never be dropped or reallocated
+                    // here. It was cloned from `request_headers` at init and only
+                    // ever shrinks (`ordered_remove`), so its capacity is enough.
+                    debug_assert!(
+                        (*this).client.header_entries.capacity()
+                            >= (*this).request_headers.len()
+                    );
+                    (*this).client.header_entries.clear_retaining_capacity();
+                    (*this)
+                        .client
+                        .header_entries
+                        .append_list_assume_capacity(&(*this).request_headers);
                     let original_url = (*this).url.clone();
+                    let original_method = (*this).method;
                     let client = &mut (*this).client;
                     client.url = original_url;
                     client.connected_url = URL::default();
+                    client.method = original_method;
                     // Clone-owned (allocated after `ptr::read`).
                     drop(core::mem::take(&mut client.redirect));
                     drop(core::mem::take(&mut client.prev_redirect));

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -769,7 +769,13 @@ impl<'a> AsyncHTTP<'a> {
                 // its `Box<AsyncHTTP>` is reclaimed. Only the state the clone
                 // built up itself during request processing is torn down.
                 {
+                    // After a redirect, `client.url` (and `connected_url`) self-borrow
+                    // `client.redirect`, freed just below. The copy-back into the
+                    // JS-thread original must not hand a retry those dangling slices.
+                    let original_url = (*this).url.clone();
                     let client = &mut (*this).client;
+                    client.url = original_url;
+                    client.connected_url = URL::default();
                     // Clone-owned (allocated after `ptr::read`).
                     drop(core::mem::take(&mut client.redirect));
                     drop(core::mem::take(&mut client.prev_redirect));

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -781,8 +781,7 @@ impl<'a> AsyncHTTP<'a> {
                     // here. It was cloned from `request_headers` at init and only
                     // ever shrinks (`ordered_remove`), so its capacity is enough.
                     debug_assert!(
-                        (*this).client.header_entries.capacity()
-                            >= (*this).request_headers.len()
+                        (*this).client.header_entries.capacity() >= (*this).request_headers.len()
                     );
                     (*this).client.header_entries.clear_retaining_capacity();
                     (*this)

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -779,8 +779,10 @@ impl<'a> AsyncHTTP<'a> {
                     // `header_entries` is bitwise-shared with the original (see the
                     // comment above), so it must never be dropped or reallocated
                     // here. It was cloned from `request_headers` at init and only
-                    // ever shrinks (`ordered_remove`), so its capacity is enough.
-                    debug_assert!(
+                    // ever shrinks (`ordered_remove`), so its capacity is enough;
+                    // the unchecked append below would corrupt the shared heap
+                    // allocation otherwise, so keep this assertion in release too.
+                    assert!(
                         (*this).client.header_entries.capacity() >= (*this).request_headers.len()
                     );
                     (*this).client.header_entries.clear_retaining_capacity();

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -97,6 +97,82 @@ it("retries a manifest whose redirect target 500s once", async () => {
   });
 });
 
+// A cross-origin redirect strips Authorization from the in-flight header list
+// (per the fetch spec). That list is bitwise-shared with the task's AsyncHTTP,
+// so the stripped state used to leak into the install retry and the
+// re-requested registry URL went out unauthenticated (401). The retry must
+// restore the original headers along with the original URL.
+it("retries an authorized manifest whose cross-origin redirect target 500s once", async () => {
+  const token = "test-registry-token";
+  const registryUrls: string[] = [];
+  const cdnAuth: (string | null)[] = [];
+  let cdnHits = 0;
+  // A second server on its own port stands in for the CDN the registry
+  // redirects to; a different port makes the redirect cross-origin.
+  await using cdn = Bun.serve({
+    port: 0,
+    fetch(request) {
+      if (new URL(request.url).pathname !== "/cdn/BaR") {
+        return new Response("unexpected", { status: 404 });
+      }
+      cdnAuth.push(request.headers.get("authorization"));
+      if (cdnHits++ === 0) {
+        return new Response("transient", { status: 500 });
+      }
+      return Response.json({
+        name: "BaR",
+        versions: {
+          "0.0.2": { name: "BaR", version: "0.0.2", dist: { tarball: `${root_url}/BaR-0.0.2.tgz` } },
+        },
+        "dist-tags": { latest: "0.0.2" },
+      });
+    },
+  });
+  setHandler(async request => {
+    const { pathname } = new URL(request.url);
+    registryUrls.push(pathname);
+    if (pathname === "/BaR") {
+      // The registry requires the token on every request, including the retry.
+      if (request.headers.get("authorization") !== `Bearer ${token}`) {
+        return new Response("missing authorization", { status: 401 });
+      }
+      return new Response(null, {
+        status: 302,
+        headers: { Location: `http://localhost:${cdn.port}/cdn/BaR` },
+      });
+    }
+    if (pathname === "/BaR-0.0.2.tgz") {
+      return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+    }
+    return new Response("unexpected", { status: 404 });
+  });
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = { url = "${root_url}/", token = "${token}" }\nsaveTextLockfile = false\n`,
+  );
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { BaR: "0.0.2" } }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(err).toContain("Saved lockfile");
+  expect(out).toContain("1 package installed");
+  expect(exitCode).toBe(0);
+  // Both registry hits carried the token (the handler 401s otherwise); the
+  // cross-origin CDN hops must NOT have (the spec strips it for that hop).
+  expect(registryUrls).toEqual(["/BaR", "/BaR", "/BaR-0.0.2.tgz"]);
+  expect(cdnAuth).toEqual([null, null]);
+});
+
 // Same bug, sibling retry site (tarball downloads in runTasks): the tarball URL
 // 302-redirects and the target 500s once before serving the archive.
 it("retries a tarball whose redirect target 500s once", async () => {

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -87,6 +87,7 @@ it("retries a manifest whose redirect target 500s once", async () => {
   expect(err).not.toContain("error:");
   expect(err).toContain("Saved lockfile");
   expect(out).toContain("1 package installed");
+  expect(exitCode).toBe(0);
   // The retry restarts from the original manifest URL, so the server sees the
   // whole redirect chain a second time.
   expect(urls).toEqual(["/BaR", "/redirected/BaR", "/BaR", "/redirected/BaR", "/BaR-0.0.2.tgz"]);
@@ -94,7 +95,6 @@ it("retries a manifest whose redirect target 500s once", async () => {
     name: "bar",
     version: "0.0.2",
   });
-  expect(exitCode).toBe(0);
 });
 
 // Same bug, sibling retry site (tarball downloads in runTasks): the tarball URL
@@ -141,6 +141,7 @@ it("retries a tarball whose redirect target 500s once", async () => {
   expect(err).not.toContain("error:");
   expect(err).toContain("Saved lockfile");
   expect(out).toContain("1 package installed");
+  expect(exitCode).toBe(0);
   expect(urls).toEqual([
     "/BaR",
     "/BaR-0.0.2.tgz",
@@ -152,7 +153,6 @@ it("retries a tarball whose redirect target 500s once", async () => {
     name: "bar",
     version: "0.0.2",
   });
-  expect(exitCode).toBe(0);
 });
 
 it("retries on 500", async () => {

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -40,6 +40,121 @@ afterEach(async () => {
   await dummyAfterEach();
 });
 
+// Manifest request 302-redirects; the redirect target answers a retryable 500
+// once, then the real packument. The retry used to go out through a URL that
+// was a dangling self-borrow into the first attempt's freed redirect buffer
+// (ASAN: heap-use-after-free in URL::get_port on the HTTP-client thread), so
+// the retries never reached the server. It must restart from the original URL.
+it("retries a manifest whose redirect target 500s once", async () => {
+  const urls: string[] = [];
+  let redirectTargetHits = 0;
+  setHandler(async request => {
+    const { pathname } = new URL(request.url);
+    urls.push(pathname);
+    if (pathname === "/BaR") {
+      return new Response(null, { status: 302, headers: { Location: `${root_url}/redirected/BaR` } });
+    }
+    if (pathname === "/redirected/BaR") {
+      if (redirectTargetHits++ === 0) {
+        return new Response("transient", { status: 500 });
+      }
+      return Response.json({
+        name: "BaR",
+        versions: {
+          "0.0.2": { name: "BaR", version: "0.0.2", dist: { tarball: `${root_url}/BaR-0.0.2.tgz` } },
+        },
+        "dist-tags": { latest: "0.0.2" },
+      });
+    }
+    if (pathname === "/BaR-0.0.2.tgz") {
+      return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+    }
+    return new Response("unexpected", { status: 404 });
+  });
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { BaR: "0.0.2" } }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(err).toContain("Saved lockfile");
+  expect(out).toContain("1 package installed");
+  // The retry restarts from the original manifest URL, so the server sees the
+  // whole redirect chain a second time.
+  expect(urls).toEqual(["/BaR", "/redirected/BaR", "/BaR", "/redirected/BaR", "/BaR-0.0.2.tgz"]);
+  expect(await file(join(package_dir, "node_modules", "BaR", "package.json")).json()).toEqual({
+    name: "bar",
+    version: "0.0.2",
+  });
+  expect(exitCode).toBe(0);
+});
+
+// Same bug, sibling retry site (tarball downloads in runTasks): the tarball URL
+// 302-redirects and the target 500s once before serving the archive.
+it("retries a tarball whose redirect target 500s once", async () => {
+  const urls: string[] = [];
+  let redirectTargetHits = 0;
+  setHandler(async request => {
+    const { pathname } = new URL(request.url);
+    urls.push(pathname);
+    if (pathname === "/BaR") {
+      return Response.json({
+        name: "BaR",
+        versions: {
+          "0.0.2": { name: "BaR", version: "0.0.2", dist: { tarball: `${root_url}/BaR-0.0.2.tgz` } },
+        },
+        "dist-tags": { latest: "0.0.2" },
+      });
+    }
+    if (pathname === "/BaR-0.0.2.tgz") {
+      return new Response(null, { status: 302, headers: { Location: `${root_url}/redirected/BaR-0.0.2.tgz` } });
+    }
+    if (pathname === "/redirected/BaR-0.0.2.tgz") {
+      if (redirectTargetHits++ === 0) {
+        return new Response("transient", { status: 500 });
+      }
+      return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+    }
+    return new Response("unexpected", { status: 404 });
+  });
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { BaR: "0.0.2" } }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(err).toContain("Saved lockfile");
+  expect(out).toContain("1 package installed");
+  expect(urls).toEqual([
+    "/BaR",
+    "/BaR-0.0.2.tgz",
+    "/redirected/BaR-0.0.2.tgz",
+    "/BaR-0.0.2.tgz",
+    "/redirected/BaR-0.0.2.tgz",
+  ]);
+  expect(await file(join(package_dir, "node_modules", "BaR", "package.json")).json()).toEqual({
+    name: "bar",
+    version: "0.0.2",
+  });
+  expect(exitCode).toBe(0);
+});
+
 it("retries on 500", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, undefined, 4));

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -40,11 +40,8 @@ afterEach(async () => {
   await dummyAfterEach();
 });
 
-// Manifest request 302-redirects; the redirect target answers a retryable 500
-// once, then the real packument. The retry used to go out through a URL that
-// was a dangling self-borrow into the first attempt's freed redirect buffer
-// (ASAN: heap-use-after-free in URL::get_port on the HTTP-client thread), so
-// the retries never reached the server. It must restart from the original URL.
+// Manifest request 302-redirects and the redirect target answers a retryable
+// 500 once. The install retry must restart from the original manifest URL.
 it("retries a manifest whose redirect target 500s once", async () => {
   const urls: string[] = [];
   let redirectTargetHits = 0;
@@ -97,11 +94,9 @@ it("retries a manifest whose redirect target 500s once", async () => {
   });
 });
 
-// A cross-origin redirect strips Authorization from the in-flight header list
-// (per the fetch spec). That list is bitwise-shared with the task's AsyncHTTP,
-// so the stripped state used to leak into the install retry and the
-// re-requested registry URL went out unauthenticated (401). The retry must
-// restore the original headers along with the original URL.
+// A cross-origin redirect strips Authorization from the request (per the fetch
+// spec). The install retry restarts from the original registry URL and must
+// carry the original headers, including Authorization, again.
 it("retries an authorized manifest whose cross-origin redirect target 500s once", async () => {
   const token = "test-registry-token";
   const registryUrls: string[] = [];
@@ -173,7 +168,7 @@ it("retries an authorized manifest whose cross-origin redirect target 500s once"
   expect(cdnAuth).toEqual([null, null]);
 });
 
-// Same bug, sibling retry site (tarball downloads in runTasks): the tarball URL
+// Sibling retry site (tarball downloads in runTasks): the tarball URL
 // 302-redirects and the target 500s once before serving the archive.
 it("retries a tarball whose redirect target 500s once", async () => {
   const urls: string[] = [];


### PR DESCRIPTION
### What

After a 3xx redirect, `handle_response_metadata` rewrites per-hop request state on the HTTP-thread clone of the `AsyncHTTP`:

- `client.url` (and `connected_url`) become a self-borrow into `client.redirect`, a `Vec<u8>` the clone owns and frees in the final-callback teardown (`AsyncHTTP::on_async_http_callback_raw`).
- On a cross-origin hop, `Authorization`/`Proxy-Authorization`/`Cookie`/`Host` are removed from `client.header_entries` in place.
- The method may be downgraded to GET.

`NetworkTask::notify`'s bitwise copy-back (`ptr::write(real, ptr::read(async_http))`) carries all of that into the JS-thread `AsyncHTTP`. When `bun install` retries the task after a retryable failure (5xx or a connection reset on the redirect target), the re-scheduled request therefore:

1. connects through the freed redirect buffer (use after free), and
2. if the redirect was cross-origin, goes out without `Authorization`, so an authorized registry answers 401.

ASAN (debug build), deterministic on the first try:

```
ERROR: AddressSanitizer: heap-use-after-free ... thread T1 (HTTP Client)
READ of size 1
    #0 bun_core::fmt::parse_int::<u16>              src/bun_core/fmt.rs:929
    #1 <bun_url::URL>::get_port                     src/url/lib.rs:470
    #2 <bun_url::URL>::get_port_auto                src/url/lib.rs:474
    #3 <bun_http::http_thread::HttpThread>::connect src/http/HTTPThread.rs:602
    #4 <bun_http::HTTPClient>::start_               src/http/lib.rs:2635
    #6 <bun_http::async_http::AsyncHTTP>::on_start  src/http/AsyncHTTP.rs:893
freed by thread T1 (HTTP Client):
    <bun_http::async_http::AsyncHTTP>::on_async_http_callback_raw src/http/AsyncHTTP.rs:774
previously allocated by thread T1 (HTTP Client):
    <bun_http::HTTPClient>::handle_response_metadata src/http/lib.rs:5038
```

On a release build the same sequence does not crash, but the retries never reach the server (each one connects through freed memory) and the install fails.

### Repro

A scripted registry where the manifest URL 302-redirects and the redirect target answers a 500 once, then the real packument:

```
GET /BaR              -> 302 Location: /redirected/BaR
GET /redirected/BaR   -> 500 on the first hit, then the packument
GET /BaR-0.0.2.tgz    -> tarball
```

`bun install` against it aborts under ASAN and fails on release. Any 301/302/307/308 and 1- or 2-hop chains hit the same path. With an authorized registry that redirects cross-origin (the common Artifactory / CodeArtifact / GitHub Packages shape), the retry also loses `Authorization`; that variant fails with `GET <registry>/BaR - 401` even once the URL is fixed.

### Fix

`src/http/AsyncHTTP.rs`: the `!has_more` teardown block already releases every clone-owned allocation. Before freeing `client.redirect`, restore the per-hop state that a re-scheduled attempt must not inherit:

- `client.url` back to the caller-owned pre-redirect URL (`AsyncHTTP.url`, which borrows memory valid for the original's whole lifetime), and `client.connected_url` (which `connect` derives from it) to default.
- `client.header_entries` back to the untouched `AsyncHTTP.request_headers`. The list is bitwise-shared with the JS-thread original, so it must not be dropped or reallocated on the HTTP thread; it was cloned from `request_headers` at init and only ever shrinks, so `clear_retaining_capacity()` + `append_list_assume_capacity()` restores it in place.
- `client.method` back to `AsyncHTTP.method`.

Nothing that crosses back to the JS thread references clone-freed memory anymore, and a retried request restarts from the original URL with the original headers instead of the last redirect hop's, which is what the install-level retry is meant to do.

### Tests

`test/cli/install/bun-install-retry.test.ts`:
- `retries a manifest whose redirect target 500s once`
- `retries a tarball whose redirect target 500s once` (the sibling retry site in `runTasks`)
- `retries an authorized manifest whose cross-origin redirect target 500s once` (also asserts the cross-origin hop itself still does NOT carry `Authorization`, so the spec-mandated strip is unchanged)

All three fail on the unfixed build (ASAN abort under `bun bd`, install error with `USE_SYSTEM_BUN=1`). The third additionally fails with a 401 if only the URL is restored and not the headers, so each restore is load-bearing. `test/js/web/fetch/fetch-redirect.test.ts` and `fetch-url-after-redirect.test.ts` still pass, so `response.url` after a redirect is unaffected (it comes from the owned `metadata.url` copy, not from `client.url`).
