### PR TITLE
shell: make exit end the script instead of just the current command

### DIFF
--- a/src/runtime/shell/builtin/exit.rs
+++ b/src/runtime/shell/builtin/exit.rs
@@ -33,14 +33,22 @@ impl Exit {
                 return Self::fail(interp, cmd, b"exit: too many arguments\n");
             }
         };
-        // Intentional divergence from bash: this completes only the current
-        // Cmd rather than unwinding the whole script.
+        Self::request_exit(interp, cmd, code);
         Builtin::done(interp, cmd, code)
     }
 
+    /// Like bash, a bad argument still ends the script, with status 1.
     fn fail(interp: &Interpreter, cmd: NodeId, msg: &[u8]) -> Yield {
         Self::state_mut(interp, cmd).state = State::WaitingIo;
+        Self::request_exit(interp, cmd, 1);
         Builtin::write_failing_error(interp, cmd, msg, 1)
+    }
+
+    /// End the enclosing execution context with `code`. A subshell, command
+    /// substitution, or pipeline element owns its own `ShellExecEnv`, so
+    /// `exit` never escapes the context that ran it.
+    fn request_exit(interp: &Interpreter, cmd: NodeId, code: crate::shell::ExitCode) {
+        interp.as_cmd_mut(cmd).base.shell_mut().exit_requested = Some(code);
     }
 
     pub(crate) fn on_io_writer_chunk(

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -588,6 +588,7 @@ impl Interpreter {
                 __cwd: cwd_arr,
                 cwd_fd,
                 async_pids: SmolList::default(),
+                exit_requested: None,
             }),
             root_io: JsCell::new(IO {
                 stdin: crate::shell::io::InKind::Fd(stdin_reader),
@@ -1793,6 +1794,10 @@ pub struct ShellExecEnv {
     pub __cwd: Vec<u8>,
     pub cwd_fd: Fd,
     pub async_pids: SmolList<PidT, 4>,
+    /// Status the `exit` builtin asked this execution context to end with.
+    /// Nodes sharing this env stop running children. A subshell, command
+    /// substitution, or pipeline element gets its own env, which scopes `exit`.
+    pub exit_requested: Option<ExitCode>,
 }
 
 pub enum Bufio {
@@ -1958,6 +1963,8 @@ impl ShellExecEnv {
             __cwd: self.__cwd.clone(),
             cwd_fd: dupedfd,
             async_pids: SmolList::default(),
+            // Fresh execution context: `exit` neither carries in nor escapes.
+            exit_requested: None,
         });
         Ok(bun_core::heap::into_raw(duped))
     }

--- a/src/runtime/shell/states/Base.rs
+++ b/src/runtime/shell/states/Base.rs
@@ -4,7 +4,7 @@
 //! `parent: NodeId` and the `*mut ShellExecEnv` (which may be owned or
 //! borrowed — see field doc) are stored here.
 
-use crate::shell::interpreter::{NodeId, ShellExecEnv, StateKind};
+use crate::shell::interpreter::{ExitCode, NodeId, ShellExecEnv, StateKind};
 
 pub struct Base {
     pub kind: StateKind,
@@ -48,6 +48,13 @@ impl Base {
         // runs on one thread) and the trampoline only holds one `&mut` at a
         // time.
         unsafe { &mut *self.shell }
+    }
+
+    /// `Some(status)` once `exit` ran in this node's execution context: stop
+    /// walking children and unwind with it. See `ShellExecEnv::exit_requested`.
+    #[inline]
+    pub fn exit_requested(&self) -> Option<ExitCode> {
+        self.shell().exit_requested
     }
 }
 

--- a/src/runtime/shell/states/Binary.rs
+++ b/src/runtime/shell/states/Binary.rs
@@ -45,6 +45,12 @@ impl Binary {
         };
         let n = node.get();
 
+        // Checked before the short-circuit below: `exit 0 && echo hi` must not
+        // run the right-hand side even though the left side succeeded.
+        if let Some(code) = interp.as_binary(this).base.exit_requested() {
+            return interp.child_done(parent, this, code);
+        }
+
         if let Some(right) = right_exit {
             return interp.child_done(parent, this, right);
         }

--- a/src/runtime/shell/states/If.rs
+++ b/src/runtime/shell/states/If.rs
@@ -78,6 +78,12 @@ impl If {
 
     pub fn next(interp: &Interpreter, this: NodeId) -> Yield {
         let parent = interp.as_if(this).base.parent;
+        // A Pipeline spawns an If directly into its own env, with no Stmt in
+        // between to report the status, so the `Action::Done(0)` arms below
+        // would swallow it: `echo hi | if exit 5; then echo t; fi` exits 5.
+        if let Some(code) = interp.as_if(this).base.exit_requested() {
+            return interp.child_done(parent, this, code);
+        }
         loop {
             // Read/mutate `state` via a short-lived borrow, decide an action,
             // then drop the borrow before calling back into `interp`.

--- a/src/runtime/shell/states/Stmt.rs
+++ b/src/runtime/shell/states/Stmt.rs
@@ -58,6 +58,12 @@ impl Stmt {
                 me.base.shell,
             )
         };
+        // Every command in a script body or an `if` branch is spawned as a
+        // Stmt, so refusing to run one here is what unwinds the enclosing list.
+        // `Binary` spawns its right side directly, and checks separately.
+        if let Some(code) = interp.as_stmt(this).base.exit_requested() {
+            return interp.child_done(parent, this, code);
+        }
         if idx >= len {
             return interp.child_done(parent, this, last.unwrap_or(0));
         }

--- a/src/runtime/shell/states/Stmt.rs
+++ b/src/runtime/shell/states/Stmt.rs
@@ -59,8 +59,8 @@ impl Stmt {
             )
         };
         // Every command in a script body or an `if` branch is spawned as a
-        // Stmt, so refusing to run one here is what unwinds the enclosing list.
-        // `Binary` spawns its right side directly, and checks separately.
+        // Stmt, so refusing to run one here stops the enclosing list. `Binary`
+        // and `If` do not go through a Stmt, and check for themselves.
         if let Some(code) = interp.as_stmt(this).base.exit_requested() {
             return interp.child_done(parent, this, code);
         }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -2644,12 +2644,10 @@ describe("subshell", () => {
     // test_oE 'effect of subshell'
     TestBuilder.command /* sh */ `
   a=1
-  # (a=2; echo $a; exit; echo not reached)
-  # NOTE: We actually implemented exit wrong so changing this for now until we fix it
-  (a=2; echo $a; exit; echo reached)
+  (a=2; echo $a; exit; echo not reached)
   echo $a
   `
-      .stdout("2\nreached\n1\n")
+      .stdout("2\n1\n")
       .runAsTest("effect of subshell");
 
     // test_x -e 23 'exit status of subshell'

--- a/test/js/bun/shell/commands/exit.test.ts
+++ b/test/js/bun/shell/commands/exit.test.ts
@@ -17,4 +17,87 @@ describe("exit", async () => {
 
   // prettier-ignore
   TestBuilder.command`exit abc`.exitCode(1).stderr("exit: numeric argument required\n").runAsTest("numeric argument required");
+
+  describe("ends the script", async () => {
+    TestBuilder.command`echo start; exit 5; echo never`
+      .exitCode(5)
+      .stdout("start\n")
+      .runAsTest("skips the statements after it");
+
+    TestBuilder.command`exit 1; exit 2`.exitCode(1).runAsTest("the first exit wins");
+
+    // Not short-circuiting on a status: `exit 0` ends an && chain and
+    // `exit 5` ends an || chain, where the status alone would keep going.
+    TestBuilder.command`exit 0 && echo never`.exitCode(0).stdout("").runAsTest("exit 0 ends an && chain");
+
+    TestBuilder.command`exit 5 || echo never`.exitCode(5).stdout("").runAsTest("exit 5 ends an || chain");
+
+    TestBuilder.command`false || exit 3; echo never`
+      .exitCode(3)
+      .stdout("")
+      .runAsTest("from the right side of ||");
+
+    TestBuilder.command`if true; then exit 7; echo never; fi; echo never2`
+      .exitCode(7)
+      .stdout("")
+      .runAsTest("from an if body");
+
+    TestBuilder.command`if exit 5; then echo t; else echo f; fi`
+      .exitCode(5)
+      .stdout("")
+      .runAsTest("from an if condition");
+
+    // A compound command may be followed by another expression in the same
+    // statement (`fi` is not a statement terminator).
+    TestBuilder.command`if true; then exit 5; fi echo never`
+      .exitCode(5)
+      .stdout("")
+      .runAsTest("from a compound command sharing a statement");
+
+    TestBuilder.command`exit abc; echo never`
+      .exitCode(1)
+      .stdout("")
+      .stderr("exit: numeric argument required\n")
+      .runAsTest("on a numeric argument error");
+
+    TestBuilder.command`exit 3 5; echo never`
+      .exitCode(1)
+      .stdout("")
+      .stderr("exit: too many arguments\n")
+      .runAsTest("on too many arguments");
+  });
+
+  // `exit` ends the execution context that ran it, not the whole interpreter:
+  // a subshell, command substitution, or pipeline element is its own context.
+  describe("stays inside its execution context", async () => {
+    TestBuilder.command`(echo sub; exit 6; echo never); echo after`
+      .exitCode(0)
+      .stdout("sub\nafter\n")
+      .runAsTest("subshell");
+
+    TestBuilder.command`(echo sub; exit 6; echo never) && echo never2`
+      .exitCode(6)
+      .stdout("sub\n")
+      .runAsTest("subshell status reaches the parent");
+
+    TestBuilder.command`echo cs=$(echo sub; exit 4; echo never); echo after`
+      .exitCode(0)
+      .stdout("cs=sub\nafter\n")
+      .runAsTest("command substitution");
+
+    TestBuilder.command`echo a; exit 5 | cat; echo b`
+      .exitCode(0)
+      .stdout("a\nb\n")
+      .runAsTest("pipeline element");
+
+    TestBuilder.command`(if true; then exit 2; fi; echo never); echo after`
+      .exitCode(0)
+      .stdout("after\n")
+      .runAsTest("if body nested in a subshell");
+
+    TestBuilder.command`if true; then (exit 2); fi; echo after`
+      .exitCode(0)
+      .stdout("after\n")
+      .runAsTest("subshell nested in an if body");
+  });
 });

--- a/test/js/bun/shell/commands/exit.test.ts
+++ b/test/js/bun/shell/commands/exit.test.ts
@@ -38,6 +38,13 @@ echo "Bad Bun!"
       .stdout("Good Bun!\n")
       .runAsTest("a bare exit on its own line");
 
+    // Bare `exit` should report the last command's status. That needs the
+    // shell to track it, which it does not do yet, so this exits 0 today.
+    TestBuilder.command`false; exit`
+      .exitCode(1)
+      .todo("the shell does not track the last command's status yet")
+      .runAsTest("a bare exit reports the last command's status");
+
     // Not short-circuiting on a status: `exit 0` ends an && chain and
     // `exit 5` ends an || chain, where the status alone would keep going.
     TestBuilder.command`exit 0 && echo never`.exitCode(0).stdout("").runAsTest("exit 0 ends an && chain");
@@ -55,6 +62,18 @@ echo "Bad Bun!"
       .exitCode(5)
       .stdout("")
       .runAsTest("from an if condition");
+
+    // A failed condition would normally pick the else arm, and a failed elif
+    // condition the next one. No command in any arm may run after `exit`.
+    TestBuilder.command`if exit 5; then echo t1; echo t2; else echo f1; echo f2; fi`
+      .exitCode(5)
+      .stdout("")
+      .runAsTest("from an if condition, with multi-statement arms");
+
+    TestBuilder.command`if exit 5; then echo t; elif echo e; then echo t2; else echo f; fi`
+      .exitCode(5)
+      .stdout("")
+      .runAsTest("from an if condition, skipping the elif condition");
 
     // A compound command may be followed by another expression in the same
     // statement (`fi` is not a statement terminator).

--- a/test/js/bun/shell/commands/exit.test.ts
+++ b/test/js/bun/shell/commands/exit.test.ts
@@ -115,6 +115,18 @@ echo "Bad Bun!"
 
     TestBuilder.command`echo a; exit 5 | cat; echo b`.exitCode(0).stdout("a\nb\n").runAsTest("pipeline element");
 
+    // A pipeline spawns an if-clause straight into its own env, with no
+    // statement in between, so the status has to come from the if itself.
+    TestBuilder.command`echo hi | if exit 5; then echo t; fi`
+      .exitCode(5)
+      .stdout("")
+      .runAsTest("if-clause as a pipeline element");
+
+    TestBuilder.command`echo hi | if false; then echo x; elif exit 5; then echo y; fi`
+      .exitCode(5)
+      .stdout("")
+      .runAsTest("if-clause with an elif as a pipeline element");
+
     TestBuilder.command`(if true; then exit 2; fi; echo never); echo after`
       .exitCode(0)
       .stdout("after\n")

--- a/test/js/bun/shell/commands/exit.test.ts
+++ b/test/js/bun/shell/commands/exit.test.ts
@@ -26,6 +26,18 @@ describe("exit", async () => {
 
     TestBuilder.command`exit 1; exit 2`.exitCode(1).runAsTest("the first exit wins");
 
+    // https://github.com/oven-sh/bun/issues/20368
+    TestBuilder.command /* sh */ `
+echo "Good Bun!"
+exit
+exit 0
+exit 1
+echo "Bad Bun!"
+`
+      .exitCode(0)
+      .stdout("Good Bun!\n")
+      .runAsTest("a bare exit on its own line");
+
     // Not short-circuiting on a status: `exit 0` ends an && chain and
     // `exit 5` ends an || chain, where the status alone would keep going.
     TestBuilder.command`exit 0 && echo never`.exitCode(0).stdout("").runAsTest("exit 0 ends an && chain");

--- a/test/js/bun/shell/commands/exit.test.ts
+++ b/test/js/bun/shell/commands/exit.test.ts
@@ -32,10 +32,7 @@ describe("exit", async () => {
 
     TestBuilder.command`exit 5 || echo never`.exitCode(5).stdout("").runAsTest("exit 5 ends an || chain");
 
-    TestBuilder.command`false || exit 3; echo never`
-      .exitCode(3)
-      .stdout("")
-      .runAsTest("from the right side of ||");
+    TestBuilder.command`false || exit 3; echo never`.exitCode(3).stdout("").runAsTest("from the right side of ||");
 
     TestBuilder.command`if true; then exit 7; echo never; fi; echo never2`
       .exitCode(7)
@@ -85,10 +82,7 @@ describe("exit", async () => {
       .stdout("cs=sub\nafter\n")
       .runAsTest("command substitution");
 
-    TestBuilder.command`echo a; exit 5 | cat; echo b`
-      .exitCode(0)
-      .stdout("a\nb\n")
-      .runAsTest("pipeline element");
+    TestBuilder.command`echo a; exit 5 | cat; echo b`.exitCode(0).stdout("a\nb\n").runAsTest("pipeline element");
 
     TestBuilder.command`(if true; then exit 2; fi; echo never); echo after`
       .exitCode(0)


### PR DESCRIPTION
Fixes #20368

### What does this PR do?

#### Repro

```js
import { $ } from "bun";

const r = await $`echo start; exit 5; echo never`.nothrow();
// bash: stdout "start\n", exit 5
// bun:  stdout "start\nnever\n", exit 0
```

`exit` did not stop the script, and the reported status came from whatever command happened to run last. `exit` mid-script is the standard early return in shell (`cmd || exit 1` guards), so code ported into `Bun.$` kept running past its guards, and the wrong status defeated `.nothrow()` exit-code checks.

#### Cause

The `exit` builtin completed only its own `Cmd` and returned the status to its parent, like any other builtin. Nothing told the enclosing `Stmt`/`Script` to stop. `src/runtime/shell/builtin/exit.rs` carried a `TODO(port)` about this ("bash `exit` should unwind the whole script... the Zig version sets a flag on the interpreter"), which #31783 reworded into "intentional divergence from bash" without implementing it.

#### Fix

Record the requested status on the `ShellExecEnv` that the `exit` builtin shares with its script. `ShellExecEnv` is duped for each subshell, command substitution, and pipeline element, which are the contexts bash forks, so the scoping falls out for free: `exit` ends the context that ran it and no more.

Three state nodes consume the flag:

- `Stmt::next` refuses to run a command once it is set. Every command in a script body or an `if` arm is spawned as a `Stmt`, so this one check stops both.
- `Binary::next` checks before its short-circuit, so `exit 0 && echo hi` stops even though the left side succeeded.
- `If::next` checks because a pipeline spawns an if-clause straight into its own env, with no `Stmt` in between to carry the status out. A failed condition with no `else` arm reports a hardcoded `Done(0)`, which would otherwise swallow it (`echo hi | if exit 5; then echo t; fi`).

`Script` needs no check of its own: it only ever spawns `Stmt`s, which refuse. Confirmed by ablation, where removing any of the three above breaks tests and adding a fourth in `Script::child_done` breaks none.

Matching bash, a bad argument (`exit abc`, `exit 1 2`) also ends the script, with the status it already used.

### How did you verify your code works?

Differential run against bash, 19 `exit` scenarios: 8/19 matched before, 17/19 after.

The two that still differ are separate missing features, not this bug:

- `false; exit` (bare `exit` should reuse `$?`) and `echo $?` need `$?`, which does not exist in Bun's shell yet. #33274 implements it; once both land, bare `exit` can read `last_exit_code` and that case closes too.
- `{ ...; }` brace grouping is unimplemented (`command not found: {`) and is already marked `.todo` in the suite.

<details>
<summary>Before / after vs bash</summary>

```
                                              before             after              bash
echo start; exit 5; echo never             0 "start\nnever\n"  5 "start\n"        5 "start\n"
exit 0 && echo x                           0 "x\n"             0 ""               0 ""
false || exit 3; echo never                0 "never\n"         3 ""               3 ""
if true; then exit 7; fi; echo never       0 "never\n"         7 ""               7 ""
if exit 5; then echo t; else echo f; fi    0 "f\n"             5 ""               5 ""
exit 1; exit 2                             2 ""                1 ""               1 ""
echo a; exit; echo b                       0 "a\nb\n"          0 "a\n"            0 "a\n"
(exit 6; echo inner); echo after           0 "inner\nafter\n"  0 "after\n"        0 "after\n"
echo cs=$(exit 4; echo inner); echo after  0 "cs=inner\n..."   0 "cs=\nafter\n"   0 "cs=\nafter\n"
echo a; exit 5 | cat; echo b               0 "a\nb\n"          0 "a\nb\n"         0 "a\nb\n"
```

</details>

22 tests added to `test/js/bun/shell/commands/exit.test.ts`: the statements after `exit` are skipped, `&&`/`||`/`if`-body/`if`-condition all unwind, argument errors still end the script, and the negative contract that a subshell, command substitution, and pipeline element each contain their own `exit`. 19 of them fail on `main`.

`test/js/bun/shell/bunshell.test.ts` had the upstream `effect of subshell` case weakened to assert the buggy output:

```js
# (a=2; echo $a; exit; echo not reached)
# NOTE: We actually implemented exit wrong so changing this for now until we fix it
(a=2; echo $a; exit; echo reached)
```

Restored to its original form, asserting `2\n1\n`.

Whole `test/js/bun/shell/` suite: no new failures (the pre-existing fd-leak timeouts and root-only `ls` permission cases are unchanged).



