### PR TITLE
node:net: don't flip socket.pending back to true on a live socket after a peer half-close

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -165,10 +165,6 @@ function endNT(socket, callback, err) {
 function emitCloseNT(self, hasError) {
   self.emit("close", hasError);
 }
-function detachSocket(self) {
-  if (!self) self = this;
-  self._handle = null;
-}
 function destroyNT(self, err) {
   self.destroy(err);
 }
@@ -259,8 +255,9 @@ const SocketHandlers: SocketHandler = {
     const self = socket.data;
     if (!self || self[kclosed]) return;
     self[kclosed] = true;
-    //socket cannot be used after close
-    detachSocket(self);
+    // Node keeps `_handle` attached until Socket.prototype._destroy: a live,
+    // half-closed socket must not report `pending === true`. The native handle
+    // is already detached internally, so every method on it is a safe no-op.
     SocketEmitEndNT(self, err);
     self.data = null;
   },
@@ -705,8 +702,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     {
       if (!data[kclosed]) {
         data[kclosed] = true;
-        //socket cannot be used after close
-        detachSocket(data);
+        // See SocketHandlers.close: `_handle` stays attached until _destroy.
         SocketEmitEndNT(data, err);
         data.data = null;
         socket[owner_symbol] = null;

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -774,32 +774,30 @@ it("should not hang after destroy", async () => {
   }
 }, 120_000);
 
-// `pending` is `!_handle || connecting`, and Node only detaches `_handle` in
-// Socket.prototype._destroy. The native close callback (which fires as soon as
-// the transport fully closes, i.e. before the 'end' event is delivered when our
-// writable side already finished) must not detach it early, or a live,
-// connected socket reports the pre-connection `pending === true` state.
+// Like Node, `_handle` must stay attached until _destroy. The native close
+// callback fires before 'end' is delivered here (our FIN already went out);
+// detaching there made a live socket report the pre-connection pending state.
 it("keeps `pending` false on a live socket after the peer half-closes", async () => {
   const { promise, resolve, reject } = Promise.withResolvers<{ atEnd: unknown; atClose: unknown }>();
   const server = createServer({ allowHalfOpen: true }, socket => {
-    // Finish our writable side first so the peer's FIN fully closes the
-    // transport before the 'end' event reaches JS.
+    // End our writable side first so the peer's FIN fully closes the transport.
     socket.end("hi");
     socket.on("error", reject);
     socket.resume();
+    let atEnd: { pending: boolean; destroyed: boolean } | undefined;
+    socket.once("close", () => {
+      if (!atEnd) return reject(new Error("server socket closed before 'end'"));
+      resolve({ atEnd, atClose: { pending: socket.pending, destroyed: socket.destroyed } });
+    });
     socket.on("end", () => {
-      const atEnd = { pending: socket.pending, destroyed: socket.destroyed };
-      socket.once("close", () => {
-        resolve({ atEnd, atClose: { pending: socket.pending, destroyed: socket.destroyed } });
-      });
+      atEnd = { pending: socket.pending, destroyed: socket.destroyed };
     });
   });
   try {
     await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
     const client = connect({ port: server.address().port, host: "127.0.0.1", allowHalfOpen: true });
     client.on("error", reject);
-    // Only half-close after the server's FIN arrived, so its writable side is
-    // already finished when ours shuts the transport down.
+    // Half-close only once the server's FIN arrives, i.e. its side is finished.
     client.on("end", () => client.end("bye"));
     client.resume();
     expect(await promise).toEqual({

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -774,6 +774,43 @@ it("should not hang after destroy", async () => {
   }
 }, 120_000);
 
+// `pending` is `!_handle || connecting`, and Node only detaches `_handle` in
+// Socket.prototype._destroy. The native close callback (which fires as soon as
+// the transport fully closes, i.e. before the 'end' event is delivered when our
+// writable side already finished) must not detach it early, or a live,
+// connected socket reports the pre-connection `pending === true` state.
+it("keeps `pending` false on a live socket after the peer half-closes", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<{ atEnd: unknown; atClose: unknown }>();
+  const server = createServer({ allowHalfOpen: true }, socket => {
+    // Finish our writable side first so the peer's FIN fully closes the
+    // transport before the 'end' event reaches JS.
+    socket.end("hi");
+    socket.on("error", reject);
+    socket.resume();
+    socket.on("end", () => {
+      const atEnd = { pending: socket.pending, destroyed: socket.destroyed };
+      socket.once("close", () => {
+        resolve({ atEnd, atClose: { pending: socket.pending, destroyed: socket.destroyed } });
+      });
+    });
+  });
+  try {
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+    const client = connect({ port: server.address().port, host: "127.0.0.1", allowHalfOpen: true });
+    client.on("error", reject);
+    // Only half-close after the server's FIN arrived, so its writable side is
+    // already finished when ours shuts the transport down.
+    client.on("end", () => client.end("bye"));
+    client.resume();
+    expect(await promise).toEqual({
+      atEnd: { pending: false, destroyed: false },
+      atClose: { pending: true, destroyed: true },
+    });
+  } finally {
+    server.close();
+  }
+});
+
 it("should trigger error when aborted even if connection failed #13126", async () => {
   const signal = AbortSignal.timeout(100);
   const socket = createConnection({


### PR DESCRIPTION
### What does this PR do?

After a peer half-close that fully shuts the transport down, a live, connected `net.Socket` flipped `socket.pending` back to `true`. `pending` is documented as "not yet connected", so connection-pool and keep-alive code that uses it to classify sockets would misread a live socket as never having connected. Node never does this: post-connect, `pending` only becomes `true` again after the socket is destroyed.

```js
const { createServer, connect } = require("node:net");
const server = createServer({ allowHalfOpen: true }, socket => {
  socket.end("hi"); // our writable side finishes first
  socket.resume();
  socket.on("end", () => {
    console.log(socket.pending, socket.destroyed);
    server.close();
  });
});
server.listen(0, "127.0.0.1", () => {
  const c = connect({ port: server.address().port, allowHalfOpen: true });
  c.on("end", () => c.end("bye"));
  c.resume();
});
```

```
node: false false
bun:  true  false
```

### Cause

`pending` is `!this._handle || this.connecting` (same formula as Node). The divergence is the lifetime of `_handle`: Node only clears it inside `Socket.prototype._destroy`, but Bun's server-accepted and fd-connect close handlers also cleared it from the native close callback (`detachSocket`). That callback fires as soon as the transport closes, which is before the `'end'` event is delivered when our writable side already finished (both FINs have happened, so uSockets closes the socket in the same dispatch that reports EOF). In that window the socket is still live (`destroyed === false`) but `_handle` is already `null`.

The outbound-client close handler in `net.ts` already follows Node's model and never detaches early; this brings the other two handler tables in line and removes the now unused `detachSocket` helper. `_destroy` already nulls `_handle` on every destroy path.

This is safe because the native wrapper marks itself detached before the JS close callback runs, so every method and getter on it is a guarded no-op afterwards (`_write` already handles the handle-present-but-closed case via its `readyState < 0` check).

### Verification

New test in `test/js/node/net/node-net.test.ts` fails before and passes after:

```
$ git stash push -- src/ && bun bd test test/js/node/net/node-net.test.ts -t "keeps .pending. false"
(fail) keeps `pending` false on a live socket after the peer half-closes
$ git stash pop && bun bd test test/js/node/net/node-net.test.ts -t "keeps .pending. false"
(pass) keeps `pending` false on a live socket after the peer half-closes
```

Node 26 produces the asserted values.

<details>
<summary>Regression sweep (debug ASAN build)</summary>

All failures below also reproduce on `main` without this change; none are introduced by it.

- `test/js/node/net/node-net.test.ts`: same 10 pre-existing failures as main, the new test flips fail to pass
- `test/js/node/net/{node-net-allowHalfOpen,node-net-server,handle-leak,socket-reconnect-live,double-connect,net-mongodb-pattern-leak}`: 25 pass, 0 fail
- `test/js/node/tls/{node-tls-server,node-tls-connect,node-tls-socket-allow-half-open-option,node-tls-upgrade,node-tls-duplex-close-throw-uaf}`: 55 pass, 1 pre-existing fail
- `test/js/node/http/node-http.test.ts`: 127 pass, 1 pre-existing fail (external proxy)
- vendored Node tests: `test-net-*.js` 143/143 pass, `test-tls-*.js` 151/151 pass, `test-http-*.js` 325/327 pass (both failures pre-existing)
</details>
