### PR TITLE
node:tls: keep ALPN across an SNI SecureContext selection

### DIFF
--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -794,6 +794,10 @@ impl Listener {
             return Ok(JSValue::UNDEFINED);
         };
 
+        // SNI selects a tree entry with SSL_set_SSL_CTX before BoringSSL
+        // negotiates ALPN; carry the per-connection selector over.
+        super::socket_body::install_sni_alpn_selector(sni_ctx.as_ptr());
+
         // The C SNI tree SSL_CTX_up_ref()s; ours drops here.
         // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
         let ls_ref = bun_opaque::opaque_deref_mut(ls);
@@ -2036,7 +2040,11 @@ fn decode_sni_result(result: JSValue, abort_handshake: *mut core::ffi::c_int) ->
     }
     if let Some(sc) = result.as_class_ref::<SecureContext>() {
         // The C dispatcher frees this +1 after `SSL_set_SSL_CTX` takes its own.
-        return sc.ctx.clone().into_raw().cast();
+        let ctx = sc.ctx.clone().into_raw();
+        // The dispatcher installs `ctx` with SSL_set_SSL_CTX before BoringSSL
+        // negotiates ALPN; carry the per-connection selector over.
+        super::socket_body::install_sni_alpn_selector(ctx);
+        return ctx.cast();
     }
     // Anything else is not a SecureContext: Node treats this as an invalid SNI
     // context and drops the connection.

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -794,8 +794,6 @@ impl Listener {
             return Ok(JSValue::UNDEFINED);
         };
 
-        // SNI selects a tree entry with SSL_set_SSL_CTX before BoringSSL
-        // negotiates ALPN; carry the per-connection selector over.
         super::socket_body::install_sni_alpn_selector(sni_ctx.as_ptr());
 
         // The C SNI tree SSL_CTX_up_ref()s; ours drops here.
@@ -2041,8 +2039,6 @@ fn decode_sni_result(result: JSValue, abort_handshake: *mut core::ffi::c_int) ->
     if let Some(sc) = result.as_class_ref::<SecureContext>() {
         // The C dispatcher frees this +1 after `SSL_set_SSL_CTX` takes its own.
         let ctx = sc.ctx.clone().into_raw();
-        // The dispatcher installs `ctx` with SSL_set_SSL_CTX before BoringSSL
-        // negotiates ALPN; carry the per-connection selector over.
         super::socket_body::install_sni_alpn_selector(ctx);
         return ctx.cast();
     }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -272,15 +272,11 @@ extern "C" fn select_alpn_callback(
     }
 }
 
-/// Installs `select_alpn_callback` on `ctx`. BoringSSL resolves the server
-/// ALPN selection callback off the *current* `ssl->ctx`, and the SNI machinery
-/// replaces that with `SSL_set_SSL_CTX` before ALPN negotiation runs - so
-/// every context SNI can select (an `SNICallback`/`resumeSNI` result, an
-/// `addContext`/`addServerName` tree entry) must carry the same registration
-/// `on_open` puts on the listener's default context, or selecting it silently
-/// drops ALPN. The selector dispatches through the per-SSL ex_data slot set in
-/// `on_open` (NOACK when unset), so registering it on a shared or user-owned
-/// context is inert for connections that don't negotiate ALPN.
+/// BoringSSL looks up the server ALPN callback on the *current* `ssl->ctx`,
+/// which SNI replaces with `SSL_set_SSL_CTX` before ALPN negotiation, so every
+/// context SNI can install needs the registration `on_open` gives the default
+/// one. The selector is keyed on per-SSL ex_data (NOACK when unset), so the
+/// registration is inert for every other connection on a shared context.
 pub(in crate::socket) fn install_sni_alpn_selector(ctx: *mut boringssl_sys::SSL_CTX) {
     if ctx.is_null() {
         return;
@@ -911,9 +907,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         } else {
             core::ptr::null_mut()
         };
-        // us_select_cert_cb installs the resolved context with SSL_set_SSL_CTX
-        // when the handshake resumes, before BoringSSL negotiates ALPN; carry
-        // the per-connection selector over.
         install_sni_alpn_selector(ctx_ptr);
         socket.sni_resolve(ctx_ptr, is_error);
         Ok(JSValue::UNDEFINED)

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -272,6 +272,26 @@ extern "C" fn select_alpn_callback(
     }
 }
 
+/// Installs `select_alpn_callback` on `ctx`. BoringSSL resolves the server
+/// ALPN selection callback off the *current* `ssl->ctx`, and the SNI machinery
+/// replaces that with `SSL_set_SSL_CTX` before ALPN negotiation runs - so
+/// every context SNI can select (an `SNICallback`/`resumeSNI` result, an
+/// `addContext`/`addServerName` tree entry) must carry the same registration
+/// `on_open` puts on the listener's default context, or selecting it silently
+/// drops ALPN. The selector dispatches through the per-SSL ex_data slot set in
+/// `on_open` (NOACK when unset), so registering it on a shared or user-owned
+/// context is inert for connections that don't negotiate ALPN.
+pub(in crate::socket) fn install_sni_alpn_selector(ctx: *mut boringssl_sys::SSL_CTX) {
+    if ctx.is_null() {
+        return;
+    }
+    tls_socket_functions::ffi::SSL_CTX_set_alpn_select_cb(
+        SSL_CTX::opaque_ref(ctx),
+        Some(select_alpn_callback),
+        ptr::null_mut(),
+    );
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // NewSocket<SSL>
 // ──────────────────────────────────────────────────────────────────────────
@@ -891,6 +911,10 @@ impl<const SSL: bool> NewSocket<SSL> {
         } else {
             core::ptr::null_mut()
         };
+        // us_select_cert_cb installs the resolved context with SSL_set_SSL_CTX
+        // when the handshake resumes, before BoringSSL negotiates ALPN; carry
+        // the per-connection selector over.
+        install_sni_alpn_selector(ctx_ptr);
         socket.sni_resolve(ctx_ptr, is_error);
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -272,11 +272,8 @@ extern "C" fn select_alpn_callback(
     }
 }
 
-/// BoringSSL looks up the server ALPN callback on the *current* `ssl->ctx`,
-/// which SNI replaces with `SSL_set_SSL_CTX` before ALPN negotiation, so every
-/// context SNI can install needs the registration `on_open` gives the default
-/// one. The selector is keyed on per-SSL ex_data (NOACK when unset), so the
-/// registration is inert for every other connection on a shared context.
+/// BoringSSL reads the server ALPN callback off the *current* `ssl->ctx`, and
+/// SNI replaces that with `SSL_set_SSL_CTX` before ALPN negotiation.
 pub(in crate::socket) fn install_sni_alpn_selector(ctx: *mut boringssl_sys::SSL_CTX) {
     if ctx.is_null() {
         return;

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "bun:test";
 
 import { bunEnv, bunExe, tempDir } from "harness";
 import { X509Certificate } from "node:crypto";
+import { once } from "node:events";
 import { readFileSync } from "node:fs";
 import { AddressInfo } from "node:net";
 import { join } from "node:path";
@@ -356,6 +357,128 @@ describe("tls.Server", () => {
       true,
       "chain.example.com",
     );
+  });
+});
+
+describe("ALPN survives an SNI-selected SecureContext", () => {
+  // Node negotiates ALPN at the connection level, independent of which
+  // SecureContext SNI selected; an SNI/multi-domain server is exactly the
+  // deployment shape that needs ALPN (h2, gRPC), so selecting a per-domain
+  // context must not drop the server's ALPN configuration.
+  const identity = { key: agent1Key, cert: agent1Cert };
+  type SNICb = (err: Error | null, ctx?: unknown) => void;
+  const cases: [string, object, undefined | ((server: tls.Server) => void)][] = [
+    [
+      "synchronous SNICallback",
+      { SNICallback: (_name: string, cb: SNICb) => cb(null, tls.createSecureContext(identity)) },
+      undefined,
+    ],
+    [
+      "asynchronous SNICallback",
+      {
+        SNICallback(_name: string, cb: SNICb) {
+          setImmediate(() => cb(null, tls.createSecureContext(identity)));
+        },
+      },
+      undefined,
+    ],
+    ["addContext", {}, (server: tls.Server) => server.addContext("alpn.sni.test", identity)],
+  ];
+
+  for (const [label, extraOptions, setup] of cases) {
+    it(`negotiates the server's ALPNProtocols: ${label}`, async () => {
+      const serverSide = Promise.withResolvers<string | false | null>();
+      const server = tls.createServer({ ...identity, ALPNProtocols: ["h2", "http/1.1"], ...extraOptions }, socket => {
+        serverSide.resolve(socket.alpnProtocol);
+        socket.end();
+      });
+      server.on("tlsClientError", serverSide.reject);
+      server.listen(0);
+      await once(server, "listening");
+      setup?.(server);
+      const { port } = server.address() as AddressInfo;
+      const client = tls.connect({
+        port,
+        host: "127.0.0.1",
+        servername: "alpn.sni.test",
+        ALPNProtocols: ["h2"],
+        rejectUnauthorized: false,
+      });
+      client.on("error", serverSide.reject);
+      await once(client, "secureConnect");
+      expect({ client: client.alpnProtocol, server: await serverSide.promise }).toEqual({
+        client: "h2",
+        server: "h2",
+      });
+      client.end();
+      server.close();
+      await once(server, "close");
+    });
+  }
+
+  it("still consults the server's ALPNCallback", async () => {
+    const seen: { servername: string; protocols: string[] }[] = [];
+    const failed = Promise.withResolvers<never>();
+    const server = tls.createServer(
+      {
+        ...identity,
+        ALPNCallback(arg: { servername: string; protocols: string[] }) {
+          seen.push(arg);
+          return "h2";
+        },
+        SNICallback: (_name: string, cb: SNICb) => cb(null, tls.createSecureContext(identity)),
+      },
+      socket => socket.end(),
+    );
+    server.on("tlsClientError", failed.reject);
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    const client = tls.connect({
+      port,
+      host: "127.0.0.1",
+      servername: "alpn.sni.test",
+      ALPNProtocols: ["http/1.1", "h2"],
+      rejectUnauthorized: false,
+    });
+    client.on("error", failed.reject);
+    await Promise.race([once(client, "secureConnect"), failed.promise]);
+    expect(client.alpnProtocol).toBe("h2");
+    expect(seen).toEqual([{ servername: "alpn.sni.test", protocols: ["http/1.1", "h2"] }]);
+    client.end();
+    server.close();
+    await once(server, "close");
+  });
+
+  it("sends the fatal no_application_protocol alert on a genuine mismatch", async () => {
+    // RFC 7301 3.2: no overlap between the offered and configured protocol
+    // lists is a fatal no_application_protocol alert, not a silent handshake
+    // that negotiated nothing.
+    const server = tls.createServer({
+      ...identity,
+      ALPNProtocols: ["h2"],
+      SNICallback: (_name: string, cb: SNICb) => cb(null, tls.createSecureContext(identity)),
+    });
+    server.on("tlsClientError", () => {});
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    const client = tls.connect({
+      port,
+      host: "127.0.0.1",
+      servername: "alpn.sni.test",
+      ALPNProtocols: ["spdy/3"],
+      rejectUnauthorized: false,
+    });
+    const outcome = Promise.withResolvers<Error & { code?: string }>();
+    client.on("error", outcome.resolve);
+    client.on("secureConnect", () => {
+      outcome.reject(new Error(`handshake succeeded with alpnProtocol=${JSON.stringify(client.alpnProtocol)}`));
+    });
+    const err = await outcome.promise;
+    expect(err.code).toBe("ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL");
+    server.close();
+    await once(server, "close");
   });
 });
 

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -388,16 +388,19 @@ describe("ALPN survives an SNI-selected SecureContext", () => {
   for (const [label, extraOptions, setup] of cases) {
     it(`negotiates the server's ALPNProtocols: ${label}`, async () => {
       const serverSide = Promise.withResolvers<string | false | null>();
-      const server = tls.createServer({ ...identity, ALPNProtocols: ["h2", "http/1.1"], ...extraOptions }, socket => {
-        serverSide.resolve(socket.alpnProtocol);
-        socket.end();
-      });
+      await using server = tls.createServer(
+        { ...identity, ALPNProtocols: ["h2", "http/1.1"], ...extraOptions },
+        socket => {
+          serverSide.resolve(socket.alpnProtocol);
+          socket.end();
+        },
+      );
       server.on("tlsClientError", serverSide.reject);
       server.listen(0);
       await once(server, "listening");
       setup?.(server);
       const { port } = server.address() as AddressInfo;
-      const client = tls.connect({
+      await using client = tls.connect({
         port,
         host: "127.0.0.1",
         servername: "alpn.sni.test",
@@ -410,9 +413,6 @@ describe("ALPN survives an SNI-selected SecureContext", () => {
         client: "h2",
         server: "h2",
       });
-      client.end();
-      server.close();
-      await once(server, "close");
     });
   }
 
@@ -420,7 +420,7 @@ describe("ALPN survives an SNI-selected SecureContext", () => {
   it("still consults the server's ALPNCallback", async () => {
     const seen: { servername: string; protocols: string[] }[] = [];
     const failed = Promise.withResolvers<never>();
-    const server = tls.createServer(
+    await using server = tls.createServer(
       {
         ...identity,
         ALPNCallback(arg: { servername: string; protocols: string[] }) {
@@ -435,7 +435,7 @@ describe("ALPN survives an SNI-selected SecureContext", () => {
     server.listen(0);
     await once(server, "listening");
     const { port } = server.address() as AddressInfo;
-    const client = tls.connect({
+    await using client = tls.connect({
       port,
       host: "127.0.0.1",
       servername: "alpn.sni.test",
@@ -446,16 +446,13 @@ describe("ALPN survives an SNI-selected SecureContext", () => {
     await Promise.race([once(client, "secureConnect"), failed.promise]);
     expect(client.alpnProtocol).toBe("h2");
     expect(seen).toEqual([{ servername: "alpn.sni.test", protocols: ["http/1.1", "h2"] }]);
-    client.end();
-    server.close();
-    await once(server, "close");
   });
 
   it("sends the fatal no_application_protocol alert on a genuine mismatch", async () => {
     // RFC 7301 3.2: no overlap between the offered and configured protocol
     // lists is a fatal no_application_protocol alert, not a silent handshake
     // that negotiated nothing.
-    const server = tls.createServer({
+    await using server = tls.createServer({
       ...identity,
       ALPNProtocols: ["h2"],
       SNICallback: (_name: string, cb: SNICb) => cb(null, tls.createSecureContext(identity)),
@@ -464,6 +461,8 @@ describe("ALPN survives an SNI-selected SecureContext", () => {
     server.listen(0);
     await once(server, "listening");
     const { port } = server.address() as AddressInfo;
+    // Not `await using`: a Readable's Symbol.asyncDispose rejects with the
+    // stream's terminal error, and this client is expected to end in one.
     const client = tls.connect({
       port,
       host: "127.0.0.1",
@@ -471,15 +470,17 @@ describe("ALPN survives an SNI-selected SecureContext", () => {
       ALPNProtocols: ["spdy/3"],
       rejectUnauthorized: false,
     });
-    const outcome = Promise.withResolvers<Error & { code?: string }>();
-    client.on("error", outcome.resolve);
-    client.on("secureConnect", () => {
-      outcome.reject(new Error(`handshake succeeded with alpnProtocol=${JSON.stringify(client.alpnProtocol)}`));
-    });
-    const err = await outcome.promise;
-    expect(err.code).toBe("ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL");
-    server.close();
-    await once(server, "close");
+    try {
+      const outcome = Promise.withResolvers<Error & { code?: string }>();
+      client.on("error", outcome.resolve);
+      client.on("secureConnect", () => {
+        outcome.reject(new Error(`handshake succeeded with alpnProtocol=${JSON.stringify(client.alpnProtocol)}`));
+      });
+      const err = await outcome.promise;
+      expect(err.code).toBe("ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL");
+    } finally {
+      client.destroy();
+    }
   });
 });
 

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -416,6 +416,7 @@ describe("ALPN survives an SNI-selected SecureContext", () => {
     });
   }
 
+  // https://github.com/oven-sh/bun/issues/17932
   it("still consults the server's ALPNCallback", async () => {
     const seen: { servername: string; protocols: string[] }[] = [];
     const failed = Promise.withResolvers<never>();


### PR DESCRIPTION
### What

Any `SecureContext` selected through SNI silently drops the server's ALPN configuration. An h2/gRPC client that negotiates `h2` against the default context gets no ALPN at all (`alpnProtocol === false` on both ends) once `SNICallback` or `addContext` picks a per-domain certificate, and nothing logs why. A genuine ALPN mismatch also completes the handshake instead of sending the RFC 7301 `no_application_protocol` alert. This affects every SNI/multi-domain `tls`/`https`/`http2` server, which is exactly the deployment shape that needs ALPN.

```js
const srv = tls.createServer({
  key, cert,
  ALPNProtocols: ["h2", "http/1.1"],
  SNICallback(name, cb) {
    cb(null, tls.createSecureContext({ key, cert })); // the standard multi-domain pattern
  },
});
// client: tls.connect({ servername: "a.example.com", ALPNProtocols: ["h2"], ... })
// node: socket.alpnProtocol === "h2"
// bun:  socket.alpnProtocol === false
```

All three paths that hand a context to the SNI machinery reproduce it: a synchronous `SNICallback`, an asynchronous `SNICallback` (the `resumeSNI` resume), and `server.addContext()`. The same loss also silences a server `ALPNCallback` whenever an `SNICallback` is present, which is the remaining half of #17932 (its exact `SNICallback` + `ALPNCallback` repro gives `alpnCalled: 0, alpnProtocol: false` before this change and matches Node after it). It is invisible in single-cert tests because without SNI the default context never gets replaced.

Fixes #17932

### Why

BoringSSL resolves the server ALPN selection callback off the *current* `ssl->ctx` (`ssl_negotiate_alpn`, `vendor/boringssl/ssl/extensions.cc`), and resolves it *after* the SNI callbacks have run. Bun registered its selector (`select_alpn_callback` in `src/runtime/socket/socket_body.rs`) only on the listener's default `SSL_CTX`, in `on_open` at accept time. Every SNI selection path installs a different context with `SSL_set_SSL_CTX` (`us_select_cert_cb` / `sni_cb` in `packages/bun-usockets/src/crypto/openssl.c`). The freshly created `SecureContext` has no `alpn_select_cb`, so BoringSSL's "ignore ALPN if not configured" branch fires and ALPN is skipped without an error.

Node never hits this because it copies only the certificate/key/chain from the SNI-selected `SecureContext` onto the connection; its connection-level ALPN handling is independent of which context SNI selected.

### Fix

The selector already dispatches entirely through per-SSL state (it reads the `TLSSocket` back from the ex_data slot `on_open` sets, never from the `SSL_CTX`), so the context it is registered on does not matter as long as it is the one BoringSSL looks at. Add a helper that installs it on a given `SSL_CTX`, and call it from the three places a context reaches the native SNI machinery:

- `decode_sni_result` (`src/runtime/socket/Listener.rs`), which `us_dispatch_server_name` calls to turn the synchronous `SNICallback` result into the `SSL_CTX*` handed back to C.
- `resume_sni` (`src/runtime/socket/socket_body.rs`): the asynchronous `SNICallback` result.
- `Listener::add_server_name` (`src/runtime/socket/Listener.rs`): `addContext` / `addServerName` static SNI tree entries.

The selector returns `SSL_TLSEXT_ERR_NOACK` when the per-SSL ex_data is unset, so installing it on a shared or user-owned context is inert for connections that do not negotiate ALPN, including clients (BoringSSL only invokes it server-side).

Not changed: the bind-hostname SNI tree entry points at the listener's own default context, which `on_open` already registers. `setKeyCert` also calls `SSL_set_SSL_CTX`, but Node restricts it to `ALPNCallback`, which runs from inside BoringSSL's ALPN negotiation after the callback has already been resolved, so it cannot drop ALPN.

### Tests

`test/js/node/tls/node-tls-context.test.ts`, "ALPN survives an SNI-selected SecureContext": five cases covering the synchronous `SNICallback`, the asynchronous `SNICallback`, `addContext`, the `ALPNCallback` (the other consumer of the same selector), and the fatal `no_application_protocol` alert on a genuine mismatch.

<details>
<summary>Before / after</summary>

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/tls/node-tls-context.test.ts
 7 pass
 5 fail
(fail) ALPN survives an SNI-selected SecureContext > negotiates the server's ALPNProtocols: synchronous SNICallback
       Expected: "h2"   Received: false
(fail) ... asynchronous SNICallback
(fail) ... addContext
(fail) ... still consults the server's ALPNCallback
(fail) ... sends the fatal no_application_protocol alert on a genuine mismatch
       error: handshake succeeded with alpnProtocol=false

$ bun bd test test/js/node/tls/node-tls-context.test.ts
 12 pass
 0 fail
```

Also green with the fix: `test/js/node/tls/` (the three remaining failures there reproduce with this diff stashed), `test-tls-sni-option.js`, `test-tls-empty-sni-context.js`, `test-tls-snicallback-error.js`, `test-tls-psk-alpn-callback-exception-handling.js`, `test-tls-secure-context-usage-order.js`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 9 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-context.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/node/tls/node-tls-context.test.ts:
(pass) tls.Server > addContext [839.84ms]
(pass) tls.Server > should select the most recently added SecureContext [130.96ms]
(pass) tls.Server > should allow multiple CA [193.47ms]
(pass) tls.Server > should allow multiple CA in newline-separated strings [57.69ms]
(pass) tls.Server > SNI tls.Server + tls.connect [264.73ms]
407 |         ALPNProtocols: ["h2"],
408 |         rejectUnauthorized: false,
409 |       });
410 |       client.on("error", serverSide.reject);
411 |       await once(client, "secureConnect");
412 |       expect({ client: client.alpnProtocol, server: await serverSide.promise }).toEqual({
                                                                                      ^
error: expect(received).toEqual(expected)

  {
-   "client": "h2",
-   "server": "h2",
+   "client": false,
+   "server": false,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/tls/node-tls-conte
... (truncated)

release without fix: 5 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/node/tls/node-tls-context.test.ts:
(pass) tls.Server > addContext [21.87ms]
(pass) tls.Server > should select the most recently added SecureContext [6.61ms]
(pass) tls.Server > should allow multiple CA [4.43ms]
(pass) tls.Server > should allow multiple CA in newline-separated strings [2.60ms]
(pass) tls.Server > SNI tls.Server + tls.connect [11.45ms]
407 |         ALPNProtocols: ["h2"],
408 |         rejectUnauthorized: false,
409 |       });
410 |       client.on("error", serverSide.reject);
411 |       await once(client, "secureConnect");
412 |       expect({ client: client.alpnProtocol, server: await serverSide.promise }).toEqual({
                                                                                      ^
error: expect(received).toEqual(expected)

  {
-   "client": "h2",
-   "server": "h2",
+   "client": false,
+   "server": false,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/tls/node-tls-context.test.ts:412:81)
(fail) ALPN survives an SNI-selected SecureContext > negotiates the server's ALPNProtocols: synchronous SNICallback [4.69ms]
407 |         ALPNProtocols:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-context.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/node/tls/node-tls-context.test.ts:
(pass) tls.Server > addContext [755.87ms]
(pass) tls.Server > should select the most recently added SecureContext [135.77ms]
(pass) tls.Server > should allow multiple CA [186.57ms]
(pass) tls.Server > should allow multiple CA in newline-separated strings [59.20ms]
(pass) tls.Server > SNI tls.Server + tls.connect [260.59ms]
(pass) ALPN survives an SNI-selected SecureContext > negotiates the server's ALPNProtocols: synchronous SNICallback [157.00ms]
(pass) ALPN survives an SNI-selected SecureContext > negotiates the server's ALPNProtocols: asynchronous SNICallback [49.18ms]
(pass) ALPN survives an SNI-selected SecureContext > negotiates the server's ALPNProtocols: addContext [47.24ms]
(pass) ALPN survives an SNI-selected SecureContext > still consults the server's ALPNCallback [74.28ms]
(pass) ALPN survives an SNI-selected SecureContext > sends the fatal no_application_protocol alert on a genuine mismatch [72.35ms]
(pass) Bun.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 595ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 16s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+77846daff
[build] done
bun test v1.4.1-canary.1 (77846daff)

test/js/node/tls/node-tls-context.test.ts:
(pass) tls.Server > addContext [21.66ms]
(pass) tls.Server > should select the most recently added SecureContext [6.55ms]
(pass) tls.Server > should allow multiple CA [4.27ms]
(pass) tls.Server > should allow multiple CA in newline-separated strings [2.54ms]
(pass) tls.Server > SNI tls.Server + tls.connect [11.72ms]
(pass) ALPN survives an SNI-selected SecureContext > negotiates the server's ALPNProtocols: synchronous SNICallback [4.37ms]
(pass) ALPN survives an SNI-selected Secu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/socket/Listener.rs            |   6 +-
 src/runtime/socket/socket_body.rs         |  14 ++++
 test/js/node/tls/node-tls-context.test.ts | 125 ++++++++++++++++++++++++++++++
 3 files changed, 144 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 9

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/socket/Listener.rs                 7      9     29
src/runtime/socket/socket_body.rs              7      6     29
test/js/node/tls/node-tls-context.test.ts      3      6     29
```

</details>

<!-- robobun:evidence:end -->
