### PR TITLE
Bun.build: stop blocking the event loop on an async plugin setup()

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4080,6 +4080,10 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH3__onResolve;
     } else if (handler == Bun__HTTPRequestContextDebugH3__onResolveStream) {
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH3__onResolveStream;
+    } else if (handler == Bun__JSBundler__onResolvePluginSetup) {
+        return GlobalObject::PromiseFunctions::Bun__JSBundler__onResolvePluginSetup;
+    } else if (handler == Bun__JSBundler__onRejectPluginSetup) {
+        return GlobalObject::PromiseFunctions::Bun__JSBundler__onRejectPluginSetup;
     } else {
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -412,8 +412,10 @@ public:
         Bun__HTTPRequestContextDebugH3__onRejectStream,
         Bun__HTTPRequestContextDebugH3__onResolve,
         Bun__HTTPRequestContextDebugH3__onResolveStream,
+        Bun__JSBundler__onResolvePluginSetup,
+        Bun__JSBundler__onRejectPluginSetup,
     };
-    static constexpr size_t promiseFunctionsSize = 42;
+    static constexpr size_t promiseFunctionsSize = 44;
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -719,6 +719,9 @@ ZIG_DECL JSC::EncodedJSValue Bun__Timer__setImmediate(JSC::JSGlobalObject* globa
 BUN_DECLARE_HOST_FUNCTION(BunServe__onResolvePlugins);
 BUN_DECLARE_HOST_FUNCTION(BunServe__onRejectPlugins);
 
+BUN_DECLARE_HOST_FUNCTION(Bun__JSBundler__onResolvePluginSetup);
+BUN_DECLARE_HOST_FUNCTION(Bun__JSBundler__onRejectPluginSetup);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -596,9 +596,8 @@ pub mod js_bundler {
         ) -> JsResult<SetupStep> {
             let plugin = array.get_index(global_this, index)?;
             if !plugin.is_object() {
-                return Err(global_this.throw_invalid_arguments(format_args!(
-                    "Expected plugin to be an object"
-                )));
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("Expected plugin to be an object")));
             }
 
             if let Some(slice) = plugin.get_optional_slice(global_this, b"name")? {
@@ -609,9 +608,8 @@ pub mod js_bundler {
                 }
                 drop(slice);
             } else {
-                return Err(global_this.throw_invalid_arguments(format_args!(
-                    "Expected plugin to have a name"
-                )));
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("Expected plugin to have a name")));
             }
 
             let Some(function) = plugin.get_function(global_this, b"setup")? else {
@@ -1579,9 +1577,16 @@ pub mod js_bundler {
                 }
             }
 
-            let partial = self.partial.take().expect("DeferredBuild resumed after completion");
-            let config =
-                Config::finish_from_js(global_this, self.config_js.get(), partial, self.did_set_target)?;
+            let partial = self
+                .partial
+                .take()
+                .expect("DeferredBuild resumed after completion");
+            let config = Config::finish_from_js(
+                global_this,
+                self.config_js.get(),
+                partial,
+                self.did_set_target,
+            )?;
 
             let event_loop = global_this.bun_vm().event_loop();
             let completion =

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -451,8 +451,9 @@ pub mod js_bundler {
     /// [`DeferredBuild`] and continues from the promise's `.then`
     /// continuation.
     pub struct SuspendedPluginSetup {
-        /// The still-pending promise `runSetupFunction` returned.
-        pending: JSValue,
+        /// The still-pending promise `runSetupFunction` returned, kept
+        /// GC-rooted until `build` attaches the `.then` reactions to it.
+        pending: jsc::Strong,
         /// `config.plugins`, snapshotted before any `setup()` ran so a getter
         /// is not re-invoked on resume.
         plugins_array: jsc::Strong,
@@ -553,7 +554,7 @@ pub mod js_bundler {
                             // config parse, from this promise's `.then`
                             // continuation.
                             *suspended = Some(SuspendedPluginSetup {
-                                pending,
+                                pending: jsc::Strong::create(pending, global_this),
                                 plugins_array: jsc::Strong::create(array, global_this),
                                 next_index: index + 1,
                                 length,
@@ -1460,7 +1461,10 @@ pub mod js_bundler {
             let suspended = suspended.expect("from_js returned None without a suspension");
             let result = jsc::JSPromiseStrong::init(global_this);
             let return_value = result.value();
-            let pending = suspended.pending;
+            // `suspended.pending` (the Strong that is GC-rooting the promise)
+            // drops at the end of this block, after `.then` has attached its
+            // reactions.
+            let pending = suspended.pending.get();
             let deferred = bun_core::heap::into_raw(Box::new(DeferredBuild {
                 config_js: jsc::Strong::create(arguments[0], global_this),
                 plugins_array: suspended.plugins_array,

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -434,12 +434,56 @@ pub mod js_bundler {
         }
     }
 
+    /// One resolved step of the plugin `setup()` chain.
+    enum SetupStep {
+        /// `runSetupFunction` (and, for the last plugin, its `onStart()`
+        /// promises) settled synchronously; carries the updated promise array
+        /// to thread into the next plugin's `runSetupFunction` call.
+        Settled(JSValue),
+        /// `runSetupFunction` returned a promise that is still pending: an
+        /// async `setup()` that suspended on an `await`, or the last plugin's
+        /// `Promise.all` over pending `onStart()` promises.
+        Pending(JSValue),
+    }
+
+    /// Where [`Config::from_js`] stopped when a plugin `setup()` yielded a
+    /// promise that had not settled yet. `build` turns this into a
+    /// [`DeferredBuild`] and continues from the promise's `.then`
+    /// continuation.
+    pub struct SuspendedPluginSetup {
+        /// The still-pending promise `runSetupFunction` returned.
+        pending: JSValue,
+        /// `config.plugins`, snapshotted before any `setup()` ran so a getter
+        /// is not re-invoked on resume.
+        plugins_array: jsc::Strong,
+        /// Plugin index to resume the chain from.
+        next_index: u32,
+        /// Snapshot of the plugin array length.
+        length: u32,
+        plugin_target: jsc::BunPluginTarget,
+        /// The partially-parsed config: only the pre-plugin `target` fields
+        /// are set. The rest is parsed by `finish_from_js` once every
+        /// `setup()` has settled, because plugins may mutate the config
+        /// object before then.
+        config: Config,
+        did_set_target: bool,
+    }
+
     impl Config {
+        /// Parses `Bun.build`'s config object.
+        ///
+        /// Returns `Ok(None)` when a plugin's `setup()` (or the last plugin's
+        /// pending `onStart()` promises) yielded a promise that is still
+        /// pending. `*suspended` then records where the chain stopped and
+        /// owns the partially-parsed config; the caller must continue from
+        /// that promise's `.then` continuation instead of re-entering the
+        /// event loop (#33261).
         pub fn from_js(
             global_this: &JSGlobalObject,
             config: JSValue,
             plugins: &mut Option<*mut Plugin>,
-        ) -> JsResult<Config> {
+            suspended: &mut Option<SuspendedPluginSetup>,
+        ) -> JsResult<Option<Config>> {
             // Config implements Drop, so functional-record-update from Default::default()
             // is rejected by rustc (E0509). Construct default then mutate instead.
             let mut this = Config::default();
@@ -481,94 +525,163 @@ pub mod js_bundler {
 
             // Plugins must be resolved first as they are allowed to mutate the config JSValue
             if let Some(array) = config.get_array(global_this, "plugins")? {
-                let length = array.get_length(global_this)?;
-                let mut iter = array.array_iterator(global_this)?;
+                let length = array.get_length(global_this)? as u32;
+                let plugin_target = match this.target {
+                    Target::Bun | Target::BunMacro => jsc::BunPluginTarget::Bun,
+                    Target::Node => jsc::BunPluginTarget::Node,
+                    _ => jsc::BunPluginTarget::Browser,
+                };
                 let mut onstart_promise_array = JSValue::UNDEFINED;
-                let mut i: usize = 0;
-                while let Some(plugin) = iter.next()? {
-                    if !plugin.is_object() {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected plugin to be an object"
-                        )));
-                    }
-
-                    if let Some(slice) = plugin.get_optional_slice(global_this, b"name")? {
-                        if slice.slice().is_empty() {
-                            return Err(global_this.throw_invalid_arguments(format_args!(
-                                "Expected plugin to have a non-empty name"
-                            )));
-                        }
-                        drop(slice);
-                    } else {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected plugin to have a name"
-                        )));
-                    }
-
-                    let Some(function) = plugin.get_function(global_this, b"setup")? else {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected plugin to have a setup() function"
-                        )));
-                    };
-
-                    let bun_plugins: *mut Plugin = match **plugins {
-                        Some(p) => p,
-                        None => {
-                            let p = Plugin::create(
-                                global_this,
-                                match this.target {
-                                    Target::Bun | Target::BunMacro => jsc::BunPluginTarget::Bun,
-                                    Target::Node => jsc::BunPluginTarget::Node,
-                                    _ => jsc::BunPluginTarget::Browser,
-                                },
-                            );
-                            **plugins = Some(p);
-                            p
-                        }
-                    };
-
-                    let is_last = i == (length as usize).saturating_sub(1);
-                    // SAFETY: bun_plugins is a valid pointer created/stored above
-                    let mut plugin_result = unsafe {
-                        (*bun_plugins).add_plugin(
-                            function,
-                            config,
-                            onstart_promise_array,
-                            is_last,
-                            false,
-                        )?
-                    };
-
-                    if !plugin_result.is_empty_or_undefined_or_null() {
-                        if let Some(promise) = plugin_result.as_any_promise() {
-                            promise.set_handled(global_this.vm());
-                            // SAFETY: bun_vm() returns the live process VirtualMachine pointer.
-                            global_this.bun_vm().as_mut().wait_for_promise(promise);
-                            match promise
-                                .unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled)
-                            {
-                                jsc::PromiseResult::Pending => unreachable!(),
-                                jsc::PromiseResult::Fulfilled(val) => {
-                                    plugin_result = val;
-                                }
-                                jsc::PromiseResult::Rejected(err) => {
-                                    return Err(global_this.throw_value(err));
-                                }
-                            }
+                for index in 0..length {
+                    match Self::run_one_plugin_setup(
+                        global_this,
+                        config,
+                        &mut **plugins,
+                        plugin_target,
+                        array,
+                        index,
+                        length,
+                        onstart_promise_array,
+                    )? {
+                        SetupStep::Settled(value) => onstart_promise_array = value,
+                        SetupStep::Pending(pending) => {
+                            // An async `setup()` (or the last plugin's pending
+                            // `onStart()` promises) has not settled. Never
+                            // re-enter the event loop from here (#33261):
+                            // record where the chain stopped so `build` can
+                            // run the remaining plugins, and the rest of the
+                            // config parse, from this promise's `.then`
+                            // continuation.
+                            *suspended = Some(SuspendedPluginSetup {
+                                pending,
+                                plugins_array: jsc::Strong::create(array, global_this),
+                                next_index: index + 1,
+                                length,
+                                plugin_target,
+                                config: this,
+                                did_set_target,
+                            });
+                            // Ownership of the plugin registry transfers to
+                            // the continuation; disarm the error cleanup.
+                            scopeguard::ScopeGuard::into_inner(plugins);
+                            return Ok(None);
                         }
                     }
-
-                    if let Some(err) = plugin_result.to_error() {
-                        return Err(global_this.throw_value(err));
-                    } else if global_this.has_exception() {
-                        return Err(JsError::Thrown);
-                    }
-
-                    onstart_promise_array = plugin_result;
-                    i += 1;
                 }
             }
 
+            let this = Self::finish_from_js(global_this, config, this, did_set_target)?;
+            scopeguard::ScopeGuard::into_inner(plugins);
+            Ok(Some(this))
+        }
+
+        /// Validate plugin `index` of the `plugins` array, lazily create the
+        /// shared plugin registry, and invoke the plugin's `setup()` through
+        /// the `runSetupFunction` builtin.
+        ///
+        /// `runSetupFunction` stores the `onStart()` promise array it is
+        /// given on the plugin registry before calling `setup()`, so the
+        /// chain has to advance one plugin at a time with the previous
+        /// plugin's settled result.
+        #[allow(clippy::too_many_arguments)]
+        fn run_one_plugin_setup(
+            global_this: &JSGlobalObject,
+            config: JSValue,
+            plugins: &mut Option<*mut Plugin>,
+            plugin_target: jsc::BunPluginTarget,
+            array: JSValue,
+            index: u32,
+            length: u32,
+            onstart_promise_array: JSValue,
+        ) -> JsResult<SetupStep> {
+            let plugin = array.get_index(global_this, index)?;
+            if !plugin.is_object() {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "Expected plugin to be an object"
+                )));
+            }
+
+            if let Some(slice) = plugin.get_optional_slice(global_this, b"name")? {
+                if slice.slice().is_empty() {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected plugin to have a non-empty name"
+                    )));
+                }
+                drop(slice);
+            } else {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "Expected plugin to have a name"
+                )));
+            }
+
+            let Some(function) = plugin.get_function(global_this, b"setup")? else {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "Expected plugin to have a setup() function"
+                )));
+            };
+
+            let bun_plugins: *mut Plugin = match *plugins {
+                Some(p) => p,
+                None => {
+                    let p = Plugin::create(global_this, plugin_target);
+                    *plugins = Some(p);
+                    p
+                }
+            };
+
+            let is_last = index + 1 == length;
+            // SAFETY: bun_plugins is a valid pointer created/stored above
+            let mut plugin_result = unsafe {
+                (*bun_plugins).add_plugin(
+                    function,
+                    config,
+                    onstart_promise_array,
+                    is_last,
+                    false,
+                )?
+            };
+
+            if !plugin_result.is_empty_or_undefined_or_null() {
+                if let Some(promise) = plugin_result.as_any_promise() {
+                    promise.set_handled(global_this.vm());
+                    if matches!(promise.status(), jsc::js_promise::Status::Pending) {
+                        // Never block the event loop waiting for this promise
+                        // (#33261): the caller attaches `.then` reactions and
+                        // continues the chain from there.
+                        return Ok(SetupStep::Pending(plugin_result));
+                    }
+                    match promise.unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled) {
+                        jsc::PromiseResult::Pending => unreachable!(),
+                        jsc::PromiseResult::Fulfilled(val) => {
+                            plugin_result = val;
+                        }
+                        jsc::PromiseResult::Rejected(err) => {
+                            return Err(global_this.throw_value(err));
+                        }
+                    }
+                }
+            }
+
+            if let Some(err) = plugin_result.to_error() {
+                return Err(global_this.throw_value(err));
+            } else if global_this.has_exception() {
+                return Err(JsError::Thrown);
+            }
+
+            Ok(SetupStep::Settled(plugin_result))
+        }
+
+        /// Everything `from_js` parses after the plugin `setup()` chain has
+        /// settled. Split out so that, when a `setup()` suspends, the
+        /// remainder can run in its `.then` continuation: plugins are
+        /// allowed to mutate the config object before their promise settles,
+        /// so none of these fields may be read earlier.
+        fn finish_from_js(
+            global_this: &JSGlobalObject,
+            config: JSValue,
+            mut this: Config,
+            did_set_target: bool,
+        ) -> JsResult<Config> {
             if let Some(macros_flag) = config.get_boolean_loose(global_this, "macros")? {
                 this.no_macros = !macros_flag;
             }
@@ -1278,7 +1391,6 @@ pub mod js_bundler {
                 }
             }
 
-            scopeguard::ScopeGuard::into_inner(plugins);
             Ok(this)
         }
     }
@@ -1337,7 +1449,39 @@ pub mod js_bundler {
         }
 
         let mut plugins: Option<*mut Plugin> = None;
-        let config = Config::from_js(global_this, arguments[0], &mut plugins)?;
+        let mut suspended: Option<SuspendedPluginSetup> = None;
+        let Some(config) =
+            Config::from_js(global_this, arguments[0], &mut plugins, &mut suspended)?
+        else {
+            // A plugin `setup()` (or the last plugin's `onStart()` promises)
+            // suspended on a promise that has not settled. `Bun.build`
+            // already returns a promise, so run the remaining plugins, finish
+            // the config parse, and schedule the bundle from that promise's
+            // `.then` continuation instead of re-entering the event loop
+            // (#33261).
+            let suspended = suspended.expect("from_js returned None without a suspension");
+            let result = jsc::JSPromiseStrong::init(global_this);
+            let return_value = result.value();
+            let pending = suspended.pending;
+            let deferred = bun_core::heap::into_raw(Box::new(DeferredBuild {
+                config_js: jsc::Strong::create(arguments[0], global_this),
+                plugins_array: suspended.plugins_array,
+                next_index: suspended.next_index,
+                length: suspended.length,
+                plugin_target: suspended.plugin_target,
+                plugin: plugins,
+                partial: Some(suspended.config),
+                did_set_target: suspended.did_set_target,
+                result,
+            }));
+            pending.then(
+                global_this,
+                deferred,
+                __jsc_host_on_deferred_build_resolve,
+                __jsc_host_on_deferred_build_reject,
+            );
+            return Ok(return_value);
+        };
 
         let event_loop = vm.event_loop();
 
@@ -1368,6 +1512,159 @@ pub mod js_bundler {
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         build(global_this, callframe.arguments())
+    }
+
+    /// A `Bun.build` whose plugin `setup()` chain suspended on a pending
+    /// promise.
+    ///
+    /// Leaked with `heap::into_raw` and handed to the promise's `.then`
+    /// reactions as their context pointer; exactly one of the two reactions
+    /// runs and reclaims it (or leaks it again if the chain suspends on a
+    /// later plugin).
+    struct DeferredBuild {
+        /// `Bun.build(config)`'s config argument; the rest of the parse reads
+        /// it after the chain settles.
+        config_js: jsc::Strong,
+        /// See [`SuspendedPluginSetup::plugins_array`].
+        plugins_array: jsc::Strong,
+        next_index: u32,
+        length: u32,
+        plugin_target: jsc::BunPluginTarget,
+        /// The plugin registry, owned here until it either transfers to the
+        /// completion task (success) or is destroyed (failure).
+        plugin: Option<*mut Plugin>,
+        /// The partially-parsed config (pre-plugin `target` fields only);
+        /// `None` once it has moved into the completion task.
+        partial: Option<Config>,
+        did_set_target: bool,
+        /// `Bun.build`'s result promise. Moved into the completion task on
+        /// success, rejected here on failure.
+        result: jsc::JSPromiseStrong,
+    }
+
+    impl DeferredBuild {
+        /// Continue the plugin `setup()` chain from `next_index` with the
+        /// value the last pending step settled to, then, once every plugin
+        /// has settled, finish the config parse and schedule the bundle.
+        ///
+        /// Returns `Some(pending)` when the chain suspended again on a later
+        /// plugin's promise.
+        fn resume(
+            &mut self,
+            global_this: &JSGlobalObject,
+            mut onstart_promise_array: JSValue,
+        ) -> JsResult<Option<JSValue>> {
+            // The synchronous chain rejects when a step settles to an Error;
+            // preserve that for a step that settled through `.then`.
+            if let Some(err) = onstart_promise_array.to_error() {
+                return Err(global_this.throw_value(err));
+            }
+
+            let array = self.plugins_array.get();
+            while self.next_index < self.length {
+                let index = self.next_index;
+                self.next_index += 1;
+                match Config::run_one_plugin_setup(
+                    global_this,
+                    self.config_js.get(),
+                    &mut self.plugin,
+                    self.plugin_target,
+                    array,
+                    index,
+                    self.length,
+                    onstart_promise_array,
+                )? {
+                    SetupStep::Settled(value) => onstart_promise_array = value,
+                    SetupStep::Pending(pending) => return Ok(Some(pending)),
+                }
+            }
+
+            let partial = self.partial.take().expect("DeferredBuild resumed after completion");
+            let config =
+                Config::finish_from_js(global_this, self.config_js.get(), partial, self.did_set_target)?;
+
+            let event_loop = global_this.bun_vm().event_loop();
+            let completion =
+                crate::api::js_bundle_completion_task::create_and_schedule_completion_task(
+                    config,
+                    self.plugin.take().and_then(core::ptr::NonNull::new),
+                    global_this,
+                    event_loop,
+                )
+                .map_err(|_| JsError::OutOfMemory)?;
+            // SAFETY: `completion` is the freshly-boxed allocation returned
+            // above; sole owner on the JS thread until the enqueued task runs.
+            unsafe {
+                (*completion).promise = self.result.take();
+            }
+            Ok(None)
+        }
+
+        /// Reject `Bun.build`'s result promise with the pending exception and
+        /// destroy the plugin registry.
+        fn fail(&mut self, global_this: &JSGlobalObject, err: JsError) {
+            if let Some(plugin) = self.plugin.take() {
+                Plugin::destroy(plugin);
+            }
+            if matches!(err, JsError::Terminated) {
+                // The VM is terminating; leave the termination exception in
+                // place and don't settle the promise.
+                return;
+            }
+            let exception = global_this.take_exception(err);
+            let _ = self.result.reject(global_this, Ok(exception));
+        }
+    }
+
+    /// `.then` resolve reaction for a suspended plugin `setup()` chain: the
+    /// step's settled value (the `onStart()` promise array) arrives as the
+    /// first argument.
+    #[bun_jsc::host_fn(export = "Bun__JSBundler__onResolvePluginSetup")]
+    fn on_deferred_build_resolve(
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let [onstart_promise_array, ctx] = callframe.arguments_as_array::<2>();
+        let deferred: *mut DeferredBuild = ctx.as_promise_ptr::<DeferredBuild>();
+        // SAFETY: `deferred` was leaked via `heap::into_raw` by `build` (or a
+        // previous re-suspension) and exactly one of the two `.then`
+        // reactions runs; reclaiming it here is the unique owner transition.
+        let mut this: Box<DeferredBuild> = unsafe { bun_core::heap::take(deferred) };
+        match this.resume(global_this, onstart_promise_array) {
+            Ok(Some(pending)) => {
+                // Another plugin suspended; hand the allocation to the next
+                // pair of reactions.
+                let deferred = bun_core::heap::into_raw(this);
+                pending.then(
+                    global_this,
+                    deferred,
+                    __jsc_host_on_deferred_build_resolve,
+                    __jsc_host_on_deferred_build_reject,
+                );
+            }
+            Ok(None) => {}
+            Err(err) => this.fail(global_this, err),
+        }
+        Ok(JSValue::UNDEFINED)
+    }
+
+    /// `.then` reject reaction for a suspended plugin `setup()` chain: a
+    /// plugin's async `setup()` (or one of its `onStart()` callbacks)
+    /// rejected.
+    #[bun_jsc::host_fn(export = "Bun__JSBundler__onRejectPluginSetup")]
+    fn on_deferred_build_reject(
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let [error, ctx] = callframe.arguments_as_array::<2>();
+        let deferred: *mut DeferredBuild = ctx.as_promise_ptr::<DeferredBuild>();
+        // SAFETY: see `on_deferred_build_resolve`.
+        let mut this: Box<DeferredBuild> = unsafe { bun_core::heap::take(deferred) };
+        if let Some(plugin) = this.plugin.take() {
+            Plugin::destroy(plugin);
+        }
+        let _ = this.result.reject(global_this, Ok(error));
+        Ok(JSValue::UNDEFINED)
     }
 
     // NOTE: `Resolve`/`Load`/`MiniImportRecord`/etc. are owned by

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -436,49 +436,30 @@ pub mod js_bundler {
 
     /// One resolved step of the plugin `setup()` chain.
     enum SetupStep {
-        /// `runSetupFunction` (and, for the last plugin, its `onStart()`
-        /// promises) settled synchronously; carries the updated promise array
-        /// to thread into the next plugin's `runSetupFunction` call.
+        /// The updated `onStart()` promise array, threaded into the next step.
         Settled(JSValue),
-        /// `runSetupFunction` returned a promise that is still pending: an
-        /// async `setup()` that suspended on an `await`, or the last plugin's
-        /// `Promise.all` over pending `onStart()` promises.
+        /// A still-pending async `setup()` or last-plugin `onStart()` `Promise.all`.
         Pending(JSValue),
     }
 
-    /// Where [`Config::from_js`] stopped when a plugin `setup()` yielded a
-    /// promise that had not settled yet. `build` turns this into a
-    /// [`DeferredBuild`] and continues from the promise's `.then`
-    /// continuation.
+    /// Where [`Config::from_js`] stopped when a plugin `setup()` suspended; see [`DeferredBuild`].
     pub struct SuspendedPluginSetup {
-        /// The still-pending promise `runSetupFunction` returned, kept
-        /// GC-rooted until `build` attaches the `.then` reactions to it.
+        /// GC-roots the `runSetupFunction` promise until `build` attaches `.then` reactions.
         pending: jsc::Strong,
-        /// `config.plugins`, snapshotted before any `setup()` ran so a getter
-        /// is not re-invoked on resume.
+        /// `config.plugins`, snapshotted so getters aren't re-invoked on resume.
         plugins_array: jsc::Strong,
         /// Plugin index to resume the chain from.
         next_index: u32,
         /// Snapshot of the plugin array length.
         length: u32,
         plugin_target: jsc::BunPluginTarget,
-        /// The partially-parsed config: only the pre-plugin `target` fields
-        /// are set. The rest is parsed by `finish_from_js` once every
-        /// `setup()` has settled, because plugins may mutate the config
-        /// object before then.
+        /// Only `target` is set; the rest is parsed by `finish_from_js` once the chain settles.
         config: Config,
         did_set_target: bool,
     }
 
     impl Config {
-        /// Parses `Bun.build`'s config object.
-        ///
-        /// Returns `Ok(None)` when a plugin's `setup()` (or the last plugin's
-        /// pending `onStart()` promises) yielded a promise that is still
-        /// pending. `*suspended` then records where the chain stopped and
-        /// owns the partially-parsed config; the caller must continue from
-        /// that promise's `.then` continuation instead of re-entering the
-        /// event loop (#33261).
+        /// `Ok(None)` means a plugin `setup()` suspended; `*suspended` records where the chain stopped (#33261).
         pub fn from_js(
             global_this: &JSGlobalObject,
             config: JSValue,
@@ -546,13 +527,6 @@ pub mod js_bundler {
                     )? {
                         SetupStep::Settled(value) => onstart_promise_array = value,
                         SetupStep::Pending(pending) => {
-                            // An async `setup()` (or the last plugin's pending
-                            // `onStart()` promises) has not settled. Never
-                            // re-enter the event loop from here (#33261):
-                            // record where the chain stopped so `build` can
-                            // run the remaining plugins, and the rest of the
-                            // config parse, from this promise's `.then`
-                            // continuation.
                             *suspended = Some(SuspendedPluginSetup {
                                 pending: jsc::Strong::create(pending, global_this),
                                 plugins_array: jsc::Strong::create(array, global_this),
@@ -562,8 +536,7 @@ pub mod js_bundler {
                                 config: this,
                                 did_set_target,
                             });
-                            // Ownership of the plugin registry transfers to
-                            // the continuation; disarm the error cleanup.
+                            // Plugin registry ownership moves to the continuation; disarm cleanup.
                             scopeguard::ScopeGuard::into_inner(plugins);
                             return Ok(None);
                         }
@@ -576,14 +549,7 @@ pub mod js_bundler {
             Ok(Some(this))
         }
 
-        /// Validate plugin `index` of the `plugins` array, lazily create the
-        /// shared plugin registry, and invoke the plugin's `setup()` through
-        /// the `runSetupFunction` builtin.
-        ///
-        /// `runSetupFunction` stores the `onStart()` promise array it is
-        /// given on the plugin registry before calling `setup()`, so the
-        /// chain has to advance one plugin at a time with the previous
-        /// plugin's settled result.
+        /// Run plugin `index`'s `setup()`; one at a time because the builtin stashes the prior step's array.
         #[allow(clippy::too_many_arguments)]
         fn run_one_plugin_setup(
             global_this: &JSGlobalObject,
@@ -644,9 +610,6 @@ pub mod js_bundler {
                 if let Some(promise) = plugin_result.as_any_promise() {
                     promise.set_handled(global_this.vm());
                     if matches!(promise.status(), jsc::js_promise::Status::Pending) {
-                        // Never block the event loop waiting for this promise
-                        // (#33261): the caller attaches `.then` reactions and
-                        // continues the chain from there.
                         return Ok(SetupStep::Pending(plugin_result));
                     }
                     match promise.unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled) {
@@ -670,11 +633,7 @@ pub mod js_bundler {
             Ok(SetupStep::Settled(plugin_result))
         }
 
-        /// Everything `from_js` parses after the plugin `setup()` chain has
-        /// settled. Split out so that, when a `setup()` suspends, the
-        /// remainder can run in its `.then` continuation: plugins are
-        /// allowed to mutate the config object before their promise settles,
-        /// so none of these fields may be read earlier.
+        /// The post-setup tail of `from_js`; plugins may mutate the config, so nothing here can be read earlier.
         fn finish_from_js(
             global_this: &JSGlobalObject,
             config: JSValue,
@@ -1452,18 +1411,10 @@ pub mod js_bundler {
         let Some(config) =
             Config::from_js(global_this, arguments[0], &mut plugins, &mut suspended)?
         else {
-            // A plugin `setup()` (or the last plugin's `onStart()` promises)
-            // suspended on a promise that has not settled. `Bun.build`
-            // already returns a promise, so run the remaining plugins, finish
-            // the config parse, and schedule the bundle from that promise's
-            // `.then` continuation instead of re-entering the event loop
-            // (#33261).
             let suspended = suspended.expect("from_js returned None without a suspension");
             let result = jsc::JSPromiseStrong::init(global_this);
             let return_value = result.value();
-            // `suspended.pending` (the Strong that is GC-rooting the promise)
-            // drops at the end of this block, after `.then` has attached its
-            // reactions.
+            // `suspended.pending` stays rooted through this block and drops after `.then` attaches.
             let pending = suspended.pending.get();
             let deferred = bun_core::heap::into_raw(Box::new(DeferredBuild {
                 config_js: jsc::Strong::create(arguments[0], global_this),
@@ -1516,48 +1467,32 @@ pub mod js_bundler {
         build(global_this, callframe.arguments())
     }
 
-    /// A `Bun.build` whose plugin `setup()` chain suspended on a pending
-    /// promise.
-    ///
-    /// Leaked with `heap::into_raw` and handed to the promise's `.then`
-    /// reactions as their context pointer; exactly one of the two reactions
-    /// runs and reclaims it (or leaks it again if the chain suspends on a
-    /// later plugin).
+    /// Leaked via `heap::into_raw`; exactly one `.then` reaction reclaims it (or re-leaks on another suspension).
     struct DeferredBuild {
-        /// `Bun.build(config)`'s config argument; the rest of the parse reads
-        /// it after the chain settles.
+        /// `Bun.build`'s config argument; re-read by `finish_from_js` after the chain settles.
         config_js: jsc::Strong,
         /// See [`SuspendedPluginSetup::plugins_array`].
         plugins_array: jsc::Strong,
         next_index: u32,
         length: u32,
         plugin_target: jsc::BunPluginTarget,
-        /// The plugin registry, owned here until it either transfers to the
-        /// completion task (success) or is destroyed (failure).
+        /// Owned here until moved to the completion task or destroyed on failure.
         plugin: Option<*mut Plugin>,
-        /// The partially-parsed config (pre-plugin `target` fields only);
-        /// `None` once it has moved into the completion task.
+        /// The pre-plugin config; `None` once it moves to the completion task.
         partial: Option<Config>,
         did_set_target: bool,
-        /// `Bun.build`'s result promise. Moved into the completion task on
-        /// success, rejected here on failure.
+        /// `Bun.build`'s result promise; moves to the completion task or is rejected here.
         result: jsc::JSPromiseStrong,
     }
 
     impl DeferredBuild {
-        /// Continue the plugin `setup()` chain from `next_index` with the
-        /// value the last pending step settled to, then, once every plugin
-        /// has settled, finish the config parse and schedule the bundle.
-        ///
-        /// Returns `Some(pending)` when the chain suspended again on a later
-        /// plugin's promise.
+        /// Continue from `next_index`; returns `Some(pending)` on another suspension.
         fn resume(
             &mut self,
             global_this: &JSGlobalObject,
             mut onstart_promise_array: JSValue,
         ) -> JsResult<Option<JSValue>> {
-            // The synchronous chain rejects when a step settles to an Error;
-            // preserve that for a step that settled through `.then`.
+            // Preserve the sync chain's reject-on-Error for a `.then`-settled step.
             if let Some(err) = onstart_promise_array.to_error() {
                 return Err(global_this.throw_value(err));
             }
@@ -1609,15 +1544,12 @@ pub mod js_bundler {
             Ok(None)
         }
 
-        /// Reject `Bun.build`'s result promise with the pending exception and
-        /// destroy the plugin registry.
+        /// Reject the result promise with the pending exception and free the plugin registry.
         fn fail(&mut self, global_this: &JSGlobalObject, err: JsError) {
             if let Some(plugin) = self.plugin.take() {
                 Plugin::destroy(plugin);
             }
             if matches!(err, JsError::Terminated) {
-                // The VM is terminating; leave the termination exception in
-                // place and don't settle the promise.
                 return;
             }
             let exception = global_this.take_exception(err);
@@ -1625,9 +1557,7 @@ pub mod js_bundler {
         }
     }
 
-    /// `.then` resolve reaction for a suspended plugin `setup()` chain: the
-    /// step's settled value (the `onStart()` promise array) arrives as the
-    /// first argument.
+    /// `.then` resolve reaction; arg[0] is the settled `onStart()` promise array.
     #[bun_jsc::host_fn(export = "Bun__JSBundler__onResolvePluginSetup")]
     fn on_deferred_build_resolve(
         global_this: &JSGlobalObject,
@@ -1641,8 +1571,6 @@ pub mod js_bundler {
         let mut this: Box<DeferredBuild> = unsafe { bun_core::heap::take(deferred) };
         match this.resume(global_this, onstart_promise_array) {
             Ok(Some(pending)) => {
-                // Another plugin suspended; hand the allocation to the next
-                // pair of reactions.
                 let deferred = bun_core::heap::into_raw(this);
                 pending.then(
                     global_this,
@@ -1657,9 +1585,7 @@ pub mod js_bundler {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// `.then` reject reaction for a suspended plugin `setup()` chain: a
-    /// plugin's async `setup()` (or one of its `onStart()` callbacks)
-    /// rejected.
+    /// `.then` reject reaction for a suspended plugin `setup()` chain.
     #[bun_jsc::host_fn(export = "Bun__JSBundler__onRejectPluginSetup")]
     fn on_deferred_build_reject(
         global_this: &JSGlobalObject,

--- a/test/bundler/bun-build-plugin-async-setup.test.ts
+++ b/test/bundler/bun-build-plugin-async-setup.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// `Bun.build({ plugins })` used to run each plugin's `setup()` during
+// synchronous config parsing and, when `setup()` returned a promise that was
+// still pending, spin the whole event loop (`waitForPromise`) until it
+// settled. Synchronously re-entering the event loop from inside whatever
+// callback called `Bun.build` is the bug class tracked in
+// https://github.com/oven-sh/bun/issues/33261: a nested tick run from inside
+// a ready-poll dispatch can clobber the shared ready-poll batch and lose
+// one-shot events. It was also a deterministic hang on its own, because the
+// nested loop blocks the very JS frame that would have settled the promise.
+//
+// `Bun.build` now returns without blocking: the remaining plugins and the
+// rest of the config parse run in the pending promise's `.then` continuation.
+describe("Bun.build with an async plugin setup()", () => {
+  const entry = `export const hello = "world";\n`;
+
+  test(
+    "returns before a pending setup() promise settles",
+    async () => {
+      using dir = tempDir("bun-build-async-setup", {
+        "entry.js": entry,
+        "build-fixture.ts": /* ts */ `
+          let release!: () => void;
+          const gate = new Promise<void>(resolve => (release = resolve));
+          const order: string[] = [];
+
+          const built = Bun.build({
+            entrypoints: ["./entry.js"],
+            plugins: [
+              {
+                name: "gated",
+                async setup(build) {
+                  order.push("setup:start");
+                  await gate;
+                  order.push("setup:resume");
+                  // A filter registered after the await must still be
+                  // installed: they only take effect once setup() settles.
+                  build.onLoad({ filter: /entry\\.js$/ }, () => ({
+                    contents: "export const hello = 'patched';",
+                    loader: "js",
+                  }));
+                },
+              },
+            ],
+          });
+
+          // Unreachable when Bun.build spins the event loop: release() is the
+          // only thing that can settle the promise it would be waiting on.
+          order.push("returned");
+          release();
+
+          const result = await built;
+          order.push("built");
+          if (!result.success) throw new AggregateError(result.logs, "build failed");
+          const text = await result.outputs[0].text();
+          if (!text.includes("patched")) {
+            throw new Error("onLoad registered after an await was ignored:\\n" + text);
+          }
+          console.log(JSON.stringify(order));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build-fixture.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        // Only reached when Bun.build blocks; the non-blocking path exits in
+        // well under a second.
+        timeout: 15_000,
+        killSignal: "SIGKILL",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(exitCode === 0 ? JSON.parse(stdout.trim()) : { exitCode, stdout, stderr }).toEqual([
+        "setup:start",
+        "returned",
+        "setup:resume",
+        "built",
+      ]);
+    },
+    30_000,
+  );
+
+  test("still waits for a setup() that suspends on I/O", async () => {
+    using dir = tempDir("bun-build-async-setup-io", { "entry.js": entry });
+    let setupResumed = false;
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      plugins: [
+        {
+          name: "sleepy",
+          async setup() {
+            await Bun.sleep(10);
+            setupResumed = true;
+          },
+        },
+      ],
+    });
+    expect(setupResumed).toBe(true);
+    expect(result.success).toBe(true);
+  });
+
+  test("still waits for pending onStart() promises before loading any file", async () => {
+    using dir = tempDir("bun-build-async-setup-onstart", { "entry.js": entry });
+    const order: string[] = [];
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      plugins: [
+        {
+          name: "starter",
+          setup(build) {
+            build.onStart(async () => {
+              await Bun.sleep(10);
+              order.push("onStart");
+            });
+            build.onLoad({ filter: /entry\.js$/ }, () => {
+              order.push("onLoad");
+              return { contents: entry, loader: "js" };
+            });
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(order).toEqual(["onStart", "onLoad"]);
+  });
+
+  test("runs the remaining plugins after an earlier async setup() settles", async () => {
+    using dir = tempDir("bun-build-async-setup-chain", { "entry.js": entry });
+    const order: string[] = [];
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      plugins: [
+        {
+          name: "first",
+          async setup() {
+            order.push("first:start");
+            await Bun.sleep(10);
+            order.push("first:done");
+          },
+        },
+        {
+          name: "second",
+          setup() {
+            order.push("second");
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(order).toEqual(["first:start", "first:done", "second"]);
+  });
+
+  test("config mutated after an await in setup() is respected", async () => {
+    using dir = tempDir("bun-build-async-setup-mutate", {
+      "entry.js": `export const flag = BUILD_FLAG;\n`,
+    });
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      plugins: [
+        {
+          name: "definer",
+          async setup(build) {
+            await Bun.sleep(10);
+            build.config.define = { BUILD_FLAG: JSON.stringify("after-await") };
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(await result.outputs[0].text()).toContain("after-await");
+  });
+
+  test("rejects the build promise when an async setup() rejects", async () => {
+    using dir = tempDir("bun-build-async-setup-reject", { "entry.js": entry });
+    await expect(
+      Bun.build({
+        entrypoints: [`${dir}/entry.js`],
+        plugins: [
+          {
+            name: "explosive",
+            async setup() {
+              await Bun.sleep(10);
+              throw new Error("setup exploded");
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow("setup exploded");
+  });
+});

--- a/test/bundler/bun-build-plugin-async-setup.test.ts
+++ b/test/bundler/bun-build-plugin-async-setup.test.ts
@@ -16,12 +16,10 @@ import { bunEnv, bunExe, tempDir } from "harness";
 describe("Bun.build with an async plugin setup()", () => {
   const entry = `export const hello = "world";\n`;
 
-  test(
-    "returns before a pending setup() promise settles",
-    async () => {
-      using dir = tempDir("bun-build-async-setup", {
-        "entry.js": entry,
-        "build-fixture.ts": /* ts */ `
+  test("returns before a pending setup() promise settles", async () => {
+    using dir = tempDir("bun-build-async-setup", {
+      "entry.js": entry,
+      "build-fixture.ts": /* ts */ `
           let release!: () => void;
           const gate = new Promise<void>(resolve => (release = resolve));
           const order: string[] = [];
@@ -60,33 +58,27 @@ describe("Bun.build with an async plugin setup()", () => {
           }
           console.log(JSON.stringify(order));
         `,
-      });
+    });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "build-fixture.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-        // Only reached when Bun.build blocks; the non-blocking path exits in
-        // well under a second.
-        timeout: 15_000,
-        killSignal: "SIGKILL",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
-      expect(exitCode === 0 ? JSON.parse(stdout.trim()) : { exitCode, stdout, stderr }).toEqual([
-        "setup:start",
-        "returned",
-        "setup:resume",
-        "built",
-      ]);
-    },
-    30_000,
-  );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build-fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      // Only reached when Bun.build blocks; the non-blocking path exits in
+      // well under a second.
+      timeout: 15_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode === 0 ? JSON.parse(stdout.trim()) : { exitCode, stdout, stderr }).toEqual([
+      "setup:start",
+      "returned",
+      "setup:resume",
+      "built",
+    ]);
+  }, 30_000);
 
   test("still waits for a setup() that suspends on I/O", async () => {
     using dir = tempDir("bun-build-async-setup-io", { "entry.js": entry });

--- a/test/bundler/bun-build-plugin-async-setup.test.ts
+++ b/test/bundler/bun-build-plugin-async-setup.test.ts
@@ -1,19 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// `Bun.build({ plugins })` used to run each plugin's `setup()` during
-// synchronous config parsing and, when `setup()` returned a promise that was
-// still pending, spin the whole event loop (`waitForPromise`) until it
-// settled. Synchronously re-entering the event loop from inside whatever
-// callback called `Bun.build` is the bug class tracked in
-// https://github.com/oven-sh/bun/issues/33261: a nested tick run from inside
-// a ready-poll dispatch can clobber the shared ready-poll batch and lose
-// one-shot events. It was also a deterministic hang on its own, because the
-// nested loop blocks the very JS frame that would have settled the promise.
-//
-// `Bun.build` now returns without blocking: the remaining plugins and the
-// rest of the config parse run in the pending promise's `.then` continuation.
-describe("Bun.build with an async plugin setup()", () => {
+// https://github.com/oven-sh/bun/issues/33261
+// `Bun.build` must not block the event loop on a pending plugin setup()
+// promise; it resumes config parsing in that promise's `.then` continuation.
+describe.concurrent("Bun.build with an async plugin setup()", () => {
   const entry = `export const hello = "world";\n`;
 
   test("returns before a pending setup() promise settles", async () => {

--- a/test/bundler/bun-build-plugin-async-setup.test.ts
+++ b/test/bundler/bun-build-plugin-async-setup.test.ts
@@ -161,6 +161,44 @@ describe.concurrent("Bun.build with an async plugin setup()", () => {
     expect(await result.outputs[0].text()).toContain("after-await");
   });
 
+  test("lets a caller escape a never-settling setup() with Promise.race", async () => {
+    using dir = tempDir("bun-build-async-setup-race", {
+      "entry.js": entry,
+      "race-fixture.ts": /* ts */ `
+          const cfg = {
+            entrypoints: ["./entry.js"],
+            plugins: [
+              {
+                name: "never-settles",
+                async setup() {
+                  await new Promise(() => {});
+                },
+              },
+            ],
+          };
+          const buildPromise = Bun.build(cfg);
+          const winner = await Promise.race([
+            buildPromise.then(() => "build"),
+            Bun.sleep(200).then(() => "timeout"),
+          ]);
+          console.log(JSON.stringify({ winner }));
+          process.exit(winner === "timeout" ? 0 : 1);
+        `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "race-fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode === 0 ? JSON.parse(stdout.trim()) : { exitCode, stdout, stderr }).toEqual({ winner: "timeout" });
+  }, 30_000);
+
   test("rejects the build promise when an async setup() rejects", async () => {
     using dir = tempDir("bun-build-async-setup-reject", { "entry.js": entry });
     await expect(


### PR DESCRIPTION
Part of the #33261 audit (work item 3).

### Repro

An async plugin `setup()` whose promise has not settled by the time `setup()` returns makes `Bun.build` spin the event loop at 100% CPU. When the thing that settles it is later on the same stack, that is a permanent hang:

```js
let release;
const gate = new Promise(r => (release = r));
const p = Bun.build({
  entrypoints: ["./entry.js"],
  plugins: [{ name: "p", setup: async () => { await gate; } }],
});
release(); // unreachable: Bun.build is blocked three lines up
await p;
```

Hangs on 1.3.x, every time.

### Cause

`Config::from_js` (`src/runtime/api/JSBundler.rs`) runs each plugin's `setup()` during synchronous config parsing and, when the `runSetupFunction` builtin hands back a promise that is still pending, calls `waitForPromise`, which runs the whole event loop until it settles. `Bun.build` is reachable from any JS, including an I/O completion callback, so this is the synchronous re-entry #33261 forbids: a nested `epoll_wait`/`kevent` inside a poll-dispatch callback overwrites the shared ready-poll batch and loses one-shot events. It is also the deterministic hang above, since the nested loop blocks the JS frame that would have settled the promise.

That one call was also the only implementation of the documented "the bundler waits until all `onStart()` callbacks have completed before continuing" guarantee: the builtin folds a pending async `setup()` together with the last plugin's pending `onStart()` promises into the single promise it hands back.

### Fix

Chain instead of blocking. `Bun.build` already returns its own promise, so:

- `Config::from_js` no longer blocks. When a step's promise is still pending it records where the chain stopped (`SuspendedPluginSetup`) and returns early. The chain has to advance one plugin at a time because `runSetupFunction` needs the previous plugin's settled `onStart()` array.
- `build()` creates the result promise immediately and parks the parse state in a heap `DeferredBuild` owned by the pending promise's `.then` reactions (registered in `PromiseFunctions`, like every other native promise reaction). The resolve reaction runs the remaining plugins, re-suspending on each further pending promise, then the rest of the config parse, then schedules the bundle, moving the already-returned promise into the completion task. The reject reaction rejects it.
- Everything after the plugin loop was already forbidden from running before the chain settled (plugins may mutate the config object), so it all moves into `finish_from_js` and defers with the chain.

The synchronous path (no plugins, or every `setup()` and `onStart()` settled before returning) is unchanged. The `onStart()`-gates-the-bundle guarantee is preserved: the bundle task is not created until the chain settles.

### Behavior change

Only on the path that used to block. A rejecting async `setup()` (or `onStart()`) now rejects the returned promise instead of throwing synchronously from the `Bun.build(...)` call, and so does a config parse error raised after an async `setup()` settles. Synchronous `setup()` errors still throw synchronously.

### Verification

`test/bundler/bun-build-plugin-async-setup.test.ts`.

```
USE_SYSTEM_BUN=1 bun test test/bundler/bun-build-plugin-async-setup.test.ts
  -> 4 pass, 2 fail (the gated subprocess hangs and is SIGKILLed after 15s with
     no output; the rejection test throws synchronously instead of rejecting)
bun bd test test/bundler/bun-build-plugin-async-setup.test.ts
  -> 6 pass
```

No regressions: `bun-build-api.test.ts` (48 pass), and `bundler_plugin.test.ts` + `bundler_plugin_chain.test.ts` + `plugin-error-nested-throw.test.ts` + `plugin-sync-exception-fallback.test.ts` (69 pass across the four).

The audit of the other non-top-level `waitForPromise` callers (the rest of work item 3) is on #33261. The remaining violation, `bake_body.rs:378` via `Bun.serve({ app: { plugins } })`, needs a different shape (`Bun.serve` returns a `Server`, not a promise) and is left for a follow-up.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bun-build-plugin-async-setup.test.ts
bun test v1.4.0 (112f49c3a)

test/bundler/bun-build-plugin-async-setup.test.ts:
(pass) Bun.build with an async plugin setup() > still waits for a setup() that suspends on I/O [262.56ms]
(pass) Bun.build with an async plugin setup() > still waits for pending onStart() promises before loading any file [257.32ms]
207 |         plugins: [
208 |           {
209 |             name: "explosive",
210 |             async setup() {
211 |               await Bun.sleep(10);
212 |               throw new Error("setup exploded");
                              ^
error: setup exploded
      at setup (/workspace/bun/test/bundler/bun-build-plugin-async-setup.test.ts:212:25)
      at <anonymous> (/workspace/bun/test/bundler/bun-build-plugin-async-setup.test.ts:205:11)
      at <anonymous> (/workspace/bun/test/bundler/bun-build-plugin-async-setup.test.ts:202:67)
(fail) Bun.build with an async plugin setup() > rejects the build promise when an async setup() rejects [86.02ms]
(pass) Bun.build with an async p
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bun-build-plugin-async-setup.test.ts:
207 |         plugins: [
208 |           {
209 |             name: "explosive",
210 |             async setup() {
211 |               await Bun.sleep(10);
212 |               throw new Error("setup exploded");
                              ^
error: setup exploded
      at setup (/workspace/bun/test/bundler/bun-build-plugin-async-setup.test.ts:212:25)
      at <anonymous> (/workspace/bun/test/bundler/bun-build-plugin-async-setup.test.ts:205:11)
(fail) Bun.build with an async plugin setup() > rejects the build promise when an async setup() rejects [58.95ms]
(pass) Bun.build with an async plugin setup() > still waits for a setup() that suspends on I/O [239.56ms]
(pass) Bun.build with an async plugin setup() > still waits for pending onStart() promises before loading any file [208.77ms]
(pass) Bun.build with an async plugin setup() > runs the remaining plugins after an earlier async setup() settles [186.32ms]
(pass) Bun.build with an async plugin setup() > config mutated after an await in setup() is respected [114.98ms]
61 |       // well under a second.
62 |       timeout: 15_000,

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bun-build-plugin-async-setup.test.ts
bun test v1.4.0 (112f49c3a)

test/bundler/bun-build-plugin-async-setup.test.ts:
(pass) Bun.build with an async plugin setup() > still waits for a setup() that suspends on I/O [290.46ms]
(pass) Bun.build with an async plugin setup() > still waits for pending onStart() promises before loading any file [421.97ms]
(pass) Bun.build with an async plugin setup() > rejects the build promise when an async setup() rejects [39.50ms]
(pass) Bun.build with an async plugin setup() > runs the remaining plugins after an earlier async setup() settles [477.35ms]
(pass) Bun.build with an async plugin setup() > returns before a pending setup() promise settles [615.60ms]
(pass) Bun.build with an async plugin setup() > config mutated after an await in setup() is respected [488.17ms]
(pass) Bun.build with an async plugin setup() > lets a caller escape a never-settling setup() with Promise.race [592.43ms]

 7 pass
 0 fail
 11 expect() calls
Ran 7 tests across 1 file. [3.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     112f49c3a4
  features     baseline

22 deps, 108 codegen, 1171 objects in 2040ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch picohttpparser
[picohttpparser] up to date
[2/1234] gen ErrorCode+*.h
[3/1234] fetch zlib
[zlib] up to date
[4/1234] gen bindgenv2
[5/1234] gen .bind.ts → GeneratedBindings.cpp
[6/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1234] subst deps/zlib/zlib.h
[11/1234] subst deps/zlib/zconf.h
[12/1234] subst deps/libjpeg-turbo/jconfigint.h
[13/1234] subst deps/libjpeg-turbo/jconfig.h
[14/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[15/1234] gen ProcessBindingB
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp              |   4 +
 src/jsc/bindings/ZigGlobalObject.h                |   4 +-
 src/jsc/bindings/headers.h                        |   3 +
 src/runtime/api/JSBundler.rs                      | 390 +++++++++++++++++-----
 test/bundler/bun-build-plugin-async-setup.test.ts | 219 ++++++++++++
 5 files changed, 540 insertions(+), 80 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp                   1      2      0
src/jsc/bindings/ZigGlobalObject.h                     1      1      0
src/jsc/bindings/headers.h                             1      1      0
src/runtime/api/JSBundler.rs                          10     12      0
test/bundler/bun-build-plugin-async-setup.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->