### PR TITLE
child_process: match node's spawn-failure event contract

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -583,11 +583,15 @@ function spawnSync(file, args, options) {
   const outputStdout = typeof stdout === "number" ? null : stdout;
   const outputStderr = typeof stderr === "number" ? null : stderr;
 
+  // Node's `output` is 1:1 with the stdio array; slots the parent never reads are null.
+  const output = [null, outputStdout, outputStderr];
+  for (let i = 3; i < bunStdio.length; i++) output[i] = null;
+
   const result = {
     signal: signalCode ?? null,
     status: exitCode,
     // TODO: Need to expose extra pipes from Bun.spawnSync to child_process
-    output: [null, outputStdout, outputStderr],
+    output,
     pid,
   };
 
@@ -1476,9 +1480,13 @@ class ChildProcess extends EventEmitter {
         this.#handle = null;
         ex.syscall = "spawn " + this.spawnfile;
         ex.spawnargs = Array.prototype.slice.$call(this.spawnargs, 1);
+        const errno = (ex as SystemError).errno ?? -1;
         process.nextTick(() => {
+          // A spawn that never ran reports the negative errno as its exit code,
+          // and `signalCode` stays null because nothing killed it.
+          this.exitCode = errno;
           this.emit("error", ex);
-          this.emit("close", (ex as SystemError).errno ?? -1);
+          this.#maybeClose();
         });
         if (exCode === "EMFILE" || exCode === "ENFILE") {
           // emfile/enfile error; in this case node does not initialize stdio streams.
@@ -1787,7 +1795,7 @@ function normalizeStdio(stdio): string[] {
       case "inherit":
         return ["inherit", "inherit", "inherit"];
       default:
-        throw ERR_INVALID_OPT_VALUE("stdio", stdio);
+        throw $ERR_INVALID_ARG_VALUE("stdio", stdio);
     }
   } else if ($isJSArray(stdio)) {
     // Validate if each is a valid stdio type
@@ -1801,7 +1809,7 @@ function normalizeStdio(stdio): string[] {
 
     return processedStdio;
   } else {
-    throw ERR_INVALID_OPT_VALUE("stdio", stdio);
+    throw $ERR_INVALID_ARG_VALUE("stdio", stdio);
   }
 }
 
@@ -2056,12 +2064,6 @@ function genericNodeError(message, errorProperties) {
 function ERR_UNKNOWN_SIGNAL(name) {
   const err = new TypeError(`Unknown signal: ${name}`);
   err.code = "ERR_UNKNOWN_SIGNAL";
-  return err;
-}
-
-function ERR_INVALID_OPT_VALUE(name, value) {
-  const err = new TypeError(`The value "${value}" is invalid for option "${name}"`);
-  err.code = "ERR_INVALID_OPT_VALUE";
   return err;
 }
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -494,6 +494,32 @@ describe("spawn() failure lifecycle", () => {
       killed: false,
     });
   });
+
+  // `close` only fires once every stdio stream has closed, so materializing the
+  // streams of a failed spawn must not leave it unfired.
+  it.each([
+    ["default stdio", undefined],
+    ["an extra pipe", ["pipe", "pipe", "pipe", "pipe"]],
+  ])("close still fires after the stdio streams are materialized (%s)", async (_label, stdio) => {
+    const child = spawn("bun-definitely-not-a-real-binary", [], { stdio } as any);
+    void child.stdin;
+    void child.stdout;
+    void child.stderr;
+    void child.stdio;
+
+    const { error, summary } = await lifecycleOf(child);
+
+    expect(error.code).toBe("ENOENT");
+    expect(error.errno).toBeLessThan(0);
+    expect(summary).toEqual({
+      events: ["error", "close"],
+      whenErrored: { exitCode: error.errno, signalCode: null },
+      closeArgs: [error.errno, null],
+      exitCode: error.errno,
+      signalCode: null,
+      killed: false,
+    });
+  });
 });
 
 describe("execFile()", () => {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -421,6 +421,10 @@ describe("spawn()", () => {
         code: "ERR_INVALID_ARG_VALUE",
         message: "The argument 'stdio' is invalid. Received 5",
       });
+      expect(() => spawnSync(bunExe(), ["-v"], { stdio: 5 as any })).toThrow({
+        code: "ERR_INVALID_ARG_VALUE",
+        message: "The argument 'stdio' is invalid. Received 5",
+      });
     });
   });
 });

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,7 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tempDir, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { promisify } from "node:util";
@@ -404,6 +404,91 @@ describe("spawn()", () => {
       expect(child.stdout).not.toBeNull();
       expect(child.stderr).not.toBeNull();
     });
+
+    it("an unknown stdio string throws ERR_INVALID_ARG_VALUE", () => {
+      expect(() => spawn(bunExe(), ["-v"], { stdio: "bogus" as any })).toThrow({
+        code: "ERR_INVALID_ARG_VALUE",
+        message: "The argument 'stdio' is invalid. Received 'bogus'",
+      });
+      expect(() => spawnSync(bunExe(), ["-v"], { stdio: "bogus" as any })).toThrow({
+        code: "ERR_INVALID_ARG_VALUE",
+        message: "The argument 'stdio' is invalid. Received 'bogus'",
+      });
+    });
+
+    it("stdio that is neither a string nor an array throws ERR_INVALID_ARG_VALUE", () => {
+      expect(() => spawn(bunExe(), ["-v"], { stdio: 5 as any })).toThrow({
+        code: "ERR_INVALID_ARG_VALUE",
+        message: "The argument 'stdio' is invalid. Received 5",
+      });
+    });
+  });
+});
+
+describe("spawn() failure lifecycle", () => {
+  // Node reports the negative errno of a spawn that never ran as the child's
+  // exit code, emits no `exit`, and closes with a null signal.
+  async function lifecycleOf(child: ChildProcess) {
+    const events: string[] = [];
+    let error: any;
+    let whenErrored: any;
+    child.on("error", e => {
+      error = e;
+      events.push("error");
+      whenErrored = { exitCode: child.exitCode, signalCode: child.signalCode };
+    });
+    child.on("exit", () => events.push("exit"));
+    const closeArgs: unknown[] = await new Promise(resolve => {
+      child.on("close", (...args) => {
+        events.push("close");
+        resolve(args);
+      });
+    });
+    return {
+      error,
+      summary: {
+        events,
+        whenErrored,
+        closeArgs,
+        exitCode: child.exitCode,
+        signalCode: child.signalCode,
+        killed: child.killed,
+      },
+    };
+  }
+
+  it("ENOENT", async () => {
+    const { error, summary } = await lifecycleOf(spawn("bun-definitely-not-a-real-binary"));
+
+    expect(error.code).toBe("ENOENT");
+    expect(error.errno).toBeLessThan(0);
+    expect(summary).toEqual({
+      events: ["error", "close"],
+      whenErrored: { exitCode: error.errno, signalCode: null },
+      closeArgs: [error.errno, null],
+      exitCode: error.errno,
+      signalCode: null,
+      killed: false,
+    });
+  });
+
+  it.if(!isWindows)("EACCES", async () => {
+    using dir = tempDir("child-process-eacces", { "not-executable.sh": "#!/bin/sh\necho hi\n" });
+    const file = path.join(String(dir), "not-executable.sh");
+    fs.chmodSync(file, 0o644);
+
+    const { error, summary } = await lifecycleOf(spawn(file));
+
+    expect(error.code).toBe("EACCES");
+    expect(error.errno).toBeLessThan(0);
+    expect(summary).toEqual({
+      events: ["error", "close"],
+      whenErrored: { exitCode: error.errno, signalCode: null },
+      closeArgs: [error.errno, null],
+      exitCode: error.errno,
+      signalCode: null,
+      killed: false,
+    });
   });
 });
 
@@ -450,6 +535,34 @@ describe("spawnSync()", () => {
   it("should spawn a process synchronously", () => {
     const { stdout } = spawnSync("bun", ["-v"], { encoding: "utf8" });
     expect(isValidSemver(stdout.trim())).toBe(true);
+  });
+
+  // `output` is 1:1 with the stdio array, null for every slot the parent does
+  // not read from.
+  it("output has one entry per stdio slot", () => {
+    const result = spawnSync(bunExe(), ["-e", `process.stdout.write("out"); process.stderr.write("err")`], {
+      env: bunEnv,
+      stdio: ["pipe", "pipe", "pipe", "ignore", "ignore"],
+    });
+
+    expect({
+      output: result.output.map(entry => (entry === null ? null : entry.toString())),
+      stdout: result.stdout?.toString(),
+      stderr: result.stderr?.toString(),
+      status: result.status,
+    }).toEqual({
+      output: [null, "out", "err", null, null],
+      stdout: "out",
+      stderr: "err",
+      status: 0,
+    });
+  });
+
+  it("output has three entries for the default stdio", () => {
+    const result = spawnSync(bunExe(), ["-e", `process.stdout.write("out")`], { env: bunEnv });
+
+    expect(result.output.map(entry => (entry === null ? null : entry.toString()))).toEqual([null, "out", ""]);
+    expect(result.status).toBe(0);
   });
 
   it.if(isLinux)("detached: true starts the child in a new process group", () => {


### PR DESCRIPTION
## Repro

```js
const { spawn, spawnSync } = require("child_process");

const c = spawn("definitely-not-a-binary");
c.on("error", () => {});
c.on("close", (code, signal) => console.log(code, signal, c.exitCode));
// node: -2 null -2
// bun:  -2 undefined null

console.log(spawnSync("echo", ["hi"], { stdio: ["pipe", "pipe", "pipe", "ignore", "ignore"] }).output.length);
// node: 5    bun: 3

try {
  spawn("echo", [], { stdio: "bogus" });
} catch (e) {
  console.log(e.code);
}
// node: ERR_INVALID_ARG_VALUE    bun: ERR_INVALID_OPT_VALUE (removed in Node 15)
```

## Cause

All three live in `src/js/node/child_process.ts`.

**1. Spawn-failure lifecycle.** The deferred-error branch in `ChildProcess#spawn()` emitted `close` directly with a single argument:

```js
process.nextTick(() => {
  this.emit("error", ex);
  this.emit("close", (ex as SystemError).errno ?? -1);
});
```

so listeners got `signal === undefined`, and `this.exitCode` was never assigned. Node's `_handle.onexit(err)` sets `this.exitCode = err` (the negative errno) and then calls `maybeClose()`, which emits `close` with `(this.exitCode, this.signalCode)`. The divergence is not ENOENT-specific; it covers every code in the deferred list (EACCES gives `close(-13, undefined)` with `exitCode === null`).

This matters for supervision code, which is exactly the code that reads these fields: `if (signal === null && code !== 0)` takes the wrong branch on `undefined`, and `child.exitCode ?? fallback` hides the errno.

**2. `spawnSync().output`.** The result was hardcoded to three entries regardless of how many stdio slots the caller asked for, so `output.length` disagreed with `stdio.length` and any slot past stderr vanished.

**3. Retired error code.** `ERR_INVALID_OPT_VALUE` was removed from Node in v15. Node's `getValidStdio`/`stdioStringToArray` throw `ERR_INVALID_ARG_VALUE` for an unknown stdio string and for a stdio value that is neither a string nor an array. (`validateMaxBuffer`/`validateTimeout` already used `$ERR_OUT_OF_RANGE` correctly.)

## Fix

- The deferred-error branch sets `this.exitCode = errno` inside the `nextTick` (same ordering as Node: the `error` listener already sees it) and emits `close` through `#maybeClose()`, which supplies `(exitCode, signalCode)`. `signalCode` stays `null`, and no `exit` event is emitted, matching Node.
- `spawnSync()` builds `output` with one entry per normalized stdio slot. Slots the parent does not read from are `null`, which is what Node reports for `ignore`/`inherit`/fd entries.
- `normalizeStdio()` throws `$ERR_INVALID_ARG_VALUE`, whose message is already byte-identical to Node's (`The argument 'stdio' is invalid. Received 'bogus'`). The now-dead local `ERR_INVALID_OPT_VALUE` helper is deleted.

## Not fixed here

A literal `pipe` at `stdio[3]` or beyond still reports `null` in `output`, because `Bun.spawnSync` does not buffer the extra pipes (the pre-existing `TODO` above `output`). That slot also deadlocks today once the child writes more than the pipe buffer, so closing the gap properly needs native work in `Bun.spawnSync` rather than a change in this layer. Every other stdio shape (`ignore`, `inherit`, fd numbers) now matches Node exactly.

## Verification

New tests in `test/js/node/child_process/child_process.test.ts`:

- `spawn() failure lifecycle > ENOENT` / `> EACCES`: assert the event order is `["error", "close"]` (no `exit`), that `exitCode === err.errno` both when `error` fires and after `close`, that `close` receives `(errno, null)`, and that `signalCode` / `killed` are unchanged.
- `spawnSync() > output has one entry per stdio slot` and `> output has three entries for the default stdio`.
- `spawn() > stdio > an unknown stdio string throws ERR_INVALID_ARG_VALUE` (async and sync) and `> stdio that is neither a string nor an array throws ERR_INVALID_ARG_VALUE`, asserting the code and Node's exact message.

```
# fail-before (released bun):
$ USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t "failure lifecycle"
- "exitCode": -13
+ "exitCode": null
  "closeArgs": [ -13, -     null, ]
 0 pass  2 fail

# pass-after (debug build):
$ bun bd test test/js/node/child_process/child_process.test.ts
 44 pass  3 fail (all three fail identically on main in this container: two
                  5s timeouts under debug+ASAN and a missing default shell)
```

<details>
<summary>Node differential, before and after</summary>

```
                                               node            bun (before)           bun (after)
spawn(missing)   error           ENOENT, exitCode=-2    ENOENT, exitCode=null   ENOENT, exitCode=-2
                 close              (-2, null)            (-2, undefined)          (-2, null)
spawn(noexec)    error           EACCES, exitCode=-13   EACCES, exitCode=null   EACCES, exitCode=-13
                 close              (-13, null)           (-13, undefined)         (-13, null)
spawnSync stdio ["pipe","pipe","pipe","ignore","ignore"]
                 output.length          5                       3                      5
spawnSync stdio ["pipe","pipe","pipe", 1]
                 output.length          4                       3                      4
spawn stdio "bogus"              ERR_INVALID_ARG_VALUE  ERR_INVALID_OPT_VALUE  ERR_INVALID_ARG_VALUE
spawn stdio 5                    ERR_INVALID_ARG_VALUE  ERR_INVALID_OPT_VALUE  ERR_INVALID_ARG_VALUE
```

</details>

Node's own ported tests still pass: every `test/js/node/test/parallel/test-child-process-*.js` that passes on `main` still passes, including `test-child-process-spawn-error.js` (which touches `child.stdin`/`stdout`/`stderr`/`stdio` synchronously on a failed spawn, the case where `#maybeClose()`'s `#closesNeeded` bookkeeping could have swallowed the `close`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->