### PR TITLE
shell: brace-expand every word an IFS split completes

### DIFF
--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -588,10 +588,9 @@ impl Expansion {
         if s.is_empty() {
             return;
         }
-        // Each field completed here is a finished word the end-of-walk brace
-        // expansion never sees (only the final field stays in `current_out`),
-        // so it has to be brace-expanded as it is flushed. Otherwise the word's
-        // recorded metacharacter offsets are discarded along with it.
+        // Each flushed field is a finished word the end-of-walk brace expansion
+        // never sees (only the final field stays in `current_out`), so it must
+        // be brace-expanded here or its `meta_offsets` are discarded with it.
         let has_brace = me.node.get().has_brace_expansion();
         // Split on runs of spaces — each run is a word boundary.
         let mut prev_ws = false;

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -317,25 +317,40 @@ impl Expansion {
             me.state = ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
             return;
         }
-        let count = count as usize;
-        let mut expanded: Vec<Vec<u8>> = (0..count).map(|_| Vec::new()).collect();
+        // `brace_expansion_hint` is a static AST property, but the assembled
+        // word can lose its only complete `{...}` group by the time it gets
+        // here: an unquoted `$(...)` whose output IFS-splits calls
+        // `push_current_out` mid-word, flushing the brace prefix out of
+        // `current_out` (and clearing `meta_offsets`). `{a,b}$(echo x y)`
+        // reaches this point with `current_out == "y"`. `expand` writes into
+        // `out[0]` unconditionally, so a zero-count word must short-circuit
+        // to its single, literal result (the same `count == 0` contract
+        // `braces()` in `BunObject.rs` applies).
+        let expanded: Vec<Vec<u8>> = if count == 0 {
+            vec![me.current_out.clone()]
+        } else {
+            let count = count as usize;
+            let mut expanded: Vec<Vec<u8>> = (0..count).map(|_| Vec::new()).collect();
 
-        let arena = bun_alloc::Arena::new();
-        if let Err(e) = braces::expand(
-            &arena,
-            &mut lexer_output.tokens[..],
-            &mut expanded[..],
-            lexer_output.contains_nested,
-        ) {
-            if matches!(e, braces::ParserError::TooManyBraces) {
-                let msg = "too many braces in brace expansion".to_string();
-                me.state = ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
-                return;
+            let arena = bun_alloc::Arena::new();
+            if let Err(e) = braces::expand(
+                &arena,
+                &mut lexer_output.tokens[..],
+                &mut expanded[..],
+                lexer_output.contains_nested,
+            ) {
+                if matches!(e, braces::ParserError::TooManyBraces) {
+                    let msg = "too many braces in brace expansion".to_string();
+                    me.state =
+                        ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
+                    return;
+                }
+                // An unexpected token from brace expansion is a parser bug.
+                panic!("unexpected error from Braces.expand: {e:?}");
             }
-            // An unexpected token from brace expansion is a parser bug.
-            panic!("unexpected error from Braces.expand: {e:?}");
-        }
-        drop(arena);
+            drop(arena);
+            expanded
+        };
 
         // Push each variant as its own word; word boundaries are recorded
         // via `bounds`.

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -317,15 +317,14 @@ impl Expansion {
             me.state = ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
             return;
         }
-        // `brace_expansion_hint` is a static AST property, but the assembled
-        // word can lose its only complete `{...}` group by the time it gets
-        // here: an unquoted `$(...)` whose output IFS-splits calls
-        // `push_current_out` mid-word, flushing the brace prefix out of
-        // `current_out` (and clearing `meta_offsets`). `{a,b}$(echo x y)`
-        // reaches this point with `current_out == "y"`. `expand` writes into
-        // `out[0]` unconditionally, so a zero-count word must short-circuit
-        // to its single, literal result (the same `count == 0` contract
-        // `braces()` in `BunObject.rs` applies).
+        // `brace_expansion_hint` is a static AST property, but an unquoted
+        // `$(...)` whose output IFS-splits flushes the brace prefix out of
+        // `current_out` mid-word, so `{a,b}$(echo x y)` arrives here as just
+        // `y`, with no complete group. `expand` writes `out[0]`
+        // unconditionally; emit the group-less word as its single result
+        // instead, as `braces()` in `BunObject.rs` does. It must be the raw
+        // `current_out` and not `escaped`: the brace lexer consumes backslash
+        // escapes, and nothing downstream puts them back.
         let expanded: Vec<Vec<u8>> = if count == 0 {
             vec![me.current_out.clone()]
         } else {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -317,14 +317,9 @@ impl Expansion {
             me.state = ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
             return;
         }
-        // `brace_expansion_hint` is a static AST property, but an unquoted
-        // `$(...)` whose output IFS-splits flushes the brace prefix out of
-        // `current_out` mid-word, so `{a,b}$(echo x y)` arrives here as just
-        // `y`, with no complete group. `expand` writes `out[0]`
-        // unconditionally; emit the group-less word as its single result
-        // instead, as `braces()` in `BunObject.rs` does. It must be the raw
-        // `current_out` and not `escaped`: the brace lexer consumes backslash
-        // escapes, and nothing downstream puts them back.
+        // An IFS-split `$(...)` can leave zero brace groups here despite
+        // `atom.has_brace_expansion()`, and `expand` indexes `out[0]`. Emit the
+        // word raw, not `escaped`: the brace lexer consumes backslash escapes.
         let expanded: Vec<Vec<u8>> = if count == 0 {
             vec![me.current_out.clone()]
         } else {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -282,6 +282,29 @@ impl Expansion {
     /// fully-expanded word with `{`/`,`/`}` markers preserved by
     /// `expand_simple_no_io`) and push each variant as a separate argv word.
     fn do_brace_expand(me: &mut Expansion) {
+        if !Self::brace_expand_current_out(me) {
+            return;
+        }
+
+        let node = me.node;
+        let atom = node.get();
+        if atom.has_glob_expansion() {
+            // brace + glob composes. Keep
+            // `current_out` (the original pattern, e.g. `src/*.{ts,tsx}`) so
+            // the glob walker brace-expands and globs it; its matches are
+            // appended after the literal brace variants already pushed above.
+            me.state = ExpansionState::Glob;
+        } else {
+            me.current_out.clear();
+            me.state = ExpansionState::Done;
+        }
+    }
+
+    /// Brace-expand `current_out`, pushing each variant into `out` as its own
+    /// argv word. `current_out` and `meta_offsets` are left for the caller to
+    /// reset, since the brace + glob path re-reads them. Returns `false` after
+    /// setting [`ExpansionState::Err`] when the word cannot be expanded.
+    fn brace_expand_current_out(me: &mut Expansion) -> bool {
         use bun_shell_parser::braces;
         // Only the `{`/`,`/`}` bytes recorded in `meta_offsets` (written
         // by literal BraceBegin/Comma/BraceEnd atoms) are brace-expansion
@@ -315,11 +338,11 @@ impl Expansion {
         if count > MAX_BRACE_EXPANSIONS {
             let msg = format!("too many brace expansions ({count} > {MAX_BRACE_EXPANSIONS})");
             me.state = ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
-            return;
+            return false;
         }
-        // An IFS-split `$(...)` can leave zero brace groups here despite
-        // `atom.has_brace_expansion()`, and `expand` indexes `out[0]`. Emit the
-        // word raw, not `escaped`: the brace lexer consumes backslash escapes.
+        // A field split can leave zero brace groups in this word (the group may
+        // sit across the split), and `expand` indexes `out[0]`. Emit the word
+        // raw, not `escaped`: the brace lexer consumes backslash escapes.
         let expanded: Vec<Vec<u8>> = if count == 0 {
             vec![me.current_out.clone()]
         } else {
@@ -337,7 +360,7 @@ impl Expansion {
                     let msg = "too many braces in brace expansion".to_string();
                     me.state =
                         ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
-                    return;
+                    return false;
                 }
                 // An unexpected token from brace expansion is a parser bug.
                 panic!("unexpected error from Braces.expand: {e:?}");
@@ -354,19 +377,7 @@ impl Expansion {
             }
             me.out.buf.extend_from_slice(&s);
         }
-
-        let node = me.node;
-        let atom = node.get();
-        if atom.has_glob_expansion() {
-            // brace + glob composes. Keep
-            // `current_out` (the original pattern, e.g. `src/*.{ts,tsx}`) so
-            // the glob walker brace-expands and globs it; its matches are
-            // appended after the literal brace variants already pushed above.
-            me.state = ExpansionState::Glob;
-        } else {
-            me.current_out.clear();
-            me.state = ExpansionState::Done;
-        }
+        true
     }
 
     /// Build the pattern handed to the glob walker from `current_out`,
@@ -577,6 +588,11 @@ impl Expansion {
         if s.is_empty() {
             return;
         }
+        // Each field completed here is a finished word the end-of-walk brace
+        // expansion never sees (only the final field stays in `current_out`),
+        // so it has to be brace-expanded as it is flushed. Otherwise the word's
+        // recorded metacharacter offsets are discarded along with it.
+        let has_brace = me.node.get().has_brace_expansion();
         // Split on runs of spaces — each run is a word boundary.
         let mut prev_ws = false;
         let mut a = 0usize;
@@ -591,7 +607,15 @@ impl Expansion {
             if c == b' ' {
                 prev_ws = true;
                 me.current_out.extend_from_slice(&s[a..i]);
-                Self::push_current_out(me);
+                if has_brace {
+                    if !Self::brace_expand_current_out(me) {
+                        return;
+                    }
+                    me.current_out.clear();
+                    me.meta_offsets.clear();
+                } else {
+                    Self::push_current_out(me);
+                }
             }
         }
         me.current_out.extend_from_slice(&s[a..]);
@@ -640,7 +664,11 @@ impl Expansion {
                 Self::post_subshell_expansion(me, stdout);
             }
             me.word_idx += 1;
-            me.state = ExpansionState::Walking;
+            // Brace expansion of a word completed by the field split can fail;
+            // keep that error rather than resuming the walk.
+            if !matches!(me.state, ExpansionState::Err(_)) {
+                me.state = ExpansionState::Walking;
+            }
             me.child_script = None;
         }
         interp.deinit_node(child);

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -128,12 +128,15 @@ describe("brace + glob composition", () => {
   });
 });
 
-// An unquoted `$(...)` whose output contains whitespace is IFS-split, which
-// flushes the already-assembled prefix of the word out of `current_out` mid
-// assembly. When that flush took the word's only complete `{...}` group with
-// it, `do_brace_expand` tokenized the leftover fragment to zero brace groups
-// and `braces::expand` indexed an empty output slice:
+// An unquoted `$(...)` whose output contains whitespace is IFS-split. Each
+// field the split completes is flushed out of `current_out` mid assembly, and
+// only the final field was ever brace-expanded, so a flushed field silently
+// lost the `{...}` group it carried. When the word's *only* group went with it,
+// `do_brace_expand` tokenized the remainder to zero groups and `braces::expand`
+// indexed an empty output slice:
 //   panic: index out of bounds: the len is 0 but the index is 0
+// Every field is now brace-expanded as it is flushed, so the word expands the
+// same way whichever side of the split its group lands on.
 describe.concurrent("brace expansion after an IFS-split command substitution", () => {
   async function run(script: string) {
     await using proc = Bun.spawn({
@@ -146,18 +149,17 @@ describe.concurrent("brace expansion after an IFS-split command substitution", (
     return { stdout, stderr, exitCode };
   }
 
-  // Each of these panicked. Run in a subprocess so an unfixed build aborts
-  // the child, not the test runner. The surviving fragment has no complete
-  // brace group, so the word is emitted literally (the same `count == 0`
-  // contract `$.braces()` already applies to a group-less input).
-  test("group entirely in the flushed prefix", async () => {
+  // Run in a subprocess so an unfixed build aborts the child, not the runner.
+  test("group entirely in the flushed field", async () => {
     expect(await run("echo {a,b}$(echo x y)")).toEqual({
-      stdout: "{a,b}x y\n",
+      stdout: "ax bx y\n",
       stderr: "",
       exitCode: 0,
     });
   });
 
+  // The group straddles the split, so neither field holds a complete one and
+  // both are emitted literally.
   test("split lands inside the group, before the comma", async () => {
     expect(await run("echo {$(echo a b),c}")).toEqual({
       stdout: "{a b,c}\n",
@@ -174,7 +176,7 @@ describe.concurrent("brace expansion after an IFS-split command substitution", (
     });
   });
 
-  // A group that survives the split still expands.
+  // Already worked: the group rides on the final field.
   test("group entirely after the split still expands", async () => {
     expect(await run("echo $(echo x y){a,b}")).toEqual({
       stdout: "x ya yb\n",
@@ -182,6 +184,46 @@ describe.concurrent("brace expansion after an IFS-split command substitution", (
       exitCode: 0,
     });
   });
+
+  // Same root cause, without the panic: the flushed field used to leak its
+  // braces into argv literally (`{a,b}x yc yd`).
+  test("a group on each side of the split", async () => {
+    expect(await run("echo {a,b}$(echo x y){c,d}")).toEqual({
+      stdout: "ax bx yc yd\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Each variant is its own argv word, not one word containing a space.
+  test("the expanded fields are separate argv words", async () => {
+    expect(await run(`printf "[%s]" {a,b}$(echo x y); echo`)).toEqual({
+      stdout: "[ax][bx][y]\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // A quoted substitution is not field-split, so the whole word stays intact.
+  test("a quoted substitution is not split", async () => {
+    expect(await run(`echo {a,b}"$(echo x y)"`)).toEqual({
+      stdout: "ax y bx y\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
+// `braces::expand` round-trips its input through the brace lexer, which
+// consumes backslash escapes. `calculate_expanded_amount` returning 0 is what
+// lets `$.braces()` hand back the raw word instead, so a word with no brace
+// group must never be routed through `expand`.
+test("$.braces preserves escapes in a word with no brace group", () => {
+  expect(Bun.$.braces("a\\{b")).toEqual(["a\\{b"]);
+  expect(Bun.$.braces("a\\,b")).toEqual(["a\\,b"]);
+  // With a group present the lexer does consume them, which is why the
+  // group-less word cannot take the same path.
+  expect(Bun.$.braces("a\\{b{c,d}")).toEqual(["a{bc", "a{bd"]);
 });
 
 // $.braces() recursed once per `{` group (parse_atom <-> parse_expansion /

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -128,6 +128,66 @@ describe("brace + glob composition", () => {
   });
 });
 
+// An unquoted `$(...)` whose output contains whitespace is IFS-split, which
+// flushes the already-assembled prefix of the word out of `current_out` mid
+// assembly. When that flush took the word's only complete `{...}` group with
+// it, `do_brace_expand` tokenized the leftover fragment to zero brace groups
+// and `braces::expand` indexed an empty output slice:
+//   panic: index out of bounds: the len is 0 but the index is 0
+describe.concurrent("brace expansion after an IFS-split command substitution", () => {
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "exec", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // Each of these panicked. Run in a subprocess so an unfixed build aborts
+  // the child, not the test runner. The surviving fragment has no complete
+  // brace group, so the word is emitted literally (the same `count == 0`
+  // contract `$.braces()` already applies to a group-less input).
+  test("group entirely in the flushed prefix", async () => {
+    expect(await run("echo {a,b}$(echo x y)")).toEqual({
+      stdout: "{a,b}x y\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("split lands inside the group, before the comma", async () => {
+    expect(await run("echo {$(echo a b),c}")).toEqual({
+      stdout: "{a b,c}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("split lands inside the group, after the comma", async () => {
+    expect(await run("echo {a,$(echo x y)}")).toEqual({
+      stdout: "{a,x y}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // A group that survives the split still expands.
+  test("group entirely after the split still expands", async () => {
+    expect(await run("echo $(echo x y){a,b}")).toEqual({
+      stdout: "x ya yb\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 // $.braces() recursed once per `{` group (parse_atom <-> parse_expansion /
 // expand_nested), so a word made of tens of thousands of nested braces drove
 // the parser that many native stack frames deep. The parser now rejects words

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -142,11 +142,7 @@ describe.concurrent("brace expansion after an IFS-split command substitution", (
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stdout, stderr, exitCode };
   }
 


### PR DESCRIPTION
### Repro

```sh
bun exec 'echo {a,b}$(echo x y)'
```

```
panic: index out of bounds: the len is 0 but the index is 0
bun_shell_parser::braces::expand_flat
    src/shell_parser/braces.rs:869
bun_shell_parser::braces::expand
    src/shell_parser/braces.rs:685
<bun_runtime::shell::states::expansion::Expansion>::do_brace_expand
    src/runtime/shell/states/Expansion.rs:324
```

`echo {$(echo a b),c}` and `echo {a,$(echo x y)}` abort the same way, as does the equivalent through `Bun.$`.

### Cause

A word mixing a brace group with an unquoted `$(...)` is assembled left to right into `current_out`, with the byte offsets of its literal `{` `,` `}` atoms recorded in `meta_offsets`. When the substitution's output is field-split, `post_subshell_expansion` flushes each completed field out of `current_out` and clears `meta_offsets` along with it. Only the *final* field is ever brace-expanded, at the end of the walk.

So a flushed field silently loses the group it was carrying. That is already visible on main without any crash:

```sh
$ bun exec 'echo {a,b}$(echo x y){c,d}'
{a,b}x yc yd          # the flushed field leaked its braces into argv
```

And when the word's only group rides on a flushed field, there is nothing left to expand: `do_brace_expand` tokenizes the remainder to zero groups, `calculate_expanded_amount` returns 0, and `braces::expand` indexes an empty output slice. That is the panic.

### Fix

Brace-expand each field as it is flushed, so a word expands the same way whichever side of the split its group lands on:

```sh
echo {a,b}$(echo x y)       ->  ax bx y
echo {a,b}$(echo x y){c,d}  ->  ax bx yc yd
```

This matches the half of the pattern that already worked on main, `echo $(echo x y){a,b}` -> `x ya yb`, i.e. substitute, field-split, then brace-expand each resulting word. `{a,b}$(echo x y)` is three argv words (`[ax][bx][y]`), not two.

A group that straddles the split leaves neither field with a complete one, so both are emitted literally and `echo {$(echo a b),c}` prints `{a b,c}`. That is why the zero-count case still has to be handled per field rather than assumed away: `braces::expand` round-trips its input through the brace lexer, and the lexer consumes backslash escapes. The group-less word is handed back raw instead of being routed through `expand`, which is the same reason `braces()` in `src/runtime/api/BunObject.rs` keeps its own `count == 0` guard:

```js
Bun.$.braces("a\\{b");      // ["a\\{b"]   -- no group, returned raw
Bun.$.braces("a\\{b{c,d}"); // ["a{bc", "a{bd"]  -- went through expand, escape consumed
```

Folding that guard away (having `calculate_expanded_amount` return at least 1 and deleting the `BunObject.rs` case as dead) would silently turn the first line into `["a{b"]`. There is now a test pinning it.

Bun still does not match bash here, and cannot without reordering the expansion phases: bash brace-expands *before* substituting, so each variant gets its own copy of the substitution (`[ax][y][bx][y]`, four words). That ordering difference predates this PR and is unchanged by it.

### Verification

New tests in `test/js/bun/shell/brace.test.ts` cover each position the group can take relative to the split (entirely in the flushed field, straddling it on either side of the comma, entirely in the final field, one group on each side), assert the argv word boundaries rather than just `echo` output, and pin the `$.braces` escape behavior above. The crashing inputs run in a subprocess so an unfixed build aborts the child rather than the test runner.

Against `main`: 5 fail, 19 pass. With the fix: 24 pass. The rest of `test/js/bun/shell/` (951 tests) shows no new failures.
