### PR TITLE
perf(crypto): avoid redundant std::get_if call in DH keygen

### DIFF
--- a/src/jsc/bindings/node/crypto/CryptoGenDhKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenDhKeyPair.cpp
@@ -68,10 +68,8 @@ ncrypto::EVPKeyCtxPointer DhKeyPairJobCtx::setup()
         }
 
         keyParams = ncrypto::EVPKeyPointer::NewDH(WTF::move(dh));
-    } else if (std::get_if<int>(&m_prime)) {
+    } else if (int* primeLength = std::get_if<int>(&m_prime)) {
         auto paramCtx = ncrypto::EVPKeyCtxPointer::NewFromID(EVP_PKEY_DH);
-
-        int* primeLength = std::get_if<int>(&m_prime);
         if (!paramCtx.initForParamgen() || !paramCtx.setDhParameters(*primeLength, m_generator)) {
             m_opensslError = ERR_get_error();
             return {};


### PR DESCRIPTION
### What does this PR do?
This PR provides a small C++ micro-optimization for Diffie-Hellman key pair generation in `node:crypto` by removing a redundant runtime type check in `CryptoGenDhKeyPair.cpp`.

Previously, when generating DH parameters, `std::get_if<int>(&m_prime)` was called twice: once in the else if condition, and again inside the block to extract the primeLength value.

This change declares and initializes the primeLength pointer directly within the else if condition. This allows us to safely reuse the result of the `std::get_if` lookup inside the block, avoiding the overhead of querying the variant a second time.

### How did you verify your code works?
- Verified visually that the pointer initialization successfully scopes primeLength to the else if block.
- Confirmed that `paramCtx.setDhParameters` correctly dereferences the initialized *primeLength pointer without altering any of the underlying cryptographic logic.
- Ensured the C++ compiles cleanly and that existing Diffie-Hellman tests continue to pass with identical behavior.