### PR TITLE
shell: don't panic on a brace word with more than 65535 tokens

### DIFF
--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -1134,8 +1134,13 @@ fn build_expansion_table(
     }
     let mut brace_stack: SmallVec<[BraceState; MAX_NESTED_BRACES]> = SmallVec::new();
 
+    // Token indices are stored as `u16`. Adjacent text is merged into one
+    // token by the lexer, so only a word with that many brace metacharacters
+    // can overflow. Report it as TooManyBraces, which every caller already
+    // turns into an error; UnexpectedToken is treated as an unreachable
+    // parser bug by the shell's expansion state, which panics on it.
     if tokens.len() > u16::MAX as usize {
-        return Err(ParserError::UnexpectedToken);
+        return Err(ParserError::TooManyBraces);
     }
 
     let mut i: u16 = 0;

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -1134,11 +1134,9 @@ fn build_expansion_table(
     }
     let mut brace_stack: SmallVec<[BraceState; MAX_NESTED_BRACES]> = SmallVec::new();
 
-    // Token indices are stored as `u16`. Adjacent text is merged into one
-    // token by the lexer, so only a word with that many brace metacharacters
-    // can overflow. Report it as TooManyBraces, which every caller already
-    // turns into an error; UnexpectedToken is treated as an unreachable
-    // parser bug by the shell's expansion state, which panics on it.
+    // Token indices are stored as `u16`, and only a word with that many brace
+    // metacharacters can overflow (the lexer merges adjacent text into one
+    // token). Report it as TooManyBraces, which callers turn into an error.
     if tokens.len() > u16::MAX as usize {
         return Err(ParserError::TooManyBraces);
     }

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -167,14 +167,20 @@ console.log(JSON.stringify(Bun.$.braces("echo {a,b}")));`,
 
   // One group with 40000 alternatives stays under the expander's
   // 65536-variant cap but produces more than 65535 brace tokens, which
-  // overflows its u16 token indices. That limit was reported as an internal
-  // UnexpectedToken error, which the shell treats as unreachable:
-  //   panic: unexpected error from Braces.expand: UnexpectedToken
+  // overflows its u16 token indices.
   test("rejects a word with an excessive number of brace tokens instead of crashing", async () => {
     // Run in a subprocess so an unfixed build aborts the child, not the runner.
-    const word = "{a" + Buffer.alloc(2 * 39999, ",a").toString() + "}";
+    // The word is built inside the child: it is far too long for argv on Windows.
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "exec", `echo ${word}`],
+      cmd: [
+        bunExe(),
+        "-e",
+        [
+          `const word = "{a" + Buffer.alloc(2 * 39999, ",a").toString() + "}";`,
+          "const { exitCode, stderr } = await Bun.$`echo ${{ raw: word }}`.quiet().nothrow();",
+          `console.log(JSON.stringify({ exitCode, stderr: stderr.toString() }));`,
+        ].join("\n"),
+      ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -182,10 +188,7 @@ console.log(JSON.stringify(Bun.$.braces("echo {a,b}")));`,
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "",
-      stderr: "bun: too many braces in brace expansion\n",
-      exitCode: 1,
-    });
+    expect(stdout).toBe('{"exitCode":1,"stderr":"bun: too many braces in brace expansion\\n"}\n');
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -164,4 +164,28 @@ console.log(JSON.stringify(Bun.$.braces("echo {a,b}")));`,
     `);
     expect(exitCode).toBe(0);
   });
+
+  // One group with 40000 alternatives stays under the expander's
+  // 65536-variant cap but produces more than 65535 brace tokens, which
+  // overflows its u16 token indices. That limit was reported as an internal
+  // UnexpectedToken error, which the shell treats as unreachable:
+  //   panic: unexpected error from Braces.expand: UnexpectedToken
+  test("rejects a word with an excessive number of brace tokens instead of crashing", async () => {
+    // Run in a subprocess so an unfixed build aborts the child, not the runner.
+    const word = "{a" + Buffer.alloc(2 * 39999, ",a").toString() + "}";
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "exec", `echo ${word}`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: "bun: too many braces in brace expansion\n",
+      exitCode: 1,
+    });
+  });
 });


### PR DESCRIPTION
### Repro

```js
import { $ } from "bun";
const word = "{" + Array(40000).fill("a").join(",") + "}";
await $`echo ${{ raw: word }}`;
```

```
panic: unexpected error from Braces.expand: UnexpectedToken
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

`bun exec "echo $(python3 -c "print('{'+','.join(['a']*40000)+'}')")"` aborts the same way. The whole process goes down, not just the shell command.

### Cause

`build_expansion_table` in `src/shell_parser/braces.rs` stores token indices as `u16` and rejects token streams longer than `u16::MAX`, but it reports that limit as `ParserError::UnexpectedToken`:

```rust
if tokens.len() > u16::MAX as usize {
    return Err(ParserError::UnexpectedToken);
}
```

`do_brace_expand` in `src/runtime/shell/states/Expansion.rs` handles `TooManyBraces` as a shell error and treats every other error from `Braces::expand` as an unreachable parser bug:

```rust
// An unexpected token from brace expansion is a parser bug.
panic!("unexpected error from Braces.expand: {e:?}");
```

The input slips past both existing guards: it has a single brace group (the 256-group cap does not trigger) and 40000 variants (under the 65536-expansion cap), but each alternative costs two tokens, so the token count is over 65535.

### Fix

Classify the token-count limit as what it is. Adjacent text is merged into one token by the lexer, so only a word with that many brace metacharacters can exceed it: `build_expansion_table` now returns `ParserError::TooManyBraces`, which both callers already turn into an error.

- `$` / `bun exec`: `bun: too many braces in brace expansion`, exit 1
- `$.braces()`: throws `Too many braces in brace expansion` (previously `Unexpected token while expanding braces`)

One line plus a comment, no caller changes.

### Verification

New test in `test/js/bun/shell/brace.test.ts` runs the word through `Bun.$` in a spawned child (on an unfixed build the panic aborts the child, not the test runner) and asserts the shell's error message and exit code. The word is built inside the child rather than passed through argv, which would exceed the Windows command-line length limit.

```
# without the src change
(fail) $.braces input bounds > rejects a word with an excessive number of brace tokens instead of crashing
# with it
 17 pass, 0 fail
```

Related: #33262 fixes a different panic (`index out of bounds` in `expand_flat`) reached through the same shell state. The two diffs do not overlap.

