### PR TITLE
Make mock functions return an object when used as a constructor

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -826,7 +827,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static EncodedJSValue invokeMockFunction(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -838,7 +839,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -979,6 +979,27 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return invokeMockFunction(lexicalGlobalObject, callframe, callframe->thisValue());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // A [[Construct]] implemented in C++ must create `this` itself and must always return an object.
+    JSC::Structure* structure = JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, asObject(callframe->newTarget()), lexicalGlobalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    JSC::JSObject* thisObject = JSC::constructEmptyObject(vm, structure);
+
+    JSValue result = JSValue::decode(invokeMockFunction(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return JSValue::encode(result.isObject() ? result : thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,59 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  describe("used as a constructor", () => {
+    test("returns a new object when there is no implementation", () => {
+      const fn = jest.fn();
+      expect(typeof new fn()).toBe("object");
+      expect(typeof Reflect.construct(fn, [])).toBe("object");
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test.each([
+      ["undefined", undefined],
+      ["a string", "a string"],
+      ["a number", 1234],
+      ["a boolean", true],
+      ["a symbol", Symbol.iterator],
+      ["a bigint", 1234n],
+      ["null", null],
+    ])("ignores an implementation returning %s", (_label, returnValue) => {
+      const fn = jest.fn(() => returnValue);
+      expect(typeof new fn()).toBe("object");
+      expect(typeof Reflect.construct(fn, [])).toBe("object");
+      expect(fn()).toBe(returnValue);
+    });
+
+    test("returns the object an implementation returns", () => {
+      const returnValue = { a: 1 };
+      const fn = jest.fn(() => returnValue);
+      expect(new fn()).toBe(returnValue);
+      expect(Reflect.construct(fn, [])).toBe(returnValue);
+    });
+
+    test("passes the new object as `this` to the implementation", () => {
+      const fn = jest.fn(function (value) {
+        this.value = value;
+      });
+      const instance = new fn(42);
+      expect(instance).toEqual({ value: 42 });
+      expect(fn.mock.contexts[0]).toBe(instance);
+    });
+
+    test("mockReturnValue with a primitive still returns an object", () => {
+      const fn = jest.fn();
+      fn.mockReturnValue("nope");
+      expect(typeof new fn()).toBe("object");
+      expect(fn()).toBe("nope");
+    });
+
+    test("Reflect.construct honors an explicit newTarget", () => {
+      class Target {}
+      const fn = jest.fn();
+      expect(Reflect.construct(fn, [], Target)).toBeInstanceOf(Target);
+    });
+  });
 });
 
 describe("spyOn", () => {


### PR DESCRIPTION
Fuzzilli found this crash:

```
ASSERTION FAILED: cell->isObjectSlow()
JavaScriptCore/JSObject.h(1051) : JSObject *JSC::asObject(JSCell *)
```

Minimal reproduction:

```js
const { spyOn } = Bun.jest();
Date.foo = "hello";
const spy = spyOn(Date, "foo");
Reflect.construct(spy, []); // boom
```

## What was wrong

`JSMockFunction` is a `JSC::InternalFunction`, and it passed `jsMockFunctionCall` as *both* its call function and its construct function:

```cpp
: Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
```

`jsMockFunctionCall` returns whatever the mock implementation returns, which is very often not an object (`undefined` for a fresh `mock()`, the spied-on value for `spyOn`, whatever `mockReturnValue` was given).

A native `[[Construct]]` must always return an object. `JSC::Interpreter::executeConstruct` (reached from `Reflect.construct`, `JSC::construct()`, proxy construct traps) ends with:

```cpp
return asObject(JSValue::decode(result));
```

There is no type check there, so a primitive return was an assertion failure in debug and a non-object cell reinterpreted as a `JSObject*` in release. On the released build you could see it directly:

```js
typeof Reflect.construct(Bun.jest().mock(() => "a string"), []); // "string"
```

The bytecode `new` path did not assert, but it was wrong too: `new mock()` returned the primitive instead of the new instance, so `new (mock(() => 42))()` evaluated to `42`.

## The fix

`JSMockFunction` gets its own construct function. It derives `this` from `new.target` (via `InternalFunction::createSubclassStructure`, the same helper JSC's own constructors use), runs the mock with that as the receiver, and returns the implementation's result only when it is an object. Otherwise it returns the newly created object.

That is what an ordinary JS constructor does, and it matches jest, whose mocks are plain JS functions:

| expression | before | after |
| --- | --- | --- |
| `Reflect.construct(mock(), [])` | assert / UB | new object |
| `new (mock())()` | `undefined` | new object |
| `new (mock(() => 42))()` | `42` | new object |
| `new (mock(() => ({x:1})))()` | `{x:1}` | `{x:1}` |
| `new (mock(function(){this.x=1}))()` | `undefined` | `{x:1}` |

`mock.contexts` now records the constructed instance for `new` calls rather than `new.target`, which is also what jest records.

I checked the other `InternalFunction` subclasses in the tree for the same "call function doubles as the construct function" shape. `JSBufferListConstructor` and `JSStringDecoderConstructor` do reuse one function for both, but theirs always return an object, and `v8::shim::ObjectTemplate`'s is `ASSERT_NOT_REACHED`. None of the separate `constructX` host functions return a primitive, so this was the only instance.

## Tests

Added a `used as a constructor` block to `test/js/bun/test/mock-fn.test.js`, covering every primitive an implementation can return (including `undefined`, symbols and bigints, which are the cells that tripped the original assertion), the object passthrough case, `this` binding, `mockReturnValue`, and `Reflect.construct` with an explicit `newTarget`. That file is written to run under jest and vitest too, so the assertions are the cross-runtime behavior.

10 of the 11 new assertions fail on the current release build and all pass with this change. The original Fuzzilli sample now exits cleanly, and a 2000-iteration construct + `Bun.gc(true)` stress loop runs clean under the debug ASAN build.