### PR TITLE
fetch: implement the referrer and referrerPolicy options

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -171,6 +171,9 @@ fn make_client<'a>(
         allow_retry: false,
         h2_retries: 0,
         redirect_type,
+        referrer: Box::default(),
+        referrer_policy: crate::ReferrerPolicy::Empty,
+        computed_referer: Vec::new(),
         redirect: Vec::new(),
         prev_redirect: Vec::new(),
         progress_node: None,
@@ -259,6 +262,11 @@ pub struct Options<'a> {
     pub reject_unauthorized: Option<bool>,
     pub tls_props: Option<SSLConfigSharedPtr>,
     pub compress: Option<crate::compress_body::CompressOption>,
+    /// The request's referrer (stored serialized form) and referrer policy,
+    /// used by `build_request` to compute the `Referer` header on each hop.
+    /// Leave `referrer` empty when the caller set an explicit `Referer` header.
+    pub referrer: Box<[u8]>,
+    pub referrer_policy: crate::ReferrerPolicy,
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -497,6 +505,8 @@ impl<'a> AsyncHTTP<'a> {
         }
         this.client.compress = options.compress;
         this.client.proxy_settings = options.proxy_settings;
+        this.client.referrer = options.referrer;
+        this.client.referrer_policy = options.referrer_policy;
 
         // `client.proxy_authorization` stays `None` on the JS-thread original;
         // `on_start` derives it on the HTTP-thread clone so redirects can
@@ -752,6 +762,7 @@ impl<'a> AsyncHTTP<'a> {
                     drop(core::mem::take(&mut client.redirect));
                     drop(core::mem::take(&mut client.prev_redirect));
                     drop(core::mem::take(&mut client.compressed_request_body));
+                    drop(core::mem::take(&mut client.computed_referer));
                     drop(core::mem::take(&mut client.proxy_authorization));
                     if let Some(tunnel) = client.proxy_tunnel.take() {
                         // SAFETY: tunnel was created by ProxyTunnel::start

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -262,9 +262,8 @@ pub struct Options<'a> {
     pub reject_unauthorized: Option<bool>,
     pub tls_props: Option<SSLConfigSharedPtr>,
     pub compress: Option<crate::compress_body::CompressOption>,
-    /// The request's referrer (stored serialized form) and referrer policy,
-    /// used by `build_request` to compute the `Referer` header on each hop.
-    /// Leave `referrer` empty when the caller set an explicit `Referer` header.
+    /// See `HTTPClient.referrer`. Leave empty when the caller set an explicit
+    /// `Referer` header.
     pub referrer: Box<[u8]>,
     pub referrer_policy: crate::ReferrerPolicy,
 }

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1045,6 +1045,7 @@ impl HttpThread {
                 drop(core::mem::take(&mut client.redirect));
                 drop(core::mem::take(&mut client.prev_redirect));
                 drop(core::mem::take(&mut client.compressed_request_body));
+                drop(core::mem::take(&mut client.computed_referer));
                 drop(core::mem::take(&mut client.proxy_authorization));
                 if let Some(tunnel) = client.proxy_tunnel.take() {
                     (*tunnel.as_ptr()).detach_socket();

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -741,16 +741,12 @@ pub struct HTTPClient<'a> {
     /// `MAX_H2_RETRIES`.
     pub h2_retries: u8,
     pub redirect_type: FetchRedirect,
-    /// The request's referrer in its stored serialized form (see the
-    /// `bun_http_types::ReferrerPolicy::determine_referer_header` docs) and the
-    /// request's referrer policy. Empty when the caller set an explicit
-    /// `Referer` header, so `build_request` leaves that header untouched
-    /// across redirects. `referrer_policy` may be updated by a
-    /// `Referrer-Policy` response header on a redirect hop.
+    /// Stored referrer (see `determine_referer_header`) and policy; empty when
+    /// the caller set an explicit `Referer` header so `build_request` leaves
+    /// that header alone. A `Referrer-Policy` response header updates `policy`.
     pub referrer: Box<[u8]>,
     pub referrer_policy: ReferrerPolicy,
-    /// Backing storage for the `Referer` header value `build_request` emits
-    /// each hop. Lives on `self` so the `picohttp::Request` can borrow it.
+    /// Backs the `Referer` value `build_request` emits each hop.
     pub computed_referer: Vec<u8>,
     pub redirect: Vec<u8>,
     /// The previous hop's `redirect` buffer, parked by `handle_response_metadata`
@@ -2489,11 +2485,9 @@ impl<'a> HTTPClient<'a> {
             header_count += 1;
         }
 
-        // Compute the `Referer` header for this hop. `self.referrer` is empty
-        // when the caller set an explicit `Referer` (already in the loop
-        // above, which sets `override_referer`), so this recomputes only when
-        // the header came from the `referrer` / `referrerPolicy` options. It
-        // runs per `build_request`, i.e. freshly on every redirect hop.
+        // Compute `Referer` for this hop. `self.referrer` is empty when the
+        // caller set an explicit `Referer` header (handled above), so this only
+        // applies to the `referrer`/`referrerPolicy` options.
         if !override_referer && !self.referrer.is_empty() {
             self.computed_referer.clear();
             if let Some(value) =
@@ -4917,10 +4911,7 @@ impl<'a> HTTPClient<'a> {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Referrer-Policy") => {
-                    // "Set request's referrer policy on redirect"
-                    // (https://fetch.spec.whatwg.org/#http-redirect-fetch,
-                    // step 19). Applied unconditionally: when no redirect is
-                    // followed, `referrer_policy` is never read again.
+                    // https://fetch.spec.whatwg.org/#http-redirect-fetch step 19
                     if let Some(policy) = ReferrerPolicy::from_response_header(header.value()) {
                         self.referrer_policy = policy;
                     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -84,6 +84,7 @@ pub type AsyncHttp<'a> = AsyncHTTP<'a>;
 pub type ThreadlocalAsyncHttp<'a> = ThreadlocalAsyncHTTP<'a>;
 pub use bun_http_types::FetchRedirect::FetchRedirect;
 pub use bun_http_types::Method::Method;
+pub use bun_http_types::ReferrerPolicy::{ReferrerPolicy, determine_referer_header};
 pub use bun_picohttp as picohttp;
 
 #[repr(u8)]
@@ -740,6 +741,17 @@ pub struct HTTPClient<'a> {
     /// `MAX_H2_RETRIES`.
     pub h2_retries: u8,
     pub redirect_type: FetchRedirect,
+    /// The request's referrer in its stored serialized form (see the
+    /// `bun_http_types::ReferrerPolicy::determine_referer_header` docs) and the
+    /// request's referrer policy. Empty when the caller set an explicit
+    /// `Referer` header, so `build_request` leaves that header untouched
+    /// across redirects. `referrer_policy` may be updated by a
+    /// `Referrer-Policy` response header on a redirect hop.
+    pub referrer: Box<[u8]>,
+    pub referrer_policy: ReferrerPolicy,
+    /// Backing storage for the `Referer` header value `build_request` emits
+    /// each hop. Lives on `self` so the `picohttp::Request` can borrow it.
+    pub computed_referer: Vec<u8>,
     pub redirect: Vec<u8>,
     /// The previous hop's `redirect` buffer, parked by `handle_response_metadata`
     /// when it overwrites `redirect`. `connected_url` may still borrow from it
@@ -950,6 +962,7 @@ pub type GenHttpContext<const SSL: bool> = http_context::HTTPContext<SSL>;
 
 // ── header constants ────────────────────────────────────────────────────
 const HOST_HEADER_NAME: &[u8] = b"Host";
+const REFERER_HEADER_NAME: &[u8] = b"Referer";
 const CONTENT_LENGTH_HEADER_NAME: &[u8] = b"Content-Length";
 const CHUNKED_ENCODED_HEADER: picohttp::Header =
     picohttp::Header::new(b"Transfer-Encoding", b"chunked");
@@ -2336,12 +2349,14 @@ impl<'a> HTTPClient<'a> {
         let mut override_host_header = false;
         let mut override_connection_header = false;
         let mut override_user_agent = false;
+        let mut override_referer = false;
         let mut add_transfer_encoding = true;
         let mut original_content_length: Option<&[u8]> = None;
 
         // Reserve slots for default headers that may be appended after user headers
-        // (Connection, User-Agent, Accept, Host, Accept-Encoding, Content-Length/Transfer-Encoding).
-        const MAX_DEFAULT_HEADERS: usize = 6;
+        // (Connection, User-Agent, Accept, Host, Accept-Encoding, Referer,
+        // Content-Length/Transfer-Encoding).
+        const MAX_DEFAULT_HEADERS: usize = 7;
         const MAX_USER_HEADERS: usize = MAX_REQUEST_HEADERS - MAX_DEFAULT_HEADERS;
 
         for (i, head) in header_names.iter().enumerate() {
@@ -2392,6 +2407,11 @@ impl<'a> HTTPClient<'a> {
                 h if h == hash_header_const(HOST_HEADER_NAME) => {
                     if will_append {
                         override_host_header = true;
+                    }
+                }
+                h if h == hash_header_const(REFERER_HEADER_NAME) => {
+                    if will_append {
+                        override_referer = true;
                     }
                 }
                 h if h == hash_header_const(b"Accept") => {
@@ -2467,6 +2487,27 @@ impl<'a> HTTPClient<'a> {
         if !override_accept_encoding && !self.flags.disable_decompression {
             request_headers_buf[header_count] = ACCEPT_ENCODING_HEADER;
             header_count += 1;
+        }
+
+        // Compute the `Referer` header for this hop. `self.referrer` is empty
+        // when the caller set an explicit `Referer` (already in the loop
+        // above, which sets `override_referer`), so this recomputes only when
+        // the header came from the `referrer` / `referrerPolicy` options. It
+        // runs per `build_request`, i.e. freshly on every redirect hop.
+        if !override_referer && !self.referrer.is_empty() {
+            self.computed_referer.clear();
+            if let Some(value) =
+                determine_referer_header(&self.referrer, self.referrer_policy, &self.url)
+            {
+                self.computed_referer = value;
+                request_headers_buf[header_count] = picohttp::Header::new(
+                    REFERER_HEADER_NAME,
+                    // SAFETY: `computed_referer` lives on `self`; same erasure
+                    // as `request_content_len_buf` below.
+                    unsafe { bun_ptr::detach_lifetime(self.computed_referer.as_slice()) },
+                );
+                header_count += 1;
+            }
         }
 
         if body_len > 0 || self.method.has_request_body() {
@@ -4874,6 +4915,15 @@ impl<'a> HTTPClient<'a> {
                 }
                 h if h == hash_header_const(b"Location") => {
                     location = header.value();
+                }
+                h if h == hash_header_const(b"Referrer-Policy") => {
+                    // "Set request's referrer policy on redirect"
+                    // (https://fetch.spec.whatwg.org/#http-redirect-fetch,
+                    // step 19). Applied unconditionally: when no redirect is
+                    // followed, `referrer_policy` is never read again.
+                    if let Some(policy) = ReferrerPolicy::from_response_header(header.value()) {
+                        self.referrer_policy = policy;
+                    }
                 }
                 h if h == hash_header_const(b"Connection") => {
                     if response.status_code >= 200 && response.status_code <= 299 {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1033,8 +1033,9 @@ const PRINT_EVERY: usize = 0;
 static PRINT_EVERY_I: AtomicUsize = AtomicUsize::new(0);
 
 // we always rewrite the entire HTTP request when write() returns EAGAIN
-// so we can reuse this buffer
-const MAX_REQUEST_HEADERS: usize = 256;
+// so we can reuse this buffer. Sized so `MAX_USER_HEADERS` (this minus
+// `MAX_DEFAULT_HEADERS` in `build_request`) stays at the user-facing 250.
+const MAX_REQUEST_HEADERS: usize = 257;
 static SHARED_REQUEST_HEADERS_BUF: bun_core::RacyCell<[picohttp::Header; MAX_REQUEST_HEADERS]> =
     bun_core::RacyCell::new([picohttp::Header::ZERO; MAX_REQUEST_HEADERS]);
 
@@ -4911,6 +4912,14 @@ impl<'a> HTTPClient<'a> {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Referrer-Policy") => {
+                    // A proxy's CONNECT reply must not influence the referrer
+                    // policy of the tunneled request.
+                    if self.flags.proxy_tunneling
+                        && self.proxy_tunnel.is_none()
+                        && response.status_code == 200
+                    {
+                        continue;
+                    }
                     // https://fetch.spec.whatwg.org/#http-redirect-fetch step 19
                     if let Some(policy) = ReferrerPolicy::from_response_header(header.value()) {
                         self.referrer_policy = policy;

--- a/src/http_types/ReferrerPolicy.rs
+++ b/src/http_types/ReferrerPolicy.rs
@@ -45,19 +45,8 @@ impl ReferrerPolicy {
     /// module-level `MAP` static.
     pub const MAP: __ComptimeStringMap_MAP = __ComptimeStringMap_MAP(());
 
-    /// https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy
-    pub const DEFAULT: ReferrerPolicy = ReferrerPolicy::StrictOriginWhenCrossOrigin;
-
     pub fn as_str(self) -> &'static str {
         self.into()
-    }
-
-    /// The empty policy defers to the policy container's default.
-    pub fn resolve(self) -> ReferrerPolicy {
-        match self {
-            ReferrerPolicy::Empty => Self::DEFAULT,
-            other => other,
-        }
     }
     // to_js lives as an extension-trait method in bun_http_jsc (see PORTING.md §Idiom map).
 }

--- a/src/http_types/ReferrerPolicy.rs
+++ b/src/http_types/ReferrerPolicy.rs
@@ -1,0 +1,63 @@
+/// https://developer.mozilla.org/en-US/docs/Web/API/Request/referrerPolicy
+/// https://w3c.github.io/webappsec-referrer-policy/#referrer-policy
+#[repr(u8)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, strum::IntoStaticStr)]
+pub enum ReferrerPolicy {
+    /// The empty string: defer to the environment's default policy, which for
+    /// `fetch()` is `strict-origin-when-cross-origin`.
+    #[default]
+    #[strum(serialize = "")]
+    Empty,
+    #[strum(serialize = "no-referrer")]
+    NoReferrer,
+    #[strum(serialize = "no-referrer-when-downgrade")]
+    NoReferrerWhenDowngrade,
+    #[strum(serialize = "same-origin")]
+    SameOrigin,
+    #[strum(serialize = "origin")]
+    Origin,
+    #[strum(serialize = "strict-origin")]
+    StrictOrigin,
+    #[strum(serialize = "origin-when-cross-origin")]
+    OriginWhenCrossOrigin,
+    #[strum(serialize = "strict-origin-when-cross-origin")]
+    StrictOriginWhenCrossOrigin,
+    #[strum(serialize = "unsafe-url")]
+    UnsafeUrl,
+}
+
+bun_core::comptime_string_map! {
+    pub static MAP: ReferrerPolicy = {
+        b"" => ReferrerPolicy::Empty,
+        b"no-referrer" => ReferrerPolicy::NoReferrer,
+        b"no-referrer-when-downgrade" => ReferrerPolicy::NoReferrerWhenDowngrade,
+        b"same-origin" => ReferrerPolicy::SameOrigin,
+        b"origin" => ReferrerPolicy::Origin,
+        b"strict-origin" => ReferrerPolicy::StrictOrigin,
+        b"origin-when-cross-origin" => ReferrerPolicy::OriginWhenCrossOrigin,
+        b"strict-origin-when-cross-origin" => ReferrerPolicy::StrictOriginWhenCrossOrigin,
+        b"unsafe-url" => ReferrerPolicy::UnsafeUrl,
+    };
+}
+
+impl ReferrerPolicy {
+    /// The map type is a zero-sized handle, so this is the same map as the
+    /// module-level `MAP` static.
+    pub const MAP: __ComptimeStringMap_MAP = __ComptimeStringMap_MAP(());
+
+    /// https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy
+    pub const DEFAULT: ReferrerPolicy = ReferrerPolicy::StrictOriginWhenCrossOrigin;
+
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// The empty policy defers to the policy container's default.
+    pub fn resolve(self) -> ReferrerPolicy {
+        match self {
+            ReferrerPolicy::Empty => Self::DEFAULT,
+            other => other,
+        }
+    }
+    // to_js lives as an extension-trait method in bun_http_jsc (see PORTING.md §Idiom map).
+}

--- a/src/http_types/ReferrerPolicy.rs
+++ b/src/http_types/ReferrerPolicy.rs
@@ -49,11 +49,9 @@ impl ReferrerPolicy {
         self.into()
     }
 
-    /// Parses a `Referrer-Policy` response header.
+    /// Parses a `Referrer-Policy` response header: the last token naming a
+    /// valid non-empty policy wins, `None` if none does.
     /// https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header
-    ///
-    /// The header is a comma-separated list of tokens; the *last* token that
-    /// names a valid non-empty policy wins. Returns `None` if no token does.
     pub fn from_response_header(value: &[u8]) -> Option<ReferrerPolicy> {
         let mut result = None;
         for token in value.split(|&b| b == b',') {
@@ -72,21 +70,9 @@ impl ReferrerPolicy {
 use bun_core::strings;
 use bun_url::URL as ZigURL;
 
-/// The `Referer` request-header value for a request whose stored referrer is
-/// `referrer` and whose current URL is `request_url`, or `None` when no
-/// `Referer` header should be sent.
-///
-/// Implements "determine request's referrer"
-/// (https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer)
-/// followed by the fetch spec's "HTTP-network-or-cache fetch" Referer step.
-///
-/// `referrer` is the request's stored referrer in its serialized form: `b""`
-/// for "no-referrer", `b"about:client"` for "client", otherwise a
-/// WHATWG-normalized referrer URL. `request_url` must likewise be parsed from
-/// a WHATWG-normalized href.
-///
-/// Lives here rather than in `bun_runtime` so the HTTP client can recompute
-/// the header on each redirect hop.
+/// The `Referer` request-header value (or `None` for no header). `referrer` is
+/// the stored serialized form (`b""` / `b"about:client"` / normalized URL).
+/// https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer
 pub fn determine_referer_header(
     referrer: &[u8],
     policy: ReferrerPolicy,
@@ -96,16 +82,12 @@ pub fn determine_referer_header(
     if referrer.is_empty() {
         return None;
     }
-    // "client": Bun has no document or environment creation URL to resolve it
-    // against, so a "client" referrer yields no referrer. (undici behaves the
-    // same way when no global origin is configured.)
+    // "client": Bun has no environment creation URL to resolve against.
     if referrer == b"about:client" {
         return None;
     }
-    // "Strip url for use as a referrer" step 2: the local schemes yield no
-    // referrer. Matched on the normalized href rather than on the parsed
-    // scheme because `ZigURL` only recognizes a scheme spelled `scheme://`,
-    // so the browser form `blob:https://origin/uuid` parses as `blob:https`.
+    // Local schemes yield no referrer. Matched on the href because `ZigURL`
+    // mis-parses the browser form `blob:https://origin/uuid` as `blob:https`.
     if strings::has_prefix_comptime(referrer, b"about:")
         || strings::has_prefix_comptime(referrer, b"blob:")
         || strings::has_prefix_comptime(referrer, b"data:")
@@ -123,18 +105,14 @@ pub fn determine_referer_header(
     let referrer_host = strip_userinfo(referrer_url.host);
     let request_host = strip_userinfo(request_url.host);
 
-    // The stripped referrer URL: `scheme "://" host[":" port] path ["?" query]`.
-    // `ZigURL.pathname` is path + query with the fragment excluded, so together
-    // with the credential-stripped host this is the spec's "strip url for use
-    // as a referrer".
+    // `scheme "://" host pathname` is the stripped referrer (`pathname` has no
+    // fragment, and credentials were stripped above). Up to `origin_len` plus
+    // a `/` is the origin-only form.
     let origin_len = scheme.len() + b"://".len() + referrer_host.len();
     let mut value: Vec<u8> = Vec::with_capacity(origin_len + referrer_url.pathname.len());
     value.extend_from_slice(scheme);
     value.extend_from_slice(b"://");
     value.extend_from_slice(referrer_host);
-    // `pathname` always begins with `/`, so truncating to `origin_len` and
-    // pushing a `/` yields the origin-only form ("set url's path to the empty
-    // string" serializes as origin + "/").
     value.extend_from_slice(referrer_url.pathname);
 
     let same_origin = scheme == request_url.protocol && referrer_host == request_host;
@@ -166,9 +144,7 @@ pub fn determine_referer_header(
             true
         }
         ReferrerPolicy::OriginWhenCrossOrigin => same_origin,
-        // The empty policy resolves to the policy container's default,
-        // `strict-origin-when-cross-origin`.
-        // https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy
+        // Empty policy == the default, `strict-origin-when-cross-origin`.
         ReferrerPolicy::Empty | ReferrerPolicy::StrictOriginWhenCrossOrigin => {
             if same_origin {
                 true
@@ -189,10 +165,8 @@ pub fn determine_referer_header(
     Some(value)
 }
 
-/// `ZigURL::parse` only splits off credentials when a `:` precedes the `@`, so
-/// a URL with a username but no password keeps `user@` inside `host` and
-/// `hostname`. Userinfo ends at the authority's last `@` (any `@` within it is
-/// percent-encoded in a normalized href).
+/// `ZigURL` leaves `user@` inside `host` when there is no password. Userinfo
+/// ends at the last `@` (any `@` within it is percent-encoded when normalized).
 fn strip_userinfo(host: &[u8]) -> &[u8] {
     match strings::last_index_of_char(host, b'@') {
         Some(at) => &host[at + 1..],
@@ -200,19 +174,15 @@ fn strip_userinfo(host: &[u8]) -> &[u8] {
     }
 }
 
+/// `hostname` must come from a WHATWG-normalized href (loopbacks canonical).
 /// https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
-///
-/// `hostname` must come from a WHATWG-normalized href, so an IPv4 loopback is a
-/// canonical dotted quad (`127.x.y.z`) and the IPv6 loopback serializes as
-/// `[::1]`.
 fn is_potentially_trustworthy(scheme: &[u8], hostname: &[u8]) -> bool {
     if scheme == b"https" || scheme == b"wss" || scheme == b"file" {
         return true;
     }
     hostname == b"localhost"
         || strings::has_suffix_comptime(hostname, b".localhost")
-        // Only an IPv4 address in 127/8 is loopback; a domain name whose first
-        // label happens to be `127` is not.
+        // Only an IPv4 127/8 address is loopback, not any `127.*` domain name.
         || (strings::has_prefix_comptime(hostname, b"127.") && strings::is_ip_address(hostname))
         || hostname == b"[::1]"
 }

--- a/src/http_types/ReferrerPolicy.rs
+++ b/src/http_types/ReferrerPolicy.rs
@@ -48,5 +48,171 @@ impl ReferrerPolicy {
     pub fn as_str(self) -> &'static str {
         self.into()
     }
+
+    /// Parses a `Referrer-Policy` response header.
+    /// https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header
+    ///
+    /// The header is a comma-separated list of tokens; the *last* token that
+    /// names a valid non-empty policy wins. Returns `None` if no token does.
+    pub fn from_response_header(value: &[u8]) -> Option<ReferrerPolicy> {
+        let mut result = None;
+        for token in value.split(|&b| b == b',') {
+            let token = bun_core::strings::trim(token, b" \t");
+            if let Some(&policy) = Self::MAP.get(token)
+                && policy != ReferrerPolicy::Empty
+            {
+                result = Some(policy);
+            }
+        }
+        result
+    }
     // to_js lives as an extension-trait method in bun_http_jsc (see PORTING.md §Idiom map).
+}
+
+use bun_core::strings;
+use bun_url::URL as ZigURL;
+
+/// The `Referer` request-header value for a request whose stored referrer is
+/// `referrer` and whose current URL is `request_url`, or `None` when no
+/// `Referer` header should be sent.
+///
+/// Implements "determine request's referrer"
+/// (https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer)
+/// followed by the fetch spec's "HTTP-network-or-cache fetch" Referer step.
+///
+/// `referrer` is the request's stored referrer in its serialized form: `b""`
+/// for "no-referrer", `b"about:client"` for "client", otherwise a
+/// WHATWG-normalized referrer URL. `request_url` must likewise be parsed from
+/// a WHATWG-normalized href.
+///
+/// Lives here rather than in `bun_runtime` so the HTTP client can recompute
+/// the header on each redirect hop.
+pub fn determine_referer_header(
+    referrer: &[u8],
+    policy: ReferrerPolicy,
+    request_url: &ZigURL<'_>,
+) -> Option<Vec<u8>> {
+    // "no-referrer"
+    if referrer.is_empty() {
+        return None;
+    }
+    // "client": Bun has no document or environment creation URL to resolve it
+    // against, so a "client" referrer yields no referrer. (undici behaves the
+    // same way when no global origin is configured.)
+    if referrer == b"about:client" {
+        return None;
+    }
+    // "Strip url for use as a referrer" step 2: the local schemes yield no
+    // referrer. Matched on the normalized href rather than on the parsed
+    // scheme because `ZigURL` only recognizes a scheme spelled `scheme://`,
+    // so the browser form `blob:https://origin/uuid` parses as `blob:https`.
+    if strings::has_prefix_comptime(referrer, b"about:")
+        || strings::has_prefix_comptime(referrer, b"blob:")
+        || strings::has_prefix_comptime(referrer, b"data:")
+    {
+        return None;
+    }
+
+    let referrer_url = ZigURL::parse(referrer);
+    // A referrer with no `scheme://` authority cannot produce a Referer.
+    let scheme = referrer_url.protocol;
+    if scheme.is_empty() {
+        return None;
+    }
+
+    let referrer_host = strip_userinfo(referrer_url.host);
+    let request_host = strip_userinfo(request_url.host);
+
+    // The stripped referrer URL: `scheme "://" host[":" port] path ["?" query]`.
+    // `ZigURL.pathname` is path + query with the fragment excluded, so together
+    // with the credential-stripped host this is the spec's "strip url for use
+    // as a referrer".
+    let origin_len = scheme.len() + b"://".len() + referrer_host.len();
+    let mut value: Vec<u8> = Vec::with_capacity(origin_len + referrer_url.pathname.len());
+    value.extend_from_slice(scheme);
+    value.extend_from_slice(b"://");
+    value.extend_from_slice(referrer_host);
+    // `pathname` always begins with `/`, so truncating to `origin_len` and
+    // pushing a `/` yields the origin-only form ("set url's path to the empty
+    // string" serializes as origin + "/").
+    value.extend_from_slice(referrer_url.pathname);
+
+    let same_origin = scheme == request_url.protocol && referrer_host == request_host;
+    // "referrerURL is a potentially trustworthy URL and request's current URL
+    // is not a potentially trustworthy URL" -- the strict/downgrade guard.
+    let downgrade = is_potentially_trustworthy(scheme, strip_userinfo(referrer_url.hostname))
+        && !is_potentially_trustworthy(request_url.protocol, strip_userinfo(request_url.hostname));
+
+    let send_full = match policy {
+        ReferrerPolicy::NoReferrer => return None,
+        ReferrerPolicy::Origin => false,
+        ReferrerPolicy::UnsafeUrl => true,
+        ReferrerPolicy::StrictOrigin => {
+            if downgrade {
+                return None;
+            }
+            false
+        }
+        ReferrerPolicy::NoReferrerWhenDowngrade => {
+            if downgrade {
+                return None;
+            }
+            true
+        }
+        ReferrerPolicy::SameOrigin => {
+            if !same_origin {
+                return None;
+            }
+            true
+        }
+        ReferrerPolicy::OriginWhenCrossOrigin => same_origin,
+        // The empty policy resolves to the policy container's default,
+        // `strict-origin-when-cross-origin`.
+        // https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy
+        ReferrerPolicy::Empty | ReferrerPolicy::StrictOriginWhenCrossOrigin => {
+            if same_origin {
+                true
+            } else if downgrade {
+                return None;
+            } else {
+                false
+            }
+        }
+    };
+
+    // "If the result of serializing referrerURL is a string whose length is
+    // greater than 4096, set referrerURL to referrerOrigin."
+    if !send_full || value.len() > 4096 {
+        value.truncate(origin_len);
+        value.push(b'/');
+    }
+    Some(value)
+}
+
+/// `ZigURL::parse` only splits off credentials when a `:` precedes the `@`, so
+/// a URL with a username but no password keeps `user@` inside `host` and
+/// `hostname`. Userinfo ends at the authority's last `@` (any `@` within it is
+/// percent-encoded in a normalized href).
+fn strip_userinfo(host: &[u8]) -> &[u8] {
+    match strings::last_index_of_char(host, b'@') {
+        Some(at) => &host[at + 1..],
+        None => host,
+    }
+}
+
+/// https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
+///
+/// `hostname` must come from a WHATWG-normalized href, so an IPv4 loopback is a
+/// canonical dotted quad (`127.x.y.z`) and the IPv6 loopback serializes as
+/// `[::1]`.
+fn is_potentially_trustworthy(scheme: &[u8], hostname: &[u8]) -> bool {
+    if scheme == b"https" || scheme == b"wss" || scheme == b"file" {
+        return true;
+    }
+    hostname == b"localhost"
+        || strings::has_suffix_comptime(hostname, b".localhost")
+        // Only an IPv4 address in 127/8 is loopback; a domain name whose first
+        // label happens to be `127` is not.
+        || (strings::has_prefix_comptime(hostname, b"127.") && strings::is_ip_address(hostname))
+        || hostname == b"[::1]"
 }

--- a/src/http_types/lib.rs
+++ b/src/http_types/lib.rs
@@ -6,6 +6,7 @@ pub mod FetchCacheMode;
 pub mod FetchRedirect;
 pub mod FetchRequestMode;
 pub mod Method;
+pub mod ReferrerPolicy;
 pub mod URLPath;
 pub mod h2;
 pub mod mime_type_list_enum;

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1359,6 +1359,24 @@ impl FromJsEnum for bun_http_types::FetchCacheMode::FetchCacheMode {
     }
 }
 
+impl FromJsEnum for bun_http_types::ReferrerPolicy::ReferrerPolicy {
+    fn from_js_value(
+        v: JSValue,
+        global: &JSGlobalObject,
+        property_name: &'static str,
+    ) -> JsResult<Self> {
+        use bun_http_types::ReferrerPolicy::ReferrerPolicy;
+        v.to_enum_from_map(
+            global,
+            property_name,
+            &ReferrerPolicy::MAP,
+            "'', 'no-referrer', 'no-referrer-when-downgrade', 'same-origin', 'origin', \
+             'strict-origin', 'origin-when-cross-origin', 'strict-origin-when-cross-origin' \
+             or 'unsafe-url'",
+        )
+    }
+}
+
 // `URL::path_from_file_url` / `URL::href_from_js` live in `URL.rs` (the
 // dedicated port file); the lib.rs copies were duplicate definitions.
 

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -245,6 +245,9 @@ pub use response::Response;
 pub mod request;
 pub use request::Request;
 
+#[path = "webcore/referrer.rs"]
+pub mod referrer;
+
 #[path = "webcore/ReadableStream.rs"]
 pub mod readable_stream;
 pub use readable_stream::{

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -86,9 +86,8 @@ const _: () = {
 #[repr(C)]
 pub struct Request {
     pub url: bun_core::OwnedStringCell,
-    /// The request's referrer, stored serialized: `""` == "no-referrer",
-    /// `"about:client"` == "client" (the default), anything else is a
-    /// WHATWG-normalized referrer URL. See `crate::webcore::referrer`.
+    /// The request's referrer in its stored serialized form; see
+    /// `crate::webcore::referrer`.
     pub referrer: bun_core::OwnedStringCell,
 
     headers: JsCell<Option<HeadersRef>>,
@@ -775,8 +774,8 @@ impl Request {
         if this.weak_ptr_data.on_finalize() {
             // Hot path: no outstanding weak refs. Reclaim and drop the whole
             // allocation in one shot — `Box::from_raw`'s drop runs
-            // `drop_in_place` over every field (headers / url / referrer /
-            // signal / js_ref / internal_event_callback) once, without the 4× `Cell::set`
+            // `drop_in_place` over every field (headers / url / signal /
+            // js_ref / internal_event_callback) once, without the 4× `Cell::set`
             // read-write-drop round-trips the old `finalize_without_deinit()`
             // call performed here before re-dropping the (now-empty) fields.
             // SAFETY: `this` is the live Box-allocated payload.
@@ -795,8 +794,7 @@ impl Request {
     }
 
     /// https://fetch.spec.whatwg.org/#dom-request-referrer
-    /// The stored referrer is already the getter's serialization: `""` for
-    /// "no-referrer", `"about:client"` for "client", the URL otherwise.
+    /// The stored referrer is already the getter's serialization.
     pub fn get_referrer(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         self.referrer.get().to_js(global_object)
     }
@@ -810,8 +808,6 @@ impl Request {
         self.url.get().to_js(global_object)
     }
 
-    /// The referrer is always set (to the `"about:client"` static by default),
-    /// so unlike the url there is nothing to lazily compute here.
     pub fn size_of_referrer(&self) -> usize {
         self.referrer.get().byte_slice().len()
     }
@@ -1472,14 +1468,12 @@ impl Request {
                 }
             }
 
-            // Extract referrer option
-            // https://fetch.spec.whatwg.org/#dom-request (constructor step 14)
+            // Extract referrer option (Request ctor step 14)
             if !fields.contains(Fields::Referrer) {
                 match value.get(global_this, "referrer") {
                     Ok(Some(referrer_value)) if !referrer_value.is_undefined() => {
                         fields.insert(Fields::Referrer);
-                        // USVString conversion; `OwnedString` releases the +1
-                        // on every exit path.
+                        // `OwnedString` releases the +1 on every exit path.
                         let raw = OwnedString::new(
                             match BunString::from_js(referrer_value, global_this) {
                                 Ok(s) => s,
@@ -1639,9 +1633,8 @@ impl Request {
         // `clone()` seeds it with a dangling sentinel, and `construct_into`
         // releases its seed via the ptr-equality arm of its `cleanup`.
         // `url` was bitwise-copied above (preserve_url) or is the empty
-        // sentinel; `referrer` is an empty or static (non-owning) sentinel in
-        // both callers; remaining incoming fields are None/weak/Copy by
-        // contract.
+        // sentinel; `referrer` is a non-owning sentinel in both callers;
+        // remaining incoming fields are None/weak/Copy by contract.
         // SAFETY: `req` is a valid &mut, fully initialized by the caller;
         // nothing between here and the write can panic.
         unsafe {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -381,6 +381,7 @@ impl Request {
         core::mem::size_of::<Request>()
             + self.request_context.memory_cost()
             + self.url.get().byte_slice().len()
+            + self.size_of_referrer()
             + self.body_value().memory_cost()
     }
 
@@ -503,6 +504,7 @@ impl Request {
         self.reported_estimated_size.set(
             self.body_value().estimated_size()
                 + self.size_of_url()
+                + self.size_of_referrer()
                 + core::mem::size_of::<Request>(),
         );
     }
@@ -806,6 +808,12 @@ impl Request {
     pub fn get_url(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         self.ensure_url()?;
         self.url.get().to_js(global_object)
+    }
+
+    /// The referrer is always set (to the `"about:client"` static by default),
+    /// so unlike the url there is nothing to lazily compute here.
+    pub fn size_of_referrer(&self) -> usize {
+        self.referrer.get().byte_slice().len()
     }
 
     pub fn size_of_url(&self) -> usize {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1482,7 +1482,7 @@ impl Request {
                         );
                         match referrer::parse_init_referrer(&raw) {
                             Some(stored) => req.referrer.set(stored),
-                            None => bail!(Err(global_this.throw(format_args!(
+                            None => bail!(Err(global_this.throw_type_error(format_args!(
                                 "Failed to construct 'Request': Invalid referrer \"{}\"",
                                 raw.get()
                             )))),

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -16,10 +16,11 @@ use crate::webcore::body::{self, BodyHiveHandle, BodyMixin, Value as BodyValue};
 use crate::webcore::jsc::{
     self as jsc, CallFrame, HTTPHeaderName, JSGlobalObject, JSValue, JsError, JsRef, JsResult,
 };
+use crate::webcore::referrer;
 use crate::webcore::{AbortSignal, Blob, CookieMap, FetchHeaders, ReadableStream, Response};
 use bun_alloc::AllocError;
 use bun_core::{Output, fmt as bun_fmt};
-use bun_core::{OwnedStringCell, String as BunString, ZigString, strings};
+use bun_core::{OwnedString, OwnedStringCell, String as BunString, ZigString, strings};
 use bun_http_jsc::fetch_enums_jsc::{
     fetch_cache_mode_to_js, fetch_redirect_to_js, fetch_request_mode_to_js,
 };
@@ -28,6 +29,7 @@ use bun_http_types::FetchCacheMode::FetchCacheMode;
 use bun_http_types::FetchRedirect::FetchRedirect;
 use bun_http_types::FetchRequestMode::FetchRequestMode;
 use bun_http_types::Method::Method;
+use bun_http_types::ReferrerPolicy::ReferrerPolicy;
 use bun_jsc::AbortSignalRef;
 use bun_jsc::StringJsc as _;
 use bun_jsc::generated::JSRequest as js_gen;
@@ -84,6 +86,10 @@ const _: () = {
 #[repr(C)]
 pub struct Request {
     pub url: bun_core::OwnedStringCell,
+    /// The request's referrer, stored serialized: `""` == "no-referrer",
+    /// `"about:client"` == "client" (the default), anything else is a
+    /// WHATWG-normalized referrer URL. See `crate::webcore::referrer`.
+    pub referrer: bun_core::OwnedStringCell,
 
     headers: JsCell<Option<HeadersRef>>,
     // AbortSignal is an opaque C++ handle with intrusive WebCore refcounting —
@@ -119,9 +125,10 @@ pub struct Flags {
     pub cache: FetchCacheMode,
     pub mode: FetchRequestMode,
     pub https: bool,
+    pub referrer_policy: ReferrerPolicy,
 }
 
-bun_core::assert_ffi_layout!(Flags, 4, 1; redirect @ 0, cache @ 1, mode @ 2, https @ 3);
+bun_core::assert_ffi_layout!(Flags, 5, 1; redirect @ 0, cache @ 1, mode @ 2, https @ 3, referrer_policy @ 4);
 
 impl Default for Flags {
     fn default() -> Self {
@@ -130,6 +137,7 @@ impl Default for Flags {
             cache: FetchCacheMode::Default,
             mode: FetchRequestMode::Cors,
             https: false,
+            referrer_policy: ReferrerPolicy::Empty,
         }
     }
 }
@@ -457,6 +465,7 @@ impl Request {
     ) -> Request {
         Request {
             url: OwnedStringCell::new(url),
+            referrer: OwnedStringCell::new(referrer::client()),
             headers: JsCell::new(headers),
             signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
@@ -743,6 +752,7 @@ impl Request {
         self.headers.set(None);
 
         self.url.set(BunString::empty());
+        self.referrer.set(BunString::empty());
 
         // AbortSignalRef::Drop unrefs the C++ handle.
         self.signal.set(None);
@@ -763,8 +773,8 @@ impl Request {
         if this.weak_ptr_data.on_finalize() {
             // Hot path: no outstanding weak refs. Reclaim and drop the whole
             // allocation in one shot — `Box::from_raw`'s drop runs
-            // `drop_in_place` over every field (headers / url / signal /
-            // js_ref / internal_event_callback) once, without the 4× `Cell::set`
+            // `drop_in_place` over every field (headers / url / referrer /
+            // signal / js_ref / internal_event_callback) once, without the 4× `Cell::set`
             // read-write-drop round-trips the old `finalize_without_deinit()`
             // call performed here before re-dropping the (now-empty) fields.
             // SAFETY: `this` is the live Box-allocated payload.
@@ -782,18 +792,15 @@ impl Request {
         fetch_redirect_to_js(self.flags.redirect, global_this)
     }
 
-    pub fn get_referrer(&self, global_object: &JSGlobalObject) -> JSValue {
-        if let Some(headers_ref) = self.headers_mut().as_mut() {
-            if let Some(referrer) = headers_ref.get(b"referrer", global_object) {
-                return referrer.to_js(global_object);
-            }
-        }
-
-        ZigString::init(b"").to_js(global_object)
+    /// https://fetch.spec.whatwg.org/#dom-request-referrer
+    /// The stored referrer is already the getter's serialization: `""` for
+    /// "no-referrer", `"about:client"` for "client", the URL otherwise.
+    pub fn get_referrer(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+        self.referrer.get().to_js(global_object)
     }
 
-    pub fn get_referrer_policy(_this: &Self, global_this: &JSGlobalObject) -> JSValue {
-        ZigString::init(b"").to_js(global_this)
+    pub fn get_referrer_policy(&self, global_this: &JSGlobalObject) -> JSValue {
+        ZigString::init(self.flags.referrer_policy.as_str().as_bytes()).to_js(global_this)
     }
 
     pub fn get_url(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
@@ -990,8 +997,8 @@ enum Fields {
     Method,
     Headers,
     Body,
-    // Referrer,
-    // ReferrerPolicy,
+    Referrer,
+    ReferrerPolicy,
     Mode,
     // Credentials,
     Redirect,
@@ -1023,6 +1030,7 @@ impl Request {
         let body_seed_ptr = body.as_ptr();
         let mut req = Request {
             url: OwnedStringCell::new(BunString::empty()),
+            referrer: OwnedStringCell::new(referrer::client()),
             headers: JsCell::new(None),
             signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
@@ -1157,6 +1165,16 @@ impl Request {
                     if !fields.contains(Fields::Mode) {
                         req.flags.mode = request.flags.mode;
                         fields.insert(Fields::Mode);
+                    }
+
+                    if !fields.contains(Fields::Referrer) {
+                        req.referrer.set(request.referrer.get().dupe_ref());
+                        fields.insert(Fields::Referrer);
+                    }
+
+                    if !fields.contains(Fields::ReferrerPolicy) {
+                        req.flags.referrer_policy = request.flags.referrer_policy;
+                        fields.insert(Fields::ReferrerPolicy);
                     }
 
                     if !fields.contains(Fields::Headers) {
@@ -1445,6 +1463,45 @@ impl Request {
                     Err(e) => bail!(Err(e)),
                 }
             }
+
+            // Extract referrer option
+            // https://fetch.spec.whatwg.org/#dom-request (constructor step 14)
+            if !fields.contains(Fields::Referrer) {
+                match value.get(global_this, "referrer") {
+                    Ok(Some(referrer_value)) if !referrer_value.is_undefined() => {
+                        fields.insert(Fields::Referrer);
+                        // USVString conversion; `OwnedString` releases the +1
+                        // on every exit path.
+                        let raw = OwnedString::new(
+                            match BunString::from_js(referrer_value, global_this) {
+                                Ok(s) => s,
+                                Err(e) => bail!(Err(e)),
+                            },
+                        );
+                        match referrer::parse_init_referrer(&raw) {
+                            Some(stored) => req.referrer.set(stored),
+                            None => bail!(Err(global_this.throw(format_args!(
+                                "Failed to construct 'Request': Invalid referrer \"{}\"",
+                                raw.get()
+                            )))),
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => bail!(Err(e)),
+                }
+            }
+
+            // Extract referrerPolicy option
+            if !fields.contains(Fields::ReferrerPolicy) {
+                match value.get_optional_enum::<ReferrerPolicy>(global_this, "referrerPolicy") {
+                    Ok(Some(policy_value)) => {
+                        req.flags.referrer_policy = policy_value;
+                        fields.insert(Fields::ReferrerPolicy);
+                    }
+                    Ok(None) => {}
+                    Err(e) => bail!(Err(e)),
+                }
+            }
         }
 
         if global_this.has_exception() {
@@ -1574,7 +1631,9 @@ impl Request {
         // `clone()` seeds it with a dangling sentinel, and `construct_into`
         // releases its seed via the ptr-equality arm of its `cleanup`.
         // `url` was bitwise-copied above (preserve_url) or is the empty
-        // sentinel; remaining incoming fields are None/weak/Copy by contract.
+        // sentinel; `referrer` is an empty or static (non-owning) sentinel in
+        // both callers; remaining incoming fields are None/weak/Copy by
+        // contract.
         // SAFETY: `req` is a valid &mut, fully initialized by the caller;
         // nothing between here and the write can panic.
         unsafe {
@@ -1582,6 +1641,7 @@ impl Request {
                 req,
                 Request {
                     url: OwnedStringCell::new(url),
+                    referrer: OwnedStringCell::new(self.referrer.get().dupe_ref()),
                     headers: JsCell::new(headers),
                     signal: JsCell::new(None),
                     body: ManuallyDrop::new(body),
@@ -1609,6 +1669,7 @@ impl Request {
         // without reading or dropping it.
         let mut req = Box::new(Request {
             url: OwnedStringCell::new(BunString::empty()),
+            referrer: OwnedStringCell::new(BunString::empty()),
             headers: JsCell::new(None),
             signal: JsCell::new(None),
             // `clone_into` `ptr::write`s the whole struct without dropping the
@@ -1684,6 +1745,7 @@ impl Request {
     ) -> Request {
         Request {
             url: OwnedStringCell::new(BunString::empty()),
+            referrer: OwnedStringCell::new(referrer::client()),
             headers: JsCell::new(None),
             signal: JsCell::new(signal),
             body: ManuallyDrop::new(body),

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1408,14 +1408,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
-    // referrer: string | undefined;
-    //
-    // `fetch(input, init)` constructs a `Request` from its arguments, so the
-    // `referrer` init member resolves exactly as in the `Request` constructor
-    // (https://fetch.spec.whatwg.org/#dom-request, step 14). Stored in the
-    // serialized form described in `crate::webcore::referrer`; the init
-    // object overrides a `Request` first argument, which overrides the
-    // default ("about:client").
+    // referrer: string | undefined; resolved as in the `Request` constructor
+    // and stored as described in `crate::webcore::referrer`.
     let request_referrer: bun_core::OwnedString = bun_core::OwnedString::new('extract_referrer: {
         let objects_to_try = [
             options_object.unwrap_or(JSValue::ZERO),
@@ -1733,13 +1727,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         ));
     }
 
-    // `build_request` computes the `Referer` header from `referrer` /
-    // `referrer_policy` on each hop, so it's not appended to the header list
-    // here. An explicit user-set `Referer` header wins: the spec appends
-    // unconditionally, but only because in browsers `Referer` is a forbidden
-    // header name that can never already be present, and RFC 9110 makes
-    // `Referer` a singleton field. An empty `referrer` tells `build_request`
-    // to leave the `Referer` header entirely to the user's header list.
+    // `build_request` computes `Referer` on each hop, so it's not appended
+    // here. An explicit user-set `Referer` header wins: an empty `referrer`
+    // tells `build_request` to leave the user's header alone.
     let referrer: Box<[u8]> = match headers.as_ref().and_then(|h| h.get(b"referer")) {
         Some(_) => Box::default(),
         None => {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -52,6 +52,7 @@ use bun_core::{String as BunString, Tag as BunStringTag, ZigStringSlice};
 use bun_http::{self as http, FetchRedirect, Headers, HeadersExt as _, MimeType};
 use bun_http_jsc::method_jsc;
 use bun_http_types::Method::Method;
+use bun_http_types::ReferrerPolicy::ReferrerPolicy;
 use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _};
 use bun_paths::{self, PathBuffer};
 use bun_sys::FdExt as _;
@@ -64,6 +65,7 @@ use crate::socket::ssl_config::{SSLConfig, SSLConfigFromJs};
 use crate::webcore::blob::BlobExt as _;
 use crate::webcore::body::{Action as BodyValueLockedAction, InternalBlob, Value as BodyValue};
 use crate::webcore::headers_ref::any_blob_content_type_opt;
+use crate::webcore::referrer;
 use crate::webcore::s3::client as s3;
 use crate::webcore::{
     AbortSignal, Blob, Body, FetchHeaders, ObjectURLRegistry, ReadableStream, Request, Response,
@@ -1404,6 +1406,108 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     if global_this.has_exception() {
         return Ok(JSValue::ZERO);
+    }
+
+    // referrer: string | undefined;
+    //
+    // `fetch(input, init)` constructs a `Request` from its arguments, so the
+    // `referrer` init member resolves exactly as in the `Request` constructor
+    // (https://fetch.spec.whatwg.org/#dom-request, step 14). Stored in the
+    // serialized form described in `crate::webcore::referrer`; the init
+    // object overrides a `Request` first argument, which overrides the
+    // default ("about:client").
+    let request_referrer: bun_core::OwnedString = bun_core::OwnedString::new('extract_referrer: {
+        let objects_to_try = [
+            options_object.unwrap_or(JSValue::ZERO),
+            request_init_object.unwrap_or(JSValue::ZERO),
+        ];
+
+        for obj in objects_to_try {
+            if !obj.is_empty() {
+                match obj.get(global_this, "referrer")? {
+                    Some(referrer_value) if !referrer_value.is_undefined() => {
+                        let raw = bun_core::OwnedString::new(BunString::from_js(
+                            referrer_value,
+                            global_this,
+                        )?);
+                        match referrer::parse_init_referrer(&raw) {
+                            Some(stored) => break 'extract_referrer stored,
+                            None => {
+                                return Err(global_this.throw(format_args!(
+                                    "fetch() referrer is not a valid URL: \"{}\"",
+                                    raw.get()
+                                )));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+
+                if global_this.has_exception() {
+                    return Ok(JSValue::ZERO);
+                }
+            }
+        }
+
+        if let Some(req) = request_mut!() {
+            break 'extract_referrer req.referrer.get().dupe_ref();
+        }
+
+        break 'extract_referrer referrer::client();
+    });
+
+    if global_this.has_exception() {
+        return Ok(JSValue::ZERO);
+    }
+
+    // referrerPolicy: ReferrerPolicy | undefined;
+    let referrer_policy: ReferrerPolicy = 'extract_referrer_policy: {
+        let mut referrer_policy = ReferrerPolicy::Empty;
+        if let Some(req) = request_mut!() {
+            referrer_policy = req.flags.referrer_policy;
+        }
+
+        let objects_to_try = [
+            options_object.unwrap_or(JSValue::ZERO),
+            request_init_object.unwrap_or(JSValue::ZERO),
+        ];
+
+        for obj in objects_to_try {
+            if !obj.is_empty() {
+                match obj.get_optional_enum::<ReferrerPolicy>(global_this, "referrerPolicy") {
+                    Err(_) => {
+                        return Ok(JSValue::ZERO);
+                    }
+                    Ok(Some(policy_value)) => {
+                        break 'extract_referrer_policy policy_value;
+                    }
+                    Ok(None) => {}
+                }
+            }
+        }
+
+        break 'extract_referrer_policy referrer_policy;
+    };
+
+    if global_this.has_exception() {
+        return Ok(JSValue::ZERO);
+    }
+
+    // Serialize the `Referer` request header from the resolved referrer and
+    // policy. An explicit user-set `Referer` header wins: the spec appends
+    // unconditionally, but only because in browsers `Referer` is a forbidden
+    // header name that can never already be present, and RFC 9110 makes
+    // `Referer` a singleton field.
+    if url_type == URLType::Remote {
+        let referrer_utf8 = request_referrer.to_utf8();
+        if let Some(referer_value) =
+            referrer::determine_referer_header(referrer_utf8.slice(), referrer_policy, &url)
+        {
+            let request_headers = headers.get_or_insert_with(Headers::default);
+            if request_headers.get(b"referer").is_none() {
+                request_headers.append(b"Referer", &referer_value);
+            }
+        }
     }
 
     if proxy.is_some() && !unix_socket_path.slice().is_empty() {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1427,7 +1427,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         match referrer::parse_init_referrer(&raw) {
                             Some(stored) => break 'extract_referrer stored,
                             None => {
-                                return Err(global_this.throw(format_args!(
+                                return Err(global_this.throw_type_error(format_args!(
                                     "fetch() referrer is not a valid URL: \"{}\"",
                                     raw.get()
                                 )));

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1733,25 +1733,20 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         ));
     }
 
-    // Serialize the `Referer` request header from the resolved referrer and
-    // policy. Must come after the body Content-Type fallback above, which only
-    // fires while `headers` is still `None`.
-    //
-    // An explicit user-set `Referer` header wins: the spec appends
+    // `build_request` computes the `Referer` header from `referrer` /
+    // `referrer_policy` on each hop, so it's not appended to the header list
+    // here. An explicit user-set `Referer` header wins: the spec appends
     // unconditionally, but only because in browsers `Referer` is a forbidden
     // header name that can never already be present, and RFC 9110 makes
-    // `Referer` a singleton field.
-    {
-        let referrer_utf8 = request_referrer.to_utf8();
-        if let Some(referer_value) =
-            referrer::determine_referer_header(referrer_utf8.slice(), referrer_policy, &url)
-        {
-            let request_headers = headers.get_or_insert_with(Headers::default);
-            if request_headers.get(b"referer").is_none() {
-                request_headers.append(b"Referer", &referer_value);
-            }
+    // `Referer` a singleton field. An empty `referrer` tells `build_request`
+    // to leave the `Referer` header entirely to the user's header list.
+    let referrer: Box<[u8]> = match headers.as_ref().and_then(|h| h.get(b"referer")) {
+        Some(_) => Box::default(),
+        None => {
+            let utf8 = request_referrer.to_utf8();
+            Box::from(utf8.slice())
         }
-    }
+    };
 
     // `body` is mutated in place for the sendfile/readfile paths and then
     // *moved* into `FetchOptions`.
@@ -2185,6 +2180,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         max_redirects,
         reject_unauthorized,
         redirect_type,
+        referrer,
+        referrer_policy,
         verbose,
         proxy: proxy_static,
         proxy_headers: proxy_headers.take(),

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1493,23 +1493,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
-    // Serialize the `Referer` request header from the resolved referrer and
-    // policy. An explicit user-set `Referer` header wins: the spec appends
-    // unconditionally, but only because in browsers `Referer` is a forbidden
-    // header name that can never already be present, and RFC 9110 makes
-    // `Referer` a singleton field.
-    if url_type == URLType::Remote {
-        let referrer_utf8 = request_referrer.to_utf8();
-        if let Some(referer_value) =
-            referrer::determine_referer_header(referrer_utf8.slice(), referrer_policy, &url)
-        {
-            let request_headers = headers.get_or_insert_with(Headers::default);
-            if request_headers.get(b"referer").is_none() {
-                request_headers.append(b"Referer", &referer_value);
-            }
-        }
-    }
-
     if proxy.is_some() && !unix_socket_path.slice().is_empty() {
         let err = ctx.to_type_error(
             jsc::ErrorCode::INVALID_ARG_VALUE,
@@ -1748,6 +1731,26 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             None,
             any_blob_content_type_opt(body.get_any_blob().map(|b| &*b)),
         ));
+    }
+
+    // Serialize the `Referer` request header from the resolved referrer and
+    // policy. Must come after the body Content-Type fallback above, which only
+    // fires while `headers` is still `None`.
+    //
+    // An explicit user-set `Referer` header wins: the spec appends
+    // unconditionally, but only because in browsers `Referer` is a forbidden
+    // header name that can never already be present, and RFC 9110 makes
+    // `Referer` a singleton field.
+    {
+        let referrer_utf8 = request_referrer.to_utf8();
+        if let Some(referer_value) =
+            referrer::determine_referer_header(referrer_utf8.slice(), referrer_policy, &url)
+        {
+            let request_headers = headers.get_or_insert_with(Headers::default);
+            if request_headers.get(b"referer").is_none() {
+                request_headers.append(b"Referer", &referer_value);
+            }
+        }
     }
 
     // `body` is mutated in place for the sendfile/readfile paths and then

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2043,6 +2043,8 @@ impl FetchTasklet {
                 verbose: Some(fetch_options.verbose),
                 tls_props: fetch_options.ssl_config,
                 compress: fetch_options.compress,
+                referrer: fetch_options.referrer,
+                referrer_policy: fetch_options.referrer_policy,
             },
         )));
         // enable streaming the write side
@@ -2566,6 +2568,11 @@ pub struct FetchOptions {
     pub url: ZigURL<'static>,
     pub verbose: http::HTTPVerboseLevel,
     pub redirect_type: FetchRedirect,
+    /// The request's referrer (stored serialized form) and referrer policy,
+    /// from which the HTTP client computes the `Referer` header on each hop.
+    /// Empty when the caller set an explicit `Referer` header.
+    pub referrer: Box<[u8]>,
+    pub referrer_policy: http::ReferrerPolicy,
     pub proxy: Option<ZigURL<'static>>,
     pub proxy_headers: Option<Headers>,
     pub url_proxy_buffer: Box<[u8]>,
@@ -2603,6 +2610,8 @@ impl Default for FetchOptions {
             url: ZigURL::default(),
             verbose: http::HTTPVerboseLevel::None,
             redirect_type: FetchRedirect::Follow,
+            referrer: Box::default(),
+            referrer_policy: http::ReferrerPolicy::Empty,
             proxy: None,
             proxy_headers: None,
             url_proxy_buffer: Box::default(),

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2568,9 +2568,8 @@ pub struct FetchOptions {
     pub url: ZigURL<'static>,
     pub verbose: http::HTTPVerboseLevel,
     pub redirect_type: FetchRedirect,
-    /// The request's referrer (stored serialized form) and referrer policy,
-    /// from which the HTTP client computes the `Referer` header on each hop.
-    /// Empty when the caller set an explicit `Referer` header.
+    /// See `HTTPClient.referrer`. Empty when the caller set an explicit
+    /// `Referer` header.
     pub referrer: Box<[u8]>,
     pub referrer_policy: http::ReferrerPolicy,
     pub proxy: Option<ZigURL<'static>>,

--- a/src/runtime/webcore/referrer.rs
+++ b/src/runtime/webcore/referrer.rs
@@ -1,0 +1,164 @@
+//! The fetch-spec referrer plumbing shared by `Request` and `fetch()`.
+//!
+//! A request's referrer is stored in its serialized form, which is exactly
+//! what the `Request.referrer` getter returns:
+//!   - `""`             == the spec's "no-referrer"
+//!   - `"about:client"` == the spec's "client" (the default)
+//!   - anything else    == a WHATWG-normalized referrer URL
+//!
+//! https://fetch.spec.whatwg.org/#dom-request-referrer
+
+use bun_core::{String as BunString, strings};
+use bun_http_types::ReferrerPolicy::ReferrerPolicy;
+use bun_url::URL as ZigURL;
+
+/// The serialization of the "client" referrer.
+pub const CLIENT_SERIALIZED: &[u8] = b"about:client";
+
+/// A request's default referrer ("client"), in stored form.
+#[inline]
+pub fn client() -> BunString {
+    BunString::static_(CLIENT_SERIALIZED)
+}
+
+/// Fetch spec `new Request(input, init)` step 14 ("If `init["referrer"]`
+/// exists"): turn `init.referrer` into the request's stored referrer.
+///
+/// `None` means `referrer` is not a parsable absolute URL; the caller throws
+/// a `TypeError`. (Bun has no base URL, so relative referrers fail here.)
+///
+/// Bun has no environment settings object, so step 14.3.3's "parsedReferrer's
+/// origin is not same origin with [the environment's] origin" branch never
+/// applies; undici skips it the same way when no global origin is configured.
+pub fn parse_init_referrer(referrer: &BunString) -> Option<BunString> {
+    // Step 14.2: the empty string means "no-referrer".
+    if referrer.is_empty() {
+        return Some(BunString::empty());
+    }
+    let href = bun_url::href_from_string(referrer);
+    if href.is_empty() {
+        return None;
+    }
+    // Step 14.3.3: `about:client` is the "client" sentinel.
+    if href.eql_comptime(CLIENT_SERIALIZED) {
+        href.deref();
+        return Some(client());
+    }
+    Some(href)
+}
+
+/// The `Referer` request-header value for a request whose stored referrer is
+/// `referrer` and whose current URL is `request_url`, or `None` when no
+/// `Referer` header should be sent.
+///
+/// Implements "determine request's referrer"
+/// (https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer)
+/// followed by the fetch spec's "HTTP-network-or-cache fetch" Referer step.
+/// Both `referrer` and `request_url` must be WHATWG-normalized hrefs.
+pub fn determine_referer_header(
+    referrer: &[u8],
+    policy: ReferrerPolicy,
+    request_url: &ZigURL<'_>,
+) -> Option<Vec<u8>> {
+    // "no-referrer"
+    if referrer.is_empty() {
+        return None;
+    }
+    // "client": Bun has no document or environment creation URL to resolve it
+    // against, so a "client" referrer yields no referrer. (undici behaves the
+    // same way when no global origin is configured.)
+    if referrer == CLIENT_SERIALIZED {
+        return None;
+    }
+
+    let referrer_url = ZigURL::parse(referrer);
+    // "Strip url for use as a referrer" returns no referrer for local schemes
+    // (`about:`, `blob:`, `data:`). A referrer without a `scheme://` authority
+    // cannot produce a meaningful Referer either.
+    let scheme = referrer_url.protocol;
+    if scheme.is_empty() || scheme == b"about" || scheme == b"blob" || scheme == b"data" {
+        return None;
+    }
+
+    // The stripped referrer URL: `scheme "://" host[":" port] path ["?" query]`.
+    // On a normalized href, `ZigURL.host` is hostname[:port] (credentials
+    // excluded) and `ZigURL.pathname` is path + query (fragment excluded), so
+    // this is the spec's "strip url for use as a referrer": credentials and
+    // the fragment are dropped.
+    let origin_len = scheme.len() + b"://".len() + referrer_url.host.len();
+    let mut value: Vec<u8> = Vec::with_capacity(origin_len + referrer_url.pathname.len());
+    value.extend_from_slice(scheme);
+    value.extend_from_slice(b"://");
+    value.extend_from_slice(referrer_url.host);
+    // `pathname` always begins with `/`, so `value[..origin_len + 1]` is the
+    // origin-only form ("set url's path to the empty string" serializes as
+    // origin + "/").
+    value.extend_from_slice(referrer_url.pathname);
+
+    let same_origin = scheme == request_url.protocol && referrer_url.host == request_url.host;
+    // "referrerURL is a potentially trustworthy URL and request's current URL
+    // is not a potentially trustworthy URL" -- the strict/downgrade guard.
+    let downgrade =
+        is_potentially_trustworthy(&referrer_url) && !is_potentially_trustworthy(request_url);
+
+    let send_full = match policy {
+        ReferrerPolicy::NoReferrer => return None,
+        ReferrerPolicy::Origin => false,
+        ReferrerPolicy::UnsafeUrl => true,
+        ReferrerPolicy::StrictOrigin => {
+            if downgrade {
+                return None;
+            }
+            false
+        }
+        ReferrerPolicy::NoReferrerWhenDowngrade => {
+            if downgrade {
+                return None;
+            }
+            true
+        }
+        ReferrerPolicy::SameOrigin => {
+            if !same_origin {
+                return None;
+            }
+            true
+        }
+        ReferrerPolicy::OriginWhenCrossOrigin => same_origin,
+        // The empty policy resolves to the policy container's default,
+        // `strict-origin-when-cross-origin`.
+        // https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy
+        ReferrerPolicy::Empty | ReferrerPolicy::StrictOriginWhenCrossOrigin => {
+            if same_origin {
+                true
+            } else if downgrade {
+                return None;
+            } else {
+                false
+            }
+        }
+    };
+
+    // "If the result of serializing referrerURL is a string whose length is
+    // greater than 4096, set referrerURL to referrerOrigin."
+    if !send_full || value.len() > 4096 {
+        value.truncate(origin_len);
+        value.push(b'/');
+    }
+    Some(value)
+}
+
+/// https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
+///
+/// `url` must come from a WHATWG-normalized href, so IPv4 loopbacks are
+/// canonical dotted quads (`127.x.y.z`) and the IPv6 loopback serializes as
+/// `[::1]`.
+fn is_potentially_trustworthy(url: &ZigURL<'_>) -> bool {
+    if url.is_https() || url.protocol == b"wss" || url.is_file() {
+        return true;
+    }
+    let host = url.hostname;
+    host == b"localhost"
+        || strings::ends_with_comptime(host, b".localhost")
+        || strings::has_prefix_comptime(host, b"127.")
+        || host == b"[::1]"
+}

--- a/src/runtime/webcore/referrer.rs
+++ b/src/runtime/webcore/referrer.rs
@@ -70,36 +70,46 @@ pub fn determine_referer_header(
     if referrer == CLIENT_SERIALIZED {
         return None;
     }
-
-    let referrer_url = ZigURL::parse(referrer);
-    // "Strip url for use as a referrer" returns no referrer for local schemes
-    // (`about:`, `blob:`, `data:`). A referrer without a `scheme://` authority
-    // cannot produce a meaningful Referer either.
-    let scheme = referrer_url.protocol;
-    if scheme.is_empty() || scheme == b"about" || scheme == b"blob" || scheme == b"data" {
+    // "Strip url for use as a referrer" step 2: the local schemes yield no
+    // referrer. Matched on the normalized href rather than on the parsed
+    // scheme because `ZigURL` only recognizes a scheme spelled `scheme://`,
+    // so the browser form `blob:https://origin/uuid` parses as `blob:https`.
+    if strings::has_prefix_comptime(referrer, b"about:")
+        || strings::has_prefix_comptime(referrer, b"blob:")
+        || strings::has_prefix_comptime(referrer, b"data:")
+    {
         return None;
     }
 
+    let referrer_url = ZigURL::parse(referrer);
+    // A referrer with no `scheme://` authority cannot produce a Referer.
+    let scheme = referrer_url.protocol;
+    if scheme.is_empty() {
+        return None;
+    }
+
+    let referrer_host = strip_userinfo(referrer_url.host);
+    let request_host = strip_userinfo(request_url.host);
+
     // The stripped referrer URL: `scheme "://" host[":" port] path ["?" query]`.
-    // On a normalized href, `ZigURL.host` is hostname[:port] (credentials
-    // excluded) and `ZigURL.pathname` is path + query (fragment excluded), so
-    // this is the spec's "strip url for use as a referrer": credentials and
-    // the fragment are dropped.
-    let origin_len = scheme.len() + b"://".len() + referrer_url.host.len();
+    // `ZigURL.pathname` is path + query with the fragment excluded, so together
+    // with the credential-stripped host this is the spec's "strip url for use
+    // as a referrer".
+    let origin_len = scheme.len() + b"://".len() + referrer_host.len();
     let mut value: Vec<u8> = Vec::with_capacity(origin_len + referrer_url.pathname.len());
     value.extend_from_slice(scheme);
     value.extend_from_slice(b"://");
-    value.extend_from_slice(referrer_url.host);
-    // `pathname` always begins with `/`, so `value[..origin_len + 1]` is the
-    // origin-only form ("set url's path to the empty string" serializes as
-    // origin + "/").
+    value.extend_from_slice(referrer_host);
+    // `pathname` always begins with `/`, so truncating to `origin_len` and
+    // pushing a `/` yields the origin-only form ("set url's path to the empty
+    // string" serializes as origin + "/").
     value.extend_from_slice(referrer_url.pathname);
 
-    let same_origin = scheme == request_url.protocol && referrer_url.host == request_url.host;
+    let same_origin = scheme == request_url.protocol && referrer_host == request_host;
     // "referrerURL is a potentially trustworthy URL and request's current URL
     // is not a potentially trustworthy URL" -- the strict/downgrade guard.
-    let downgrade =
-        is_potentially_trustworthy(&referrer_url) && !is_potentially_trustworthy(request_url);
+    let downgrade = is_potentially_trustworthy(scheme, strip_userinfo(referrer_url.hostname))
+        && !is_potentially_trustworthy(request_url.protocol, strip_userinfo(request_url.hostname));
 
     let send_full = match policy {
         ReferrerPolicy::NoReferrer => return None,
@@ -147,18 +157,30 @@ pub fn determine_referer_header(
     Some(value)
 }
 
+/// `ZigURL::parse` only splits off credentials when a `:` precedes the `@`, so
+/// a URL with a username but no password keeps `user@` inside `host` and
+/// `hostname`. Userinfo ends at the authority's last `@` (any `@` within it is
+/// percent-encoded in a normalized href).
+fn strip_userinfo(host: &[u8]) -> &[u8] {
+    match strings::last_index_of_char(host, b'@') {
+        Some(at) => &host[at + 1..],
+        None => host,
+    }
+}
+
 /// https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
 ///
-/// `url` must come from a WHATWG-normalized href, so IPv4 loopbacks are
-/// canonical dotted quads (`127.x.y.z`) and the IPv6 loopback serializes as
+/// `hostname` must come from a WHATWG-normalized href, so an IPv4 loopback is a
+/// canonical dotted quad (`127.x.y.z`) and the IPv6 loopback serializes as
 /// `[::1]`.
-fn is_potentially_trustworthy(url: &ZigURL<'_>) -> bool {
-    if url.is_https() || url.protocol == b"wss" || url.is_file() {
+fn is_potentially_trustworthy(scheme: &[u8], hostname: &[u8]) -> bool {
+    if scheme == b"https" || scheme == b"wss" || scheme == b"file" {
         return true;
     }
-    let host = url.hostname;
-    host == b"localhost"
-        || strings::ends_with_comptime(host, b".localhost")
-        || strings::has_prefix_comptime(host, b"127.")
-        || host == b"[::1]"
+    hostname == b"localhost"
+        || strings::ends_with_comptime(hostname, b".localhost")
+        // Only an IPv4 address in 127/8 is loopback; a domain name whose first
+        // label happens to be `127` is not.
+        || (strings::has_prefix_comptime(hostname, b"127.") && strings::is_ip_address(hostname))
+        || hostname == b"[::1]"
 }

--- a/src/runtime/webcore/referrer.rs
+++ b/src/runtime/webcore/referrer.rs
@@ -1,16 +1,10 @@
-//! The `Request`/`fetch()` construction-time referrer parsing.
-//!
 //! A request's referrer is stored in its serialized form, which is exactly
-//! what the `Request.referrer` getter returns:
-//!   - `""`             == the spec's "no-referrer"
-//!   - `"about:client"` == the spec's "client" (the default)
-//!   - anything else    == a WHATWG-normalized referrer URL
-//!
-//! The header-computation algorithm lives in
-//! `bun_http_types::ReferrerPolicy::determine_referer_header` so the HTTP
-//! client can reach it to recompute `Referer` on each redirect hop.
-//!
+//! what the `Request.referrer` getter returns: `""` for "no-referrer",
+//! `"about:client"` for "client" (the default), otherwise a normalized URL.
 //! https://fetch.spec.whatwg.org/#dom-request-referrer
+//!
+//! The header algorithm (`determine_referer_header`) lives in `bun_http_types`
+//! so the HTTP client can recompute `Referer` on each redirect hop.
 
 use bun_core::String as BunString;
 
@@ -25,15 +19,9 @@ pub fn client() -> BunString {
     BunString::static_(CLIENT_SERIALIZED)
 }
 
-/// Fetch spec `new Request(input, init)` step 14 ("If `init["referrer"]`
-/// exists"): turn `init.referrer` into the request's stored referrer.
-///
-/// `None` means `referrer` is not a parsable absolute URL; the caller throws
-/// a `TypeError`. (Bun has no base URL, so relative referrers fail here.)
-///
-/// Bun has no environment settings object, so step 14.3.3's "parsedReferrer's
-/// origin is not same origin with [the environment's] origin" branch never
-/// applies; undici skips it the same way when no global origin is configured.
+/// Request ctor step 14: turn `init.referrer` into the stored referrer.
+/// `None` means the value is not a parsable absolute URL; the caller throws.
+/// Bun has no environment origin, so step 14.3.3 never applies.
 pub fn parse_init_referrer(referrer: &BunString) -> Option<BunString> {
     // Step 14.2: the empty string means "no-referrer".
     if referrer.is_empty() {

--- a/src/runtime/webcore/referrer.rs
+++ b/src/runtime/webcore/referrer.rs
@@ -1,4 +1,4 @@
-//! The fetch-spec referrer plumbing shared by `Request` and `fetch()`.
+//! The `Request`/`fetch()` construction-time referrer parsing.
 //!
 //! A request's referrer is stored in its serialized form, which is exactly
 //! what the `Request.referrer` getter returns:
@@ -6,11 +6,15 @@
 //!   - `"about:client"` == the spec's "client" (the default)
 //!   - anything else    == a WHATWG-normalized referrer URL
 //!
+//! The header-computation algorithm lives in
+//! `bun_http_types::ReferrerPolicy::determine_referer_header` so the HTTP
+//! client can reach it to recompute `Referer` on each redirect hop.
+//!
 //! https://fetch.spec.whatwg.org/#dom-request-referrer
 
-use bun_core::{String as BunString, strings};
-use bun_http_types::ReferrerPolicy::ReferrerPolicy;
-use bun_url::URL as ZigURL;
+use bun_core::String as BunString;
+
+pub use bun_http_types::ReferrerPolicy::determine_referer_header;
 
 /// The serialization of the "client" referrer.
 pub const CLIENT_SERIALIZED: &[u8] = b"about:client";
@@ -45,142 +49,4 @@ pub fn parse_init_referrer(referrer: &BunString) -> Option<BunString> {
         return Some(client());
     }
     Some(href)
-}
-
-/// The `Referer` request-header value for a request whose stored referrer is
-/// `referrer` and whose current URL is `request_url`, or `None` when no
-/// `Referer` header should be sent.
-///
-/// Implements "determine request's referrer"
-/// (https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer)
-/// followed by the fetch spec's "HTTP-network-or-cache fetch" Referer step.
-/// Both `referrer` and `request_url` must be WHATWG-normalized hrefs.
-pub fn determine_referer_header(
-    referrer: &[u8],
-    policy: ReferrerPolicy,
-    request_url: &ZigURL<'_>,
-) -> Option<Vec<u8>> {
-    // "no-referrer"
-    if referrer.is_empty() {
-        return None;
-    }
-    // "client": Bun has no document or environment creation URL to resolve it
-    // against, so a "client" referrer yields no referrer. (undici behaves the
-    // same way when no global origin is configured.)
-    if referrer == CLIENT_SERIALIZED {
-        return None;
-    }
-    // "Strip url for use as a referrer" step 2: the local schemes yield no
-    // referrer. Matched on the normalized href rather than on the parsed
-    // scheme because `ZigURL` only recognizes a scheme spelled `scheme://`,
-    // so the browser form `blob:https://origin/uuid` parses as `blob:https`.
-    if strings::has_prefix_comptime(referrer, b"about:")
-        || strings::has_prefix_comptime(referrer, b"blob:")
-        || strings::has_prefix_comptime(referrer, b"data:")
-    {
-        return None;
-    }
-
-    let referrer_url = ZigURL::parse(referrer);
-    // A referrer with no `scheme://` authority cannot produce a Referer.
-    let scheme = referrer_url.protocol;
-    if scheme.is_empty() {
-        return None;
-    }
-
-    let referrer_host = strip_userinfo(referrer_url.host);
-    let request_host = strip_userinfo(request_url.host);
-
-    // The stripped referrer URL: `scheme "://" host[":" port] path ["?" query]`.
-    // `ZigURL.pathname` is path + query with the fragment excluded, so together
-    // with the credential-stripped host this is the spec's "strip url for use
-    // as a referrer".
-    let origin_len = scheme.len() + b"://".len() + referrer_host.len();
-    let mut value: Vec<u8> = Vec::with_capacity(origin_len + referrer_url.pathname.len());
-    value.extend_from_slice(scheme);
-    value.extend_from_slice(b"://");
-    value.extend_from_slice(referrer_host);
-    // `pathname` always begins with `/`, so truncating to `origin_len` and
-    // pushing a `/` yields the origin-only form ("set url's path to the empty
-    // string" serializes as origin + "/").
-    value.extend_from_slice(referrer_url.pathname);
-
-    let same_origin = scheme == request_url.protocol && referrer_host == request_host;
-    // "referrerURL is a potentially trustworthy URL and request's current URL
-    // is not a potentially trustworthy URL" -- the strict/downgrade guard.
-    let downgrade = is_potentially_trustworthy(scheme, strip_userinfo(referrer_url.hostname))
-        && !is_potentially_trustworthy(request_url.protocol, strip_userinfo(request_url.hostname));
-
-    let send_full = match policy {
-        ReferrerPolicy::NoReferrer => return None,
-        ReferrerPolicy::Origin => false,
-        ReferrerPolicy::UnsafeUrl => true,
-        ReferrerPolicy::StrictOrigin => {
-            if downgrade {
-                return None;
-            }
-            false
-        }
-        ReferrerPolicy::NoReferrerWhenDowngrade => {
-            if downgrade {
-                return None;
-            }
-            true
-        }
-        ReferrerPolicy::SameOrigin => {
-            if !same_origin {
-                return None;
-            }
-            true
-        }
-        ReferrerPolicy::OriginWhenCrossOrigin => same_origin,
-        // The empty policy resolves to the policy container's default,
-        // `strict-origin-when-cross-origin`.
-        // https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy
-        ReferrerPolicy::Empty | ReferrerPolicy::StrictOriginWhenCrossOrigin => {
-            if same_origin {
-                true
-            } else if downgrade {
-                return None;
-            } else {
-                false
-            }
-        }
-    };
-
-    // "If the result of serializing referrerURL is a string whose length is
-    // greater than 4096, set referrerURL to referrerOrigin."
-    if !send_full || value.len() > 4096 {
-        value.truncate(origin_len);
-        value.push(b'/');
-    }
-    Some(value)
-}
-
-/// `ZigURL::parse` only splits off credentials when a `:` precedes the `@`, so
-/// a URL with a username but no password keeps `user@` inside `host` and
-/// `hostname`. Userinfo ends at the authority's last `@` (any `@` within it is
-/// percent-encoded in a normalized href).
-fn strip_userinfo(host: &[u8]) -> &[u8] {
-    match strings::last_index_of_char(host, b'@') {
-        Some(at) => &host[at + 1..],
-        None => host,
-    }
-}
-
-/// https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
-///
-/// `hostname` must come from a WHATWG-normalized href, so an IPv4 loopback is a
-/// canonical dotted quad (`127.x.y.z`) and the IPv6 loopback serializes as
-/// `[::1]`.
-fn is_potentially_trustworthy(scheme: &[u8], hostname: &[u8]) -> bool {
-    if scheme == b"https" || scheme == b"wss" || scheme == b"file" {
-        return true;
-    }
-    hostname == b"localhost"
-        || strings::ends_with_comptime(hostname, b".localhost")
-        // Only an IPv4 address in 127/8 is loopback; a domain name whose first
-        // label happens to be `127` is not.
-        || (strings::has_prefix_comptime(hostname, b"127.") && strings::is_ip_address(hostname))
-        || hostname == b"[::1]"
 }

--- a/test/js/web/fetch/fetch-referrer.test.ts
+++ b/test/js/web/fetch/fetch-referrer.test.ts
@@ -126,6 +126,16 @@ describe("fetch referrer and referrerPolicy", () => {
     await fetch(`${base}/client`, { referrer: "about:client", referrerPolicy: "unsafe-url" });
     // local schemes are stripped to "no referrer"
     await fetch(`${base}/blank`, { referrer: "about:blank", referrerPolicy: "unsafe-url" });
+    await fetch(`${base}/data`, { referrer: "data:text/plain,hi", referrerPolicy: "unsafe-url" });
+    // both blob: forms: bun's own object URLs and the browser origin form
+    await fetch(`${base}/blob`, {
+      referrer: "blob:550e8400-e29b-41d4-a716-446655440000",
+      referrerPolicy: "unsafe-url",
+    });
+    await fetch(`${base}/blob-origin`, {
+      referrer: "blob:https://origin.example/550e8400-e29b-41d4-a716-446655440000",
+      referrerPolicy: "unsafe-url",
+    });
 
     expect(received).toEqual({
       "/none": null,
@@ -133,6 +143,9 @@ describe("fetch referrer and referrerPolicy", () => {
       "/empty": null,
       "/client": null,
       "/blank": null,
+      "/data": null,
+      "/blob": null,
+      "/blob-origin": null,
     });
   });
 
@@ -145,6 +158,12 @@ describe("fetch referrer and referrerPolicy", () => {
       referrer: "https://user:pw@app.example:8443/a/b?x=1#f",
       referrerPolicy: "unsafe-url",
     });
+    // a username with no password, with and without a port
+    await fetch(`${base}/user-port`, {
+      referrer: "https://alice@app.example:8443/a/b",
+      referrerPolicy: "unsafe-url",
+    });
+    await fetch(`${base}/user-only`, { referrer: "https://alice@app.example/a/b", referrerPolicy: "unsafe-url" });
     // a stripped referrer longer than 4096 falls back to the origin
     await fetch(`${base}/long`, {
       referrer: "https://app.example/" + Buffer.alloc(5000, "a").toString(),
@@ -153,8 +172,45 @@ describe("fetch referrer and referrerPolicy", () => {
 
     expect(received).toEqual({
       "/cred": "https://app.example:8443/a/b?x=1",
+      "/user-port": "https://app.example:8443/a/b",
+      "/user-only": "https://app.example/a/b",
       "/long": "https://app.example/",
     });
+  });
+
+  // A Referer must never displace the Content-Type that fetch() derives from
+  // the body when the caller passed no headers of their own.
+  it("fetch() keeps the body-derived Content-Type when it sends a Referer", async () => {
+    const received: Record<string, string | null> = {};
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        received[new URL(req.url).pathname] = req.headers.get("content-type");
+        return new Response("ok");
+      },
+    });
+    const base = `http://127.0.0.1:${server.port}`;
+    const referrer = "https://app.example/page";
+    const blob = () => new Blob(["{}"], { type: "application/json" });
+    const formData = () => {
+      const form = new FormData();
+      form.append("k", "v");
+      return form;
+    };
+
+    await fetch(`${base}/form-data`, { method: "POST", body: formData(), referrer, referrerPolicy: "unsafe-url" });
+    await fetch(`${base}/blob`, { method: "POST", body: blob(), referrer, referrerPolicy: "unsafe-url" });
+    // the same requests with no referrer, as the baseline
+    await fetch(`${base}/form-data-baseline`, { method: "POST", body: formData() });
+    await fetch(`${base}/blob-baseline`, { method: "POST", body: blob() });
+
+    // the multipart boundary is random per request, so compare only the rest
+    expect(received["/form-data"]).toStartWith("multipart/form-data; boundary=");
+    expect(received["/form-data"]?.replace(/boundary=.*$/, "")).toBe(
+      received["/form-data-baseline"]!.replace(/boundary=.*$/, ""),
+    );
+    expect(received["/blob"]).toStartWith("application/json");
+    expect(received["/blob"]).toBe(received["/blob-baseline"]);
   });
 
   it("an explicit Referer header wins over the referrer option", async () => {
@@ -208,6 +264,9 @@ describe("fetch referrer and referrerPolicy", () => {
       await fetch(`${base}/nrwd`, { unix, referrer, referrerPolicy: "no-referrer-when-downgrade" });
       await fetch(`${base}/strict-origin`, { unix, referrer, referrerPolicy: "strict-origin" });
       await fetch(`${base}/socwo`, { unix, referrer, referrerPolicy: "strict-origin-when-cross-origin" });
+      // a domain whose first label is "127" is not an IPv4 loopback, so this is
+      // still a downgrade
+      await fetch(`http://127.example.com/domain-127`, { unix, referrer, referrerPolicy: "strict-origin" });
       // the non-strict equivalents still send it
       await fetch(`${base}/origin`, { unix, referrer, referrerPolicy: "origin" });
       await fetch(`${base}/unsafe-url`, { unix, referrer, referrerPolicy: "unsafe-url" });
@@ -216,11 +275,29 @@ describe("fetch referrer and referrerPolicy", () => {
         "/nrwd": null,
         "/strict-origin": null,
         "/socwo": null,
+        "/domain-127": null,
         "/origin": "https://secure.example/",
         "/unsafe-url": "https://secure.example/page?q=1",
       });
     } finally {
       rmSync(unix, { force: true });
     }
+  });
+
+  // A real 127/8 loopback target IS potentially trustworthy, so an https
+  // referrer is not a downgrade and the strict policies still send it.
+  it("an IPv4 loopback target is potentially trustworthy", async () => {
+    const received: Record<string, string | null> = {};
+    await using server = referrerServer(received);
+    const base = `http://127.0.0.1:${server.port}`;
+    const referrer = "https://secure.example/page?q=1";
+
+    await fetch(`${base}/strict-origin`, { referrer, referrerPolicy: "strict-origin" });
+    await fetch(`${base}/nrwd`, { referrer, referrerPolicy: "no-referrer-when-downgrade" });
+
+    expect(received).toEqual({
+      "/strict-origin": "https://secure.example/",
+      "/nrwd": "https://secure.example/page?q=1",
+    });
   });
 });

--- a/test/js/web/fetch/fetch-referrer.test.ts
+++ b/test/js/web/fetch/fetch-referrer.test.ts
@@ -4,7 +4,8 @@
 import { describe, expect, it } from "bun:test";
 import { rmSync } from "fs";
 
-describe("fetch referrer and referrerPolicy", () => {
+// Each test binds its own server and reads only its own `received` map.
+describe.concurrent("fetch referrer and referrerPolicy", () => {
   // Collect the Referer header each request arrives with, keyed by pathname.
   function referrerServer(received: Record<string, string | null>, options: { unix?: string } = {}) {
     return Bun.serve({

--- a/test/js/web/fetch/fetch-referrer.test.ts
+++ b/test/js/web/fetch/fetch-referrer.test.ts
@@ -1,0 +1,226 @@
+// fetch() referrer / referrerPolicy
+// https://fetch.spec.whatwg.org/#dom-request-referrer
+// https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer
+import { describe, expect, it } from "bun:test";
+import { rmSync } from "fs";
+
+describe("fetch referrer and referrerPolicy", () => {
+  // Collect the Referer header each request arrives with, keyed by pathname.
+  function referrerServer(received: Record<string, string | null>, options: { unix?: string } = {}) {
+    return Bun.serve({
+      ...(options.unix ? { unix: options.unix } : { port: 0 }),
+      fetch(req) {
+        received[new URL(req.url).pathname] = req.headers.get("referer");
+        return new Response("ok");
+      },
+    });
+  }
+
+  it("Request.referrer and Request.referrerPolicy reflect the init options", () => {
+    const url = "http://example.com/a";
+    expect(new Request(url).referrer).toBe("about:client");
+    expect(new Request(url).referrerPolicy).toBe("");
+    expect(new Request(url, { referrer: "https://app.example/page" }).referrer).toBe("https://app.example/page");
+    // the empty string means "no-referrer"
+    expect(new Request(url, { referrer: "" }).referrer).toBe("");
+    expect(new Request(url, { referrer: "about:client" }).referrer).toBe("about:client");
+    expect(new Request(url, { referrerPolicy: "unsafe-url" }).referrerPolicy).toBe("unsafe-url");
+    // the stored referrer is the normalized href (scheme/host lowercased, default port dropped)
+    expect(new Request(url, { referrer: "HTTPS://App.Example:443/P" }).referrer).toBe("https://app.example/P");
+  });
+
+  it("Request constructor rejects an invalid referrer or referrerPolicy", () => {
+    const url = "http://example.com/a";
+    expect(() => new Request(url, { referrer: "ht tp://x" })).toThrow(/referrer/i);
+    // there is no base URL to resolve a relative referrer against
+    expect(() => new Request(url, { referrer: "/relative" })).toThrow(/referrer/i);
+    // @ts-expect-error deliberately invalid enum value
+    expect(() => new Request(url, { referrerPolicy: "bogus" })).toThrow(/referrerPolicy/);
+  });
+
+  it("referrer and referrerPolicy survive clone() and new Request(request)", () => {
+    const original = new Request("http://example.com/a", {
+      referrer: "https://app.example/p",
+      referrerPolicy: "origin",
+    });
+    const cloned = original.clone();
+    expect({ referrer: cloned.referrer, referrerPolicy: cloned.referrerPolicy }).toEqual({
+      referrer: "https://app.example/p",
+      referrerPolicy: "origin",
+    });
+    const rewrapped = new Request(original);
+    expect({ referrer: rewrapped.referrer, referrerPolicy: rewrapped.referrerPolicy }).toEqual({
+      referrer: "https://app.example/p",
+      referrerPolicy: "origin",
+    });
+    // an init override wins over the source request's value
+    expect(new Request(original, { referrerPolicy: "no-referrer" }).referrerPolicy).toBe("no-referrer");
+    expect(new Request(original, { referrer: "https://other.example/q" }).referrer).toBe("https://other.example/q");
+  });
+
+  // The target (127.0.0.1) is potentially trustworthy, so none of these are a
+  // downgrade; the referrer is cross-origin with the target.
+  it("fetch() sends the Referer header per the referrer policy", async () => {
+    const received: Record<string, string | null> = {};
+    await using server = referrerServer(received);
+    const base = `http://127.0.0.1:${server.port}`;
+    const referrer = "https://app.example/page?q=1#frag";
+
+    await fetch(`${base}/no-referrer`, { referrer, referrerPolicy: "no-referrer" });
+    await fetch(`${base}/no-referrer-when-downgrade`, { referrer, referrerPolicy: "no-referrer-when-downgrade" });
+    await fetch(`${base}/origin`, { referrer, referrerPolicy: "origin" });
+    await fetch(`${base}/origin-when-cross-origin`, { referrer, referrerPolicy: "origin-when-cross-origin" });
+    await fetch(`${base}/same-origin`, { referrer, referrerPolicy: "same-origin" });
+    await fetch(`${base}/strict-origin`, { referrer, referrerPolicy: "strict-origin" });
+    await fetch(`${base}/strict-origin-when-cross-origin`, {
+      referrer,
+      referrerPolicy: "strict-origin-when-cross-origin",
+    });
+    await fetch(`${base}/unsafe-url`, { referrer, referrerPolicy: "unsafe-url" });
+    // the empty policy resolves to strict-origin-when-cross-origin
+    await fetch(`${base}/default`, { referrer, referrerPolicy: "" });
+    await fetch(`${base}/unset`, { referrer });
+
+    // Credentials and the fragment are always stripped for the Referer header.
+    expect(received).toEqual({
+      "/no-referrer": null,
+      "/no-referrer-when-downgrade": "https://app.example/page?q=1",
+      "/origin": "https://app.example/",
+      "/origin-when-cross-origin": "https://app.example/",
+      "/same-origin": null,
+      "/strict-origin": "https://app.example/",
+      "/strict-origin-when-cross-origin": "https://app.example/",
+      "/unsafe-url": "https://app.example/page?q=1",
+      "/default": "https://app.example/",
+      "/unset": "https://app.example/",
+    });
+  });
+
+  it("fetch() sends the full referrer when it is same-origin with the target", async () => {
+    const received: Record<string, string | null> = {};
+    await using server = referrerServer(received);
+    const base = `http://127.0.0.1:${server.port}`;
+    const referrer = `${base}/other?z=1`;
+
+    await fetch(`${base}/socwo`, { referrer, referrerPolicy: "strict-origin-when-cross-origin" });
+    await fetch(`${base}/same-origin`, { referrer, referrerPolicy: "same-origin" });
+    await fetch(`${base}/owco`, { referrer, referrerPolicy: "origin-when-cross-origin" });
+
+    expect(received).toEqual({
+      "/socwo": referrer,
+      "/same-origin": referrer,
+      "/owco": referrer,
+    });
+  });
+
+  it("fetch() sends no Referer for a client, no-referrer, or local-scheme referrer", async () => {
+    const received: Record<string, string | null> = {};
+    await using server = referrerServer(received);
+    const base = `http://127.0.0.1:${server.port}`;
+
+    // no referrer option: the default "about:client" has nothing to resolve to
+    await fetch(`${base}/none`);
+    await fetch(`${base}/policy-only`, { referrerPolicy: "unsafe-url" });
+    // the empty string is the spec's "no-referrer"
+    await fetch(`${base}/empty`, { referrer: "", referrerPolicy: "unsafe-url" });
+    await fetch(`${base}/client`, { referrer: "about:client", referrerPolicy: "unsafe-url" });
+    // local schemes are stripped to "no referrer"
+    await fetch(`${base}/blank`, { referrer: "about:blank", referrerPolicy: "unsafe-url" });
+
+    expect(received).toEqual({
+      "/none": null,
+      "/policy-only": null,
+      "/empty": null,
+      "/client": null,
+      "/blank": null,
+    });
+  });
+
+  it("fetch() strips credentials and caps an over-long referrer to its origin", async () => {
+    const received: Record<string, string | null> = {};
+    await using server = referrerServer(received);
+    const base = `http://127.0.0.1:${server.port}`;
+
+    await fetch(`${base}/cred`, {
+      referrer: "https://user:pw@app.example:8443/a/b?x=1#f",
+      referrerPolicy: "unsafe-url",
+    });
+    // a stripped referrer longer than 4096 falls back to the origin
+    await fetch(`${base}/long`, {
+      referrer: "https://app.example/" + Buffer.alloc(5000, "a").toString(),
+      referrerPolicy: "unsafe-url",
+    });
+
+    expect(received).toEqual({
+      "/cred": "https://app.example:8443/a/b?x=1",
+      "/long": "https://app.example/",
+    });
+  });
+
+  it("an explicit Referer header wins over the referrer option", async () => {
+    const received: Record<string, string | null> = {};
+    await using server = referrerServer(received);
+    const base = `http://127.0.0.1:${server.port}`;
+
+    await fetch(`${base}/both`, {
+      headers: { referer: "https://manual.example/" },
+      referrer: "https://auto.example/x",
+      referrerPolicy: "unsafe-url",
+    });
+    await fetch(`${base}/header-only`, { headers: { referer: "https://manual.example/" } });
+
+    expect(received).toEqual({
+      "/both": "https://manual.example/",
+      "/header-only": "https://manual.example/",
+    });
+  });
+
+  it("fetch() honors the referrer of a Request argument and lets init override it", async () => {
+    const received: Record<string, string | null> = {};
+    await using server = referrerServer(received);
+    const base = `http://127.0.0.1:${server.port}`;
+
+    await fetch(
+      new Request(`${base}/from-request`, { referrer: "https://app.example/r", referrerPolicy: "unsafe-url" }),
+    );
+    await fetch(new Request(`${base}/override`, { referrer: "https://app.example/r", referrerPolicy: "unsafe-url" }), {
+      referrerPolicy: "no-referrer",
+    });
+
+    expect(received).toEqual({
+      "/from-request": "https://app.example/r",
+      "/override": null,
+    });
+  });
+
+  // The strict/downgrade branches need a target URL that is NOT potentially
+  // trustworthy (https/wss/file, localhost, 127.*, [::1]). A unix socket lets
+  // the request URL carry an arbitrary non-loopback hostname while the
+  // connection still reaches a local server.
+  it("strict policies drop the Referer on a trustworthy -> untrustworthy downgrade", async () => {
+    const received: Record<string, string | null> = {};
+    const unix = `.fetch-referrer-${Math.random().toString(36).slice(2)}.sock`;
+    await using server = referrerServer(received, { unix });
+    try {
+      const referrer = "https://secure.example/page?q=1";
+      const base = "http://insecure.example";
+
+      await fetch(`${base}/nrwd`, { unix, referrer, referrerPolicy: "no-referrer-when-downgrade" });
+      await fetch(`${base}/strict-origin`, { unix, referrer, referrerPolicy: "strict-origin" });
+      await fetch(`${base}/socwo`, { unix, referrer, referrerPolicy: "strict-origin-when-cross-origin" });
+      // the non-strict equivalents still send it
+      await fetch(`${base}/origin`, { unix, referrer, referrerPolicy: "origin" });
+      await fetch(`${base}/unsafe-url`, { unix, referrer, referrerPolicy: "unsafe-url" });
+
+      expect(received).toEqual({
+        "/nrwd": null,
+        "/strict-origin": null,
+        "/socwo": null,
+        "/origin": "https://secure.example/",
+        "/unsafe-url": "https://secure.example/page?q=1",
+      });
+    } finally {
+      rmSync(unix, { force: true });
+    }
+  });
+});

--- a/test/js/web/fetch/fetch-referrer.test.ts
+++ b/test/js/web/fetch/fetch-referrer.test.ts
@@ -301,4 +301,155 @@ describe.concurrent("fetch referrer and referrerPolicy", () => {
       "/nrwd": "https://secure.example/page?q=1",
     });
   });
+
+  // The Referer header is computed per hop, so a redirect to a different
+  // origin applies the referrer policy against that hop's URL.
+  // https://fetch.spec.whatwg.org/#http-redirect-fetch
+  describe("redirects", () => {
+    // Two servers on different ports = two origins. A redirects to itself
+    // (same-origin) or to B (cross-origin). An optional `referrer-policy` key
+    // sets that response header on the redirect.
+    function redirectServers(hops: Record<string, string | null>) {
+      const B = Bun.serve({
+        port: 0,
+        fetch(req) {
+          hops["B " + new URL(req.url).search] = req.headers.get("referer");
+          return new Response("ok");
+        },
+      });
+      const A = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const url = new URL(req.url);
+          hops["A " + url.search] = req.headers.get("referer");
+          const target = url.pathname.slice(1);
+          const redirectHeaders: Record<string, string> = {};
+          const policy = url.searchParams.get("respond-policy");
+          if (policy !== null) redirectHeaders["referrer-policy"] = policy;
+          if (target === "same") {
+            return Response.redirect(`http://127.0.0.1:${A.port}/landed${url.search}`, {
+              status: 302,
+              headers: redirectHeaders,
+            });
+          }
+          if (target === "cross") {
+            return Response.redirect(`http://127.0.0.1:${B.port}/landed${url.search}`, {
+              status: 302,
+              headers: redirectHeaders,
+            });
+          }
+          return new Response("ok");
+        },
+      });
+      return { A, B, urlA: `http://127.0.0.1:${A.port}` };
+    }
+
+    it("fetch() recomputes the Referer header on each redirect hop", async () => {
+      const hops: Record<string, string | null> = {};
+      const { A, B, urlA } = redirectServers(hops);
+      await using _a = A;
+      await using _b = B;
+
+      // With the default policy, a referrer that is same-origin with A sends
+      // the full URL to A but only its origin to B (the cross-origin hop). On
+      // the unpatched path the initial Referer would be re-sent verbatim.
+      await fetch(`${urlA}/cross?c=per-hop`, { referrer: `${urlA}/page?x=1` });
+      // unsafe-url: the full URL on every hop
+      await fetch(`${urlA}/cross?c=unsafe`, { referrer: `${urlA}/page?x=1`, referrerPolicy: "unsafe-url" });
+      // same-origin: A gets the full URL, B gets nothing
+      await fetch(`${urlA}/cross?c=same-origin`, { referrer: `${urlA}/page?x=1`, referrerPolicy: "same-origin" });
+      // origin: both hops get only the origin
+      await fetch(`${urlA}/cross?c=origin`, {
+        referrer: "https://app.example/page?x=1",
+        referrerPolicy: "origin",
+      });
+
+      expect(hops).toEqual({
+        "A ?c=per-hop": `${urlA}/page?x=1`,
+        "B ?c=per-hop": `${urlA}/`,
+        "A ?c=unsafe": `${urlA}/page?x=1`,
+        "B ?c=unsafe": `${urlA}/page?x=1`,
+        "A ?c=same-origin": `${urlA}/page?x=1`,
+        "B ?c=same-origin": null,
+        "A ?c=origin": "https://app.example/",
+        "B ?c=origin": "https://app.example/",
+      });
+    });
+
+    it("fetch() applies a Referrer-Policy response header to subsequent hops", async () => {
+      const hops: Record<string, string | null> = {};
+      const { A, B, urlA } = redirectServers(hops);
+      await using _a = A;
+      await using _b = B;
+      const referrer = "https://app.example/page?x=1";
+
+      // the redirect response's Referrer-Policy overrides the request's
+      await fetch(`${urlA}/cross?c=set-none&respond-policy=no-referrer`, {
+        referrer,
+        referrerPolicy: "unsafe-url",
+      });
+      await fetch(`${urlA}/cross?c=set-unsafe&respond-policy=unsafe-url`, {
+        referrer,
+        referrerPolicy: "origin",
+      });
+      // an unrecognized token is ignored (policy stays unsafe-url)
+      await fetch(`${urlA}/cross?c=bad&respond-policy=bogus`, {
+        referrer,
+        referrerPolicy: "unsafe-url",
+      });
+      // a comma-separated list: the last valid non-empty token wins
+      const list = encodeURIComponent("bogus, no-referrer, ");
+      await fetch(`${urlA}/cross?c=list&respond-policy=${list}`, {
+        referrer,
+        referrerPolicy: "unsafe-url",
+      });
+
+      expect(hops).toEqual({
+        "A ?c=set-none&respond-policy=no-referrer": referrer,
+        "B ?c=set-none&respond-policy=no-referrer": null,
+        "A ?c=set-unsafe&respond-policy=unsafe-url": "https://app.example/",
+        "B ?c=set-unsafe&respond-policy=unsafe-url": referrer,
+        "A ?c=bad&respond-policy=bogus": referrer,
+        "B ?c=bad&respond-policy=bogus": referrer,
+        [`A ?c=list&respond-policy=${list}`]: referrer,
+        [`B ?c=list&respond-policy=${list}`]: null,
+      });
+    });
+
+    it("an explicit Referer header is forwarded verbatim across redirects", async () => {
+      const hops: Record<string, string | null> = {};
+      const { A, B, urlA } = redirectServers(hops);
+      await using _a = A;
+      await using _b = B;
+
+      // user-set Referer passes through both hops unchanged (parity with Node)
+      await fetch(`${urlA}/cross?c=user`, { headers: { referer: "https://manual.example/set-by-user" } });
+      // and a Referrer-Policy response header does not touch it
+      await fetch(`${urlA}/cross?c=user-policy&respond-policy=no-referrer`, {
+        headers: { referer: "https://manual.example/set-by-user" },
+      });
+
+      expect(hops).toEqual({
+        "A ?c=user": "https://manual.example/set-by-user",
+        "B ?c=user": "https://manual.example/set-by-user",
+        "A ?c=user-policy&respond-policy=no-referrer": "https://manual.example/set-by-user",
+        "B ?c=user-policy&respond-policy=no-referrer": "https://manual.example/set-by-user",
+      });
+    });
+
+    it("fetch() sends no Referer on any redirect hop when none was computed for the first", async () => {
+      const hops: Record<string, string | null> = {};
+      const { A, B, urlA } = redirectServers(hops);
+      await using _a = A;
+      await using _b = B;
+
+      // no referrer option: "about:client" yields no Referer on any hop
+      await fetch(`${urlA}/cross?c=none`);
+
+      expect(hops).toEqual({
+        "A ?c=none": null,
+        "B ?c=none": null,
+      });
+    });
+  });
 });

--- a/test/js/web/fetch/fetch-referrer.test.ts
+++ b/test/js/web/fetch/fetch-referrer.test.ts
@@ -1,8 +1,16 @@
 // fetch() referrer / referrerPolicy
 // https://fetch.spec.whatwg.org/#dom-request-referrer
 // https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer
-import { describe, expect, it } from "bun:test";
-import { rmSync } from "fs";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { tmpdirSync } from "harness";
+import { join } from "path";
+import {
+  clearProxyEnv,
+  createAdversarialOrigin,
+  createAdversarialProxy,
+  laxTls,
+  restoreProxyEnv,
+} from "../../bun/http/proxy-stress-helpers";
 
 // Each test binds its own server and reads only its own `received` map.
 describe.concurrent("fetch referrer and referrerPolicy", () => {
@@ -256,33 +264,29 @@ describe.concurrent("fetch referrer and referrerPolicy", () => {
   // connection still reaches a local server.
   it("strict policies drop the Referer on a trustworthy -> untrustworthy downgrade", async () => {
     const received: Record<string, string | null> = {};
-    const unix = `.fetch-referrer-${Math.random().toString(36).slice(2)}.sock`;
+    const unix = join(tmpdirSync(), "fetch-referrer.sock");
     await using server = referrerServer(received, { unix });
-    try {
-      const referrer = "https://secure.example/page?q=1";
-      const base = "http://insecure.example";
+    const referrer = "https://secure.example/page?q=1";
+    const base = "http://insecure.example";
 
-      await fetch(`${base}/nrwd`, { unix, referrer, referrerPolicy: "no-referrer-when-downgrade" });
-      await fetch(`${base}/strict-origin`, { unix, referrer, referrerPolicy: "strict-origin" });
-      await fetch(`${base}/socwo`, { unix, referrer, referrerPolicy: "strict-origin-when-cross-origin" });
-      // a domain whose first label is "127" is not an IPv4 loopback, so this is
-      // still a downgrade
-      await fetch(`http://127.example.com/domain-127`, { unix, referrer, referrerPolicy: "strict-origin" });
-      // the non-strict equivalents still send it
-      await fetch(`${base}/origin`, { unix, referrer, referrerPolicy: "origin" });
-      await fetch(`${base}/unsafe-url`, { unix, referrer, referrerPolicy: "unsafe-url" });
+    await fetch(`${base}/nrwd`, { unix, referrer, referrerPolicy: "no-referrer-when-downgrade" });
+    await fetch(`${base}/strict-origin`, { unix, referrer, referrerPolicy: "strict-origin" });
+    await fetch(`${base}/socwo`, { unix, referrer, referrerPolicy: "strict-origin-when-cross-origin" });
+    // a domain whose first label is "127" is not an IPv4 loopback, so this is
+    // still a downgrade
+    await fetch(`http://127.example.com/domain-127`, { unix, referrer, referrerPolicy: "strict-origin" });
+    // the non-strict equivalents still send it
+    await fetch(`${base}/origin`, { unix, referrer, referrerPolicy: "origin" });
+    await fetch(`${base}/unsafe-url`, { unix, referrer, referrerPolicy: "unsafe-url" });
 
-      expect(received).toEqual({
-        "/nrwd": null,
-        "/strict-origin": null,
-        "/socwo": null,
-        "/domain-127": null,
-        "/origin": "https://secure.example/",
-        "/unsafe-url": "https://secure.example/page?q=1",
-      });
-    } finally {
-      rmSync(unix, { force: true });
-    }
+    expect(received).toEqual({
+      "/nrwd": null,
+      "/strict-origin": null,
+      "/socwo": null,
+      "/domain-127": null,
+      "/origin": "https://secure.example/",
+      "/unsafe-url": "https://secure.example/page?q=1",
+    });
   });
 
   // A real 127/8 loopback target IS potentially trustworthy, so an https
@@ -451,5 +455,47 @@ describe.concurrent("fetch referrer and referrerPolicy", () => {
         "B ?c=none": null,
       });
     });
+  });
+});
+
+// A proxy's CONNECT reply must not influence the referrer policy of the
+// tunneled request: the Referrer-Policy response header only applies on a
+// redirect (fetch spec HTTP-redirect fetch, step 19), and a CONNECT 200 is
+// not one. Isolated from the concurrent block so clearProxyEnv cannot race.
+describe("fetch referrer through a CONNECT proxy", () => {
+  let savedEnv: Record<string, string | undefined>;
+  beforeAll(() => {
+    savedEnv = clearProxyEnv();
+  });
+  afterAll(() => {
+    restoreProxyEnv(savedEnv);
+  });
+
+  it("ignores a Referrer-Policy header on the proxy's CONNECT reply", async () => {
+    await using origin = await createAdversarialOrigin({ tls: true });
+    await using proxy = await createAdversarialProxy({
+      connectReplyHeaders: { "Referrer-Policy": "unsafe-url" },
+    });
+
+    // the caller's no-referrer policy must survive the tunnel intact
+    const res = await fetch(origin.url, {
+      proxy: proxy.url,
+      tls: laxTls,
+      referrer: "https://app.example/secret?token=xyz",
+      referrerPolicy: "no-referrer",
+    });
+    expect(await res.text()).toBe("ok");
+    expect(origin.requests[0].headers["referer"]).toBeUndefined();
+
+    // and unsafe-url still works end to end through the same tunnel setup
+    await using origin2 = await createAdversarialOrigin({ tls: true });
+    const res2 = await fetch(origin2.url, {
+      proxy: proxy.url,
+      tls: laxTls,
+      referrer: "https://app.example/secret?token=xyz",
+      referrerPolicy: "unsafe-url",
+    });
+    expect(await res2.text()).toBe("ok");
+    expect(origin2.requests[0].headers["referer"]).toBe("https://app.example/secret?token=xyz");
   });
 });

--- a/test/js/web/fetch/fetch-referrer.test.ts
+++ b/test/js/web/fetch/fetch-referrer.test.ts
@@ -40,9 +40,10 @@ describe.concurrent("fetch referrer and referrerPolicy", () => {
 
   it("Request constructor rejects an invalid referrer or referrerPolicy", () => {
     const url = "http://example.com/a";
+    expect(() => new Request(url, { referrer: "ht tp://x" })).toThrow(TypeError);
     expect(() => new Request(url, { referrer: "ht tp://x" })).toThrow(/referrer/i);
     // there is no base URL to resolve a relative referrer against
-    expect(() => new Request(url, { referrer: "/relative" })).toThrow(/referrer/i);
+    expect(() => new Request(url, { referrer: "/relative" })).toThrow(TypeError);
     // @ts-expect-error deliberately invalid enum value
     expect(() => new Request(url, { referrerPolicy: "bogus" })).toThrow(/referrerPolicy/);
   });


### PR DESCRIPTION
Addresses the `referrer` and `referrerPolicy` half of #30124.

`fetch()` and the `Request` constructor accepted `referrer` and `referrerPolicy` and silently discarded both: `Request.referrer` was always `""`, `Request.referrerPolicy` was always `""`, and no `Referer` request header was ever sent under any policy on the initial request or on any redirect hop. Node (undici) and browsers implement the full matrix.

## Repro

```js
await fetch(url, { referrer: "https://app.example/page", referrerPolicy: "unsafe-url" });
// node / browsers: Referer: https://app.example/page
// bun: no Referer header at all

new Request(url, { referrer: "https://app.example/page" }).referrer;
// node / browsers: "https://app.example/page"
// bun: ""
```

## Cause

- `Referrer` and `ReferrerPolicy` were commented out of the `Fields` enum in `Request::construct_into`, so neither init member was ever read.
- `get_referrer` looked up a header literally named `referrer` (not the real `Referer` header), which never exists, so it always fell through to `""`. `get_referrer_policy` was hardcoded to `""`.
- `fetch()` never computed or set a `Referer` header, and the HTTP client had no referrer state to recompute from on redirects.

## Fix

- New `ReferrerPolicy` enum (`src/http_types/ReferrerPolicy.rs`) with the nine WHATWG values, a `FromJsEnum` impl, and `from_response_header` (last valid non-empty token wins from a comma-separated list). `determine_referer_header` (the referrer-policy spec's "determine request's referrer" followed by the fetch spec's Referer serialization) lives alongside it so both `fetch()` and the HTTP client can reach it.
- `Request` gains a `referrer` string (stored in the getter's serialization: `""` is "no-referrer", `"about:client"` is "client", anything else is the normalized referrer URL) and `Flags` gains `referrer_policy`. Both are parsed in `construct_into` per the Request constructor spec (step 14), copied from a `Request` source argument, carried through `clone`, counted in the size estimate, and released in `finalize`.
- `get_referrer` / `get_referrer_policy` reflect the stored values. An invalid or relative `referrer` throws a `TypeError`, like undici.
- `fetch()` resolves the referrer and policy with the same precedence as every other option (init object, then a `Request` argument, then the default) and threads them as `referrer: Box<[u8]>` + `referrer_policy` through `FetchOptions` and `AsyncHTTP::Options` onto `HTTPClient`.
- `HTTPClient::build_request` computes `Referer` fresh on every hop from `self.referrer` and `self.referrer_policy` against `self.url`, so a same-origin hop gets the full URL and a subsequent cross-origin hop gets only the origin under the default policy. A caller-set `Referer` header suppresses the computed one and is forwarded verbatim across redirects, matching Node.
- `handle_response_metadata` reads the `Referrer-Policy` response header on a redirect and updates the request's referrer policy for subsequent hops (fetch spec HTTP-redirect fetch, step 19). Unrecognized tokens are ignored.

`determine_referer_header` implements local-scheme stripping, credential and fragment stripping, the 4096-character origin fallback, the potentially-trustworthy origin check (https/wss/file, `localhost`, `*.localhost`, `127.*` IPv4 addresses, `[::1]`), and all nine policies.

Deliberate choices worth calling out:

- An explicit user-set `Referer` header wins over the `referrer` option and is left untouched across redirects. The spec appends unconditionally, but only because in browsers `Referer` is a forbidden header name that can never already be present; Node forwards a user-set `Referer` verbatim.
- `fetch(requestObject)` honors the request's own referrer and policy, per the spec. undici drops them because its `Request` re-wrap treats an absent init as non-empty; browsers preserve them.
- A `Request` created by `Bun.serve` from an incoming connection now reports `referrer === "about:client"` (the spec default for a request) instead of `""`. The incoming `Referer` header is unaffected and still readable from `request.headers`.

The `Request.referrer` storage and getter here overlap with the referrer portion of #30127, which also covers `integrity` (implemented independently in #32815) and `keepalive`; neither of those is in scope here.

## Verification

`test/js/web/fetch/fetch-referrer.test.ts`: 16 tests covering reflection, normalization, invalid inputs, clone and `new Request(request)`, the full nine-policy header matrix, the same-origin cases, credential/fragment stripping, the 4096 cap, header-vs-option precedence, the `Request`-argument path, the trustworthy-to-untrustworthy downgrade, body `Content-Type` preservation, and across redirects: per-hop recomputation (a referrer same-origin with A sends full to A and origin-only to B), the `Referrer-Policy` response header updating the policy mid-chain, user-set `Referer` pass-through, and the no-referrer redirect path. 11 of 16 fail on main; all 16 pass with this change. Every `Referer` value asserted matches Node 26 for the same inputs (with the one documented `same-origin`-policy divergence above).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 12 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-referrer.test.ts
bun test v1.4.0 (15cb22186)

test/js/web/fetch/fetch-referrer.test.ts:
25 |     });
26 |   }
27 | 
28 |   it("Request.referrer and Request.referrerPolicy reflect the init options", () => {
29 |     const url = "http://example.com/a";
30 |     expect(new Request(url).referrer).toBe("about:client");
                                           ^
error: expect(received).toBe(expected)

Expected: "about:client"
Received: ""

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-referrer.test.ts:30:39)
(fail) fetch referrer and referrerPolicy > Request.referrer and Request.referrerPolicy reflect the init options [11.42ms]
38 |     expect(new Request(url, { referrer: "HTTPS://App.Example:443/P" }).referrer).toBe("https://app.example/P");
39 |   });
40 | 
41 |   it("Request constructor rejects an invalid referrer or referrerPolicy", () => {
42 |     const url = "http://example.com/a";
43 |     expect(() => new Request(url, { referrer: "ht tp://x" })).toThrow(TypeError);
                           
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (5badaaa7f)

test/js/web/fetch/fetch-referrer.test.ts:
(pass) fetch referrer and referrerPolicy > Request.referrer and Request.referrerPolicy reflect the init options [0.79ms]
38 |     expect(new Request(url, { referrer: "HTTPS://App.Example:443/P" }).referrer).toBe("https://app.example/P");
39 |   });
40 | 
41 |   it("Request constructor rejects an invalid referrer or referrerPolicy", () => {
42 |     const url = "http://example.com/a";
43 |     expect(() => new Request(url, { referrer: "ht tp://x" })).toThrow(TypeError);
                                                                   ^
error: expect(received).toThrow(expected)

Expected constructor: TypeError
Received constructor: Error

Received message: "Failed to construct 'Request': Invalid referrer \"ht tp://x\""

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-referrer.test.ts:43:63)
(fail) fetch referrer and referrerPolicy > Request constructor rejects an invalid referrer or referrerPolicy [1.76ms]
(pass) fetch referrer and referrerPolicy > referrer and referrerPolicy survive clone() and new Request(request) [0.92ms]
(pass) fetch referrer and referrerPolicy > an expl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-referrer.test.ts
bun test v1.4.0 (15cb22186)

test/js/web/fetch/fetch-referrer.test.ts:
(pass) fetch referrer and referrerPolicy > Request.referrer and Request.referrerPolicy reflect the init options [7.90ms]
(pass) fetch referrer and referrerPolicy > Request constructor rejects an invalid referrer or referrerPolicy [11.44ms]
(pass) fetch referrer and referrerPolicy > referrer and referrerPolicy survive clone() and new Request(request) [5.77ms]
(pass) fetch referrer and referrerPolicy > fetch() sends the full referrer when it is same-origin with the target [179.41ms]
(pass) fetch referrer and referrerPolicy > fetch() strips credentials and caps an over-long referrer to its origin [183.25ms]
(pass) fetch referrer and referrerPolicy > an explicit Referer header wins over the referrer option [83.92ms]
(pass) fetch referrer and referrerPolicy > fetch() keeps the body-derived Content-Type when it sends a Referer [233.49ms]
(pass) fetch referrer and referrerPolicy > fetch() honors the referrer of a Request argument an
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1002ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/AsyncHTTP.rs                     |  10 +
 src/http/HTTPThread.rs                    |   1 +
 src/http/lib.rs                           |  58 +++-
 src/http_types/ReferrerPolicy.rs          | 188 +++++++++++
 src/http_types/lib.rs                     |   1 +
 src/jsc/lib.rs                            |  18 ++
 src/runtime/webcore.rs                    |   3 +
 src/runtime/webcore/Request.rs            |  93 +++++-
 src/runtime/webcore/fetch.rs              |  94 ++++++
 src/runtime/webcore/fetch/FetchTasklet.rs |   8 +
 src/runtime/webcore/referrer.rs           |  40 +++
 test/js/web/fetch/fetch-referrer.test.ts  | 502 ++++++++++++++++++++++++++++++
 12 files changed, 997 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/AsyncHTTP.rs                          4      5      0
src/http/HTTPThread.rs                         1      1      0
src/http/lib.rs                                7     13      0
src/http_types/ReferrerPolicy.rs               2     13      0
src/http_types/lib.rs                          1      1      0
src/jsc/lib.rs                                 2      1      0
src/runtime/webcore.rs                         1      2      0
src/runtime/webcore/Request.rs                 8     30      0
src/runtime/webcore/fetch.rs                  12     10      0
src/runtime/webcore/fetch/FetchTasklet.rs      2      4      0
src/runtime/webcore/referrer.rs                1      9      0
test/js/web/fetch/fetch-referrer.test.ts       8     15      0
```

</details>

<!-- robobun:evidence:end -->