### PR TITLE
event loop: count ticks that re-enter a mid-batch poll dispatch

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -355,12 +355,14 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
 
     loop->data.tick_depth++;
 
+#ifdef BUN_DEBUG
     /* A tick starting while an outer ready-poll dispatch is still mid-batch
      * means a poll callback synchronously waited on the event loop. Unlike
      * tick_depth (any re-entry), this counts only mid-dispatch re-entry. */
     if (loop->current_ready_poll < loop->num_ready_polls) {
         loop->data.nested_dispatch_ticks++;
     }
+#endif
 
     struct us_internal_callback_t *timer_callback = (struct us_internal_callback_t*)loop->data.sweep_timer;
 

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -355,6 +355,13 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
 
     loop->data.tick_depth++;
 
+    /* A tick starting while an outer ready-poll dispatch is still mid-batch
+     * means a poll callback synchronously waited on the event loop. Unlike
+     * tick_depth (any re-entry), this counts only mid-dispatch re-entry. */
+    if (loop->current_ready_poll < loop->num_ready_polls) {
+        loop->data.nested_dispatch_ticks++;
+    }
+
     struct us_internal_callback_t *timer_callback = (struct us_internal_callback_t*)loop->data.sweep_timer;
 
     // Only integrate the loop if we haven't already.

--- a/packages/bun-usockets/src/internal/loop_data.h
+++ b/packages/bun-usockets/src/internal/loop_data.h
@@ -82,7 +82,8 @@ struct us_internal_loop_data_t {
     int tick_depth;
     /* Ticks that began while an outer ready-poll dispatch was still mid-batch,
      * i.e. a poll callback synchronously waited on the event loop. Only
-     * incremented under BUN_DEBUG; always 0 in release (oven-sh/bun#33261). */
+     * incremented under BUN_DEBUG; always 0 in release (oven-sh/bun#33261).
+     * Fills what was already this struct's tail padding, so it costs no space. */
     int nested_dispatch_ticks;
 };
 

--- a/packages/bun-usockets/src/internal/loop_data.h
+++ b/packages/bun-usockets/src/internal/loop_data.h
@@ -80,10 +80,12 @@ struct us_internal_loop_data_t {
      * sockets must be deferred to the outermost tick so the outer dispatch
      * doesn't read a freed poll. */
     int tick_depth;
+#ifdef BUN_DEBUG
     /* Ticks that began while an outer ready-poll dispatch was still mid-batch,
-     * i.e. a poll callback synchronously waited on the event loop. Read by
-     * bun:internal-for-testing's getEventLoopStats (oven-sh/bun#33261). */
+     * i.e. a poll callback synchronously waited on the event loop. Debug builds
+     * only; getEventLoopStats() reads it (oven-sh/bun#33261). */
     int nested_dispatch_ticks;
+#endif
 };
 
 #endif // LOOP_DATA_H

--- a/packages/bun-usockets/src/internal/loop_data.h
+++ b/packages/bun-usockets/src/internal/loop_data.h
@@ -80,12 +80,10 @@ struct us_internal_loop_data_t {
      * sockets must be deferred to the outermost tick so the outer dispatch
      * doesn't read a freed poll. */
     int tick_depth;
-#ifdef BUN_DEBUG
     /* Ticks that began while an outer ready-poll dispatch was still mid-batch,
-     * i.e. a poll callback synchronously waited on the event loop. Debug builds
-     * only; getEventLoopStats() reads it (oven-sh/bun#33261). */
+     * i.e. a poll callback synchronously waited on the event loop. Only
+     * incremented under BUN_DEBUG; always 0 in release (oven-sh/bun#33261). */
     int nested_dispatch_ticks;
-#endif
 };
 
 #endif // LOOP_DATA_H

--- a/packages/bun-usockets/src/internal/loop_data.h
+++ b/packages/bun-usockets/src/internal/loop_data.h
@@ -80,6 +80,10 @@ struct us_internal_loop_data_t {
      * sockets must be deferred to the outermost tick so the outer dispatch
      * doesn't read a freed poll. */
     int tick_depth;
+    /* Ticks that began while an outer ready-poll dispatch was still mid-batch,
+     * i.e. a poll callback synchronously waited on the event loop. Read by
+     * bun:internal-for-testing's getEventLoopStats (oven-sh/bun#33261). */
+    int nested_dispatch_ticks;
 };
 
 #endif // LOOP_DATA_H

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -41,6 +41,7 @@
 
 #if ASSERT_ENABLED
 extern const size_t Bun__lock__size;
+extern const size_t Bun__internal_loop_data__size;
 #endif
 
 extern void Bun__internal_ensureDateHeaderTimerIsEnabled(struct us_loop_t *loop);
@@ -80,6 +81,11 @@ void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct
 #if ASSERT_ENABLED
     if (Bun__lock__size != sizeof(loop->data.mutex)) {
         BUN_PANIC("The size of the mutex must match the size of the lock");
+    }
+    /* The Rust mirror (src/uws_sys/InternalLoopData.rs) must match this struct
+     * exactly, including build-type-conditional fields (BUN_DEBUG/bun_debug). */
+    if (Bun__internal_loop_data__size != sizeof(loop->data)) {
+        BUN_PANIC("us_internal_loop_data_t layout differs between C and Rust");
     }
 #endif
 }

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -82,8 +82,8 @@ void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct
     if (Bun__lock__size != sizeof(loop->data.mutex)) {
         BUN_PANIC("The size of the mutex must match the size of the lock");
     }
-    /* The Rust mirror (src/uws_sys/InternalLoopData.rs) must match this struct
-     * exactly, including build-type-conditional fields (BUN_DEBUG/bun_debug). */
+    /* The Rust mirror (src/uws_sys/InternalLoopData.rs) must stay
+     * layout-identical to this struct (size-only check). */
     if (Bun__internal_loop_data__size != sizeof(loop->data)) {
         BUN_PANIC("us_internal_loop_data_t layout differs between C and Rust");
     }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -364,7 +364,8 @@ export const getEventLoopStats: () => {
   concurrentRef: number;
   numPolls: number;
   /** Ticks entered while an outer poll dispatch was still mid-batch, i.e. a
-   * callback synchronously waited on the event loop. POSIX only (0 on Windows). */
+   * callback synchronously waited on the event loop. Debug builds only, POSIX
+   * only; always 0 in release builds and on Windows. */
   nestedDispatchTicks: number;
 } = $newRustFunction("event_loop.rs", "getActiveTasks", 0);
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -359,8 +359,14 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
   0,
 );
 
-export const getEventLoopStats: () => { activeTasks: number; concurrentRef: number; numPolls: number } =
-  $newRustFunction("event_loop.rs", "getActiveTasks", 0);
+export const getEventLoopStats: () => {
+  activeTasks: number;
+  concurrentRef: number;
+  numPolls: number;
+  /** Ticks entered while an outer poll dispatch was still mid-batch, i.e. a
+   * callback synchronously waited on the event loop. POSIX only (0 on Windows). */
+  nestedDispatchTicks: number;
+} = $newRustFunction("event_loop.rs", "getActiveTasks", 0);
 
 export const hostedGitInfo = {
   parseUrl: $newRustFunction("hosted_git_info.rs", "TestingAPIs.jsParseUrl", 1),

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1174,14 +1174,10 @@ pub fn get_active_tasks(global_object: &JSGlobalObject, _frame: &CallFrame) -> J
         b"numPolls",
         JSValue::js_number(num_polls as f64),
     );
-    // The field only exists in debug builds (BUN_DEBUG / `bun_debug`), and
-    // only the POSIX tick increments it; report 0 everywhere else.
-    #[cfg(bun_debug)]
+    // Only the debug-build POSIX tick increments this; 0 everywhere else.
     // SAFETY: uws::Loop::get() returns a live process-global loop.
     let nested_dispatch_ticks =
         unsafe { (*uws::Loop::get()).internal_loop_data.nested_dispatch_ticks };
-    #[cfg(not(bun_debug))]
-    let nested_dispatch_ticks = 0;
     result.put(
         global_object,
         b"nestedDispatchTicks",

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1174,10 +1174,14 @@ pub fn get_active_tasks(global_object: &JSGlobalObject, _frame: &CallFrame) -> J
         b"numPolls",
         JSValue::js_number(num_polls as f64),
     );
-    // Only the POSIX tick increments this; on Windows it stays 0.
+    // The field only exists in debug builds (BUN_DEBUG / `bun_debug`), and
+    // only the POSIX tick increments it; report 0 everywhere else.
+    #[cfg(bun_debug)]
     // SAFETY: uws::Loop::get() returns a live process-global loop.
     let nested_dispatch_ticks =
         unsafe { (*uws::Loop::get()).internal_loop_data.nested_dispatch_ticks };
+    #[cfg(not(bun_debug))]
+    let nested_dispatch_ticks = 0;
     result.put(
         global_object,
         b"nestedDispatchTicks",

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1150,7 +1150,7 @@ pub fn get_active_tasks(global_object: &JSGlobalObject, _frame: &CallFrame) -> J
     // fields and call &-methods on it for the duration of this host fn.
     let vm_ref = global_object.bun_vm();
     let event_loop = vm_ref.event_loop_shared();
-    let result = JSValue::create_empty_object(global_object, 3);
+    let result = JSValue::create_empty_object(global_object, 4);
     result.put(
         global_object,
         b"activeTasks",
@@ -1173,6 +1173,15 @@ pub fn get_active_tasks(global_object: &JSGlobalObject, _frame: &CallFrame) -> J
         global_object,
         b"numPolls",
         JSValue::js_number(num_polls as f64),
+    );
+    // Only the POSIX tick increments this; on Windows it stays 0.
+    // SAFETY: uws::Loop::get() returns a live process-global loop.
+    let nested_dispatch_ticks =
+        unsafe { (*uws::Loop::get()).internal_loop_data.nested_dispatch_ticks };
+    result.put(
+        global_object,
+        b"nestedDispatchTicks",
+        JSValue::js_number(nested_dispatch_ticks as f64),
     );
     Ok(result)
 }

--- a/src/uws_sys/InternalLoopData.rs
+++ b/src/uws_sys/InternalLoopData.rs
@@ -55,6 +55,8 @@ pub struct InternalLoopData {
     // Higher tier (`bun_runtime`) casts this back when reading.
     pub jsc_vm: *const c_void,
     pub tick_depth: c_int,
+    /// See `nested_dispatch_ticks` in `loop_data.h` (oven-sh/bun#33261).
+    pub nested_dispatch_ticks: c_int,
 }
 
 impl InternalLoopData {

--- a/src/uws_sys/InternalLoopData.rs
+++ b/src/uws_sys/InternalLoopData.rs
@@ -66,8 +66,7 @@ pub struct InternalLoopData {
 /// `us_internal_loop_data_init` (loop.c) so a C/Rust layout skew (e.g. a
 /// mismatched `BUN_DEBUG`/`bun_debug` pairing) panics at startup.
 #[unsafe(no_mangle)]
-pub(crate) static Bun__internal_loop_data__size: usize =
-    core::mem::size_of::<InternalLoopData>();
+pub(crate) static Bun__internal_loop_data__size: usize = core::mem::size_of::<InternalLoopData>();
 
 impl InternalLoopData {
     const LIBUS_RECV_BUFFER_LENGTH: usize = 524288;

--- a/src/uws_sys/InternalLoopData.rs
+++ b/src/uws_sys/InternalLoopData.rs
@@ -56,15 +56,13 @@ pub struct InternalLoopData {
     pub jsc_vm: *const c_void,
     pub tick_depth: c_int,
     /// See `nested_dispatch_ticks` in `loop_data.h` (oven-sh/bun#33261).
-    /// `cfg(bun_debug)` and C's `BUN_DEBUG` are both set by the Debug build
-    /// type; `Bun__internal_loop_data__size` below asserts they never skew.
-    #[cfg(bun_debug)]
+    /// Only the debug (`BUN_DEBUG`) POSIX tick increments it.
     pub nested_dispatch_ticks: c_int,
 }
 
 /// Checked against `sizeof(struct us_internal_loop_data_t)` in
-/// `us_internal_loop_data_init` (loop.c) so a C/Rust layout skew (e.g. a
-/// mismatched `BUN_DEBUG`/`bun_debug` pairing) panics at startup.
+/// `us_internal_loop_data_init` (loop.c) so C/Rust drift in this mirror panics
+/// at startup. Size-only: it cannot see drift that hides in padding.
 #[unsafe(no_mangle)]
 pub(crate) static Bun__internal_loop_data__size: usize = core::mem::size_of::<InternalLoopData>();
 

--- a/src/uws_sys/InternalLoopData.rs
+++ b/src/uws_sys/InternalLoopData.rs
@@ -56,8 +56,18 @@ pub struct InternalLoopData {
     pub jsc_vm: *const c_void,
     pub tick_depth: c_int,
     /// See `nested_dispatch_ticks` in `loop_data.h` (oven-sh/bun#33261).
+    /// `cfg(bun_debug)` and C's `BUN_DEBUG` are both set by the Debug build
+    /// type; `Bun__internal_loop_data__size` below asserts they never skew.
+    #[cfg(bun_debug)]
     pub nested_dispatch_ticks: c_int,
 }
+
+/// Checked against `sizeof(struct us_internal_loop_data_t)` in
+/// `us_internal_loop_data_init` (loop.c) so a C/Rust layout skew (e.g. a
+/// mismatched `BUN_DEBUG`/`bun_debug` pairing) panics at startup.
+#[unsafe(no_mangle)]
+pub(crate) static Bun__internal_loop_data__size: usize =
+    core::mem::size_of::<InternalLoopData>();
 
 impl InternalLoopData {
     const LIBUS_RECV_BUFFER_LENGTH: usize = 524288;

--- a/test/js/bun/util/event-loop-stats.test.ts
+++ b/test/js/bun/util/event-loop-stats.test.ts
@@ -1,35 +1,51 @@
 import { getEventLoopStats } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
-import { isWindows } from "harness";
+import { isDebug, isWindows } from "harness";
 
 // `nestedDispatchTicks` counts event-loop ticks that began while an outer
 // ready-poll dispatch was still mid-batch, i.e. a poll callback synchronously
 // waited on the event loop. https://github.com/oven-sh/bun/issues/33261
-// POSIX only: Windows readiness is driven by libuv, so it reports 0 there.
-test.skipIf(isWindows)("nestedDispatchTicks counts re-entrant ticks started inside a dispatch callback", async () => {
-  const before = getEventLoopStats().nestedDispatchTicks;
-  expect(before).toBeNumber();
+// The counter only exists in debug builds (BUN_DEBUG), and only the POSIX
+// event loop increments it: release builds and Windows always report 0.
+test.skipIf(isWindows || !isDebug)(
+  "nestedDispatchTicks counts re-entrant ticks started inside a dispatch callback",
+  async () => {
+    const before = getEventLoopStats().nestedDispatchTicks;
+    expect(before).toBeNumber();
 
-  // The fetch handler runs inside the server socket's poll dispatch, and
-  // HTMLRewriter.transform with an async handler synchronously waits on that
-  // handler's promise (waitForPromise), so a nested tick starts while the
-  // dispatch is still mid-batch. Sockets are level-triggered, so the nested
-  // tick cannot lose any one-shot event. When #33261 de-blocks HTMLRewriter,
-  // this trigger must become another synchronous waiter (or an internal hook).
-  const rewriter = new HTMLRewriter().on("p", {
-    async element() {
-      await Bun.sleep(1);
-    },
-  });
-  using server = Bun.serve({
-    port: 0,
-    fetch() {
-      rewriter.transform("<p>x</p>");
-      return new Response("ok");
-    },
-  });
-  const res = await fetch(`http://localhost:${server.port}/`);
-  expect(await res.text()).toBe("ok");
+    // The fetch handler runs inside the server socket's poll dispatch, and
+    // HTMLRewriter.transform with an async handler synchronously waits on that
+    // handler's promise (waitForPromise), so a nested tick starts while the
+    // dispatch is still mid-batch. Sockets are level-triggered, so the nested
+    // tick cannot lose any one-shot event. When #33261 de-blocks HTMLRewriter,
+    // this trigger must become another synchronous waiter (or an internal hook).
+    const rewriter = new HTMLRewriter().on("p", {
+      async element() {
+        await Bun.sleep(1);
+      },
+    });
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        rewriter.transform("<p>x</p>");
+        return new Response("ok");
+      },
+    });
+    const res = await fetch(`http://localhost:${server.port}/`);
+    expect(await res.text()).toBe("ok");
 
-  expect(getEventLoopStats().nestedDispatchTicks).toBeGreaterThan(before);
+    expect(getEventLoopStats().nestedDispatchTicks).toBeGreaterThan(before);
+  },
+);
+
+// Runs in every build flavor: the field always exists, and outside debug
+// builds it must stay 0 (the counter is compiled out).
+test("getEventLoopStats() always reports nestedDispatchTicks", async () => {
+  const stats = getEventLoopStats();
+  expect(stats.nestedDispatchTicks).toBeNumber();
+  expect(stats.nestedDispatchTicks).toBeGreaterThanOrEqual(0);
+  if (!isDebug) {
+    await Promise.all(Array.from({ length: 4 }, (_, i) => Bun.$`printf %s r${i}`.quiet()));
+    expect(getEventLoopStats().nestedDispatchTicks).toBe(0);
+  }
 });

--- a/test/js/bun/util/event-loop-stats.test.ts
+++ b/test/js/bun/util/event-loop-stats.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { getEventLoopStats } from "bun:internal-for-testing";
+import { isWindows } from "harness";
+
+// `nestedDispatchTicks` counts event-loop ticks that began while an outer
+// ready-poll dispatch was still mid-batch, i.e. a poll callback synchronously
+// waited on the event loop. https://github.com/oven-sh/bun/issues/33261
+// POSIX only: Windows readiness is driven by libuv, so it reports 0 there.
+test.skipIf(isWindows)("nestedDispatchTicks counts re-entrant ticks started inside a dispatch callback", async () => {
+  const before = getEventLoopStats().nestedDispatchTicks;
+  expect(before).toBeNumber();
+
+  // The fetch handler runs inside the server socket's poll dispatch, and
+  // HTMLRewriter.transform with an async handler synchronously waits on that
+  // handler's promise (waitForPromise), so a nested tick starts while the
+  // dispatch is still mid-batch. Sockets are level-triggered, so the nested
+  // tick cannot lose any one-shot event. When #33261 de-blocks HTMLRewriter,
+  // this trigger must become another synchronous waiter (or an internal hook).
+  const rewriter = new HTMLRewriter().on("p", {
+    async element() {
+      await Bun.sleep(1);
+    },
+  });
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      rewriter.transform("<p>x</p>");
+      return new Response("ok");
+    },
+  });
+  const res = await fetch(`http://localhost:${server.port}/`);
+  expect(await res.text()).toBe("ok");
+
+  expect(getEventLoopStats().nestedDispatchTicks).toBeGreaterThan(before);
+});

--- a/test/js/bun/util/event-loop-stats.test.ts
+++ b/test/js/bun/util/event-loop-stats.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
 import { getEventLoopStats } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
 import { isWindows } from "harness";
 
 // `nestedDispatchTicks` counts event-loop ticks that began while an outer


### PR DESCRIPTION
### What does this PR do?

Adds a `nested_dispatch_ticks` counter to the POSIX event loop: it increments when `us_loop_run_bun_tick` begins while an outer ready-poll dispatch is still mid-batch — i.e. a poll callback (or a continuation it drained inline) synchronously waited on the event loop through one of the `waitForPromise` callers. The counter is exposed as `getEventLoopStats().nestedDispatchTicks` in `bun:internal-for-testing` (always `0` on Windows, whose readiness is driven by libuv).

First step of #33261: before synchronous event-loop re-entry from inside dispatch callbacks can be forbidden (and `expect().resolves` / `HTMLRewriter.transform` de-blocked), the violation has to be *observable*. This counter is that detector — the follow-up work uses it to prove "this API no longer re-enters the loop", and it is the condition a future debug assertion will fire on.

No behavior change: one well-predicted integer compare + increment at tick entry, no allocation. `nested_dispatch_ticks` is deliberately narrower than `tick_depth` (which also counts re-entry from the pre/post phases): it counts only re-entry that starts while a ready-poll batch is mid-dispatch, which is exactly the state that loses one-shot events.

### How did you verify your code works?

`test/js/bun/util/event-loop-stats.test.ts`: an `HTMLRewriter.transform()` with an async element handler, called from inside a `Bun.serve` fetch handler, synchronously waits on the event loop from inside the server socket's poll dispatch — the counter increments. Server sockets are level-triggered, so unlike subprocess-based triggers this cannot lose one-shot events and does not depend on pidfd/waiter-thread differences across platforms. The test fails without the native change (`USE_SYSTEM_BUN=1`).

Also verified outside the test runner with a plain script through the CLI: a fresh process reports `0`, concurrent shell commands leave it at `0`, a normal async server handler leaves it at `0`, and a synchronously-waiting handler moves it to `1`.
