### PR TITLE
Reject unknown import attribute type values

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1403,7 +1403,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     path.loader = Some(bun_ast::Loader::SqliteEmbedded);
                                 }
                             } else {
-                                // unknown loader; consider erroring
+                                let r = p.lexer.range();
+                                p.lexer.add_range_error(
+                                    r,
+                                    format_args!(
+                                        "Import attribute \"type\" with value {} is not supported",
+                                        bun_core::fmt::quote(type_attr)
+                                    ),
+                                )?;
                             }
                         }
                         SupportedAttribute::Embed => {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1388,6 +1388,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.lexer.next()?;
                 p.lexer.expect(T::TColon)?;
 
+                // `expect` advances past the value, so grab its range now for
+                // error reporting.
+                let value_range = p.lexer.range();
                 p.lexer.expect(T::TStringLiteral)?;
                 let estr = p.lexer.to_utf8_e_string()?;
                 let string_literal_text = estr.slice8();
@@ -1403,9 +1406,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     path.loader = Some(bun_ast::Loader::SqliteEmbedded);
                                 }
                             } else {
-                                let r = p.lexer.range();
                                 p.lexer.add_range_error(
-                                    r,
+                                    value_range,
                                     format_args!(
                                         "Import attribute \"type\" with value {} is not supported",
                                         bun_core::fmt::quote(type_attr)

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1427,9 +1427,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             if string_literal_text == b"ssr" {
                                 path.import_tag = bun_ast::ImportRecordTag::BakeResolveToSsrGraph;
                             } else {
-                                let r = p.lexer.range();
                                 p.lexer.add_range_error(
-                                    r,
+                                    value_range,
                                     format_args!("'bunBakeGraph' can only be set to 'ssr'"),
                                 )?;
                             }

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -345,5 +345,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INVALID_BUFFER_SIZE", RangeError],
   ["ERR_TRACE_EVENTS_CATEGORY_REQUIRED", TypeError],
   ["ERR_TRACE_EVENTS_UNAVAILABLE", Error],
+  ["ERR_IMPORT_ATTRIBUTE_UNSUPPORTED", TypeError],
 ];
 export default errors;

--- a/src/jsc/bindings/JSCommonJSExtensions.cpp
+++ b/src/jsc/bindings/JSCommonJSExtensions.cpp
@@ -271,7 +271,9 @@ JSC::EncodedJSValue builtinLoader(JSC::JSGlobalObject* globalObject, JSC::CallFr
         &specifierBunString,
         specifier,
         &empty,
-        &empty,
+        // No `type` import attribute on this path. Passing a non-null empty
+        // string would be rejected as an unsupported attribute value.
+        nullptr,
         &res,
         mod,
         specifierWtfString,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4081,8 +4081,31 @@ unsafe fn transpile_file(
 
     // `type_attribute` may be null (no `with { type }`).
     // SAFETY: per fn contract — null or a live `bun.String*`.
-    let type_attribute_str: Option<&[u8]> =
-        unsafe { type_attribute.as_ref() }.and_then(|s| s.as_utf8());
+    let type_attribute = unsafe { type_attribute.as_ref() };
+    let type_attribute_str: Option<&[u8]> = type_attribute.and_then(|s| s.as_utf8());
+
+    // An unknown `type` must fail the load instead of silently falling back to
+    // the extension-derived loader (import-attributes proposal; Node throws
+    // ERR_IMPORT_ATTRIBUTE_UNSUPPORTED).
+    if let Some(attr) = type_attribute {
+        let attr_utf8 = attr.to_utf8();
+        if Loader::from_string(attr_utf8.slice()).is_none() {
+            let js = global_ref
+                .err(
+                    bun_jsc::ErrCode::ERR_IMPORT_ATTRIBUTE_UNSUPPORTED,
+                    format_args!(
+                        "Import attribute \"type\" with value {} is not supported",
+                        bun_core::fmt::quote(attr_utf8.slice())
+                    ),
+                )
+                .to_js();
+            // SAFETY: per fn contract — `ret` is a valid out-param.
+            unsafe {
+                *ret = ErrorableResolvedSource::err(bun_core::err!("JSErrorObject"), js);
+            }
+            return ptr::null_mut();
+        }
+    }
 
     let mut virtual_source_to_use: Option<bun_ast::Source> = None;
     let mut blob_to_deinit: Option<crate::webcore::Blob> = None;

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -1,8 +1,8 @@
-import { bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import * as path from "path";
 
 const loaders = ["js", "jsx", "ts", "tsx", "json", "jsonc", "toml", "yaml", "text", "sqlite", "file"];
-const other_loaders_do_not_crash = ["webassembly", "does_not_exist"];
+const unsupported_type_values = ["webassembly", "does_not_exist"];
 
 async function runCmd(cmd: string[], dir: string): Promise<unknown> {
   await using proc = Bun.spawn({
@@ -335,12 +335,92 @@ test("tsconfig.json is assumed jsonc", async () => {
 `);
 });
 
-describe("other loaders do not crash", () => {
-  for (const skipped_loader of other_loaders_do_not_crash) {
-    test(skipped_loader, async () => {
-      await compileAndTest(`export const a = "demo";`);
+// An unknown `type` must fail the import rather than silently falling back to
+// the extension-derived loader: a parse error for static imports and
+// `Bun.build`, and ERR_IMPORT_ATTRIBUTE_UNSUPPORTED for `import()` at runtime.
+describe("unknown type values are rejected", () => {
+  for (const unknown_loader of unsupported_type_values) {
+    test(unknown_loader, async () => {
+      expect(
+        await compileAndTest(`export const a = "demo";`, {
+          [unknown_loader]: { loader: unknown_loader, filename: "no_extension" },
+        }),
+      ).toEqual({ [unknown_loader]: "error" });
     });
   }
+});
+
+describe("unsupported import attribute type", () => {
+  async function runFile(dir: string, file: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", file],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("static import is rejected at parse time", async () => {
+    const dir = tempDirWithFiles("import-attributes-unknown", {
+      "data.json": `{"hello":"world"}`,
+      "index.ts": `import data from "./data.json" with { type: "kaboom" };\nconsole.log("loaded", JSON.stringify(data));\n`,
+    });
+    const { stdout, stderr, exitCode } = await runFile(dir, "index.ts");
+    expect(stdout).not.toContain("loaded");
+    expect(stderr).toContain('Import attribute "type" with value "kaboom" is not supported');
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("dynamic import rejects with ERR_IMPORT_ATTRIBUTE_UNSUPPORTED", async () => {
+    const dir = tempDirWithFiles("import-attributes-unknown", {
+      "data.json": `{"hello":"world"}`,
+      "index.ts": `try {
+  await import("./data.json", { with: { type: "kaboom" } });
+  console.log("loaded");
+} catch (err) {
+  console.log([err.constructor.name, err.code, err.message].join("|"));
+}\n`,
+    });
+    const { stdout, stderr, exitCode } = await runFile(dir, "index.ts");
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({
+      stdout: 'TypeError|ERR_IMPORT_ATTRIBUTE_UNSUPPORTED|Import attribute "type" with value "kaboom" is not supported',
+      exitCode: 0,
+    });
+  });
+
+  test("require with an unknown type option throws", async () => {
+    const dir = tempDirWithFiles("import-attributes-unknown", {
+      "data.json": `{"hello":"world"}`,
+      "index.cjs": `try {
+  require("./data.json", { type: "kaboom" });
+  console.log("loaded");
+} catch (err) {
+  console.log([err.constructor.name, err.code].join("|"));
+}\n`,
+    });
+    const { stdout, stderr, exitCode } = await runFile(dir, "index.cjs");
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({
+      stdout: "TypeError|ERR_IMPORT_ATTRIBUTE_UNSUPPORTED",
+      exitCode: 0,
+    });
+  });
+
+  test("known type values still override the loader", async () => {
+    const dir = tempDirWithFiles("import-attributes-known", {
+      "data.txt": `{"hello":"world"}`,
+      "index.ts": `import staticData from "./data.txt" with { type: "json" };
+const dynamicData = (await import("./data.txt", { with: { type: "json" } })).default;
+console.log(JSON.stringify([staticData.hello, dynamicData.hello]));\n`,
+    });
+    const { stdout, stderr, exitCode } = await runFile(dir, "index.ts");
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({
+      stdout: '["world","world"]',
+      exitCode: 0,
+    });
+  });
 });
 
 describe("?raw", () => {


### PR DESCRIPTION
### Problem

An unknown `type` import attribute is silently accepted, both statically and dynamically:

```js
import data from "./data.json" with { type: "kaboom" }; // loads fine on Bun
await import("./data.json", { with: { type: "kaboom" } }); // same
```

Node rejects both with `TypeError [ERR_IMPORT_ATTRIBUTE_UNSUPPORTED]: Import attribute "type" with value "kaboom" is not supported`, and the import-attributes proposal requires unsupported `type` values to fail the load: `type` exists to make the interpretation of a module explicit and fail-closed, so a typo (`"josn"`) must not silently fall back to extension-based loading.

### Cause

Both layers map the attribute with `Loader::from_string` and drop unknown values on the floor:

- static imports: `parse_path` in `src/js_parser/parse/mod.rs` (the else branch was literally `// unknown loader; consider erroring`), so the attribute never even reaches the module loader
- dynamic imports: `get_loader_and_virtual_source` in `src/runtime/jsc_hooks.rs` falls back to the extension-derived loader

### Fix

- `js_parser`: a `type` value that does not name a Bun loader (and is not `macro`) is a parse error, reported at the value's source range. This covers static `import`/`export ... from` in `bun run`, `bun build`, and `Bun.build`. Dynamic `import()` is intentionally not a parse error (per spec it must reject the promise at evaluation time, not fail the containing module).
- module loader (`transpile_file`): a runtime `type` attribute that does not name a loader fails the load with `TypeError` code `ERR_IMPORT_ATTRIBUTE_UNSUPPORTED`, matching Node. This covers dynamic `import()` (literal or computed options) and `require(id, { type })` as emitted by bundled output.
- `JSCommonJSExtensions.cpp`: the built-in `Module._extensions` handlers passed a pointer to an empty string as the `type` attribute where "no attribute" was meant; they now pass `nullptr` like every other caller, so the new validation does not misfire on `require.extensions` overrides that delegate to the original handler.
- `ErrorCode.ts`: adds `ERR_IMPORT_ATTRIBUTE_UNSUPPORTED` (appended at the end; the table is index-aligned with the checked-in Rust mirror).

Supported values are unchanged: every `Loader` name (`js`, `jsx`, `ts`, `tsx`, `json`, `jsonc`, `json5`, `toml`, `yaml`, `text`, `file`, `wasm`, `napi`, `base64`, `dataurl`, `sh`, `sqlite`, `html`, `md`, `css`, ...). `type: "macro"` keeps working in static imports, where the transpiler runs the macro. A `type: "macro"` that reaches the runtime loader (a non-analyzable dynamic `import()` or `require(id, { type })`) is rejected like any other non-loader value: macros cannot run there, and previously the module silently loaded as plain code with no macro semantics, which is the same fail-open bug this PR removes.

Out of scope, noted for completeness:

- unknown attribute *keys* (`with { foo: "bar" }`) are a separate report with an open PR, #28512
- a bogus `type` on a builtin specifier (`import("node:fs", { with: { type: "kaboom" } })`) is still ignored: builtins never reach loader selection, so nothing can be misinterpreted there
- `Bun.build` on a dynamic `import("./x", { with: { type: "kaboom" } })` with a literal options object still falls back to the extension loader: the bundler reads that attribute via `E::Import::import_record_loader()` in `src/ast/e.rs`, which silently returns `None` for unknown values. Pre-existing, and fixing it needs an error channel from that helper; follow-up.
- `require(id, { type: "" })` still falls through (the C++ call site maps an empty string to "no attribute"). Dynamic `import()` with `type: ""` is already rejected by JSC'''s own `retrieveTypeImportAttribute`, unchanged by this PR. Follow-up.

### Verification

`test/js/bun/import-attributes/import-attributes.test.ts` gains:

- `unknown type values are rejected` (webassembly, does_not_exist): static, dynamic, and `Bun.build` all error
- static import of `type: "kaboom"` fails to parse with the new message
- dynamic import rejects with `TypeError` + `code === "ERR_IMPORT_ATTRIBUTE_UNSUPPORTED"`
- `require(id, { type: "kaboom" })` throws the same error
- control: valid `type: "json"` on a `.txt` file still overrides the loader (static and dynamic)

The 5 new assertions fail on bun without the fix (imports silently succeed) and pass with it. The existing loader matrix, macro, transpiler, esbuild loader, and `Module._extensions` override suites (`require-extensions-override`, `22929-module-extensions-asi`, `node/module/require-extensions`) pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/import-attributes/import-attributes.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (cf20662e3)

test/js/bun/import-attributes/import-attributes.test.ts:
(pass) javascript [1679.06ms]
(pass) typescript [1422.46ms]
(pass) json [1371.49ms]
(pass) jsonc [1562.13ms]
(pass) toml [1586.02ms]
(pass) yaml [1727.56ms]
(pass) tsconfig.json is assumed jsonc [1088.45ms]
====  regular import  ====
{
  "webassembly": {
    "a": "demo"
  }
}

====  await import  ====
{
  "webassembly": {
    "a": "demo"
  }
}

====  build  ====
{
  "webassembly": {
    "default": "./no_extension-h5fnandv."
  }
}

107 |   ]);
108 |   if (!Bun.deepEquals(v1, v2) || !Bun.deepEquals(v2, v3)) {
109 |     console.log("====  regular import  ====\n" + JSON.stringify(v1, null, 2) + "\n");
110 |     console.log("====  await import  ===
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e24c1eed5)

test/js/bun/import-attributes/import-attributes.test.ts:
(pass) javascript [103.01ms]
(pass) typescript [126.11ms]
(pass) json [106.30ms]
(pass) jsonc [83.48ms]
(pass) toml [100.48ms]
(pass) yaml [98.28ms]
(pass) tsconfig.json is assumed jsonc [44.80ms]
(pass) unknown type values are rejected > webassembly [14.08ms]
(pass) unknown type values are rejected > does_not_exist [13.82ms]
(pass) unsupported import attribute type > static import is rejected at parse time [14.57ms]
(pass) unsupported import attribute type > dynamic import rejects with ERR_IMPORT_ATTRIBUTE_UNSUPPORTED [15.49ms]
(pass) unsupported import attribute type > require with an unknown type option throws [15.69ms]
(pass) unsupported import attribute type > known type values still override the loader [16.61ms]
(pass) ?raw > bun run [15.38ms]
(pass) ?raw > bun run await import [16.18ms]
(pass) ?raw > require [15.75ms]

 16 pass
 0 fail
 8 snapshots, 79 expect() calls
Ran 16 tests across 1 file. [953.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/import-attributes/import-attributes.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (cf20662e3)

test/js/bun/import-attributes/import-attributes.test.ts:
(pass) javascript [1836.78ms]
(pass) typescript [1557.46ms]
(pass) json [1556.42ms]
(pass) jsonc [1574.80ms]
(pass) toml [1911.10ms]
(pass) yaml [1944.67ms]
(pass) tsconfig.json is assumed jsonc [1190.16ms]
(pass) unknown type values are rejected > webassembly [532.54ms]
(pass) unknown type values are rejected > does_not_exist [488.09ms]
(pass) unsupported import attribute type > static import is rejected at parse time [485.71ms]
(pass) unsupported import attribute type > dynamic import rejects with ERR_IMPORT_ATTRIBUTE_UNSUPPORTED [465.24ms]
(pass) unsupported import attribute type > require with an unknown type option throws [477.00ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     cf20662e31
  features     (none)

22 deps, 106 codegen, 1168 objects in 709ms

ninja: Entering directory `/workspace/bun/build/release'
[1/75] gen ErrorCode+*.h
[2/24] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/24] gen cpp.rs (cppbind)
[4/24] gen JS modules (bundle-modules)
Preprocess modules (6784ms)
Bundle modules (89ms)
Postprocesss modules (504ms)
Bundle Functions (1051ms)
Generate Code (86ms)

[8.53s] Bundled "src/js" for production
  1913 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[4/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nigh
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/mod.rs                         | 14 +++-
 src/jsc/bindings/ErrorCode.ts                      |  1 +
 src/jsc/bindings/JSCommonJSExtensions.cpp          |  4 +-
 src/runtime/jsc_hooks.rs                           | 27 ++++++-
 .../import-attributes/import-attributes.test.ts    | 92 ++++++++++++++++++++--
 5 files changed, 126 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/js_parser/parse/mod.rs                                   3      4      0
src/jsc/bindings/ErrorCode.ts                                1      2      0
src/jsc/bindings/JSCommonJSExtensions.cpp                    1      1      0
src/runtime/jsc_hooks.rs                                     4      1      0
test/js/bun/import-attributes/import-attributes.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->
