### PR TITLE
node:http: close the connection after rejecting Expect: 100-continue

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -812,6 +812,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             // parserOnIncoming (RFC 7231 5.1.1: expectation values compare
             // case-insensitively).
             if (continueExpression.test(expectHeader)) {
+              http_res._expect_continue = true;
               if (server.listenerCount("checkContinue") > 0) {
                 server.emit("checkContinue", http_req, http_res);
               } else {
@@ -1454,6 +1455,15 @@ function _writeHead(statusCode, reason, obj, response) {
 
 Object.defineProperty(NodeHTTPServerSocket, "name", { value: "Socket" });
 
+// Like Node.js's writeHead: answering an Expect: 100-continue request with a
+// final status instead of the 100 Continue leaves the announced request body
+// unsent, so the connection is no longer framed and must not be reused.
+function clearKeepAliveIfContinueNotSent(res) {
+  if (res._expect_continue && !res._sent100) {
+    res.shouldKeepAlive = false;
+  }
+}
+
 function ServerResponse(req, options): void {
   if (!(this instanceof ServerResponse)) return new ServerResponse(req, options);
   OutgoingMessage.$call(this, options);
@@ -1471,6 +1481,7 @@ function ServerResponse(req, options): void {
   this.req = req;
   this.sendDate = true;
   this._sent100 = false;
+  this._expect_continue = false;
   this[headerStateSymbol] = NodeHTTPHeaderState.none;
   this[kPendingCallbacks] = [];
   this.finished = false;
@@ -1594,6 +1605,11 @@ function renderNativeHeaders(res) {
       forceChunked = true;
     }
   }
+
+  // Headers are rendered lazily here, so a response that never went through
+  // writeHead() (the fast path in callWriteHeadIfObservable) still has to
+  // make Node's Expect: 100-continue keep-alive decision before this point.
+  clearKeepAliveIfContinueNotSent(res);
 
   if (res._removedConnection) {
     // Node's _storeHeader: `this._last = !this.shouldKeepAlive` - no
@@ -2348,6 +2364,8 @@ ServerResponse.prototype.writeHead = function (statusCode, statusMessage, header
     throw $ERR_HTTP_HEADERS_SENT("writeHead");
   }
   _writeHead(statusCode, statusMessage, headers, this);
+
+  clearKeepAliveIfContinueNotSent(this);
 
   // Node.js renders the header block immediately in writeHead(), so mutating
   // res.statusCode/statusMessage afterwards has no effect on the wire.

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3485,6 +3485,179 @@ it("Expect: 100-Continue matches case-insensitively like Node.js", async () => {
   }
 });
 
+describe("a final response to an unanswered Expect: 100-continue", () => {
+  // The client withholds the announced body until it sees the 100 Continue, so
+  // a final status instead of it leaves the connection unframed: Node's
+  // writeHead clears shouldKeepAlive, which answers Connection: close and ends
+  // the socket - otherwise the next request is read as the unsent body.
+  const expectHead = "POST /upload HTTP/1.1\r\nHost: x\r\nExpect: 100-continue\r\nContent-Length: 36\r\n\r\n";
+
+  // Reads the socket as a sequence of protocol units: until(needle) resolves
+  // with the bytes up to and including needle, and every failure event
+  // (error, premature close) rejects the pending read.
+  async function dial(server: Server) {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    const socket = connect(port, "127.0.0.1");
+
+    let buffer = "";
+    let received = "";
+    let waiter: { needle: string; resolve: (chunk: string) => void; reject: (err: Error) => void } | null = null;
+    const check = () => {
+      if (!waiter) return;
+      const at = buffer.indexOf(waiter.needle);
+      if (at === -1) return;
+      const cut = at + waiter.needle.length;
+      const { resolve } = waiter;
+      waiter = null;
+      const out = buffer.slice(0, cut);
+      buffer = buffer.slice(cut);
+      resolve(out);
+    };
+    const fail = (err: Error) => {
+      const pending = waiter;
+      waiter = null;
+      pending?.reject(err);
+    };
+    socket.on("data", chunk => {
+      buffer += chunk;
+      received += chunk;
+      check();
+    });
+    socket.on("error", fail);
+    socket.on("end", () => fail(new Error(`server closed the connection; buffered: ${JSON.stringify(buffer)}`)));
+
+    return {
+      socket,
+      received: () => received,
+      until(needle: string) {
+        const { promise, resolve, reject } = Promise.withResolvers<string>();
+        waiter = { needle, resolve, reject };
+        check();
+        return promise;
+      },
+    };
+  }
+
+  it("closes the connection after a 417 instead of reading the next request as the unsent body", async () => {
+    let keepAliveInHandler: boolean | undefined;
+    const server = createServer((req, res) => res.end("SECOND"));
+    server.on("checkContinue", (req, res) => {
+      res.writeHead(417);
+      keepAliveInHandler = res.shouldKeepAlive;
+      res.end();
+    });
+    const { socket, until, received } = await dial(server);
+    try {
+      // Pipeline the request the client would send next on a reusable
+      // connection: its bytes must not be consumed as the rejected body.
+      socket.write(expectHead + "GET /second HTTP/1.1\r\nHost: x\r\n\r\n");
+
+      const head = await until("\r\n\r\n");
+      expect(head).toContain("HTTP/1.1 417 Expectation Failed");
+      expect(head).toContain("Connection: close");
+      expect(head).not.toContain("keep-alive");
+      expect(keepAliveInHandler).toBe(false);
+
+      // The server must send FIN on its own; the client never half-closes.
+      await once(socket, "end");
+      expect(received()).not.toContain("SECOND");
+      expect(received().match(/HTTP\/1\.1 \d{3}/g)).toEqual(["HTTP/1.1 417"]);
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  });
+
+  it("closes the connection when the status is set without writeHead()", async () => {
+    const server = createServer();
+    server.on("checkContinue", (req, res) => {
+      res.statusCode = 417;
+      res.end();
+    });
+    const { socket, until } = await dial(server);
+    try {
+      socket.write(expectHead);
+      const head = await until("\r\n\r\n");
+      expect(head).toContain("HTTP/1.1 417 Expectation Failed");
+      expect(head).toContain("Connection: close");
+      expect(head).not.toContain("keep-alive");
+      await once(socket, "end");
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  });
+
+  it("closes the connection even when the final status is a 2xx", async () => {
+    // Node does not gate this on the status code: any final response without a
+    // preceding writeContinue() leaves the announced body unsent.
+    const server = createServer();
+    server.on("checkContinue", (req, res) => {
+      res.writeHead(200);
+      res.end("nope");
+    });
+    const { socket, until } = await dial(server);
+    try {
+      socket.write(expectHead);
+      const head = await until("\r\n\r\n");
+      expect(head).toContain("HTTP/1.1 200 OK");
+      expect(head).toContain("Connection: close");
+      expect(head).not.toContain("keep-alive");
+      await once(socket, "end");
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  });
+
+  it("keeps the connection reusable once writeContinue() was sent", async () => {
+    const server = createServer((req, res) => res.end("SECOND"));
+    server.on("checkContinue", (req, res) => {
+      res.writeContinue();
+      req.resume();
+      req.on("end", () => res.end("first"));
+    });
+    const { socket, until } = await dial(server);
+    try {
+      socket.write("POST /one HTTP/1.1\r\nHost: x\r\nExpect: 100-continue\r\nContent-Length: 5\r\n\r\n");
+      expect(await until("\r\n\r\n")).toContain("HTTP/1.1 100 Continue");
+
+      socket.write("hello");
+      const head = await until("\r\n\r\n");
+      expect(head).toContain("HTTP/1.1 200 OK");
+      expect(head).toContain("Connection: keep-alive");
+      expect(await until("first")).toBe("first");
+
+      socket.write("GET /two HTTP/1.1\r\nHost: x\r\n\r\n");
+      expect(await until("SECOND")).toContain("HTTP/1.1 200 OK");
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  });
+
+  it("keeps the connection reusable for a non-100 expectation's 417", async () => {
+    // Only a 100-continue expectation withholds the request body, so the
+    // default 417 for any other expectation still leaves the connection framed.
+    const server = createServer((req, res) => res.end("SECOND"));
+    const { socket, until } = await dial(server);
+    try {
+      socket.write("GET /one HTTP/1.1\r\nHost: x\r\nExpect: meoww\r\n\r\n");
+      const head = await until("\r\n\r\n");
+      expect(head).toContain("HTTP/1.1 417 Expectation Failed");
+      expect(head).toContain("Connection: keep-alive");
+
+      socket.write("GET /two HTTP/1.1\r\nHost: x\r\n\r\n");
+      expect(await until("SECOND")).toContain("HTTP/1.1 200 OK");
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  });
+});
+
 it("the over-limit 503 advertises Connection: close, not keep-alive", async () => {
   // Node sets maxRequestsOnConnectionReached unconditionally
   // (maxRequestsPerSocket <= count), so the dropRequest 503 carries

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3493,8 +3493,8 @@ describe("a final response to an unanswered Expect: 100-continue", () => {
   const expectHead = "POST /upload HTTP/1.1\r\nHost: x\r\nExpect: 100-continue\r\nContent-Length: 36\r\n\r\n";
 
   // Reads the socket as a sequence of protocol units: until(needle) resolves
-  // with the bytes up to and including needle, and every failure event
-  // (error, premature close) rejects the pending read.
+  // with the bytes up to and including needle, and every failure event rejects
+  // the pending read rather than leaving it to hang.
   async function dial(server: Server) {
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
@@ -3526,7 +3526,8 @@ describe("a final response to an unanswered Expect: 100-continue", () => {
       check();
     });
     socket.on("error", fail);
-    socket.on("end", () => fail(new Error(`server closed the connection; buffered: ${JSON.stringify(buffer)}`)));
+    socket.on("end", () => fail(new Error(`server sent FIN mid-read; buffered: ${JSON.stringify(buffer)}`)));
+    socket.on("close", () => fail(new Error(`socket closed mid-read; buffered: ${JSON.stringify(buffer)}`)));
 
     return {
       socket,


### PR DESCRIPTION
## Repro

A client that sends `Expect: 100-continue` withholds the request body until it sees a `100 Continue`. Rejecting the expectation from `checkContinue` (the documented way to turn away a large upload early on auth/quota) therefore leaves the announced `Content-Length` unsent:

```js
const srv = http.createServer();
srv.on("checkContinue", (req, res) => {
  res.writeHead(417);
  res.end();
});
// client: POST with `Expect: 100-continue` and `Content-Length: 36`, gets the 417,
// and per RFC 9110 10.1.1 never sends the body.
```

```
node: HTTP/1.1 417 Expectation Failed ... Connection: close
bun:  HTTP/1.1 417 Expectation Failed ... Connection: keep-alive
```

Bun keeps the connection alive while the parser is still armed for the 36 body bytes that will never arrive, so the client's next request on that connection gets consumed as the previous request's body: it is silently swallowed and never dispatched, and the connection stalls.

## Cause

Node's `lib/_http_server.js` records `res._expect_continue = true` when it parses the expectation, and `writeHead` then does:

```js
// Don't keep alive connections where the client expects 100 Continue
// but we sent a final status; they may put extra bytes on the wire.
if (this._expect_continue && !this._sent100) {
  this.shouldKeepAlive = false;
}
```

Bun's `ServerResponse` already tracks `_sent100` and already honours `shouldKeepAlive === false` (`renderNativeHeaders` answers `Connection: close` and sets `kMustCloseConnection`, whose `finish` listener ends the socket), but nothing ever set `_expect_continue`, so the rule never fired.

## Fix

Set `_expect_continue` where the expectation is parsed, and clear `shouldKeepAlive` for a final response that was not preceded by `writeContinue()`. Note this is not gated on the status code: any final response, 417 or 200, leaves the announced body unsent, and Node closes in both cases.

The check runs in two places because Bun renders headers lazily: `ServerResponse.prototype.writeHead` (Node's location, which also makes `res.shouldKeepAlive` observably `false` inside the handler) and `renderNativeHeaders`, since `callWriteHeadIfObservable` skips `writeHead` entirely when the user never overrode it, so `res.statusCode = 417; res.end()` would otherwise miss the rule. `_sent100` cannot change between the two (`writeContinue()` throws once headers are sent), so they always agree.

Responses that did send the `100 Continue`, and the default 417 for any other expectation (which never withholds a body), keep the connection reusable exactly as before. `node:http2` is untouched: a rejected h2 stream does not poison the connection.

## Verification

Five new raw-socket tests in `test/js/node/http/node-http.test.ts`. Three of them fail on unpatched Bun, and all five pass verbatim on real Node v26.3.0 (the file requires Node parity):

| variant | before | after / node |
| --- | --- | --- |
| `checkContinue` &rarr; `writeHead(417)` | keep-alive, socket stays open | `Connection: close` + FIN |
| `checkContinue` &rarr; `statusCode = 417`, no `writeHead` | keep-alive | `Connection: close` + FIN |
| `checkContinue` &rarr; `200` without `writeContinue()` | keep-alive | `Connection: close` + FIN |
| `checkContinue` &rarr; `writeContinue()` then `200` | keep-alive | keep-alive, 2nd request answered |
| `Expect: meoww` &rarr; default 417 | keep-alive | keep-alive, 2nd request answered |

The first test pipelines the request a client would send next and asserts it is never answered and that the server sends FIN on its own, so the swallowed-request shape is what is actually being checked.

<details>
<summary>Regression sweep</summary>

- `test/js/node/http/node-http.test.ts` (only pre-existing `issue#4295` external-proxy failure, fails identically without the change)
- 29 vendored Node keep-alive / pipeline / response tests, including `test-http-expect-continue-reuse-race.js` and `test-https-expect-continue-reuse-race.js`, which each reuse one keep-alive socket for 100 `Expect: 100-continue` requests
- `test-http-expect-continue.js`, `test-http-expect-handling.js`, `test-http-sync-write-error-during-continue.js`, `test-http-write-callbacks.js`, the three `test-http2-compat-expect-*` tests

</details>