### PR TITLE
stream: keep chunk order in Readable.fromWeb()

### DIFF
--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -49,6 +49,7 @@ class ReadableFromWeb extends Readable {
   #closed;
   #pendingChunks;
   #stream;
+  #reading;
 
   constructor(options, stream) {
     const { objectMode, highWaterMark, encoding, signal } = options;
@@ -62,6 +63,7 @@ class ReadableFromWeb extends Readable {
     this.#reader = undefined;
     this.#stream = stream;
     this.#closed = false;
+    this.#reading = false;
   }
 
   #drainPending() {
@@ -95,6 +97,19 @@ class ReadableFromWeb extends Readable {
 
   async _read() {
     $debug("ReadableFromWeb _read()", this.__id);
+    // Readable calls _read() again as soon as push() is called, but #pump()
+    // pushes many chunks per call. Two pumps hold two read requests on the same
+    // reader, and readMany() drains the queue into whichever settles first.
+    if (this.#reading) return;
+    this.#reading = true;
+    try {
+      await this.#pump();
+    } finally {
+      this.#reading = false;
+    }
+  }
+
+  async #pump() {
     var stream = this.#stream,
       reader = this.#reader;
     if (stream) {

--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -95,32 +95,30 @@ class ReadableFromWeb extends Readable {
     return;
   }
 
-  async _read() {
+  _read() {
     $debug("ReadableFromWeb _read()", this.__id);
     // Readable calls _read() again as soon as push() is called, but #pump()
     // pushes many chunks per call. Two pumps hold two read requests on the same
     // reader, and readMany() drains the queue into whichever settles first.
     if (this.#reading) return;
     this.#reading = true;
-    try {
-      await this.#pump();
-    } finally {
-      this.#reading = false;
-    }
+    return this.#pump();
   }
 
   async #pump() {
-    var stream = this.#stream,
-      reader = this.#reader;
-    if (stream) {
-      reader = this.#reader = stream.getReader();
-      this.#stream = undefined;
-    } else if (this.#drainPending()) {
-      return;
-    }
-
-    var deferredError: Error | undefined;
+    // #reading must be cleared as the body exits, not one microtask later: a
+    // paused-mode read() loop calls _read() again without yielding, and
+    // Readable leaves kReading set when _read() neither pushes nor pumps.
     try {
+      var stream = this.#stream,
+        reader = this.#reader;
+      if (stream) {
+        reader = this.#reader = stream.getReader();
+        this.#stream = undefined;
+      } else if (this.#drainPending()) {
+        return;
+      }
+
       do {
         var done = false,
           value;
@@ -154,11 +152,9 @@ class ReadableFromWeb extends Readable {
           }
         }
       } while (!this.#closed);
-    } catch (e) {
-      deferredError = e as Error;
+    } finally {
+      this.#reading = false;
     }
-
-    if (deferredError) throw deferredError;
   }
 
   _destroy(error, callback) {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -735,6 +735,45 @@ describe("webstreams adapters (Node v26 sync)", () => {
     expect(chunks).toEqual(expected);
   });
 
+  // Paused mode drains inside the 'readable' handler, so no microtask runs
+  // between read() calls. _read() has to be able to start the next pump on
+  // every one of them or the stream stalls with kReading stuck on.
+  it.each([1, 2, 16])(
+    "Readable.fromWeb(Readable.toWeb()) preserves chunk order in paused mode (highWaterMark: %i)",
+    async highWaterMark => {
+      const expected = Array.from({ length: 30 }, (_, i) => `p${i}`);
+      const src = Readable.from(expected);
+      const dst = Readable.fromWeb(Readable.toWeb(src), { objectMode: true, highWaterMark });
+
+      const { promise, resolve, reject } = Promise.withResolvers();
+      const chunks = [];
+      dst.on("readable", () => {
+        let chunk;
+        while ((chunk = dst.read()) !== null) chunks.push(chunk);
+      });
+      dst.on("end", resolve);
+      dst.on("error", reject);
+      await promise;
+
+      expect(chunks).toEqual(expected);
+    },
+  );
+
+  it("Readable.fromWeb(Readable.toWeb()) preserves chunk order in flowing mode", async () => {
+    const expected = Array.from({ length: 30 }, (_, i) => `f${i}`);
+    const src = Readable.from(expected);
+    const dst = Readable.fromWeb(Readable.toWeb(src), { objectMode: true, highWaterMark: 1 });
+
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const chunks = [];
+    dst.on("data", chunk => chunks.push(chunk));
+    dst.on("end", resolve);
+    dst.on("error", reject);
+    await promise;
+
+    expect(chunks).toEqual(expected);
+  });
+
   // Upstream: v26 Writable.toWeb wraps (Shared)ArrayBuffer chunks in a
   // Uint8Array before writing to the Node stream.
   it("Writable.toWeb accepts ArrayBuffer chunks", async () => {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -701,6 +701,40 @@ describe("webstreams adapters (Node v26 sync)", () => {
     duplex.destroy();
   });
 
+  // Readable.fromWeb()'s pump pushes several chunks per _read(), and Readable
+  // calls _read() again as soon as push() is called. Two pumps racing on one
+  // reader used to hand back the chunks out of order.
+  it("Readable.fromWeb(Readable.toWeb()) preserves chunk order", async () => {
+    const src = Readable.from(["A", "B", "C", "D", "E", "F"]);
+    const chunks = [];
+    for await (const chunk of Readable.fromWeb(Readable.toWeb(src))) {
+      chunks.push(chunk.toString());
+    }
+    expect(chunks.join("")).toBe("ABCDEF");
+  });
+
+  it("Readable.fromWeb(Readable.toWeb()) preserves chunk order in object mode", async () => {
+    const expected = Array.from({ length: 30 }, (_, i) => `chunk-${i}`);
+    const src = Readable.from(expected);
+    const chunks = [];
+    for await (const chunk of Readable.fromWeb(Readable.toWeb(src), { objectMode: true })) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual(expected);
+  });
+
+  it("Readable.fromWeb(Readable.toWeb()) preserves chunk order under backpressure", async () => {
+    const expected = Array.from({ length: 25 }, (_, i) => `x${i}`);
+    const src = Readable.from(expected);
+    const dst = Readable.fromWeb(Readable.toWeb(src), { objectMode: true, highWaterMark: 2 });
+    const chunks = [];
+    for await (const chunk of dst) {
+      chunks.push(chunk);
+      await null;
+    }
+    expect(chunks).toEqual(expected);
+  });
+
   // Upstream: v26 Writable.toWeb wraps (Shared)ArrayBuffer chunks in a
   // Uint8Array before writing to the Node stream.
   it("Writable.toWeb accepts ArrayBuffer chunks", async () => {


### PR DESCRIPTION
`Readable.fromWeb(Readable.toWeb(src))` deterministically reorders chunks. Each adapter is correct on its own; the composition permutes the stream.

```js
import { Readable } from "node:stream";

const src = Readable.from(["A", "B", "C", "D", "E", "F"]);
const out = [];
for await (const chunk of Readable.fromWeb(Readable.toWeb(src))) out.push(String(chunk));
console.log(out.join(""));
// node: ABCDEF
// bun:  ABCEDF
```

The permutation is stable across runs and gets worse with more chunks (30 chunks come back as `c0 c1 c2 c4 c3 c5 c8 c6 c7 c12 ...`).

## Cause

`ReadableFromWeb._read()` in `src/js/internal/webstreams_adapters.ts` is a pump: it loops on `reader.readMany()` and pushes every chunk it gets back, until `push()` returns false. But `Readable` calls `_read()` again as soon as `push()` is called, so the pump's first `push()` lets a second `_read()` start while the first is still awaiting `readMany()`.

Two pumps means two pending read requests on the same reader. The controller hands incoming chunks to read requests in arrival order, but `readMany()` also drains the controller queue and appends it to its own chunk. So with pumps P1 and P2 outstanding:

- `C` fulfills P1's read request
- `D` fulfills P2's read request
- `E` has no pending request left, so it lands in the controller queue
- P1's reaction runs first and returns `[C, E]`, then P2's returns `[D]`

which is where `C E D` comes from. `Readable.toWeb()` is what makes the window reachable: its `pull()` resumes the node stream, which emits several `data` events in one turn, so chunks arrive while more than one read request is parked.

## Fix

Let only one pump run at a time, and release the guard as the pump body exits rather than a microtask later.

That second half matters: `await <resolved>` always yields, so holding the guard across `await this.#pump()` in `_read()` would keep it set for one microtask after a pump that returned synchronously through `#drainPending()`. A paused-mode consumer never yields inside `while ((c = r.read()) !== null)`, so the next `read()` would set `kReading`, hit the guard, and return without pushing. Nothing clears `kReading` after that (`maybeReadMore_` skips while it is set), and the stream stalls with chunks stranded in `#pendingChunks`. Putting the release in `#pump()`'s own `finally` removes the gap, because an async function body that returns before its first `await` runs its `finally` synchronously. `#reading` is then set only while a pump is executing or parked on `await readMany()`, which is exactly when another `push()` is still coming.

This also removes a second hazard, where two pumps would clobber each other's `#pendingChunks` (`this.#pendingChunks = value.slice(i + 1)` is an assignment, not an append).

## Verification

Seven tests in `test/js/node/stream/node-stream.test.js` covering all three consumption modes:

| | |
|---|---|
| `for await` | the 6-chunk repro, a 30-chunk object-mode round trip, and `highWaterMark: 2` backpressure |
| paused (`on('readable')` + `while (read())`) | `highWaterMark` 1, 2 and 16 |
| flowing (`on('data')`) | `highWaterMark: 1` |

Four of the seven fail on `main`. The `highWaterMark: 1` paused case is the one that stalls if the guard is released a microtask late.

<details>
<summary>Suites run with the debug build</summary>

- `test/js/node/stream/` 76 pass / 0 fail
- the 3 `test-webstreams-*` node-compat files: 70 pass / 0 fail
- all 254 `test/js/node/test/parallel/test-stream*.js` / `test-readable*.js`: same 4 pre-existing failures with and without the diff (`test-stream-pipeline.js`, `test-stream-wrap{,-drain,-encoding}.js`)
- `test/js/web/streams/streams.test.js`: same 2 pre-existing debug-build timeouts with and without the diff
- round trips of 2/3/6/17/30/64/200/1000 chunks, `highWaterMark` 1/2/3/8/16/64, `Duplex.from(ReadableStream)`, and binary (non-object-mode) mode all preserve order

</details>
