### PR TITLE
s3: stop rewriting a backslash in an object key to a forward slash

### DIFF
--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -490,7 +490,12 @@ impl S3Credentials {
         let service_name: &str = "s3";
 
         let aws_content_hash: &[u8] = content_hash.unwrap_or(b"UNSIGNED-PAYLOAD");
-        let mut tmp_buffer = [0u8; 4096];
+        // Holds the canonical request, whose largest part is `normalized_path`. `host`
+        // and `extra_path` split the endpoint between them, so one endpoint budget
+        // covers both; the rest leaves room for the headers and the session token.
+        const MAX_CANONICAL_REQUEST_LEN: usize =
+            MAX_ENDPOINT_LEN + MAX_BUCKET_LEN + MAX_ENCODED_KEY_LEN + 4096;
+        let mut tmp_buffer = [0u8; MAX_CANONICAL_REQUEST_LEN];
 
         let authorization: Box<[u8]> = 'brk: {
             // we hash the hash so we need 2 buffers

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -374,11 +374,16 @@ impl S3Credentials {
             return Err(SignError::InvalidPath);
         }
 
-        // A 1024-byte key can percent-encode to 3x that. Bucket names are unreserved
-        // characters only, so their 63-byte limit is also their encoded bound.
+        // The key limit is enforced on the raw bytes so it doesn't depend on how much
+        // of the key percent-encodes, which expands a byte to at most 3. Bucket names
+        // are unreserved characters only, so their limit is also their encoded bound.
+        const MAX_KEY_LEN: usize = 1024;
         const MAX_BUCKET_LEN: usize = 63;
-        const MAX_ENCODED_KEY_LEN: usize = 1024 * 3;
+        const MAX_ENCODED_KEY_LEN: usize = MAX_KEY_LEN * 3;
         const MAX_ENDPOINT_LEN: usize = 2048;
+        if path.len() > MAX_KEY_LEN {
+            return Err(SignError::InvalidPath);
+        }
         let mut normalized_path_buffer =
             [0u8; MAX_ENDPOINT_LEN + MAX_BUCKET_LEN + MAX_ENCODED_KEY_LEN + 2];
         let mut path_buffer = [0u8; MAX_ENCODED_KEY_LEN];

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -365,15 +365,24 @@ impl S3Credentials {
         let path = normalize_name(path);
         let bucket = normalize_name(bucket);
 
+        // Checked before encoding: `\` survives encode_uri_component as `%5C`, so
+        // the `/` test below would no longer catch it.
+        let bucket_has_separator = bucket.contains(&b'/') || bucket.contains(&b'\\');
+
         // if we allow path.len == 0 it will list the bucket for now we disallow
         if !ALLOW_EMPTY_PATH && path.is_empty() {
             return Err(SignError::InvalidPath);
         }
 
-        // 1024 max key size and 63 max bucket name
-        let mut normalized_path_buffer = [0u8; 1024 + 63 + 2];
-        let mut path_buffer = [0u8; 1024];
-        let mut bucket_buffer = [0u8; 63];
+        // A 1024-byte key can percent-encode to 3x that. Bucket names are unreserved
+        // characters only, so their 63-byte limit is also their encoded bound.
+        const MAX_BUCKET_LEN: usize = 63;
+        const MAX_ENCODED_KEY_LEN: usize = 1024 * 3;
+        const MAX_ENDPOINT_LEN: usize = 2048;
+        let mut normalized_path_buffer =
+            [0u8; MAX_ENDPOINT_LEN + MAX_BUCKET_LEN + MAX_ENCODED_KEY_LEN + 2];
+        let mut path_buffer = [0u8; MAX_ENCODED_KEY_LEN];
+        let mut bucket_buffer = [0u8; MAX_BUCKET_LEN];
         let bucket = encode_uri_component::<false>(bucket, &mut bucket_buffer)
             .map_err(|_| SignError::InvalidPath)?;
         let path = encode_uri_component::<false>(path, &mut path_buffer)
@@ -386,7 +395,7 @@ impl S3Credentials {
         let mut extra_path: &[u8] = b"";
         let host: Box<[u8]> = 'brk_host: {
             if !self.endpoint.is_empty() {
-                if self.endpoint.len() >= 2048 {
+                if self.endpoint.len() >= MAX_ENDPOINT_LEN {
                     return Err(SignError::InvalidEndpoint);
                 }
                 let mut host: &[u8] = &self.endpoint;
@@ -402,10 +411,10 @@ impl S3Credentials {
                     if bucket.is_empty() {
                         return Err(SignError::InvalidEndpoint);
                     }
-                    // The bucket is interpolated into the host; a `/` (or `\`,
-                    // which encode_uri_component normalizes to `/`) would let a
-                    // crafted bucket redirect the signed request to another host.
-                    if bucket.contains(&b'/') {
+                    // The bucket is interpolated into the host; a path separator
+                    // would let a crafted bucket redirect the signed request to
+                    // another host.
+                    if bucket_has_separator {
                         return Err(SignError::InvalidEndpoint);
                     }
                     // default to https://<BUCKET_NAME>.s3.<REGION>.amazonaws.com/
@@ -1178,11 +1187,12 @@ pub fn encode_uri_component<'b, const ENCODE_SLASH: bool>(
             }
             // All other characters need to be percent-encoded
             _ => {
-                if !ENCODE_SLASH && (c == b'/' || c == b'\\') {
+                // `\` is a legal S3 key byte distinct from `/`; it percent-encodes.
+                if !ENCODE_SLASH && c == b'/' {
                     if written >= buffer.len() {
                         return Err(EncodeError::BufferTooSmall);
                     }
-                    buffer[written] = if c == b'\\' { b'/' } else { c };
+                    buffer[written] = c;
                     written += 1;
                     continue;
                 }

--- a/test/js/bun/s3/s3-key-encoding.test.ts
+++ b/test/js/bun/s3/s3-key-encoding.test.ts
@@ -91,8 +91,6 @@ test.each(["evil.example.com/other", "evil.example.com\\other"])(
       virtualHostedStyle: true,
     });
 
-    expect(() => s3.presign("object.txt")).toThrow(
-      expect.objectContaining({ code: "ERR_S3_INVALID_ENDPOINT" }),
-    );
+    expect(() => s3.presign("object.txt")).toThrow(expect.objectContaining({ code: "ERR_S3_INVALID_ENDPOINT" }));
   },
 );

--- a/test/js/bun/s3/s3-key-encoding.test.ts
+++ b/test/js/bun/s3/s3-key-encoding.test.ts
@@ -1,6 +1,6 @@
 import { S3Client } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
 
 // S3 object keys are raw byte strings: `\` is a legal character and names a
 // different object than `/` does. Both must survive into the signed request.
@@ -80,6 +80,11 @@ test("presign distinguishes a backslash from a slash", () => {
   expect(s3.presign("a/b").split("?")[0]).toBe("http://s3.example.com/bucket/a/b");
 });
 
+// Every S3 key argument is parsed as a path-like, and that parser rejects anything
+// over PATH_MAX before the signer runs. macOS sets PATH_MAX to the same 1024 bytes
+// S3 allows, so over-long keys die one layer earlier there than on Linux.
+const tooLongCode = isMacOS ? "ENAMETOOLONG" : "ERR_S3_INVALID_PATH";
+
 // The 1024-byte S3 key limit holds whatever the key is made of, rather than
 // varying with how many of its bytes percent-encode. A space triples in length,
 // a letter does not, so the accepted pair spans the encoder's whole range.
@@ -98,7 +103,7 @@ test.each([
   const key = Buffer.alloc(length, fill).toString();
 
   if (encodedByte === null) {
-    expect(() => s3.presign(key)).toThrow(expect.objectContaining({ code: "ERR_S3_INVALID_PATH" }));
+    expect(() => s3.presign(key)).toThrow(expect.objectContaining({ code: tooLongCode }));
   } else {
     expect(s3.presign(key).split("?")[0]).toBe(`http://s3.example.com/bucket/${encodedByte.repeat(length)}`);
   }

--- a/test/js/bun/s3/s3-key-encoding.test.ts
+++ b/test/js/bun/s3/s3-key-encoding.test.ts
@@ -80,6 +80,29 @@ test("presign distinguishes a backslash from a slash", () => {
   expect(s3.presign("a/b").split("?")[0]).toBe("http://s3.example.com/bucket/a/b");
 });
 
+// The 1024-byte S3 key limit holds whatever the key is made of, rather than
+// varying with how many of its bytes percent-encode.
+test.each([
+  ["a", 1024, true],
+  ["a", 1025, false],
+  [" ", 1024, true],
+  [" ", 1025, false],
+])("a %j key of %i bytes is accepted: %j", (fill, length, accepted) => {
+  const s3 = new S3Client({
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+    bucket: "bucket",
+    endpoint: "http://s3.example.com",
+  });
+  const key = Buffer.alloc(length, fill).toString();
+
+  if (accepted) {
+    expect(s3.presign(key)).toStartWith("http://s3.example.com/bucket/");
+  } else {
+    expect(() => s3.presign(key)).toThrow(expect.objectContaining({ code: "ERR_S3_INVALID_PATH" }));
+  }
+});
+
 test.each(["evil.example.com/other", "evil.example.com\\other"])(
   "a virtual-hosted bucket name containing a path separator (%j) is rejected",
   bucket => {

--- a/test/js/bun/s3/s3-key-encoding.test.ts
+++ b/test/js/bun/s3/s3-key-encoding.test.ts
@@ -1,0 +1,98 @@
+import { S3Client } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// S3 object keys are raw byte strings: `\` is a legal character and names a
+// different object than `/` does. Both must survive into the signed request.
+const fixture = `
+import net from "node:net";
+
+const requestLines = [];
+const server = net.createServer(socket => {
+  let buffer = Buffer.alloc(0);
+  socket.on("error", () => {});
+  socket.on("data", chunk => {
+    buffer = Buffer.concat([buffer, chunk]);
+    const headerEnd = buffer.indexOf("\\r\\n\\r\\n");
+    if (headerEnd === -1) return;
+    const head = buffer.subarray(0, headerEnd).toString();
+    const match = /content-length: *(\\d+)/i.exec(head);
+    if (buffer.length - headerEnd - 4 < (match ? Number(match[1]) : 0)) return;
+    requestLines.push(head.split("\\r\\n")[0]);
+    socket.write("HTTP/1.1 200 OK\\r\\nContent-Length: 0\\r\\n\\r\\n");
+    buffer = Buffer.alloc(0);
+  });
+});
+await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+const s3 = new Bun.S3Client({
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+  bucket: "bucket",
+  endpoint: "http://127.0.0.1:" + server.address().port,
+});
+
+for (const key of ["a\\\\b", "a/b", Buffer.alloc(500, " ").toString()]) {
+  await s3.write(key, "hello");
+}
+await s3.delete("a\\\\b");
+
+console.log(JSON.stringify(requestLines));
+process.exit(0);
+`;
+
+test("a backslash in an object key reaches the wire as %5C, not /", async () => {
+  using dir = tempDir("s3-key-encoding", { "fixture.ts": fixture });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    // The S3 client does not honor NO_PROXY, so an inherited proxy would
+    // hijack the request to the stub server.
+    env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim().slice(0, 120), exitCode }).toMatchObject({ exitCode: 0 });
+  expect(stderr).not.toContain("S3Error");
+
+  expect(JSON.parse(stdout)).toEqual([
+    "PUT /bucket/a%5Cb HTTP/1.1",
+    "PUT /bucket/a/b HTTP/1.1",
+    // A 1024-byte key can percent-encode to 3072 bytes; the signer must not
+    // reject it for overflowing its own buffer.
+    `PUT /bucket/${"%20".repeat(500)} HTTP/1.1`,
+    "DELETE /bucket/a%5Cb HTTP/1.1",
+  ]);
+});
+
+test("presign distinguishes a backslash from a slash", () => {
+  const s3 = new S3Client({
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+    bucket: "bucket",
+    endpoint: "http://s3.example.com",
+  });
+
+  expect(s3.presign("a\\b").split("?")[0]).toBe("http://s3.example.com/bucket/a%5Cb");
+  expect(s3.presign("a/b").split("?")[0]).toBe("http://s3.example.com/bucket/a/b");
+});
+
+test.each(["evil.example.com/other", "evil.example.com\\other"])(
+  "a virtual-hosted bucket name containing a path separator (%j) is rejected",
+  bucket => {
+    const s3 = new S3Client({
+      accessKeyId: "key",
+      secretAccessKey: "secret",
+      bucket,
+      region: "us-east-1",
+      virtualHostedStyle: true,
+    });
+
+    expect(() => s3.presign("object.txt")).toThrow(
+      expect.objectContaining({ code: "ERR_S3_INVALID_ENDPOINT" }),
+    );
+  },
+);

--- a/test/js/bun/s3/s3-key-encoding.test.ts
+++ b/test/js/bun/s3/s3-key-encoding.test.ts
@@ -81,13 +81,14 @@ test("presign distinguishes a backslash from a slash", () => {
 });
 
 // The 1024-byte S3 key limit holds whatever the key is made of, rather than
-// varying with how many of its bytes percent-encode.
+// varying with how many of its bytes percent-encode. A space triples in length,
+// a letter does not, so the accepted pair spans the encoder's whole range.
 test.each([
-  ["a", 1024, true],
-  ["a", 1025, false],
-  [" ", 1024, true],
-  [" ", 1025, false],
-])("a %j key of %i bytes is accepted: %j", (fill, length, accepted) => {
+  ["a", 1024, "a"],
+  ["a", 1025, null],
+  [" ", 1024, "%20"],
+  [" ", 1025, null],
+])("a %j key of %i bytes signs as %j per byte", (fill, length, encodedByte) => {
   const s3 = new S3Client({
     accessKeyId: "key",
     secretAccessKey: "secret",
@@ -96,11 +97,28 @@ test.each([
   });
   const key = Buffer.alloc(length, fill).toString();
 
-  if (accepted) {
-    expect(s3.presign(key)).toStartWith("http://s3.example.com/bucket/");
-  } else {
+  if (encodedByte === null) {
     expect(() => s3.presign(key)).toThrow(expect.objectContaining({ code: "ERR_S3_INVALID_PATH" }));
+  } else {
+    expect(s3.presign(key).split("?")[0]).toBe(`http://s3.example.com/bucket/${encodedByte.repeat(length)}`);
   }
+});
+
+// The canonical request the signature is computed over embeds the whole encoded
+// key, so its buffer has to keep up with the key buffer. A session token lands in
+// the same buffer and is what used to push it over.
+test("a maximal key signs alongside a session token", () => {
+  const s3 = new S3Client({
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+    bucket: "bucket",
+    region: "us-east-1",
+    sessionToken: Buffer.alloc(2000, "t").toString(),
+    endpoint: "http://s3.example.com",
+  });
+  const key = Buffer.alloc(1024, " ").toString();
+
+  expect(s3.presign(key).split("?")[0]).toBe(`http://s3.example.com/bucket/${"%20".repeat(1024)}`);
 });
 
 test.each(["evil.example.com/other", "evil.example.com\\other"])(


### PR DESCRIPTION
S3 object keys are raw byte strings: `\` is legal and names a different object than `/` does. `Bun.S3Client` rewrites it, so two distinct keys silently alias onto one object. The write succeeds, signed and accepted, and nothing reports a problem.

## Repro

```js
const s3 = new Bun.S3Client({ accessKeyId: "key", secretAccessKey: "secret", bucket: "b", endpoint });

await s3.write("a\\b", "hello"); // PUT /b/a/b
await s3.write("a/b", "hello");  // PUT /b/a/b  <- same object

s3.presign("a\\b"); // http://endpoint/b/a/b
s3.presign("a/b");  // http://endpoint/b/a/b
```

## Cause

`encode_uri_component`, which builds both the canonical path that gets signed and the request URL, substitutes the byte instead of percent-encoding it:

```rust
if !ENCODE_SLASH && (c == b'/' || c == b'\\') {
    buffer[written] = if c == b'\\' { b'/' } else { c };
```

Because the signature is computed over the already-rewritten path, the server sees a well-formed, correctly-signed request for the wrong key. There is no `SignatureDoesNotMatch` to surface it.

The same encoder is used for list-objects' `prefix` / `start-after` with `ENCODE_SLASH = true`, where `\` *is* percent-encoded to `%5C`. So `write("a\b")` and `list({ prefix: "a\b" })` already disagreed about what the key is.

## Fix

Percent-encode `\` like any other reserved byte, so it reaches the wire as `%5C`. This is what the AWS SDKs send.

Two things hang off that encoder and are handled in the same change:

- The virtual-hosted bucket check relied on the rewrite: a `\` collapsed to `/`, which a single `contains(b'/')` test then caught. Without the rewrite a crafted bucket could carry a `\` into the host, so the check now tests for both separators on the raw bucket name, before encoding. `"evil.example.com\other"` is still rejected with `ERR_S3_INVALID_ENDPOINT`.
- The key buffer was sized at 1024 bytes, the raw key limit, but percent-encoding expands up to 3x, so the old buffer rejected a 500-byte key of spaces with `ERR_S3_INVALID_PATH` while accepting a 1024-byte key of letters. A backslash now contributes to that expansion, so the buffer is sized for the worst-case encoded length and the 1024-byte S3 key limit is enforced on the raw key instead of emerging from the buffer's capacity. The limit no longer slides with how much of the key percent-encodes.
- The canonical request embeds that key, so its scratch buffer is sized from the same limits. Left at a fixed 4096 bytes, a near-maximal key plus a session token overflowed it and surfaced as `ERR_S3_INVALID_SIGNATURE` (internally `NoSpaceLeft`). `host` and `extra_path` are both slices of the endpoint and partition it, so a single endpoint budget covers both, and the encoded session token is capped at 2048 by `token_encoded_buffer`. The `search_params` overflow on the list-objects path (`sign_request::<true>`, where the query is built from unbounded user prefixes) is untouched and pre-existing; #32973 fixes that properly by heap-allocating.

`\` still works as the bucket/key separator when the bucket is taken from the path (`"bucket\key"`), and `normalize_name` still trims a leading or trailing one. Only the in-key rewrite goes away.

## Verification

`test/js/bun/s3/s3-key-encoding.test.ts`: `write`/`delete`/`presign` with `a\b` vs `a/b` against a stub that records the request line, a 500-byte key that needs the larger buffer, and both rejection cases for a bucket name containing a separator. The backslash and presign assertions fail on `main` (`PUT /bucket/a/b` twice) and pass with the fix.

The existing credentialed round-trip tests in `s3.test.ts` ("should allow backslashes in the path", the leading/trailing separator cases) write and read back the same key, so they are unaffected.

One cross-platform wrinkle the test has to account for: every S3 key argument is parsed as a path-like, and that parser rejects anything over `PATH_MAX` with `ENAMETOOLONG` before the signer runs. macOS sets `PATH_MAX` to 1024, exactly the size S3 allows for a key, so an over-long key is caught a layer earlier there than on Linux (`PATH_MAX` 4096). The key-length rows branch on that rather than asserting the Linux error code everywhere. No user-visible difference, since the two limits coincide.
