### PR TITLE
fetch: decode every coding in a multi-coding Content-Encoding response

### DIFF
--- a/src/http/ContentCodings.rs
+++ b/src/http/ContentCodings.rs
@@ -34,6 +34,26 @@ impl Default for ContentCodings {
     }
 }
 
+/// Map a compressed-coding token (RFC 9110 section 8.4.1: names are
+/// case-insensitive; `x-gzip` is a registered deprecated alias of `gzip`) to
+/// the [`Encoding`] we decode it with. `None` for everything else, including
+/// the `identity` no-op.
+pub(crate) fn token_to_encoding(token: &[u8]) -> Option<Encoding> {
+    if strings::eql_case_insensitive_ascii_check_length(token, b"gzip")
+        || strings::eql_case_insensitive_ascii_check_length(token, b"x-gzip")
+    {
+        Some(Encoding::Gzip)
+    } else if strings::eql_case_insensitive_ascii_check_length(token, b"deflate") {
+        Some(Encoding::Deflate)
+    } else if strings::eql_case_insensitive_ascii_check_length(token, b"br") {
+        Some(Encoding::Brotli)
+    } else if strings::eql_case_insensitive_ascii_check_length(token, b"zstd") {
+        Some(Encoding::Zstd)
+    } else {
+        None
+    }
+}
+
 impl ContentCodings {
     pub const fn new() -> Self {
         Self {
@@ -50,23 +70,12 @@ impl ContentCodings {
     pub fn append_header_value(&mut self, value: &[u8]) -> bool {
         let mut tokens = HeaderValueIterator::init(value);
         while let Some(token) = tokens.next() {
-            // RFC 9110 section 8.4.1: coding names are case-insensitive.
-            // `x-gzip` is a registered deprecated alias of `gzip`.
-            let coding = if strings::eql_case_insensitive_ascii_check_length(token, b"gzip")
-                || strings::eql_case_insensitive_ascii_check_length(token, b"x-gzip")
-            {
-                Encoding::Gzip
-            } else if strings::eql_case_insensitive_ascii_check_length(token, b"deflate") {
-                Encoding::Deflate
-            } else if strings::eql_case_insensitive_ascii_check_length(token, b"br") {
-                Encoding::Brotli
-            } else if strings::eql_case_insensitive_ascii_check_length(token, b"zstd") {
-                Encoding::Zstd
-            } else if strings::eql_case_insensitive_ascii_check_length(token, b"identity") {
-                // "identity" means "no transformation": it contributes no
-                // decoder but doesn't make the rest of the list undecodable.
-                continue;
-            } else {
+            let Some(coding) = token_to_encoding(token) else {
+                if strings::eql_case_insensitive_ascii_check_length(token, b"identity") {
+                    // "identity" means "no transformation": it contributes no
+                    // decoder but doesn't make the rest of the list undecodable.
+                    continue;
+                }
                 self.set_unsupported();
                 return false;
             };

--- a/src/http/ContentCodings.rs
+++ b/src/http/ContentCodings.rs
@@ -1,0 +1,110 @@
+use bun_core::strings;
+use bun_http_types::Encoding::Encoding;
+
+use crate::HeaderValueIterator;
+
+/// Upper bound on the number of content codings the client will chain.
+/// Real responses carry one (occasionally two, e.g. an origin that applied
+/// `br` behind a proxy that re-applied `gzip`); a longer list is treated as
+/// unsupported so a hostile response can't make us allocate an unbounded
+/// number of decoder states.
+pub const MAX_CONTENT_CODINGS: usize = 8;
+
+/// The response's `Content-Encoding` codings in the order they were applied,
+/// i.e. the order they are listed in the header (RFC 9110 section 8.4), across
+/// every `Content-Encoding` field line. The body is decoded in the reverse of
+/// this order.
+///
+/// A coding we can't decode (an unknown token, or more than
+/// [`MAX_CONTENT_CODINGS`] of them) marks the whole list unsupported:
+/// `is_compressed()` turns false and stays false, so the body is handed over
+/// exactly as received. The one thing this type must never allow is decoding
+/// only some of the layers and reporting the remaining compressed bytes as the
+/// response body.
+#[derive(Copy, Clone)]
+pub struct ContentCodings {
+    list: [Encoding; MAX_CONTENT_CODINGS],
+    len: u8,
+    unsupported: bool,
+}
+
+impl Default for ContentCodings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ContentCodings {
+    pub const fn new() -> Self {
+        Self {
+            list: [Encoding::Identity; MAX_CONTENT_CODINGS],
+            len: 0,
+            unsupported: false,
+        }
+    }
+
+    /// Parse one `Content-Encoding` field value (a `#content-coding` list,
+    /// so possibly several comma-separated codings) and append the codings
+    /// in order. Returns whether the response still has a coding chain we
+    /// will decode afterwards.
+    pub fn append_header_value(&mut self, value: &[u8]) -> bool {
+        let mut tokens = HeaderValueIterator::init(value);
+        while let Some(token) = tokens.next() {
+            // RFC 9110 section 8.4.1: coding names are case-insensitive.
+            // `x-gzip` is a registered deprecated alias of `gzip`.
+            let coding = if strings::eql_case_insensitive_ascii_check_length(token, b"gzip")
+                || strings::eql_case_insensitive_ascii_check_length(token, b"x-gzip")
+            {
+                Encoding::Gzip
+            } else if strings::eql_case_insensitive_ascii_check_length(token, b"deflate") {
+                Encoding::Deflate
+            } else if strings::eql_case_insensitive_ascii_check_length(token, b"br") {
+                Encoding::Brotli
+            } else if strings::eql_case_insensitive_ascii_check_length(token, b"zstd") {
+                Encoding::Zstd
+            } else if strings::eql_case_insensitive_ascii_check_length(token, b"identity") {
+                // "identity" means "no transformation": it contributes no
+                // decoder but doesn't make the rest of the list undecodable.
+                continue;
+            } else {
+                self.set_unsupported();
+                return false;
+            };
+            if self.unsupported || self.len as usize == MAX_CONTENT_CODINGS {
+                self.set_unsupported();
+                return false;
+            }
+            self.list[self.len as usize] = coding;
+            self.len += 1;
+        }
+        self.is_compressed()
+    }
+
+    fn set_unsupported(&mut self) {
+        self.unsupported = true;
+        self.len = 0;
+    }
+
+    /// The codings in the order they were applied. Empty when the response
+    /// is not compressed or lists a coding we won't decode.
+    #[inline]
+    pub fn as_slice(&self) -> &[Encoding] {
+        &self.list[..self.len as usize]
+    }
+
+    /// True when there is at least one coding to decode.
+    #[inline]
+    pub fn is_compressed(&self) -> bool {
+        self.len != 0
+    }
+
+    /// The response's only coding, when exactly one was listed.
+    #[inline]
+    pub fn single(&self) -> Option<Encoding> {
+        if self.len == 1 {
+            Some(self.list[0])
+        } else {
+            None
+        }
+    }
+}

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -107,9 +107,11 @@ impl DecompressorChain {
         is_done: bool,
     ) -> crate::Result<()> {
         // Callers only decompress when `ContentCodings::is_compressed()`.
+        // Erroring (rather than returning Ok) keeps a broken caller from
+        // silently dropping the chunk's bytes.
         let Some(last) = codings.len().checked_sub(1) else {
             debug_assert!(false, "decompress_chunk requires at least one coding");
-            return Ok(());
+            return Err(crate::Error::InvalidHTTPResponse);
         };
         if self.stages.is_empty() {
             self.stages

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -76,3 +76,82 @@ impl Decompressor {
         }
     }
 }
+
+/// Streaming decoder pipeline for the response's whole `Content-Encoding`
+/// chain. `Content-Encoding: br, gzip` means brotli was applied first and
+/// gzip last, so the wire bytes are gunzipped first and that output is then
+/// brotli-decoded: codings decode in the reverse of the listed order
+/// (RFC 9110 section 8.4).
+#[derive(Default)]
+pub struct DecompressorChain {
+    /// One streaming decoder per coding; index 0 decodes the last-listed
+    /// (outermost) coding. Each is created lazily by
+    /// [`Decompressor::decompress_chunk`] on the first bytes it sees, which
+    /// the deflate decoder relies on to sniff raw-vs-zlib framing.
+    stages: Vec<Decompressor>,
+    /// Ping-pong buffers carrying stage `i`'s output to stage `i + 1` when
+    /// there is more than one coding; reused across body chunks.
+    scratch: [MutableString; 2],
+}
+
+impl DecompressorChain {
+    /// Feed one body chunk through every coding, appending the fully decoded
+    /// bytes to `body_out_str`. `codings` is the `Content-Encoding` list in
+    /// the order the codings were applied; it must be non-empty and the same
+    /// on every call for a given response.
+    pub fn decompress_chunk(
+        &mut self,
+        codings: &[Encoding],
+        buffer: &[u8],
+        body_out_str: &mut MutableString,
+        is_done: bool,
+    ) -> crate::Result<()> {
+        // Callers only decompress when `ContentCodings::is_compressed()`.
+        let Some(last) = codings.len().checked_sub(1) else {
+            debug_assert!(false, "decompress_chunk requires at least one coding");
+            return Ok(());
+        };
+        if self.stages.is_empty() {
+            self.stages
+                .resize_with(codings.len(), Decompressor::default);
+        }
+        debug_assert_eq!(self.stages.len(), codings.len());
+
+        if let ([stage], &[coding]) = (self.stages.as_mut_slice(), codings) {
+            return stage.decompress_chunk(coding, buffer, body_out_str, is_done);
+        }
+        let [ping, pong] = &mut self.scratch;
+        let (mut stage_in, mut stage_out): (&mut MutableString, &mut MutableString) = (ping, pong);
+        for (i, (&coding, stage)) in codings.iter().rev().zip(self.stages.iter_mut()).enumerate() {
+            let input: &[u8] = if i == 0 { buffer } else { &stage_in.list };
+            // A stage that never received a byte has produced none for the
+            // stages after it either, so there is nothing left to do for
+            // this chunk. With `is_done` this is the "response declared a
+            // Content-Encoding but the stream decoded to zero bytes" case,
+            // which the single-coding path also treats as an empty body
+            // rather than a truncated stream.
+            if input.is_empty() && matches!(stage, Decompressor::None) {
+                return Ok(());
+            }
+            let result = if i == last {
+                stage.decompress_chunk(coding, input, body_out_str, is_done)
+            } else {
+                stage_out.list.clear();
+                stage.decompress_chunk(coding, input, stage_out, is_done)
+            };
+            match result {
+                Ok(()) => {}
+                // This layer needs more input before it can make progress.
+                // Not an error while the body is still streaming in, and
+                // whatever it did decode is already in its output buffer for
+                // the next layer to consume.
+                Err(crate::Error::ShortRead) if !is_done => {}
+                Err(err) => return Err(err),
+            }
+            if i != last {
+                core::mem::swap(&mut stage_in, &mut stage_out);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -4,7 +4,10 @@ use crate::Error;
 use bun_core::MutableString;
 use bun_core::Output;
 
-use crate::{CertificateInfo, Decompressor, Encoding, HTTPRequestBody, HTTPResponseMetadata};
+use crate::{
+    CertificateInfo, ContentCodings, DecompressorChain, Encoding, HTTPRequestBody,
+    HTTPResponseMetadata,
+};
 
 bun_core::define_scoped_log!(log, HTTPInternalState, hidden);
 
@@ -26,10 +29,14 @@ pub struct InternalState<'a> {
     pub flags: InternalStateFlags,
 
     pub transfer_encoding: Encoding,
-    pub encoding: Encoding,
+    /// The response's `Content-Encoding` codings, collected across every
+    /// field line in the order they were applied. Empty when the body is not
+    /// compressed (or uses a coding we won't decode, in which case the bytes
+    /// are passed through untouched).
+    pub content_codings: ContentCodings,
     pub content_encoding_i: u8,
     pub chunked_decoder: bun_picohttp::phr_chunked_decoder,
-    pub decompressor: Decompressor,
+    pub decompressor: DecompressorChain,
     pub stage: Stage,
     /// This is owned by the user and should not be freed here.
     /// Non-owning back-reference, kept as a raw `NonNull` (BACKREF per PORTING.md).
@@ -125,10 +132,10 @@ impl Default for InternalState<'_> {
             cloned_metadata: None,
             flags: InternalStateFlags::new(),
             transfer_encoding: Encoding::Identity,
-            encoding: Encoding::Identity,
+            content_codings: ContentCodings::new(),
             content_encoding_i: u8::MAX,
             chunked_decoder: bun_picohttp::phr_chunked_decoder::default(),
-            decompressor: Decompressor::None,
+            decompressor: DecompressorChain::default(),
             stage: Stage::Pending,
             body_out_str: None,
             compressed_body: MutableString::init_empty(),
@@ -210,7 +217,7 @@ impl<'a> InternalState<'a> {
     /// still run without panicking; those bytes are discarded on the next
     /// `reset()`.
     pub fn get_body_buffer(&mut self) -> &mut MutableString {
-        if self.encoding.is_compressed() {
+        if self.content_codings.is_compressed() {
             return &mut self.compressed_body;
         }
         match self.body_out_str {
@@ -230,7 +237,7 @@ impl<'a> InternalState<'a> {
         &mut self,
     ) -> (&mut bun_picohttp::phr_chunked_decoder, &mut MutableString) {
         match self.body_out_str {
-            _ if self.encoding.is_compressed() => {
+            _ if self.content_codings.is_compressed() => {
                 (&mut self.chunked_decoder, &mut self.compressed_body)
             }
             // body_out_str is a separate heap allocation, never aliasing
@@ -280,9 +287,14 @@ impl<'a> InternalState<'a> {
 
             'libdeflate: {
                 use bun_libdeflate_sys::libdeflate as bun_libdeflate;
+                // libdeflate decodes one whole gzip/deflate stream at a time,
+                // so only a response with exactly one such coding can take it.
+                let Some(encoding) = self.content_codings.single() else {
+                    break 'libdeflate;
+                };
                 if !(is_final_chunk
                     && !self.flags.is_libdeflate_fast_path_disabled
-                    && self.encoding.can_use_lib_deflate()
+                    && encoding.can_use_lib_deflate()
                     && self.is_done())
                 {
                     break 'libdeflate;
@@ -297,7 +309,7 @@ impl<'a> InternalState<'a> {
                 // If we know that the stream is going to be larger than our
                 // pre-allocated buffer, then let's dynamically allocate the exact
                 // size.
-                if self.encoding == Encoding::Gzip
+                if encoding == Encoding::Gzip
                     && buffer.len() > 16
                     && buffer.len() < 1024 * 1024 * 1024
                 {
@@ -341,7 +353,7 @@ impl<'a> InternalState<'a> {
                 let result = decompressor.decompress(
                     buffer,
                     &mut deflater.shared_buffer,
-                    match self.encoding {
+                    match encoding {
                         Encoding::Gzip => bun_libdeflate::Encoding::Gzip,
                         Encoding::Deflate => bun_libdeflate::Encoding::Deflate,
                         _ => unreachable!(),
@@ -377,10 +389,15 @@ impl<'a> InternalState<'a> {
             }
 
             let is_done = self.is_done();
-            if let Err(err) =
-                self.decompressor
-                    .decompress_chunk(self.encoding, buffer, body_out_str, is_done)
-            {
+            // Copy out the (small, `Copy`) coding list so the `&mut
+            // self.decompressor` call below doesn't overlap a `&self` borrow.
+            let codings = self.content_codings;
+            if let Err(err) = self.decompressor.decompress_chunk(
+                codings.as_slice(),
+                buffer,
+                body_out_str,
+                is_done,
+            ) {
                 if is_done || err != crate::Error::ShortRead {
                     bun_core::pretty_errorln!(
                         "<r><red>Decompression error: {}<r>",
@@ -436,30 +453,27 @@ impl<'a> InternalState<'a> {
         };
         let body_out_str = crate::body_out::as_mut(body_out_ptr);
 
-        match self.encoding {
-            Encoding::Brotli | Encoding::Gzip | Encoding::Deflate | Encoding::Zstd => {
-                self.decompress_bytes(&buffer, body_out_str, is_final_chunk)?;
-                // Retain capacity by
-                // returning the (cleared) allocation to compressed_body instead of dropping it.
-                buffer.clear();
-                self.compressed_body.list = buffer;
-            }
-            _ => {
-                // Uncompressed: caller took `buffer` from `body_out_str.list`, leaving it
-                // empty — move the bytes back. If body_out_str is
-                // somehow non-empty, fall back to append.
-                if body_out_str.list.is_empty() {
-                    body_out_str.list = buffer;
-                } else if !body_out_str.owns(&buffer) {
-                    if let Err(err) = body_out_str.append(&buffer) {
-                        let err: Error = err.into();
-                        bun_core::pretty_errorln!(
-                            "<r><red>Failed to append to body buffer: {}<r>",
-                            bstr::BStr::new(err.name()),
-                        );
-                        Output::flush();
-                        return Err(err);
-                    }
+        if self.content_codings.is_compressed() {
+            self.decompress_bytes(&buffer, body_out_str, is_final_chunk)?;
+            // Retain capacity by
+            // returning the (cleared) allocation to compressed_body instead of dropping it.
+            buffer.clear();
+            self.compressed_body.list = buffer;
+        } else {
+            // Uncompressed: caller took `buffer` from `body_out_str.list`, leaving it
+            // empty — move the bytes back. If body_out_str is
+            // somehow non-empty, fall back to append.
+            if body_out_str.list.is_empty() {
+                body_out_str.list = buffer;
+            } else if !body_out_str.owns(&buffer) {
+                if let Err(err) = body_out_str.append(&buffer) {
+                    let err: Error = err.into();
+                    bun_core::pretty_errorln!(
+                        "<r><red>Failed to append to body buffer: {}<r>",
+                        bstr::BStr::new(err.name()),
+                    );
+                    Output::flush();
+                    return Err(err);
                 }
             }
         }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -8,6 +8,8 @@ pub mod async_http;
 #[path = "CertificateInfo.rs"]
 pub mod certificate_info;
 pub mod compress_body;
+#[path = "ContentCodings.rs"]
+pub mod content_codings;
 #[path = "Decompressor.rs"]
 pub mod decompressor;
 #[path = "H2Client.rs"]
@@ -51,7 +53,8 @@ pub mod zlib;
 // ── crate-root re-exports ──
 pub use async_http::AsyncHTTP;
 pub use certificate_info::CertificateInfo;
-pub use decompressor::Decompressor;
+pub use content_codings::ContentCodings;
+pub use decompressor::{Decompressor, DecompressorChain};
 pub use header_builder::HeaderBuilder;
 pub use headers::{Headers, HeadersExt};
 pub use http_cert_error::HTTPCertError;
@@ -4699,7 +4702,7 @@ impl<'a> HTTPClient<'a> {
         }
         // we can ignore the body data in redirects
         if !self.state.flags.is_redirect_pending {
-            if self.state.encoding.is_compressed() {
+            if self.state.content_codings.is_compressed() {
                 if let Some(body_out) = self.state.body_out_str {
                     self.state
                         .decompress_bytes(incoming_data, body_out::as_mut(body_out), true)?;
@@ -5027,24 +5030,18 @@ impl<'a> HTTPClient<'a> {
                 }
                 h if h == hash_header_const(b"Content-Encoding") => {
                     if !self.flags.disable_decompression {
-                        // RFC 9110 §8.4.1: content codings are case-insensitive.
-                        // `x-gzip` is a registered deprecated alias of `gzip`.
-                        let value = header.value();
-                        if strings::eql_case_insensitive_ascii_check_length(value, b"gzip")
-                            || strings::eql_case_insensitive_ascii_check_length(value, b"x-gzip")
+                        // RFC 9110 §8.4: the field value is a list of codings in
+                        // the order they were applied, possibly split across
+                        // several Content-Encoding field lines. Collect every
+                        // coding; the body is decoded through all of them in
+                        // reverse order, or not at all when the list contains a
+                        // coding we can't decode (decoding only some layers
+                        // would silently hand over a still-compressed body).
+                        if self
+                            .state
+                            .content_codings
+                            .append_header_value(header.value())
                         {
-                            self.state.encoding = Encoding::Gzip;
-                            self.state.content_encoding_i = header_i as u8;
-                        } else if strings::eql_case_insensitive_ascii_check_length(
-                            value, b"deflate",
-                        ) {
-                            self.state.encoding = Encoding::Deflate;
-                            self.state.content_encoding_i = header_i as u8;
-                        } else if strings::eql_case_insensitive_ascii_check_length(value, b"br") {
-                            self.state.encoding = Encoding::Brotli;
-                            self.state.content_encoding_i = header_i as u8;
-                        } else if strings::eql_case_insensitive_ascii_check_length(value, b"zstd") {
-                            self.state.encoding = Encoding::Zstd;
                             self.state.content_encoding_i = header_i as u8;
                         }
                     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5043,6 +5043,8 @@ impl<'a> HTTPClient<'a> {
                             .append_header_value(header.value())
                         {
                             self.state.content_encoding_i = header_i as u8;
+                        } else {
+                            self.state.content_encoding_i = u8::MAX;
                         }
                     }
                 }
@@ -5058,23 +5060,9 @@ impl<'a> HTTPClient<'a> {
                     }
                     // RFC 9112 §7: transfer-coding names are case-insensitive.
                     let value = header.value();
-                    if strings::eql_case_insensitive_ascii_check_length(value, b"gzip")
-                        || strings::eql_case_insensitive_ascii_check_length(value, b"x-gzip")
-                    {
+                    if let Some(encoding) = content_codings::token_to_encoding(value) {
                         if !self.flags.disable_decompression {
-                            self.state.transfer_encoding = Encoding::Gzip;
-                        }
-                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"deflate") {
-                        if !self.flags.disable_decompression {
-                            self.state.transfer_encoding = Encoding::Deflate;
-                        }
-                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"br") {
-                        if !self.flags.disable_decompression {
-                            self.state.transfer_encoding = Encoding::Brotli;
-                        }
-                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"zstd") {
-                        if !self.flags.disable_decompression {
-                            self.state.transfer_encoding = Encoding::Zstd;
+                            self.state.transfer_encoding = encoding;
                         }
                     } else if strings::eql_case_insensitive_ascii_check_length(value, b"identity") {
                         self.state.transfer_encoding = Encoding::Identity;

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -400,7 +400,8 @@ describe("fetch() decodes multiple Content-Encoding codings", () => {
   // A truncated inner stream must reject, not resolve with garbage: the gzip
   // layer decodes fine but the brotli stream inside it is cut short. The
   // error can surface on fetch() itself (the body is buffered before the
-  // promise resolves) or on the body read.
+  // promise resolves) or on the body read, and it must be the decoder's
+  // truncation error, not some unrelated failure.
   it.concurrent("rejects when an inner coding's stream is truncated", async () => {
     const brotli = brotliCompressSync(payload);
     const body = gzipSync(brotli.subarray(0, brotli.length - 8));
@@ -411,7 +412,9 @@ describe("fetch() decodes multiple Content-Encoding codings", () => {
     await once(server.listen(0), "listening");
     try {
       const { port } = server.address() as import("node:net").AddressInfo;
-      await expect(fetch(`http://127.0.0.1:${port}/`).then(res => res.text())).rejects.toThrow();
+      await expect(fetch(`http://127.0.0.1:${port}/`).then(res => res.text())).rejects.toThrow(
+        /BrotliDecompressionError/,
+      );
     } finally {
       server.close();
     }

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -258,6 +258,166 @@ describe("fetch() decodes Content-Encoding case-insensitively", () => {
   });
 });
 
+// RFC 9110 §8.4: Content-Encoding lists every coding applied to the body, in
+// order, either as one comma-separated field value or as several field lines.
+// The client must decode all of them (last listed = outermost = decoded
+// first). Decoding only one layer silently hands the caller compressed bytes.
+describe("fetch() decodes multiple Content-Encoding codings", () => {
+  const payload = JSON.stringify({
+    msg: Buffer.alloc(4096, "abcdefghij").toString(),
+    n: 42,
+  });
+  const expected = { msg: Buffer.alloc(4096, "abcdefghij").toString(), n: 42 };
+  const apply: Record<string, (b: Uint8Array | string) => Buffer> = {
+    gzip: gzipSync,
+    "x-gzip": gzipSync,
+    deflate: deflateSync,
+    br: brotliCompressSync,
+    zstd: zstdCompressSync,
+  };
+  // Compress `payload` with each coding in `codings`, in order (so the last
+  // one is the outermost layer on the wire, matching the header's meaning).
+  function encodeBody(codings: string[]): Buffer {
+    let body: Buffer | string = payload;
+    for (const coding of codings) body = apply[coding](body);
+    return body as Buffer;
+  }
+
+  // [Content-Encoding header value(s) as sent on the wire, codings actually applied in order]
+  const cases: Array<[string | string[], string[]]> = [
+    ["br, gzip", ["br", "gzip"]],
+    ["gzip, br", ["gzip", "br"]],
+    ["gzip, gzip", ["gzip", "gzip"]],
+    ["deflate, gzip", ["deflate", "gzip"]],
+    ["zstd, gzip", ["zstd", "gzip"]],
+    ["gzip, zstd", ["gzip", "zstd"]],
+    ["x-gzip, br", ["x-gzip", "br"]],
+    // Three layers, exercising the intermediate ping-pong buffers.
+    ["gzip, br, zstd", ["gzip", "br", "zstd"]],
+    // Case-insensitive with optional whitespace around each element.
+    ["  BR ,  Gzip  ", ["br", "gzip"]],
+    // "identity" is a no-op coding; empty list elements are ignored.
+    ["identity, gzip", ["gzip"]],
+    ["gzip, identity", ["gzip"]],
+    ["br,, gzip,", ["br", "gzip"]],
+    // The same list split across two Content-Encoding field lines is
+    // equivalent to the comma-joined value (RFC 9110 §5.3).
+    [
+      ["br", "gzip"],
+      ["br", "gzip"],
+    ],
+    [
+      ["gzip", "br, gzip"],
+      ["gzip", "br", "gzip"],
+    ],
+  ];
+
+  it.concurrent.each(cases)("Content-Encoding: %j", async (headerValue, codings) => {
+    const body = encodeBody(codings);
+    // node:http so the header value reaches the wire exactly as written.
+    const server = createServer((req, res) => {
+      res.setHeader("Content-Encoding", headerValue);
+      res.setHeader("Content-Type", "application/json");
+      res.end(body);
+    });
+    await once(server.listen(0), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(expected);
+    } finally {
+      server.close();
+    }
+  });
+
+  // A coding we can't decode anywhere in the list means the body must be
+  // passed through exactly as received (fetch's "handle content codings"
+  // step; same as node/undici and Chromium). Decoding only the codings we do
+  // know would hand the caller a half-decoded body.
+  it.concurrent.each([
+    ["snappy, gzip", ["gzip"]],
+    ["gzip, snappy", ["gzip"]],
+    ["br, unknown, gzip", ["br", "gzip"]],
+  ])("unsupported coding in the list (%s) passes the body through untouched", async (headerValue, codings) => {
+    const body = encodeBody(codings);
+    const server = createServer((req, res) => {
+      res.setHeader("Content-Encoding", headerValue);
+      res.end(body);
+    });
+    await once(server.listen(0), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.status).toBe(200);
+      expect(Buffer.from(await res.arrayBuffer()).equals(body)).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  // Same multi-coding chain, but streamed: the body arrives over many small
+  // chunked writes and is consumed through `res.body`, so every decoder in
+  // the chain is driven incrementally across many reads instead of in one
+  // buffered shot.
+  it.concurrent("streams a br, gzip response across many chunks", async () => {
+    const big = JSON.stringify({
+      data: Array.from({ length: 256 }, (_, i) => ({ i, s: `item-${i}` })),
+    });
+    const compressed = gzipSync(brotliCompressSync(big));
+    const server = createNetServer(socket => {
+      socket.setNoDelay(true);
+      socket.write(
+        "HTTP/1.1 200 OK\r\n" +
+          "Content-Encoding: br, gzip\r\n" +
+          "Transfer-Encoding: chunked\r\n" +
+          "Content-Type: application/json\r\n" +
+          "Connection: close\r\n\r\n",
+      );
+      (async () => {
+        for (let i = 0; i < compressed.length; i += 17) {
+          const chunk = compressed.subarray(i, i + 17);
+          socket.write(chunk.length.toString(16) + "\r\n");
+          socket.write(chunk);
+          socket.write("\r\n");
+          await new Promise(r => setImmediate(r));
+        }
+        socket.end("0\r\n\r\n");
+      })().catch(() => socket.destroy());
+    });
+    await once(server.listen(0), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      const chunks = [];
+      for await (const chunk of res.body!) chunks.push(chunk);
+      expect(Buffer.concat(chunks).toString()).toBe(big);
+    } finally {
+      server.close();
+    }
+  });
+
+  // A truncated inner stream must reject, not resolve with garbage: the gzip
+  // layer decodes fine but the brotli stream inside it is cut short. The
+  // error can surface on fetch() itself (the body is buffered before the
+  // promise resolves) or on the body read.
+  it.concurrent("rejects when an inner coding's stream is truncated", async () => {
+    const brotli = brotliCompressSync(payload);
+    const body = gzipSync(brotli.subarray(0, brotli.length - 8));
+    const server = createServer((req, res) => {
+      res.setHeader("Content-Encoding", "br, gzip");
+      res.end(body);
+    });
+    await once(server.listen(0), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      await expect(fetch(`http://127.0.0.1:${port}/`).then(res => res.text())).rejects.toThrow();
+    } finally {
+      server.close();
+    }
+  });
+});
+
 it("fetch() with a gzip response works (multiple chunks, TCP server)", async done => {
   const compressed = await Bun.file(gzipped).arrayBuffer();
   var socketToClose!: Socket;


### PR DESCRIPTION
### What

`fetch()` treated a response's `Content-Encoding` as a single opaque token, so a response whose body went through more than one coding resolved with a still-compressed body and no error:

- `Content-Encoding: br, gzip` (one field value, comma list): the value matched none of the exact string comparisons, so nothing was decoded at all.
- `Content-Encoding: br` + `Content-Encoding: gzip` (two field lines): the last line won and only that layer was decoded.

```js
// server: body = gzip(br(payload)), header: Content-Encoding: br, gzip
const res = await fetch(url);
await res.text();
// node / undici / browsers: payload
// bun before this change: the still-compressed bytes, silently
```

RFC 9110 section 8.4 defines the header as the list of codings in the order they were applied (possibly split across several field lines), so a client has to decode them in reverse order. Multi-coding responses are what you get from an origin that compresses (`br`) behind a proxy or CDN that re-compresses (`gzip`), and the failure mode is silent data corruption: `JSON.parse` fails downstream, file writes persist compressed bytes.

### How

- `ContentCodings` (new, `src/http/ContentCodings.rs`): collects the codings from every `Content-Encoding` field line, splitting each value on commas (`HeaderValueIterator`), case-insensitively, in application order. `identity` and empty list elements are no-ops. A coding we can't decode anywhere in the list (or more than 8 codings) marks the whole list unsupported, so the body is passed through exactly as received. That matches the fetch spec's "handle content codings" step, undici, and Chromium; the one thing it never does is decode only some of the layers.
- `DecompressorChain` (new, in `src/http/Decompressor.rs`): one streaming decoder per coding, decoding in reverse list order, each stage's output feeding the next through two reused scratch buffers. A response with a single coding goes straight into the caller's buffer exactly as before, and the libdeflate whole-body fast path still applies to single gzip/deflate responses.

HTTP/1.1, HTTP/2, and HTTP/3 share this path (`handle_response_metadata` + `InternalState::decompress_bytes`), so all three are covered.

### Tests

New `describe` block in `test/js/web/fetch/fetch-gzip.test.ts`: comma lists, multiple field lines, 2- and 3-layer chains of gzip/x-gzip/deflate/br/zstd, whitespace/case/`identity`/empty list elements, unknown codings (body must come through byte-for-byte untouched), a chunked `br, gzip` response streamed in 17-byte writes and consumed through `res.body`, and a truncated inner stream (must reject, not resolve with garbage).

Before the fix 16 of the 19 new cases fail (the passing 3 are the pass-through ones, correct today by accident); with it, all 51 tests in the file pass:

```
bun bd test test/js/web/fetch/fetch-gzip.test.ts
 51 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-gzip.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d025989ee)

test/js/web/fetch/fetch-gzip.test.ts:

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:31:3)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:17:63)
 HTTP/1.1 GET http://localhost:36195/
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:36195
 Accept-Encoding: gzip, deflate, br, zstd

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at fetch (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:22:7)
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Mon, 13 Jul 2026 10:31:50 GMT
< Content-Length: 16139


      at gcTick (/workspace/bun/
... (truncated)

release without fix: 41 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/fetch-gzip.test.ts:

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:31:3)
 HTTP/1.1 GET http://localhost:44715/
 Connection: keep-alive
 User-Agent: Bun/1.4.0
 Accept: */*
 Host: localhost:44715
 Accept-Encoding: gzip, deflate, br, zstd

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at fetch (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:22:7)
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Mon, 13 Jul 2026 10:32:12 GMT
< Content-Length: 16139


      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:34:3)

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:37:3)

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:40:5)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:41:43)

      at gcTick (/workspace/bun/test/harness.t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-gzip.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d025989ee)

test/js/web/fetch/fetch-gzip.test.ts:

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:31:3)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:17:63)
 HTTP/1.1 GET http://localhost:42259/
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:42259
 Accept-Encoding: gzip, deflate, br, zstd

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at fetch (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:22:7)
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Mon, 13 Jul 2026 10:33:06 GMT
< Content-Length: 16139


      at gcTick (/workspace/bun/
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d025989ee2
  features     (none)

22 deps, 106 codegen, 1168 objects in 782ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [7.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] gen ErrorCode+*.h
[5/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[6/1231] fetch zlib
[zlib] up to date
[7/1231] gen .bind.ts → GeneratedBindings.cpp
[8/1231] gen ProcessBindingCo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/ContentCodings.rs           | 119 +++++++++++++++++++++++++
 src/http/Decompressor.rs             |  81 +++++++++++++++++
 src/http/InternalState.rs            |  90 +++++++++++--------
 src/http/lib.rs                      |  55 +++++-------
 test/js/web/fetch/fetch-gzip.test.ts | 163 +++++++++++++++++++++++++++++++++++
 5 files changed, 435 insertions(+), 73 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/http/ContentCodings.rs                1      2      0
src/http/Decompressor.rs                  4      7      0
src/http/InternalState.rs                 4     13      0
src/http/lib.rs                           8      6      0
test/js/web/fetch/fetch-gzip.test.ts      3      5      0
```

</details>

**root cause** · written by the author bot

Bun's HTTP client parsed the Content-Encoding header as a single token and ran exactly one decompressor, so responses with stacked codings such as `br, gzip` were decoded only through the outermost layer and resolved with still-compressed bytes instead of failing. The fix introduces a ContentCodings parser that reads the full comma-separated list and a DecompressorChain that pipes each chunk through every listed coding in reverse order, with chains containing unsupported codings rejected as a network error rather than partially decoded. InternalState and the HTTP client now use these in pla…

<!-- robobun:evidence:end -->