### PR TITLE
shell: implement `$?`, `$$`, `$#`, and `${NAME}`; reject unsupported expansions

### DIFF
--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -327,6 +327,55 @@ const foo = "bar123; rm -rf /tmp";
 await $`FOO=${foo} bun -e 'console.log(process.env.FOO)'`; // bar123; rm -rf /tmp\n
 ```
 
+### Reading variables
+
+Read a variable with `$NAME` or `${NAME}`. The braced form is for when the
+name would otherwise run into the characters that follow it:
+
+```sh
+FOO=bar
+echo ${FOO}baz # barbaz
+echo $FOObaz   # reads the variable "FOObaz"
+```
+
+<Note>
+
+Inside the `$` template literal, `${...}` is JavaScript interpolation, so it
+never reaches the shell as syntax. To pass a literal `${NAME}` to the shell
+from JavaScript, use the `{ raw: string }` escape hatch (see `$.escape` under
+Utilities):
+
+```js
+import { $ } from "bun";
+
+await $`FOO=bar; echo ${{ raw: "${FOO}baz" }}`; // barbaz\n
+```
+
+In a `.sh` file run with `bun`, `${NAME}` works as written. The other
+parameters below have no meaning in a JavaScript template literal and can be
+written directly.
+
+</Note>
+
+These POSIX special parameters are also supported:
+
+| Parameter         | Expands to                                           |
+| ----------------- | ---------------------------------------------------- |
+| `$?` / `${?}`     | Exit status of the most recently completed command   |
+| `$$` / `${$}`     | PID of the current process                           |
+| `$#` / `${#}`     | Number of positional parameters                      |
+| `$0`…`$9`, `${N}` | Positional parameters (`${N}` is required past `$9`) |
+
+```js
+import { $ } from "bun";
+
+await $`false; echo $?`; // 1\n
+```
+
+Parameter expansion operators such as `${NAME:-default}`, and the special
+parameters `$!`, `$*`, `$@`, and `$-`, are not implemented yet. They are
+reported as a parse error rather than silently expanding to literal text.
+
 ### Changing the environment variables
 
 By default, all commands use `process.env` as their environment variables.

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -588,6 +588,7 @@ impl Interpreter {
                 __cwd: cwd_arr,
                 cwd_fd,
                 async_pids: SmolList::default(),
+                last_exit_code: 0,
             }),
             root_io: JsCell::new(IO {
                 stdin: crate::shell::io::InKind::Fd(stdin_reader),
@@ -1733,6 +1734,51 @@ impl Interpreter {
             }
         }
     }
+
+    /// Number of positional parameters (`$#`): how many `N >= 1` resolve to a
+    /// value in [`Self::append_var_argv`]. `$0` (the program name) is not
+    /// counted, matching POSIX.
+    ///
+    /// `command_ctx` must be null or point to a live `ContextData` that
+    /// outlives this call.
+    // `*mut T` sig shared with `append_var_argv`; the body's internal deref is SAFETY-commented.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub fn var_argv_count(
+        event_loop: EventLoopHandle,
+        command_ctx: *mut bun_options_types::context::ContextData,
+    ) -> usize {
+        match event_loop {
+            EventLoopHandle::Js { .. } => {
+                let vm_ptr = event_loop
+                    .bun_vm()
+                    .cast::<bun_jsc::virtual_machine::VirtualMachine>();
+                if vm_ptr.is_null() {
+                    return 0;
+                }
+                // SAFETY: `bun_vm()` on a JS event loop returns the live
+                // `*VirtualMachine` owning that loop.
+                let vm = unsafe { &*vm_ptr };
+                let mut count = usize::from(!vm.main().is_empty());
+                count += if let Some(worker_ptr) = vm.worker {
+                    // SAFETY: `vm.worker` is set in `VirtualMachine::initWorker`
+                    // to a live `*WebWorker` for the worker's lifetime.
+                    let worker = unsafe { &*worker_ptr.cast::<bun_jsc::web_worker::WebWorker>() };
+                    worker.argv().len()
+                } else {
+                    vm.argv.len()
+                };
+                count
+            }
+            EventLoopHandle::Mini(_) => {
+                if command_ctx.is_null() {
+                    return 0;
+                }
+                // SAFETY: `command_ctx` is the process-global `ContextData`
+                // (see `init`); it outlives the interpreter.
+                unsafe { &*command_ctx }.passthrough.len()
+            }
+        }
+    }
 }
 
 /// Moves the captured stdout/stderr
@@ -1793,6 +1839,13 @@ pub struct ShellExecEnv {
     pub __cwd: Vec<u8>,
     pub cwd_fd: Fd,
     pub async_pids: SmolList<PidT, 4>,
+    /// What `$?` expands to: the exit status of the most recently completed
+    /// statement / `&&`-`||` operand in this exec env. Written by
+    /// `Stmt::child_done` and `Binary::child_done`. Starts at 0 and is
+    /// inherited (copied, not shared) by `dupe_for_subshell`, so a command
+    /// substitution or subshell sees the parent's value but never writes it
+    /// back — which is also POSIX behavior.
+    pub last_exit_code: ExitCode,
 }
 
 pub enum Bufio {
@@ -1958,6 +2011,7 @@ impl ShellExecEnv {
             __cwd: self.__cwd.clone(),
             cwd_fd: dupedfd,
             async_pids: SmolList::default(),
+            last_exit_code: self.last_exit_code,
         });
         Ok(bun_core::heap::into_raw(duped))
     }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1661,122 +1661,173 @@ impl Interpreter {
         command_ctx: *mut bun_options_types::context::ContextData,
         vm_args_utf8: &mut Vec<bun_core::ZigStringSlice>,
     ) {
-        let mut int = original_int;
-        match event_loop {
-            EventLoopHandle::Js { .. } => {
-                if int == 0 {
+        // `$0` is the program name, not a positional parameter.
+        if original_int == 0 {
+            match event_loop {
+                EventLoopHandle::Js { .. } => {
                     if let Ok(p) = bun_core::self_exe_path() {
                         out.extend_from_slice(p.as_bytes());
                     }
-                    return;
                 }
-                int -= 1;
+                EventLoopHandle::Mini(_) => {
+                    if command_ctx.is_null() {
+                        return;
+                    }
+                    // SAFETY: `command_ctx` is the process-global `ContextData`
+                    // (see `init`); it outlives the interpreter.
+                    if let Some(last) = unsafe { &*command_ctx }.positionals.last() {
+                        out.extend_from_slice(last);
+                    }
+                }
+            }
+            return;
+        }
 
-                let vm_ptr = event_loop
-                    .bun_vm()
-                    .cast::<bun_jsc::virtual_machine::VirtualMachine>();
-                if vm_ptr.is_null() {
-                    return;
-                }
-                // SAFETY: `bun_vm()` on a JS event loop returns the live
-                // `*VirtualMachine` owning that loop.
-                let vm = unsafe { &*vm_ptr };
-                let main = vm.main();
+        let mut idx = usize::from(original_int) - 1;
+        // SAFETY: the borrows do not escape this call, and `command_ctx` is
+        // null or live per this function's contract.
+        match unsafe { Self::positional_args(event_loop, command_ctx) } {
+            PositionalArgs::None => {}
+            PositionalArgs::Js { main, rest } => {
                 if !main.is_empty() {
-                    if int == 0 {
+                    if idx == 0 {
                         out.extend_from_slice(main);
                         return;
                     }
-                    int -= 1;
+                    idx -= 1;
                 }
-
-                if let Some(worker_ptr) = vm.worker {
-                    // SAFETY: `vm.worker` is set in `VirtualMachine::initWorker`
-                    // to a live `*WebWorker` for the worker's lifetime.
-                    let worker = unsafe { &*worker_ptr.cast::<bun_jsc::web_worker::WebWorker>() };
-                    let argv = worker.argv();
-                    if int as usize >= argv.len() {
-                        return;
+                match rest {
+                    JsPositionals::Worker(argv) => {
+                        if idx >= argv.len() {
+                            return;
+                        }
+                        if vm_args_utf8.len() != argv.len() {
+                            vm_args_utf8.reserve(argv.len());
+                            for arg in argv {
+                                // SAFETY: each `WTFStringImpl` in `argv` is a live
+                                // `*WTF::StringImpl` borrowed from `worker.argv`.
+                                vm_args_utf8.push(unsafe { (**arg).to_utf8() });
+                            }
+                        }
+                        out.extend_from_slice(vm_args_utf8[idx].slice());
                     }
-                    if vm_args_utf8.len() != argv.len() {
-                        vm_args_utf8.reserve(argv.len());
-                        for arg in argv {
-                            // SAFETY: each `WTFStringImpl` in `argv` is a live
-                            // `*WTF::StringImpl` borrowed from `worker.argv`.
-                            vm_args_utf8.push(unsafe { (**arg).to_utf8() });
+                    JsPositionals::Vm(argv) => {
+                        if let Some(arg) = argv.get(idx) {
+                            out.extend_from_slice(arg);
                         }
                     }
-                    out.extend_from_slice(vm_args_utf8[int as usize].slice());
-                    return;
-                }
-
-                if (int as usize) < vm.argv.len() {
-                    out.extend_from_slice(&vm.argv[int as usize]);
                 }
             }
-            EventLoopHandle::Mini(_) => {
-                if command_ctx.is_null() {
-                    return;
+            PositionalArgs::Mini(passthrough) => {
+                if let Some(arg) = passthrough.get(idx) {
+                    out.extend_from_slice(arg);
                 }
-                // SAFETY: `command_ctx` is the process-global `ContextData`
-                // (see `init`); it outlives the interpreter.
-                let ctx = unsafe { &*command_ctx };
-                if int as usize > ctx.passthrough.len() {
-                    return;
-                }
-                if int == 0 {
-                    if let Some(last) = ctx.positionals.last() {
-                        out.extend_from_slice(last);
-                    }
-                    return;
-                }
-                out.extend_from_slice(&ctx.passthrough[int as usize - 1]);
             }
         }
     }
 
-    /// Number of positional parameters (`$#`): how many `N >= 1` resolve to a
-    /// value in [`Self::append_var_argv`]. `$0` (the program name) is not
-    /// counted, matching POSIX.
+    /// Number of positional parameters (`$#`). Counts the same
+    /// [`PositionalArgs`] source [`Self::append_var_argv`] indexes into, so the
+    /// count cannot drift from the range of `$N` that actually resolves. `$0`
+    /// (the program name) is not counted, matching POSIX.
     ///
     /// `command_ctx` must be null or point to a live `ContextData` that
     /// outlives this call.
-    // `*mut T` sig shared with `append_var_argv`; the body's internal deref is SAFETY-commented.
+    // `*mut T` sig shared with `append_var_argv`; the deref is SAFETY-commented.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn var_argv_count(
         event_loop: EventLoopHandle,
         command_ctx: *mut bun_options_types::context::ContextData,
     ) -> usize {
+        // SAFETY: the borrows do not escape this call, and `command_ctx` is
+        // null or live per this function's contract.
+        unsafe { Self::positional_args(event_loop, command_ctx) }.len()
+    }
+
+    /// Resolve where `$1`…`$N` come from for this event loop.
+    ///
+    /// # Safety
+    /// `command_ctx` must be null or point to a live `ContextData`. The
+    /// returned lifetime is unbounded: the borrows must not outlive the VM or
+    /// `ContextData` they point into.
+    unsafe fn positional_args<'a>(
+        event_loop: EventLoopHandle,
+        command_ctx: *mut bun_options_types::context::ContextData,
+    ) -> PositionalArgs<'a> {
         match event_loop {
             EventLoopHandle::Js { .. } => {
                 let vm_ptr = event_loop
                     .bun_vm()
                     .cast::<bun_jsc::virtual_machine::VirtualMachine>();
                 if vm_ptr.is_null() {
-                    return 0;
+                    return PositionalArgs::None;
                 }
                 // SAFETY: `bun_vm()` on a JS event loop returns the live
                 // `*VirtualMachine` owning that loop.
                 let vm = unsafe { &*vm_ptr };
-                let mut count = usize::from(!vm.main().is_empty());
-                count += if let Some(worker_ptr) = vm.worker {
-                    // SAFETY: `vm.worker` is set in `VirtualMachine::initWorker`
-                    // to a live `*WebWorker` for the worker's lifetime.
-                    let worker = unsafe { &*worker_ptr.cast::<bun_jsc::web_worker::WebWorker>() };
-                    worker.argv().len()
-                } else {
-                    vm.argv.len()
+                let rest = match vm.worker {
+                    Some(worker_ptr) => {
+                        // SAFETY: `vm.worker` is set in `VirtualMachine::initWorker`
+                        // to a live `*WebWorker` for the worker's lifetime.
+                        let worker =
+                            unsafe { &*worker_ptr.cast::<bun_jsc::web_worker::WebWorker>() };
+                        JsPositionals::Worker(worker.argv())
+                    }
+                    None => JsPositionals::Vm(&vm.argv),
                 };
-                count
+                PositionalArgs::Js {
+                    main: vm.main(),
+                    rest,
+                }
             }
             EventLoopHandle::Mini(_) => {
                 if command_ctx.is_null() {
-                    return 0;
+                    return PositionalArgs::None;
                 }
                 // SAFETY: `command_ctx` is the process-global `ContextData`
                 // (see `init`); it outlives the interpreter.
-                unsafe { &*command_ctx }.passthrough.len()
+                let ctx = unsafe { &*command_ctx };
+                PositionalArgs::Mini(&ctx.passthrough)
             }
+        }
+    }
+}
+
+/// Where the shell's positional parameters `$1`…`$N` come from. Resolved in one
+/// place so indexing ([`Interpreter::append_var_argv`]) and counting (`$#`,
+/// [`Interpreter::var_argv_count`]) cannot disagree about the range.
+///
+/// `$0` is the program name, not a positional, so it is not represented here.
+enum PositionalArgs<'a> {
+    None,
+    /// `$1` is `main` when it is non-empty; `rest` continues the list.
+    Js {
+        main: &'a [u8],
+        rest: JsPositionals<'a>,
+    },
+    /// `$N` is `passthrough[N - 1]`.
+    Mini(&'a [Box<[u8]>]),
+}
+
+/// The tail of [`PositionalArgs::Js`]: a worker's argv (still WTF strings,
+/// converted lazily) or the VM's.
+enum JsPositionals<'a> {
+    Worker(&'a [bun_core::WTFStringImpl]),
+    Vm(&'a [Box<[u8]>]),
+}
+
+impl PositionalArgs<'_> {
+    fn len(&self) -> usize {
+        match self {
+            PositionalArgs::None => 0,
+            PositionalArgs::Js { main, rest } => {
+                usize::from(!main.is_empty())
+                    + match rest {
+                        JsPositionals::Worker(argv) => argv.len(),
+                        JsPositionals::Vm(argv) => argv.len(),
+                    }
+            }
+            PositionalArgs::Mini(passthrough) => passthrough.len(),
         }
     }
 }

--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -153,7 +153,7 @@ pub use bun_shell_parser::{
 pub mod ast {
     pub use bun_shell_parser::parse::SmolList;
     use bun_shell_parser::parse::ast as p;
-    pub use p::{BinaryOp, CondExprOp, IoKind, JSBuf, RedirectFlags};
+    pub use p::{BinaryOp, CondExprOp, IoKind, JSBuf, RedirectFlags, SpecialParam};
 
     pub type Script = p::Script<'static>;
     pub type Stmt = p::Stmt<'static>;

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -529,6 +529,8 @@ pub mod test {
         CloseParen,
         Var(&'a [u8]),
         VarArgv(u8),
+        /// The single byte naming the special parameter (`?`, `$`, `#`).
+        SpecialParam(u8),
         Text(&'a [u8]),
         SingleQuotedText(&'a [u8]),
         DoubleQuotedText(&'a [u8]),
@@ -544,6 +546,7 @@ pub mod test {
             match the_token {
                 Token::Var(txt) => TestToken::Var(&buf[txt.start as usize..txt.end as usize]),
                 Token::VarArgv(int) => TestToken::VarArgv(int),
+                Token::SpecialParam(sp) => TestToken::SpecialParam(sp.as_byte()),
                 Token::Text(txt) => TestToken::Text(&buf[txt.start as usize..txt.end as usize]),
                 Token::SingleQuotedText(txt) => {
                     TestToken::SingleQuotedText(&buf[txt.start as usize..txt.end as usize])
@@ -620,6 +623,11 @@ pub mod test {
                     w.write_char('}')
                 }
                 T::VarArgv(n) => write!(w, "{{\"VarArgv\":{}}}", n),
+                T::SpecialParam(c) => {
+                    w.write_str("{\"SpecialParam\":")?;
+                    encode_json_string(w, core::slice::from_ref(c))?;
+                    w.write_char('}')
+                }
                 T::Text(s) => {
                     w.write_str("{\"Text\":")?;
                     encode_json_string(w, s)?;

--- a/src/runtime/shell/states/Binary.rs
+++ b/src/runtime/shell/states/Binary.rs
@@ -80,6 +80,9 @@ impl Binary {
         {
             let me = interp.as_binary_mut(this);
             me.currently_executing = None;
+            // The right operand of `a && b` / `a || b` sees `a`'s exit
+            // status in `$?`.
+            me.base.shell_mut().last_exit_code = exit_code;
             if me.left.is_none() {
                 me.left = Some(exit_code);
             } else {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -491,6 +491,28 @@ impl Expansion {
                 // SAFETY: `command_ctx` is the live VM ctx; `vm_args_utf8` borrows it.
                 Interpreter::append_var_argv(out, *int, event_loop, command_ctx, vm_args_utf8);
             }
+            ast::SimpleAtom::SpecialParam(sp) => {
+                // `write!` on `Vec<u8>` via `io::Write` is infallible.
+                use std::io::Write as _;
+                match sp {
+                    ast::SpecialParam::ExitCode => {
+                        let _ = write!(out, "{}", shell.last_exit_code);
+                    }
+                    // The shell runs in-process and never forks, so `$$` is
+                    // this process's PID even inside `(...)` / `$(...)` —
+                    // which is also what POSIX specifies for subshells.
+                    ast::SpecialParam::Pid => {
+                        let _ = write!(out, "{}", std::process::id());
+                    }
+                    ast::SpecialParam::ArgvCount => {
+                        let _ = write!(
+                            out,
+                            "{}",
+                            Interpreter::var_argv_count(event_loop, command_ctx)
+                        );
+                    }
+                }
+            }
             ast::SimpleAtom::Asterisk => {
                 meta_offsets.push(out.len() as u32);
                 out.push(b'*');

--- a/src/runtime/shell/states/Stmt.rs
+++ b/src/runtime/shell/states/Stmt.rs
@@ -78,6 +78,9 @@ impl Stmt {
         {
             let me = interp.as_stmt_mut(this);
             me.last_exit_code = Some(exit_code);
+            // `$?` in the statements that follow (including an `if`/`then`
+            // body, which is also a list of `Stmt`s) expands to this exit.
+            me.base.shell_mut().last_exit_code = exit_code;
             me.idx += 1;
             me.currently_executing = None;
         }

--- a/src/shell_parser/json_fmt.rs
+++ b/src/shell_parser/json_fmt.rs
@@ -264,6 +264,10 @@ fn write_simple_atom(w: &mut impl Write, s: &SimpleAtom<'_>) -> fmt::Result {
         SimpleAtom::VarArgv(n) => {
             write!(w, "{{\"VarArgv\":{}", n)?;
         }
+        SimpleAtom::SpecialParam(sp) => {
+            w.write_str("{\"special_param\":")?;
+            encode_json_string(w, &[sp.as_byte()])?;
+        }
         SimpleAtom::Text(t) => {
             w.write_str("{\"Text\":")?;
             encode_json_string(w, t)?;

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -855,10 +855,45 @@ pub mod ast {
         }
     }
 
+    /// POSIX special parameters the shell can expand. `$!` (last background
+    /// PID), `$*` / `$@` (positional lists whose word-splitting semantics the
+    /// shell does not implement), and `$-` (option flags) are rejected by the
+    /// lexer instead.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub enum SpecialParam {
+        /// `$?` / `${?}`: exit status of the most recently completed command.
+        ExitCode,
+        /// `$$` / `${$}`: PID of the process running the shell.
+        Pid,
+        /// `$#` / `${#}`: number of positional parameters.
+        ArgvCount,
+    }
+
+    impl SpecialParam {
+        /// The byte that names this parameter after `$` (or inside `${}`).
+        pub const fn as_byte(self) -> u8 {
+            match self {
+                SpecialParam::ExitCode => b'?',
+                SpecialParam::Pid => b'$',
+                SpecialParam::ArgvCount => b'#',
+            }
+        }
+
+        pub const fn from_byte(c: u8) -> Option<SpecialParam> {
+            match c {
+                b'?' => Some(SpecialParam::ExitCode),
+                b'$' => Some(SpecialParam::Pid),
+                b'#' => Some(SpecialParam::ArgvCount),
+                _ => None,
+            }
+        }
+    }
+
     #[derive(Clone)]
     pub enum SimpleAtom<'arena> {
         Var(&'arena [u8]),
         VarArgv(u8),
+        SpecialParam(SpecialParam),
         Text(&'arena [u8]),
         /// An empty string from a quoted context (e.g. "", '', or ${''}). Preserved as an
         /// explicit empty argument during expansion, unlike unquoted empty text which is dropped.
@@ -1855,6 +1890,16 @@ impl<'bump> Parser<'bump> {
                             }
                         }
                     }
+                    Token::SpecialParam(sp) => {
+                        let _ = self.expect(TokenTag::SpecialParam);
+                        atoms.push(ast::SimpleAtom::SpecialParam(sp));
+                        if next_delimits {
+                            let _ = self.r#match(TokenTag::Delimit);
+                            if should_break {
+                                break;
+                            }
+                        }
+                    }
                     Token::OpenParen | Token::CloseParen => {
                         self.add_error(format_args!(
                             "Unexpected token: `{}`",
@@ -2217,6 +2262,7 @@ pub enum TokenTag {
     CloseParen,
     Var,
     VarArgv,
+    SpecialParam,
     Text,
     SingleQuotedText,
     DoubleQuotedText,
@@ -2272,6 +2318,8 @@ pub enum Token {
 
     Var(TextRange),
     VarArgv(u8),
+    /// `$?`, `$$`, `$#` and the braced `${?}`, `${$}`, `${#}` forms.
+    SpecialParam(ast::SpecialParam),
     Text(TextRange),
     /// Quotation information is lost from the lexer -> parser stage and it is
     /// helpful to disambiguate from regular text and quoted text
@@ -2332,6 +2380,11 @@ impl Token {
             Token::CloseParen => b"`)",
             Token::Var(r) => &strpool[r.start as usize..r.end as usize],
             Token::VarArgv(n) => VARARGV_STRINGS[n as usize],
+            Token::SpecialParam(sp) => match sp {
+                ast::SpecialParam::ExitCode => b"$?",
+                ast::SpecialParam::Pid => b"$$",
+                ast::SpecialParam::ArgvCount => b"$#",
+            },
             Token::Text(r) => &strpool[r.start as usize..r.end as usize],
             Token::SingleQuotedText(r) => &strpool[r.start as usize..r.end as usize],
             Token::DoubleQuotedText(r) => &strpool[r.start as usize..r.end as usize],
@@ -2377,6 +2430,15 @@ pub struct LexError {
 /// easy for the user to accidentally use this char in their script.
 const SPECIAL_JS_CHAR: u8 = 8;
 const MAX_SUBSHELL_DEPTH: u32 = 128;
+
+/// Every `${...}` form beyond the plain `${NAME}` / `${N}` / `${?}` ones is
+/// either a parameter-expansion operator the shell does not implement or text
+/// bash itself rejects as a `bad substitution`. In both cases producing the
+/// characters literally (the behavior this message replaced) silently corrupts
+/// the command, so the lexer reports it instead.
+const ERR_BRACED_PARAM_UNSUPPORTED: &[u8] = b"Unsupported parameter expansion `${...}`. Only the plain `${NAME}` form is supported; `${NAME:-default}` and other parameter expansion operators are not supported yet. Please file an issue on GitHub.";
+const ERR_BRACED_PARAM_UNCLOSED: &[u8] =
+    b"Unclosed parameter expansion: expected a `}` to match `${`";
 pub const LEX_JS_OBJREF_PREFIX: &[u8] = b"\x08__bun_";
 pub const LEX_JS_STRING_PREFIX: &[u8] = b"\x08__bunstr_";
 
@@ -2896,6 +2958,42 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 break 'escaped;
                             }
 
+                            // `${...}`: braced parameter expansion.
+                            if !peeked.escaped && peeked.char == u32::from(b'{') {
+                                self.break_word(false)?;
+                                let _ = self.eat();
+                                if !self.eat_braced_param()? {
+                                    return Ok(());
+                                }
+                                self.word_start = self.j;
+                                fell_through = true;
+                                break 'escaped;
+                            }
+
+                            if !peeked.escaped && peeked.char < 0x80 {
+                                let next = peeked.char as u8;
+                                // `$?`, `$$`, `$#`: special parameters the
+                                // shell can expand.
+                                if let Some(special) = ast::SpecialParam::from_byte(next) {
+                                    self.break_word(false)?;
+                                    let _ = self.eat();
+                                    self.tokens.push(Token::SpecialParam(special));
+                                    self.word_start = self.j;
+                                    fell_through = true;
+                                    break 'escaped;
+                                }
+                                // `$!`, `$*`, `$@`, `$-`: POSIX special
+                                // parameters the shell does not implement.
+                                // Every POSIX shell expands these, so emitting
+                                // the two bytes literally silently corrupts
+                                // the command; reject the script the way other
+                                // unsupported syntax is rejected.
+                                if matches!(next, b'!' | b'*' | b'@' | b'-') {
+                                    self.add_error_unsupported_special_param(next);
+                                    return Ok(());
+                                }
+                            }
+
                             // Handle variable
                             self.break_word(false)?;
                             let var_tok = self.eat_var()?;
@@ -3232,6 +3330,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
             && match self.tokens[self.tokens.len() - 1].tag() {
                 TokenTag::Var
                 | TokenTag::VarArgv
+                | TokenTag::SpecialParam
                 | TokenTag::Text
                 | TokenTag::SingleQuotedText
                 | TokenTag::DoubleQuotedText
@@ -3720,6 +3819,120 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
             }
         }
         Ok(TextRange { start, end: self.j })
+    }
+
+    /// Lex the body of a `${...}` parameter expansion; the `${` has already
+    /// been consumed. Only the forms with a direct token are accepted:
+    /// `${NAME}`, `${N}` (a positional parameter, the only way to address
+    /// index > 9), and `${?}` / `${$}` / `${#}`.
+    ///
+    /// Anything else (`${NAME:-default}` and the rest of the operator family,
+    /// indirection, `${#NAME}`, an unterminated `${`, ...) records an error
+    /// and returns `false`; the caller must stop lexing. See
+    /// [`ERR_BRACED_PARAM_UNSUPPORTED`] for why this is an error rather than
+    /// literal text.
+    fn eat_braced_param(&mut self) -> Result<bool, LexerError> {
+        let Some(first) = self.peek() else {
+            self.add_error(ERR_BRACED_PARAM_UNCLOSED);
+            return Ok(false);
+        };
+        if first.escaped || first.char >= 0x80 {
+            self.add_error(ERR_BRACED_PARAM_UNSUPPORTED);
+            return Ok(false);
+        }
+        let first = first.char as u8;
+
+        // `${?}` / `${$}` / `${#}`
+        if let Some(special) = ast::SpecialParam::from_byte(first) {
+            let _ = self.eat();
+            if !self.eat_braced_param_close() {
+                return Ok(false);
+            }
+            self.tokens.push(Token::SpecialParam(special));
+            return Ok(true);
+        }
+
+        // `${N}`
+        if first.is_ascii_digit() {
+            let mut n: u32 = 0;
+            while let Some(c) = self.peek() {
+                if c.escaped || c.char >= 0x80 || !(c.char as u8).is_ascii_digit() {
+                    break;
+                }
+                let _ = self.eat();
+                n = n
+                    .saturating_mul(10)
+                    .saturating_add(c.char - u32::from(b'0'));
+            }
+            // `Token::VarArgv` stores a `u8`. A positional index this large
+            // never resolves to anything, so treat it like any other
+            // unsupported `${...}` body rather than silently truncating it.
+            let Ok(n) = u8::try_from(n) else {
+                self.add_error(ERR_BRACED_PARAM_UNSUPPORTED);
+                return Ok(false);
+            };
+            if !self.eat_braced_param_close() {
+                return Ok(false);
+            }
+            self.tokens.push(Token::VarArgv(n));
+            return Ok(true);
+        }
+
+        // `${NAME}`
+        let start = self.j;
+        while let Some(c) = self.peek() {
+            if c.escaped || c.char >= 0x80 {
+                break;
+            }
+            let b = c.char as u8;
+            if !(b.is_ascii_alphanumeric() || b == b'_') {
+                break;
+            }
+            let _ = self.eat();
+            self.append_char_to_str_pool(c.char)?;
+        }
+        let name = TextRange { start, end: self.j };
+        if name.len() == 0 {
+            self.add_error(ERR_BRACED_PARAM_UNSUPPORTED);
+            return Ok(false);
+        }
+        if !self.eat_braced_param_close() {
+            return Ok(false);
+        }
+        self.tokens.push(Token::Var(name));
+        Ok(true)
+    }
+
+    /// Consume the `}` terminating a `${...}` expansion. Any other character
+    /// here means the body continued into an operator form the shell does not
+    /// implement; record an error and return `false`.
+    fn eat_braced_param_close(&mut self) -> bool {
+        match self.peek() {
+            Some(c) if !c.escaped && c.char == u32::from(b'}') => {
+                let _ = self.eat();
+                true
+            }
+            Some(_) => {
+                self.add_error(ERR_BRACED_PARAM_UNSUPPORTED);
+                false
+            }
+            None => {
+                self.add_error(ERR_BRACED_PARAM_UNCLOSED);
+                false
+            }
+        }
+    }
+
+    /// Record a lexer error for a POSIX special parameter (`$!`, `$*`, `$@`,
+    /// `$-`) the shell does not implement. Every POSIX shell expands these,
+    /// so emitting the two characters literally silently corrupts the
+    /// command.
+    fn add_error_unsupported_special_param(&mut self, c: u8) {
+        let mut msg: Vec<u8> = Vec::with_capacity(128);
+        msg.extend_from_slice(b"The special shell parameter `$");
+        msg.push(c);
+        msg.extend_from_slice(b"` is not supported yet. Please file an issue on GitHub.");
+        self.add_error(&msg);
     }
 
     fn eat(&mut self) -> Option<InputChar> {

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2379,7 +2379,10 @@ impl Token {
             Token::OpenParen => b"`(`",
             Token::CloseParen => b"`)",
             Token::Var(r) => &strpool[r.start as usize..r.end as usize],
-            Token::VarArgv(n) => VARARGV_STRINGS[n as usize],
+            // Indices past 9 reach here only from the braced `${N}` form and
+            // have no static spelling; this runs on a parse-error path, so it
+            // must never panic.
+            Token::VarArgv(n) => VARARGV_STRINGS.get(n as usize).copied().unwrap_or(b"${N}"),
             Token::SpecialParam(sp) => match sp {
                 ast::SpecialParam::ExitCode => b"$?",
                 ast::SpecialParam::Pid => b"$$",

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -973,6 +973,106 @@ booga"
 
       expect(procEnv).toEqual({ ...bunEnv, BUN_TEST_VAR: "1", FOO: "bar" });
     });
+
+    // POSIX parameter expansion. `${...}` in a JS template literal is a JS
+    // interpolation (and `\${` reaches the shell as an *escaped* `$`), so
+    // `{ raw }` is used to splice the shell source in verbatim.
+    //
+    // Before these were implemented the lexer emitted the characters
+    // literally (`echo $?` printed `$?`), silently diverging from every
+    // POSIX shell; found by a bash-differential fuzzer.
+    describe("parameter expansion", () => {
+      const raw = (src: string) => TestBuilder.command`${{ raw: src }}`;
+
+      describe("${NAME}", () => {
+        raw("FOO=bar; echo ${FOO}").stdout("bar\n").runAsTest("basic");
+        raw('FOO=bar; echo "${FOO}"').stdout("bar\n").runAsTest("double quoted");
+        raw("FOO=bar; echo a${FOO}b").stdout("abarb\n").runAsTest("mid word");
+        // The whole point of the braced form: `$FOObar` would read the
+        // variable `FOObar`.
+        raw("FOO=bar; echo ${FOO}bar").stdout("barbar\n").runAsTest("name boundary");
+        raw("echo a${__BUN_UNSET_XYZ__}b").stdout("ab\n").runAsTest("unset is empty");
+        raw("echo '${FOO}'").stdout("${FOO}\n").runAsTest("single quotes stay literal");
+
+        test("${N} positional", async () => {
+          // `$N` and `${N}` read the same positional parameter
+          // (env.positionals.test.ts pins what that is, and its
+          // positionals3 fixture covers `$#` and multi-digit `${10}`).
+          const plain = await $`echo "[$1]"`;
+          const braced = await $`echo ${{ raw: '"[${1}]"' }}`;
+          expect(braced.stdout.toString()).toEqual(plain.stdout.toString());
+        });
+      });
+
+      describe("$?", () => {
+        raw("echo $?").stdout("0\n").runAsTest("starts at 0");
+        raw("false; echo $?").stdout("1\n").runAsTest("after a failing builtin");
+        raw('false; echo "$?"').stdout("1\n").runAsTest("double quoted");
+        raw("false; echo a$?b").stdout("a1b\n").runAsTest("mid word");
+        raw("false; echo ${?}").stdout("1\n").runAsTest("braced");
+        TestBuilder.command`BUN_DEBUG_QUIET_LOGS=1 ${BUN} -e "process.exit(42)"; echo $?`
+          .stdout("42\n")
+          .runAsTest("after an external command");
+        // The right operand of `||` / `&&` sees the left operand's status.
+        raw("false || echo $?").stdout("1\n").runAsTest("right of ||");
+        raw("true && false; echo $?").stdout("1\n").runAsTest("after &&");
+        raw("if false; then echo no; else echo $?; fi").stdout("1\n").runAsTest("in an else branch");
+        // A command substitution runs in its own environment and must not
+        // overwrite the parent's `$?` (POSIX: `$?` is the status of the
+        // last *foreground pipeline*).
+        raw("false; echo $(true)$?").stdout("1\n").runAsTest("not clobbered by $()");
+        raw("echo '$?'").stdout("$?\n").runAsTest("single quotes stay literal");
+      });
+
+      describe("$$", () => {
+        // The shell runs in-process, so `$$` is this process's PID.
+        raw("echo $$").stdout(`${process.pid}\n`).runAsTest("unbraced");
+        raw('echo "$$"').stdout(`${process.pid}\n`).runAsTest("double quoted");
+        raw("echo ${$}").stdout(`${process.pid}\n`).runAsTest("braced");
+        // `$$` is read greedily: `$$HOME` is `$$` then the literal `HOME`,
+        // never `$` + `$HOME`.
+        raw("echo $$HOME").stdout(`${process.pid}HOME\n`).runAsTest("greedy");
+      });
+
+      describe("$#", () => {
+        // `$N` already resolves to `process.argv[N]` (see
+        // env.positionals.test.ts), so the count is `process.argv.length - 1`.
+        const count = `${process.argv.length - 1}`;
+        raw("echo $#").stdout(`${count}\n`).runAsTest("unbraced");
+        raw("echo ${#}").stdout(`${count}\n`).runAsTest("braced");
+        raw('echo "[$#]"').stdout(`[${count}]\n`).runAsTest("double quoted");
+      });
+
+      // Parameter expansions the shell does not implement are a hard parse
+      // error instead of flowing through as literal text, consistent with
+      // how `&` and `|&` are reported.
+      describe("unsupported forms are parse errors", () => {
+        const operatorError =
+          "Unsupported parameter expansion `${...}`. Only the plain `${NAME}` form is supported; `${NAME:-default}` and other parameter expansion operators are not supported yet. Please file an issue on GitHub.";
+        const unclosedError = "Unclosed parameter expansion: expected a `}` to match `${`";
+        const specialError = (c: string) =>
+          `The special shell parameter \`$${c}\` is not supported yet. Please file an issue on GitHub.`;
+
+        raw("echo ${FOO:-fallback}").error(operatorError).runAsTest("${FOO:-fallback}");
+        raw("echo ${FOO:=x}").error(operatorError).runAsTest("${FOO:=x}");
+        raw("echo ${FOO%.txt}").error(operatorError).runAsTest("${FOO%.txt}");
+        raw("echo ${#FOO}").error(operatorError).runAsTest("${#FOO}");
+        raw("echo ${!FOO}").error(operatorError).runAsTest("${!FOO}");
+        raw("echo ${}").error(operatorError).runAsTest("${}");
+        raw('echo "${FOO:-x}"').error(operatorError).runAsTest("double quoted operator");
+        raw("echo ${FOO").error(unclosedError).runAsTest("unclosed");
+
+        raw('echo "$@"').error(specialError("@")).runAsTest("$@");
+        raw("echo $*").error(specialError("*")).runAsTest("$*");
+        raw("echo $!").error(specialError("!")).runAsTest("$!");
+        raw("echo $-").error(specialError("-")).runAsTest("$-");
+
+        // A `$` not introducing any expansion is still literal, as in POSIX.
+        raw('echo 100$ "$ " a$%b').stdout("100$ $  a$%b\n").runAsTest("bare $ stays literal");
+        // An escaped `$` never starts an expansion.
+        raw("echo \\${FOO:-x} \\$? \\$@").stdout("${FOO:-x} $? $@\n").runAsTest("escaped $ stays literal");
+      });
+    });
   });
 
   describe("cd & pwd", () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1002,6 +1002,21 @@ booga"
           const braced = await $`echo ${{ raw: '"[${1}]"' }}`;
           expect(braced.stdout.toString()).toEqual(plain.stdout.toString());
         });
+
+        // `${N}` is the only source of a positional index past 9, and the
+        // `[[ ... ]]` parse errors render the offending token. Rendering must
+        // cover every index the lexer can emit.
+        raw("[[ x $9 ]]")
+          .error("Expected a conditional expression operator, but got: $9")
+          .runAsTest("single-digit positional renders in a parse error");
+        raw("[[ x ${10} ]]")
+          .error("Expected a conditional expression operator, but got: ${N}")
+          .runAsTest("positional past 9 renders in a parse error");
+        raw("echo ${256}")
+          .error(
+            "Unsupported parameter expansion `${...}`. Only the plain `${NAME}` form is supported; `${NAME:-default}` and other parameter expansion operators are not supported yet. Please file an issue on GitHub.",
+          )
+          .runAsTest("positional index past 255 is rejected");
       });
 
       describe("$?", () => {

--- a/test/js/bun/shell/env.positionals.test.ts
+++ b/test/js/bun/shell/env.positionals.test.ts
@@ -77,7 +77,7 @@ test("$ argv: standalone: only 10", async () => {
 // only way to address index > 9: `$10` lexes as `$1` then a literal `0`).
 test("$ argv: standalone: $# and ${N}", async () => {
   const script = path.join(import.meta.dir, "fixtures", "positionals3.bun.sh");
-  const { stdout, stderr } = spawn({
+  const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "run", script, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
     stdout: "pipe",
     stdin: "ignore",
@@ -92,6 +92,7 @@ test("$ argv: standalone: $# and ${N}", async () => {
   expect(stdout).toBeDefined();
   const out = await stdout.text();
   expect(out.split("\n")).toEqual(["11", "a", "j", "bxc", "11", ""]);
+  expect(await exited).toBe(0);
 });
 
 test("$ argv: standalone: non-ascii", async () => {

--- a/test/js/bun/shell/env.positionals.test.ts
+++ b/test/js/bun/shell/env.positionals.test.ts
@@ -73,6 +73,27 @@ test("$ argv: standalone: only 10", async () => {
   expect(out.split("\n")).toEqual([script, "a", "bb", "c", "d", "e", "f", "g", "h", "i", "a0", ""]);
 });
 
+// `$#` is the positional count and `${N}` is the braced form of `$N` (and the
+// only way to address index > 9: `$10` lexes as `$1` then a literal `0`).
+test("$ argv: standalone: $# and ${N}", async () => {
+  const script = path.join(import.meta.dir, "fixtures", "positionals3.bun.sh");
+  const { stdout, stderr } = spawn({
+    cmd: [bunExe(), "run", script, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  expect(stderr).toBeDefined();
+  const err = await stderr.text();
+  expect(err).toBeEmpty();
+
+  expect(stdout).toBeDefined();
+  const out = await stdout.text();
+  expect(out.split("\n")).toEqual(["11", "a", "j", "bxc", "11", ""]);
+});
+
 test("$ argv: standalone: non-ascii", async () => {
   const script = path.join(import.meta.dir, "fixtures", "positionals2.bun.sh");
   const { stdout, stderr, exited } = spawn({

--- a/test/js/bun/shell/fixtures/positionals3.bun.sh
+++ b/test/js/bun/shell/fixtures/positionals3.bun.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo $#
+echo ${1}
+echo ${10}
+echo ${2}x${3}
+echo ${#}

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -706,6 +706,95 @@ describe("lex shell", () => {
     expect(JSON.parse(result)).toEqual(expected);
   });
 
+  // `${...}` in a JS template literal is a JS interpolation, so `{ raw }` is
+  // used wherever the *shell* needs to see a `${`.
+  describe("parameter expansion", () => {
+    test("special param $?", () => {
+      expect(JSON.parse(lex`echo $?`)).toEqual([{ Text: "echo" }, { Delimit: {} }, { SpecialParam: "?" }, { Eof: {} }]);
+    });
+
+    test("special param followed by a word delimits", () => {
+      expect(JSON.parse(lex`echo $? next`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { SpecialParam: "?" },
+        { Delimit: {} },
+        { Text: "next" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("$$ is read greedily", () => {
+      expect(JSON.parse(lex`echo $$HOME`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { SpecialParam: "$" },
+        { Text: "HOME" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("special param $#", () => {
+      expect(JSON.parse(lex`echo $#x`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { SpecialParam: "#" },
+        { Text: "x" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("${NAME} is the same token as $NAME", () => {
+      expect(JSON.parse(lex`echo ${{ raw: "${PORT}" }}`)).toEqual(JSON.parse(lex`echo $PORT`));
+    });
+
+    test("${NAME} bounds the name", () => {
+      expect(JSON.parse(lex`echo ${{ raw: "${FOO}bar" }}`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { Var: "FOO" },
+        { Text: "bar" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+    });
+
+    test("${N} supports multi-digit positionals", () => {
+      expect(JSON.parse(lex`echo ${{ raw: "${10}" }}`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { VarArgv: 10 },
+        { Eof: {} },
+      ]);
+    });
+
+    test("braced special params", () => {
+      expect(JSON.parse(lex`echo ${{ raw: "${?}${$}${#}" }}`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { SpecialParam: "?" },
+        { SpecialParam: "$" },
+        { SpecialParam: "#" },
+        { Eof: {} },
+      ]);
+    });
+
+    test("an escaped $ never starts an expansion", () => {
+      expect(JSON.parse(lex`echo \$? \$HOME`)).toEqual([
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "$?" },
+        { Delimit: {} },
+        { Text: "$HOME" },
+        { Delimit: {} },
+        { Eof: {} },
+      ]);
+    });
+  });
+
   describe("errors", async () => {
     // This is disallowed because the js object references get turned into special vars: $__bun_0, $__bun_1, etc.
     // this will break things inside of a quote.


### PR DESCRIPTION
### Problem

The Bun Shell lexer silently emits unsupported POSIX parameter expansions as literal text. `echo $?` prints the two characters `$?`, and `${VAR}`, `${VAR:-default}`, `$#`, and `$$` behave the same way. No error is reported, so the literal dollar-text flows straight into the command's argv or output.

```js
import { $ } from "bun";

await $`false; echo $?`.text();                  // bash: "1"       bun: "$?"
await $`echo ${{ raw: "${HOME}" }}`.text();      // bash: "/root"   bun: "${HOME}"
await $`echo ${{ raw: "${X:-fallback}" }}`.text(); // bash: "fallback" bun: "${X:-fallback}"
```

`$VAR` (the bare form) works, which hides the gap until someone writes `${...}` or `$?`. `$?` is the exit-status idiom and `${VAR:-default}` is everywhere in one-liners people paste into `Bun.$`, so scripts end up silently operating on garbage strings: conditions that always pass, directories literally named `${TMPDIR:-/tmp}`, and so on.

This also affects every `.sh` file run with `bun`, `bun exec`, and, on Windows, every `package.json` script run with `bun run` and every `bun install` lifecycle script, since those all default to the Bun Shell there.

Fixes #17396

### Cause

In the lexer's `$` branch, `eat_var` returns an empty range whenever `$` is not followed by `[A-Za-z0-9_]`, and the caller's `len() == 0` arm just appends a literal `$` to the string pool. Nothing ever looks at the character that follows.

### Fix

`src/shell_parser/parse.rs` (lexer + AST), `src/runtime/shell/` (interpreter):

Implemented, with bash semantics:

- `$?` / `${?}`: exit status of the most recently completed statement or `&&`/`||` operand. Tracked as a `last_exit_code` field on `ShellExecEnv`, written from `Stmt::child_done` and `Binary::child_done`, and inherited (copied, not shared) by `dupe_for_subshell`, so a command substitution or subshell sees the parent's value but never writes it back, matching POSIX (`false; echo $(true)$?` prints `1`).
- `$$` / `${$}`: the process PID. The shell runs in-process and never forks, so this is correct for subshells too.
- `$#` / `${#}`: the positional-parameter count, via a new `var_argv_count` that mirrors `append_var_argv`'s two argv sources.
- `${NAME}` and `${N}`: lexed to the existing `Var` / `VarArgv` tokens. `${N}` is also the only way to address a positional past `$9` (`$10` lexes as `$1` followed by a literal `0`).
- `$$` is read greedily: `echo $$HOME` is the PID followed by the literal `HOME`, as in bash. Previously it produced `$` + the expansion of `$HOME`.

Rejected with a parse error, following the shell's existing convention for unsupported syntax (`&`, `|&`, subshell redirections, unknown conditional operators):

- Every other `${...}` form: the `${NAME:-default}` operator family, `${#NAME}`, indirection, an unclosed `${`, and the text bash itself rejects as a `bad substitution`.
  > Unsupported parameter expansion `${...}`. Only the plain `${NAME}` form is supported; `${NAME:-default}` and other parameter expansion operators are not supported yet. Please file an issue on GitHub.
- `$!`, `$*`, `$@`, `$-`. These have semantics the shell cannot yet honor (`$*`/`$@` need POSIX word splitting, `$!` needs job control), and every POSIX shell expands them, so flowing them through as literal text silently corrupts the command. `$*` was the worst offender: the `*` became a glob and matched against the working directory.
  > The special shell parameter `$@` is not supported yet. Please file an issue on GitHub.

A `$` that does not introduce any expansion is still literal, exactly as in POSIX: `echo "$ "`, `echo 100$`, `echo a$%b`, `\$?`, and `'$?'` are all unchanged, as are interpolated JS values after a `$`.

### Tests

- `test/js/bun/shell/bunshell.test.ts`: a new `parameter expansion` describe covering every implemented form (including the `$?` plumbing through `;`, `||`, `&&`, `if`/`else`, and `$(...)`) and every rejected form, plus `literal $` regression guards. `${...}` in a JS template literal is JS interpolation (and `Bun.$` reads the template's *raw* strings, so `\${` is an escaped `$`), so the tests use the documented `{ raw }` splice to feed the shell real `${` syntax.
- `test/js/bun/shell/lex.test.ts`: token-level assertions for the new `SpecialParam` token, the `${NAME}` / `${N}` forms, and the escape guard.
- `test/js/bun/shell/env.positionals.test.ts` + a new `positionals3.bun.sh` fixture: end-to-end `$#`, `${1}`, `${10}`, and `${2}x${3}` through the `.sh` loader (the CLI argv source, which is distinct from the JS one).

`test/js/bun/shell/` before the fix: 35 of the 39 new `bunshell` tests fail (the 4 that pass are the intentional "literal `$` is unchanged" guards), plus 8 `lex` and 1 `env.positionals`. After: all pass, and the full `bunshell.test.ts` suite is 415 pass / 0 fail.

`docs/runtime/shell.mdx` gets a "Reading variables" section documenting the braced form, the special parameters, the `{ raw }` caveat, and the forms that are intentionally parse errors.
