### PR TITLE
test: await order- and lifetime-dependent async matcher assertions

### DIFF
--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -263,7 +263,7 @@ describe("websocket", () => {
       }).toMatchObject(expected);
 
       const webSocket = new WebSocket(url);
-      expect(
+      await expect(
         new Promise<void>((resolve, reject) => {
           webSocket.addEventListener("open", () => resolve());
           webSocket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
@@ -272,7 +272,7 @@ describe("websocket", () => {
       ).resolves.toBeUndefined();
 
       webSocket.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
-      expect(
+      await expect(
         new Promise(resolve => {
           webSocket.addEventListener("message", ({ data }) => {
             resolve(JSON.parse(data.toString()));

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -1366,8 +1366,8 @@ describe("bun pm migrate for existing yarn.lock", () => {
       stdin: "ignore",
     });
 
-    expect(migrateResult.exited).resolves.toBe(0);
-    expect(Bun.file(join(tempDir, "bun.lock")).exists()).resolves.toBe(true);
+    await expect(migrateResult.exited).resolves.toBe(0);
+    await expect(Bun.file(join(tempDir, "bun.lock")).exists()).resolves.toBe(true);
 
     const bunLockContent = await Bun.file(join(tempDir, "bun.lock")).text();
     expect(bunLockContent).toMatchSnapshot(folder);

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1787,7 +1787,7 @@ registry = "${mockRegistryUrl}"`,
         stderr: "pipe",
       });
 
-      expect(proc.exited).resolves.toBe(0);
+      await expect(proc.exited).resolves.toBe(0);
 
       const lockfile = await Bun.file(`${dir}/bun.lock`).text();
       // Scoped package should be filtered (1.5.0 not 2.0.0)

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -440,14 +440,14 @@ describe.concurrent("Server", () => {
     // Test that HTTPS keep-alive doesn't cause it to re-use the connection on
     // the next attempt, when the next attempt has reject unauthorized enabled
     {
-      expect(
+      await expect(
         async () => await fetch(server.url, { tls: { rejectUnauthorized: true } }).then(res => res.text()),
       ).toThrow("self signed certificate");
     }
 
     {
       using _ = rejectUnauthorizedScope(true);
-      expect(async () => await fetch(server.url).then(res => res.text())).toThrow("self signed certificate");
+      await expect(async () => await fetch(server.url).then(res => res.text())).toThrow("self signed certificate");
     }
 
     {
@@ -574,7 +574,7 @@ test("should be able to await server.stop()", async () => {
   // Wait for the server to stop
   await stopped;
   // Ensure the server is completely stopped
-  expect(async () => await fetch(server.url)).toThrow();
+  await expect(async () => await fetch(server.url)).toThrow();
 });
 
 test("should be able to await server.stop(true) with keep alive", async () => {
@@ -605,12 +605,12 @@ test("should be able to await server.stop(true) with keep alive", async () => {
   await stopped;
 
   // It should fail before the server responds
-  expect(async () => {
+  await expect(async () => {
     await (await responsePromise).text();
   }).toThrow();
 
   // Ensure the server is completely stopped
-  expect(async () => await fetch(server.url)).toThrow();
+  await expect(async () => await fetch(server.url)).toThrow();
 });
 
 test("should be able to async upgrade using custom protocol", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -531,7 +531,7 @@ describe("streaming", () => {
         const response = await fetch(url);
         expect(response.status).toBe(402);
         expect(response.headers.get("X-Hey")).toBe("123");
-        expect(response.text()).resolves.toBe("");
+        await expect(response.text()).resolves.toBe("");
         subprocess.kill();
       });
 
@@ -556,7 +556,7 @@ describe("streaming", () => {
         const response = await fetch(url);
         expect(response.status).toBe(402);
         expect(response.headers.get("X-Hey")).toBe("123");
-        expect(response.text()).resolves.toBe("");
+        await expect(response.text()).resolves.toBe("");
         subprocess.kill();
       });
 
@@ -2016,7 +2016,7 @@ it.concurrent("should work with dispose keyword", async () => {
     url = server.url;
     expect((await fetch(url)).status).toBe(200);
   }
-  expect(fetch(url)).rejects.toThrow();
+  await expect(fetch(url)).rejects.toThrow();
 });
 
 // prettier-ignore
@@ -2288,9 +2288,9 @@ it.concurrent(
       const res = await fetch(new URL(pathname, server.url.origin));
       expect(res.status).toBe(200);
       if (success) {
-        expect(res.text()).resolves.toBe("Hello, World!");
+        await expect(res.text()).resolves.toBe("Hello, World!");
       } else {
-        expect(res.text()).rejects.toThrow(/The socket connection was closed unexpectedly./);
+        await expect(res.text()).rejects.toThrow(/The socket connection was closed unexpectedly./);
       }
     }
     await Promise.all([testTimeout("/ok", true), testTimeout("/timeout", false)]);
@@ -2386,7 +2386,7 @@ it.concurrent(
     expect(server.timeout).toBeFunction();
     const res = await fetch(new URL("/long-timeout", server.url.origin));
     expect(res.status).toBe(200);
-    expect(res.text()).resolves.toBe("Hello, World!");
+    await expect(res.text()).resolves.toBe("Hello, World!");
   },
   20_000,
 );

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1879,7 +1879,7 @@ it("should support promise returned from error", async () => {
   {
     const resp = await fetch(new URL("async-fulfilled", url));
     expect(resp.status).toBe(200);
-    expect(resp.text()).resolves.toBe("Async fulfilled");
+    await expect(resp.text()).resolves.toBe("Async fulfilled");
   }
 
   {
@@ -1890,7 +1890,7 @@ it("should support promise returned from error", async () => {
   {
     const resp = await fetch(new URL("async-pending", url));
     expect(resp.status).toBe(200);
-    expect(resp.text()).resolves.toBe("Async pending");
+    await expect(resp.text()).resolves.toBe("Async pending");
   }
 
   {

--- a/test/js/bun/shell/lazy.test.ts
+++ b/test/js/bun/shell/lazy.test.ts
@@ -11,7 +11,7 @@ test("$ is lazy", async () => {
   const path = join(base, "bun-lazy");
   rmSync(path, { force: true, recursive: true });
   const pending = $`echo 123 > ${path}`;
-  expect(async () => await Bun.file(path).text()).toThrow();
+  await expect(async () => await Bun.file(path).text()).toThrow();
   await Bun.write(path, "456");
   expect(await Bun.file(path).text()).toBe("456");
   await pending;

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -9,11 +9,11 @@ test("delete() and stat() should work with unicode paths", async () => {
   });
   const filename = join(dir, "🌟.txt");
 
-  expect(async () => {
+  await expect(async () => {
     await Bun.file(filename).delete();
   }).toThrow(`ENOENT: no such file or directory, unlink '${filename}'`);
 
-  expect(async () => {
+  await expect(async () => {
     await Bun.file(filename).stat();
   }).toThrow(`ENOENT: no such file or directory, stat '${filename}'`);
 

--- a/test/js/node/util/test-aborted.test.ts
+++ b/test/js/node/util/test-aborted.test.ts
@@ -5,14 +5,14 @@ import { expect, test } from "bun:test";
 import { getEventListeners } from "events";
 import { aborted } from "util";
 
-test("aborted works when provided a resource that was already aborted", () => {
+test("aborted works when provided a resource that was already aborted", async () => {
   const ac = new AbortController();
   const abortedPromise = aborted(ac.signal, {});
   ac.abort();
 
   expect(ac.signal.aborted).toBe(true);
   expect(getEventListeners(ac.signal, "abort").length).toBe(0);
-  return expect(abortedPromise).resolves.toBeUndefined();
+  await expect(abortedPromise).resolves.toBeUndefined();
 });
 
 test("aborted works when provided a resource that was not already aborted", async () => {
@@ -32,7 +32,7 @@ test("aborted works when provided a resource that was not already aborted", asyn
   expect(ac.signal.aborted).toBe(true);
   expect(getEventListeners(ac.signal, "abort").length).toBe(0);
   delete globalThis.strong;
-  return expect(abortedPromise).resolves.toBeUndefined();
+  await expect(abortedPromise).resolves.toBeUndefined();
 });
 
 test("aborted with gc cleanup", async () => {

--- a/test/js/web/fetch/blob-write.test.ts
+++ b/test/js/web/fetch/blob-write.test.ts
@@ -32,14 +32,14 @@ test("blob.delete() throws for data-backed blob", () => {
 test("Bun.file(path).unlink() does not throw", async () => {
   const dir = tempDirWithFiles("bun-unlink", { a: "Hello, world!" });
   const file = Bun.file(path.join(dir, "a"));
-  expect(file.unlink()).resolves.toBeUndefined();
+  await expect(file.unlink()).resolves.toBeUndefined();
   expect(await Bun.file(path.join(dir, "a")).exists()).toBe(false);
 });
 
 test("Bun.file(path).delete() does not throw", async () => {
   const dir = tempDirWithFiles("bun-unlink", { a: "Hello, world!" });
   const file = Bun.file(path.join(dir, "a"));
-  expect(file.delete()).resolves.toBeUndefined();
+  await expect(file.delete()).resolves.toBeUndefined();
   expect(await Bun.file(path.join(dir, "a")).exists()).toBe(false);
 });
 

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -119,7 +119,9 @@ test("unsupported formData 1", async () => {
     res.end();
   }).listen(0);
   await once(server, "listening");
-  expect(fetch(`http://localhost:${server.address().port}`).then(res => res.formData())).rejects.toThrow(TypeError);
+  await expect(fetch(`http://localhost:${server.address().port}`).then(res => res.formData())).rejects.toThrow(
+    TypeError,
+  );
 });
 
 test("multipart formdata not base64", async () => {
@@ -508,7 +510,7 @@ test("error on redirect", async () => {
   }).listen(0);
   await once(server, "listening");
 
-  expect(
+  await expect(
     fetch(`http://localhost:${server.address().port}`, {
       redirect: "error",
     }),
@@ -556,7 +558,9 @@ test("fetching with Request object - issue #1527", async () => {
       body,
     });
 
-    expect(await fetch(request)).resolves.pass();
+    const res = await fetch(request);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("");
   } finally {
     server.closeAllConnections();
   }

--- a/test/regression/issue/06443.test.ts
+++ b/test/regression/issue/06443.test.ts
@@ -31,7 +31,7 @@ describe("Bun.serve()", () => {
       const proto = options.tls ? "https" : "http";
       const target = `${proto}://localhost:${server.port}/`;
       const response = await fetch(target, { tls: { rejectUnauthorized: false } });
-      expect(response.text()).resolves.toMatch(url);
+      await expect(response.text()).resolves.toMatch(url);
     } finally {
       server.stop(true);
     }


### PR DESCRIPTION
### What does this PR do?

Test-only. Adds `await` in front of `expect(promise).resolves…` / `.rejects…` and `expect(asyncFn).toThrow(…)` assertions whose surrounding code depends on them having completed — later statements rely on the awaited side effect, or the assertion lives inside a `using` / `await using` scope whose disposal would race it, or its value is consumed. The few enclosing sync callbacks become `async`.

Today these matchers block internally (they wait on the promise inside the matcher), so leaving them un-awaited happens to work. Awaiting them is correct under both the current semantics (they return `undefined`) and Jest's (they return a promise), makes the tests read as they behave, and unblocks #33261's work item 1: once `.resolves`/`.rejects`/async `toThrow` stop blocking the event loop and return real promises, none of these tests changes meaning.

One assertion is also strengthened rather than just awaited: `client-fetch.test.ts` "fetching with Request object - issue #1527" used `expect(await fetch(request)).resolves.pass()`, which asserts nothing (`pass()` ignores the received value, and the subject was already awaited). It now asserts the response status and body.

Deliberately untouched: un-awaited matcher assertions that are the last statement of their test with no resource or ordering dependence — those are the compatibility contract the later matcher change must keep working via end-of-test settlement, so this PR leaves them as evidence.

### How did you verify your code works?

Every touched file was run with the same debug build against `main` and against this branch: identical results (the two files with pre-existing failures — snapshot mismatches in `yarn-lock-migration.test.ts`, one machine-local network test in `serve.test.ts` — fail identically on `main`).
