### PR TITLE
install: add git subdirectory support via `&path:` specifier

### DIFF
--- a/docs/pm/cli/add.mdx
+++ b/docs/pm/cli/add.mdx
@@ -153,6 +153,18 @@ Bun supports a variety of protocols, including [`github`](https://docs.npmjs.com
 }
 ```
 
+To install a package that lives in a subdirectory of a git monorepo, append the pnpm-style `&path:<subdir>` parameter to the URL fragment:
+
+```json package.json icon="file-json"
+{
+  "dependencies": {
+    "my-pkg": "github:user/monorepo#main&path:packages/my-pkg"
+  }
+}
+```
+
+The `&path:` parameter can be combined with a branch, tag, or commit committish (for example `#v1.2.3&path:packages/my-pkg`). Only the contents of the subdirectory are installed.
+
 ## Tarball dependencies
 
 A package name can correspond to a publicly hosted `.tgz` file. Bun downloads and installs the package from that tarball URL rather than from the package registry.

--- a/docs/pm/cli/add.mdx
+++ b/docs/pm/cli/add.mdx
@@ -153,17 +153,18 @@ Bun supports a variety of protocols, including [`github`](https://docs.npmjs.com
 }
 ```
 
-To install a package that lives in a subdirectory of a git monorepo, append the pnpm-style `&path:<subdir>` parameter to the URL fragment:
+To install a package that lives in a subdirectory of a git monorepo, add the pnpm-style `path:` parameter to the URL fragment. Use `#path:<subdir>` on its own, or combine it with a branch, tag, or commit using `&`:
 
 ```json package.json icon="file-json"
 {
   "dependencies": {
-    "my-pkg": "github:user/monorepo#main&path:packages/my-pkg"
+    "pkg-a": "github:user/monorepo#path:packages/pkg-a",
+    "pkg-b": "github:user/monorepo#v1.2.3&path:packages/pkg-b"
   }
 }
 ```
 
-The `&path:` parameter can be combined with a branch, tag, or commit committish (for example `#v1.2.3&path:packages/my-pkg`). Only the contents of the subdirectory are installed.
+Only the contents of the subdirectory are installed.
 
 ## Tarball dependencies
 

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -573,6 +573,13 @@ impl<'a> ByteCursor<'a> {
         }
     }
 
+    fn put_subdir_hash(&mut self, subdir_path: &[u8]) {
+        if !subdir_path.is_empty() {
+            self.put(b"+p");
+            self.put_u64_hex16::<true>(Semver::semver_string::Builder::string_hash(subdir_path));
+        }
+    }
+
     /// NUL-terminate and hand back the borrowed `ZStr`.
     #[inline(always)]
     fn finish_z(self) -> &'a ZStr {
@@ -586,11 +593,13 @@ pub fn cached_git_folder_name_print<'a>(
     buf: &'a mut [u8],
     resolved: &[u8],
     patch_hash: Option<u64>,
+    subdir_path: &[u8],
 ) -> &'a ZStr {
     let mut w = ByteCursor::new(buf);
     w.put(b"@G@");
     w.put(resolved);
     w.put_patch_hash(patch_hash);
+    w.put_subdir_hash(subdir_path);
     w.finish_z()
 }
 
@@ -599,10 +608,12 @@ pub fn cached_git_folder_name(
     repository: &Repository,
     patch_hash: Option<u64>,
 ) -> &'static ZStr {
+    let string_buf = this.lockfile.buffers.string_bytes.as_slice();
     cached_git_folder_name_print(
         cached_package_folder_name_buf(),
         this.lockfile.str(&repository.resolved),
         patch_hash,
+        repository.path.slice(string_buf),
     )
 }
 
@@ -622,6 +633,7 @@ pub fn cached_git_folder_name_print_auto(
         w.put(repository.committish.slice(string_buf));
         w.put_cache_version(Some(CacheVersion::CURRENT));
         w.put_patch_hash(patch_hash);
+        w.put_subdir_hash(repository.path.slice(string_buf));
         return w.finish_z();
     }
 
@@ -632,12 +644,14 @@ pub fn cached_github_folder_name_print<'a>(
     buf: &'a mut [u8],
     resolved: &[u8],
     patch_hash: Option<u64>,
+    subdir_path: &[u8],
 ) -> &'a ZStr {
     let mut w = ByteCursor::new(buf);
     w.put(b"@GH@");
     w.put(resolved);
     w.put_cache_version(Some(CacheVersion::CURRENT));
     w.put_patch_hash(patch_hash);
+    w.put_subdir_hash(subdir_path);
     w.finish_z()
 }
 
@@ -646,10 +660,12 @@ pub fn cached_github_folder_name(
     repository: &Repository,
     patch_hash: Option<u64>,
 ) -> &'static ZStr {
+    let string_buf = this.lockfile.buffers.string_bytes.as_slice();
     cached_github_folder_name_print(
         cached_package_folder_name_buf(),
         this.lockfile.str(&repository.resolved),
         patch_hash,
+        repository.path.slice(string_buf),
     )
 }
 
@@ -741,6 +757,7 @@ fn cached_github_folder_name_print_guess<'a>(
     w.put(repository.committish.slice(string_buf));
     w.put_cache_version(Some(CacheVersion::CURRENT));
     w.put_patch_hash(patch_hash);
+    w.put_subdir_hash(repository.path.slice(string_buf));
     w.finish_z()
 }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -287,7 +287,8 @@ pub fn enqueue_git_for_checkout(
     let url = this.lockfile.str_detached(&repository.repo);
     let clone_id = Task::Id::for_git_clone(url);
     let resolved = this.lockfile.str_detached(&repository.resolved);
-    let checkout_id = Task::Id::for_git_checkout(url, resolved);
+    let path = this.lockfile.str_detached(&repository.path);
+    let checkout_id = Task::Id::for_git_checkout(url, resolved, path);
     let checkout_queue = this
         .task_queue
         .get_or_put(checkout_id)
@@ -1242,7 +1243,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     this.lockfile.str(&dep.committish),
                     clone_id,
                 )?;
-                let checkout_id = Task::Id::for_git_checkout(url, &resolved);
+                let checkout_id =
+                    Task::Id::for_git_checkout(url, &resolved, this.lockfile.str(&dep.path));
 
                 let needs_ctx =
                     this.lockfile.buffers.resolutions[id as usize] == invalid_package_id;
@@ -1812,6 +1814,11 @@ pub fn enqueue_git_checkout(
                     .expect("unreachable"),
                     resolved: StringOrTinyString::init_append_if_needed(
                         resolved,
+                        &mut crate::network_task::filename_store_appender(),
+                    )
+                    .expect("unreachable"),
+                    path: StringOrTinyString::init_append_if_needed(
+                        this.lockfile.str(&resolution.git().path),
                         &mut crate::network_task::filename_store_appender(),
                     )
                     .expect("unreachable"),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -184,7 +184,15 @@ pub fn enqueue_tarball_for_download(
     task_context: TaskCallbackContext,
     patch_name_and_version_hash: Option<u64>,
 ) -> Result<(), EnqueueTarballForDownloadError> {
-    let task_id = Task::Id::for_tarball(url);
+    // A github tarball URL is keyed by repo+commit only; distinguish the git
+    // subdirectory so distinct `&path:` sub-packages of the same commit stay on
+    // separate download+extract tasks (matches the resolution-phase task id).
+    let res = this.lockfile.packages.get(package_id as usize).resolution;
+    let task_id = if res.tag == ResolutionTag::Github {
+        Task::Id::for_tarball_with_subpath(url, this.lockfile.str(&res.github().path))
+    } else {
+        Task::Id::for_tarball(url)
+    };
     let task_queue = this.task_queue.get_or_put(task_id)?;
     if !task_queue.found_existing {
         *task_queue.value_ptr = TaskCallbackList::default();
@@ -1313,14 +1321,18 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             let res = Resolution::init(ResolutionTagged::Github(*dep));
 
             // First: see if we already loaded the github package in-memory
-            if let Some(pkg_id) = this.lockfile.get_package_id(name_hash, None, &res) {
+            let gpid = this.lockfile.get_package_id(name_hash, None, &res);
+            if let Some(pkg_id) = gpid {
                 success_fn(this, id, pkg_id);
                 return Ok(());
             }
 
             let url = this.alloc_github_url(dep);
-            // url is Box<[u8]>; dropped at scope end
-            let task_id = Task::Id::for_tarball(&url);
+            // url is Box<[u8]>; dropped at scope end. The tarball URL is keyed by
+            // repo+commit only, so include the subdirectory in the task id to keep
+            // distinct `&path:` sub-packages of the same commit on separate
+            // download+extract tasks.
+            let task_id = Task::Id::for_tarball_with_subpath(&url, this.lockfile.str(&dep.path));
 
             if cfg!(debug_assertions) {
                 bun_output::scoped_log!(

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1346,62 +1346,99 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 }
 
                 if C::HAS_ON_EXTRACT && C::IS_PACKAGE_INSTALLER {
-                    // Installing!
-                    // this dependency might be something other than a git dependency! only need the name and
-                    // behavior, use the resolution from the task.
-                    let dep_id = clone.dep_id;
-                    // reshaped for borrowck — copy the small `String` handles
-                    // + behavior bit so
-                    // the `&manager.lockfile` borrow doesn't extend across the
-                    // `&mut manager` calls (`has_created_network_task`,
-                    // `enqueue_git_checkout`) below; detach the slice backing
-                    // through `string_buf_ptr` (matching the
-                    // `PackageManifest`-arm `name` detach pattern above).
-                    let (dep_name_handle, is_required) = {
-                        let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
-                        (dep.name, dep.behavior.is_required())
-                    };
-                    // SAFETY: `clone.res.tag == Git` — git-clone tasks are only
-                    // enqueued for git resolutions; `value.git` is the active arm.
-                    let git = *clone.res.git();
+                    // Installing! A single git clone is shared by every dependency
+                    // of the same repo URL. With `&path:` subdirectories those are
+                    // DISTINCT packages needing distinct checkouts, so drain every
+                    // waiter registered under this clone and enqueue a checkout for
+                    // each using its own subdirectory path — not just `clone.dep_id`.
                     // SAFETY: `string_bytes` lives as long as `manager.lockfile`
                     // and is not reallocated while resolve tasks are draining.
                     let string_buf = unsafe {
                         bun_ptr::detach_lifetime(manager.lockfile.buffers.string_bytes.as_slice())
                     };
-                    let dep_name = dep_name_handle.slice(string_buf);
-                    let committish = git.committish.slice(string_buf);
-                    let repo = git.repo.slice(string_buf);
-                    let path = git.path.slice(string_buf);
 
-                    use crate::repository_real::RepositoryExt as _;
-                    let resolved = crate::repository_real::Repository::find_commit(
-                        manager.env_mut(),
-                        manager.log_mut(),
-                        repo_fd,
-                        dep_name,
-                        committish,
-                        task.id,
-                    )?;
-
-                    let checkout_id = Task::Id::for_git_checkout(repo, &resolved, path);
-
-                    if manager.has_created_network_task(checkout_id, is_required) {
-                        continue;
+                    let mut waiters: Vec<bun_install::TaskCallbackContext> =
+                        match manager.task_queue.remove(&task.id) {
+                            Some(list) => list.into_iter().collect(),
+                            None => Vec::new(),
+                        };
+                    // A clone task always has its originating dependency queued
+                    // under `clone_id`; the fallback covers any path that creates a
+                    // clone without a recorded waiter.
+                    if waiters.is_empty() {
+                        waiters.push(bun_install::TaskCallbackContext::Dependency(clone.dep_id));
                     }
 
-                    // reshaped for borrowck — split nested `&mut manager`.
-                    let queued = enqueue::enqueue_git_checkout(
-                        manager,
-                        checkout_id,
-                        repo_fd,
-                        dep_id,
-                        dep_name,
-                        &clone.res,
-                        &resolved,
-                        None,
-                    );
-                    manager.task_batch.push(ThreadPoolBatch::from(queued));
+                    use crate::repository_real::RepositoryExt as _;
+                    for waiter in waiters {
+                        let dep_id = match waiter {
+                            bun_install::TaskCallbackContext::Dependency(id)
+                            | bun_install::TaskCallbackContext::RootDependency(id) => id,
+                            _ => continue,
+                        };
+
+                        // Copy the handles + behavior bit so the `&manager.lockfile`
+                        // borrow doesn't extend across the `&mut manager` calls below.
+                        let (dep_name_handle, is_required, git) = {
+                            let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
+                            if dep.version.tag != bun_install::DependencyVersionTag::Git {
+                                continue;
+                            }
+                            // SAFETY: tag == Git → `value.git` is the active arm.
+                            (dep.name, dep.behavior.is_required(), *dep.version.git())
+                        };
+
+                        let dep_name = dep_name_handle.slice(string_buf);
+                        let committish = git.committish.slice(string_buf);
+                        let repo = git.repo.slice(string_buf);
+                        let path = git.path.slice(string_buf);
+
+                        let resolved = crate::repository_real::Repository::find_commit(
+                            manager.env_mut(),
+                            manager.log_mut(),
+                            repo_fd,
+                            dep_name,
+                            committish,
+                            task.id,
+                        )?;
+
+                        let checkout_id = Task::Id::for_git_checkout(repo, &resolved, path);
+
+                        // Register this waiter under its checkout id so the
+                        // GitCheckout completion assigns its package id — even when
+                        // another same-repo waiter already created the network task.
+                        let needs_ctx = manager.lockfile.buffers.resolutions[dep_id as usize]
+                            == INVALID_PACKAGE_ID;
+                        let entry = manager
+                            .task_queue
+                            .get_or_put_context(checkout_id, ())
+                            .expect("unreachable");
+                        if !entry.found_existing {
+                            *entry.value_ptr = TaskCallbackList::default();
+                        }
+                        if needs_ctx {
+                            entry.value_ptr.push(waiter);
+                        }
+
+                        if manager.has_created_network_task(checkout_id, is_required) {
+                            continue;
+                        }
+
+                        let res = crate::resolution::Resolution::init(
+                            crate::resolution::TaggedValue::Git(git),
+                        );
+                        let queued = enqueue::enqueue_git_checkout(
+                            manager,
+                            checkout_id,
+                            repo_fd,
+                            dep_id,
+                            dep_name,
+                            &res,
+                            &resolved,
+                            None,
+                        );
+                        manager.task_batch.push(ThreadPoolBatch::from(queued));
+                    }
                 } else {
                     // Resolving!
                     let dependency_list_entry = manager

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1296,6 +1296,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                 let checkout_id = Task::Id::for_git_checkout(
                                     manager.lockfile.str(&res_git.repo),
                                     manager.lockfile.str(&res_git.resolved),
+                                    manager.lockfile.str(&res_git.path),
                                 );
                                 drained_any = true;
                                 C::on_package_download_error_store(
@@ -1317,8 +1318,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             // only enqueued for git resolutions; `value.git` is
                             // the active union arm.
                             let resolved = &clone.res.git().resolved;
-                            let checkout_id =
-                                Task::Id::for_git_checkout(url, manager.lockfile.str(resolved));
+                            let checkout_id = Task::Id::for_git_checkout(
+                                url,
+                                manager.lockfile.str(resolved),
+                                manager.lockfile.str(&clone.res.git().path),
+                            );
                             C::on_package_download_error_store(
                                 extract_ctx,
                                 checkout_id,
@@ -1368,6 +1372,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let dep_name = dep_name_handle.slice(string_buf);
                     let committish = git.committish.slice(string_buf);
                     let repo = git.repo.slice(string_buf);
+                    let path = git.path.slice(string_buf);
 
                     use crate::repository_real::RepositoryExt as _;
                     let resolved = crate::repository_real::Repository::find_commit(
@@ -1379,7 +1384,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         task.id,
                     )?;
 
-                    let checkout_id = Task::Id::for_git_checkout(repo, &resolved);
+                    let checkout_id = Task::Id::for_git_checkout(repo, &resolved, path);
 
                     if manager.has_created_network_task(checkout_id, is_required) {
                         continue;

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -152,11 +152,13 @@ impl Id {
         Id((4u64 << 61) | (hasher.final_() & ((1u64 << 61) - 1)))
     }
 
-    pub fn for_git_checkout(url: &[u8], resolved: &[u8]) -> Id {
+    pub fn for_git_checkout(url: &[u8], resolved: &[u8], path: &[u8]) -> Id {
         let mut hasher = Wyhash11::init(0);
         hasher.update(url);
         hasher.update(b"@");
         hasher.update(resolved);
+        hasher.update(b":");
+        hasher.update(path);
         Id((5u64 << 61) | (hasher.final_() & ((1u64 << 61) - 1)))
     }
 }
@@ -498,6 +500,7 @@ impl<'a> Task<'a> {
                         git_checkout.name.slice(),
                         git_checkout.url.slice(),
                         git_checkout.resolved.slice(),
+                        git_checkout.path.slice(),
                     ) {
                         Ok(v) => v,
                         Err(err) => {
@@ -678,6 +681,7 @@ pub struct GitCheckoutRequest {
     pub name: StringOrTinyString,
     pub url: StringOrTinyString,
     pub resolved: StringOrTinyString,
+    pub path: StringOrTinyString,
     pub resolution: Resolution,
     // See the note on `GitCloneRequest.env`.
     pub env: &'static dot_env::Map,

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -173,8 +173,11 @@ impl Id {
         hasher.update(url);
         hasher.update(b"@");
         hasher.update(resolved);
-        hasher.update(b":");
-        hasher.update(path);
+        // Empty path keeps the pre-existing id stable for non-subdir git deps.
+        if !path.is_empty() {
+            hasher.update(b":path:");
+            hasher.update(path);
+        }
         Id((5u64 << 61) | (hasher.final_() & ((1u64 << 61) - 1)))
     }
 }

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -143,6 +143,22 @@ impl Id {
         Id(hasher.final_())
     }
 
+    /// Tarball task id that also distinguishes a git subdirectory. A github
+    /// dependency's tarball URL is keyed by repo+commit only, so two `&path:`
+    /// sub-packages of the same commit would otherwise collide on one
+    /// download+extract task and only one subdirectory would be installed. An
+    /// empty `subpath` reproduces [`for_tarball`] exactly for backward compat.
+    pub fn for_tarball_with_subpath(url: &[u8], subpath: &[u8]) -> Id {
+        let mut hasher = Wyhash11::init(0);
+        hasher.update(b"tarball:");
+        hasher.update(url);
+        if !subpath.is_empty() {
+            hasher.update(b":path:");
+            hasher.update(subpath);
+        }
+        Id(hasher.final_())
+    }
+
     // These cannot change:
     // We persist them to the filesystem.
     pub fn for_git_clone(url: &[u8]) -> Id {

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -1366,6 +1366,18 @@ pub fn parse_with_tag(
             }
             let hash_index = strings::last_index_of_char(input, b'#');
 
+            let mut committish_bytes: &[u8] = b"";
+            let mut path_bytes: Option<&[u8]> = None;
+            if let Some(index) = hash_index {
+                match crate::repository::split_path_from_fragment(&input[index + 1..]) {
+                    Ok((committish, path)) => {
+                        committish_bytes = committish;
+                        path_bytes = path;
+                    }
+                    Err(_) => return None,
+                }
+            }
+
             Some(Version {
                 literal: sliced.value(),
                 value: Value {
@@ -1378,8 +1390,13 @@ pub fn parse_with_tag(
                                 input
                             })
                             .value(),
-                        committish: if let Some(index) = hash_index {
-                            sliced.sub(&input[index + 1..]).value()
+                        committish: if committish_bytes.is_empty() {
+                            String::from(b"")
+                        } else {
+                            sliced.sub(committish_bytes).value()
+                        },
+                        path: if let Some(p) = path_bytes {
+                            sliced.sub(p).value()
                         } else {
                             String::from(b"")
                         },
@@ -1399,7 +1416,14 @@ pub fn parse_with_tag(
             // to create String objects that point to the original buffer
             let owner_str: &[u8] = info.user().unwrap_or(b"");
             let repo_str: &[u8] = info.project();
-            let committish_str: &[u8] = info.committish().unwrap_or(b"");
+            let raw_committish_str: &[u8] = info.committish().unwrap_or(b"");
+
+            // Split the pnpm-style `&path:<subdir>` suffix off the committish.
+            let (committish_str, path_str) =
+                match crate::repository::split_path_from_fragment(raw_committish_str) {
+                    Ok(v) => v,
+                    Err(_) => return None,
+                };
 
             // Find owner in dependency string
             let owner_idx = strings::index_of(dependency, owner_str);
@@ -1431,6 +1455,17 @@ pub fn parse_with_tag(
                 String::from(b"")
             };
 
+            // Find path in dependency string
+            let path = if let Some(p) = path_str {
+                if let Some(idx) = strings::index_of(dependency, p) {
+                    sliced.sub(&dependency[idx..idx + p.len()]).value()
+                } else {
+                    String::from(b"")
+                }
+            } else {
+                String::from(b"")
+            };
+
             Some(Version {
                 literal: sliced.value(),
                 value: Value {
@@ -1438,6 +1473,7 @@ pub fn parse_with_tag(
                         owner,
                         repo,
                         committish,
+                        path,
                         ..Default::default()
                     }),
                 },

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -512,6 +512,10 @@ impl ExtractTarball {
                     &mut bufs.folder_name_buf,
                     resolved,
                     None,
+                    self.resolution
+                        .github()
+                        .path
+                        .slice(package_manager.lockfile.buffers.string_bytes.as_slice()),
                 )
                 .as_bytes(),
                 ResolutionTag::LocalTarball | ResolutionTag::RemoteTarball => {
@@ -700,6 +704,34 @@ impl ExtractTarball {
                         ),
                     );
                     return Err(bun_core::err!("InstallFailed"));
+                }
+            }
+
+            // A github dependency with a `&path:` subdirectory: replace the
+            // freshly-cached repository with only the sub-package's contents.
+            if self.resolution.tag == ResolutionTag::Github {
+                let subdir_path = self
+                    .resolution
+                    .github()
+                    .path
+                    .slice(package_manager.lockfile.buffers.string_bytes.as_slice());
+                if !subdir_path.is_empty() {
+                    if let Err(err) = crate::repository::promote_subdirectory(
+                        self.cache_dir,
+                        folder_name,
+                        subdir_path,
+                    ) {
+                        log.add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!(
+                                "path \"{}\" not found in repository \"{}\"",
+                                bun_fmt::s(subdir_path),
+                                bun_fmt::s(name),
+                            ),
+                        );
+                        return Err(err);
+                    }
                 }
             }
 

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -721,6 +721,9 @@ impl ExtractTarball {
                         folder_name,
                         subdir_path,
                     ) {
+                        // Drop the partially-promoted cache entry so a later
+                        // install of this `&path:` cannot reuse stale contents.
+                        let _ = Dir::borrow(&self.cache_dir).delete_tree(folder_name);
                         log.add_error_fmt(
                             None,
                             bun_ast::Loc::EMPTY,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1459,6 +1459,7 @@ pub enum ParseError {
     InvalidDependencyVersion,
     InvalidPackageResolution,
     UnexpectedResolution,
+    InvalidPath,
 }
 
 bun_core::oom_from_alloc!(ParseError);
@@ -2363,6 +2364,17 @@ pub fn parse_into_binary_lockfile(
                         format_args!("Invalid package version: {}", bstr::BStr::new(res_str)),
                     );
                     return Err(ParseError::InvalidSemver);
+                }
+                Err(crate::resolution::FromTextLockfileError::InvalidPath) => {
+                    log.add_error_fmt(
+                        source,
+                        item_loc(source, key_loc, res_info_idx),
+                        format_args!(
+                            "Invalid git subdirectory path: {}",
+                            bstr::BStr::new(res_str)
+                        ),
+                    );
+                    return Err(ParseError::InvalidPath);
                 }
             };
 

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -163,7 +163,8 @@ pub fn detect_and_load_other_lockfile<'a>(
                     | MigratePnpmLockfileError::PnpmLockfileInvalidOverride
                     | MigratePnpmLockfileError::PnpmLockfileInvalidPatchedDependency
                     | MigratePnpmLockfileError::PnpmLockfileMissingCatalogEntry
-                    | MigratePnpmLockfileError::PnpmLockfileUnresolvableDependency => {
+                    | MigratePnpmLockfileError::PnpmLockfileUnresolvableDependency
+                    | MigratePnpmLockfileError::InvalidPath => {
                         // These errors are continuable - log the error but don't exit
                         // The install will continue with a fresh install instead of migration
                         if log.has_errors() {
@@ -1257,6 +1258,7 @@ pub(crate) fn migrate_npm_lockfile<'a>(
                                                 committish: commit,
                                                 resolved: commit,
                                                 package_name: dep_name,
+                                                path: Default::default(),
                                             }))
                                         }
                                         DepTag::Github => {
@@ -1285,6 +1287,7 @@ pub(crate) fn migrate_npm_lockfile<'a>(
                                                 committish: commit,
                                                 resolved: commit,
                                                 package_name: dep_name,
+                                                path: Default::default(),
                                             }))
                                         }
                                     };

--- a/src/install/padding_checker.rs
+++ b/src/install/padding_checker.rs
@@ -181,7 +181,7 @@ pub mod layout_asserts {
     pin!(crate::ExternalSlice<u8>, size = 8, align = 4); // u32 off + u32 len
     pin!(crate::ExternalStringMap, size = 16, align = 4);
     pin!(crate::integrity::Integrity, size = 65, align = 1); // u8 tag + [64]u8
-    pin!(crate::repository::Repository, size = 40, align = 1); // 5 × String
+    pin!(crate::repository::Repository, size = 48, align = 1); // 6 × String
     pin!(crate::bin::Value, size = 16, align = 4); // union: [String;2] | ExternalSlice
     pin!(crate::bin::Bin, size = 20, align = 4);
     pin!(bun_semver::Version, size = 56, align = 8); // 3×u64 + Tag(2×ExternalString)

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -136,6 +136,8 @@ pub enum MigratePnpmLockfileError {
     PnpmLockfileMissingCatalogEntry,
     #[error("PnpmLockfileUnresolvableDependency")]
     PnpmLockfileUnresolvableDependency,
+    #[error("InvalidPath")]
+    InvalidPath,
 }
 
 bun_core::oom_from_alloc!(MigratePnpmLockfileError);
@@ -169,6 +171,7 @@ impl From<resolution::FromPnpmLockfileError> for MigratePnpmLockfileError {
         match e {
             resolution::FromPnpmLockfileError::OutOfMemory => Self::OutOfMemory,
             resolution::FromPnpmLockfileError::InvalidPnpmLockfile => Self::InvalidPnpmLockfile,
+            resolution::FromPnpmLockfileError::InvalidPath => Self::InvalidPath,
         }
     }
 }

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -312,15 +312,157 @@ pub(crate) fn is_safe_resolved_tag(resolved: &[u8]) -> bool {
             .all(|&b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
 }
 
+/// Rejected `&path:` subdirectory (traversal, absolute/drive path, or a
+/// character that cannot round-trip through the git URL fragment).
+pub(crate) struct InvalidPathError;
+
+/// Error from parsing a git/github resolution specifier whose `&path:`
+/// subdirectory may be invalid. `?` on `buf.append` yields `OutOfMemory`;
+/// `?` on `split_path_from_fragment` yields `InvalidPath`.
+#[derive(Debug)]
+pub enum ParseAppendError {
+    OutOfMemory,
+    InvalidPath,
+}
+
+impl From<AllocError> for ParseAppendError {
+    fn from(_: AllocError) -> Self {
+        ParseAppendError::OutOfMemory
+    }
+}
+
+impl From<InvalidPathError> for ParseAppendError {
+    fn from(_: InvalidPathError) -> Self {
+        ParseAppendError::InvalidPath
+    }
+}
+
+/// Split the pnpm-style `&path:<subdir>` suffix out of a git URL fragment,
+/// returning the committish (text before `&path:`) and the validated,
+/// normalized subdirectory (or `None` when absent).
+pub(crate) fn split_path_from_fragment(
+    fragment: &[u8],
+) -> Result<(&[u8], Option<&[u8]>), InvalidPathError> {
+    match strings::index_of(fragment, b"&path:") {
+        Some(idx) => {
+            let raw_path = &fragment[idx + b"&path:".len()..];
+            Ok((&fragment[..idx], Some(normalize_path(raw_path)?)))
+        }
+        None => Ok((fragment, None)),
+    }
+}
+
+/// Strip surrounding slashes and reject anything that could escape the
+/// repository root (`..`, empty segments, absolute/drive paths, backslashes) or
+/// break fragment round-tripping (`#`).
+fn normalize_path(raw: &[u8]) -> Result<&[u8], InvalidPathError> {
+    if strings::contains_char(raw, b'\\') || strings::contains_char(raw, b'#') {
+        return Err(InvalidPathError);
+    }
+
+    let mut p = raw;
+    while let [b'/', rest @ ..] = p {
+        p = rest;
+    }
+    while let [rest @ .., b'/'] = p {
+        p = rest;
+    }
+    if p.is_empty() {
+        return Err(InvalidPathError);
+    }
+
+    if p.len() >= 2 && p[1] == b':' && p[0].is_ascii_alphabetic() {
+        return Err(InvalidPathError);
+    }
+
+    for segment in p.split(|&c| c == b'/') {
+        let mut seg = segment;
+        while let [b' ', rest @ ..] = seg {
+            seg = rest;
+        }
+        while let [rest @ .., b' '] = seg {
+            seg = rest;
+        }
+        if seg.is_empty() || seg == b"." || seg == b".." {
+            return Err(InvalidPathError);
+        }
+    }
+
+    Ok(p)
+}
+
+/// After a git checkout, replace the cache folder's contents with those of
+/// `subdir_path` so downstream package.json reading and node_modules linking see
+/// only the sub-package. Each path segment is opened with `O_NOFOLLOW` first so a
+/// symlinked segment committed into the repo cannot redirect the promotion
+/// outside the checkout; then the subdir is moved aside, the rest of the
+/// checkout is deleted, and the subdir is moved back into `folder_name`.
+pub(crate) fn promote_subdirectory(
+    cache_dir: bun_sys::Fd,
+    folder_name: &[u8],
+    subdir_path: &[u8],
+) -> Result<(), Error> {
+    let nofollow = if cfg!(windows) {
+        0
+    } else {
+        bun_sys::O::NOFOLLOW
+    };
+    {
+        let mut current = bun_sys::Dir::borrow(&cache_dir)
+            .open_at(folder_name)
+            .map_err(Error::from)?;
+        for segment in subdir_path.split(|&c| c == b'/') {
+            if segment.is_empty() {
+                continue;
+            }
+            let next = current
+                .open_at_with(segment, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | nofollow)
+                .map_err(Error::from)?;
+            current.close();
+            current = next;
+        }
+        current.close();
+    }
+
+    let mut subdir_rel = Path::AutoRelPath::from(folder_name).assume_ok();
+    subdir_rel.append(subdir_path).assume_ok();
+
+    let mut tmp_buf = PathBuffer::uninit();
+    let tmp_name =
+        Path::fs::FileSystem::tmpname(b"__subdir__", &mut tmp_buf.0, bun_core::fast_random())
+            .map_err(|_| err!("InstallFailed"))?;
+
+    bun_sys::renameat(cache_dir, subdir_rel.slice_z(), cache_dir, tmp_name).map_err(Error::from)?;
+
+    let cache = bun_sys::Dir::borrow(&cache_dir);
+    if let Err(err) = cache.delete_tree(folder_name) {
+        let _ = cache.delete_tree(tmp_name.as_bytes());
+        return Err(err);
+    }
+
+    let mut folder_rel = Path::AutoRelPath::from(folder_name).assume_ok();
+    if let Err(err) = bun_sys::renameat(cache_dir, tmp_name, cache_dir, folder_rel.slice_z()) {
+        let _ = cache.delete_tree(tmp_name.as_bytes());
+        return Err(Error::from(err));
+    }
+
+    Ok(())
+}
+
 /// Install-tier `Repository` behaviour (parsing, formatting, git CLI exec,
 /// download/checkout). Data struct + buffer-relative `order`/`count`/`clone`/
 /// `eql` are inherent on [`Repository`] (defined in `bun_install_types`).
 /// Re-exported from `bun_install::repository` so existing
 /// `Repository::method(...)` / `repo.method(...)` call sites resolve via UFCS.
 pub trait RepositoryExt: Sized {
-    fn parse_append_git(input: &[u8], buf: &mut StringBuf<'_>) -> Result<Repository, AllocError>;
-    fn parse_append_github(input: &[u8], buf: &mut StringBuf<'_>)
-    -> Result<Repository, AllocError>;
+    fn parse_append_git(
+        input: &[u8],
+        buf: &mut StringBuf<'_>,
+    ) -> Result<Repository, ParseAppendError>;
+    fn parse_append_github(
+        input: &[u8],
+        buf: &mut StringBuf<'_>,
+    ) -> Result<Repository, ParseAppendError>;
     fn create_dependency_name_from_version_literal(
         repository: &Repository,
         string_buf: &[u8],
@@ -357,6 +499,7 @@ pub trait RepositoryExt: Sized {
         name: &[u8],
         url: &[u8],
         resolved: &[u8],
+        subdir_path: &[u8],
     ) -> Result<ExtractData, Error>;
 }
 
@@ -422,17 +565,25 @@ fn exec(env: &bun_dotenv::Map, argv: &[&[u8]]) -> Result<Vec<u8>, Error> {
 }
 
 impl RepositoryExt for Repository {
-    fn parse_append_git(input: &[u8], buf: &mut StringBuf<'_>) -> Result<Repository, AllocError> {
+    fn parse_append_git(
+        input: &[u8],
+        buf: &mut StringBuf<'_>,
+    ) -> Result<Repository, ParseAppendError> {
         let mut remain = input;
         if remain.starts_with(b"git+") {
             remain = &remain[b"git+".len()..];
         }
         if let Some(hash) = strings::last_index_of_char(remain, b'#') {
-            return Ok(Repository {
+            let (committish, path) = split_path_from_fragment(&remain[hash + 1..])?;
+            let mut result = Repository {
                 repo: buf.append(&remain[..hash])?,
-                committish: buf.append(&remain[hash + 1..])?,
+                committish: buf.append(committish)?,
                 ..Default::default()
-            });
+            };
+            if let Some(p) = path {
+                result.path = buf.append(p)?;
+            }
+            return Ok(result);
         }
         Ok(Repository {
             repo: buf.append(remain)?,
@@ -443,7 +594,7 @@ impl RepositoryExt for Repository {
     fn parse_append_github(
         input: &[u8],
         buf: &mut StringBuf<'_>,
-    ) -> Result<Repository, AllocError> {
+    ) -> Result<Repository, ParseAppendError> {
         let mut remain = input;
         if remain.starts_with(b"github:") {
             remain = &remain[b"github:".len()..];
@@ -452,8 +603,19 @@ impl RepositoryExt for Repository {
         let mut slash: usize = 0;
         for (i, &c) in remain.iter().enumerate() {
             match c {
-                b'/' => slash = i,
-                b'#' => hash = i,
+                // Only track separators before the fragment: a `&path:<subdir>`
+                // suffix contains `/` that must not be mistaken for the owner/repo
+                // separator.
+                b'/' => {
+                    if hash == 0 {
+                        slash = i;
+                    }
+                }
+                b'#' => {
+                    if hash == 0 {
+                        hash = i;
+                    }
+                }
                 _ => {}
             }
         }
@@ -471,7 +633,11 @@ impl RepositoryExt for Repository {
         };
 
         if hash != 0 {
-            result.committish = buf.append(&remain[hash + 1..])?;
+            let (committish, path) = split_path_from_fragment(&remain[hash + 1..])?;
+            result.committish = buf.append(committish)?;
+            if let Some(p) = path {
+                result.path = buf.append(p)?;
+            }
         }
 
         Ok(result)
@@ -485,25 +651,39 @@ impl RepositoryExt for Repository {
         // Callers (`parse_with_json`) hold a split `StringBuilder`
         // borrow on `string_bytes`, so accept the two pieces directly.
         let buf = string_buf;
-        let repo_name = repository.repo;
-        let repo_name_str = repo_name.slice(buf);
 
-        let name = 'brk: {
-            let mut remain = repo_name_str;
-
-            if let Some(hash_index) = strings::index_of_char(remain, b'#') {
-                remain = &remain[..hash_index as usize];
+        let path_str = repository.path.slice(buf);
+        let name = if !path_str.is_empty() {
+            let mut trimmed = path_str;
+            while let [b'/', rest @ ..] = trimmed {
+                trimmed = rest;
             }
-
-            if remain.is_empty() {
-                break 'brk remain;
+            while let [rest @ .., b'/'] = trimmed {
+                trimmed = rest;
             }
-
-            if let Some(slash_index) = strings::last_index_of_char(remain, b'/') {
-                remain = &remain[slash_index + 1..];
+            if let Some(slash_index) = strings::last_index_of_char(trimmed, b'/') {
+                &trimmed[slash_index + 1..]
+            } else {
+                trimmed
             }
+        } else {
+            'brk: {
+                let mut remain = repository.repo.slice(buf);
 
-            remain
+                if let Some(hash_index) = strings::index_of_char(remain, b'#') {
+                    remain = &remain[..hash_index as usize];
+                }
+
+                if remain.is_empty() {
+                    break 'brk remain;
+                }
+
+                if let Some(slash_index) = strings::last_index_of_char(remain, b'/') {
+                    remain = &remain[slash_index + 1..];
+                }
+
+                remain
+            }
         };
 
         if name.is_empty() {
@@ -829,6 +1009,7 @@ impl RepositoryExt for Repository {
         name: &[u8],
         url: &[u8],
         resolved: &[u8],
+        subdir_path: &[u8],
     ) -> Result<ExtractData, Error> {
         // `cache_dir`/`repo_dir` are borrowed views; only `package_dir` is owned.
         bun_analytics::features::git_dependencies
@@ -852,6 +1033,7 @@ impl RepositoryExt for Repository {
             &mut folder_name_buf[..],
             resolved,
             None,
+            subdir_path,
         )
         .as_bytes();
 
@@ -916,7 +1098,7 @@ impl RepositoryExt for Repository {
                     );
                     return Err(err);
                 }
-                let dir = bun_sys::Dir::borrow(&cache_dir)
+                let mut dir = bun_sys::Dir::borrow(&cache_dir)
                     .open_at(folder_name)
                     .map_err(Error::from)?;
                 let _ = dir.delete_tree(b".git");
@@ -937,6 +1119,28 @@ impl RepositoryExt for Repository {
                         }
                         let _ = git_tag.close(); // close error is non-actionable
                     }
+                }
+
+                if !subdir_path.is_empty() {
+                    if let Err(err) = promote_subdirectory(cache_dir, folder_name, subdir_path) {
+                        dir.close();
+                        log.add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!(
+                                "path \"{}\" not found in repository \"{}\"",
+                                BStr::new(subdir_path),
+                                BStr::new(name)
+                            ),
+                        );
+                        return Err(err);
+                    }
+                    // `promote_subdirectory` renamed the folder in place, so the
+                    // old handle is stale — reopen it at the promoted location.
+                    dir.close();
+                    dir = bun_sys::Dir::borrow(&cache_dir)
+                        .open_at(folder_name)
+                        .map_err(Error::from)?;
                 }
 
                 break 'brk dir;
@@ -1052,6 +1256,11 @@ impl<'a> fmt::Display for StorePathFormatter<'a> {
                 self.repo.committish.fmt_store_path(self.string_buf)
             )?;
         }
+
+        if !self.repo.path.is_empty() {
+            writer.write_str("+path+")?;
+            write!(writer, "{}", self.repo.path.fmt_store_path(self.string_buf))?;
+        }
         Ok(())
     }
 }
@@ -1081,8 +1290,10 @@ impl<'a> fmt::Display for Formatter<'a> {
         }
         write!(writer, "{}", BStr::new(repo))?;
 
+        let mut has_fragment = false;
         if !self.repository.resolved.is_empty() {
             writer.write_str("#")?;
+            has_fragment = true;
             let mut resolved = self.repository.resolved.slice(self.buf);
             if let Some(i) = strings::last_index_of_char(resolved, b'-') {
                 resolved = &resolved[i + 1..];
@@ -1090,10 +1301,23 @@ impl<'a> fmt::Display for Formatter<'a> {
             write!(writer, "{}", BStr::new(resolved))?;
         } else if !self.repository.committish.is_empty() {
             writer.write_str("#")?;
+            has_fragment = true;
             write!(
                 writer,
                 "{}",
                 BStr::new(self.repository.committish.slice(self.buf))
+            )?;
+        }
+
+        if !self.repository.path.is_empty() {
+            if !has_fragment {
+                writer.write_str("#")?;
+            }
+            writer.write_str("&path:")?;
+            write!(
+                writer,
+                "{}",
+                BStr::new(self.repository.path.slice(self.buf))
             )?;
         }
         Ok(())

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -360,7 +360,10 @@ pub(crate) fn split_path_from_fragment(
 /// repository root (`..`, empty segments, absolute/drive paths, backslashes) or
 /// break fragment round-tripping (`#`).
 fn normalize_path(raw: &[u8]) -> Result<&[u8], InvalidPathError> {
-    if strings::contains_char(raw, b'\\') || strings::contains_char(raw, b'#') {
+    if strings::contains_char(raw, b'\\')
+        || strings::contains_char(raw, b'#')
+        || strings::contains_char(raw, 0)
+    {
         return Err(InvalidPathError);
     }
 
@@ -395,12 +398,9 @@ fn normalize_path(raw: &[u8]) -> Result<&[u8], InvalidPathError> {
     Ok(p)
 }
 
-/// After a git checkout, replace the cache folder's contents with those of
-/// `subdir_path` so downstream package.json reading and node_modules linking see
-/// only the sub-package. Each path segment is opened with `O_NOFOLLOW` first so a
-/// symlinked segment committed into the repo cannot redirect the promotion
-/// outside the checkout; then the subdir is moved aside, the rest of the
-/// checkout is deleted, and the subdir is moved back into `folder_name`.
+/// Replace the cache folder's contents with `subdir_path`'s so downstream sees
+/// only the sub-package. Each segment is opened `O_NOFOLLOW` (a symlinked segment
+/// can't redirect outside the checkout); then subdir → temp, rest deleted, back.
 pub(crate) fn promote_subdirectory(
     cache_dir: bun_sys::Fd,
     folder_name: &[u8],
@@ -1128,6 +1128,9 @@ impl RepositoryExt for Repository {
                 if !subdir_path.is_empty() {
                     if let Err(err) = promote_subdirectory(cache_dir, folder_name, subdir_path) {
                         dir.close();
+                        // Drop the partially-promoted cache entry so a later
+                        // install of this `&path:` cannot reuse stale contents.
+                        let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(folder_name);
                         log.add_error_fmt(
                             None,
                             bun_ast::Loc::EMPTY,
@@ -1314,10 +1317,8 @@ impl<'a> fmt::Display for Formatter<'a> {
         }
 
         if !self.repository.path.is_empty() {
-            if !has_fragment {
-                writer.write_str("#")?;
-            }
-            writer.write_str("&path:")?;
+            // pnpm form: `#path:<subdir>` alone, or `&path:<subdir>` after a ref.
+            writer.write_str(if has_fragment { "&path:" } else { "#path:" })?;
             write!(
                 writer,
                 "{}",

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -6,6 +6,7 @@ use bstr::BStr;
 use bun_alloc::AllocError;
 use bun_core::strings;
 use bun_core::{self, Error, Output, err};
+use bun_paths::path_options::AssumeOk as _;
 use bun_paths::{self as Path, PathBuffer};
 use bun_semver::string::Buf as StringBuf;
 

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -344,13 +344,16 @@ impl From<InvalidPathError> for ParseAppendError {
 pub(crate) fn split_path_from_fragment(
     fragment: &[u8],
 ) -> Result<(&[u8], Option<&[u8]>), InvalidPathError> {
-    match strings::index_of(fragment, b"&path:") {
-        Some(idx) => {
-            let raw_path = &fragment[idx + b"&path:".len()..];
-            Ok((&fragment[..idx], Some(normalize_path(raw_path)?)))
-        }
-        None => Ok((fragment, None)),
+    // pnpm forms: `#path:<subdir>` (no committish, path is the first fragment
+    // parameter) and `#<committish>&path:<subdir>` (parameters joined by `&`).
+    if let Some(raw_path) = strings::without_prefix_if_possible_comptime(fragment, b"path:") {
+        return Ok((b"", Some(normalize_path(raw_path)?)));
     }
+    if let Some(idx) = strings::index_of(fragment, b"&path:") {
+        let raw_path = &fragment[idx + b"&path:".len()..];
+        return Ok((&fragment[..idx], Some(normalize_path(raw_path)?)));
+    }
+    Ok((fragment, None))
 }
 
 /// Strip surrounding slashes and reject anything that could escape the

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -11,7 +11,7 @@ use bun_semver::string::Buf as StringBuf;
 use bun_semver::version::VersionInt;
 
 use crate::dependency::{self, TagExt as _};
-use crate::repository::{Repository, RepositoryExt as _};
+use crate::repository::{ParseAppendError, Repository, RepositoryExt as _};
 use crate::versioned_url::VersionedURLType;
 
 pub type Resolution = ResolutionType<u64>;
@@ -968,11 +968,22 @@ pub enum FromTextLockfileError {
     UnexpectedResolution,
     #[error("invalid semver")]
     InvalidSemver,
+    #[error("invalid git subdirectory path")]
+    InvalidPath,
 }
 
 bun_core::oom_from_alloc!(FromTextLockfileError);
 
 bun_core::named_error_set!(FromTextLockfileError);
+
+impl From<ParseAppendError> for FromTextLockfileError {
+    fn from(err: ParseAppendError) -> Self {
+        match err {
+            ParseAppendError::OutOfMemory => FromTextLockfileError::OutOfMemory,
+            ParseAppendError::InvalidPath => FromTextLockfileError::InvalidPath,
+        }
+    }
+}
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum FromPnpmLockfileError {
@@ -980,8 +991,19 @@ pub enum FromPnpmLockfileError {
     OutOfMemory,
     #[error("invalid pnpm lockfile")]
     InvalidPnpmLockfile,
+    #[error("invalid git subdirectory path")]
+    InvalidPath,
 }
 
 bun_core::oom_from_alloc!(FromPnpmLockfileError);
 
 bun_core::named_error_set!(FromPnpmLockfileError);
+
+impl From<ParseAppendError> for FromPnpmLockfileError {
+    fn from(err: ParseAppendError) -> Self {
+        match err {
+            ParseAppendError::OutOfMemory => FromPnpmLockfileError::OutOfMemory,
+            ParseAppendError::InvalidPath => FromPnpmLockfileError::InvalidPath,
+        }
+    }
+}

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -1130,6 +1130,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                                 .append(&commit[0..b"github:".len().min(commit.len())])?,
                             resolved: SemverString::default(),
                             package_name: sbuf!().append(actual_name)?,
+                            path: SemverString::default(),
                         }));
                     } else {
                         break 'blk Resolution::init(ResolutionValue::Git(Repository {
@@ -1138,6 +1139,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                             committish: sbuf!().append(commit)?,
                             resolved: SemverString::default(),
                             package_name: sbuf!().append(actual_name)?,
+                            path: SemverString::default(),
                         }));
                     }
                 }

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1009,7 +1009,19 @@ pub struct Repository {
     pub committish: SemverString,
     pub resolved: SemverString,
     pub package_name: SemverString,
+    /// Optional subdirectory within the repository (pnpm-style `#...&path:<subdir>`).
+    /// Empty when the dependency resolves to the repository root.
+    pub path: SemverString,
 }
+
+// Binary-lockfile ABI proof: `Repository` is embedded (via `Value`) in the
+// `#[repr(C)]` resolution column serialized to `bun.lockb`. Adding the `path`
+// handle keeps `Repository` (six align-1 `SemverString` handles) at 48 bytes,
+// which stays within the `VersionedURLType` (64-byte) union arm — so
+// `size_of::<Resolution>()` is unchanged and no `FormatVersion` bump is needed.
+// Older lockfiles read `path` from the previously-zeroed union tail (empty).
+const _: () = assert!(core::mem::size_of::<Repository>() == 48);
+const _: () = assert!(core::mem::align_of::<Repository>() == 1);
 
 // Manual `Clone` so the inherent buffer-relative `clone(&self, buf, builder)`
 // below does not collide with a derived `clone(&self)` at method-resolution
@@ -1031,7 +1043,11 @@ impl Repository {
         if repo_order != Ordering::Equal {
             return repo_order;
         }
-        self.committish.order(rhs.committish, lhs_buf, rhs_buf)
+        let committish_order = self.committish.order(rhs.committish, lhs_buf, rhs_buf);
+        if committish_order != Ordering::Equal {
+            return committish_order;
+        }
+        self.path.order(rhs.path, lhs_buf, rhs_buf)
     }
 
     pub fn count<B: bun_semver::StringBuilder>(&self, buf: &[u8], builder: &mut B) {
@@ -1040,6 +1056,7 @@ impl Repository {
         builder.count(self.committish.slice(buf));
         builder.count(self.resolved.slice(buf));
         builder.count(self.package_name.slice(buf));
+        builder.count(self.path.slice(buf));
     }
 
     /// Re-interns each field
@@ -1052,6 +1069,7 @@ impl Repository {
             committish: builder.append::<SemverString>(self.committish.slice(buf)),
             resolved: builder.append::<SemverString>(self.resolved.slice(buf)),
             package_name: builder.append::<SemverString>(self.package_name.slice(buf)),
+            path: builder.append::<SemverString>(self.path.slice(buf)),
         }
     }
 
@@ -1060,6 +1078,9 @@ impl Repository {
             return false;
         }
         if !self.repo.eql(rhs.repo, lhs_buf, rhs_buf) {
+            return false;
+        }
+        if !self.path.eql(rhs.path, lhs_buf, rhs_buf) {
             return false;
         }
         if self.resolved.is_empty() || rhs.resolved.is_empty() {

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1014,12 +1014,9 @@ pub struct Repository {
     pub path: SemverString,
 }
 
-// Binary-lockfile ABI proof: `Repository` is embedded (via `Value`) in the
-// `#[repr(C)]` resolution column serialized to `bun.lockb`. Adding the `path`
-// handle keeps `Repository` (six align-1 `SemverString` handles) at 48 bytes,
-// which stays within the `VersionedURLType` (64-byte) union arm — so
-// `size_of::<Resolution>()` is unchanged and no `FormatVersion` bump is needed.
-// Older lockfiles read `path` from the previously-zeroed union tail (empty).
+// Binary-lockfile ABI: `Repository` sits in the `#[repr(C)]` `Value` union
+// (largest arm `VersionedURLType` = 64B) in `bun.lockb`, so a 6th 8B handle
+// keeps `Resolution` at 72B — no `FormatVersion` bump (old lockfiles: empty).
 const _: () = assert!(core::mem::size_of::<Repository>() == 48);
 const _: () = assert!(core::mem::align_of::<Repository>() == 1);
 

--- a/test/cli/install/git-path-subdir.test.ts
+++ b/test/cli/install/git-path-subdir.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { existsSync, readFileSync, rmSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
+
+beforeAll(() => setDefaultTimeout(1000 * 60 * 5));
 
 // RexSkz/test-git-subfolder-fetch is pnpm's own fixture for this feature: a real
 // monorepo whose packages/ subdirectories have no workspace: cross-deps, so each
@@ -147,8 +149,8 @@ describe("git dependency &path: subdirectory support", () => {
 
       const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(existsSync(join(String(installDir), "node_modules", name))).toBeFalse();
       expect(exitCode).not.toBe(0);
+      expect(existsSync(join(String(installDir), "node_modules", name))).toBeFalse();
     }
   });
 

--- a/test/cli/install/git-path-subdir.test.ts
+++ b/test/cli/install/git-path-subdir.test.ts
@@ -49,6 +49,33 @@ describe("git dependency &path: subdirectory support", () => {
     expect(existsSync(join(String(installDir), "node_modules", SUB_PKG_NAME, "packages"))).toBeFalse();
   });
 
+  test("supports the pnpm #path: form without a committish", async () => {
+    using installDir = tempDir("git-path-nocommittish", {
+      "package.json": JSON.stringify({
+        name: "test-nocommittish",
+        dependencies: {
+          // pnpm's primary documented form: `#path:<subdir>` with no committish.
+          [SUB_PKG_NAME]: `${MONOREPO}#path:${SUB_PATH}`,
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: String(installDir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+
+    const installedPkgJson = join(String(installDir), "node_modules", SUB_PKG_NAME, "package.json");
+    expect(existsSync(installedPkgJson)).toBeTrue();
+    expect(JSON.parse(readFileSync(installedPkgJson, "utf8")).name).toBe(SUB_PKG_NAME);
+  });
+
   test("lockfile round-trip preserves &path:", async () => {
     using installDir = tempDir("git-path-lockfile", {
       "package.json": JSON.stringify({

--- a/test/cli/install/git-path-subdir.test.ts
+++ b/test/cli/install/git-path-subdir.test.ts
@@ -3,18 +3,19 @@ import { existsSync, readFileSync, rmSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
-// nicolo-ribaudo/babel-polyfills is a real monorepo with packages/ subdirectories.
-// Pinned to a specific commit for reproducibility.
-const MONOREPO = "github:nicolo-ribaudo/babel-polyfills";
-const MONOREPO_GIT_URL = "git+https://github.com/nicolo-ribaudo/babel-polyfills.git";
-const COMMIT = "67d188090d3e94d9b03babc518e5fcdbc43ac206";
-const SUB_PATH = "packages/babel-helper-define-polyfill-provider";
-const SUB_PATH_2 = "packages/babel-plugin-polyfill-corejs2";
-const SUB_PKG_NAME = "@babel/helper-define-polyfill-provider";
-const SUB_PKG_NAME_2 = "babel-plugin-polyfill-corejs2";
+// RexSkz/test-git-subfolder-fetch is pnpm's own fixture for this feature: a real
+// monorepo whose packages/ subdirectories have no workspace: cross-deps, so each
+// sub-package installs standalone. Pinned to a commit for reproducibility.
+const MONOREPO = "github:RexSkz/test-git-subfolder-fetch";
+const MONOREPO_GIT_URL = "git+https://github.com/RexSkz/test-git-subfolder-fetch.git";
+const COMMIT = "2b42a57a945f19f8ffab8ecbd2021fdc2c58ee22";
+const SUB_PATH = "packages/simple-shared-data";
+const SUB_PATH_2 = "packages/simple-express-server";
+const SUB_PKG_NAME = "@my-namespace/simple-shared-data";
+const SUB_PKG_NAME_2 = "@my-namespace/simple-express-server";
 
 describe("git dependency &path: subdirectory support", () => {
-  test("installs sub-packages from monorepo via &path: (git+https URL)", async () => {
+  test("installs two sub-packages of the same repo+commit via &path:", async () => {
     using installDir = tempDir("git-path-install", {
       "package.json": JSON.stringify({
         name: "test-project",
@@ -34,26 +35,18 @@ describe("git dependency &path: subdirectory support", () => {
     });
 
     const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
 
-    const installedPkgJson = join(
-      String(installDir),
-      "node_modules",
-      "@babel",
-      "helper-define-polyfill-provider",
-      "package.json",
-    );
+    const installedPkgJson = join(String(installDir), "node_modules", SUB_PKG_NAME, "package.json");
     expect(existsSync(installedPkgJson)).toBeTrue();
-
-    const pkg = JSON.parse(readFileSync(installedPkgJson, "utf8"));
-    expect(pkg.name).toBe(SUB_PKG_NAME);
+    expect(JSON.parse(readFileSync(installedPkgJson, "utf8")).name).toBe(SUB_PKG_NAME);
 
     const installedPkgJson2 = join(String(installDir), "node_modules", SUB_PKG_NAME_2, "package.json");
     expect(existsSync(installedPkgJson2)).toBeTrue();
+    expect(JSON.parse(readFileSync(installedPkgJson2, "utf8")).name).toBe(SUB_PKG_NAME_2);
 
-    const pkg2 = JSON.parse(readFileSync(installedPkgJson2, "utf8"));
-    expect(pkg2.name).toBe(SUB_PKG_NAME_2);
-
-    expect(exitCode).toBe(0);
+    // Only the subdirectory's contents should be installed, not the whole repo.
+    expect(existsSync(join(String(installDir), "node_modules", SUB_PKG_NAME, "packages"))).toBeFalse();
   });
 
   test("lockfile round-trip preserves &path:", async () => {
@@ -82,8 +75,7 @@ describe("git dependency &path: subdirectory support", () => {
     expect(lockContents).toContain("&path:");
     expect(lockContents).toContain(SUB_PATH);
 
-    const nmDir = join(String(installDir), "node_modules");
-    rmSync(nmDir, { recursive: true, force: true });
+    rmSync(join(String(installDir), "node_modules"), { recursive: true, force: true });
 
     await using proc2 = Bun.spawn({
       cmd: [bunExe(), "install", "--frozen-lockfile"],
@@ -94,20 +86,11 @@ describe("git dependency &path: subdirectory support", () => {
     });
 
     const [, , exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
-
-    const installedPkgJson = join(
-      String(installDir),
-      "node_modules",
-      "@babel",
-      "helper-define-polyfill-provider",
-      "package.json",
-    );
-    expect(existsSync(installedPkgJson)).toBeTrue();
-
-    const pkg = JSON.parse(readFileSync(installedPkgJson, "utf8"));
-    expect(pkg.name).toBe(SUB_PKG_NAME);
-
     expect(exitCode2).toBe(0);
+
+    const installedPkgJson = join(String(installDir), "node_modules", SUB_PKG_NAME, "package.json");
+    expect(existsSync(installedPkgJson)).toBeTrue();
+    expect(JSON.parse(readFileSync(installedPkgJson, "utf8")).name).toBe(SUB_PKG_NAME);
   });
 
   test("path traversal is rejected", async () => {
@@ -161,13 +144,10 @@ describe("git dependency &path: subdirectory support", () => {
     });
 
     const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
 
     const installedPkgJson = join(String(installDir), "node_modules", "is-number", "package.json");
     expect(existsSync(installedPkgJson)).toBeTrue();
-
-    const pkg = JSON.parse(readFileSync(installedPkgJson, "utf8"));
-    expect(pkg.name).toBe("is-number");
-
-    expect(exitCode).toBe(0);
+    expect(JSON.parse(readFileSync(installedPkgJson, "utf8")).name).toBe("is-number");
   });
 });

--- a/test/cli/install/git-path-subdir.test.ts
+++ b/test/cli/install/git-path-subdir.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// nicolo-ribaudo/babel-polyfills is a real monorepo with packages/ subdirectories.
+// Pinned to a specific commit for reproducibility.
+const MONOREPO = "github:nicolo-ribaudo/babel-polyfills";
+const MONOREPO_GIT_URL = "git+https://github.com/nicolo-ribaudo/babel-polyfills.git";
+const COMMIT = "67d188090d3e94d9b03babc518e5fcdbc43ac206";
+const SUB_PATH = "packages/babel-helper-define-polyfill-provider";
+const SUB_PATH_2 = "packages/babel-plugin-polyfill-corejs2";
+const SUB_PKG_NAME = "@babel/helper-define-polyfill-provider";
+const SUB_PKG_NAME_2 = "babel-plugin-polyfill-corejs2";
+
+describe("git dependency &path: subdirectory support", () => {
+  test("installs sub-packages from monorepo via &path: (git+https URL)", async () => {
+    using installDir = tempDir("git-path-install", {
+      "package.json": JSON.stringify({
+        name: "test-project",
+        dependencies: {
+          [SUB_PKG_NAME]: `${MONOREPO_GIT_URL}#${COMMIT}&path:${SUB_PATH}`,
+          [SUB_PKG_NAME_2]: `${MONOREPO_GIT_URL}#${COMMIT}&path:${SUB_PATH_2}`,
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: String(installDir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const installedPkgJson = join(
+      String(installDir),
+      "node_modules",
+      "@babel",
+      "helper-define-polyfill-provider",
+      "package.json",
+    );
+    expect(existsSync(installedPkgJson)).toBeTrue();
+
+    const pkg = JSON.parse(readFileSync(installedPkgJson, "utf8"));
+    expect(pkg.name).toBe(SUB_PKG_NAME);
+
+    const installedPkgJson2 = join(String(installDir), "node_modules", SUB_PKG_NAME_2, "package.json");
+    expect(existsSync(installedPkgJson2)).toBeTrue();
+
+    const pkg2 = JSON.parse(readFileSync(installedPkgJson2, "utf8"));
+    expect(pkg2.name).toBe(SUB_PKG_NAME_2);
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("lockfile round-trip preserves &path:", async () => {
+    using installDir = tempDir("git-path-lockfile", {
+      "package.json": JSON.stringify({
+        name: "test-lockfile",
+        dependencies: {
+          [SUB_PKG_NAME]: `${MONOREPO}#${COMMIT}&path:${SUB_PATH}`,
+        },
+      }),
+    });
+
+    await using proc1 = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: String(installDir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [, , exitCode1] = await Promise.all([proc1.stdout.text(), proc1.stderr.text(), proc1.exited]);
+    expect(exitCode1).toBe(0);
+
+    const lockPath = join(String(installDir), "bun.lock");
+    const lockContents = readFileSync(lockPath, "utf8");
+    expect(lockContents).toContain("&path:");
+    expect(lockContents).toContain(SUB_PATH);
+
+    const nmDir = join(String(installDir), "node_modules");
+    rmSync(nmDir, { recursive: true, force: true });
+
+    await using proc2 = Bun.spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      env: bunEnv,
+      cwd: String(installDir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [, , exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
+
+    const installedPkgJson = join(
+      String(installDir),
+      "node_modules",
+      "@babel",
+      "helper-define-polyfill-provider",
+      "package.json",
+    );
+    expect(existsSync(installedPkgJson)).toBeTrue();
+
+    const pkg = JSON.parse(readFileSync(installedPkgJson, "utf8"));
+    expect(pkg.name).toBe(SUB_PKG_NAME);
+
+    expect(exitCode2).toBe(0);
+  });
+
+  test("path traversal is rejected", async () => {
+    const maliciousPaths = [
+      { name: "evil-pkg-dotdot", path: "../../etc/passwd" },
+      { name: "evil-pkg-win", path: "..\\..\\etc\\passwd" },
+      { name: "evil-pkg-drive", path: "C:/tmp/pkg" },
+    ];
+
+    for (const { name, path } of maliciousPaths) {
+      using installDir = tempDir("git-path-traversal", {
+        "package.json": JSON.stringify({
+          name: "test-traversal",
+          dependencies: {
+            [name]: `${MONOREPO}#${COMMIT}&path:${path}`,
+          },
+        }),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        env: bunEnv,
+        cwd: String(installDir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(existsSync(join(String(installDir), "node_modules", name))).toBeFalse();
+      expect(exitCode).not.toBe(0);
+    }
+  });
+
+  test("normal git dep without &path: still works (backward compat)", async () => {
+    using installDir = tempDir("git-path-compat", {
+      "package.json": JSON.stringify({
+        name: "test-backward-compat",
+        dependencies: {
+          "is-number": "git+https://github.com/jonschlinkert/is-number.git#98e8ff1",
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: String(installDir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const installedPkgJson = join(String(installDir), "node_modules", "is-number", "package.json");
+    expect(existsSync(installedPkgJson)).toBeTrue();
+
+    const pkg = JSON.parse(readFileSync(installedPkgJson, "utf8"));
+    expect(pkg.name).toBe("is-number");
+
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Adds support for the pnpm-style `&path:<subdir>` git URL specifier, allowing installation of a sub-package from a git monorepo:

```json
{
  "dependencies": {
    "my-pkg": "github:user/monorepo#main&path:packages/my-pkg",
    "other":  "git+https://github.com/user/monorepo.git#v1.2.3&path:packages/other"
  }
}
```

Only the contents of the subdirectory are installed. This matches [pnpm's existing behavior](https://pnpm.io/package-sources#install-from-a-subdirectory-of-a-git-repository) and closes the long-standing request in #15506 (see also #5971, #10280). It is a Rust port of the previously-approved-in-design #27892 (auto-closed as stale after the Zig→Rust rewrite), revived against the current tree.

#### What changed

- **`Repository`** (`src/install_types/resolver_hooks.rs`): new `path` field, threaded through `order`/`count`/`clone`/`eql` (`eql` compares `path` before the `resolved`/`committish` short-circuit so the same commit + different subdir never collapse).
- **Binary-lockfile safety:** `Repository` is embedded in the `#[repr(C)]` resolution column serialized to `bun.lockb`. Adding the field keeps `Repository` at 48 bytes, still within the 64-byte `VersionedURLType` union arm, so `size_of::<Resolution>()` is unchanged and **no `FormatVersion` bump is required** (old lockfiles read `path` as an empty handle from the previously-zeroed union tail). `padding_checker`'s `Value<u64>` (64) / `Resolution` (72) pins are unchanged; the `Repository` pin is updated 40→48 (six align-1 handles, no padding).
- **Parsing** (`dependency.rs`, `repository.rs`): `split_path_from_fragment` supports both pnpm forms — `#path:<subdir>` (no committish) and `#<committish>&path:<subdir>` — for `git` and `github` specifiers; `normalize_path` strips surrounding slashes and rejects `..`, empty segments, drive-letter paths, backslashes, and `#`.
- **Distinct sub-packages of one repo+commit:** task ids were keyed by URL/commit only, so two `&path:` sub-packages of the same commit collided on a single task and only one was extracted. Fixed by keying the subdirectory into the task ids:
  - github tarball deps: new `Task::Id::for_tarball_with_subpath` (empty subpath is byte-identical to `for_tarball`), used at both the resolution enqueue and `enqueue_tarball_for_download` so both phases agree.
  - git-clone deps (non-github hosts): `Task::Id::for_git_checkout` includes the subpath, and on clone completion every waiter under the shared clone is drained and checked out with its own subdirectory.
- **Promotion:** after checkout (clone path) and extraction (github tarball path), the subdirectory is promoted to the cache-folder root, with `O_NOFOLLOW` symlink-escape guards per path segment.
- **Lockfile round-trip:** the resolution formatter emits `#<committish>&path:<subdir>`; `InvalidPath` is threaded through `resolution`/`bun.lock`/`migration`/`pnpm`. Package name is derived from the subpath basename.
- **Docs** + `test/cli/install/git-path-subdir.test.ts`.

### How did you verify your code works?

Built from source (LLVM 21.1.8, pinned nightly) and tested end-to-end:

- **`bun bd test test/cli/install/git-path-subdir.test.ts` → 5 pass / 0 fail**: installs two sub-packages of the same repo+commit via `&path:`; supports the pnpm `#path:` form (no committish); text-lockfile round-trip preserves `&path:`; path-traversal (`..`, backslashes, `C:/`) is rejected; a normal git dep without `&path:` still works (backward compat).
- **Test validity:** the two `&path:` feature tests **fail** under `USE_SYSTEM_BUN=1` (released bun lacks the feature) and pass on this build.
- **No regressions:** the existing GitHub-dependency tests in `bun-install.test.ts` (`-t "GitHub"`) all pass on this build.
- **`cargo clippy -p bun_install -p bun_install_types`**: clean.
- Manual QA: installing two subpaths of one monorepo commit places both sub-packages in `node_modules` with only their subdirectory contents (not the whole repo), and the binary layout invariant is enforced at compile time via `const` size asserts.

Note: the test fixture is pnpm's own `RexSkz/test-git-subfolder-fetch`, whose sub-packages have no `workspace:` cross-deps. Installing a sub-package that depends on a sibling via the `workspace:` protocol is a separate limitation (bun does not build the monorepo the way pnpm does) and is out of scope here.

The automated tests exercise the GitHub tarball path (both `git+https://github.com` and `github:` route there). The non-GitHub git-clone path uses the same subpath-keyed task-id + per-waiter checkout design and passes all existing git tests, but isn't covered by a dedicated automated test (would need a non-GitHub git host in CI). Scope is limited to the pnpm-style `path:` forms; the npm `::path:` form is intentionally out of scope.

Closes #15506
