### PR TITLE
fetch: cap redirects at 20 and reject redirect failures with a TypeError

### DIFF
--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -260,9 +260,40 @@ const response = await fetch("http://example.com", {
   // Disable connection reuse for this request
   keepalive: false,
 
+  // How many redirects to follow (default: 20, maximum: 126)
+  maxRedirects: 5,
+
   // Debug logging level
   verbose: true, // or "curl" for more detailed output
 });
+```
+
+### Redirects
+
+By default, `fetch` follows up to 20 redirects, the limit the [fetch specification](https://fetch.spec.whatwg.org/#http-redirect-fetch) mandates. The 21st redirect rejects with a `TypeError`:
+
+```ts
+try {
+  await fetch("http://example.com/a-very-long-redirect-chain");
+} catch (error) {
+  error instanceof TypeError; // true
+  error.code; // "TooManyRedirects"
+}
+```
+
+Use the `maxRedirects` option to raise or lower the limit. It accepts any integer from `0` (reject the first redirect) through `126`; larger values are clamped to `126`.
+
+```ts
+// Follow at most 5 redirects
+await fetch("http://example.com/", { maxRedirects: 5 });
+```
+
+The standard `redirect` option works as the specification describes. `"manual"` returns the redirect response itself, and `"error"` rejects with a `TypeError` whose `code` is `"UnexpectedRedirect"`.
+
+```ts
+const response = await fetch("http://example.com/", { redirect: "manual" });
+response.status; // 302
+response.headers.get("location"); // the redirect target
 ```
 
 ### Protocol support
@@ -335,6 +366,7 @@ Bun's fetch implementation includes several specific error cases:
 - Using the `proxy` and `unix` options together throws an error
 - TLS certificate validation failures when `rejectUnauthorized` is true (or undefined)
 - S3 operations may throw specific errors related to authentication or permissions
+- Redirect failures reject with a `TypeError` carrying a `code` property, such as `"TooManyRedirects"` or `"UnexpectedRedirect"`
 
 ### Content-Type handling
 

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -288,7 +288,7 @@ Use the `maxRedirects` option to raise or lower the limit. It accepts any intege
 await fetch("http://example.com/", { maxRedirects: 5 });
 ```
 
-The standard `redirect` option works as the specification describes. `"manual"` returns the redirect response itself, and `"error"` rejects with a `TypeError` whose `code` is `"UnexpectedRedirect"`.
+The standard `redirect` option is also available. `"error"` rejects with a `TypeError` whose `code` is `"UnexpectedRedirect"`. `"manual"` resolves with the raw redirect response, so its status and `Location` header are readable; browsers instead return an opaque-redirect filtered response whose status is `0` and whose headers are hidden, and Bun (like Node.js) does not apply that filtering.
 
 ```ts
 const response = await fetch("http://example.com/", { redirect: "manual" });

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -2071,10 +2071,13 @@ interface BunFetchRequestInit extends RequestInit {
   /**
    * The maximum number of redirects to follow when `redirect` is `"follow"`.
    * If the response chain redirects more than this many times, the request
-   * rejects with a "too many redirects" error.
+   * rejects with a `TypeError` whose `code` is `"TooManyRedirects"`.
    * Not part of the Fetch API specification.
    *
-   * @default 126
+   * The default matches the limit the Fetch specification mandates.
+   * The maximum accepted value is 126.
+   *
+   * @default 20
    * @example
    * ```js
    * const response = await fetch("https://example.com/", { maxRedirects: 3 });

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -2070,12 +2070,13 @@ interface BunFetchRequestInit extends RequestInit {
 
   /**
    * The maximum number of redirects to follow when `redirect` is `"follow"`.
-   * If the response chain redirects more than this many times, the request
-   * rejects with a `TypeError` whose `code` is `"TooManyRedirects"`.
+   * Once the chain redirects more than this many times, the request rejects
+   * with a `TypeError` whose `code` is `"TooManyRedirects"`.
    * Not part of the Fetch API specification.
    *
-   * The default matches the limit the Fetch specification mandates.
-   * The maximum accepted value is 126.
+   * `0` rejects the first redirect rather than meaning "unlimited". Values
+   * above the maximum of `126` are clamped to `126`. The default matches the
+   * 20-redirect limit the Fetch specification mandates.
    *
    * @default 20
    * @example

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -482,8 +482,7 @@ impl<'a> AsyncHTTP<'a> {
             this.client.flags.disable_decompression = val;
         }
         if let Some(val) = options.max_redirects {
-            // +1: the stored budget includes the terminal check; see
-            // `DEFAULT_REDIRECT_COUNT`. Clamped to 126 so the result fits `i8`.
+            // +1 for the terminal check (see `DEFAULT_REDIRECT_COUNT`); clamped to fit `i8`.
             this.client.remaining_redirect_count = (val.min(126) + 1) as i8;
         }
         if let Some(val) = options.disable_keepalive {

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -13,8 +13,8 @@ use bun_picohttp as picohttp;
 
 use crate::headers::{self, Headers};
 use crate::{
-    FetchRedirect, Flags, HTTPClient, HTTPRequestBody, HTTPVerboseLevel, InternalState, Method,
-    Signals, ThreadlocalAsyncHTTP,
+    DEFAULT_REDIRECT_COUNT, FetchRedirect, Flags, HTTPClient, HTTPRequestBody, HTTPVerboseLevel,
+    InternalState, Method, Signals, ThreadlocalAsyncHTTP,
 };
 use crate::{HTTPClientResult, HTTPClientResultCallback};
 
@@ -165,9 +165,7 @@ fn make_client<'a>(
         url,
         connected_url: URL::default(),
         verbose: HTTPVerboseLevel::None,
-        // Note: DEFAULT_REDIRECT_COUNT (= 127) is crate-private in lib.rs;
-        // duplicated as a literal here.
-        remaining_redirect_count: 127,
+        remaining_redirect_count: DEFAULT_REDIRECT_COUNT,
         allow_retry: false,
         h2_retries: 0,
         redirect_type,
@@ -484,6 +482,8 @@ impl<'a> AsyncHTTP<'a> {
             this.client.flags.disable_decompression = val;
         }
         if let Some(val) = options.max_redirects {
+            // +1: the stored budget includes the terminal check; see
+            // `DEFAULT_REDIRECT_COUNT`. Clamped to 126 so the result fits `i8`.
             this.client.remaining_redirect_count = (val.min(126) + 1) as i8;
         }
         if let Some(val) = options.disable_keepalive {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -238,6 +238,15 @@ pub static EXPERIMENTAL_HTTP3_CLIENT_FROM_CLI: AtomicBool = AtomicBool::new(fals
 
 const MAX_REDIRECT_URL_LENGTH: usize = 128 * 1024;
 
+/// Default budget for `HTTPClient::remaining_redirect_count`.
+///
+/// <https://fetch.spec.whatwg.org/#http-redirect-fetch> step 5: "If request's
+/// redirect count is 20, then return a network error." `do_redirect` decrements
+/// the budget and then fails on 0, so the stored value is one larger than the
+/// number of redirects actually followed: 20 are followed and the 21st redirect
+/// response rejects with `TooManyRedirects`.
+pub(crate) const DEFAULT_REDIRECT_COUNT: i8 = 20 + 1;
+
 /// The static is exported to
 /// C++ via `BUN_DEFAULT_MAX_HTTP_HEADER_SIZE`; `AtomicUsize` has the same
 /// size/alignment as `usize` so the symbol layout is unchanged.
@@ -2634,8 +2643,9 @@ impl<'a> HTTPClient<'a> {
             self.hostname = None;
         }
 
-        // TODO: should this check be before decrementing the redirect count?
-        // the current logic will allow one less redirect than requested
+        // Decrement-then-check means a budget of N allows N-1 follows, so every
+        // initializer stores one more than the redirect limit it grants; see
+        // `DEFAULT_REDIRECT_COUNT`.
         if self.remaining_redirect_count == 0 {
             self.fail(crate::Error::TooManyRedirects);
             return;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -238,13 +238,7 @@ pub static EXPERIMENTAL_HTTP3_CLIENT_FROM_CLI: AtomicBool = AtomicBool::new(fals
 
 const MAX_REDIRECT_URL_LENGTH: usize = 128 * 1024;
 
-/// Default budget for `HTTPClient::remaining_redirect_count`.
-///
-/// <https://fetch.spec.whatwg.org/#http-redirect-fetch> step 5: "If request's
-/// redirect count is 20, then return a network error." `do_redirect` decrements
-/// the budget and then fails on 0, so the stored value is one larger than the
-/// number of redirects actually followed: 20 are followed and the 21st redirect
-/// response rejects with `TooManyRedirects`.
+/// <https://fetch.spec.whatwg.org/#http-redirect-fetch> caps redirects at 20; `do_redirect` decrements then checks for 0, so the stored budget is `+1`.
 pub(crate) const DEFAULT_REDIRECT_COUNT: i8 = 20 + 1;
 
 /// The static is exported to
@@ -2643,9 +2637,7 @@ impl<'a> HTTPClient<'a> {
             self.hostname = None;
         }
 
-        // Decrement-then-check means a budget of N allows N-1 follows, so every
-        // initializer stores one more than the redirect limit it grants; see
-        // `DEFAULT_REDIRECT_COUNT`.
+        // Decrement-then-check: see `DEFAULT_REDIRECT_COUNT` for why every initializer stores `limit + 1`.
         if self.remaining_redirect_count == 0 {
             self.fail(crate::Error::TooManyRedirects);
             return;

--- a/src/jsc/SystemError.rs
+++ b/src/jsc/SystemError.rs
@@ -72,6 +72,10 @@ pub type Maybe<R> = core::result::Result<R, SystemError>;
 // is ABI-identical to a non-null `JSGlobalObject*` with write provenance.
 unsafe extern "C" {
     safe fn SystemError__toErrorInstance(this: &SystemError, global: &JSGlobalObject) -> JSValue;
+    safe fn SystemError__toTypeErrorInstance(
+        this: &SystemError,
+        global: &JSGlobalObject,
+    ) -> JSValue;
     safe fn SystemError__toErrorInstanceWithInfoObject(
         this: &SystemError,
         global: &JSGlobalObject,
@@ -89,6 +93,14 @@ impl SystemError {
     /// first when two `Error`s are genuinely wanted.
     pub fn to_error_instance(self, global: &JSGlobalObject) -> JSValue {
         SystemError__toErrorInstance(&self, global)
+    }
+
+    /// Like [`to_error_instance`](Self::to_error_instance), but the instance
+    /// is a JS `TypeError` with the same `code`/`path`/`errno`/... properties.
+    /// The fetch spec maps network errors to `TypeError`, which callers
+    /// feature-detect via `instanceof`. Consumes `self` for the same reason.
+    pub fn to_type_error_instance(self, global: &JSGlobalObject) -> JSValue {
+        SystemError__toTypeErrorInstance(&self, global)
     }
 
     /// Like `to_error_instance` but populates the error's stack trace with async

--- a/src/jsc/SystemError.rs
+++ b/src/jsc/SystemError.rs
@@ -95,10 +95,7 @@ impl SystemError {
         SystemError__toErrorInstance(&self, global)
     }
 
-    /// Like [`to_error_instance`](Self::to_error_instance), but the instance
-    /// is a JS `TypeError` with the same `code`/`path`/`errno`/... properties.
-    /// The fetch spec maps network errors to `TypeError`, which callers
-    /// feature-detect via `instanceof`. Consumes `self` for the same reason.
+    /// [`to_error_instance`](Self::to_error_instance) as a JS `TypeError` (same `code`/`path`/`errno` properties), for fetch-spec network errors.
     pub fn to_type_error_instance(self, global: &JSGlobalObject) -> JSValue {
         SystemError__toTypeErrorInstance(&self, global)
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2353,7 +2353,7 @@ JSC::EncodedJSValue JSGlobalObject__createOutOfMemoryError(JSC::JSGlobalObject* 
     return JSValue::encode(exception);
 }
 
-JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject)
+static JSC::EncodedJSValue systemErrorToErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject, JSC::ErrorType errorType)
 {
     SystemError err = *arg0;
 
@@ -2367,7 +2367,7 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
 
     auto& names = WebCore::builtinNames(vm);
 
-    JSC::JSObject* result = createError(globalObject, ErrorType::Error, message);
+    JSC::JSObject* result = createError(globalObject, errorType, message);
 
     auto clientData = WebCore::clientData(vm);
 
@@ -2424,6 +2424,19 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
     result->putDirect(vm, names.errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
 
     return JSC::JSValue::encode(result);
+}
+
+JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject)
+{
+    return systemErrorToErrorInstance(arg0, globalObject, ErrorType::Error);
+}
+
+// Same property layout as `SystemError__toErrorInstance` (`code`, `path`,
+// `errno`, ...) but the instance is a `TypeError`. The fetch specification
+// requires network errors to reject with a `TypeError`.
+JSC::EncodedJSValue SystemError__toTypeErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject)
+{
+    return systemErrorToErrorInstance(arg0, globalObject, ErrorType::TypeError);
 }
 
 JSC::EncodedJSValue SystemError__toErrorInstanceWithInfoObject(const SystemError* arg0, JSC::JSGlobalObject* globalObject)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2431,9 +2431,7 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
     return systemErrorToErrorInstance(arg0, globalObject, ErrorType::Error);
 }
 
-// Same property layout as `SystemError__toErrorInstance` (`code`, `path`,
-// `errno`, ...) but the instance is a `TypeError`. The fetch specification
-// requires network errors to reject with a `TypeError`.
+// `SystemError__toErrorInstance` as a `TypeError`, for fetch-spec network errors.
 JSC::EncodedJSValue SystemError__toTypeErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject)
 {
     return systemErrorToErrorInstance(arg0, globalObject, ErrorType::TypeError);

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -99,6 +99,7 @@ CPP_DECL void WebCore__FetchHeaders__remove(WebCore::FetchHeaders* arg0, const Z
 CPP_DECL JSC::EncodedJSValue WebCore__FetchHeaders__toJS(WebCore::FetchHeaders* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0, UWSResponseKind kind, void* arg2);
 CPP_DECL JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* arg1);
+CPP_DECL JSC::EncodedJSValue SystemError__toTypeErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* arg1);
 
 #pragma mark - JSC::JSCell
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -564,10 +564,7 @@ pub enum Tag {
 pub enum ValueError {
     AbortReason(CommonAbortReason),
     SystemError(SystemError),
-    /// Like `SystemError` (same `code`/`path`/`errno` properties) but the
-    /// instance is a JS `TypeError`. The fetch spec maps every "network
-    /// error" to TypeError; use this over `TypeError` when callers also
-    /// rely on the error's machine-readable `code`.
+    /// [`SystemError`](Self::SystemError) surfaced as a JS `TypeError`; use over [`TypeError`](Self::TypeError) when callers also rely on the error's `code`.
     SystemTypeError(SystemError),
     Message(BunString),
     /// Surfaces as a JS `TypeError`. The fetch spec maps every "network

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -564,6 +564,11 @@ pub enum Tag {
 pub enum ValueError {
     AbortReason(CommonAbortReason),
     SystemError(SystemError),
+    /// Like `SystemError` (same `code`/`path`/`errno` properties) but the
+    /// instance is a JS `TypeError`. The fetch spec maps every "network
+    /// error" to TypeError; use this over `TypeError` when callers also
+    /// rely on the error's machine-readable `code`.
+    SystemTypeError(SystemError),
     Message(BunString),
     /// Surfaces as a JS `TypeError`. The fetch spec maps every "network
     /// error" to TypeError, so use this for fetch-layer rejections that
@@ -579,6 +584,7 @@ impl ValueError {
         match self {
             // The bun.String fields are dropped by the assignment below.
             ValueError::SystemError(_system_error) => {}
+            ValueError::SystemTypeError(_system_error) => {}
             ValueError::Message(message) => message.deref(),
             ValueError::TypeError(message) => message.deref(),
             ValueError::JSValue(v) => v.deinit(),
@@ -612,6 +618,9 @@ impl ValueError {
             ValueError::SystemError(system_error) => {
                 core::mem::take(system_error).to_error_instance(global_object)
             }
+            ValueError::SystemTypeError(system_error) => {
+                core::mem::take(system_error).to_type_error_instance(global_object)
+            }
             ValueError::Message(message) => message.to_error_instance(global_object),
             ValueError::TypeError(message) => message.to_type_error_instance(global_object),
             // do an early return in this case we don't need to create a new Strong
@@ -628,6 +637,7 @@ impl ValueError {
             // `.clone()` on BunString/SystemError already bumps the refcount (paired
             // with their Drop deref); an extra `.ref_()` here would leak +1 per dupe.
             ValueError::SystemError(e) => ValueError::SystemError(e.clone()),
+            ValueError::SystemTypeError(e) => ValueError::SystemTypeError(e.clone()),
             ValueError::Message(m) => ValueError::Message(m.clone()),
             ValueError::TypeError(m) => ValueError::TypeError(m.clone()),
             ValueError::JSValue(js_ref) => {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1291,10 +1291,7 @@ impl FetchTasklet {
 
         let fail = self.result.fail.unwrap();
 
-        // Fetch-spec "network error" cases that callers feature-detect via
-        // `instanceof TypeError`. Keep this list narrow (redirect failures are
-        // handled below so their `code` property survives); the catch-all
-        // SystemError below is still a plain Error for backwards compat.
+        // Fetch-spec "network error" `TypeError`s; redirect failures go through `SystemTypeError` below so their `code` survives.
         if fail == http::Error::RequestBodyNotReusable {
             return BodyValueError::TypeError(BunString::static_(
                 "Request body is a ReadableStream and cannot be replayed for this redirect",
@@ -1568,9 +1565,7 @@ impl FetchTasklet {
             ..Default::default()
         };
 
-        // HTTP-redirect fetch returns a network error for each of these
-        // (https://fetch.spec.whatwg.org/#http-redirect-fetch), and a network
-        // error rejects fetch() with a `TypeError`. Same `code`/`path`/message.
+        // <https://fetch.spec.whatwg.org/#http-redirect-fetch>: each of these is a network error, so a `TypeError`.
         if matches!(
             fail,
             http::Error::TooManyRedirects

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1292,7 +1292,8 @@ impl FetchTasklet {
         let fail = self.result.fail.unwrap();
 
         // Fetch-spec "network error" cases that callers feature-detect via
-        // `instanceof TypeError`. Keep this list narrow; the catch-all
+        // `instanceof TypeError`. Keep this list narrow (redirect failures are
+        // handled below so their `code` property survives); the catch-all
         // SystemError below is still a plain Error for backwards compat.
         if fail == http::Error::RequestBodyNotReusable {
             return BodyValueError::TypeError(BunString::static_(
@@ -1566,6 +1567,21 @@ impl FetchTasklet {
             path: path.into(),
             ..Default::default()
         };
+
+        // HTTP-redirect fetch returns a network error for each of these
+        // (https://fetch.spec.whatwg.org/#http-redirect-fetch), and a network
+        // error rejects fetch() with a `TypeError`. Same `code`/`path`/message.
+        if matches!(
+            fail,
+            http::Error::TooManyRedirects
+                | http::Error::UnexpectedRedirect
+                | http::Error::RedirectURLInvalid
+                | http::Error::InvalidRedirectURL
+                | http::Error::RedirectURLTooLong
+                | http::Error::UnsupportedRedirectProtocol
+        ) {
+            return BodyValueError::SystemTypeError(fetch_error);
+        }
 
         BodyValueError::SystemError(fetch_error)
     }

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -328,3 +328,104 @@ describe("fetch() follows a redirect whose Location scheme is not lowercase", ()
     }
   });
 });
+
+// https://fetch.spec.whatwg.org/#http-redirect-fetch step 5: "If request's
+// redirect count is 20, then return a network error." A network error rejects
+// the fetch() promise with a TypeError.
+describe("fetch() redirect limit", () => {
+  // `/0 -> /1 -> ... -> /hops` via 302, then a 200. `requests.count` is the
+  // number of round trips the client actually made.
+  function redirectChain(hops: number) {
+    const requests = { count: 0 };
+    const server = Bun.serve({
+      port: 0,
+      fetch(request: Request) {
+        requests.count++;
+        const n = Number(new URL(request.url).pathname.slice("/".length));
+        if (n >= hops) return new Response("done");
+        return new Response(null, { status: 302, headers: { Location: `/${n + 1}` } });
+      },
+    });
+    return { server, requests, [Symbol.dispose]: () => server.stop(true) };
+  }
+
+  async function rejection(promise: Promise<unknown>): Promise<any> {
+    return await promise.then(
+      () => {
+        throw new Error("expected the fetch promise to reject");
+      },
+      (e: unknown) => e,
+    );
+  }
+
+  it.concurrent("follows exactly 20 redirects by default", async () => {
+    using chain = redirectChain(20);
+    const resp = await fetch(`${chain.server.url}0`);
+    expect(await resp.text()).toBe("done");
+    expect(resp.status).toBe(200);
+    expect(chain.requests.count).toBe(21);
+  });
+
+  it.concurrent("rejects the 21st redirect with a TypeError", async () => {
+    using chain = redirectChain(21);
+    const err = await rejection(fetch(`${chain.server.url}0`));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("TooManyRedirects");
+    expect(err.message).toContain("redirected too many times");
+    // 20 redirects were followed; the 21st redirect response is the error.
+    expect(chain.requests.count).toBe(21);
+  });
+
+  it.concurrent("a self-redirect loop makes exactly 21 requests before rejecting", async () => {
+    let requests = 0;
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests++;
+        return new Response(null, { status: 302, headers: { Location: "/" } });
+      },
+    });
+    const err = await rejection(fetch(server.url));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("TooManyRedirects");
+    expect(requests).toBe(21);
+  });
+
+  it.concurrent("exceeding an explicit maxRedirects rejects with a TypeError", async () => {
+    using chain = redirectChain(3);
+    const err = await rejection(fetch(`${chain.server.url}0`, { maxRedirects: 2 }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("TooManyRedirects");
+    expect(chain.requests.count).toBe(3);
+  });
+
+  it.concurrent('redirect: "error" rejects with a TypeError', async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(null, { status: 302, headers: { Location: "/elsewhere" } }),
+    });
+    const err = await rejection(fetch(server.url, { redirect: "error" }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("UnexpectedRedirect");
+  });
+
+  it.concurrent("a redirect to a non-HTTP(S) scheme rejects with a TypeError", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(null, { status: 302, headers: { Location: "ftp://example.com/" } }),
+    });
+    const err = await rejection(fetch(server.url));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("UnsupportedRedirectProtocol");
+  });
+
+  it.concurrent("a redirect to an unparseable URL rejects with a TypeError", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(null, { status: 302, headers: { Location: "http://[/" } }),
+    });
+    const err = await rejection(fetch(server.url));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("RedirectURLInvalid");
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Related to #20486 (partially: that issue also covers DNS, connect, and URL-parse errors, which this PR leaves alone).

`fetch()` was not enforcing the WHATWG fetch specification's redirect limit, and redirect failures rejected with a plain `Error` instead of a `TypeError`.

<https://fetch.spec.whatwg.org/#http-redirect-fetch> step 5: "If request's redirect count is 20, then return a network error." A network error rejects the `fetch()` promise with a `TypeError` (<https://fetch.spec.whatwg.org/#fetch-method>).

#### Reproduction

```js
let count = 0;
const server = Bun.serve({
  port: 0,
  fetch(req) {
    count++;
    const { pathname } = new URL(req.url);
    if (pathname === "/loop") return Response.redirect("/loop", 302);
    const [, , n, max] = pathname.split("/"); // /chain/<n>/<max>
    if (Number(n) >= Number(max)) return new Response("done");
    return Response.redirect(`/chain/${Number(n) + 1}/${max}`, 302);
  },
});

await fetch(`${server.url}chain/0/25`);            // Bun 1.4.0: 200    Node/spec: TypeError
await fetch(`${server.url}loop`).catch(e => count); // Bun 1.4.0: 127   Node/spec: 21
await fetch(`${server.url}chain/0/1`, { redirect: "error" })
  .catch(e => e.constructor.name);                 // Bun 1.4.0: "Error"  Node/spec: "TypeError"
```

Bun 1.4.0 (and `main`):
- a 25-hop redirect chain resolves with a `200` after 26 requests
- a self-redirect loop makes 127 round trips before rejecting (6x the traffic Node makes before giving up)
- the rejection is a plain `Error`, which breaks `err instanceof TypeError` feature detection
  - `error: The response redirected too many times. ... code: "TooManyRedirects"`
  - `error: UnexpectedRedirect fetching "..." ... code: "UnexpectedRedirect"`

Node 26.3.0 rejects both after 21 requests with a `TypeError`.

### Cause

- `make_client` in `src/http/AsyncHTTP.rs` hardcoded `remaining_redirect_count: 127`.
- `FetchTasklet::on_reject` converts every HTTP client failure into a `SystemError`, which `SystemError__toErrorInstance` materializes with `ErrorType::Error`.

### Fix

- `src/http/lib.rs`: add `DEFAULT_REDIRECT_COUNT = 20 + 1` (`do_redirect` decrements before checking for 0, so the stored budget is one larger than the number of redirects followed) and use it in `make_client`. 20 redirects are followed and the 21st redirect response rejects, matching Node exactly. The existing `maxRedirects` fetch option still overrides the default, up to 126.
- `src/jsc/bindings/bindings.cpp`: factor `SystemError__toErrorInstance` into a helper parameterized on `JSC::ErrorType` and add `SystemError__toTypeErrorInstance`. Exposed to Rust as `SystemError::to_type_error_instance` and `Body::ValueError::SystemTypeError`.
- `FetchTasklet::on_reject`: route the redirect failure codes (`TooManyRedirects`, `UnexpectedRedirect`, `RedirectURLInvalid`, `InvalidRedirectURL`, `RedirectURLTooLong`, `UnsupportedRedirectProtocol`) through the new `TypeError` path. Every one of these is a network error under HTTP-redirect fetch. Messages and the `code`, `path`, and `errno` properties are unchanged, so existing `err.code === "UnexpectedRedirect"` handling (and the tests that assert it) keeps working; only the error's constructor changes.

Out of scope, deliberately: non-redirect network errors (`ConnectionRefused`, `ECONNRESET`, DNS and TLS failures, ...) stay plain `Error`s. Those carry `code` values users widely branch on, and widening further is a separate, larger compatibility decision.

### How did you verify your code works?

New tests in `test/js/web/fetch/fetch-redirect.test.ts`, next to the existing redirect coverage. On `main`, 6 of the 7 fail (the 7th proves exactly 20 redirects is still allowed); all pass with the fix:

```
(pass) fetch() redirect limit > follows exactly 20 redirects by default
(pass) fetch() redirect limit > rejects the 21st redirect with a TypeError
(pass) fetch() redirect limit > a self-redirect loop makes exactly 21 requests before rejecting
(pass) fetch() redirect limit > exceeding an explicit maxRedirects rejects with a TypeError
(pass) fetch() redirect limit > redirect: "error" rejects with a TypeError
(pass) fetch() redirect limit > a redirect to a non-HTTP(S) scheme rejects with a TypeError
(pass) fetch() redirect limit > a redirect to an unparseable URL rejects with a TypeError
```

Also ran `test/js/web/fetch/fetch.test.ts` (`maxRedirects` and `redirect:` blocks), `test/js/web/fetch/client-fetch.test.ts`, `test/js/web/fetch/fetch-http2-client.test.ts`, `test/js/first_party/undici/undici.test.ts`, `test/js/bun/http/proxy.test.ts`, and `test/integration/bun-types/bun-types.test.ts` against the debug build; no new failures.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-redirect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b145491fe)

test/js/web/fetch/fetch-redirect.test.ts:
(pass) fetch() preserves body on redirect [54.46ms]
(pass) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:/etc/hosts) [30.97ms]
(pass) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:hosts) [17.59ms]
(pass) fetch() normalizes a redirect Location containing a raw tab character before re-requesting [390.88ms]
DEBUG: Malformed HTTP response:
HTTP/1.1 302 Found
Location: /ab
Content-Length: 0
Connection: close


(pass) fetch() rejects a redirect response whose Location contains a raw vertical tab character [54.73ms]
DEBUG: Malformed HTTP response:
HTTP/1.1 302 Found
Location: /ab
Content-Length: 0
Conne
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/fetch-redirect.test.ts:
(pass) fetch() preserves body on redirect [3.72ms]
51 | 
52 |     const outcome = await fetch(new URL("/start", server.url)).then(
53 |       () => ({ rejected: false as const }),
54 |       e => ({ rejected: true as const, code: e.code }),
55 |     );
56 |     expect(outcome).toEqual({ rejected: true, code: "UnsupportedRedirectProtocol" });
                         ^
error: expect(received).toEqual(expected)

  {
-   "code": "UnsupportedRedirectProtocol",
+   "code": "ENOTFOUND",
    "rejected": true,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-redirect.test.ts:56:21)
(fail) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:/etc/hosts) [1.52ms]
51 | 
52 |     const outcome = await fetch(new URL("/start", server.url)).then(
53 |       () => ({ rejected: false as const }),
54 |       e => ({ rejected: true as const, code: e.code }),
55 |     );
56 |     expect(outcome).toEqual({ rejected: true, code: "UnsupportedRedirectProtocol" });
                         ^
error: expect(received).toEqual(expected)

  
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-redirect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b145491fe)

test/js/web/fetch/fetch-redirect.test.ts:
(pass) fetch() preserves body on redirect [54.16ms]
(pass) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:/etc/hosts) [38.48ms]
(pass) fetch() rejects following a redirect to a Location with a non-HTTP scheme (file:hosts) [16.80ms]
(pass) fetch() normalizes a redirect Location containing a raw tab character before re-requesting [437.71ms]
DEBUG: Malformed HTTP response:
HTTP/1.1 302 Found
Location: /ab
Content-Length: 0
Connection: close


(pass) fetch() rejects a redirect response whose Location contains a raw vertical tab character [54.71ms]
DEBUG: Malformed HTTP response:
HTTP/1.1 302 Found
Location: /ab
Content-Length: 0
Conne
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b145491fe6
  features     (none)

22 deps, 105 codegen, 1167 objects in 863ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1230] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [4.00ms]
[2/1230] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [5.00ms]
[3/1230] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [4.00ms]
[4/1230] gen ErrorCode+*.h
[5/1230] gen bindgenv2
[6/1230] fetch zlib
[zlib] up to date
[7/1230] gen .bind.ts → GeneratedBindings.cpp
[8/1230] gen ProcessBindingCon
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/networking/fetch.mdx         |  32 ++++++++++
 packages/bun-types/globals.d.ts           |  10 ++-
 src/http/AsyncHTTP.rs                     |  10 +--
 src/http/lib.rs                           |  14 +++-
 src/jsc/SystemError.rs                    |  14 ++++
 src/jsc/bindings/bindings.cpp             |  17 ++++-
 src/jsc/bindings/headers.h                |   1 +
 src/runtime/webcore/Body.rs               |  10 +++
 src/runtime/webcore/fetch/FetchTasklet.rs |  16 ++++-
 test/js/web/fetch/fetch-redirect.test.ts  | 103 +++++++++++++++++++++++++++++-
 10 files changed, 213 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
docs/runtime/networking/fetch.mdx              2      2      0
packages/bun-types/globals.d.ts                2      2      0
src/http/AsyncHTTP.rs                          3      4      0
src/http/lib.rs                                2      2      0
src/jsc/SystemError.rs                         2      3      0
src/jsc/bindings/bindings.cpp                  4      2      0
src/jsc/bindings/headers.h                     1      1      0
src/runtime/webcore/Body.rs                    2      5      0
src/runtime/webcore/fetch/FetchTasklet.rs      2      2      0
test/js/web/fetch/fetch-redirect.test.ts       1      2      0
```

</details>

<!-- robobun:evidence:end -->