### PR TITLE
process.hrtime: coerce tuple elements with ToNumber instead of a raw int64 cast

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -928,8 +928,8 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionHRTime, (JSC::JSGlobalObject * globalOb
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     uint64_t time = Bun__readOriginTimer(globalObject->bunVM());
-    int64_t seconds = static_cast<int64_t>(time / 1000000000);
-    int64_t nanoseconds = time % 1000000000;
+    double seconds = static_cast<double>(time / 1000000000);
+    double nanoseconds = static_cast<double>(time % 1000000000);
 
     auto arg0 = callFrame->argument(0);
     if (callFrame->argumentCount() > 0 && !arg0.isUndefined()) {
@@ -944,14 +944,16 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionHRTime, (JSC::JSGlobalObject * globalOb
         JSValue relativeNanosecondsValue = relativeArray->getIndex(globalObject, 1);
         RETURN_IF_EXCEPTION(throwScope, {});
 
-        int64_t relativeSeconds = JSC__JSValue__toInt64(JSC::JSValue::encode(relativeSecondsValue));
-        int64_t relativeNanoseconds = JSC__JSValue__toInt64(JSC::JSValue::encode(relativeNanosecondsValue));
-        seconds -= relativeSeconds;
-        nanoseconds -= relativeNanoseconds;
-        if (nanoseconds < 0) {
-            seconds--;
-            nanoseconds += 1000000000;
-        }
+        // Node subtracts the tuple in JS, so the elements go through ToNumber and
+        // non-numeric ones propagate NaN rather than reaching an int64 conversion.
+        double relativeSeconds = relativeSecondsValue.toNumber(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        double relativeNanoseconds = relativeNanosecondsValue.toNumber(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+
+        bool needsBorrow = nanoseconds < relativeNanoseconds;
+        seconds = needsBorrow ? seconds - relativeSeconds - 1 : seconds - relativeSeconds;
+        nanoseconds = needsBorrow ? nanoseconds + 1000000000 - relativeNanoseconds : nanoseconds - relativeNanoseconds;
     }
 
     JSC::JSArray* array = nullptr;

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -137,6 +137,64 @@ it("process.hrtime.bigint()", () => {
   expect(end > start).toBe(true);
 });
 
+// Runs in a subprocess because passing a non-numeric element used to trip an
+// assertion in the int64 conversion, which aborts assert-enabled builds.
+it("process.hrtime() coerces tuple elements with ToNumber like node", async () => {
+  const fixture = /* js */ `
+    const classify = v => {
+      if (typeof v !== "number") return typeof v;
+      if (Number.isNaN(v)) return "NaN";
+      if (!Number.isFinite(v)) return String(v);
+      if (!Number.isInteger(v)) return "fraction:" + Math.abs(v % 1);
+      return v < 0 ? "negative" : "integer";
+    };
+    const probe = time => {
+      try {
+        return process.hrtime(time).map(classify);
+      } catch (e) {
+        return e.name;
+      }
+    };
+    console.log(
+      JSON.stringify({
+        strings: probe(["a", "b"]),
+        objects: probe([{}, {}]),
+        sparse: probe(new Array(2)),
+        undefineds: probe([undefined, undefined]),
+        nulls: probe([null, null]),
+        numericStrings: probe(["0", "0"]),
+        fractions: probe([-1, 0.5]),
+        bigints: probe([1n, 2n]),
+        symbols: probe([Symbol("x"), 0]),
+      }),
+    );
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim() || stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
+      strings: ["NaN", "NaN"],
+      objects: ["NaN", "NaN"],
+      sparse: ["NaN", "NaN"],
+      undefineds: ["NaN", "NaN"],
+      nulls: ["integer", "integer"],
+      numericStrings: ["integer", "integer"],
+      fractions: ["integer", "fraction:0.5"],
+      bigints: "TypeError",
+      symbols: "TypeError",
+    }),
+    exitCode: 0,
+  });
+});
+
 it("process.release", () => {
   expect(process.release.name).toBe("node");
   const platform = process.platform == "win32" ? "windows" : process.platform;


### PR DESCRIPTION
### Repro

```js
process.hrtime(["a", "b"]);
```

```
ASSERTION FAILED: value.isHeapBigInt() || value.isNumber()
src/jsc/bindings/bindings.cpp(4237) : int64_t JSC__JSValue__toInt64(JSC::EncodedJSValue)
```

On release builds there is no abort, just wrong numbers:

```console
$ bun -e 'console.log(process.hrtime(["a", "b"]))'
[ 9223372036854776000, -9223372035842194000 ]
# node: [ NaN, NaN ]
```

### Cause

`Process_functionHRTime` read the two tuple elements and handed them straight to
`JSC__JSValue__toInt64`, which asserts `value.isHeapBigInt() || value.isNumber()`
and otherwise reinterprets the value as a double. Anything that is not already a
number or a BigInt (string, object, `undefined`, `null`, boolean, symbol, a hole in
a sparse array) reached that conversion unvalidated.

Node does the subtraction in JS, so each element goes through `ToNumber`:

```js
const needsBorrow = nsec < time[1];
return [
  needsBorrow ? sec - time[0] - 1 : sec - time[0],
  needsBorrow ? nsec + 1e9 - time[1] : nsec - time[1],
];
```

That is why node returns `[NaN, NaN]` for `["a", "b"]`, accepts `["0", "0"]`, and
keeps the fractional part of `[1.5, 2.5]`. Bun's int64 cast got all three wrong,
and `[null, null]` too.

### Fix

Coerce both elements with `toNumber()` (with the matching exception checks) and
do the subtraction in doubles, mirroring node's expression including the borrow.
Symbols and BigInts now throw `TypeError` as they do in node, instead of
asserting or silently converting.

### Verification

`test/js/node/process/process.test.js` grows a case that classifies both slots of
the returned tuple for each input shape. It runs in a subprocess so the abort on
assert-enabled builds shows up as a missing stdout rather than killing the test
runner.

Before (on `main`, every row wrong), after (matches node):

| `time` | before | after / node |
| --- | --- | --- |
| `["a", "b"]` | `[9223372036854776000, -9223372035842194000]` | `[NaN, NaN]` |
| `[{}, {}]` | garbage | `[NaN, NaN]` |
| `new Array(2)` | garbage | `[NaN, NaN]` |
| `[undefined, undefined]` | garbage | `[NaN, NaN]` |
| `[null, null]` | garbage | integer tuple |
| `["0", "0"]` | garbage | integer tuple |
| `[-1, 0.5]` | fraction truncated | fraction kept |
| `[1n, 2n]` | silently converted | `TypeError` |
| `[Symbol(), 0]` | assertion / garbage | `TypeError` |

<details>
<summary>Side-by-side against node after the fix</summary>

Every difference that remains is in the seconds slot and comes from Bun's hrtime
origin being process start (`process.hrtime()[0] === 0`) while node's is boot time.
That is pre-existing and untouched here: `process.hrtime([0, 1e9 - 1])[0]` is `-1`
on `main` as well. The subtraction itself now matches node exactly.

</details>

Node's own `test/js/node/test/parallel/test-process-hrtime.js` and
`test-process-hrtime-bigint.js` still pass, along with
`process-array-accessor-crash.test.ts` and the console suite (`console.timeEnd`
is the main in-tree `process.hrtime` consumer).
