### PR TITLE
build: disable clang-cl's default stack buffer security check on Windows release (/GS-)

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -236,6 +236,21 @@ export const globalFlags: Flag[] = [
     desc: "Undefine _DLL (we link statically)",
   },
 
+  // ─── Stack protector (Windows) ───
+  {
+    // clang-cl turns /GS on by default (cc1 gets `-stack-protector 2`,
+    // "strong"), while plain clang defaults to off, so the Linux and macOS
+    // release binaries have never carried a stack canary. Nothing in this
+    // repo ever chose /GS for Windows; it is a driver default. Spelling
+    // matters: clang-cl silently ignores `-fno-stack-protector` and still
+    // emits `-stack-protector 2` (verified with `clang-cl -###`); only the
+    // /GS- form reaches cc1. Release only: debug builds keep the check as
+    // an extra crash-detection net, where its size does not matter.
+    flag: "/GS-",
+    when: c => c.windows && c.release,
+    desc: "Disable the stack buffer security check (parity with the Linux and macOS release builds)",
+  },
+
   // ─── Optimization ───
   {
     // cmake's Release/RelWithDebInfo build types append this to

--- a/test/internal/windows-cross-config.test.ts
+++ b/test/internal/windows-cross-config.test.ts
@@ -140,6 +140,26 @@ describe.skipIf(isWindows)("Windows cross-compile LTO config (non-windows host)"
     expect(plain.cxxflags).not.toContain("-fno-split-lto-unit");
   });
 
+  test("release builds disable clang-cl's default stack buffer security check; debug keeps it", () => {
+    // clang-cl turns /GS on by its own driver default while plain clang turns
+    // it off, so the Linux and macOS release binaries have never carried a
+    // stack canary. /GS- makes the Windows release binary match. Only the
+    // /GS- spelling works: clang-cl silently ignores `-fno-stack-protector`
+    // and still emits `-stack-protector 2` on the cc1 line, so that spelling
+    // must never appear here.
+    const release = computeFlags(resolveWindowsCross());
+    expect(release.cflags).toContain("/GS-");
+    expect(release.cxxflags).toContain("/GS-");
+    expect(release.cflags).not.toContain("-fno-stack-protector");
+    expect(release.cxxflags).not.toContain("-fno-stack-protector");
+
+    // Debug keeps the driver default: the canary is a useful crash-detection
+    // net during development, where its size does not matter.
+    const debug = computeFlags(resolveWindowsCross({ buildType: "Debug", ci: false }));
+    expect(debug.cflags).not.toContain("/GS-");
+    expect(debug.cxxflags).not.toContain("/GS-");
+  });
+
   test("the link uses rustc's lld-link sibling when rustc's LLVM is newer than clang's", () => {
     // resolveConfig swaps cfg.ld so lld-link can read the LLVM-22 bitcode
     // rustc emits under -Clinker-plugin-lto (bitcode is forward-compatible


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR is a security-posture decision, not a free win, and it deliberately poses one question for the maintainers.** If the answer is no, the right response is to close this PR.
>
> **The question:** is platform parity an acceptable rationale for removing the stack buffer security check from `bun.exe` on Windows, and therefore from every Windows `bun build --compile` output it produces, given that `bun-linux` and `bun-darwin` have never had one?

Part of the binary size reduction effort requested by @Jarred-Sumner and @dylan-conway. The full analysis is at [size-research/03-FINAL.md](https://github.com/oven-sh/bun/blob/farm/73f947d6/size-research/size-research/03-FINAL.md) (this is its single largest Windows-only item).

### What this is

Bun already sets every size-relevant clang-cl codegen flag on Windows (`/Gy /Gw /GF /GR- /EHs-c- /Oy-` are all in `flags.ts`), but nothing in the repository has ever set `/GS`. clang-cl turns it on **by its own driver default**, and plain clang turns it **off** by its own driver default. So the three release binaries disagree about a mitigation nobody chose on any of them. This is reproducible in one command against the build toolchain:

| invocation | cc1 `-stack-protector` | meaning |
|---|---|---|
| `clang-cl -### -c x.c` (default) | `"2"` | **on** ("strong") |
| `clang-cl /GS- -### -c x.c` | absent | **off** |
| `clang-cl -fno-stack-protector -### -c x.c` | `"2"` | **silently ignored** |
| `clang --target=x86_64-linux-gnu -### -c x.c` (default) | absent | **off**: `bun-linux` has never had a stack canary |

The third row is why this PR cannot be written as `-fno-stack-protector`: clang-cl accepts that flag, says nothing, and changes nothing. `/GS-` is the only spelling that reaches cc1. (This same "a default nobody chose, visible only on the real driver line" class also turned up `-fno-strict-aliasing` being clang-cl's default, which is a Windows-only perf-parity bug, noted in the analysis separately.)

### The honest cost and the honest size

- **Cost:** `/GS` is a real (if partial) mitigation against stack buffer overruns in the C/C++ paths. Removing it is a weakening of `bun.exe`'s exploit-mitigation posture on Windows, and of every binary a user produces with `bun build --compile` on Windows.
- **The case for:** `bun-linux` and `bun-darwin` compile the exact same C/C++ source under the exact same threat model with **no** stack canary, and always have. `/GS` on Windows protects one of three platforms against a bug class the codebase handles identically on all three. Nobody ever decided to have it; we just never noticed the driver disagreement.
- **Size:** the analysis measured the cookie load + `__security_check_cookie` call pair across `bun-windows-x64.exe` at ~49 bytes across ~28,400 functions, about **1.45 MB**. That figure is for the whole binary. `flags.ts` only reaches bun's own C/C++ and the deps bun compiles; the WebKit prebuilt carries its own `/GS` setting and would need a matching change in oven-sh/WebKit to recover the rest. **The number that counts is CI's per-platform `Binary size` annotation on this build, which reports this PR's share exactly.** I have not overstated it anywhere in the code or this description.

### Scope and verification

- One entry in `globalFlags` (bun plus all deps bun compiles), `c.windows && c.release`. Debug builds keep the check (an extra crash-detection net where size does not matter). No other platform is touched.
- `bunx tsc --noEmit -p scripts/build/tsconfig.json`: no new errors.
- Regenerated the Windows build graph from a clean checkout (`--configure-only --profile=windows-x64-release`) and confirmed the cflags line becomes:
  ```
  ... /MT /U_DLL /GS- -DNDEBUG /O2 /Z7 /EHs-c- /GR- /Oy- /Gy /Gw /GF /GA ...
  ```
  next to its identical-predicate siblings (`/MT` is `c.windows && c.release` too).
