### PR TITLE
crypto: X509Certificate.checkHost() returns the subject name that matched

### DIFF
--- a/src/jsc/bindings/JSX509Certificate.cpp
+++ b/src/jsc/bindings/JSX509Certificate.cpp
@@ -623,12 +623,12 @@ static bool handleMatchResult(JSGlobalObject* globalObject, ASCIILiteral errorMe
     }
 }
 
-bool JSX509Certificate::checkHost(JSGlobalObject* globalObject, std::span<const char> name, uint32_t flags)
+bool JSX509Certificate::checkHost(JSGlobalObject* globalObject, std::span<const char> name, uint32_t flags, ncrypto::DataPointer* peerName)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto result = view().checkHost(name, flags);
+    auto result = view().checkHost(name, flags, peerName);
     return handleMatchResult(globalObject, "Invalid name"_s, scope, result);
 }
 

--- a/src/jsc/bindings/JSX509Certificate.h
+++ b/src/jsc/bindings/JSX509Certificate.h
@@ -65,7 +65,9 @@ public:
     JSValue publicKey();
 
     // Certificate validation methods
-    bool checkHost(JSGlobalObject*, std::span<const char>, uint32_t flags);
+    // `peerName`, when provided, receives the subject name that matched, which
+    // can differ from the queried host (wildcard SANs, case-insensitive matches).
+    bool checkHost(JSGlobalObject*, std::span<const char>, uint32_t flags, ncrypto::DataPointer* peerName = nullptr);
     bool checkEmail(JSGlobalObject*, std::span<const char>, uint32_t flags);
     bool checkIP(JSGlobalObject*, const char*);
     bool checkIssued(JSGlobalObject*, JSX509Certificate* issuer);

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -306,9 +306,16 @@ JSC_DEFINE_HOST_FUNCTION(jsX509CertificateProtoFuncCheckHost, (JSGlobalObject * 
 
     Bun::UTF8View hostView(view);
 
-    auto check = thisObject->checkHost(globalObject, hostView.span(), flags);
+    ncrypto::DataPointer peerName;
+    auto check = thisObject->checkHost(globalObject, hostView.span(), flags, &peerName);
     RETURN_IF_EXCEPTION(scope, {});
     if (!check) return JSValue::encode(jsUndefined());
+    // Node returns the subject name that matched, which differs from the query
+    // for wildcard SAN entries and for case-insensitive matches.
+    if (peerName) {
+        auto matched = WTF::String::fromUTF8WithLatin1Fallback(peerName.span());
+        return JSValue::encode(jsString(vm, WTF::move(matched)));
+    }
     return JSValue::encode(hostString);
 }
 

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -313,7 +313,7 @@ JSC_DEFINE_HOST_FUNCTION(jsX509CertificateProtoFuncCheckHost, (JSGlobalObject * 
     // Node returns the subject name that matched, which differs from the query
     // for wildcard SAN entries and for case-insensitive matches.
     if (peerName) {
-        auto matched = WTF::String::fromUTF8WithLatin1Fallback(peerName.span());
+        auto matched = WTF::String::fromUTF8ReplacingInvalidSequences(peerName.span());
         return JSValue::encode(jsString(vm, WTF::move(matched)));
     }
     return JSValue::encode(hostString);

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { X509Certificate } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Self-signed, valid until 2126. Subject CN=wildcard-san.example.com,
+// subjectAltName: DNS:*.wildcard.example.com, DNS:exact.example.com
+const wildcardSanCertPem = `-----BEGIN CERTIFICATE-----
+MIIDKDCCAhCgAwIBAgIBATANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDDBh3aWxk
+Y2FyZC1zYW4uZXhhbXBsZS5jb20wIBcNMjYwNzAzMDY1MDAxWhgPMjEyNjA2MDkw
+NjUwMDFaMCMxITAfBgNVBAMMGHdpbGRjYXJkLXNhbi5leGFtcGxlLmNvbTCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMEOoI3qCSq9CdlwWhHFf8xdUbhC
+jp0MCgmRKqJh0JppBPykV808jOZeyZpFvtE3wM68YwsrVSwqrZgrClEb0GzYIpFI
+Mxo5YoCIOluU6EL7ll/z7WyJ0SyfnSRt5braMXP3UQXYWv5XwDBFu1gXX6oC6o0S
+0SJZTo4qg0agS9g17f1TmyUYA4wNDmEPS2hN6p3J+2uEIZE4GqxLgkvv8ON4iC2m
+3/8xB5qGnZA+IT3f0dWC4IcMSeXSiWGyuEA+6/Otn/Iz073bOXAFkhv9DwXZca0O
+YI6ecmwAFDjH6hBgX3jjwZL6Os1AZ/w9vLlb7vxEvdg9YiDEi/Io8sInkzcCAwEA
+AaNlMGMwDAYDVR0TAQH/BAIwADA0BgNVHREELTArghYqLndpbGRjYXJkLmV4YW1w
+bGUuY29tghFleGFjdC5leGFtcGxlLmNvbTAdBgNVHQ4EFgQUXkMY5bxwAaEAOtb7
+v8++jiYQvbswDQYJKoZIhvcNAQELBQADggEBAKTfuXjBbtAvFyk2+pdqMzcQJlDl
+eu1N06IvkTip0/Z0CKeRstkrqqmcspeHss7l/bnWXT83wUsZ2OJAM2dAxG7IsOPU
+fsGlO6BSvzzPfsA/sGpxNxWitXtQAjGRDSw12xQ+KAgG3Outyc2aPeEkzcVV2SBm
+o5JV0Big7OjvV0VQhN/6lrqSSknx0ZC2nV8GtWwew/mQP+MsuHsrmNTirH+raXBl
+fzCNBW+YrUHAgV7gxvsqtld5sp+AA6rO9SO4kOCeXwxnJhxIafI8D2tZqNUf04LW
+xoF/4xgOUMNvA8O5H/sm5QwghflFqkpuvqdeYHLNzb0yWUvPvtTfYiA7+vo=
+-----END CERTIFICATE-----
+`;
+
+// CN=agent1, no subjectAltName, so the subject is the only thing to match against.
+const cnOnlyCertPem = readFileSync(path.join(import.meta.dir, "..", "test", "fixtures", "keys", "agent1-cert.pem"));
+
+describe("X509Certificate.checkHost()", () => {
+  const cert = new X509Certificate(wildcardSanCertPem);
+  const cnOnly = new X509Certificate(cnOnlyCertPem);
+
+  test.each([
+    ["sub.wildcard.example.com", "*.wildcard.example.com"],
+    ["SUB.WILDCARD.EXAMPLE.COM", "*.wildcard.example.com"],
+    ["exact.example.com", "exact.example.com"],
+    ["EXACT.EXAMPLE.COM", "exact.example.com"],
+  ])("%p returns the subjectAltName entry that matched", (host, matched) => {
+    expect(cert.checkHost(host)).toBe(matched);
+  });
+
+  test.each([
+    "a.b.wildcard.example.com", // wildcards match a single label by default
+    "wildcard.example.com", // "*." requires at least one label
+    "wildcard-san.example.com", // the subject CN is skipped when a SAN is present
+    "nomatch.example.org",
+  ])("%p does not match", host => {
+    expect(cert.checkHost(host)).toBeUndefined();
+  });
+
+  test("wildcards: false only disables the wildcard entry", () => {
+    expect(cert.checkHost("sub.wildcard.example.com", { wildcards: false })).toBeUndefined();
+    expect(cert.checkHost("exact.example.com", { wildcards: false })).toBe("exact.example.com");
+  });
+
+  test.each(["agent1", "AGENT1", "AgEnT1"])("%p falls back to the subject CN and returns it", host => {
+    expect(cnOnly.checkHost(host)).toBe("agent1");
+  });
+
+  test("subject: 'never' disables the subject CN fallback", () => {
+    expect(cnOnly.checkHost("agent1", { subject: "never" })).toBeUndefined();
+    expect(cnOnly.checkHost("agent2")).toBeUndefined();
+  });
+
+  test("checkEmail and checkIP are unaffected", () => {
+    expect(cnOnly.checkEmail("ry@tinyclouds.org")).toBe("ry@tinyclouds.org");
+    expect(cnOnly.checkEmail("ry@TINYCLOUDS.ORG")).toBe("ry@TINYCLOUDS.ORG");
+    expect(cnOnly.checkEmail("sally@example.com")).toBeUndefined();
+    expect(cnOnly.checkIP("127.0.0.1")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### What

`X509Certificate.checkHost()` returned the host string the caller passed in instead of the subject name that actually matched. Node returns the matching name, which is what the return value is for: with a wildcard SAN you cannot otherwise tell which entry hit.

### Repro

```js
const { X509Certificate } = require("node:crypto");
// SAN: DNS:*.wildcard.example.com, DNS:exact.example.com
const cert = new X509Certificate(pem);

cert.checkHost("sub.wildcard.example.com");
// node: "*.wildcard.example.com"
// bun:  "sub.wildcard.example.com"   <- the query echoed back

cert.checkHost("EXACT.EXAMPLE.COM");
// node: "exact.example.com"
// bun:  "EXACT.EXAMPLE.COM"
```

Non-matches correctly returned `undefined` on both.

### Cause

`X509_check_host` reports the matching name through its `peername` out-parameter, and `ncrypto::X509View::checkHost` already plumbs it into a `DataPointer`. `jsX509CertificateProtoFuncCheckHost` never passed one, and unconditionally returned the `hostString` it had coerced from `arg0`.

### Fix

Thread the `peerName` out-parameter from `X509View::checkHost` up through `JSX509Certificate::checkHost` into the prototype function, and return it when set. This is the same shape as Node's `X509Certificate::CheckHost`, including the fallback to the query when the out-parameter is left unset. `checkEmail` / `checkIP` keep echoing the query, also matching Node.

### Verification

`test/js/node/crypto/x509.test.ts` covers the matched-name matrix against a committed wildcard-SAN cert plus the existing CN-only `agent1-cert.pem` fixture: wildcard SAN, exact SAN, case-insensitive SAN, subject CN fallback, case-insensitive CN, `wildcards: false`, `subject: 'never'`, and the non-matching cases. 5 of the 14 fail on `main`, all 14 pass with this change. Node's upstream `test-crypto-x509.js` and the rest of `test/js/node/crypto/` still pass.

Re-ran the matched path 20k times under ASAN to confirm the `DataPointer` frees the `OPENSSL_strndup`'d name: no leaks attributable to it.

### Not covered

Two other `checkHost` divergences from Node are BoringSSL limitations rather than bugs here, and would need wildcard matching implemented outside of `X509_check_host`:

- `{ multiLabelWildcards: true }` is ignored (`X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS` is `#define`d to `0`)
- `{ subject: "always" }` is ignored (same, and BoringSSL never consults the subject when a SAN is present)
