### PR TITLE
webcrypto: validate the view type and 65536-byte quota in getRandomValues

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -766,7 +766,7 @@ var require_wasi = __commonJS({
         kill: signal => {
           process.kill(process.pid, signal);
         },
-        randomFillSync: array => crypto.getRandomValues(array),
+        randomFillSync: require("node:crypto").randomFillSync,
         isTTY: fd => require("node:tty").isatty(fd),
         fs: require("node:fs"),
         path: require("node:path"),
@@ -1845,11 +1845,11 @@ var require_wasi = __commonJS({
             bindings.kill(constants_1.SIGNAL_MAP[sig]);
             return constants_1.WASI_ESUCCESS;
           },
-          random_get: (bufPtr, bufLen) => {
+          random_get: wrap((bufPtr, bufLen) => {
             this.refreshMemory();
-            crypto.getRandomValues(this.memory.buffer, bufPtr, bufLen);
-            return bufLen;
-          },
+            bindings.randomFillSync(new Uint8Array(this.memory.buffer), bufPtr, bufLen);
+            return constants_1.WASI_ESUCCESS;
+          }),
           sched_yield() {
             return constants_1.WASI_ESUCCESS;
           },

--- a/src/runtime/webcore/Crypto.rs
+++ b/src/runtime/webcore/Crypto.rs
@@ -1,8 +1,13 @@
 use bun_core::String as BunString;
 use bun_jsc::uuid::{self, UUID, UUID5, UUID7};
-use bun_jsc::{CallFrame, JSGlobalObject, JSUint8Array, JSValue, JsClass, JsResult, StringJsc};
+use bun_jsc::{
+    CallFrame, JSGlobalObject, JSType, JSUint8Array, JSValue, JsClass, JsError, JsResult, StringJsc,
+};
 
 use crate::node::Encoding;
+
+/// <https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues> step 2.
+const MAX_RANDOM_VALUES_BYTE_LENGTH: usize = 65536;
 
 // `.classes.ts`-backed type: the C++ JSCell wrapper stays generated C++.
 // This struct is the `m_ctx` payload. `toJS`/`fromJS`/`fromJSDirect` are
@@ -68,23 +73,24 @@ impl Crypto {
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let arguments = callframe.arguments();
-        if arguments.is_empty() {
-            return Err(global.throw_dom_exception(
-                bun_jsc::DOMExceptionCode::TypeMismatchError,
-                format_args!("The data argument must be an integer-type TypedArray"),
-            ));
-        }
 
-        let Some(mut array_buffer) = arguments[0].as_array_buffer(global) else {
+        let array = arguments
+            .first()
+            .and_then(|value| value.as_array_buffer(global))
+            .filter(|array| is_integer_typed_array(array.typed_array_type));
+
+        let Some(mut array) = array else {
             return Err(global.throw_dom_exception(
                 bun_jsc::DOMExceptionCode::TypeMismatchError,
                 format_args!("The data argument must be an integer-type TypedArray"),
             ));
         };
 
-        let slice = array_buffer.byte_slice_mut();
+        if array.byte_len > MAX_RANDOM_VALUES_BYTE_LENGTH {
+            return Err(throw_quota_exceeded(global));
+        }
 
-        random_data(global, slice);
+        random_data(global, array.byte_slice_mut());
 
         Ok(arguments[0])
     }
@@ -95,6 +101,13 @@ impl Crypto {
         global: &JSGlobalObject,
         array: &JSUint8Array,
     ) -> JSValue {
+        if array.len() > MAX_RANDOM_VALUES_BYTE_LENGTH {
+            // Throw, then return the empty value — the DOMJIT wrapper surfaces the
+            // pending exception (the C-ABI shim encodes it as zero).
+            let _ = throw_quota_exceeded(global);
+            return JSValue::ZERO;
+        }
+
         // `JSUint8Array::slice()` takes
         // `&mut self`; use ptr()/len() (which take `&self`) to avoid the &mut requirement.
         // SAFETY: JSC guarantees `ptr()` is valid for `len()` writable bytes while the
@@ -149,6 +162,30 @@ impl Crypto {
     pub fn constructor(global: &JSGlobalObject, _callframe: &CallFrame) -> JsResult<*mut Crypto> {
         Err(global.throw_illegal_constructor("Crypto"))
     }
+}
+
+fn throw_quota_exceeded(global: &JSGlobalObject) -> JsError {
+    global.throw_dom_exception(
+        bun_jsc::DOMExceptionCode::QuotaExceededError,
+        format_args!("The requested length exceeds 65,536 bytes"),
+    )
+}
+
+/// Step 1 of `getRandomValues`: `Float16Array`, `Float32Array`, `Float64Array`,
+/// `DataView` and `ArrayBuffer` are excluded.
+fn is_integer_typed_array(ty: JSType) -> bool {
+    matches!(
+        ty,
+        JSType::Int8Array
+            | JSType::Uint8Array
+            | JSType::Uint8ClampedArray
+            | JSType::Int16Array
+            | JSType::Uint16Array
+            | JSType::Int32Array
+            | JSType::Uint32Array
+            | JSType::BigInt64Array
+            | JSType::BigUint64Array
+    )
 }
 
 fn random_data(global: &JSGlobalObject, slice: &mut [u8]) {

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -85,6 +85,34 @@ it("path_open reports the host errno to the guest when the open fails", () => {
   expect(wasi.FD_MAP.has(4)).toBe(false);
 });
 
+it("random_get succeeds and only writes the requested range of memory", () => {
+  const WASI_ESUCCESS = 0;
+  const wasi = new WASI({});
+  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+  const memory = new Uint8Array(wasi.memory.buffer);
+
+  const bufPtr = 1024;
+  const bufLen = 32;
+
+  expect(wasi.wasiImport.random_get(bufPtr, bufLen)).toBe(WASI_ESUCCESS);
+  expect(memory.subarray(bufPtr, bufPtr + bufLen).some(byte => byte !== 0)).toBe(true);
+  expect(memory.subarray(0, bufPtr).every(byte => byte === 0)).toBe(true);
+  expect(memory.subarray(bufPtr + bufLen).every(byte => byte === 0)).toBe(true);
+});
+
+it("random_get returns an errno for a span outside of guest memory", () => {
+  const WASI_EINVAL = 28;
+  const wasi = new WASI({});
+  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+  const memory = new Uint8Array(wasi.memory.buffer);
+  const pageSize = memory.length;
+
+  // A guest can hand us any pointer and length; the span must not escape as a throw.
+  expect(wasi.wasiImport.random_get(pageSize - 4, 100)).toBe(WASI_EINVAL);
+  expect(wasi.wasiImport.random_get(-1, 8)).toBe(WASI_EINVAL);
+  expect(memory.every(byte => byte === 0)).toBe(true);
+});
+
 it("path_* syscalls cannot escape the preopened directory", () => {
   using dir = tempDir("wasi-sandbox", {
     "secret.txt": "outside",

--- a/test/js/node/test/parallel/test-webcrypto-random.js
+++ b/test/js/node/test/parallel/test-webcrypto-random.js
@@ -11,11 +11,9 @@ const { crypto } = globalThis;
 
 [
   undefined, null, '', 1, {}, [],
-
-  // These types are allowed in Bun
-  // new Float32Array(1),
-  // new Float64Array(1),
-  // new DataView(new ArrayBuffer(1)),
+  new Float32Array(1),
+  new Float64Array(1),
+  new DataView(new ArrayBuffer(1)),
 ].forEach((i) => {
   assert.throws(
     () => crypto.getRandomValues(i),
@@ -38,10 +36,6 @@ const intTypedConstructors = [
   Uint8ClampedArray,
   BigInt64Array,
   BigUint64Array,
-
-  Float16Array,
-  Float32Array,
-  Float64Array,
 ];
 
 for (const ctor of intTypedConstructors) {
@@ -68,14 +62,12 @@ for (const ctor of intTypedConstructors) {
     // Ignore if error here.
   }
 
-  // Bun allows more than 65536 bytes
-
-  // if (kData !== undefined) {
-  //   assert.throws(
-  //     () => crypto.getRandomValues(kData),
-  //     { name: 'QuotaExceededError', code: 22 },
-  //   );
-  // }
+  if (kData !== undefined) {
+    assert.throws(
+      () => crypto.getRandomValues(kData),
+      { name: 'QuotaExceededError', code: 22 },
+    );
+  }
 }
 
 {

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -207,6 +207,102 @@ describe("Web Crypto", () => {
   });
 });
 
+// https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues
+describe("crypto.getRandomValues", () => {
+  const typeMismatch = {
+    name: "TypeMismatchError",
+    code: 17,
+    message: "The data argument must be an integer-type TypedArray",
+  };
+  const quotaExceeded = {
+    name: "QuotaExceededError",
+    code: 22,
+    message: "The requested length exceeds 65,536 bytes",
+  };
+
+  const bytesOf = (view: ArrayBufferView) =>
+    new Uint8Array(view.buffer as ArrayBuffer, view.byteOffset, view.byteLength);
+
+  function expectRejected(argument: unknown, expected: typeof typeMismatch) {
+    let error: any;
+    try {
+      crypto.getRandomValues(argument as any);
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(DOMException);
+    expect({ name: error.name, code: error.code, message: error.message }).toEqual(expected);
+  }
+
+  const integerViews: [string, new (length: number) => ArrayBufferView][] = [
+    ["Int8Array", Int8Array],
+    ["Uint8Array", Uint8Array],
+    ["Uint8ClampedArray", Uint8ClampedArray],
+    ["Int16Array", Int16Array],
+    ["Uint16Array", Uint16Array],
+    ["Int32Array", Int32Array],
+    ["Uint32Array", Uint32Array],
+    ["BigInt64Array", BigInt64Array],
+    ["BigUint64Array", BigUint64Array],
+  ];
+
+  for (const [name, ctor] of integerViews) {
+    it(`fills a ${name}`, () => {
+      const view = new ctor(8);
+      expect(crypto.getRandomValues(view)).toBe(view);
+      expect(bytesOf(view).some(byte => byte !== 0)).toBe(true);
+    });
+  }
+
+  const rejectedArguments: [string, () => unknown][] = [
+    ["Float16Array", () => new Float16Array(4)],
+    ["Float32Array", () => new Float32Array(4)],
+    ["Float64Array", () => new Float64Array(4)],
+    ["DataView", () => new DataView(new ArrayBuffer(8))],
+    ["ArrayBuffer", () => new ArrayBuffer(8)],
+    ["SharedArrayBuffer", () => new SharedArrayBuffer(8)],
+    ["plain object", () => ({})],
+    ["null", () => null],
+  ];
+
+  for (const [name, make] of rejectedArguments) {
+    it(`throws TypeMismatchError for ${name}`, () => {
+      expectRejected(make(), typeMismatch);
+    });
+  }
+
+  it("leaves a non-integer view untouched", () => {
+    const view = new Float64Array(4);
+    expectRejected(view, typeMismatch);
+    expect(bytesOf(view).every(byte => byte === 0)).toBe(true);
+  });
+
+  it("allows exactly 65536 bytes", () => {
+    const view = new Uint8Array(65536);
+    expect(crypto.getRandomValues(view)).toBe(view);
+    expect(view.some(byte => byte !== 0)).toBe(true);
+  });
+
+  const oversized: [string, () => ArrayBufferView][] = [
+    ["Uint8Array", () => new Uint8Array(65537)],
+    ["Uint32Array", () => new Uint32Array(16385)],
+    ["BigInt64Array", () => new BigInt64Array(8193)],
+    ["Buffer", () => Buffer.alloc(65537)],
+  ];
+
+  for (const [name, make] of oversized) {
+    it(`throws QuotaExceededError for an oversized ${name}`, () => {
+      const view = make();
+      expectRejected(view, quotaExceeded);
+      expect(bytesOf(view).every(byte => byte === 0)).toBe(true);
+    });
+  }
+
+  it("checks the view type before the quota", () => {
+    expectRejected(new DataView(new ArrayBuffer(65537)), typeMismatch);
+  });
+});
+
 describe("oversized inputs", () => {
   // Every SubtleCrypto entry point copies its BufferSource argument into a
   // WTF::Vector<uint8_t>, whose capacity is capped below the maximum legal

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,5 +1,6 @@
 import { file, spawn, version } from "bun";
 import { describe, expect, test } from "bun:test";
+import { randomFillSync } from "crypto";
 import { bunEnv, bunExe, exampleSite } from "harness";
 
 const exampleServer = exampleSite("http");
@@ -35,6 +36,9 @@ const bufferTypes = [
   Float32Array,
   Float64Array,
 ];
+
+// crypto.getRandomValues() only accepts integer-typed views of at most 65536 bytes.
+const fillRandom = <T>(buffer: T): T => randomFillSync(buffer as any) as T;
 
 const utf8 = [
   {
@@ -82,11 +86,11 @@ for (const { body, fn } of bodyTypes) {
           },
           {
             label: "small buffer",
-            buffer: () => crypto.getRandomValues(new bufferType(1_000)),
+            buffer: () => fillRandom(new bufferType(1_000)),
           },
           {
             label: "large buffer",
-            buffer: () => crypto.getRandomValues(new bufferType(1_000_000)),
+            buffer: () => fillRandom(new bufferType(1_000_000)),
           },
         ];
         describe(bufferType.name, () => {

--- a/test/js/web/fetch/fetch-compress.test.ts
+++ b/test/js/web/fetch/fetch-compress.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";
+import { randomFillSync } from "node:crypto";
 import { join } from "node:path";
 import { brotliDecompressSync, gunzipSync, inflateSync, zstdDecompressSync } from "node:zlib";
 
@@ -209,7 +210,8 @@ describe("fetch compress option", () => {
         });
       },
     });
-    const big = crypto.getRandomValues(Buffer.alloc(600 * 1024));
+    // crypto.getRandomValues() is capped at 65536 bytes per the WebCrypto spec.
+    const big = randomFillSync(Buffer.alloc(600 * 1024));
     const res = await fetch(server.url, {
       method: "POST",
       body: big,

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -51,9 +51,6 @@ afterAll(() => {
   httpsServer.stop();
 });
 
-const payload = new Uint8Array(1024 * 1024 * 2);
-crypto.getRandomValues(payload);
-
 it("new Request(invalid url) throws", () => {
   expect(() => new Request("http")).toThrow();
   expect(() => new Request("")).toThrow();


### PR DESCRIPTION
## Repro

```js
crypto.getRandomValues(new Float64Array(4));                    // node/browsers: TypeMismatchError
crypto.getRandomValues(new DataView(new ArrayBuffer(65537)));   // node/browsers: TypeMismatchError
crypto.getRandomValues(new Uint8Array(65537));                  // node/browsers: QuotaExceededError
// bun 1.4.0 and main: all three are silently filled
```

## Cause

`Crypto::get_random_values` accepted anything `JSValue::asArrayBuffer` recognized, which
includes `DataView`, the float views, `ArrayBuffer` and `SharedArrayBuffer`, and it never
looked at the byte length. Both checks in
[the spec](https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues) were missing:

1. throw `TypeMismatchError` unless the argument is an integer-typed view
2. throw `QuotaExceededError` if its byte length exceeds 65536

Those two steps were a known gap rather than a deliberate deviation: #19264 added the
`TypeMismatchError` path for a missing or non-buffer argument and states in its own
description that it "does not throw errors for buffers larger than 65kb or float buffers".
The commented-out assertions in `test-webcrypto-random.js` are the note of what was left.

Meanwhile, code written against Bun ships patterns that throw everywhere else, and libraries
that use the errors for feature detection (chunking a large request through the CSPRNG, for
example) take the wrong branch.

## Fix

Both steps now run at the top of `getRandomValues`, in spec order, with the same error names,
codes and messages Node produces. The quota is also enforced on the DOMJIT fast path, which
only receives `Uint8Array` and so already satisfies step 1.

`node:wasi` was the one in-tree caller that depended on the missing validation:

```js
random_get: (bufPtr, bufLen) => {
  this.refreshMemory();
  crypto.getRandomValues(this.memory.buffer, bufPtr, bufLen);  // offset + length ignored
  return bufLen;
},
```

`memory.buffer` is the whole WebAssembly linear memory and the extra arguments were dropped,
so `random_get` overwrote *all* of guest memory with random bytes on every call, then returned
`bufLen` where WASI expects an errno. It now matches upstream `wasi-js`:
`bindings.randomFillSync(new Uint8Array(this.memory.buffer), bufPtr, bufLen)` followed by
`return WASI_ESUCCESS`, routed through the file's `wrap()` helper so that an out-of-range
guest span comes back as `EINVAL` rather than escaping as a `RangeError` and trapping the
instance. #22664 by @mattfysh reported and fixed the same `random_get` bugs; this PR carries
that fix because the `getRandomValues` validation above would otherwise make `random_get`
throw, and adds the regression tests.

## Verification

| argument | before | after / node 26 |
| --- | --- | --- |
| `new Float64Array(4)` | filled | `TypeMismatchError` (code 17) |
| `new DataView(new ArrayBuffer(8))` | filled | `TypeMismatchError` (code 17) |
| `new ArrayBuffer(8)` | filled | `TypeMismatchError` (code 17) |
| `new Uint8Array(65536)` | filled | filled |
| `new Uint8Array(65537)` | filled | `QuotaExceededError` (code 22) |
| `new Uint32Array(16385)` | filled | `QuotaExceededError` (code 22) |

- `test/js/web/crypto/web-crypto.test.ts` covers every integer view, every rejected type
  (including `Float16Array`), the exact 65536/65537 boundary, that a rejected view is left
  untouched, and that step 1 runs before step 2 (`DataView(65537)` is a `TypeMismatchError`,
  not a quota error).
- `test/js/node/test/parallel/test-webcrypto-random.js` is only *un-modified* here: the
  float-view and quota assertions Bun had commented out are restored, and the three float
  constructors Bun had added to `intTypedConstructors` are removed. Nothing Bun-specific is
  added, so the file matches upstream Node apart from the quota-assertion vintage already
  carried in the vendored copy (upstream now also asserts `err instanceof QuotaExceededError`
  and `err.quota` / `err.requested`, which need the `QuotaExceededError` interface Bun does
  not implement yet).
- `test/js/bun/wasm/wasi.test.js` asserts `random_get` returns `WASI_ESUCCESS`, writes only
  `[bufPtr, bufPtr + bufLen)`, leaves the rest of memory zeroed, and returns `EINVAL` for a
  span that falls outside of guest memory.
- Three existing tests passed buffers that the spec rejects (`ArrayBuffer`/`SharedArrayBuffer`/
  float views in `body.test.ts`, 600 KB and 2 MB buffers in `fetch-compress.test.ts` and
  `fetch.test.ts`) and now use `randomFillSync`, which has no type or size restriction. The
  2 MB `payload` in `fetch.test.ts` had no remaining users, so it is removed rather than
  rewritten.
