### PR TITLE
ci: ignore image publish and windows signing tags on fork PRs

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1423,6 +1423,20 @@ async function getPipelineOptions() {
     imageFilter = undefined;
   }
 
+  // Image bake/publish and Windows signing run privileged steps (image
+  // credentials, signing keys), so commit-subject tags from fork PRs are
+  // ignored — only same-repo branches may request them.
+  let signWindows = parseOption(/\[(sign windows)\]/i);
+  if (isFork() && (buildImages || publishImages || signWindows)) {
+    console.log(
+      `Ignoring [${publishImages || buildImages || signWindows}] on a fork pull request — image and signing steps only run for same-repo branches.`,
+    );
+    buildImages = false;
+    publishImages = false;
+    imageFilter = undefined;
+    signWindows = false;
+  }
+
   return {
     canary: isCanary ? canary : 0,
     skipEverything: parseOption(/\[(skip ci|no ci)\]/i),
@@ -1430,7 +1444,7 @@ async function getPipelineOptions() {
     forceBuilds: parseOption(/\[(force builds?)\]/i),
     skipTests: parseOption(/\[(skip tests?|no tests?|only builds?)\]/i),
     skipSizeCheck: parseOption(/\[(skip size( check)?|allow size)\]/i),
-    signWindows: parseOption(/\[(sign windows)\]/i),
+    signWindows,
     buildImages,
     dryRun: parseOption(/\[(dry run)\]/i),
     publishImages,


### PR DESCRIPTION
### What does this PR do?

`.buildkite/ci.mjs` reads option tags like `[publish images]`, `[build images]`, and `[sign windows]` from the commit subject. Those tags enable privileged pipeline steps: baking/publishing the live CI base images and running the Windows code-signing step. On a fork pull request the commit subject is controlled by the PR author, so this change ignores those tags when the build comes from a fork (mirroring the existing guard that ignores them on `main`) and only honors them on same-repo branches. The maintainer-driven "New Build" metadata path is unaffected.

Follow-up to the recent drive-by fork PRs (#33263, #33264, #33266): defense in depth so an accidentally-unblocked fork build cannot request image publishing or signing via its commit message.

Note for reviewers: the gate uses the existing `isFork()` helper, which string-compares `BUILDKITE_PULL_REQUEST_REPO` against `BUILDKITE_REPO` — worth confirming both are reported in the same URL format on real builds so same-repo PRs keep their `[publish images]` behavior.

### How did you verify your code works?

Generated the pipeline locally with simulated Buildkite env:

- fork repo + `[publish images] [sign windows]` → logs the ignore message, generated `ci.yml` contains no `build-image`/`windows-sign` steps
- same repo + same tags → `build-images` and `windows-sign` steps still generated (unchanged)
- fork repo, no tags → normal pipeline, no ignore message