### PR TITLE
dns: fix RFC 8305 family interleaving of getaddrinfo results

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -405,6 +405,17 @@ export const stringsInternals = {
   ) => string,
 };
 
+export const dnsInternals = {
+  /**
+   * Feeds a synthetic getaddrinfo result with the given address families
+   * (4 | 6) through the connect path's result packing and returns
+   * `family * 1000 + originalIndex` in the order connections are attempted.
+   */
+  getaddrinfoInterleave: $newRustFunction("runtime/dns_jsc/dns.rs", "TestingAPIs.getaddrinfoInterleave", 1) as (
+    families: number[],
+  ) => number[],
+};
+
 export const fetchH2Internals = {
   liveCounts: $newRustFunction("http/H2Client.rs", "TestingAPIs.liveCounts", 0) as () => {
     sessions: number;

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2612,24 +2612,51 @@ pub mod internal {
     }
 
     // re-order result to interleave ipv4 and ipv6 (also pack into a single allocation)
-    fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
+    pub(crate) fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
         let mut count: usize = 0;
+        let mut n_first: usize = 0;
+        let first_family = if info.is_null() {
+            netc::AF_UNSPEC
+        } else {
+            // SAFETY: info is a live addrinfo node; freed by caller after we return.
+            unsafe { (*info).ai_family }
+        };
         let mut info_: *mut AddrInfo = info;
         while !info_.is_null() {
             count += 1;
             // SAFETY: info_ walks the libc-allocated addrinfo list; freed by caller after we return.
-            info_ = unsafe { (*info_).ai_next };
+            unsafe {
+                if (*info_).ai_family == first_family {
+                    n_first += 1;
+                }
+                info_ = (*info_).ai_next;
+            }
         }
+        let n_other = count - n_first;
 
         let mut results: Box<[MaybeUninit<ResultEntry>]> = Box::new_uninit_slice(count);
 
-        // copy results
-        let mut i: usize = 0;
+        // Copy results, interleaving address families (RFC 8305 §4): alternate
+        // between the first entry's family and the rest, preserving resolver order
+        // within each family, so a run of unroutable same-family addresses cannot
+        // occupy every concurrent connection attempt (#33278).
+        let mut i_first: usize = 0;
+        let mut i_other: usize = 0;
         info_ = info;
         while !info_.is_null() {
-            // SAFETY: info_ is a valid addrinfo node (counted above); results[i] is a
-            // MaybeUninit slot we fully initialize in this iteration.
+            // SAFETY: info_ is a valid addrinfo node (counted above); the slot
+            // mapping is a bijection over 0..count, so every results[i] is a
+            // MaybeUninit slot fully initialized exactly once.
             unsafe {
+                let i = if (*info_).ai_family == first_family {
+                    let i = i_first;
+                    i_first += 1;
+                    if i < n_other { 2 * i } else { n_other + i }
+                } else {
+                    let j = i_other;
+                    i_other += 1;
+                    if j < n_first { 2 * j + 1 } else { n_first + j }
+                };
                 let entry = results[i].as_mut_ptr();
                 (*entry).info = *info_;
                 // Always initialize `addr`: assume_init() below requires every byte written.
@@ -2646,33 +2673,12 @@ pub mod internal {
                 } else {
                     (*entry).addr = bun_core::ffi::zeroed();
                 }
-                i += 1;
                 info_ = (*info_).ai_next;
             }
         }
 
         // SAFETY: every slot 0..count was written above
         let mut results: Box<[ResultEntry]> = unsafe { results.assume_init() };
-
-        // sort (interleave ipv4 and ipv6)
-        let mut want = netc::AF_INET6 as usize;
-        'outer: for idx in 0..count {
-            if results[idx].info.ai_family as usize == want {
-                continue;
-            }
-            for j in (idx + 1)..count {
-                if results[j].info.ai_family as usize == want {
-                    results.swap(idx, j);
-                    want = if want == netc::AF_INET6 as usize {
-                        netc::AF_INET as usize
-                    } else {
-                        netc::AF_INET6 as usize
-                    };
-                }
-            }
-            // the rest of the list is all one address family
-            break 'outer;
-        }
 
         // set up pointers
         for idx in 0..count {
@@ -3310,6 +3316,88 @@ pub mod internal {
 }
 
 pub use internal::Request as InternalDNSRequest;
+
+/// `bun:internal-for-testing` bridge — see `src/js/internal-for-testing.ts`.
+pub mod testing_apis {
+    use super::*;
+
+    /// Probe for `internal::process_results`: builds a synthetic getaddrinfo
+    /// chain from an array of address families (4 | 6) and returns
+    /// `family * 1000 + originalIndex` in the packed/interleaved result order.
+    #[bun_jsc::host_fn]
+    pub fn getaddrinfo_interleave(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let families = frame.argument(0);
+        let len = families.get_length(global)? as usize;
+
+        let mut addrs: Vec<SockaddrStorage> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();
+        let mut nodes: Vec<AddrInfo> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();
+        for i in 0..len {
+            let family = families.get_index(global, i as u32)?.to_int32();
+            let node = &mut nodes[i];
+            // Stash the original index in the port so the caller can verify
+            // that resolver order is preserved within each family.
+            match family {
+                4 => {
+                    // SAFETY: sockaddr_in fits in the zeroed sockaddr_storage.
+                    let sa = unsafe { &mut *(&raw mut addrs[i]).cast::<netc::sockaddr_in>() };
+                    sa.sin_family = netc::AF_INET as _;
+                    sa.sin_port = i as u16;
+                    node.ai_family = netc::AF_INET;
+                    node.ai_addrlen = size_of::<netc::sockaddr_in>() as _;
+                }
+                6 => {
+                    // SAFETY: sockaddr_in6 fits in the zeroed sockaddr_storage.
+                    let sa = unsafe { &mut *(&raw mut addrs[i]).cast::<netc::sockaddr_in6>() };
+                    sa.sin6_family = netc::AF_INET6 as _;
+                    sa.sin6_port = i as u16;
+                    node.ai_family = netc::AF_INET6;
+                    node.ai_addrlen = size_of::<netc::sockaddr_in6>() as _;
+                }
+                other => {
+                    return Err(global.throw(format_args!("family must be 4 or 6, got {other}")));
+                }
+            }
+            node.ai_addr = (&raw mut addrs[i]).cast::<Sockaddr>();
+        }
+        let base = nodes.as_mut_ptr();
+        for i in 0..len.saturating_sub(1) {
+            // SAFETY: i and i + 1 are in-bounds; the Vec is never reallocated.
+            unsafe { (*base.add(i)).ai_next = base.add(i + 1) };
+        }
+
+        let results = internal::process_results(if len == 0 {
+            ptr::null_mut()
+        } else {
+            nodes.as_mut_ptr()
+        });
+
+        // Walk the rebuilt ai_next chain (not the slice) so the intrusive
+        // pointer fixup is exercised too.
+        let out = JSValue::create_empty_array(global, results.len())?;
+        let mut p: *const AddrInfo = if results.is_empty() {
+            ptr::null()
+        } else {
+            &raw const results[0].info
+        };
+        let mut idx: u32 = 0;
+        while !p.is_null() {
+            // SAFETY: p walks the chain inside the live `results` allocation.
+            let encoded = unsafe {
+                if (*p).ai_family == netc::AF_INET {
+                    4000 + i32::from((*(*p).ai_addr.cast::<netc::sockaddr_in>()).sin_port)
+                } else {
+                    6000 + i32::from((*(*p).ai_addr.cast::<netc::sockaddr_in6>()).sin6_port)
+                }
+            };
+            out.put_index(global, idx, JSValue::js_number_from_int32(encoded))?;
+            idx += 1;
+            // SAFETY: same as above.
+            p = unsafe { (*p).ai_next };
+        }
+        Ok(out)
+    }
+}
+pub use testing_apis as testing_ap_is;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Resolver — JSC-exposed `dns.Resolver` (m_ctx payload of JSDNSResolver)

--- a/src/runtime/dns_jsc/mod.rs
+++ b/src/runtime/dns_jsc/mod.rs
@@ -12,6 +12,13 @@
 mod dns_body;
 pub(crate) use dns_body::netc;
 
+/// Codegen path alias: `generated_js2native.rs` lowers
+/// `$rust(runtime/dns_jsc/dns.rs, TestingAPIs.*)` to
+/// `crate::dns_jsc::dns::testing_ap_is::*` (cf. `crate::socket::socket`).
+pub mod dns {
+    pub use super::dns_body::testing_ap_is;
+}
+
 #[path = "cares_jsc.rs"]
 pub mod cares_jsc; // c-ares reply struct → JSValue bridges
 

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -1,5 +1,6 @@
 import { dns } from "bun";
 import { describe, expect, it, test } from "bun:test";
+import { dnsInternals } from "bun:internal-for-testing";
 import { bunEnv, bunExe } from "harness";
 
 // The DNS cache is process-global, so this runs in its own process to get
@@ -70,5 +71,30 @@ describe("dns.prefetch", () => {
     const newStats2 = dns.getCacheStats();
     // Ensure it's cached.
     expect(newStats2.cacheHitsCompleted).toBeGreaterThan(currentStats.cacheHitsCompleted);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/33278
+describe("getaddrinfo result interleaving (RFC 8305)", () => {
+  // Entries are encoded as family * 1000 + original resolver index.
+  test.each([
+    // 4 AAAA before any A (the aiplatform.googleapis.com shape from the
+    // issue): an IPv4 address must reach the first batch of 4 attempts.
+    {
+      families: [6, 6, 6, 6, 4, 4, 4, 4],
+      expected: [6000, 4004, 6001, 4005, 6002, 4006, 6003, 4007],
+    },
+    // The resolver's preferred family stays first (RFC 6724 order is policy).
+    { families: [4, 4, 6, 6], expected: [4000, 6002, 4001, 6003] },
+    // Uneven counts: the surplus family keeps resolver order at the tail.
+    { families: [6, 6, 6, 6, 4, 4], expected: [6000, 4004, 6001, 4005, 6002, 6003] },
+    { families: [6, 4, 4, 4], expected: [6000, 4001, 4002, 4003] },
+    // Single-family and already-interleaved lists are untouched.
+    { families: [6, 6, 6], expected: [6000, 6001, 6002] },
+    { families: [4], expected: [4000] },
+    { families: [6, 4, 6, 4], expected: [6000, 4001, 6002, 4003] },
+    { families: [], expected: [] },
+  ])("$families → $expected", ({ families, expected }) => {
+    expect(dnsInternals.getaddrinfoInterleave(families)).toEqual(expected);
   });
 });


### PR DESCRIPTION
_(Disclosure: Code and writeup by Claude Fable 5)_

Fixes #33278.

A cold `fetch()` (or any usockets connect) on a network with advertised-but-unroutable IPv6 stalls for the full OS connect timeout (~70 s) when the host resolves to several AAAA records before any A record: all `CONCURRENT_CONNECTIONS = 4` parallel attempts go to the first four addresses in resolver order — all dead IPv6 — and blackholed SYNs never fail, so the IPv4 addresses are never tried.

### Root cause

`process_results()` in `src/runtime/dns_jsc/dns.rs` — the function that packs getaddrinfo results for the usockets/QUIC connect cache — has always had a `// sort (interleave ipv4 and ipv6)` pass, but it never worked:

- It is a line-for-line port of a Zig loop whose `for … else { break }` fired unconditionally (the port note said so explicitly), so the outer loop dies after a single index.
- `want` starts at `AF_INET6` and only toggles when a swap happens, so any list *starting* with IPv6 — the exact failing shape — just `continue`s and returns **completely untouched**.

### Fix

Ordering now happens while the entries are copied into the packed allocation: alternate between the first entry's family and the rest, preserving resolver order within each family (RFC 8305 §4). Starting from the resolver's first family (rather than hardcoding IPv6) respects the OS's RFC 6724 policy, so v4-first results stay v4-first. The slot mapping is a closed-form bijection over `0..count`, so the `MaybeUninit`/`assume_init` invariant is unchanged; the old post-hoc swap block is deleted.

With interleaving in place, the first batch of 4 attempts covers both families, so a run of dead same-family addresses can no longer monopolize it. This is deliberately scoped to the existing (broken) mechanism; making `dns.setDefaultResultOrder` visible to the native path is a separate concern tracked in #28817.

### Test

The packing is exposed through `bun:internal-for-testing` (`dnsInternals.getaddrinfoInterleave`), following the `socket_body.rs` / `linear_fifo_testing.rs` pattern: the probe builds a synthetic getaddrinfo chain from a list of families, runs the real `process_results`, and walks the rebuilt `ai_next` chain (original index stashed in the port so stability is observable). 8 cases in `test/js/bun/dns/dns-prefetch.test.ts` cover the issue's exact shape, v4-first, uneven counts, single-family, and empty inputs.

Verified the test fails for the right reason: with the copy loop reverted to sequential order, the three mixed-family cases fail (the others are fixed points of interleaving by design). The slot formula was additionally checked exhaustively for every family sequence up to length 8 (bijection, alternating prefix, per-family stability).

Honest caveat on the end-to-end repro: the network I filed the issue from has since changed — IPv6 now fails in ~2 ms (unreachable) instead of blackholing, and fast-failing attempts always recovered via the refill-on-error path — so I could not re-measure the 70 s → sub-second improvement live. Deleting the fix and re-running the new tests is the deterministic evidence.