### PR TITLE
HTMLRewriter: suspend async content handlers instead of nesting the event loop

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -55,7 +55,7 @@ The workflow runs all three formatters simultaneously:
 
 1. Bump `channel` in `rust-toolchain.toml` (and `Dockerfile`/`bootstrap.sh` to match).
 2. Bump `RUSTUP_TOOLCHAIN` in the `Format Code` step's `env:` block in `format.yml` to the same value.
-3. Bump `RUSTUP_TOOLCHAIN` in the workflow-level `env:` block in `clippy.yml` and `miri.yml` to the same value.
+3. Bump `RUSTUP_TOOLCHAIN` in the workflow-level `env:` block in `clippy.yml`, `miri.yml` and `lolhtml.yml` to the same value.
 4. `cargo fmt` formatting can change between nightlies; run `cargo fmt --all` locally on the new toolchain and include the resulting diff in the same PR.
 
 #### To update clang-format version:

--- a/.github/workflows/lolhtml.yml
+++ b/.github/workflows/lolhtml.yml
@@ -1,0 +1,73 @@
+name: lol-html
+
+permissions:
+  contents: read
+
+# The vendored lol-html carries a substantial fork (`patches/lolhtml/*.patch`),
+# and its own test suite is the only thing that guards the fork's invariants —
+# nothing in the Bun test suite reaches, for example, the parser's suspension
+# bookkeeping or `Arena::compact()`. Run it whenever the patch, the pinned
+# commit, or this workflow changes.
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "patches/lolhtml/**"
+      - "scripts/build/deps/lolhtml.ts"
+      - ".github/workflows/lolhtml.yml"
+  merge_group:
+
+env:
+  BUN_VERSION: "1.3.2"
+  LLVM_VERSION_MAJOR: "21"
+  # Keep in sync with `channel` in rust-toolchain.toml.
+  RUSTUP_TOOLCHAIN: nightly-2026-05-06
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup system deps
+        # cmake/ninja/clang for `--configure-only`, which is what generates the
+        # ninja edge that fetches + patches the vendored source.
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ env.LLVM_VERSION_MAJOR }} main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends cmake ninja-build clang-${{ env.LLVM_VERSION_MAJOR }} lld-${{ env.LLVM_VERSION_MAJOR }} llvm-${{ env.LLVM_VERSION_MAJOR }}
+
+      - name: Setup Rust
+        run: |
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
+          rustup override set "$RUSTUP_TOOLCHAIN"
+          echo "::add-matcher::.github/rust-matcher.json"
+
+      - name: Fetch and patch lol-html
+        # `clone-lolhtml` extracts the pinned `cloudflare/lol-html` archive into
+        # `vendor/lolhtml/` and applies `patches/lolhtml/*.patch`. A patch that
+        # no longer applies fails right here.
+        run: |
+          bun install --frozen-lockfile
+          bun scripts/build.ts --configure-only
+          ninja -C build/debug clone-lolhtml
+
+      - name: cargo test
+        # `lol_html` is a path dependency, not a workspace member (it carries
+        # dev-dependencies the Bun workspace does not), so run it in place.
+        working-directory: vendor/lolhtml
+        run: cargo test

--- a/docs/runtime/html-rewriter.mdx
+++ b/docs/runtime/html-rewriter.mdx
@@ -351,7 +351,7 @@ When transforming a Response:
 - Invalid input types (for example, passing a Symbol)
 - Body already used errors
 - An async handler on a `string` / `ArrayBuffer` input that needs the event loop
-  (see [Content Handlers](#content-handlers))
+  (see [Element Handlers](#element-handlers))
 
 ```ts
 try {

--- a/docs/runtime/html-rewriter.mdx
+++ b/docs/runtime/html-rewriter.mdx
@@ -113,16 +113,55 @@ rewriter.on("div.content", {
 });
 ```
 
-Handlers can be asynchronous and return a Promise. Async operations block the transformation until they complete:
+Handlers can be asynchronous and return a Promise. The transformation pauses on
+that element until the Promise settles, so handlers still run one at a time, in
+document order:
 
 ```ts
 rewriter.on("div", {
   async element(element) {
-    await Bun.sleep(1000);
-    element.setInnerContent("<span>replace</span>", { html: true });
+    const fragment = await fetch("https://example.com/fragment").then(r => r.text());
+    element.setInnerContent(fragment, { html: true });
   },
 });
 ```
+
+`transform(response)` returns immediately; the rewrite continues in the
+background and you read the result off the returned `Response`. Because the
+rewrite outlives `transform()`, an error thrown by an async handler (or a
+Promise it returns that rejects) rejects the response body instead of throwing
+from `transform()`:
+
+```ts
+try {
+  const output = await rewriter.transform(new Response(html)).text();
+} catch (error) {
+  console.error("a handler failed:", error);
+}
+```
+
+`transform()` on a `string` or `ArrayBuffer` has to return its result
+synchronously, so it cannot wait for a handler that needs the event loop to turn
+(a timer, I/O, a `fetch`). Such a handler makes `transform()` throw a
+`TypeError`, and the rewrite fails without running any further handlers:
+
+```ts
+new HTMLRewriter()
+  .on("div", {
+    async element(element) {
+      await Bun.sleep(1000); // needs a timer
+    },
+  })
+  .transform("<div></div>");
+// TypeError: HTMLRewriter.transform() cannot synchronously return a string
+// because a content handler returned a Promise that did not resolve within a
+// microtask. Pass a Response instead and await its body
+```
+
+A handler whose Promise settles within a microtask checkpoint (anything that
+does not need the event loop, including `process.nextTick` and already-resolved
+Promises) still works with `transform(string)`. Pass a `Response` whenever a
+handler might await real work.
 
 ### CSS Selector Support
 
@@ -306,23 +345,35 @@ When transforming a Response:
 
 ## Error Handling
 
-HTMLRewriter operations can throw errors in several cases:
+`transform()` itself throws for problems it can see right away:
 
-- Invalid selector syntax in `on()` method
-- Invalid HTML content in transformation methods
-- Stream errors when processing Response bodies
-- Memory allocation failures
+- Invalid selector syntax in the `on()` method
 - Invalid input types (for example, passing a Symbol)
 - Body already used errors
-
-Catch and handle these errors:
+- An async handler on a `string` / `ArrayBuffer` input that needs the event loop
+  (see [Content Handlers](#content-handlers))
 
 ```ts
 try {
-  const result = rewriter.transform(input);
-  // Process result
+  const result = rewriter.transform("<div></div>");
 } catch (error) {
   console.error("HTMLRewriter error:", error);
+}
+```
+
+Everything the rewrite discovers while it runs surfaces on the output body
+instead, because `transform(response)` returns before the rewrite finishes:
+
+- An error thrown by a content handler, or a rejected Promise one returned
+- Malformed or truncated input
+- Stream errors reading the input body
+- Memory allocation failures
+
+```ts
+try {
+  const output = await rewriter.transform(new Response(html)).text();
+} catch (error) {
+  console.error("the rewrite failed:", error);
 }
 ```
 

--- a/docs/runtime/html-rewriter.mdx
+++ b/docs/runtime/html-rewriter.mdx
@@ -163,6 +163,11 @@ does not need the event loop, including `process.nextTick` and already-resolved
 Promises) still works with `transform(string)`. Pass a `Response` whenever a
 handler might await real work.
 
+<Warning>
+  `.clone()` of the returned `Response` does not work yet while the rewrite is still in progress: both branches hang.
+  Buffer the output first (for example with `.arrayBuffer()`) if you need two consumers.
+</Warning>
+
 ### CSS Selector Support
 
 The `on()` method supports a wide range of CSS selectors:
@@ -345,13 +350,15 @@ When transforming a Response:
 
 ## Error Handling
 
-`transform()` itself throws for problems it can see right away:
+Which channel an error takes is decided by the overload you called, never by
+timing. `transform()` itself throws for:
 
 - Invalid selector syntax in the `on()` method
 - Invalid input types (for example, passing a Symbol)
-- Body already used errors
-- An async handler on a `string` / `ArrayBuffer` input that needs the event loop
-  (see [Element Handlers](#element-handlers))
+- Body already used errors, and input bodies that have already failed or aborted
+- Anything a content handler raises on a `string` / `ArrayBuffer` input, since
+  those have to produce their result before `transform()` returns — including a
+  handler that needs the event loop (see [Element Handlers](#element-handlers))
 
 ```ts
 try {
@@ -361,8 +368,8 @@ try {
 }
 ```
 
-Everything the rewrite discovers while it runs surfaces on the output body
-instead, because `transform(response)` returns before the rewrite finishes:
+For a `Response` input, `transform()` returns before the rewrite finishes, so
+everything the rewrite discovers surfaces on the output body instead:
 
 - An error thrown by a content handler, or a rejected Promise one returned
 - Malformed or truncated input
@@ -376,6 +383,11 @@ try {
   console.error("the rewrite failed:", error);
 }
 ```
+
+A rejection from a Promise a handler creates but neither returns nor awaits
+reaches neither channel: like any detached rejection, it goes to the
+process-global `unhandledRejection` path. Earlier versions of Bun could surface
+it from `transform()` itself.
 
 ---
 

--- a/packages/bun-types/html-rewriter.d.ts
+++ b/packages/bun-types/html-rewriter.d.ts
@@ -163,20 +163,32 @@ declare class HTMLRewriter {
 
   /**
    * Transform HTML content
+   *
+   * Returns immediately; the rewrite continues in the background. An error
+   * thrown by a content handler (or a Promise it returns that rejects) rejects
+   * the returned response's body rather than throwing from `transform()`.
+   *
    * @param input - The HTML to transform
    * @returns A new {@link Response} with the transformed HTML
    */
   transform(input: Response | Blob | Bun.BufferSource): Response;
   /**
    * Transform HTML content
+   *
    * @param input - The HTML string to transform
    * @returns The transformed HTML as a string
+   * @throws {TypeError} If a content handler returns a Promise that needs the
+   * event loop to turn (a timer, I/O, a `fetch`). The result has to be produced
+   * synchronously, so pass a {@link Response} and await its body instead.
    */
   transform(input: string): string;
   /**
    * Transform HTML content
+   *
    * @param input - The HTML to transform as a {@link ArrayBuffer}
    * @returns A new {@link ArrayBuffer} with the transformed HTML
+   * @throws {TypeError} If a content handler returns a Promise that needs the
+   * event loop to turn. See {@link transform} for `string` inputs.
    */
   transform(input: ArrayBuffer): ArrayBuffer;
 }

--- a/packages/bun-types/html-rewriter.d.ts
+++ b/packages/bun-types/html-rewriter.d.ts
@@ -171,7 +171,7 @@ declare class HTMLRewriter {
    * @param input - The HTML to transform
    * @returns A new {@link Response} with the transformed HTML
    */
-  transform(input: Response | Blob | Bun.BufferSource): Response;
+  transform(input: Response): Response;
   /**
    * Transform HTML content
    *
@@ -185,10 +185,13 @@ declare class HTMLRewriter {
   /**
    * Transform HTML content
    *
-   * @param input - The HTML to transform as a {@link ArrayBuffer}
+   * Every {@link Bun.BufferSource} (a TypedArray, DataView, or ArrayBuffer)
+   * produces an `ArrayBuffer`, not a `Response`.
+   *
+   * @param input - The HTML to transform as bytes
    * @returns A new {@link ArrayBuffer} with the transformed HTML
    * @throws {TypeError} If a content handler returns a Promise that needs the
    * event loop to turn. See {@link transform} for `string` inputs.
    */
-  transform(input: ArrayBuffer): ArrayBuffer;
+  transform(input: Bun.BufferSource): ArrayBuffer;
 }

--- a/patches/lolhtml/content-handler-suspension.patch
+++ b/patches/lolhtml/content-handler-suspension.patch
@@ -111,6 +111,96 @@
      pub use super::selectors_vm::SelectorError;
  }
  
+--- a/src/memory/arena.rs
++++ b/src/memory/arena.rs
+@@ -6,6 +6,9 @@ use super::{MemoryLimitExceededError, SharedMemoryLimiter};
+ pub(crate) struct Arena {
+     limiter: SharedMemoryLimiter,
+     data: Vec<u8>,
++    /// Offset of the live region within `data`. `shift` only advances this;
++    /// the dead prefix is reclaimed lazily by the next `append`.
++    start: usize,
+ }
+ 
+ impl Arena {
+@@ -23,10 +26,28 @@ impl Arena {
+             "Total preallocated memory size should be less than `MemorySettings::max_allowed_memory_usage`."
+         );
+ 
+-        Self { limiter, data }
++        Self {
++            limiter,
++            data,
++            start: 0,
++        }
++    }
++
++    /// Reclaim the dead prefix left behind by `shift`, in one memmove.
++    fn compact(&mut self) {
++        if self.start > 0 {
++            self.data.copy_within(self.start.., 0);
++            let live = self.data.len() - self.start;
++            self.data.truncate(live);
++            self.start = 0;
++        }
+     }
+ 
+     pub fn append(&mut self, slice: &[u8]) -> Result<(), MemoryLimitExceededError> {
++        // Only the multi-write streaming path appends after a `shift`, and it
++        // is the only place the dead prefix has to go away.
++        self.compact();
++
+         // this specific form of capacity check optimizes out redundant resizing in extend_from_slice
+         if self.data.capacity() - self.data.len() < slice.len() {
+             let additional = slice.len() + self.data.len() - self.data.capacity();
+@@ -51,16 +72,20 @@ impl Arena {
+ 
+     pub fn init_with(&mut self, slice: &[u8]) -> Result<(), MemoryLimitExceededError> {
+         self.data.clear();
++        self.start = 0;
+         self.append(slice)
+     }
+ 
++    /// O(1): advances the live-region start instead of memmoving the tail.
++    /// A suspended rewrite resumes by re-feeding the unconsumed tail, so this
++    /// runs once per suspension — memmoving there is O(suspensions × tail).
+     pub fn shift(&mut self, byte_count: usize) {
+-        self.data.copy_within(byte_count.., 0);
+-        self.data.truncate(self.data.len() - byte_count);
++        debug_assert!(byte_count <= self.data.len() - self.start);
++        self.start += byte_count;
+     }
+ 
+     pub fn bytes(&self) -> &[u8] {
+-        &self.data
++        &self.data[self.start..]
+     }
+ }
+ 
+@@ -140,4 +165,23 @@ mod tests {
+         assert_eq!(arena.bytes(), &[2, 3, 4, 5]);
+         assert_eq!(limiter.current_usage(), 5);
+     }
++
++    // A suspended rewrite shifts once per resume with no append in between;
++    // the dead prefix must accumulate and then be reclaimed by the next append.
++    #[test]
++    fn consecutive_shifts_without_append() {
++        let limiter = SharedMemoryLimiter::new(10);
++        let mut arena = Arena::new(limiter.clone(), 0);
++
++        arena.append(&[0, 1, 2, 3, 4]).unwrap();
++        arena.shift(1);
++        arena.shift(2);
++        assert_eq!(arena.bytes(), &[3, 4]);
++
++        arena.shift(2);
++        assert!(arena.bytes().is_empty());
++
++        arena.append(&[9]).unwrap();
++        assert_eq!(arena.bytes(), &[9]);
++    }
+ }
 --- a/src/parser/lexer/actions.rs
 +++ b/src/parser/lexer/actions.rs
 @@ -19,6 +19,10 @@ macro_rules! get_token_part_range {
@@ -151,7 +241,19 @@
          let token = self
              .current_tag_token
              .take()
-@@ -138,6 +155,9 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
+@@ -120,6 +137,11 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
+         context: &mut ParserContext<S>,
+         input: &[u8],
+     ) -> ActionResult {
++        // As in `emit_current_token`: the comment/doctype ends the preceding
++        // text node, so flush its pending last chunk before the lexeme is
++        // built. `emit_eof` below then finds nothing left to flush.
++        self.flush_pending_text(context)?;
++
+         let token = self.current_non_tag_content_token.take();
+         let lexeme = self.create_lexeme_with_raw_exclusive(
+             context.previously_consumed_byte_count,
+@@ -138,6 +160,9 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
          context: &mut ParserContext<S>,
          input: &[u8],
      ) -> ActionResult {
@@ -161,6 +263,19 @@
          let lexeme = self.create_lexeme_with_raw_inclusive(
              context.previously_consumed_byte_count,
              input,
+@@ -153,6 +178,12 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
+         context: &mut ParserContext<S>,
+         input: &[u8],
+     ) -> ActionResult {
++        // As in `emit_raw_without_token`. This lexeme carries no token, so
++        // nothing is dispatched between here and `emit_eof`'s own flush, but
++        // keeping the hoist uniform means every suspension point sees the
++        // in-flight lexeme either fully consumed or not yet built.
++        self.flush_pending_text(context)?;
++
+         // NOTE: since we are at EOF we use exclusive range for token's raw.
+         let lexeme = self.create_lexeme_with_raw_exclusive(
+             context.previously_consumed_byte_count,
 --- a/src/parser/lexer/mod.rs
 +++ b/src/parser/lexer/mod.rs
 @@ -7,12 +7,22 @@ mod lexeme;
@@ -1884,7 +1999,7 @@
  }
  
  // NOTE: this opaque Debug implementation is required to make
-@@ -992,4 +1122,467 @@ mod tests {
+@@ -992,4 +1122,557 @@ mod tests {
              );
          }
      }
@@ -2349,6 +2464,96 @@
 +                }))
 +                .is_err()
 +            );
++        }
++
++        /// Records the order handlers fire in, plus the serialized output.
++        fn eof_order(input: &str) -> (Vec<&'static str>, String) {
++            let order = Rc::new(RefCell::new(Vec::new()));
++            let (o_text, o_comment, o_doctype) = (order.clone(), order.clone(), order.clone());
++            let (out, _) = drive(
++                &[input],
++                Settings {
++                    document_content_handlers: vec![
++                        doc_text!(move |t| {
++                            if t.last_in_text_node() {
++                                o_text.borrow_mut().push("text-last");
++                            }
++                            Ok(())
++                        }),
++                        doc_comments!(move |_| {
++                            o_comment.borrow_mut().push("comment");
++                            Ok(())
++                        }),
++                        doctype!(move |_| {
++                            o_doctype.borrow_mut().push("doctype");
++                            Ok(())
++                        }),
++                    ],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            let order = order.borrow().clone();
++            (order, out)
++        }
++
++        // `emit_current_token_and_eof` must flush the pending last text chunk
++        // before the comment/doctype lexeme it builds, exactly like the
++        // non-EOF `emit_current_token` does. Otherwise an input that ends
++        // inside a comment (a truncated upstream body) dispatches the comment
++        // first, inverting both handler order and output byte order.
++        #[test]
++        fn pending_text_flushes_before_unterminated_comment_at_eof() {
++            let (order, out) = eof_order("hello<!-- unterminated");
++            assert_eq!(order, ["text-last", "comment"]);
++            assert_eq!(out, "hello<!-- unterminated");
++        }
++
++        #[test]
++        fn pending_text_flushes_before_unterminated_doctype_at_eof() {
++            let (order, out) = eof_order("hello<!doctype html");
++            assert_eq!(order, ["text-last", "doctype"]);
++            assert_eq!(out, "hello<!doctype html");
++        }
++
++        // The same hoist, on the `emit_raw_without_token_and_eof` path: an
++        // input that ends inside an unterminated tag.
++        #[test]
++        fn pending_text_flushes_before_unterminated_tag_at_eof() {
++            let (order, out) = eof_order("hello<div attr");
++            assert_eq!(order, ["text-last"]);
++            assert_eq!(out, "hello<div attr");
++        }
++
++        // A text handler that suspends on the last chunk, flushed from inside
++        // the composite EOF action: the resume must still emit the comment.
++        #[test]
++        fn text_suspension_at_unterminated_comment_eof() {
++            let order = Rc::new(RefCell::new(Vec::new()));
++            let (o_text, o_comment) = (order.clone(), order.clone());
++            let (out, n) = drive(
++                &["hello<!-- unterminated"],
++                Settings {
++                    document_content_handlers: vec![
++                        doc_text!(move |t| {
++                            if t.last_in_text_node() {
++                                o_text.borrow_mut().push("text-last");
++                                return SUSPEND();
++                            }
++                            Ok(())
++                        }),
++                        doc_comments!(move |_| {
++                            o_comment.borrow_mut().push("comment");
++                            Ok(())
++                        }),
++                    ],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(*order.borrow(), ["text-last", "comment"]);
++            assert_eq!(out, "hello<!-- unterminated");
++            assert_eq!(n, 1);
 +        }
 +    }
  }

--- a/patches/lolhtml/content-handler-suspension.patch
+++ b/patches/lolhtml/content-handler-suspension.patch
@@ -1999,7 +1999,7 @@
  }
  
  // NOTE: this opaque Debug implementation is required to make
-@@ -992,4 +1122,557 @@ mod tests {
+@@ -992,4 +1122,608 @@ mod tests {
              );
          }
      }
@@ -2523,6 +2523,57 @@
 +            let (order, out) = eof_order("hello<div attr");
 +            assert_eq!(order, ["text-last"]);
 +            assert_eq!(out, "hello<div attr");
++        }
++
++        // `resume_dispatch` step 2 re-serializes the parked token, but only
++        // when emission is enabled. A handler suspending inside content an
++        // outer handler removed must not resurrect that content.
++        #[test]
++        fn suspension_inside_removed_content_emits_nothing() {
++            let (out, n) = drive(
++                &["a<div>b<span>c</span>d</div>e"],
++                Settings {
++                    element_content_handlers: vec![
++                        element!("div", |el| {
++                            el.remove();
++                            Ok(())
++                        }),
++                        // Runs against content that is being removed.
++                        element!("span", |_| SUSPEND()),
++                    ],
++                    document_content_handlers: vec![doc_text!(|_| SUSPEND())],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(out, "ae");
++            assert!(n > 0, "the handlers must actually have suspended");
++        }
++
++        // `emit_raw_without_token`'s flush hoist: `<![CDATA[` in foreign
++        // content is the only lexeme that reaches it.
++        #[test]
++        fn text_suspension_around_cdata() {
++            let chunks = Rc::new(RefCell::new(Vec::new()));
++            let c = chunks.clone();
++            let (out, n) = drive(
++                &["<svg><foo>a<![CDATA[b]]>c</foo></svg>"],
++                Settings {
++                    document_content_handlers: vec![doc_text!(move |t| {
++                        c.borrow_mut().push(t.as_str().to_owned());
++                        SUSPEND()
++                    })],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(out, "<svg><foo>a<![CDATA[b]]>c</foo></svg>");
++            assert!(n > 0);
++            assert!(
++                chunks.borrow().iter().any(|t| t == "a"),
++                "expected a text chunk 'a' before the CDATA, got {:?}",
++                chunks.borrow()
++            );
 +        }
 +
 +        // A text handler that suspends on the last chunk, flushed from inside

--- a/patches/lolhtml/content-handler-suspension.patch
+++ b/patches/lolhtml/content-handler-suspension.patch
@@ -1,0 +1,2850 @@
+--- a/src/base/bytes.rs
++++ b/src/base/bytes.rs
+@@ -59,6 +59,16 @@ impl<'b> BytesCow<'b> {
+         BytesCow(Cow::Owned(self.0.into_owned()))
+     }
+ 
++    /// Detaches the bytes from the input buffer they may borrow, leaving an
++    /// empty value behind. Used when a token has to outlive the parser's
++    /// input buffer (handler suspension).
++    #[inline]
++    pub(crate) fn take_owned(&mut self) -> BytesCow<'static> {
++        BytesCow(Cow::Owned(
++            std::mem::replace(&mut self.0, Cow::Borrowed(&[])).into_owned(),
++        ))
++    }
++
+     #[inline]
+     pub(crate) fn as_ref(&self) -> Bytes<'_> {
+         Bytes(&self.0)
+@@ -75,7 +85,7 @@ impl<'b> BytesCow<'b> {
+ 
+ impl<'b> Bytes<'b> {
+     #[inline]
+-    pub(crate) fn new(bytes: &'b [u8]) -> Self {
++    pub(crate) const fn new(bytes: &'b [u8]) -> Self {
+         Self(bytes)
+     }
+ 
+--- a/src/base/spanned.rs
++++ b/src/base/spanned.rs
+@@ -48,9 +48,13 @@ pub(crate) struct Spanned<B> {
+     source_location_byte_start: usize,
+ }
+ 
+-#[derive(Debug, Copy, Clone)]
++#[derive(Debug, Clone)]
+ pub(crate) enum RawBytes<'input> {
+     Original(&'input [u8]),
++    /// Raw bytes copied out of the input buffer so that they can outlive it.
++    /// Produced by [`SpannedRawBytes::take_owned`] when a token is detached
++    /// from the parser (handler suspension).
++    Owned(Box<[u8]>),
+     /// Keeps the len of the original
+     Modified(usize),
+ }
+@@ -58,9 +62,10 @@ pub(crate) enum RawBytes<'input> {
+ impl<'input> SpannedRawBytes<'input> {
+     #[inline]
+     pub fn len(&self) -> usize {
+-        match self.bytes {
++        match &self.bytes {
+             RawBytes::Original(s) => s.len(),
+-            RawBytes::Modified(l) => l,
++            RawBytes::Owned(s) => s.len(),
++            RawBytes::Modified(l) => *l,
+         }
+     }
+ 
+@@ -71,13 +76,30 @@ impl<'input> SpannedRawBytes<'input> {
+     }
+ 
+     #[inline]
+-    pub fn original(&self) -> Option<&'input [u8]> {
+-        match self.bytes {
++    pub fn original(&self) -> Option<&[u8]> {
++        match &self.bytes {
+             RawBytes::Original(s) => Some(s),
++            RawBytes::Owned(s) => Some(s),
+             RawBytes::Modified(_) => None,
+         }
+     }
+ 
++    /// Detaches the raw bytes from the input buffer, leaving `self` behind as
++    /// `Modified(len)` (the source is abandoned after a `take_owned`, so the
++    /// leftover only has to keep `len()`/`source_location()` correct).
++    pub(crate) fn take_owned(&mut self) -> SpannedRawBytes<'static> {
++        let len = self.len();
++        let bytes = match std::mem::replace(&mut self.bytes, RawBytes::Modified(len)) {
++            RawBytes::Original(s) => RawBytes::Owned(s.into()),
++            RawBytes::Owned(s) => RawBytes::Owned(s),
++            RawBytes::Modified(l) => RawBytes::Modified(l),
++        };
++        Spanned {
++            bytes,
++            source_location_byte_start: self.source_location_byte_start,
++        }
++    }
++
+     #[inline]
+     pub fn source_location(&self) -> SourceLocation {
+         SourceLocation::from_start_len(self.source_location_byte_start, self.len())
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -43,8 +43,8 @@ use cfg_if::cfg_if;
+ pub use self::rewriter::{
+     AsciiCompatibleEncoding, CommentHandler, DoctypeHandler, DocumentContentHandlers,
+     ElementContentHandlers, ElementHandler, EndHandler, EndTagHandler, HandlerResult, HandlerTypes,
+-    HtmlRewriter, LocalHandlerTypes, MemorySettings, RewriteStrSettings, Settings, TextHandler,
+-    rewrite_str,
++    HtmlRewriter, LocalHandlerTypes, MemorySettings, RewriteStrSettings, Settings,
++    SuspensionRequest, TextHandler, rewrite_str,
+ };
+ pub use self::selectors_vm::Selector;
+ pub use self::transform_stream::OutputSink;
+@@ -88,7 +88,7 @@ pub mod errors {
+     pub use super::rewritable_units::{
+         AttributeNameError, CommentTextError, TagNameError, Utf8Error,
+     };
+-    pub use super::rewriter::RewritingError;
++    pub use super::rewriter::{RewritingError, SuspensionRequest};
+     pub use super::selectors_vm::SelectorError;
+ }
+ 
+--- a/src/parser/lexer/actions.rs
++++ b/src/parser/lexer/actions.rs
+@@ -19,6 +19,10 @@ macro_rules! get_token_part_range {
+ 
+ impl<S: LexemeSink> Lexer<S> {
+     fn emit_eof(&mut self, context: &mut ParserContext<S>, input: &[u8]) -> ActionResult {
++        // The EOF ends the final text node; flush its pending last chunk
++        // before the lexeme exists so a suspension can simply re-lex the EOF.
++        self.flush_pending_text(context)?;
++
+         let lexeme = self.create_lexeme_with_raw_exclusive(
+             context.previously_consumed_byte_count,
+             input,
+@@ -61,6 +65,11 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
+ 
+     #[inline(never)]
+     fn emit_current_token(&mut self, context: &mut ParserContext<S>, input: &[u8]) -> ActionResult {
++        // A comment/doctype ends the preceding text node; flush its pending
++        // last chunk before the lexeme exists so a suspension can simply
++        // re-lex the comment/doctype (`lexeme_start` still points at it).
++        self.flush_pending_text(context)?;
++
+         let token = self.current_non_tag_content_token.take();
+         let lexeme = self.create_lexeme_with_raw_inclusive(
+             context.previously_consumed_byte_count,
+@@ -73,6 +82,14 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
+ 
+     #[inline(never)]
+     fn emit_tag(&mut self, context: &mut ParserContext<S>, input: &[u8]) -> ActionResult {
++        // A tag ends the preceding text node. Flush its pending last chunk
++        // *before* building the lexeme or applying tree-builder feedback: a
++        // text handler that suspends here leaves no live lexeme above it,
++        // the tree-builder simulator untouched, and `last_text_type` at the
++        // pre-tag value, so the resume just re-lexes the tag from
++        // `lexeme_start` (which still points at its `<`).
++        self.flush_pending_text(context)?;
++
+         let token = self
+             .current_tag_token
+             .take()
+@@ -138,6 +155,9 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
+         context: &mut ParserContext<S>,
+         input: &[u8],
+     ) -> ActionResult {
++        // A CDATA marker ends the preceding text node (see `emit_tag`).
++        self.flush_pending_text(context)?;
++
+         let lexeme = self.create_lexeme_with_raw_inclusive(
+             context.previously_consumed_byte_count,
+             input,
+--- a/src/parser/lexer/mod.rs
++++ b/src/parser/lexer/mod.rs
+@@ -7,12 +7,22 @@ mod lexeme;
+ pub(crate) use self::lexeme::*;
+ use crate::base::{Align, Bytes, Range};
+ use crate::html::{LocalNameHash, Namespace, TextType};
+-use crate::parser::state_machine::{ActionResult, FeedbackDirective, StateMachine, StateResult};
++use crate::parser::state_machine::{
++    ActionError, ActionResult, FeedbackDirective, StateMachine, StateResult,
++};
+ use crate::parser::{ParserContext, ParserDirective, ParsingAmbiguityError, TreeBuilderFeedback};
++use crate::rewriter::RewritingError;
+ 
+ pub(crate) trait LexemeSink {
+     fn handle_tag(&mut self, lexeme: &TagLexeme<'_>) -> ActionResult<ParserDirective>;
+     fn handle_non_tag_content(&mut self, lexeme: &NonTagContentLexeme<'_>) -> ActionResult;
++    /// Flushes the pending captured-text chunk: the one the text decoder
++    /// could not mark `last_in_text_node` until it knew the next lexeme
++    /// would not be text. The lexer calls this *before* it builds each
++    /// non-text lexeme, so a text handler that suspends here has no live
++    /// lexeme above it on the stack and the tag/comment/... can simply be
++    /// re-lexed from the suspension bookmark.
++    fn flush_pending_text(&mut self) -> ActionResult;
+ }
+ 
+ pub(crate) type State<S> = fn(&mut Lexer<S>, context: &mut ParserContext<S>, &[u8]) -> StateResult;
+@@ -97,6 +107,40 @@ impl<S: LexemeSink> Lexer<S> {
+         }
+     }
+ 
++    /// Converts a handler suspension (`RewritingError::Suspended` escaping a
++    /// dispatch) into the lexer-level [`ActionError::Suspended`]. Captures
++    /// the bookmark needed to continue lexing at `lexeme_start` once the
++    /// parked dispatch is resumed and rebases the lexer's input-relative
++    /// state, because the unconsumed tail gets re-buffered at offset 0.
++    #[cold]
++    fn map_suspension<T>(&mut self, res: ActionResult<T>) -> ActionResult<T> {
++        match res {
++            Err(e) if matches!(*e, ActionError::RewritingError(RewritingError::Suspended)) => {
++                let consumed_byte_count = self.lexeme_start;
++                // Unconditionally: unlike `break_on_end_of_input` this runs
++                // even on the last input, because the resume always re-feeds
++                // the tail.
++                self.adjust_for_next_input();
++                let bookmark = self.create_bookmark(0, FeedbackDirective::None);
++                Err(Box::new(ActionError::Suspended {
++                    consumed_byte_count,
++                    bookmark,
++                }))
++            }
++            other => other,
++        }
++    }
++
++    /// Flush the pending captured-text chunk before a non-text lexeme is
++    /// built. At this point `lexeme_start` is still the position of that
++    /// upcoming lexeme, so a suspension here makes the resume re-lex it from
++    /// scratch (with no stale tree-builder feedback: none was applied yet).
++    #[inline]
++    fn flush_pending_text(&mut self, context: &mut ParserContext<S>) -> ActionResult {
++        let res = context.output_sink.flush_pending_text();
++        self.map_suspension(res)
++    }
++
+     #[inline]
+     fn emit_lexeme(
+         &mut self,
+@@ -107,8 +151,8 @@ impl<S: LexemeSink> Lexer<S> {
+ 
+         self.lexeme_start = lexeme.raw_range().end;
+ 
+-        context.output_sink.handle_non_tag_content(lexeme)?;
+-        Ok(())
++        let res = context.output_sink.handle_non_tag_content(lexeme);
++        self.map_suspension(res)
+     }
+ 
+     #[inline]
+@@ -121,7 +165,8 @@ impl<S: LexemeSink> Lexer<S> {
+ 
+         self.lexeme_start = lexeme.raw_range().end;
+ 
+-        context.output_sink.handle_tag(lexeme)
++        let res = context.output_sink.handle_tag(lexeme);
++        self.map_suspension(res)
+     }
+ 
+     #[inline]
+--- a/src/parser/mod.rs
++++ b/src/parser/mod.rs
+@@ -10,8 +10,8 @@ pub(crate) use self::lexer::{
+     AttributeBuffer, AttributeOutline, Lexeme, LexemeSink, NonTagContentLexeme,
+     NonTagContentTokenOutline, TagLexeme, TagTokenOutline,
+ };
+-use self::state_machine::StateMachine;
+ pub(crate) use self::state_machine::{ActionError, ActionResult};
++use self::state_machine::{ParseResult, StateMachine, StateMachineBookmark};
+ pub(crate) use self::tag_scanner::TagHintSink;
+ use self::tag_scanner::TagScanner;
+ pub use self::tree_builder_simulator::ParsingAmbiguityError;
+@@ -45,6 +45,11 @@ pub struct Parser<S> {
+     tag_scanner: TagScanner<S>,
+     current_directive: ParserDirective,
+     context: ParserContext<S>,
++    /// Set when a content handler suspended the dispatch mid-parse (see
++    /// [`RewritingError::Suspended`]). Holds the state-machine bookmark
++    /// (positions relative to the re-buffered unconsumed tail) that
++    /// [`Self::resume`] continues from.
++    suspension: Option<StateMachineBookmark>,
+ }
+ 
+ // public only for integration tests
+@@ -64,6 +69,7 @@ impl<S: ParserOutputSink> Parser<S> {
+             tag_scanner: TagScanner::new(),
+             current_directive: initial_directive,
+             context,
++            suspension: None,
+         }
+     }
+ 
+@@ -72,7 +78,9 @@ impl<S: ParserOutputSink> Parser<S> {
+     // It's better to outline it, and let its callers be inlined.
+     #[inline(never)]
+     pub fn parse(&mut self, input: &[u8], last: bool) -> Result<usize, RewritingError> {
+-        let mut parse_result = match self.current_directive {
++        debug_assert!(self.suspension.is_none());
++
++        let parse_result = match self.current_directive {
+             ParserDirective::WherePossibleScanForTagsOnly => {
+                 self.tag_scanner
+                     .run_parsing_loop(&mut self.context, input, last)
+@@ -80,6 +88,58 @@ impl<S: ParserOutputSink> Parser<S> {
+             ParserDirective::Lex => self.lexer.run_parsing_loop(&mut self.context, input, last),
+         };
+ 
++        self.handle_parse_result(parse_result, input, last)
++    }
++
++    /// `true` if the last `parse`/`resume` call was suspended by a content
++    /// handler. The number of bytes it reported as consumed is final; the
++    /// rest of the input must be buffered and handed back to [`Self::resume`].
++    #[inline]
++    pub const fn is_suspended(&self) -> bool {
++        self.suspension.is_some()
++    }
++
++    /// Continues a suspended parse over the re-buffered unconsumed tail.
++    /// Must only be called once the suspended dispatch itself has been
++    /// resumed (see `Dispatcher::resume_dispatch`). `directive`, when given,
++    /// is the one the suspended `handle_tag` never got to return.
++    #[inline(never)]
++    pub fn resume(
++        &mut self,
++        input: &[u8],
++        last: bool,
++        directive: Option<ParserDirective>,
++    ) -> Result<usize, RewritingError> {
++        let bookmark = self
++            .suspension
++            .take()
++            .expect("Parser::resume called without a suspension");
++
++        if let Some(directive) = directive {
++            self.current_directive = directive;
++        }
++
++        trace!(@continue_from_bookmark bookmark, self.current_directive, input);
++
++        let parse_result = match self.current_directive {
++            ParserDirective::WherePossibleScanForTagsOnly => self
++                .tag_scanner
++                .continue_from_bookmark(&mut self.context, input, last, bookmark),
++            ParserDirective::Lex => {
++                self.lexer
++                    .continue_from_bookmark(&mut self.context, input, last, bookmark)
++            }
++        };
++
++        self.handle_parse_result(parse_result, input, last)
++    }
++
++    fn handle_parse_result(
++        &mut self,
++        mut parse_result: ParseResult,
++        input: &[u8],
++        last: bool,
++    ) -> Result<usize, RewritingError> {
+         loop {
+             let unboxed = match parse_result {
+                 Ok(unreachable) => match unreachable {},
+@@ -92,6 +152,14 @@ impl<S: ParserOutputSink> Parser<S> {
+                     self.context.previously_consumed_byte_count += consumed_byte_count;
+                     return Ok(consumed_byte_count);
+                 }
++                ActionError::Suspended {
++                    consumed_byte_count,
++                    bookmark,
++                } => {
++                    self.context.previously_consumed_byte_count += consumed_byte_count;
++                    self.suspension = Some(bookmark);
++                    return Ok(consumed_byte_count);
++                }
+                 ActionError::ParserDirectiveChangeRequired(new_directive, sm_bookmark) => {
+                     self.current_directive = new_directive;
+ 
+--- a/src/parser/state_machine/mod.rs
++++ b/src/parser/state_machine/mod.rs
+@@ -51,7 +51,19 @@ pub(crate) struct StateMachineBookmark {
+ pub(crate) enum ActionError {
+     RewritingError(RewritingError),
+     ParserDirectiveChangeRequired(ParserDirective, StateMachineBookmark),
+-    EndOfInput { consumed_byte_count: usize },
++    EndOfInput {
++        consumed_byte_count: usize,
++    },
++    /// A content handler requested suspension (see
++    /// [`crate::SuspensionRequest`]). The first `consumed_byte_count` bytes
++    /// of the current input are fully processed; the rest must be buffered
++    /// and re-fed on resume. `bookmark` (with `pos` relative to that re-fed
++    /// tail, always `0`) restores the state machine once the parked dispatch
++    /// completes.
++    Suspended {
++        consumed_byte_count: usize,
++        bookmark: StateMachineBookmark,
++    },
+     Internal(&'static str),
+ }
+ 
+--- a/src/rewritable_units/document_end.rs
++++ b/src/rewritable_units/document_end.rs
+@@ -1,5 +1,8 @@
++use super::mutations::{DynamicString, StringChunk};
+ use super::{ContentType, StreamingHandlerSink};
++use crate::errors::RewritingError;
+ use encoding_rs::Encoding;
++use std::marker::PhantomData;
+ 
+ use crate::transform_stream::OutputSink;
+ 
+@@ -8,21 +11,47 @@ use crate::transform_stream::OutputSink;
+ /// This exposes the [append](#method.append) function that can be used to append content at the
+ /// end of the document. The content will only be appended after the rewriter has finished processing
+ /// the final chunk.
++// Note: appended content is buffered (as a `DynamicString`, like every other
++// mutation) and flushed to the output sink once all the document-end handlers
++// have run. This is what lets the unit own all of its state, which in turn
++// lets a handler suspend on it. The lifetime parameter is kept for backward
++// compatibility with the `DocumentEnd<'_>` spelling; the type owns everything.
+ pub struct DocumentEnd<'a> {
+-    output_sink: &'a mut dyn OutputSink,
++    appended: DynamicString,
+     encoding: &'static Encoding,
++    _lifetime: PhantomData<&'a ()>,
+ }
+ 
+ impl<'a> DocumentEnd<'a> {
+     #[inline]
+     #[must_use]
+-    pub(crate) fn new(output_sink: &'a mut dyn OutputSink, encoding: &'static Encoding) -> Self {
++    pub(crate) fn new(encoding: &'static Encoding) -> Self {
+         DocumentEnd {
+-            output_sink,
++            appended: DynamicString::new(),
+             encoding,
++            _lifetime: PhantomData,
+         }
+     }
+ 
++    /// Detaches the unit so it can outlive the current `end()` call (handler
++    /// suspension). Leaves `self` behind empty; the caller abandons it.
++    pub(crate) fn take_owned(&mut self) -> DocumentEnd<'static> {
++        DocumentEnd {
++            appended: std::mem::take(&mut self.appended),
++            encoding: self.encoding,
++            _lifetime: PhantomData,
++        }
++    }
++
++    /// Encodes the buffered appends into `output_sink`. Consumes the unit.
++    pub(crate) fn flush_into(self, output_sink: &mut dyn OutputSink) -> Result<(), RewritingError> {
++        let mut handle_chunk = |c: &[u8]| output_sink.handle_chunk(c);
++        let mut sink = StreamingHandlerSink::new(self.encoding, &mut handle_chunk);
++        self.appended
++            .encode(&mut sink)
++            .map_err(RewritingError::ContentHandlerError)
++    }
++
+     /// Appends `content` at the end of the document.
+     ///
+     /// Subsequent calls to this method append `content` to the previously inserted content.
+@@ -49,10 +78,8 @@ impl<'a> DocumentEnd<'a> {
+     /// ```
+     #[inline]
+     pub fn append(&mut self, content: &str, content_type: ContentType) {
+-        StreamingHandlerSink::new(self.encoding, &mut |c| {
+-            self.output_sink.handle_chunk(c);
+-        })
+-        .write_str(content, content_type);
++        self.appended
++            .push_back(StringChunk::from_str(content, content_type));
+     }
+ }
+ 
+--- a/src/rewritable_units/element.rs
++++ b/src/rewritable_units/element.rs
+@@ -37,18 +37,26 @@ pub enum TagNameError {
+     UnencodableCharacter,
+ }
+ 
++/// Either a borrow of the `StartTag` living in the dispatcher's stack-local
++/// [`Token`], or — once the element has been detached by a handler suspension
++/// — an owned, heap-allocated copy of it.
++enum StartTagRef<'rewriter, 'input_token> {
++    Borrowed(&'rewriter mut StartTag<'input_token>),
++    Owned(Box<StartTag<'input_token>>),
++}
++
+ /// An HTML element rewritable unit.
+ ///
+ /// Exposes API for examination and modification of a parsed HTML element.
+ pub struct Element<'rewriter, 'input_token, H: HandlerTypes = LocalHandlerTypes> {
+-    start_tag: &'rewriter mut StartTag<'input_token>,
++    start_tag: StartTagRef<'rewriter, 'input_token>,
+     end_tag_mutations: Option<Mutations>,
+     modified_end_tag_name: Option<Box<[u8]>>,
+     end_tag_handlers: Vec<H::EndTagHandler<'static>>,
+     can_have_content: bool,
+     should_remove_content: bool,
+     encoding: &'static Encoding,
+-    user_data: Box<dyn Any>,
++    user_data: Box<dyn Any + Send>,
+ }
+ 
+ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token, H> {
+@@ -61,7 +69,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+         let encoding = start_tag.encoding();
+ 
+         Element {
+-            start_tag,
++            start_tag: StartTagRef::Borrowed(start_tag),
+             end_tag_mutations: None,
+             modified_end_tag_name: None,
+             end_tag_handlers: Vec::new(),
+@@ -72,6 +80,44 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+         }
+     }
+ 
++    #[inline]
++    fn tag(&self) -> &StartTag<'input_token> {
++        match &self.start_tag {
++            StartTagRef::Borrowed(t) => t,
++            StartTagRef::Owned(t) => t,
++        }
++    }
++
++    #[inline]
++    fn tag_mut(&mut self) -> &mut StartTag<'input_token> {
++        match &mut self.start_tag {
++            StartTagRef::Borrowed(t) => t,
++            StartTagRef::Owned(t) => t,
++        }
++    }
++
++    /// Detaches the element from the parser's stack-local [`Token`] so it can
++    /// outlive the current `write()` call (handler suspension). The start tag
++    /// (and every byte slice it borrows from the input buffer) is deep-copied
++    /// onto the heap.
++    pub(crate) fn into_suspended(self) -> Element<'static, 'static, H> {
++        let start_tag = Box::new(match self.start_tag {
++            StartTagRef::Borrowed(t) => t.take_owned(),
++            StartTagRef::Owned(mut t) => t.take_owned(),
++        });
++
++        Element {
++            start_tag: StartTagRef::Owned(start_tag),
++            end_tag_mutations: self.end_tag_mutations,
++            modified_end_tag_name: self.modified_end_tag_name,
++            end_tag_handlers: self.end_tag_handlers,
++            can_have_content: self.can_have_content,
++            should_remove_content: self.should_remove_content,
++            encoding: self.encoding,
++            user_data: self.user_data,
++        }
++    }
++
+     fn tag_name_bytes_from_str(&self, name: &str) -> Result<BytesCow<'static>, TagNameError> {
+         match name.as_bytes().first() {
+             Some(ch) if !ch.is_ascii_alphabetic() => Err(TagNameError::InvalidFirstCharacter),
+@@ -98,7 +144,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+ 
+     #[inline]
+     fn remove_content(&mut self) {
+-        self.start_tag.mutations.mutate().content_after.clear();
++        self.tag_mut().mutations.mutate().content_after.clear();
+         if let Some(end) = self.end_tag_mutations.as_mut().and_then(|m| m.if_mutated()) {
+             end.content_before.clear();
+         }
+@@ -116,14 +162,14 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     #[inline]
+     #[must_use]
+     pub fn tag_name(&self) -> String {
+-        self.start_tag.name()
++        self.tag().name()
+     }
+ 
+     /// Returns the tag name of the element, preserving its case.
+     #[inline]
+     #[must_use]
+     pub fn tag_name_preserve_case(&self) -> String {
+-        self.start_tag.name_preserve_case()
++        self.tag().name_preserve_case()
+     }
+ 
+     /// Sets the tag name of the element.
+@@ -139,7 +185,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+             self.modified_end_tag_name = Some((*name).into());
+         }
+ 
+-        self.start_tag.set_name_raw(name);
++        self.tag_mut().set_name_raw(name);
+ 
+         Ok(())
+     }
+@@ -158,7 +204,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     #[inline]
+     #[must_use]
+     pub fn is_self_closing(&self) -> bool {
+-        self.start_tag.self_closing()
++        self.tag().self_closing()
+     }
+ 
+     /// Whether the element can have inner content.
+@@ -181,14 +227,14 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     #[inline]
+     #[must_use]
+     pub fn namespace_uri(&self) -> &'static str {
+-        self.start_tag.namespace_uri()
++        self.tag().namespace_uri()
+     }
+ 
+     /// Returns an immutable collection of element's attributes.
+     #[inline]
+     #[must_use]
+     pub fn attributes(&self) -> &[Attribute<'input_token>] {
+-        self.start_tag.attributes()
++        self.tag().attributes()
+     }
+ 
+     /// Returns the value of an attribute with the `name`. The value may have HTML/XML entities.
+@@ -225,13 +271,13 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     /// to the element with `name` and `value`.
+     #[inline]
+     pub fn set_attribute(&mut self, name: &str, value: &str) -> Result<(), AttributeNameError> {
+-        self.start_tag.set_attribute(name, value)
++        self.tag_mut().set_attribute(name, value)
+     }
+ 
+     /// Removes an attribute with the `name` if it is present.
+     #[inline]
+     pub fn remove_attribute(&mut self, name: &str) {
+-        self.start_tag.remove_attribute(name);
++        self.tag_mut().remove_attribute(name);
+     }
+ 
+     /// Inserts `content` before the element.
+@@ -264,7 +310,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     /// ```
+     #[inline]
+     pub fn before(&mut self, content: &str, content_type: ContentType) {
+-        self.start_tag
++        self.tag_mut()
+             .mutations
+             .mutate()
+             .content_before
+@@ -277,7 +323,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     ///
+     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
+     pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
+-        self.start_tag
++        self.tag_mut()
+             .mutations
+             .mutate()
+             .content_before
+@@ -321,7 +367,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+         if self.can_have_content {
+             &mut self.end_tag_mutations_mut().content_after
+         } else {
+-            &mut self.start_tag.mutations.mutate().content_after
++            &mut self.tag_mut().mutations.mutate().content_after
+         }
+         .push_front(chunk);
+     }
+@@ -378,12 +424,9 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+ 
+     fn prepend_chunk(&mut self, chunk: StringChunk) {
+         if self.can_have_content {
+-            self.start_tag.set_self_closing_syntax(false);
+-            self.start_tag
+-                .mutations
+-                .mutate()
+-                .content_after
+-                .push_front(chunk);
++            let tag = self.tag_mut();
++            tag.set_self_closing_syntax(false);
++            tag.mutations.mutate().content_after.push_front(chunk);
+         }
+     }
+ 
+@@ -443,7 +486,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+ 
+     fn append_chunk(&mut self, chunk: StringChunk) {
+         if self.can_have_content {
+-            self.start_tag.set_self_closing_syntax(false);
++            self.tag_mut().set_self_closing_syntax(false);
+             self.end_tag_mutations_mut().content_before.push_back(chunk);
+         }
+     }
+@@ -502,9 +545,9 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+ 
+     fn set_inner_content_chunk(&mut self, chunk: StringChunk) {
+         if self.can_have_content {
+-            self.start_tag.set_self_closing_syntax(false);
++            self.tag_mut().set_self_closing_syntax(false);
+             self.remove_content();
+-            self.start_tag
++            self.tag_mut()
+                 .mutations
+                 .mutate()
+                 .content_after
+@@ -561,7 +604,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     }
+ 
+     fn replace_chunk(&mut self, chunk: StringChunk) {
+-        self.start_tag.mutations.mutate().replace(chunk);
++        self.tag_mut().mutations.mutate().replace(chunk);
+ 
+         if self.can_have_content {
+             self.remove_content();
+@@ -582,7 +625,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     /// Removes the element and its inner content.
+     #[inline]
+     pub fn remove(&mut self) {
+-        self.start_tag.mutations.mutate().remove();
++        self.tag_mut().mutations.mutate().remove();
+ 
+         if self.can_have_content {
+             self.remove_content();
+@@ -615,7 +658,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     /// ```
+     #[inline]
+     pub fn remove_and_keep_content(&mut self) {
+-        self.start_tag.remove();
++        self.tag_mut().remove();
+ 
+         if self.can_have_content {
+             self.end_tag_mutations_mut().remove();
+@@ -626,7 +669,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     #[inline]
+     #[must_use]
+     pub fn removed(&self) -> bool {
+-        self.start_tag.mutations.removed()
++        self.tag().mutations.removed()
+     }
+ 
+     #[inline]
+@@ -637,7 +680,7 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     /// Returns the start tag.
+     #[inline]
+     pub fn start_tag(&mut self) -> &mut StartTag<'input_token> {
+-        self.start_tag
++        self.tag_mut()
+     }
+ 
+     /// Returns the handlers that will run when the end tag is reached.
+@@ -701,10 +744,18 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+     }
+ 
+     pub(crate) fn into_end_tag_handler(self) -> Option<H::EndTagHandler<'static>> {
+-        let end_tag_mutations = self.end_tag_mutations;
+-        let modified_end_tag_name = self.modified_end_tag_name;
+-        let mut end_tag_handlers = self.end_tag_handlers;
+-
++        Self::make_end_tag_handler(
++            self.end_tag_mutations,
++            self.modified_end_tag_name,
++            self.end_tag_handlers,
++        )
++    }
++
++    fn make_end_tag_handler(
++        end_tag_mutations: Option<Mutations>,
++        modified_end_tag_name: Option<Box<[u8]>>,
++        mut end_tag_handlers: Vec<H::EndTagHandler<'static>>,
++    ) -> Option<H::EndTagHandler<'static>> {
+         if end_tag_mutations.is_some()
+             || modified_end_tag_name.is_some()
+             || !end_tag_handlers.is_empty()
+@@ -730,19 +781,41 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token,
+         }
+     }
+ 
++    /// Splits a suspended (owned) element back into the start tag it captured
++    /// plus the bookkeeping `ContentHandlersDispatcher::handle_start_tag`
++    /// applies after the handlers run. Only valid once `into_suspended` has
++    /// detached the element.
++    pub(crate) fn into_owned_parts(
++        self,
++    ) -> (
++        Box<StartTag<'input_token>>,
++        bool,
++        Option<H::EndTagHandler<'static>>,
++    ) {
++        let StartTagRef::Owned(start_tag) = self.start_tag else {
++            unreachable!("into_owned_parts called on an element that still borrows its start tag");
++        };
++        let handler = Self::make_end_tag_handler(
++            self.end_tag_mutations,
++            self.modified_end_tag_name,
++            self.end_tag_handlers,
++        );
++        (start_tag, self.should_remove_content, handler)
++    }
++
+     /// Position of this element's start tag in the source document, before any rewriting
+     ///
+     /// The end of this element hasn't been parsed yet. To find it, use [`Element::end_tag_handlers`].
+     #[must_use]
+     pub fn source_location(&self) -> SourceLocation {
+-        self.start_tag.source_location()
++        self.tag().source_location()
+     }
+ 
+     /// [Self::namespace_uri], but as a `CStr`
+     #[inline]
+     #[must_use]
+     pub fn namespace_uri_c_str(&self) -> &'static std::ffi::CStr {
+-        self.start_tag.namespace_uri_c_str()
++        self.tag().namespace_uri_c_str()
+     }
+ }
+ 
+--- a/src/rewritable_units/mod.rs
++++ b/src/rewritable_units/mod.rs
+@@ -60,7 +60,10 @@ pub trait UserData {
+     /// Returns a mutable reference to the attached user data.
+     fn user_data_mut(&mut self) -> &mut dyn Any;
+     /// Attaches user data to a rewritable unit.
+-    fn set_user_data(&mut self, data: impl Any);
++    ///
++    /// The data must be [`Send`] so that a rewritable unit detached by a
++    /// handler suspension doesn't strip [`Send`] from a `send::HtmlRewriter`.
++    fn set_user_data(&mut self, data: impl Any + Send);
+ }
+ 
+ macro_rules! impl_user_data {
+@@ -77,7 +80,7 @@ macro_rules! impl_user_data {
+             }
+ 
+             #[inline]
+-            fn set_user_data(&mut self, data: impl Any){
++            fn set_user_data(&mut self, data: impl Any + Send){
+                 self.user_data = Box::new(data);
+             }
+         }
+--- a/src/rewritable_units/text_decoder.rs
++++ b/src/rewritable_units/text_decoder.rs
+@@ -9,6 +9,24 @@ pub(crate) struct TextDecoder {
+     pending_source_location_bytes_start: usize,
+     pending_text_streaming_decoder: Option<Decoder>,
+     text_buffer: String,
++    /// Where the current `feed_text` call was when a text handler suspended
++    /// (`None` otherwise). Recorded *only* on the error path so the success
++    /// path pays nothing.
++    suspended: Option<TextFeedSuspension>,
++}
++
++/// Where a [`TextDecoder::feed_text`] call was when the text handler for one
++/// of its chunks suspended. Lets [`TextDecoder::resume_feed`] finish decoding
++/// the rest of that text lexeme once the parked chunk completes. The
++/// undecoded tail is copied because it pointed into the `write()` call's
++/// input buffer, which is gone by the time the resume runs.
++pub(crate) struct TextFeedSuspension {
++    remaining: Vec<u8>,
++    next_source_location_bytes_start: usize,
++    last_in_text_node: bool,
++    /// `true` if the chunk that suspended was this feed's final one; the
++    /// resume then only has to run the loop's epilogue.
++    finished: bool,
+ }
+ 
+ pub(crate) type OutputHandlerCallback<'tmp> =
+@@ -25,6 +43,7 @@ impl TextDecoder {
+             // this will be later initialized to DEFAULT_BUFFER_LEN,
+             // because encoding_rs wants a slice
+             text_buffer: String::new(),
++            suspended: None,
+         }
+     }
+ 
+@@ -43,6 +62,39 @@ impl TextDecoder {
+         Ok(())
+     }
+ 
++    /// The feed state recorded when a text handler suspended, if any.
++    #[inline]
++    pub fn take_suspended(&mut self) -> Option<TextFeedSuspension> {
++        self.suspended.take()
++    }
++
++    /// Continues a `feed_text` call that a text handler suspended, starting
++    /// right after the chunk that suspended.
++    pub fn resume_feed(
++        &mut self,
++        suspension: TextFeedSuspension,
++        output_handler: &mut OutputHandlerCallback<'_>,
++    ) -> Result<(), RewritingError> {
++        if suspension.finished {
++            // The chunk that suspended was this feed's final one: only the
++            // loop epilogue is left.
++            if suspension.last_in_text_node {
++                self.pending_text_streaming_decoder = None;
++            } else {
++                self.pending_source_location_bytes_start =
++                    suspension.next_source_location_bytes_start;
++            }
++            return Ok(());
++        }
++
++        self.feed_decoder_loop(
++            &suspension.remaining,
++            suspension.next_source_location_bytes_start,
++            suspension.last_in_text_node,
++            output_handler,
++        )
++    }
++
+     #[inline(never)]
+     pub fn feed_text(
+         &mut self,
+@@ -63,7 +115,16 @@ impl TextDecoder {
+                 SourceLocation::from_start_len(next_source_location_bytes_start, utf8_text.len());
+             next_source_location_bytes_start = source_location.bytes().end;
+ 
+-            (output_handler)(utf8_text, really_last, encoding, source_location)?;
++            let res = (output_handler)(utf8_text, really_last, encoding, source_location);
++            if res.is_err() {
++                self.suspended = Some(TextFeedSuspension {
++                    remaining: rest.to_vec(),
++                    next_source_location_bytes_start,
++                    last_in_text_node,
++                    finished: really_last,
++                });
++            }
++            res?;
+ 
+             if really_last {
+                 debug_assert!(self.pending_text_streaming_decoder.is_none());
+@@ -71,6 +132,25 @@ impl TextDecoder {
+             }
+         }
+ 
++        self.feed_decoder_loop(
++            raw_input,
++            next_source_location_bytes_start,
++            last_in_text_node,
++            output_handler,
++        )
++    }
++
++    /// The streaming-decoder tail of [`Self::feed_text`], also the re-entry
++    /// point for [`Self::resume_feed`].
++    fn feed_decoder_loop(
++        &mut self,
++        mut raw_input: &[u8],
++        mut next_source_location_bytes_start: usize,
++        last_in_text_node: bool,
++        output_handler: &mut OutputHandlerCallback<'_>,
++    ) -> Result<(), RewritingError> {
++        let encoding = self.encoding.get();
++
+         if self.pending_text_streaming_decoder.is_none() && self.text_buffer.is_empty() {
+             // repeat() avoids utf8 check comapred to `String::from_utf8(vec![0; len])`
+             self.text_buffer = "\0".repeat(DEFAULT_BUFFER_LEN);
+@@ -94,13 +174,22 @@ impl TextDecoder {
+                 // but only one call to output_handler can be *the* last one.
+                 let really_last = last_in_text_node && finished_decoding;
+ 
+-                (output_handler)(
++                let res = (output_handler)(
+                     // this will always be in bounds, but unwrap_or_default optimizes better
+                     buffer.get(..written).unwrap_or_default(),
+                     really_last,
+                     encoding,
+                     source_location,
+-                )?;
++                );
++                if res.is_err() {
++                    self.suspended = Some(TextFeedSuspension {
++                        remaining: raw_input.get(read..).unwrap_or_default().to_vec(),
++                        next_source_location_bytes_start,
++                        last_in_text_node,
++                        finished: finished_decoding,
++                    });
++                }
++                res?;
+             }
+ 
+             if finished_decoding {
+--- a/src/rewritable_units/tokens/attributes.rs
++++ b/src/rewritable_units/tokens/attributes.rs
+@@ -39,7 +39,7 @@ pub enum AttributeNameError {
+ pub struct Attribute<'i> {
+     name: BytesCow<'i>,
+     value: BytesCow<'i>,
+-    raw: Option<Bytes<'i>>,
++    raw: Option<BytesCow<'i>>,
+     encoding: &'static Encoding,
+ }
+ 
+@@ -49,7 +49,7 @@ impl<'i> Attribute<'i> {
+     const fn new(
+         name: BytesCow<'i>,
+         value: BytesCow<'i>,
+-        raw: Bytes<'i>,
++        raw: BytesCow<'i>,
+         encoding: &'static Encoding,
+     ) -> Self {
+         Attribute {
+@@ -60,6 +60,16 @@ impl<'i> Attribute<'i> {
+         }
+     }
+ 
++    /// Detaches the attribute from the input buffer it may borrow.
++    fn into_owned(self) -> Attribute<'static> {
++        Attribute {
++            name: self.name.into_owned(),
++            value: self.value.into_owned(),
++            raw: self.raw.map(BytesCow::into_owned),
++            encoding: self.encoding,
++        }
++    }
++
+     #[inline]
+     fn name_from_str(
+         name: &str,
+@@ -242,7 +252,8 @@ impl<'i> Attributes<'i> {
+                         .into(),
+                     self.input
+                         .opt_slice(Some(a.raw_range))
+-                        .unwrap_or_else(cant_fail),
++                        .unwrap_or_else(cant_fail)
++                        .into(),
+                     self.encoding,
+                 )
+             })
+@@ -264,12 +275,45 @@ impl<'i> Attributes<'i> {
+         self.items.get_mut().unwrap_or_else(|| unreachable!())
+     }
+ 
++    /// Detaches the collection from the lexeme's input buffer, leaving an
++    /// empty collection behind. The lazy `items` vec is forced *while the
++    /// backing lexeme is still alive* and every attribute is deep-copied, so
++    /// the result owns all of its bytes.
++    pub(crate) fn take_owned(&mut self) -> Attributes<'static> {
++        // Ensure `items` is materialized from `input`/`attribute_buffer`
++        // before those references go away.
++        let _ = self.as_mut_vec();
++        let items: Vec<Attribute<'static>> = self
++            .items
++            .take()
++            .unwrap_or_default()
++            .into_iter()
++            .map(Attribute::into_owned)
++            .collect();
++
++        let cell = OnceCell::new();
++        let _ = cell.set(items);
++
++        Attributes {
++            input: &EMPTY_INPUT,
++            attribute_buffer: &EMPTY_ATTRIBUTE_BUFFER,
++            items: cell,
++            encoding: self.encoding,
++        }
++    }
++
+     #[cfg(test)]
+     pub(crate) const fn raw_attributes(&self) -> (&'i Bytes<'i>, &'i AttributeBuffer) {
+         (self.input, self.attribute_buffer)
+     }
+ }
+ 
++// Placeholder backing for an owned `Attributes`. Once `take_owned` has
++// materialized `items`, `input`/`attribute_buffer` are never read again
++// (`is_empty` and `as_mut_vec` both short-circuit on an initialized cell).
++static EMPTY_INPUT: Bytes<'static> = Bytes::new(&[]);
++static EMPTY_ATTRIBUTE_BUFFER: AttributeBuffer = Vec::new();
++
+ impl Serialize for &mut Attributes<'_> {
+     #[inline]
+     fn into_bytes(self, output_handler: &mut dyn FnMut(&[u8])) -> Result<(), RewritingError> {
+--- a/src/rewritable_units/tokens/comment.rs
++++ b/src/rewritable_units/tokens/comment.rs
+@@ -33,7 +33,7 @@ pub struct Comment<'i> {
+     raw: SpannedRawBytes<'i>,
+     encoding: &'static Encoding,
+     mutations: Mutations,
+-    user_data: Box<dyn Any>,
++    user_data: Box<dyn Any + Send>,
+ }
+ 
+ impl<'i> Comment<'i> {
+@@ -242,6 +242,19 @@ impl<'i> Comment<'i> {
+         self.mutations.removed()
+     }
+ 
++    /// Detaches the comment from the parser's input buffer so it can outlive
++    /// the current `write()` call (handler suspension). Leaves `self` behind
++    /// in a drained state; the caller abandons it.
++    pub(crate) fn take_owned(&mut self) -> Comment<'static> {
++        Comment {
++            text: self.text.take_owned(),
++            raw: self.raw.take_owned(),
++            encoding: self.encoding,
++            mutations: std::mem::replace(&mut self.mutations, Mutations::new()),
++            user_data: std::mem::replace(&mut self.user_data, Box::new(())),
++        }
++    }
++
+     #[inline]
+     fn serialize_self(&self, sink: &mut StreamingHandlerSink<'_>) -> Result<(), RewritingError> {
+         let output_handler = sink.output_handler();
+--- a/src/rewritable_units/tokens/doctype.rs
++++ b/src/rewritable_units/tokens/doctype.rs
+@@ -1,5 +1,5 @@
+ use crate::base::Bytes;
+-use crate::base::Spanned;
++use crate::base::{BytesCow, Spanned, SpannedRawBytes};
+ use crate::errors::RewritingError;
+ use crate::html_content::SourceLocation;
+ use crate::rewritable_units::{Serialize, Token};
+@@ -35,14 +35,14 @@ use std::fmt::{self, Debug};
+ ///
+ /// [document type declaration]: https://developer.mozilla.org/en-US/docs/Glossary/Doctype
+ pub struct Doctype<'i> {
+-    name: Option<Bytes<'i>>,
+-    public_id: Option<Bytes<'i>>,
+-    system_id: Option<Bytes<'i>>,
++    name: Option<BytesCow<'i>>,
++    public_id: Option<BytesCow<'i>>,
++    system_id: Option<BytesCow<'i>>,
+     force_quirks: bool,
+     removed: bool,
+-    raw: Spanned<Bytes<'i>>,
++    raw: SpannedRawBytes<'i>,
+     encoding: &'static Encoding,
+-    user_data: Box<dyn Any>,
++    user_data: Box<dyn Any + Send>,
+ }
+ 
+ impl<'i> Doctype<'i> {
+@@ -58,17 +58,33 @@ impl<'i> Doctype<'i> {
+         encoding: &'static Encoding,
+     ) -> Token<'i> {
+         Token::Doctype(Doctype {
+-            name,
+-            public_id,
+-            system_id,
++            name: name.map(Into::into),
++            public_id: public_id.map(Into::into),
++            system_id: system_id.map(Into::into),
+             force_quirks,
+             removed,
+-            raw,
++            raw: raw.into(),
+             encoding,
+             user_data: Box::new(()),
+         })
+     }
+ 
++    /// Detaches the doctype from the parser's input buffer so it can outlive
++    /// the current `write()` call (handler suspension). Leaves `self` behind
++    /// in a drained state; the caller abandons it.
++    pub(crate) fn take_owned(&mut self) -> Doctype<'static> {
++        Doctype {
++            name: self.name.as_mut().map(BytesCow::take_owned),
++            public_id: self.public_id.as_mut().map(BytesCow::take_owned),
++            system_id: self.system_id.as_mut().map(BytesCow::take_owned),
++            force_quirks: self.force_quirks,
++            removed: self.removed,
++            raw: self.raw.take_owned(),
++            encoding: self.encoding,
++            user_data: std::mem::replace(&mut self.user_data, Box::new(())),
++        }
++    }
++
+     /// The name of the doctype.
+     #[inline]
+     #[must_use]
+@@ -125,7 +141,9 @@ impl Serialize for &Doctype<'_> {
+     #[inline]
+     fn into_bytes(self, output_handler: &mut dyn FnMut(&[u8])) -> Result<(), RewritingError> {
+         if !self.removed() {
+-            output_handler(self.raw.as_slice());
++            // A doctype is never mutated, so its raw bytes are always present
++            // (`Original` from the lexeme, or `Owned` after a suspension).
++            output_handler(self.raw.original().unwrap_or_default());
+         }
+         Ok(())
+     }
+--- a/src/rewritable_units/tokens/end_tag.rs
++++ b/src/rewritable_units/tokens/end_tag.rs
+@@ -160,6 +160,18 @@ impl<'i> EndTag<'i> {
+         self.mutations.removed()
+     }
+ 
++    /// Detaches the tag from the parser's input buffer so it can outlive the
++    /// current `write()` call (handler suspension). Leaves `self` behind in a
++    /// drained state; the caller abandons it.
++    pub(crate) fn take_owned(&mut self) -> EndTag<'static> {
++        EndTag {
++            name: self.name.take_owned(),
++            raw: self.raw.take_owned(),
++            encoding: self.encoding,
++            mutations: std::mem::replace(&mut self.mutations, Mutations::new()),
++        }
++    }
++
+     #[inline]
+     fn serialize_self(&self, sink: &mut StreamingHandlerSink<'_>) -> Result<(), RewritingError> {
+         let output_handler = sink.output_handler();
+--- a/src/rewritable_units/tokens/start_tag.rs
++++ b/src/rewritable_units/tokens/start_tag.rs
+@@ -215,6 +215,20 @@ impl<'input_token> StartTag<'input_token> {
+         self.mutations.mutate().remove();
+     }
+ 
++    /// Detaches the tag from the parser's input buffer so it can outlive the
++    /// current `write()` call (handler suspension). Leaves `self` behind in a
++    /// drained state; the caller abandons it.
++    pub(crate) fn take_owned(&mut self) -> StartTag<'static> {
++        StartTag {
++            name: self.name.take_owned(),
++            attributes: self.attributes.take_owned(),
++            ns: self.ns,
++            self_closing: self.self_closing,
++            raw: self.raw.take_owned(),
++            mutations: std::mem::replace(&mut self.mutations, Mutations::new()),
++        }
++    }
++
+     fn serialize_self(
+         &mut self,
+         sink: &mut StreamingHandlerSink<'_>,
+--- a/src/rewritable_units/tokens/text_chunk.rs
++++ b/src/rewritable_units/tokens/text_chunk.rs
+@@ -78,7 +78,7 @@ pub struct TextChunk<'i> {
+     last_in_text_node: bool,
+     encoding: &'static Encoding,
+     mutations: Mutations,
+-    user_data: Box<dyn Any>,
++    user_data: Box<dyn Any + Send>,
+     source_location: SourceLocation,
+ }
+ 
+@@ -108,6 +108,21 @@ impl<'i> TextChunk<'i> {
+         self.encoding
+     }
+ 
++    /// Detaches the chunk from the parser's text buffer so it can outlive the
++    /// current `write()` call (handler suspension). Leaves `self` behind in a
++    /// drained state; the caller abandons it.
++    pub(crate) fn take_owned(&mut self) -> TextChunk<'static> {
++        TextChunk {
++            text: Cow::Owned(std::mem::take(&mut self.text).into_owned()),
++            text_type: self.text_type,
++            last_in_text_node: self.last_in_text_node,
++            encoding: self.encoding,
++            mutations: std::mem::replace(&mut self.mutations, Mutations::new()),
++            user_data: std::mem::replace(&mut self.user_data, Box::new(())),
++            source_location: self.source_location.clone(),
++        }
++    }
++
+     /// Returns the content of the chunk, which [`may not be a complete text node`](TextChunk).
+     ///
+     /// It may contain markup, such as HTML/XML entities. See [`TextChunk::text_type`].
+--- a/src/rewriter/handlers_dispatcher.rs
++++ b/src/rewriter/handlers_dispatcher.rs
+@@ -1,8 +1,36 @@
+ use super::ElementDescriptor;
++use super::is_suspension_request;
+ use super::settings::*;
+-use crate::rewritable_units::{DocumentEnd, Element, StartTag, Token, TokenCaptureFlags};
++use crate::rewritable_units::{
++    Comment, Doctype, DocumentEnd, Element, EndTag, StartTag, TextChunk, Token, TokenCaptureFlags,
++};
+ use crate::selectors_vm::MatchInfo;
+ 
++/// A rewritable unit detached from the parser's stack by a handler
++/// suspension. Boxed so its address stays stable across `resume` calls: an
++/// embedder may hold a raw pointer to it for the whole suspension.
++pub(crate) enum SuspendedToken<H: HandlerTypes> {
++    Element {
++        element: Box<Element<'static, 'static, H>>,
++        /// Index of the first element handler not yet run for this token.
++        next_handler_idx: usize,
++    },
++    EndTag(Box<EndTag<'static>>),
++    TextChunk {
++        chunk: Box<TextChunk<'static>>,
++        next_handler_idx: usize,
++    },
++    Comment {
++        comment: Box<Comment<'static>>,
++        next_handler_idx: usize,
++    },
++    Doctype {
++        doctype: Box<Doctype<'static>>,
++        next_handler_idx: usize,
++    },
++    DocumentEnd(Box<DocumentEnd<'static>>),
++}
++
+ #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
+ pub(crate) struct SelectorHandlersLocator {
+     pub element_handler_idx: Option<usize>,
+@@ -73,33 +101,53 @@ impl<H> HandlerVec<H> {
+         self.user_count > 0
+     }
+ 
++    /// Runs `cb` for every active item starting from `start_idx`. `*next_idx`
++    /// is kept pointed past the item currently being invoked, so a handler
++    /// that suspends (returns `Err`) can be resumed from the following item.
+     #[inline]
+-    pub fn for_each_active(
++    pub fn for_each_active_from(
+         &mut self,
++        start_idx: usize,
++        next_idx: &mut usize,
+         mut cb: impl FnMut(&mut H) -> HandlerResult,
+     ) -> HandlerResult {
+-        for item in &mut self.items {
+-            if item.user_count > 0 {
+-                cb(&mut item.handler)?;
++        for i in start_idx..self.items.len() {
++            if self.items[i].user_count > 0 {
++                *next_idx = i + 1;
++                cb(&mut self.items[i].handler)?;
+             }
+         }
+ 
++        *next_idx = self.items.len();
+         Ok(())
+     }
+ 
++    /// Like [`Self::for_each_active_from`], but each visited item is
++    /// deactivated. Deactivation happens *before* an error is propagated, so
++    /// a handler that suspends is not re-run when the loop is resumed from
++    /// `*next_idx`.
+     #[inline]
+-    pub fn do_for_each_active_and_deactivate(
++    pub fn do_for_each_active_and_deactivate_from(
+         &mut self,
++        start_idx: usize,
++        next_idx: &mut usize,
+         mut cb: impl FnMut(&mut H) -> HandlerResult,
+     ) -> HandlerResult {
+-        for item in &mut self.items {
+-            if item.user_count > 0 {
+-                cb(&mut item.handler)?;
++        for i in start_idx..self.items.len() {
++            if self.items[i].user_count > 0 {
++                *next_idx = i + 1;
++
++                let item = &mut self.items[i];
++                let res = cb(&mut item.handler);
++
+                 self.user_count -= item.user_count;
+                 item.user_count = 0;
++
++                res?;
+             }
+         }
+ 
++        *next_idx = self.items.len();
+         Ok(())
+     }
+ 
+@@ -131,6 +179,9 @@ pub(crate) struct ContentHandlersDispatcher<'h, H: HandlerTypes> {
+     end_handlers: HandlerVec<H::EndHandler<'h>>,
+     next_element_can_have_content: bool,
+     matched_elements_with_removed_content: usize,
++    /// The rewritable unit a handler suspended on, if any. See
++    /// [`crate::SuspensionRequest`].
++    suspended: Option<SuspendedToken<H>>,
+ }
+ 
+ impl<H: HandlerTypes> Default for ContentHandlersDispatcher<'_, H> {
+@@ -144,6 +195,7 @@ impl<H: HandlerTypes> Default for ContentHandlersDispatcher<'_, H> {
+             end_handlers: Default::default(),
+             next_element_can_have_content: false,
+             matched_elements_with_removed_content: 0,
++            suspended: None,
+         }
+     }
+ }
+@@ -236,35 +288,63 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
+         }
+     }
+ 
+-    pub fn handle_start_tag(
++    /// The post-handler bookkeeping for an element: mark its descriptor on
++    /// the open-element stack with the `remove()`/end-tag state the handlers
++    /// accumulated. Shared by the normal and the resume path.
++    fn apply_element_result(
+         &mut self,
+-        start_tag: &mut StartTag<'_>,
++        should_remove_content: bool,
++        end_tag_handler: Option<H::EndTagHandler<'static>>,
+         current_element_data: Option<&mut ElementDescriptor>,
+-    ) -> HandlerResult {
+-        if self.matched_elements_with_removed_content > 0 {
+-            start_tag.remove();
+-        }
+-
+-        let mut element = Element::new(start_tag, self.next_element_can_have_content);
+-
+-        self.element_handlers
+-            .do_for_each_active_and_deactivate(|h| h(&mut element))?;
+-
++    ) {
+         if self.next_element_can_have_content {
+             if let Some(elem_desc) = current_element_data {
+-                if element.should_remove_content() {
++                if should_remove_content {
+                     elem_desc.remove_content = true;
+                     self.matched_elements_with_removed_content += 1;
+                 }
+ 
+-                debug_assert!(element.can_have_content());
+-                if let Some(handler) = element.into_end_tag_handler() {
++                if let Some(handler) = end_tag_handler {
+                     elem_desc.end_tag_handler_idx = Some(self.end_tag_handlers.len());
+ 
+                     self.end_tag_handlers.push(handler, false);
+                 }
+             }
+         }
++    }
++
++    pub fn handle_start_tag(
++        &mut self,
++        start_tag: &mut StartTag<'_>,
++        current_element_data: Option<&mut ElementDescriptor>,
++    ) -> HandlerResult {
++        if self.matched_elements_with_removed_content > 0 {
++            start_tag.remove();
++        }
++
++        let mut element = Element::new(start_tag, self.next_element_can_have_content);
++
++        let mut next_handler_idx = 0;
++        if let Err(e) = self
++            .element_handlers
++            .do_for_each_active_and_deactivate_from(0, &mut next_handler_idx, |h| h(&mut element))
++        {
++            if is_suspension_request(&*e) {
++                // Deep-copy the element (and the stack-local start tag it
++                // borrows) onto the heap so it survives the unwind out of
++                // `write()`.
++                self.suspended = Some(SuspendedToken::Element {
++                    element: Box::new(element.into_suspended()),
++                    next_handler_idx,
++                });
++            }
++            return Err(e);
++        }
++
++        debug_assert!(!self.next_element_can_have_content || element.can_have_content());
++        let should_remove_content = element.should_remove_content();
++        let end_tag_handler = element.into_end_tag_handler();
++        self.apply_element_result(should_remove_content, end_tag_handler, current_element_data);
+ 
+         Ok(())
+     }
+@@ -274,20 +354,240 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
+         token: &mut Token<'_>,
+         current_element_data: Option<&mut ElementDescriptor>,
+     ) -> HandlerResult {
++        debug_assert!(
++            self.suspended.is_none(),
++            "a token was dispatched while a suspension is pending"
++        );
++
+         match token {
+-            Token::Doctype(doctype) => self.doctype_handlers.for_each_active(|h| h(doctype)),
+-            Token::StartTag(start_tag) => self.handle_start_tag(start_tag, current_element_data),
+-            Token::EndTag(end_tag) => self
+-                .end_tag_handlers
+-                .do_for_each_active_and_remove(|h| h(end_tag)),
+-            Token::TextChunk(text) => self.text_handlers.for_each_active(|h| h(text)),
+-            Token::Comment(comment) => self.comment_handlers.for_each_active(|h| h(comment)),
++            Token::StartTag(start_tag) => {
++                return self.handle_start_tag(start_tag, current_element_data);
++            }
++            Token::EndTag(end_tag) => {
++                let res = self
++                    .end_tag_handlers
++                    .do_for_each_active_and_remove(|h| h(end_tag));
++                if let Err(e) = res {
++                    if is_suspension_request(&*e) {
++                        self.suspended =
++                            Some(SuspendedToken::EndTag(Box::new(end_tag.take_owned())));
++                    }
++                    return Err(e);
++                }
++            }
++            Token::Doctype(doctype) => {
++                let mut next_handler_idx = 0;
++                let res =
++                    self.doctype_handlers
++                        .for_each_active_from(0, &mut next_handler_idx, |h| h(doctype));
++                if let Err(e) = res {
++                    if is_suspension_request(&*e) {
++                        self.suspended = Some(SuspendedToken::Doctype {
++                            doctype: Box::new(doctype.take_owned()),
++                            next_handler_idx,
++                        });
++                    }
++                    return Err(e);
++                }
++            }
++            Token::TextChunk(text) => {
++                let mut next_handler_idx = 0;
++                let res = self
++                    .text_handlers
++                    .for_each_active_from(0, &mut next_handler_idx, |h| h(text));
++                if let Err(e) = res {
++                    if is_suspension_request(&*e) {
++                        self.suspended = Some(SuspendedToken::TextChunk {
++                            chunk: Box::new(text.take_owned()),
++                            next_handler_idx,
++                        });
++                    }
++                    return Err(e);
++                }
++            }
++            Token::Comment(comment) => {
++                let mut next_handler_idx = 0;
++                let res =
++                    self.comment_handlers
++                        .for_each_active_from(0, &mut next_handler_idx, |h| h(comment));
++                if let Err(e) = res {
++                    if is_suspension_request(&*e) {
++                        self.suspended = Some(SuspendedToken::Comment {
++                            comment: Box::new(comment.take_owned()),
++                            next_handler_idx,
++                        });
++                    }
++                    return Err(e);
++                }
++            }
+         }
++
++        Ok(())
+     }
+ 
+     pub fn handle_end(&mut self, document_end: &mut DocumentEnd<'_>) -> HandlerResult {
+-        self.end_handlers
+-            .do_for_each_active_and_remove(|h| h(document_end))
++        let res = self
++            .end_handlers
++            .do_for_each_active_and_remove(|h| h(document_end));
++        if let Err(e) = res {
++            if is_suspension_request(&*e) {
++                self.suspended = Some(SuspendedToken::DocumentEnd(Box::new(
++                    document_end.take_owned(),
++                )));
++            }
++            return Err(e);
++        }
++        Ok(())
++    }
++
++    /// The unit a handler is suspended on, if any. The returned reference is
++    /// into a `Box`, so its address is stable until the token completes.
++    #[inline]
++    pub fn suspended_token_mut(&mut self) -> Option<&mut SuspendedToken<H>> {
++        self.suspended.as_mut()
++    }
++
++    /// Runs the handlers that had not yet run for the parked token and hands
++    /// the completed token back for serialization. If another handler
++    /// suspends, the (already owned) unit is re-parked at its *same* heap
++    /// address and the suspension error propagates.
++    ///
++    /// Must not be called for a parked `DocumentEnd`; use
++    /// [`Self::resume_suspended_document_end`].
++    pub fn resume_suspended_token(
++        &mut self,
++        current_element_data: Option<&mut ElementDescriptor>,
++    ) -> Result<Token<'static>, Box<dyn std::error::Error + Send + Sync>> {
++        match self
++            .suspended
++            .take()
++            .expect("resume_suspended_token called without a pending suspension")
++        {
++            SuspendedToken::Element {
++                mut element,
++                next_handler_idx,
++            } => {
++                let mut next = next_handler_idx;
++                if let Err(e) = self
++                    .element_handlers
++                    .do_for_each_active_and_deactivate_from(next_handler_idx, &mut next, |h| {
++                        h(&mut element)
++                    })
++                {
++                    if is_suspension_request(&*e) {
++                        self.suspended = Some(SuspendedToken::Element {
++                            element,
++                            next_handler_idx: next,
++                        });
++                    }
++                    return Err(e);
++                }
++
++                debug_assert!(!self.next_element_can_have_content || element.can_have_content());
++                let (start_tag, should_remove_content, end_tag_handler) =
++                    element.into_owned_parts();
++                self.apply_element_result(
++                    should_remove_content,
++                    end_tag_handler,
++                    current_element_data,
++                );
++                Ok(Token::StartTag(*start_tag))
++            }
++            SuspendedToken::EndTag(mut end_tag) => {
++                if let Err(e) = self
++                    .end_tag_handlers
++                    .do_for_each_active_and_remove(|h| h(&mut end_tag))
++                {
++                    if is_suspension_request(&*e) {
++                        self.suspended = Some(SuspendedToken::EndTag(end_tag));
++                    }
++                    return Err(e);
++                }
++                Ok(Token::EndTag(*end_tag))
++            }
++            SuspendedToken::TextChunk {
++                mut chunk,
++                next_handler_idx,
++            } => {
++                let mut next = next_handler_idx;
++                if let Err(e) =
++                    self.text_handlers
++                        .for_each_active_from(next_handler_idx, &mut next, |h| h(&mut chunk))
++                {
++                    if is_suspension_request(&*e) {
++                        self.suspended = Some(SuspendedToken::TextChunk {
++                            chunk,
++                            next_handler_idx: next,
++                        });
++                    }
++                    return Err(e);
++                }
++                Ok(Token::TextChunk(*chunk))
++            }
++            SuspendedToken::Comment {
++                mut comment,
++                next_handler_idx,
++            } => {
++                let mut next = next_handler_idx;
++                if let Err(e) =
++                    self.comment_handlers
++                        .for_each_active_from(next_handler_idx, &mut next, |h| h(&mut comment))
++                {
++                    if is_suspension_request(&*e) {
++                        self.suspended = Some(SuspendedToken::Comment {
++                            comment,
++                            next_handler_idx: next,
++                        });
++                    }
++                    return Err(e);
++                }
++                Ok(Token::Comment(*comment))
++            }
++            SuspendedToken::Doctype {
++                mut doctype,
++                next_handler_idx,
++            } => {
++                let mut next = next_handler_idx;
++                if let Err(e) =
++                    self.doctype_handlers
++                        .for_each_active_from(next_handler_idx, &mut next, |h| h(&mut doctype))
++                {
++                    if is_suspension_request(&*e) {
++                        self.suspended = Some(SuspendedToken::Doctype {
++                            doctype,
++                            next_handler_idx: next,
++                        });
++                    }
++                    return Err(e);
++                }
++                Ok(Token::Doctype(*doctype))
++            }
++            SuspendedToken::DocumentEnd(_) => {
++                unreachable!("a DocumentEnd suspension is resumed through resume_finish")
++            }
++        }
++    }
++
++    /// Runs the remaining document-end handlers for the parked
++    /// [`DocumentEnd`]. See [`Self::resume_suspended_token`].
++    pub fn resume_suspended_document_end(
++        &mut self,
++    ) -> Result<DocumentEnd<'static>, Box<dyn std::error::Error + Send + Sync>> {
++        let Some(SuspendedToken::DocumentEnd(mut document_end)) = self.suspended.take() else {
++            unreachable!("resume_suspended_document_end called without a parked DocumentEnd")
++        };
++
++        if let Err(e) = self
++            .end_handlers
++            .do_for_each_active_and_remove(|h| h(&mut document_end))
++        {
++            if is_suspension_request(&*e) {
++                self.suspended = Some(SuspendedToken::DocumentEnd(document_end));
++            }
++            return Err(e);
++        }
++
++        Ok(*document_end)
+     }
+ 
+     #[inline]
+--- a/src/rewriter/mod.rs
++++ b/src/rewriter/mod.rs
+@@ -4,12 +4,13 @@ mod rewrite_controller;
+ #[macro_use]
+ pub(crate) mod settings;
+ 
++use self::handlers_dispatcher::SuspendedToken;
+ use self::rewrite_controller::{ElementDescriptor, HtmlRewriteController};
+ pub use self::settings::*;
+ use crate::base::SharedEncoding;
+ use crate::memory::{MemoryLimitExceededError, SharedMemoryLimiter};
+ use crate::parser::ParsingAmbiguityError;
+-use crate::rewritable_units::Element;
++use crate::rewritable_units::{Comment, Doctype, DocumentEnd, Element, EndTag, TextChunk};
+ use crate::transform_stream::*;
+ use encoding_rs::Encoding;
+ use mime::Mime;
+@@ -58,11 +59,30 @@ impl TryFrom<&'static Encoding> for AsciiCompatibleEncoding {
+     }
+ }
+ 
++/// Returned from a content handler (as `Err(Box::new(SuspensionRequest))`) to
++/// make the rewriter park the current rewritable unit and exit `write()`/
++/// `end()` with [`RewritingError::Suspended`] instead of running the rest of
++/// the handlers for it.
++///
++/// Unlike every other handler error, a suspension does **not** poison the
++/// rewriter. The parked unit stays alive (reachable through the
++/// `HtmlRewriter::suspended_*` accessors) until [`HtmlRewriter::resume`] is
++/// called, which runs the remaining handlers for it and continues the
++/// document.
++///
++/// This is the hook an embedder with asynchronous content handlers uses to
++/// get out of `write()` without nesting an event loop inside it: park, return
++/// to the real event loop, and `resume()` once the handler's pending work has
++/// settled.
++#[derive(Error, Debug)]
++#[error("the content handler requested suspension")]
++pub struct SuspensionRequest;
++
+ /// A compound error type that can be returned by [`write`] and [`end`] methods of the rewriter.
+ ///
+ /// # Note
+-/// This error is unrecoverable. The rewriter instance will panic on attempt to use it after such an
+-/// error.
++/// This error is unrecoverable (except for [`Suspended`](Self::Suspended)).
++/// The rewriter instance will panic on attempt to use it after such an error.
+ ///
+ /// [`write`]: ../struct.HtmlRewriter.html#method.write
+ /// [`end`]: ../struct.HtmlRewriter.html#method.end
+@@ -83,6 +103,33 @@ pub enum RewritingError {
+     /// An error that was propagated from one of the content handlers.
+     #[error("{0}")]
+     ContentHandlerError(Box<dyn StdError + Send + Sync + 'static>),
++
++    /// A content handler returned [`SuspensionRequest`]. The rewriter parked
++    /// its state and returned early; it is **not** poisoned. Call
++    /// [`HtmlRewriter::resume`] to continue.
++    #[error("the rewriter is suspended on a content handler")]
++    Suspended,
++}
++
++/// Maps a content handler's error onto [`RewritingError`], turning the
++/// [`SuspensionRequest`] sentinel into [`RewritingError::Suspended`] so the
++/// rest of the pipeline can match on the variant instead of downcasting.
++#[inline]
++pub(crate) fn content_handler_error(
++    e: Box<dyn StdError + Send + Sync + 'static>,
++) -> RewritingError {
++    if e.is::<SuspensionRequest>() {
++        RewritingError::Suspended
++    } else {
++        RewritingError::ContentHandlerError(e)
++    }
++}
++
++/// `true` for the [`SuspensionRequest`] sentinel a content handler returns to
++/// suspend the rewriter.
++#[inline]
++pub(crate) fn is_suspension_request(e: &(dyn StdError + Send + Sync + 'static)) -> bool {
++    e.is::<SuspensionRequest>()
+ }
+ 
+ /// A streaming HTML rewriter.
+@@ -139,8 +186,12 @@ macro_rules! guarded {
+ 
+         let res = $expr;
+ 
+-        if res.is_err() {
+-            $self.poisoned = true;
++        // `Suspended` is the one non-fatal escape: the rewriter parked its
++        // state and expects `resume()` to be called.
++        if let Err(e) = &res {
++            if !matches!(e, RewritingError::Suspended) {
++                $self.poisoned = true;
++            }
+         }
+ 
+         res
+@@ -210,8 +261,87 @@ impl<'h, O: OutputSink, H: HandlerTypes> HtmlRewriter<'h, O, H> {
+     /// [`write`]: struct.HtmlRewriter.html#method.write
+     #[inline]
+     pub fn end(mut self) -> Result<(), RewritingError> {
++        self.end_mut()
++    }
++
++    /// Same as [`end`](Self::end), but keeps the rewriter alive. Required
++    /// when content handlers can suspend: the rewriter must survive an
++    /// `Err(RewritingError::Suspended)` so [`resume`](Self::resume) can be
++    /// called on it. No further `write` may follow.
++    #[inline]
++    pub fn end_mut(&mut self) -> Result<(), RewritingError> {
+         guarded!(self, self.stream.end())
+     }
++
++    /// `true` if a content handler returned [`SuspensionRequest`] during the
++    /// last `write()`/`end_mut()`/`resume()` call and the rewriter is
++    /// waiting for [`resume`](Self::resume).
++    #[inline]
++    pub fn is_suspended(&self) -> bool {
++        self.stream.is_suspended()
++    }
++
++    /// Continues a rewrite that a content handler suspended (see
++    /// [`SuspensionRequest`]): runs the remaining handlers for the parked
++    /// rewritable unit, serializes it, and keeps going until the suspended
++    /// operation (`write` or `end_mut`) completes or another handler
++    /// suspends.
++    ///
++    /// If the suspension happened during `write()`, the caller still has to
++    /// call [`end_mut`](Self::end_mut) once this returns `Ok`.
++    #[inline]
++    pub fn resume(&mut self) -> Result<(), RewritingError> {
++        guarded!(self, self.stream.resume())
++    }
++
++    /// The [`Element`] a handler is suspended on, if any. Its address is
++    /// stable until the element's handlers all complete.
++    pub fn suspended_element(&mut self) -> Option<&mut Element<'static, 'static, H>> {
++        match self.stream.controller_mut().suspended_token_mut()? {
++            SuspendedToken::Element { element, .. } => Some(element),
++            _ => None,
++        }
++    }
++
++    /// The [`EndTag`] a handler is suspended on, if any.
++    pub fn suspended_end_tag(&mut self) -> Option<&mut EndTag<'static>> {
++        match self.stream.controller_mut().suspended_token_mut()? {
++            SuspendedToken::EndTag(end_tag) => Some(end_tag),
++            _ => None,
++        }
++    }
++
++    /// The [`TextChunk`] a handler is suspended on, if any.
++    pub fn suspended_text_chunk(&mut self) -> Option<&mut TextChunk<'static>> {
++        match self.stream.controller_mut().suspended_token_mut()? {
++            SuspendedToken::TextChunk { chunk, .. } => Some(chunk),
++            _ => None,
++        }
++    }
++
++    /// The [`Comment`] a handler is suspended on, if any.
++    pub fn suspended_comment(&mut self) -> Option<&mut Comment<'static>> {
++        match self.stream.controller_mut().suspended_token_mut()? {
++            SuspendedToken::Comment { comment, .. } => Some(comment),
++            _ => None,
++        }
++    }
++
++    /// The [`Doctype`] a handler is suspended on, if any.
++    pub fn suspended_doctype(&mut self) -> Option<&mut Doctype<'static>> {
++        match self.stream.controller_mut().suspended_token_mut()? {
++            SuspendedToken::Doctype { doctype, .. } => Some(doctype),
++            _ => None,
++        }
++    }
++
++    /// The [`DocumentEnd`] a handler is suspended on, if any.
++    pub fn suspended_document_end(&mut self) -> Option<&mut DocumentEnd<'static>> {
++        match self.stream.controller_mut().suspended_token_mut()? {
++            SuspendedToken::DocumentEnd(document_end) => Some(document_end),
++            _ => None,
++        }
++    }
+ }
+ 
+ // NOTE: this opaque Debug implementation is required to make
+@@ -992,4 +1122,467 @@ mod tests {
+             );
+         }
+     }
++
++    /// Content-handler suspension (see [`SuspensionRequest`]).
++    mod suspension {
++        use super::*;
++        use std::cell::{Cell, RefCell};
++        use std::rc::Rc;
++
++        type TestSink = Box<dyn FnMut(&[u8])>;
++
++        /// Drives `write(chunk)*` + `end_mut()` to completion, invoking
++        /// `on_suspend(&mut rewriter)` after every suspension and then
++        /// `resume()`-ing. Returns the output and the suspension count.
++        fn drive<'h>(
++            chunks: &[&str],
++            settings: Settings<'h, '_>,
++            mut on_suspend: impl FnMut(&mut HtmlRewriter<'h, TestSink>),
++        ) -> (String, usize) {
++            let out = Rc::new(RefCell::new(Vec::<u8>::new()));
++            let out_in_sink = Rc::clone(&out);
++            let sink: TestSink = Box::new(move |c: &[u8]| {
++                out_in_sink.borrow_mut().extend_from_slice(c);
++            });
++
++            let mut rewriter = HtmlRewriter::new(settings, sink);
++            let mut suspensions = 0;
++
++            let mut pump = |rewriter: &mut HtmlRewriter<'h, TestSink>,
++                            mut res: Result<(), RewritingError>| {
++                loop {
++                    match res {
++                        Ok(()) => return,
++                        Err(RewritingError::Suspended) => {
++                            assert!(rewriter.is_suspended());
++                            suspensions += 1;
++                            on_suspend(rewriter);
++                            res = rewriter.resume();
++                        }
++                        Err(e) => panic!("unexpected rewriting error: {e}"),
++                    }
++                }
++            };
++
++            for chunk in chunks {
++                let res = rewriter.write(chunk.as_bytes());
++                pump(&mut rewriter, res);
++            }
++            let res = rewriter.end_mut();
++            pump(&mut rewriter, res);
++
++            assert!(!rewriter.is_suspended());
++            drop(rewriter);
++
++            let out = Rc::try_unwrap(out).unwrap().into_inner();
++            (String::from_utf8(out).unwrap(), suspensions)
++        }
++
++        const SUSPEND: fn() -> HandlerResult = || Err(SuspensionRequest.into());
++
++        #[test]
++        fn element_identity() {
++            // A handler that only ever suspends must not change the output.
++            let (out, n) = drive(
++                &[r#"a<div id="x">b<span>c</span></div>d"#],
++                Settings {
++                    element_content_handlers: vec![element!("div, span", |_| SUSPEND())],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(out, r#"a<div id="x">b<span>c</span></div>d"#);
++            assert_eq!(n, 2);
++        }
++
++        #[test]
++        fn element_mutations_before_and_after_suspension() {
++            let (out, n) = drive(
++                &["<div>content</div><div>two</div>"],
++                Settings {
++                    element_content_handlers: vec![element!("div", |el| {
++                        // Mutations made *before* suspending must survive it.
++                        el.set_attribute("pre", "1")?;
++                        el.before("[", ContentType::Text);
++                        SUSPEND()
++                    })],
++                    ..Settings::new()
++                },
++                |rewriter| {
++                    // Mutations made *during* the suspension, through the
++                    // parked (heap-allocated) element.
++                    let el = rewriter.suspended_element().unwrap();
++                    el.set_attribute("post", "2").unwrap();
++                    el.set_inner_content("REPLACED", ContentType::Text);
++                },
++            );
++            assert_eq!(
++                out,
++                r#"[<div pre="1" post="2">REPLACED</div>[<div pre="1" post="2">REPLACED</div>"#
++            );
++            assert_eq!(n, 2);
++        }
++
++        #[test]
++        fn later_element_handlers_run_after_resume() {
++            let order = Rc::new(RefCell::new(Vec::new()));
++            let (o1, o2, o3) = (order.clone(), order.clone(), order.clone());
++            let (out, n) = drive(
++                &["<div></div>"],
++                Settings {
++                    element_content_handlers: vec![
++                        element!("div", move |el| {
++                            o1.borrow_mut().push("a");
++                            el.set_attribute("a", "")?;
++                            SUSPEND()
++                        }),
++                        element!("div", move |el| {
++                            o2.borrow_mut().push("b");
++                            el.set_attribute("b", "")?;
++                            SUSPEND()
++                        }),
++                        element!("div", move |el| {
++                            o3.borrow_mut().push("c");
++                            el.set_attribute("c", "")?;
++                            Ok(())
++                        }),
++                    ],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(*order.borrow(), ["a", "b", "c"]);
++            assert_eq!(out, r#"<div a="" b="" c=""></div>"#);
++            assert_eq!(n, 2);
++        }
++
++        #[test]
++        fn remove_across_suspension() {
++            // `el.remove()` affects the parser's emission gating through the
++            // `handle_tag` epilogue, which the suspension skips and the
++            // resume has to replay.
++            let (out, n) = drive(
++                &["a<div>gone<span>too</span></div>b"],
++                Settings {
++                    element_content_handlers: vec![element!("div", |el| {
++                        el.remove();
++                        SUSPEND()
++                    })],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(out, "ab");
++            assert_eq!(n, 1);
++        }
++
++        #[test]
++        fn remove_during_suspension() {
++            // Same, but `remove()` is called on the parked element.
++            let (out, n) = drive(
++                &["a<div>gone<span>too</span></div>b"],
++                Settings {
++                    element_content_handlers: vec![element!("div", |_| SUSPEND())],
++                    ..Settings::new()
++                },
++                |rewriter| rewriter.suspended_element().unwrap().remove(),
++            );
++            assert_eq!(out, "ab");
++            assert_eq!(n, 1);
++        }
++
++        #[test]
++        fn set_tag_name_and_end_tag_handler_across_suspension() {
++            let (out, n) = drive(
++                &["<div>x</div>"],
++                Settings {
++                    element_content_handlers: vec![element!("div", |el: &mut Element<'_, '_>| {
++                        el.set_tag_name("section").unwrap();
++                        el.end_tag_handlers().unwrap().push(Box::new(|end| {
++                            end.before("!", ContentType::Text);
++                            Ok(())
++                        }));
++                        SUSPEND()
++                    })],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(out, "<section>x!</section>");
++            assert_eq!(n, 1);
++        }
++
++        #[test]
++        fn end_tag_handler_suspension() {
++            let (out, n) = drive(
++                &["<div>x</div>y"],
++                Settings {
++                    element_content_handlers: vec![element!("div", |el: &mut Element<'_, '_>| {
++                        el.end_tag_handlers().unwrap().push(Box::new(|_| SUSPEND()));
++                        Ok(())
++                    })],
++                    ..Settings::new()
++                },
++                |rewriter| {
++                    rewriter
++                        .suspended_end_tag()
++                        .unwrap()
++                        .after("#", ContentType::Text);
++                },
++            );
++            assert_eq!(out, "<div>x</div>#y");
++            assert_eq!(n, 1);
++        }
++
++        #[test]
++        fn text_suspension() {
++            // Suspends on every text chunk, including the empty
++            // `last_in_text_node` one fired just before the closing tag.
++            let seen = Rc::new(RefCell::new(Vec::new()));
++            let seen2 = seen.clone();
++            let (out, n) = drive(
++                &["<div>hello</div>"],
++                Settings {
++                    element_content_handlers: vec![text!("div", move |t| {
++                        seen2
++                            .borrow_mut()
++                            .push((t.as_str().to_owned(), t.last_in_text_node()));
++                        SUSPEND()
++                    })],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(out, "<div>hello</div>");
++            assert_eq!(
++                *seen.borrow(),
++                [("hello".to_owned(), false), (String::new(), true)]
++            );
++            assert_eq!(n, 2);
++        }
++
++        #[test]
++        fn text_suspension_replace_during() {
++            let (out, n) = drive(
++                &["<div>hello</div>"],
++                Settings {
++                    element_content_handlers: vec![text!("div", |t| {
++                        if t.last_in_text_node() {
++                            Ok(())
++                        } else {
++                            SUSPEND()
++                        }
++                    })],
++                    ..Settings::new()
++                },
++                |rewriter| {
++                    let chunk = rewriter.suspended_text_chunk().unwrap();
++                    assert_eq!(chunk.as_str(), "hello");
++                    chunk.replace("goodbye", ContentType::Text);
++                },
++            );
++            assert_eq!(out, "<div>goodbye</div>");
++            assert_eq!(n, 1);
++        }
++
++        #[test]
++        fn last_text_chunk_suspension_does_not_drop_the_following_element() {
++            // The `last_in_text_node` chunk is flushed from inside the
++            // lexer action that is about to emit the *next* lexeme.
++            // Suspending there must not lose that lexeme: it gets re-lexed
++            // from the suspension bookmark on resume.
++            let (out, n) = drive(
++                &["<div>text<span>inner</span>tail<!--c--></div>"],
++                Settings {
++                    element_content_handlers: vec![
++                        (
++                            Cow::Owned("div".parse().unwrap()),
++                            ElementContentHandlers::default().text(|t: &mut TextChunk<'_>| {
++                                if t.last_in_text_node() {
++                                    SUSPEND()
++                                } else {
++                                    Ok(())
++                                }
++                            }),
++                        ),
++                        element!("span", |el| {
++                            el.set_attribute("hit", "")?;
++                            Ok(())
++                        }),
++                        comments!("div", |c| {
++                            c.set_text("seen").unwrap();
++                            Ok(())
++                        }),
++                    ],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            assert_eq!(
++                out,
++                r#"<div>text<span hit="">inner</span>tail<!--seen--></div>"#
++            );
++            // `<span>`, `</span>`, and `<!--c-->` each end a text node
++            // (there's no text between `-->` and `</div>`, so that flush
++            // is a no-op).
++            assert_eq!(n, 3);
++        }
++
++        #[test]
++        fn comment_suspension() {
++            let (out, n) = drive(
++                &["<div><!--a--></div><!--b-->"],
++                Settings {
++                    element_content_handlers: vec![comments!("div", |_| SUSPEND())],
++                    document_content_handlers: vec![doc_comments!(|_| SUSPEND())],
++                    ..Settings::new()
++                },
++                |rewriter| {
++                    let comment = rewriter.suspended_comment().unwrap();
++                    let text = comment.text();
++                    comment.set_text(&format!("{text}{text}")).unwrap();
++                },
++            );
++            // `<!--a-->` is matched by both the element and the document
++            // handler, so it suspends (and gets doubled) twice.
++            assert_eq!(out, "<div><!--aaaa--></div><!--bb-->");
++            assert_eq!(n, 3);
++        }
++
++        #[test]
++        fn doctype_suspension() {
++            let (out, n) = drive(
++                &["<!DOCTYPE html><p>x</p>"],
++                Settings {
++                    document_content_handlers: vec![doctype!(|_| SUSPEND())],
++                    ..Settings::new()
++                },
++                |rewriter| {
++                    let doctype = rewriter.suspended_doctype().unwrap();
++                    assert_eq!(doctype.name(), Some("html".into()));
++                },
++            );
++            assert_eq!(out, "<!DOCTYPE html><p>x</p>");
++            assert_eq!(n, 1);
++        }
++
++        #[test]
++        fn document_end_suspension() {
++            let (out, n) = drive(
++                &["<div></div>"],
++                Settings {
++                    document_content_handlers: vec![end!(|end| {
++                        end.append("<early>", ContentType::Html);
++                        SUSPEND()
++                    })],
++                    ..Settings::new()
++                },
++                |rewriter| {
++                    rewriter
++                        .suspended_document_end()
++                        .unwrap()
++                        .append("<late>", ContentType::Html);
++                },
++            );
++            assert_eq!(out, "<div></div><early><late>");
++            assert_eq!(n, 1);
++        }
++
++        #[test]
++        fn script_content_model_survives_suspension() {
++            // `<b>` inside `<script>` must stay raw text after the resume,
++            // i.e. the bookmark restores the ScriptData text type the
++            // tree-builder feedback set before the handler ran.
++            let (out, n) = drive(
++                &["<script>a<b>c</script><b>d</b>"],
++                Settings {
++                    element_content_handlers: vec![element!("script, b", |el| {
++                        el.set_attribute("hit", "")?;
++                        SUSPEND()
++                    })],
++                    ..Settings::new()
++                },
++                |_| {},
++            );
++            // Only `<script>` and the *real* `<b>` match; the one inside the
++            // script is raw text.
++            assert_eq!(out, r#"<script hit="">a<b>c</script><b hit="">d</b>"#);
++            assert_eq!(n, 2);
++        }
++
++        #[test]
++        fn multi_chunk_input() {
++            for chunk_size in [1, 2, 3, 7] {
++                let html = r#"pre<div id="a">in<span>ner</span></div><!--c-->post"#;
++                let chunks: Vec<String> = html
++                    .as_bytes()
++                    .chunks(chunk_size)
++                    .map(|c| String::from_utf8(c.to_vec()).unwrap())
++                    .collect();
++                let chunks: Vec<&str> = chunks.iter().map(String::as_str).collect();
++
++                let (out, n) = drive(
++                    &chunks,
++                    Settings {
++                        element_content_handlers: vec![element!("div, span", |el| {
++                            el.set_attribute("hit", "")?;
++                            SUSPEND()
++                        })],
++                        document_content_handlers: vec![doc_comments!(|_| SUSPEND())],
++                        ..Settings::new()
++                    },
++                    |_| {},
++                );
++                assert_eq!(
++                    out, r#"pre<div id="a" hit="">in<span hit="">ner</span></div><!--c-->post"#,
++                    "chunk_size={chunk_size}"
++                );
++                assert_eq!(n, 3, "chunk_size={chunk_size}");
++            }
++        }
++
++        #[test]
++        fn suspension_does_not_poison() {
++            let mut rewriter = HtmlRewriter::new(
++                Settings {
++                    element_content_handlers: vec![element!("div", |_| SUSPEND())],
++                    encoding: AsciiCompatibleEncoding::utf_8(),
++                    ..Settings::new()
++                },
++                |_: &[u8]| {},
++            );
++
++            assert!(matches!(
++                rewriter.write(b"<div>"),
++                Err(RewritingError::Suspended)
++            ));
++            // A poisoned rewriter would panic here.
++            rewriter.resume().unwrap();
++            rewriter.end_mut().unwrap();
++        }
++
++        #[test]
++        fn real_handler_error_still_poisons() {
++            let mut rewriter = HtmlRewriter::new(
++                Settings {
++                    element_content_handlers: vec![element!("div", |_| Err("boom".into()))],
++                    encoding: AsciiCompatibleEncoding::utf_8(),
++                    ..Settings::new()
++                },
++                |_: &[u8]| {},
++            );
++
++            assert!(matches!(
++                rewriter.write(b"<div>"),
++                Err(RewritingError::ContentHandlerError(_))
++            ));
++            assert!(!rewriter.is_suspended());
++            assert!(
++                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
++                    let _ = rewriter.write(b"x");
++                }))
++                .is_err()
++            );
++        }
++    }
+ }
+--- a/src/rewriter/rewrite_controller.rs
++++ b/src/rewriter/rewrite_controller.rs
+@@ -1,5 +1,5 @@
+ use super::handlers_dispatcher::{ContentHandlersDispatcher, SelectorHandlersLocator};
+-use super::{HandlerTypes, RewritingError, Settings};
++use super::{HandlerTypes, RewritingError, Settings, content_handler_error};
+ use crate::base::SharedEncoding;
+ use crate::html::{LocalName, Namespace};
+ use crate::memory::SharedMemoryLimiter;
+@@ -9,6 +9,8 @@ use crate::selectors_vm::{AuxStartTagInfoRequest, ElementData, SelectorMatchingV
+ use crate::transform_stream::{DispatcherError, StartTagHandlingResult, TransformController};
+ use hashbrown::{DefaultHashBuilder, HashSet};
+ 
++pub(crate) use super::handlers_dispatcher::SuspendedToken;
++
+ pub(crate) struct ElementDescriptor {
+     pub matched_content_handlers: HashSet<SelectorHandlersLocator>,
+     pub end_tag_handler_idx: Option<usize>,
+@@ -123,6 +125,12 @@ impl<H: HandlerTypes> HtmlRewriteController<'_, H> {
+     fn get_capture_flags(&self) -> TokenCaptureFlags {
+         self.handlers_dispatcher.get_token_capture_flags()
+     }
++
++    /// The rewritable unit a handler is currently suspended on, if any.
++    #[inline]
++    pub(crate) fn suspended_token_mut(&mut self) -> Option<&mut SuspendedToken<H>> {
++        self.handlers_dispatcher.suspended_token_mut()
++    }
+ }
+ 
+ impl<H: HandlerTypes> TransformController for HtmlRewriteController<'_, H> {
+@@ -173,13 +181,30 @@ impl<H: HandlerTypes> TransformController for HtmlRewriteController<'_, H> {
+ 
+         self.handlers_dispatcher
+             .handle_token(token, current_element_data)
+-            .map_err(RewritingError::ContentHandlerError)
++            .map_err(content_handler_error)
+     }
+ 
+     fn handle_end(&mut self, document_end: &mut DocumentEnd<'_>) -> Result<(), RewritingError> {
+         self.handlers_dispatcher
+             .handle_end(document_end)
+-            .map_err(RewritingError::ContentHandlerError)
++            .map_err(content_handler_error)
++    }
++
++    fn resume_suspended_token(&mut self) -> Result<Token<'static>, RewritingError> {
++        let current_element_data = self
++            .selector_matching_vm
++            .as_mut()
++            .and_then(SelectorMatchingVm::current_element_data_mut);
++
++        self.handlers_dispatcher
++            .resume_suspended_token(current_element_data)
++            .map_err(content_handler_error)
++    }
++
++    fn resume_suspended_document_end(&mut self) -> Result<DocumentEnd<'static>, RewritingError> {
++        self.handlers_dispatcher
++            .resume_suspended_document_end()
++            .map_err(content_handler_error)
+     }
+ 
+     #[inline]
+--- a/src/transform_stream/dispatcher.rs
++++ b/src/transform_stream/dispatcher.rs
+@@ -3,8 +3,7 @@ use crate::html::{LocalName, Namespace};
+ use crate::html_content::{TextChunk, TextType};
+ use crate::parser::{
+     ActionError, ActionResult, AttributeBuffer, Lexeme, LexemeSink, NonTagContentLexeme,
+-    NonTagContentTokenOutline, ParserDirective, ParserOutputSink, TagHintSink, TagLexeme,
+-    TagTokenOutline,
++    ParserDirective, ParserOutputSink, TagHintSink, TagLexeme, TagTokenOutline,
+ };
+ use crate::rewritable_units::TextDecoder;
+ use crate::rewritable_units::ToTokenResult;
+@@ -43,6 +42,40 @@ pub trait TransformController: Sized {
+     fn handle_token(&mut self, token: &mut Token<'_>) -> Result<(), RewritingError>;
+     fn handle_end(&mut self, document_end: &mut DocumentEnd<'_>) -> Result<(), RewritingError>;
+     fn should_emit_content(&self) -> bool;
++
++    /// Runs the handlers that had not yet run for the token a previous
++    /// `handle_token` parked (see [`RewritingError::Suspended`]) and returns
++    /// the completed, owned token for serialization. May suspend again.
++    ///
++    /// Only called after `handle_token` returned `RewritingError::Suspended`.
++    fn resume_suspended_token(&mut self) -> Result<Token<'static>, RewritingError> {
++        unreachable!("this TransformController does not support suspension")
++    }
++
++    /// Same as [`Self::resume_suspended_token`], for a [`DocumentEnd`] that
++    /// `handle_end` parked.
++    fn resume_suspended_document_end(&mut self) -> Result<DocumentEnd<'static>, RewritingError> {
++        unreachable!("this TransformController does not support suspension")
++    }
++}
++
++/// Where in the dispatch pipeline a suspension escaped from. Decides which
++/// epilogue [`Dispatcher::resume_dispatch`] has to replay.
++#[derive(Copy, Clone)]
++enum SuspensionSite {
++    /// `handle_tag`'s `try_produce_token_from_lexeme`: the tag's own token.
++    /// The `emission_enabled` update and the returned `ParserDirective` were
++    /// skipped and must be recomputed on resume.
++    Tag,
++    /// `handle_non_tag_content` or the pre-lexeme `flush_pending_text`:
++    /// neither has an epilogue, and the parser directive doesn't change.
++    NonTag,
++}
++
++/// `true` iff `e` is the non-fatal suspension escape.
++#[inline]
++fn is_suspension(e: &ActionError) -> bool {
++    matches!(e, ActionError::RewritingError(RewritingError::Suspended))
+ }
+ 
+ /// Defines an interface for the [`HtmlRewriter`]'s output.
+@@ -74,6 +107,9 @@ pub struct Dispatcher<C, O> {
+     got_flags_from_hint: bool,
+     pending_element_aux_info_req: Option<AuxStartTagInfoRequest<C>>,
+     encoding: SharedEncoding,
++    /// `Some` while a content handler has the dispatch suspended. The parked
++    /// token itself lives on the transform controller.
++    suspended_at: Option<SuspensionSite>,
+ }
+ 
+ /// Fields split out of `Dispatcher` for borrow checking of event handlers
+@@ -107,10 +143,18 @@ where
+     fn finish(&mut self, encoding: &'static Encoding, input: &[u8]) -> Result<(), RewritingError> {
+         self.flush_remaining_input(input, input.len());
+ 
+-        let mut document_end = DocumentEnd::new(&mut self.output_sink, encoding);
++        let mut document_end = DocumentEnd::new(encoding);
+ 
+         self.transform_controller.handle_end(&mut document_end)?;
+ 
++        self.flush_document_end(document_end)
++    }
++
++    /// Encode the buffered document-end appends to the output sink and emit
++    /// the zero-length finalizing chunk.
++    fn flush_document_end(&mut self, document_end: DocumentEnd<'_>) -> Result<(), RewritingError> {
++        document_end.flush_into(&mut self.output_sink)?;
++
+         // NOTE: output the finalizing chunk.
+         self.output_sink.handle_chunk(&[]);
+ 
+@@ -200,6 +244,7 @@ where
+             encoding,
+             got_flags_from_hint: false,
+             pending_element_aux_info_req: None,
++            suspended_at: None,
+         }
+     }
+ 
+@@ -350,6 +395,85 @@ where
+     pub fn finish(&mut self, input: &[u8]) -> Result<(), RewritingError> {
+         self.delegate.finish(self.encoding.get(), input)
+     }
++
++    /// The transform controller, for reaching the parked token of a
++    /// suspension from the embedder.
++    pub(crate) const fn transform_controller_mut(&mut self) -> &mut C {
++        &mut self.delegate.transform_controller
++    }
++
++    /// Completes a dispatch that a content handler suspended: runs the
++    /// remaining handlers for the parked token, serializes it, drains the
++    /// rest of the text lexeme it may have come from, and replays the
++    /// `handle_tag` epilogue the suspension skipped.
++    ///
++    /// Returns the `ParserDirective` that `handle_tag` never got to return,
++    /// or `None` when the suspension was not on a tag lexeme's own token (the
++    /// directive is then unchanged).
++    ///
++    /// If a later handler suspends, the new token is parked (the dispatcher
++    /// stays suspended) and `RewritingError::Suspended` is returned; call
++    /// again once it settles.
++    pub(crate) fn resume_dispatch(&mut self) -> Result<Option<ParserDirective>, RewritingError> {
++        let site = *self
++            .suspended_at
++            .as_ref()
++            .expect("resume_dispatch called without a pending suspension");
++
++        // 1. The handlers that had not yet run for the parked token.
++        let token = self
++            .delegate
++            .transform_controller
++            .resume_suspended_token()?;
++
++        // 2. The serialization step `token_produced`/`text_token_produced`
++        //    never reached.
++        if self.delegate.emission_enabled {
++            token.into_bytes(&mut |c| self.delegate.output_sink.handle_chunk(c))?;
++        }
++
++        // 3. If the token was a chunk of a partially-decoded text lexeme,
++        //    keep feeding the decoder. Every produced chunk goes through
++        //    `text_token_produced` and can suspend again (re-recording the
++        //    decoder's state), so loop until the feed runs dry.
++        while let Some(feed) = self.text_decoder.take_suspended() {
++            self.text_decoder.resume_feed(
++                feed,
++                &mut |text, is_last, encoding, source_location| {
++                    self.delegate.text_token_produced(
++                        text,
++                        encoding,
++                        self.last_text_type,
++                        is_last,
++                        source_location,
++                    )
++                },
++            )?;
++        }
++
++        self.suspended_at = None;
++
++        match site {
++            SuspensionSite::Tag => {
++                // The epilogue of `handle_tag`.
++                self.delegate.emission_enabled =
++                    self.delegate.transform_controller.should_emit_content();
++
++                Ok(Some(self.get_next_parser_directive()))
++            }
++            SuspensionSite::NonTag => Ok(None),
++        }
++    }
++
++    /// Completes a `finish` that a document-end handler suspended.
++    pub(crate) fn resume_finish(&mut self) -> Result<(), RewritingError> {
++        let document_end = self
++            .delegate
++            .transform_controller
++            .resume_suspended_document_end()?;
++
++        self.delegate.flush_document_end(document_end)
++    }
+ }
+ 
+ impl<C, O> LexemeSink for Dispatcher<C, O>
+@@ -358,13 +482,9 @@ where
+     O: OutputSink,
+ {
+     fn handle_tag(&mut self, lexeme: &TagLexeme<'_>) -> ActionResult<ParserDirective> {
+-        // NOTE: flush pending text before reporting tag to the transform controller.
+-        // Otherwise, transform controller can enable or disable text handlers too early.
+-        // In case of start tag, newly matched element text handlers
+-        // will receive leftovers from the previous match. And, in case of end tag,
+-        // handlers will be disabled before the receive the finalizing chunk.
+-        self.flush_pending_captured_text()?;
+-
++        // NOTE: the pending captured text is flushed by the lexer *before*
++        // this lexeme was built (see `Lexer::emit_tag`), so by now the
++        // transform controller can safely enable/disable text handlers.
+         if self.got_flags_from_hint {
+             self.got_flags_from_hint = false;
+         } else {
+@@ -378,7 +498,13 @@ where
+             }
+         }
+ 
+-        self.try_produce_token_from_lexeme(lexeme)?;
++        if let Err(e) = self.try_produce_token_from_lexeme(lexeme) {
++            if is_suspension(&e) {
++                self.suspended_at = Some(SuspensionSite::Tag);
++            }
++            return Err(e);
++        }
++
+         self.delegate.emission_enabled = self.delegate.transform_controller.should_emit_content();
+ 
+         Ok(self.get_next_parser_directive())
+@@ -386,12 +512,26 @@ where
+ 
+     #[inline]
+     fn handle_non_tag_content(&mut self, lexeme: &NonTagContentLexeme<'_>) -> ActionResult {
+-        match lexeme.token_outline() {
+-            Some(NonTagContentTokenOutline::Text(_)) => {}
+-            // when it's None, it still needs a flush for CDATA
+-            _ => self.flush_pending_captured_text()?,
++        // NOTE: for non-text lexemes the pending captured text was already
++        // flushed by the lexer (see `Lexer::emit_current_token` & friends).
++        if let Err(e) = self.try_produce_token_from_lexeme(lexeme) {
++            if is_suspension(&e) {
++                self.suspended_at = Some(SuspensionSite::NonTag);
++            }
++            return Err(e);
+         }
+-        self.try_produce_token_from_lexeme(lexeme)
++        Ok(())
++    }
++
++    fn flush_pending_text(&mut self) -> ActionResult {
++        if let Err(e) = self.flush_pending_captured_text() {
++            let e: Box<ActionError> = e.into();
++            if is_suspension(&e) {
++                self.suspended_at = Some(SuspensionSite::NonTag);
++            }
++            return Err(e);
++        }
++        Ok(())
+     }
+ }
+ 
+--- a/src/transform_stream/mod.rs
++++ b/src/transform_stream/mod.rs
+@@ -23,6 +23,19 @@ where
+     pub strict: bool,
+ }
+ 
++/// Which stage of the rewrite a content handler suspended, if any.
++#[derive(Copy, Clone, PartialEq, Eq)]
++enum SuspendedPhase {
++    /// Not suspended.
++    None,
++    /// `write()`'s parse suspended.
++    Write,
++    /// `end()`'s (final) parse suspended.
++    EndParse,
++    /// `end()`'s parse completed but a document-end handler suspended.
++    Finish,
++}
++
+ // Pub only for integration tests
+ pub struct TransformStream<C, O>
+ where
+@@ -32,6 +45,7 @@ where
+     parser: Parser<Dispatcher<C, O>>,
+     buffer: Arena,
+     has_buffered_data: bool,
++    suspended: SuspendedPhase,
+ }
+ 
+ impl<C, O> TransformStream<C, O>
+@@ -67,11 +81,13 @@ where
+             parser,
+             buffer,
+             has_buffered_data: false,
++            suspended: SuspendedPhase::None,
+         }
+     }
+ 
+     pub fn write(&mut self, data: &[u8]) -> Result<(), RewritingError> {
+         trace!(@write data);
++        debug_assert!(self.suspended == SuspendedPhase::None);
+ 
+         let chunk = if self.has_buffered_data {
+             self.buffer
+@@ -107,11 +123,20 @@ where
+             self.has_buffered_data = false;
+         }
+ 
++        // NOTE: a suspension reports `consumed_byte_count` exactly like an
++        // end-of-input, so the tail bookkeeping above already saved the
++        // unconsumed rest of the chunk for `resume`.
++        if self.parser.is_suspended() {
++            self.suspended = SuspendedPhase::Write;
++            return Err(RewritingError::Suspended);
++        }
++
+         Ok(())
+     }
+ 
+     pub fn end(&mut self) -> Result<(), RewritingError> {
+         trace!(@end);
++        debug_assert!(self.suspended == SuspendedPhase::None);
+ 
+         let chunk = if self.has_buffered_data {
+             self.buffer.bytes()
+@@ -121,8 +146,123 @@ where
+ 
+         trace!(@chunk chunk);
+ 
+-        self.parser.parse(chunk, true)?;
+-        self.parser.get_dispatcher().finish(chunk)
++        let total = chunk.len();
++        let consumed_byte_count = self.parser.parse(chunk, true)?;
++
++        if self.parser.is_suspended() {
++            // `finish` (which flushes the raw tail) won't run; emit the
++            // consumed part now and keep the rest for `resume`.
++            self.parser
++                .get_dispatcher()
++                .flush_remaining_input(chunk, consumed_byte_count);
++
++            if consumed_byte_count < total {
++                self.buffer.shift(consumed_byte_count);
++            } else {
++                self.has_buffered_data = false;
++            }
++
++            self.suspended = SuspendedPhase::EndParse;
++            return Err(RewritingError::Suspended);
++        }
++
++        match self.parser.get_dispatcher().finish(chunk) {
++            Err(RewritingError::Suspended) => {
++                self.suspended = SuspendedPhase::Finish;
++                Err(RewritingError::Suspended)
++            }
++            res => res,
++        }
++    }
++
++    /// `true` if a content handler suspended the last `write()`/`end()`/
++    /// `resume()` call.
++    pub const fn is_suspended(&self) -> bool {
++        !matches!(self.suspended, SuspendedPhase::None)
++    }
++
++    /// Continues a rewrite that a content handler suspended.
++    ///
++    /// Returns `Err(RewritingError::Suspended)` again if another handler
++    /// suspends. If the suspension happened during `write()`, the caller
++    /// still has to call `end()` once this returns `Ok`.
++    pub fn resume(&mut self) -> Result<(), RewritingError> {
++        match self.suspended {
++            SuspendedPhase::None => {
++                debug_assert!(false, "TransformStream::resume without a suspension");
++                Ok(())
++            }
++            SuspendedPhase::Write | SuspendedPhase::EndParse => {
++                let last = self.suspended == SuspendedPhase::EndParse;
++
++                // 1. Complete the parked dispatch. If another handler
++                //    suspends here, the parser bookmark and the buffered
++                //    tail are untouched; the phase stays as-is.
++                let directive = self.parser.get_dispatcher().resume_dispatch()?;
++
++                // 2. Continue the parse over the tail that was buffered at
++                //    suspension time (positions in the bookmark are
++                //    relative to it).
++                let chunk: &[u8] = if self.has_buffered_data {
++                    self.buffer.bytes()
++                } else {
++                    &[]
++                };
++
++                trace!(@chunk chunk);
++
++                let total = chunk.len();
++                let consumed_byte_count = self.parser.resume(chunk, last, directive)?;
++
++                self.parser
++                    .get_dispatcher()
++                    .flush_remaining_input(chunk, consumed_byte_count);
++
++                if consumed_byte_count < total {
++                    self.buffer.shift(consumed_byte_count);
++                } else {
++                    self.has_buffered_data = false;
++                }
++
++                if self.parser.is_suspended() {
++                    return Err(RewritingError::Suspended);
++                }
++
++                self.suspended = SuspendedPhase::None;
++
++                if !last {
++                    return Ok(());
++                }
++
++                // The final parse is done; run the document-end handlers.
++                let chunk: &[u8] = if self.has_buffered_data {
++                    self.buffer.bytes()
++                } else {
++                    &[]
++                };
++
++                match self.parser.get_dispatcher().finish(chunk) {
++                    Err(RewritingError::Suspended) => {
++                        self.suspended = SuspendedPhase::Finish;
++                        Err(RewritingError::Suspended)
++                    }
++                    res => res,
++                }
++            }
++            SuspendedPhase::Finish => match self.parser.get_dispatcher().resume_finish() {
++                Err(RewritingError::Suspended) => Err(RewritingError::Suspended),
++                res => {
++                    self.suspended = SuspendedPhase::None;
++                    res
++                }
++            },
++        }
++    }
++
++    /// The transform controller, for reaching the parked token of a
++    /// suspension from the embedder.
++    pub(crate) fn controller_mut(&mut self) -> &mut C {
++        self.parser.get_dispatcher().transform_controller_mut()
+     }
+ 
+     #[cfg(feature = "integration_test")]

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -33,6 +33,15 @@ export const lolhtml: Dependency = {
     commit: LOLHTML_COMMIT,
   }),
 
+  // Content-handler suspension: a handler can return
+  // `Err(SuspensionRequest)` to park the current rewritable unit on the
+  // heap and exit `write()`/`end()` with the non-poisoning
+  // `RewritingError::Suspended`; `HtmlRewriter::resume()` continues from
+  // there. HTMLRewriter needs this so an `async` JS content handler can
+  // suspend the rewrite and resume it from a promise reaction instead of
+  // spinning a nested event loop inside lol-html's `write()`.
+  patches: ["patches/lolhtml/content-handler-suspension.patch"],
+
   // No separate build — compiled as part of the workspace cargo build via
   // `bun_runtime`/`bun_bundler`'s path dep on `vendor/lolhtml`.
   build: () => ({ kind: "none" }),

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -185,6 +185,17 @@ pub struct VirtualMachine {
     pub pending_unref_counter: core::sync::atomic::AtomicI32,
     pub preload: Vec<Box<[u8]>>,
     pub unhandled_pending_rejection_to_capture: Option<*mut JSValue>,
+    /// LAYERING: the real type is `bun_runtime`'s
+    /// `html_rewriter::BufferOutputSink` (a forward dep), stored type-erased.
+    ///
+    /// The HTMLRewriter sink whose lol-html `write()`/`end()`/`resume()` call
+    /// is currently on this VM's native stack, if any. Content handlers reach
+    /// their sink through it (to record a thrown exception, and to park the JS
+    /// wrapper + pending promise when an async handler suspends the rewrite).
+    /// Saved and restored LIFO around every lol-html call, so a handler body
+    /// that synchronously starts a nested `transform()` nests correctly.
+    /// All-zero bytes decode as `None` (null niche).
+    pub html_rewriter_active_sink: Option<core::ptr::NonNull<c_void>>,
     // Note: layering — the concrete `bun_standalone_graph::Graph` lives
     // in a higher-tier crate. The resolver already broke that cycle with the
     // `bun_resolver::StandaloneModuleGraph` trait; we hold the same trait

--- a/src/jsc/bindings/NativePromiseContext.h
+++ b/src/jsc/bindings/NativePromiseContext.h
@@ -45,6 +45,7 @@ public:
         BodyValueBufferer,
         HTTPSServerH3RequestContext,
         DebugHTTPSServerH3RequestContext,
+        HTMLRewriterSuspension,
     };
 
     static NativePromiseContext* create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3949,6 +3949,10 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH3__onResolve;
     } else if (handler == Bun__HTTPRequestContextDebugH3__onResolveStream) {
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH3__onResolveStream;
+    } else if (handler == Bun__HTMLRewriter__onHandlerResolve) {
+        return GlobalObject::PromiseFunctions::Bun__HTMLRewriter__onHandlerResolve;
+    } else if (handler == Bun__HTMLRewriter__onHandlerReject) {
+        return GlobalObject::PromiseFunctions::Bun__HTMLRewriter__onHandlerReject;
     } else {
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -412,8 +412,10 @@ public:
         Bun__HTTPRequestContextDebugH3__onRejectStream,
         Bun__HTTPRequestContextDebugH3__onResolve,
         Bun__HTTPRequestContextDebugH3__onResolveStream,
+        Bun__HTMLRewriter__onHandlerResolve,
+        Bun__HTMLRewriter__onHandlerReject,
     };
-    static constexpr size_t promiseFunctionsSize = 42;
+    static constexpr size_t promiseFunctionsSize = 44;
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -779,6 +779,8 @@ BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugTLS__onResolveStream);
 
 BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onRejectStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onResolveStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTMLRewriter__onHandlerResolve);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTMLRewriter__onHandlerReject);
 
 #endif
 

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -143,6 +143,22 @@ unsafe extern "C" {
     safe fn JSC__JSGlobalObject__drainMicrotasks(global: &JSGlobalObject) -> u8;
 }
 
+impl JSGlobalObject {
+    /// Run one microtask checkpoint: `process.nextTick` callbacks, then the
+    /// JSC microtask queue, and nothing else. No timers, no I/O, no deferred
+    /// tasks, so this cannot re-enter the event loop.
+    ///
+    /// `Err` means JS was terminated; a termination exception is left pending.
+    pub fn drain_microtasks_and_next_ticks(&self) -> Result<(), JsTerminated> {
+        jsc::mark_binding();
+        match JSC__JSGlobalObject__drainMicrotasks(self) {
+            drain_result::SUCCESS => Ok(()),
+            drain_result::JS_TERMINATED => Err(JsTerminated::JSTerminated),
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[derive(thiserror::Error, strum::IntoStaticStr, Debug)]
 pub enum JsTerminated {
     #[error("JSTerminated")]

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -716,6 +716,19 @@ impl RareData {
             .push(CleanupHook::from(global_this, ctx, func));
     }
 
+    /// Drop the hook registered for `(ctx, func)`. A caller that frees `ctx`
+    /// before exit must do this, or `on_exit()` would invoke the hook on freed
+    /// memory.
+    pub fn remove_cleanup_hook(&mut self, ctx: *mut c_void, func: CleanupHookFunction) {
+        if let Some(i) = self
+            .cleanup_hooks
+            .iter()
+            .position(|h| h.ctx == ctx && core::ptr::fn_addr_eq(h.func, func))
+        {
+            self.cleanup_hooks.swap_remove(i);
+        }
+    }
+
     pub fn spawn_sync_event_loop(&mut self, vm: &mut VirtualMachine) -> &mut SpawnSyncEventLoop {
         if self.spawn_sync_event_loop_.is_none() {
             // In-place out-param init: `event_loop` inside captures the

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -725,7 +725,7 @@ impl RareData {
             .iter()
             .position(|h| h.ctx == ctx && core::ptr::fn_addr_eq(h.func, func))
         {
-            self.cleanup_hooks.swap_remove(i);
+            self.cleanup_hooks.remove(i);
         }
     }
 

--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -56,10 +56,11 @@ pub enum Tag {
     BodyValueBufferer,
     HTTPSServerH3RequestContext,
     DebugHTTPSServerH3RequestContext,
+    HTMLRewriterSuspension,
 }
 
 impl Tag {
-    pub const COUNT: usize = 7;
+    pub const COUNT: usize = 8;
 
     #[inline]
     const fn from_raw(n: u8) -> Tag {
@@ -71,6 +72,7 @@ impl Tag {
             4 => Tag::BodyValueBufferer,
             5 => Tag::HTTPSServerH3RequestContext,
             6 => Tag::DebugHTTPSServerH3RequestContext,
+            7 => Tag::HTMLRewriterSuspension,
             _ => unreachable!(),
         }
     }
@@ -105,6 +107,9 @@ impl<ThisServer, const SSL: bool, const DBG: bool, const H3: bool> NativePromise
 }
 impl NativePromiseContextType for body::ValueBufferer<'_> {
     const TAG: Tag = Tag::BodyValueBufferer;
+}
+impl NativePromiseContextType for html_rewriter::SuspensionContext {
+    const TAG: Tag = Tag::HTMLRewriterSuspension;
 }
 
 // `&JSGlobalObject` is ABI-identical to a non-null pointer. `ctx` is stored
@@ -230,6 +235,14 @@ impl DeferredDerefTask {
                 Tag::DebugHTTPSServerH3RequestContext => {
                     (*ctx.cast::<DebugHTTPSServerH3RequestContext>()).deref()
                 }
+                Tag::HTMLRewriterSuspension => {
+                    // The handler's promise was collected without settling, so
+                    // the rewrite can never continue: fail the output body and
+                    // drop everything the suspension parked.
+                    html_rewriter::SuspensionContext::abandon(
+                        ctx.cast::<html_rewriter::SuspensionContext>(),
+                    );
+                }
             }
         }
     }
@@ -248,3 +261,6 @@ const _: () =
     assert!(core::mem::align_of::<DebugHTTPSServerRequestContext>() > DeferredDerefTask::TAG_MASK);
 const _: () =
     assert!(core::mem::align_of::<body::ValueBufferer<'_>>() > DeferredDerefTask::TAG_MASK);
+const _: () = assert!(
+    core::mem::align_of::<html_rewriter::SuspensionContext>() > DeferredDerefTask::TAG_MASK
+);

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -2669,6 +2669,13 @@ impl WrapperLike for Element {
         self.invalidate();
     }
     fn retarget(&self, raw: *mut Self::Raw) {
+        // A retarget means the element's lol-html backing (including the
+        // attribute buffer) was replaced by the owned copy `into_suspended`
+        // parked on the heap. Any `AttributeIterator` handed to JS before
+        // the handler's `await` still borrows the abandoned buffer, so it
+        // must be detached, exactly like `set_attribute`/`remove_attribute`
+        // do before they invalidate the buffer.
+        self.detach_attribute_iterators();
         self.element.set(raw);
     }
     fn suspended_raw(rewriter: &mut LolRewriter) -> *mut Self::Raw {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -511,10 +511,8 @@ impl HTMLRewriter {
             // to return.
             // SAFETY: out_response is the m_ctx of out_response_value (kept
             // alive on the stack via ensure_still_alive above).
-            if matches!(
-                unsafe { &*(*out_response).get_body_value() },
-                webcore::body::Value::Locked(_)
-            ) {
+            let out_body = unsafe { &*(*out_response).get_body_value() };
+            if matches!(out_body, webcore::body::Value::Locked(_)) {
                 // The suspended rewrite still runs when its handler's promise
                 // settles and its sink still points at `out_response` (and
                 // keeps its JS wrapper alive through a Strong), so the eager
@@ -1067,10 +1065,17 @@ impl BufferOutputSink {
 
         // SAFETY: sink is live (fn safety contract).
         match unsafe { (*sink).phase.get() } {
-            // The suspended `write` completed; `end()` is still owed.
-            RewritePhase::WritePending => unsafe { Self::end_rewrite(sink, true) },
-            // The suspended `end` completed; `done()` already ran.
-            RewritePhase::EndPending => unsafe { (*sink).phase.set(RewritePhase::Done) },
+            RewritePhase::WritePending => {
+                // The suspended `write` completed; `end()` is still owed.
+                // SAFETY: sink is live (fn safety contract); the guard above
+                // is still installed.
+                unsafe { Self::end_rewrite(sink, true) }
+            }
+            RewritePhase::EndPending => {
+                // The suspended `end` completed; `done()` already ran.
+                // SAFETY: sink is live (fn safety contract).
+                unsafe { (*sink).phase.set(RewritePhase::Done) }
+            }
             RewritePhase::Done => unreachable!("resumed a completed HTMLRewriter transform"),
         }
     }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -612,6 +612,37 @@ struct PendingSuspension {
     promise: JSValue,
 }
 
+impl PendingSuspension {
+    /// Hand the parts to a caller that takes over the wrapper's ref and the
+    /// promise's protect, without running [`Drop`].
+    #[allow(clippy::type_complexity)]
+    fn into_parts(
+        self,
+    ) -> (
+        *mut core::ffi::c_void,
+        unsafe fn(*mut core::ffi::c_void, *mut LolRewriter),
+        unsafe fn(*mut core::ffi::c_void),
+        JSValue,
+    ) {
+        let me = core::mem::ManuallyDrop::new(self);
+        (me.wrapper, me.retarget, me.release, me.promise)
+    }
+}
+
+impl Drop for PendingSuspension {
+    /// Reached when a suspension was armed but never consumed by
+    /// [`BufferOutputSink::begin_suspension`] — lol-html returned something
+    /// other than `Suspended`, or the sink is being torn down. Release exactly
+    /// what the `Suspend` arm of [`handler_callback`] took, so the exactly-once
+    /// contract is structural rather than a property of the call order.
+    fn drop(&mut self) {
+        self.promise.unprotect();
+        // SAFETY: `wrapper` is the live, ref'd wrapper `handler_callback`
+        // parked here; it was never retargeted, so `detach` just nulls it.
+        unsafe { (self.release)(self.wrapper) };
+    }
+}
+
 /// `PendingSuspension::retarget` for a concrete wrapper type.
 ///
 /// # Safety
@@ -988,7 +1019,7 @@ impl BufferOutputSink {
         }
 
         // SAFETY: `sink` is live (refcount > 0, see fn safety contract).
-        unsafe { Self::run_output_sink(sink, bytes, is_async) }
+        unsafe { Self::run_output_sink(sink, bytes) }
     }
 
     /// Run the whole (already buffered) input through lol-html: `write` then
@@ -1005,7 +1036,7 @@ impl BufferOutputSink {
     /// # Safety
     /// `sink` must be a live `BufferOutputSink` heap allocation with
     /// refcount > 0; `(*sink).rewriter` and `(*sink).response` must be set.
-    unsafe fn run_output_sink(sink: *mut Self, bytes: &[u8], is_async: bool) {
+    unsafe fn run_output_sink(sink: *mut Self, bytes: &[u8]) {
         // SAFETY: sink is a live heap allocation (refcount > 0, caller
         // invariant). Read fields into locals before the rewriter calls so no
         // borrow of `*sink` is live across the re-entrant output sink.
@@ -1022,11 +1053,11 @@ impl BufferOutputSink {
         // SAFETY: rewriter heap-allocated by init(), not yet freed.
         if let Err(e) = unsafe { (*rewriter).write(bytes) } {
             // SAFETY: sink is live (fn safety contract).
-            return unsafe { Self::on_rewriting_error(sink, &e, is_async) };
+            return unsafe { Self::on_rewriting_error(sink, &e) };
         }
 
         // SAFETY: sink is live (fn safety contract); the guard is installed.
-        unsafe { Self::end_rewrite(sink, is_async) }
+        unsafe { Self::end_rewrite(sink) }
     }
 
     /// `write` completed: run `end()`. The caller must have an
@@ -1034,7 +1065,7 @@ impl BufferOutputSink {
     ///
     /// # Safety
     /// Same as [`Self::run_output_sink`].
-    unsafe fn end_rewrite(sink: *mut Self, is_async: bool) {
+    unsafe fn end_rewrite(sink: *mut Self) {
         // SAFETY: sink is live (fn safety contract).
         let rewriter = unsafe {
             (*sink).phase.set(RewritePhase::EndPending);
@@ -1046,7 +1077,7 @@ impl BufferOutputSink {
         // SAFETY: rewriter heap-allocated by init(), not yet freed.
         if let Err(e) = unsafe { (*rewriter).end_mut() } {
             // SAFETY: sink is live (fn safety contract).
-            return unsafe { Self::on_rewriting_error(sink, &e, is_async) };
+            return unsafe { Self::on_rewriting_error(sink, &e) };
         }
 
         // `end()` emitted the zero-length finalizing chunk, which ran
@@ -1071,7 +1102,7 @@ impl BufferOutputSink {
             // The resumed half of the rewrite runs from the event loop, long
             // after `transform()` returned; every failure here is async.
             // SAFETY: sink is live (fn safety contract).
-            return unsafe { Self::on_rewriting_error(sink, &e, true) };
+            return unsafe { Self::on_rewriting_error(sink, &e) };
         }
 
         // SAFETY: sink is live (fn safety contract).
@@ -1080,7 +1111,7 @@ impl BufferOutputSink {
                 // The suspended `write` completed; `end()` is still owed.
                 // SAFETY: sink is live (fn safety contract); the guard above
                 // is still installed.
-                unsafe { Self::end_rewrite(sink, true) }
+                unsafe { Self::end_rewrite(sink) }
             }
             RewritePhase::EndPending => {
                 // The suspended `end` completed; `done()` already ran.
@@ -1098,25 +1129,43 @@ impl BufferOutputSink {
     /// # Safety
     /// Same as [`Self::run_output_sink`]; an [`ActiveSinkGuard`] must be
     /// installed.
-    unsafe fn on_rewriting_error(
-        sink: *mut Self,
-        e: &lol_html::errors::RewritingError,
-        is_async: bool,
-    ) {
+    unsafe fn on_rewriting_error(sink: *mut Self, e: &lol_html::errors::RewritingError) {
         if matches!(e, lol_html::errors::RewritingError::Suspended) {
             // SAFETY: sink is live (fn safety contract).
             return unsafe { Self::begin_suspension(sink) };
         }
 
+        // A `Suspend` outcome should always make the lol-html call return
+        // `Suspended`, but that is lol-html's invariant, not ours: drain any
+        // armed suspension so its `Drop` releases the wrapper and the promise's
+        // protect rather than leaving a parked wrapper pointing at a unit the
+        // rewriter's `Drop` is about to free.
+        // SAFETY: sink is live (fn safety contract).
+        let leftover = unsafe { (*sink).pending_suspension.take() };
+        debug_assert!(
+            leftover.is_none(),
+            "lol-html returned a non-suspension error with a suspension armed"
+        );
+        drop(leftover);
+
         // The rewriter is poisoned (`Drop` frees it). Surface the real cause:
         // the exception/rejection a handler recorded, or lol-html's own error.
         // SAFETY: sink is live (fn safety contract).
-        let (global, captured) = unsafe {
+        let (global, captured, sync_only) = unsafe {
             (*sink).phase.set(RewritePhase::Done);
-            ((*sink).global, (*sink).take_handler_error())
+            (
+                (*sink).global,
+                (*sink).take_handler_error(),
+                (*sink).sync_only_noun.get().is_some(),
+            )
         };
 
-        if !is_async {
+        // Which channel a rewrite failure takes is decided by the overload, not
+        // by whether the input body happened to be buffered when `transform()`
+        // ran: `transform(string)`/`transform(ArrayBuffer)` have to hand back a
+        // value, so they throw; every `Response` input rejects its output body,
+        // which is the one contract the docs can state and users can rely on.
+        if sync_only {
             // `init()` is still on the stack; make `transform()` throw.
             // SAFETY: sink is live (fn safety contract).
             return unsafe {
@@ -1149,35 +1198,36 @@ impl BufferOutputSink {
         // SAFETY: sink is live (fn safety contract).
         let (global, rewriter) = unsafe { ((*sink).global, (*sink).rewriter) };
         // SAFETY: sink is live (fn safety contract).
-        let suspension = unsafe { (*sink).pending_suspension.take() }
-            .expect("lol-html suspended without a pending HTMLRewriter handler promise");
+        // `into_parts` disarms the `Drop`: from here the wrapper's ref and the
+        // promise's protect belong to this frame.
+        let (wrapper, retarget, release, promise) = unsafe { (*sink).pending_suspension.take() }
+            .expect("lol-html suspended without a pending HTMLRewriter handler promise")
+            .into_parts();
 
         // SAFETY: `rewriter` is suspended on exactly the unit type the
-        // `handler_callback::<_, Z, _>` that built `suspension` dispatched,
-        // and `suspension.wrapper` is that call's live, ref'd wrapper.
-        unsafe { (suspension.retarget)(suspension.wrapper, rewriter) };
+        // `handler_callback::<_, Z, _>` that built the suspension dispatched,
+        // and `wrapper` is that call's live, ref'd wrapper.
+        unsafe { retarget(wrapper, rewriter) };
 
         // The in-flight continuation keeps the sink (and through it the
         // suspended lol-html state) alive until the promise settles.
         // SAFETY: sink is live (fn safety contract).
         unsafe {
-            (*sink).suspended_wrapper.set(suspension.wrapper);
-            (*sink)
-                .suspended_wrapper_release
-                .set(Some(suspension.release));
+            (*sink).suspended_wrapper.set(wrapper);
+            (*sink).suspended_wrapper_release.set(Some(release));
             (*sink).ref_();
         }
 
         // Adopt the protection `handler_callback` took; once `then_with_value`
         // attaches, the reaction roots the promise and this can go.
-        let promise = jsc::ProtectedJSValue::adopt(suspension.promise);
+        let promise = jsc::ProtectedJSValue::adopt(promise);
 
         // The reactions' context is a GC-managed cell holding the sink's `+1`,
         // not a raw pointer: a promise collected without ever settling takes
         // the cell with it, and its destructor abandons the parked rewrite
         // instead of leaking it (`SuspensionContext::abandon`).
         // SAFETY: the `ref_()` above is the `+1` this context now owns.
-        let ctx = unsafe { SuspensionContext::new(sink) };
+        let ctx = unsafe { SuspensionContext::new(&global, sink) };
         let cell = NativePromiseContext::create(&global, ctx);
         promise.value().then_with_value(
             &global,
@@ -1327,36 +1377,74 @@ pub struct SuspensionContext {
     sink: *mut BufferOutputSink,
 }
 
+/// `RareData` cleanup-hook shim for an abandoned-at-exit suspension.
+///
+/// The GC'd-cell path alone does not cover `worker.terminate()`: teardown sets
+/// `vm.is_shutting_down` before sweeping the heap, and `DeferredDerefTask::
+/// schedule` bails on that flag, so the cell's destructor is a no-op. Registering
+/// here instead means `vm.on_exit()` — which runs on worker terminate and on main
+/// exit, while the JSC heap is still alive — drains the parked rewrite.
+extern "C" fn suspension_cleanup_hook(ctx: *mut core::ffi::c_void) {
+    // SAFETY: `ctx` is the `SuspensionContext` registered in `begin_suspension`
+    // and not yet taken (both `take` and `abandon` unregister first).
+    unsafe { SuspensionContext::abandon(ctx.cast::<SuspensionContext>()) };
+}
+
 impl SuspensionContext {
-    /// Consumes one ref on `sink`.
+    /// Consumes one ref on `sink`, and registers the exit-time cleanup hook.
     ///
     /// # Safety
     /// `sink` must be live with a `+1` transferred to the returned context.
-    unsafe fn new(sink: *mut BufferOutputSink) -> *mut Self {
-        bun_core::heap::into_raw(Box::new(Self { sink }))
+    unsafe fn new(global: &JSGlobalObject, sink: *mut BufferOutputSink) -> *mut Self {
+        let this = bun_core::heap::into_raw(Box::new(Self { sink }));
+        global.bun_vm().as_mut().rare_data().push_cleanup_hook(
+            global,
+            this.cast::<core::ffi::c_void>(),
+            suspension_cleanup_hook,
+        );
+        this
+    }
+
+    /// Drop the exit-time hook. Must run before `this` is freed.
+    ///
+    /// # Safety
+    /// Called on the JS thread, with `this` still live.
+    fn unregister_cleanup_hook(global: &JSGlobalObject, this: *mut Self) {
+        global
+            .bun_vm()
+            .as_mut()
+            .rare_data()
+            .remove_cleanup_hook(this.cast::<core::ffi::c_void>(), suspension_cleanup_hook);
     }
 
     /// Reclaim the sink from a settling reaction's context argument. `None` if
     /// the cell was already taken (it can only be taken once).
-    fn take(cell: JSValue) -> Option<*mut BufferOutputSink> {
+    fn take(global: &JSGlobalObject, cell: JSValue) -> Option<*mut BufferOutputSink> {
         let ctx = NativePromiseContext::take::<Self>(cell)?;
+        Self::unregister_cleanup_hook(global, ctx.as_ptr());
         // SAFETY: `take` hands back the pointer `new` leaked, exactly once.
         let this = unsafe { bun_core::heap::take(ctx.as_ptr()) };
         Some(this.sink)
     }
 
-    /// The promise was collected without settling: the rewrite can never
-    /// continue. Fail the output body and release everything the suspension
-    /// parked. Runs from the event loop, not the GC sweep (see
+    /// The rewrite can never continue — the handler's promise was collected
+    /// unsettled, or the VM is exiting with it still parked. Fail the output
+    /// body and release everything the suspension holds. Runs from the event
+    /// loop or from `on_exit`, never from the GC sweep (see
     /// `DeferredDerefTask`), so touching the JSC heap is safe here.
     ///
     /// # Safety
-    /// `this` must be the live context the GC'd cell owned.
+    /// `this` must be the live context, with its cleanup hook still registered.
     pub(crate) unsafe fn abandon(this: *mut Self) {
         // SAFETY: fn contract — `this` is the leaked `new` allocation.
         let sink = unsafe { bun_core::heap::take(this) }.sink;
         // SAFETY: the context held a `+1` on `sink`; `adopt` consumes it.
         let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
+        // SAFETY: `sink` is live for this scope (the ref above).
+        let global = unsafe { (*sink).global };
+        // Running from the hook itself? `on_exit` already took the Vec, so the
+        // remove is a no-op; from the GC path it is the one that matters.
+        Self::unregister_cleanup_hook(&global, this);
         // SAFETY: `sink` is live for this scope (the ref above).
         unsafe {
             BufferOutputSink::release_suspended_wrapper(sink);
@@ -1371,9 +1459,9 @@ impl SuspensionContext {
     }
 }
 
-fn on_handler_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+fn on_handler_resolve(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
-    let Some(sink) = SuspensionContext::take(args[args.len() - 1]) else {
+    let Some(sink) = SuspensionContext::take(global, args[args.len() - 1]) else {
         return Ok(JSValue::UNDEFINED);
     };
     // SAFETY: the context held a `+1` on `sink`; `adopt` releases it.
@@ -1392,7 +1480,7 @@ fn on_handler_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<J
 fn on_handler_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
     let reason = args[0];
-    let Some(sink) = SuspensionContext::take(args[args.len() - 1]) else {
+    let Some(sink) = SuspensionContext::take(global, args[args.len() - 1]) else {
         return Ok(JSValue::UNDEFINED);
     };
     // SAFETY: see `on_handler_resolve`.
@@ -1416,8 +1504,10 @@ impl Drop for BufferOutputSink {
     fn drop(&mut self) {
         // bytes, body_value_bufferer, context (Rc), response_value (Strong) drop automatically.
         // An error recorded but never taken (a throwing `init()`) still holds
-        // its protect.
+        // its protect, and an armed-but-unconsumed suspension still holds the
+        // wrapper's ref (`PendingSuspension::drop` releases both).
         self.handler_error.replace(JSValue::ZERO).unprotect();
+        drop(self.pending_suspension.take());
         if !self.rewriter.is_null() {
             // SAFETY: rewriter heap-allocated by init() and not yet freed
             // (the sink is its sole owner for its whole life).
@@ -1629,13 +1719,26 @@ macro_rules! impl_wrapper_like {
 /// Record a content handler's exception / rejection on the sink whose
 /// lol-html call is on the stack, so `transform()` (sync) or the output body
 /// (async) surfaces it instead of lol-html's generic "stopped" message.
-fn record_handler_error(global: &JSGlobalObject, err: JSValue) {
-    if let Some(sink) = active_sink(global) {
-        err.ensure_still_alive();
-        // SAFETY: the active sink drives the lol-html call that invoked this
-        // handler and is live (refcount > 0) for that call's whole duration.
-        unsafe { (*sink).set_handler_error(err) };
-    }
+/// The value an `Exception` cell wraps. Handing the cell itself to
+/// `JSPromise::reject` asserts, and a `Locked` body can now reject with any
+/// handler error, so unwrap at the point of capture. `to_error` falls back to
+/// the cell for a non-`Exception` (it cannot happen here).
+fn exception_value(exc: NonNull<jsc::Exception>) -> JSValue {
+    let cell = JSValue::from_cell(exc.as_ptr());
+    cell.to_error().unwrap_or(cell)
+}
+
+/// Takes the sink explicitly rather than re-deriving it from `global`: a caller
+/// that has already established there is none would otherwise silently drop the
+/// error.
+///
+/// # Safety
+/// `sink` must be the live `BufferOutputSink` driving the lol-html call that
+/// invoked this handler (refcount > 0 for that call's whole duration).
+unsafe fn record_handler_error(sink: *mut BufferOutputSink, err: JSValue) {
+    err.ensure_still_alive();
+    // SAFETY: see fn contract.
+    unsafe { (*sink).set_handler_error(err) };
 }
 
 fn handler_callback<H, Z, L>(
@@ -1673,6 +1776,15 @@ where
     let this = unsafe { &*this };
     let global = this.global();
 
+    // Content handlers only ever run from inside a sink's lol-html call, which
+    // installs the guard. Read it once here so every error path below has a
+    // sink to record onto, and a new entry point that forgets the guard fails
+    // before running any user code rather than dropping its result later.
+    let Some(sink) = active_sink(global) else {
+        debug_assert!(false, "HTMLRewriter handler ran outside a rewrite");
+        return HandlerOutcome::Stop;
+    };
+
     // Use a TopExceptionScope to properly handle exceptions from the JavaScript
     // callback. A post-hoc `try_take_exception()`
     // is *not* equivalent under
@@ -1698,7 +1810,9 @@ where
             // Record the exception so `transform()` / the output body throws
             // the real error instead of lol-html's generic "stopped" message.
             if let Some(exc) = scope.exception() {
-                record_handler_error(global, JSValue::from_cell(exc.as_ptr()));
+                // SAFETY: `sink` is the live sink for this rewrite.
+                // SAFETY: `sink` is the live sink for this rewrite.
+                unsafe { record_handler_error(sink, exception_value(exc)) };
             }
             // Clear the exception from the scope to prevent assertion failures
             scope.clear_exception();
@@ -1710,7 +1824,9 @@ where
 
     // Check if there's an exception that was thrown but not caught by the error union
     if let Some(exc) = scope.exception() {
-        record_handler_error(global, JSValue::from_cell(exc.as_ptr()));
+        // SAFETY: `sink` is the live sink for this rewrite.
+        // SAFETY: `sink` is the live sink for this rewrite.
+        unsafe { record_handler_error(sink, exception_value(exc)) };
         // Clear the exception to prevent assertion failures
         scope.clear_exception();
         return HandlerOutcome::Stop;
@@ -1753,27 +1869,16 @@ where
     match promise.status() {
         jsc::js_promise::Status::Fulfilled => HandlerOutcome::Continue,
         jsc::js_promise::Status::Rejected => {
-            // `result()` marks the rejection as handled.
-            record_handler_error(global, promise.result(global.vm()));
+            // We take the rejection and route it to the output body, so it is
+            // handled. Without this the handler's own returned promise is also
+            // reported to `unhandledRejection`; a fire-and-forget rejection the
+            // handler never returned still is, which is intended.
+            promise.set_handled(global.vm());
+            // SAFETY: `sink` is the live sink for this rewrite.
+            unsafe { record_handler_error(sink, promise.result(global.vm())) };
             HandlerOutcome::Stop
         }
         jsc::js_promise::Status::Pending => {
-            let Some(sink) = active_sink(global) else {
-                // Content handlers only ever run from inside a sink's lol-html
-                // call, which installs the guard. Reaching here means a new
-                // entry point forgot it; record a real error (not a
-                // compiled-out assert + silent `Stop`, which would drop the
-                // handler's result on the floor in release builds).
-                debug_assert!(false, "HTMLRewriter handler ran outside a rewrite");
-                record_handler_error(
-                    global,
-                    global.create_type_error_instance(format_args!(
-                        "HTMLRewriter content handler ran outside of a rewrite"
-                    )),
-                );
-                return HandlerOutcome::Stop;
-            };
-
             // `transform(string)` / `transform(ArrayBuffer)` must hand back the
             // result before `transform()` returns. Fail the whole rewrite here
             // rather than suspend: a suspension would keep lexing the rest of
@@ -1786,7 +1891,8 @@ where
                      content handler returned a Promise that did not resolve within a microtask. \
                      Pass a Response instead and await its body"
                 ));
-                record_handler_error(global, err);
+                // SAFETY: `sink` is the live sink for this rewrite.
+                unsafe { record_handler_error(sink, err) };
                 return HandlerOutcome::Stop;
             }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1436,15 +1436,19 @@ impl SuspensionContext {
     /// # Safety
     /// `this` must be the live context, with its cleanup hook still registered.
     pub(crate) unsafe fn abandon(this: *mut Self) {
-        // SAFETY: fn contract — `this` is the leaked `new` allocation.
-        let sink = unsafe { bun_core::heap::take(this) }.sink;
+        // SAFETY: fn contract — `this` is live here.
+        let sink = unsafe { (*this).sink };
         // SAFETY: the context held a `+1` on `sink`; `adopt` consumes it.
         let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
         // SAFETY: `sink` is live for this scope (the ref above).
         let global = unsafe { (*sink).global };
-        // Running from the hook itself? `on_exit` already took the Vec, so the
-        // remove is a no-op; from the GC path it is the one that matters.
+        // Unregister before freeing, as `take` does: `remove_cleanup_hook`
+        // matches on the address. Running from the hook itself? `on_exit` already
+        // took the Vec, so the remove is a no-op; from the GC path it matters.
         Self::unregister_cleanup_hook(&global, this);
+        // SAFETY: fn contract — `this` is the leaked `new` allocation, and
+        // nothing above frees it.
+        unsafe { bun_core::heap::destroy(this) };
         // SAFETY: `sink` is live for this scope (the ref above).
         unsafe {
             BufferOutputSink::release_suspended_wrapper(sink);

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -404,15 +404,19 @@ impl HTMLRewriter {
     #[expect(clippy::boxed_local)]
     pub fn finalize(self: Box<Self>) {}
 
+    /// `sync_only_noun` is `Some("string" | "ArrayBuffer")` when the caller
+    /// needs the rewrite to finish before `transform()` returns; a handler that
+    /// would suspend then fails the rewrite instead.
     pub fn begin_transform(
         &self,
         global: &JSGlobalObject,
         response: &mut Response,
+        sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
         let new_context = Rc::clone(&self.context);
         // SAFETY: `response` is a live `Response` whose JS wrapper is on
         // the caller's stack (see `transform_`).
-        unsafe { BufferOutputSink::init(new_context, global, response) }
+        unsafe { BufferOutputSink::init(new_context, global, response, sync_only_noun) }
     }
 
     pub fn transform_(
@@ -435,7 +439,7 @@ impl HTMLRewriter {
             }
             // SAFETY: `response` is the live m_ctx of `response_value` (kept
             // alive on the caller's stack), never null.
-            let out = self.begin_transform(global, unsafe { &mut *response })?;
+            let out = self.begin_transform(global, unsafe { &mut *response }, None)?;
             // Check if the returned value is an error and throw it properly
             if let Some(err) = out.to_error() {
                 return Err(global.throw_value(err));
@@ -474,8 +478,14 @@ impl HTMLRewriter {
                 Response::finalize(unsafe { Box::from_raw(r) })
             });
 
+            let noun = if kind == ResponseKind::String {
+                "string"
+            } else {
+                "ArrayBuffer"
+            };
             // SAFETY: `resp` is a live `heap::into_raw` allocation, never null.
-            let out_response_value = self.begin_transform(global, unsafe { &mut *resp })?;
+            let out_response_value =
+                self.begin_transform(global, unsafe { &mut *resp }, Some(noun))?;
             // Check if the returned value is an error and throw it properly
             if let Some(err) = out_response_value.to_error() {
                 return Err(global.throw_value(err));
@@ -487,7 +497,7 @@ impl HTMLRewriter {
                 return Ok(out_response_value);
             };
 
-            let out_guard = scopeguard::guard((out_response_value, out_response), |(v, r)| {
+            let _out_guard = scopeguard::guard((out_response_value, out_response), |(v, r)| {
                 // `Response.js.dangerouslySetPtr(v, null)` — null out the JS
                 // wrapper's `m_ctx` so its GC finalize is a no-op, then finalize
                 // the native side ourselves.
@@ -505,32 +515,9 @@ impl HTMLRewriter {
                 }
             });
 
-            // `transform(string)` / `transform(ArrayBuffer)` must produce the
-            // result synchronously. A body still `Locked` here means an async
-            // content handler suspended the rewrite; there is nothing sound
-            // to return.
-            // SAFETY: out_response is the m_ctx of out_response_value (kept
-            // alive on the stack via ensure_still_alive above).
-            let out_body = unsafe { &*(*out_response).get_body_value() };
-            if matches!(out_body, webcore::body::Value::Locked(_)) {
-                // The suspended rewrite still runs when its handler's promise
-                // settles and its sink still points at `out_response` (and
-                // keeps its JS wrapper alive through a Strong), so the eager
-                // finalize above would be a use-after-free. Disarm it: the
-                // orphaned Response is collected normally once the rewrite
-                // completes and the sink drops.
-                let _ = scopeguard::ScopeGuard::into_inner(out_guard);
-                return Err(global.throw_type_error(format_args!(
-                    "HTMLRewriter.transform() cannot synchronously return a {} because a content \
-                     handler returned a Promise that did not resolve within a microtask. Pass a \
-                     Response instead and await its body",
-                    if kind == ResponseKind::String {
-                        "string"
-                    } else {
-                        "ArrayBuffer"
-                    }
-                )));
-            }
+            // The body is never still `Locked` here: `sync_only_noun` makes a
+            // handler that would suspend fail the rewrite instead, and `init`
+            // rethrows that as the synchronous TypeError above.
 
             // SAFETY: out_response is the m_ctx of out_response_value (kept alive
             // on the stack via ensure_still_alive above).
@@ -711,6 +698,11 @@ pub struct BufferOutputSink {
     /// and that same lol-html call returning -- a purely native window -- so
     /// it never needs a GC root.
     handler_error: Cell<JSValue>,
+    /// Set for `transform(string)` / `transform(ArrayBuffer)`, which must
+    /// produce their result before `transform()` returns. Holds the noun for
+    /// the error message. A handler that would suspend fails the whole rewrite
+    /// instead, so no handler outlives the throw.
+    sync_only_noun: Cell<Option<&'static str>>,
     /// Which lol-html call still has to run (or finish).
     phase: Cell<RewritePhase>,
     /// Handed from the suspending [`handler_callback`] to
@@ -746,6 +738,7 @@ impl BufferOutputSink {
         context: Rc<RefCell<LOLHTMLContext>>,
         global: &JSGlobalObject,
         original: *mut Response,
+        sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
         let sink = bun_core::heap::into_raw(Box::new(BufferOutputSink {
             ref_count: Cell::new(1),
@@ -757,6 +750,7 @@ impl BufferOutputSink {
             response_value: StrongOptional::empty(),
             body_value_bufferer: None,
             handler_error: Cell::new(JSValue::ZERO),
+            sync_only_noun: Cell::new(sync_only_noun),
             phase: Cell::new(RewritePhase::WritePending),
             pending_suspension: Cell::new(None),
             suspended_wrapper: Cell::new(core::ptr::null_mut()),
@@ -1654,17 +1648,22 @@ where
         return HandlerOutcome::Continue;
     };
 
-    // An `async` handler's promise settles through the microtask queue even
+    // An `async` handler's promise settles through a microtask checkpoint even
     // when its body never truly awaits (`async element(el) { el.remove() }`),
-    // so drain the microtask queue ONCE — never the event loop — before
-    // deciding. A promise that is still pending afterwards is waiting on I/O
-    // or a timer; that is the one case that has to suspend the rewrite
-    // instead of nesting the whole event loop inside lol-html's `write()`.
+    // so run ONE checkpoint — nextTick + microtasks, never the event loop —
+    // before deciding. A promise still pending afterwards is waiting on I/O or
+    // a timer; that is the one case that has to suspend the rewrite instead of
+    // nesting the whole event loop inside lol-html's `write()`.
+    //
+    // A termination landing in the checkpoint (`worker.terminate()`) must keep
+    // its exception pending and abort the rewrite, never be recorded as a
+    // handler error.
     if promise.status() == jsc::js_promise::Status::Pending {
-        global.vm().drain_microtasks();
-        // Microtasks that ran during the drain can leave a JS exception
-        // pending; don't let it escape through the host-function wrapper.
-        scope.clear_exception();
+        if global.drain_microtasks_and_next_ticks().is_err()
+            || !global.clear_exception_except_termination()
+        {
+            return HandlerOutcome::Stop;
+        }
     }
 
     match promise.status() {
@@ -1682,6 +1681,23 @@ where
                 debug_assert!(false, "HTMLRewriter handler ran outside a rewrite");
                 return HandlerOutcome::Stop;
             };
+
+            // `transform(string)` / `transform(ArrayBuffer)` must hand back the
+            // result before `transform()` returns. Fail the whole rewrite here
+            // rather than suspend: a suspension would keep lexing the rest of
+            // the input and run later handlers against a Response nobody can
+            // reach, and a post-throw rejection would be swallowed.
+            // SAFETY: `sink` is the live BufferOutputSink for this rewrite.
+            if let Some(noun) = unsafe { (*sink).sync_only_noun.get() } {
+                let err = global.create_type_error_instance(format_args!(
+                    "HTMLRewriter.transform() cannot synchronously return a {noun} because a \
+                     content handler returned a Promise that did not resolve within a microtask. \
+                     Pass a Response instead and await its body"
+                ));
+                record_handler_error(global, err);
+                return HandlerOutcome::Stop;
+            }
+
             // Hand the wrapper to the suspension: it has to stay valid across
             // the handler's `await` (the post-`await` code keeps mutating the
             // unit), so disarm the guard here. `begin_suspension` re-points
@@ -2171,25 +2187,27 @@ impl_wrapper_like!(EndTag, RawEndTag, end_tag, suspended_end_tag);
 // ───────────────────────── AttributeIterator ─────────────────────────────
 
 /// The JS `AttributeIterator` heap-boxes one of these over `Element::attributes`
-/// (the Rust crate exposes a slice, not a boxed iterator like the C API did).
-/// Lifetimes are erased; `Element` detaches every iterator before invalidation.
-type RawAttributeIterator = core::slice::Iter<'static, lol_html::html_content::Attribute<'static>>;
-
 #[bun_jsc::JsClass(no_construct, no_finalize, no_constructor)]
 #[derive(bun_ptr::CellRefCounted)]
 #[ref_count(destroy = AttributeIterator::destroy_on_zero)]
 pub struct AttributeIterator {
     // Intrusive RefCount; *Self is the JS wrapper m_ctx.
     ref_count: Cell<u32>,
-    // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
-    pub iterator: Cell<*mut RawAttributeIterator>,
+    /// Non-owning backref to the `Element` wrapper that handed this iterator
+    /// out. Reading the attributes through it (rather than caching a
+    /// `slice::Iter` into the attribute buffer) means a suspension, which
+    /// re-points the element at lol-html's heap-parked copy, re-points this
+    /// iterator too. The element keeps a `+1` on us and nulls this in
+    /// `detach()`, so it never dangles. R-2: `Cell` so host-fns take `&self`.
+    element: Cell<*const Element>,
+    /// Index of the next attribute to yield.
+    index: Cell<usize>,
 }
 
 impl AttributeIterator {
     // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
 
-    /// `CellRefCounted::destroy` target — detach the lol-html iterator before
-    /// freeing the Box.
+    /// `CellRefCounted::destroy` target.
     ///
     /// Safe fn: only reachable via the `#[ref_count(destroy = …)]` derive,
     /// whose generated trait `destroy` upholds the sole-owner contract.
@@ -2201,14 +2219,10 @@ impl AttributeIterator {
         }
     }
 
+    /// Drop the backref. The element owns our `+1` and clears it here, so the
+    /// raw pointer is never read after the element stops tracking us.
     fn detach(&self) {
-        let iterator = self.iterator.replace(core::ptr::null_mut());
-        if !iterator.is_null() {
-            // SAFETY: `iterator` was `heap::into_raw`'d in
-            // `Element::get_attributes`; the Cell is its sole owner and was
-            // nulled above, so this runs at most once.
-            unsafe { bun_core::heap::destroy(iterator) };
-        }
+        self.element.set(core::ptr::null());
     }
 
     pub fn finalize(self: Box<Self>) {
@@ -2227,9 +2241,18 @@ impl AttributeIterator {
         let done_label = bun_core::ZigString::init(b"done");
         let value_label = bun_core::ZigString::init(b"value");
 
-        let Some(attribute) = cell_get(&self.iterator).and_then(|it| it.next()) else {
-            // Exhausted or already detached: free the boxed iterator eagerly
-            // (a no-op once the Cell is null), matching the c-api path.
+        // SAFETY: a non-null backref means the `Element` still tracks this
+        // iterator in `attribute_iterators` (it nulls the backref in `detach`,
+        // which every path that frees it runs first), so the allocation is
+        // live. `&`, never `&mut`: Element's host-fns take `&self`.
+        let element: Option<&Element> = unsafe { self.element.get().as_ref() };
+
+        // Detached (the handler returned, or an attribute was mutated), the
+        // element itself is gone, or we ran off the end of the buffer.
+        let attribute = element
+            .and_then(|el| cell_get(&el.element))
+            .and_then(|raw| raw.attributes().get(self.index.get()));
+        let Some(attribute) = attribute else {
             self.detach();
             return JSValue::create_object2(
                 global_object,
@@ -2239,6 +2262,7 @@ impl AttributeIterator {
                 JSValue::UNDEFINED,
             );
         };
+        self.index.set(self.index.get() + 1);
 
         let value = attribute.value();
         let name = attribute.name();
@@ -2615,24 +2639,20 @@ impl Element {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_attributes(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-        let Some(el) = cell_get(&self.element) else {
+        if cell_get(&self.element).is_none() {
             return Ok(JSValue::UNDEFINED);
-        };
+        }
 
-        // `cell_get`'s erased `'static` carries through `attributes()`. The
-        // boxed iterator never outlives the real attribute buffer: it is
-        // tracked below and detached in `invalidate()` (when the handler
-        // returns) and before any attribute mutation.
-        let attrs: &'static [lol_html::html_content::Attribute<'static>] = el.attributes();
-        let iter = bun_core::heap::into_raw(Box::new(attrs.iter()));
+        // The iterator reads attributes back through `self` on every `next()`,
+        // so it follows a retarget (suspension) and never caches a borrow into
+        // the attribute buffer.
         let attr_iter = bun_core::heap::into_raw(Box::new(AttributeIterator {
             ref_count: Cell::new(1),
-            iterator: Cell::new(iter),
+            element: Cell::new(std::ptr::from_ref(self)),
+            index: Cell::new(0),
         }));
-        // Track this iterator so we can detach it when the handler returns.
-        // lol-html's attribute slice borrows from the element's token buffer
-        // which is freed after the callback; leaking the iterator to JS
-        // without detaching it would be a use-after-free.
+        // Track this iterator so we can detach it when the handler returns or
+        // an attribute mutation invalidates it.
         // SAFETY: attr_iter is a fresh heap::alloc allocation (refcount==1).
         unsafe { (*attr_iter).ref_() };
         // R-2: `with_mut` — closure does not call into JS (push only).
@@ -2669,13 +2689,11 @@ impl WrapperLike for Element {
         self.invalidate();
     }
     fn retarget(&self, raw: *mut Self::Raw) {
-        // A retarget means the element's lol-html backing (including the
-        // attribute buffer) was replaced by the owned copy `into_suspended`
-        // parked on the heap. Any `AttributeIterator` handed to JS before
-        // the handler's `await` still borrows the abandoned buffer, so it
-        // must be detached, exactly like `set_attribute`/`remove_attribute`
-        // do before they invalidate the buffer.
-        self.detach_attribute_iterators();
+        // The element's lol-html backing (including the attribute buffer) was
+        // replaced by the owned copy `into_suspended` parked on the heap.
+        // `AttributeIterator` reads through this same cell on every `next()`,
+        // so iterators handed out before the handler's `await` keep working,
+        // resuming at the same index into the copied buffer.
         self.element.set(raw);
     }
     fn suspended_raw(rewriter: &mut LolRewriter) -> *mut Self::Raw {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -479,10 +479,11 @@ impl HTMLRewriter {
                 Response::finalize(unsafe { Box::from_raw(r) })
             });
 
+            // Carries its own article: "an ArrayBuffer", not "a ArrayBuffer".
             let noun = if kind == ResponseKind::String {
-                "string"
+                "a string"
             } else {
-                "ArrayBuffer"
+                "an ArrayBuffer"
             };
             // SAFETY: `resp` is a live `heap::into_raw` allocation, never null.
             let out_response_value =
@@ -713,8 +714,8 @@ pub struct BufferOutputSink {
     handler_error: Cell<JSValue>,
     /// Set for `transform(string)` / `transform(ArrayBuffer)`, which must
     /// produce their result before `transform()` returns. Holds the noun for
-    /// the error message. A handler that would suspend fails the whole rewrite
-    /// instead, so no handler outlives the throw.
+    /// the error message, article included. A handler that would suspend fails
+    /// the whole rewrite instead, so no handler outlives the throw.
     sync_only_noun: Cell<Option<&'static str>>,
     /// Which lol-html call still has to run (or finish).
     phase: Cell<RewritePhase>,
@@ -1782,7 +1783,7 @@ where
             // SAFETY: `sink` is the live BufferOutputSink for this rewrite.
             if let Some(noun) = unsafe { (*sink).sync_only_noun.get() } {
                 let err = global.create_type_error_instance(format_args!(
-                    "HTMLRewriter.transform() cannot synchronously return a {noun} because a \
+                    "HTMLRewriter.transform() cannot synchronously return {noun} because a \
                      content handler returned a Promise that did not resolve within a microtask. \
                      Pass a Response instead and await its body"
                 ));

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -16,6 +16,7 @@ use bun_jsc::{
 // owner of the `on_quiet_unhandled_rejection_handler_capture_value` assoc fn.
 use bun_jsc::virtual_machine::VirtualMachine;
 
+use crate::api::NativePromiseContext;
 use crate::webcore::response::HeadersRef;
 use crate::webcore::{self, Response};
 use bun_core::String as BunString;
@@ -1153,13 +1154,19 @@ impl BufferOutputSink {
 
         // No JS has run (so no GC can have happened) between
         // `handler_callback` recording `promise` and here: the lol-html
-        // unwind in between is pure native code. Once attached, the
-        // reactions (and `sink`, smuggled as their context argument) are
-        // rooted on the promise itself.
+        // unwind in between is pure native code.
         suspension.promise.ensure_still_alive();
-        suspension.promise.then(
+
+        // The reactions' context is a GC-managed cell holding the sink's `+1`,
+        // not a raw pointer: a promise collected without ever settling takes
+        // the cell with it, and its destructor abandons the parked rewrite
+        // instead of leaking it (`SuspensionContext::abandon`).
+        // SAFETY: the `ref_()` above is the `+1` this context now owns.
+        let ctx = unsafe { SuspensionContext::new(sink) };
+        let cell = NativePromiseContext::create(&global, ctx);
+        suspension.promise.then_with_value(
             &global,
-            sink,
+            cell,
             Bun__HTMLRewriter__onHandlerResolve,
             Bun__HTMLRewriter__onHandlerReject,
         );
@@ -1293,11 +1300,68 @@ bun_jsc::jsc_host_abi! {
     }
 }
 
+/// The `.then()` context for one suspension, wrapped in a GC-managed
+/// `NativePromiseContext` cell rather than passed as a raw pointer. If the
+/// handler's promise is collected without ever settling (a handler that awaits
+/// a promise nothing will resolve), the cell's destructor reaches
+/// [`Self::abandon`] instead of leaking the parked rewrite forever.
+///
+/// Holds the `+1` on `sink` that the settling reaction (or `abandon`) releases.
+#[repr(align(8))]
+pub struct SuspensionContext {
+    sink: *mut BufferOutputSink,
+}
+
+impl SuspensionContext {
+    /// Consumes one ref on `sink`.
+    ///
+    /// # Safety
+    /// `sink` must be live with a `+1` transferred to the returned context.
+    unsafe fn new(sink: *mut BufferOutputSink) -> *mut Self {
+        bun_core::heap::into_raw(Box::new(Self { sink }))
+    }
+
+    /// Reclaim the sink from a settling reaction's context argument. `None` if
+    /// the cell was already taken (it can only be taken once).
+    fn take(cell: JSValue) -> Option<*mut BufferOutputSink> {
+        let ctx = NativePromiseContext::take::<Self>(cell)?;
+        // SAFETY: `take` hands back the pointer `new` leaked, exactly once.
+        let this = unsafe { bun_core::heap::take(ctx.as_ptr()) };
+        Some(this.sink)
+    }
+
+    /// The promise was collected without settling: the rewrite can never
+    /// continue. Fail the output body and release everything the suspension
+    /// parked. Runs from the event loop, not the GC sweep (see
+    /// `DeferredDerefTask`), so touching the JSC heap is safe here.
+    ///
+    /// # Safety
+    /// `this` must be the live context the GC'd cell owned.
+    pub(crate) unsafe fn abandon(this: *mut Self) {
+        // SAFETY: fn contract — `this` is the leaked `new` allocation.
+        let sink = unsafe { bun_core::heap::take(this) }.sink;
+        // SAFETY: the context held a `+1` on `sink`; `adopt` consumes it.
+        let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
+        // SAFETY: `sink` is live for this scope (the ref above).
+        unsafe {
+            BufferOutputSink::release_suspended_wrapper(sink);
+            (*sink).phase.set(RewritePhase::Done);
+            BufferOutputSink::deliver_body_error(
+                sink,
+                webcore::body::ValueError::Message(BunString::static_(
+                    "HTMLRewriter content handler returned a Promise that will never settle",
+                )),
+            );
+        }
+    }
+}
+
 fn on_handler_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
-    let sink: *mut BufferOutputSink = args[args.len() - 1].as_promise_ptr();
-    // SAFETY: `begin_suspension` took a +1 on `sink` for this reaction;
-    // `adopt` releases it on scope exit.
+    let Some(sink) = SuspensionContext::take(args[args.len() - 1]) else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    // SAFETY: the context held a `+1` on `sink`; `adopt` releases it.
     let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
     // The handler's post-`await` code already ran (as earlier reactions on
     // the same promise), so the parked unit is done being mutated: detach
@@ -1313,7 +1377,9 @@ fn on_handler_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<J
 fn on_handler_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let args = frame.arguments();
     let reason = args[0];
-    let sink: *mut BufferOutputSink = args[args.len() - 1].as_promise_ptr();
+    let Some(sink) = SuspensionContext::take(args[args.len() - 1]) else {
+        return Ok(JSValue::UNDEFINED);
+    };
     // SAFETY: see `on_handler_resolve`.
     let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
     // The handler failed. Don't resume: `Drop` destroys the suspended

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1716,9 +1716,6 @@ macro_rules! impl_wrapper_like {
     };
 }
 
-/// Record a content handler's exception / rejection on the sink whose
-/// lol-html call is on the stack, so `transform()` (sync) or the output body
-/// (async) surfaces it instead of lol-html's generic "stopped" message.
 /// The value an `Exception` cell wraps. Handing the cell itself to
 /// `JSPromise::reject` asserts, and a `Locked` body can now reject with any
 /// handler error, so unwrap at the point of capture. `to_error` falls back to
@@ -1728,6 +1725,10 @@ fn exception_value(exc: NonNull<jsc::Exception>) -> JSValue {
     cell.to_error().unwrap_or(cell)
 }
 
+/// Record a content handler's exception / rejection on the sink whose lol-html
+/// call is on the stack, so `transform()` (sync) or the output body (async)
+/// surfaces it instead of lol-html's generic "stopped" message.
+///
 /// Takes the sink explicitly rather than re-deriving it from `global`: a caller
 /// that has already established there is none would otherwise silently drop the
 /// error.
@@ -1811,7 +1812,6 @@ where
             // the real error instead of lol-html's generic "stopped" message.
             if let Some(exc) = scope.exception() {
                 // SAFETY: `sink` is the live sink for this rewrite.
-                // SAFETY: `sink` is the live sink for this rewrite.
                 unsafe { record_handler_error(sink, exception_value(exc)) };
             }
             // Clear the exception from the scope to prevent assertion failures
@@ -1824,7 +1824,6 @@ where
 
     // Check if there's an exception that was thrown but not caught by the error union
     if let Some(exc) = scope.exception() {
-        // SAFETY: `sink` is the live sink for this rewrite.
         // SAFETY: `sink` is the live sink for this rewrite.
         unsafe { record_handler_error(sink, exception_value(exc)) };
         // Clear the exception to prevent assertion failures

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -589,9 +589,14 @@ enum RewritePhase {
 
 /// Recorded by [`handler_callback`] when a handler returned a still-pending
 /// promise, consumed by [`BufferOutputSink::begin_suspension`] immediately
-/// after the lol-html call returns `Err(Suspended)`. Only ever `Some` inside
-/// that purely-native window, so `promise` needs no GC root: no JS runs (and
-/// therefore no GC can happen) between the two points.
+/// after the lol-html call returns `Err(Suspended)`.
+///
+/// `promise` is `protect()`ed for that window. The window is pure native code
+/// (the lol-html unwind), so today no GC can observe it unrooted, but that
+/// property is owned by a vendored patch rather than by this file, and JSC's
+/// rule is "rooted whenever a safepoint is reachable", not "rooted whenever JS
+/// runs". One `gcProtect` per suspension buys the invariant outright.
+/// `begin_suspension` adopts the protection into a [`ProtectedJSValue`].
 struct PendingSuspension {
     /// The JS wrapper handed to the suspending handler. It must stay usable
     /// across the handler's `await` so the post-`await` code can keep
@@ -602,7 +607,8 @@ struct PendingSuspension {
     retarget: unsafe fn(*mut core::ffi::c_void, *mut LolRewriter),
     /// `(*wrapper).detach()` + release the ref [`handler_callback`] took.
     release: unsafe fn(*mut core::ffi::c_void),
-    /// The still-pending promise the handler returned.
+    /// The still-pending promise the handler returned. Carries a `protect()`
+    /// that `begin_suspension` adopts and releases.
     promise: JSValue,
 }
 
@@ -642,6 +648,12 @@ unsafe fn release_wrapper<Z: WrapperLike>(wrapper: *mut core::ffi::c_void) {
 /// one lol-html `write()`/`end()`/`resume()` call, restoring the previous
 /// one on drop. LIFO so a handler body that synchronously runs a nested
 /// `transform()` nests correctly.
+///
+/// Why ambient rather than captured: the element/document closures are built in
+/// `build_settings` from a `LOLHTMLContext` that exists before any sink does
+/// (the sink's `init` takes the context), and `Element::on_end_tag_` builds its
+/// closure at handler-run time from `&self`, with no sink anywhere in scope.
+/// Threading a sink to that one site would mean a sink field on every `Element`.
 struct ActiveSinkGuard {
     prev: Option<NonNull<core::ffi::c_void>>,
 }
@@ -692,12 +704,12 @@ pub struct BufferOutputSink {
     pub response: *mut Response, // BORROW_FIELD: kept alive by response_value Strong
     pub response_value: StrongOptional,
     pub body_value_bufferer: Option<webcore::body::ValueBufferer<'static>>,
-    /// An exception thrown (or rejection captured) by a content handler
-    /// during the lol-html call currently on the stack. The sink owns it (it
-    /// has to outlive `transform()` now that a handler can suspend the
-    /// rewrite), but it is only ever non-empty between a handler setting it
-    /// and that same lol-html call returning -- a purely native window -- so
-    /// it never needs a GC root.
+    /// An exception thrown (or rejection captured) by a content handler during
+    /// the lol-html call currently on the stack. The sink owns it (it has to
+    /// outlive `transform()` now that a handler can suspend the rewrite), and
+    /// `protect()`s it while held: the window is native-only today, but it is a
+    /// heap slot the conservative stack scan never sees, so root it rather than
+    /// lean on an invariant a vendored patch could change.
     handler_error: Cell<JSValue>,
     /// Set for `transform(string)` / `transform(ArrayBuffer)`, which must
     /// produce their result before `transform()` returns. Holds the noun for
@@ -720,15 +732,19 @@ impl BufferOutputSink {
 
     /// Record a handler's exception for the enclosing lol-html call to pick
     /// up once it returns. Overwrites (the last failure wins, matching the
-    /// previous capture-slot behavior).
+    /// previous capture-slot behavior). Roots `err` until it is taken.
     fn set_handler_error(&self, err: JSValue) {
-        self.handler_error.set(err);
+        err.protect();
+        let prev = self.handler_error.replace(err);
+        prev.unprotect();
     }
 
     /// Take (and clear) the handler error recorded during the lol-html call
-    /// that just returned.
+    /// that just returned, handing the caller an unrooted value to consume
+    /// within its own frame (where the conservative stack scan covers it).
     fn take_handler_error(&self) -> Option<JSValue> {
         let err = self.handler_error.replace(JSValue::ZERO);
+        err.unprotect();
         (!err.is_empty()).then_some(err)
     }
 
@@ -1152,10 +1168,9 @@ impl BufferOutputSink {
             (*sink).ref_();
         }
 
-        // No JS has run (so no GC can have happened) between
-        // `handler_callback` recording `promise` and here: the lol-html
-        // unwind in between is pure native code.
-        suspension.promise.ensure_still_alive();
+        // Adopt the protection `handler_callback` took; once `then_with_value`
+        // attaches, the reaction roots the promise and this can go.
+        let promise = jsc::ProtectedJSValue::adopt(suspension.promise);
 
         // The reactions' context is a GC-managed cell holding the sink's `+1`,
         // not a raw pointer: a promise collected without ever settling takes
@@ -1164,7 +1179,7 @@ impl BufferOutputSink {
         // SAFETY: the `ref_()` above is the `+1` this context now owns.
         let ctx = unsafe { SuspensionContext::new(sink) };
         let cell = NativePromiseContext::create(&global, ctx);
-        suspension.promise.then_with_value(
+        promise.value().then_with_value(
             &global,
             cell,
             Bun__HTMLRewriter__onHandlerResolve,
@@ -1400,6 +1415,9 @@ fn on_handler_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSV
 impl Drop for BufferOutputSink {
     fn drop(&mut self) {
         // bytes, body_value_bufferer, context (Rc), response_value (Strong) drop automatically.
+        // An error recorded but never taken (a throwing `init()`) still holds
+        // its protect.
+        self.handler_error.replace(JSValue::ZERO).unprotect();
         if !self.rewriter.is_null() {
             // SAFETY: rewriter heap-allocated by init() and not yet freed
             // (the sink is its sole owner for its whole life).
@@ -1741,10 +1759,18 @@ where
         }
         jsc::js_promise::Status::Pending => {
             let Some(sink) = active_sink(global) else {
-                // Content handlers only ever run from inside a sink's
-                // lol-html call, which installs itself; fail loudly rather
-                // than dangle the wrapper.
+                // Content handlers only ever run from inside a sink's lol-html
+                // call, which installs the guard. Reaching here means a new
+                // entry point forgot it; record a real error (not a
+                // compiled-out assert + silent `Stop`, which would drop the
+                // handler's result on the floor in release builds).
                 debug_assert!(false, "HTMLRewriter handler ran outside a rewrite");
+                record_handler_error(
+                    global,
+                    global.create_type_error_instance(format_args!(
+                        "HTMLRewriter content handler ran outside of a rewrite"
+                    )),
+                );
                 return HandlerOutcome::Stop;
             };
 
@@ -1771,6 +1797,9 @@ where
             // detaches + derefs it once the promise settles, which runs AFTER
             // the handler's own post-`await` continuations.
             let wrapper = scopeguard::ScopeGuard::into_inner(guard);
+            // Root the promise for the native window between here and
+            // `begin_suspension`, which adopts the protection.
+            result.protect();
             // SAFETY: `sink` is the live BufferOutputSink whose lol-html call
             // is on this native stack (installed by `ActiveSinkGuard`).
             unsafe {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -223,14 +223,28 @@ pub struct LOLHTMLContext {
     pub document_handlers: Vec<Box<DocumentHandler>>,
 }
 
-/// `true` = the STOP directive from an `ElementHandler`/`DocumentHandler`/
-/// `EndTagHandler` callback. The message is load-bearing: lol-html's C API
-/// produced exactly this string for a stopped rewriter; it reaches JS as-is.
-fn directive_result(stop: bool) -> lol_html::HandlerResult {
-    if stop {
-        Err("The rewriter has been stopped.".into())
-    } else {
-        Ok(())
+/// What a JS content handler decided.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HandlerOutcome {
+    /// The handler completed; keep rewriting.
+    Continue,
+    /// The handler threw / rejected / returned an Error: abort the rewrite.
+    Stop,
+    /// The handler returned a promise that is still pending after one
+    /// microtask drain: make lol-html park the current rewritable unit and
+    /// return from `write()`/`end()`/`resume()` so the event loop can run.
+    /// See [`BufferOutputSink::begin_suspension`].
+    Suspend,
+}
+
+/// Map the outcome onto lol-html's `HandlerResult`. The `Stop` message is
+/// load-bearing: lol-html's C API produced exactly this string for a stopped
+/// rewriter; it reaches JS as-is.
+fn handler_result(outcome: HandlerOutcome) -> lol_html::HandlerResult {
+    match outcome {
+        HandlerOutcome::Continue => Ok(()),
+        HandlerOutcome::Stop => Err("The rewriter has been stopped.".into()),
+        HandlerOutcome::Suspend => Err(Box::new(lol_html::SuspensionRequest)),
     }
 }
 
@@ -262,21 +276,21 @@ fn build_settings(
             handlers = handlers.element(move |el: &mut lol_html::html_content::Element| {
                 let raw: *mut lol_html::html_content::Element<'static, 'static> =
                     core::ptr::from_mut(el).cast();
-                directive_result(ElementHandler::on_element(h.as_ptr(), raw))
+                handler_result(ElementHandler::on_element(h.as_ptr(), raw))
             });
         }
         if has_comment {
             handlers = handlers.comments(move |c: &mut lol_html::html_content::Comment| {
                 let raw: *mut lol_html::html_content::Comment<'static> =
                     core::ptr::from_mut(c).cast();
-                directive_result(ElementHandler::on_comment(h.as_ptr(), raw))
+                handler_result(ElementHandler::on_comment(h.as_ptr(), raw))
             });
         }
         if has_text {
             handlers = handlers.text(move |t: &mut lol_html::html_content::TextChunk| {
                 let raw: *mut lol_html::html_content::TextChunk<'static> =
                     core::ptr::from_mut(t).cast();
-                directive_result(ElementHandler::on_text(h.as_ptr(), raw))
+                handler_result(ElementHandler::on_text(h.as_ptr(), raw))
             });
         }
         element_content_handlers.push((std::borrow::Cow::Owned(selector.clone()), handlers));
@@ -297,28 +311,28 @@ fn build_settings(
             handlers = handlers.doctype(move |d: &mut lol_html::html_content::Doctype| {
                 let raw: *mut lol_html::html_content::Doctype<'static> =
                     core::ptr::from_mut(d).cast();
-                directive_result(DocumentHandler::on_doc_type(h.as_ptr(), raw))
+                handler_result(DocumentHandler::on_doc_type(h.as_ptr(), raw))
             });
         }
         if has_comment {
             handlers = handlers.comments(move |c: &mut lol_html::html_content::Comment| {
                 let raw: *mut lol_html::html_content::Comment<'static> =
                     core::ptr::from_mut(c).cast();
-                directive_result(DocumentHandler::on_comment(h.as_ptr(), raw))
+                handler_result(DocumentHandler::on_comment(h.as_ptr(), raw))
             });
         }
         if has_text {
             handlers = handlers.text(move |t: &mut lol_html::html_content::TextChunk| {
                 let raw: *mut lol_html::html_content::TextChunk<'static> =
                     core::ptr::from_mut(t).cast();
-                directive_result(DocumentHandler::on_text(h.as_ptr(), raw))
+                handler_result(DocumentHandler::on_text(h.as_ptr(), raw))
             });
         }
         if has_end {
             handlers = handlers.end(move |e: &mut lol_html::html_content::DocumentEnd| {
                 let raw: *mut lol_html::html_content::DocumentEnd<'static> =
                     core::ptr::from_mut(e).cast();
-                directive_result(DocumentHandler::on_end(h.as_ptr(), raw))
+                handler_result(DocumentHandler::on_end(h.as_ptr(), raw))
             });
         }
         document_content_handlers.push(handlers);
@@ -472,15 +486,8 @@ impl HTMLRewriter {
             else {
                 return Ok(out_response_value);
             };
-            // SAFETY: out_response is the m_ctx of out_response_value (kept alive
-            // on the stack via ensure_still_alive above).
-            let mut blob = unsafe {
-                (*out_response)
-                    .get_body_value()
-                    .use_as_any_blob_allow_non_utf8_string()
-            };
 
-            let _out_guard = scopeguard::guard((out_response_value, out_response), |(v, r)| {
+            let out_guard = scopeguard::guard((out_response_value, out_response), |(v, r)| {
                 // `Response.js.dangerouslySetPtr(v, null)` — null out the JS
                 // wrapper's `m_ctx` so its GC finalize is a no-op, then finalize
                 // the native side ourselves.
@@ -497,6 +504,43 @@ impl HTMLRewriter {
                     Response::finalize(Box::from_raw(r));
                 }
             });
+
+            // `transform(string)` / `transform(ArrayBuffer)` must produce the
+            // result synchronously. A body still `Locked` here means an async
+            // content handler suspended the rewrite; there is nothing sound
+            // to return.
+            // SAFETY: out_response is the m_ctx of out_response_value (kept
+            // alive on the stack via ensure_still_alive above).
+            if matches!(
+                unsafe { &*(*out_response).get_body_value() },
+                webcore::body::Value::Locked(_)
+            ) {
+                // The suspended rewrite still runs when its handler's promise
+                // settles and its sink still points at `out_response` (and
+                // keeps its JS wrapper alive through a Strong), so the eager
+                // finalize above would be a use-after-free. Disarm it: the
+                // orphaned Response is collected normally once the rewrite
+                // completes and the sink drops.
+                let _ = scopeguard::ScopeGuard::into_inner(out_guard);
+                return Err(global.throw_type_error(format_args!(
+                    "HTMLRewriter.transform() cannot synchronously return a {} because a content \
+                     handler returned a Promise that did not resolve within a microtask. Pass a \
+                     Response instead and await its body",
+                    if kind == ResponseKind::String {
+                        "string"
+                    } else {
+                        "ArrayBuffer"
+                    }
+                )));
+            }
+
+            // SAFETY: out_response is the m_ctx of out_response_value (kept alive
+            // on the stack via ensure_still_alive above).
+            let mut blob = unsafe {
+                (*out_response)
+                    .get_body_value()
+                    .use_as_any_blob_allow_non_utf8_string()
+            };
 
             return match kind {
                 ResponseKind::String => blob.to_string(global, webcore::Lifetime::Transfer),
@@ -542,6 +586,112 @@ impl HTMLRewriter {
 
 // ───────────────────────── BufferOutputSink ──────────────────────────────
 
+/// The concrete lol-html rewriter type backing one `transform()`.
+type LolRewriter = lol_html::HtmlRewriter<'static, SinkRef>;
+
+/// Which lol-html call the sink still has to run (or finish). Advanced by
+/// [`BufferOutputSink::run_output_sink`] / [`BufferOutputSink::resume_rewrite`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RewritePhase {
+    /// `write(input)` has not completed (not started, or a handler suspended it).
+    WritePending,
+    /// `write` completed; `end()` has not (not started, or suspended).
+    EndPending,
+    /// The rewrite ran to completion or failed; nothing left to drive.
+    Done,
+}
+
+/// Recorded by [`handler_callback`] when a handler returned a still-pending
+/// promise, consumed by [`BufferOutputSink::begin_suspension`] immediately
+/// after the lol-html call returns `Err(Suspended)`. Only ever `Some` inside
+/// that purely-native window, so `promise` needs no GC root: no JS runs (and
+/// therefore no GC can happen) between the two points.
+struct PendingSuspension {
+    /// The JS wrapper handed to the suspending handler. It must stay usable
+    /// across the handler's `await` so the post-`await` code can keep
+    /// mutating the unit.
+    wrapper: *mut core::ffi::c_void,
+    /// `(*wrapper).retarget(rewriter.suspended_<unit>())` for the wrapper's
+    /// concrete type: points it at the heap copy lol-html parked.
+    retarget: unsafe fn(*mut core::ffi::c_void, *mut LolRewriter),
+    /// `(*wrapper).detach()` + release the ref [`handler_callback`] took.
+    release: unsafe fn(*mut core::ffi::c_void),
+    /// The still-pending promise the handler returned.
+    promise: JSValue,
+}
+
+/// `PendingSuspension::retarget` for a concrete wrapper type.
+///
+/// # Safety
+/// `wrapper` must be a live `Z`; `rewriter` must be suspended on a `Z::Raw`
+/// unit (guaranteed: the same `handler_callback::<_, Z, _>` that parked
+/// `wrapper` is what suspended it).
+unsafe fn retarget_wrapper<Z: WrapperLike>(
+    wrapper: *mut core::ffi::c_void,
+    rewriter: *mut LolRewriter,
+) {
+    // SAFETY: see fn contract.
+    let raw = unsafe { Z::suspended_raw(&mut *rewriter) };
+    debug_assert!(!raw.is_null());
+    // SAFETY: `wrapper` is a live `Z` (see fn contract).
+    unsafe { (*wrapper.cast::<Z>()).retarget(raw) };
+}
+
+/// `PendingSuspension::release` for a concrete wrapper type: detach the
+/// wrapper from the (about to be freed) lol-html unit and drop the ref
+/// [`handler_callback`] took for the suspension.
+///
+/// # Safety
+/// `wrapper` must be a live `Z` with refcount >= 1.
+unsafe fn release_wrapper<Z: WrapperLike>(wrapper: *mut core::ffi::c_void) {
+    let wrapper = wrapper.cast::<Z>();
+    // SAFETY: see fn contract.
+    unsafe {
+        (*wrapper).detach();
+        Z::deref(wrapper);
+    }
+}
+
+/// Installs `sink` as the VM's active HTMLRewriter sink for the duration of
+/// one lol-html `write()`/`end()`/`resume()` call, restoring the previous
+/// one on drop. LIFO so a handler body that synchronously runs a nested
+/// `transform()` nests correctly.
+struct ActiveSinkGuard {
+    prev: Option<NonNull<core::ffi::c_void>>,
+}
+
+impl ActiveSinkGuard {
+    /// # Safety
+    /// `sink` must be a live `BufferOutputSink` heap allocation.
+    unsafe fn enter(sink: *mut BufferOutputSink) -> Self {
+        // SAFETY: bun_vm() returns the live VM raw ptr; the short-lived
+        // `&mut` is dropped at the end of the statement (JS can re-enter
+        // `bun_vm()` from the handlers that run while this guard is live).
+        // SAFETY: `sink` is live per the fn contract.
+        let global = unsafe { (*sink).global };
+        let vm: &mut VirtualMachine = global.bun_vm().as_mut();
+        Self {
+            prev: core::mem::replace(&mut vm.html_rewriter_active_sink, NonNull::new(sink.cast())),
+        }
+    }
+}
+
+impl Drop for ActiveSinkGuard {
+    fn drop(&mut self) {
+        // SAFETY: the JS thread's VM outlives this synchronous frame.
+        VirtualMachine::get().as_mut().html_rewriter_active_sink = self.prev;
+    }
+}
+
+/// The `BufferOutputSink` whose lol-html call is on this VM's native stack,
+/// if any. Content handlers can only run inside such a call.
+fn active_sink(global: &JSGlobalObject) -> Option<*mut BufferOutputSink> {
+    global
+        .bun_vm_ref()
+        .html_rewriter_active_sink
+        .map(|p| p.as_ptr().cast())
+}
+
 #[derive(bun_ptr::CellRefCounted)]
 pub struct BufferOutputSink {
     // Intrusive RefCount; *Self is the `SinkRef` carried inside `rewriter`.
@@ -551,33 +701,44 @@ pub struct BufferOutputSink {
     // Heap-allocated (never held by value): `run_output_sink` must reach the
     // rewriter through a raw pointer, never a `&mut` of `*sink`, because the
     // output sink re-enters `&mut *sink` while the rewriter runs.
-    pub rewriter: *mut lol_html::HtmlRewriter<'static, SinkRef>, // null when unset
+    pub rewriter: *mut LolRewriter, // null when unset
     pub context: Rc<RefCell<LOLHTMLContext>>,
     pub response: *mut Response, // BORROW_FIELD: kept alive by response_value Strong
     pub response_value: StrongOptional,
     pub body_value_bufferer: Option<webcore::body::ValueBufferer<'static>>,
-    // Points at the `sink_error` stack local in `init()`;
-    // only written while `init()` is on the stack.
-    // See `write_tmp_sync_error` for the full liveness/provenance argument.
-    pub tmp_sync_error: Option<NonNull<JSValue>>,
+    /// An exception thrown (or rejection captured) by a content handler
+    /// during the lol-html call currently on the stack. The sink owns it (it
+    /// has to outlive `transform()` now that a handler can suspend the
+    /// rewrite), but it is only ever non-empty between a handler setting it
+    /// and that same lol-html call returning -- a purely native window -- so
+    /// it never needs a GC root.
+    handler_error: Cell<JSValue>,
+    /// Which lol-html call still has to run (or finish).
+    phase: Cell<RewritePhase>,
+    /// Handed from the suspending [`handler_callback`] to
+    /// [`Self::begin_suspension`] across the lol-html unwind.
+    pending_suspension: Cell<Option<PendingSuspension>>,
+    /// The suspended handler's JS wrapper (retargeted at lol-html's
+    /// heap-parked unit), released when the handler's promise settles.
+    suspended_wrapper: Cell<*mut core::ffi::c_void>,
+    suspended_wrapper_release: Cell<Option<unsafe fn(*mut core::ffi::c_void)>>,
 }
 
 impl BufferOutputSink {
     // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
 
-    /// Single unsafe deref site for the set-once
-    /// `tmp_sync_error: Option<NonNull<JSValue>>` field, so the two callers in
-    /// `on_finished_buffering` stay safe. `tmp_sync_error` points at the
-    /// `sink_error: Cell<JSValue>` stack local in [`init`]; it is only written
-    /// through on the synchronous (`is_async == false`) path while `init` is
-    /// still on the stack, so the pointee is live and the `Cell`-derived
-    /// pointer carries `SharedReadWrite` provenance.
-    #[inline]
-    fn write_tmp_sync_error(sink: *mut Self, err: JSValue) {
-        // SAFETY: `sink` is a live heap allocation (refcount > 0, caller
-        // invariant); `tmp_sync_error` was set in `init()` and the synchronous
-        // caller is reached only while `init()` is still on the stack.
-        unsafe { *(*sink).tmp_sync_error.unwrap().as_ptr() = err };
+    /// Record a handler's exception for the enclosing lol-html call to pick
+    /// up once it returns. Overwrites (the last failure wins, matching the
+    /// previous capture-slot behavior).
+    fn set_handler_error(&self, err: JSValue) {
+        self.handler_error.set(err);
+    }
+
+    /// Take (and clear) the handler error recorded during the lol-html call
+    /// that just returned.
+    fn take_handler_error(&self) -> Option<JSValue> {
+        let err = self.handler_error.replace(JSValue::ZERO);
+        (!err.is_empty()).then_some(err)
     }
 
     /// # Safety
@@ -597,7 +758,11 @@ impl BufferOutputSink {
             response: core::ptr::null_mut(),
             response_value: StrongOptional::empty(),
             body_value_bufferer: None,
-            tmp_sync_error: None,
+            handler_error: Cell::new(JSValue::ZERO),
+            phase: Cell::new(RewritePhase::WritePending),
+            pending_suspension: Cell::new(None),
+            suspended_wrapper: Cell::new(core::ptr::null_mut()),
+            suspended_wrapper_release: Cell::new(None),
         }));
         // SAFETY: `sink` is the `heap::into_raw` allocation above; refcount >= 1.
         let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
@@ -606,57 +771,32 @@ impl BufferOutputSink {
         // output-sink callback during `bufferer.run()` and by `deref(sink)`
         // below. Access fields via raw-pointer place expressions instead.
 
+        // NOTE: the output body starts as a pristine `Locked(PendingValue)`.
+        // `task` and `on_receive_value` deliberately stay `None`: they are a
+        // PAIR that means "a consumer registered a callback for this body".
+        // Whoever consumes the output Response (`.text()`, `Bun.serve`,
+        // another `transform()`) registers itself on the PendingValue; the
+        // sink's `done()` then hands it the buffered output via
+        // `Value::resolve`. Stamping `task` here (without `on_receive_value`)
+        // would make `Bun.serve` believe someone else already owns the body
+        // and fall back to piping a ReadableStream nobody ever feeds.
         let result = bun_core::heap::into_raw(Box::new(Response::init(
             webcore::response::Init {
                 status_code: 200,
                 ..Default::default()
             },
-            webcore::Body::new({
-                let mut pv = webcore::body::PendingValue::new(global);
-                pv.task = Some(sink.cast::<core::ffi::c_void>());
-                webcore::body::Value::Locked(pv)
-            }),
+            webcore::Body::new(webcore::body::Value::Locked(
+                webcore::body::PendingValue::new(global),
+            )),
             BunString::empty(),
             false,
         )));
 
         // SAFETY: sink was just allocated via heap::alloc above; refcount==1.
         unsafe { (*sink).response = result };
-        // Note (Stacked Borrows): `sink_error` is written via raw pointer
-        // by the unhandled-rejection handler during `bufferer.run()` and via
-        // `tmp_sync_error` from `on_finished_buffering`. Use a `Cell` so the
-        // exported `*mut` (via `Cell::as_ptr`, i.e. `UnsafeCell::get`) carries
-        // SharedReadWrite provenance — local `.get()` reads do NOT invalidate
-        // the stored raw pointer the way a `&`/`&mut` reborrow of a plain
-        // `mut` local would.
-        let sink_error: core::cell::Cell<JSValue> = core::cell::Cell::new(JSValue::ZERO);
-        let sink_error_ptr: *mut JSValue = sink_error.as_ptr();
         // SAFETY: original is a live *Response passed from begin_transform; its
         // JS wrapper is on the caller's stack.
         let input_size = unsafe { (*original).get_body_len() };
-        // SAFETY: bun_vm() returns the live VM raw ptr; VM outlives this fn.
-        let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-
-        // Since we're still using vm.waitForPromise, we have to also override
-        // the error rejection handler. That way, we can propagate errors to the
-        // caller.
-        let scope = vm.unhandled_rejection_scope();
-        let prev_unhandled_pending_rejection_to_capture = vm.unhandled_pending_rejection_to_capture;
-        vm.unhandled_pending_rejection_to_capture = Some(sink_error_ptr);
-        // SAFETY: sink is a live heap allocation (refcount >= 1); sink_error_ptr
-        // is non-null (addr of stack local).
-        unsafe { (*sink).tmp_sync_error = Some(NonNull::new_unchecked(sink_error_ptr)) };
-        vm.on_unhandled_rejection =
-            VirtualMachine::on_quiet_unhandled_rejection_handler_capture_value;
-        // Read the *live* slot at scope exit (Cell shares provenance with the
-        // raw-pointer writers).
-        scopeguard::defer! {
-            sink_error.get().ensure_still_alive();
-            // SAFETY: VM outlives this guard (sync stack frame).
-            let vm = VirtualMachine::get().as_mut();
-            vm.unhandled_pending_rejection_to_capture = prev_unhandled_pending_rejection_to_capture;
-            scope.apply(vm);
-        }
 
         // The handler closures point into `Box`es owned by `(*sink).context`,
         // which `sink` keeps alive for the rewriter's whole lifetime.
@@ -769,12 +909,12 @@ impl BufferOutputSink {
             });
         }
 
-        // sync error occurs — read via the Cell (shares SharedReadWrite
-        // provenance with the raw-pointer writers; see Note above).
-        let captured = sink_error.get();
-        if !captured.is_empty() {
+        // A handler that failed synchronously (the input was already buffered,
+        // so the whole rewrite ran inline above) surfaces as a synchronous
+        // throw from `transform()`, same as it always has.
+        // SAFETY: sink is a live heap allocation (refcount >= 1).
+        if let Some(captured) = unsafe { (*sink).take_handler_error() } {
             captured.ensure_still_alive();
-            captured.unprotect();
             // Throw directly: the callers gate on `JSValue::to_error()`, which
             // only recognises `ErrorInstance`/`Exception`, so an abort reason
             // (a DOMException or any user value) would be returned instead.
@@ -822,55 +962,31 @@ impl BufferOutputSink {
         let global = unsafe { (*sink).global };
 
         if let Some(mut err) = js_err {
-            // SAFETY: (*sink).response is the heap Response allocated in init()
-            // and kept alive by (*sink).response_value (Strong root).
-            let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
-            let sink_ptr_usize = sink as usize;
-            // If a `.body` readable is already attached, stay `Locked` so
-            // `to_error_instance` delivers the error to its ByteStream; clearing
-            // to `Empty` here would strand any pending `reader.read()` forever.
-            let has_readable = match sink_body_value {
-                webcore::body::Value::Locked(l) => l.readable.has(),
-                _ => false,
-            };
-            if !has_readable
-                && matches!(sink_body_value, webcore::body::Value::Locked(l)
-                    if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_none())
-            {
-                // No reader and no pending read: normalize to `Empty` so
-                // `to_error_instance` takes the simple (non-`Locked`) path.
-                *sink_body_value = webcore::body::Value::Empty;
-            } else if matches!(sink_body_value, webcore::body::Value::Locked(l)
-                if l.task.map_or(0, |p| p as usize) == sink_ptr_usize && l.promise.is_some())
-            {
-                if let webcore::body::Value::Locked(l) = sink_body_value {
-                    l.on_receive_value = None;
-                    l.task = None;
-                }
-            }
             if is_async {
-                let _ = sink_body_value.to_error_instance(err.dupe(&global), &global);
-                // TODO: properly propagate exception upwards
+                // SAFETY: `sink` is live (refcount > 0, fn safety contract).
+                unsafe { Self::deliver_body_error(sink, err.dupe(&global)) };
             } else {
-                let ret_err = err.to_js(&global);
-                ret_err.ensure_still_alive();
-                ret_err.protect();
-                Self::write_tmp_sync_error(sink, ret_err);
+                // `init()` is still on the stack; make `transform()` throw it.
+                // SAFETY: `sink` is live (refcount > 0, fn safety contract).
+                unsafe { (*sink).set_handler_error(err.to_js(&global)) };
             }
             // Do not `end()` the rewriter: that would run `done()`, replacing
             // the error just stored on the body with the truncated output.
             // `Drop` destroys the rewriter once the sink's refcount hits zero.
+            // SAFETY: `sink` is live (refcount > 0, fn safety contract).
+            unsafe { (*sink).phase.set(RewritePhase::Done) };
             return;
         }
 
         // SAFETY: `sink` is live (refcount > 0, see fn safety contract).
-        if let Some(ret_err) = unsafe { Self::run_output_sink(sink, bytes, is_async) } {
-            ret_err.ensure_still_alive();
-            ret_err.protect();
-            Self::write_tmp_sync_error(sink, ret_err);
-        }
+        unsafe { Self::run_output_sink(sink, bytes, is_async) }
     }
 
+    /// Run the whole (already buffered) input through lol-html: `write` then
+    /// `end`. A content handler that returns a still-pending promise suspends
+    /// either call; [`Self::resume_rewrite`] picks up from where it stopped
+    /// once the promise settles.
+    ///
     /// Note: takes `*mut Self` (not `&mut self`) because
     /// `HtmlRewriter::write/end` re-enter
     /// `SinkRef::handle_chunk(&mut self)` through the
@@ -880,52 +996,230 @@ impl BufferOutputSink {
     /// # Safety
     /// `sink` must be a live `BufferOutputSink` heap allocation with
     /// refcount > 0; `(*sink).rewriter` and `(*sink).response` must be set.
-    unsafe fn run_output_sink(sink: *mut Self, bytes: &[u8], is_async: bool) -> Option<JSValue> {
+    unsafe fn run_output_sink(sink: *mut Self, bytes: &[u8], is_async: bool) {
         // SAFETY: sink is a live heap allocation (refcount > 0, caller
         // invariant). Read fields into locals before the rewriter calls so no
         // borrow of `*sink` is live across the re-entrant output sink.
-        let (global, response, rewriter) = unsafe {
+        let rewriter = unsafe {
             let _ = (*sink).bytes.grow_by(bytes.len()); // OOM/capacity: fire-and-forget
-            ((*sink).global, (*sink).response, (*sink).rewriter)
+            debug_assert!((*sink).phase.get() == RewritePhase::WritePending);
+            (*sink).rewriter
         };
+
+        // Make `sink` reachable from the content handlers the write invokes.
+        // SAFETY: sink is a live heap allocation (refcount > 0).
+        let _active = unsafe { ActiveSinkGuard::enter(sink) };
 
         // SAFETY: rewriter heap-allocated by init(), not yet freed.
         if let Err(e) = unsafe { (*rewriter).write(bytes) } {
-            // Poisoned: never call `end()` after a failed `write()`. The
-            // field stays non-null so `Drop` frees the rewriter.
-            if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
-                return None;
-            } else {
-                return Some(create_lolhtml_error(&global, &e));
-            }
+            // SAFETY: sink is live (fn safety contract).
+            return unsafe { Self::on_rewriting_error(sink, &e, is_async) };
         }
 
-        // `HtmlRewriter::end(self)` consumes the rewriter: null the field
-        // first so `Drop` does not free it a second time.
-        // SAFETY: sink is a live heap allocation (refcount > 0).
-        unsafe { (*sink).rewriter = core::ptr::null_mut() };
-        // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
-        if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
-            if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
-                return None;
-            } else {
-                return Some(create_lolhtml_error(&global, &e));
-            }
+        // SAFETY: sink is live (fn safety contract); the guard is installed.
+        unsafe { Self::end_rewrite(sink, is_async) }
+    }
+
+    /// `write` completed: run `end()`. The caller must have an
+    /// [`ActiveSinkGuard`] installed.
+    ///
+    /// # Safety
+    /// Same as [`Self::run_output_sink`].
+    unsafe fn end_rewrite(sink: *mut Self, is_async: bool) {
+        // SAFETY: sink is live (fn safety contract).
+        let rewriter = unsafe {
+            (*sink).phase.set(RewritePhase::EndPending);
+            (*sink).rewriter
+        };
+
+        // `end_mut` (unlike the consuming `end`) keeps the rewriter alive: a
+        // document-end handler can suspend it, and `Drop` is what frees it.
+        // SAFETY: rewriter heap-allocated by init(), not yet freed.
+        if let Err(e) = unsafe { (*rewriter).end_mut() } {
+            // SAFETY: sink is live (fn safety contract).
+            return unsafe { Self::on_rewriting_error(sink, &e, is_async) };
         }
 
-        None
+        // `end()` emitted the zero-length finalizing chunk, which ran
+        // `done()` and settled the output body.
+        // SAFETY: sink is live (fn safety contract).
+        unsafe { (*sink).phase.set(RewritePhase::Done) };
+    }
+
+    /// The promise a content handler suspended on has resolved: continue the
+    /// rewrite from wherever lol-html parked it.
+    ///
+    /// # Safety
+    /// `sink` must be a live, suspended `BufferOutputSink` (refcount > 0).
+    unsafe fn resume_rewrite(sink: *mut Self) {
+        // SAFETY: sink is live (fn safety contract).
+        let rewriter = unsafe { (*sink).rewriter };
+        // SAFETY: sink is live (fn safety contract).
+        let _active = unsafe { ActiveSinkGuard::enter(sink) };
+
+        // SAFETY: rewriter heap-allocated by init(), not yet freed.
+        if let Err(e) = unsafe { (*rewriter).resume() } {
+            // The resumed half of the rewrite runs from the event loop, long
+            // after `transform()` returned; every failure here is async.
+            // SAFETY: sink is live (fn safety contract).
+            return unsafe { Self::on_rewriting_error(sink, &e, true) };
+        }
+
+        // SAFETY: sink is live (fn safety contract).
+        match unsafe { (*sink).phase.get() } {
+            // The suspended `write` completed; `end()` is still owed.
+            RewritePhase::WritePending => unsafe { Self::end_rewrite(sink, true) },
+            // The suspended `end` completed; `done()` already ran.
+            RewritePhase::EndPending => unsafe { (*sink).phase.set(RewritePhase::Done) },
+            RewritePhase::Done => unreachable!("resumed a completed HTMLRewriter transform"),
+        }
+    }
+
+    /// A lol-html call returned an error: either the (non-fatal) handler
+    /// suspension escape, or a real failure to surface to whoever is waiting
+    /// for the output.
+    ///
+    /// # Safety
+    /// Same as [`Self::run_output_sink`]; an [`ActiveSinkGuard`] must be
+    /// installed.
+    unsafe fn on_rewriting_error(
+        sink: *mut Self,
+        e: &lol_html::errors::RewritingError,
+        is_async: bool,
+    ) {
+        if matches!(e, lol_html::errors::RewritingError::Suspended) {
+            // SAFETY: sink is live (fn safety contract).
+            return unsafe { Self::begin_suspension(sink) };
+        }
+
+        // The rewriter is poisoned (`Drop` frees it). Surface the real cause:
+        // the exception/rejection a handler recorded, or lol-html's own error.
+        // SAFETY: sink is live (fn safety contract).
+        let (global, captured) = unsafe {
+            (*sink).phase.set(RewritePhase::Done);
+            ((*sink).global, (*sink).take_handler_error())
+        };
+
+        if !is_async {
+            // `init()` is still on the stack; make `transform()` throw.
+            // SAFETY: sink is live (fn safety contract).
+            return unsafe {
+                (*sink)
+                    .set_handler_error(captured.unwrap_or_else(|| create_lolhtml_error(&global, e)))
+            };
+        }
+
+        let value_error = match captured {
+            Some(js_err) => {
+                js_err.ensure_still_alive();
+                webcore::body::ValueError::JSValue(jsc::strong::Optional::create(js_err, &global))
+            }
+            None => webcore::body::ValueError::Message(lol_err_string(e)),
+        };
+        // SAFETY: sink is live (fn safety contract).
+        unsafe { Self::deliver_body_error(sink, value_error) };
+    }
+
+    /// A content handler returned a still-pending promise and lol-html parked
+    /// the current rewritable unit on its heap. Re-point the handler's JS
+    /// wrapper at that heap copy — so the handler's post-`await` mutations
+    /// land on the unit that will be serialized — and attach the continuation
+    /// that drives the rest of the rewrite once the promise settles.
+    ///
+    /// # Safety
+    /// `sink` must be live (refcount > 0) and `(*sink).rewriter` suspended by
+    /// the `handler_callback` that populated `(*sink).pending_suspension`.
+    unsafe fn begin_suspension(sink: *mut Self) {
+        // SAFETY: sink is live (fn safety contract).
+        let (global, rewriter) = unsafe { ((*sink).global, (*sink).rewriter) };
+        // SAFETY: sink is live (fn safety contract).
+        let suspension = unsafe { (*sink).pending_suspension.take() }
+            .expect("lol-html suspended without a pending HTMLRewriter handler promise");
+
+        // SAFETY: `rewriter` is suspended on exactly the unit type the
+        // `handler_callback::<_, Z, _>` that built `suspension` dispatched,
+        // and `suspension.wrapper` is that call's live, ref'd wrapper.
+        unsafe { (suspension.retarget)(suspension.wrapper, rewriter) };
+
+        // The in-flight continuation keeps the sink (and through it the
+        // suspended lol-html state) alive until the promise settles.
+        // SAFETY: sink is live (fn safety contract).
+        unsafe {
+            (*sink).suspended_wrapper.set(suspension.wrapper);
+            (*sink)
+                .suspended_wrapper_release
+                .set(Some(suspension.release));
+            (*sink).ref_();
+        }
+
+        // No JS has run (so no GC can have happened) between
+        // `handler_callback` recording `promise` and here: the lol-html
+        // unwind in between is pure native code. Once attached, the
+        // reactions (and `sink`, smuggled as their context argument) are
+        // rooted on the promise itself.
+        suspension.promise.ensure_still_alive();
+        suspension.promise.then(
+            &global,
+            sink,
+            Bun__HTMLRewriter__onHandlerResolve,
+            Bun__HTMLRewriter__onHandlerReject,
+        );
+    }
+
+    /// Detach and release the JS wrapper kept alive across a suspension.
+    /// Must run once the handler's promise settles, before the parked
+    /// lol-html unit it points at is consumed (resume) or freed (rejection).
+    ///
+    /// # Safety
+    /// `sink` must be live (refcount > 0).
+    unsafe fn release_suspended_wrapper(sink: *mut Self) {
+        // SAFETY: sink is live (fn safety contract).
+        let wrapper = unsafe { (*sink).suspended_wrapper.replace(core::ptr::null_mut()) };
+        // SAFETY: sink is live (fn safety contract).
+        let release = unsafe { (*sink).suspended_wrapper_release.take() };
+        if let Some(release) = release {
+            if !wrapper.is_null() {
+                // SAFETY: `wrapper` is the live, ref'd wrapper
+                // `begin_suspension` stashed; `release` matches its type.
+                unsafe { release(wrapper) };
+            }
+        }
+    }
+
+    /// Put `err` on the output `Response`'s body: reject a pending `.text()`
+    /// promise, error an attached `ReadableStream`, or park it for a later
+    /// reader.
+    ///
+    /// # Safety
+    /// `sink` must be live (refcount > 0); `(*sink).response` must be set.
+    unsafe fn deliver_body_error(sink: *mut Self, err: webcore::body::ValueError) {
+        // SAFETY: sink is live (fn safety contract).
+        let global = unsafe { (*sink).global };
+        // SAFETY: (*sink).response is the heap Response allocated in init()
+        // and kept alive by (*sink).response_value (Strong root).
+        let sink_body_value = unsafe { (*(*sink).response).get_body_value() };
+        // If a `.body` readable is already attached, stay `Locked` so
+        // `to_error_instance` delivers the error to its ByteStream; clearing
+        // to `Empty` here would strand any pending `reader.read()` forever.
+        let has_readable = match sink_body_value {
+            webcore::body::Value::Locked(l) => l.readable.has(),
+            _ => false,
+        };
+        // "pristine" = still exactly the `PendingValue` `init()` made: no
+        // consumer (`Bun.serve`, a nested `transform()`, ...) registered a
+        // receive callback on it yet.
+        let is_pristine = matches!(sink_body_value, webcore::body::Value::Locked(l)
+            if l.task.is_none() && l.on_receive_value.is_none());
+        if !has_readable
+            && is_pristine
+            && matches!(sink_body_value, webcore::body::Value::Locked(l) if l.promise.is_none())
+        {
+            // No reader, no pending read, no registered consumer: normalize to
+            // `Empty` so `to_error_instance` takes the simple (non-`Locked`)
+            // path.
+            *sink_body_value = webcore::body::Value::Empty;
+        }
+        let _ = sink_body_value.to_error_instance(err, &global);
     }
 
     pub fn done(&mut self) {
@@ -969,11 +1263,73 @@ impl lol_html::OutputSink for SinkRef {
     }
 }
 
-#[derive(Clone, Copy)]
-pub enum BufferOutputSinkSync {
-    Suspended,
-    Pending,
-    Done,
+// `.then` reactions for the promise a content handler suspended on. `ctx`
+// (the trailing reaction argument) is the `*mut BufferOutputSink` whose
+// rewrite is parked; `begin_suspension` took a ref on it for the reaction.
+//
+// These MUST be *function* symbols: C++'s `promiseHandlerID` compares the
+// handler pointer passed to `JSValue::then` against them by identity and
+// `RELEASE_ASSERT`s on a miss (see `ZigGlobalObject::PromiseFunctions`).
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn Bun__HTMLRewriter__onHandlerResolve(
+        global: *mut JSGlobalObject,
+        frame: *mut CallFrame,
+    ) -> JSValue {
+        // SAFETY: JSC passes valid non-null pointers for the host call's duration.
+        let (global, frame) = unsafe { (&*global, &*frame) };
+        jsc::host_fn::to_js_host_fn_result(global, on_handler_resolve(global, frame))
+    }
+}
+
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn Bun__HTMLRewriter__onHandlerReject(
+        global: *mut JSGlobalObject,
+        frame: *mut CallFrame,
+    ) -> JSValue {
+        // SAFETY: JSC passes valid non-null pointers for the host call's duration.
+        let (global, frame) = unsafe { (&*global, &*frame) };
+        jsc::host_fn::to_js_host_fn_result(global, on_handler_reject(global, frame))
+    }
+}
+
+fn on_handler_resolve(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let args = frame.arguments();
+    let sink: *mut BufferOutputSink = args[args.len() - 1].as_promise_ptr();
+    // SAFETY: `begin_suspension` took a +1 on `sink` for this reaction;
+    // `adopt` releases it on scope exit.
+    let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
+    // The handler's post-`await` code already ran (as earlier reactions on
+    // the same promise), so the parked unit is done being mutated: detach
+    // its JS wrapper BEFORE the resume consumes the unit.
+    // SAFETY: sink is live (the +1 above).
+    unsafe {
+        BufferOutputSink::release_suspended_wrapper(sink);
+        BufferOutputSink::resume_rewrite(sink);
+    }
+    Ok(JSValue::UNDEFINED)
+}
+
+fn on_handler_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let args = frame.arguments();
+    let reason = args[0];
+    let sink: *mut BufferOutputSink = args[args.len() - 1].as_promise_ptr();
+    // SAFETY: see `on_handler_resolve`.
+    let _sink_guard = unsafe { bun_ptr::ScopedRef::<BufferOutputSink>::adopt(sink) };
+    // The handler failed. Don't resume: `Drop` destroys the suspended
+    // rewriter once the sink's refcount hits zero, and the rejection reason
+    // surfaces on the output body exactly like any other async handler error.
+    // SAFETY: sink is live (the +1 above).
+    unsafe {
+        BufferOutputSink::release_suspended_wrapper(sink);
+        (*sink).phase.set(RewritePhase::Done);
+        BufferOutputSink::deliver_body_error(
+            sink,
+            webcore::body::ValueError::JSValue(jsc::strong::Optional::create(reason, global)),
+        );
+    }
+    Ok(JSValue::UNDEFINED)
 }
 
 impl Drop for BufferOutputSink {
@@ -981,7 +1337,7 @@ impl Drop for BufferOutputSink {
         // bytes, body_value_bufferer, context (Rc), response_value (Strong) drop automatically.
         if !self.rewriter.is_null() {
             // SAFETY: rewriter heap-allocated by init() and not yet freed
-            // (`run_output_sink` nulls the field before consuming it in `end`).
+            // (the sink is its sole owner for its whole life).
             unsafe { bun_core::heap::destroy(self.rewriter) };
         }
     }
@@ -1005,49 +1361,25 @@ pub struct DocumentHandler {
 }
 
 impl DocumentHandler {
-    pub fn on_doc_type(
-        this: *mut Self,
-        value: *mut lol_html::html_content::Doctype<'static>,
-    ) -> bool {
-        handler_callback::<Self, DocType, lol_html::html_content::Doctype<'static>>(
-            this,
-            value,
-            |w| w.doctype.set(core::ptr::null_mut()),
-            |h| h.on_doc_type_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub fn on_doc_type(this: *mut Self, value: *mut RawDoctype) -> HandlerOutcome {
+        handler_callback::<Self, DocType, RawDoctype>(this, value, |h| {
+            h.on_doc_type_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
-    pub fn on_comment(
-        this: *mut Self,
-        value: *mut lol_html::html_content::Comment<'static>,
-    ) -> bool {
-        handler_callback::<Self, Comment, lol_html::html_content::Comment<'static>>(
-            this,
-            value,
-            |w| w.comment.set(core::ptr::null_mut()),
-            |h| h.on_comment_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub fn on_comment(this: *mut Self, value: *mut RawComment) -> HandlerOutcome {
+        handler_callback::<Self, Comment, RawComment>(this, value, |h| {
+            h.on_comment_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
-    pub fn on_text(
-        this: *mut Self,
-        value: *mut lol_html::html_content::TextChunk<'static>,
-    ) -> bool {
-        handler_callback::<Self, TextChunk, lol_html::html_content::TextChunk<'static>>(
-            this,
-            value,
-            |w| w.text_chunk.set(core::ptr::null_mut()),
-            |h| h.on_text_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub fn on_text(this: *mut Self, value: *mut RawTextChunk) -> HandlerOutcome {
+        handler_callback::<Self, TextChunk, RawTextChunk>(this, value, |h| {
+            h.on_text_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
-    pub fn on_end(
-        this: *mut Self,
-        value: *mut lol_html::html_content::DocumentEnd<'static>,
-    ) -> bool {
-        handler_callback::<Self, DocEnd, lol_html::html_content::DocumentEnd<'static>>(
-            this,
-            value,
-            |w| w.doc_end.set(core::ptr::null_mut()),
-            |h| h.on_end_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub fn on_end(this: *mut Self, value: *mut RawDocumentEnd) -> HandlerOutcome {
+        handler_callback::<Self, DocEnd, RawDocumentEnd>(this, value, |h| {
+            h.on_end_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 
     pub fn init(global: &JSGlobalObject, this_object: JSValue) -> JsResult<DocumentHandler> {
@@ -1137,7 +1469,8 @@ impl HandlerLike for EndTagHandler {
     }
 }
 
-/// Trait abstracting the wrapper-type bits `HandlerCallback` needs.
+/// Trait abstracting the wrapper-type bits [`handler_callback`] and the
+/// suspension plumbing need.
 pub trait WrapperLike {
     type Raw;
     fn init(value: *mut Self::Raw) -> *mut Self;
@@ -1154,24 +1487,35 @@ pub trait WrapperLike {
     /// # Safety
     /// `this` must be a live `heap::alloc` allocation with refcount >= 1.
     unsafe fn to_js(this: *mut Self, global: &JSGlobalObject) -> JSValue;
-    /// Some wrapper types (Element) hand out sub-objects that borrow from the
-    /// underlying lol-html value and must be detached along with the wrapper
-    /// itself. Default: no-op (caller passes a `clear_field` closure instead).
-    fn invalidate(&self) {}
-    const HAS_INVALIDATE: bool = false;
+    /// Null out the wrapper's lol-html pointer and detach any sub-objects it
+    /// handed to JS (Element's AttributeIterators). Every host-fn on the
+    /// wrapper is a harmless no-op afterwards.
+    fn detach(&self);
+    /// Re-point the wrapper at a different lol-html unit: the heap copy
+    /// lol-html parks when one of the unit's handlers suspends on it.
+    fn retarget(&self, raw: *mut Self::Raw);
+    /// The lol-html unit of this type the rewriter is suspended on, as the
+    /// lifetime-erased raw pointer the wrapper stores. Null if the rewriter
+    /// is not suspended on a `Self::Raw`.
+    fn suspended_raw(rewriter: &mut LolRewriter) -> *mut Self::Raw;
 }
 
 /// Forwarding `WrapperLike` impl — every wrapper type's trait impl is a pure
 /// pass-through to inherent / `CellRefCounted`-derived / `JsClass`-codegen
-/// methods. The optional `, invalidate`
-/// tail wires up types (Element) that hand out sub-objects which must be
-/// detached alongside the lol-html value.
+/// methods. `$field` is the wrapper's `Cell<*mut $raw>`; `$suspended` is the
+/// `lol_html::HtmlRewriter` accessor for the parked unit of that type.
+/// `Element` implements the trait by hand: its `detach` also has to
+/// invalidate the `AttributeIterator`s it handed out.
 macro_rules! impl_wrapper_like {
-    ($ty:ty, $raw:ty $(, $invalidate:ident)?) => {
+    ($ty:ty, $raw:ty, $field:ident, $suspended:ident) => {
         impl WrapperLike for $ty {
             type Raw = $raw;
-            fn init(v: *mut Self::Raw) -> *mut Self { Self::init(v) }
-            fn ref_(&self) { self.ref_() }
+            fn init(v: *mut Self::Raw) -> *mut Self {
+                Self::init(v)
+            }
+            fn ref_(&self) {
+                self.ref_()
+            }
             unsafe fn deref(this: *mut Self) {
                 // SAFETY: `WrapperLike::deref` contract — `this` is a live
                 // `heap::alloc` allocation with refcount >= 1.
@@ -1184,20 +1528,38 @@ macro_rules! impl_wrapper_like {
                 // `Self::finalize` → `deref`).
                 unsafe { Self::to_js_ptr(this, g) }
             }
-            $(
-                fn invalidate(&self) { Self::$invalidate(self) }
-                const HAS_INVALIDATE: bool = true;
-            )?
+            fn detach(&self) {
+                self.$field.set(core::ptr::null_mut());
+            }
+            fn retarget(&self, raw: *mut Self::Raw) {
+                self.$field.set(raw);
+            }
+            fn suspended_raw(rewriter: &mut LolRewriter) -> *mut Self::Raw {
+                rewriter.$suspended().map_or(core::ptr::null_mut(), |unit| {
+                    core::ptr::from_mut(unit).cast()
+                })
+            }
         }
     };
+}
+
+/// Record a content handler's exception / rejection on the sink whose
+/// lol-html call is on the stack, so `transform()` (sync) or the output body
+/// (async) surfaces it instead of lol-html's generic "stopped" message.
+fn record_handler_error(global: &JSGlobalObject, err: JSValue) {
+    if let Some(sink) = active_sink(global) {
+        err.ensure_still_alive();
+        // SAFETY: the active sink drives the lol-html call that invoked this
+        // handler and is live (refcount > 0) for that call's whole duration.
+        unsafe { (*sink).set_handler_error(err) };
+    }
 }
 
 fn handler_callback<H, Z, L>(
     this: *mut H,
     value: *mut L,
-    clear_field: impl FnOnce(&Z),
     get_callback: impl FnOnce(&H) -> Option<JSValue>,
-) -> bool
+) -> HandlerOutcome
 where
     H: HandlerLike,
     Z: WrapperLike<Raw = L>,
@@ -1212,16 +1574,11 @@ where
     // opaque type now. The init values are handled by Box::new with Cell::new(1).
 
     // SAFETY: wrapper is a live heap allocation (ref'd above) for the entire
-    // scope of this guard; deref runs at most once on this path.
-    let _guard = scopeguard::guard(wrapper, |w| unsafe {
-        if Z::HAS_INVALIDATE {
-            // Some wrapper types (Element) hand out sub-objects that borrow
-            // from the underlying lol-html value and must be detached along
-            // with the wrapper itself.
-            (*w).invalidate();
-        } else {
-            clear_field(&*w);
-        }
+    // scope of this guard; the detach+deref runs at most once on this path.
+    // On the SUSPEND path the guard is disarmed and `release_wrapper::<Z>`
+    // runs the same detach+deref once the handler's promise settles instead.
+    let guard = scopeguard::guard(wrapper, |w| unsafe {
+        (*w).detach();
         Z::deref(w);
     });
 
@@ -1232,14 +1589,6 @@ where
     // (R-2); aliased `&H` is sound, aliased `&mut H` is not.
     let this = unsafe { &*this };
     let global = this.global();
-    // Note: re-derive the VM at each use site rather than caching a `&mut`.
-    // `cb.call(...)` and `wait_for_promise(...)` re-enter JS / the event loop,
-    // which mutate the same VirtualMachine through `global.bun_vm()` (and a
-    // nested handler_callback would form its own `&mut VirtualMachine`).
-    // Holding a long-lived `&mut` across those calls is two-live-&mut UB under
-    // Stacked Borrows, so re-acquire a short-lived borrow at each touch.
-    // SAFETY: bun_vm() returns the live VM raw ptr; VM outlives this call.
-    let vm = || -> &mut VirtualMachine { global.bun_vm().as_mut() };
 
     // Use a TopExceptionScope to properly handle exceptions from the JavaScript
     // callback. A post-hoc `try_take_exception()`
@@ -1263,59 +1612,91 @@ where
     ) {
         Ok(v) => v,
         Err(_) => {
-            // If there's an exception in the scope, capture it for later retrieval
+            // Record the exception so `transform()` / the output body throws
+            // the real error instead of lol-html's generic "stopped" message.
             if let Some(exc) = scope.exception() {
-                let exc_value = JSValue::from_cell(exc.as_ptr());
-                // Store the exception in the VM's unhandled rejection capture
-                // mechanism if it's available (this is the same mechanism used
-                // by BufferOutputSink)
-                if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-                    // SAFETY: VM-owned pointer set by BufferOutputSink::init.
-                    unsafe { *err_ptr = exc_value };
-                    exc_value.protect();
-                }
+                record_handler_error(global, JSValue::from_cell(exc.as_ptr()));
             }
             // Clear the exception from the scope to prevent assertion failures
             scope.clear_exception();
-            // Return true to indicate failure to LOLHTML, which will cause the
-            // write operation to fail and the error handling logic to take over.
-            return true;
+            // Stop tells LOLHTML to fail the write; the error handling logic
+            // takes over from there.
+            return HandlerOutcome::Stop;
         }
     };
 
     // Check if there's an exception that was thrown but not caught by the error union
     if let Some(exc) = scope.exception() {
-        let exc_value = JSValue::from_cell(exc.as_ptr());
-        // Store the exception in the VM's unhandled rejection capture mechanism
-        if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-            // SAFETY: VM-owned pointer set by BufferOutputSink::init.
-            unsafe { *err_ptr = exc_value };
-            exc_value.protect();
-        }
+        record_handler_error(global, JSValue::from_cell(exc.as_ptr()));
         // Clear the exception to prevent assertion failures
         scope.clear_exception();
-        return true;
+        return HandlerOutcome::Stop;
     }
 
-    if !result.is_undefined_or_null() {
-        // Note: `is_error() || is_aggregate_error(global)` —
-        // NOT `isAnyError`, which has different
-        // coverage (Exception cells / `Symbol.error` vs cross-realm
-        // AggregateError).
-        if result.is_error() || result.is_aggregate_error(global) {
-            return true;
-        }
+    if result.is_undefined_or_null() {
+        return HandlerOutcome::Continue;
+    }
 
-        if let Some(promise) = result.as_any_promise() {
-            vm().wait_for_promise(promise);
-            let fail = promise.status() == jsc::js_promise::Status::Rejected;
-            if fail {
-                vm().unhandled_rejection(global, promise.result(global.vm()), promise.as_value());
+    // Note: `is_error() || is_aggregate_error(global)` —
+    // NOT `isAnyError`, which has different
+    // coverage (Exception cells / `Symbol.error` vs cross-realm
+    // AggregateError).
+    if result.is_error() || result.is_aggregate_error(global) {
+        return HandlerOutcome::Stop;
+    }
+
+    let Some(promise) = result.as_any_promise() else {
+        return HandlerOutcome::Continue;
+    };
+
+    // An `async` handler's promise settles through the microtask queue even
+    // when its body never truly awaits (`async element(el) { el.remove() }`),
+    // so drain the microtask queue ONCE — never the event loop — before
+    // deciding. A promise that is still pending afterwards is waiting on I/O
+    // or a timer; that is the one case that has to suspend the rewrite
+    // instead of nesting the whole event loop inside lol-html's `write()`.
+    if promise.status() == jsc::js_promise::Status::Pending {
+        global.vm().drain_microtasks();
+        // Microtasks that ran during the drain can leave a JS exception
+        // pending; don't let it escape through the host-function wrapper.
+        scope.clear_exception();
+    }
+
+    match promise.status() {
+        jsc::js_promise::Status::Fulfilled => HandlerOutcome::Continue,
+        jsc::js_promise::Status::Rejected => {
+            // `result()` marks the rejection as handled.
+            record_handler_error(global, promise.result(global.vm()));
+            HandlerOutcome::Stop
+        }
+        jsc::js_promise::Status::Pending => {
+            let Some(sink) = active_sink(global) else {
+                // Content handlers only ever run from inside a sink's
+                // lol-html call, which installs itself; fail loudly rather
+                // than dangle the wrapper.
+                debug_assert!(false, "HTMLRewriter handler ran outside a rewrite");
+                return HandlerOutcome::Stop;
+            };
+            // Hand the wrapper to the suspension: it has to stay valid across
+            // the handler's `await` (the post-`await` code keeps mutating the
+            // unit), so disarm the guard here. `begin_suspension` re-points
+            // it at lol-html's heap-parked copy, and `release_wrapper::<Z>`
+            // detaches + derefs it once the promise settles, which runs AFTER
+            // the handler's own post-`await` continuations.
+            let wrapper = scopeguard::ScopeGuard::into_inner(guard);
+            // SAFETY: `sink` is the live BufferOutputSink whose lol-html call
+            // is on this native stack (installed by `ActiveSinkGuard`).
+            unsafe {
+                (*sink).pending_suspension.set(Some(PendingSuspension {
+                    wrapper: wrapper.cast(),
+                    retarget: retarget_wrapper::<Z>,
+                    release: release_wrapper::<Z>,
+                    promise: result,
+                }));
             }
-            return fail;
+            HandlerOutcome::Suspend
         }
     }
-    false
 }
 
 // ───────────────────────── ElementHandler ────────────────────────────────
@@ -1372,40 +1753,22 @@ impl ElementHandler {
         Ok(handler)
     }
 
-    pub fn on_element(
-        this: *mut Self,
-        value: *mut lol_html::html_content::Element<'static, 'static>,
-    ) -> bool {
-        handler_callback::<Self, Element, lol_html::html_content::Element<'static, 'static>>(
-            this,
-            value,
-            |_| {}, // Element uses HAS_INVALIDATE
-            |h| h.on_element_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub fn on_element(this: *mut Self, value: *mut RawElement) -> HandlerOutcome {
+        handler_callback::<Self, Element, RawElement>(this, value, |h| {
+            h.on_element_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 
-    pub fn on_comment(
-        this: *mut Self,
-        value: *mut lol_html::html_content::Comment<'static>,
-    ) -> bool {
-        handler_callback::<Self, Comment, lol_html::html_content::Comment<'static>>(
-            this,
-            value,
-            |w| w.comment.set(core::ptr::null_mut()),
-            |h| h.on_comment_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub fn on_comment(this: *mut Self, value: *mut RawComment) -> HandlerOutcome {
+        handler_callback::<Self, Comment, RawComment>(this, value, |h| {
+            h.on_comment_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 
-    pub fn on_text(
-        this: *mut Self,
-        value: *mut lol_html::html_content::TextChunk<'static>,
-    ) -> bool {
-        handler_callback::<Self, TextChunk, lol_html::html_content::TextChunk<'static>>(
-            this,
-            value,
-            |w| w.text_chunk.set(core::ptr::null_mut()),
-            |h| h.on_text_callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub fn on_text(this: *mut Self, value: *mut RawTextChunk) -> HandlerOutcome {
+        handler_callback::<Self, TextChunk, RawTextChunk>(this, value, |h| {
+            h.on_text_callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 }
 
@@ -1424,18 +1787,10 @@ fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Displa
         // it's a synchronous error
         return err;
     }
-    // SAFETY: bun_vm() returns the live VM raw ptr; VM outlives this call.
-    let vm: &VirtualMachine = global.bun_vm();
-    if let Some(err_ptr) = vm.unhandled_pending_rejection_to_capture {
-        // SAFETY: VM-owned pointer; valid while VM lives.
-        let slot = unsafe { &mut *err_ptr };
-        if !slot.is_empty() {
-            // it's a promise rejection
-            let result = *slot;
-            *slot = JSValue::ZERO;
-            return result;
-        }
-    }
+    // NOTE: the exception a content handler threw is NOT read from here.
+    // `handler_callback` records it on the sink driving the rewrite
+    // (`record_handler_error`) and `on_rewriting_error` prefers it over the
+    // generic lol-html message once `write()`/`end()` returns.
 
     let err = lol_err_string(message);
     let value = bun_string_jsc::to_error_instance(&err, global);
@@ -1547,7 +1902,7 @@ impl TextChunk {
     }
 }
 
-impl_wrapper_like!(TextChunk, RawTextChunk);
+impl_wrapper_like!(TextChunk, RawTextChunk, text_chunk, suspended_text_chunk);
 
 // ──────────────────────────── DocType ────────────────────────────────────
 
@@ -1617,7 +1972,7 @@ impl DocType {
     }
 }
 
-impl_wrapper_like!(DocType, RawDoctype);
+impl_wrapper_like!(DocType, RawDoctype, doctype, suspended_doctype);
 
 // ──────────────────────────── DocEnd ─────────────────────────────────────
 
@@ -1649,7 +2004,7 @@ impl DocEnd {
     }
 }
 
-impl_wrapper_like!(DocEnd, RawDocumentEnd);
+impl_wrapper_like!(DocEnd, RawDocumentEnd, doc_end, suspended_document_end);
 
 // ──────────────────────────── Comment ────────────────────────────────────
 
@@ -1726,7 +2081,7 @@ impl Comment {
     }
 }
 
-impl_wrapper_like!(Comment, RawComment);
+impl_wrapper_like!(Comment, RawComment, comment, suspended_comment);
 
 // ──────────────────────────── EndTag ─────────────────────────────────────
 
@@ -1747,13 +2102,10 @@ pub struct EndTagHandler {
 }
 
 impl EndTagHandler {
-    pub fn on_end_tag(this: *mut Self, value: *mut RawEndTag) -> bool {
-        handler_callback::<Self, EndTag, RawEndTag>(
-            this,
-            value,
-            |w| w.end_tag.set(core::ptr::null_mut()),
-            |h| h.callback.as_ref().map(ProtectedJSValue::value),
-        )
+    pub fn on_end_tag(this: *mut Self, value: *mut RawEndTag) -> HandlerOutcome {
+        handler_callback::<Self, EndTag, RawEndTag>(this, value, |h| {
+            h.callback.as_ref().map(ProtectedJSValue::value)
+        })
     }
 }
 
@@ -1809,7 +2161,7 @@ impl EndTag {
     }
 }
 
-impl_wrapper_like!(EndTag, RawEndTag);
+impl_wrapper_like!(EndTag, RawEndTag, end_tag, suspended_end_tag);
 
 // ───────────────────────── AttributeIterator ─────────────────────────────
 
@@ -2017,11 +2369,12 @@ impl Element {
         };
         handlers.push(Box::new(move |end_tag| {
             // SAFETY: lifetime erasure. `end_tag` only lives for this
-            // synchronous call; `handler_callback`'s `clear_field` nulls the
-            // `EndTag` JsClass `Cell` before this closure returns, so JS can
-            // never reach the erased pointer afterwards.
+            // synchronous call; `handler_callback`'s guard detaches the
+            // `EndTag` JsClass `Cell` before this closure returns (or, on a
+            // suspension, re-points it at the heap copy lol-html parks), so
+            // JS can never reach a dangling pointer.
             let raw: *mut RawEndTag = core::ptr::from_mut(end_tag).cast();
-            directive_result(EndTagHandler::on_end_tag(
+            handler_result(EndTagHandler::on_end_tag(
                 core::ptr::from_mut(&mut end_tag_handler),
                 raw,
             ))
@@ -2285,4 +2638,39 @@ impl Element {
     }
 }
 
-impl_wrapper_like!(Element, RawElement, invalidate);
+// `Element` is the one wrapper whose `detach` has to do more than null out
+// the raw pointer: the `AttributeIterator`s it handed to JS borrow the same
+// lol-html attribute buffer and must be detached with it (see `invalidate`).
+impl WrapperLike for Element {
+    type Raw = RawElement;
+    fn init(v: *mut Self::Raw) -> *mut Self {
+        Self::init(v)
+    }
+    fn ref_(&self) {
+        self.ref_()
+    }
+    unsafe fn deref(this: *mut Self) {
+        // SAFETY: `WrapperLike::deref` contract — `this` is a live
+        // `heap::alloc` allocation with refcount >= 1.
+        unsafe { Self::deref(this) }
+    }
+    unsafe fn to_js(this: *mut Self, g: &JSGlobalObject) -> JSValue {
+        // SAFETY: `this` is a live `heap::alloc` allocation (refcount >= 1);
+        // ownership is shared with the GC wrapper via the intrusive refcount
+        // (`ElementClass__finalize` → `Self::finalize` → `deref`).
+        unsafe { Self::to_js_ptr(this, g) }
+    }
+    fn detach(&self) {
+        self.invalidate();
+    }
+    fn retarget(&self, raw: *mut Self::Raw) {
+        self.element.set(raw);
+    }
+    fn suspended_raw(rewriter: &mut LolRewriter) -> *mut Self::Raw {
+        rewriter
+            .suspended_element()
+            .map_or(core::ptr::null_mut(), |unit| {
+                core::ptr::from_mut(unit).cast()
+            })
+    }
+}

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -12,8 +12,7 @@ use bun_jsc::{
 // Note: `bun_jsc::VirtualMachine` is a *module* re-export
 // (`pub use self::virtual_machine as VirtualMachine;`). The struct lives at
 // `bun_jsc::virtual_machine::VirtualMachine` — import that directly so the
-// name resolves as a type at `&mut VirtualMachine` annotations and as the
-// owner of the `on_quiet_unhandled_rejection_handler_capture_value` assoc fn.
+// name resolves as a type at `&mut VirtualMachine` annotations.
 use bun_jsc::virtual_machine::VirtualMachine;
 
 use crate::api::NativePromiseContext;
@@ -2394,10 +2393,9 @@ pub struct Element {
     ref_count: Cell<u32>,
     // R-2: `Cell` so host-fns take `&self` (re-entry-safe).
     pub element: Cell<*mut RawElement>,
-    /// AttributeIterator instances created by `getAttributes()` that borrow
-    /// from `element`. They must be detached in `invalidate()` when the
-    /// handler returns so that JS cannot dereference the freed lol-html
-    /// attribute buffer.
+    /// AttributeIterator instances handed out by `getAttributes()`. Each holds
+    /// a non-owning backref to this `Element` plus a `+1` we own; `invalidate()`
+    /// nulls those backrefs when the handler returns, so none can outlive us.
     /// R-2: `JsCell` (non-Copy `Vec`) — pushed/drained from `&self` host-fns
     /// (`get_attributes`, `set_attribute`, `remove_attribute`). The `with_mut`
     /// closures do not call into JS, so the short `&mut Vec` borrow cannot
@@ -2433,10 +2431,10 @@ impl Element {
         bun_ptr::finalize_js_box_noop(self);
     }
 
-    /// Detach every `AttributeIterator` we handed to JS. Called when the
-    /// underlying attribute buffer is about to become invalid — either because
-    /// the handler is returning, or because `setAttribute` / `removeAttribute`
-    /// is about to mutate the `Vec<Attribute>` the iterators borrow from.
+    /// End every `AttributeIterator` we handed to JS: null its backref to us
+    /// and release our `+1`. Called when the handler is returning (we are about
+    /// to stop being a valid target) or when `setAttribute` / `removeAttribute`
+    /// is about to renumber the attributes their index refers into.
     fn detach_attribute_iterators(&self) {
         // R-2: take the Vec out of the cell, drain on the stack — no `&mut`
         // projection of `self` is held across `detach()`/`deref()` (which do
@@ -2453,9 +2451,8 @@ impl Element {
     }
 
     /// Called by `handler_callback` when the handler returns. The underlying
-    /// `*LOLHTML.Element` (and the attribute buffer any `AttributeIterator`
-    /// borrows from) is only valid during handler execution, so we must null
-    /// it out here along with any iterators we handed to JS.
+    /// `*LOLHTML.Element` is only valid during handler execution, so null it
+    /// out here, and end the iterators that read through it.
     pub fn invalidate(&self) {
         self.element.set(core::ptr::null_mut());
         self.detach_attribute_iterators();
@@ -2548,8 +2545,8 @@ impl Element {
             return Ok(JSValue::UNDEFINED);
         };
 
-        // Mutating the attribute Vec (push → possible realloc) invalidates the
-        // slice::Iter any live AttributeIterator borrows from.
+        // A push shifts what the index any live AttributeIterator holds refers
+        // to, so end their iteration rather than let them repeat or skip one.
         self.detach_attribute_iterators();
 
         let name_slice = name_.to_slice();
@@ -2574,8 +2571,8 @@ impl Element {
             return Ok(JSValue::UNDEFINED);
         };
 
-        // Vec::remove shifts trailing elements and shrinks len, leaving any
-        // live slice::Iter's end pointer past the new end.
+        // `Vec::remove` shifts the trailing attributes down, so a live
+        // AttributeIterator's index would skip the one that took this slot.
         self.detach_attribute_iterators();
 
         let name_slice = name.to_slice();
@@ -2759,9 +2756,9 @@ impl Element {
     }
 }
 
-// `Element` is the one wrapper whose `detach` has to do more than null out
-// the raw pointer: the `AttributeIterator`s it handed to JS borrow the same
-// lol-html attribute buffer and must be detached with it (see `invalidate`).
+// `Element` is the one wrapper whose `detach` has to do more than null out the
+// raw pointer: it also ends the `AttributeIterator`s it handed to JS, which
+// hold a backref to it and read through it (see `invalidate`).
 impl WrapperLike for Element {
     type Raw = RawElement;
     fn init(v: *mut Self::Raw) -> *mut Self {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1926,7 +1926,12 @@ where
     pub(crate) fn do_render_with_body_locked(this: *mut c_void, value: &mut Body::Value) {
         // SAFETY: caller upholds the fn-level contract — `this` is the
         // `*mut RequestContext` previously registered as `lock.task`.
-        Self::do_render_with_body(unsafe { bun_ptr::callback_ctx::<Self>(this) }, value, None);
+        let this = unsafe { bun_ptr::callback_ctx::<Self>(this) };
+        // Release the +1 the `on_receive_value` registration in
+        // `do_render_with_body` took, once the render below returns (it may
+        // itself end the request and drop another ref).
+        let _pending_ref = RequestContextRef(std::ptr::from_mut::<Self>(this));
+        Self::do_render_with_body(this, value, None);
     }
 
     fn render_with_blob_from_body_value(&mut self) {
@@ -3192,7 +3197,15 @@ where
                     return;
                 }
 
-                // when there's no stream, we need to
+                // No stream and no other consumer: wait for whoever owns the
+                // `Locked` body (e.g. a suspended `HTMLRewriter` transform) to
+                // deliver its value through `Value::resolve`. The registered
+                // callback owns a +1 on `this` (released by
+                // `do_render_with_body_locked`), and `has_marked_pending`
+                // keeps `should_render_missing` from 404-ing (and
+                // deinit-ing) a request that is merely waiting for its body.
+                this.ref_();
+                this.flags.set_has_marked_pending(true);
                 lock.on_receive_value =
                     Some(|ctx, value| Self::do_render_with_body_locked(ctx, value));
                 lock.task = Some(std::ptr::from_mut::<Self>(this).cast::<c_void>());

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1091,11 +1091,15 @@ impl Value {
         if let Value::Locked(locked) = self {
             if let Some(readable) = locked.readable.get(global) {
                 // A consumer already turned this pending body into a stream
-                // (`.body`, `.clone()`, `new Response(res.body)`) and is
-                // waiting on it. Hand it the bytes we resolved to instead of
-                // closing it empty — `to_error_instance` does the same with the
-                // failure. Only when the stream is the sole consumer: a promise
-                // or a registered callback means somebody else owns the value.
+                // (`.body`, `new Response(res.body)`) and is waiting on it.
+                // Hand it the bytes we resolved to instead of closing it empty —
+                // `to_error_instance` does the same with the failure. Only when
+                // the stream is the sole consumer: a promise or a registered
+                // callback means somebody else owns the value.
+                //
+                // `.clone()` is NOT one of these. `Value::tee` leaves both of
+                // its branches on a `PendingValue` that nothing settles, so a
+                // clone of a still-pending body never reaches here and hangs.
                 let sole_consumer = locked.promise.is_none() && locked.on_receive_value.is_none();
                 let fed = sole_consumer
                     .then(|| readable.ptr.bytes())

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1090,7 +1090,35 @@ impl Value {
         bun_core::scoped_log!(BodyValue, "resolve");
         if let Value::Locked(locked) = self {
             if let Some(readable) = locked.readable.get(global) {
-                readable.done(global);
+                // A consumer already turned this pending body into a stream
+                // (`.body`, `.clone()`, `new Response(res.body)`) and is
+                // waiting on it. Hand it the bytes we resolved to instead of
+                // closing it empty — `to_error_instance` does the same with the
+                // failure. Only when the stream is the sole consumer: a promise
+                // or a registered callback means somebody else owns the value.
+                let sole_consumer = locked.promise.is_none() && locked.on_receive_value.is_none();
+                let fed = sole_consumer
+                    .then(|| readable.ptr.bytes())
+                    .flatten()
+                    .map(|bytes| {
+                        // BACKREF: `Source::bytes()` payload is live for the
+                        // ReadableStream JS wrapper's lifetime.
+                        let mut blob = new.use_as_any_blob_allow_non_utf8_string();
+                        let res = bytes.on_data(streams::Result::TemporaryAndDone(
+                            // Borrowed for the duration of `on_data`.
+                            bun_ptr::RawSlice::new(blob.slice()),
+                        ));
+                        blob.detach();
+                        res
+                    })
+                    .transpose()?;
+
+                if fed.is_some() {
+                    // The stream took the body.
+                    *new = Value::Used;
+                } else {
+                    readable.done(global);
+                }
                 locked.readable.deinit();
             }
 

--- a/test/integration/bun-types/fixture/index.ts
+++ b/test/integration/bun-types/fixture/index.ts
@@ -346,7 +346,7 @@ new HTMLRewriter()
       console.log(element.getAttribute("src"));
     },
   })
-  .transform(new Blob(['<script src="/main.js"></script>']));
+  .transform(new Response('<script src="/main.js"></script>'));
 
 Buffer.from("foo").equals(Buffer.from("bar"));
 

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -120,3 +120,67 @@ test.skipIf(isDebug)(
   },
   15_000,
 );
+
+// A suspension parks the sink (+1), the rewritable unit's JS wrapper (+1), a
+// Strong on the output Response, and the boxed lol-html rewriter. All of it is
+// owned by the handler's promise reaction, so it is released only when that
+// promise settles.
+test("suspended rewrites release their parked state once the handler settles", async () => {
+  const suspendingRewrites = async (count: number) => {
+    for (let i = 0; i < count; i++) {
+      await new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await new Promise(r => setTimeout(r, 0));
+            element.setInnerContent("x");
+          },
+        })
+        .transform(new Response("<p>y</p>"))
+        .text();
+    }
+  };
+
+  const counts = () => {
+    Bun.gc(true);
+    const { objectTypeCounts, protectedObjectTypeCounts } = heapStats();
+    return {
+      responses: objectTypeCounts.Response ?? 0,
+      functions: protectedObjectTypeCounts.Function ?? 0,
+    };
+  };
+
+  await suspendingRewrites(40);
+  const before = counts();
+  await suspendingRewrites(120);
+  const after = counts();
+
+  // Each leaked suspension would pin one Response (the Strong on the sink's
+  // output) and the handler's protected closure.
+  expect(after.responses - before.responses).toBeLessThan(30);
+  expect(after.functions - before.functions).toBeLessThan(30);
+});
+
+// A handler that awaits a promise nothing will ever resolve: the promise is
+// collected unsettled, so the GC-managed reaction context is collected with it
+// and abandons the parked rewrite instead of leaking it forever.
+test("a never-settling handler promise fails the body instead of leaking", async () => {
+  const res = new HTMLRewriter()
+    .on("p", {
+      async element() {
+        await new Promise(() => {});
+      },
+    })
+    .transform(new Response("<p>x</p>"));
+
+  const body = res.text().then(
+    v => ({ ok: v }),
+    e => ({ err: e.message }),
+  );
+  // Collect the unreachable, never-settling promise.
+  for (let i = 0; i < 3; i++) {
+    Bun.gc(true);
+    await new Promise(r => setTimeout(r, 1));
+  }
+
+  expect(await body).toEqual({ err: "HTMLRewriter content handler returned a Promise that will never settle" });
+});

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -124,7 +124,7 @@ test.skipIf(isDebug)(
 // A suspension parks the sink (+1), the rewritable unit's JS wrapper (+1), a
 // Strong on the output Response, and the boxed lol-html rewriter. All of it is
 // owned by the handler's promise reaction, so it is released only when that
-// promise settles.
+// promise settles. A general canary for the settle path.
 test("suspended rewrites release their parked state once the handler settles", async () => {
   const suspendingRewrites = async (count: number) => {
     for (let i = 0; i < count; i++) {
@@ -154,33 +154,74 @@ test("suspended rewrites release their parked state once the handler settles", a
   await suspendingRewrites(120);
   const after = counts();
 
-  // Each leaked suspension would pin one Response (the Strong on the sink's
-  // output) and the handler's protected closure.
   expect(after.responses - before.responses).toBeLessThan(30);
   expect(after.functions - before.functions).toBeLessThan(30);
 });
 
-// A handler that awaits a promise nothing will ever resolve: the promise is
-// collected unsettled, so the GC-managed reaction context is collected with it
-// and abandons the parked rewrite instead of leaking it forever.
-test("a never-settling handler promise fails the body instead of leaking", async () => {
-  const res = new HTMLRewriter()
-    .on("p", {
-      async element() {
-        await new Promise(() => {});
-      },
-    })
-    .transform(new Response("<p>x</p>"));
+// The abandon path: a handler awaiting a promise nothing will ever resolve.
+// The promise is collected unsettled, its GC-managed reaction context goes with
+// it, and `SuspensionContext::abandon` fails the body and releases the parked
+// wrapper / Strong / sink.
+//
+// This is the only guard for that mechanism, so it has to assert the release,
+// not just the rejection. Poll for the rejections rather than forcing exactly N
+// GCs, so a slow ASAN lane doesn't turn a pass into a 5s hang.
+test("never-settling handler promises are abandoned and release their parked state", async () => {
+  const N = 60;
 
-  const body = res.text().then(
-    v => ({ ok: v }),
-    e => ({ err: e.message }),
-  );
-  // Collect the unreachable, never-settling promise.
-  for (let i = 0; i < 3; i++) {
+  const abandonAll = async (count: number) => {
+    const bodies = [];
+    for (let i = 0; i < count; i++) {
+      bodies.push(
+        new HTMLRewriter()
+          .on("p", {
+            async element() {
+              await new Promise(() => {});
+            },
+          })
+          .transform(new Response("<p>x</p>"))
+          .text()
+          .then(
+            () => "resolved",
+            e => e.message,
+          ),
+      );
+    }
+    // The handler promises are unreachable now; collect until every body has
+    // been abandoned, rather than guessing a GC count.
+    const settled: string[] = [];
+    for (let i = 0; i < 100 && settled.length < count; i++) {
+      Bun.gc(true);
+      await new Promise(r => setTimeout(r, 1));
+      settled.length = 0;
+      settled.push(
+        ...(await Promise.all(bodies.map(b => Promise.race([b, Promise.resolve(undefined)])))).filter(Boolean),
+      );
+    }
+    return await Promise.all(bodies);
+  };
+
+  const counts = () => {
     Bun.gc(true);
-    await new Promise(r => setTimeout(r, 1));
-  }
+    const { objectTypeCounts, protectedObjectTypeCounts } = heapStats();
+    return {
+      responses: objectTypeCounts.Response ?? 0,
+      functions: protectedObjectTypeCounts.Function ?? 0,
+    };
+  };
 
-  expect(await body).toEqual({ err: "HTMLRewriter content handler returned a Promise that will never settle" });
+  // Warm up so one-time allocations don't land in the measured delta.
+  const warm = await abandonAll(10);
+  expect(warm.every(m => m.includes("will never settle"))).toBe(true);
+
+  const before = counts();
+  const results = await abandonAll(N);
+  const after = counts();
+
+  // Every one was abandoned with the real reason...
+  expect(results.every(m => m.includes("will never settle"))).toBe(true);
+  // ...and nothing it parked is still pinned. A regression that keeps rejecting
+  // the body but stops releasing would show up as ~N leaked Responses.
+  expect(after.responses - before.responses).toBeLessThan(N / 4);
+  expect(after.functions - before.functions).toBeLessThan(N / 4);
 });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -259,6 +259,11 @@ describe("HTMLRewriter", () => {
     // generic "The rewriter has been stopped."
     it("a throwing handler on a streaming input surfaces the real error", async () => {
       const encoder = new TextEncoder();
+      // The body must still be incomplete when `transform()` runs, or the
+      // rewrite finishes inline and the handler throws synchronously instead
+      // (also correct, but a different code path). Hold the tail back until
+      // `transform()` has returned rather than racing the loopback.
+      const transformCalled = Promise.withResolvers();
       await using server = Bun.serve({
         port: 0,
         fetch: () =>
@@ -266,7 +271,7 @@ describe("HTMLRewriter", () => {
             new ReadableStream({
               async start(controller) {
                 controller.enqueue(encoder.encode("<div>"));
-                await setImmediatePromise();
+                await transformCalled.promise;
                 controller.enqueue(encoder.encode("x</div>"));
                 controller.close();
               },
@@ -281,6 +286,7 @@ describe("HTMLRewriter", () => {
           },
         })
         .transform(upstream);
+      transformCalled.resolve();
       await expect(res.text()).rejects.toThrow("boom");
     });
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { gcTick, tempDir, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -385,6 +385,56 @@ describe("HTMLRewriter", () => {
       await setImmediatePromise();
       await setImmediatePromise();
       expect(later).toBe(0);
+    });
+
+    // A suspended transform hands back a Response whose body is still pending.
+    // Every consumer of that body has to get the bytes once the rewrite
+    // finishes, not just `.text()`.
+    describe("consumers of a still-pending output body", () => {
+      const suspending = () =>
+        new HTMLRewriter()
+          .on("p", {
+            async element(element) {
+              await setImmediatePromise();
+              element.setInnerContent("new");
+            },
+          })
+          .transform(new Response("<p>old</p>"));
+
+      it(".text()", async () => {
+        expect(await suspending().text()).toBe("<p>new</p>");
+      });
+
+      it(".blob()", async () => {
+        expect(await (await suspending().blob()).text()).toBe("<p>new</p>");
+      });
+
+      it(".arrayBuffer()", async () => {
+        const buf = await suspending().arrayBuffer();
+        expect(new TextDecoder().decode(buf)).toBe("<p>new</p>");
+      });
+
+      it(".body reader drains the bytes", async () => {
+        const reader = suspending().body.getReader();
+        const chunks = [];
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+        }
+        expect(new TextDecoder().decode(Buffer.concat(chunks))).toBe("<p>new</p>");
+      });
+
+      it("new Response(res.body).text()", async () => {
+        expect(await new Response(suspending().body).text()).toBe("<p>new</p>");
+      });
+
+      it("Bun.write(file, res)", async () => {
+        using dir = tempDir("hr-pending-body", {});
+        const out = path.join(String(dir), "out.html");
+        await Bun.write(out, suspending());
+        expect(await Bun.file(out).text()).toBe("<p>new</p>");
+      });
     });
 
     it("transform(ArrayBuffer) throws the ArrayBuffer wording", () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tempDir, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, tempDir, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -239,6 +239,110 @@ describe("HTMLRewriter", () => {
       expect(await res.text()).toBe("<div>HELLO</div>world");
     });
 
+    // The canonical "append once the text node ends" idiom, suspended on the
+    // lastInTextNode chunk itself and mutated after the resume.
+    it("async text handler suspending on lastInTextNode and mutating it", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async text(chunk) {
+            if (!chunk.lastInTextNode) return;
+            await setImmediatePromise();
+            chunk.after("|", { html: false });
+          },
+        })
+        .transform(new Response("<div>hello</div>"));
+      expect(await res.text()).toBe("<div>hello|</div>");
+    });
+
+    // The `is_async` arm of `on_rewriting_error`: a handler throwing while the
+    // input is still streaming must surface the real error, not lol-html's
+    // generic "The rewriter has been stopped."
+    it("a throwing handler on a streaming input surfaces the real error", async () => {
+      const encoder = new TextEncoder();
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new Response(
+            new ReadableStream({
+              async start(controller) {
+                controller.enqueue(encoder.encode("<div>"));
+                await setImmediatePromise();
+                controller.enqueue(encoder.encode("x</div>"));
+                controller.close();
+              },
+            }),
+          ),
+      });
+      const upstream = await fetch(`http://localhost:${server.port}/`);
+      const res = new HTMLRewriter()
+        .on("div", {
+          element() {
+            throw new Error("boom");
+          },
+        })
+        .transform(upstream);
+      await expect(res.text()).rejects.toThrow("boom");
+    });
+
+    // Two rewriters chained, both suspending: `init()`'s own comment names
+    // "another transform()" as a supported consumer of a pending body.
+    it("chained suspending transforms", async () => {
+      const first = new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await setImmediatePromise();
+            element.setAttribute("one", "");
+          },
+        })
+        .transform(new Response("<p>x</p>"));
+      const second = new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await setImmediatePromise();
+            element.setAttribute("two", "");
+          },
+        })
+        .transform(first);
+      expect(await second.text()).toBe('<p one="" two="">x</p>');
+    });
+
+    it("a rejection in the first of two chained transforms rejects the last body", async () => {
+      const first = new HTMLRewriter()
+        .on("p", {
+          async element() {
+            await setImmediatePromise();
+            throw new Error("inner boom");
+          },
+        })
+        .transform(new Response("<p>x</p>"));
+      const second = new HTMLRewriter().on("p", { element() {} }).transform(first);
+      await expect(second.text()).rejects.toThrow("inner boom");
+    });
+
+    // The resume path's own `handler_callback` sees a Fulfilled promise only
+    // when a microtask-only handler follows a real-await one.
+    it("a microtask-only handler after a suspending one", async () => {
+      const order = [];
+      const res = new HTMLRewriter()
+        .on("p", {
+          async element(element) {
+            await setImmediatePromise();
+            order.push("slow");
+            element.setAttribute("slow", "");
+          },
+        })
+        .on("p", {
+          async element(element) {
+            await Promise.resolve();
+            order.push("fast");
+            element.setAttribute("fast", "");
+          },
+        })
+        .transform(new Response("<p>x</p>"));
+      expect(await res.text()).toBe('<p slow="" fast="">x</p>');
+      expect(order).toEqual(["slow", "fast"]);
+    });
+
     it("async comments, doctype, and document end handlers", async () => {
       const res = new HTMLRewriter()
         .onDocument({
@@ -447,6 +551,79 @@ describe("HTMLRewriter", () => {
           })
           .transform(new TextEncoder().encode("<div></div>")),
       ).toThrow("cannot synchronously return a ArrayBuffer");
+    });
+
+    // A rejection the handler neither awaits nor returns is the user's to
+    // handle, exactly as for a sync handler. It must reach unhandledRejection
+    // rather than being hijacked into transform()'s result.
+    it("a detached rejection inside a handler reaches unhandledRejection", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("unhandledRejection", e => { console.log("UNHANDLED:" + e.message); process.exit(0); });
+           const out = new HTMLRewriter()
+             .on("p", { element(e) { (async () => { throw new Error("detached"); })(); e.setInnerContent("ok"); } })
+             .transform("<p>x</p>");
+           console.log("OUT:" + out);
+           setTimeout(() => { console.log("NONE"); process.exit(1); }, 500);`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+        stdout: ["OUT:<p>ok</p>", "UNHANDLED:detached"],
+        exitCode: 0,
+      });
+    });
+
+    // The headline production shape: returning a suspended transform straight
+    // out of a Bun.serve handler, with a live client waiting.
+    it("Bun.serve delivers a suspended transform to a live client", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new HTMLRewriter()
+            .on("p", {
+              async element(element) {
+                await setImmediatePromise();
+                element.setInnerContent("served");
+              },
+            })
+            .transform(new Response("<p>x</p>")),
+      });
+      const res = await fetch(`http://localhost:${server.port}/`);
+      expect(await res.text()).toBe("<p>served</p>");
+      expect(res.status).toBe(200);
+    });
+
+    it("Bun.serve routes a rejecting async handler to the error() hook", async () => {
+      const seen = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        error(e) {
+          seen.resolve(e.message);
+          return new Response("handled", { status: 500 });
+        },
+        fetch: () =>
+          new HTMLRewriter()
+            .on("p", {
+              async element() {
+                await setImmediatePromise();
+                throw new Error("handler blew up");
+              },
+            })
+            .transform(new Response("<p>x</p>")),
+      });
+      const res = await fetch(`http://localhost:${server.port}/`);
+      expect(await seen.promise).toBe("handler blew up");
+      expect({ body: await res.text(), status: res.status }).toEqual({ body: "handled", status: 500 });
+
+      // The server keeps serving afterwards.
+      const after = await fetch(`http://localhost:${server.port}/`);
+      expect(after.status).toBe(500);
     });
 
     // The response body is still a pending/locked value when the client goes

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -550,7 +550,7 @@ describe("HTMLRewriter", () => {
             },
           })
           .transform(new TextEncoder().encode("<div></div>")),
-      ).toThrow("cannot synchronously return a ArrayBuffer");
+      ).toThrow("cannot synchronously return an ArrayBuffer");
     });
 
     // A rejection the handler neither awaits nor returns is the user's to

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -147,6 +147,31 @@ describe("HTMLRewriter", () => {
       expect(await res.text()).toBe('<div id="x" before="1" after="2">inner</div>');
     });
 
+    it("an attribute iterator from before the await is detached", async () => {
+      // The suspension deep-copies the element (and its attribute buffer)
+      // onto the heap. An iterator handed out before the `await` borrows the
+      // abandoned buffer, so it must report done, exactly like an iterator
+      // leaked past a synchronous handler's return.
+      let after;
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            const before = element.attributes;
+            await setImmediatePromise();
+            expect(before.next()).toEqual({ done: true, value: undefined });
+            // A fresh iterator reads the heap copy's attributes.
+            after = [...element.attributes];
+            element.setAttribute("c", "3");
+          },
+        })
+        .transform(new Response('<div a="1" b="2">x</div>'));
+      expect(await res.text()).toBe('<div a="1" b="2" c="3">x</div>');
+      expect(after).toEqual([
+        ["a", "1"],
+        ["b", "2"],
+      ]);
+    });
+
     it("runs the next handler for the same element after the previous one's await", async () => {
       const order = [];
       const res = new HTMLRewriter()

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -327,8 +327,9 @@ describe("HTMLRewriter", () => {
     // away; the rewrite must still be allowed to finish (or fail) afterwards
     // without corrupting the RequestContext it was registered against, and the
     // server must keep working.
-    for (const settle of ["resolves", "rejects"]) {
-      it(`client aborts while the handler is suspended, then the handler ${settle}`, async () => {
+    it.concurrent.each(["resolves", "rejects"])(
+      "client aborts while the handler is suspended, then the handler %s",
+      async settle => {
         const suspended = Promise.withResolvers();
         const serverSawAbort = Promise.withResolvers();
         const gate = Promise.withResolvers();
@@ -364,7 +365,9 @@ describe("HTMLRewriter", () => {
         // and only resume it once the server has observed the abort.
         await suspended.promise;
         controller.abort();
-        expect(await clientResult).toBeInstanceOf(DOMException);
+        const abortError = await clientResult;
+        expect(abortError).toBeInstanceOf(DOMException);
+        expect(abortError.name).toBe("AbortError");
         await serverSawAbort.promise;
 
         if (settle === "resolves") {
@@ -377,8 +380,8 @@ describe("HTMLRewriter", () => {
         const after = await fetch(`http://localhost:${server.port}/after`);
         expect(await after.text()).toBe("still alive");
         expect(handlerFinished).toBe(settle === "resolves" ? 1 : 0);
-      });
-    }
+      },
+    );
   });
 
   it("HTMLRewriter handles Symbol invalid type error", async () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -147,29 +147,48 @@ describe("HTMLRewriter", () => {
       expect(await res.text()).toBe('<div id="x" before="1" after="2">inner</div>');
     });
 
-    it("an attribute iterator from before the await is detached", async () => {
-      // The suspension deep-copies the element (and its attribute buffer)
-      // onto the heap. An iterator handed out before the `await` borrows the
-      // abandoned buffer, so it must report done, exactly like an iterator
-      // leaked past a synchronous handler's return.
-      let after;
+    it("an attribute iterator from before the await keeps working", async () => {
+      // The suspension deep-copies the element (and its attribute buffer) onto
+      // the heap. The iterator reads attributes back through the element on
+      // every next(), so it follows the copy and resumes at the same index
+      // instead of silently reporting done.
+      let partial, rest, fresh;
       const res = new HTMLRewriter()
         .on("div", {
           async element(element) {
-            const before = element.attributes;
+            const it = element.attributes;
+            partial = it.next().value;
             await setImmediatePromise();
-            expect(before.next()).toEqual({ done: true, value: undefined });
-            // A fresh iterator reads the heap copy's attributes.
-            after = [...element.attributes];
+            rest = [...it];
+            fresh = [...element.attributes];
             element.setAttribute("c", "3");
           },
         })
         .transform(new Response('<div a="1" b="2">x</div>'));
       expect(await res.text()).toBe('<div a="1" b="2" c="3">x</div>');
-      expect(after).toEqual([
+      expect(partial).toEqual(["a", "1"]);
+      // Resumes mid-iteration against the parked copy.
+      expect(rest).toEqual([["b", "2"]]);
+      expect(fresh).toEqual([
         ["a", "1"],
         ["b", "2"],
       ]);
+    });
+
+    it("a for..of over attributes with an await in the body visits all of them", async () => {
+      const seen = [];
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            for (const [name, value] of element.attributes) {
+              await setImmediatePromise();
+              seen.push(`${name}=${value}`);
+            }
+          },
+        })
+        .transform(new Response('<div a="1" b="2" c="3">x</div>'));
+      expect(await res.text()).toBe('<div a="1" b="2" c="3">x</div>');
+      expect(seen).toEqual(["a=1", "b=2", "c=3"]);
     });
 
     it("runs the next handler for the same element after the previous one's await", async () => {
@@ -321,6 +340,63 @@ describe("HTMLRewriter", () => {
         })
         .transform("<div>old</div>");
       expect(out).toBe("<div>sync enough</div>");
+    });
+
+    // The suspend decision runs one microtask checkpoint, which drains
+    // process.nextTick before the promise jobs (Node ordering), so a handler
+    // that completes via nextTick is still "synchronous enough".
+    for (const [label, schedule] of [
+      ["process.nextTick", "process.nextTick(r)"],
+      ["queueMicrotask", "queueMicrotask(r)"],
+    ]) {
+      it(`transform(string) stays synchronous for a handler awaiting ${label}`, () => {
+        const out = new HTMLRewriter()
+          .on("div", {
+            async element(element) {
+              await new Promise(r => eval(schedule));
+              element.setInnerContent("ok");
+            },
+          })
+          .transform("<div>old</div>");
+        expect(out).toBe("<div>ok</div>");
+      });
+    }
+
+    // transform(string) must fail atomically: the throw means the whole
+    // rewrite failed, so no later handler may run against the orphaned output
+    // and no post-throw rejection may be swallowed.
+    it("transform(string) throwing runs no later handlers", async () => {
+      let later = 0;
+      expect(() =>
+        new HTMLRewriter()
+          .on("a", {
+            async element() {
+              await setImmediatePromise();
+            },
+          })
+          .on("b", {
+            element() {
+              later++;
+            },
+          })
+          .transform("<a></a><b></b>"),
+      ).toThrow("cannot synchronously return a string");
+      // Give the orphaned rewrite every chance to resume and run `b`.
+      await setImmediatePromise();
+      await setImmediatePromise();
+      expect(later).toBe(0);
+    });
+
+    it("transform(ArrayBuffer) throws the ArrayBuffer wording", () => {
+      expect(() =>
+        new HTMLRewriter()
+          .on("div", {
+            async element() {
+              await setImmediatePromise();
+            },
+          })
+          .transform(new TextEncoder().encode("<div></div>")),
+      ).toThrow("cannot synchronously return a ArrayBuffer");
     });
 
     // The response body is still a pending/locked value when the client goes

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -538,6 +538,22 @@ describe("HTMLRewriter", () => {
         expect(await new Response(suspending().body).text()).toBe("<p>new</p>");
       });
 
+      // `Value::tee` builds a ByteStream, tees it, and leaves both branches on
+      // a `PendingValue` nothing settles, so a clone of a still-pending body
+      // never completes. Pre-existing in `tee`, but a suspended transform is
+      // what makes a pending output body the common case. Pinned as a hang so
+      // the day `tee` is fixed, this test fails and gets promoted.
+      it(".clone() does not work yet: both branches hang", async () => {
+        const res = suspending();
+        const clone = res.clone();
+        const raced = await Promise.race([
+          clone.text().then(() => "resolved"),
+          res.text().then(() => "original resolved"),
+          new Promise(r => setTimeout(() => r("hung"), 250)),
+        ]);
+        expect(raced).toBe("hung");
+      });
+
       it("Bun.write(file, res)", async () => {
         using dir = tempDir("hr-pending-body", {});
         const out = path.join(String(dir), "out.html");
@@ -558,29 +574,39 @@ describe("HTMLRewriter", () => {
       ).toThrow("cannot synchronously return an ArrayBuffer");
     });
 
-    // A rejection the handler neither awaits nor returns is the user's to
-    // handle, exactly as for a sync handler. It must reach unhandledRejection
-    // rather than being hijacked into transform()'s result.
+    // A rejection from a Promise a handler creates but neither returns nor
+    // awaits is the user's to handle. Main's nested event loop hijacked it into
+    // `transform()`'s synchronous throw (swallowing unrelated rejections with
+    // exit 0); now it reaches the process-global unhandledRejection path.
+    //
+    // Fixture note: it has to be a real-await handler on a Response. A sync
+    // handler on a string input behaves the same pre- and post-PR, so that
+    // shape pins nothing.
     it("a detached rejection inside a handler reaches unhandledRejection", async () => {
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),
           "-e",
-          `process.on("unhandledRejection", e => { console.log("UNHANDLED:" + e.message); process.exit(0); });
-           const out = new HTMLRewriter()
-             .on("p", { element(e) { (async () => { throw new Error("detached"); })(); e.setInnerContent("ok"); } })
-             .transform("<p>x</p>");
-           console.log("OUT:" + out);
-           setTimeout(() => { console.log("NONE"); process.exit(1); }, 500);`,
+          `const r = new HTMLRewriter()
+             .on("p", { async element(e) {
+               (async () => { throw new Error("detached"); })();
+               await Bun.sleep(5);
+               e.setInnerContent("ok");
+             } })
+             .transform(new Response("<p>x</p>"));
+           console.log("BODY:" + (await r.text()));`,
         ],
         env: bunEnv,
         stdout: "pipe",
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
-        stdout: ["OUT:<p>ok</p>", "UNHANDLED:detached"],
-        exitCode: 0,
+      // The rewrite itself succeeds; the detached rejection is reported and
+      // takes the process down, rather than being captured by transform().
+      expect({ stdout: stdout.trim(), reported: stderr.includes("detached"), exitCode }).toEqual({
+        stdout: "BODY:<p>ok</p>",
+        reported: true,
+        exitCode: 1,
       });
     });
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -22,16 +22,18 @@ describe("HTMLRewriter", () => {
     expect(() => new HTMLRewriter().transform(Symbol("ok"))).toThrow();
   });
 
-  it("error inside element handler", () => {
-    expect(() =>
-      new HTMLRewriter()
-        .on("div", {
-          element(element) {
-            throw new Error("test");
-          },
-        })
-        .transform(new Response("<div>hello</div>")),
-    ).toThrow("test");
+  // Which channel a handler error takes is decided by the overload, not by
+  // whether the input body happened to be buffered: every `Response` input
+  // rejects its output body.
+  it("error inside element handler rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        element(element) {
+          throw new Error("test");
+        },
+      })
+      .transform(new Response("<div>hello</div>"));
+    await expect(res.text()).rejects.toThrow("test");
   });
 
   it("error inside element handler (string)", () => {
@@ -46,18 +48,15 @@ describe("HTMLRewriter", () => {
     ).toThrow("test");
   });
 
-  // An `async` handler whose rejection is reachable by draining microtasks
-  // alone (no await on a timer / I/O) still fails `transform()` synchronously.
-  it("async error without a real await inside element handler", () => {
-    expect(() =>
-      new HTMLRewriter()
-        .on("div", {
-          async element(element) {
-            throw new Error("test");
-          },
-        })
-        .transform(new Response("<div>hello</div>")),
-    ).toThrow("test");
+  it("async error without a real await inside element handler rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        async element(element) {
+          throw new Error("test");
+        },
+      })
+      .transform(new Response("<div>hello</div>"));
+    await expect(res.text()).rejects.toThrow("test");
   });
 
   // A handler that only settles once the event loop turns (setImmediate /
@@ -1703,28 +1702,26 @@ describe("doctype publicId/systemId distinguish empty from absent", () => {
 });
 
 describe("invalid arguments throw instead of returning an error value", () => {
-  it("setAttribute with a forbidden character in the name throws", () => {
-    expect(() =>
-      new HTMLRewriter()
-        .on("div", {
-          element(el) {
-            el.setAttribute("a b", "1");
-          },
-        })
-        .transform(new Response("<div>t</div>")),
-    ).toThrow("character is forbidden in the attribute name");
+  it("setAttribute with a forbidden character in the name rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.setAttribute("a b", "1");
+        },
+      })
+      .transform(new Response("<div>t</div>"));
+    await expect(res.text()).rejects.toThrow("character is forbidden in the attribute name");
   });
 
-  it("setAttribute with an empty name throws", () => {
-    expect(() =>
-      new HTMLRewriter()
-        .on("div", {
-          element(el) {
-            el.setAttribute("", "1");
-          },
-        })
-        .transform(new Response("<div>t</div>")),
-    ).toThrow("Attribute name can't be empty.");
+  it("setAttribute with an empty name rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.setAttribute("", "1");
+        },
+      })
+      .transform(new Response("<div>t</div>"));
+    await expect(res.text()).rejects.toThrow("Attribute name can't be empty.");
   });
 
   it("setAttribute failure leaves the element unchanged", async () => {
@@ -1756,19 +1753,18 @@ describe("invalid arguments throw instead of returning an error value", () => {
     ).toThrow("character is forbidden in the attribute name");
   });
 
-  it("onEndTag with a non-function throws a TypeError", () => {
-    let err;
-    try {
-      new HTMLRewriter()
-        .on("div", {
-          element(el) {
-            el.onEndTag("nope");
-          },
-        })
-        .transform(new Response("<div>t</div>"));
-    } catch (e) {
-      err = e;
-    }
+  it("onEndTag with a non-function rejects the body with a TypeError", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.onEndTag("nope");
+        },
+      })
+      .transform(new Response("<div>t</div>"));
+    const err = await res.text().then(
+      () => null,
+      e => e,
+    );
     expect(err).toBeInstanceOf(TypeError);
     expect(err.message).toBe("Expected a function");
   });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -46,44 +46,49 @@ describe("HTMLRewriter", () => {
     ).toThrow("test");
   });
 
-  it("fast async error inside element handler", () => {
-    let caught = false;
-    try {
+  // An `async` handler whose rejection is reachable by draining microtasks
+  // alone (no await on a timer / I/O) still fails `transform()` synchronously.
+  it("async error without a real await inside element handler", () => {
+    expect(() =>
       new HTMLRewriter()
         .on("div", {
           async element(element) {
-            await setImmediatePromise();
             throw new Error("test");
           },
         })
-        .transform(new Response("<div>hello</div>"));
-      expect.unreachable();
-    } catch (e) {
-      caught = true;
-      expect(e.message).toBe("test");
-    } finally {
-      expect(caught).toBeTrue();
-    }
+        .transform(new Response("<div>hello</div>")),
+    ).toThrow("test");
   });
 
-  it("slow async error inside element handler", () => {
-    let caught = false;
-    try {
-      new HTMLRewriter()
-        .on("div", {
-          async element(element) {
-            await Bun.sleep(1);
-            throw new Error("test");
-          },
-        })
-        .transform(new Response("<div>hello</div>"));
-      expect.unreachable();
-    } catch (e) {
-      caught = true;
-      expect(e.message).toBe("test");
-    } finally {
-      expect(caught).toBeTrue();
-    }
+  // A handler that only settles once the event loop turns (setImmediate /
+  // setTimeout / I/O) suspends the rewrite: `transform()` returns the
+  // Response immediately and the failure surfaces on its body, exactly like
+  // Cloudflare's HTMLRewriter. It can no longer throw synchronously, because
+  // HTMLRewriter no longer nests the event loop inside `transform()`.
+  it("fast async error inside element handler rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        async element(element) {
+          await setImmediatePromise();
+          throw new Error("test");
+        },
+      })
+      .transform(new Response("<div>hello</div>"));
+    expect(res).toBeInstanceOf(Response);
+    await expect(res.text()).rejects.toThrow("test");
+  });
+
+  it("slow async error inside element handler rejects the body", async () => {
+    const res = new HTMLRewriter()
+      .on("div", {
+        async element(element) {
+          await Bun.sleep(1);
+          throw new Error("test");
+        },
+      })
+      .transform(new Response("<div>hello</div>"));
+    expect(res).toBeInstanceOf(Response);
+    await expect(res.text()).rejects.toThrow("test");
   });
 
   it("HTMLRewriter: async replacement", async () => {
@@ -100,6 +105,198 @@ describe("HTMLRewriter", () => {
     await gcTick();
     expect(await res.text()).toBe("<div><span>replace</span></div>");
     await gcTick();
+  });
+
+  // Async content handlers suspend the lol-html rewrite until their promise
+  // settles, instead of spinning a nested event loop inside `transform()`.
+  // The rewritable unit is moved onto the heap for the duration of the
+  // `await`, so post-`await` mutations still land on the element that gets
+  // serialized, and handlers stay strictly one-at-a-time.
+  describe("async handlers suspend the rewrite", () => {
+    it("runs async element handlers strictly in document order", async () => {
+      const count = 8;
+      const order = [];
+      const html = Array.from({ length: count }, (_, i) => `<i id="${i}"></i>`).join("");
+      const res = new HTMLRewriter()
+        .on("i", {
+          async element(element) {
+            const id = element.getAttribute("id");
+            await setImmediatePromise();
+            order.push(id);
+            element.setInnerContent(id);
+          },
+        })
+        .transform(new Response(html));
+      expect(await res.text()).toBe(Array.from({ length: count }, (_, i) => `<i id="${i}">${i}</i>`).join(""));
+      // Each handler must finish (including its awaited half) before the
+      // parser reaches the next element.
+      expect(order).toEqual(Array.from({ length: count }, (_, i) => String(i)));
+    });
+
+    it("mutations made before and after the await both land", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            element.setAttribute("before", "1");
+            await setImmediatePromise();
+            element.setAttribute("after", "2");
+            element.setAttribute("id", "x");
+          },
+        })
+        .transform(new Response('<div id="a">inner</div>'));
+      expect(await res.text()).toBe('<div id="x" before="1" after="2">inner</div>');
+    });
+
+    it("runs the next handler for the same element after the previous one's await", async () => {
+      const order = [];
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            await setImmediatePromise();
+            order.push("a");
+            element.setAttribute("a", "");
+          },
+        })
+        .on("div", {
+          async element(element) {
+            await setImmediatePromise();
+            order.push("b");
+            element.setAttribute("b", "");
+          },
+        })
+        .transform(new Response("<div></div>"));
+      expect(await res.text()).toBe('<div a="" b=""></div>');
+      expect(order).toEqual(["a", "b"]);
+    });
+
+    it("element removed after the await suppresses its content", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            await setImmediatePromise();
+            element.remove();
+          },
+        })
+        .transform(new Response("a<div>gone<span>too</span></div>b"));
+      expect(await res.text()).toBe("ab");
+    });
+
+    it("async text handler", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async text(chunk) {
+            if (chunk.lastInTextNode) return;
+            const original = chunk.text;
+            await setImmediatePromise();
+            chunk.replace(original.toUpperCase());
+          },
+        })
+        .transform(new Response("<div>hello</div>world"));
+      expect(await res.text()).toBe("<div>HELLO</div>world");
+    });
+
+    it("async comments, doctype, and document end handlers", async () => {
+      const res = new HTMLRewriter()
+        .onDocument({
+          async doctype(doctype) {
+            await setImmediatePromise();
+            doctype.remove();
+          },
+          async comments(comment) {
+            const text = comment.text;
+            await setImmediatePromise();
+            comment.text = `${text}${text}`;
+          },
+          async end(end) {
+            await setImmediatePromise();
+            end.append("<tail>", { html: true });
+          },
+        })
+        .transform(new Response("<!DOCTYPE html><p><!--x--></p>"));
+      expect(await res.text()).toBe("<p><!--xx--></p><tail>");
+    });
+
+    it("async onEndTag handler", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          element(element) {
+            element.onEndTag(async endTag => {
+              await setImmediatePromise();
+              endTag.before("!");
+            });
+          },
+        })
+        .transform(new Response("<div>x</div>y"));
+      expect(await res.text()).toBe("<div>x!</div>y");
+    });
+
+    it("the element survives a GC during the await", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            element.setAttribute("pre", "1");
+            await gcTick();
+            await setImmediatePromise();
+            await gcTick();
+            element.setAttribute("post", "2");
+            element.setInnerContent("<b>ok</b>", { html: true });
+          },
+        })
+        .transform(new Response("<div>old</div>"));
+      // One more collection while the transform is suspended and `transform()`
+      // has already returned.
+      await gcTick();
+      expect(await res.text()).toBe('<div pre="1" post="2"><b>ok</b></div>');
+    });
+
+    it("a nested transform inside a suspended handler", async () => {
+      const res = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            const inner = await new HTMLRewriter()
+              .on("b", {
+                async element(b) {
+                  await setImmediatePromise();
+                  b.setInnerContent("inner");
+                },
+              })
+              .transform(new Response("<b>x</b>"))
+              .text();
+            element.setInnerContent(inner, { html: true });
+          },
+        })
+        .transform(new Response("<div>outer</div>"));
+      expect(await res.text()).toBe("<div><b>inner</b></div>");
+    });
+
+    it("transform(string) throws if a handler needs the event loop to settle", () => {
+      expect(() =>
+        new HTMLRewriter()
+          .on("div", {
+            async element(element) {
+              await setImmediatePromise();
+            },
+          })
+          .transform("<div></div>"),
+      ).toThrow(
+        "HTMLRewriter.transform() cannot synchronously return a string because a content " +
+          "handler returned a Promise that did not resolve within a microtask. Pass a " +
+          "Response instead and await its body",
+      );
+    });
+
+    it("transform(string) stays synchronous for microtask-only async handlers", () => {
+      const out = new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            await Promise.resolve();
+            await null;
+            element.setInnerContent("sync enough");
+          },
+        })
+        .transform("<div>old</div>");
+      expect(out).toBe("<div>sync enough</div>");
+    });
   });
 
   it("HTMLRewriter handles Symbol invalid type error", async () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -322,6 +322,63 @@ describe("HTMLRewriter", () => {
         .transform("<div>old</div>");
       expect(out).toBe("<div>sync enough</div>");
     });
+
+    // The response body is still a pending/locked value when the client goes
+    // away; the rewrite must still be allowed to finish (or fail) afterwards
+    // without corrupting the RequestContext it was registered against, and the
+    // server must keep working.
+    for (const settle of ["resolves", "rejects"]) {
+      it(`client aborts while the handler is suspended, then the handler ${settle}`, async () => {
+        const suspended = Promise.withResolvers();
+        const serverSawAbort = Promise.withResolvers();
+        const gate = Promise.withResolvers();
+        let handlerFinished = 0;
+
+        await using server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            if (new URL(req.url).pathname === "/after") return new Response("still alive");
+            req.signal.addEventListener("abort", () => serverSawAbort.resolve());
+            return new HTMLRewriter()
+              .on("p", {
+                async element(element) {
+                  suspended.resolve();
+                  await gate.promise;
+                  element.setInnerContent("too late");
+                  handlerFinished++;
+                },
+              })
+              .transform(new Response("<p>original</p>"));
+          },
+        });
+
+        const controller = new AbortController();
+        const clientResult = fetch(`http://localhost:${server.port}/`, {
+          signal: controller.signal,
+        }).then(
+          r => r.text(),
+          e => e,
+        );
+
+        // Only abort once the handler has actually suspended the rewrite,
+        // and only resume it once the server has observed the abort.
+        await suspended.promise;
+        controller.abort();
+        expect(await clientResult).toBeInstanceOf(DOMException);
+        await serverSawAbort.promise;
+
+        if (settle === "resolves") {
+          gate.resolve();
+        } else {
+          gate.reject(new Error("handler failed after the client left"));
+        }
+
+        // The aborted request is gone; the server must still answer.
+        const after = await fetch(`http://localhost:${server.port}/after`);
+        expect(await after.text()).toBe("still alive");
+        expect(handlerFinished).toBe(settle === "resolves" ? 1 : 0);
+      });
+    }
   });
 
   it("HTMLRewriter handles Symbol invalid type error", async () => {

--- a/test/regression/issue/19219.test.ts
+++ b/test/regression/issue/19219.test.ts
@@ -52,7 +52,8 @@ test("HTMLRewriter should handle errors in async handlers", async () => {
   const html = "<div>test</div>";
   const response = new Response(html);
 
-  expect(() => {
-    rewriter.transform(response);
-  }).toThrow("Async handler error");
+  // A `Response` input surfaces handler errors on the output body, so the
+  // descriptive error this issue is about arrives there rather than from
+  // `transform()`. The `string` inputs above still throw.
+  await expect(rewriter.transform(response).text()).rejects.toThrow("Async handler error");
 });

--- a/test/regression/issue/21680.test.ts
+++ b/test/regression/issue/21680.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { tempDirWithFiles } from "harness";
 
-test("HTMLRewriter should not crash when element handler throws an exception - issue #21680", () => {
+test("HTMLRewriter should not crash when element handler throws an exception - issue #21680", async () => {
   // The most important test: ensure the original crashing case from the GitHub issue doesn't crash
   // This was the exact case from the issue that caused "ASSERTION FAILED: Unexpected exception observed"
 
@@ -20,15 +20,15 @@ test("HTMLRewriter should not crash when element handler throws an exception - i
     rewriter.transform(new Response(Bun.file(`${dir}/min.html`)));
   }).not.toThrow(); // The important thing is it doesn't crash, we're ok with it silently failing
 
-  // Test with Response containing string content
-  expect(() => {
-    const rewriter = new HTMLRewriter().on("script", {
-      element(a) {
-        throw new Error("response test");
-      },
-    });
-    rewriter.transform(new Response("<script></script>"));
-  }).toThrow("response test");
+  // Test with Response containing string content. A `Response` input surfaces
+  // the handler's error on the output body rather than throwing from
+  // `transform()`; the point of this test is that neither crashes.
+  const rewriter = new HTMLRewriter().on("script", {
+    element(a) {
+      throw new Error("response test");
+    },
+  });
+  await expect(rewriter.transform(new Response("<script></script>")).text()).rejects.toThrow("response test");
 });
 
 test("HTMLRewriter exception handling should not break normal operation", () => {


### PR DESCRIPTION
### What

`HTMLRewriter.prototype.transform` no longer re-enters the event loop. When a content handler returns a promise that is still pending after one microtask checkpoint, lol-html parks the current rewritable unit on the heap and returns from `write()`; a `.then` reaction resumes the rewrite from the real event loop once the promise settles.

### Why

`handler_callback` called `vm.wait_for_promise(promise)` for async handlers (`src/runtime/api/html_rewriter.rs`, previously line 1311). That spins the whole event loop (timers, I/O completions, GC, arbitrary user JS) from six native frames deep inside lol-html's `write()`, while the `Element` the handler's JS wrapper points at is a stack borrow inside that call. Nested event loops are a known hazard class in this codebase (deadlocks like #14950, the uSockets ready-poll clobbering fixed in a05b9c03b4, the pending-exception leak fixed in 289cce1c0f), and HTMLRewriter was one of the last users.

It could not be removed before because lol-html's tokens are stack locals borrowing a stack-local lexeme: returning from `write()` destroys them, and an async handler must be able to mutate the element after its `await`. Now that lol-html is vendored as Rust source (#33048), the token can be heap-allocated.

### lol-html fork (`patches/lolhtml/content-handler-suspension.patch`)

- A handler returns `Err(SuspensionRequest)` to suspend. The in-flight unit is deep-copied onto the heap (boxed, stable address), `write()`/`end()` return a new non-poisoning `RewritingError::Suspended`, and `HtmlRewriter::resume()` continues from a `StateMachineBookmark`.
- The key simplification: the pending captured-text flush is hoisted from `Dispatcher::handle_tag` into the lexer actions, before the lexeme is built. Every suspension point then has a uniform shape (the in-flight lexeme is either fully consumed or not yet built), the parser never has to save a lexeme, and the resume reuses the crate's existing `continue_from_bookmark` machinery. Tree-builder feedback (`<script>` content model etc.) is applied before the handler runs, so it is never replayed.
- `Arena::shift` advances a `start` offset instead of memmoving the remaining tail. A suspended rewrite re-feeds its unconsumed tail on every resume, so the old `copy_within` cost O(suspensions x tail) on the JS thread; the dead prefix is now reclaimed in one memmove by the next `append`, which only the multi-write streaming path performs.
- 23 new in-crate tests (170 total, up from 146) cover element/text/comment/doctype/end-tag/document-end suspension, `el.remove()` across a suspension, re-suspension by a later handler on the same unit, the `<script>` content model surviving a suspension, multi-chunk input, text ordering around an unterminated comment/doctype/tag at EOF, a suspension inside removed content emitting nothing, and text around `<![CDATA[`. All existing unit tests and the html5lib integration fixtures still pass.

### Bun side

- `handler_callback` returns `HandlerOutcome::{Continue, Stop, Suspend}`. On a pending promise it runs one microtask checkpoint (`process.nextTick` then promise jobs, never the event loop), so `async element(el) { el.remove() }` and anything else reachable without a macrotask stays synchronous. A genuinely pending promise suspends: the handler's JS wrapper is kept alive, re-pointed at the heap-parked unit so post-`await` mutations land on what gets serialized, and released when the promise settles.
- Two new `PromiseFunctions` (`Bun__HTMLRewriter__onHandlerResolve/Reject`) carry the continuation. Their context is a `NativePromiseContext` cell, not a raw pointer, so a handler promise collected without ever settling takes the reaction with it and `SuspensionContext::abandon` fails the output body instead of leaking the parked rewrite forever.
- `AttributeIterator` holds a backref to the `Element` wrapper plus an index rather than a `slice::Iter` into the attribute buffer, so an iterator handed out before an `await` follows the element onto the heap and keeps working.
- The per-transform error slot moves from a stack `Cell` in `init()` onto the heap sink, and the `vm.on_unhandled_rejection` + `unhandled_pending_rejection_to_capture` overrides are removed. A new `VirtualMachine::html_rewriter_active_sink` field (saved/restored LIFO around each lol-html call) is how handlers reach their sink. This also fixes a bug where a handler exception on a streaming input surfaced as `The rewriter has been stopped.` instead of the real error.
- `init()` no longer stamps `pv.task` on the output body as an identity tag. `Bun.serve` reads `lock.task.is_some()` as "another consumer owns this body" and piped a `ReadableStream` that nothing ever feeds.
- `RequestContext`'s `on_receive_value` registration for a `Locked` response body now takes a ref and sets `has_marked_pending`, with the matching release in `do_render_with_body_locked`. Without it, `should_render_missing` rendered a 404 and released the context back to the pool while the body's owner still held the callback pointer (heap-use-after-free). That branch was unreachable from JS before this change.
- `Body::Value::resolve` hands a pending body's attached readable the bytes it resolved to instead of closing it empty (its error twin `to_error_instance` already did). A suspended transform makes a pending output body the default state, so `.body`, `new Response(res.body)`, `.blob()`, `.arrayBuffer()` and `Bun.write(file, res)` all observed the empty result.

### Behavior changes

1. **The error channel for a content handler is decided by the overload, not by timing.** `transform(string)` / `transform(ArrayBuffer)` must hand back a value, so anything a handler raises throws from `transform()`. Every `Response` input rejects its output body instead. Previously the channel was selected by whether the input body happened to be buffered when `transform()` ran, which for `transform(await fetch(u))` is a race against the network. This means a handler error on an already-buffered Response (a synchronous `throw`, a `TypeError` from `setAttribute`) now rejects the body where it used to throw; five tests that pinned the old split are updated. Input-body errors keep their own channel: an already-failed or aborted body still throws synchronously, since `transform()` observes it before returning.
2. A rejection a handler neither awaits nor returns (fire-and-forget) now reaches `unhandledRejection`, matching sync handlers. The old code captured it and turned it into `transform()`'s thrown error, which hijacked unrelated rejections and swallowed them with exit 0. This is a process-exit-code change: a program that used to print `CAUGHT:...` and exit 0 now reports the rejection and exits 1.
3. `transform()`'s declared types were wrong and are fixed: `Bun.BufferSource` returns an `ArrayBuffer`, not a `Response`, and `Blob` threw `"Expected Response or Body"` at runtime and is no longer in the type. Dropping `Blob` turns a runtime throw into a compile error.

`docs/runtime/html-rewriter.mdx` and `packages/bun-types/html-rewriter.d.ts` are updated for all three.

### Known gap (not fixed here)

`res.clone()` on a still-suspended transform hangs. `Value::tee` builds a `ByteStream`, tees it, and leaves both branches on a `PendingValue` the sink never settles. Teeing a native ByteStream works fine in general, so this is a specific defect in `tee`'s interaction with a body whose value arrives later; it predates this PR in mechanism and is better fixed on its own. It is disclosed in the docs, asserted as a hang by a test (so the day `tee` is fixed that test fails and gets promoted), and called out in the `Body.rs` comment. Every other consumer of a pending output body works and is covered by a test matrix.

### Verification

- `test/js/workerd/html-rewriter.test.js` + the four sibling suites: 116 pass, 0 fail under the ASAN debug build. New coverage includes `Bun.gc(true)` twice while an `Element` is heap-parked across an `await` plus a post-`await` mutation (the use-after-free shape this design has to get right), async text/comment/doctype/onEndTag/document-end handlers, the `lastInTextNode` idiom mutated after a resume, re-suspension by a second handler on the same element, a nested `transform()` inside a suspended handler, chained suspending transforms, strict document-order sequencing across 8 awaiting handlers, `Bun.serve` with a live client (delivery and a rejecting handler routed to `error()`), a client aborting mid-suspension, and the consumer matrix for a pending output body.
- Fail-before checks: a throwing handler on a *streaming* input rejects with `The rewriter has been stopped.` on the released bun and with the real error here; the two updated error tests and the `transform(string)` throw also fail on the released bun.
- `test/js/workerd/html-rewriter-leak.test.ts` gains a protected-object/Response count regression over 120 suspending rewrites, and a never-settling handler asserted to reject the body rather than leak it.
- `bun-types` green, `cargo clippy` clean.
- `.github/workflows/lolhtml.yml` runs the vendored crate's own `cargo test` (170 unit + 34 integration) after the fetch+patch edge, gated on `patches/lolhtml/**`. Nothing ran it before, so the fork's invariants (the composite-EOF flush, `Arena::compact()`, the suspension bookkeeping) were unguarded by CI.
- The `patches/lolhtml` diff is validated through the real fetch edge: `ninja vendor/lolhtml/.ref` re-extracts the pristine `cloudflare/lol-html@77127cd2` and applies the patch, producing a byte-identical tree. Note for anyone adding a `patches/*` file: `fetch-cli.ts` applies them with `git apply` from inside `vendor/<dep>`, which is a subdirectory of the bun git worktree, so a git-format patch (with `diff --git` and `index` headers) gets its paths resolved against the repo root and is silently skipped with exit 0. The existing patches are all traditional `--- a/x` unified diffs, and this one is too.

