### PR TITLE
Store internal JS module sources zstd-compressed; decompress on a module's first require

### DIFF
--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -16,7 +16,7 @@ import jsclasses from "./../jsc/bindings/js_classes";
 import { sliceSourceCode } from "./builtin-parser";
 import { createAssertClientJS, createLogClientJS } from "./client-js";
 import { getJS2NativeCPP, getJS2NativeRust } from "./generate-js2native";
-import { cap, declareASCIILiteral, writeIfNotChanged } from "./helpers";
+import { cap, declareASCIILiteral, declareZstdCompressedSource, writeIfNotChanged } from "./helpers";
 import { createInternalModuleRegistry } from "./internal-module-registry-scanner";
 import { define } from "./replacements";
 
@@ -362,10 +362,11 @@ JSValue InternalModuleRegistry::createInternalModuleById(JSGlobalObject* globalO
 );
 
 // This header is used by InternalModuleRegistry.cpp, and should only be included in that file.
-// It inlines all the strings for the module IDs.
+// It inlines the source of every internal JS module.
 //
-// We cannot use ASCIILiteral's `_s` operator for the module source code because for long
-// strings it fails a constexpr assert. Instead, we do that assert in JS before we format the string
+// In release each source is one zstd frame; keeping ~1.7 MB of raw module
+// source in `.rodata` was the single largest avoidable block in the binary,
+// and a module's source is only ever read once (requireId caches the result).
 if (!debug) {
   writeIfNotChanged(
     path.join(CODEGEN_DIR, "InternalModuleRegistryConstants.h"),
@@ -374,6 +375,17 @@ if (!debug) {
 
 namespace Bun {
 namespace InternalModuleRegistryConstants {
+
+// One entry per internal JS module. \`zstd\` is a single complete zstd frame
+// whose decompressed content is exactly \`rawSize\` ASCII bytes; it is inflated
+// once, on the module's first require, by decompressInternalModuleSource in
+// InternalModuleRegistry.cpp.
+struct CompressedSourceCode {
+  const unsigned char* zstd;
+  unsigned zstdSize;
+  unsigned rawSize;
+};
+
   ${moduleList
     .slice(0, nativeStartIndex)
     .map((id, n) => {
@@ -381,7 +393,7 @@ namespace InternalModuleRegistryConstants {
       if (!out) {
         throw new Error(`Missing output for ${id}`);
       }
-      return declareASCIILiteral(`${idToEnumName(id)}Code`, out);
+      return declareZstdCompressedSource(`${idToEnumName(id)}Code`, out);
     })
     .join("\n")}
 }

--- a/src/codegen/helpers.ts
+++ b/src/codegen/helpers.ts
@@ -37,6 +37,23 @@ export function declareASCIILiteral(name: string, value: string) {
 static constexpr ASCIILiteral ${name} = ASCIILiteral::fromLiteralUnsafe(${name}Bytes);`;
 }
 
+// Emit a module's source as one zstd frame plus a CompressedSourceCode
+// descriptor; InternalModuleRegistry.cpp decompresses it on the module's
+// first require. rawSize is the length declareASCIILiteral would produce.
+export function declareZstdCompressedSource(name: string, value: string) {
+  const normalized = value + "\n";
+  // The runtime decompresses straight into an 8-bit StringImpl, and the
+  // uncompressed debug path stores these as ASCIILiteral, so the bundled
+  // source must already be ASCII.
+  if (Buffer.byteLength(normalized, "utf8") !== normalized.length) {
+    throw new Error(`${name}: bundled internal-module source must be ASCII`);
+  }
+  const raw = Buffer.from(normalized, "latin1");
+  const compressed = Bun.zstdCompressSync(raw, { level: 19 });
+  return `static constexpr const unsigned char ${name}ZstdBytes[${compressed.length}] = {${Array.from(compressed).join(",")}};
+static constexpr CompressedSourceCode ${name} { ${name}ZstdBytes, ${compressed.length}, ${raw.length} };`;
+}
+
 export function cap(str: string) {
   return str[0].toUpperCase() + str.slice(1);
 }

--- a/src/codegen/helpers.ts
+++ b/src/codegen/helpers.ts
@@ -50,7 +50,7 @@ export function declareZstdCompressedSource(name: string, value: string) {
   }
   const raw = Buffer.from(normalized, "latin1");
   const compressed = Bun.zstdCompressSync(raw, { level: 19 });
-  return `static constexpr const unsigned char ${name}ZstdBytes[${compressed.length}] = {${Array.from(compressed).join(",")}};
+  return `static constexpr const unsigned char ${name}ZstdBytes[${compressed.length}] = {${compressed.join(",")}};
 static constexpr CompressedSourceCode ${name} { ${name}ZstdBytes, ${compressed.length}, ${raw.length} };`;
 }
 

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -8,6 +8,7 @@
 #include <JavaScriptCore/JSModuleLoader.h>
 #include <JavaScriptCore/Debugger.h>
 #include <utility>
+#include <zstd.h>
 
 #include "InternalModuleRegistryConstants.h"
 #include "wtf/Forward.h"
@@ -115,8 +116,20 @@ JSValue initializeInternalModuleFromDisk(JSGlobalObject* globalObject, VM& vm, c
     return initializeInternalModuleFromDisk(globalObject, vm, moduleId, filename, urlString)
 #else
 
+// The per-module constants in InternalModuleRegistryConstants.h are single
+// zstd frames produced by src/codegen/bundle-modules.ts, decompressed once:
+// requireId caches the module and makeSource keeps the source String alive.
+static WTF::String decompressInternalModuleSource(const InternalModuleRegistryConstants::CompressedSourceCode& compressed)
+{
+    std::span<Latin1Character> out;
+    WTF::String source = WTF::String::createUninitialized(compressed.rawSize, out);
+    size_t decoded = ZSTD_decompress(out.data(), compressed.rawSize, compressed.zstd, compressed.zstdSize);
+    RELEASE_ASSERT(!ZSTD_isError(decoded) && decoded == compressed.rawSize);
+    return source;
+}
+
 #define INTERNAL_MODULE_REGISTRY_GENERATE(globalObject, vm, moduleId, filename, SOURCE, urlString) \
-    return generateModule(globalObject, vm, SOURCE, moduleId, urlString)
+    return generateModule(globalObject, vm, decompressInternalModuleSource(SOURCE), moduleId, urlString)
 #endif
 
 const ClassInfo InternalModuleRegistry::s_info = { "InternalModuleRegistry"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(InternalModuleRegistry) };

--- a/test/internal/codegen-helpers.test.ts
+++ b/test/internal/codegen-helpers.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the internal-module source code generator
+ * (src/codegen/helpers.ts::declareZstdCompressedSource).
+ *
+ * The release binary stores each internal JS module's source as one zstd frame
+ * plus a { zstd, zstdSize, rawSize } descriptor, which
+ * InternalModuleRegistry.cpp decompresses on the module's first require. These
+ * tests lock in the two invariants that path depends on: the descriptor's byte
+ * counts are exact, and the decompressed bytes are byte-for-byte equal to the
+ * raw ASCIILiteral representation (declareASCIILiteral) that debug builds, and
+ * every release build before this, embedded directly.
+ */
+import { describe, expect, test } from "bun:test";
+import { declareASCIILiteral, declareZstdCompressedSource } from "../../src/codegen/helpers.ts";
+
+/** Parse declareZstdCompressedSource's two generated C++ lines back into their components. */
+function parseCompressed(cpp: string) {
+  const m = cpp.match(
+    /^static constexpr const unsigned char (\w+)ZstdBytes\[(\d+)\] = \{([\d,]*)\};\nstatic constexpr CompressedSourceCode \1 \{ \1ZstdBytes, (\d+), (\d+) \};$/,
+  );
+  if (!m) throw new Error(`declareZstdCompressedSource emitted an unexpected shape:\n${cpp}`);
+  const bytes = new Uint8Array(m[3] === "" ? [] : m[3].split(",").map(Number));
+  return { name: m[1], arrayLen: Number(m[2]), bytes, zstdSize: Number(m[4]), rawSize: Number(m[5]) };
+}
+
+/** Parse declareASCIILiteral's byte array (the raw, uncompressed representation). */
+function parseASCIILiteral(cpp: string) {
+  const m = cpp.match(/^static constexpr const char \w+Bytes\[(\d+)\] = \{([\d,]*)\};/);
+  if (!m) throw new Error(`declareASCIILiteral emitted an unexpected shape:\n${cpp}`);
+  return { count: Number(m[1]), bytes: m[2] === "" ? [] : m[2].split(",").map(Number) };
+}
+
+describe("declareZstdCompressedSource", () => {
+  // A realistic module body plus a long repetitive tail so the compressor has
+  // real work to do. Built without String#repeat (slow in debug JSC builds).
+  const source =
+    "export default function add(a, b) {\n  return a + b;\n}\n// " +
+    Buffer.alloc(4096, "padding for the compressor ").toString() +
+    "\n";
+
+  test("the descriptor's byte counts are exact and internally consistent", () => {
+    const p = parseCompressed(declareZstdCompressedSource("TestModuleCode", source));
+    expect(p.name).toBe("TestModuleCode");
+    // The C array's declared length, the descriptor's zstdSize, and the actual
+    // byte count must all agree: the runtime hands zstdSize to ZSTD_decompress
+    // as the frame length.
+    expect({ arrayLen: p.arrayLen, zstdSize: p.zstdSize }).toEqual({
+      arrayLen: p.bytes.length,
+      zstdSize: p.bytes.length,
+    });
+    // rawSize is the decompressed length: the source plus the trailing newline
+    // the module codegen has always appended.
+    expect(p.rawSize).toBe(source.length + 1);
+  });
+
+  test("the frame decompresses byte-for-byte to the string the raw ASCIILiteral representation carried", () => {
+    // The pre-existing representation for the same source: a NUL-terminated
+    // char array whose ASCIILiteral length is strlen (everything but the NUL).
+    const lit = parseASCIILiteral(declareASCIILiteral("RefCode", source));
+    expect(lit.count).toBe(source.length + 1 + 1);
+    expect(lit.bytes[lit.bytes.length - 1]).toBe(0);
+
+    const p = parseCompressed(declareZstdCompressedSource("RefCode", source));
+    const decompressed = Bun.zstdDecompressSync(p.bytes);
+    expect(decompressed.length).toBe(p.rawSize);
+    // Byte-for-byte equal to what the ASCIILiteral held (minus its NUL, which a
+    // StringImpl does not need). This is the behavior-preserving invariant the
+    // release runtime depends on.
+    expect(Array.from(decompressed)).toEqual(lit.bytes.slice(0, -1));
+  });
+
+  test("a large repetitive source actually compresses and still round-trips", () => {
+    const big = Buffer.alloc(80_000, "const value = 1;\nexport { value };\n").toString();
+    const p = parseCompressed(declareZstdCompressedSource("BigCode", big));
+    expect(p.rawSize).toBe(big.length + 1);
+    // If the stored bytes were not a real zstd frame this cannot hold.
+    expect(p.zstdSize).toBeLessThan(p.rawSize / 10);
+    expect(Buffer.from(Bun.zstdDecompressSync(p.bytes)).toString("latin1")).toBe(big + "\n");
+  });
+
+  test("rejects non-ASCII source at codegen time", () => {
+    // The runtime decompresses straight into an 8-bit StringImpl and the debug
+    // representation is ASCIILiteral, so the codegen must refuse anything
+    // outside ASCII rather than silently mis-encode it.
+    expect(() => declareZstdCompressedSource("BadCode", 'const s = "caf\u00e9";')).toThrow(
+      "bundled internal-module source must be ASCII",
+    );
+  });
+});


### PR DESCRIPTION
Part of the binary size reduction effort requested by @Jarred-Sumner and @dylan-conway; the full analysis is at [size-research/03-FINAL.md](https://github.com/oven-sh/bun/blob/farm/73f947d6/size-research/size-research/03-FINAL.md). This is its single largest cross-platform item, and it is the same mechanism already shipped three times in this codebase (the ICU per-item compression, the lshpack Huffman tables, and the `node_fallbacks` modules), applied to the biggest asset family that did not yet use it.

### What this is

Bun embeds 161 internal JS modules (`node:fs`, `node:http2`, `bun:sqlite`, ...) as raw source in `.rodata`. Measured by running the real release codegen on this branch:

| | bytes |
|---|--:|
| raw module source in `.rodata` today | 1,791,699 |
| the same 161 modules as zstd-19 frames | 396,580 |
| **reduction, on every platform** | **1,395,119 (1.33 MiB)** |

For scale, `node:http2` alone goes from 151,769 B to 25,570 B.

A module's source is only ever read **once**: `InternalModuleRegistry::requireId` caches the evaluated module on first require, and `makeSource` keeps the source `String` alive for as long as JSC's executables reference it. So the source string is already a one-shot input, and storing it compressed costs exactly one `ZSTD_decompress` on that first require, behind a cache check that already exists. The change is three files and 48 lines:

- `src/codegen/bundle-modules.ts`: the release branch emits each module as one zstd frame plus a `{zstd, zstdSize, rawSize}` descriptor instead of a raw `char[]`.
- `src/codegen/helpers.ts`: the `declareZstdCompressedSource` helper (with a codegen-time ASCII assertion, since the runtime decompresses into an 8-bit `StringImpl`).
- `src/jsc/bindings/InternalModuleRegistry.cpp`: the release-only `INTERNAL_MODULE_REGISTRY_GENERATE` macro decompresses the descriptor into a `StringImpl` before handing it to `generateModule`. The decoder is already linked (`ProcessBindingConstants.cpp` in the same directory already `#include`s `<zstd.h>`).

### Why it is performance-neutral

- A bare `bun` invocation requires **zero** internal modules, so startup is untouched.
- The decompress sits in front of an already-lazy path (module parse + bytecode compile + evaluate) that is orders of magnitude slower than inflating a ~10 KB frame.
- `fn.toString()` of any builtin is **byte-identical**: the decompressed source equals the old `ASCIILiteral` exactly, character for character. This is not minification; no observable JS surface changes.
- The debug build is untouched in every respect: the debug macro loads from disk and never references the constant (the `SOURCE` token is discarded before it reaches the preprocessor's output), and the debug codegen branch still emits empty `ASCIILiteral`s. The edit-`src/js`-without-recompiling dev loop is exactly as it was.

### The one honest cost

Today a loaded module's `StringImpl` points directly at the `.rodata` array (`createWithoutCopying`), so its source costs file-backed, cross-process-shareable pages. After this change it costs a per-`globalObject` heap allocation of `rawSize` bytes instead. For one VM that is approximately RSS-neutral (anonymous pages instead of touched file-backed pages). For a process whose Workers all load the same large module, each Worker now pays its own copy where today they would share the `.rodata` pages; the worst conceivable bound (every Worker loads every module) is ~1.7 MB per Worker. I am calling this out explicitly rather than hiding it; if the maintainers consider it disqualifying, the right response is to close this PR.

### Verification

All four checks were run against the real release build graph on this branch, not against an approximation:

1. **Codegen**: `ninja -C build/release codegen/InternalModuleRegistryConstants.h` produces 161 `CompressedSourceCode` entries whose array byte sums match the descriptors exactly.
2. **Data**: a standalone C++ program including the real generated header, linked against the **vendored** `vendor/zstd` decoder (the exact code the release binary links), decompresses all 161 frames with the identical `ZSTD_decompress(dst, rawSize, zstd, zstdSize)` call shape the runtime uses: **161/161 decode to exactly `rawSize` bytes, all ASCII, all newline-terminated.**
3. **Release compile**: the real release compile command for `InternalModuleRegistry.cpp` (extracted from `compile_commands.json`), re-run with `-fsyntax-only`: **clean, zero diagnostics**, with `BUN_DYNAMIC_JS_LOAD_PATH` confirmed absent so the embedded (decompressing) branch is the one being compiled.
4. **Debug compile**: the same for the debug profile: clean, with `BUN_DYNAMIC_JS_LOAD_PATH` confirmed present, and the debug-generated header confirmed to still contain 161 `ASCIILiteral`s and zero `CompressedSourceCode`s.

### Test coverage

**New, in this PR: `test/internal/codegen-helpers.test.ts`** unit-tests `declareZstdCompressedSource` directly. Its load-bearing assertion is a byte-for-byte comparison of the decompressed zstd frame against the array `declareASCIILiteral` emits for the same input, minus its NUL terminator: a direct, automated proof that the new representation is identical to the one every build used before. It also locks in the descriptor's size invariants (the C array length, `zstdSize`, and the real frame size must all agree; `rawSize` is the source plus the trailing newline the codegen has always appended), a large-input round trip, and the codegen-time rejection of non-ASCII source. Fail-before proven: with `origin/main`'s `src/` checked out over this branch's, the test fails on the missing export (0 pass, 1 fail); with this branch's it is 4 for 4.

**Existing, on every release CI lane**: `test/js/bun/test/parallel/test-require-builtins.ts` spawns a fresh process for **every** `node:module.builtinModules` entry and requires it, asserting exit 0, and the rest of `test/js/node/` loads the internal modules thousands of times. Every CI `test-bun` lane tests a release binary, so that exercises the runtime decompress path exhaustively, and the `x64-asan` lane is a release-ASAN build, so `createUninitialized` + `ZSTD_decompress` also run under ASAN in CI. A new *runtime* test would add nothing on top of that: a debug build (`bun bd`) does not compile this code path at all (the debug macro reads from disk), which is why the new test targets the codegen half instead.

The authoritative per-platform size delta is CI's `Binary size` annotation on this PR.

Three implementation notes for the reviewer, all of which I only caught by reading the real headers bun links rather than relying on the analysis document: (1) bun's WebKit uses `Latin1Character`, not the older `LChar` name; (2) the `#include <zstd.h>` must be at file scope, because the `#ifdef`/`#else` block it is otherwise needed in sits inside `namespace Bun`; (3) `String::createUninitialized(unsigned, std::span<Latin1Character>&)` is the existing in-tree idiom (6 callers), which is why the descriptor's sizes are `unsigned` rather than `size_t`.
