### PR TITLE
test: add JSC stress fixture for the DFG fast ArrayIterator entries path

### DIFF
--- a/test/js/bun/jsc-stress/fixtures/array-iterator-fast-entries-double-array-fixup-exit-ok.js
+++ b/test/js/bun/jsc-stress/fixtures/array-iterator-fast-entries-double-array-fixup-exit-ok.js
@@ -1,0 +1,31 @@
+// @bun
+//@ runDefault("--useConcurrentJIT=false", "--validateGraphAtEachPhase=true")
+// From WebKit/JSTests/stress/array-iterator-fast-entries-double-array-fixup-exit-ok.js
+// (added by WebKit/WebKit@ae69ef2312c0, "entries" ArrayIterator should emit
+// ExitOK before NewArray).
+//
+// The DFG fast path for iterating `doubleArray.entries()` emits GetByVal (which
+// clobbers exit state) followed by NewArray([index, value]) inside a single
+// bytecode origin. Without an ExitOK between them, the NewArray is exit-invalid,
+// so FixupPhase inserted the ValueRep that re-boxes the double element at the
+// last exit-OK node: one slot before the GetByVal that defines its operand. The
+// resulting use-before-def graph crashed VirtualRegisterAllocationPhase on the
+// JIT worker thread (Vector<unsigned, 64, CrashOnOverflow> abort).
+//
+// --validateGraphAtEachPhase makes a reintroduction fail deterministically right
+// after fixup; without it the crash is probabilistic at register allocation.
+
+function inner(iterator) {
+    for (const item of iterator) { }
+}
+
+function driver() {
+    // Double (copy-on-write) storage: 4294967295 does not fit in Int32.
+    const values = [268435456, 4294967295, 268435456, 268435456, 268435456];
+    const iterator = values.entries();
+    for (let i = 0; i < 100; ++i)
+        inner(iterator);
+}
+
+for (let i = 0; i < testLoopCount; ++i)
+    driver();

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -112,6 +112,7 @@ const jsFixtures = [
   "dfg-exception-try-catch-in-constructor-with-inlined-throw.js",
   "dfg-call-class-constructor.js",
   "dfg-osr-entry-should-not-use-callframe-argument.js",
+  "array-iterator-fast-entries-double-array-fixup-exit-ok.js",
   // Allocation sinking / OSR / LICM
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",


### PR DESCRIPTION
### What

Ports WebKit's regression test `JSTests/stress/array-iterator-fast-entries-double-array-fixup-exit-ok.js` (added by WebKit/WebKit@ae69ef2312c05f2d4e25f77e4bbaeaf249e2f1e4) into `test/js/bun/jsc-stress/`, and runs it with `--useConcurrentJIT=false --validateGraphAtEachPhase=true`.

### Why

Bun builds whose WebKit pin was in the range `cd821fecca0d` (#32437, Jun 16) through `f72c0151d39e` (#32184, Jun 27) could abort on the JIT worker thread while DFG-compiling any hot function containing:

```js
for (const [i, v] of someDoubleArray.entries()) { ... }
```

Native stack of the abort:

```
WTFCrashWithInfo
WTF::Vector<unsigned int, 64, CrashOnOverflow>::expandCapacity<FailureAction::Crash>
JSC::DFG::performVirtualRegisterAllocation(JSC::DFG::Graph&)
JSC::DFG::Plan::compileInThreadImpl()
```

Root cause (upstream WebKit/WebKit@3d1bebd7930d0a95df5bb4740908f6e1e4db0b29): the fast path for `ArrayIterator` with kind `entries` emits `GetByVal` (which clobbers exit state) immediately followed by `NewArray([index, value])` in the same bytecode origin, with no `ExitOK` in between, so the NewArray is exit-invalid. When the array has double storage, FixupPhase gives the GetByVal an unboxed Double result and must insert a `ValueRep` to re-box it for NewArray's edge. Fixup inserts such conversions at the most recent exit-OK node, which here is the GetByVal itself, so the ValueRep lands one slot above the node that defines its operand. The use-before-def graph then crashes virtual register allocation: the child's VirtualRegister is still the invalid sentinel, and `toLocal()` of it indexes the ScoreBoard's `Vector<uint32_t, 64>` at about 3.2e9, which trips `CrashOnOverflow`.

Upstream fixed this in WebKit/WebKit@ae69ef2312c05f2d4e25f77e4bbaeaf249e2f1e4 ("entries" ArrayIterator should emit ExitOK before NewArray, [webkit.org/b/317327](https://bugs.webkit.org/show_bug.cgi?id=317327)). That commit is in bun's current WebKit pin (`d81bcc3d833c`, picked up by #33133), so bun main is not affected today, and no tagged release was ever affected (1.3.14 predates the regression). Only canary/main builds between Jun 16 and Jun 29 were.

This fixture keeps the shape covered by bun's own CI so a future WebKit upgrade that drops or reintroduces the bug fails deterministically (graph validation aborts right after fixup) instead of as a probabilistic SIGABRT on a concurrent compiler thread.

### Verification

- `bun bd test test/js/bun/jsc-stress/jsc-stress.test.ts -t array-iterator-fast-entries` passes (debug build).
- Same with `USE_SYSTEM_BUN=1` (release).
- The fixture reaches the intended shape: with `reportDFGCompileTimes=1`, `inner` is DFG-compiled, and the post-fixup graph shows the boxing conversion being required and correctly placed after its operand.

<details>
<summary>post-fixup DFG excerpt (block 5 of inner)</summary>

```
10: D@81  GetByVal(Check:KnownCell:D@80, Check:Int32:D@76, Check:KnownStorage:D@185, Double|MustGen|VarArgs, Double+OriginalCopyOnWriteArray+InBounds+AsIs+Read, bc#40, ExitValid)
11: D@82  ExitOK(MustGen, W:SideState, bc#40, ExitValid)
12: D@183 ValueRep(Check:DoubleRep:D@81<Double>, JS|PureInt, BytecodeDouble, bc#40, ExitValid)
13: D@83  NewArray(Check:Untyped:D@76, Check:Untyped:D@183, Array, vectorLengthHint = 2, ArrayWithContiguous, bc#40, ExitValid)
```

Without the upstream fix the `ExitOK` at index 11 does not exist and the `ValueRep` is inserted at the GetByVal's own index, above its operand, which `--validateGraphAtEachPhase` rejects with `validation failed: block->isInPhis(child) || seenNodes.contains(child)`.

</details>
