### PR TITLE
redis: cancel the armed auto-reconnect timer in close()

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1040,10 +1040,12 @@ impl JSValkeyClient {
         self.ref_();
         let _d = deref_guard(self);
 
-        // An armed retry means `disconnect()` has no socket to close, so the
-        // timer would reopen the connection. Cancelling it leaves the queued
-        // commands and the pending `connect()` promise with nobody to settle them.
-        let retry_armed = self.reconnect_timer.get().state == Timer::State::ACTIVE;
+        // A retry armed with no socket: `disconnect()` finds nothing to close, so
+        // cancelling the timer leaves the queued commands and the pending
+        // `connect()` promise with nobody to settle them. Run that close path here.
+        // With a socket (an explicit `connect()` can arm-and-connect) it runs itself.
+        let retry_armed = self.reconnect_timer.get().state == Timer::State::ACTIVE
+            && self.client.get().status == valkey::Status::Disconnected;
         self.stop_reconnect_timer();
         self.client_mut().disconnect();
         if retry_armed {

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1037,10 +1037,20 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn js_disconnect(&self, _global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-        if self.client.get().status == valkey::Status::Disconnected {
-            return Ok(JSValue::UNDEFINED);
-        }
+        self.ref_();
+        let _d = deref_guard(self);
+
+        // An armed retry means `disconnect()` has no socket to close, so the
+        // timer would reopen the connection. Cancelling it leaves the queued
+        // commands and the pending `connect()` promise with nobody to settle them.
+        let retry_armed = self.reconnect_timer.get().state == Timer::State::ACTIVE;
+        self.stop_reconnect_timer();
         self.client_mut().disconnect();
+        if retry_armed {
+            self.client_fail(b"Connection closed", protocol::RedisError::ConnectionClosed)?;
+            self.notify_close()?;
+            self.update_poll_ref();
+        }
         Ok(JSValue::UNDEFINED)
     }
 
@@ -1385,9 +1395,7 @@ impl JSValkeyClient {
     // Callback for when Valkey client needs to reconnect
     pub fn on_valkey_reconnect(&self) {
         // Schedule reconnection using our safe timer methods
-        if self.reconnect_timer.get().state == Timer::State::ACTIVE {
-            self.remove_timer(&self.reconnect_timer);
-        }
+        self.stop_reconnect_timer();
 
         let delay_ms = self.client.get().get_reconnect_delay();
         if delay_ms > 0 {
@@ -1407,8 +1415,6 @@ impl JSValkeyClient {
 
     // Callback for when Valkey client closes
     pub fn on_valkey_close(&self) -> JsTerminatedResult<()> {
-        let global_object = self.global_object;
-
         let self_ptr = self.as_ctx_ptr();
         let _defer = scopeguard::guard(self_ptr, |p| {
             // SAFETY: `p` was `self.as_ctx_ptr()`; the socket dispatch path
@@ -1419,6 +1425,15 @@ impl JSValkeyClient {
                 JSValkeyClient::deref(p);
             }
         });
+
+        self.notify_close()
+    }
+
+    /// Reject the pending `connect()` promise and invoke `onclose`. Split out so
+    /// `js_disconnect` can settle the same state without the `deref` that
+    /// balances `connect()`'s socket keep-alive ref.
+    fn notify_close(&self) -> JsTerminatedResult<()> {
+        let global_object = self.global_object;
 
         let Some(this_jsvalue) = self.this_value.get().try_get() else {
             return Ok(());
@@ -1558,6 +1573,10 @@ impl JSValkeyClient {
         if self.timer.get().state == Timer::State::ACTIVE {
             self.remove_timer(&self.timer);
         }
+        self.stop_reconnect_timer();
+    }
+
+    fn stop_reconnect_timer(&self) {
         if self.reconnect_timer.get().state == Timer::State::ACTIVE {
             self.remove_timer(&self.reconnect_timer);
         }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -1487,8 +1487,12 @@ impl ValkeyClient {
     }
 
     /// Close the Valkey connection
+    ///
+    /// The caller cancels the reconnect timer; `is_reconnecting` is cleared here
+    /// so a reconnect that is already in flight stops retrying.
     pub fn disconnect(&mut self) {
         self.flags.is_manually_closed = true;
+        self.flags.is_reconnecting = false;
         self.unregister_auto_flusher();
         if self.status == Status::Connected || self.status == Status::Connecting {
             self.close();

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -450,8 +450,10 @@ describe("Valkey: Auto-Reconnect In-Flight Commands", () => {
 describe("Valkey: close() during auto-reconnect", () => {
   type Conn = { id: number; socket: net.Socket; open: boolean };
 
-  // Minimal RESP3 mock that records every connection the client opens.
-  function mockRedisServer() {
+  // Minimal RESP3 mock that records every connection the client opens. A
+  // connection `helloOk` rejects never gets a handshake reply, so the client
+  // stays in its "connecting" state on it.
+  function mockRedisServer(helloOk: (id: number) => boolean = () => true) {
     const conns: Conn[] = [];
     const server = net.createServer(socket => {
       const conn: Conn = { id: conns.length + 1, socket, open: true };
@@ -461,7 +463,7 @@ describe("Valkey: close() during auto-reconnect", () => {
         conn.open = false;
       });
       socket.on("data", data => {
-        if (data.includes("HELLO")) socket.write("+OK\r\n");
+        if (data.includes("HELLO") && helloOk(conn.id)) socket.write("+OK\r\n");
       });
     });
 
@@ -546,6 +548,37 @@ describe("Valkey: close() during auto-reconnect", () => {
       expect(closes).toBe(1);
     } finally {
       client.close();
+    }
+  });
+
+  test("close() during a reconnect attempt reports the close exactly once", async () => {
+    // Only the first connection gets a handshake reply, so the explicit connect()
+    // below leaves the client connecting with the retry timer still armed. The
+    // socket close reports the close, so close() must not report it again.
+    const { conns, port, close } = await mockRedisServer(id => id === 1);
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: true });
+    let closes = 0;
+    client.onclose = () => closes++;
+
+    try {
+      await client.connect();
+      expect(client.connected).toBe(true);
+
+      conns[0].socket.destroy();
+      expect(await until(() => !client.connected)).toBe(true);
+
+      const reconnecting = client.connect();
+      reconnecting.catch(() => {}); // settled by close() below
+      expect(await until(() => conns.length >= 2)).toBe(true);
+
+      client.close();
+
+      await until(() => closes >= 2, 200);
+      expect(closes).toBe(1);
+      await expect(reconnecting).rejects.toThrow(/connection closed/i);
+    } finally {
+      client.close();
+      close();
     }
   });
 });

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -441,3 +441,107 @@ describe("Valkey: Auto-Reconnect In-Flight Commands", () => {
     }
   });
 });
+
+/**
+ * A client that lost its connection sits between auto-reconnect attempts with a
+ * timer armed and no socket. `close()` has to cancel that timer, or the client
+ * reconnects moments later and nothing ever settles the offline queue.
+ */
+describe("Valkey: close() during auto-reconnect", () => {
+  type Conn = { id: number; socket: net.Socket; open: boolean };
+
+  // Minimal RESP3 mock that records every connection the client opens.
+  function mockRedisServer() {
+    const conns: Conn[] = [];
+    const server = net.createServer(socket => {
+      const conn: Conn = { id: conns.length + 1, socket, open: true };
+      conns.push(conn);
+      socket.on("error", () => {});
+      socket.on("close", () => {
+        conn.open = false;
+      });
+      socket.on("data", data => {
+        if (data.includes("HELLO")) socket.write("+OK\r\n");
+      });
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      conns: Conn[];
+      port: number;
+      close: () => void;
+    }>();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        conns,
+        port: (server.address() as net.AddressInfo).port,
+        close() {
+          for (const conn of conns) conn.socket.destroy();
+          server.close();
+        },
+      });
+    });
+    return promise;
+  }
+
+  // Polls a condition over a bounded window and reports whether it ever held.
+  async function until(condition: () => boolean, timeoutMs = 1000) {
+    const deadline = Date.now() + timeoutMs;
+    while (!condition() && Date.now() < deadline) await delay(1);
+    return condition();
+  }
+
+  test("close() cancels the armed retry and settles the offline queue", async () => {
+    const { conns, port, close } = await mockRedisServer();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: true });
+    let closes = 0;
+    client.onclose = () => closes++;
+
+    try {
+      await client.connect();
+      expect(client.connected).toBe(true);
+
+      // The server drops the connection; the client arms its 50ms reconnect timer.
+      conns[0].socket.destroy();
+      expect(await until(() => !client.connected)).toBe(true);
+
+      // Queued into the offline queue; close() is the only thing left to settle it.
+      const settled = client.get("orphan").then(
+        () => ({ rejected: false }),
+        (error: any) => ({ rejected: true, code: error.code }),
+      );
+
+      client.close();
+
+      // The timer fires 50ms after the drop: give it 10x that to prove it no
+      // longer reopens the connection.
+      await until(() => conns.length >= 2, 500);
+      expect(conns.map(conn => conn.id)).toEqual([1]);
+      expect(client.connected).toBe(false);
+      expect(await settled).toEqual({ rejected: true, code: "ERR_REDIS_CONNECTION_CLOSED" });
+      expect(closes).toBe(1);
+    } finally {
+      close();
+    }
+  });
+
+  test("close() after the retries are exhausted does not report a second close", async () => {
+    // Nothing listens on this port, so every attempt is refused and the client
+    // gives up after one retry. The timer is no longer armed by then, so close()
+    // must not re-run the close path.
+    const client = new RedisClient("redis://127.0.0.1:12345", { autoReconnect: true, maxRetries: 1 });
+    let closes = 0;
+    client.onclose = () => closes++;
+
+    try {
+      await client.connect().catch(() => {});
+      expect(await until(() => closes >= 1)).toBe(true);
+
+      client.close();
+      await delay(50);
+      expect(closes).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -521,6 +521,7 @@ describe("Valkey: close() during auto-reconnect", () => {
       expect(await settled).toEqual({ rejected: true, code: "ERR_REDIS_CONNECTION_CLOSED" });
       expect(closes).toBe(1);
     } finally {
+      client.close();
       close();
     }
   });
@@ -541,7 +542,7 @@ describe("Valkey: close() during auto-reconnect", () => {
       expect(await until(() => closes >= 1)).toBe(true);
 
       client.close();
-      await delay(50);
+      await until(() => closes >= 2, 200);
       expect(closes).toBe(1);
     } finally {
       client.close();

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -526,10 +526,13 @@ describe("Valkey: close() during auto-reconnect", () => {
   });
 
   test("close() after the retries are exhausted does not report a second close", async () => {
-    // Nothing listens on this port, so every attempt is refused and the client
-    // gives up after one retry. The timer is no longer armed by then, so close()
-    // must not re-run the close path.
-    const client = new RedisClient("redis://127.0.0.1:12345", { autoReconnect: true, maxRetries: 1 });
+    // Take a port and give it straight back, so every attempt is refused and the
+    // client gives up after one retry. The timer is no longer armed by then, so
+    // close() must not re-run the close path.
+    const { port, close } = await mockRedisServer();
+    close();
+
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: true, maxRetries: 1 });
     let closes = 0;
     client.onclose = () => closes++;
 


### PR DESCRIPTION
### What does this PR do?

`RedisClient.close()` is ignored while the client is between auto-reconnect attempts. The client reconnects moments later, `client.connected` flips back to `true` after the user closed it, and nothing ever settles the commands that were sitting in the offline queue.

Reproduction (scripted in-process RESP3 server, same as the test):

```js
const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: true });
await client.connect();

serverSocket.destroy();             // the client arms its 50ms reconnect timer
while (client.connected) await delay(1);

const queued = client.get("orphan"); // goes into the offline queue
client.close();

await delay(500);
client.connected;                    // true  -- the timer reconnected anyway
await queued;                        // never settles
```

### Cause

`js_disconnect` returned early when `status == Disconnected`:

```rust
if self.client.get().status == valkey::Status::Disconnected {
    return Ok(JSValue::UNDEFINED);
}
self.client_mut().disconnect();
```

That is exactly the state a client is in between retries: the socket is gone, `is_reconnecting` is set, and `reconnect_timer` is armed. `close()` therefore set no flags and cancelled no timer, and `on_reconnect_timer()` reopened the connection. The only thing that used to settle the offline queue and a pending `connect()` promise was the socket's `on_close`, and there is no socket.

### Fix

- `js_disconnect` cancels the reconnect timer and always calls `disconnect()`; `disconnect()` already skips the socket close when there is nothing to close.
- `ValkeyClient::disconnect()` clears `is_reconnecting`, so a retry already in flight stops retrying.
- When a cancelled retry leaves no socket behind, `js_disconnect` runs the close path by hand: `fail()` rejects the queued commands, `notify_close()` (split out of `on_valkey_close()`, minus the `deref` that balances `connect()`'s socket keep-alive ref) rejects the pending `connect()` promise and invokes `onclose`, and `update_poll_ref()` drops the event-loop keepalive the retry was holding. The condition is the timer being `ACTIVE` **and** the status being `Disconnected`, which is exactly when `disconnect()` finds nothing to close. A client that exhausted its retries (no timer, `on_valkey_close()` already ran) and a client whose explicit `connect()` left a socket connecting under an armed timer both take the normal socket-close path and report the close once.

This is adjacent to but distinct from #32803, which stops a stale reconnect timer from clobbering an in-flight socket. That one is about a timer firing during an explicit `connect()`; this one is about a timer firing after an explicit `close()`. Neither fixes the other.

### Verification

`test/js/valkey/reliability/connection-failures.test.ts` gets two tests on a scripted in-process RESP3 server (no docker needed):

- `close()` during an armed retry: the server accepts exactly one connection, `connected` stays `false`, the offline-queued command rejects with `ERR_REDIS_CONNECTION_CLOSED`, and `onclose` fires once.
- `close()` after the retries are exhausted: `onclose` is not reported a second time.
- `close()` during a reconnect attempt (explicit `connect()` under an armed timer, socket still connecting): `onclose` fires once and the pending `connect()` promise rejects.

<details>
<summary>before / after</summary>

```
# unfixed (src/ stashed), USE_SYSTEM_BUN=1 bun test .../connection-failures.test.ts
error: expect(received).toEqual(expected)
  [
    1,
+   2,
  ]
(fail) Valkey: close() during auto-reconnect > close() cancels the armed retry and settles the offline queue

# with the fix, bun bd test .../connection-failures.test.ts
(pass) Valkey: close() during auto-reconnect > close() cancels the armed retry and settles the offline queue
(pass) Valkey: close() during auto-reconnect > close() after the retries are exhausted does not report a second close
```

Also checked by hand against a real redis (`bun bd`, ASAN): basic commands, `close()` on a fresh client, `close()` then `connect()` recovery, `onclose` firing once, concurrent `connect()`, auto-reconnect after a server-side `CLIENT KILL` with the offline queue flushing, and pub/sub. All unchanged, process exits cleanly.
</details>