### PR TITLE
nit: a missing space is breaking the Figlet "Bun!" logo @/docs/quickstart

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -148,7 +148,7 @@ Build a minimal HTTP server with `Bun.serve`, run it locally, then evolve it by 
     Visit [`http://localhost:3000/figlet`](http://localhost:3000/figlet) to test the server. You should see a page that says `"Bun!"` in ASCII art.
 
     ```txt
-    ____              _
+     ____              _
     | __ ) _   _ _ __ | |
     |  _ \| | | | '_ \| |
     | |_) | |_| | | | |_|


### PR DESCRIPTION
While working through the Quickstart @<https://bun.com/docs/quickstart> I noticed that the "Bun!" Figlet ASCII art seemed broken. So I checked with my build and added the missing space.

### What does this PR do?

This PR fixes the Quickstart which currently has a subtly broken ASCII-art Figlet "Bun!" (as seen below).

### How did you verify your code works?

I used a diff-checker to verify the ASCII art matches what mine produced. It looks correct; see below.

What is currently at <https://bun.com/docs/quickstart>: https://snipboard.io/PKcFth.jpg
```
____              _
| __ ) _   _ _ __ | |
|  _ \| | | | '_ \| |
| |_) | |_| | | | |_|
|____/ \__,_|_| |_(_)
```
This PR fixes it to 
```
  ____              _ 
 | __ ) _   _ _ __ | |
 |  _ \| | | | '_ \| |
 | |_) | |_| | | | |_|
 |____/ \__,_|_| |_(_)
```