### PR TITLE
diagnostics_channel: snapshot the subscriber list per publish

### DIFF
--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -8,6 +8,7 @@ const SafeFinalizationRegistry = FinalizationRegistry;
 
 const ArrayPrototypeAt = Array.prototype.at;
 const ArrayPrototypeIndexOf = Array.prototype.indexOf;
+const ArrayPrototypeSlice = Array.prototype.slice;
 const ArrayPrototypeSplice = Array.prototype.splice;
 const ObjectGetPrototypeOf = Object.getPrototypeOf;
 const ObjectSetPrototypeOf = Object.setPrototypeOf;
@@ -99,15 +100,23 @@ class ActiveChannel {
   subscribe(subscription) {
     validateFunction(subscription, "subscription");
 
+    // Copy on write: publish() iterates the array it captured, so mutating in
+    // place would let a subscriber's subscribe() append to the in-flight publish.
+    this._subscribers = ArrayPrototypeSlice.$call(this._subscribers);
     $arrayPush(this._subscribers, subscription);
     channels.incRef(this.name);
   }
 
   unsubscribe(subscription) {
-    const index = ArrayPrototypeIndexOf.$call(this._subscribers, subscription);
+    const subscribers = this._subscribers;
+    const index = ArrayPrototypeIndexOf.$call(subscribers, subscription);
     if (index === -1) return false;
 
-    ArrayPrototypeSplice.$call(this._subscribers, index, 1);
+    // Copy on write: publish() iterates the array it captured, so mutating in
+    // place would shift it under the loop and skip later subscribers.
+    const next = ArrayPrototypeSlice.$call(subscribers);
+    ArrayPrototypeSplice.$call(next, index, 1);
+    this._subscribers = next;
 
     channels.decRef(this.name);
     maybeMarkInactive(this);
@@ -139,9 +148,10 @@ class ActiveChannel {
   }
 
   publish(data) {
-    for (let i = 0; i < (this._subscribers?.length || 0); i++) {
+    const subscribers = this._subscribers;
+    for (let i = 0; i < (subscribers?.length || 0); i++) {
       try {
-        const onMessage = this._subscribers[i];
+        const onMessage = subscribers[i];
         onMessage(data, this.name);
       } catch (err) {
         process.nextTick(() => reportError(err));

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -53,6 +53,7 @@ describe("Channel", () => {
     const onMessageHandler: any = mustCall(() => unsubscribe(name, onMessageHandler));
 
     subscribe(name, onMessageHandler);
+    subscribe(name, mustCall(() => {}));
 
     // This must not throw.
     channel(name).publish(data);
@@ -336,6 +337,185 @@ describe("Channel", () => {
     const heapUsedAfter = process.memoryUsage().heapUsed;
 
     expect(heapUsedBefore).toBeGreaterThanOrEqual(heapUsedAfter);
+  });
+});
+
+// publish() dispatches to the subscribers registered when it started, so a
+// subscriber that subscribes or unsubscribes cannot change the in-flight publish.
+describe("mutating subscribers during publish", () => {
+  test("a subscriber that unsubscribes itself does not skip later subscribers", () => {
+    const dc = channel("mutate1");
+    const calls: string[] = [];
+
+    const f1 = () => {
+      calls.push("f1");
+      dc.unsubscribe(f1);
+    };
+    const f2 = () => void calls.push("f2");
+    const f3 = () => void calls.push("f3");
+
+    dc.subscribe(f1);
+    dc.subscribe(f2);
+    dc.subscribe(f3);
+
+    dc.publish({ x: 1 });
+    expect(calls).toEqual(["f1", "f2", "f3"]);
+
+    // The unsubscribe still took effect for the next publish.
+    calls.length = 0;
+    dc.publish({ x: 2 });
+    expect(calls).toEqual(["f2", "f3"]);
+  });
+
+  test("several subscribers unsubscribing themselves do not skip later subscribers", () => {
+    const dc = channel("mutate2");
+    const calls: string[] = [];
+
+    const f1 = () => {
+      calls.push("f1");
+      dc.unsubscribe(f1);
+    };
+    const f2 = () => {
+      calls.push("f2");
+      dc.unsubscribe(f2);
+    };
+    const f3 = () => void calls.push("f3");
+
+    dc.subscribe(f1);
+    dc.subscribe(f2);
+    dc.subscribe(f3);
+
+    dc.publish({ x: 1 });
+    expect(calls).toEqual(["f1", "f2", "f3"]);
+
+    calls.length = 0;
+    dc.publish({ x: 2 });
+    expect(calls).toEqual(["f3"]);
+  });
+
+  test("unsubscribing a later subscriber still delivers the in-flight publish to it", () => {
+    const dc = channel("mutate3");
+    const calls: string[] = [];
+
+    const f2 = () => void calls.push("f2");
+    const f1 = () => {
+      calls.push("f1");
+      dc.unsubscribe(f2);
+    };
+
+    dc.subscribe(f1);
+    dc.subscribe(f2);
+
+    dc.publish({ x: 1 });
+    expect(calls).toEqual(["f1", "f2"]);
+
+    calls.length = 0;
+    dc.publish({ x: 2 });
+    expect(calls).toEqual(["f1"]);
+  });
+
+  test("unsubscribing every subscriber mid-publish finishes the in-flight publish", () => {
+    const name = "mutate4";
+    const dc = channel(name);
+    const calls: string[] = [];
+
+    const f2 = () => void calls.push("f2");
+    const f1 = () => {
+      calls.push("f1");
+      dc.unsubscribe(f1);
+      dc.unsubscribe(f2);
+    };
+
+    dc.subscribe(f1);
+    dc.subscribe(f2);
+
+    dc.publish({ x: 1 });
+    expect(calls).toEqual(["f1", "f2"]);
+    expect(hasSubscribers(name)).toBeFalse();
+  });
+
+  test("a subscriber added during publish does not receive the in-flight publish", () => {
+    const dc = channel("mutate5");
+    const calls: string[] = [];
+
+    const late = () => void calls.push("late");
+    const f1 = () => {
+      calls.push("f1");
+      dc.subscribe(late);
+    };
+
+    dc.subscribe(f1);
+
+    dc.publish({ x: 1 });
+    expect(calls).toEqual(["f1"]);
+
+    calls.length = 0;
+    dc.publish({ x: 2 });
+    expect(calls).toEqual(["f1", "late"]);
+  });
+
+  test("a channel emptied mid-publish can be re-subscribed by a later subscriber", () => {
+    const name = "mutate6";
+    const dc = channel(name);
+    const calls: string[] = [];
+
+    const f3 = () => void calls.push("f3");
+    const f2 = () => {
+      calls.push("f2");
+      dc.subscribe(f3);
+    };
+    const f1 = () => {
+      calls.push("f1");
+      dc.unsubscribe(f1);
+      dc.unsubscribe(f2);
+    };
+
+    dc.subscribe(f1);
+    dc.subscribe(f2);
+
+    dc.publish({ x: 1 });
+    expect(calls).toEqual(["f1", "f2"]);
+    expect(hasSubscribers(name)).toBeTrue();
+
+    calls.length = 0;
+    dc.publish({ x: 2 });
+    expect(calls).toEqual(["f3"]);
+  });
+
+  test("unsubscribing one of two registrations of the same function", () => {
+    const dc = channel("mutate7");
+    const calls: string[] = [];
+
+    const f1 = () => {
+      calls.push("f1");
+      dc.unsubscribe(f1);
+    };
+    const f2 = () => void calls.push("f2");
+
+    dc.subscribe(f1);
+    dc.subscribe(f2);
+    dc.subscribe(f1);
+
+    // Only the first registration is removed, so the second one still runs.
+    dc.publish({ x: 1 });
+    expect(calls).toEqual(["f1", "f2", "f1"]);
+  });
+
+  test("runStores publishes to every subscriber registered when it started", () => {
+    const dc = channel("mutate8");
+    const calls: string[] = [];
+
+    const f1 = () => {
+      calls.push("f1");
+      dc.unsubscribe(f1);
+    };
+    const f2 = () => void calls.push("f2");
+
+    dc.subscribe(f1);
+    dc.subscribe(f2);
+
+    dc.runStores({ a: 1 }, () => void calls.push("fn"));
+    expect(calls).toEqual(["f1", "f2", "fn"]);
   });
 });
 

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -53,7 +53,10 @@ describe("Channel", () => {
     const onMessageHandler: any = mustCall(() => unsubscribe(name, onMessageHandler));
 
     subscribe(name, onMessageHandler);
-    subscribe(name, mustCall(() => {}));
+    subscribe(
+      name,
+      mustCall(() => {}),
+    );
 
     // This must not throw.
     channel(name).publish(data);


### PR DESCRIPTION
## Repro

A subscriber that unsubscribes itself (the one-shot / trace-once idiom) silently prevents a later subscriber from seeing the publish it is in the middle of:

```js
const dc = require("node:diagnostics_channel");
const ch = dc.channel("app");
const got = [];

const f1 = () => { got.push("f1"); ch.unsubscribe(f1); };
const f2 = () => got.push("f2");
const f3 = () => got.push("f3");

ch.subscribe(f1);
ch.subscribe(f2);
ch.subscribe(f3);
ch.publish({ x: 1 });

console.log(got.join(","));
// node: f1,f2,f3
// bun:  f1,f3     <- f2 never sees the publish
```

Other shapes of the same bug, all confirmed against node v26.3.0:

| case | node | bun 1.4.0 |
| --- | --- | --- |
| subscriber unsubscribes itself | `f1,f2,f3` | `f1,f3` |
| subscriber unsubscribes a later subscriber | `f1,f2` | `f1` |
| subscriber unsubscribes everyone | `f1,f2` | `f1` |
| subscriber subscribes during publish | `f1` | `f1,late` |
| same function subscribed twice, unsubscribes itself | `f1,f2,f1` | `f1,f1` |
| channel emptied mid-publish, re-subscribed by a later subscriber | `f1,f2`, then `f3` | `f1`, then nothing (channel left with no subscribers) |
| unsubscribe during `runStores` | `f1,f2,fn` | `f1,fn` |

## Cause

`ActiveChannel.publish()` re-read `this._subscribers` on every iteration, while `ActiveChannel.unsubscribe()` spliced that same array in place:

```js
publish(data) {
  for (let i = 0; i < (this._subscribers?.length || 0); i++) {
    const onMessage = this._subscribers[i];
    onMessage(data, this.name);
  }
}
```

So when a subscriber unsubscribed during dispatch the live array shifted left under the loop index and the next subscriber was skipped, and when it subscribed during dispatch the new function was appended to the in-flight publish. Unsubscribing the last subscriber also set `_subscribers` to `undefined` via `maybeMarkInactive`, which ended the publish early.

The same function subscribed twice is the worst shape: removing the first registration shifts the second one onto the current index, so the one-shot subscriber runs a second time while the subscriber between them is skipped.

## Fix

Match node ([nodejs/node#55116](https://github.com/nodejs/node/pull/55116)): make `subscribe()`/`unsubscribe()` copy on write, and have `publish()` capture the array once. A publish then dispatches to exactly the subscribers registered when it started, and the mutation takes effect from the next publish on.

Copy-on-write rather than copying inside `publish()` keeps the hot path allocation-free: `publish()` is what runs per request (`http2.ts`, `_http_client.ts`, `dgram.ts` only ever publish), while `subscribe`/`unsubscribe` are setup-time. `publish()` is also marginally cheaper now, since the property load is hoisted out of the loop.

## Verification

`test/js/node/diagnostics_channel/diagnostics_channel.test.ts` gains 8 tests covering every row of the table above, each asserting the exact dispatch order plus that the mutation did take effect on the following publish. `does not throw when unsubscribed` is also brought in line with the upstream test, which node extended in the same commit to assert the second subscriber still runs.

All 9 differential cases now match node v26.3.0 byte for byte, and node's `test-diagnostics-channel-*` ports under `test/js/node/test/parallel/` still pass. (`test-diagnostics-channel-http2-server-stream-close.js` fails identically before and after this change, for an unrelated http2 `stream.destroyed` lifecycle reason.)