### PR TITLE
spawn: stop reading once maxBuffer is exceeded

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -225,6 +225,10 @@ const result = Bun.spawnSync({
 // process exits
 ```
 
+Bun stops reading as soon as the limit is passed, so the returned output can
+exceed `maxBuffer` only by the single read that passed it, never by whatever
+the process manages to write before the kill lands. This matches Node.js.
+
 ## Inter-process communication (IPC)
 
 Bun supports a direct inter-process communication channel between two `bun` processes. To receive messages from a spawned Bun subprocess, specify an `ipc` handler.

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -552,6 +552,31 @@ impl PosixBufferedReader {
         false
     }
 
+    /// Charges `bytes_read` against the `maxBuffer` budget, returning `true`
+    /// once it is gone. The overflow callback only kills the child, which takes
+    /// effect asynchronously, so the caller must also stop reading.
+    #[inline]
+    fn charge_max_buffer(parent: &mut PosixBufferedReader, bytes_read: usize) -> bool {
+        let Some(maxbuf) = parent.maxbuf else {
+            return false;
+        };
+        if !MaxBuf::on_read_bytes(maxbuf, bytes_read as u64) {
+            return false;
+        }
+        parent.vtable.on_max_buffer_overflow(maxbuf);
+        true
+    }
+
+    /// Closes the handle so the child cannot put more bytes in the pipe, then
+    /// reports what was buffered. Tail position: `done()` may free `parent`.
+    /// Callers must already have handed the overflowing chunk to the consumer.
+    fn stop_for_max_buffer(parent: &mut PosixBufferedReader) {
+        parent.close_without_reporting();
+        if !parent.flags.contains(PosixFlags::IS_DONE) {
+            parent.done();
+        }
+    }
+
     fn read_file(parent: &mut PosixBufferedReader, fd: Fd, size_hint: isize, received_hup: bool) {
         fn pread_fn(fd1: Fd, buf: &mut [u8], offset: usize) -> sys::Result<usize> {
             sys::pread(fd1, buf, i64::try_from(offset).expect("int cast"))
@@ -643,11 +668,7 @@ impl PosixBufferedReader {
 
                 match sys::read_nonblocking(fd, stack_buffer) {
                     sys::Result::Ok(bytes_read) => {
-                        if let Some(l) = parent.maxbuf {
-                            if MaxBuf::on_read_bytes(l, bytes_read as u64) {
-                                parent.vtable.on_max_buffer_overflow(l);
-                            }
-                        }
+                        let over_budget = Self::charge_max_buffer(parent, bytes_read);
 
                         if bytes_read == 0 {
                             // EOF - finished and closed pipe
@@ -673,6 +694,11 @@ impl PosixBufferedReader {
                                 ._buffer
                                 .extend_from_slice(&stack_buffer[..bytes_read]);
                         }
+
+                        if over_budget {
+                            Self::stop_for_max_buffer(parent);
+                            return;
+                        }
                     }
                     sys::Result::Err(err) => {
                         if !err.is_retry() {
@@ -692,11 +718,7 @@ impl PosixBufferedReader {
                     let buf_len = buf.len();
                     match sys::read_nonblocking(fd, buf) {
                         sys::Result::Ok(bytes_read) => {
-                            if let Some(l) = parent.maxbuf {
-                                if MaxBuf::on_read_bytes(l, bytes_read as u64) {
-                                    parent.vtable.on_max_buffer_overflow(l);
-                                }
-                            }
+                            let over_budget = Self::charge_max_buffer(parent, bytes_read);
                             parent._offset += bytes_read;
                             // SAFETY: bytes_read bytes were just initialized by the syscall.
                             unsafe { bun_core::vec::commit_spare(&mut parent._buffer, bytes_read) };
@@ -712,16 +734,25 @@ impl PosixBufferedReader {
                             if streaming {
                                 let new_len = parent._buffer.len();
                                 let chunk = &parent._buffer[new_len - bytes_read..new_len];
-                                if !parent.vtable.on_read_chunk(
+                                let keep_going = parent.vtable.on_read_chunk(
                                     chunk,
                                     if received_hup && bytes_read < buf_len {
                                         ReadState::Eof
                                     } else {
                                         ReadState::Progress
                                     },
-                                ) {
+                                );
+                                // Closing for `over_budget` outranks the
+                                // consumer asking us to stop: it must still
+                                // happen, or nothing ever caps the pipe.
+                                if !keep_going && !over_budget {
                                     return;
                                 }
+                            }
+
+                            if over_budget {
+                                Self::stop_for_max_buffer(parent);
+                                return;
                             }
                             buf_len
                         }
@@ -836,15 +867,14 @@ impl PosixBufferedReader {
 
                     match sys_fn(fd, buf, parent._offset) {
                         sys::Result::Ok(bytes_read) => {
-                            if let Some(l) = parent.maxbuf {
-                                if MaxBuf::on_read_bytes(l, bytes_read as u64) {
-                                    parent.vtable.on_max_buffer_overflow(l);
-                                }
-                            }
+                            let over_budget = Self::charge_max_buffer(parent, bytes_read);
                             parent._offset += bytes_read;
                             head_start += bytes_read;
 
-                            if bytes_read == 0 {
+                            // `over_budget` is terminal for the same reason EOF
+                            // is: the child was killed and nothing past the cap
+                            // may reach the consumer.
+                            if bytes_read == 0 || over_budget {
                                 parent.close_without_reporting();
                                 if head_start > 0 {
                                     let _ = parent.vtable.on_read_chunk(
@@ -954,14 +984,12 @@ impl PosixBufferedReader {
                             ._buffer
                             .extend_from_slice(&stack_buffer[..bytes_read]);
                     }
-                    if let Some(l) = parent.maxbuf {
-                        if MaxBuf::on_read_bytes(l, bytes_read as u64) {
-                            parent.vtable.on_max_buffer_overflow(l);
-                        }
-                    }
+                    let over_budget = Self::charge_max_buffer(parent, bytes_read);
                     parent._offset += bytes_read;
 
-                    if bytes_read == 0 {
+                    // `over_budget` is terminal for the same reason EOF is: the
+                    // child was killed and nothing past the cap may be buffered.
+                    if bytes_read == 0 || over_budget {
                         parent.close_without_reporting();
                         let _ = Self::drain_chunk(&parent.vtable, &parent._buffer, ReadState::Eof);
                         if !parent.flags.contains(PosixFlags::IS_DONE) {
@@ -996,16 +1024,14 @@ impl PosixBufferedReader {
 
             match sys_fn(fd, buf, parent._offset) {
                 sys::Result::Ok(bytes_read) => {
-                    if let Some(l) = parent.maxbuf {
-                        if MaxBuf::on_read_bytes(l, bytes_read as u64) {
-                            parent.vtable.on_max_buffer_overflow(l);
-                        }
-                    }
+                    let over_budget = Self::charge_max_buffer(parent, bytes_read);
                     parent._offset += bytes_read;
                     // SAFETY: bytes_read bytes initialized by sys_fn.
                     unsafe { bun_core::vec::commit_spare(&mut parent._buffer, bytes_read) };
 
-                    if bytes_read == 0 {
+                    // `over_budget` is terminal for the same reason EOF is: the
+                    // child was killed and nothing past the cap may be buffered.
+                    if bytes_read == 0 || over_budget {
                         parent.close_without_reporting();
                         let _ = Self::drain_chunk(&parent.vtable, &parent._buffer, ReadState::Eof);
                         if !parent.flags.contains(PosixFlags::IS_DONE) {
@@ -1240,13 +1266,21 @@ impl WindowsBufferedReader {
         }
     }
 
-    fn _on_read_chunk(&mut self, buf: &[u8], has_more: ReadState) -> bool {
-        if let Some(m) = self.maxbuf {
-            if MaxBuf::on_read_bytes(m, buf.len() as u64) {
-                self.vtable.on_max_buffer_overflow(m);
-            }
+    /// Charges `bytes_read` against the `maxBuffer` budget, returning `true`
+    /// once it is gone. The overflow callback only kills the child, which takes
+    /// effect asynchronously, so the caller must also close the handle.
+    fn charge_max_buffer(&mut self, bytes_read: usize) -> bool {
+        let Some(maxbuf) = self.maxbuf else {
+            return false;
+        };
+        if !MaxBuf::on_read_bytes(maxbuf, bytes_read as u64) {
+            return false;
         }
+        self.vtable.on_max_buffer_overflow(maxbuf);
+        true
+    }
 
+    fn _on_read_chunk(&mut self, buf: &[u8], has_more: ReadState) -> bool {
         if has_more == ReadState::Eof {
             self.flags.insert(WindowsFlags::RECEIVED_EOF);
         }
@@ -1852,6 +1886,8 @@ impl WindowsBufferedReader {
         // SAFETY: slice is inside _buffer's spare capacity; libuv wrote `amount_result` bytes.
         unsafe { bun_core::vec::commit_spare(&mut self._buffer, amount_result) };
 
+        let over_budget = self.charge_max_buffer(amount_result);
+
         let should_continue = self._on_read_chunk(slice, has_more);
 
         // Streaming parents (shell IOReader, subprocess) cannot re-derive
@@ -1866,7 +1902,9 @@ impl WindowsBufferedReader {
             self._buffer.clear();
         }
 
-        if has_more == ReadState::Eof {
+        // `over_budget` is terminal for the same reason EOF is: the child was
+        // killed and nothing past the cap may be buffered.
+        if has_more == ReadState::Eof || over_budget {
             self.close();
         }
     }

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -70,7 +70,7 @@ describe("maxBuffer caps the buffer while the child is still writing", () => {
     }
   `;
 
-  test("Bun.spawnSync", () => {
+  test.concurrent("Bun.spawnSync", () => {
     const proc = Bun.spawnSync([bunExe(), "-e", firehose], {
       maxBuffer,
       killSignal: 0,
@@ -81,8 +81,8 @@ describe("maxBuffer caps the buffer while the child is still writing", () => {
     expect(proc.stderr.length).toBe(0);
   });
 
-  test("Bun.spawn", async () => {
-    const proc = Bun.spawn([bunExe(), "-e", firehose], {
+  test.concurrent("Bun.spawn", async () => {
+    await using proc = Bun.spawn([bunExe(), "-e", firehose], {
       maxBuffer,
       killSignal: 0,
       stdio: ["ignore", "pipe", "pipe"],

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -51,6 +51,48 @@ describe("yes is killed", () => {
   });
 });
 
+describe("maxBuffer caps the buffer while the child is still writing", () => {
+  const maxBuffer = 1024;
+  // Nothing that lands after the limit trips is buffered, so the result can
+  // only overshoot by the read that tripped it: one pipe scratch buffer.
+  // (Node bounds spawnSync the same way, at its 64 KB read size.)
+  const bound = maxBuffer + 256 * 1024;
+
+  // `killSignal: 0` sends no signal at all, so the child outlives the kill and
+  // keeps writing for as long as Bun keeps reading. A child that merely
+  // installs a SIGTERM handler, or is slow to die, behaves the same way.
+  const firehose = `
+    const { writeSync } = require("fs");
+    const chunk = Buffer.alloc(1024 * 1024, 97);
+    for (let i = 0; i < 8; i++) {
+      // Throws EPIPE once Bun has stopped reading.
+      try { writeSync(1, chunk); } catch { break; }
+    }
+  `;
+
+  test("Bun.spawnSync", () => {
+    const proc = Bun.spawnSync([bunExe(), "-e", firehose], {
+      maxBuffer,
+      killSignal: 0,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(proc.exitedDueToMaxBuffer).toBe(true);
+    expect(proc.stdout.length).toBeLessThanOrEqual(bound);
+    expect(proc.stderr.length).toBe(0);
+  });
+
+  test("Bun.spawn", async () => {
+    const proc = Bun.spawn([bunExe(), "-e", firehose], {
+      maxBuffer,
+      killSignal: 0,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await proc.exited;
+    const stdout = await proc.stdout.bytes();
+    expect(stdout.length).toBeLessThanOrEqual(bound);
+  });
+});
+
 describe("maxBuffer infinity does not limit the number of bytes", () => {
   const sample = "this is a long example string\n";
   const sample_repeat_count = 10000;


### PR DESCRIPTION
`maxBuffer` is meant to be the guard that stops a chatty child from blowing up the parent's memory, but it only kills the child; it never stops the read loop. The kill is asynchronous, so the reader keeps appending everything the child writes before it dies.

## Repro

```js
const { spawnSync } = require("child_process");

// child installs a SIGTERM handler (or is simply slow to die), then firehoses
const child = `process.on("SIGTERM", () => {}); process.stdout.write(Buffer.alloc(8e6, 97));`;

const r = spawnSync(process.execPath, ["-e", child], { maxBuffer: 1024 });
console.log(r.stdout.length, r.status, r.error?.code);
```

|         | `stdout.length` | `status` |
| ------- | --------------- | -------- |
| Node    | `65536`         | `1`      |
| Bun     | `8388608`       | `0`      |

The whole 8 MB comes back, with `status: 0`. The only hint anything went wrong is `error.code === "ENOBUFS"`, which a caller that only checks `status` never sees. Without the SIGTERM handler it is the same bug with a timing-dependent size: against a 50 MB writer `maxBuffer: 4096` returned 365 KB to 475 KB across runs here (Node: a flat 65 KB).

## Cause

`MaxBuf::on_read_bytes` goes negative, `on_max_buffer_overflow` fires, `Subprocess::on_max_buffer` sends `killSignal`, and the read loop in `src/io/PipeReader.rs` carries straight on, reserving more capacity and draining the pipe until the child actually exits. Node's `spawn_sync.cc` `uv_read_stop`s and closes the stdio pipes at this point, which is why its overshoot is bounded by one 64 KB read.

## Fix

Treat a negative budget the same way the loops already treat EOF: close the handle and report what is buffered, at the read that tripped it. The chunk that tripped the limit is still kept, matching Node (`test-child-process-spawnsync-maxbuf.js` asserts exactly this: "We can have buffers larger than maxBuffer because underneath we alloc 64k that matches our read sizes").

Applied to every read path that charges the budget: both POSIX loops (buffered and streaming), plus `WindowsBufferedReader::on_read`.

Closing the handle, rather than only pausing, is what Node does and is what lets the child stop being a firehose: its next write gets `EPIPE` instead of succeeding into a buffer nobody will read. The pending kill signal is delivered before the child can run another `write`, so the process still reports `killSignal` rather than `SIGPIPE`, and `spawn-maxbuf.test.ts`'s existing `signalCode === "SIGHUP"` assertions still hold.

## Verification

`Bun.spawnSync` and `Bun.spawn` now cap at 262144 bytes (one 256 KB pipe scratch read) where they previously returned all 8388608. The lazily-streamed `proc.stdout` path is capped the same way.

New tests in `test/js/bun/spawn/spawn-maxbuf.test.ts` fail on `main` (`Expected: <= 263168`, `Received: 8388608`) and pass with the fix.

<details>
<summary>Suites run against the debug build</summary>

- `test/js/bun/spawn/**`: the only failures are ones that fail identically on an unmodified tree (debug/ASAN timing budgets in `spawn-pipe-leak`, `spawn-stdin-readable-stream-edge-cases`, `spawn_waiter_thread`, plus `spawn-maxbuf`'s pre-existing `< 100ms` assertion, which this change actually speeds up).
- `test/js/node/child_process/**`: identical failure set before and after.
- `test/js/bun/shell/**`: 21 failures before and after (flaky set, same count).
- Node compat: `test-child-process-{spawnsync,exec,execfile,execsync,execfilesync}-maxbuf.js`, `test-child-process-spawnsync-validation-errors.js`, `test-fs-readfile{,sync}-pipe-large.js` all pass.
- `bun run rust:check-all`: 10/10 targets, including Windows x64/aarch64.

</details>

## Relationship to #31517

The duplicate bot flagged #31517, but the two fix different halves of `maxBuffer` and neither subsumes the other:

- **#31517** fixes *the kill never firing* on the streaming path. Converting `proc.stdout` to a `ReadableStream` hands the `MaxBuf` to a `FileReader` whose vtable has no subprocess back-reference, so `on_max_buffer_overflow` reaches a no-op. It moves the dispatch onto the `MaxBuf` itself.
- **This PR** fixes *the read loop never stopping* once the budget is gone, on every path including `spawnSync`. It leaves the dispatch alone and changes the five read sites that charge the budget.

They touch `src/io/PipeReader.rs` in disjoint regions (#31517 edits the `BufferedReaderParent::on_max_buffer_overflow` default body; this edits the read loops and `WindowsBufferedReader::on_read`), and the APIs this PR calls (`MaxBuf::on_read_bytes`'s return value, `vtable.on_max_buffer_overflow`) survive #31517 unchanged.

They compose: with only this PR the streaming path is bounded but the child is not killed; with only #31517 the child is killed but the buffer still overshoots by however much it writes first. Happy to rebase onto whichever lands first.
