### PR TITLE
bun:test: settle async matchers with promise reactions instead of re-entering the event loop

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -445,6 +445,29 @@ declare module "bun:test" {
      * Accepts `[1, 2, 3] | ["a", "b", "c"]` and returns `[1 | "a", 2 | "b", 3 | "c"]`
      */
     type Flatten<T, Copy extends T = T> = { [Key in keyof T]: Copy[Key] };
+
+    /** `any` extends both branches of a conditional type, so it needs its own check. */
+    type IsAny<T> = 0 extends 1 & T ? true : false;
+
+    /**
+     * Return type of the `toThrow` family of matchers: `Promise<void>` when the received value
+     * is an async function (or a function returning a promise) — the matcher settles once that
+     * promise does — otherwise the chain's usual return type `R`.
+     */
+    type ToThrowResult<T, R> =
+      IsAny<T> extends true
+        ? R
+        : [T] extends [never]
+          ? R
+          : [T] extends [(...args: any) => infer Return]
+            ? IsAny<Return> extends false
+              ? [Return] extends [never]
+                ? R
+                : [Return] extends [Promise<unknown>]
+                  ? Promise<void>
+                  : R
+              : R
+            : R;
   }
 
   /**
@@ -748,7 +771,7 @@ declare module "bun:test" {
    *   }
    * }
    */
-  export interface Matchers<T = unknown> extends MatchersBuiltin<T> {}
+  export interface Matchers<T = unknown, R = void> extends MatchersBuiltin<T, R> {}
 
   /**
    * Extend this interface with declaration merging to add type support for custom asymmetric matchers.
@@ -905,7 +928,7 @@ declare module "bun:test" {
     closeTo(num: number, numDigits?: number): AsymmetricMatcher;
   }
 
-  export interface MatchersBuiltin<T = unknown> {
+  export interface MatchersBuiltin<T = unknown, R = void> {
     /**
      * Negates the result of a subsequent assertion.
      *
@@ -917,23 +940,27 @@ declare module "bun:test" {
      * expect(42).toEqual(42); // will pass
      * expect(42).not.toEqual(42); // will fail
      */
-    not: Matchers<unknown>;
+    not: Matchers<T, R>;
 
     /**
      * Expects the value to be a promise that resolves.
      *
+     * Matchers used through `.resolves` return a `Promise<void>` that must be awaited.
+     *
      * @example
-     * expect(Promise.resolve(1)).resolves.toBe(1);
+     * await expect(Promise.resolve(1)).resolves.toBe(1);
      */
-    resolves: Matchers<Awaited<T>>;
+    resolves: Matchers<Awaited<T>, Promise<void>>;
 
     /**
      * Expects the value to be a promise that rejects.
      *
+     * Matchers used through `.rejects` return a `Promise<void>` that must be awaited.
+     *
      * @example
-     * expect(Promise.reject("error")).rejects.toBe("error");
+     * await expect(Promise.reject("error")).rejects.toBe("error");
      */
-    rejects: Matchers<unknown>;
+    rejects: Matchers<unknown, Promise<void>>;
 
     /**
      * Assertion which passes.
@@ -947,7 +974,7 @@ declare module "bun:test" {
      *
      * @param message the message to display if the test fails (optional)
      */
-    pass: (message?: string) => void;
+    pass: (message?: string) => R;
 
     /**
      * Assertion which fails.
@@ -959,7 +986,7 @@ declare module "bun:test" {
      * expect().not.fail();
      * expect().not.fail("hi");
      */
-    fail: (message?: string) => void;
+    fail: (message?: string) => R;
 
     /**
      * Asserts that a value equals what is expected.
@@ -980,8 +1007,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toBe(expected: T): void;
-    toBe<X = T>(expected: NoInfer<X>): void;
+    toBe(expected: T): R;
+    toBe<X = T>(expected: NoInfer<X>): R;
 
     /**
      * Asserts that a number is odd.
@@ -991,7 +1018,7 @@ declare module "bun:test" {
      * expect(1).toBeOdd();
      * expect(2).not.toBeOdd();
      */
-    toBeOdd(): void;
+    toBeOdd(): R;
 
     /**
      * Asserts that a number is even.
@@ -1001,7 +1028,7 @@ declare module "bun:test" {
      * expect(2).toBeEven();
      * expect(1).not.toBeEven();
      */
-    toBeEven(): void;
+    toBeEven(): R;
 
     /**
      * Asserts that a value is close to the expected value, within floating point precision.
@@ -1020,7 +1047,7 @@ declare module "bun:test" {
      * @param expected the expected value
      * @param numDigits the number of digits to check after the decimal point. Default is `2`
      */
-    toBeCloseTo(expected: number, numDigits?: number): void;
+    toBeCloseTo(expected: number, numDigits?: number): R;
 
     /**
      * Asserts that a value is deeply equal to what is expected.
@@ -1033,8 +1060,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toEqual(expected: T): void;
-    toEqual<X = T>(expected: NoInfer<X>): void;
+    toEqual(expected: T): R;
+    toEqual<X = T>(expected: NoInfer<X>): R;
 
     /**
      * Asserts that a value is deeply and strictly equal to
@@ -1059,8 +1086,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toStrictEqual(expected: T): void;
-    toStrictEqual<X = T>(expected: NoInfer<X>): void;
+    toStrictEqual(expected: T): R;
+    toStrictEqual<X = T>(expected: NoInfer<X>): R;
 
     /**
      * Asserts that the value is deeply equal to an element in the expected array.
@@ -1074,8 +1101,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toBeOneOf(expected: Iterable<T>): void;
-    toBeOneOf<X = T>(expected: NoInfer<Iterable<X>>): void;
+    toBeOneOf(expected: Iterable<T>): R;
+    toBeOneOf<X = T>(expected: NoInfer<Iterable<X>>): R;
 
     /**
      * Asserts that a value contains what is expected.
@@ -1090,8 +1117,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContain(expected: T extends Iterable<infer U> ? U : T): void;
-    toContain<X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void;
+    toContain(expected: T extends Iterable<infer U> ? U : T): R;
+    toContain<X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): R;
 
     /**
      * Asserts that an `object` contains a key.
@@ -1106,8 +1133,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainKey(expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void;
-    toContainKey<X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void;
+    toContainKey(expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): R;
+    toContainKey<X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): R;
 
     /**
      * Asserts that an `object` contains all the provided keys.
@@ -1123,8 +1150,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainAllKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void;
-    toContainAllKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void;
+    toContainAllKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): R;
+    toContainAllKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): R;
 
     /**
      * Asserts that an `object` contains at least one of the provided keys.
@@ -1139,8 +1166,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainAnyKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void;
-    toContainAnyKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void;
+    toContainAnyKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): R;
+    toContainAnyKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): R;
 
     /**
      * Asserts that an `object` contains the provided value.
@@ -1174,7 +1201,7 @@ declare module "bun:test" {
      */
     // Contributor note: In theory we could type this better but it would be a
     // slow union to compute...
-    toContainValue(expected: unknown): void;
+    toContainValue(expected: unknown): R;
 
     /**
      * Asserts that an `object` contains the provided values.
@@ -1191,7 +1218,7 @@ declare module "bun:test" {
      * expect(o).not.toContainValues(['qux', 'foo']);
      * @param expected the expected value
      */
-    toContainValues(expected: Array<unknown>): void;
+    toContainValues(expected: Array<unknown>): R;
 
     /**
      * Asserts that an `object` contains all the provided values.
@@ -1205,7 +1232,7 @@ declare module "bun:test" {
      * expect(o).not.toContainAllValues(['bar', 'foo']);
      * @param expected the expected value
      */
-    toContainAllValues(expected: Array<unknown>): void;
+    toContainAllValues(expected: Array<unknown>): R;
 
     /**
      * Asserts that an `object` contains any of the provided values.
@@ -1220,7 +1247,7 @@ declare module "bun:test" {
      * expect(o).not.toContainAnyValues(['qux']);
      * @param expected the expected value
      */
-    toContainAnyValues(expected: Array<unknown>): void;
+    toContainAnyValues(expected: Array<unknown>): R;
 
     /**
      * Asserts that an `object` contains all the provided keys.
@@ -1232,8 +1259,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void;
-    toContainKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void;
+    toContainKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): R;
+    toContainKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): R;
 
     /**
      * Asserts that a value contains and equals what is expected.
@@ -1247,8 +1274,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainEqual(expected: T extends Iterable<infer U> ? U : T): void;
-    toContainEqual<X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void;
+    toContainEqual(expected: T extends Iterable<infer U> ? U : T): R;
+    toContainEqual<X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): R;
 
     /**
      * Asserts that a value has a `.length` property
@@ -1260,7 +1287,7 @@ declare module "bun:test" {
      *
      * @param length the expected length
      */
-    toHaveLength(length: number): void;
+    toHaveLength(length: number): R;
 
     /**
      * Asserts that a value has a property with the
@@ -1275,7 +1302,7 @@ declare module "bun:test" {
      * @param keyPath the expected property name or path, or an index
      * @param value the expected property value, if provided
      */
-    toHaveProperty(keyPath: string | number | Array<string | number>, value?: unknown): void;
+    toHaveProperty(keyPath: string | number | Array<string | number>, value?: unknown): R;
 
     /**
      * Asserts that a value is "truthy".
@@ -1288,7 +1315,7 @@ declare module "bun:test" {
      * expect(1).toBeTruthy();
      * expect({}).toBeTruthy();
      */
-    toBeTruthy(): void;
+    toBeTruthy(): R;
 
     /**
      * Asserts that a value is "falsy".
@@ -1301,7 +1328,7 @@ declare module "bun:test" {
      * expect(0).toBeFalsy();
      * expect("").toBeFalsy();
      */
-    toBeFalsy(): void;
+    toBeFalsy(): R;
 
     /**
      * Asserts that a value is defined (that is, not `undefined`).
@@ -1310,7 +1337,7 @@ declare module "bun:test" {
      * expect(true).toBeDefined();
      * expect(undefined).toBeDefined(); // fail
      */
-    toBeDefined(): void;
+    toBeDefined(): R;
 
     /**
      * Asserts that a value is an instance of the given class or constructor.
@@ -1319,7 +1346,7 @@ declare module "bun:test" {
      * expect([]).toBeInstanceOf(Array);
      * expect(null).toBeInstanceOf(Array); // fail
      */
-    toBeInstanceOf(value: unknown): void;
+    toBeInstanceOf(value: unknown): R;
 
     /**
      * Asserts that a value is `undefined`.
@@ -1328,7 +1355,7 @@ declare module "bun:test" {
      * expect(undefined).toBeUndefined();
      * expect(null).toBeUndefined(); // fail
      */
-    toBeUndefined(): void;
+    toBeUndefined(): R;
 
     /**
      * Asserts that a value is `null`.
@@ -1337,7 +1364,7 @@ declare module "bun:test" {
      * expect(null).toBeNull();
      * expect(undefined).toBeNull(); // fail
      */
-    toBeNull(): void;
+    toBeNull(): R;
 
     /**
      * Asserts that a value is `NaN`.
@@ -1349,7 +1376,7 @@ declare module "bun:test" {
      * expect(Infinity).toBeNaN(); // fail
      * expect("notanumber").toBeNaN(); // fail
      */
-    toBeNaN(): void;
+    toBeNaN(): R;
 
     /**
      * Asserts that a value is a `number` and is greater than the expected value.
@@ -1361,7 +1388,7 @@ declare module "bun:test" {
      *
      * @param expected the expected number
      */
-    toBeGreaterThan(expected: number | bigint): void;
+    toBeGreaterThan(expected: number | bigint): R;
 
     /**
      * Asserts that a value is a `number` and is greater than or equal to the expected value.
@@ -1373,7 +1400,7 @@ declare module "bun:test" {
      *
      * @param expected the expected number
      */
-    toBeGreaterThanOrEqual(expected: number | bigint): void;
+    toBeGreaterThanOrEqual(expected: number | bigint): R;
 
     /**
      * Asserts that a value is a `number` and is less than the expected value.
@@ -1385,7 +1412,7 @@ declare module "bun:test" {
      *
      * @param expected the expected number
      */
-    toBeLessThan(expected: number | bigint): void;
+    toBeLessThan(expected: number | bigint): R;
 
     /**
      * Asserts that a value is a `number` and is less than or equal to the expected value.
@@ -1397,7 +1424,7 @@ declare module "bun:test" {
      *
      * @param expected the expected number
      */
-    toBeLessThanOrEqual(expected: number | bigint): void;
+    toBeLessThanOrEqual(expected: number | bigint): R;
 
     /**
      * Asserts that a function throws an error.
@@ -1416,9 +1443,12 @@ declare module "bun:test" {
      * expect(fail).toThrow(Error);
      * expect(fail).toThrow();
      *
+     * When the received value is an async function (or a function that returns a promise),
+     * the assertion is asynchronous and returns a `Promise<void>` that must be awaited.
+     *
      * @param expected the expected error, error message, or error pattern
      */
-    toThrow(expected?: unknown): void;
+    toThrow(expected?: unknown): __internal.ToThrowResult<T, R>;
 
     /**
      * Asserts that a function throws an error.
@@ -1437,10 +1467,13 @@ declare module "bun:test" {
      * expect(fail).toThrowError(Error);
      * expect(fail).toThrowError();
      *
+     * When the received value is an async function (or a function that returns a promise),
+     * the assertion is asynchronous and returns a `Promise<void>` that must be awaited.
+     *
      * @param expected the expected error, error message, or error pattern
      * @alias toThrow
      */
-    toThrowError(expected?: unknown): void;
+    toThrowError(expected?: unknown): __internal.ToThrowResult<T, R>;
 
     /**
      * Asserts that a value matches a regular expression or includes a substring.
@@ -1451,7 +1484,7 @@ declare module "bun:test" {
      *
      * @param expected the expected substring or pattern.
      */
-    toMatch(expected: string | RegExp): void;
+    toMatch(expected: string | RegExp): R;
 
     /**
      * Asserts that a value matches the most recent snapshot.
@@ -1460,7 +1493,7 @@ declare module "bun:test" {
      * expect([1, 2, 3]).toMatchSnapshot('hint message');
      * @param hint Hint used to identify the snapshot in the snapshot file.
      */
-    toMatchSnapshot(hint?: string): void;
+    toMatchSnapshot(hint?: string): R;
 
     /**
      * Asserts that a value matches the most recent snapshot.
@@ -1473,7 +1506,7 @@ declare module "bun:test" {
      * @param propertyMatchers Object containing properties to match against the value.
      * @param hint Hint used to identify the snapshot in the snapshot file.
      */
-    toMatchSnapshot(propertyMatchers?: object, hint?: string): void;
+    toMatchSnapshot(propertyMatchers?: object, hint?: string): R;
 
     /**
      * Asserts that a value matches the most recent inline snapshot.
@@ -1484,7 +1517,7 @@ declare module "bun:test" {
      *
      * @param value The latest automatically-updated snapshot value.
      */
-    toMatchInlineSnapshot(value?: string): void;
+    toMatchInlineSnapshot(value?: string): R;
 
     /**
      * Asserts that a value matches the most recent inline snapshot.
@@ -1500,7 +1533,7 @@ declare module "bun:test" {
      * @param propertyMatchers Object containing properties to match against the value.
      * @param value The latest automatically-updated snapshot value.
      */
-    toMatchInlineSnapshot(propertyMatchers?: object, value?: string): void;
+    toMatchInlineSnapshot(propertyMatchers?: object, value?: string): R;
 
     /**
      * Asserts that a function throws an error matching the most recent snapshot.
@@ -1512,9 +1545,12 @@ declare module "bun:test" {
      * expect(fail).toThrowErrorMatchingSnapshot();
      * expect(fail).toThrowErrorMatchingSnapshot("This one should say Oops!");
      *
+     * When the received value is an async function (or a function that returns a promise),
+     * the assertion is asynchronous and returns a `Promise<void>` that must be awaited.
+     *
      * @param hint Hint used to identify the snapshot in the snapshot file.
      */
-    toThrowErrorMatchingSnapshot(hint?: string): void;
+    toThrowErrorMatchingSnapshot(hint?: string): __internal.ToThrowResult<T, R>;
 
     /**
      * Asserts that a function throws an error matching the most recent snapshot.
@@ -1526,9 +1562,12 @@ declare module "bun:test" {
      * expect(fail).toThrowErrorMatchingInlineSnapshot();
      * expect(fail).toThrowErrorMatchingInlineSnapshot(`"Oops!"`);
      *
+     * When the received value is an async function (or a function that returns a promise),
+     * the assertion is asynchronous and returns a `Promise<void>` that must be awaited.
+     *
      * @param value The latest automatically-updated snapshot value.
      */
-    toThrowErrorMatchingInlineSnapshot(value?: string): void;
+    toThrowErrorMatchingInlineSnapshot(value?: string): __internal.ToThrowResult<T, R>;
 
     /**
      * Asserts that an object matches a subset of properties.
@@ -1539,7 +1578,7 @@ declare module "bun:test" {
      *
      * @param subset Subset of properties to match with.
      */
-    toMatchObject(subset: object): void;
+    toMatchObject(subset: object): R;
 
     /**
      * Asserts that a value is empty.
@@ -1550,7 +1589,7 @@ declare module "bun:test" {
      * expect({}).toBeEmpty();
      * expect(new Set()).toBeEmpty();
      */
-    toBeEmpty(): void;
+    toBeEmpty(): R;
 
     /**
      * Asserts that a value is an empty `object`.
@@ -1559,7 +1598,7 @@ declare module "bun:test" {
      * expect({}).toBeEmptyObject();
      * expect({ a: 'hello' }).not.toBeEmptyObject();
      */
-    toBeEmptyObject(): void;
+    toBeEmptyObject(): R;
 
     /**
      * Asserts that a value is `null` or `undefined`.
@@ -1568,7 +1607,7 @@ declare module "bun:test" {
      * expect(null).toBeNil();
      * expect(undefined).toBeNil();
      */
-    toBeNil(): void;
+    toBeNil(): R;
 
     /**
      * Asserts that a value is an `array`.
@@ -1579,7 +1618,7 @@ declare module "bun:test" {
      * expect(new Array(1)).toBeArray();
      * expect({}).not.toBeArray();
      */
-    toBeArray(): void;
+    toBeArray(): R;
 
     /**
      * Asserts that a value is an `array` of a certain length.
@@ -1591,7 +1630,7 @@ declare module "bun:test" {
      * expect(new Array(1)).toBeArrayOfSize(1);
      * expect({}).not.toBeArrayOfSize(0);
      */
-    toBeArrayOfSize(size: number): void;
+    toBeArrayOfSize(size: number): R;
 
     /**
      * Asserts that a value is a `boolean`.
@@ -1602,7 +1641,7 @@ declare module "bun:test" {
      * expect(null).not.toBeBoolean();
      * expect(0).not.toBeBoolean();
      */
-    toBeBoolean(): void;
+    toBeBoolean(): R;
 
     /**
      * Asserts that a value is `true`.
@@ -1612,7 +1651,7 @@ declare module "bun:test" {
      * expect(false).not.toBeTrue();
      * expect(1).not.toBeTrue();
      */
-    toBeTrue(): void;
+    toBeTrue(): R;
 
     /**
      * Asserts that a value matches a specific type.
@@ -1623,7 +1662,7 @@ declare module "bun:test" {
      * expect("hello").toBeTypeOf("string");
      * expect([]).not.toBeTypeOf("boolean");
      */
-    toBeTypeOf(type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined"): void;
+    toBeTypeOf(type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined"): R;
 
     /**
      * Asserts that a value is `false`.
@@ -1633,7 +1672,7 @@ declare module "bun:test" {
      * expect(true).not.toBeFalse();
      * expect(0).not.toBeFalse();
      */
-    toBeFalse(): void;
+    toBeFalse(): R;
 
     /**
      * Asserts that a value is a `number`.
@@ -1644,7 +1683,7 @@ declare module "bun:test" {
      * expect(NaN).toBeNumber();
      * expect(BigInt(1)).not.toBeNumber();
      */
-    toBeNumber(): void;
+    toBeNumber(): R;
 
     /**
      * Asserts that a value is a `number`, and is an integer.
@@ -1654,7 +1693,7 @@ declare module "bun:test" {
      * expect(3.14).not.toBeInteger();
      * expect(NaN).not.toBeInteger();
      */
-    toBeInteger(): void;
+    toBeInteger(): R;
 
     /**
      * Asserts that a value is an `object`.
@@ -1664,7 +1703,7 @@ declare module "bun:test" {
      * expect("notAnObject").not.toBeObject();
      * expect(NaN).not.toBeObject();
      */
-    toBeObject(): void;
+    toBeObject(): R;
 
     /**
      * Asserts that a value is a `number`, and is not `NaN` or `Infinity`.
@@ -1675,7 +1714,7 @@ declare module "bun:test" {
      * expect(NaN).not.toBeFinite();
      * expect(Infinity).not.toBeFinite();
      */
-    toBeFinite(): void;
+    toBeFinite(): R;
 
     /**
      * Asserts that a value is a positive `number`.
@@ -1685,7 +1724,7 @@ declare module "bun:test" {
      * expect(-3.14).not.toBePositive();
      * expect(NaN).not.toBePositive();
      */
-    toBePositive(): void;
+    toBePositive(): R;
 
     /**
      * Asserts that a value is a negative `number`.
@@ -1695,7 +1734,7 @@ declare module "bun:test" {
      * expect(1).not.toBeNegative();
      * expect(NaN).not.toBeNegative();
      */
-    toBeNegative(): void;
+    toBeNegative(): R;
 
     /**
      * Asserts that a value is a number between a start and end value.
@@ -1703,7 +1742,7 @@ declare module "bun:test" {
      * @param start the start number (inclusive)
      * @param end the end number (exclusive)
      */
-    toBeWithin(start: number, end: number): void;
+    toBeWithin(start: number, end: number): R;
 
     /**
      * Asserts that a value is equal to the expected string, ignoring any whitespace.
@@ -1714,7 +1753,7 @@ declare module "bun:test" {
      *
      * @param expected the expected string
      */
-    toEqualIgnoringWhitespace(expected: string): void;
+    toEqualIgnoringWhitespace(expected: string): R;
 
     /**
      * Asserts that a value is a `symbol`.
@@ -1723,7 +1762,7 @@ declare module "bun:test" {
      * expect(Symbol("foo")).toBeSymbol();
      * expect("foo").not.toBeSymbol();
      */
-    toBeSymbol(): void;
+    toBeSymbol(): R;
 
     /**
      * Asserts that a value is a `function`.
@@ -1731,7 +1770,7 @@ declare module "bun:test" {
      * @example
      * expect(() => {}).toBeFunction();
      */
-    toBeFunction(): void;
+    toBeFunction(): R;
 
     /**
      * Asserts that a value is a `Date` object.
@@ -1743,7 +1782,7 @@ declare module "bun:test" {
      * expect(new Date(null)).toBeDate();
      * expect("2020-03-01").not.toBeDate();
      */
-    toBeDate(): void;
+    toBeDate(): R;
 
     /**
      * Asserts that a value is a valid `Date` object.
@@ -1753,7 +1792,7 @@ declare module "bun:test" {
      * expect(new Date(null)).not.toBeValidDate();
      * expect("2020-03-01").not.toBeValidDate();
      */
-    toBeValidDate(): void;
+    toBeValidDate(): R;
 
     /**
      * Asserts that a value is a `string`.
@@ -1763,7 +1802,7 @@ declare module "bun:test" {
      * expect(new String("bar")).toBeString();
      * expect(123).not.toBeString();
      */
-    toBeString(): void;
+    toBeString(): R;
 
     /**
      * Asserts that a value includes a `string`.
@@ -1772,14 +1811,14 @@ declare module "bun:test" {
      *
      * @param expected the expected substring
      */
-    toInclude(expected: string): void;
+    toInclude(expected: string): R;
 
     /**
      * Asserts that a value includes a `string` the given number of times.
      * @param expected the expected substring
      * @param times the number of times the substring should occur
      */
-    toIncludeRepeated(expected: string, times: number): void;
+    toIncludeRepeated(expected: string, times: number): R;
 
     /**
      * Asserts that a value satisfies a custom condition.
@@ -1791,47 +1830,47 @@ declare module "bun:test" {
      * @link https://vitest.dev/api/expect.html#tosatisfy
      * @link https://jest-extended.jestcommunity.dev/docs/matchers/toSatisfy
      */
-    toSatisfy(predicate: (value: T) => boolean): void;
+    toSatisfy(predicate: (value: T) => boolean): R;
 
     /**
      * Asserts that a value starts with a `string`.
      *
      * @param expected the string to start with
      */
-    toStartWith(expected: string): void;
+    toStartWith(expected: string): R;
 
     /**
      * Asserts that a value ends with a `string`.
      *
      * @param expected the string to end with
      */
-    toEndWith(expected: string): void;
+    toEndWith(expected: string): R;
 
     /**
      * Ensures that a mock function has returned successfully at least once.
      *
      * An unfulfilled promise counts as a failure, as does a thrown error.
      */
-    toHaveReturned(): void;
+    toHaveReturned(): R;
 
     /**
      * Ensures that a mock function has returned successfully `times` times.
      *
      * An unfulfilled promise counts as a failure, as does a thrown error.
      */
-    toHaveReturnedTimes(times: number): void;
+    toHaveReturnedTimes(times: number): R;
 
     /**
      * Ensures that a mock function has returned a specific value.
      * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
      */
-    toHaveReturnedWith(expected: unknown): void;
+    toHaveReturnedWith(expected: unknown): R;
 
     /**
      * Ensures that a mock function has returned a specific value on its last invocation.
      * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
      */
-    toHaveLastReturnedWith(expected: unknown): void;
+    toHaveLastReturnedWith(expected: unknown): R;
 
     /**
      * Ensures that a mock function has returned a specific value on the nth invocation.
@@ -1839,62 +1878,62 @@ declare module "bun:test" {
      * @param n The 1-based index of the function call
      * @param expected The expected return value
      */
-    toHaveNthReturnedWith(n: number, expected: unknown): void;
+    toHaveNthReturnedWith(n: number, expected: unknown): R;
 
     /**
      * Ensures that a mock function is called.
      */
-    toHaveBeenCalled(): void;
+    toHaveBeenCalled(): R;
 
     /**
      * Ensures that a mock function is called.
      * @alias toHaveBeenCalled
      */
-    toBeCalled(): void;
+    toBeCalled(): R;
 
     /**
      * Ensures that a mock function is called an exact number of times.
      */
-    toHaveBeenCalledTimes(expected: number): void;
+    toHaveBeenCalledTimes(expected: number): R;
 
     /**
      * Ensures that a mock function is called an exact number of times.
      * @alias toHaveBeenCalledTimes
      */
-    toBeCalledTimes(expected: number): void;
+    toBeCalledTimes(expected: number): R;
 
     /**
      * Ensure that a mock function is called with specific arguments.
      */
-    toHaveBeenCalledWith(...expected: unknown[]): void;
+    toHaveBeenCalledWith(...expected: unknown[]): R;
 
     /**
      * Ensure that a mock function is called with specific arguments.
      * @alias toHaveBeenCalledWith
      */
-    toBeCalledWith(...expected: unknown[]): void;
+    toBeCalledWith(...expected: unknown[]): R;
 
     /**
      * Ensure that a mock function is called with specific arguments for the last call.
      */
-    toHaveBeenLastCalledWith(...expected: unknown[]): void;
+    toHaveBeenLastCalledWith(...expected: unknown[]): R;
 
     /**
      * Ensure that a mock function is called with specific arguments for the last call.
      * @alias toHaveBeenLastCalledWith
      */
-    lastCalledWith(...expected: unknown[]): void;
+    lastCalledWith(...expected: unknown[]): R;
 
     /**
      * Ensure that a mock function is called with specific arguments for the nth call.
      */
-    toHaveBeenNthCalledWith(n: number, ...expected: unknown[]): void;
+    toHaveBeenNthCalledWith(n: number, ...expected: unknown[]): R;
 
     /**
      * Ensure that a mock function is called with specific arguments for the nth call.
      * @alias toHaveBeenNthCalledWith
      */
-    nthCalledWith(n: number, ...expected: unknown[]): void;
+    nthCalledWith(n: number, ...expected: unknown[]): R;
   }
 
   /**

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3909,6 +3909,10 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__TestScope__Describe2__bunTestThen;
     } else if (handler == Bun__TestScope__Describe2__bunTestCatch) {
         return GlobalObject::PromiseFunctions::Bun__TestScope__Describe2__bunTestCatch;
+    } else if (handler == Bun__Expect__onSubjectResolve) {
+        return GlobalObject::PromiseFunctions::Bun__Expect__onSubjectResolve;
+    } else if (handler == Bun__Expect__onSubjectReject) {
+        return GlobalObject::PromiseFunctions::Bun__Expect__onSubjectReject;
     } else if (handler == Bun__BodyValueBufferer__onResolveStream) {
         return GlobalObject::PromiseFunctions::Bun__BodyValueBufferer__onResolveStream;
     } else if (handler == Bun__BodyValueBufferer__onRejectStream) {

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -392,6 +392,8 @@ public:
         jsFunctionOnLoadObjectResultReject,
         Bun__TestScope__Describe2__bunTestThen,
         Bun__TestScope__Describe2__bunTestCatch,
+        Bun__Expect__onSubjectResolve,
+        Bun__Expect__onSubjectReject,
         Bun__BodyValueBufferer__onRejectStream,
         Bun__BodyValueBufferer__onResolveStream,
         Bun__onResolveEntryPointResult,
@@ -413,7 +415,7 @@ public:
         Bun__HTTPRequestContextDebugH3__onResolve,
         Bun__HTTPRequestContextDebugH3__onResolveStream,
     };
-    static constexpr size_t promiseFunctionsSize = 42;
+    static constexpr size_t promiseFunctionsSize = 44;
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -786,6 +786,8 @@ BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onResolveStream);
 
 BUN_DECLARE_HOST_FUNCTION(Bun__TestScope__Describe2__bunTestThen);
 BUN_DECLARE_HOST_FUNCTION(Bun__TestScope__Describe2__bunTestCatch);
+BUN_DECLARE_HOST_FUNCTION(Bun__Expect__onSubjectResolve);
+BUN_DECLARE_HOST_FUNCTION(Bun__Expect__onSubjectReject);
 BUN_DECLARE_HOST_FUNCTION(Bun__CronJob__onPromiseResolve);
 BUN_DECLARE_HOST_FUNCTION(Bun__CronJob__onPromiseReject);
 

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -38,7 +38,7 @@
 use core::ptr::NonNull;
 
 use bun_core::{Timespec, TimespecMockMode};
-use bun_jsc::{JSGlobalObject, JsResult};
+use bun_jsc::{JSGlobalObject, JSValue, JsResult, Strong};
 // `bun_jsc::VirtualMachine` is the *module* re-export; the struct lives one level deeper.
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_core::scoped_log;
@@ -159,21 +159,48 @@ pub struct ExecutionSequence {
     /// matchers) registered on this sequence that have not settled yet. The sequence does
     /// not complete while this is nonzero (see [`Execution::finish_sequence`]). Like
     /// `expect_call_count`, this is only tracked when the owning sequence is resolvable
-    /// (`get_current_state_data()` with `entry_data: Some`); `test.concurrent` groups
-    /// cannot resolve a single sequence, so per-test tracking degrades the same way.
+    /// (`get_current_state_data()` with `entry_data: Some`); a concurrent group running
+    /// 2+ sequences cannot resolve which one is calling (a lone `test.concurrent` is a
+    /// group of one, so it still tracks), so per-test tracking degrades the same way.
     pub pending_matcher_promises: u32,
     /// Generation for `pending_matcher_promises`: captured by [`Self::register_matcher_promise`],
     /// checked by [`Self::settle_matcher_promise`]. Monotonic for the lifetime of the slot
     /// (bumped by the timeout-abandon path and by every retry/repeat `reset_sequence`), so a
     /// settlement from an abandoned or previous attempt never touches a later attempt's counter.
     pub matcher_epoch: u32,
-    /// The sequence ran out of entries while `pending_matcher_promises > 0`: completion
-    /// was deferred and is driven by `step_deferred_completion` once the promises settle
-    /// or the per-test timeout fires.
+    /// The sequence is parked on `pending_matcher_promises > 0` — either at the boundary
+    /// after the test entry (before the afterEach entries) or after it ran out of entries.
+    /// `step_deferred_completion` resumes/finishes it once they settle or the timeout fires.
     pub completion_deferred: bool,
+    /// Set while parked at the test-entry boundary: the entry (first afterEach) to resume
+    /// into once the pending matcher promises settle. `None` for the end-of-sequence park.
+    pub deferred_resume_entry: Option<NonNull<ExecutionEntry>>,
+    /// Failing deferred matchers of the current attempt whose outcome is decided once, at
+    /// sequence completion (see [`ProvisionalMatcherFailure`]). Their plain rejections are
+    /// suppressed by the bun:test unhandled-rejection handler in the meantime.
+    pub provisional_matcher_failures: Vec<ProvisionalMatcherFailure>,
     /// Expectation set by expect.hasAssertions() or expect.assertions(n).
     pub expect_assertions: ExpectAssertions,
     pub maybe_skip: bool,
+}
+
+/// A deferred matcher promise `D` whose matcher failed on the re-invocation pass. `D` was
+/// rejected plainly (not as-handled) so a user `await`/`.catch` can observe the failure;
+/// at sequence completion an entry whose `D` is still unhandled (or was leaked) is
+/// recorded as a failure, otherwise it is dropped. Both `Strong`s are released whenever
+/// the entry is removed.
+pub struct ProvisionalMatcherFailure {
+    /// Root of the deferred matcher promise `D`.
+    pub deferred: Strong,
+    /// The attributed matcher exception `D` was rejected with.
+    pub exception: Strong,
+    /// [`ExecutionSequence::matcher_epoch`] at registration; stale entries are dropped.
+    pub epoch: u32,
+    /// The `expect()` was created in a beforeEach/afterEach entry, not the test entry.
+    pub in_hook: bool,
+    /// The user adopted `D` but let a promise derived from it reject unhandled (e.g. a
+    /// floating `D.finally(..)` re-throws the reason): still the test's failure.
+    pub leaked: bool,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -207,6 +234,8 @@ impl ExecutionSequence {
             pending_matcher_promises: 0,
             matcher_epoch: 0,
             completion_deferred: false,
+            deferred_resume_entry: None,
+            provisional_matcher_failures: Vec::new(),
             expect_assertions: ExpectAssertions::NotSet,
             maybe_skip: false,
         }
@@ -238,6 +267,26 @@ impl ExecutionSequence {
         debug_assert!(self.pending_matcher_promises > 0);
         self.pending_matcher_promises -= 1;
         self.pending_matcher_promises == 0 && self.completion_deferred
+    }
+
+    /// `rejection` was reported as an unhandled rejection. Returns whether the
+    /// provisional-matcher machinery owns it (the caller must not report it). The handler
+    /// only receives the rejection *reason*, so entries are matched by the exception `D`
+    /// was rejected with: an un-adopted `D`'s own rejection is decided at completion,
+    /// while a promise the user derived from an adopted `D` (a floating `D.finally(..)`
+    /// re-rejects the same reason) marks the entry [`leaked`](ProvisionalMatcherFailure).
+    pub fn claim_provisional_matcher_rejection(&mut self, rejection: JSValue) -> bool {
+        for p in &mut self.provisional_matcher_failures {
+            if p.exception.get() != rejection {
+                continue;
+            }
+            let Some(deferred) = p.deferred.get().as_promise() else { continue };
+            if bun_jsc::js_promise::JSPromise::opaque_ref(deferred).is_handled() {
+                p.leaked = true;
+            }
+            return true;
+        }
+        false
     }
 
     fn entry_mode(&self) -> ScopeMode {
@@ -481,6 +530,17 @@ impl Execution {
         Some(&self.groups[self.group_index])
     }
 
+    /// See [`ExecutionSequence::claim_provisional_matcher_rejection`]. Checks every
+    /// sequence of the active group: a sequence parked on pending matcher promises has
+    /// no `active_entry`, so `get_current_state_data` cannot resolve it for the caller.
+    pub fn claim_provisional_matcher_rejection(&mut self, rejection: JSValue) -> bool {
+        let Some(group) = self.active_group_ref() else { return false };
+        let (start, end) = (group.sequence_start, group.sequence_end);
+        self.sequences[start..end]
+            .iter_mut()
+            .any(|sequence| sequence.claim_provisional_matcher_rejection(rejection))
+    }
+
     /// Returns `NonNull` pointers (not `&mut`) into `self.sequences` / `self.groups` so the
     /// caller can hold both alongside other borrows of `self` without aliased-`&mut` UB.
     /// Dereference at point-of-use only.
@@ -571,6 +631,22 @@ impl Execution {
             } else {
                 sequence.active_entry = nn(entry.next);
             }
+
+            // Deferred matcher promises settle before the afterEach entries run (so they
+            // observe pre-afterEach state): park at the test-entry boundary, exactly like
+            // the end-of-sequence park below, and resume via `step_deferred_completion`.
+            if sequence.pending_matcher_promises > 0
+                && Some(entry_ptr) == sequence.test_entry
+                && sequence.active_entry.is_some()
+            {
+                group_log::log(format_args!(
+                    "advanceSequence: parking after the test entry; {} pending matcher promise(s)",
+                    sequence.pending_matcher_promises
+                ));
+                sequence.deferred_resume_entry = sequence.active_entry.take();
+                sequence.completion_deferred = true;
+                return;
+            }
         } else {
             debug_assert!(false, "can't call advanceSequence on a completed sequence");
         }
@@ -603,12 +679,24 @@ impl Execution {
         sequence_ptr: NonNull<ExecutionSequence>,
         group_ptr: NonNull<ConcurrentGroup>,
     ) {
+        // A rejection derived from a deferred `D` (e.g. a floating `D.finally(..)`) settled by
+        // a task in the current tick batch has not been notified yet: deliver it now so its
+        // claim marks the entry leaked before the commit below drops `D` as cleanly adopted.
+        // SAFETY: `sequence_ptr` is valid (caller contract); the shared borrow ends before the
+        // drain, which re-enters `claim_provisional_matcher_rejection` on this sequence.
+        if !unsafe { sequence_ptr.as_ref() }.provisional_matcher_failures.is_empty() {
+            VirtualMachine::get().global().handle_rejected_promises();
+        }
         // SAFETY: sequence_ptr / group_ptr point into disjoint fields of `buntest.execution`
         // (`sequences` vs `groups`); no `&mut Execution` is live in this scope.
         let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
         debug_assert!(sequence.active_entry.is_none());
         debug_assert!(!sequence.executing);
         sequence.completion_deferred = false;
+
+        // Decide the attempt's provisional matcher failures first: they may flip the
+        // result the retry/repeat logic below inspects.
+        Execution::commit_provisional_matcher_failures(buntest, sequence);
 
         // just completed the sequence
         let test_failed = sequence.result.is_fail();
@@ -651,6 +739,58 @@ impl Execution {
             return;
         }
         group.remaining_incomplete_entries -= 1;
+    }
+
+    /// Decide every provisional matcher failure recorded on `sequence` (see
+    /// [`ProvisionalMatcherFailure`]) now that the attempt is completing: a `D` nobody
+    /// adopted fails the test; an adopted (or timeout-abandoned) one is dropped. Runs
+    /// before the retry/repeat decision so a committed failure can trigger a retry, and
+    /// drains the list on every completion path, releasing both `Strong`s per entry.
+    fn commit_provisional_matcher_failures(
+        buntest: NonNull<BunTest>,
+        sequence: &mut ExecutionSequence,
+    ) {
+        if sequence.provisional_matcher_failures.is_empty() {
+            return;
+        }
+        let epoch = sequence.matcher_epoch;
+        let mode = sequence.entry_mode();
+        for provisional in core::mem::take(&mut sequence.provisional_matcher_failures) {
+            let Some(deferred_ptr) = provisional.deferred.get().as_promise() else {
+                debug_assert!(false); // only ever recorded with a `JSPromise` `D`
+                continue;
+            };
+            // SAFETY: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
+            let deferred = bun_jsc::js_promise::JSPromise::opaque_mut(deferred_ptr);
+            let adopted = deferred.is_handled();
+            // The provisional machinery owns `D`'s outcome either way: the generic
+            // unhandled-rejection path must never report it after this point.
+            deferred.set_handled();
+            if provisional.epoch != epoch || (adopted && !provisional.leaked) {
+                // The entry belongs to an abandoned/previous attempt, or the user adopted
+                // `D` without leaking it: their `await`/`catch`/`finally` observed it.
+                continue;
+            }
+            let (result, show) = classify_uncaught(mode, provisional.in_hook);
+            // A synchronous hook failure preempts the test callback and its result; one
+            // only learned now must equally override whatever the callback recorded
+            // (e.g. `test.failing`'s inversion to `Pass`).
+            if sequence.result == Result::Pending
+                || (provisional.in_hook && !sequence.result.is_fail())
+            {
+                sequence.result = result;
+            }
+            if show {
+                // SAFETY: `bun_test_root` is disjoint from `execution.sequences` (which
+                // `sequence` points into); dereferenced at point-of-use only.
+                unsafe { buntest.as_ref() }.bun_test_root.on_before_print();
+                // SAFETY: `VirtualMachine::get()` is the live per-thread VM.
+                VirtualMachine::get()
+                    .as_mut()
+                    .run_error_handler(provisional.exception.get(), None);
+                bun_core::Output::flush();
+            }
+        }
     }
 
     fn on_group_started(global_this: &JSGlobalObject) {
@@ -818,6 +958,10 @@ impl Execution {
             }
         }
 
+        // `commit_provisional_matcher_failures` drained the finished attempt's provisional
+        // failures; the re-init below drops (and so releases) anything left regardless.
+        debug_assert!(sequence.provisional_matcher_failures.is_empty());
+
         // Preserve retry/repeat counts and flaky attempt history across reset
         let saved_flaky_attempt_count = sequence.flaky_attempt_count;
         let saved_flaky_attempts_buf = sequence.flaky_attempts_buf;
@@ -863,34 +1007,33 @@ impl Execution {
         let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
 
         sequence.maybe_skip = true;
-        if sequence.active_entry != sequence.test_entry {
-            // executing hook
-            if sequence.result == Result::Pending {
-                sequence.result = Result::Fail;
-            }
-            return HandleUncaughtExceptionResult::ShowHandledError;
+        let in_hook = sequence.active_entry != sequence.test_entry;
+        let (result, show) = classify_uncaught(sequence.entry_mode(), in_hook);
+        if sequence.result == Result::Pending {
+            sequence.result = result;
         }
+        if show {
+            HandleUncaughtExceptionResult::ShowHandledError
+        } else {
+            HandleUncaughtExceptionResult::HideError // failing tests prevent the error from being displayed
+        }
+    }
+}
 
-        match sequence.entry_mode() {
-            ScopeMode::Failing => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::Pass; // executing test() callback
-                }
-                HandleUncaughtExceptionResult::HideError // failing tests prevent the error from being displayed
-            }
-            ScopeMode::Todo => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::Todo; // executing test() callback
-                }
-                HandleUncaughtExceptionResult::ShowHandledError // todo tests with --todo will still display the error
-            }
-            _ => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::Fail;
-                }
-                HandleUncaughtExceptionResult::ShowHandledError
-            }
-        }
+/// Single source of truth for how an uncaught failure affects the owning test: maps the
+/// test's `ScopeMode` (and whether the failure happened in a hook) to the sequence
+/// `Result` to record and whether the error should be displayed.
+pub(crate) fn classify_uncaught(mode: ScopeMode, in_hook: bool) -> (Result, bool) {
+    if in_hook {
+        // Hook failures always fail the test: they are never inverted by `test.failing`
+        // and never downgraded to todo.
+        return (Result::Fail, true);
+    }
+    match mode {
+        ScopeMode::Failing => (Result::Pass, false),
+        // todo tests with --todo will still display the error
+        ScopeMode::Todo => (Result::Todo, true),
+        _ => (Result::Fail, true),
     }
 }
 
@@ -1159,10 +1302,11 @@ fn step_sequence_one(
     }
 }
 
-/// A sequence whose entries all completed while matcher promises were still pending
-/// (`ExecutionSequence::completion_deferred`) is held open here. The test's own deadline still
-/// applies: if it expires first, the pending promises are abandoned and the sequence completes
-/// through the normal timeout path. Returns `None` when the sequence should be stepped again.
+/// A sequence parked on pending matcher promises (`ExecutionSequence::completion_deferred`) —
+/// either at the test-entry boundary before its afterEach entries, or with no entries left —
+/// is held open here. The test's own deadline still applies: if it expires first, the pending
+/// promises are abandoned and the sequence resumes/completes through the normal timeout path.
+/// Returns `None` when the sequence should be stepped again.
 ///
 /// `sequence_ptr` / `group` carry the same raw-pointer contract as `advance_sequence`.
 fn step_deferred_completion(
@@ -1191,12 +1335,26 @@ fn step_deferred_completion(
             ));
             return Some(AdvanceSequenceStatus::Execute { timeout: test_entry.timespec });
         }
-        // The per-test timeout fired first: abandon the pending promises and fail as a
-        // timeout. Bumping the epoch invalidates the abandoned registrations, so a late
-        // settlement fails `settle_matcher_promise`'s epoch check instead of decrementing a
-        // counter it is no longer part of (this attempt's, or a retry's after `reset_sequence`).
+        // The per-test timeout fired first. Failures that already settled are real
+        // assertion failures: commit them now (which reports them and marks their `D`s
+        // handled so the generic unhandled-rejection path never picks them up later).
+        Execution::commit_provisional_matcher_failures(buntest_ptr, sequence);
+        // Then abandon the still-pending registrations. Bumping the epoch invalidates
+        // them, so a late settlement fails `settle_matcher_promise`'s epoch check instead
+        // of decrementing a counter it is no longer part of (this attempt's, or a retry's).
         sequence.matcher_epoch = sequence.matcher_epoch.wrapping_add(1);
         sequence.pending_matcher_promises = 0;
+    }
+
+    // Parked at the test-entry boundary: resume into the afterEach entries. If the timeout
+    // abandoned the promises above, `evaluate_timeout` set `maybe_skip` for the (already
+    // advanced-past) test entry; clear it so it is not misapplied to the resumed entry.
+    if let Some(resume_entry) = sequence.deferred_resume_entry.take() {
+        group_log::log(format_args!("runOne: matcher promises settled; resuming into afterEach"));
+        sequence.completion_deferred = false;
+        sequence.maybe_skip = false;
+        sequence.active_entry = Some(resume_entry);
+        return None;
     }
 
     group_log::log(format_args!("runOne: deferred completion; all matcher promises settled"));

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -155,6 +155,22 @@ pub struct ExecutionSequence {
     pub started_at: Timespec,
     /// Number of expect() calls observed in this sequence.
     pub expect_call_count: u32,
+    /// Deferred matcher promises (`.resolves`/`.rejects`, async `toThrow`, async custom
+    /// matchers) registered on this sequence that have not settled yet. The sequence does
+    /// not complete while this is nonzero (see [`Execution::finish_sequence`]). Like
+    /// `expect_call_count`, this is only tracked when the owning sequence is resolvable
+    /// (`get_current_state_data()` with `entry_data: Some`); `test.concurrent` groups
+    /// cannot resolve a single sequence, so per-test tracking degrades the same way.
+    pub pending_matcher_promises: u32,
+    /// Generation for `pending_matcher_promises`: captured by [`Self::register_matcher_promise`],
+    /// checked by [`Self::settle_matcher_promise`]. Monotonic for the lifetime of the slot
+    /// (bumped by the timeout-abandon path and by every retry/repeat `reset_sequence`), so a
+    /// settlement from an abandoned or previous attempt never touches a later attempt's counter.
+    pub matcher_epoch: u32,
+    /// The sequence ran out of entries while `pending_matcher_promises > 0`: completion
+    /// was deferred and is driven by `step_deferred_completion` once the promises settle
+    /// or the per-test timeout fires.
+    pub completion_deferred: bool,
     /// Expectation set by expect.hasAssertions() or expect.assertions(n).
     pub expect_assertions: ExpectAssertions,
     pub maybe_skip: bool,
@@ -188,6 +204,9 @@ impl ExecutionSequence {
             executing: false,
             started_at: Timespec::EPOCH,
             expect_call_count: 0,
+            pending_matcher_promises: 0,
+            matcher_epoch: 0,
+            completion_deferred: false,
             expect_assertions: ExpectAssertions::NotSet,
             maybe_skip: false,
         }
@@ -195,6 +214,30 @@ impl ExecutionSequence {
 
     pub(crate) fn flaky_attempts(&self) -> &[FlakyAttempt] {
         &self.flaky_attempts_buf[0..self.flaky_attempt_count]
+    }
+
+    /// Count a deferred matcher promise (`.resolves`, async `toThrow`, async custom matcher)
+    /// so the sequence does not complete until it settles. Returns the epoch the settle
+    /// reaction must hand back to [`Self::settle_matcher_promise`].
+    pub fn register_matcher_promise(&mut self) -> u32 {
+        self.pending_matcher_promises += 1;
+        self.matcher_epoch
+    }
+
+    /// Release one registration made at `epoch`. Returns whether the caller must wake the
+    /// runner (via `RefDataValue::Start` — a parked sequence has `active_entry == None`, so
+    /// `get_current_and_valid_execution_sequence` rejects `Execution` refdata for it).
+    /// Stale settlements (abandoned by the per-test timeout, or from a previous retry/repeat
+    /// attempt of this slot) fail the epoch check and are ignored.
+    pub fn settle_matcher_promise(&mut self, epoch: u32) -> bool {
+        if epoch != self.matcher_epoch {
+            return false;
+        }
+        // The epoch matched, so this registration was neither abandoned nor reset away and
+        // is still counted; a promise reaction settles at most once.
+        debug_assert!(self.pending_matcher_promises > 0);
+        self.pending_matcher_promises -= 1;
+        self.pending_matcher_promises == 0 && self.completion_deferred
     }
 
     fn entry_mode(&self) -> ScopeMode {
@@ -533,48 +576,81 @@ impl Execution {
         }
 
         if sequence.active_entry.is_none() {
-            // just completed the sequence
-            let test_failed = sequence.result.is_fail();
-            let test_passed = sequence.result.is_pass(PendingIs::PendingIsPass);
-
-            // Handle retry logic: if test failed and we have retries remaining, retry it
-            if test_failed && sequence.remaining_retry_count > 0 {
-                if sequence.flaky_attempt_count < ExecutionSequence::MAX_FLAKY_ATTEMPTS {
-                    let elapsed_ns: u64 = if sequence.started_at.eql(&Timespec::EPOCH) {
-                        0
-                    } else {
-                        sequence.started_at.since_now_force_real_time()
-                    };
-                    sequence.flaky_attempts_buf[sequence.flaky_attempt_count] = FlakyAttempt {
-                        result: sequence.result,
-                        elapsed_ns,
-                    };
-                    sequence.flaky_attempt_count += 1;
-                }
-                sequence.remaining_retry_count -= 1;
-                Execution::reset_sequence(sequence);
+            // The sequence ran out of entries; it only completes once every deferred matcher
+            // promise has settled. `step_deferred_completion` finishes it (or times it out).
+            // While parked here `active_entry` is None, so an `Execution` refdata can never
+            // re-step it (`get_current_and_valid_execution_sequence` rejects it as outdated):
+            // the settle reaction must wake the runner with `RefDataValue::Start`.
+            if sequence.pending_matcher_promises > 0 {
+                group_log::log(format_args!(
+                    "advanceSequence: deferring completion; {} pending matcher promise(s)",
+                    sequence.pending_matcher_promises
+                ));
+                sequence.completion_deferred = true;
                 return;
             }
-
-            // Handle repeat logic: if test passed and we have repeats remaining, repeat it
-            if test_passed && sequence.remaining_repeat_count > 0 {
-                sequence.remaining_repeat_count -= 1;
-                Execution::reset_sequence(sequence);
-                return;
-            }
-
-            // Only report the final result after all retries/repeats are done
-            Execution::on_sequence_completed(buntest, sequence);
-
-            // No more retries or repeats; mark sequence as complete
-            // SAFETY: group_ptr points into `buntest.execution.groups`, disjoint from `sequence`.
-            let group = unsafe { &mut *group_ptr.as_ptr() };
-            if group.remaining_incomplete_entries == 0 {
-                debug_assert!(false); // remaining_incomplete_entries should never go below 0
-                return;
-            }
-            group.remaining_incomplete_entries -= 1;
+            Execution::finish_sequence(buntest, sequence_ptr, group_ptr);
         }
+    }
+
+    /// Retry/repeat handling, final reporting, and group accounting for a sequence with no
+    /// entries left and no pending matcher promises. Reached from [`Execution::advance_sequence`]
+    /// (immediate completion) and `step_deferred_completion` (deferred completion).
+    ///
+    /// `sequence_ptr` / `group_ptr` carry the same raw-pointer contract as `advance_sequence`.
+    fn finish_sequence(
+        buntest: NonNull<BunTest>,
+        sequence_ptr: NonNull<ExecutionSequence>,
+        group_ptr: NonNull<ConcurrentGroup>,
+    ) {
+        // SAFETY: sequence_ptr / group_ptr point into disjoint fields of `buntest.execution`
+        // (`sequences` vs `groups`); no `&mut Execution` is live in this scope.
+        let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
+        debug_assert!(sequence.active_entry.is_none());
+        debug_assert!(!sequence.executing);
+        sequence.completion_deferred = false;
+
+        // just completed the sequence
+        let test_failed = sequence.result.is_fail();
+        let test_passed = sequence.result.is_pass(PendingIs::PendingIsPass);
+
+        // Handle retry logic: if test failed and we have retries remaining, retry it
+        if test_failed && sequence.remaining_retry_count > 0 {
+            if sequence.flaky_attempt_count < ExecutionSequence::MAX_FLAKY_ATTEMPTS {
+                let elapsed_ns: u64 = if sequence.started_at.eql(&Timespec::EPOCH) {
+                    0
+                } else {
+                    sequence.started_at.since_now_force_real_time()
+                };
+                sequence.flaky_attempts_buf[sequence.flaky_attempt_count] = FlakyAttempt {
+                    result: sequence.result,
+                    elapsed_ns,
+                };
+                sequence.flaky_attempt_count += 1;
+            }
+            sequence.remaining_retry_count -= 1;
+            Execution::reset_sequence(sequence);
+            return;
+        }
+
+        // Handle repeat logic: if test passed and we have repeats remaining, repeat it
+        if test_passed && sequence.remaining_repeat_count > 0 {
+            sequence.remaining_repeat_count -= 1;
+            Execution::reset_sequence(sequence);
+            return;
+        }
+
+        // Only report the final result after all retries/repeats are done
+        Execution::on_sequence_completed(buntest, sequence);
+
+        // No more retries or repeats; mark sequence as complete
+        // SAFETY: group_ptr points into `buntest.execution.groups`, disjoint from `sequence`.
+        let group = unsafe { &mut *group_ptr.as_ptr() };
+        if group.remaining_incomplete_entries == 0 {
+            debug_assert!(false); // remaining_incomplete_entries should never go below 0
+            return;
+        }
+        group.remaining_incomplete_entries -= 1;
     }
 
     fn on_group_started(global_this: &JSGlobalObject) {
@@ -638,6 +714,9 @@ impl Execution {
     fn on_entry_completed(_entry: NonNull<ExecutionEntry>) {}
 
     fn on_sequence_completed(buntest: NonNull<BunTest>, sequence: &mut ExecutionSequence) {
+        // A sequence never completes with unsettled matcher promises: `finish_sequence` is
+        // gated on the counter, and the timeout path abandons them (epoch bump + zero) first.
+        debug_assert_eq!(sequence.pending_matcher_promises, 0);
         let elapsed_ns: u64 = if sequence.started_at.eql(&Timespec::EPOCH) {
             0
         } else {
@@ -742,6 +821,7 @@ impl Execution {
         // Preserve retry/repeat counts and flaky attempt history across reset
         let saved_flaky_attempt_count = sequence.flaky_attempt_count;
         let saved_flaky_attempts_buf = sequence.flaky_attempts_buf;
+        let saved_matcher_epoch = sequence.matcher_epoch;
         *sequence = ExecutionSequence::init(
             sequence.first_entry,
             sequence.test_entry,
@@ -750,6 +830,10 @@ impl Execution {
         );
         sequence.flaky_attempt_count = saved_flaky_attempt_count;
         sequence.flaky_attempts_buf = saved_flaky_attempts_buf;
+        // The epoch stays monotonic across attempts: `init` zeroed `pending_matcher_promises`,
+        // so any matcher promise registered by a previous attempt must fail the epoch check
+        // instead of decrementing (and corrupting) this attempt's counter when it settles.
+        sequence.matcher_epoch = saved_matcher_epoch.wrapping_add(1);
 
         // Snapshot counters are keyed by full test name and incremented on every
         // toMatchSnapshot() call. Without this reset, retries / repeats would
@@ -988,6 +1072,10 @@ fn step_sequence_one(
     }
 
     let Some(next_item_ptr) = sequence.active_entry else {
+        // Completion was deferred on pending matcher promises; wait / time out / finish it.
+        if sequence.completion_deferred {
+            return Ok(step_deferred_completion(buntest_ptr, sequence_ptr, group, now));
+        }
         // Sequence is complete - either because:
         // 1. It ran out of entries (normal completion)
         // 2. All retry/repeat attempts have been exhausted
@@ -1069,4 +1157,50 @@ fn step_sequence_one(
         Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
         return Ok(None); // run again
     }
+}
+
+/// A sequence whose entries all completed while matcher promises were still pending
+/// (`ExecutionSequence::completion_deferred`) is held open here. The test's own deadline still
+/// applies: if it expires first, the pending promises are abandoned and the sequence completes
+/// through the normal timeout path. Returns `None` when the sequence should be stepped again.
+///
+/// `sequence_ptr` / `group` carry the same raw-pointer contract as `advance_sequence`.
+fn step_deferred_completion(
+    buntest_ptr: NonNull<BunTest>,
+    sequence_ptr: NonNull<ExecutionSequence>,
+    group: NonNull<ConcurrentGroup>,
+    now: &Timespec,
+) -> Option<AdvanceSequenceStatus> {
+    let _g = group_begin!();
+    // SAFETY: sequence_ptr points into `buntest.execution.sequences`; unique live `&mut` here.
+    let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
+    debug_assert!(sequence.active_entry.is_none());
+    debug_assert!(!sequence.executing);
+
+    if sequence.pending_matcher_promises > 0 {
+        let Some(test_entry_ptr) = sequence.test_entry else {
+            // No test entry to derive a deadline from; wait for the promises to settle.
+            return Some(AdvanceSequenceStatus::Execute { timeout: Timespec::EPOCH });
+        };
+        // SAFETY: arena-owned entry, alive for lifetime of BunTest
+        let test_entry = unsafe { test_entry_ptr.as_ref() };
+        if !test_entry.evaluate_timeout(sequence, now) {
+            group_log::log(format_args!(
+                "runOne: no more entries; waiting for {} pending matcher promise(s)",
+                sequence.pending_matcher_promises
+            ));
+            return Some(AdvanceSequenceStatus::Execute { timeout: test_entry.timespec });
+        }
+        // The per-test timeout fired first: abandon the pending promises and fail as a
+        // timeout. Bumping the epoch invalidates the abandoned registrations, so a late
+        // settlement fails `settle_matcher_promise`'s epoch check instead of decrementing a
+        // counter it is no longer part of (this attempt's, or a retry's after `reset_sequence`).
+        sequence.matcher_epoch = sequence.matcher_epoch.wrapping_add(1);
+        sequence.pending_matcher_promises = 0;
+    }
+
+    group_log::log(format_args!("runOne: deferred completion; all matcher promises settled"));
+    Execution::finish_sequence(buntest_ptr, sequence_ptr, group);
+    // finish_sequence may have reset the sequence for a retry/repeat; step it again either way.
+    None
 }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -38,8 +38,85 @@ use bun_jsc::js_error_to_write_error;
 #[bun_jsc::JsClass]
 pub struct Expect {
     pub flags: Cell<Flags>,
+    /// Rust-only (the C++-mirrored `Flags(u8)` byte is full). Set while a deferred
+    /// matcher's settle reaction re-invokes the same matcher, so the second pass takes
+    /// the synchronous path and per-test bookkeeping is not double-counted.
+    pub reentry: Cell<bool>,
+    /// Rust-only. Settlement handed to the running settle re-invocation; `Some` only for
+    /// its synchronous duration ([`Expect::on_subject_settled`] sets/clears it around
+    /// `callee.call`), during which the reaction frame + context array root its values.
+    pub reentry_settlement: Cell<Option<ReentrySettlement>>,
+    /// Rust-only. User call site of the deferring invocation, restored for the settle
+    /// re-invocation window (same rooting as [`Expect::reentry_settlement`]): that pass
+    /// runs from a reaction job with no user frames for inline snapshots to walk.
+    pub reentry_call_site: Cell<Option<ReentryCallSite>>,
+    /// Rust-only. The running settle re-invocation's own deferral (same window/rooting as
+    /// [`Expect::reentry_settlement`]); a re-invocation that defers AGAIN takes and
+    /// reuses it instead of minting a second `D` — see [`ReentryDeferred`].
+    pub reentry_deferred: Cell<Option<ReentryDeferred>>,
     pub parent: Option<bun_test::RefDataPtr>,
     pub custom_label: bun_core::String,
+}
+
+/// Which await point inside a matcher invocation created a deferral. Recorded in the
+/// reaction context and handed back through [`Expect::take_reentry_settlement`] so the
+/// re-invoked matcher resumes past that point instead of re-running its producer.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum DeferralOrigin {
+    /// `.resolves`/`.rejects` subject promise (`process_promise`). The re-invocation
+    /// re-reads the (now settled) subject, so it never consumes the settlement.
+    Subject = 0,
+    /// Promise returned by the function under `toThrow` (`get_value_as_to_throw`): the
+    /// function already ran on the first pass and must not be called again.
+    ThrownValue = 1,
+    /// Promise returned by an async `expect.extend` matcher (`apply_custom_matcher`):
+    /// the user matcher already ran on the first pass and must not be called again.
+    MatcherResult = 2,
+}
+
+impl DeferralOrigin {
+    /// Inverse of the `js_number_from_int32(origin as i32)` encoding used for the
+    /// [`deferred_ctx::ORIGIN`] reaction-context slot.
+    fn from_ctx_slot(value: JSValue) -> Self {
+        match value.is_int32().then(|| value.as_int32()) {
+            Some(1) => Self::ThrownValue,
+            Some(2) => Self::MatcherResult,
+            _ => Self::Subject,
+        }
+    }
+}
+
+/// The user call site captured when a matcher deferred ([`deferred_ctx::SRC_URL`]),
+/// handed back to its settle re-invocation through [`Expect::reentry_call_site`].
+/// `source_url` (a `JSString`) is rooted by the reaction's context array for the whole
+/// re-invocation window, exactly like [`ReentrySettlement`]'s values.
+#[derive(Clone, Copy)]
+pub struct ReentryCallSite {
+    pub source_url: JSValue,
+    pub line: u32,
+    pub column: u32,
+}
+
+/// `D` (the promise the FIRST pass returned to the user) + the call-site error, reused by
+/// a chained deferral: the user only holds that `D`, so the awaited/un-awaited probe and
+/// the settlement must target it, and only the first pass had user frames to attribute to.
+#[derive(Clone, Copy)]
+pub struct ReentryDeferred {
+    pub deferred: JSValue,
+    pub call_site_error: JSValue,
+}
+
+/// How the promise a matcher deferred on settled, handed from the settle reaction to the
+/// re-invoked matcher (see [`Expect::reentry_settlement`] for the rooting invariant).
+#[derive(Clone, Copy)]
+pub struct ReentrySettlement {
+    pub origin: DeferralOrigin,
+    /// The promise the deferral's reactions were attached to.
+    pub subject: JSValue,
+    /// Its fulfillment value or rejection reason.
+    pub value: JSValue,
+    pub rejected: bool,
 }
 
 
@@ -182,6 +259,33 @@ impl Flags {
     }
 }
 
+/// How [`Expect::get_value`] hands the received value back to a matcher.
+///
+/// The `T` parameter exists so scaffold helpers wrapping `get_value`
+/// ([`Expect::matcher_prelude`], [`Expect::mock_prologue`]) can propagate a
+/// deferral while returning their richer ready payload.
+pub enum GetValueResult<T = JSValue> {
+    /// The received value is available; run the matcher synchronously.
+    Ready(T),
+    /// `.resolves`/`.rejects` on a promise subject that must settle first:
+    /// the matcher returns this promise to JS and is re-invoked on settlement.
+    Deferred(JSValue),
+}
+
+/// Unwraps a [`GetValueResult`]: yields the `Ready` payload, or early-returns
+/// `Ok(promise)` from the enclosing matcher on `Deferred`.
+macro_rules! ready_or_defer {
+    ($result:expr) => {
+        match $result {
+            $crate::test_runner::expect_core::GetValueResult::Ready(ready) => ready,
+            $crate::test_runner::expect_core::GetValueResult::Deferred(promise) => {
+                return Ok(promise);
+            }
+        }
+    };
+}
+pub(crate) use ready_or_defer;
+
 impl Expect {
     /// R-2 helper: read-modify-write the packed `Cell<Flags>` through `&self`.
     #[inline]
@@ -191,7 +295,15 @@ impl Expect {
         self.flags.set(v);
     }
 
+    /// Ordering invariant: every matcher entry point must call this BEFORE its
+    /// `Deferred` early-return (`get_value`/`process_promise`), so the deferring first
+    /// pass counts exactly once and the `reentry` re-invocation is gated off below.
     pub fn increment_expect_call_counter(&self) {
+        // A deferred matcher promise's settle reaction re-invokes the same matcher on the
+        // same `Expect` with `reentry` set; the first invocation already counted it.
+        if self.reentry.get() {
+            return;
+        }
         let Some(parent) = self.parent.as_ref() else { return }; // not in bun:test
         let Some(buntest_strong) = parent.bun_test() else { return }; // the test file this expect() call was for is no longer
         let buntest = buntest_strong.get();
@@ -210,6 +322,35 @@ impl Expect {
                 }
             }
         }
+    }
+
+    /// Consume the settlement the settle reaction stashed for the deferral made at
+    /// `origin`. Returns `None` outside a re-invocation, or when the pending settlement
+    /// belongs to a different await point of the same matcher (e.g. the subject deferral
+    /// of a `.resolves.toThrow()` chain), so each site only ever resumes its own deferral.
+    pub fn take_reentry_settlement(&self, origin: DeferralOrigin) -> Option<ReentrySettlement> {
+        let settlement = self.reentry_settlement.get()?;
+        if settlement.origin != origin {
+            return None;
+        }
+        self.reentry_settlement.set(None);
+        Some(settlement)
+    }
+
+    /// The user call site captured when the matcher currently being re-invoked deferred
+    /// ([`deferred_ctx::SRC_URL`]); `None` outside a settle re-invocation. Like
+    /// [`CallFrame::get_caller_src_loc`], the returned `str` is +1 and the caller owns
+    /// releasing it.
+    pub fn reentry_caller_src_loc(
+        &self,
+        global_this: &JSGlobalObject,
+    ) -> JsResult<Option<bun_jsc::call_frame::CallerSrcLoc>> {
+        let Some(site) = self.reentry_call_site.get() else { return Ok(None) };
+        Ok(Some(bun_jsc::call_frame::CallerSrcLoc {
+            str: bun_core::String::from_js(site.source_url, global_this)?,
+            line: site.line,
+            column: site.column,
+        }))
     }
 
     pub fn bun_test(&self) -> Option<bun_test::BunTestPtr> {
@@ -357,15 +498,20 @@ impl Expect {
         Ok(this_value)
     }
 
+    /// Resolves the received value for a matcher call. Takes the matcher's
+    /// `CallFrame` (not just `this`) so the deferral path can capture the
+    /// callee + args + `this` needed to re-invoke the matcher once a
+    /// `.resolves`/`.rejects` subject promise settles.
     pub fn get_value(
         &self,
         global_this: &JSGlobalObject,
-        this_value: JSValue,
+        call_frame: &CallFrame,
         // Every caller passes a string literal, so accept `&str`
         // (BStr::new below takes `AsRef<[u8]>`, so no copy).
         matcher_name: &str,
         matcher_params_fmt: &'static str,
-    ) -> JsResult<JSValue> {
+    ) -> JsResult<GetValueResult> {
+        let this_value = call_frame.this();
         let Some(value) = super::expect::js::captured_value_get_cached(this_value) else {
             return Err(global_this.throw2(
                 "Internal error: the expect(value) was garbage collected but it should not have been!",
@@ -373,6 +519,14 @@ impl Expect {
             ));
         };
         value.ensure_still_alive();
+
+        // A `.resolves`/`.rejects` subject promise is never awaited synchronously from
+        // inside the matcher (oven-sh/bun#33261) — defer even if it is already settled
+        // (Jest parity: one-microtask minimum). The settle re-invocation (`reentry`) and
+        // non-promise subjects fall through to `process_promise`'s synchronous logic.
+        if let Some(deferred) = self.try_defer_subject(global_this, call_frame, value) {
+            return Ok(GetValueResult::Deferred(deferred?));
+        }
 
         #[allow(clippy::disallowed_methods)] // template is a runtime parameter
         let matcher_params = Output::pretty_fmt_rt(matcher_params_fmt, Output::enable_ansi_colors_stderr());
@@ -385,11 +539,13 @@ impl Expect {
             matcher_params,
             false,
         )
+        .map(GetValueResult::Ready)
     }
 
-    /// Processes the async flags (resolves/rejects), waiting for the async value if needed.
-    /// If no flags, returns the original value
-    /// If either flag is set, waits for the result, and returns either it as a JSValue, or null if the expectation failed (in which case if silent is false, also throws a js exception)
+    /// Synchronous half of `.resolves`/`.rejects`: direction-check a settled subject and
+    /// return its settled value (pretty matcher error on mismatch unless `silent`). Never
+    /// waits: pending subjects were deferred before this (oven-sh/bun#33261); a caller
+    /// with no matcher to re-invoke treats `Pending` as a mismatch.
     pub fn process_promise(
         custom_label: bun_core::String,
         flags: Flags,
@@ -399,84 +555,67 @@ impl Expect {
         matcher_params: impl fmt::Display,
         silent: bool,
     ) -> JsResult<JSValue> {
-        match flags.promise() {
-            resolution @ (Promise::Resolves | Promise::Rejects) => {
-                if let Some(promise) = value.as_any_promise() {
-                    let vm = global_this.vm();
-                    promise.set_handled(vm);
-
-                    // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
-            global_this.bun_vm().as_mut().wait_for_promise(promise);
-
-                    let new_value = promise.result(vm);
-                    match promise.status() {
-                        js_promise::Status::Fulfilled => match resolution {
-                            Promise::Resolves => {}
-                            Promise::Rejects => {
-                                if !silent {
-                                    let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-                                    return Err(Self::throw_pretty_matcher_error(
-                                        global_this,
-                                        custom_label,
-                                        matcher_name,
-                                        matcher_params,
-                                        flags,
-                                        format_args!(
-                                            "Expected promise that rejects<r>\nReceived promise that resolved: <red>{}<r>\n",
-                                            value.to_fmt(&mut formatter),
-                                        ),
-                                    ));
-                                }
-                                return Err(JsError::Thrown);
-                            }
-                            Promise::None => unreachable!(),
-                        },
-                        js_promise::Status::Rejected => match resolution {
-                            Promise::Rejects => {}
-                            Promise::Resolves => {
-                                if !silent {
-                                    let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-                                    return Err(Self::throw_pretty_matcher_error(
-                                        global_this,
-                                        custom_label,
-                                        matcher_name,
-                                        matcher_params,
-                                        flags,
-                                        format_args!(
-                                            "Expected promise that resolves<r>\nReceived promise that rejected: <red>{}<r>\n",
-                                            value.to_fmt(&mut formatter),
-                                        ),
-                                    ));
-                                }
-                                return Err(JsError::Thrown);
-                            }
-                            Promise::None => unreachable!(),
-                        },
-                        js_promise::Status::Pending => unreachable!(),
-                    }
-
-                    new_value.ensure_still_alive();
-                    Ok(new_value)
-                } else {
-                    if !silent {
-                        let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-                        return Err(Self::throw_pretty_matcher_error(
-                            global_this,
-                            custom_label,
-                            matcher_name,
-                            matcher_params,
-                            flags,
-                            format_args!(
-                                "Expected promise<r>\nReceived: <red>{}<r>\n",
-                                value.to_fmt(&mut formatter),
-                            ),
-                        ));
-                    }
-                    Err(JsError::Thrown)
-                }
-            }
-            _ => Ok(value),
+        let resolution = flags.promise();
+        if resolution == Promise::None {
+            return Ok(value);
         }
+        let Some(promise) = value.as_any_promise() else {
+            if !silent {
+                let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
+                return Err(Self::throw_pretty_matcher_error(
+                    global_this,
+                    custom_label,
+                    matcher_name,
+                    matcher_params,
+                    flags,
+                    format_args!(
+                        "Expected promise<r>\nReceived: <red>{}<r>\n",
+                        value.to_fmt(&mut formatter),
+                    ),
+                ));
+            }
+            return Err(JsError::Thrown);
+        };
+
+        let vm = global_this.vm();
+        // Invariant: the subject is marked handled so an un-awaited rejecting subject is
+        // never reported as an unhandled rejection.
+        promise.set_handled(vm);
+
+        // `Some((expected, received))` describes a state mismatch for the failure message.
+        let mismatch: Option<(&str, &str)> = match promise.status() {
+            js_promise::Status::Fulfilled => {
+                if resolution == Promise::Rejects { Some(("rejects", "resolved")) } else { None }
+            }
+            js_promise::Status::Rejected => {
+                if resolution == Promise::Resolves { Some(("resolves", "rejected")) } else { None }
+            }
+            js_promise::Status::Pending => Some((
+                if resolution == Promise::Rejects { "rejects" } else { "resolves" },
+                "is still pending",
+            )),
+        };
+        if let Some((expected, received)) = mismatch {
+            if !silent {
+                let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
+                return Err(Self::throw_pretty_matcher_error(
+                    global_this,
+                    custom_label,
+                    matcher_name,
+                    matcher_params,
+                    flags,
+                    format_args!(
+                        "Expected promise that {expected}<r>\nReceived promise that {received}: <red>{}<r>\n",
+                        value.to_fmt(&mut formatter),
+                    ),
+                ));
+            }
+            return Err(JsError::Thrown);
+        }
+
+        let new_value = promise.result(vm);
+        new_value.ensure_still_alive();
+        Ok(new_value)
     }
 
     pub fn is_asymmetric_matcher(value: JSValue) -> bool {
@@ -536,6 +675,23 @@ impl Expect {
         // (note that matcher_name/matcher_args are not used because silent=true)
         // SAFETY: value is a valid in/out-ptr provided by C++ caller
         let v = unsafe { *value };
+        // `expect.resolvesTo`/`expect.rejectsTo` run inside a synchronous deep-equality
+        // walk that needs a boolean back, so a still-pending received promise cannot be
+        // deferred the way a `.resolves` matcher is (there is no matcher invocation to
+        // re-run once it settles). Keep the pre-existing blocking wait for this
+        // asymmetric-only entry point (as `execute_custom_matcher` does for an async
+        // asymmetric custom matcher); every matcher entry point defers instead.
+        if flags.promise() != Promise::None {
+            if let Some(promise) = v.as_any_promise() {
+                // Handled BEFORE the wait, or the rejection is reported as unhandled while
+                // the event loop runs it to settlement.
+                promise.set_handled(global_this.vm());
+                if promise.status() == js_promise::Status::Pending {
+                    // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
+                    global_this.bun_vm().as_mut().wait_for_promise(promise);
+                }
+            }
+        }
         match Self::process_promise(bun_core::String::empty(), flags, global_this, v, "", "", true) {
             Ok(new) => {
                 // SAFETY: value is a valid in/out-ptr provided by C++ caller
@@ -550,10 +706,18 @@ impl Expect {
         let parent = self.parent.as_ref().ok_or_else(|| bun_core::err!("NoTest"))?;
         let buntest_strong = parent.bun_test().ok_or_else(|| bun_core::err!("TestNotActive"))?;
         let buntest = buntest_strong.get();
-        let execution_entry = parent
-            .phase
-            .entry(buntest)
-            .ok_or_else(|| bun_core::err!("SnapshotInConcurrentGroup"))?;
+        // A sequence parked on pending matcher promises has no `active_entry`, but it is
+        // still the owning test: resolve it through the sequence's `test_entry`, exactly
+        // like `record_unawaited_matcher_failure`.
+        let execution_entry: *const bun_test::ExecutionEntry = match parent.phase.entry(buntest) {
+            Some(entry) => entry,
+            None => match parent.phase.sequence(buntest).and_then(|s| s.test_entry) {
+                Some(entry) => entry.as_ptr(),
+                None => return Err(bun_core::err!("SnapshotInConcurrentGroup")),
+            },
+        };
+        // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
+        let execution_entry = unsafe { &*execution_entry };
 
         let test_name: &[u8] = execution_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
 
@@ -649,6 +813,10 @@ impl Expect {
 
         let expect = Expect {
             flags: Cell::new(Flags::default()),
+            reentry: Cell::new(false),
+            reentry_settlement: Cell::new(None),
+            reentry_call_site: Cell::new(None),
+            reentry_deferred: Cell::new(None),
             custom_label,
             parent: active_execution_entry_ref,
         };
@@ -810,11 +978,22 @@ pub struct TrimResult<'a> {
 }
 
 impl Expect {
+    /// Resolves the received value of `toThrow`-family matchers: calls the received
+    /// function and reports what it threw (or, for a promise it returned, what that
+    /// promise rejected with).
+    ///
+    /// `Ready((thrown, returned))` when the function threw (or returned) synchronously.
+    /// A returned promise is never observed in place — the matcher must not wait for it
+    /// (oven-sh/bun#33261) and always evaluates to a promise (one-microtask minimum, like
+    /// a `.resolves`/`.rejects` subject): it is `Deferred` on that promise, and the
+    /// settle reaction re-invokes the matcher, which resumes here from the stashed
+    /// settlement (the received function is never called a second time).
     pub fn get_value_as_to_throw(
         &self,
         global_this: &JSGlobalObject,
+        call_frame: &CallFrame,
         value: JSValue,
-    ) -> JsResult<(Option<JSValue>, JSValue)> {
+    ) -> JsResult<GetValueResult<(Option<JSValue>, JSValue)>> {
         // SAFETY: bun_vm() returns the live thread-local VirtualMachine; valid for this call.
         let vm = global_this.bun_vm().as_mut();
 
@@ -822,9 +1001,20 @@ impl Expect {
 
         if !value.js_type().is_function() {
             if self.flags.get().promise() != Promise::None {
-                return Ok((Some(value), return_value_from_function));
+                return Ok(GetValueResult::Ready((Some(value), return_value_from_function)));
             }
             return Err(global_this.throw(format_args!("Expected value must be a function")));
+        }
+
+        // Settle re-invocation of a deferred `toThrow`: the received function already ran
+        // on the deferring pass; resume from how its returned promise settled.
+        if let Some(settlement) = self.take_reentry_settlement(DeferralOrigin::ThrownValue) {
+            return Ok(GetValueResult::Ready(if settlement.rejected {
+                let reason = settlement.value;
+                (Some(reason.to_error().unwrap_or(reason)), settlement.subject)
+            } else {
+                (None, settlement.subject)
+            }));
         }
 
         let mut return_value: JSValue = JSValue::ZERO;
@@ -849,18 +1039,32 @@ impl Expect {
         }
 
         if let Some(promise) = return_value.as_any_promise() {
-            vm.wait_for_promise(promise);
+            // Restored before the deferral early-return: the quiet capture handler
+            // installed above must never leak past this matcher call.
             scope.apply(vm);
-            match promise.unwrap(global_this.vm(), js_promise::UnwrapMode::MarkHandled) {
-                js_promise::Unwrapped::Fulfilled(_) => {
-                    return Ok((None, return_value_from_function));
-                }
-                js_promise::Unwrapped::Rejected(rejected) => {
-                    // since we know for sure it rejected, we should always return the error
-                    return Ok((Some(rejected.to_error().unwrap_or(rejected)), return_value_from_function));
-                }
-                js_promise::Unwrapped::Pending => unreachable!(),
+            promise.set_handled(global_this.vm());
+            if self.can_track_matcher_promise() {
+                // Park the matcher on the promise the function returned, even if it
+                // already settled; only the settle re-invocation above reads its status.
+                return Ok(GetValueResult::Deferred(self.defer_matcher(
+                    global_this,
+                    call_frame,
+                    return_value,
+                    DeferralOrigin::ThrownValue,
+                )?));
             }
+            // No owning sequence can keep the test alive across a deferral
+            // (`test.concurrent`, outside bun:test, a torn-down phase): keep the
+            // pre-existing synchronous wait so a failing assertion still fails in place.
+            // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
+            global_this.bun_vm().as_mut().wait_for_promise(promise);
+            let rejected = promise.status() == js_promise::Status::Rejected;
+            let settled = promise.result(global_this.vm());
+            return Ok(GetValueResult::Ready(if rejected {
+                (Some(settled.to_error().unwrap_or(settled)), return_value_from_function)
+            } else {
+                (None, return_value_from_function)
+            }));
         }
 
         if return_value != return_value_from_function {
@@ -871,20 +1075,30 @@ impl Expect {
 
         scope.apply(vm);
 
-        Ok((
+        Ok(GetValueResult::Ready((
             return_value.to_error().or_else(|| return_value_from_function.to_error()),
             return_value_from_function,
-        ))
+        )))
     }
 
+    /// `Deferred` when [`Expect::get_value_as_to_throw`] deferred on the promise the
+    /// received function returned; the settle re-invocation takes the `Ready` path.
     pub fn fn_to_err_string_or_undefined(
         &self,
         global_this: &JSGlobalObject,
+        call_frame: &CallFrame,
         value: JSValue,
-    ) -> JsResult<Option<JSValue>> {
-        let (err_value, _) = self.get_value_as_to_throw(global_this, value)?;
+    ) -> JsResult<GetValueResult<Option<JSValue>>> {
+        // `ready_or_defer!` early-returns a bare `Ok(promise)`, which does not fit this
+        // return type; propagate the deferral variant instead.
+        let (err_value, _) = match self.get_value_as_to_throw(global_this, call_frame, value)? {
+            GetValueResult::Ready(ready) => ready,
+            GetValueResult::Deferred(promise) => return Ok(GetValueResult::Deferred(promise)),
+        };
 
-        let Some(mut err_value_res) = err_value else { return Ok(None) };
+        let Some(mut err_value_res) = err_value else {
+            return Ok(GetValueResult::Ready(None));
+        };
         if err_value_res.is_any_error() {
             let message: JSValue = err_value_res
                 .get_truthy(global_this, "message")?
@@ -893,7 +1107,7 @@ impl Expect {
         } else {
             err_value_res = JSValue::UNDEFINED;
         }
-        Ok(Some(err_value_res))
+        Ok(GetValueResult::Ready(Some(err_value_res)))
     }
 
     pub fn trim_leading_whitespace_for_inline_snapshot<'a>(
@@ -1074,8 +1288,14 @@ impl Expect {
             };
             let buntest = buntest_strong.get();
 
-            // 1. find the src loc of the snapshot
-            let srcloc = call_frame.get_caller_src_loc(global_this);
+            // 1. find the src loc of the snapshot. In the settle re-invocation of a
+            // deferred matcher (`.resolves.toMatchInlineSnapshot()`) this frame is a
+            // promise-reaction job with no user JS frames to walk, so use the call site
+            // captured when the matcher deferred instead.
+            let srcloc = match this.reentry_caller_src_loc(global_this)? {
+                Some(srcloc) => srcloc,
+                None => call_frame.get_caller_src_loc(global_this),
+            };
             // bun_core::String is Copy
             // with no Drop, so wrap in the RAII guard to release the +1 on
             // every exit path (including the early returns below).
@@ -1427,8 +1647,41 @@ impl Expect {
         global_this.throw_value(err)
     }
 
-    /// Execute the custom matcher for the given args (the left value + the args passed to the matcher call).
-    /// This function is called both for symmetric and asymmetric matching.
+    /// Call a user-provided `expect.extend` matcher with a fresh
+    /// [`ExpectMatcherContext`] receiver. The result may be a thenable.
+    fn call_custom_matcher(
+        global_this: &JSGlobalObject,
+        matcher_fn: JSValue,
+        args: &[JSValue],
+        flags: Flags,
+    ) -> JsResult<JSValue> {
+        // JsClass::to_js takes `self` by value and boxes internally.
+        let matcher_context_jsvalue = ExpectMatcherContext { flags }.to_js(global_this);
+        matcher_context_jsvalue.ensure_still_alive();
+        matcher_fn.call(global_this, matcher_context_jsvalue, args)
+    }
+
+    /// A custom matcher's promise rejected: report the reason, then throw.
+    fn throw_custom_matcher_rejected(
+        global_this: &JSGlobalObject,
+        matcher_name: bun_core::String,
+        reason: JSValue,
+    ) -> JsError {
+        // SAFETY: per-use reborrow of the thread-local VM (see VirtualMachine::get docs).
+        VirtualMachine::get().as_mut().run_error_handler(reason, None);
+        global_this.throw(format_args!(
+            "Matcher `{}` returned a promise that rejected",
+            matcher_name,
+        ))
+    }
+
+    /// Execute the custom matcher for the given args (the left value + the args passed to
+    /// the matcher call) in ASYMMETRIC position (`expect(x).toEqual(expect.myMatcher())`).
+    ///
+    /// This runs inside a synchronous equality walk that needs a boolean back, so a
+    /// still-pending async matcher result cannot be deferred the way the symmetric path
+    /// (`apply_custom_matcher`) defers; it keeps the pre-existing blocking wait (see the
+    /// comment at the wait site).
     /// If silent=false, throws an exception in JS if the matcher result didn't result in a pass (or if the matcher result is invalid).
     pub fn execute_custom_matcher(
         global_this: &JSGlobalObject,
@@ -1438,39 +1691,56 @@ impl Expect {
         flags: Flags,
         silent: bool,
     ) -> JsResult<bool> {
-        // prepare the this object
-        // JsClass::to_js takes `self` by value and boxes internally.
-        let matcher_context_jsvalue = ExpectMatcherContext { flags }.to_js(global_this);
-        matcher_context_jsvalue.ensure_still_alive();
-
-        // call the custom matcher implementation
-        let mut result = matcher_fn.call(global_this, matcher_context_jsvalue, args)?;
+        let mut result = Self::call_custom_matcher(global_this, matcher_fn, args, flags)?;
         // support for async matcher results
         if let Some(promise) = result.as_any_promise() {
             let vm = global_this.vm();
             promise.set_handled(vm);
-
-            // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
-            global_this.bun_vm().as_mut().wait_for_promise(promise);
-
-            result = promise.result(vm);
-            result.ensure_still_alive();
-            debug_assert!(!result.is_empty());
+            if promise.status() == js_promise::Status::Pending {
+                // Deliberate, test-backed exception to "matchers never re-enter the event
+                // loop" (oven-sh/bun#33261), mirroring the `expect.resolvesTo`/`rejectsTo`
+                // subject wait in `Expect_readFlagsAndProcessPromise`: the pre-existing
+                // blocking wait is kept because deferring is impossible here.
+                // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
+                global_this.bun_vm().as_mut().wait_for_promise(promise);
+            }
             match promise.status() {
-                js_promise::Status::Pending => unreachable!(),
-                js_promise::Status::Fulfilled => {}
+                js_promise::Status::Fulfilled => {
+                    result = promise.result(vm);
+                    result.ensure_still_alive();
+                    debug_assert!(!result.is_empty());
+                }
                 js_promise::Status::Rejected => {
-                    // TODO: rewrite this code to use .then() instead of blocking the event loop
-                    // SAFETY: per-use reborrow of the thread-local VM (see VirtualMachine::get docs).
-                    VirtualMachine::get().as_mut().run_error_handler(result, None);
+                    return Err(Self::throw_custom_matcher_rejected(
+                        global_this,
+                        matcher_name,
+                        promise.result(vm),
+                    ));
+                }
+                // `wait_for_promise` returns with the promise still pending only when the
+                // VM forbade further execution (termination) mid-wait.
+                js_promise::Status::Pending => {
                     return Err(global_this.throw(format_args!(
-                        "Matcher `{}` returned a promise that rejected",
+                        "Matcher `{}` returned a promise that has not resolved yet",
                         matcher_name,
                     )));
                 }
             }
         }
+        Self::process_custom_matcher_result(global_this, matcher_name, matcher_fn, result, flags, silent)
+    }
 
+    /// Validate and apply a custom matcher's (settled, non-promise) `result`, which must
+    /// conform to `{ pass: boolean, message?: string | () => string }`.
+    /// If silent=false, throws in JS when the result is not a pass (or is invalid).
+    fn process_custom_matcher_result(
+        global_this: &JSGlobalObject,
+        matcher_name: bun_core::String,
+        matcher_fn: JSValue,
+        result: JSValue,
+        flags: Flags,
+        silent: bool,
+    ) -> JsResult<bool> {
         let mut pass: bool = false;
         let mut message: JSValue = JSValue::UNDEFINED;
 
@@ -1579,6 +1849,17 @@ impl Expect {
                 "Internal consistency error: failed to retrieve the captured value"
             )));
         };
+        // Counted before the deferral point, so the deferring first pass counts and the
+        // `reentry` re-invocation is the gated no-op.
+        expect.increment_expect_call_counter();
+
+        // A `.resolves`/`.rejects` subject promise defers the custom matcher exactly like
+        // `get_value` defers the built-in matchers; the settle reaction re-invokes this
+        // entry point with `reentry` set and the (now settled) subject falls through below.
+        if let Some(deferred) = expect.try_defer_subject(global_this, call_frame, value) {
+            return deferred;
+        }
+
         value = Self::process_promise(
             expect.custom_label.clone(),
             expect.flags.get(),
@@ -1590,19 +1871,87 @@ impl Expect {
         )?;
         value.ensure_still_alive();
 
-        expect.increment_expect_call_counter();
-
-        // prepare the args array
-        let args = call_frame.arguments();
-        // MarkedArgumentBuffer::new is scoped (closure-borrow); collect into a Vec
-        // since execute_custom_matcher takes &[JSValue].
-        let mut matcher_args: Vec<JSValue> = Vec::with_capacity(args.len() + 1);
-        matcher_args.push(value);
-        for arg in args {
-            matcher_args.push(*arg);
-        }
-
-        let _ = Self::execute_custom_matcher(global_this, matcher_name, matcher_fn, &matcher_args, expect.flags.get(), false)?;
+        // The settle re-invocation of a deferred async matcher resumes from the stashed
+        // settlement: the user matcher already ran on the deferring pass and must not be
+        // called a second time.
+        let result: JSValue = match expect.take_reentry_settlement(DeferralOrigin::MatcherResult) {
+            Some(settlement) if settlement.rejected => {
+                return Err(Self::throw_custom_matcher_rejected(
+                    global_this,
+                    matcher_name,
+                    settlement.value,
+                ));
+            }
+            Some(settlement) => settlement.value,
+            None => {
+                // MarkedArgumentBuffer::new is scoped (closure-borrow); collect into a Vec
+                // since the matcher call takes &[JSValue].
+                let args = call_frame.arguments();
+                let mut matcher_args: Vec<JSValue> = Vec::with_capacity(args.len() + 1);
+                matcher_args.push(value);
+                for arg in args {
+                    matcher_args.push(*arg);
+                }
+                let result =
+                    Self::call_custom_matcher(global_this, matcher_fn, &matcher_args, expect.flags.get())?;
+                let Some(promise) = result.as_any_promise() else {
+                    // Synchronous matcher result: apply it in place.
+                    let _ = Self::process_custom_matcher_result(
+                        global_this,
+                        matcher_name,
+                        matcher_fn,
+                        result,
+                        expect.flags.get(),
+                        false,
+                    )?;
+                    return Ok(this_value);
+                };
+                promise.set_handled(global_this.vm());
+                if expect.can_track_matcher_promise() {
+                    // Async matcher: park this matcher call on the promise it returned and
+                    // hand that deferred to the caller, even if it is already settled
+                    // (one-microtask minimum, Jest parity). The deferring pass never runs
+                    // from a settle reaction, so this cannot recurse.
+                    return expect.defer_matcher(
+                        global_this,
+                        call_frame,
+                        result,
+                        DeferralOrigin::MatcherResult,
+                    );
+                }
+                // No owning sequence can keep the test alive across a deferral
+                // (`test.concurrent`, outside bun:test, a torn-down phase): keep the
+                // pre-existing synchronous wait so a failing matcher still fails in place.
+                // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
+                global_this.bun_vm().as_mut().wait_for_promise(promise);
+                match promise.status() {
+                    js_promise::Status::Fulfilled => promise.result(global_this.vm()),
+                    js_promise::Status::Rejected => {
+                        return Err(Self::throw_custom_matcher_rejected(
+                            global_this,
+                            matcher_name,
+                            promise.result(global_this.vm()),
+                        ));
+                    }
+                    // `wait_for_promise` only returns on a pending promise when the VM
+                    // forbade further execution (termination) mid-wait.
+                    js_promise::Status::Pending => {
+                        return Err(global_this.throw(format_args!(
+                            "Matcher `{}` returned a promise that has not resolved yet",
+                            matcher_name,
+                        )));
+                    }
+                }
+            }
+        };
+        let _ = Self::process_custom_matcher_result(
+            global_this,
+            matcher_name,
+            matcher_fn,
+            result,
+            expect.flags.get(),
+            false,
+        )?;
 
         Ok(this_value)
     }
@@ -1708,6 +2057,10 @@ impl Expect {
         Err(global_this.throw(format_args!("Not implemented")))
     }
 
+    /// Only triggers a GC sweep. It intentionally does NOT reset `flags`
+    /// (not/resolves/rejects), `reentry`, or the cached captured value, so an `Expect`
+    /// whose matcher deferred on a pending promise still carries all of them when the
+    /// settle reaction re-invokes the same matcher.
     pub fn post_match(&self, global_this: &JSGlobalObject) {
         global_this.bun_vm().auto_garbage_collect();
     }
@@ -1729,22 +2082,30 @@ impl Expect {
     /// [`Self::mock_prologue`], for matchers that need the received value but
     /// are NOT a pure unary predicate and NOT a mock-function matcher.
     ///
-    /// Returns `(guard, received_value, not)`. The guard derefs to `&Expect`
+    /// Returns `Ready((guard, received_value, not))`, or `Deferred(promise)`
+    /// when the subject promise must settle before the matcher can run
+    /// (callers unwrap with `ready_or_defer!`). The guard derefs to `&Expect`
     /// and runs `post_match` on drop; `not` is `flags.not()` snapshotted once.
     /// Callers that don't need `not` until later destructure as `(this, v, _)`.
     #[inline]
     pub fn matcher_prelude<'a>(
         &'a self,
         global: &'a JSGlobalObject,
-        this_value: JSValue,
+        frame: &CallFrame,
         matcher_name: &str,
         matcher_params: &'static str,
-    ) -> JsResult<(PostMatchGuard<'a>, JSValue, bool)> {
+    ) -> JsResult<GetValueResult<(PostMatchGuard<'a>, JSValue, bool)>> {
         let this = self.post_match_guard(global);
-        let value = this.get_value(global, this_value, matcher_name, matcher_params)?;
+        let value = this.get_value(global, frame, matcher_name, matcher_params)?;
+        // Counted before the deferral early-return: the re-invocation runs with
+        // `reentry` set, so `increment_expect_call_counter` is a no-op there.
         this.increment_expect_call_counter();
+        let value = match value {
+            GetValueResult::Ready(value) => value,
+            GetValueResult::Deferred(promise) => return Ok(GetValueResult::Deferred(promise)),
+        };
         let not = this.flags.get().not();
-        Ok((this, value, not))
+        Ok(GetValueResult::Ready((this, value, not)))
     }
 
     // extern shim emitted by `#[bun_jsc::JsClass]` codegen (TypeClass__construct/__call); bare `#[host_fn]` cannot target an associated fn without a receiver.
@@ -2014,7 +2375,7 @@ impl Expect {
         matcher_name: &'static str,
         pred: impl FnOnce(JSValue) -> bool,
     ) -> JsResult<JSValue> {
-        let (this, value, not) = self.matcher_prelude(global, frame.this(), matcher_name, "")?;
+        let (this, value, not) = ready_or_defer!(self.matcher_prelude(global, frame, matcher_name, "")?);
         if pred(value) != not {
             return Ok(JSValue::UNDEFINED);
         }
@@ -2065,8 +2426,9 @@ impl Expect {
             )));
         }
 
-        let value = this.get_value(global, frame.this(), matcher_name, "<green>expected<r>")?;
+        let value = this.get_value(global, frame, matcher_name, "<green>expected<r>")?;
         this.increment_expect_call_counter();
+        let value = ready_or_defer!(value);
 
         let mut pass = value.is_string();
         if pass {
@@ -2194,7 +2556,7 @@ impl Expect {
         }
         expected.ensure_still_alive();
 
-        let value = this.get_value(global, this_value, matcher_name, "<green>expected<r>")?;
+        let value = ready_or_defer!(this.get_value(global, frame, matcher_name, "<green>expected<r>")?);
         if matches!(expected_array, ExpectedArray::AfterValue) && !expected.js_type().is_array() {
             return Err(global.throw_invalid_argument_type(matcher_name, "expected", "array"));
         }
@@ -3050,18 +3412,23 @@ pub mod mock {
         /// `.rejects`), bumps the assertion counter, fetches the requested
         /// mock-backed array, and emits the kind-appropriate "not a mock" error.
         ///
-        /// Returns the [`PostMatchGuard`] (so `post_match` runs when the caller
-        /// drops it), the `mock.calls` / `mock.results` JSArray, and the raw
-        /// received value (some matchers print it again on later error paths).
+        /// Returns `Ready` with the [`PostMatchGuard`] (so `post_match` runs when
+        /// the caller drops it), the `mock.calls` / `mock.results` JSArray, and
+        /// the raw received value (some matchers print it again on later error
+        /// paths) — or `Deferred(promise)` when the subject must settle first
+        /// (callers unwrap with `ready_or_defer!`).
         pub fn mock_prologue<'a>(
             &'a self,
             global: &'a JSGlobalObject,
-            this_value: JSValue,
+            frame: &CallFrame,
             matcher_name: &'static str,
             matcher_params: &'static str,
             kind: MockKind,
-        ) -> JsResult<(PostMatchGuard<'a>, JSValue, JSValue)> {
-            let (this, value, _) = self.matcher_prelude(global, this_value, matcher_name, matcher_params)?;
+        ) -> JsResult<GetValueResult<(PostMatchGuard<'a>, JSValue, JSValue)>> {
+            let (this, value, _) = match self.matcher_prelude(global, frame, matcher_name, matcher_params)? {
+                GetValueResult::Ready(ready) => ready,
+                GetValueResult::Deferred(promise) => return Ok(GetValueResult::Deferred(promise)),
+            };
             let arr = match kind {
                 MockKind::Calls | MockKind::CallsWithSig => JSMockFunction__getCalls(global, value)?,
                 MockKind::Returns => JSMockFunction__getReturns(global, value)?,
@@ -3085,7 +3452,7 @@ pub mod mock {
                     )),
                 });
             }
-            Ok((this, arr, value))
+            Ok(GetValueResult::Ready((this, arr, value)))
         }
     }
 
@@ -3251,6 +3618,583 @@ pub mod mock {
             }
             Ok(())
         }
+    }
+}
+
+// ───────────────────── deferred matcher promise settlement ──────────────────────
+// Async matchers must not re-enter the event loop from inside the matcher
+// (oven-sh/bun#33261): the matcher returns a deferred promise `D`, and native reactions
+// on the subject re-invoke it (with `Expect.reentry` set) once the subject settles.
+
+/// Indices into the GC-rooted reaction context array built by [`Expect::defer_subject`]
+/// and unpacked by [`Expect::on_subject_settled`]. The array is the reaction's context
+/// argument, so JSC roots every captured value until the subject settles.
+mod deferred_ctx {
+    /// The `Expect` wrapper (`expect(value)…`), i.e. the matcher's `this`.
+    pub(super) const EXPECT_THIS: u32 = 0;
+    /// The matcher function itself (`call_frame.callee()`), re-invoked on settlement.
+    pub(super) const CALLEE: u32 = 1;
+    /// `JSArray` of the original matcher arguments.
+    pub(super) const ARGS: u32 = 2;
+    /// The deferred promise `D` the matcher returned to user code.
+    pub(super) const DEFERRED: u32 = 3;
+    /// Error created at defer time: its stack points at the user's `expect()` call and is
+    /// used to attribute an un-awaited failing matcher to that line.
+    pub(super) const CALL_SITE_ERROR: u32 = 4;
+    /// [`super::DeferralOrigin`] discriminant (an int32) identifying which await point of
+    /// the matcher deferred, handed back to the re-invocation through
+    /// `Expect::reentry_settlement`.
+    pub(super) const ORIGIN: u32 = 5;
+    /// The promise the reactions were attached to. A call-produced deferral
+    /// (`ThrownValue` / `MatcherResult`) resumes from it instead of re-running its
+    /// producer.
+    pub(super) const SUBJECT: u32 = 6;
+    /// The owning sequence's [`matcher_epoch`](super::execution::ExecutionSequence::matcher_epoch)
+    /// at registration time (an int32), or `undefined` when no sequence was resolvable.
+    /// `settle_matcher_promise` ignores a settlement whose epoch no longer matches
+    /// (abandoned by the per-test timeout, or reset away by a retry/repeat attempt).
+    pub(super) const EPOCH: u32 = 7;
+    /// User call site of the deferring matcher invocation (`SRC_URL` is a `JSString`;
+    /// line/column are int32s), restored on the `Expect` for the re-invocation window
+    /// (see [`super::Expect::reentry_call_site`]).
+    pub(super) const SRC_URL: u32 = 8;
+    pub(super) const SRC_LINE: u32 = 9;
+    pub(super) const SRC_COL: u32 = 10;
+    /// int32 [`super::SettlePhase`] discriminant. `Invoke` re-invokes the matcher;
+    /// `Report` runs one job later so user code that adopts `D` in the same drain
+    /// (e.g. an async callback's implicit `return`) is not misread as un-awaited.
+    pub(super) const PHASE: u32 = 11;
+    /// `Report` phase only: the matcher failure (already attributed to the call site).
+    pub(super) const FAILURE: u32 = 12;
+    pub(super) const LEN: usize = 13;
+}
+
+/// Which pass of the settle reaction a context array describes; see [`deferred_ctx::PHASE`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+enum SettlePhase {
+    /// Re-invoke the deferred matcher (the subject settled).
+    Invoke = 0,
+    /// Decide how to report a matcher failure: by rejecting `D` (user awaited it) or by
+    /// failing the owning test directly (nobody did).
+    Report = 1,
+}
+
+impl Expect {
+    /// Shared gate for the matcher entry points that observe the `.resolves`/`.rejects`
+    /// subject (`get_value`, `apply_custom_matcher`): when promise flags are set, this is
+    /// the first pass (`!reentry`), and the subject is a plain `JSPromise` (`then2` cannot
+    /// attach native reactions to a `JSInternalPromise`), mark the subject handled, defer
+    /// the matcher, and return the deferred promise it must hand back to JS. `None` means
+    /// the caller proceeds with the synchronous `process_promise` logic.
+    fn try_defer_subject(
+        &self,
+        global_this: &JSGlobalObject,
+        call_frame: &CallFrame,
+        value: JSValue,
+    ) -> Option<JsResult<JSValue>> {
+        if self.flags.get().promise() == Promise::None
+            || self.reentry.get()
+            || value.as_promise().is_none()
+        {
+            return None;
+        }
+        if let Some(promise) = value.as_any_promise() {
+            // An un-awaited rejecting subject must not report as an unhandled rejection.
+            promise.set_handled(global_this.vm());
+            if !self.can_track_matcher_promise() {
+                // No owning sequence can keep the test alive across a deferral
+                // (`test.concurrent`, outside bun:test, a torn-down phase): keep the
+                // pre-existing synchronous wait and fall through to the settled logic.
+                if promise.status() == js_promise::Status::Pending {
+                    // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
+                    global_this.bun_vm().as_mut().wait_for_promise(promise);
+                }
+                return None;
+            }
+        }
+        Some(self.defer_subject(global_this, call_frame, value))
+    }
+
+    /// Defer a matcher whose `.resolves`/`.rejects` subject promise has not been observed
+    /// yet. See [`Expect::defer_matcher`].
+    pub fn defer_subject(
+        &self,
+        global_this: &JSGlobalObject,
+        call_frame: &CallFrame,
+        subject: JSValue,
+    ) -> JsResult<JSValue> {
+        // The settle re-invocation must never defer its (now settled) subject again
+        // (`process_promise` is gated on `!reentry`), or the counter would never reach zero.
+        debug_assert!(!self.reentry.get());
+        self.defer_matcher(global_this, call_frame, subject, DeferralOrigin::Subject)
+    }
+
+    /// Defer the calling matcher until `subject` settles: create the deferred `D` the
+    /// matcher returns to JS, capture a GC-rooted reaction context (see [`deferred_ctx`]),
+    /// register the pending deferral on the owning test's sequence, and attach the native
+    /// settle reactions to `subject`.
+    ///
+    /// `subject` must already be `set_handled` (an un-awaited rejecting subject must not
+    /// report as an unhandled rejection) and must be a plain `JSPromise`:
+    /// `JSValue::then2` cannot attach native reactions to a `JSInternalPromise`.
+    pub fn defer_matcher(
+        &self,
+        global_this: &JSGlobalObject,
+        call_frame: &CallFrame,
+        subject: JSValue,
+        origin: DeferralOrigin,
+    ) -> JsResult<JSValue> {
+        debug_assert!(subject.as_promise().is_some());
+
+        // Count the deferral on the owning sequence FIRST and release it again if anything
+        // below throws; once the reactions are attached (infallible) they own the release.
+        let epoch = self.register_pending_matcher_promise();
+        let registration =
+            scopeguard::guard((), |()| self.settle_pending_matcher_promise(global_this, epoch));
+
+        // A deferral made from inside a settle re-invocation (the chained half of
+        // `.resolves.toThrow(...)` / `.resolves` + async custom matcher) reuses the
+        // deferred `D` and the call-site error the first pass already created instead of
+        // minting new ones (see [`ReentryDeferred`]): only that pass ran with the user's
+        // `expect()` call on the stack, and `D` is the promise the user holds.
+        let chained = self.reentry_deferred.take();
+        let deferred_js = match &chained {
+            Some(outer) => outer.deferred,
+            None => js_promise::JSPromise::create(global_this).to_js(),
+        };
+        // A fresh one is created NOW so its stack points at the user's `expect()` call,
+        // not at the promise-reaction job that later re-invokes the matcher.
+        let call_site_error = match &chained {
+            Some(outer) => outer.call_site_error,
+            None => global_this.create_error_instance(format_args!("Matcher promise was not awaited")),
+        };
+        // The user call site, captured for the same reason. A deferral made from inside a
+        // settle re-invocation (e.g. the `toThrow` half of `.resolves.toThrow(...)`)
+        // inherits the site captured by the deferral driving it: this frame is a
+        // promise-reaction job with no user frames to walk.
+        let call_site = match self.reentry_call_site.get() {
+            Some(site) => site,
+            None => {
+                let srcloc = call_frame.get_caller_src_loc(global_this);
+                // `str` is +1; the JSString made from it is an independent GC-owned copy.
+                let _srcloc_str = bun_core::OwnedString::new(srcloc.str);
+                ReentryCallSite {
+                    source_url: srcloc.str.to_js(global_this)?,
+                    line: srcloc.line,
+                    column: srcloc.column,
+                }
+            }
+        };
+        let args = call_frame.arguments();
+        let args_js = JSValue::create_array_from_iter(global_this, args.iter().copied(), Ok)?;
+
+        let ctx = JSValue::create_empty_array(global_this, deferred_ctx::LEN)?;
+        ctx.put_index(global_this, deferred_ctx::EXPECT_THIS, call_frame.this())?;
+        ctx.put_index(global_this, deferred_ctx::CALLEE, call_frame.callee())?;
+        ctx.put_index(global_this, deferred_ctx::ARGS, args_js)?;
+        ctx.put_index(global_this, deferred_ctx::DEFERRED, deferred_js)?;
+        ctx.put_index(global_this, deferred_ctx::CALL_SITE_ERROR, call_site_error)?;
+        ctx.put_index(
+            global_this,
+            deferred_ctx::ORIGIN,
+            JSValue::js_number_from_int32(origin as i32),
+        )?;
+        ctx.put_index(global_this, deferred_ctx::SUBJECT, subject)?;
+        ctx.put_index(global_this, deferred_ctx::EPOCH, Self::epoch_to_ctx_slot(epoch))?;
+        ctx.put_index(global_this, deferred_ctx::SRC_URL, call_site.source_url)?;
+        ctx.put_index(
+            global_this,
+            deferred_ctx::SRC_LINE,
+            JSValue::js_number_from_int32(call_site.line as i32),
+        )?;
+        ctx.put_index(
+            global_this,
+            deferred_ctx::SRC_COL,
+            JSValue::js_number_from_int32(call_site.column as i32),
+        )?;
+        ctx.put_index(
+            global_this,
+            deferred_ctx::PHASE,
+            JSValue::js_number_from_int32(SettlePhase::Invoke as i32),
+        )?;
+
+        // The reaction only runs on a later microtask, so it can never observe a missing
+        // registration; from here on it owns the release the guard above was armed for.
+        subject.then2(
+            global_this,
+            ctx,
+            Bun__Expect__onSubjectResolve,
+            Bun__Expect__onSubjectReject,
+        );
+        scopeguard::ScopeGuard::into_inner(registration);
+        Ok(deferred_js)
+    }
+
+    /// [`deferred_ctx::EPOCH`] encoding of an optional registration epoch: the epoch's
+    /// int32 bit pattern, or `undefined` when nothing was registered.
+    fn epoch_to_ctx_slot(epoch: Option<u32>) -> JSValue {
+        match epoch {
+            Some(epoch) => JSValue::js_number_from_int32(epoch as i32),
+            None => JSValue::UNDEFINED,
+        }
+    }
+
+    /// Inverse of [`Expect::epoch_to_ctx_slot`].
+    fn epoch_from_ctx_slot(value: JSValue) -> Option<u32> {
+        value.is_int32().then(|| value.as_int32() as u32)
+    }
+
+    /// Decode an int32 reaction-context slot written by
+    /// [`Expect::defer_matcher`] (`SRC_LINE` / `SRC_COL`) back to its `u32`.
+    fn u32_from_ctx_slot(value: JSValue) -> u32 {
+        debug_assert!(value.is_int32());
+        value.is_int32().then(|| value.as_int32() as u32).unwrap_or(0)
+    }
+
+    /// Count a deferred matcher promise on the owning test's sequence so the runner keeps
+    /// the test open until it settles, and return the registration epoch the settle
+    /// reaction must hand back to [`Expect::settle_pending_matcher_promise`]. `None`
+    /// (nothing registered) degrades exactly like `expect_call_count` when no single
+    /// sequence is resolvable (`test.concurrent`, outside `bun:test`, stale phase).
+    fn register_pending_matcher_promise(&self) -> Option<u32> {
+        let parent = self.parent.as_ref()?;
+        let buntest_strong = parent.bun_test()?;
+        let buntest = buntest_strong.get();
+        let sequence = parent.phase.sequence(buntest)?;
+        Some(sequence.register_matcher_promise())
+    }
+
+    /// A deferral can only be tracked (and therefore gate its test's completion) when the
+    /// owning sequence is resolvable; see [`Expect::register_pending_matcher_promise`].
+    /// Callers fall back to the pre-existing synchronous wait when it is not.
+    fn can_track_matcher_promise(&self) -> bool {
+        let Some(parent) = self.parent.as_ref() else { return false };
+        let Some(buntest_strong) = parent.bun_test() else { return false };
+        let buntest = buntest_strong.get();
+        parent.phase.sequence(buntest).is_some()
+    }
+
+    /// The settle reaction ran (or the deferral failed to attach): release the
+    /// registration made at `epoch` and, if the owning sequence already ran out of
+    /// entries and was only waiting on matcher promises, wake the runner so it
+    /// re-evaluates completion (the same `run_next_tick` / `RunTestsTask` path
+    /// `bun_test_then_or_catch` uses). A settlement whose epoch no longer matches — the
+    /// per-test timeout abandoned it, or a retry/repeat attempt reset the sequence —
+    /// never touches the later attempt's counter.
+    fn settle_pending_matcher_promise(&self, global_this: &JSGlobalObject, epoch: Option<u32>) {
+        let Some(epoch) = epoch else { return };
+        let Some(parent) = self.parent.as_ref() else { return };
+        let Some(buntest_strong) = parent.bun_test() else { return };
+        let notify = {
+            let buntest = buntest_strong.get();
+            let Some(sequence) = parent.phase.sequence(buntest) else { return };
+            sequence.settle_matcher_promise(epoch)
+        };
+        if !notify {
+            return;
+        }
+        // `Start` re-evaluates the whole group (`step_group`); it never advances an
+        // in-flight entry, so it cannot complete a test whose callback is still running.
+        buntest_strong.get().add_result(bun_test::RefDataValue::Start);
+        bun_test::BunTest::run_next_tick(
+            &parent.buntest_weak,
+            global_this,
+            bun_test::RefDataValue::Start,
+        );
+    }
+
+    /// An un-awaited matcher promise failed: fail the owning TEST now with the
+    /// call-site-attributed `exception`. A stale `epoch` (attempt timed out / retried) is
+    /// ignored. `Execution::handle_uncaught_exception` cannot be reused: it validates
+    /// against the active entry, which the callback has long advanced past by now.
+    fn record_unawaited_matcher_failure(
+        &self,
+        global_this: &JSGlobalObject,
+        exception: JSValue,
+        epoch: Option<u32>,
+    ) {
+        use super::execution::Result as SequenceResult;
+
+        let Some(parent) = self.parent.as_ref() else {
+            // Not inside bun:test: report it like any other unhandled error.
+            global_this.bun_vm().as_mut().run_error_handler(exception, None);
+            return;
+        };
+        let Some(buntest_strong) = parent.bun_test() else {
+            global_this.bun_vm().as_mut().run_error_handler(exception, None);
+            return;
+        };
+        let buntest = buntest_strong.get();
+        let Some(sequence) = parent.phase.sequence(buntest) else {
+            // Concurrent group / stale phase: no single owning sequence. Route through the
+            // shared handler so the failure is still reported (as an unhandled error).
+            buntest.on_uncaught_exception(global_this, Some(exception), true, &parent.phase);
+            return;
+        };
+        if epoch.is_some_and(|epoch| epoch != sequence.matcher_epoch) {
+            // Stale deferral: the attempt it belonged to already timed out or was
+            // retried, so the sequence now describes a different attempt.
+            return;
+        }
+        // Mirror `Execution::handle_uncaught_exception`'s test-entry arm.
+        let mode = sequence
+            .test_entry
+            // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
+            .map_or(bun_test::ScopeMode::Normal, |e| unsafe { e.as_ref() }.base.mode);
+        let show = match mode {
+            bun_test::ScopeMode::Failing => {
+                if sequence.result == SequenceResult::Pending {
+                    sequence.result = SequenceResult::Pass;
+                }
+                false // `test.failing` expects the failure; hide it like the sync path
+            }
+            bun_test::ScopeMode::Todo => {
+                if sequence.result == SequenceResult::Pending {
+                    sequence.result = SequenceResult::Todo;
+                }
+                true
+            }
+            _ => {
+                if sequence.result == SequenceResult::Pending {
+                    sequence.result = SequenceResult::Fail;
+                }
+                true
+            }
+        };
+        if show {
+            buntest.bun_test_root.on_before_print();
+            global_this.bun_vm().as_mut().run_error_handler(exception, None);
+            Output::flush();
+        }
+    }
+
+    /// Best-effort: report the matcher failure through the call-site error (whose stack
+    /// points at the user's `expect()` line) carrying the failure's message. The reaction
+    /// job's own stack is useless for attribution. Never leaves a pending exception.
+    fn attributed_matcher_error(
+        global_this: &JSGlobalObject,
+        exception: JSValue,
+        call_site_error: JSValue,
+    ) -> JSValue {
+        if !exception.is_object() || !call_site_error.is_object() {
+            return exception;
+        }
+        match exception.get(global_this, "message") {
+            Ok(Some(message)) if message.is_string() => {
+                call_site_error.put(global_this, "message", message);
+                call_site_error
+            }
+            Ok(_) => exception,
+            Err(JsError::Terminated) => exception,
+            Err(_) => {
+                // Attribution is cosmetic; a throwing `message` getter must not derail the
+                // settle path or leak a pending exception out of the reaction.
+                let _ = global_this.clear_exception_except_termination();
+                exception
+            }
+        }
+    }
+
+    /// The registration at `epoch` still belongs to the attempt currently occupying the
+    /// owning sequence. A per-test timeout or a retry/repeat reset bumps `matcher_epoch`,
+    /// abandoning every deferral registered before it.
+    fn matcher_epoch_is_current(&self, epoch: Option<u32>) -> bool {
+        let Some(epoch) = epoch else {
+            // Never registered (untracked context): nothing can have been abandoned.
+            return true;
+        };
+        let Some(parent) = self.parent.as_ref() else { return false };
+        let Some(buntest_strong) = parent.bun_test() else { return false };
+        let buntest = buntest_strong.get();
+        let Some(sequence) = parent.phase.sequence(buntest) else { return false };
+        sequence.matcher_epoch == epoch
+    }
+
+    /// Shared body of `Bun__Expect__onSubjectResolve/Reject`. `Invoke` phase: re-invoke
+    /// the deferred matcher now that the subject settled; a failure re-arms the context
+    /// as a `Report` reaction one job later, so user code adopting `D` in the same drain
+    /// (an async callback's implicit `return`) is seen before the un-awaited decision.
+    fn on_subject_settled(
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+        rejected: bool,
+    ) -> JsResult<JSValue> {
+        let [settled_value, ctx] = callframe.arguments_as_array::<2>();
+        if !ctx.is_object() {
+            debug_assert!(false); // `defer_matcher` always passes the context array
+            return Ok(JSValue::UNDEFINED);
+        }
+        let expect_this = ctx.get_index(global_this, deferred_ctx::EXPECT_THIS)?;
+        let callee = ctx.get_index(global_this, deferred_ctx::CALLEE)?;
+        let args_js = ctx.get_index(global_this, deferred_ctx::ARGS)?;
+        let deferred_js = ctx.get_index(global_this, deferred_ctx::DEFERRED)?;
+        let call_site_error = ctx.get_index(global_this, deferred_ctx::CALL_SITE_ERROR)?;
+        let origin = DeferralOrigin::from_ctx_slot(ctx.get_index(global_this, deferred_ctx::ORIGIN)?);
+        let subject = ctx.get_index(global_this, deferred_ctx::SUBJECT)?;
+        let epoch = Self::epoch_from_ctx_slot(ctx.get_index(global_this, deferred_ctx::EPOCH)?);
+        let phase = ctx.get_index(global_this, deferred_ctx::PHASE)?;
+        let call_site = ReentryCallSite {
+            source_url: ctx.get_index(global_this, deferred_ctx::SRC_URL)?,
+            line: Self::u32_from_ctx_slot(ctx.get_index(global_this, deferred_ctx::SRC_LINE)?),
+            column: Self::u32_from_ctx_slot(ctx.get_index(global_this, deferred_ctx::SRC_COL)?),
+        };
+
+        let (Some(expect_ptr), Some(deferred_ptr)) =
+            (Expect::from_js(expect_this), deferred_js.as_promise())
+        else {
+            debug_assert!(false); // `defer_subject` always packs an Expect and a JSPromise
+            return Ok(JSValue::UNDEFINED);
+        };
+        // SAFETY: `expect_ptr` is the live payload of the wrapper rooted by `ctx`.
+        let expect: &Expect = unsafe { &*expect_ptr };
+        // SAFETY: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
+        let deferred = js_promise::JSPromise::opaque_mut(deferred_ptr);
+
+        // Report phase: the matcher already failed on the Invoke pass one job ago.
+        if phase.is_int32() && phase.as_int32() == SettlePhase::Report as i32 {
+            let exception = ctx.get_index(global_this, deferred_ctx::FAILURE)?;
+            if deferred.is_handled() {
+                // The user awaited (or `.catch`ed) the matcher promise: reject it and let
+                // their handler surface the failure.
+                let _ = deferred.reject(global_this, Ok(exception));
+            } else {
+                // Un-awaited failing matcher: fail the owning test and settle `D` without
+                // an unhandled-rejection report.
+                expect.record_unawaited_matcher_failure(global_this, exception, epoch);
+                let _ = deferred.reject_as_handled(global_this, exception);
+            }
+            expect.settle_pending_matcher_promise(global_this, epoch);
+            return Ok(JSValue::UNDEFINED);
+        }
+
+        // The attempt this deferral belonged to is gone (per-test timeout or retry/repeat
+        // reset): do not re-run the matcher — its side effects (snapshot counters, expect
+        // counts) would land in the attempt now occupying the sequence.
+        if !expect.matcher_epoch_is_current(epoch) {
+            let _ = deferred.reject_as_handled(global_this, call_site_error);
+            expect.settle_pending_matcher_promise(global_this, epoch);
+            return Ok(JSValue::UNDEFINED);
+        }
+
+        let arg_count = args_js.get_length(global_this)? as u32;
+        let mut args: Vec<JSValue> = Vec::with_capacity(arg_count as usize);
+        for i in 0..arg_count {
+            args.push(args_js.get_index(global_this, i)?);
+        }
+
+        // Re-invoke the SAME matcher. With `reentry` set and a settled subject,
+        // `process_promise` falls through the synchronous Fulfilled/Rejected logic, and a
+        // call-produced deferral (async `toThrow` / async custom matcher) resumes from the
+        // stashed settlement instead of running the producer a second time.
+        expect.reentry.set(true);
+        expect.reentry_settlement.set(Some(ReentrySettlement {
+            origin,
+            subject,
+            value: settled_value,
+            rejected,
+        }));
+        expect.reentry_call_site.set(Some(call_site));
+        // Consumed (taken) only if this re-invocation defers again; see [`ReentryDeferred`].
+        expect.reentry_deferred.set(Some(ReentryDeferred { deferred: deferred_js, call_site_error }));
+        let call_result = {
+            let (reentry, settlement, site, chained) = (
+                &expect.reentry,
+                &expect.reentry_settlement,
+                &expect.reentry_call_site,
+                &expect.reentry_deferred,
+            );
+            // Reset even if the matcher throws or a nested panic unwinds; the settlement's
+            // and call site's `JSValue`s are only rooted (by this frame + `ctx`) for the
+            // call below.
+            let _reset = scopeguard::guard((), |()| {
+                reentry.set(false);
+                settlement.set(None);
+                site.set(None);
+                chained.set(None);
+            });
+            callee.call(global_this, expect_this, &args)
+        };
+
+        match call_result {
+            Ok(result) => {
+                // A re-invocation that deferred again returned the reused `D` itself: it
+                // is settled by the follow-up settle reaction, and resolving `D` with
+                // itself would reject it with a self-resolution TypeError. Otherwise `D`
+                // resolves with undefined: matchers have no meaningful value (a custom
+                // matcher returns the `Expect` for chaining, which must not leak into `D`
+                // — resolving with it would even probe its `then` as a thenable).
+                if result != deferred_js {
+                    // Termination is the only failure; the VM is going down.
+                    let _ = deferred.resolve(global_this, JSValue::UNDEFINED);
+                }
+            }
+            Err(JsError::Terminated) => {
+                // No JS may run; release the registration and propagate.
+                expect.settle_pending_matcher_promise(global_this, epoch);
+                return Err(JsError::Terminated);
+            }
+            Err(e) => {
+                let raw = global_this.take_exception(e);
+                // The failure was thrown from a promise-reaction job whose stack has no
+                // user frames: attribute it to the `expect()` call site captured at defer
+                // time, so the awaited rejection and the direct report both point there.
+                let exception = Self::attributed_matcher_error(
+                    global_this,
+                    raw.to_error().unwrap_or(raw),
+                    call_site_error,
+                );
+                // Whether the failure is "awaited" cannot be decided yet: the job that
+                // adopts `D` (e.g. the async callback's implicit-return thenable job) may
+                // still be queued behind this reaction. Re-arm the same context as a
+                // Report reaction — it runs after those jobs — and keep the registration
+                // (and `D`) pending until it decides.
+                ctx.put_index(
+                    global_this,
+                    deferred_ctx::PHASE,
+                    JSValue::js_number_from_int32(SettlePhase::Report as i32),
+                )?;
+                ctx.put_index(global_this, deferred_ctx::FAILURE, exception)?;
+                subject.then2(
+                    global_this,
+                    ctx,
+                    Bun__Expect__onSubjectResolve,
+                    Bun__Expect__onSubjectReject,
+                );
+                return Ok(JSValue::UNDEFINED);
+            }
+        }
+        // Exactly one decrement per registration: each reaction pair runs at most once
+        // per phase, and only the final phase reaches a release path.
+        expect.settle_pending_matcher_promise(global_this, epoch);
+        Ok(JSValue::UNDEFINED)
+    }
+}
+
+// `ZigGlobalObject::promiseHandlerID` (C++) compares the fn-ptr handed to
+// `JSValue::then2` against `&Bun__Expect__onSubjectResolve` by identity, so these thunks
+// must be the exported symbols themselves — see the equivalent note on
+// `Bun__TestScope__Describe2__bunTestThen` in bun_test.rs.
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn Bun__Expect__onSubjectResolve(
+        global: *mut JSGlobalObject,
+        frame: *mut CallFrame,
+    ) -> JSValue {
+        // SAFETY: JSC passes non-null live pointers for both.
+        let (global, frame) = unsafe { (&*global, &*frame) };
+        bun_jsc::host_fn::to_js_host_fn_result(global, Expect::on_subject_settled(global, frame, false))
+    }
+}
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn Bun__Expect__onSubjectReject(
+        global: *mut JSGlobalObject,
+        frame: *mut CallFrame,
+    ) -> JSValue {
+        // SAFETY: JSC passes non-null live pointers for both.
+        let (global, frame) = unsafe { (&*global, &*frame) };
+        bun_jsc::host_fn::to_js_host_fn_result(global, Expect::on_subject_settled(global, frame, true))
     }
 }
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -38,22 +38,12 @@ use bun_jsc::js_error_to_write_error;
 #[bun_jsc::JsClass]
 pub struct Expect {
     pub flags: Cell<Flags>,
-    /// Rust-only (the C++-mirrored `Flags(u8)` byte is full). Set while a deferred
-    /// matcher's settle reaction re-invokes the same matcher, so the second pass takes
-    /// the synchronous path and per-test bookkeeping is not double-counted.
-    pub reentry: Cell<bool>,
-    /// Rust-only. Settlement handed to the running settle re-invocation; `Some` only for
-    /// its synchronous duration ([`Expect::on_subject_settled`] sets/clears it around
-    /// `callee.call`), during which the reaction frame + context array root its values.
-    pub reentry_settlement: Cell<Option<ReentrySettlement>>,
-    /// Rust-only. User call site of the deferring invocation, restored for the settle
-    /// re-invocation window (same rooting as [`Expect::reentry_settlement`]): that pass
-    /// runs from a reaction job with no user frames for inline snapshots to walk.
-    pub reentry_call_site: Cell<Option<ReentryCallSite>>,
-    /// Rust-only. The running settle re-invocation's own deferral (same window/rooting as
-    /// [`Expect::reentry_settlement`]); a re-invocation that defers AGAIN takes and
-    /// reuses it instead of minting a second `D` — see [`ReentryDeferred`].
-    pub reentry_deferred: Cell<Option<ReentryDeferred>>,
+    /// Rust-only (the C++-mirrored `Flags(u8)` byte is full). Non-null exactly while a
+    /// deferred matcher's settle reaction re-invokes the same matcher; it points at the
+    /// [`ReentryWindow`] stack local of [`Expect::on_subject_settled`], which saves the
+    /// previous value and restores it (nested windows are a stack). Never dereferenced
+    /// outside that synchronous window — see [`Expect::with_reentry_window`].
+    pub reentry_window: Cell<*const ReentryWindow>,
     pub parent: Option<bun_test::RefDataPtr>,
     pub custom_label: bun_core::String,
 }
@@ -64,8 +54,11 @@ pub struct Expect {
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum DeferralOrigin {
-    /// `.resolves`/`.rejects` subject promise (`process_promise`). The re-invocation
-    /// re-reads the (now settled) subject, so it never consumes the settlement.
+    /// `.resolves`/`.rejects` subject promise (`get_value` / `apply_custom_matcher`).
+    /// The re-invocation consumes the settlement; the raw subject's internal slots are
+    /// never re-read (a subclass with a delegating `then` may never settle its own).
+    /// A chained deferral carries the consumed settlement into every later re-invocation
+    /// ([`ReentryWindow::consumed_subject`]) so that stays true past the first pass.
     Subject = 0,
     /// Promise returned by the function under `toThrow` (`get_value_as_to_throw`): the
     /// function already ran on the first pass and must not be called again.
@@ -87,8 +80,36 @@ impl DeferralOrigin {
     }
 }
 
+/// State of one settle re-invocation of a deferred matcher. A STACK local of
+/// [`Expect::on_subject_settled`], alive strictly for the synchronous `callee.call`;
+/// `Expect::reentry_window` points at it for exactly that window (the previous pointer is
+/// saved and restored, so a nested settle reaction gets its own window). All `JSValue`s
+/// inside are rooted by the reaction frame + its context array for that whole window.
+pub struct ReentryWindow {
+    /// The `Expect` being re-invoked; only for the accessors' debug_assert.
+    expect: *const Expect,
+    /// How the deferral's subject settled; taken by the await point that deferred.
+    settlement: Cell<Option<ReentrySettlement>>,
+    /// The `.resolves`/`.rejects` subject settlement an earlier (or this) pass already
+    /// consumed, carried across chained deferrals: every later re-invocation resumes the
+    /// Subject await point from it instead of re-reading the raw subject's internal
+    /// slots (which a subclass with a delegating `then` never settles). Recorded by
+    /// [`Expect::take_reentry_settlement`] and forwarded by [`Expect::defer_matcher`].
+    consumed_subject: Cell<Option<ReentrySettlement>>,
+    /// User call site of the deferring invocation: this pass runs from a reaction job
+    /// with no user frames for inline snapshots / a chained deferral to walk.
+    call_site: ReentryCallSite,
+    /// The re-invocation's own deferral; a re-invocation that defers AGAIN takes and
+    /// reuses it instead of minting a second `D` — see [`ReentryDeferred`].
+    deferred: Cell<Option<ReentryDeferred>>,
+    /// The `Expect`'s flags at defer time ([`deferred_ctx::FLAGS`]), installed on the
+    /// `Expect` for the window so later `.not`/`.resolves` mutations of the same handle
+    /// cannot re-label an earlier deferral.
+    flags: Flags,
+}
+
 /// The user call site captured when a matcher deferred ([`deferred_ctx::SRC_URL`]),
-/// handed back to its settle re-invocation through [`Expect::reentry_call_site`].
+/// handed back to its settle re-invocation through [`ReentryWindow::call_site`].
 /// `source_url` (a `JSString`) is rooted by the reaction's context array for the whole
 /// re-invocation window, exactly like [`ReentrySettlement`]'s values.
 #[derive(Clone, Copy)]
@@ -108,7 +129,7 @@ pub struct ReentryDeferred {
 }
 
 /// How the promise a matcher deferred on settled, handed from the settle reaction to the
-/// re-invoked matcher (see [`Expect::reentry_settlement`] for the rooting invariant).
+/// re-invoked matcher (see [`ReentryWindow`] for the rooting invariant).
 #[derive(Clone, Copy)]
 pub struct ReentrySettlement {
     pub origin: DeferralOrigin,
@@ -297,11 +318,11 @@ impl Expect {
 
     /// Ordering invariant: every matcher entry point must call this BEFORE its
     /// `Deferred` early-return (`get_value`/`process_promise`), so the deferring first
-    /// pass counts exactly once and the `reentry` re-invocation is gated off below.
+    /// pass counts exactly once and the settle re-invocation is gated off below.
     pub fn increment_expect_call_counter(&self) {
         // A deferred matcher promise's settle reaction re-invokes the same matcher on the
-        // same `Expect` with `reentry` set; the first invocation already counted it.
-        if self.reentry.get() {
+        // same `Expect` inside a reentry window; the first invocation already counted it.
+        if self.in_settle_reentry() {
             return;
         }
         let Some(parent) = self.parent.as_ref() else { return }; // not in bun:test
@@ -324,28 +345,76 @@ impl Expect {
         }
     }
 
+    /// Run `f` against the active settle re-invocation window, or return `None` when the
+    /// matcher is running as an ordinary (first-pass) invocation. The window is only
+    /// handed out for the duration of `f` so a `&ReentryWindow` can never escape it.
+    // SAFETY: the pointer is non-null only while `on_subject_settled`'s `callee.call` is
+    // on the stack; the pointee is that frame's stack local, which strictly outlives the
+    // synchronous window (the scopeguard restores the previous pointer before it dies).
+    fn with_reentry_window<R>(&self, f: impl FnOnce(&ReentryWindow) -> R) -> Option<R> {
+        let window = self.reentry_window.get();
+        if window.is_null() {
+            return None;
+        }
+        // SAFETY: see above — non-null implies the pointee is a live stack local.
+        let window = unsafe { &*window };
+        debug_assert!(core::ptr::eq(window.expect, self));
+        Some(f(window))
+    }
+
+    /// This matcher invocation is the settle re-invocation of its own deferral, so it
+    /// takes the synchronous path and skips the per-test bookkeeping the first pass did.
+    pub fn in_settle_reentry(&self) -> bool {
+        self.with_reentry_window(|_| ()).is_some()
+    }
+
     /// Consume the settlement the settle reaction stashed for the deferral made at
     /// `origin`. Returns `None` outside a re-invocation, or when the pending settlement
     /// belongs to a different await point of the same matcher (e.g. the subject deferral
     /// of a `.resolves.toThrow()` chain), so each site only ever resumes its own deferral.
+    ///
+    /// The Subject settlement stays available past the pass that took it: a chained
+    /// deferral's re-invocations resume the Subject await point from the carried copy
+    /// ([`ReentryWindow::consumed_subject`]), never from the raw subject's internal slots.
     pub fn take_reentry_settlement(&self, origin: DeferralOrigin) -> Option<ReentrySettlement> {
-        let settlement = self.reentry_settlement.get()?;
-        if settlement.origin != origin {
-            return None;
-        }
-        self.reentry_settlement.set(None);
-        Some(settlement)
+        self.with_reentry_window(|window| {
+            if let Some(settlement) = window.settlement.get()
+                && settlement.origin == origin
+            {
+                window.settlement.set(None);
+                if origin == DeferralOrigin::Subject {
+                    window.consumed_subject.set(Some(settlement));
+                }
+                return Some(settlement);
+            }
+            if origin == DeferralOrigin::Subject {
+                return window.consumed_subject.get();
+            }
+            None
+        })
+        .flatten()
     }
 
     /// The user call site captured when the matcher currently being re-invoked deferred
-    /// ([`deferred_ctx::SRC_URL`]); `None` outside a settle re-invocation. Like
-    /// [`CallFrame::get_caller_src_loc`], the returned `str` is +1 and the caller owns
-    /// releasing it.
+    /// ([`deferred_ctx::SRC_URL`]); `None` outside a settle re-invocation.
+    fn reentry_call_site(&self) -> Option<ReentryCallSite> {
+        self.with_reentry_window(|window| window.call_site)
+    }
+
+    /// The running settle re-invocation's own deferral, or `None` outside one (or when
+    /// this re-invocation already deferred again); see [`ReentryDeferred`].
+    fn take_reentry_deferred(&self) -> Option<ReentryDeferred> {
+        self.with_reentry_window(|window| window.deferred.take()).flatten()
+    }
+
+    /// [`Expect::reentry_call_site`] as a [`CallerSrcLoc`](bun_jsc::call_frame::CallerSrcLoc).
+    /// Like [`CallFrame::get_caller_src_loc`], the returned `str` is +1 and the caller
+    /// owns releasing it.
     pub fn reentry_caller_src_loc(
         &self,
         global_this: &JSGlobalObject,
     ) -> JsResult<Option<bun_jsc::call_frame::CallerSrcLoc>> {
-        let Some(site) = self.reentry_call_site.get() else { return Ok(None) };
+        let Some(site) = self.reentry_call_site() else { return Ok(None) };
         Ok(Some(bun_jsc::call_frame::CallerSrcLoc {
             str: bun_core::String::from_js(site.source_url, global_this)?,
             line: site.line,
@@ -522,7 +591,7 @@ impl Expect {
 
         // A `.resolves`/`.rejects` subject promise is never awaited synchronously from
         // inside the matcher (oven-sh/bun#33261) — defer even if it is already settled
-        // (Jest parity: one-microtask minimum). The settle re-invocation (`reentry`) and
+        // (Jest parity: one-microtask minimum). The settle re-invocation (reentry window) and
         // non-promise subjects fall through to `process_promise`'s synchronous logic.
         if let Some(deferred) = self.try_defer_subject(global_this, call_frame, value) {
             return Ok(GetValueResult::Deferred(deferred?));
@@ -530,6 +599,23 @@ impl Expect {
 
         #[allow(clippy::disallowed_methods)] // template is a runtime parameter
         let matcher_params = Output::pretty_fmt_rt(matcher_params_fmt, Output::enable_ansi_colors_stderr());
+        // The settle re-invocation of a `.resolves`/`.rejects` deferral resumes from the
+        // settlement its reaction captured; the raw subject's internal slots are never
+        // re-read (a subclass with a delegating `then` may never settle its own).
+        if let Some(settlement) = self.take_reentry_settlement(DeferralOrigin::Subject) {
+            return Self::process_settled_subject(
+                self.custom_label.clone(),
+                self.flags.get(),
+                global_this,
+                value,
+                settlement.rejected,
+                settlement.value,
+                bstr::BStr::new(matcher_name),
+                matcher_params,
+                false,
+            )
+            .map(GetValueResult::Ready);
+        }
         Self::process_promise(
             self.custom_label.clone(),
             self.flags.get(),
@@ -582,40 +668,100 @@ impl Expect {
         // never reported as an unhandled rejection.
         promise.set_handled(vm);
 
-        // `Some((expected, received))` describes a state mismatch for the failure message.
-        let mismatch: Option<(&str, &str)> = match promise.status() {
-            js_promise::Status::Fulfilled => {
-                if resolution == Promise::Rejects { Some(("rejects", "resolved")) } else { None }
-            }
-            js_promise::Status::Rejected => {
-                if resolution == Promise::Resolves { Some(("resolves", "rejected")) } else { None }
-            }
-            js_promise::Status::Pending => Some((
+        let status = promise.status();
+        if status == js_promise::Status::Pending {
+            return Err(Self::promise_state_mismatch_error(
+                custom_label,
+                flags,
+                global_this,
+                value,
+                matcher_name,
+                matcher_params,
+                silent,
                 if resolution == Promise::Rejects { "rejects" } else { "resolves" },
                 "is still pending",
-            )),
+            ));
+        }
+        Self::process_settled_subject(
+            custom_label,
+            flags,
+            global_this,
+            value,
+            status == js_promise::Status::Rejected,
+            promise.result(vm),
+            matcher_name,
+            matcher_params,
+            silent,
+        )
+    }
+
+    /// Settled half of [`Expect::process_promise`], taking the settlement explicitly:
+    /// direction-check `(rejected, settled_value)` against `flags` and return the settled
+    /// value. The `.resolves`/`.rejects` settle re-invocation resumes here from the
+    /// settlement its reaction captured, never from the raw subject's internal slots.
+    fn process_settled_subject(
+        custom_label: bun_core::String,
+        flags: Flags,
+        global_this: &JSGlobalObject,
+        subject: JSValue,
+        rejected: bool,
+        settled_value: JSValue,
+        matcher_name: impl fmt::Display,
+        matcher_params: impl fmt::Display,
+        silent: bool,
+    ) -> JsResult<JSValue> {
+        let resolution = flags.promise();
+        // `Some((expected, received))` describes a direction mismatch for the failure message.
+        let mismatch: Option<(&str, &str)> = if rejected {
+            (resolution == Promise::Resolves).then_some(("resolves", "rejected"))
+        } else {
+            (resolution == Promise::Rejects).then_some(("rejects", "resolved"))
         };
         if let Some((expected, received)) = mismatch {
-            if !silent {
-                let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-                return Err(Self::throw_pretty_matcher_error(
-                    global_this,
-                    custom_label,
-                    matcher_name,
-                    matcher_params,
-                    flags,
-                    format_args!(
-                        "Expected promise that {expected}<r>\nReceived promise that {received}: <red>{}<r>\n",
-                        value.to_fmt(&mut formatter),
-                    ),
-                ));
-            }
-            return Err(JsError::Thrown);
+            return Err(Self::promise_state_mismatch_error(
+                custom_label,
+                flags,
+                global_this,
+                subject,
+                matcher_name,
+                matcher_params,
+                silent,
+                expected,
+                received,
+            ));
         }
+        settled_value.ensure_still_alive();
+        Ok(settled_value)
+    }
 
-        let new_value = promise.result(vm);
-        new_value.ensure_still_alive();
-        Ok(new_value)
+    /// The `.resolves`/`.rejects` state-mismatch failure ("expected a promise that
+    /// {expected}, received one that {received}"), thrown pretty unless `silent`.
+    fn promise_state_mismatch_error(
+        custom_label: bun_core::String,
+        flags: Flags,
+        global_this: &JSGlobalObject,
+        subject: JSValue,
+        matcher_name: impl fmt::Display,
+        matcher_params: impl fmt::Display,
+        silent: bool,
+        expected: &str,
+        received: &str,
+    ) -> JsError {
+        if silent {
+            return JsError::Thrown;
+        }
+        let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
+        Self::throw_pretty_matcher_error(
+            global_this,
+            custom_label,
+            matcher_name,
+            matcher_params,
+            flags,
+            format_args!(
+                "Expected promise that {expected}<r>\nReceived promise that {received}: <red>{}<r>\n",
+                subject.to_fmt(&mut formatter),
+            ),
+        )
     }
 
     pub fn is_asymmetric_matcher(value: JSValue) -> bool {
@@ -708,7 +854,7 @@ impl Expect {
         let buntest = buntest_strong.get();
         // A sequence parked on pending matcher promises has no `active_entry`, but it is
         // still the owning test: resolve it through the sequence's `test_entry`, exactly
-        // like `record_unawaited_matcher_failure`.
+        // like `record_provisional_matcher_failure`.
         let execution_entry: *const bun_test::ExecutionEntry = match parent.phase.entry(buntest) {
             Some(entry) => entry,
             None => match parent.phase.sequence(buntest).and_then(|s| s.test_entry) {
@@ -813,10 +959,7 @@ impl Expect {
 
         let expect = Expect {
             flags: Cell::new(Flags::default()),
-            reentry: Cell::new(false),
-            reentry_settlement: Cell::new(None),
-            reentry_call_site: Cell::new(None),
-            reentry_deferred: Cell::new(None),
+            reentry_window: Cell::new(core::ptr::null()),
             custom_label,
             parent: active_execution_entry_ref,
         };
@@ -1053,9 +1196,9 @@ impl Expect {
                     DeferralOrigin::ThrownValue,
                 )?));
             }
-            // No owning sequence can keep the test alive across a deferral
-            // (`test.concurrent`, outside bun:test, a torn-down phase): keep the
-            // pre-existing synchronous wait so a failing assertion still fails in place.
+            // No owning test entry can keep this deferral alive (a concurrent group running
+            // 2+ sequences, a hook-only beforeAll/afterAll sequence, outside bun:test):
+            // keep the pre-existing synchronous wait so a failing assertion fails in place.
             // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
             global_this.bun_vm().as_mut().wait_for_promise(promise);
             let rejected = promise.status() == js_promise::Status::Rejected;
@@ -1850,25 +1993,40 @@ impl Expect {
             )));
         };
         // Counted before the deferral point, so the deferring first pass counts and the
-        // `reentry` re-invocation is the gated no-op.
+        // settle re-invocation is the gated no-op.
         expect.increment_expect_call_counter();
 
         // A `.resolves`/`.rejects` subject promise defers the custom matcher exactly like
         // `get_value` defers the built-in matchers; the settle reaction re-invokes this
-        // entry point with `reentry` set and the (now settled) subject falls through below.
+        // entry point inside a reentry window and consumes the captured settlement below.
         if let Some(deferred) = expect.try_defer_subject(global_this, call_frame, value) {
             return deferred;
         }
 
-        value = Self::process_promise(
-            expect.custom_label.clone(),
-            expect.flags.get(),
-            global_this,
-            value,
-            matcher_name,
-            &matcher_params,
-            false,
-        )?;
+        // The settle re-invocation resumes from the settlement its reaction captured
+        // (never from the raw subject's internal slots — see `get_value`).
+        value = match expect.take_reentry_settlement(DeferralOrigin::Subject) {
+            Some(settlement) => Self::process_settled_subject(
+                expect.custom_label.clone(),
+                expect.flags.get(),
+                global_this,
+                value,
+                settlement.rejected,
+                settlement.value,
+                matcher_name,
+                &matcher_params,
+                false,
+            )?,
+            None => Self::process_promise(
+                expect.custom_label.clone(),
+                expect.flags.get(),
+                global_this,
+                value,
+                matcher_name,
+                &matcher_params,
+                false,
+            )?,
+        };
         value.ensure_still_alive();
 
         // The settle re-invocation of a deferred async matcher resumes from the stashed
@@ -1919,9 +2077,9 @@ impl Expect {
                         DeferralOrigin::MatcherResult,
                     );
                 }
-                // No owning sequence can keep the test alive across a deferral
-                // (`test.concurrent`, outside bun:test, a torn-down phase): keep the
-                // pre-existing synchronous wait so a failing matcher still fails in place.
+                // No owning test entry can keep this deferral alive (a concurrent group
+                // running 2+ sequences, a hook-only beforeAll/afterAll sequence, outside
+                // bun:test): the pre-existing synchronous wait fails the matcher in place.
                 // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
                 global_this.bun_vm().as_mut().wait_for_promise(promise);
                 match promise.status() {
@@ -2058,9 +2216,9 @@ impl Expect {
     }
 
     /// Only triggers a GC sweep. It intentionally does NOT reset `flags`
-    /// (not/resolves/rejects), `reentry`, or the cached captured value, so an `Expect`
-    /// whose matcher deferred on a pending promise still carries all of them when the
-    /// settle reaction re-invokes the same matcher.
+    /// (not/resolves/rejects) or the cached captured value, so an `Expect` whose matcher
+    /// deferred on a pending promise still carries both when the settle reaction
+    /// re-invokes the same matcher (inside a [`ReentryWindow`]).
     pub fn post_match(&self, global_this: &JSGlobalObject) {
         global_this.bun_vm().auto_garbage_collect();
     }
@@ -2097,8 +2255,8 @@ impl Expect {
     ) -> JsResult<GetValueResult<(PostMatchGuard<'a>, JSValue, bool)>> {
         let this = self.post_match_guard(global);
         let value = this.get_value(global, frame, matcher_name, matcher_params)?;
-        // Counted before the deferral early-return: the re-invocation runs with
-        // `reentry` set, so `increment_expect_call_counter` is a no-op there.
+        // Counted before the deferral early-return: the re-invocation runs inside a
+        // reentry window, so `increment_expect_call_counter` is a no-op there.
         this.increment_expect_call_counter();
         let value = match value {
             GetValueResult::Ready(value) => value,
@@ -3624,7 +3782,7 @@ pub mod mock {
 // ───────────────────── deferred matcher promise settlement ──────────────────────
 // Async matchers must not re-enter the event loop from inside the matcher
 // (oven-sh/bun#33261): the matcher returns a deferred promise `D`, and native reactions
-// on the subject re-invoke it (with `Expect.reentry` set) once the subject settles.
+// on the subject re-invoke it (inside a [`ReentryWindow`]) once the subject settles.
 
 /// Indices into the GC-rooted reaction context array built by [`Expect::defer_subject`]
 /// and unpacked by [`Expect::on_subject_settled`]. The array is the reaction's context
@@ -3642,8 +3800,8 @@ mod deferred_ctx {
     /// used to attribute an un-awaited failing matcher to that line.
     pub(super) const CALL_SITE_ERROR: u32 = 4;
     /// [`super::DeferralOrigin`] discriminant (an int32) identifying which await point of
-    /// the matcher deferred, handed back to the re-invocation through
-    /// `Expect::reentry_settlement`.
+    /// the matcher deferred, handed back to the re-invocation through the
+    /// [`super::ReentryWindow`]'s settlement.
     pub(super) const ORIGIN: u32 = 5;
     /// The promise the reactions were attached to. A call-produced deferral
     /// (`ThrownValue` / `MatcherResult`) resumes from it instead of re-running its
@@ -3655,38 +3813,43 @@ mod deferred_ctx {
     /// (abandoned by the per-test timeout, or reset away by a retry/repeat attempt).
     pub(super) const EPOCH: u32 = 7;
     /// User call site of the deferring matcher invocation (`SRC_URL` is a `JSString`;
-    /// line/column are int32s), restored on the `Expect` for the re-invocation window
-    /// (see [`super::Expect::reentry_call_site`]).
+    /// line/column are int32s), carried into the re-invocation's
+    /// [`super::ReentryWindow::call_site`].
     pub(super) const SRC_URL: u32 = 8;
     pub(super) const SRC_LINE: u32 = 9;
     pub(super) const SRC_COL: u32 = 10;
-    /// int32 [`super::SettlePhase`] discriminant. `Invoke` re-invokes the matcher;
-    /// `Report` runs one job later so user code that adopts `D` in the same drain
-    /// (e.g. an async callback's implicit `return`) is not misread as un-awaited.
-    pub(super) const PHASE: u32 = 11;
-    /// `Report` phase only: the matcher failure (already attributed to the call site).
-    pub(super) const FAILURE: u32 = 12;
-    pub(super) const LEN: usize = 13;
-}
-
-/// Which pass of the settle reaction a context array describes; see [`deferred_ctx::PHASE`].
-#[derive(Clone, Copy, PartialEq, Eq)]
-#[repr(i32)]
-enum SettlePhase {
-    /// Re-invoke the deferred matcher (the subject settled).
-    Invoke = 0,
-    /// Decide how to report a matcher failure: by rejecting `D` (user awaited it) or by
-    /// failing the owning test directly (nobody did).
-    Report = 1,
+    /// int32 [`super::Flags`] byte of the `Expect` at defer time. The re-invocation runs
+    /// with these flags restored: `.not`/`.resolves` mutate the shared wrapper, so a
+    /// later chained getter must not relabel an earlier call's deferral.
+    pub(super) const FLAGS: u32 = 11;
+    /// The already-consumed `.resolves`/`.rejects` subject settlement a chained deferral
+    /// carries forward ([`super::ReentryWindow::consumed_subject`]), so every later
+    /// re-invocation resumes the Subject await point from it instead of re-reading the
+    /// raw subject's internal slots. `CARRIED_SUBJECT_REJECTED` is an int32 boolean, or
+    /// `undefined` when the deferral has no subject settlement to carry (a first-pass
+    /// deferral); the other two slots are only read when it is present.
+    pub(super) const CARRIED_SUBJECT_REJECTED: u32 = 12;
+    pub(super) const CARRIED_SUBJECT_VALUE: u32 = 13;
+    pub(super) const CARRIED_SUBJECT: u32 = 14;
+    pub(super) const LEN: usize = 15;
 }
 
 impl Expect {
     /// Shared gate for the matcher entry points that observe the `.resolves`/`.rejects`
     /// subject (`get_value`, `apply_custom_matcher`): when promise flags are set, this is
-    /// the first pass (`!reentry`), and the subject is a plain `JSPromise` (`then2` cannot
-    /// attach native reactions to a `JSInternalPromise`), mark the subject handled, defer
-    /// the matcher, and return the deferred promise it must hand back to JS. `None` means
-    /// the caller proceeds with the synchronous `process_promise` logic.
+    /// the first pass (no reentry window), and the subject is a `JSPromise` cell, mark the
+    /// subject handled, defer the matcher, and return the deferred promise it must hand
+    /// back to JS. `None` means the caller proceeds with the synchronous
+    /// `process_promise` logic.
+    ///
+    /// The `JSPromise` requirement is the deferral machinery's own invariant: the settle
+    /// re-invocation and the rooted `deferred_ctx::SUBJECT` slot need a stable `JSPromise`
+    /// cell to mark handled and to resume the matcher from once it settles. A bare
+    /// thenable (a non-promise object with a `then`) has no such cell, so it is
+    /// deliberately not deferred: it keeps the pre-existing synchronous path, where
+    /// `process_promise` rejects non-promise subjects. That is a scope cut, not a `then2`
+    /// limitation — the settle reactions attach to a tracking promise this code creates,
+    /// never to the subject itself.
     fn try_defer_subject(
         &self,
         global_this: &JSGlobalObject,
@@ -3694,7 +3857,7 @@ impl Expect {
         value: JSValue,
     ) -> Option<JsResult<JSValue>> {
         if self.flags.get().promise() == Promise::None
-            || self.reentry.get()
+            || self.in_settle_reentry()
             || value.as_promise().is_none()
         {
             return None;
@@ -3703,9 +3866,9 @@ impl Expect {
             // An un-awaited rejecting subject must not report as an unhandled rejection.
             promise.set_handled(global_this.vm());
             if !self.can_track_matcher_promise() {
-                // No owning sequence can keep the test alive across a deferral
-                // (`test.concurrent`, outside bun:test, a torn-down phase): keep the
-                // pre-existing synchronous wait and fall through to the settled logic.
+                // No owning test entry can keep this deferral alive (a concurrent group
+                // running 2+ sequences, a hook-only beforeAll/afterAll sequence, outside
+                // bun:test): synchronously wait and fall through to the settled logic.
                 if promise.status() == js_promise::Status::Pending {
                     // SAFETY: bun_vm() returns the live thread-local VirtualMachine.
                     global_this.bun_vm().as_mut().wait_for_promise(promise);
@@ -3724,20 +3887,21 @@ impl Expect {
         call_frame: &CallFrame,
         subject: JSValue,
     ) -> JsResult<JSValue> {
-        // The settle re-invocation must never defer its (now settled) subject again
-        // (`process_promise` is gated on `!reentry`), or the counter would never reach zero.
-        debug_assert!(!self.reentry.get());
+        // The settle re-invocation must never defer its (now settled) subject again (the
+        // reentry window gates `process_promise`), or the counter would never reach zero.
+        debug_assert!(!self.in_settle_reentry());
         self.defer_matcher(global_this, call_frame, subject, DeferralOrigin::Subject)
     }
 
     /// Defer the calling matcher until `subject` settles: create the deferred `D` the
     /// matcher returns to JS, capture a GC-rooted reaction context (see [`deferred_ctx`]),
     /// register the pending deferral on the owning test's sequence, and attach the native
-    /// settle reactions to `subject`.
+    /// settle reactions to a tracking promise that adopts `subject`.
     ///
     /// `subject` must already be `set_handled` (an un-awaited rejecting subject must not
-    /// report as an unhandled rejection) and must be a plain `JSPromise`:
-    /// `JSValue::then2` cannot attach native reactions to a `JSInternalPromise`.
+    /// report as an unhandled rejection) and must be a `JSPromise` cell: the settle
+    /// re-invocation and the rooted `deferred_ctx::SUBJECT` slot both key on that cell.
+    /// Bare thenables are deliberately never deferred (see [`Expect::try_defer_subject`]).
     pub fn defer_matcher(
         &self,
         global_this: &JSGlobalObject,
@@ -3758,7 +3922,7 @@ impl Expect {
         // deferred `D` and the call-site error the first pass already created instead of
         // minting new ones (see [`ReentryDeferred`]): only that pass ran with the user's
         // `expect()` call on the stack, and `D` is the promise the user holds.
-        let chained = self.reentry_deferred.take();
+        let chained = self.take_reentry_deferred();
         let deferred_js = match &chained {
             Some(outer) => outer.deferred,
             None => js_promise::JSPromise::create(global_this).to_js(),
@@ -3767,13 +3931,18 @@ impl Expect {
         // not at the promise-reaction job that later re-invokes the matcher.
         let call_site_error = match &chained {
             Some(outer) => outer.call_site_error,
-            None => global_this.create_error_instance(format_args!("Matcher promise was not awaited")),
+            None => {
+                // Only its stack matters: it donates the user's `expect()` frames to the
+                // real failure (`attributed_matcher_error`) and to the stale-epoch reason.
+                global_this
+                    .create_error_instance(format_args!("expect() call site for a deferred matcher"))
+            }
         };
         // The user call site, captured for the same reason. A deferral made from inside a
         // settle re-invocation (e.g. the `toThrow` half of `.resolves.toThrow(...)`)
         // inherits the site captured by the deferral driving it: this frame is a
         // promise-reaction job with no user frames to walk.
-        let call_site = match self.reentry_call_site.get() {
+        let call_site = match self.reentry_call_site() {
             Some(site) => site,
             None => {
                 let srcloc = call_frame.get_caller_src_loc(global_this);
@@ -3813,11 +3982,29 @@ impl Expect {
             deferred_ctx::SRC_COL,
             JSValue::js_number_from_int32(call_site.column as i32),
         )?;
+        // Chained getters (`.not`, `.resolves`) mutate the shared wrapper's flags, so the
+        // re-invocation must observe the flags THIS call saw, not the latest ones.
         ctx.put_index(
             global_this,
-            deferred_ctx::PHASE,
-            JSValue::js_number_from_int32(SettlePhase::Invoke as i32),
+            deferred_ctx::FLAGS,
+            JSValue::js_number_from_int32(self.flags.get().encode() as i32),
         )?;
+        // A chained deferral carries the `.resolves`/`.rejects` subject settlement this
+        // re-invocation already consumed, so every later pass resumes the Subject await
+        // point from it and never re-reads the raw subject's internal slots.
+        let carried_subject =
+            self.with_reentry_window(|window| window.consumed_subject.get()).flatten();
+        let (carried_rejected, carried_value, carried_subject_js) = match carried_subject {
+            Some(settlement) => (
+                JSValue::js_number_from_int32(settlement.rejected as i32),
+                settlement.value,
+                settlement.subject,
+            ),
+            None => (JSValue::UNDEFINED, JSValue::UNDEFINED, JSValue::UNDEFINED),
+        };
+        ctx.put_index(global_this, deferred_ctx::CARRIED_SUBJECT_REJECTED, carried_rejected)?;
+        ctx.put_index(global_this, deferred_ctx::CARRIED_SUBJECT_VALUE, carried_value)?;
+        ctx.put_index(global_this, deferred_ctx::CARRIED_SUBJECT, carried_subject_js)?;
 
         // Adopt the subject through the generic promise-resolve path: a promise subclass
         // or thenable (e.g. `Bun.$`'s lazy ShellPromise) is adopted via its own `.then` —
@@ -3868,24 +4055,36 @@ impl Expect {
     /// Count a deferred matcher promise on the owning test's sequence so the runner keeps
     /// the test open until it settles, and return the registration epoch the settle
     /// reaction must hand back to [`Expect::settle_pending_matcher_promise`]. `None`
-    /// (nothing registered) degrades exactly like `expect_call_count` when no single
-    /// sequence is resolvable (`test.concurrent`, outside `bun:test`, stale phase).
+    /// (nothing registered) degrades exactly like `expect_call_count` when no test entry
+    /// owns the deferral: a concurrent group running 2+ sequences, a hook-only
+    /// `beforeAll`/`afterAll` sequence, or outside `bun:test` (stale phase).
     fn register_pending_matcher_promise(&self) -> Option<u32> {
         let parent = self.parent.as_ref()?;
         let buntest_strong = parent.bun_test()?;
         let buntest = buntest_strong.get();
         let sequence = parent.phase.sequence(buntest)?;
+        // A hook-only sequence has no test entry to derive a completion deadline from, so
+        // a tracked deferral could park the run forever; fall back to the synchronous wait
+        // instead. That wait ignores the hook timeout, so a never-settling subject in a
+        // beforeAll/afterAll still blocks the run — the same behavior as released Bun.
+        if sequence.test_entry.is_none() {
+            return None;
+        }
         Some(sequence.register_matcher_promise())
     }
 
     /// A deferral can only be tracked (and therefore gate its test's completion) when the
-    /// owning sequence is resolvable; see [`Expect::register_pending_matcher_promise`].
-    /// Callers fall back to the pre-existing synchronous wait when it is not.
+    /// owning sequence has a test entry to bound the wait; see
+    /// [`Expect::register_pending_matcher_promise`]. Callers otherwise fall back to the
+    /// pre-existing synchronous wait.
     fn can_track_matcher_promise(&self) -> bool {
         let Some(parent) = self.parent.as_ref() else { return false };
         let Some(buntest_strong) = parent.bun_test() else { return false };
         let buntest = buntest_strong.get();
-        parent.phase.sequence(buntest).is_some()
+        parent
+            .phase
+            .sequence(buntest)
+            .is_some_and(|sequence| sequence.test_entry.is_some())
     }
 
     /// The settle reaction ran (or the deferral failed to attach): release the
@@ -3917,74 +4116,76 @@ impl Expect {
         );
     }
 
-    /// An un-awaited matcher promise failed: fail the owning TEST now with the
-    /// call-site-attributed `exception`. A stale `epoch` (attempt timed out / retried) is
-    /// ignored. `Execution::handle_uncaught_exception` cannot be reused: it validates
-    /// against the active entry, which the callback has long advanced past by now.
-    fn record_unawaited_matcher_failure(
+    /// The re-invoked matcher failed. Reject `D` PLAINLY (not as-handled), so a user
+    /// `await`/`.catch` observes the failure, and record a provisional failure on the
+    /// owning sequence: whether anyone adopted `D` is decided once, when that sequence
+    /// completes (`Execution::commit_provisional_matcher_failures`). Until then the
+    /// bun:test unhandled-rejection handler suppresses `D`'s own rejection report.
+    fn record_provisional_matcher_failure(
         &self,
         global_this: &JSGlobalObject,
+        deferred: &mut js_promise::JSPromise,
         exception: JSValue,
         epoch: Option<u32>,
     ) {
-        use super::execution::Result as SequenceResult;
+        use super::execution::ProvisionalMatcherFailure;
 
-        let Some(parent) = self.parent.as_ref() else {
-            // Not inside bun:test: report it like any other unhandled error.
+        let deferred_js = deferred.to_js();
+        // Contexts with no owning sequence cannot decide "awaited or not" at a later
+        // sequence completion: report the failure now, like any other unhandled error,
+        // and settle `D` without an unhandled-rejection report of its own.
+        let Some((parent, buntest_strong)) = self
+            .parent
+            .as_ref()
+            .and_then(|parent| Some((parent, parent.bun_test()?)))
+        else {
+            deferred.set_handled();
+            let _ = deferred.reject(global_this, Ok(exception));
             global_this.bun_vm().as_mut().run_error_handler(exception, None);
             return;
         };
-        let Some(buntest_strong) = parent.bun_test() else {
-            global_this.bun_vm().as_mut().run_error_handler(exception, None);
-            return;
-        };
+        {
+            let buntest = buntest_strong.get();
+            if parent.phase.sequence(buntest).is_none() {
+                // Multi-sequence concurrent group / stale phase: no single owning
+                // sequence. Route through the shared handler so it is still reported.
+                deferred.set_handled();
+                let _ = deferred.reject(global_this, Ok(exception));
+                buntest.on_uncaught_exception(global_this, Some(exception), true, &parent.phase);
+                return;
+            }
+        }
+
+        // Reject before re-borrowing the sequence: settling a promise never runs user JS
+        // synchronously (reactions are queued), but it does enter the rejection tracker.
+        if deferred.reject(global_this, Ok(exception)).is_err() {
+            return; // terminated
+        }
         let buntest = buntest_strong.get();
-        let Some(sequence) = parent.phase.sequence(buntest) else {
-            // Concurrent group / stale phase: no single owning sequence. Route through the
-            // shared handler so the failure is still reported (as an unhandled error).
-            buntest.on_uncaught_exception(global_this, Some(exception), true, &parent.phase);
-            return;
+        let Some(sequence) = parent.phase.sequence(buntest) else { return };
+        // The `expect()` was created inside a hook if the entry it captured at creation
+        // time is not the sequence's test entry (e.g. a beforeEach of a `test.failing`).
+        let in_hook = match &parent.phase {
+            bun_test::RefDataValue::Execution { entry_data: Some(entry_data), .. } => {
+                sequence.test_entry.is_none_or(|test_entry| {
+                    !core::ptr::eq(test_entry.as_ptr().cast::<()>().cast_const(), entry_data.entry)
+                })
+            }
+            _ => false,
         };
-        if epoch.is_some_and(|epoch| epoch != sequence.matcher_epoch) {
-            // Stale deferral: the attempt it belonged to already timed out or was
-            // retried, so the sequence now describes a different attempt.
-            return;
-        }
-        // Mirror `Execution::handle_uncaught_exception`'s test-entry arm.
-        let mode = sequence
-            .test_entry
-            // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
-            .map_or(bun_test::ScopeMode::Normal, |e| unsafe { e.as_ref() }.base.mode);
-        let show = match mode {
-            bun_test::ScopeMode::Failing => {
-                if sequence.result == SequenceResult::Pending {
-                    sequence.result = SequenceResult::Pass;
-                }
-                false // `test.failing` expects the failure; hide it like the sync path
-            }
-            bun_test::ScopeMode::Todo => {
-                if sequence.result == SequenceResult::Pending {
-                    sequence.result = SequenceResult::Todo;
-                }
-                true
-            }
-            _ => {
-                if sequence.result == SequenceResult::Pending {
-                    sequence.result = SequenceResult::Fail;
-                }
-                true
-            }
-        };
-        if show {
-            buntest.bun_test_root.on_before_print();
-            global_this.bun_vm().as_mut().run_error_handler(exception, None);
-            Output::flush();
-        }
+        sequence.provisional_matcher_failures.push(ProvisionalMatcherFailure {
+            deferred: bun_jsc::Strong::create(deferred_js, global_this),
+            exception: bun_jsc::Strong::create(exception, global_this),
+            epoch: epoch.unwrap_or(sequence.matcher_epoch),
+            in_hook,
+            leaked: false,
+        });
     }
 
-    /// Best-effort: report the matcher failure through the call-site error (whose stack
-    /// points at the user's `expect()` line) carrying the failure's message. The reaction
-    /// job's own stack is useless for attribution. Never leaves a pending exception.
+    /// Best-effort: the failure surfaced from a promise-reaction job, so graft the user's
+    /// `expect()` call-site frames (captured at defer time in `call_site_error`) onto the
+    /// real exception, keeping its class, name, message, `cause`, extra properties — and
+    /// any user frames of its own. Never leaves a pending exception.
     fn attributed_matcher_error(
         global_this: &JSGlobalObject,
         exception: JSValue,
@@ -3993,20 +4194,90 @@ impl Expect {
         if !exception.is_object() || !call_site_error.is_object() {
             return exception;
         }
-        match exception.get(global_this, "message") {
-            Ok(Some(message)) if message.is_string() => {
-                call_site_error.put(global_this, "message", message);
-                call_site_error
-            }
-            Ok(_) => exception,
-            Err(JsError::Terminated) => exception,
+        match Self::graft_call_site_stack(global_this, exception, call_site_error) {
+            Ok(()) | Err(JsError::Terminated) => {}
             Err(_) => {
-                // Attribution is cosmetic; a throwing `message` getter must not derail the
+                // Attribution is cosmetic; a throwing `stack` getter must not derail the
                 // settle path or leak a pending exception out of the reaction.
                 let _ = global_this.clear_exception_except_termination();
-                exception
             }
         }
+        exception
+    }
+
+    /// Append `call_site_error`'s user frames (`"\n    at ..."`, file/line included) to
+    /// `exception`'s `stack` after any user frames of its own, keeping the exception's
+    /// header (name and message) and every other property. An exception raised from user
+    /// JS inside the re-invoked matcher keeps its real throw site; one raised natively
+    /// from the reaction job has no user frames of its own, so the call-site frames are
+    /// all it gets.
+    fn graft_call_site_stack(
+        global_this: &JSGlobalObject,
+        exception: JSValue,
+        call_site_error: JSValue,
+    ) -> JsResult<()> {
+        use bstr::ByteSlice;
+        // The V8-format frame prefix every stack line Bun serializes starts with.
+        const FRAME: &[u8] = b"\n    at ";
+        // The reporter hides source-less native frames of an intact trace; keep that
+        // parity by dropping their serialized form (`(unknown)`/`(native)` locations).
+        fn is_native_frame(line: &[u8]) -> bool {
+            line.ends_with(b"(unknown)")
+                || line.ends_with(b"(native)")
+                || line.ends_with(b" at unknown")
+                || line.ends_with(b" at native")
+        }
+        let Some(site_stack) = call_site_error.get(global_this, "stack")?.filter(|v| v.is_string())
+        else {
+            return Ok(());
+        };
+        let site_stack =
+            bun_core::OwnedString::new(site_stack.to_bun_string(global_this)?).to_utf8_bytes();
+        // No user frames were captured at the call site: nothing to attribute with.
+        let Some(site_frames_at) = site_stack.find(FRAME) else { return Ok(()) };
+        // Reading `stack` materializes the exception's own (reaction-job) trace, so the
+        // `put` below is what every later consumer (the failure reporter included) sees.
+        let Some(own_stack) = exception.get(global_this, "stack")?.filter(|v| v.is_string()) else {
+            return Ok(());
+        };
+        let own_stack =
+            bun_core::OwnedString::new(own_stack.to_bun_string(global_this)?).to_utf8_bytes();
+        let header_len = own_stack.find(FRAME).unwrap_or(own_stack.len());
+        let mut grafted = Vec::with_capacity(own_stack.len() + (site_stack.len() - site_frames_at));
+        grafted.extend_from_slice(&own_stack[..header_len]);
+        // The exception's own user frames come first: they name the real throw site.
+        let mut own_frames: Vec<&[u8]> = Vec::new();
+        for line in own_stack[header_len..].split(|&byte| byte == b'\n') {
+            if line.is_empty() || is_native_frame(line) {
+                continue;
+            }
+            grafted.push(b'\n');
+            grafted.extend_from_slice(line);
+            own_frames.push(line);
+        }
+        // Then the call-site frames it does not already carry, so the failure also points
+        // back at the user's `expect()` line.
+        let mut grafted_a_frame = !own_frames.is_empty();
+        for line in site_stack[site_frames_at..].split(|&byte| byte == b'\n') {
+            if line.is_empty() || is_native_frame(line) || own_frames.contains(&line) {
+                continue;
+            }
+            grafted.push(b'\n');
+            grafted.extend_from_slice(line);
+            grafted_a_frame = true;
+        }
+        if !grafted_a_frame {
+            return Ok(());
+        }
+        // NOT mirrored onto own `sourceURL`/`line`/`column` properties: `put` would make
+        // them enumerable (JSC materializes them DontEnum), so the reporter would dump
+        // them as extra fields. The reporter takes the location from the frames instead.
+        exception.put(
+            global_this,
+            "stack",
+            bun_jsc::bun_string_jsc::create_utf8_for_js(global_this, &grafted)?,
+        );
+        Ok(())
     }
 
     /// The registration at `epoch` still belongs to the attempt currently occupying the
@@ -4024,10 +4295,11 @@ impl Expect {
         sequence.matcher_epoch == epoch
     }
 
-    /// Shared body of `Bun__Expect__onSubjectResolve/Reject`. `Invoke` phase: re-invoke
-    /// the deferred matcher now that the subject settled; a failure re-arms the context
-    /// as a `Report` reaction one job later, so user code adopting `D` in the same drain
-    /// (an async callback's implicit `return`) is seen before the un-awaited decision.
+    /// Shared body of `Bun__Expect__onSubjectResolve/Reject`: re-invoke the deferred
+    /// matcher now that the subject settled. A matcher failure rejects `D` plainly and
+    /// records a provisional failure on the owning sequence; whether anyone adopted `D`
+    /// is decided once, when that sequence completes (see
+    /// [`Expect::record_provisional_matcher_failure`]).
     fn on_subject_settled(
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
@@ -4046,11 +4318,26 @@ impl Expect {
         let origin = DeferralOrigin::from_ctx_slot(ctx.get_index(global_this, deferred_ctx::ORIGIN)?);
         let subject = ctx.get_index(global_this, deferred_ctx::SUBJECT)?;
         let epoch = Self::epoch_from_ctx_slot(ctx.get_index(global_this, deferred_ctx::EPOCH)?);
-        let phase = ctx.get_index(global_this, deferred_ctx::PHASE)?;
+        let flags_snapshot =
+            Flags::decode(Self::u32_from_ctx_slot(ctx.get_index(global_this, deferred_ctx::FLAGS)?) as FlagsCppType);
         let call_site = ReentryCallSite {
             source_url: ctx.get_index(global_this, deferred_ctx::SRC_URL)?,
             line: Self::u32_from_ctx_slot(ctx.get_index(global_this, deferred_ctx::SRC_LINE)?),
             column: Self::u32_from_ctx_slot(ctx.get_index(global_this, deferred_ctx::SRC_COL)?),
+        };
+        // The `.resolves`/`.rejects` subject settlement a chained deferral carried
+        // forward (`undefined` for a first-pass deferral): re-seeded into the window so
+        // this re-invocation's Subject await point never re-reads the raw subject.
+        let carried_rejected = ctx.get_index(global_this, deferred_ctx::CARRIED_SUBJECT_REJECTED)?;
+        let consumed_subject = if carried_rejected.is_int32() {
+            Some(ReentrySettlement {
+                origin: DeferralOrigin::Subject,
+                subject: ctx.get_index(global_this, deferred_ctx::CARRIED_SUBJECT)?,
+                value: ctx.get_index(global_this, deferred_ctx::CARRIED_SUBJECT_VALUE)?,
+                rejected: carried_rejected.as_int32() != 0,
+            })
+        } else {
+            None
         };
 
         let (Some(expect_ptr), Some(deferred_ptr)) =
@@ -4064,28 +4351,16 @@ impl Expect {
         // SAFETY: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
         let deferred = js_promise::JSPromise::opaque_mut(deferred_ptr);
 
-        // Report phase: the matcher already failed on the Invoke pass one job ago.
-        if phase.is_int32() && phase.as_int32() == SettlePhase::Report as i32 {
-            let exception = ctx.get_index(global_this, deferred_ctx::FAILURE)?;
-            if deferred.is_handled() {
-                // The user awaited (or `.catch`ed) the matcher promise: reject it and let
-                // their handler surface the failure.
-                let _ = deferred.reject(global_this, Ok(exception));
-            } else {
-                // Un-awaited failing matcher: fail the owning test and settle `D` without
-                // an unhandled-rejection report.
-                expect.record_unawaited_matcher_failure(global_this, exception, epoch);
-                let _ = deferred.reject_as_handled(global_this, exception);
-            }
-            expect.settle_pending_matcher_promise(global_this, epoch);
-            return Ok(JSValue::UNDEFINED);
-        }
-
         // The attempt this deferral belonged to is gone (per-test timeout or retry/repeat
         // reset): do not re-run the matcher — its side effects (snapshot counters, expect
         // counts) would land in the attempt now occupying the sequence.
         if !expect.matcher_epoch_is_current(epoch) {
-            let _ = deferred.reject_as_handled(global_this, call_site_error);
+            // Reject with the real reason, attributed to the user's `expect()` line.
+            let stale = global_this.create_error_instance(format_args!(
+                "Test attempt ended (timeout or retry) before the matcher promise settled"
+            ));
+            let stale = Self::attributed_matcher_error(global_this, stale, call_site_error);
+            let _ = deferred.reject_as_handled(global_this, stale);
             expect.settle_pending_matcher_promise(global_this, epoch);
             return Ok(JSValue::UNDEFINED);
         }
@@ -4096,36 +4371,42 @@ impl Expect {
             args.push(args_js.get_index(global_this, i)?);
         }
 
-        // Re-invoke the SAME matcher. With `reentry` set and a settled subject,
-        // `process_promise` falls through the synchronous Fulfilled/Rejected logic, and a
-        // call-produced deferral (async `toThrow` / async custom matcher) resumes from the
-        // stashed settlement instead of running the producer a second time.
-        expect.reentry.set(true);
-        expect.reentry_settlement.set(Some(ReentrySettlement {
-            origin,
-            subject,
-            value: settled_value,
-            rejected,
-        }));
-        expect.reentry_call_site.set(Some(call_site));
-        // Consumed (taken) only if this re-invocation defers again; see [`ReentryDeferred`].
-        expect.reentry_deferred.set(Some(ReentryDeferred { deferred: deferred_js, call_site_error }));
+        // Re-invoke the SAME matcher. Inside the reentry window, every await point resumes from
+        // the stashed settlement: a subject deferral direction-checks it instead of
+        // re-reading the subject's internal slots, and a call-produced deferral (async
+        // `toThrow` / async custom matcher) never runs its producer a second time.
+        // The re-invocation window (see [`ReentryWindow`]): every `JSValue` in it is
+        // rooted by this reaction frame + `ctx` for the synchronous `callee.call` below.
+        let window = ReentryWindow {
+            expect: expect_ptr,
+            settlement: Cell::new(Some(ReentrySettlement {
+                origin,
+                subject,
+                value: settled_value,
+                rejected,
+            })),
+            consumed_subject: Cell::new(consumed_subject),
+            call_site,
+            // Consumed (taken) only if this re-invocation defers again; see [`ReentryDeferred`].
+            deferred: Cell::new(Some(ReentryDeferred { deferred: deferred_js, call_site_error })),
+            flags: flags_snapshot,
+        };
         let call_result = {
-            let (reentry, settlement, site, chained) = (
-                &expect.reentry,
-                &expect.reentry_settlement,
-                &expect.reentry_call_site,
-                &expect.reentry_deferred,
-            );
-            // Reset even if the matcher throws or a nested panic unwinds; the settlement's
-            // and call site's `JSValue`s are only rooted (by this frame + `ctx`) for the
-            // call below.
-            let _reset = scopeguard::guard((), |()| {
-                reentry.set(false);
-                settlement.set(None);
-                site.set(None);
-                chained.set(None);
+            // Restore the PREVIOUS window and flags — not null/default — even if the
+            // matcher throws or a nested panic unwinds: a further settle reaction firing
+            // inside this one (nested window) must hand back what it found. Armed before
+            // the two `replace` calls below so no path can leave the stale pointer behind.
+            let previous_window = expect.reentry_window.get();
+            let previous_flags = expect.flags.get();
+            let _restore = scopeguard::guard((), move |()| {
+                expect.reentry_window.set(previous_window);
+                expect.flags.set(previous_flags);
             });
+            // The re-invoked matcher must observe the flags captured at defer time
+            // ([`deferred_ctx::FLAGS`]): a later `.not`/`.resolves` on the same handle
+            // already mutated the shared byte.
+            expect.reentry_window.set(&window);
+            expect.flags.set(window.flags);
             callee.call(global_this, expect_this, &args)
         };
 
@@ -4157,28 +4438,14 @@ impl Expect {
                     raw.to_error().unwrap_or(raw),
                     call_site_error,
                 );
-                // Whether the failure is "awaited" cannot be decided yet: the job that
-                // adopts `D` (e.g. the async callback's implicit-return thenable job) may
-                // still be queued behind this reaction. Re-arm the same context as a
-                // Report reaction — it runs after those jobs — and keep the registration
-                // (and `D`) pending until it decides.
-                ctx.put_index(
-                    global_this,
-                    deferred_ctx::PHASE,
-                    JSValue::js_number_from_int32(SettlePhase::Report as i32),
-                )?;
-                ctx.put_index(global_this, deferred_ctx::FAILURE, exception)?;
-                subject.then2(
-                    global_this,
-                    ctx,
-                    Bun__Expect__onSubjectResolve,
-                    Bun__Expect__onSubjectReject,
-                );
-                return Ok(JSValue::UNDEFINED);
+                // Whether the failure was "awaited" cannot be decided yet (the user may
+                // adopt `D` any time before the test ends): reject `D` plainly and record
+                // a provisional failure the owning sequence commits at completion.
+                expect.record_provisional_matcher_failure(global_this, deferred, exception, epoch);
             }
         }
-        // Exactly one decrement per registration: each reaction pair runs at most once
-        // per phase, and only the final phase reaches a release path.
+        // Exactly one decrement per registration: the reaction pair runs at most once,
+        // and every arm above that returns early releases it first.
         expect.settle_pending_matcher_promise(global_this, epoch);
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -3819,9 +3819,22 @@ impl Expect {
             JSValue::js_number_from_int32(SettlePhase::Invoke as i32),
         )?;
 
+        // Adopt the subject through the generic promise-resolve path: a promise subclass
+        // or thenable (e.g. `Bun.$`'s lazy ShellPromise) is adopted via its own `.then` —
+        // which is what starts it — while reactions attached directly to its internal
+        // slots (`then2`) never would. A plain promise adopts natively (fast path).
+        let tracked = js_promise::JSPromise::create(global_this);
+        let tracked_js = tracked.to_js();
+        if tracked.resolve(global_this, subject).is_err() {
+            return Err(JsError::Terminated);
+        }
+        if global_this.has_exception() {
+            // A hostile `then` getter threw during the adoption.
+            return Err(JsError::Thrown);
+        }
         // The reaction only runs on a later microtask, so it can never observe a missing
         // registration; from here on it owns the release the guard above was armed for.
-        subject.then2(
+        tracked_js.then2(
             global_this,
             ctx,
             Bun__Expect__onSubjectResolve,

--- a/src/runtime/test_runner/expect/toBe.rs
+++ b/src/runtime/test_runner/expect/toBe.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
 use super::Expect;
+use super::ready_or_defer;
 
 impl Expect {
     /// Object.is()
@@ -12,7 +13,7 @@ impl Expect {
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let (this, left, not) =
-            self.matcher_prelude(global_this, callframe.this(), "toBe", "<green>expected<r>")?;
+            ready_or_defer!(self.matcher_prelude(global_this, callframe, "toBe", "<green>expected<r>")?);
 
         let arguments_ = callframe.arguments_old::<2>();
         let arguments = arguments_.slice();

--- a/src/runtime/test_runner/expect/toBeArrayOfSize.rs
+++ b/src/runtime/test_runner/expect/toBeArrayOfSize.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -13,7 +14,6 @@ pub(crate) fn to_be_array_of_size(
     // post-match guard instead.
     let this = this.post_match_guard(global);
 
-    let this_value = frame.this();
     let _arguments = frame.arguments_old::<1>();
     let arguments = &_arguments.ptr[0.._arguments.len];
 
@@ -21,8 +21,8 @@ pub(crate) fn to_be_array_of_size(
         return Err(global.throw_invalid_arguments(format_args!("toBeArrayOfSize() requires 1 argument")));
     }
 
-    let value: JSValue = this.get_value(global, this_value, "toBeArrayOfSize", "")?;
-
+    // Argument validation stays ahead of `get_value`: a `Deferred` result has already
+    // registered a pending deferral, so nothing fallible may sit between it and its unwrap.
     let size = arguments[0];
     size.ensure_still_alive();
 
@@ -31,6 +31,7 @@ pub(crate) fn to_be_array_of_size(
     }
 
     this.increment_expect_call_counter();
+    let value = ready_or_defer!(this.get_value(global, frame, "toBeArrayOfSize", "")?);
 
     let not = this.flags.get().not();
     let mut pass = value.js_type().is_array()

--- a/src/runtime/test_runner/expect/toBeCloseTo.rs
+++ b/src/runtime/test_runner/expect/toBeCloseTo.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -12,7 +13,6 @@ impl Expect {
     ) -> JsResult<JSValue> {
         let this = self.post_match_guard(global);
 
-        let this_value = call_frame.this();
         let this_arguments = call_frame.arguments_old::<2>();
         let arguments = this_arguments.slice();
 
@@ -40,7 +40,7 @@ impl Expect {
         }
 
         let received_: JSValue =
-            this.get_value(global, this_value, "toBeCloseTo", "<green>expected<r>, precision")?;
+            ready_or_defer!(this.get_value(global, call_frame, "toBeCloseTo", "<green>expected<r>, precision")?);
         if !received_.is_number() {
             return Err(global.throw_invalid_argument_type("expect", "received", "number"));
         }

--- a/src/runtime/test_runner/expect/toBeEmpty.rs
+++ b/src/runtime/test_runner/expect/toBeEmpty.rs
@@ -3,6 +3,7 @@ use core::ffi::c_void;
 use bun_jsc::{CallFrame, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue, JsResult, VM};
 
 use super::Expect;
+use super::ready_or_defer;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -11,7 +12,7 @@ pub(crate) fn to_be_empty(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let (_this, value, not) = this.matcher_prelude(global, frame.this(), "toBeEmpty", "")?;
+    let (_this, value, not) = ready_or_defer!(this.matcher_prelude(global, frame, "toBeEmpty", "")?);
     let mut pass;
     let mut formatter = super::make_formatter(global);
     // `defer formatter.deinit()` — handled by Drop.

--- a/src/runtime/test_runner/expect/toBeEmptyObject.rs
+++ b/src/runtime/test_runner/expect/toBeEmptyObject.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
+use super::ready_or_defer;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -9,7 +10,7 @@ pub(crate) fn to_be_empty_object(
     call_frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let this_value = call_frame.this();
-    let (this, value, not) = this.matcher_prelude(global, this_value, "toBeEmptyObject", "")?;
+    let (this, value, not) = ready_or_defer!(this.matcher_prelude(global, call_frame, "toBeEmptyObject", "")?);
     let mut pass = value.is_object_empty(global)?;
 
     if not {

--- a/src/runtime/test_runner/expect/toBeInstanceOf.rs
+++ b/src/runtime/test_runner/expect/toBeInstanceOf.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -14,7 +15,6 @@ pub(crate) fn to_be_instance_of(
     // Run the matcher body in an inner closure so `this` is released when it returns,
     // then call `post_match` exactly once on every exit path (success or throw).
     let res = (|| -> JsResult<JSValue> {
-    let this_value = frame.this();
     // Collapsed `arguments_old(1)` + ptr/len slice into a single &[JSValue].
     let arguments_ = frame.arguments_old::<1>(); let arguments: &[JSValue] = arguments_.slice();
 
@@ -38,7 +38,7 @@ pub(crate) fn to_be_instance_of(
     expected_value.ensure_still_alive();
 
     let value: JSValue =
-        this.get_value(global, this_value, "toBeInstanceOf", "<green>expected<r>")?;
+        ready_or_defer!(this.get_value(global, frame, "toBeInstanceOf", "<green>expected<r>")?);
 
     let not = this.flags.get().not();
     let mut pass = value.is_instance_of(global, expected_value)?;

--- a/src/runtime/test_runner/expect/toBeObject.rs
+++ b/src/runtime/test_runner/expect/toBeObject.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
+use super::ready_or_defer;
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -15,9 +16,10 @@ impl Expect {
         // (incl. `?` early-returns) is covered without a raw `*mut Expect`.
         let result = (|| -> JsResult<JSValue> {
         let this_value = frame.this();
-        let value: JSValue = this.get_value(global, this_value, "toBeObject", "")?;
+        let value = this.get_value(global, frame, "toBeObject", "")?;
 
         this.increment_expect_call_counter();
+        let value = ready_or_defer!(value);
 
         let not = this.flags.get().not();
         let pass = value.is_object() != not;

--- a/src/runtime/test_runner/expect/toBeOneOf.rs
+++ b/src/runtime/test_runner/expect/toBeOneOf.rs
@@ -4,6 +4,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
 
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 struct ExpectedEntry<'a> {
     global_this: &'a JSGlobalObject,
@@ -37,7 +38,7 @@ pub(crate) fn to_be_one_of(
     call_frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let (this, expected, not) =
-        this.matcher_prelude(global_this, call_frame.this(), "toBeOneOf", "<green>expected<r>")?;
+        ready_or_defer!(this.matcher_prelude(global_this, call_frame, "toBeOneOf", "<green>expected<r>")?);
 
     let arguments_ = call_frame.arguments_old::<1>();
     let arguments = arguments_.slice();

--- a/src/runtime/test_runner/expect/toBeTypeOf.rs
+++ b/src/runtime/test_runner/expect/toBeTypeOf.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 bun_core::comptime_string_map! {
     static JS_TYPE_OF_MAP: &'static [u8] = {
@@ -22,7 +23,7 @@ pub(crate) fn to_be_type_of(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let (this, value, not) = this.matcher_prelude(global, frame.this(), "toBeTypeOf", "")?;
+    let (this, value, not) = ready_or_defer!(this.matcher_prelude(global, frame, "toBeTypeOf", "")?);
     let _arguments = frame.arguments_old::<1>();
     let arguments = _arguments.slice();
 

--- a/src/runtime/test_runner/expect/toBeValidDate.rs
+++ b/src/runtime/test_runner/expect/toBeValidDate.rs
@@ -3,6 +3,7 @@ use super::make_formatter;
 
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -12,7 +13,7 @@ pub(crate) fn to_be_valid_date(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let this_value = frame.this();
-    let (this, value, not) = this.matcher_prelude(global, this_value, "toBeValidDate", "")?;
+    let (this, value, not) = ready_or_defer!(this.matcher_prelude(global, frame, "toBeValidDate", "")?);
     let mut pass = value.is_date() && !value.get_unix_timestamp().is_nan();
     if not {
         pass = !pass;

--- a/src/runtime/test_runner/expect/toBeWithin.rs
+++ b/src/runtime/test_runner/expect/toBeWithin.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
+use super::ready_or_defer;
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -9,12 +10,12 @@ impl Expect {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (this, value, not) = self.matcher_prelude(
+        let (this, value, not) = ready_or_defer!(self.matcher_prelude(
             global,
-            frame.this(),
+            frame,
             "toBeWithin",
             "<green>start<r><d>, <r><green>end<r>",
-        )?;
+        )?);
 
         let _arguments = frame.arguments_old::<2>();
         let arguments = _arguments.slice();

--- a/src/runtime/test_runner/expect/toContain.rs
+++ b/src/runtime/test_runner/expect/toContain.rs
@@ -5,6 +5,7 @@ use bun_core::strings;
 
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -14,7 +15,7 @@ impl Expect {
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let (this, value, not) =
-            self.matcher_prelude(global, frame.this(), "toContain", "<green>expected<r>")?;
+            ready_or_defer!(self.matcher_prelude(global, frame, "toContain", "<green>expected<r>")?);
 
         let arguments_ = frame.arguments_old::<1>();
         let arguments = arguments_.slice();

--- a/src/runtime/test_runner/expect/toContainEqual.rs
+++ b/src/runtime/test_runner/expect/toContainEqual.rs
@@ -3,7 +3,7 @@ use core::ffi::c_void;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
 use bun_core::strings;
 
-use super::{get_signature, Expect};
+use super::{get_signature, ready_or_defer, Expect};
 
 struct ExpectedEntry<'a> {
     global_this: &'a JSGlobalObject,
@@ -37,7 +37,7 @@ pub(crate) fn to_contain_equal(
 ) -> JsResult<JSValue> {
     let this_value = frame.this();
     let (this, value, not) =
-        this.matcher_prelude(global, this_value, "toContainEqual", "<green>expected<r>")?;
+        ready_or_defer!(this.matcher_prelude(global, frame, "toContainEqual", "<green>expected<r>")?);
     let arguments_ = frame.arguments_old::<1>();
     let arguments = arguments_.slice();
 

--- a/src/runtime/test_runner/expect/toEqual.rs
+++ b/src/runtime/test_runner/expect/toEqual.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
 use super::Expect;
+use super::ready_or_defer;
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -11,7 +12,7 @@ impl Expect {
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let (this, value, not) =
-            self.matcher_prelude(global, frame.this(), "toEqual", "<green>expected<r>")?;
+            ready_or_defer!(self.matcher_prelude(global, frame, "toEqual", "<green>expected<r>")?);
 
         let _arguments = frame.arguments_old::<1>();
         let arguments: &[JSValue] = _arguments.slice();

--- a/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
+++ b/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
+use super::ready_or_defer;
 
 // Matches ' ' and '\t'..'\r' (0x09–0x0D) — includes VT (0x0B), which Rust's
 // u8::is_ascii_whitespace does not.
@@ -16,7 +17,7 @@ pub(crate) fn to_equal_ignoring_whitespace(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let (this, value, not) =
-        this.matcher_prelude(global, frame.this(), "toEqualIgnoringWhitespace", "<green>expected<r>")?;
+        ready_or_defer!(this.matcher_prelude(global, frame, "toEqualIgnoringWhitespace", "<green>expected<r>")?);
 
     let arguments_ = frame.arguments_old::<1>(); let arguments: &[JSValue] = arguments_.slice();
 

--- a/src/runtime/test_runner/expect/toHaveBeenCalled.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalled.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_been_called(
     this: &Expect,
@@ -8,7 +9,7 @@ pub(crate) fn to_have_been_called(
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
     let (this, calls, _value) =
-        this.mock_prologue(global, frame.this(), "toHaveBeenCalled", "", super::mock::MockKind::Calls)?;
+        ready_or_defer!(this.mock_prologue(global, frame, "toHaveBeenCalled", "", super::mock::MockKind::Calls)?);
     // arg-check after prologue: counter bump + post_match still fire on bad-arity.
     if !frame.arguments_as_array::<1>()[0].is_undefined() {
         return Err(global.throw_invalid_arguments(format_args!(

--- a/src/runtime/test_runner/expect/toHaveBeenCalledOnce.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalledOnce.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_been_called_once(
     this: &Expect,
@@ -8,13 +9,13 @@ pub(crate) fn to_have_been_called_once(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
-    let (this, calls, _value) = this.mock_prologue(
+    let (this, calls, _value) = ready_or_defer!(this.mock_prologue(
         global,
-        frame.this(),
+        frame,
         "toHaveBeenCalledOnce",
         "<green>expected<r>",
         super::mock::MockKind::Calls,
-    )?;
+    )?);
 
     let calls_length = calls.get_length(global)?;
     let mut pass = calls_length == 1;

--- a/src/runtime/test_runner/expect/toHaveBeenCalledTimes.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalledTimes.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_been_called_times(
     this: &Expect,
@@ -9,13 +10,13 @@ pub(crate) fn to_have_been_called_times(
 ) -> JsResult<JSValue> {
     let arguments_ = frame.arguments_old::<1>();
     let arguments: &[JSValue] = arguments_.slice();
-    let (this, calls, _value) = this.mock_prologue(
+    let (this, calls, _value) = ready_or_defer!(this.mock_prologue(
         global,
-        frame.this(),
+        frame,
         "toHaveBeenCalledTimes",
         "<green>expected<r>",
         super::mock::MockKind::Calls,
-    )?;
+    )?);
 
     if arguments.len() < 1 || !arguments[0].is_uint32_as_any_int() {
         return Err(global.throw_invalid_arguments(format_args!(

--- a/src/runtime/test_runner/expect/toHaveBeenCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalledWith.rs
@@ -3,6 +3,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::DiffFormatter;
 use super::mock;
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_been_called_with(
     this: &Expect,
@@ -11,13 +12,13 @@ pub(crate) fn to_have_been_called_with(
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
     let arguments = frame.arguments();
-    let (this, calls, _value) = this.mock_prologue(
+    let (this, calls, _value) = ready_or_defer!(this.mock_prologue(
         global,
-        frame.this(),
+        frame,
         "toHaveBeenCalledWith",
         "<green>...expected<r>",
         mock::MockKind::CallsWithSig,
-    )?;
+    )?);
 
     let mut pass = false;
 

--- a/src/runtime/test_runner/expect/toHaveBeenLastCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenLastCalledWith.rs
@@ -1,7 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
-use super::{Expect, get_signature};
+use super::{Expect, get_signature, ready_or_defer};
 
 pub(crate) fn to_have_been_last_called_with(
     this: &Expect,
@@ -10,13 +10,13 @@ pub(crate) fn to_have_been_last_called_with(
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
     let arguments = frame.arguments();
-    let (this, calls, value) = this.mock_prologue(
+    let (this, calls, value) = ready_or_defer!(this.mock_prologue(
         global,
-        frame.this(),
+        frame,
         "toHaveBeenLastCalledWith",
         "<green>...expected<r>",
         super::mock::MockKind::CallsWithSig,
-    )?;
+    )?);
 
     let total_calls: u32 = calls.get_length(global)? as u32;
     let mut last_call_value: JSValue = JSValue::ZERO;

--- a/src/runtime/test_runner/expect/toHaveBeenNthCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenNthCalledWith.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::DiffFormatter;
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_been_nth_called_with(
     this: &Expect,
@@ -8,13 +9,13 @@ pub(crate) fn to_have_been_nth_called_with(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let arguments = frame.arguments();
-    let (this, calls, _value) = this.mock_prologue(
+    let (this, calls, _value) = ready_or_defer!(this.mock_prologue(
         global,
-        frame.this(),
+        frame,
         "toHaveBeenNthCalledWith",
         "<green>n<r>, <green>...expected<r>",
         super::mock::MockKind::CallsWithSig,
-    )?;
+    )?);
 
     if arguments.is_empty() || !arguments[0].is_any_int() {
         return Err(global.throw_invalid_arguments(format_args!(

--- a/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
@@ -4,6 +4,7 @@ use bun_jsc::console_object::Formatter;
 
 use super::DiffFormatter;
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_last_returned_with(
     this: &Expect,
@@ -12,13 +13,13 @@ pub(crate) fn to_have_last_returned_with(
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
     let expected = callframe.arguments_as_array::<1>()[0];
-    let (this, returns, _value) = this.mock_prologue(
+    let (this, returns, _value) = ready_or_defer!(this.mock_prologue(
         global_this,
-        callframe.this(),
+        callframe,
         "toHaveBeenLastReturnedWith",
         "<green>expected<r>",
         super::mock::MockKind::Returns,
-    )?;
+    )?);
 
     let calls_count = u32::try_from(returns.get_length(global_this)?).unwrap();
     let mut pass = false;

--- a/src/runtime/test_runner/expect/toHaveLength.rs
+++ b/src/runtime/test_runner/expect/toHaveLength.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_length(
     this: &Expect,
@@ -9,7 +10,7 @@ pub(crate) fn to_have_length(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let (this, value, not) =
-        this.matcher_prelude(global, frame.this(), "toHaveLength", "<green>expected<r>")?;
+        ready_or_defer!(this.matcher_prelude(global, frame, "toHaveLength", "<green>expected<r>")?);
 
     let arguments_ = frame.arguments_old::<1>();
     let arguments = arguments_.slice();

--- a/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
@@ -1,7 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
-use super::{Expect, get_signature};
+use super::{Expect, get_signature, ready_or_defer};
 
 pub(crate) fn to_have_nth_returned_with(
     this: &Expect,
@@ -10,13 +10,13 @@ pub(crate) fn to_have_nth_returned_with(
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
     let [nth_arg, expected] = frame.arguments_as_array::<2>();
-    let (this, returns, _value) = this.mock_prologue(
+    let (this, returns, _value) = ready_or_defer!(this.mock_prologue(
         global,
-        frame.this(),
+        frame,
         "toHaveNthReturnedWith",
         "<green>n<r>, <green>expected<r>",
         super::mock::MockKind::Returns,
-    )?;
+    )?);
 
     // Validate n is a number
     if !nth_arg.is_any_int() {

--- a/src/runtime/test_runner/expect/toHaveProperty.rs
+++ b/src/runtime/test_runner/expect/toHaveProperty.rs
@@ -3,6 +3,7 @@ use bun_core::ZigString;
 
 use super::DiffFormatter;
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_property(
     this: &Expect,
@@ -12,7 +13,6 @@ pub(crate) fn to_have_property(
     // `defer this.postMatch(globalThis)` — guard owns `this` and calls post_match on drop.
     let this = scopeguard::guard(this, |this| this.post_match(global));
 
-    let this_value = frame.this();
     let _arguments = frame.arguments_old::<2>();
     let arguments: &[JSValue] = _arguments.slice();
 
@@ -31,12 +31,12 @@ pub(crate) fn to_have_property(
         ev.ensure_still_alive();
     }
 
-    let value: JSValue = this.get_value(
+    let value: JSValue = ready_or_defer!(this.get_value(
         global,
-        this_value,
+        frame,
         "toHaveProperty",
         "<green>path<r><d>, <r><green>value<r>",
-    )?;
+    )?);
 
     if !expected_property_path.is_string() && !expected_property_path.is_iterable(global)? {
         return Err(global.throw(format_args!("Expected path must be a string or an array")));

--- a/src/runtime/test_runner/expect/toHaveReturned.rs
+++ b/src/runtime/test_runner/expect/toHaveReturned.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::mock;
 use super::Expect;
+use super::ready_or_defer;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum Mode {
@@ -29,13 +30,13 @@ fn to_have_returned_times_fn(
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
     let arguments = callframe.arguments();
-    let (this, returns_arr, _value) = this.mock_prologue(
+    let (this, returns_arr, _value) = ready_or_defer!(this.mock_prologue(
         global,
-        callframe.this(),
+        callframe,
         mode.tag_name(),
         "<green>expected<r>",
         mock::MockKind::Returns,
-    )?;
+    )?);
     let mut returns = returns_arr.array_iterator(global)?;
 
     let expected_success_count: i32 = if mode == Mode::ToHaveReturned {

--- a/src/runtime/test_runner/expect/toHaveReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveReturnedWith.rs
@@ -3,6 +3,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::DiffFormatter;
 use super::mock;
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_have_returned_with(
     this: &Expect,
@@ -10,13 +11,13 @@ pub(crate) fn to_have_returned_with(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let expected = frame.arguments_as_array::<1>()[0];
-    let (this, returns, _value) = this.mock_prologue(
+    let (this, returns, _value) = ready_or_defer!(this.mock_prologue(
         global,
-        frame.this(),
+        frame,
         "toHaveReturnedWith",
         "<green>expected<r>",
         mock::MockKind::Returns,
-    )?;
+    )?);
 
     let calls_count = u32::try_from(returns.get_length(global)?).unwrap();
     let mut pass = false;

--- a/src/runtime/test_runner/expect/toMatch.rs
+++ b/src/runtime/test_runner/expect/toMatch.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::JSValueTestExt;
 
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_match(
     this: &Expect,
@@ -9,7 +10,7 @@ pub(crate) fn to_match(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let (this, value, not) =
-        this.matcher_prelude(global, frame.this(), "toMatch", "<green>expected<r>")?;
+        ready_or_defer!(this.matcher_prelude(global, frame, "toMatch", "<green>expected<r>")?);
 
     let arguments: &[JSValue] = frame.arguments();
 

--- a/src/runtime/test_runner/expect/toMatchInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchInlineSnapshot.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_core::ZigString;
 
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_match_inline_snapshot(
     this: &Expect,
@@ -13,7 +14,6 @@ pub(crate) fn to_match_inline_snapshot(
     // overlapping with the deferred call (matches toThrowErrorMatchingInlineSnapshot.rs).
     let this = scopeguard::guard(this, |this| this.post_match(global));
 
-    let this_value = frame.this();
     let arguments_ = frame.arguments_old::<2>(); let arguments: &[JSValue] = arguments_.slice();
 
     this.increment_expect_call_counter();
@@ -81,12 +81,12 @@ pub(crate) fn to_match_inline_snapshot(
 
     let expected_slice: Option<&[u8]> = if has_expected { Some(expected.slice()) } else { None };
 
-    let value = this.get_value(
+    let value = ready_or_defer!(this.get_value(
         global,
-        this_value,
+        frame,
         "toMatchInlineSnapshot",
         "<green>properties<r><d>, <r>hint",
-    )?;
+    )?);
     Expect::inline_snapshot(
         &**this,
         global,

--- a/src/runtime/test_runner/expect/toMatchObject.rs
+++ b/src/runtime/test_runner/expect/toMatchObject.rs
@@ -1,6 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::DiffFormatter;
-use super::{get_signature, Expect};
+use super::{get_signature, ready_or_defer, Expect};
 
 pub(crate) fn to_match_object(
     this: &Expect,
@@ -8,7 +8,7 @@ pub(crate) fn to_match_object(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     let (this, received_object, not) =
-        this.matcher_prelude(global, frame.this(), "toMatchObject", "<green>expected<r>")?;
+        ready_or_defer!(this.matcher_prelude(global, frame, "toMatchObject", "<green>expected<r>")?);
     let args_buf = frame.arguments_old::<1>();
     let args = args_buf.slice();
 

--- a/src/runtime/test_runner/expect/toMatchSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchSnapshot.rs
@@ -3,6 +3,7 @@ use bun_core::ZigString;
 
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 pub(crate) fn to_match_snapshot(
     this: &Expect,
@@ -14,7 +15,6 @@ pub(crate) fn to_match_snapshot(
     // deref through the guard for the body.
     let this = scopeguard::guard(this, |this| this.post_match(global));
 
-    let this_value = frame.this();
     let _arguments = frame.arguments_old::<2>();
     let arguments: &[JSValue] = &_arguments.ptr[0.._arguments.len];
 
@@ -90,12 +90,12 @@ pub(crate) fn to_match_snapshot(
     let hint = hint_string.to_slice();
     // `hint` cleanup handled by Drop.
 
-    let value: JSValue = this.get_value(
+    let value: JSValue = ready_or_defer!(this.get_value(
         global,
-        this_value,
+        frame,
         "toMatchSnapshot",
         "<green>properties<r><d>, <r>hint",
-    )?;
+    )?);
 
     Expect::snapshot(&**this, global, value, property_matchers, hint.slice(), "toMatchSnapshot")
 }

--- a/src/runtime/test_runner/expect/toStrictEqual.rs
+++ b/src/runtime/test_runner/expect/toStrictEqual.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
 use super::Expect;
+use super::ready_or_defer;
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -11,7 +12,7 @@ impl Expect {
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let (this, value, not) =
-            self.matcher_prelude(global, frame.this(), "toStrictEqual", "<green>expected<r>")?;
+            ready_or_defer!(self.matcher_prelude(global, frame, "toStrictEqual", "<green>expected<r>")?);
 
         let _arguments = frame.arguments_old::<1>();
         let arguments: &[JSValue] = _arguments.slice();

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -9,6 +9,7 @@ use super::Expect;
 use super::ExpectAny;
 use super::expect_any_js;
 use super::get_signature;
+use super::ready_or_defer;
 
 pub(crate) fn to_throw(
     this: &Expect,
@@ -20,7 +21,6 @@ pub(crate) fn to_throw(
     // runs on every exit path (Ok and Err alike).
     let this = scopeguard::guard(this, |t| t.post_match(global));
 
-    let this_value = frame.this();
     let arguments = frame.arguments_as_array::<1>();
 
     this.increment_expect_call_counter();
@@ -58,10 +58,10 @@ pub(crate) fn to_throw(
 
     let not = this.flags.get().not();
 
-    let (result_, return_value_from_function) = this.get_value_as_to_throw(
-        global,
-        this.get_value(global, this_value, "toThrow", "<green>expected<r>")?,
-    )?;
+    let received = ready_or_defer!(this.get_value(global, frame, "toThrow", "<green>expected<r>")?);
+    // Deferred while the promise returned by the received function is still pending.
+    let (result_, return_value_from_function) =
+        ready_or_defer!(this.get_value_as_to_throw(global, frame, received)?);
 
     let did_throw = result_.is_some();
 

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_core::ZigString;
 
 use super::Expect;
+use super::ready_or_defer;
 
 pub(crate) fn to_throw_error_matching_inline_snapshot(
     this: &Expect,
@@ -11,7 +12,6 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
     // The guard owns the &mut, Derefs to it, and runs post_match on Drop.
     let this = scopeguard::guard(this, |t| t.post_match(global));
 
-    let this_value = frame.this();
     let _arguments = frame.arguments_old::<2>();
     let arguments: &[JSValue] = _arguments.slice();
 
@@ -59,13 +59,15 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
 
     // reshaped for borrowck — hoist get_value out so the two &mut self
     // receivers don't overlap.
-    let received = this.get_value(
+    let received = ready_or_defer!(this.get_value(
         global,
-        this_value,
+        frame,
         "toThrowErrorMatchingInlineSnapshot",
         "<green>properties<r><d>, <r>hint",
-    )?;
-    let Some(value) = this.fn_to_err_string_or_undefined(global, received)? else {
+    )?);
+    // Deferred while the promise returned by the received function is still pending.
+    let Some(value) = ready_or_defer!(this.fn_to_err_string_or_undefined(global, frame, received)?)
+    else {
         let signature = Expect::get_signature("toThrowErrorMatchingInlineSnapshot", "", false);
         return this.throw(
             global,

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingSnapshot.rs
@@ -3,6 +3,7 @@ use bun_core::ZigString;
 
 use super::Expect;
 use super::get_signature;
+use super::ready_or_defer;
 
 pub(crate) fn to_throw_error_matching_snapshot(
     this: &Expect,
@@ -13,7 +14,6 @@ pub(crate) fn to_throw_error_matching_snapshot(
     // (early `return Err`, `?`, fall-through).
     let this = this.post_match_guard(global);
 
-    let this_value = frame.this();
     let _arguments = frame.arguments_old::<2>();
     let arguments: &[JSValue] = _arguments.slice();
 
@@ -68,15 +68,15 @@ pub(crate) fn to_throw_error_matching_snapshot(
 
     let hint = hint_string.to_slice();
 
-    let Some(value): Option<JSValue> = this.fn_to_err_string_or_undefined(
+    let received = ready_or_defer!(this.get_value(
         global,
-        this.get_value(
-            global,
-            this_value,
-            "toThrowErrorMatchingSnapshot",
-            "<green>properties<r><d>, <r>hint",
-        )?,
-    )?
+        frame,
+        "toThrowErrorMatchingSnapshot",
+        "<green>properties<r><d>, <r>hint",
+    )?);
+    // Deferred while the promise returned by the received function is still pending.
+    let Some(value): Option<JSValue> =
+        ready_or_defer!(this.fn_to_err_string_or_undefined(global, frame, received)?)
     else {
         let signature = get_signature("toThrowErrorMatchingSnapshot", "", false);
         return this.throw_fmt(

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -526,6 +526,17 @@ pub mod on_unhandled_rejection {
             // re-borrows. Const→mut projection is centralized in `buntest_as_mut`
             // pending the BunTestPtr interior-mut reshape (see bun_test.rs).
             let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
+            // A provisional matcher deferred rejects plainly so a user `await`/`.catch` can
+            // still observe it; whether the failure is recorded is decided once, at sequence
+            // completion (`commit_provisional_matcher_failures`), never here. The owning
+            // sequence may already be parked (no `active_entry`), so ask the whole group.
+            if buntest.execution.claim_provisional_matcher_rejection(rejection) {
+                // `VirtualMachine::uncaught_exception` counted this rejection before calling
+                // us; the runner owns it, so a later-adopted (passing) matcher promise must
+                // not leave the VM's unhandled-error counter latched.
+                jsc_vm.unhandled_error_counter -= 1;
+                return;
+            }
             // mark unhandled errors as belonging to the currently active test. note that this can be misleading.
             let mut current_state_data = buntest.get_current_state_data();
             // split entry()/sequence() borrows via raw-ptr capture (per-use reborrow).

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -417,7 +417,6 @@ pub mod expect {
             // `defer this.postMatch(globalThis)` — run on every exit path.
             let this = scopeguard::guard(self, |this| this.post_match(global));
 
-            let this_value = frame.this();
             let args_buf = frame.arguments_old::<1>();
             let arguments: &[JSValue] = args_buf.slice();
 
@@ -433,7 +432,7 @@ pub mod expect {
             other_value.ensure_still_alive();
 
             let value: JSValue =
-                this.get_value(global, this_value, name, "<green>expected<r>")?;
+                ready_or_defer!(this.get_value(global, frame, name, "<green>expected<r>")?);
 
             if (!value.is_number() && !value.is_big_int())
                 || (!other_value.is_number() && !other_value.is_big_int())

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -173,6 +173,45 @@ expectType(expect<string>(undefined, "Fail message")).is<import("bun:test").Matc
 expectType(expect("", "Fail message")).is<import("bun:test").Matchers<string>>();
 expectType(expect<string>("", "Fail message")).is<import("bun:test").Matchers<string>>();
 
+// matchers return `void`, except through `.resolves`/`.rejects` (and async `toThrow`),
+// where they return a `Promise<void>` that must be awaited
+expectType(expect(1).toBe(1)).is<void>();
+expectType(expect(1).not.toBe(2)).is<void>();
+expectType(expect(Promise.resolve(1)).resolves).is<import("bun:test").Matchers<number, Promise<void>>>();
+expectType(expect(Promise.resolve(1)).rejects).is<import("bun:test").Matchers<unknown, Promise<void>>>();
+expectType(expect(Promise.resolve(1)).resolves.toBe(1)).is<Promise<void>>();
+expectType(expect(Promise.resolve(1)).resolves.not.toBe(2)).is<Promise<void>>();
+expectType(expect(Promise.reject(new Error())).rejects.toThrow()).is<Promise<void>>();
+expectType(expect(Promise.reject(new Error())).rejects.toBeInstanceOf(Error)).is<Promise<void>>();
+expectType(expect(() => {}).toThrow()).is<void>();
+expectType(expect(() => {}).not.toThrow()).is<void>();
+expectType(expect(() => {}).toThrowError()).is<void>();
+// a sync function that only throws is inferred as `() => never` — still a synchronous assertion
+expectType(
+  expect(() => {
+    throw new Error("x");
+  }).toThrow("x"),
+).is<void>();
+expectType(
+  expect(() => {
+    throw new Error("x");
+  }).toThrowError("x"),
+).is<void>();
+expectType(
+  expect((): never => {
+    throw new Error("x");
+  }).toThrow(),
+).is<void>();
+expectType(expect(async () => {}).toThrow()).is<Promise<void>>();
+expectType(expect(async () => {}).toThrowError()).is<Promise<void>>();
+// `.not` preserves the subject type, so async subjects stay asynchronous through it
+expectType(expect(async () => {}).not.toThrow()).is<Promise<void>>();
+expectType(expect(async () => {}).not.toThrowError()).is<Promise<void>>();
+expectType(expect(() => {}).toThrowErrorMatchingSnapshot()).is<void>();
+expectType(expect(() => {}).toThrowErrorMatchingInlineSnapshot()).is<void>();
+expectType(expect(async () => {}).toThrowErrorMatchingSnapshot()).is<Promise<void>>();
+expectType(expect(async () => {}).toThrowErrorMatchingInlineSnapshot()).is<Promise<void>>();
+
 describe("Matcher Overload Type Tests", () => {
   const num = 1;
   const str = "hello";
@@ -410,6 +449,17 @@ declare const setOfStrings: Set<string>;
 /** 1. **/ expect(setOfStrings).toBe(new Set()); // this is inferrable to Set<string> so this should pass
 /** 2. **/ expect(setOfStrings).toBe(new Set<string>()); // exact, so we are happy!
 /** 3. **/ expect(setOfStrings).toBe<Set<string>>(new Set()); // happy! We opted out of type safety for this expectation
+
+// Custom matchers declared with the documented single-type-parameter form must
+// keep merging into `Matchers`, and remain reachable through `.resolves`/`.rejects`
+declare module "bun:test" {
+  interface Matchers<T> {
+    toBeWithinRange(floor: number, ceiling: number): void;
+  }
+}
+expectType(expect(3).toBeWithinRange(0, 5)).is<void>();
+expect(Promise.resolve(3)).resolves.toBeWithinRange(0, 5);
+expect(Promise.reject(3)).rejects.toBeWithinRange(0, 5);
 
 // Cases for #24591
 declare const unknownMatchers: Matchers<unknown>;

--- a/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
+++ b/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
@@ -7,9 +7,10 @@
 // next unrelated timer happens to wake the loop.
 //
 // The drop happens when a poll callback re-enters `us_loop_run_bun_tick`
-// (e.g. `expect(p).resolves` → `waitForPromise` → `autoTick`), which
-// overwrites the shared `loop->ready_polls` / `num_ready_polls` /
-// `current_ready_poll` while the outer dispatch is still mid-iteration.
+// (e.g. an `HTMLRewriter.transform` with an async handler → `waitForPromise`
+// → `autoTick`), which overwrites the shared `loop->ready_polls` /
+// `num_ready_polls` / `current_ready_poll` while the outer dispatch is
+// still mid-iteration.
 // The outer loop resumes with the inner tick's indices and silently skips
 // its own remaining events.
 //
@@ -20,7 +21,7 @@
 // Fix: register the pidfd level-triggered (no EPOLLONESHOT). A pidfd stays
 // readable from process exit until close, so a dropped ready_polls slot is
 // harmless — the next epoll_wait returns it again.
-import { expect, test } from "bun:test";
+import { test } from "bun:test";
 import { isLinux } from "harness";
 
 // pidfd path is Linux-only; macOS/FreeBSD use EVFILT_PROC which is keyed
@@ -45,16 +46,23 @@ test.skipIf(!isLinux)(
         stderr: "ignore",
         onExit() {
           // First onExit to run forces a synchronous nested tick of the
-          // main uws loop. Bun.sleep(1) resolves via the timer queue, which
-          // only drains inside autoTick() AFTER us_loop_run_bun_tick — so
-          // waitForPromise must enter autoTick → epoll_wait to resolve it.
+          // main uws loop. HTMLRewriter's synchronous transform() with an
+          // async element handler must waitForPromise on Bun.sleep(1), which
+          // resolves via the timer queue that only drains inside autoTick()
+          // AFTER us_loop_run_bun_tick — so it enters autoTick → epoll_wait.
           // That overwrites the outer dispatch's ready_polls state; any
           // sibling pidfd events queued after this one in the outer batch
           // are dropped. With EPOLLONESHOT those pidfds are now disarmed in
           // the kernel with no re-arm path.
           if (!nested) {
             nested = true;
-            expect(Bun.sleep(1)).resolves.toBe(undefined);
+            new HTMLRewriter()
+              .on("p", {
+                async element() {
+                  await Bun.sleep(1);
+                },
+              })
+              .transform("<p>x</p>");
           }
           resolve();
         },

--- a/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
+++ b/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
@@ -21,8 +21,9 @@
 // Fix: register the pidfd level-triggered (no EPOLLONESHOT). A pidfd stays
 // readable from process exit until close, so a dropped ready_polls slot is
 // harmless — the next epoll_wait returns it again.
-import { test } from "bun:test";
-import { isLinux } from "harness";
+import { getEventLoopStats } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { isDebug, isLinux } from "harness";
 
 // pidfd path is Linux-only; macOS/FreeBSD use EVFILT_PROC which is keyed
 // on pid and auto-removed by the kernel when the process is reaped.
@@ -35,6 +36,9 @@ test.skipIf(!isLinux)(
     const N = 20;
     const exits: Array<Promise<void>> = [];
     let nested = false;
+    // `nestedDispatchTicks` (debug-only) counts ticks entered while an outer ready-poll
+    // dispatch is mid-batch — exactly the re-entry this test relies on triggering below.
+    const nestedTicksBefore = getEventLoopStats().nestedDispatchTicks;
 
     for (let i = 0; i < N; i++) {
       const { promise, resolve } = Promise.withResolvers<void>();
@@ -73,5 +77,12 @@ test.skipIf(!isLinux)(
     // whose events were dropped never fire onExit and this await hangs until
     // the test's own 5s timeout — there is no other wake source.
     await Promise.all(exits);
+
+    // Self-verifying trigger: the HTMLRewriter transform in onExit must have re-entered
+    // the event loop from inside the outer poll dispatch. If it stops nesting (#33261),
+    // this test no longer exercises the dropped-ready_polls path and must be re-armed.
+    if (isDebug) {
+      expect(getEventLoopStats().nestedDispatchTicks).toBeGreaterThan(nestedTicksBefore);
+    }
   },
 );

--- a/test/js/bun/test/expect-resolves-rejects.test.ts
+++ b/test/js/bun/test/expect-resolves-rejects.test.ts
@@ -1,0 +1,735 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+
+async function runTestFile(files: Record<string, string>, env: NodeJS.Dict<string> = bunEnv) {
+  using dir = tempDir("expect-resolves-rejects", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "fixture.test.ts"],
+    env,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// The "N expect() calls" summary line counts matcher invocations, which is covered by the
+// expect.assertions fixtures below; keep it out of output snapshots.
+function stripExpectCallCount(output: string): string {
+  return output.replace(/^\s*\d+ expect\(\) calls\n/m, "");
+}
+
+// Every test spawns its own `bun test` subprocess in its own temp dir, so they are
+// independent and run concurrently.
+describe.concurrent("deferred matcher promises", () => {
+  // The subject promise is marked handled by the matcher, so an un-awaited
+  // `.rejects` whose subject rejects must not surface as an unhandled rejection.
+  test("un-awaited .rejects on an already-rejected subject does not report an unhandled rejection", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `
+      import { test, expect } from "bun:test";
+      test("un-awaited rejects", () => {
+        expect(Promise.reject(new Error("SUBJECT_REJECTION_MARKER"))).rejects.toThrow("SUBJECT_REJECTION_MARKER");
+      });
+    `,
+    });
+    const output = stdout + stderr;
+    // Any unhandled-rejection report would echo the rejection message.
+    expect(output).not.toContain("Unhandled");
+    expect(output).not.toContain("SUBJECT_REJECTION_MARKER");
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("un-awaited .resolves on a rejecting subject fails the test without an unhandled-rejection report", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `
+      import { test, expect } from "bun:test";
+      test("un-awaited resolves, rejecting subject", () => {
+        expect(Promise.reject(new Error("SUBJECT_REJECTION_MARKER"))).resolves.toBe(1);
+      });
+    `,
+    });
+    const output = stdout + stderr;
+    // The rejection is consumed by the matcher: it fails the test, it is not re-reported
+    // by the unhandled-rejection machinery.
+    expect(output).not.toContain("Unhandled");
+    expect(output).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("un-awaited .rejects on a subject that rejects later does not report an unhandled rejection", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `
+      import { test, expect } from "bun:test";
+      test("un-awaited rejects, pending subject", async () => {
+        const subject = (async () => {
+          await Bun.sleep(1);
+          throw new Error("SUBJECT_REJECTION_MARKER");
+        })();
+        expect(subject).rejects.toThrow("SUBJECT_REJECTION_MARKER");
+        await Bun.sleep(10);
+      });
+    `,
+    });
+    const output = stdout + stderr;
+    expect(output).not.toContain("Unhandled");
+    expect(output).not.toContain("SUBJECT_REJECTION_MARKER");
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // Awaited `.resolves`/`.rejects` matchers report the same message and location as always.
+  test("awaited .resolves/.rejects pass and fail with the expected message and location", async () => {
+    const { stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("resolves pass", async () => {
+  await expect(Promise.resolve(1)).resolves.toBe(1);
+});
+test("resolves fail", async () => {
+  await expect(Promise.resolve(1)).resolves.toBe(2);
+});
+test("rejects pass", async () => {
+  await expect(Promise.reject(new Error("boom"))).rejects.toThrow("boom");
+});
+test("rejects fail", async () => {
+  await expect(Promise.reject(new Error("boom"))).rejects.toThrow("other");
+});
+test("resolves direction mismatch", async () => {
+  await expect(Promise.reject(new Error("nope"))).resolves.toBe(1);
+});
+test("rejects direction mismatch", async () => {
+  await expect(Promise.resolve(1)).rejects.toBe(1);
+});
+`,
+    });
+    expect(stripExpectCallCount(normalizeBunSnapshot(stderr))).toMatchInlineSnapshot(`
+    "fixture.test.ts:
+    (pass) resolves pass
+    1 | import { test, expect } from "bun:test";
+    2 | test("resolves pass", async () => {
+    3 |   await expect(Promise.resolve(1)).resolves.toBe(1);
+    4 | });
+    5 | test("resolves fail", async () => {
+    6 |   await expect(Promise.resolve(1)).resolves.toBe(2);
+                                                    ^
+    error: expect(received).toBe(expected)
+
+    Expected: 2
+    Received: 1
+        at <anonymous> (file:NN:NN)
+        at <anonymous> (file:NN:NN)
+    (fail) resolves fail
+    (pass) rejects pass
+     7 | });
+     8 | test("rejects pass", async () => {
+     9 |   await expect(Promise.reject(new Error("boom"))).rejects.toThrow("boom");
+    10 | });
+    11 | test("rejects fail", async () => {
+    12 |   await expect(Promise.reject(new Error("boom"))).rejects.toThrow("other");
+                                                                   ^
+    error: expect(received).toThrow(expected)
+
+    Expected substring: "other"
+    Received message: "boom"
+        at <anonymous> (file:NN:NN)
+        at <anonymous> (file:NN:NN)
+    (fail) rejects fail
+    10 | });
+    11 | test("rejects fail", async () => {
+    12 |   await expect(Promise.reject(new Error("boom"))).rejects.toThrow("other");
+    13 | });
+    14 | test("resolves direction mismatch", async () => {
+    15 |   await expect(Promise.reject(new Error("nope"))).resolves.toBe(1);
+                                                                    ^
+    error: expect(received).resolves.toBe(expected)
+
+    Expected promise that resolves
+    Received promise that rejected: Promise { <rejected> }
+        at <anonymous> (file:NN:NN)
+        at <anonymous> (file:NN:NN)
+    (fail) resolves direction mismatch
+    13 | });
+    14 | test("resolves direction mismatch", async () => {
+    15 |   await expect(Promise.reject(new Error("nope"))).resolves.toBe(1);
+    16 | });
+    17 | test("rejects direction mismatch", async () => {
+    18 |   await expect(Promise.resolve(1)).rejects.toBe(1);
+                                                    ^
+    error: expect(received).rejects.toBe(expected)
+
+    Expected promise that rejects
+    Received promise that resolved: Promise { <resolved> }
+        at <anonymous> (file:NN:NN)
+        at <anonymous> (file:NN:NN)
+    (fail) rejects direction mismatch
+
+     2 pass
+     4 fail
+    Ran 6 tests across 1 file."
+  `);
+    expect(exitCode).toBe(1);
+  });
+
+  // An un-awaited failing `.resolves` fails its test, attributed to the `expect()` line,
+  // and is not reported a second time as an unhandled rejection.
+  test("un-awaited failing .resolves fails the test and is attributed to the expect line", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("un-awaited failing resolves", () => {
+  expect(Promise.resolve(1)).resolves.toBe(2);
+});
+test("sibling test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+    expect(stderr).toContain("(fail) un-awaited failing resolves");
+    expect(stderr).not.toContain("(fail) sibling test");
+    expect(stderr).toContain("expect(received).toBe(expected)");
+    // Attributed to the `expect()` call: the code frame excerpts line 3 of the fixture.
+    expect(stderr).toContain("3 |   expect(Promise.resolve(1)).resolves.toBe(2);");
+    expect(stderr).toMatch(/fixture\.test\.ts:3:\d+/);
+    expect(stdout + stderr).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // A matcher promise still pending when the synchronous body returns is settled before the
+  // test completes: the body is not blocked, and the next test starts only after settlement.
+  test("a matcher promise pending when the sync body returns settles before the test completes", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+const order: string[] = [];
+test("pending at body return", () => {
+  const subject = Bun.sleep(5).then(() => {
+    order.push("subject-settled");
+    return 1;
+  });
+  expect(subject).resolves.toBe(1);
+  order.push("body-returned");
+});
+test("next test", () => {
+  order.push("next-test");
+  console.log("ORDER:" + order.join(","));
+});
+`,
+    });
+    expect(stdout).toContain("ORDER:body-returned,subject-settled,next-test");
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a matcher that fails after the sync body returned still fails the test", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("late failing matcher", () => {
+  expect(Bun.sleep(5).then(() => 1)).resolves.toBe(2);
+});
+`,
+    });
+    expect(stderr).toContain("(fail) late failing matcher");
+    expect(stdout + stderr).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // The common synchronous-callback shape: several un-awaited matchers, none of which block
+  // the body while their subjects settle.
+  test("un-awaited matchers inside a synchronous test callback pass without blocking the body", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("sync body with un-awaited matchers", () => {
+  const order: string[] = [];
+  const subject = Bun.sleep(2).then(() => {
+    order.push("settled");
+    return "later";
+  });
+  expect(Promise.resolve("value")).resolves.toBe("value");
+  expect(Promise.reject(new Error("boom"))).rejects.toThrow("boom");
+  expect(subject).resolves.toBe("later");
+  order.push("body-returned");
+  console.log("E_ORDER:" + order.join(","));
+});
+`,
+    });
+    expect(stdout).toContain("E_ORDER:body-returned\n");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // A test that returns a promise and also has un-awaited matchers completes only after both
+  // the returned promise and every matcher promise settled.
+  test("a test returning a promise with un-awaited matchers waits for both", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+const order: string[] = [];
+test("returned promise and un-awaited matcher", () => {
+  const subject = Bun.sleep(4).then(() => {
+    order.push("subject-settled");
+    return 7;
+  });
+  expect(subject).resolves.toBe(7);
+  order.push("body");
+  return Promise.resolve().then(() => {
+    order.push("returned-promise");
+  });
+});
+test("verify order", () => {
+  console.log("F_ORDER:" + order.join(","));
+});
+`,
+    });
+    expect(stdout).toContain("F_ORDER:body,returned-promise,subject-settled");
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a test returning a promise still fails when an un-awaited matcher fails", async () => {
+    const { stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("returned promise with failing matcher", () => {
+  expect(Bun.sleep(2).then(() => 1)).resolves.toBe(999);
+  return Bun.sleep(1);
+});
+`,
+    });
+    expect(stderr).toContain("(fail) returned promise with failing matcher");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // Un-awaited `toThrow`/`.not.toThrow` on async functions.
+  test("un-awaited async toThrow and .not.toThrow report the settled outcome", async () => {
+    const { stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("toThrow on rejecting fn", () => {
+  expect(async () => {
+    throw new Error("async-boom");
+  }).toThrow("async-boom");
+});
+test("not.toThrow on resolving fn", () => {
+  expect(async () => {}).not.toThrow();
+});
+test("toThrow on resolving fn", () => {
+  expect(async () => {}).toThrow("async-boom");
+});
+test("not.toThrow on rejecting fn", () => {
+  expect(async () => {
+    throw new Error("async-boom");
+  }).not.toThrow();
+});
+`,
+    });
+    expect(stderr).not.toContain("(fail) toThrow on rejecting fn");
+    expect(stderr).not.toContain("(fail) not.toThrow on resolving fn");
+    expect(stderr).toContain("(fail) toThrow on resolving fn");
+    expect(stderr).toContain("(fail) not.toThrow on rejecting fn");
+    expect(stderr).toContain("expect(received).toThrow(expected)");
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 2 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // `.resolves`/`.rejects` on a non-promise subject keeps throwing synchronously.
+  test("expect(nonPromise).resolves/.rejects throws synchronously", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("non-promise subject", () => {
+  let resolvesThrew = false;
+  let resolvesMessage = "";
+  try {
+    expect(42).resolves.toBe(42);
+  } catch (error) {
+    resolvesThrew = true;
+    resolvesMessage = String((error as Error).message);
+  }
+  console.log("H_RESOLVES:" + resolvesThrew + ":" + resolvesMessage.includes("promise"));
+  let rejectsThrew = false;
+  let rejectsMessage = "";
+  try {
+    expect(42).rejects.toThrow("x");
+  } catch (error) {
+    rejectsThrew = true;
+    rejectsMessage = String((error as Error).message);
+  }
+  console.log("H_REJECTS:" + rejectsThrew + ":" + rejectsMessage.includes("promise"));
+  expect(resolvesThrew).toBe(true);
+  expect(rejectsThrew).toBe(true);
+});
+`,
+    });
+    expect(stdout).toContain("H_RESOLVES:true:true");
+    expect(stdout).toContain("H_REJECTS:true:true");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // `.resolves`/`.rejects`/async `toThrow` matchers return a real Promise; synchronous
+  // matchers keep returning undefined.
+  test(".resolves/.rejects and async toThrow matchers return a Promise", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("matcher return values", async () => {
+  const resolves = expect(Promise.resolve(1)).resolves.toBe(1);
+  const rejects = expect(Promise.reject(new Error("boom"))).rejects.toThrow("boom");
+  const asyncThrow = expect(async () => {
+    throw new Error("boom");
+  }).toThrow("boom");
+  console.log("I_RESOLVES:" + (resolves instanceof Promise));
+  console.log("I_REJECTS:" + (rejects instanceof Promise));
+  console.log("I_ASYNC_THROW:" + (asyncThrow instanceof Promise));
+  console.log("I_SYNC:" + (expect(1).toBe(1) === undefined));
+  await Promise.all([resolves, rejects, asyncThrow]);
+});
+`,
+    });
+    expect(stdout).toContain("I_RESOLVES:true");
+    expect(stdout).toContain("I_REJECTS:true");
+    expect(stdout).toContain("I_ASYNC_THROW:true");
+    expect(stdout).toContain("I_SYNC:true");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // Per-test matcher/assertion counters reset across test.each entries, retries, and repeats.
+  test("expect.assertions with un-awaited matchers across test.each, retry, and repeats", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+let attempt = 0;
+test(
+  "retry until subject matches",
+  () => {
+    attempt++;
+    console.log("ATTEMPT:" + attempt);
+    expect.assertions(1);
+    expect(Bun.sleep(1).then(() => attempt)).resolves.toBe(3);
+  },
+  { retry: 2 },
+);
+test.each([1, 2, 3])("each %i", (value: number) => {
+  expect.assertions(1);
+  expect(Promise.resolve(value)).resolves.toBe(value);
+});
+let run = 0;
+test(
+  "repeats with un-awaited matcher",
+  () => {
+    run++;
+    console.log("REPEAT:" + run);
+    expect.assertions(1);
+    expect(Bun.sleep(1).then(() => "ok")).resolves.toBe("ok");
+  },
+  { repeats: 2 },
+);
+`,
+    });
+    // retry: the first two attempts fail (the subject settles to 1, then 2) and the third passes.
+    expect(stdout).toContain("ATTEMPT:1");
+    expect(stdout).toContain("ATTEMPT:2");
+    expect(stdout).toContain("ATTEMPT:3");
+    expect(stdout).toContain("REPEAT:3");
+    expect(stderr).not.toContain("(fail)");
+    // `expect.assertions(1)` holds on every attempt/entry/repeat: the matcher counter is
+    // reset per run and the deferred re-invocation is not double-counted.
+    expect(stderr).not.toContain("AssertionError");
+    expect(stderr).toContain(" 5 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // A matcher called from inside a `Bun.serve` fetch handler must not re-enter the event loop
+  // synchronously (oven-sh/bun#33261). `nestedDispatchTicks` requires a debug build.
+  test.skipIf(!isDebug || isWindows)(
+    "a matcher inside a Bun.serve fetch handler does not re-enter the event loop",
+    async () => {
+      const { stdout, stderr, exitCode } = await runTestFile({
+        "fixture.test.ts": `import { test, expect } from "bun:test";
+import { getEventLoopStats } from "bun:internal-for-testing";
+// The counter only counts re-entrant ticks started while an outer ready-poll dispatch is
+// mid-batch, so both probes run inside a Bun.serve fetch handler (always dispatched from
+// the server socket's poll batch). HTMLRewriter's string transform still waits
+// synchronously on its async handlers, so it is the positive control proving the counter
+// detects exactly what the matcher below must avoid.
+test("nested dispatch is counted for a synchronous waiter inside a fetch handler", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      const before = getEventLoopStats().nestedDispatchTicks;
+      new HTMLRewriter()
+        .on("p", {
+          async element() {
+            await Bun.sleep(1);
+          },
+        })
+        .transform("<p>x</p>");
+      const after = getEventLoopStats().nestedDispatchTicks;
+      return new Response(JSON.stringify({ delta: after - before }));
+    },
+  });
+  const { delta } = await (await fetch(server.url)).json();
+  console.log("K_CONTROL_DELTA:" + delta);
+  expect(delta).toBeGreaterThan(0);
+});
+test("matcher inside fetch handler", async () => {
+  using server = Bun.serve({
+    port: 0,
+    async fetch() {
+      const before = getEventLoopStats().nestedDispatchTicks;
+      const pending = expect(Bun.sleep(1).then(() => "settled")).resolves.toBe("settled");
+      const after = getEventLoopStats().nestedDispatchTicks;
+      await pending;
+      return new Response(JSON.stringify({ delta: after - before }));
+    },
+  });
+  const { delta } = await (await fetch(server.url)).json();
+  console.log("K_NESTED_DELTA:" + delta);
+  expect(delta).toBe(0);
+});
+`,
+      });
+      expect(stdout).toContain("K_CONTROL_DELTA:1");
+      expect(stdout).toContain("K_NESTED_DELTA:0");
+      expect(stderr).toContain(" 2 pass");
+      expect(stderr).toContain(" 0 fail");
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  // https://github.com/oven-sh/bun/issues/14950 — the subject can only settle after the
+  // matcher call returns, so a matcher that synchronously waits on it can never finish.
+  // Jest passes this; Bun used to spin at 100% CPU until the test timeout.
+  test("a subject resolved after the matcher call settles instead of deadlocking", async () => {
+    const { stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("promise resolves after expect call", () => {
+  let resolve;
+  expect(new Promise(r => (resolve = r))).resolves.toBe(25);
+  resolve(25);
+});
+`,
+    });
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // A deferred matcher abandoned by the per-test timeout belongs to that attempt only
+  // (`ExecutionSequence::settle_matcher_promise`'s epoch check): when its subject settles
+  // during the retry attempt, it must neither release the retry's pending-matcher count
+  // (completing it while its own matcher is still pending) nor write the stale failure
+  // into the retry's result.
+  test("a deferred matcher abandoned by the timeout does not affect the retry attempt", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+let attempt = 0;
+test(
+  "stale settle",
+  () => {
+    attempt++;
+    console.log("ATTEMPT:" + attempt);
+    if (attempt === 1) {
+      // Never settles within the timeout: attempt 1 is abandoned at ~3s and retried.
+      // The subject settles at ~4.5s — during attempt 2, whose own matcher is still
+      // pending — and its re-invoked matcher fails (424242); that stale failure must
+      // not be attributed to attempt 2. Attempt 2's own work (0.5s) is far below the
+      // 3s timeout so a slow runner cannot time it out too.
+      expect(Bun.sleep(4500).then(() => 1)).resolves.toBe(424242);
+    } else {
+      expect(Bun.sleep(500).then(() => 2)).resolves.toBe(2);
+    }
+  },
+  { timeout: 3000, retry: 1 },
+);
+`,
+    });
+    expect(stdout).toContain("ATTEMPT:1");
+    expect(stdout).toContain("ATTEMPT:2");
+    // Attempt 1's stale matcher failure must not leak into attempt 2's report.
+    expect(stderr).not.toContain("424242");
+    expect(stderr).not.toContain("(fail)");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // The deferred re-invocation of an inline-snapshot matcher runs from a promise-reaction
+  // job with no user JS frames on the stack, so the snapshot's file/line/column come from
+  // the call site captured when the matcher deferred (not from a stack walk of that frame).
+  // CI=false: creating a new inline snapshot is what exercises the call-site resolution,
+  // and creation is otherwise disabled in CI.
+  test(".resolves/.rejects inline snapshot matchers resolve the expect() call site", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile(
+      {
+        "fixture.test.ts": `import { test, expect } from "bun:test";
+test("resolves inline snapshot", async () => {
+  await expect(Promise.resolve({ a: 1 })).resolves.toMatchInlineSnapshot();
+});
+test("rejects inline error snapshot", async () => {
+  await expect(Promise.reject(new Error("DEFERRED_SNAPSHOT_ERROR"))).rejects.toThrowErrorMatchingInlineSnapshot();
+});
+`,
+      },
+      { ...bunEnv, CI: "false" },
+    );
+    const output = stdout + stderr;
+    expect(output).not.toContain("must be called from the test file");
+    expect(output).toContain("+2 added");
+    expect(output).toContain(" 2 pass");
+    expect(output).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // Deferred (un-awaited) snapshot matchers that settle after the test callback returned
+  // must still resolve their owning test's snapshot state (name counter, .snap file).
+  test("un-awaited snapshot matchers that settle late still resolve the owning test", async () => {
+    using dir = tempDir("late-settling-snapshot", {
+      "late.test.js": `
+        import { test, expect } from "bun:test";
+        test("throw", () => {
+          expect(async () => {
+            await Bun.sleep(10);
+            throw new Error("late-throw");
+          }).toThrowErrorMatchingSnapshot();
+        });
+        test("resolve", () => {
+          expect(Bun.sleep(10).then(() => "late-resolve")).resolves.toMatchSnapshot();
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "late.test.js"],
+      env: { ...bunEnv, CI: "false" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    const snapshot = await Bun.file(`${dir}/__snapshots__/late.test.js.snap`)
+      .text()
+      .catch(() => "<missing snapshot file>");
+    expect({ stderr, snapshot }).toEqual({
+      stderr: expect.stringContaining("2 pass"),
+      snapshot: expect.stringContaining('exports[`throw 1`] = `"late-throw"`'),
+    });
+    expect(snapshot).toContain('exports[`resolve 1`] = `"late-resolve"`');
+    expect(exitCode).toBe(0);
+  });
+
+  // A CHAINED deferral: the settle re-invocation of `.resolves.toThrow(fn)` defers a second
+  // time on the promise the resolved function returned. The promise the user holds is the
+  // one the FIRST pass returned, so an un-awaited failure of the second deferral must still
+  // fail the test, attributed to the `expect()` line, exactly once, with no
+  // unhandled-rejection report.
+  test("un-awaited chained .resolves.toThrow on a fn returning a promise fails the test once", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("chained deferral", () => {
+  expect(Promise.resolve(async () => { throw new Error("CHAIN_INNER"); })).resolves.toThrow("nope");
+});
+test("sibling test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+    expect(stderr).toContain("(fail) chained deferral");
+    expect(stderr).not.toContain("(fail) sibling test");
+    // Attributed to the `expect()` call site, reported exactly once.
+    expect(stderr).toMatch(/fixture\.test\.ts:3:\d+/);
+    expect(stderr.split('Expected substring: "nope"').length - 1).toBe(1);
+    expect(stdout + stderr).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // The awaited form of the same chain settles the promise the matcher returned on the
+  // FIRST pass: it must resolve on a pass and reject (into the user's handler) on a failure.
+  test("awaited chained .resolves.toThrow resolves on pass and rejects on failure", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("chained pass and fail", async () => {
+  await expect(Promise.resolve(async () => { throw new Error("CHAIN_INNER"); })).resolves.toThrow("CHAIN_INNER");
+  let caught = "";
+  try {
+    await expect(Promise.resolve(async () => { throw new Error("CHAIN_INNER"); })).resolves.toThrow("nope");
+  } catch (error) {
+    caught = String((error as Error).message);
+  }
+  console.log("J_CHAIN_CAUGHT:" + caught.includes('Expected substring: "nope"'));
+});
+`,
+    });
+    expect(stdout).toContain("J_CHAIN_CAUGHT:true");
+    expect(stdout + stderr).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // Same chained shape through an async `expect.extend` matcher reached via `.resolves`:
+  // the subject deferral resolves into a matcher-result deferral. Un-awaited, its failure
+  // must fail the test with the expect-line attribution and no unhandled-rejection report.
+  test("un-awaited failing async expect.extend matcher via .resolves fails the test", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+expect.extend({
+  async _alwaysFailAsync() {
+    await Bun.sleep(1);
+    // Built at runtime so the marker only ever appears in the failure report.
+    return { pass: false, message: () => "ASYNC_EXTEND" + "_FAIL_MARKER" };
+  },
+});
+test("un-awaited async custom matcher", () => {
+  expect(Promise.resolve(1)).resolves._alwaysFailAsync();
+});
+test("sibling test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+    expect(stderr).toContain("(fail) un-awaited async custom matcher");
+    expect(stderr).not.toContain("(fail) sibling test");
+    // Attributed to the `expect()` call site, reported exactly once.
+    expect(stderr).toMatch(/fixture\.test\.ts:10:\d+/);
+    expect(stderr.split("ASYNC_EXTEND_FAIL_MARKER").length - 1).toBe(1);
+    expect(stdout + stderr).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // An argument-validation error thrown by a matcher whose `.resolves` subject is still
+  // pending must not leave a deferral registered: the settle reaction would re-invoke the
+  // matcher, hit the same argument error, and record a second failure against a test that
+  // already handled the first one (as well as hold the test open until the subject settles).
+  test("a matcher argument error on a pending .resolves subject is thrown once, synchronously", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("argument error", async () => {
+  const { promise, resolve } = Promise.withResolvers();
+  expect(() => expect(promise).resolves.toBeArrayOfSize("3")).toThrow(
+    "toBeArrayOfSize() requires the first argument to be a number",
+  );
+  resolve([1, 2, 3]);
+  await promise;
+  // A macrotask so the settle reaction of any (incorrectly) registered deferral runs.
+  await Bun.sleep(5);
+});
+`,
+    });
+    const output = stdout + stderr;
+    expect(output).toContain(" 1 pass");
+    expect(output).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/test/expect-resolves-rejects.test.ts
+++ b/test/js/bun/test/expect-resolves-rejects.test.ts
@@ -15,7 +15,9 @@ async function runTestFile(files: Record<string, string>, env: NodeJS.Dict<strin
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+  // Snapshot-friendly stderr must be normalized against the fixture dir HERE: attributed
+  // stack frames print its absolute (random) path, and the dir is gone once we return.
+  return { stdout, stderr, exitCode, normalizedStderr: normalizeBunSnapshot(stderr, String(dir)) };
 }
 
 // The "N expect() calls" summary line counts matcher invocations, which is covered by the
@@ -88,7 +90,7 @@ describe.concurrent("deferred matcher promises", () => {
 
   // Awaited `.resolves`/`.rejects` matchers report the same message and location as always.
   test("awaited .resolves/.rejects pass and fail with the expected message and location", async () => {
-    const { stderr, exitCode } = await runTestFile({
+    const { normalizedStderr, exitCode } = await runTestFile({
       "fixture.test.ts": `import { test, expect } from "bun:test";
 test("resolves pass", async () => {
   await expect(Promise.resolve(1)).resolves.toBe(1);
@@ -110,7 +112,7 @@ test("rejects direction mismatch", async () => {
 });
 `,
     });
-    expect(stripExpectCallCount(normalizeBunSnapshot(stderr))).toMatchInlineSnapshot(`
+    expect(stripExpectCallCount(normalizedStderr)).toMatchInlineSnapshot(`
     "fixture.test.ts:
     (pass) resolves pass
     1 | import { test, expect } from "bun:test";
@@ -124,8 +126,9 @@ test("rejects direction mismatch", async () => {
 
     Expected: 2
     Received: 1
-        at <anonymous> (file:NN:NN)
-        at <anonymous> (file:NN:NN)
+
+          at <dir>/fixture.test.ts:6:45
+          at <dir>/fixture.test.ts:5:23
     (fail) resolves fail
     (pass) rejects pass
      7 | });
@@ -139,8 +142,9 @@ test("rejects direction mismatch", async () => {
 
     Expected substring: "other"
     Received message: "boom"
-        at <anonymous> (file:NN:NN)
-        at <anonymous> (file:NN:NN)
+
+          at <dir>/fixture.test.ts:12:59
+          at <dir>/fixture.test.ts:11:22
     (fail) rejects fail
     10 | });
     11 | test("rejects fail", async () => {
@@ -153,8 +157,9 @@ test("rejects direction mismatch", async () => {
 
     Expected promise that resolves
     Received promise that rejected: Promise { <rejected> }
-        at <anonymous> (file:NN:NN)
-        at <anonymous> (file:NN:NN)
+
+          at <dir>/fixture.test.ts:15:60
+          at <dir>/fixture.test.ts:14:37
     (fail) resolves direction mismatch
     13 | });
     14 | test("resolves direction mismatch", async () => {
@@ -167,8 +172,9 @@ test("rejects direction mismatch", async () => {
 
     Expected promise that rejects
     Received promise that resolved: Promise { <resolved> }
-        at <anonymous> (file:NN:NN)
-        at <anonymous> (file:NN:NN)
+
+          at <dir>/fixture.test.ts:18:44
+          at <dir>/fixture.test.ts:17:36
     (fail) rejects direction mismatch
 
      2 pass
@@ -181,7 +187,7 @@ test("rejects direction mismatch", async () => {
   // An un-awaited failing `.resolves` fails its test, attributed to the `expect()` line,
   // and is not reported a second time as an unhandled rejection.
   test("un-awaited failing .resolves fails the test and is attributed to the expect line", async () => {
-    const { stdout, stderr, exitCode } = await runTestFile({
+    const { stdout, stderr, normalizedStderr, exitCode } = await runTestFile({
       "fixture.test.ts": `import { test, expect } from "bun:test";
 test("un-awaited failing resolves", () => {
   expect(Promise.resolve(1)).resolves.toBe(2);
@@ -191,16 +197,177 @@ test("sibling test", () => {
 });
 `,
     });
-    expect(stderr).toContain("(fail) un-awaited failing resolves");
-    expect(stderr).not.toContain("(fail) sibling test");
-    expect(stderr).toContain("expect(received).toBe(expected)");
-    // Attributed to the `expect()` call: the code frame excerpts line 3 of the fixture.
-    expect(stderr).toContain("3 |   expect(Promise.resolve(1)).resolves.toBe(2);");
-    expect(stderr).toMatch(/fixture\.test\.ts:3:\d+/);
+    // The whole report is pinned: the failure is attributed to the `expect()` call (the
+    // code frame excerpts fixture line 3), the sibling test still passes, and the failure
+    // is reported exactly once.
+    expect(stripExpectCallCount(normalizedStderr)).toMatchInlineSnapshot(`
+      "fixture.test.ts:
+      1 | import { test, expect } from "bun:test";
+      2 | test("un-awaited failing resolves", () => {
+      3 |   expect(Promise.resolve(1)).resolves.toBe(2);
+                                                ^
+      error: expect(received).toBe(expected)
+
+      Expected: 2
+      Received: 1
+
+            at <dir>/fixture.test.ts:3:39
+      (fail) un-awaited failing resolves
+      (pass) sibling test
+
+       1 pass
+       1 fail
+      Ran 2 tests across 1 file."
+    `);
     expect(stdout + stderr).not.toContain("Unhandled");
+    expect(exitCode).toBe(1);
+  });
+
+  // A failing deferred matcher created in a beforeEach fails the test even when the test
+  // itself is `test.failing`: hook failures are never inverted by the failing mode.
+  test("an un-awaited failing matcher in a beforeEach fails a test.failing test", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect, beforeEach } from "bun:test";
+beforeEach(() => {
+  expect(Promise.resolve(1)).resolves.toBe(2);
+});
+test.failing("failing test with hook matcher failure", () => {
+  throw new Error("expected failure");
+});
+`,
+    });
+    const output = stdout + stderr;
+    expect(output).toContain("expect(received).toBe(expected)");
+    // Exactly one report, attributed by the runner (not the generic unhandled path).
+    expect(output.split("expect(received).toBe(expected)").length - 1).toBe(1);
+    expect(output).not.toContain("Unhandled");
+    expect(output).toContain("1 fail");
+    expect(output).not.toContain("1 pass");
+    expect(exitCode).toBe(1);
+  });
+
+  // Whether an un-awaited matcher failure is reported belongs to the user's handling of the
+  // returned promise `D`, decided when the test completes — not to how quickly they adopt it.
+  // (a) Adopting `D` after a macrotask and swallowing the rejection is a pass, printed 0 times.
+  test("a failing matcher promise adopted late and caught passes and prints nothing", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("delayed adoption, caught", async () => {
+  const d = expect(Promise.resolve(1)).resolves.toBe(4141);
+  await Bun.sleep(5);
+  try {
+    await d;
+  } catch {}
+});
+`,
+    });
+    const output = stdout + stderr;
+    // The user observed and swallowed the failure: it is reported zero times.
+    expect(output.split("4141").length - 1).toBe(0);
+    expect(output).not.toContain("expect(received).toBe(expected)");
+    expect(output).not.toContain("Unhandled");
     expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // (b) The same adoption without a catch fails the test and prints the failure exactly once
+  // (no second print through the unhandled-rejection or uncaught-exception paths).
+  test("a failing matcher promise adopted late without a catch fails and prints exactly once", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("delayed adoption, uncaught", async () => {
+  const d = expect(Promise.resolve(1)).resolves.toBe(4242);
+  await Bun.sleep(5);
+  await d;
+});
+`,
+    });
+    const output = stdout + stderr;
+    expect(stderr).toContain("(fail) delayed adoption, uncaught");
+    expect(output.split("Expected: 4242").length - 1).toBe(1);
+    expect(output).not.toContain("Unhandled");
     expect(stderr).toContain(" 1 fail");
     expect(exitCode).toBe(1);
+  });
+
+  // (c) `.finally()` attaches a reaction without handling the rejection: a failing matcher
+  // with only a floating `.finally()` must not leave the test reported as passing.
+  test("a failing matcher with only a floating .finally() does not report the test as passing", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("floating finally", () => {
+  const d = expect(Bun.sleep(5).then(() => 1)).resolves.toBe(4343);
+  d.finally(() => {});
+});
+`,
+    });
+    const output = stdout + stderr;
+    expect(stderr).not.toContain("(pass) floating finally");
+    expect(stderr).not.toContain(" 1 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(output).toContain("Expected: 4343");
+    // Reported exactly once, as the test's failure — never doubled by the generic
+    // unhandled-rejection path (the provisional machinery claims the leaked rejection).
+    expect(output).not.toContain("Unhandled");
+    expect(output.split("Expected: 4343").length - 1).toBe(1);
+    expect(exitCode).toBe(1);
+  });
+
+  // (c) again, but with a subject settled from an `el.tasks` task (fs I/O) rather than a
+  // timer: the leaked-notification for the floating `.finally()` is only delivered after
+  // the task queue drains, so `finish_sequence` must flush it before committing.
+  test("a failing matcher with only a floating .finally() and an fs-resolved subject does not report the test as passing", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+import { readFile } from "node:fs/promises";
+test("floating finally, fs subject", () => {
+  const d = expect(readFile(import.meta.path, "utf8").then(() => 1)).resolves.toBe(4343);
+  d.finally(() => {});
+});
+`,
+    });
+    const output = stdout + stderr;
+    expect(stderr).not.toContain("(pass) floating finally, fs subject");
+    expect(stderr).not.toContain(" 1 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(output).not.toContain("Unhandled");
+    expect(output).toContain("Expected: 4343");
+    expect(exitCode).toBe(1);
+  });
+
+  // (d) An async arrow that implicitly returns the matcher promise: the runner adopts the
+  // returned promise, so the failure is the test's failure, reported exactly once.
+  test("an implicitly returned failing .rejects matcher fails the test exactly once", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("implicit return", async () => expect(Promise.reject(new Error("boom"))).rejects.toThrow("other"));
+`,
+    });
+    const output = stdout + stderr;
+    expect(stderr).toContain("(fail) implicit return");
+    expect(output.split('Expected substring: "other"').length - 1).toBe(1);
+    expect(output).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // (e) An un-awaited PASSING matcher reports nothing at all.
+  test("an un-awaited passing matcher reports nothing", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("un-awaited passing matcher", async () => {
+  const d = expect(Promise.resolve(2)).resolves.toBe(2);
+  await Bun.sleep(5);
+});
+`,
+    });
+    const output = stdout + stderr;
+    expect(output).not.toContain("expect(received)");
+    expect(output).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
   });
 
   // A matcher promise still pending when the synchronous body returns is settled before the
@@ -405,6 +572,38 @@ test("matcher return values", async () => {
     expect(exitCode).toBe(0);
   });
 
+  // On a pass, the promise a deferred matcher returns resolves with `undefined` — never the
+  // matcher result or the chainable `Expect` — for built-in matchers, async `toThrow`, and
+  // async `expect.extend` matchers (both directly and reached through `.resolves`).
+  test("a passing deferred matcher's promise resolves to undefined", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+expect.extend({
+  async _toEqualAsync(received, expected) {
+    await Bun.sleep(1);
+    return { pass: received === expected, message: () => "_toEqualAsync(" + expected + ")" };
+  },
+});
+test("deferred matcher promises resolve to undefined", async () => {
+  await expect(expect(Promise.resolve(1)).resolves.toBe(1)).resolves.toBeUndefined();
+  await expect(expect(Promise.reject(new Error("boom"))).rejects.toThrow("boom")).resolves.toBeUndefined();
+  await expect(expect(Bun.sleep(1).then(() => 3)).resolves.toBe(3)).resolves.toBeUndefined();
+  await expect(
+    expect(async () => {
+      throw new Error("boom");
+    }).toThrow("boom"),
+  ).resolves.toBeUndefined();
+  await expect(expect(7)._toEqualAsync(7)).resolves.toBeUndefined();
+  await expect(expect(Bun.sleep(1).then(() => 7)).resolves._toEqualAsync(7)).resolves.toBeUndefined();
+});
+`,
+    });
+    expect(stdout + stderr).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
   // Per-test matcher/assertion counters reset across test.each entries, retries, and repeats.
   test("expect.assertions with un-awaited matchers across test.each, retry, and repeats", async () => {
     const { stdout, stderr, exitCode } = await runTestFile({
@@ -451,10 +650,11 @@ test(
     expect(exitCode).toBe(0);
   });
 
-  // A matcher called from inside a `Bun.serve` fetch handler must not re-enter the event loop
-  // synchronously (oven-sh/bun#33261). `nestedDispatchTicks` requires a debug build.
+  // A matcher called from inside an event-loop poll callback (a `Bun.serve` fetch handler,
+  // oven-sh/bun#33261) must not re-enter the event loop synchronously.
+  // `nestedDispatchTicks` requires a debug build and only the POSIX loop increments it.
   test.skipIf(!isDebug || isWindows)(
-    "a matcher inside a Bun.serve fetch handler does not re-enter the event loop",
+    "a matcher inside an event-loop poll callback does not re-enter the event loop",
     async () => {
       const { stdout, stderr, exitCode } = await runTestFile({
         "fixture.test.ts": `import { test, expect } from "bun:test";
@@ -464,44 +664,43 @@ import { getEventLoopStats } from "bun:internal-for-testing";
 // the server socket's poll batch). HTMLRewriter's string transform still waits
 // synchronously on its async handlers, so it is the positive control proving the counter
 // detects exactly what the matcher below must avoid.
-test("nested dispatch is counted for a synchronous waiter inside a fetch handler", async () => {
-  using server = Bun.serve({
-    port: 0,
-    fetch() {
-      const before = getEventLoopStats().nestedDispatchTicks;
-      new HTMLRewriter()
-        .on("p", {
-          async element() {
-            await Bun.sleep(1);
-          },
-        })
-        .transform("<p>x</p>");
-      const after = getEventLoopStats().nestedDispatchTicks;
-      return new Response(JSON.stringify({ delta: after - before }));
-    },
-  });
-  const { delta } = await (await fetch(server.url)).json();
-  console.log("K_CONTROL_DELTA:" + delta);
-  expect(delta).toBeGreaterThan(0);
-});
-test("matcher inside fetch handler", async () => {
+async function deltaInFetchHandler(probe) {
   using server = Bun.serve({
     port: 0,
     async fetch() {
       const before = getEventLoopStats().nestedDispatchTicks;
-      const pending = expect(Bun.sleep(1).then(() => "settled")).resolves.toBe("settled");
+      const pending = probe();
       const after = getEventLoopStats().nestedDispatchTicks;
       await pending;
       return new Response(JSON.stringify({ delta: after - before }));
     },
   });
   const { delta } = await (await fetch(server.url)).json();
+  return delta;
+}
+test("nested dispatch is counted for a synchronous waiter inside a poll callback", async () => {
+  const delta = await deltaInFetchHandler(() => {
+    new HTMLRewriter()
+      .on("p", {
+        async element() {
+          await Bun.sleep(1);
+        },
+      })
+      .transform("<p>x</p>");
+  });
+  console.log("K_CONTROL_DELTA:" + delta);
+  expect(delta).toBeGreaterThan(0);
+});
+test("matcher inside poll callback", async () => {
+  const delta = await deltaInFetchHandler(() => expect(Bun.sleep(1).then(() => "settled")).resolves.toBe("settled"));
   console.log("K_NESTED_DELTA:" + delta);
   expect(delta).toBe(0);
 });
 `,
       });
-      expect(stdout).toContain("K_CONTROL_DELTA:1");
+      // The synchronous waiter may tick more than once before its promise settles, so the
+      // control only asserts a nonzero count.
+      expect(stdout).toMatch(/K_CONTROL_DELTA:[1-9]/);
       expect(stdout).toContain("K_NESTED_DELTA:0");
       expect(stderr).toContain(" 2 pass");
       expect(stderr).toContain(" 0 fail");
@@ -525,6 +724,75 @@ test("promise resolves after expect call", () => {
     expect(stderr).toContain(" 1 pass");
     expect(stderr).toContain(" 0 fail");
     expect(exitCode).toBe(0);
+  });
+
+  // The pending-matcher gate sits between the test entry and the afterEach entries: an
+  // un-awaited deferred matcher observes the state the test left behind, not the state
+  // afterEach mutates it to (Jest and released Bun both order it this way).
+  test("un-awaited deferred matchers settle before afterEach runs", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect, afterEach } from "bun:test";
+let ok = true;
+afterEach(() => {
+  console.log("AFTER_EACH:" + ok);
+  ok = false;
+});
+test("deferred matcher sees pre-afterEach state", () => {
+  expect(Bun.sleep(20).then(() => ok)).resolves.toBe(true);
+});
+test("afterEach ran after the matcher settled", () => {
+  expect(ok).toBe(false);
+});
+`,
+    });
+    // The first afterEach runs only after the deferred matcher observed `ok === true`.
+    expect(stdout).toContain("AFTER_EACH:true");
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // A failing deferred matcher whose subject settles while the sequence is parked at the
+  // test/afterEach boundary (no active entry): the deferred's rejection must be claimed by
+  // the provisional-matcher machinery, not double-reported through the generic
+  // unhandled-rejection path as "Unhandled error between tests".
+  test("a failing deferred matcher with an afterEach fails once and still runs afterEach", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect, afterEach } from "bun:test";
+afterEach(() => {
+  console.log("AFTER_EACH_RAN");
+});
+test("t", () => {
+  expect(Bun.sleep(10).then(() => 1)).resolves.toBe(4949);
+});
+`,
+    });
+    const output = stdout + stderr;
+    expect(stdout).toContain("AFTER_EACH_RAN");
+    expect(output.split("Expected: 4949").length - 1).toBe(1);
+    expect(output).not.toContain("Unhandled");
+    expect(stderr).not.toContain("(pass)");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // When the per-test timeout abandons pending deferred matchers while the sequence is
+  // parked before its afterEach entries, the afterEach hooks must still run.
+  test("afterEach still runs when the timeout abandons a pending deferred matcher", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect, afterEach } from "bun:test";
+afterEach(() => {
+  console.log("AFTER_EACH_RAN");
+});
+test("t", () => {
+  expect(new Promise(() => {})).resolves.toBe(1);
+}, 500);
+`,
+    });
+    expect(stdout).toContain("AFTER_EACH_RAN");
+    expect(stderr).toContain("timed out after 500ms");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
   });
 
   // A deferred matcher abandoned by the per-test timeout belongs to that attempt only
@@ -626,6 +894,40 @@ test("rejects inline error snapshot", async () => {
       snapshot: expect.stringContaining('exports[`throw 1`] = `"late-throw"`'),
     });
     expect(snapshot).toContain('exports[`resolve 1`] = `"late-resolve"`');
+    expect(exitCode).toBe(0);
+  });
+
+  // DELIBERATE BEHAVIOR CHANGE (Jest parity): snapshot indices are assigned in SETTLE order,
+  // not source order. A deferred `.resolves.toMatchSnapshot()` written before a synchronous
+  // one gets the later index because it settles later; existing .snap files may need `-u`.
+  test("snapshot indices are assigned in settle order, not source order", async () => {
+    using dir = tempDir("snapshot-settle-order", {
+      "order.test.js": `
+        import { test, expect } from "bun:test";
+        test("order", async () => {
+          const deferred = expect(Promise.resolve("ASYNC")).resolves.toMatchSnapshot();
+          expect("SYNC").toMatchSnapshot();
+          await deferred;
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "order.test.js"],
+      env: { ...bunEnv, CI: "false" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    const snapshot = await Bun.file(`${dir}/__snapshots__/order.test.js.snap`)
+      .text()
+      .catch(() => "<missing snapshot file>");
+    // The synchronous matcher settles first, so it owns index 1; the deferred one gets 2.
+    expect({ stderr, snapshot }).toEqual({
+      stderr: expect.stringContaining("1 pass"),
+      snapshot: expect.stringContaining('exports[`order 1`] = `"SYNC"`;'),
+    });
+    expect(snapshot).toContain('exports[`order 2`] = `"ASYNC"`;');
     expect(exitCode).toBe(0);
   });
 
@@ -771,5 +1073,329 @@ test("promise subclass with an overridden then", async () => {
     expect(stderr).toContain(" 4 pass");
     expect(stderr).toContain(" 0 fail");
     expect(exitCode).toBe(0);
+  });
+
+  // A subclass whose `then` delegates to an inner promise never settles its OWN internal
+  // slots, so the settle re-invocation must consume the settlement its reaction captured
+  // instead of re-reading the raw subject (which stays "pending" forever).
+  test("promise subclass with a delegating then whose own slots never settle", async () => {
+    const { stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+class Weird extends Promise {
+  constructor(executor) {
+    super(() => {});
+    this._p = new Promise(executor);
+  }
+  then(onFulfilled, onRejected) {
+    return this._p.then(onFulfilled, onRejected);
+  }
+}
+test("delegating subclass resolves", async () => {
+  await expect(new Weird(resolve => setTimeout(() => resolve(42), 10))).resolves.toBe(42);
+});
+test("delegating subclass rejects", async () => {
+  await expect(new Weird((_, reject) => setTimeout(() => reject(new Error("boom")), 10))).rejects.toThrow(
+    "boom",
+  );
+});
+`,
+    });
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // A chained deferral (the subject deferral followed by an async `toThrow` / async
+  // custom-matcher deferral) re-invokes the matcher a second time: that pass must resume
+  // from the carried subject settlement, never from the raw subject's internal slots
+  // (which the delegating subclass never settles). Plain-Promise controls prove the
+  // chaining itself works either way.
+  test("delegating subclass with a chained deferral never re-reads the raw subject", async () => {
+    const { stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+class Weird extends Promise {
+  constructor(executor) {
+    super(() => {});
+    this._p = new Promise(executor);
+  }
+  then(onFulfilled, onRejected) {
+    return this._p.then(onFulfilled, onRejected);
+  }
+}
+expect.extend({
+  async toEventuallyBe(received, expected) {
+    await Bun.sleep(1);
+    return { pass: received === expected, message: () => "expected " + received + " to be " + expected };
+  },
+});
+const asyncThrower = async () => {
+  throw new Error("kaboom");
+};
+test("delegating subclass + async custom matcher", async () => {
+  await expect(new Weird(resolve => setTimeout(() => resolve(42), 10))).resolves.toEventuallyBe(42);
+});
+test("delegating subclass resolving to an async-throwing function + toThrow", async () => {
+  await expect(new Weird(resolve => setTimeout(() => resolve(asyncThrower), 10))).resolves.toThrow("kaboom");
+});
+test("plain promise + async custom matcher (control)", async () => {
+  await expect(new Promise(resolve => setTimeout(() => resolve(42), 10))).resolves.toEventuallyBe(42);
+});
+test("plain promise resolving to an async-throwing function + toThrow (control)", async () => {
+  await expect(new Promise(resolve => setTimeout(() => resolve(asyncThrower), 10))).resolves.toThrow("kaboom");
+});
+`,
+    });
+    expect(stderr).toContain(" 4 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // The trackability predicate is per concurrent GROUP: a lone `test.concurrent` is a
+  // group of one sequence, so its owning test is resolvable and its matcher defers
+  // (non-blocking) exactly like a sequential test's.
+  test("a lone test.concurrent defers instead of blocking on a pending subject", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test.concurrent("lone concurrent", async () => {
+  const { promise, resolve } = Promise.withResolvers<number>();
+  const before = Date.now();
+  const deferred = expect(promise).resolves.toBe(42);
+  const dt = Date.now() - before;
+  // Only reachable because expect() returned without blocking on the still-pending subject.
+  resolve(42);
+  await deferred;
+  console.log("N_LONE_DT:" + dt);
+  // A regression to the blocking carve-out hangs on the never-yet-resolved subject: the
+  // 3s timeout turns that into a fast assertion failure instead of a stalled runner.
+}, 3000);
+`,
+    });
+    // dt only measures the (non-blocking) expect() call itself: the subject could not
+    // resolve until after it returned, so a blocking wait would never have come back.
+    const dt = Number(stdout.match(/N_LONE_DT:(\d+)/)?.[1]);
+    expect(dt).toBeLessThan(1000);
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // Two adjacent `test.concurrent`s share one group of 2 sequences, so no single owning
+  // test is resolvable: each matcher keeps the pre-existing synchronous wait (the
+  // deliberately-unchanged carve-out), returning only after its subject settled.
+  test("sibling test.concurrent tests in one group keep the synchronous wait", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+function probe(label: string, value: number) {
+  const order: string[] = [];
+  const before = Date.now();
+  const subject = Bun.sleep(50).then(() => {
+    order.push("subject-settled");
+    return value;
+  });
+  expect(subject).resolves.toBe(value);
+  order.push("expect-returned");
+  console.log(label + ":" + order.join(",") + ":" + (Date.now() - before));
+}
+test.concurrent("sibling one", () => probe("P_ONE", 1));
+test.concurrent("sibling two", () => probe("P_TWO", 2));
+`,
+    });
+    for (const label of ["P_ONE", "P_TWO"]) {
+      const [, order, dt] = stdout.match(new RegExp(`${label}:([a-z,-]+):(\\d+)`)) ?? [];
+      // Blocking: the 50ms subject settled before expect() returned, and the call took at
+      // least the subject delay (small slack for timer granularity).
+      expect(`${label}:${order}`).toBe(`${label}:subject-settled,expect-returned`);
+      expect(Number(dt)).toBeGreaterThanOrEqual(45);
+    }
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // `.resolves` returns the same wrapper, so a later `.not` mutates the flags byte an
+  // earlier call already captured. Each deferral must re-invoke with ITS call-time flags
+  // (Jest parity: `resolves` and `resolves.not` are independent matcher sets).
+  test("a reused .resolves handle applies each call's own flags, not the latest", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("per-call flags, both pass", async () => {
+  const r = expect(Promise.resolve(3)).resolves;
+  const outcomes: string[] = [];
+  const first = r.toBe(3);
+  const second = r.not.toBe(4);
+  await first.then(() => outcomes.push("first:fulfilled"), () => outcomes.push("first:rejected"));
+  await second.then(() => outcomes.push("second:fulfilled"), () => outcomes.push("second:rejected"));
+  console.log("G_OUTCOMES:" + outcomes.join(","));
+});
+`,
+    });
+    // Neither call fails under its own flags: `.resolves.toBe(3)` and `.resolves.not.toBe(4)`.
+    expect(stdout).toContain("G_OUTCOMES:first:fulfilled,second:fulfilled");
+    expect(stdout + stderr).not.toContain("Unhandled");
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // Same reuse where the later `.not` call is the failing one: the first deferral still
+  // fulfills (it was made without `.not`), and the un-awaited second fails the test once
+  // with the `.not` matcher error.
+  test("a reused .resolves handle fails only the call made through .not", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+test("per-call flags, second fails", async () => {
+  const r = expect(Promise.resolve(3)).resolves;
+  const first = r.toBe(3);
+  r.not.toBe(3);
+  await first.then(() => console.log("F_FIRST:fulfilled"), () => console.log("F_FIRST:rejected"));
+});
+`,
+    });
+    expect(stdout).toContain("F_FIRST:fulfilled");
+    // Only the `.not` call fails, reported exactly once.
+    expect(stderr.split("expect(received).not.toBe(expected)").length - 1).toBe(1);
+    expect(stdout + stderr).not.toContain("Unhandled");
+    expect(stderr).toContain(" 0 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // A beforeAll/afterAll-only sequence has no test entry to bound a deferral, so its
+  // matcher keeps the pre-existing synchronous wait. That wait ignores the hook timeout —
+  // a NEVER-settling subject in a hook still hangs the whole run, exactly as in released
+  // Bun — which is why this fixture's subject settles: it pins the blocking fallback
+  // (subject settled before expect() returned) plus the overrun hook-timeout report.
+  test("a beforeAll-only sequence keeps the synchronous wait and reports the hook timeout", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect, beforeAll } from "bun:test";
+const order: string[] = [];
+beforeAll(() => {
+  const subject = Bun.sleep(250).then(() => {
+    order.push("subject-settled");
+    return 1;
+  });
+  expect(subject).resolves.toBe(1);
+  order.push("expect-returned");
+  console.log("HOOK_ORDER:" + order.join(","));
+}, 50);
+test("t", () => {});
+`,
+    });
+    // Blocking fallback: the subject settled before expect() returned inside the hook, so
+    // the hook overran its 50ms timeout and the run still terminated with that failure.
+    expect(stdout).toContain("HOOK_ORDER:subject-settled,expect-returned");
+    expect(stdout + stderr).toContain("hook timed out");
+    expect(exitCode).toBe(1);
+  });
+});
+
+describe.concurrent("deferred matcher error attribution", () => {
+  // The rejection the user's `await` observes is the matcher's REAL exception (class,
+  // `cause`, extra properties intact) with the `expect()` call-site frames grafted onto
+  // its `stack`, not a placeholder error carrying only the message.
+  test("an awaited deferred matcher failure keeps its error class and properties and points at the expect line", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+class MatcherBoom extends Error {}
+expect.extend({
+  toFailCustom() {
+    const err = new MatcherBoom("CUSTOM_MATCHER_FAILURE");
+    err.cause = "CUSTOM_CAUSE";
+    err.detail = 42;
+    throw err;
+  },
+});
+test("attribution", async () => {
+  let caught;
+  try {
+    await expect(Bun.sleep(5).then(() => 1)).resolves.toFailCustom();
+  } catch (e) {
+    caught = e;
+  }
+  console.log(
+    "ATTRIBUTION:" +
+      JSON.stringify({
+        isMatcherBoom: caught instanceof MatcherBoom,
+        message: caught.message,
+        cause: caught.cause,
+        detail: caught.detail,
+        stackHasExpectLine: typeof caught.stack === "string" && caught.stack.includes("fixture.test.ts:14:"),
+      }),
+  );
+});
+`,
+    });
+    expect(stdout).toContain(
+      `ATTRIBUTION:{"isMatcherBoom":true,"message":"CUSTOM_MATCHER_FAILURE","cause":"CUSTOM_CAUSE","detail":42,"stackHasExpectLine":true}`,
+    );
+    expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  // Grafting the call site must not destroy the exception's own user frames: an error
+  // thrown from user JS inside the re-invoked matcher keeps its real throw site, with the
+  // `expect()` call-site frames appended after it.
+  test("a deferred custom matcher throwing from user code keeps the throw-site frame and gains the expect line", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+function deepHelper() {
+  throw new Error("DEEP_BOOM");
+}
+expect.extend({
+  toFailDeep() {
+    deepHelper();
+    return { pass: true, message: () => "" };
+  },
+});
+test("throw site survives", async () => {
+  let caught;
+  try {
+    await expect(Bun.sleep(3).then(() => 1)).resolves.toFailDeep();
+  } catch (e) {
+    caught = e;
+  }
+  const at = needle => caught.stack.indexOf(needle);
+  console.log(
+    "FRAMES:" +
+      JSON.stringify({
+        throwSite: at("deepHelper (") >= 0 && caught.stack.includes("fixture.test.ts:3:"),
+        matcher: caught.stack.includes("fixture.test.ts:7:"),
+        expectLine: caught.stack.includes("fixture.test.ts:14:"),
+        throwSiteFirst: at("fixture.test.ts:3:") < at("fixture.test.ts:14:"),
+      }),
+  );
+});
+`,
+    });
+    expect(stdout).toContain('FRAMES:{"throwSite":true,"matcher":true,"expectLine":true,"throwSiteFirst":true}');
+    expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  // A deferral abandoned by a per-test timeout (its epoch is stale by the time the subject
+  // settles) rejects `D` with a real reason attributed to the `expect()` line, never the
+  // internal call-site placeholder.
+  test("a deferral abandoned by a test timeout rejects with a real stale-attempt message", async () => {
+    const { stdout, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect, afterAll } from "bun:test";
+let d: Promise<unknown> | undefined;
+test("times out", async () => {
+  d = expect(Bun.sleep(100).then(() => 1)).resolves.toBe(1);
+  await Bun.sleep(2_000);
+}, 50);
+afterAll(async () => {
+  const outcome = await d!.then(
+    () => "fulfilled",
+    e => "rejected:" + e.message + ":stack=" + (typeof e.stack === "string" && e.stack.includes("fixture.test.ts:4:")),
+  );
+  console.log("STALE_OUTCOME:" + outcome);
+});
+`,
+    });
+    expect(stdout).toContain(
+      "STALE_OUTCOME:rejected:Test attempt ended (timeout or retry) before the matcher promise settled:stack=true",
+    );
+    expect(stdout).not.toContain("Matcher promise was not awaited");
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/test/expect-resolves-rejects.test.ts
+++ b/test/js/bun/test/expect-resolves-rejects.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+
+// Every test spawns a `bun test` child (some of which sleep for seconds by design) and
+// they all run concurrently, so the default 5s per-test timeout is too tight on CI.
+setDefaultTimeout(60_000);
 
 async function runTestFile(files: Record<string, string>, env: NodeJS.Dict<string> = bunEnv) {
   using dir = tempDir("expect-resolves-rejects", files);
@@ -730,6 +734,42 @@ test("argument error", async () => {
     const output = stdout + stderr;
     expect(output).toContain(" 1 pass");
     expect(output).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/14670 — `Bun.$` returns a lazy promise subclass
+  // that only starts when its own `.then` is called, so the deferral must adopt the
+  // subject with `Promise.resolve` semantics (native reactions on its internal slots
+  // would never start it and the matcher would never settle).
+  test("lazy thenable subjects (Bun.$, Promise subclasses) start and settle", async () => {
+    const { stderr, exitCode } = await runTestFile({
+      "fixture.test.ts": `import { test, expect } from "bun:test";
+import { $ } from "bun";
+test("rejects on a failing command", async () => {
+  await expect($\`exit 1\`.quiet()).rejects.toThrow();
+});
+test("resolves on a succeeding command", async () => {
+  await expect($\`echo hi\`.quiet().text()).resolves.toBe("hi\\n");
+});
+test("un-awaited rejects on a failing command", () => {
+  expect($\`exit 1\`.quiet()).rejects.toThrow();
+});
+test("promise subclass with an overridden then", async () => {
+  let adopted = false;
+  class Lazy extends Promise {
+    then(onFulfilled, onRejected) {
+      adopted = true;
+      return super.then(onFulfilled, onRejected);
+    }
+  }
+  const subject = new Lazy(resolve => queueMicrotask(() => resolve(7)));
+  await expect(subject).resolves.toBe(7);
+  expect(adopted).toBe(true);
+});
+`,
+    });
+    expect(stderr).toContain(" 4 pass");
+    expect(stderr).toContain(" 0 fail");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4728,11 +4728,15 @@ describe("expect()", () => {
   test("pass to return undefined", () => {
     expect(expect().pass()).toBeUndefined();
   });
-  test("rejects to return undefined", () => {
-    expect(expect(Promise.reject("error")).rejects.toBe("error")).toBeUndefined();
+  test("rejects to return a promise", () => {
+    const result = expect(Promise.reject("error")).rejects.toBe("error");
+    expect(result).toBeInstanceOf(Promise);
+    return result;
   });
-  test("resolves to return undefined", () => {
-    expect(expect(Promise.resolve(1)).resolves.toBe(1)).toBeUndefined();
+  test("resolves to return a promise", () => {
+    const result = expect(Promise.resolve(1)).resolves.toBe(1);
+    expect(result).toBeInstanceOf(Promise);
+    return result;
   });
   test("toBe to return undefined", () => {
     expect(expect(true).toBe(true)).toBeUndefined();


### PR DESCRIPTION
### What does this PR do?

`expect(promise).resolves…` / `.rejects…`, `expect(asyncFn).toThrow*`, and async `expect.extend` matchers used to call `waitForPromise` from inside the matcher — spinning the whole event loop (timers, I/O completions, GC, arbitrary user JS) from inside whatever frame called `expect()`. That synchronous re-entry is the bug class tracked in #33261 (work item 1), and it also made the matcher unable to observe anything that happens *after* the `expect()` call in the same test body: `expect(p).resolves.toBe(25); resolve(25)` deadlocked at 100% CPU until the test timeout (#14950), where Jest passes.

Now a matcher with promise flags and a promise subject **returns a real `Promise`** and never blocks:

- Native reactions on the subject re-invoke the same matcher once it settles (`Expect.reentry`), so the second pass reuses the existing synchronous direction-check/error logic unchanged; async `toThrow` and async custom matchers resume from the recorded settlement instead of re-running the user's function.
- The runner keeps the test open until every deferred matcher settles (`ExecutionSequence.pending_matcher_promises`, epoch-guarded so per-test timeouts and retry/repeat attempts can abandon stale deferrals without cross-talk).
- An **un-awaited failing matcher fails its own test**, attributed to the `expect()` call line, and does not double as an unhandled-rejection report. The awaited/un-awaited decision is made one job after the matcher settles so code that adopts the matcher promise in the same microtask drain (e.g. `async () => expect(p).rejects.toThrow(x)`) is classified correctly.
- The subject is adopted through the generic promise-resolve path, so a promise subclass or thenable works — e.g. `Bun.$`'s lazy ShellPromise, which only starts when its own `.then` is called; asserting `.rejects` on a shell command used to hang forever inside `waitForPromise` (#14670).
- Jest parity: matcher calls through `.resolves`/`.rejects` always return a promise (even for an already-settled subject); `expect(nonPromise).resolves` still throws synchronously.
- `bun-types`: the `Matchers` interface gains Jest's return-type parameter, so matcher chains through `.resolves`/`.rejects` and async `toThrow` are typed as `Promise<void>`.

Behavior changes (deliberate):

- **Snapshot indices are assigned in settle order, not source order** (Jest parity). `expect(promise).resolves.toMatchSnapshot()` no longer blocks at the `expect()` line, so it registers its snapshot when the subject settles; a synchronous `toMatchSnapshot()` written *after* it in the same test now gets the lower index. Committed `.snap` files that interleave deferred and synchronous snapshot matchers under one test name may need `bun test -u` once. This matches Jest, which also numbers snapshots at settlement; it is pinned by the "snapshot indices are assigned in settle order" test.

Deliberately unchanged (each keeps the pre-existing synchronous wait, so nothing gets *less* correct):

- Concurrent groups running more than one test (2+ adjacent `test.concurrent`s interleave, so the runner cannot resolve which of the group's sequences an `expect()` belongs to), `expect()` outside `bun:test`, and any other context with no single owning test: a deferral there could not gate its test's completion, so the matcher blocks exactly as before. A **lone** `test.concurrent` is a group of one sequence, so it resolves normally and defers like a sequential test — both sides are pinned by tests. (Follow-up: group-level tracking for multi-test groups.)
- Asymmetric-position matchers (`expect.resolvesTo`/`rejectsTo`, async custom matchers inside `toEqual`) run inside a synchronous deep-equality walk that needs a boolean back — there is no matcher invocation to re-run, so they cannot be deferred.

### Why not a JS-layer `.then` wrapper (Jest's approach)?

Jest's `expect(promise).resolves.toBe(x)` is a thin JavaScript wrapper: `.resolves`/`.rejects` returns a proxy whose matcher methods do `subject.then(...)` and hand the resulting promise back to the caller. That works for Jest because the promise Jest needs to defer on is *the subject*, known before the matcher runs, and because Jest's whole `expect` lives in JS. Neither is true here:

- **Only the `.resolves`/`.rejects` subject origin is expressible as a `.then` wrapper.** The other two deferral origins produce their promise *inside* the matcher, after the user's code has already run: async `toThrow` gets a promise back from calling the user's function, and an async `expect.extend` matcher gets one back from the user's matcher implementation. There is no subject promise to wrap ahead of time — the only way to defer is for the matcher itself to record where it was and resume on settlement, which is exactly what the native reentry pass does. A `.then` wrapper would cover one of the three origins and leave the other two blocking.
- **Bun's `expect` has no JS layer to put the wrapper in.** The matcher chain, flags, call counter, `expect.assertions` bookkeeping, snapshot registration, and error/call-site attribution are all native (`src/runtime/test_runner/expect.rs`); there is no `expect.js` sitting between the user and the matchers. Introducing one just to host a `.then` shim would mean re-plumbing every one of those through a JS boundary — far more surface (and per-call overhead) than the native reactions this PR adds.
- **The end-of-test settlement gate needs runner integration regardless.** The part of this PR that keeps a test open until its deferred matchers settle, attributes an un-awaited failure to the right test, and abandons stale deferrals on timeout/retry lives in the runner (`ExecutionSequence.pending_matcher_promises` + epochs). A JS `.then` wrapper cannot do any of that — Jest gets it from `jest-circus`, its runner. So even with a JS wrapper for the one origin it can express, the native runner work is still all required; the wrapper would save nothing.

Depends on #33267 (this branch is stacked on it: its `nestedDispatchTicks` counter is what the regression test uses to prove a matcher inside a `Bun.serve` fetch handler no longer re-enters the loop). #33279 prepared the test suite for this change.

Fixes #14950
Fixes #23420
Fixes #14670

### How did you verify your code works?

New `test/js/bun/test/expect-resolves-rejects.test.ts` (46 subprocess tests, `describe.concurrent`): awaited pass/fail messages and locations (inline-snapshotted), un-awaited failure attribution + exit code, no unhandled-rejection reports for handled subjects, settlement ordering vs test completion, sync test bodies, returned-promise + un-awaited interplay, chained deferrals (`.resolves.toThrow(fn)`), async `toThrow`/`.not.toThrow`, synchronous throw for non-promise subjects, matcher-returns-a-Promise, `expect.assertions` across `test.each`/retry/repeat, deferred snapshot + inline-snapshot matchers (call-site resolution), the stale-timeout-retry interaction, the #14950 repro, the concurrent carve-out from both sides (a lone `test.concurrent` defers without blocking; two adjacent `test.concurrent`s in one group keep the synchronous wait), and (debug builds) `getEventLoopStats().nestedDispatchTicks === 0` for a matcher inside a `Bun.serve` fetch handler with a positive control that proves the counter detects the old behavior. 8 of those fail on an unpatched build (`USE_SYSTEM_BUN=1`), and the previously-blocking semantics they replace are covered by the existing `expect.test.js` suites, which pass unchanged apart from the two tests that asserted matchers return `undefined` (now assert a `Promise`).

Full local runs: `expect.test.js`, `expect-extend*.test.*`, `expect-assertions.test.ts`, `expect-label.test.ts`, `jest-extended.test.js`, `jest-each.test.ts`, `jest-hooks.test.ts`, `test-test.test.ts`, `snapshot` suites, `pidfd-exit-nested-tick.test.ts` (its nested-tick trigger swapped from `expect().resolves` — which no longer nests — to an HTMLRewriter async transform, so it still tests what it was written for), and `test/integration/bun-types/bun-types.test.ts`.
