### PR TITLE
fix(dgram): skip redundant dns.lookup() for literal IPs

### DIFF
--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -98,17 +98,21 @@ function EINVAL(syscall) {
 let dns;
 
 function newHandle(type, lookup) {
+  let isDefaultLookup = false;
   if (lookup === undefined) {
     if (dns === undefined) {
       dns = require("node:dns");
     }
 
     lookup = dns.lookup;
+    isDefaultLookup = true;
   } else {
     validateFunction(lookup, "lookup");
   }
 
-  const handle = {};
+  const handle = {
+    isDefaultLookup
+  } as any;
   if (type === "udp4") {
     handle.lookup = FunctionPrototypeBind.$call(lookup4, handle, lookup);
   } else if (type === "udp6") {
@@ -596,7 +600,11 @@ Socket.prototype.send = function (buffer, offset, length, port, address, callbac
   };
 
   if (!connected) {
-    state.handle.lookup(address, afterDns);
+    if (state.handle.isDefaultLookup && isIP(address)) {
+      process.nextTick(afterDns, null, address);
+    } else {
+      state.handle.lookup(address, afterDns);
+    }
   } else {
     afterDns(null, null);
   }


### PR DESCRIPTION
### What does this PR do?
This PR optimizes unconnected UDP socket sends in `node:dgram` by skipping the `dns.lookup()` call when the provided destination address is already a literal IP address (e.g., "127.0.0.1").

Previously, `socket.send()` blindly routed every unconnected send through `state.handle.lookup(address, afterDns)`. Even though `dns.lookup` resolves literal IPs to themselves, invoking it forces an asynchronous tick delay and unnecessarily triggers APM/tracing tools to record a DNS query for every single datagram sent.

This safely checks if the address is a literal IP via isIP(address) and ensures we are using the default lookup function before bypassing it, routing the packet for immediate dispatch on the next tick.

### How did you verify your code works?
- Verified that `isDefaultLookup` properly tracks whether the user supplied a custom lookup function in the Socket constructor.
- Ensured that `isIP(address)` safely detects valid IPv4 and IPv6 strings.
- Checked that custom lookup functions provided by the user are still fully respected and called as expected.
- Existing `bun:udp` and `node:dgram` test suites (like `test-dgram-pingpong.js` and `dgram.test.ts`) continue to pass without changes to their asynchronous contracts.