### PR TITLE
shell: fix use-after-free when the poll re-registration issued from PipeReader::on_read_chunk fails

### DIFF
--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -16,8 +16,6 @@ use crate::shell::{self as sh, Yield};
 use crate::webcore::{self, FileSink, ReadableStream, blob};
 use bun_alloc::Arena;
 use bun_collections::VecExt;
-#[cfg(not(unix))]
-use bun_core::Output;
 use bun_io::Loop as AsyncLoop;
 #[cfg(windows)]
 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
@@ -2054,26 +2052,19 @@ impl PipeReader {
 
         self.captured_writer.do_write(chunk);
 
-        let should_continue = has_more != ReadState::Eof;
-
-        if should_continue {
-            #[cfg(unix)]
-            {
-                self.reader.register_poll();
-            }
-            #[cfg(not(unix))]
-            match self.reader.start_with_current_pipe() {
-                bun_sys::Result::Err(e) => {
-                    Output::panic(format_args!(
-                        "TODO: implement error handling in Bun Shell PipeReader.onReadChunk\n{:?}",
-                        e
-                    ));
-                }
-                _ => {}
-            }
-        }
-
-        should_continue
+        // No explicit re-arm here (`register_poll()` on POSIX /
+        // `start_with_current_pipe()` on Windows). This callback runs from
+        // inside the bun_io read loop, which still holds `&mut self.reader`
+        // on its stack and re-registers the poll itself based on the bool we
+        // return (`IOReader::on_read_chunk_cb` and
+        // `WindowsBufferedReader::on_read` document the same contract).
+        //
+        // Re-arming from here also violates `BufferedReaderParent`'s
+        // requirement that `on_read_chunk` never frees the reader:
+        // `register_poll()`'s failure path dispatches `on_reader_error`,
+        // which drops the last `Arc<PipeReader>` and frees the
+        // `PosixBufferedReader` the loop is still reading through.
+        has_more != ReadState::Eof
     }
 
     /// Reconstruct an owning `Arc<Self>` from the raw parent pointer the

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -27,6 +27,13 @@ const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 //                            read_all() and into the epoll dispatch.
 //   SHELL_FAIL_EPOLL_FROM=N  the Nth and every later epoll_ctl ADD/MOD on each
 //                            AF_UNIX socket fails with ENOMEM (1-based).
+//   SHELL_RECV_BULK=N        the first N recv()s on each AF_UNIX socket that
+//                            reach the real syscall instead return the caller's
+//                            whole buffer filled with 'A'. The PosixBufferedReader
+//                            read loop's scratch buffer is 256 KB, so one bulk
+//                            recv guarantees the streaming inner loop's mid-read
+//                            flush (`head_start` past the half-buffer cutoff)
+//                            fires in a single poll wake.
 // FilePoll registers the socketpair through the raw syscall(SYS_epoll_ctl,
 // ...) wrapper, not the libc epoll_ctl symbol, so the epoll modes interpose
 // syscall(2).
@@ -57,8 +64,10 @@ static int fail_epoll_after = -1;
 static int recv_one_chunk = -1;
 static int recv_eagain_first = -1;
 static int fail_epoll_from = -1; /* 0 = off, N >= 1 = 1-based index of the first failing call */
+static int recv_bulk = -1;       /* 0 = off, N >= 1 = number of fabricated full-buffer recvs */
 static unsigned char recv_count[MAX_FD];
 static unsigned char epoll_count[MAX_FD];
+static unsigned char bulk_count[MAX_FD];
 
 static void init_modes(void) {
   if (fail_recv < 0) fail_recv = getenv("SHELL_FAIL_RECV") != NULL;
@@ -69,6 +78,10 @@ static void init_modes(void) {
   if (fail_epoll_from < 0) {
     const char *s = getenv("SHELL_FAIL_EPOLL_FROM");
     fail_epoll_from = s ? atoi(s) : 0;
+  }
+  if (recv_bulk < 0) {
+    const char *s = getenv("SHELL_RECV_BULK");
+    recv_bulk = s ? atoi(s) : 0;
   }
 }
 
@@ -108,6 +121,11 @@ ssize_t recv(int fd, void *buf, size_t len, int flags) {
   if (recv_eagain_first && fd >= 0 && fd < MAX_FD && is_unix_sock(fd) && recv_count[fd]++ == 0) {
     errno = EAGAIN;
     return -1;
+  }
+  if (recv_bulk > 0 && fd >= 0 && fd < MAX_FD && is_unix_sock(fd) && bulk_count[fd] < recv_bulk && len > 0) {
+    bulk_count[fd]++;
+    memset(buf, 'A', len);
+    return (ssize_t)len;
   }
   return real_recv(fd, buf, len, flags);
 }
@@ -158,6 +176,7 @@ int close(int fd) {
   if (fd >= 0 && fd < MAX_FD) {
     recv_count[fd] = 0;
     epoll_count[fd] = 0;
+    bulk_count[fd] = 0;
   }
   return real_close(fd);
 }
@@ -249,7 +268,7 @@ const MODES = [
   "SHELL_RECV_EAGAIN_FIRST",
 ] as const;
 // Integer-valued fault knobs; cleared alongside MODES and set through `extraEnv`.
-const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM"] as const;
+const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM", "SHELL_RECV_BULK"] as const;
 
 async function expectShellFault(
   script: string,
@@ -343,5 +362,29 @@ test.concurrent.skipIf(!isLinux || !cc || !isASAN)(
   "shell survives a poll re-registration failure during a poll-driven read",
   async () => {
     await expectShellFault("poll-chunk.js", ["SHELL_RECV_EAGAIN_FIRST"], { SHELL_FAIL_EPOLL_FROM: "3" });
+  },
+);
+
+// Same failing epoll_ctl (#3: ADD at start, MOD after the eager read's forced
+// EAGAIN, then the first poll-driven MOD), but SHELL_RECV_BULK=1 makes the
+// poll-driven recv return the read loop's whole 256 KB scratch buffer at once.
+// That pushes `head_start` past read_with_fn's half-buffer cutoff, so the
+// shell `PipeReader::on_read_chunk` mid-loop flush fires while the inner loop
+// still has iterations left. on_read_chunk then called
+// `self.reader.register_poll()` itself; its failure dispatched
+// `on_reader_error`, which dropped the last `Arc<PipeReader>`, and the still
+// looping read_with_fn kept reading through the freed `PosixBufferedReader`.
+// ASAN: heap-use-after-free in PosixBufferedReader::read_with_fn.
+//
+// With the re-arm removed from on_read_chunk, epoll_ctl #3 is instead the read
+// loop's own EAGAIN re-registration, whose failure path already returns
+// without touching the (freed) reader, so the command just reports ENOMEM.
+test.concurrent.skipIf(!isLinux || !cc || !isASAN)(
+  "shell survives a poll re-registration failure raised from on_read_chunk's mid-read flush",
+  async () => {
+    await expectShellFault("poll-chunk.js", ["SHELL_RECV_EAGAIN_FIRST"], {
+      SHELL_FAIL_EPOLL_FROM: "3",
+      SHELL_RECV_BULK: "1",
+    });
   },
 );


### PR DESCRIPTION
## Problem

Heap use-after-free in Bun Shell when `epoll_ctl(MOD)` fails while the shell `PipeReader::on_read_chunk` callback re-registers the poll from inside the read loop. Found by syscall-fault-injection fuzzing against `origin/main`.

This is the path #32986 called out as out of scope: that PR fixed `read_with_fn`'s own `EAGAIN`-arm re-registration, but the shell `PipeReader::on_read_chunk` still called `self.reader.register_poll()` itself.

```
==ERROR: AddressSanitizer: heap-use-after-free
READ of size 8
  #0 <PosixBufferedReader>::read_with_fn   src/io/PipeReader.rs:837:43
  #1 <PosixBufferedReader>::read_socket    src/io/PipeReader.rs:581:9
  #2 <PosixBufferedReader>::on_poll        src/io/PipeReader.rs:534:17
  #3 __bun_run_file_poll                   src/runtime/dispatch.rs:677:22
```

<details>
<summary>Freed-by stack (the re-entrant callback chain)</summary>

```
freed by thread T0 here:
  core::ptr::drop_in_place::<Arc<shell::subproc::PipeReader>>
  <shell::subproc::PipeReader>::on_reader_error                      src/runtime/shell/subproc.rs:2363
  <PosixBufferedReader>::register_poll                               src/io/PipeReader.rs:433
  <shell::subproc::PipeReader>::on_read_chunk                        src/runtime/shell/subproc.rs:2062
  <PosixBufferedReader>::read_with_fn                                src/io/PipeReader.rs:875
  <PosixBufferedReader>::read_socket
  <PosixBufferedReader>::on_poll
  __bun_run_file_poll
```

</details>

## Repro

1. A shell pipe's `FilePoll` fires and `__bun_run_file_poll` dispatches into `PosixBufferedReader::on_poll` -> `read_with_fn` with a bare `&mut` and no keepalive.
2. `recv()` drains more than half of the 256 KB scratch buffer in one call, so `read_with_fn`'s streaming inner loop flushes the head mid-loop: `parent.vtable.on_read_chunk(.., Progress)`.
3. Shell `PipeReader::on_read_chunk` re-arms the poll itself: `self.reader.register_poll()`. The `epoll_ctl(MOD)` fails (`ENOMEM` in the repro; fd/watch pressure in the wild).
4. `register_poll` dispatches `on_reader_error`. The shell `PipeReader::on_reader_error` signals the `Cmd` and drops the `Readable::Pipe` `Arc`; its own `guard_from_raw` keepalive becomes the last reference, and dropping it frees the `PipeReader` (and the `PosixBufferedReader` embedded in it).
5. `register_poll` returns `false`, but `on_read_chunk` is not a direct caller of the read loop, so the `false` never reaches it. The inner loop keeps going and reads `parent._offset` from the freed reader on the next `recv`.

## Cause

`BufferedReaderParent`'s contract (and the `SAFETY` comments in `read_with_fn` / `read_blocking_pipe`) is that `on_read_chunk` never frees the reader; only `on_reader_error` may. The shell `PipeReader::on_read_chunk` broke that transitively by calling `register_poll()`, whose failure path dispatches `on_reader_error`.

#32986's `register_poll() -> bool` return value only protects direct callers in the read loop. It cannot protect a caller that reaches `register_poll` through the `on_read_chunk` vtable dispatch two frames down.

## Fix

Delete the re-arm from shell `PipeReader::on_read_chunk`. It was redundant on both platforms and the codebase already documents why:

- POSIX: every exit of `read_with_fn` / `read_blocking_pipe` that wants more data already calls `register_poll()` itself, driven by the `bool` `on_read_chunk` returns.
- Windows: `WindowsBufferedReader::on_read` notes "the re-arm is already handled by `on_file_read`'s epilogue / `uv_read_start`", and it already performs the `_buffer.clear()` that used to be `start_with_current_pipe()`'s second side effect.
- The sibling shell reader, `IOReader::on_read_chunk_cb`, already dropped its identical re-arm for the same two reasons (redundancy, plus re-deriving `&mut` to the embedded reader while the read loop holds one).

Removing it also removes the only `&mut self.reader` re-derivation inside the callback, and the `Output::panic("TODO: ...")` that was the Windows branch's only error handling.

## Test

New `SHELL_RECV_BULK=N` mode in `test/js/bun/shell/shell-pipe-read-fault.test.ts`'s `LD_PRELOAD` shim: the first N real `recv()`s on each `AF_UNIX` socket instead return the caller's whole buffer filled with `'A'`. Combined with the existing `SHELL_RECV_EAGAIN_FIRST=1` and `SHELL_FAIL_EPOLL_FROM=3`, one fabricated bulk recv deterministically pushes `head_start` past the half-buffer cutoff so the mid-loop flush (and therefore the failing re-registration) happens from `on_read_chunk`.

With the epoll failure count unchanged, the same `epoll_ctl` #3 that used to be issued by `on_read_chunk` is now the read loop's own `EAGAIN` re-registration, whose failure path already returns without touching the reader, so the command just reports `ENOMEM`.

- Before the fix: the new test fails in ~750 ms with the `heap-use-after-free` above; the other 6 tests in the file pass.
- After the fix: all 7 pass.

The test is `skipIf(!isASAN)` like its sibling.

Also ran the rest of `test/js/bun/shell/` (`bunshell*.test.ts`: 394 pass / 0 fail; `commands/` and the remaining files: every failure reproduces identically with `src/runtime/shell/subproc.rs` reverted to `main`, so they are pre-existing in this environment, not caused by this change).
