### PR TITLE
node:net: don't emit 'end' or set readableEnded when the socket is destroyed locally

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -648,7 +648,10 @@ function SocketEmitEndNT(self, _err?) {
     }
     return;
   }
-  if (!self[kended]) {
+  // A close on an already-destroyed socket is our own teardown, not the peer
+  // finishing: Node only emits 'end' / sets readableEnded when EOF is actually
+  // read, and a destroy()ed handle never reads one - it just emits 'close'.
+  if (!self[kended] && !self.destroyed) {
     finishSocketEnd(self);
     if (!self.allowHalfOpen && self[kReaderInterest] === false) {
       setImmediate(destroyAbandonedNT, self);
@@ -1359,7 +1362,10 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       }
       return;
     }
-    if (!deferEndForOnreadTail(self)) finishSocketEnd(self);
+    // Same destroyed guard as SocketEmitEndNT: a close driven by our own
+    // destroy() is not a graceful EOF, so it must not emit 'end' or set
+    // readableEnded the way a peer FIN does.
+    if (!self.destroyed && !deferEndForOnreadTail(self)) finishSocketEnd(self);
     // A write that was waiting on the native drain can never complete once the
     // socket is gone - fail it so 'finish'/destroy are not stuck behind it
     // (mirrors SocketEmitEndNT).

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -648,9 +648,7 @@ function SocketEmitEndNT(self, _err?) {
     }
     return;
   }
-  // A close on an already-destroyed socket is our own teardown, not the peer
-  // finishing: Node only emits 'end' / sets readableEnded when EOF is actually
-  // read, and a destroy()ed handle never reads one - it just emits 'close'.
+  // A close driven by our own destroy() is not a peer EOF; Node emits only 'close' there.
   if (!self[kended] && !self.destroyed) {
     finishSocketEnd(self);
     if (!self.allowHalfOpen && self[kReaderInterest] === false) {
@@ -1362,9 +1360,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       }
       return;
     }
-    // Same destroyed guard as SocketEmitEndNT: a close driven by our own
-    // destroy() is not a graceful EOF, so it must not emit 'end' or set
-    // readableEnded the way a peer FIN does.
+    // Same destroyed guard as SocketEmitEndNT: our own destroy() is not a peer EOF.
     if (!self.destroyed && !deferEndForOnreadTail(self)) finishSocketEnd(self);
     // A write that was waiting on the native drain can never complete once the
     // socket is gone - fail it so 'finish'/destroy are not stuck behind it

--- a/test/js/node/http/node-http-client-destroy.test.ts
+++ b/test/js/node/http/node-http-client-destroy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { once } from "node:events";
+import { request } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createServer as createNetServer } from "node:net";
+
+describe("req.destroy() mid-body reports the response as aborted", () => {
+  // RFC 9112 6.3: without Content-Length or Transfer-Encoding the body is
+  // framed by connection close. Destroying the request locally must surface as
+  // 'aborted' + ECONNRESET (the download is truncated), never a clean 'end'.
+  it.each([
+    ["EOF-delimited", "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\npart1-", true],
+    ["chunked", "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n6\r\npart1-\r\n", false],
+  ] as const)("%s", async (_name, responseBytes, expectedComplete) => {
+    const server = createNetServer(s => {
+      s.on("error", () => {});
+      s.on("data", () => {
+        try {
+          s.write(responseBytes);
+        } catch {}
+      });
+    });
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+
+      const { promise, resolve, reject } = Promise.withResolvers<{ events: string[]; complete: boolean }>();
+      const req = request({ host: "127.0.0.1", port }, res => {
+        const events: string[] = [];
+        res.on("data", () => {
+          events.push("data");
+          req.destroy();
+        });
+        res.on("end", () => events.push("end"));
+        res.on("aborted", () => events.push("aborted"));
+        res.on("error", (e: NodeJS.ErrnoException) => events.push(`error:${e.code}`));
+        res.on("close", () => resolve({ events, complete: res.complete }));
+      });
+      req.on("error", reject);
+      req.end();
+
+      const { events, complete } = await promise;
+      expect({ events, complete }).toEqual({
+        events: ["data", "aborted", "error:ECONNRESET"],
+        complete: expectedComplete,
+      });
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1831,7 +1831,6 @@ describe("socket.destroy() is not a graceful EOF", () => {
   it("destroying a client socket emits 'close' but never 'end'", async () => {
     const { promise, resolve, reject } = Promise.withResolvers<void>();
     const server = createServer(c => {
-      // Hold the connection open; the peer never finishes its side.
       c.on("error", () => {});
     });
     try {
@@ -1871,7 +1870,6 @@ describe("socket.destroy() is not a graceful EOF", () => {
           reject(e);
         }
       });
-      // Destroy while the readable side is flowing, mid-connection.
       c.on("data", () => c.destroy());
     });
     let client: Socket | undefined;

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1828,7 +1828,12 @@ describe("socket.destroy() is not a graceful EOF", () => {
   // Node only emits 'end' / sets readableEnded when EOF is read from the peer.
   // A locally destroy()ed socket emits 'close' alone; reporting it as cleanly
   // ended makes a torn connection look like a complete message.
-  it("destroying a client socket emits 'close' but never 'end'", async () => {
+  const teardowns = [
+    ["destroy", (s: Socket) => s.destroy()],
+    ["resetAndDestroy", (s: Socket) => s.resetAndDestroy()],
+  ] as const;
+
+  it.each(teardowns)("client %s() emits 'close' but never 'end'", async (_name, teardown) => {
     const { promise, resolve, reject } = Promise.withResolvers<void>();
     const server = createServer(c => {
       c.on("error", () => {});
@@ -1837,7 +1842,7 @@ describe("socket.destroy() is not a graceful EOF", () => {
       await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
       const port = (server.address() as import("node:net").AddressInfo).port;
       const events: string[] = [];
-      const socket = connect(port, "127.0.0.1", () => socket.destroy());
+      const socket = connect(port, "127.0.0.1", () => teardown(socket));
       socket.on("end", () => events.push("end"));
       socket.on("error", reject);
       socket.on("close", () => {
@@ -1855,7 +1860,7 @@ describe("socket.destroy() is not a graceful EOF", () => {
     }
   });
 
-  it("destroying an accepted socket emits 'close' but never 'end'", async () => {
+  it.each(teardowns)("accepted-socket %s() emits 'close' but never 'end'", async (_name, teardown) => {
     const { promise, resolve, reject } = Promise.withResolvers<void>();
     const events: string[] = [];
     const server = createServer(c => {
@@ -1870,7 +1875,7 @@ describe("socket.destroy() is not a graceful EOF", () => {
           reject(e);
         }
       });
-      c.on("data", () => c.destroy());
+      c.on("data", () => teardown(c));
     });
     let client: Socket | undefined;
     try {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1823,3 +1823,98 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
     target.close();
   }
 });
+
+describe("socket.destroy() is not a graceful EOF", () => {
+  // Node only emits 'end' / sets readableEnded when EOF is read from the peer.
+  // A locally destroy()ed socket emits 'close' alone; reporting it as cleanly
+  // ended makes a torn connection look like a complete message.
+  it("destroying a client socket emits 'close' but never 'end'", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const server = createServer(c => {
+      // Hold the connection open; the peer never finishes its side.
+      c.on("error", () => {});
+    });
+    try {
+      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+      const port = (server.address() as import("node:net").AddressInfo).port;
+      const events: string[] = [];
+      const socket = connect(port, "127.0.0.1", () => socket.destroy());
+      socket.on("end", () => events.push("end"));
+      socket.on("error", reject);
+      socket.on("close", () => {
+        try {
+          expect(events).toEqual([]);
+          expect(socket.readableEnded).toBe(false);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+      await promise;
+    } finally {
+      server.close();
+    }
+  });
+
+  it("destroying an accepted socket emits 'close' but never 'end'", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const events: string[] = [];
+    const server = createServer(c => {
+      c.on("end", () => events.push("end"));
+      c.on("error", reject);
+      c.on("close", () => {
+        try {
+          expect(events).toEqual([]);
+          expect(c.readableEnded).toBe(false);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+      // Destroy while the readable side is flowing, mid-connection.
+      c.on("data", () => c.destroy());
+    });
+    let client: Socket | undefined;
+    try {
+      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+      const port = (server.address() as import("node:net").AddressInfo).port;
+      const socket = (client = connect(port, "127.0.0.1", () => socket.write("x")));
+      socket.on("error", () => {});
+      await promise;
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  });
+
+  it("a socket that ended first still gets 'end' when the peer closes", async () => {
+    // The peer's FIN after our own arrives as a plain close (not a native
+    // 'end'), and must still end the readable side: 'end' + readableEnded.
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const server = createServer(c => {
+      c.on("error", () => {});
+      c.resume();
+    });
+    try {
+      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+      const port = (server.address() as import("node:net").AddressInfo).port;
+      const events: string[] = [];
+      const socket = connect(port, "127.0.0.1", () => socket.end());
+      socket.on("end", () => events.push("end"));
+      socket.on("error", reject);
+      socket.on("close", () => {
+        try {
+          expect(events).toEqual(["end"]);
+          expect(socket.readableEnded).toBe(true);
+          expect(socket.destroyed).toBe(true);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+      await promise;
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
### What

`socket.destroy()` and `socket.resetAndDestroy()` emit a spurious `'end'` event and set `readableEnded = true` on the locally torn-down socket, even though the peer never finished its side. Node emits only `'close'` and keeps `readableEnded === false`.

```js
const s = net.connect(port);              // server never ends its side
s.on("end", () => log("end"));            // bun: fires on destroy()   node: never fires
s.on("close", () => log("close", s.readableEnded));
s.destroy();
// bun:  end -> close, readableEnded === true
// node:        close, readableEnded === false
```

`'end'` + `readableEnded` mean "the peer cleanly finished sending". Reporting a locally destroyed socket as cleanly ended makes a torn connection look like a complete message to anything framing its own protocol over TCP (half-close handling, "did I get the whole body?", reconnect logic).

### Why

The `close` handlers in `node:net` (`SocketEmitEndNT`, used by the client/accepted/TLS-upgrade handler tables, plus the inline copy in `SocketHandlers2.close`) synthesize an EOF (`finishSocketEnd` -> `push(null)`) on every native close. That synthesis exists for one real case: after we send FIN first, the peer's FIN is delivered by the event loop as a plain close (`us_internal_socket_close_raw` in `packages/bun-usockets/src/loop.c` skips the `end` callback for a shut-down socket), so the close handler is what has to end the readable side.

But the same path runs for a close we initiated from `_destroy()` (both `destroy()` and `resetAndDestroy()` route through it), where the native close callback fires synchronously while the stream is already destroyed. Node's `onStreamRead` never reads an EOF from a handle it just closed, so it never emits `'end'` there.

### Fix

Gate the EOF synthesis in both close handlers on the socket not being already destroyed. Genuine EOF delivery (the native `end` callback, i.e. a received FIN) is untouched, and the FIN-after-our-FIN close path still pushes EOF because the socket is not destroyed at that point. `resetAndDestroy()` is covered by the same guard because it is `destroy()` with `resetAndClosing = true` (the native `terminate()` close dispatch runs inside `_destroy` after `destroyed` is set).

A side effect of not marking a destroyed socket as "ended by the other party": `write()` after `destroy()` now fails with `ERR_STREAM_DESTROYED` like Node (asserted by the vendored `test-net-socket-destroy-send.js`), instead of `EPIPE` ("This socket has been ended by the other party").

### Verification

Tests in `test/js/node/net/node-net.test.ts` (fail on stock bun, pass with this change; all scenarios verified against node v26.3.0):

- client `destroy()` and `resetAndDestroy()` each emit `'close'` but never `'end'`, `readableEnded` stays `false`
- accepted-socket `destroy()` and `resetAndDestroy()` likewise
- a socket that `end()`ed first still gets `'end'` + `readableEnded === true` when the peer closes (the path the synthesis exists for)

Plus `test/js/node/http/node-http-client-destroy.test.ts`: `req.destroy()` mid EOF-delimited/chunked body surfaces as `'aborted'` + `ECONNRESET`, never a clean `'end'`.

All vendored `test/js/node/test/parallel/test-net-*.js` and `test-tls-*.js` that pass on main also pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->