### PR TITLE
Exit 13 on an unsettled top-level await instead of hanging

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1041,6 +1041,24 @@ impl VirtualMachine {
             || !el.next_immediate_tasks.is_empty()
     }
 
+    /// Whether anything could still wake the loop and settle a pending module
+    /// promise. Unlike `is_event_loop_alive`, ignores `unhandled_error_counter`
+    /// so ref'd work (e.g. a timer that will resolve the await) isn't miscounted.
+    pub fn has_pending_loop_work(&self) -> bool {
+        let el = self.event_loop_shared();
+        let active = self
+            .platform_loop_opt()
+            .map(|h| h.is_active())
+            .unwrap_or(false);
+        active
+            || self.active_tasks > 0
+            || el.tasks.readable_length() > 0
+            || el.has_pending_refs()
+            || !el.concurrent_tasks.is_empty()
+            || !el.immediate_tasks.is_empty()
+            || !el.next_immediate_tasks.is_empty()
+    }
+
     pub fn wakeup(&mut self) {
         self.event_loop_mut().wakeup();
     }
@@ -2232,6 +2250,77 @@ impl VirtualMachine {
         self.event_loop_mut().wait_for_promise(promise);
     }
 
+    /// Like [`wait_for_promise`](Self::wait_for_promise) but returns (promise
+    /// possibly still `Pending`) once nothing could settle it
+    /// (`!has_pending_loop_work`), instead of spinning on an unsettled TLA.
+    pub fn wait_for_module_promise(&mut self, promise: *mut JSInternalPromise) {
+        // Read as a raw ptr (Copy) so it doesn't borrow `self` across the
+        // `&mut self` calls (`tick`, `auto_tick`) below.
+        let jsc_vm = self.jsc_vm;
+        // SAFETY: `promise` is a live JSC heap cell tracked by the VM (caller
+        // just obtained it from `reload_entry_point`).
+        while crate::JSPromise::status_ptr(promise) == crate::js_promise::Status::Pending {
+            // SAFETY: `jsc_vm` is the live per-thread JSC VM (set in `init`).
+            if unsafe { &*jsc_vm }.execution_forbidden() {
+                return;
+            }
+            self.event_loop_mut().tick();
+            if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending {
+                return;
+            }
+            // Nothing left that could settle the promise: return instead of
+            // busy-spinning (see `has_pending_loop_work`).
+            if !self.has_pending_loop_work() {
+                return;
+            }
+            self.auto_tick();
+        }
+    }
+
+    /// True when the entry module's evaluation promise is still pending, i.e.
+    /// (once the loop has drained) an unsettled top-level await.
+    pub fn entry_point_evaluation_is_pending(&self) -> bool {
+        match self.pending_internal_promise {
+            Some(p) => crate::JSPromise::status_ptr(p) == crate::js_promise::Status::Pending,
+            None => false,
+        }
+    }
+
+    /// Print Node's "Detected unsettled top-level await" warning to stderr,
+    /// naming the stalled module(s) from the JSC module registry (falling back
+    /// to the entry path in eval mode).
+    pub fn report_unsettled_top_level_await(&self) {
+        unsafe extern "C" {
+            fn Bun__findStalledTopLevelAwait(global: *mut JSGlobalObject) -> bun_core::String;
+        }
+        // SAFETY: `self.global` is the live per-thread global object.
+        let stalled = unsafe { Bun__findStalledTopLevelAwait(self.global) };
+        let stalled_utf8 = stalled.to_utf8();
+        let slice = stalled_utf8.slice();
+        let warn = |module: &[u8]| {
+            bun_core::pretty_errorln!(
+                "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await at <b>{}<r>",
+                bstr::BStr::new(module),
+            );
+        };
+        if !slice.is_empty() {
+            // The C++ helper NUL-joins multiple stalled specifiers (NUL can't
+            // appear in a path); print one warning per module, matching Node.
+            for module in slice.split(|&b| b == b'\0') {
+                warn(module);
+            }
+        } else if !self.main().is_empty() {
+            warn(self.main());
+        } else {
+            bun_core::pretty_errorln!(
+                "<r><yellow>Warning<r><d>:<r> Detected unsettled top-level await"
+            );
+        }
+        bun_core::Output::flush();
+        drop(stalled_utf8);
+        stalled.deref();
+    }
+
     /// `eventLoop().autoTick()` — dispatched through the runtime hook
     /// (needs `Timer::All` for the poll timeout).
     #[inline]
@@ -2434,7 +2523,9 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            self.wait_for_promise(jsc::AnyPromise::Internal(promise));
+            // Returns with the promise still pending if the loop drains, so the
+            // caller can detect an unsettled top-level await (warn + exit 13).
+            self.wait_for_module_promise(promise);
         }
 
         Ok(self.pending_internal_promise.unwrap_or(promise))

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -38,6 +38,7 @@
 #include "JavaScriptCore/JSModuleLoader.h"
 #include "JavaScriptCore/CyclicModuleRecord.h"
 #include "JavaScriptCore/ModuleRegistryEntry.h"
+#include <wtf/text/StringBuilder.h>
 #include "JavaScriptCore/JSModuleNamespaceObject.h"
 #include "JavaScriptCore/JSModuleNamespaceObjectInlines.h"
 #include "JavaScriptCore/JSModuleRecord.h"
@@ -717,6 +718,35 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
         return cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluated && !cyclic->evaluationError();
     // SyntheticModuleRecord is "evaluated" once linked (it has an environment).
     return record->moduleEnvironmentMayBeNull() != nullptr;
+}
+
+// Module specifiers suspended on their own top-level await (EvaluatingAsync,
+// syntactic TLA, no pending async dependency), NUL-joined, for the
+// unsettled-TLA warning. Empty BunString when nothing is stalled.
+extern "C" BunString Bun__findStalledTopLevelAwait(JSC::JSGlobalObject* globalObject)
+{
+    WTF::StringBuilder builder;
+    for (auto& [key, entry] : globalObject->moduleLoader()->moduleMap()) {
+        if (!key.first || !entry)
+            continue;
+        auto* record = entry->record();
+        if (!record || !record->hasTLA())
+            continue;
+        auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record);
+        if (!cyclic || cyclic->status() != JSC::CyclicModuleRecord::Status::EvaluatingAsync)
+            continue;
+        // EvaluatingAsync only because it awaits a dependency: that dependency
+        // is the real culprit, skip this one.
+        if (auto pending = record->pendingAsyncDependencies(); pending && *pending > 0)
+            continue;
+        // NUL separator: it cannot appear in a module specifier/path.
+        if (!builder.isEmpty())
+            builder.append('\0');
+        builder.append(String { key.first });
+    }
+    if (builder.isEmpty())
+        return BunStringEmpty;
+    return Bun::toStringRef(builder.toString());
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionEsmNamespaceForCjs, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1581,54 +1581,78 @@ impl Run {
                 vm.auto_tick_active();
             }
 
-            if ctx.runtime_options.eval.eval_and_print {
-                let to_print: JSValue = 'brk: {
-                    let result = vm
-                        .entry_point_result
-                        .value
-                        .get()
-                        .unwrap_or(JSValue::UNDEFINED);
-                    if let Some(promise) = result.as_any_promise() {
-                        match promise.status() {
-                            PromiseStatus::Pending => {
-                                // C-ABI shims are emitted by
-                                // `generate-host-exports.ts` into
-                                // `crate::generated_host_exports` under their
-                                // link name (`Bun__on…EntryPointResult`).
-                                result.then2(
-                                    vm.global(),
-                                    JSValue::UNDEFINED,
-                                    crate::generated_host_exports::Bun__onResolveEntryPointResult,
-                                    crate::generated_host_exports::Bun__onRejectEntryPointResult,
-                                );
-                                vm.tick();
-                                vm.auto_tick_active();
-                                while vm.is_event_loop_alive() {
-                                    vm.tick();
-                                    vm.auto_tick_active();
-                                }
-                                break 'brk result;
-                            }
-                            _ => break 'brk promise.result(vm.jsc_vm()),
-                        }
-                    }
-                    result
-                };
-                // SAFETY: `vals[..1]` is the single stack `to_print`; null
-                // `ctype` routes to the VM's stdout/stderr default.
-                unsafe {
-                    bun_jsc::ConsoleObject::message_with_type_and_level(
-                        ::core::ptr::null_mut(),
-                        bun_jsc::ConsoleObject::MessageType::Log,
-                        bun_jsc::ConsoleObject::MessageLevel::Log,
-                        vm.global(),
-                        &raw const to_print,
-                        1,
-                    );
-                }
+            // A settled entry prints its `--print` value before `beforeExit`
+            // (Node's order: value then beforeExit output); a pending/rejected
+            // entry prints nothing (a bogus `Promise { <pending> }`; reported below).
+            let eval_and_print = ctx.runtime_options.eval.eval_and_print;
+            let printed = eval_and_print && entry_point_print_ok(vm);
+            if printed {
+                print_eval_result(vm);
             }
 
             vm.on_before_exit();
+
+            // A `beforeExit` handler may resolve the entry's await (a bare
+            // `resolve()` queues a microtask `is_event_loop_alive()` ignores);
+            // drain it, and re-run the loop if the resumed body schedules work.
+            while vm.entry_point_evaluation_is_pending() {
+                vm.tick();
+                if !vm.is_event_loop_alive() {
+                    break;
+                }
+                while vm.is_event_loop_alive() {
+                    vm.tick();
+                    vm.auto_tick_active();
+                }
+                vm.on_before_exit();
+            }
+
+            // A `beforeExit` handler that just resolved the TLA prints its value
+            // now (a still-pending/rejected entry is reported below instead).
+            if eval_and_print && !printed && entry_point_print_ok(vm) {
+                print_eval_result(vm);
+            }
+
+            // The entry promise is pre-marked handled, so report it here:
+            // pending (unsettled TLA) → exit 13; late-rejected (resumed body
+            // threw) → exit 1, gated so an initial-load rejection isn't redone.
+            if let Some(p) = vm.pending_internal_promise {
+                // SAFETY: `p` is a live JSC heap cell tracked by the VM.
+                match bun_jsc::JSPromise::status_ptr(p) {
+                    PromiseStatus::Pending => {
+                        vm.report_unsettled_top_level_await();
+                        if vm.exit_handler.exit_code == 0 {
+                            vm.exit_handler.exit_code = 13;
+                        }
+                    }
+                    PromiseStatus::Rejected
+                        if vm.pending_internal_promise_reported_at != vm.hot_reload_counter =>
+                    {
+                        vm.pending_internal_promise_reported_at = vm.hot_reload_counter;
+                        // `on_before_exit` set `exit_on_uncaught_exception`, which
+                        // hard-exits before a user `uncaughtException` handler;
+                        // clear it so the throw reaches it (Node: handler -> 0).
+                        vm.exit_on_uncaught_exception = false;
+                        // SAFETY: `p` is a live JSC heap cell; `vm.jsc_vm` set in `init`.
+                        let result = unsafe { &mut *p }.result(unsafe { &mut *vm.jsc_vm });
+                        let global = vm.global;
+                        // SAFETY: `global` valid for VM lifetime. `uncaught_exception`
+                        // runs a user handler (exit 0) and sets exit_code = 1 itself
+                        // when unhandled.
+                        let _ = vm.uncaught_exception(unsafe { &*global }, result, true);
+                        // SAFETY: `p` is a live JSC heap cell.
+                        unsafe { &mut *p }.set_handled();
+                    }
+                    _ => {}
+                }
+            }
+
+            // An `uncaughtException` handler above may have scheduled async work
+            // (e.g. a timer); drain it, mirroring the initial-load path.
+            while vm.is_event_loop_alive() {
+                vm.tick();
+                vm.auto_tick_active();
+            }
         }
 
         if log_has_msgs(vm) {
@@ -1655,6 +1679,61 @@ impl Run {
         crate::webcore::bake_response::fix_dead_code_elimination();
         bun_crash_handler::fix_dead_code_elimination();
         vm.global_exit();
+    }
+}
+
+/// Whether the entry module's `--print` value is ready to print: the entry
+/// promise is absent (e.g. patched runMain) or fulfilled. A pending (unsettled
+/// TLA) or rejected entry prints nothing; it is reported (exit 13 / 1) instead.
+fn entry_point_print_ok(vm: &VirtualMachine) -> bool {
+    vm.pending_internal_promise
+        .is_none_or(|p| bun_jsc::JSPromise::status_ptr(p) == PromiseStatus::Fulfilled)
+}
+
+/// Print the `--print`/`-p` eval result: the entry module's completion value,
+/// unwrapping the pipeline promise (draining the loop if it is still pending).
+fn print_eval_result(vm: &mut VirtualMachine) {
+    let to_print: JSValue = 'brk: {
+        let result = vm
+            .entry_point_result
+            .value
+            .get()
+            .unwrap_or(JSValue::UNDEFINED);
+        if let Some(promise) = result.as_any_promise() {
+            match promise.status() {
+                PromiseStatus::Pending => {
+                    // C-ABI shims are emitted by `generate-host-exports.ts` into
+                    // `crate::generated_host_exports` under their link name.
+                    result.then2(
+                        vm.global(),
+                        JSValue::UNDEFINED,
+                        crate::generated_host_exports::Bun__onResolveEntryPointResult,
+                        crate::generated_host_exports::Bun__onRejectEntryPointResult,
+                    );
+                    vm.tick();
+                    vm.auto_tick_active();
+                    while vm.is_event_loop_alive() {
+                        vm.tick();
+                        vm.auto_tick_active();
+                    }
+                    break 'brk result;
+                }
+                _ => break 'brk promise.result(vm.jsc_vm()),
+            }
+        }
+        result
+    };
+    // SAFETY: `vals[..1]` is the single stack `to_print`; null `ctype` routes
+    // to the VM's stdout/stderr default.
+    unsafe {
+        bun_jsc::ConsoleObject::message_with_type_and_level(
+            ::core::ptr::null_mut(),
+            bun_jsc::ConsoleObject::MessageType::Log,
+            bun_jsc::ConsoleObject::MessageLevel::Log,
+            vm.global(),
+            &raw const to_print,
+            1,
+        );
     }
 }
 

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+
+// These tests spawn bun concurrently; under debug+ASAN a spawn takes seconds
+// and contention pushes some past the 5s default, so use a generous per-test
+// timeout. SPAWN_TIMEOUT bounds the pre-fix hang (killed -> non-null signal).
+const SPAWN_TIMEOUT = 20_000;
+setDefaultTimeout(isDebug ? 60_000 : 30_000);
+
+// https://github.com/oven-sh/bun/issues/33283
+// Node warns and exits 13 on an unsettled entry top-level await instead of
+// hanging; the spawn `timeout` turns the pre-fix hang into a clean failure.
+
+async function run(files: Record<string, string>, entry: string) {
+  using dir = tempDir("unsettled-tla", { "package.json": "{}", ...files });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: SPAWN_TIMEOUT,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Hang guard: the process must exit on its own, not be killed by the spawn
+  // timeout (a reintroduced busy-spin would surface as a non-null signal here).
+  expect(proc.signalCode).toBeNull();
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("unsettled top-level await", () => {
+  test("await on a never-resolving promise exits 13", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `console.log("BEFORE");\nawait new Promise(() => {});\nconsole.log("AFTER");\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stdout).toBe("BEFORE\n");
+    expect(r.stderr).toContain("Detected unsettled top-level await");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test("dynamic-import top-level-await cycle exits 13", async () => {
+    const r = await run(
+      {
+        "a.mjs": `import "./b.mjs";\n`,
+        "b.mjs": `console.log("B_BEFORE");\nawait import("./a.mjs");\nconsole.log("B_AFTER");\n`,
+      },
+      "./a.mjs",
+    );
+    expect(r.stdout).toBe("B_BEFORE\n");
+    expect(r.stderr).toContain("Detected unsettled top-level await");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test("self-import via import.meta.url exits 13", async () => {
+    // `await import(import.meta.url)` awaits the entry's own evaluation
+    // promise: a spec-level deadlock, not a bun bug, but bun must detect it
+    // and exit 13 rather than hang.
+    const r = await run(
+      {
+        "entry.mjs": `console.log("BEFORE");\nawait import(import.meta.url);\nconsole.log("AFTER");\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stdout).toBe("BEFORE\n");
+    expect(r.stderr).toContain("Detected unsettled top-level await");
+    expect(r.stderr).toContain("entry.mjs");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test("await on an unref'd timer exits 13", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `await new Promise(r => setTimeout(r, 100000).unref());\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stderr).toContain("Detected unsettled top-level await");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test("a ref'd timer keeps the loop alive and the await settles (exit 0)", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `await new Promise(r => setTimeout(r, 50));\nconsole.log("DONE");\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stdout).toBe("DONE\n");
+    expect(r.stderr).not.toContain("Detected unsettled top-level await");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a beforeExit handler can settle the await (exit 0)", async () => {
+    // Node parity: a beforeExit handler that resolves the awaited promise lets
+    // the entry resume instead of triggering exit 13.
+    const r = await run(
+      {
+        "entry.mjs": `
+          let resolve;
+          process.on("beforeExit", () => { console.log("beforeExit"); resolve(); });
+          await new Promise(r => { resolve = r; });
+          console.log("DONE");
+        `,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stdout).toBe("beforeExit\nDONE\n");
+    expect(r.stderr).not.toContain("Detected unsettled top-level await");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("warning names the stalled module, not the entry", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `import "./mid.mjs";\n`,
+        "mid.mjs": `import "./leaf.mjs";\n`,
+        "leaf.mjs": `await new Promise(() => {});\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stderr).toContain("Detected unsettled top-level await");
+    expect(r.stderr).toContain("leaf.mjs");
+    expect(r.stderr).not.toContain("entry.mjs");
+    expect(r.stderr).not.toContain("mid.mjs");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test("warning lists every stalled sibling", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `import "./sib1.mjs";\nimport "./sib2.mjs";\n`,
+        "sib1.mjs": `await new Promise(() => {});\n`,
+        "sib2.mjs": `await new Promise(() => {});\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stderr).toContain("Detected unsettled top-level await");
+    expect(r.stderr).toContain("sib1.mjs");
+    expect(r.stderr).toContain("sib2.mjs");
+    expect(r.stderr).not.toContain("entry.mjs");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test("--print prints a top-level await that beforeExit settles", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-p", `let r; process.on("beforeExit", () => r(42)); await new Promise(res => { r = res; });`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: SPAWN_TIMEOUT,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).toBeNull();
+    expect(stdout.trim()).toBe("42");
+    expect(stderr).not.toContain("Detected unsettled top-level await");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--print emits the value before beforeExit output for a non-TLA entry", async () => {
+    // A synchronously-settled entry prints before beforeExit (Node's order),
+    // exercising the print-before-beforeExit path.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-p", `process.on("beforeExit", () => console.log("BE")); 123`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: SPAWN_TIMEOUT,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).toBeNull();
+    expect(stdout).toBe("123\nBE\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a resumed body that throws after beforeExit exits 1", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `let r; process.on("beforeExit", () => r());\nawait new Promise(res => { r = res; });\nthrow new Error("boom");\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stderr).toContain("boom");
+    expect(r.stderr).not.toContain("Detected unsettled top-level await");
+    expect(r.exitCode).toBe(1);
+  });
+
+  test("uncaughtException handler runs (and its async work) for a throw after beforeExit (exit 0)", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `process.on("uncaughtException", e => { console.log("caught", e.message); setTimeout(() => console.log("cleanup done"), 1); });\nlet r; process.on("beforeExit", () => r());\nawait new Promise(res => { r = res; });\nthrow new Error("boom");\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stdout).toBe("caught boom\ncleanup done\n");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("bun -p with an unsettled top-level await exits 13 without printing a pending promise", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-p", `await new Promise(() => {})`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: SPAWN_TIMEOUT,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).toBeNull();
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Detected unsettled top-level await");
+    expect(exitCode).toBe(13);
+  });
+
+  test("bun -e with an unsettled top-level await exits 13", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `await new Promise(() => {})`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: SPAWN_TIMEOUT,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).toBeNull();
+    expect(stderr).toContain("Detected unsettled top-level await");
+    expect(exitCode).toBe(13);
+  });
+});


### PR DESCRIPTION
Fixes #33283

## Repro

```js
// entry.mjs
console.log("BEFORE");
await new Promise(() => {});   // or: await import(import.meta.url)
console.log("AFTER");
```

```console
$ bun entry.mjs     # before: prints BEFORE, then parks forever (0% CPU, no output)
$ node entry.mjs
BEFORE
Warning: Detected unsettled top-level await at file:///.../entry.mjs:2
# exit 13
```

The self-import variant (`await import(import.meta.url)`, or `await import("bun:main")` from the entry) is the same spec-level deadlock: the entry awaits its own evaluation promise.

## Cause

The main-entry loader waits on the entry module's evaluation promise via `wait_for_promise`, which loops `tick()` + `auto_tick()` until the promise settles. When the top-level await can never settle and no ref'd handle remains, `auto_tick()` takes the `!loop.is_active()` branch (non-blocking `tick_without_idle`), so the wait degenerates into a busy-spin that never returns. Node stops waiting once the loop would otherwise block with the module promise still pending, prints a warning, and exits 13.

## Fix

Scoped to the main entry (`bun <file>`, `bun -e`, `bun -p`); the test runner and workers keep their own termination semantics and are unchanged.

- `wait_for_module_promise` replaces `wait_for_promise` in `load_entry_point`. Same tick/auto_tick loop, but it returns with the promise still pending once `has_pending_loop_work()` is false (nothing active, no task/ref/immediate could settle it). A ref'd timer keeps the loop alive, so a TLA that a timer later resolves still works.
- `Run::start` detects the still-pending entry promise after `beforeExit` and reports + exits 13. A `beforeExit` handler still gets a chance to resolve the await first (and may schedule more work), matching Node's repeated-`beforeExit` behavior. `--print` emits the resolved value once the entry settles (and nothing for an unsettled one), never a bogus `Promise { <pending> }`. A late rejection (the resumed body throws) is reported via `uncaughtException` and exits 1 (or 0 if a handler swallows it).
- `Bun__findStalledTopLevelAwait` (C++) walks the module registry to name the actual stalled module(s) (status `EvaluatingAsync`, syntactic TLA, not waiting on an async dependency), so the warning points at the leaf rather than the entry.

Warning goes to stderr: `Warning: Detected unsettled top-level await at <module>`, exit code 13. The source line + caret that Node also prints is omitted; the warning text and exit code are the parity that matters.

### Intentionally deferred

`--preload` scripts with an unsettled top-level await still hang. `load_preloads` runs per-preload before the entry and would need its own "still pending" return value propagated back through `reload_entry_point` (and ideally name which preload stalled), which is the broader surface #30551 took on. Keeping this PR to the main entry per #33283; preloads are a follow-up.

`bun --watch` / `--hot` with an unsettled top-level await also still busy-spins: the watcher arm of `load_entry_point` keeps its own `tick`/`auto_tick` loop, and the right fix there is break-to-idle (return to the watcher's block-wait for file changes), not exit 13, since a watch process should stay alive. Deferred to a follow-up for the same reason.

When a `beforeExit` handler resolves a top-level await and the resumed body then schedules timers and/or throws, the exact interleaving of those timers vs `uncaughtException` vs repeated `beforeExit` emissions is best-effort rather than byte-for-byte Node parity: the module can resume inside `on_before_exit`'s own drain (especially once `process.nextTick` has initialized its queue), which runs ahead of the report below. The observable outcome that matters (exit code 0/1 and the error message) is correct; matching Node's precise ordering in those multi-way cases would need the drain to be owned by a single loop, which is a follow-up.

## Verification

`test/js/node/process/unsettled-top-level-await.test.ts` (14 cases): never-resolving promise, dynamic-import TLA cycle, `import(import.meta.url)` self-import, and unref'd timer all exit 13; a ref'd timer that settles and a `beforeExit` handler that settles both exit 0; `bun -p`/`bun -e` exit 13 on an unsettled await (and `-p` prints nothing, not `Promise { <pending> }`); the warning names the stalled leaf and lists stalled siblings; a resumed body that throws exits 1 (or 0 via `uncaughtException` handler). The spin cases hang on the released build and pass after the fix.

## Prior art

This is the exit-13 half of #14951; the broader CPU-spin fix for condition-gated drive loops is tracked separately in #32014. It supersedes the broader/stale attempts #30551 (which also changed the test runner and preloads) and #30601 (inquirer-specific), and ports @dylan-conway's pre-Rust #29739 to the current tree, scoped to the main entry as #33283 asks.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/unsettled-top-level-await.test.ts
bun test v1.4.0 (af8cb039c)

test/js/node/process/unsettled-top-level-await.test.ts:
(pass) unsettled top-level await > a ref'd timer keeps the loop alive and the await settles (exit 0) [1060.89ms]
22 |     timeout: SPAWN_TIMEOUT,
23 |   });
24 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
25 |   // Hang guard: the process must exit on its own, not be killed by the spawn
26 |   // timeout (a reintroduced busy-spin would surface as a non-null signal here).
27 |   expect(proc.signalCode).toBeNull();
                               ^
error: expect(received).toBeNull()

Received: "SIGTERM"

      at run (/workspace/bun/test/js/node/process/unsettled-top-level-await.test.ts:27:27)
(fail) unsettled top-level await > await on a never-resolving promise exits 13 [20150.53ms]
22 |     timeout: SPAWN_TIMEOUT,
23 |   });
24 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exi
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/process/unsettled-top-level-await.test.ts:
(pass) unsettled top-level await > --print emits the value before beforeExit output for a non-TLA entry [35.66ms]
(pass) unsettled top-level await > a ref'd timer keeps the loop alive and the await settles (exit 0) [74.70ms]
22 |     timeout: SPAWN_TIMEOUT,
23 |   });
24 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
25 |   // Hang guard: the process must exit on its own, not be killed by the spawn
26 |   // timeout (a reintroduced busy-spin would surface as a non-null signal here).
27 |   expect(proc.signalCode).toBeNull();
                               ^
error: expect(received).toBeNull()

Received: "SIGTERM"

      at run (/workspace/bun/test/js/node/process/unsettled-top-level-await.test.ts:27:27)
      at async <anonymous> (/workspace/bun/test/js/node/process/unsettled-top-level-await.test.ts:45:21)
22 |     timeout: SPAWN_TIMEOUT,
23 |   });
24 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
25 |   // Hang guard: the process must exit on 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/unsettled-top-level-await.test.ts
bun test v1.4.0 (af8cb039c)

test/js/node/process/unsettled-top-level-await.test.ts:
(pass) unsettled top-level await > await on a never-resolving promise exits 13 [462.83ms]
(pass) unsettled top-level await > dynamic-import top-level-await cycle exits 13 [437.43ms]
(pass) unsettled top-level await > self-import via import.meta.url exits 13 [447.72ms]
(pass) unsettled top-level await > await on an unref'd timer exits 13 [458.18ms]
(pass) unsettled top-level await > a ref'd timer keeps the loop alive and the await settles (exit 0) [485.05ms]
(pass) unsettled top-level await > a beforeExit handler can settle the await (exit 0) [421.52ms]
(pass) unsettled top-level await > warning names the stalled module, not the entry [457.56ms]
(pass) unsettled top-level await > warning lists every stalled sibling [456.55ms]
(pass) unsettled top-level await > --print prints a top-level await that beforeExit settles [459.89ms]
(pass) unsettled top-level await > --print emits the value before beforeE
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 670ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 238 extern-C blocks audited
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          |  93 ++++++++-
 src/jsc/bindings/ZigGlobalObject.cpp               |  30 +++
 src/runtime/cli/run_command.rs                     | 165 +++++++++++----
 .../node/process/unsettled-top-level-await.test.ts | 229 +++++++++++++++++++++
 4 files changed, 473 insertions(+), 44 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/jsc/VirtualMachine.rs                                  11     12      0
src/jsc/bindings/ZigGlobalObject.cpp                        2      6      0
src/runtime/cli/run_command.rs                             13     17      0
test/js/node/process/unsettled-top-level-await.test.ts      9     17      0
```

</details>

**root cause** · written by the author bot

The root cause was that Bun's promise-waiting path in load_entry_point kept the event loop ref'd while awaiting the entry module's top-level await, so a promise that never settles left the process parked indefinitely instead of exiting, diverging from Node's behavior of warning and exiting with code 13. The fix introduces a module-specific wait that detects when the entry promise is still pending and nothing else refs the event loop, uses a native module-map scan to identify the stalled async module and its awaiting location, and restructures the CLI shutdown path to emit the unsettled top-…

<!-- robobun:evidence:end -->