### PR TITLE
bun:sqlite: close() finalizes outstanding statements instead of leaving them live

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -131,9 +131,10 @@ db.close(true);
 Using a statement after the database it came from was closed throws `Database has closed`.
 
 <Note>
-  The connection is released automatically when the database is garbage collected. Unlike an explicit `close()`, that
-  does not finalize outstanding statements, which keep working until they are finalized or collected themselves.
-  `close()` is safe to call multiple times and has no effect after the first.
+  Garbage collecting the database closes the connection only once every statement prepared from it has been collected
+  too. Unlike an explicit `close()`, garbage collection does not finalize outstanding statements, so they keep working,
+  and the database file stays open, until then. `close()` is safe to call multiple times and has no effect after the
+  first.
 </Note>
 
 ### `using` statement

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -112,7 +112,7 @@ const db = new Database("./mydb.sqlite");
 
 ### `.close(throwOnError: boolean = false)`
 
-To close a database connection but allow existing queries to finish, call `.close(false)`:
+To close a database connection, call `.close(false)`. Any statements prepared from it are finalized, so the database file is released immediately:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();
@@ -120,13 +120,15 @@ const db = new Database();
 db.close(false);
 ```
 
-To close the database and throw an error if there are any pending queries, call `.close(true)`:
+To close the database and throw an error if any prepared statements are still open, call `.close(true)`:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();
 // ... do stuff
 db.close(true);
 ```
+
+Using a statement after the database it came from was closed throws `Database has closed`.
 
 <Note>
   `close(false)` is called automatically when the database is garbage collected. It is safe to call multiple times but

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -131,8 +131,9 @@ db.close(true);
 Using a statement after the database it came from was closed throws `Database has closed`.
 
 <Note>
-  `close(false)` is called automatically when the database is garbage collected. It is safe to call multiple times but
-  has no effect after the first.
+  The connection is released automatically when the database is garbage collected. Unlike an explicit `close()`, that
+  does not finalize outstanding statements, which keep working until they are finalized or collected themselves.
+  `close()` is safe to call multiple times and has no effect after the first.
 </Note>
 
 ### `using` statement

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -264,24 +264,30 @@ declare module "bun:sqlite" {
     /**
      * Close the database connection.
      *
+     * Statements prepared from this database are finalized, so the database file
+     * is released immediately. Using one of them afterwards, or running a new
+     * query, throws `Database has closed`.
+     *
      * It is safe to call this method multiple times. If the database is already
-     * closed, this is a no-op. Running queries after the database has been
-     * closed throws an error.
+     * closed, this is a no-op.
      *
      * @example
      * ```ts
      * db.close();
      * ```
-     * This is called automatically when the database instance is garbage collected.
+     * Garbage collecting the database closes the connection once every statement
+     * prepared from it has been collected too. Unlike an explicit `close()`,
+     * garbage collection does not finalize outstanding statements.
      *
-     * Internally, this calls `sqlite3_close_v2`.
+     * Internally, this finalizes outstanding statements and calls `sqlite3_close_v2`.
      */
     close(
       /**
-       * If `true`, throw an error if the database is in use
+       * If `true`, throw an error if any prepared statements are still open
        * @default false
        *
-       * When `true`, this calls `sqlite3_close` instead of `sqlite3_close_v2`.
+       * When `true`, this calls `sqlite3_close` instead of `sqlite3_close_v2`, and
+       * outstanding statements are left alone rather than finalized.
        *
        * Learn more in the [sqlite3 documentation](https://www.sqlite.org/c3ref/close.html).
        *

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -271,15 +271,16 @@ declare module "bun:sqlite" {
      * It is safe to call this method multiple times. If the database is already
      * closed, this is a no-op.
      *
-     * @example
-     * ```ts
-     * db.close();
-     * ```
      * Garbage collecting the database closes the connection once every statement
      * prepared from it has been collected too. Unlike an explicit `close()`,
      * garbage collection does not finalize outstanding statements.
      *
      * Internally, this finalizes outstanding statements and calls `sqlite3_close_v2`.
+     *
+     * @example
+     * ```ts
+     * db.close();
+     * ```
      */
     close(
       /**

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -188,16 +188,18 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
     }
 
 #define CHECK_PREPARED                                                                                             \
+    if (castedThis->version_db != nullptr && castedThis->version_db->db == nullptr) [[unlikely]] {                 \
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));     \
+        return {};                                                                                                 \
+    }                                                                                                              \
     if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                           \
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s)); \
         return {};                                                                                                 \
     }
 
-#define CHECK_PREPARED_JIT                                                                                         \
-    if (castedThis->stmt == nullptr || castedThis->version_db == nullptr) [[unlikely]] {                           \
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement has finalized"_s)); \
-        return {};                                                                                                 \
-    }
+namespace WebCore {
+class JSSQLStatement;
+}
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 
@@ -214,6 +216,10 @@ public:
     sqlite3* db;
     std::atomic<uint64_t> version;
     size_t reference_count;
+
+    // Every live JSSQLStatement prepared against this connection. Not owning:
+    // entries are added in JSSQLStatement::create, removed in ~JSSQLStatement.
+    Vector<WebCore::JSSQLStatement*> statements;
 
     void release()
     {
@@ -450,6 +456,7 @@ public:
         JSSQLStatement* ptr = new (NotNull, JSC::allocateCell<JSSQLStatement>(globalObject->vm())) JSSQLStatement(structure, *globalObject, stmt, version_db, memorySizeChange);
         if (version_db) {
             ++version_db->reference_count;
+            version_db->statements.append(ptr);
         }
         ptr->finishCreation(globalObject->vm());
         return ptr;
@@ -1775,6 +1782,21 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementOpenStatementFunction, (JSC::JSGlobalObje
     RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(index)));
 }
 
+// A prepared statement keeps the sqlite3 connection (and the database file
+// descriptor) alive until it is finalized, so finalize the ones this connection
+// handed out. Their JS wrappers then report that the database has closed.
+static void finalizeOutstandingStatements(VersionSqlite3* versionDB)
+{
+    Vector<JSSQLStatement*> statements;
+    statements.swap(versionDB->statements);
+    for (auto* statement : statements) {
+        if (statement->stmt) {
+            sqlite3_finalize(statement->stmt);
+            statement->stmt = nullptr;
+        }
+    }
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
 
@@ -1817,13 +1839,27 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
+    // close(true) is documented to fail while queries are outstanding, so let
+    // sqlite3_close() see the statements that are still alive.
+    if (!shouldThrowOnError)
+        finalizeOutstandingStatements(versionDB);
+
     // sqlite3_close_v2 is used for automatic GC cleanup
     int statusCode = shouldThrowOnError ? sqlite3_close(db) : sqlite3_close_v2(db);
     if (statusCode != SQLITE_OK) {
+        // sqlite3_close() only reports SQLITE_BUSY for unfinalized statements,
+        // but its error string says "database is locked".
+        if (statusCode == SQLITE_BUSY) {
+            throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Cannot close the database because prepared statements are still open. Finalize them first, or call close(false)."_s));
+            return {};
+        }
+
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, WTF::String::fromUTF8(sqlite3_errstr(statusCode))));
         return {};
     }
 
+    // Anything still tracked here was finalized before close(true) succeeded.
+    versionDB->statements.clear();
     versionDB->db = nullptr;
     return JSValue::encode(jsUndefined());
 }
@@ -2836,6 +2872,7 @@ JSSQLStatement::~JSSQLStatement()
 {
     if (this->stmt) {
         sqlite3_finalize(this->stmt);
+        this->stmt = nullptr;
     }
 
     if (auto* columnNames = this->columnNames.get()) {
@@ -2844,6 +2881,7 @@ JSSQLStatement::~JSSQLStatement()
     }
 
     if (this->version_db) {
+        this->version_db->statements.removeFirst(this);
         this->version_db->release();
     }
 }

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1520,6 +1520,9 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
                 JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, sql.stmt, bindings, safeIntegers, nullptr);
                 RETURN_IF_EXCEPTION(scope, {});
 
+                // A getter invoked while binding can close the database. `sql` is
+                // the last statement holding it open, so `db` is freed as soon as
+                // this iteration finalizes it.
                 if (versionDB->db != db) [[unlikely]] {
                     throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                     return {};

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1508,6 +1508,29 @@ describe("close() with a statement still alive", () => {
     expect(() => prepared.all({ $a: "x", $b: "y" })).toThrow("Database has closed");
   });
 
+  // db.run() prepares its statements internally, so once close() finalizes the
+  // tracked ones, that internal statement is the last thing holding the
+  // connection open and finalizing it frees the sqlite3* mid-call.
+  it.each(["INSERT INTO t VALUES ($a)", "INSERT INTO t VALUES ($a); INSERT INTO t VALUES (2)"])(
+    "rejects db.run(%p) when a binding getter closes the database",
+    sql => {
+      const db = new Database(":memory:");
+      db.exec("CREATE TABLE t (a INT)");
+      const keepalive = db.prepare("SELECT 1");
+
+      expect(() =>
+        db.run(sql, {
+          get $a() {
+            db.close();
+            return 1;
+          },
+        }),
+      ).toThrow("Database has closed");
+
+      expect(() => keepalive.get()).toThrow("Database has closed");
+    },
+  );
+
   it("stays safe when the statement is garbage collected afterwards", async () => {
     const db = new Database(":memory:");
     db.exec("CREATE TABLE foo (name TEXT)");

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1388,7 +1388,7 @@ it("close(true) should throw an error if the database is in use", () => {
   db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
   db.exec("INSERT INTO foo (name) VALUES ('foo')");
   const prepared = db.prepare("SELECT * FROM foo");
-  expect(() => db.close(true)).toThrow("database is locked");
+  expect(() => db.close(true)).toThrow("Cannot close the database because prepared statements are still open");
   prepared.finalize();
   expect(() => db.close(true)).not.toThrow();
 });
@@ -1398,7 +1398,7 @@ it("close() should NOT throw an error if the database is in use", () => {
   db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
   db.exec("INSERT INTO foo (name) VALUES ('foo')");
   const prepared = db.prepare("SELECT * FROM foo");
-  expect(() => db.close()).not.toThrow("database is locked");
+  expect(() => db.close()).not.toThrow();
 });
 
 it("should dispose AND throw an error if the database is in use", () => {
@@ -1410,7 +1410,105 @@ it("should dispose AND throw an error if the database is in use", () => {
       db.exec("INSERT INTO foo (name) VALUES ('foo')");
       prepared = db.prepare("SELECT * FROM foo");
     }
-  }).toThrow("database is locked");
+  }).toThrow("Cannot close the database because prepared statements are still open");
+});
+
+describe("close() with a statement still alive", () => {
+  it("makes every statement entry point throw", () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE foo (name TEXT)");
+    db.exec("INSERT INTO foo (name) VALUES ('foo')");
+    const prepared = db.prepare("SELECT * FROM foo");
+    expect(prepared.all()).toEqual([{ name: "foo" }]);
+
+    db.close();
+
+    expect(() => prepared.get()).toThrow("Database has closed");
+    expect(() => prepared.all()).toThrow("Database has closed");
+    expect(() => prepared.values()).toThrow("Database has closed");
+    expect(() => prepared.run()).toThrow("Database has closed");
+    expect(() => [...prepared]).toThrow("Database has closed");
+    expect(() => prepared.columnTypes).toThrow("Database has closed");
+    expect(() => prepared.declaredTypes).toThrow("Database has closed");
+    expect(() => prepared.paramsCount).toThrow("Database has closed");
+  });
+
+  it("releases the database file", () => {
+    // The sidecar files are only removed once the sqlite3 connection is really
+    // closed, which it is not while an unfinalized statement keeps it alive.
+    const dir = tempDirWithFiles("sqlite-close-live-statement", { "empty.txt": "" });
+    const file = path.join(dir, "my.db");
+    const db = new Database(file);
+    db.exec("PRAGMA journal_mode = WAL");
+    db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
+    db.exec("CREATE TABLE foo (name TEXT)");
+    db.exec("INSERT INTO foo (name) VALUES ('foo')");
+    const prepared = db.prepare("SELECT * FROM foo");
+    expect(prepared.all()).toEqual([{ name: "foo" }]);
+    db.exec("PRAGMA wal_checkpoint(truncate)");
+
+    db.close();
+
+    expect(readdirSync(dir).sort()).toEqual(["empty.txt", "my.db"]);
+    expect(() => prepared.all()).toThrow("Database has closed");
+  });
+
+  it("stops an in-progress iteration", () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE foo (a INTEGER)");
+    for (let i = 0; i < 5; i++) db.run("INSERT INTO foo VALUES (?)", [i]);
+    const prepared = db.prepare("SELECT * FROM foo");
+
+    const seen = [];
+    expect(() => {
+      for (const row of prepared) {
+        seen.push(row.a);
+        if (row.a === 2) db.close();
+      }
+    }).toThrow("Database has closed");
+    expect(seen).toEqual([0, 1, 2]);
+  });
+
+  it("rejects a statement whose database is closed while binding", () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE foo (a TEXT, b TEXT)");
+    db.exec("INSERT INTO foo VALUES ('x', 'y')");
+    const prepared = db.prepare("SELECT * FROM foo WHERE a = $a AND b = $b");
+
+    // Closing from a parameter getter finalizes `prepared` and frees the
+    // sqlite3* that the bind loop is holding.
+    expect(() =>
+      prepared.all({
+        get $a() {
+          db.close();
+          return "x";
+        },
+        $b: "y",
+      }),
+    ).toThrow("Statement has finalized");
+
+    expect(() => prepared.all({ $a: "x", $b: "y" })).toThrow("Database has closed");
+  });
+
+  it("stays safe when the statement is garbage collected afterwards", async () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE foo (name TEXT)");
+    db.exec("INSERT INTO foo (name) VALUES ('foo')");
+
+    // Dropped without finalize(), so ~JSSQLStatement runs after close() already
+    // finalized the underlying sqlite3_stmt.
+    (() => {
+      expect(db.prepare("SELECT * FROM foo").all()).toEqual([{ name: "foo" }]);
+    })();
+
+    db.close();
+    Bun.gc(true);
+    await Bun.sleep(0);
+    Bun.gc(true);
+
+    expect(() => db.prepare("SELECT * FROM foo")).toThrow("Cannot use a closed database");
+    expect(() => db.close()).not.toThrow();
+  });
 });
 
 it("should dispose", () => {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1414,7 +1414,7 @@ it("should dispose AND throw an error if the database is in use", () => {
 });
 
 describe("close() with a statement still alive", () => {
-  it("makes every statement entry point throw", () => {
+  it("makes the statement throw instead of reading the closed database", () => {
     const db = new Database(":memory:");
     db.exec("CREATE TABLE foo (name TEXT)");
     db.exec("INSERT INTO foo (name) VALUES ('foo')");
@@ -1426,11 +1426,29 @@ describe("close() with a statement still alive", () => {
     expect(() => prepared.get()).toThrow("Database has closed");
     expect(() => prepared.all()).toThrow("Database has closed");
     expect(() => prepared.values()).toThrow("Database has closed");
+    expect(() => prepared.raw()).toThrow("Database has closed");
     expect(() => prepared.run()).toThrow("Database has closed");
     expect(() => [...prepared]).toThrow("Database has closed");
     expect(() => prepared.columnTypes).toThrow("Database has closed");
     expect(() => prepared.declaredTypes).toThrow("Database has closed");
     expect(() => prepared.paramsCount).toThrow("Database has closed");
+    expect(() => prepared.safeIntegers()).toThrow("Database has closed");
+    expect(() => JSON.stringify(prepared)).toThrow("Database has closed");
+  });
+
+  it("leaves the statement inspectable, the way finalize() does", () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE foo (name TEXT)");
+    const prepared = db.prepare("SELECT * FROM foo");
+    expect(prepared.all()).toEqual([]);
+
+    db.close();
+
+    // Neither reads the closed database: columnNames is cached from the last
+    // execution, and toString() is how Symbol.toStringTag renders a statement.
+    expect(prepared.columnNames).toEqual(["name"]);
+    expect(prepared.toString()).toBe("");
+    expect(() => Bun.inspect(prepared)).not.toThrow();
   });
 
   it("releases the database file", () => {


### PR DESCRIPTION
## Repro

```js
import { Database } from "bun:sqlite";

const db = new Database("data.db");
db.exec("create table t (v text); insert into t values ('hello')");
const q = db.prepare("select v from t");

db.close();

q.get();   // => { v: "hello" }  (better-sqlite3 / node:sqlite throw)
q.run();   // => throws "Database has closed"
// the database fd is still open; close() cannot be relied on to release it
```

One statement object half-works after `close()`: the read paths return rows, the write path throws. `close(true)` with an outstanding statement reports `database is locked`.

## Cause

`close()` calls `sqlite3_close_v2()`, which only *defers* the close while prepared statements are outstanding, then nulls `VersionSqlite3::db`. Only the write and prepare entry points check for the null handle, so `get()`/`all()`/`values()`/`iterate()` keep stepping the still-live `sqlite3_stmt*`, and SQLite keeps the whole connection (and the database file) open until the last statement is finalized. For `close(true)`, `sqlite3_close()` returns `SQLITE_BUSY`, whose generic error string blames a locking conflict rather than the unfinalized statements.

## Fix

`VersionSqlite3` now tracks the statements prepared against it, and `close(false)` finalizes them, the same way `clearQueryCache()` already finalizes the cached ones. `CHECK_PREPARED` reports `Database has closed` once the handle is gone, so every statement entry point fails instead of just `run()`.

`close(true)` still refuses to close while statements are outstanding, which is its documented contract, but now says why. `sqlite3_close()` returns `SQLITE_BUSY` only for unfinalized statements and backups, and `bun:sqlite` exposes no backup API.

Two things deliberately keep working after `close()`, exactly as they do after `stmt.finalize()` today, because neither reads the closed database:

- `columnNames`, which is cached from the statement's last execution
- `toString()`, which backs the statement's `Symbol.toStringTag` (`src/js/bun/sqlite.ts:172`), so making it throw would break `console.log(stmt)`

The database object being garbage collected while statements are alive is unchanged: that path is refcounted through `VersionSqlite3::release()` and the statements keep working, as `can continue to use existing statements after database has been GC'd` covers.

### Rebase note

The `db.run()` close-during-bind use-after-free this originally also fixed (a binding getter calling `db.close()` frees the `sqlite3*` mid-call) has since landed on `main` via #33072, with the same guard. The conflict resolution keeps `main`'s condition and this PR's comment explaining why the `sqlite3*` is freed at that point. The `rejects db.run(%p) when a binding getter closes the database` tests here still exercise that guard but also assert that the bystander statement throws `Database has closed` afterwards, which is this PR's `CHECK_PREPARED` change.

## Verification

`bun bd test test/js/bun/sqlite/` — 106 pass, 0 fail. The new and updated assertions fail on `main`:

<details>
<summary><code>git checkout origin/main -- src/ && bun bd test test/js/bun/sqlite/sqlite.test.js -t "statement still alive"</code></summary>

```
(fail) makes the statement throw instead of reading the closed database
(fail) leaves the statement inspectable, the way finalize() does
(fail) releases the database file
(fail) stops an in-progress iteration
(fail) rejects a statement whose database is closed while binding
(fail) rejects db.run("INSERT INTO t VALUES ($a)") when a binding getter closes the database
(fail) rejects db.run("INSERT INTO t VALUES ($a); INSERT INTO t VALUES (2)") when a binding getter closes the database
(pass) stays safe when the statement is garbage collected afterwards
 1 pass
 7 fail
```

</details>

plus `close(true) should throw an error if the database is in use` and `should dispose AND throw an error if the database is in use`, which assert the new message. The debug build runs under ASAN.

`test/js/sql/sqlite-sql.test.ts` has two tests that time out in debug+ASAN builds (`properly finalizes prepared statements`, `handles exotic but valid SQL patterns`). Both time out identically on `main`.
