### PR TITLE
require(esm): evaluate top-level-await graphs that only need microtasks

### DIFF
--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -127,10 +127,10 @@ public:
     void* bunVM;
     Bun::JSCTaskScheduler deferredWorkTimer;
 
-    // A derived ShadowRealm global has its own JSModuleLoader on this VM, so a
-    // single realm's module map can no longer prove that no InnerModuleEvaluation
-    // is on the stack. $esmLoadSync reads this to skip its microtask checkpoint.
-    bool hasDerivedShadowRealmGlobalObject { false };
+    // A CyclicModuleRecord outside the calling global's JSModuleLoader map can
+    // reach status Evaluating on this VM (a ShadowRealm's own loader, a node:vm
+    // SourceTextModule), so $esmLoadSync must skip its microtask checkpoint.
+    bool hasModuleRecordsOutsideLoaderMap { false };
 
     // Backing storage for Bun::IsolatedModuleCache (see IsolatedModuleCache.h).
     // All access should go through that class. Stored as the JSC base type to

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -127,6 +127,11 @@ public:
     void* bunVM;
     Bun::JSCTaskScheduler deferredWorkTimer;
 
+    // A derived ShadowRealm global has its own JSModuleLoader on this VM, so a
+    // single realm's module map can no longer prove that no InnerModuleEvaluation
+    // is on the stack. $esmLoadSync reads this to skip its microtask checkpoint.
+    bool hasDerivedShadowRealmGlobalObject { false };
+
     // Backing storage for Bun::IsolatedModuleCache (see IsolatedModuleCache.h).
     // All access should go through that class. Stored as the JSC base type to
     // avoid pulling ZigSourceProvider.h into this header; the cache class

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -111,6 +111,9 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
         WTF::move(sourceCode), moduleWrapper, initializeImportMeta);
     RETURN_IF_EXCEPTION(scope, nullptr);
     ptr->finishCreation(vm);
+    // This module's CyclicModuleRecord never enters a JSModuleLoader map, so
+    // $esmLoadSync's Evaluating scan cannot see it mid-evaluation.
+    WebCore::clientData(vm)->hasModuleRecordsOutsideLoaderMap = true;
 
     if (cachedData.isEmpty()) {
         return ptr;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -813,7 +813,10 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
                 break;
             }
         }
-        if (!outerModuleIsEvaluating) {
+        // A derived ShadowRealm has its own module loader on this VM, so the
+        // scan above cannot see its Evaluating records, while the checkpoint
+        // below would still run their async siblings' resumes. Do not drain.
+        if (!outerModuleIsEvaluating && !WebCore::clientData(vm)->hasDerivedShadowRealmGlobalObject) {
             // Top-level await kept the load pending. Its remaining continuations
             // (await of a non-promise, thenables, Promise.all, nested async fns)
             // are plain microtasks: a checkpoint settles them without the event loop.
@@ -919,6 +922,7 @@ static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObjec
         Zig::GlobalObject::createStructure(vm),
         ScriptExecutionContext::generateIdentifier());
     shadow->setConsole(shadow);
+    WebCore::clientData(vm)->hasDerivedShadowRealmGlobalObject = true;
 
     return shadow;
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -800,16 +800,31 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
                     break;
             }
         }
-        // Top-level await kept the load pending. Its remaining continuations
-        // (await of a non-promise, thenables, Promise.all, nested async fns)
-        // are plain microtasks: a checkpoint settles them without the event loop.
-        vm.drainMicrotasks();
-        RETURN_IF_EXCEPTION(scope, {});
-        if (promise->status() == JSPromise::Status::Fulfilled)
-            break;
-        if (promise->status() == JSPromise::Status::Rejected) {
-            scope.throwException(globalObject, promise->result());
-            return {};
+        // Never run a checkpoint while an outer InnerModuleEvaluation is on the
+        // stack: an Evaluating record has no [[CycleRoot]] yet, and an unrelated
+        // async sibling's drained resume walks gatherAvailableAncestors into it.
+        bool outerModuleIsEvaluating = false;
+        for (auto& [mapKey, mapEntry] : loader->moduleMap()) {
+            if (!mapEntry)
+                continue;
+            auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(mapEntry->record());
+            if (cyclic && cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluating) {
+                outerModuleIsEvaluating = true;
+                break;
+            }
+        }
+        if (!outerModuleIsEvaluating) {
+            // Top-level await kept the load pending. Its remaining continuations
+            // (await of a non-promise, thenables, Promise.all, nested async fns)
+            // are plain microtasks: a checkpoint settles them without the event loop.
+            vm.drainMicrotasks();
+            RETURN_IF_EXCEPTION(scope, {});
+            if (promise->status() == JSPromise::Status::Fulfilled)
+                break;
+            if (promise->status() == JSPromise::Status::Rejected) {
+                scope.throwException(globalObject, promise->result());
+                return {};
+            }
         }
         // Only drop the entry we created. If the entry already existed (an
         // outer import() is mid-load, or the module is EvaluatingAsync from a

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -813,10 +813,10 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
                 break;
             }
         }
-        // A derived ShadowRealm has its own module loader on this VM, so the
-        // scan above cannot see its Evaluating records, while the checkpoint
-        // below would still run their async siblings' resumes. Do not drain.
-        if (!outerModuleIsEvaluating && !WebCore::clientData(vm)->hasDerivedShadowRealmGlobalObject) {
+        // A ShadowRealm's loader and node:vm SourceTextModules hold records the
+        // scan above cannot see, while the checkpoint below would still run
+        // their async siblings' resumes. Do not drain if any could exist.
+        if (!outerModuleIsEvaluating && !WebCore::clientData(vm)->hasModuleRecordsOutsideLoaderMap) {
             // Top-level await kept the load pending. Its remaining continuations
             // (await of a non-promise, thenables, Promise.all, nested async fns)
             // are plain microtasks: a checkpoint settles them without the event loop.
@@ -922,7 +922,7 @@ static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObjec
         Zig::GlobalObject::createStructure(vm),
         ScriptExecutionContext::generateIdentifier());
     shadow->setConsole(shadow);
-    WebCore::clientData(vm)->hasDerivedShadowRealmGlobalObject = true;
+    WebCore::clientData(vm)->hasModuleRecordsOutsideLoaderMap = true;
 
     return shadow;
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -800,6 +800,17 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
                     break;
             }
         }
+        // Top-level await kept the load pending. Its remaining continuations
+        // (await of a non-promise, thenables, Promise.all, nested async fns)
+        // are plain microtasks: a checkpoint settles them without the event loop.
+        vm.drainMicrotasks();
+        RETURN_IF_EXCEPTION(scope, {});
+        if (promise->status() == JSPromise::Status::Fulfilled)
+            break;
+        if (promise->status() == JSPromise::Status::Rejected) {
+            scope.throwException(globalObject, promise->result());
+            return {};
+        }
         // Only drop the entry we created. If the entry already existed (an
         // outer import() is mid-load, or the module is EvaluatingAsync from a
         // prior import), removing it would force a second evaluation and a

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -639,6 +639,11 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
     oldGlobal->isThreadLocalDefaultGlobalObject = false;
     JSC::gcUnprotect(oldGlobal);
 
+    // The old global's ShadowRealms and node:vm modules are discarded with it,
+    // and nothing can be mid-InnerModuleEvaluation between test files, so the
+    // per-VM out-of-loader-records bit starts clean for the next file.
+    WebCore::clientData(vm)->hasModuleRecordsOutsideLoaderMap = false;
+
     return globalObject;
 }
 

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -92,10 +92,10 @@ test("require(esm) failing on TLA does not delete an entry an outer import() own
 // $esmLoadSync runs a plain microtask checkpoint when the load promise is still
 // pending after the module-loader-internal drain; only a graph that genuinely
 // needs the host event loop keeps throwing the "async module" TypeError.
-describe("require(esm) whose top-level await only needs microtasks", () => {
-  async function run(dir: { toString(): string }) {
+describe.concurrent("require(esm) whose top-level await only needs microtasks", () => {
+  async function run(dir: { toString(): string }, entryFile = "entry.cjs") {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "entry.cjs"],
+      cmd: [bunExe(), entryFile],
       env: bunEnv,
       cwd: String(dir),
       stderr: "pipe",
@@ -217,5 +217,34 @@ describe("require(esm) whose top-level await only needs microtasks", () => {
       `,
     });
     expect(await run(dir)).toEqual({ stdout: "threw true", stderr: "", exitCode: 0 });
+  });
+
+  // require() from a module body that is itself inside an outer
+  // InnerModuleEvaluation must NOT run a microtask checkpoint: the global
+  // queue holds async-sibling.mjs's await-resume, whose async parent
+  // (entry.mjs) is still at status Evaluating with no [[CycleRoot]], so
+  // draining it would walk gatherAvailableAncestors into a half-built
+  // record. In that nested case require() keeps throwing instead.
+  test("does not drain while an outer module graph is mid-evaluation", async () => {
+    using dir = tempDir("require-esm-tla-nested-eval", {
+      "async-sibling.mjs": `export const x = await 0;`,
+      "tla.mjs": `export const v = await 0;`,
+      "sync-shim.mjs": `
+        import { createRequire } from "node:module";
+        const require = createRequire(import.meta.url);
+        try { require("./tla.mjs"); console.log("shim unexpected-success"); }
+        catch (e) { console.log("shim threw " + (e instanceof TypeError && e.message.includes("async module"))); }
+      `,
+      "entry.mjs": `
+        import "./async-sibling.mjs";
+        import "./sync-shim.mjs";
+        console.log("entry-done " + (await import("./async-sibling.mjs")).x);
+      `,
+    });
+    expect(await run(dir, "entry.mjs")).toEqual({
+      stdout: "shim threw true\nentry-done 0",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -248,6 +248,36 @@ describe.concurrent("require(esm) whose top-level await only needs microtasks", 
     });
   });
 
+  // A ShadowRealm's global has its own module loader on the same VM, so a
+  // record at status Evaluating there is invisible to the single-realm scan
+  // while its async sibling's resume sits in the VM-wide queue the checkpoint
+  // drains. Deriving a ShadowRealm therefore disables the drain entirely.
+  test("does not drain when a ShadowRealm graph is mid-evaluation on the same VM", async () => {
+    using dir = tempDir("require-esm-tla-shadowrealm", {
+      "async-sibling.mjs": `export const v = await 0;`,
+      "tla.mjs": `export const t = await 0;`,
+      "sync-shim.mjs": `
+        try { globalThis.__req("./tla.mjs"); globalThis.__msg = "shim-no-throw"; }
+        catch (e) { globalThis.__msg = "shim-threw"; }
+      `,
+      "realm-entry.mjs": `
+        import "./async-sibling.mjs";
+        import "./sync-shim.mjs";
+        export const x = 1;
+      `,
+      "entry.cjs": `
+        const realm = new ShadowRealm();
+        // Smuggle the main realm's require into the realm as a wrapped callable.
+        realm.evaluate("(fn) => { globalThis.__req = fn; return 0; }")(s => { require(s); return 0; });
+        realm.importValue("./realm-entry.mjs", "x").then(
+          v => console.log("resolved x=" + v + " | " + realm.evaluate("globalThis.__msg")),
+          () => console.log("rejected"),
+        );
+      `,
+    });
+    expect(await run(dir)).toEqual({ stdout: "resolved x=1 | shim-threw", stderr: "", exitCode: 0 });
+  });
+
   // A .then() queued before the require runs inside the checkpoint and can
   // import() the very module being required. The registry entry must survive
   // the throw so both importers share one evaluation and one namespace.

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -247,4 +247,30 @@ describe.concurrent("require(esm) whose top-level await only needs microtasks", 
       exitCode: 0,
     });
   });
+
+  // A .then() queued before the require runs inside the checkpoint and can
+  // import() the very module being required. The registry entry must survive
+  // the throw so both importers share one evaluation and one namespace.
+  test("an import() attached inside the checkpoint shares the require's entry", async () => {
+    using dir = tempDir("require-esm-tla-drain-import-identity", {
+      "timer.mjs": `
+        globalThis.evals = (globalThis.evals || 0) + 1;
+        export const x = await new Promise(r => setTimeout(r, 1));
+      `,
+      "entry.cjs": `
+        const log = [];
+        Promise.resolve().then(() => { log.push("cb-in-drain"); globalThis.p = import("./timer.mjs"); });
+        try { require("./timer.mjs"); log.push("req-ok"); } catch (e) { log.push("req-threw"); }
+        log.push("p-attached " + (globalThis.p !== undefined));
+        globalThis.p.then(m1 => import("./timer.mjs").then(m2 => {
+          console.log(log.join("|") + "|sameNs " + (m1 === m2) + "|evals " + globalThis.evals);
+        }));
+      `,
+    });
+    expect(await run(dir)).toEqual({
+      stdout: "cb-in-drain|req-threw|p-attached true|sameNs true|evals 1",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -314,6 +314,38 @@ describe.concurrent("require(esm) whose top-level await only needs microtasks", 
     });
   });
 
+  // The per-VM out-of-loader-records bit must reset at the --isolate global
+  // swap: an earlier file's in-process ShadowRealm must not disable the
+  // require(TLA) checkpoint for every later isolated file on the same VM.
+  test("bun test --isolate resets the checkpoint guard between files", async () => {
+    using dir = tempDir("require-esm-tla-isolate", {
+      "tla.mjs": `export const x = await 0;`,
+      "1-realm.test.ts": `
+        import { test, expect } from "bun:test";
+        test("constructs a ShadowRealm in-process", () => {
+          expect(typeof new ShadowRealm()).toBe("object");
+        });
+      `,
+      "2-tla.test.ts": `
+        import { test, expect } from "bun:test";
+        test("require of a microtask-only TLA module", () => {
+          expect(require("./tla.mjs").x).toBe(0);
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "./1-realm.test.ts", "./2-tla.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = stdout + stderr;
+    expect(out).toContain(" 2 pass");
+    expect(out).not.toContain("(fail)");
+    expect(exitCode).toBe(0);
+  });
+
   // A .then() queued before the require runs inside the checkpoint and can
   // import() the very module being required. The registry entry must survive
   // the throw so both importers share one evaluation and one namespace.

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -6,7 +6,7 @@
 // Separately, when the Pending path *does* throw, it used to removeEntry()
 // unconditionally. If an outer import() already created the entry, deleting
 // it forces a second evaluation when the outer import settles.
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("require(esm) rejects when a transitive dependency has top-level await", async () => {
@@ -85,4 +85,137 @@ test("require(esm) failing on TLA does not delete an entry an outer import() own
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("ok");
   expect(exitCode).toBe(0);
+});
+
+// An async module graph whose every `await` can make progress using only
+// microtasks (no timers, no I/O) is evaluable inside a synchronous require().
+// $esmLoadSync runs a plain microtask checkpoint when the load promise is still
+// pending after the module-loader-internal drain; only a graph that genuinely
+// needs the host event loop keeps throwing the "async module" TypeError.
+describe("require(esm) whose top-level await only needs microtasks", () => {
+  async function run(dir: { toString(): string }) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  test("awaits that complete without the event loop resolve synchronously", async () => {
+    using dir = tempDir("require-esm-microtask-tla", {
+      "literal.mjs": `export const x = await 0;`,
+      "nul.mjs": `export const x = await null;`,
+      "thenable.mjs": `export const x = await { then(r) { r(5); } };`,
+      "chained.mjs": `export const x = await Promise.resolve(1).then(v => v + 1);`,
+      "all.mjs": `export const x = await Promise.all([Promise.resolve(1), Promise.resolve(2), 3]);`,
+      "nested-fn.mjs": `async function f() { await Promise.resolve(); await 0; return 7; } export const x = await f();`,
+      "deep-leaf.mjs": `export const x = await 0;`,
+      "dep.mjs": `import { x as leaf } from "./deep-leaf.mjs"; export const x = leaf + 100;`,
+      // Awaiting a promise resolved *with* another promise routes through a
+      // PromiseResolveThenableJobFast, a different job kind than the others.
+      "resolved-with.mjs": `export const x = await new Promise(r => r(Promise.resolve(11)));`,
+      "settled.mjs": `export const x = await Promise.resolve(42);`,
+      "entry.cjs": `
+        const names = ["literal", "nul", "thenable", "chained", "all", "nested-fn", "dep", "resolved-with", "settled"];
+        const out = [];
+        for (const name of names) {
+          try {
+            out.push(name + " " + JSON.stringify(require("./" + name + ".mjs").x));
+          } catch (e) {
+            out.push(name + " THREW " + e.message);
+          }
+        }
+        out.push("cached " + (require("./literal.mjs") === require("./literal.mjs")));
+        console.log(out.join("\\n"));
+      `,
+    });
+
+    expect(await run(dir)).toEqual({
+      stdout: [
+        "literal 0",
+        "nul null",
+        "thenable 5",
+        "chained 2",
+        "all [1,2,3]",
+        "nested-fn 7",
+        "dep 100",
+        "resolved-with 11",
+        "settled 42",
+        "cached true",
+      ].join("\n"),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("await import() of a synchronous sibling resolves inside require()", async () => {
+    using dir = tempDir("require-esm-tla-dynamic-import", {
+      "leaf.mjs": `export const s = 9;`,
+      "dyn.mjs": `const m = await import("./leaf.mjs"); export const x = m.s;`,
+      "entry.cjs": `console.log("got " + require("./dyn.mjs").x);`,
+    });
+    expect(await run(dir)).toEqual({ stdout: "got 9", stderr: "", exitCode: 0 });
+  });
+
+  // The checkpoint is the real FIFO microtask queue, not a private reordering
+  // queue: a user microtask queued before the require runs inside it, in order,
+  // ahead of the module's own continuations. This pins that observable semantic.
+  test("preserves microtask FIFO order across the checkpoint inside require()", async () => {
+    using dir = tempDir("require-esm-tla-ordering", {
+      "tla.mjs": `
+        globalThis.__log.push("module-start");
+        Promise.resolve().then(() => globalThis.__log.push("module-queued"));
+        export const x = await 0;
+        globalThis.__log.push("module-after-await");
+      `,
+      "entry.cjs": `
+        const log = (globalThis.__log = []);
+        Promise.resolve().then(() => log.push("pre-queued"));
+        const { x } = require("./tla.mjs");
+        log.push("after-require " + x);
+        Promise.resolve().then(() => console.log(log.join("|")));
+      `,
+    });
+    expect(await run(dir)).toEqual({
+      stdout: "module-start|pre-queued|module-queued|module-after-await|after-require 0",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("works when require() itself runs inside a microtask (nested checkpoint)", async () => {
+    using dir = tempDir("require-esm-tla-nested", {
+      "tla.mjs": `export const x = await 0;`,
+      "entry.cjs": `Promise.resolve().then(() => { console.log("got " + require("./tla.mjs").x); });`,
+    });
+    expect(await run(dir)).toEqual({ stdout: "got 0", stderr: "", exitCode: 0 });
+  });
+
+  test("a throwing top-level-await module surfaces its own error, and it stays cached", async () => {
+    using dir = tempDir("require-esm-tla-reject", {
+      "boom.mjs": `await 0; throw new Error("boom-from-tla");`,
+      "entry.cjs": `
+        const msgs = [];
+        for (let i = 0; i < 2; i++) {
+          try { require("./boom.mjs"); msgs.push("no-throw"); } catch (e) { msgs.push(e.message); }
+        }
+        console.log(msgs.join("|"));
+      `,
+    });
+    expect(await run(dir)).toEqual({ stdout: "boom-from-tla|boom-from-tla", stderr: "", exitCode: 0 });
+  });
+
+  test("an await that genuinely needs the event loop still throws", async () => {
+    using dir = tempDir("require-esm-tla-event-loop", {
+      "timer.mjs": `export const x = await new Promise(r => setTimeout(r, 1));`,
+      "entry.cjs": `
+        try { require("./timer.mjs"); console.log("unexpected-success"); }
+        catch (e) { console.log("threw " + (e instanceof TypeError && e.message.includes("async module"))); }
+      `,
+    });
+    expect(await run(dir)).toEqual({ stdout: "threw true", stderr: "", exitCode: 0 });
+  });
 });

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -278,6 +278,42 @@ describe.concurrent("require(esm) whose top-level await only needs microtasks", 
     expect(await run(dir)).toEqual({ stdout: "resolved x=1 | shim-threw", stderr: "", exitCode: 0 });
   });
 
+  // node:vm SourceTextModule records live outside every JSModuleLoader map. In
+  // a module CYCLE the wrapper pre-evaluation skips the back-edge (its wrapper
+  // is already Evaluating), so the sibling's spec DFS enters it instead and
+  // runs its body while two records sit at Evaluating with no [[CycleRoot]].
+  // A main-realm require() in the sandbox must not drain microtasks there.
+  test("does not drain while a node:vm module cycle is mid-evaluation", async () => {
+    using dir = tempDir("require-esm-tla-node-vm", {
+      "tla.mjs": `export const t = await 0;`,
+      "entry.cjs": `
+        const vm = require("node:vm");
+        const path = require("node:path");
+        const ctx = vm.createContext({
+          mainReq: s => {
+            try { require(path.resolve(__dirname, s)); return "req-no-throw"; }
+            catch (e) { return "req-threw"; }
+          },
+          report: m => { globalThis.__report = m; },
+        });
+        const asyncSib = new vm.SourceTextModule('export const v = await 0;', { context: ctx, identifier: "asyncSib" });
+        const A = new vm.SourceTextModule('import "B"; report(mainReq("./tla.mjs")); export const a = 1;', { context: ctx, identifier: "A" });
+        const B = new vm.SourceTextModule('import "asyncSib"; import "A"; export const b = 1;', { context: ctx, identifier: "B" });
+        const byName = { A, B, asyncSib };
+        (async () => {
+          await A.link(s => byName[s]);
+          await A.evaluate();
+          console.log("done A=" + A.status + " B=" + B.status + " | " + globalThis.__report);
+        })().catch(e => console.log("rejected: " + String(e).slice(0, 110)));
+      `,
+    });
+    expect(await run(dir)).toEqual({
+      stdout: "done A=evaluated B=evaluated | req-threw",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   // A .then() queued before the require runs inside the checkpoint and can
   // import() the very module being required. The registry entry must survive
   // the throw so both importers share one evaluation and one namespace.


### PR DESCRIPTION
`require()` of an ES module whose graph uses top-level await throws

```
TypeError: require() async module "<path>" is unsupported. use "await import()" instead.
```

for every graph that is still pending after the synchronous module-loader drain, even when nothing in the graph actually needs the event loop.

```js
// tla.mjs
export const x = await 0;

// app.cjs
require("./tla.mjs"); // TypeError: require() async module ...
```

Meanwhile `export const x = await Promise.resolve(1)` already works under `require()`, because it happens to be the one shape the drain can handle.

### Cause

`$esmLoadSync` drives the load through `JSModuleLoader::loadModuleSync`, which diverts module-loader reaction jobs into a private queue (`VM::m_synchronousModuleQueue`) and drains it until the load promise settles. The divert only triggers for a reaction being attached to an already-settled promise, and only at the promise-reaction enqueue sites. Several await shapes never reach one of those sites:

- `await 0` / `await null` / any non-thenable: the spec fast path skips the wrapper promise and enqueues the resume directly (`JSPromise::fulfillWithInternalMicrotask`), so there is no promise for the divert to check.
- thenables, `.then()` chains, `Promise.all`, nested async functions: their progress is made by job kinds that are deliberately not on the divert whitelist.
- `await import('./sync-sibling')`: the inner load completes inside the private drain, but Bun's `import()` wraps the result in a fresh promise whose single resolve job is not whitelisted.

In every one of these the remaining continuation is an ordinary microtask sitting in the global queue. It never needs the host event loop. The load promise is reported pending and `require()` throws.

### Fix

When `loadModuleSync` returns with the load promise still pending (and after the existing Evaluating-SCC carve-out), run a plain microtask checkpoint with `vm.drainMicrotasks()` and re-check the promise.

- Fulfilled: return the namespace as usual.
- Rejected: the module body threw; surface that error. It stays cached on the record, so a second `require` rethrows it.
- Still pending: the graph genuinely needs the event loop (a timer, I/O, a promise a later task resolves). Keep throwing the `async module` TypeError.

This never touches the event loop, cannot re-enter I/O, and cannot hang: the microtask queue either drains or the chain was infinite and would have hung at the next checkpoint anyway.

### The guard, and its honest limits

The checkpoint must never run while an `InnerModuleEvaluation` DFS is anywhere on the VM's C++ stack. A record on that stack is at status `Evaluating` with `[[CycleRoot]]` unset, and if the VM-wide microtask queue holds the await-resume of one of its async siblings, draining it walks `gatherAvailableAncestors` into the half-built record and trips

```
ASSERTION FAILED: !m->cycleRoot() => m->evaluationError()
CyclicModuleRecord.cpp(579) gatherAvailableAncestors
```

in a debug build (a double-evaluation in release). The complete form of that guard is a VM-scoped `InnerModuleEvaluation` depth counter; that lives in the vendored JavaScriptCore and is listed under follow-ups. Until it exists, the Bun-side guard is an enumeration of the places such a DFS can originate. Each entry is backed by a reproduced crash and a regression test:

1. The calling global's own module loader: scanned for any `CyclicModuleRecord` at status `Evaluating` (i.e. `require()` was called from inside an outer ES module body's synchronous dependency loop). In that case `require()` keeps the pre-existing throw.
2. A ShadowRealm's derived global, which has its own module loader on the same VM, invisible to the scan.
3. node:vm `SourceTextModule` records, which live outside every `JSModuleLoader` map. Their "each dependency is pre-evaluated as its own DFS root" property only holds for acyclic graphs; a module cycle defeats it.

Cases 2 and 3 are recorded as a sticky per-VM bit (`JSVMClientData::hasModuleRecordsOutsideLoaderMap`) set where each is created, and the checkpoint is additionally gated on that bit being unset. The bit is cleared at the `bun test --isolate` global swap, where nothing can be mid-`InnerModuleEvaluation` and the discarded global's realms go with it, so it does not leak across the isolation boundary (a new file's own constructions re-set it). Both triggers require a main-realm `require` to be deliberately smuggled into the other realm, but both are a debug abort and a release-build corruption, so they are guarded rather than documented. With the bit unset, the single-realm scan in (1) is complete by construction.

Node throws `ERR_REQUIRE_ASYNC_MODULE` for all of these shapes, including `await 0`. Bun already handled the already-settled-promise shape; this covers the rest of the class.

### What changes observably

For `require(<graph with top-level await>)` only, the microtask checkpoint now runs inside the `require()` call instead of at the end of the current turn. Ordering among microtasks is unchanged: this is the real FIFO queue, not the private reordering one, so a user microtask queued earlier in the same turn runs inside the `require`, ahead of the module's own continuations, exactly as it would at the next natural checkpoint. A test pins that order. `require()` of such a graph always threw before, so no working code depends on the old timing.

### Verification

New cases in `test/js/bun/resolve/require-esm-transitive-tla.test.ts` (the existing `require(esm)` top-level-await file), in a `describe.concurrent` block:

- the shapes above all resolve under `require()`: a literal, `null`, a plain thenable, a `.then()` chain, `Promise.all`, a nested async function, a transitive dependency, `await import()` of a synchronous sibling, and a promise resolved with a promise
- microtask FIFO order is preserved across the in-require checkpoint
- `require()` from inside a `.then()` works (nested checkpoint)
- a throwing top-level-await module surfaces its own error, and a second `require` gets the same cached error
- an await on a `setTimeout` still throws the `async module` TypeError
- the nested-evaluation hazard (1) throws cleanly and the outer graph still completes, instead of aborting on the assertion
- the ShadowRealm hazard (2), with the main realm's `require()` smuggled in as a wrapped callable, throws cleanly and the realm's graph completes
- the node:vm cycle hazard (3), with the main realm's `require()` in the context sandbox, throws cleanly and the node:vm graph completes
- an `import()` of the same module started by a user microtask running inside the checkpoint shares the require's loader entry (one evaluation, one namespace identity)
- under `bun test --isolate`, a file that constructs a ShadowRealm in-process does not disable the checkpoint for later isolated files

The two existing tests in that file both use `setTimeout`-based awaits and are unchanged. The only other test in the tree asserting this message is `test/regression/issue/24387.test.ts`, whose fixture also awaits a `setTimeout`; it still throws and still passes.

Related but not a duplicate: #33184 fixes a false positive of the same message for a graph with no top-level await racing a concurrent `import()`. Different hunk in the same function, and the two compose.

Three narrower fixes are possible in the vendored JSC: divert the non-thenable await's direct enqueue in `JSPromise::fulfillWithInternalMicrotask`, have `globalFuncImportModule`'s Bun-only wrapper use `pipeFrom` under a synchronous load, and replace the guard enumeration above with a VM-scoped `InnerModuleEvaluation` depth counter (which subsumes cases 1 through 3 and any future realm source). Each would also cover a subset of these shapes with no timing change at all. They have to land in oven-sh/WebKit rather than here, so they are left as follow-ups.
