### PR TITLE
http: treat a Content-Length: 0 response as complete when keep-alive is disabled

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5233,10 +5233,13 @@ impl<'a> HTTPClient<'a> {
             return Ok(ShouldContinue::ContinueStreaming);
         }
 
+        // RFC 9112 §6.3: framing is decided by Transfer-Encoding and
+        // Content-Length alone. `Connection: close` says the socket won't be
+        // reused, not that the body runs to EOF, so `Content-Length: 0` is a
+        // complete response either way.
         if self.method.has_body()
             && (content_length.is_none()
                 || content_length.unwrap() > 0
-                || !self.state.flags.allow_keepalive
                 || self.state.transfer_encoding == Encoding::Chunked
                 || is_server_sent_events)
         {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5233,10 +5233,9 @@ impl<'a> HTTPClient<'a> {
             return Ok(ShouldContinue::ContinueStreaming);
         }
 
-        // RFC 9112 §6.3: framing is decided by Transfer-Encoding and
-        // Content-Length alone. `Connection: close` says the socket won't be
-        // reused, not that the body runs to EOF, so `Content-Length: 0` is a
-        // complete response either way.
+        // RFC 9112 §6.3: framing comes from Transfer-Encoding and Content-Length
+        // alone. `Connection: close` only means the socket won't be reused, so a
+        // `Content-Length: 0` response is still complete.
         if self.method.has_body()
             && (content_length.is_none()
                 || content_length.unwrap() > 0

--- a/test/js/bun/s3/s3-connection-close.test.ts
+++ b/test/js/bun/s3/s3-connection-close.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Every S3 PUT/DELETE answers with a zero-length body, and any endpoint behind a
+// load balancer is free to answer it with `Connection: close`. The client must
+// treat `Content-Length: 0` as a complete response instead of reading the body
+// until EOF, whether or not the peer closes the socket right away.
+function fixture(op: "write" | "delete", sendFin: boolean) {
+  return `
+import net from "node:net";
+
+const server = net.createServer(socket => {
+  let buffer = Buffer.alloc(0);
+  socket.on("error", () => {});
+  socket.on("data", chunk => {
+    buffer = Buffer.concat([buffer, chunk]);
+    const headerEnd = buffer.indexOf("\\r\\n\\r\\n");
+    if (headerEnd === -1) return;
+    const match = /content-length: *(\\d+)/i.exec(buffer.subarray(0, headerEnd).toString());
+    if (buffer.length - headerEnd - 4 < (match ? Number(match[1]) : 0)) return;
+    socket.write("HTTP/1.1 200 OK\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n");
+    ${sendFin ? "socket.end();" : "// the peer keeps the socket open"}
+  });
+});
+await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+const s3 = new Bun.S3Client({
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+  bucket: "bucket",
+  endpoint: "http://127.0.0.1:" + server.address().port,
+});
+
+${op === "write" ? 'await s3.write("object.txt", "hello");' : 'await s3.delete("object.txt");'}
+console.log("completed");
+process.exit(0);
+`;
+}
+
+describe.each([true, false])("peer sends FIN: %p", sendFin => {
+  test.each(["write", "delete"] as const)(
+    "S3Client.%s() resolves on a Content-Length: 0 + Connection: close response",
+    async op => {
+      using dir = tempDir("s3-connection-close", { "fixture.ts": fixture(op, sendFin) });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.ts"],
+        // The S3 client does not honor NO_PROXY, so an inherited proxy would
+        // hijack the request to the stub server.
+        env: {
+          ...bunEnv,
+          HTTP_PROXY: undefined,
+          HTTPS_PROXY: undefined,
+          http_proxy: undefined,
+          https_proxy: undefined,
+        },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "completed", exitCode: 0 });
+      expect(stderr).not.toContain("S3Error");
+      expect(proc.signalCode).toBeNull();
+    },
+  );
+});

--- a/test/js/bun/s3/s3-connection-close.test.ts
+++ b/test/js/bun/s3/s3-connection-close.test.ts
@@ -59,11 +59,7 @@ describe.each([true, false])("peer sends FIN: %p", sendFin => {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "completed", exitCode: 0 });
       expect(stderr).not.toContain("S3Error");

--- a/test/js/bun/s3/s3-connection-close.test.ts
+++ b/test/js/bun/s3/s3-connection-close.test.ts
@@ -37,7 +37,7 @@ process.exit(0);
 }
 
 describe.each([true, false])("peer sends FIN: %p", sendFin => {
-  test.each(["write", "delete"] as const)(
+  test.concurrent.each(["write", "delete"] as const)(
     "S3Client.%s() resolves on a Content-Length: 0 + Connection: close response",
     async op => {
       using dir = tempDir("s3-connection-close", { "fixture.ts": fixture(op, sendFin) });

--- a/test/js/bun/s3/s3-connection-close.test.ts
+++ b/test/js/bun/s3/s3-connection-close.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// Every S3 PUT/DELETE answers with a zero-length body, and any endpoint behind a
-// load balancer is free to answer it with `Connection: close`. The client must
-// treat `Content-Length: 0` as a complete response instead of reading the body
-// until EOF, whether or not the peer closes the socket right away.
+// Every S3 PUT/DELETE answers with a zero-length body, and any endpoint behind
+// a load balancer may reply with `Connection: close`. The client must treat
+// `Content-Length: 0` as complete rather than reading to EOF, FIN or not.
 function fixture(op: "write" | "delete", sendFin: boolean) {
   return `
 import net from "node:net";


### PR DESCRIPTION
A `200 OK` with `Content-Length: 0` and `Connection: close` is reported as a failure, and hangs if the peer does not send FIN promptly. Every S3 `PUT`/`DELETE` response is zero-length, so `Bun.S3Client` writes through any connection-recycling endpoint or load balancer are reported as failed even though the object landed. Retry loops then re-upload.

## Repro

```js
import net from "node:net";

const server = net.createServer(socket => {
  socket.on("data", () => {
    // A completed PUT: 200, zero-length body, socket will not be reused.
    socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
    socket.end(); // omit this and the client hangs instead
  });
});
await new Promise(r => server.listen(0, "127.0.0.1", r));

const s3 = new Bun.S3Client({
  accessKeyId: "key",
  secretAccessKey: "secret",
  bucket: "bucket",
  endpoint: "http://127.0.0.1:" + server.address().port,
});

await s3.write("object.txt", "hello"); // S3Error: ConnectionClosed
```

## Cause

`handleResponseMetadata` decides whether a response has a body to read:

```rust
if self.method.has_body()
    && (content_length.is_none()
        || content_length.unwrap() > 0
        || !self.state.flags.allow_keepalive   // <-- this
        || self.state.transfer_encoding == Encoding::Chunked
        || is_server_sent_events)
```

`allow_keepalive` is false whenever the socket will not be reused, either because the server sent `Connection: close` or because the response had no self-defined length. The second case is already covered by `content_length.is_none()`, so the only thing the `!allow_keepalive` term still changes is `Content-Length: 0` + `Connection: close`, which it sends to the body stage to read until EOF. RFC 9112 §6.3 frames the message from `Transfer-Encoding` and `Content-Length` alone; `Connection: close` says nothing about framing.

From there the request can only finish via `on_close`, which accepts EOF as a successful end-of-body only when the content length is unknown:

```rust
} else if self.state.content_length.is_none()
    && self.state.response_stage == ResponseStage::Body
{
```

`Some(0)` falls through to `self.fail(err!(ConnectionClosed))`. If the peer keeps the socket open, nothing completes the request at all.

`fetch()` hides this: it is the only caller that sets the `header_progress` signal, which runs a progress update right after the headers, and `is_done()` is already true for a zero-length body. `Bun.S3Client` and the package-manager client do not set it.

## Fix

Drop the `!allow_keepalive` term. The change is scoped to 2xx responses with `Content-Length: 0` and `Connection: close` (the `Connection` header is only parsed for 2xx), which now finish at the headers. The hang resolves with the same change.

## Verification

`test/js/bun/s3/s3-connection-close.test.ts` covers `write()` and `delete()` against a stub that sends the response with and without a prompt FIN. All four fail on `main` (two reject, two hang out at the test timeout) and pass with the fix.

`test/js/web/fetch/fetch.test.ts` and `test/js/web/fetch/proxy.test.ts` produce an identical failure set before and after.
