### PR TITLE
child_process: emit 'disconnect' before 'exit' for children with an IPC channel

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1102,6 +1102,9 @@ class ChildProcess extends EventEmitter {
   #handle;
   #closesNeeded = 1;
   #closesGot = 0;
+  #hasIpc = false;
+  #disconnectEmitted = false;
+  #pendingExit;
 
   signalCode = null;
   exitCode = null;
@@ -1118,6 +1121,15 @@ class ChildProcess extends EventEmitter {
   }
 
   #handleOnExit(exitCode, signalCode, err) {
+    // 'disconnect' precedes 'exit' in Node; the native side always closes the channel on exit.
+    if (this.#hasIpc && !this.#disconnectEmitted) {
+      this.#pendingExit = [exitCode, signalCode, err];
+      return;
+    }
+    this.#emitExit(exitCode, signalCode, err);
+  }
+
+  #emitExit(exitCode, signalCode, err) {
     if (signalCode) {
       this.signalCode = signalCode;
     } else {
@@ -1451,6 +1463,7 @@ class ChildProcess extends EventEmitter {
       });
 
       if (has_ipc) {
+        this.#hasIpc = true;
         this.send = this.#send;
         this.disconnect = this.#disconnect;
         this.channel = new Control();
@@ -1549,7 +1562,19 @@ class ChildProcess extends EventEmitter {
       return;
     }
     $assert(!this.connected);
-    process.nextTick(() => this.emit("disconnect"));
+    // The flag flips in the same tick that emits, so a #handleOnExit tick queued
+    // ahead of this one still defers and is flushed by the tick below.
+    process.nextTick(() => {
+      this.#disconnectEmitted = true;
+      this.emit("disconnect");
+    });
+    process.nextTick(() => {
+      const pendingExit = this.#pendingExit;
+      if (pendingExit !== undefined) {
+        this.#pendingExit = undefined;
+        this.#emitExit(pendingExit[0], pendingExit[1], pendingExit[2]);
+      }
+    });
     process.nextTick(() => this.#maybeClose());
   }
   #disconnect() {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -753,6 +753,43 @@ it("should call close and exit before process exits", async () => {
   expect(await proc.exited).toBe(0);
 });
 
+it("emits 'disconnect' before 'exit' when the child has an IPC channel", async () => {
+  using dir = tempDir("child-process-ipc-order", {
+    "parent.js": `
+      const { fork } = require("node:child_process");
+      const path = require("node:path");
+
+      const order = [];
+      const child = fork(path.join(__dirname, "child.js"));
+
+      child.on("message", () => {
+        // The child calls process.exit() right after sending this. Block the
+        // loop so the channel EOF and the process exit are both observed in
+        // the same poll batch, which is the interleaving that raced.
+        Bun.sleepSync(100);
+      });
+      child.on("disconnect", () => order.push("disconnect"));
+      child.on("exit", code => order.push("exit:" + code));
+      // 'close' only fires once both of the above have been emitted.
+      child.on("close", () => console.log(order.join(",")));
+    `,
+    "child.js": `
+      process.send("bye");
+      process.exit(3);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "disconnect,exit:3", stderr: "", exitCode: 0 });
+});
+
 it("it accepts stdio passthrough", async () => {
   const package_dir = tmpdirSync();
 

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -557,6 +557,54 @@ if (cluster.isPrimary) {
   expect(exitCode).toBe(0);
 });
 
+test("worker 'disconnect' is emitted before 'exit'", async () => {
+  const dir = tempDirWithFiles("bun-test", {
+    "index.js": `
+const cluster = require("node:cluster");
+
+if (cluster.isPrimary) {
+  const order = [];
+  let pending = 2;
+  const done = () => {
+    if (--pending === 0) {
+      console.log(order.join(","));
+      process.exit(0);
+    }
+  };
+
+  const worker = cluster.fork();
+  worker.on("message", () => {
+    // The worker calls process.exit() right after sending this. Block the loop
+    // so the IPC channel EOF and the worker's exit are both observed in the
+    // same poll batch, which is the interleaving that raced.
+    Bun.sleepSync(100);
+  });
+
+  cluster.on("disconnect", () => {
+    order.push("disconnect");
+    done();
+  });
+  cluster.on("exit", (_worker, code) => {
+    order.push("exit:" + code);
+    done();
+  });
+} else {
+  process.send("bye");
+  process.exit(3);
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), joinP(dir, "index.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "disconnect,exit:3", stderr: "", exitCode: 0 });
+});
+
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {
   // `kHandle` is a private symbol that only `cluster.fork()` sets, so a
   // `cluster.Worker({ process })` built around a plain object (how Node's own


### PR DESCRIPTION
> **Superseded by #39479.** That PR fixes the same ordering bug where it originates (`src/runtime/ipc.rs` reports a peer-initiated channel close via a deferred task, so it lands after an exit dispatched in the same poll batch). Fixing it there also corrects `Bun.spawn`'s `onExit`/`onDisconnect` order, which this PR does not touch, and it keeps Node's exit-first order in the case where a grandchild still holds the channel open, which a JS-side hold would invert.
>
> Verified on #39479's branch (`e741ef7`): the two regression tests in this PR pass 3 of 3 with no `child_process.ts` change, and `Bun.spawn` goes from `onExit, onDisconnect` (released binary, 3 of 3) to `onDisconnect, onExit` (3 of 3). Details in [this comment](https://github.com/oven-sh/bun/pull/39479#issuecomment-5322912642).
>
> Leaving this open as a fallback only. If #39479 lands, the `src/` change here should be dropped; the two tests (`process.exit()` through `fork()` and through `node:cluster`) are still valid additional coverage and pass on that branch.

<details>
<summary>Original description</summary>

`node:cluster` can emit a worker's `'exit'` event before `'disconnect'`. Node documents (and always produces) the opposite order, and primary-side bookkeeping written against it -- respawn logic, `exitedAfterDisconnect` checks, draining state -- sees the finalize step before the cleanup step.

It is not cluster-specific: `node:cluster` just forwards `ChildProcess`'s events, and plain `child_process.fork()` races the same way.

### Repro

```js
// child.js
process.send("bye");
process.exit(3);
```

```js
// parent.js
const { fork } = require("node:child_process");
const order = [];
const child = fork("./child.js");
child.on("message", () => Bun.sleepSync(100)); // child is already exiting
child.on("disconnect", () => order.push("disconnect"));
child.on("exit", code => order.push("exit:" + code));
child.on("close", () => console.log(order.join(",")));
```

```
node:  disconnect,exit:3
bun:   exit:3,disconnect
```

Without the `sleepSync` the outcome is racy (roughly 1 run in 3 on an idle machine, more under load). Blocking the loop for a moment after the child's last message is what makes it deterministic: it guarantees the channel EOF and the process exit are observed in the same poll batch.

### Cause

The two notifications come from independent sources and take different routes to JS:

- process exit: pidfd/kqueue poll -> `onExit` -> `process.nextTick(...)` -> `'exit'`
- channel close: socket EOF -> close task -> after-close task -> `onDisconnect` -> `process.nextTick(...)` -> `'disconnect'`

When both land in the same poll batch, the exit notification reaches the nextTick queue first and wins, because the disconnect one still has two event-loop task hops to go. When the EOF happens to land in an earlier loop iteration, the order comes out right. Node has no such race: it reads the channel's EOF (the kernel closes the child's fds before it signals the parent) and drains the nextTick queue before it processes the exit event.

### Fix

`ChildProcess` holds `'exit'` back until the channel has disconnected, which is the order Node produces. `Subprocess::on_process_exit` always closes the IPC channel, so the disconnect notification is guaranteed to arrive after the process exits -- there is nothing to wait indefinitely for. Children without an IPC channel are unaffected.

### Verification

- New tests in `test/js/node/cluster.test.ts` and `test/js/node/child_process/child_process.test.ts` assert the order; both print `exit:3,disconnect` on `main` and `disconnect,exit:3` with the fix.
- `test/js/node/test/parallel/test-cluster-*.js` (58 files): all pass.
- `test/js/node/test/parallel/test-child-process-*.js`: no new failures (`test-child-process-emfile` and `test-child-process-windows-hide` already fail on `main`).
- `test/js/node/child_process/*`, `test/js/bun/spawn/spawn.ipc*`: pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts test/js/node/cluster.test.ts

<!-- robobun:evidence:end -->

</details>
