### PR TITLE
webcore: pin the FileReader across user JS in on_reader_done

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -1000,6 +1000,12 @@ impl FileReader {
 
     pub fn on_reader_done(&self) {
         bun_core::scoped_log!(FileReader, "onReaderDone()");
+        // Pin across `p.run()` and `on_close()`: both can run user JS, and the
+        // `self.buffered` / `waiting_for_on_reader_done` reads below must not
+        // land on a freed box. Same bracket as on_read_chunk / on_reader_error.
+        let parent = self.parent();
+        // SAFETY: see `parent()`.
+        unsafe { (*parent).increment_count() };
         if !self.is_pulling() {
             self.consume_reader_buffer();
             if self.pending.get().state == streams::PendingState::Pending {
@@ -1021,18 +1027,18 @@ impl FileReader {
 
         // Only close the stream if there's no buffered data left to deliver
         if self.buffered.get().is_empty() {
-            // SAFETY: see `parent()`.
-            unsafe { (*self.parent()).on_close() };
+            // SAFETY: see `parent()`; the pin keeps the count > 0.
+            unsafe { (*parent).on_close() };
         }
         if self.waiting_for_on_reader_done.get() {
             self.waiting_for_on_reader_done.set(false);
-            let parent = self.parent();
-            // SAFETY: `parent` was produced by `Source::new` (`Box::into_raw`).
-            // Tail position — `self` (a field of `*parent`) is not accessed
-            // after this call, which may free the allocation when the refcount
-            // hits zero.
+            // SAFETY: see `parent()`; the pin above keeps the count > 0.
             let _ = unsafe { Source::decrement_count(parent) };
         }
+        // SAFETY: see `parent()`; releases the pin. Tail position — `self` (a
+        // field of `*parent`) is not accessed after this call, which may free
+        // the allocation when the refcount hits zero.
+        let _ = unsafe { Source::decrement_count(parent) };
     }
 
     pub fn on_reader_error(&self, err: sys::Error) {

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -173,6 +173,112 @@ test.skipIf(isWindows)(
   60_000,
 );
 
+// Third member of the same family: FileReader::on_reader_done. Its p.run()
+// resolves the pending pull with Done and drains microtasks, so the user's
+// {done: true} read handler runs synchronously inside on_reader_done, before
+// on_reader_done's own tail (on_close + the across-read release). The pin
+// added there (the same bracket on_read_chunk and on_reader_error already
+// have) guarantees the source cannot be downgraded or freed during that JS.
+//
+// This asserts the lifetime invariant directly: inside the handler the
+// wrapper must be Strong-protected both before and after the most aggressive
+// teardown reachable from there (cancel + dropping every JS reference + a
+// full synchronous GC). protectedBefore >= 1 is the precondition proving the
+// handler really ran inside on_reader_done's window (the across-read ref has
+// not been released yet); protectedAfter >= 1 / aliveAfter >= 1 is the
+// invariant. `cat` holds the pipe open until its stdin EOFs, so the read is
+// armed before the pipe can reach EOF: no fixed sleeps.
+// Windows uses libuv for pipe I/O; the path under test is POSIX.
+test.skipIf(isWindows)(
+  "resolving the pending read from FileReader::on_reader_done keeps the source pinned through its own tail",
+  async () => {
+    const script = /* js */ `
+      const { heapStats } = require("bun:jsc");
+      const prot = () =>
+        heapStats().protectedObjectTypeCounts.FileInternalReadableStreamSource ?? 0;
+      const alive = () =>
+        heapStats().objectTypeCounts.FileInternalReadableStreamSource ?? 0;
+
+      globalThis.__done = Promise.withResolvers();
+
+      // cat keeps fd 1 open until its stdin reaches EOF, so the FileReader
+      // (fromPipe) exists and the read() below is Pending before the pipe can
+      // close. Wire every failure into __done so nothing hangs.
+      globalThis.__p = Bun.spawn({
+        cmd: ["/bin/cat"],
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "ignore",
+      });
+      globalThis.__r = globalThis.__p.stdout.getReader();
+
+      globalThis.__r.read().then(
+        ({ done, value }) => {
+          try {
+            const protectedBefore = prot();
+            globalThis.__r.cancel().catch(() => {});
+            delete globalThis.__r;
+            delete globalThis.__p;
+            Bun.gc(true);
+            Bun.gc(true);
+            const protectedAfter = prot();
+            const aliveAfter = alive();
+            globalThis.__done.resolve({
+              done,
+              len: value?.byteLength ?? 0,
+              protectedBefore,
+              protectedAfter,
+              aliveAfter,
+            });
+          } catch (err) {
+            globalThis.__done.reject(err);
+          }
+        },
+        err => globalThis.__done.reject(err),
+      );
+
+      // EOF cat's stdin; cat exits, its stdout EOFs, and the armed poll
+      // dispatches into FileReader::on_reader_done with the pull Pending.
+      globalThis.__p.stdin.end();
+
+      console.log(JSON.stringify(await globalThis.__done.promise));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    let result: {
+      done: boolean;
+      len: number;
+      protectedBefore: number;
+      protectedAfter: number;
+      aliveAfter: number;
+    };
+    try {
+      result = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`fixture did not emit JSON (exit ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`);
+    }
+    // Precondition: the pull was resolved by on_reader_done ({done: true}, no
+    // bytes), not by on_read_chunk delivering data.
+    expect({ done: result.done, len: result.len }).toEqual({ done: true, len: 0 });
+    // Precondition: the handler ran inside on_reader_done, before its tail
+    // released the across-read ref; the wrapper is still Strong there.
+    expect(result.protectedBefore).toBeGreaterThanOrEqual(1);
+    // Invariant: nothing reachable from that JS may downgrade or free the
+    // source while on_reader_done still has reads of `self` ahead of it.
+    expect(result.protectedAfter).toBeGreaterThanOrEqual(1);
+    expect(result.aliveAfter).toBeGreaterThanOrEqual(1);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
 // Asserts the lifetime invariant rather than racing for the crash: the actual
 // free needs a GC to land inside the microtask drain, which conservative stack
 // scanning makes non-deterministic. Instead, the source wrapper must still be

--- a/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
+++ b/test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts
@@ -173,22 +173,12 @@ test.skipIf(isWindows)(
   60_000,
 );
 
-// Third member of the same family: FileReader::on_reader_done. Its p.run()
-// resolves the pending pull with Done and drains microtasks, so the user's
-// {done: true} read handler runs synchronously inside on_reader_done, before
-// on_reader_done's own tail (on_close + the across-read release). The pin
-// added there (the same bracket on_read_chunk and on_reader_error already
-// have) guarantees the source cannot be downgraded or freed during that JS.
-//
-// This asserts the lifetime invariant directly: inside the handler the
-// wrapper must be Strong-protected both before and after the most aggressive
-// teardown reachable from there (cancel + dropping every JS reference + a
-// full synchronous GC). protectedBefore >= 1 is the precondition proving the
-// handler really ran inside on_reader_done's window (the across-read ref has
-// not been released yet); protectedAfter >= 1 / aliveAfter >= 1 is the
-// invariant. `cat` holds the pipe open until its stdin EOFs, so the read is
-// armed before the pipe can reach EOF: no fixed sleeps.
-// Windows uses libuv for pipe I/O; the path under test is POSIX.
+// Asserts the on_reader_done lifetime invariant: the source must stay
+// Strong-protected across the user JS its p.run() drains, because the rest
+// of the function still reads `self` after that JS returns.
+// protectedBefore >= 1 proves the handler ran inside that window (the
+// across-read ref, released only at on_reader_done's tail, is still held);
+// protectedAfter / aliveAfter >= 1 is the invariant. POSIX-only (libuv).
 test.skipIf(isWindows)(
   "resolving the pending read from FileReader::on_reader_done keeps the source pinned through its own tail",
   async () => {
@@ -276,7 +266,6 @@ test.skipIf(isWindows)(
     expect(result.aliveAfter).toBeGreaterThanOrEqual(1);
     expect(exitCode).toBe(0);
   },
-  30_000,
 );
 
 // Asserts the lifetime invariant rather than racing for the crash: the actual


### PR DESCRIPTION
### What

`FileReader::on_reader_done` has the same shape #32921 fixed in its two siblings: it runs user JavaScript and then reads `self` with no refcount pin. A heap-use-after-free was reported there under fault injection on an instrumented build (READ in `FileReader::on_reader_done`, on the `self.buffered` length read that follows `p.run()`). #32921 added the pin to `on_read_chunk` and `on_reader_error` but not to `on_reader_done`, one screen below them in the same file.

### Cause

`on_reader_done` resolves the pending pull with `Done`/`OwnedAndDone` via `p.run()`, which fulfills a JS promise and drains microtasks. After that returns, it still reads `self.buffered`, calls `(*self.parent()).on_close()` (which can invoke a native consumer's `close_handler`), and reads `self.waiting_for_on_reader_done`. `self` is a field of a heap-allocated, refcounted `NewSource<FileReader>`; nothing holds an extra reference across those calls, so any release that lands inside them frees the box out from under the rest of the function.

On current `main` the function is safe only through a non-local invariant: while `p.run()` is executing, the count is 2 (the JS wrapper's ref plus the across-read ref that `on_reader_done` itself releases at its tail), and no synchronous release is reachable from JS inside that window, because the re-entrant `cancel -> on_cancel -> reader().close() -> done()` chain that #32921's test drives is gated on `!self.reader().is_done()`, which is always false once `on_reader_done` is on the stack. That is the same situation #32921 described for its `on_reader_error` pin: the contract holds today only through non-local ordering that nothing enforces.

### Fix

Hold one additional ref on the `NewSource` box for the duration of `on_reader_done`, released at true tail, matching the bracket `on_read_chunk` and `on_reader_error` already have. The across-read release then lands at a count of two instead of one, the wrapper stays Strong-rooted for the rest of the dispatch, and the box is collected normally on a later, off-stack GC.

I audited the other `Pending::run` call sites in `src/runtime/webcore`. `ByteStream::on_data`'s is tail-positioned, `ByteStream::on_cancel`'s is entered from JS with the wrapper a conservative stack root, and `ByteStream::finalize` defers any JS-visible resolution to the next tick. `on_reader_done` was the only remaining run-JS-then-read-`self` site without a pin.

### Verification

`test/js/bun/spawn/spawn-stdout-filereader-gc-uaf.test.ts` (the file holding the #32743 and #32921 tests) gains a third test for the third member of the family. `cat` holds the pipe open until its stdin EOFs, so `reader.read()` is armed before the pipe can close; `stdin.end()` then drives `on_reader_done` with the pull Pending and no fixed sleeps. The `{done: true}` handler, which runs synchronously inside `on_reader_done`'s `p.run()` microtask drain, asserts the source stays Strong-protected through the most aggressive teardown reachable from there (`cancel()` plus dropping every JS reference plus `Bun.gc(true)`).

Being straight about what that test is: it passes on the unfixed build too, because the across-read ref carries the invariant today (see Cause). It is a guard on the invariant the pin formalizes, and the canary for the day a change makes the release reachable from inside `p.run()`, which is exactly what happened to `on_read_chunk` between #32743 and #32921. I could not construct a plain-JS input that distinguishes the pin. In a 215-iteration probe on the unfixed ASan debug build across five shapes (pipe EOF with a pending read plus an in-handler `cancel()`, the chunk-then-done variant, `node:child_process` `end` and `close` handlers, and a cancel-initiated `on_reader_done`), with `Malloc=1` and `BUN_JSC_collectContinuously=1`, ASan never fired and the `FileInternalReadableStreamSource` count never dropped inside the window.

Also re-ran `spawn-streaming-stdout`, `spawn-unread-stdout-gc`, `spawn-stdout-iterate-leak`, `spawn-pipe-read-error-leak`, `spawn-ipc-gc`, and `native-source-onclose-leak` on the debug (ASan plus debug_assert) build: all green, which also checks the bracket's refcount balance on every path those exercise.
