### PR TITLE
install: stop leaking pretty-markup tags into user-facing messages

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1552,7 +1552,7 @@ mod __css_validation {
                         Some(&col_ref!(self.all_sources)[source_index as usize]),
                         range,
                         bun_ast::alloc_print(format_args!(
-                            "<r>The value of <b>{}<r> in the class <b>{}<r> is undefined.",
+                            "The value of {} in the class {} is undefined.",
                             bstr::BStr::new(property_name),
                             bstr::BStr::new(local_original_name),
                         )),

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1657,15 +1657,20 @@ mod draft {
                     let conf_item: &ConfigItem = &conf_item_;
                     match conf_item.optname {
                         ConfigOpt::Certfile | ConfigOpt::Keyfile => {
-                            iter.log.add_warning_fmt(
-                            Some(source),
-                            iter.config.properties.at(iter.prop_idx - 1).key.as_ref().unwrap().loc,
-                            format_args!(
+                            bun_ast::add_warning_pretty!(
+                                iter.log,
+                                Some(source),
+                                iter.config
+                                    .properties
+                                    .at(iter.prop_idx - 1)
+                                    .key
+                                    .as_ref()
+                                    .unwrap()
+                                    .loc,
                                 "The following .npmrc registry option was not applied:\n\n  <b>{}<r>\n\nBecause we currently don't support the <b>{}<r> option.",
                                 conf_item,
                                 <&'static str>::from(conf_item.optname),
-                            ),
-                        );
+                            );
                             continue;
                         }
                         _ => {}

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -645,13 +645,13 @@ impl<'a> PackageInstaller<'a> {
 
                 if let Some(err) = bin_linker.err {
                     if log_level != Options::LogLevel::Silent {
-                        manager.log_mut().add_error_fmt_opts(
-                            format_args!(
-                                "Failed to link <b>{}<r>: {}",
-                                bstr::BStr::new(alias),
-                                err.name(),
-                            ),
-                            Default::default(),
+                        bun_ast::add_error_pretty!(
+                            manager.log_mut(),
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            "Failed to link <b>{}<r>: {}",
+                            bstr::BStr::new(alias),
+                            err.name(),
                         );
                     }
 
@@ -2007,19 +2007,14 @@ impl<'a> PackageInstaller<'a> {
                                 let dir = match lazy_package_dir.get_dir() {
                                     Ok(d) => d,
                                     Err(err) => {
-                                        Output::err_tag(
+                                        Output::err(
                                             "EACCES",
-                                            format_args!(
-                                                "Permission denied while installing <b>{}<r>",
-                                                bstr::BStr::new(
-                                                    self.names[package_id as usize].slice(
-                                                        self.lockfile()
-                                                            .buffers
-                                                            .string_bytes
-                                                            .as_slice()
-                                                    )
+                                            "Permission denied while installing <b>{}<r>",
+                                            (bstr::BStr::new(
+                                                self.names[package_id as usize].slice(
+                                                    self.lockfile().buffers.string_bytes.as_slice(),
                                                 ),
-                                            ),
+                                            ),),
                                         );
                                         if cfg!(debug_assertions) {
                                             Output::err(err, "Failed to stat node_modules", ());
@@ -2030,19 +2025,14 @@ impl<'a> PackageInstaller<'a> {
                                 let stat = match bun_sys::fstat(dir) {
                                     Ok(s) => s,
                                     Err(err) => {
-                                        Output::err_tag(
+                                        Output::err(
                                             "EACCES",
-                                            format_args!(
-                                                "Permission denied while installing <b>{}<r>",
-                                                bstr::BStr::new(
-                                                    self.names[package_id as usize].slice(
-                                                        self.lockfile()
-                                                            .buffers
-                                                            .string_bytes
-                                                            .as_slice()
-                                                    )
+                                            "Permission denied while installing <b>{}<r>",
+                                            (bstr::BStr::new(
+                                                self.names[package_id as usize].slice(
+                                                    self.lockfile().buffers.string_bytes.as_slice(),
                                                 ),
-                                            ),
+                                            ),),
                                         );
                                         if cfg!(debug_assertions) {
                                             Output::err(err, "Failed to stat node_modules", ());
@@ -2077,14 +2067,12 @@ impl<'a> PackageInstaller<'a> {
                             NODE_MODULES_IS_OK.store(true, Ordering::Relaxed);
                         }
 
-                        Output::err_tag(
+                        Output::err(
                             "EACCES",
-                            format_args!(
-                                "Permission denied while installing <b>{}<r>",
-                                bstr::BStr::new(
-                                    self.names[package_id as usize].slice(string_buf!())
-                                ),
-                            ),
+                            "Permission denied while installing <b>{}<r>",
+                            (bstr::BStr::new(
+                                self.names[package_id as usize].slice(string_buf!()),
+                            ),),
                         );
 
                         self.summary.fail += 1;

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1443,49 +1443,49 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 }
             } else if dependency.behavior.is_required() {
                 if dependency_tag == dependency::version::Tag::Workspace {
-                    this.log_mut()
-                    .add_error_fmt(
-                            None,
-                            bun_ast::Loc::EMPTY,
-                            format_args!(
-                                "Workspace dependency \"{}\" not found\n\nSearched in <b>{}<r>\n\nWorkspace documentation: https://bun.com/docs/install/workspaces\n\n",
-                                bstr::BStr::new(this.lockfile.str(&name)),
-                                PackageWorkspaceSearchPathFormatter { manager: this, version, quoted: true },
-                            ),
-                        );
+                    bun_ast::add_error_pretty!(
+                        this.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Workspace dependency \"{}\" not found\n\nSearched in <b>{}<r>\n\nWorkspace documentation: https://bun.com/docs/install/workspaces\n\n",
+                        bstr::BStr::new(this.lockfile.str(&name)),
+                        PackageWorkspaceSearchPathFormatter {
+                            manager: this,
+                            version,
+                            quoted: true
+                        },
+                    );
                 } else {
-                    this.log_mut()
-                    .add_error_fmt(
-                            None,
-                            bun_ast::Loc::EMPTY,
-                            format_args!(
-                                "Package \"{}\" is not linked\n\nTo install a linked package:\n   <cyan>bun link my-pkg-name-from-package-json<r>\n\nTip: the package name is from package.json, which can differ from the folder name.\n\n",
-                                bstr::BStr::new(this.lockfile.str(&name)),
-                            ),
-                        );
+                    bun_ast::add_error_pretty!(
+                        this.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Package \"{}\" is not linked\n\nTo install a linked package:\n   <cyan>bun link my-pkg-name-from-package-json<r>\n\nTip: the package name is from package.json, which can differ from the folder name.\n\n",
+                        bstr::BStr::new(this.lockfile.str(&name)),
+                    );
                 }
             } else if this.options.log_level.is_verbose() {
                 if dependency_tag == dependency::version::Tag::Workspace {
-                    this.log_mut()
-                    .add_warning_fmt(
-                            None,
-                            bun_ast::Loc::EMPTY,
-                            format_args!(
-                                "Workspace dependency \"{}\" not found\n\nSearched in <b>{}<r>\n\nWorkspace documentation: https://bun.com/docs/install/workspaces\n\n",
-                                bstr::BStr::new(this.lockfile.str(&name)),
-                                PackageWorkspaceSearchPathFormatter { manager: this, version, quoted: true },
-                            ),
-                        );
+                    bun_ast::add_warning_pretty!(
+                        this.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Workspace dependency \"{}\" not found\n\nSearched in <b>{}<r>\n\nWorkspace documentation: https://bun.com/docs/install/workspaces\n\n",
+                        bstr::BStr::new(this.lockfile.str(&name)),
+                        PackageWorkspaceSearchPathFormatter {
+                            manager: this,
+                            version,
+                            quoted: true
+                        },
+                    );
                 } else {
-                    this.log_mut()
-                    .add_warning_fmt(
-                            None,
-                            bun_ast::Loc::EMPTY,
-                            format_args!(
-                                "Package \"{}\" is not linked\n\nTo install a linked package:\n   <cyan>bun link my-pkg-name-from-package-json<r>\n\nTip: the package name is from package.json, which can differ from the folder name.\n\n",
-                                bstr::BStr::new(this.lockfile.str(&name)),
-                            ),
-                        );
+                    bun_ast::add_warning_pretty!(
+                        this.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Package \"{}\" is not linked\n\nTo install a linked package:\n   <cyan>bun link my-pkg-name-from-package-json<r>\n\nTip: the package name is from package.json, which can differ from the folder name.\n\n",
+                        bstr::BStr::new(this.lockfile.str(&name)),
+                    );
                 }
             }
             Ok(())

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -1088,7 +1088,7 @@ impl TarballStream {
                         None,
                         bun_ast::Loc::EMPTY,
                         format_args!(
-                            "Integrity check failed<r> for tarball: {}",
+                            "Integrity check failed for tarball: {}",
                             bstr::BStr::new(tarball.name.slice()),
                         ),
                     );

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -51,7 +51,7 @@ impl ExtractTarball {
                     None,
                     bun_ast::Loc::EMPTY,
                     format_args!(
-                        "Integrity check failed<r> for tarball: {}",
+                        "Integrity check failed for tarball: {}",
                         bun_fmt::s(self.name.slice()),
                     ),
                 );

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -1050,7 +1050,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             }
             _ => {
                 Output::panic(format_args!(
-                    "<r><red>error<r>: Failed to run <b>{}<r> script from \"<b>{}<r>\" due to unexpected status\n{}",
+                    "error: Failed to run {} script from \"{}\" due to unexpected status\n{}",
                     bstr::BStr::new(self.script_name()),
                     bstr::BStr::new(&self.package_name),
                     status,

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -117,12 +117,11 @@ fn invalid_trusted_dependencies(
     source: &bun_ast::Source,
     loc: bun_ast::Loc,
 ) -> bun_core::Error {
-    let _ = log.add_error_fmt(
+    let _ = bun_ast::add_error_pretty!(
+        log,
         source,
         loc,
-        format_args!(
-            "trustedDependencies expects an array of strings, e.g.\n  <r><green>\"trustedDependencies\"<r>: [\n    <green>\"package_name\"<r>\n  ]"
-        ),
+        "trustedDependencies expects an array of strings, e.g.\n  <r><green>\"trustedDependencies\"<r>: [\n    <green>\"package_name\"<r>\n  ]"
     );
     bun_core::err!("InvalidPackageJSON")
 }

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -193,12 +193,11 @@ impl WorkspaceMap {
 
         for i in 0..item_count {
             let Some(input_path) = arr.item_str(i, &scratch) else {
-                let _ = log.add_error_fmt(
+                let _ = bun_ast::add_error_pretty!(
+                    log,
                     Some(source),
                     arr.item_loc(source, i),
-                    format_args!(
-                        "Workspaces expects an array of strings, like:\n  <r><green>\"workspaces\"<r>: [\n    <green>\"path/to/package\"<r>\n  ]"
-                    ),
+                    "Workspaces expects an array of strings, like:\n  <r><green>\"workspaces\"<r>: [\n    <green>\"path/to/package\"<r>\n  ]"
                 );
                 return Err(bun_core::err!("InvalidPackageJSON"));
             };
@@ -359,14 +358,13 @@ impl WorkspaceMap {
                 )? {
                     Ok(w) => w,
                     Err(e) => {
-                        let _ = log.add_error_fmt(
+                        let _ = bun_ast::add_error_pretty!(
+                            log,
                             Some(source),
                             loc,
-                            format_args!(
-                                "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
-                                BStr::new(user_pattern),
-                                <&'static str>::from(e.get_errno()),
-                            ),
+                            "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
+                            BStr::new(user_pattern),
+                            <&'static str>::from(e.get_errno()),
                         );
                         return Err(bun_core::err!("GlobError"));
                     }
@@ -376,14 +374,13 @@ impl WorkspaceMap {
 
                 let mut iter = glob::walk::Iterator::new(&mut walker);
                 if let Err(e) = iter.init()? {
-                    let _ = log.add_error_fmt(
+                    let _ = bun_ast::add_error_pretty!(
+                        log,
                         Some(source),
                         loc,
-                        format_args!(
-                            "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
-                            BStr::new(user_pattern),
-                            <&'static str>::from(e.get_errno()),
-                        ),
+                        "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
+                        BStr::new(user_pattern),
+                        <&'static str>::from(e.get_errno()),
                     );
                     return Err(bun_core::err!("GlobError"));
                 }
@@ -393,14 +390,13 @@ impl WorkspaceMap {
                         Ok(Some(r)) => r,
                         Ok(None) => break,
                         Err(e) => {
-                            let _ = log.add_error_fmt(
+                            let _ = bun_ast::add_error_pretty!(
+                                log,
                                 Some(source),
                                 loc,
-                                format_args!(
-                                    "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
-                                    BStr::new(user_pattern),
-                                    <&'static str>::from(e.get_errno()),
-                                ),
+                                "Failed to run workspace pattern <b>{}<r> due to error <b>{}<r>",
+                                BStr::new(user_pattern),
+                                <&'static str>::from(e.get_errno()),
                             );
                             return Err(bun_core::err!("GlobError"));
                         }

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -643,32 +643,30 @@ impl PatchTask {
                     // Not `self.manager()` — `&mut self.callback` is live.
                     // BACKREF — read-only lockfile access on the worker thread.
                     let manager = self.manager.get();
-                    log.add_error_fmt(
+                    bun_ast::add_error_pretty!(
+                        log,
                         None,
                         Loc::EMPTY,
-                        format_args!(
-                            "Couldn't find patch file: '{}'\n\nTo create a new patch file run:\n\n  <cyan>bun patch {}<r>",
-                            BStr::new(&calc_hash.patchfile_path),
-                            BStr::new(
-                                manager
-                                    .lockfile
-                                    .patched_dependencies
-                                    .get(&calc_hash.name_and_version_hash)
-                                    .unwrap()
-                                    .path
-                                    .slice(&manager.lockfile.buffers.string_bytes)
-                            ),
+                        "Couldn't find patch file: '{}'\n\nTo create a new patch file run:\n\n  <cyan>bun patch {}<r>",
+                        BStr::new(&calc_hash.patchfile_path),
+                        BStr::new(
+                            manager
+                                .lockfile
+                                .patched_dependencies
+                                .get(&calc_hash.name_and_version_hash)
+                                .unwrap()
+                                .path
+                                .slice(&manager.lockfile.buffers.string_bytes)
                         ),
                     );
                     return None;
                 }
-                log.add_warning_fmt(
+                bun_ast::add_warning_pretty!(
+                    log,
                     None,
                     Loc::EMPTY,
-                    format_args!(
-                        "patchfile <b>{}<r> is empty, please restore or delete it.",
-                        BStr::new(absolute_patchfile_path.as_bytes())
-                    ),
+                    "patchfile <b>{}<r> is empty, please restore or delete it.",
+                    BStr::new(absolute_patchfile_path.as_bytes()),
                 );
                 return None;
             }
@@ -676,13 +674,12 @@ impl PatchTask {
         };
         let size: u64 = u64::try_from(stat.st_size).expect("int cast");
         if size == 0 {
-            log.add_error_fmt(
+            bun_ast::add_error_pretty!(
+                log,
                 None,
                 Loc::EMPTY,
-                format_args!(
-                    "patchfile <b>{}<r> is empty, please restore or delete it.",
-                    BStr::new(absolute_patchfile_path.as_bytes())
-                ),
+                "patchfile <b>{}<r> is empty, please restore or delete it.",
+                BStr::new(absolute_patchfile_path.as_bytes()),
             );
             return None;
         }

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { beforeEach, expect, setDefaultTimeout, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 
 let cwd: string;
 
@@ -34,6 +34,27 @@ test("bad workspace path", () => {
 
   expect(text).toContain('Workspace not found "i-dont-exist"');
 
+  expect(exitCode).toBe(1);
+});
+
+test("non-string workspaces entry prints the error without literal markup", async () => {
+  using dir = tempDir("bad-workspace-non-string", {
+    "package.json": JSON.stringify({ name: "hey", workspaces: [123] }),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain(
+    'Workspaces expects an array of strings, like:\n  "workspaces": [\n    "path/to/package"\n  ]',
+  );
+  // Pretty-markup tags ("<r>", "<green>") must not leak into the message.
+  expect(stdout + stderr).not.toContain("<r>");
   expect(exitCode).toBe(1);
 });
 

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -602,7 +602,10 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mi
     // with the fix, bun exits cleanly on its own; on hang, Bun.spawn's
     // timeout kills the child with SIGTERM.
     expect(proc.signalCode).toBeNull();
-    expect(stderr + stdout).toContain("Integrity check failed");
+    // The exact message matters: it used to leak a literal "<r>" markup tag
+    // ("Integrity check failed<r> for tarball: ...").
+    expect(stderr + stdout).toContain("Integrity check failed for tarball: pkg");
+    expect(stderr + stdout).not.toContain("<r>");
     expect(stdout).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);
   });


### PR DESCRIPTION
### What

`bun install` prints the integrity failure message with a literal markup tag in it:

```
error: Integrity check failed<r> for tarball: p1
```

Repro: point `bun install` at a registry whose packument advertises an integrity hash that does not match the served tarball bytes (the `tarball integrity mismatch` test does exactly this). The same leak shows up in several other messages, for example:

```
error: Workspaces expects an array of strings, like:
  <r><green>"workspaces"<r>: [
    <green>"path/to/package"<r>
  ]
```

### Why

`Log` message text is printed verbatim (`Msg::write_format` interpolates it as a runtime `{}` argument of a compile-time `pretty_fmt!` template), so markup tags written into `log.add_*_fmt(format_args!(...))` literals are never converted to ANSI or stripped. The markup-aware forms for this are `bun_ast::add_error_pretty!` and `add_warning_pretty!`, which rewrite the literal before it is stored. `Output::err_tag` bodies and `Output::panic` messages have the same problem.

### Fix

- `extract_tarball.rs`, `TarballStream.rs`: drop the stray `<r>` from the two integrity messages (it styled nothing).
- `PackageManagerEnqueue.rs`, `lockfile/Package.rs`, `lockfile/Package/WorkspaceMap.rs`, `patch_install.rs`, `ini/lib.rs`, and the bin-link error in `PackageInstaller.rs`: route the messages that do use styling through `bun_ast::add_error_pretty!` / `add_warning_pretty!`, so tags render as ANSI on a terminal and are stripped when piped.
- EACCES messages in `PackageInstaller.rs`: switch `Output::err_tag(tag, format_args!(..))` to `Output::err(tag, template, args)`, which does the runtime markup rewrite.
- css `composes` diagnostic (`scanImportsAndExports.rs`) and the lifecycle script panic (`lifecycle_script_runner.rs`): drop the markup. The first is JS-visible through `Bun.build` and every sibling bundler diagnostic is plain text; the second goes through `core::panic!`.

### Verification

- `test/cli/install/bun-install-tarball-integrity.test.ts`: the integrity mismatch test now asserts the exact message (`Integrity check failed for tarball: pkg`) and that no `<r>` appears in the output.
- `test/cli/install/bad-workspace.test.ts`: new test for a non-string `workspaces` entry asserting the rendered message and no leaked tags.

Both fail on a build without the src changes and pass with them (`bun bd test test/cli/install/bun-install-tarball-integrity.test.ts test/cli/install/bad-workspace.test.ts`: 17 pass).
