### PR TITLE
HTMLRewriter: accept a Response whose body is a JS-created ReadableStream

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -755,6 +755,9 @@ impl BufferOutputSink {
             // ref taken for the in-flight bufferer.
             unsafe { BufferOutputSink::deref(sink) };
             return Ok(match buffering_error {
+                // The bufferer entered JS and it threw: that exception is
+                // already pending on the VM, so surface it instead of masking it.
+                crate::Error::JSError => return Err(jsc::JsError::Thrown),
                 crate::Error::StreamAlreadyUsed => {
                     let err = system_error(
                         "ERR_STREAM_ALREADY_FINISHED",

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -30,8 +30,6 @@ pub enum Error {
     StreamAlreadyUsed,
     #[error("InvalidStream")]
     InvalidStream,
-    #[error("UnsupportedStreamType")]
-    UnsupportedStreamType,
     #[error("JSError")]
     JSError,
     #[error("ERR_TLS_CERT_ALTNAME_INVALID")]
@@ -609,7 +607,6 @@ impl Error {
             Self::FmtError => "FmtError",
             Self::StreamAlreadyUsed => "StreamAlreadyUsed",
             Self::InvalidStream => "InvalidStream",
-            Self::UnsupportedStreamType => "UnsupportedStreamType",
             Self::JSError => "JSError",
             Self::ERR_TLS_CERT_ALTNAME_INVALID => "ERR_TLS_CERT_ALTNAME_INVALID",
             Self::RequestBodyNotReusable => "RequestBodyNotReusable",

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1,6 +1,5 @@
 //! https://developer.mozilla.org/en-US/docs/Web/API/Body
 
-use bun_collections::VecExt;
 use core::ffi::c_void;
 use core::ptr::NonNull;
 
@@ -18,7 +17,6 @@ use bun_http_types::MimeType::MimeType;
 use crate::jsc::HTTPHeaderName;
 pub use crate::webcore::InternalBlob;
 use crate::webcore::form_data::AsyncFormDataExt as _;
-use crate::webcore::sink::{self, ArrayBufferSink};
 use bun_core::{MutableString, String as BunString, ZigString};
 use bun_core::{WTFStringImpl, WTFStringImplExt as _, WTFStringImplStruct};
 use bun_jsc::ZigStringJsc as _;
@@ -1635,9 +1633,6 @@ impl Value {
 // JSC-integration: extract / BodyMixin (host-fn methods) / ValueBufferer.
 // ────────────────────────────────────────────────────────────────────────────
 
-// `sink::JSSink<T>` is a free generic (inherent associated types are unstable).
-type ArrayBufferJSSink = sink::JSSink<ArrayBufferSink>;
-
 // https://github.com/WebKit/webkit/blob/main/Source/WebCore/Modules/fetch/FetchBody.cpp#L45
 pub(crate) fn extract(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Body> {
     let body_value = Value::from_js(global_this, value)?;
@@ -2235,7 +2230,6 @@ pub struct ValueBufferer<'a> {
     pub ctx: *mut c_void,
     pub on_finished_buffering: ValueBuffererCallback,
 
-    pub js_sink: Option<Box<ArrayBufferJSSink>>,
     pub byte_stream: Option<NonNull<ByteStream>>,
     // readable stream strong ref to keep byte stream alive
     pub readable_stream_ref: webcore::readable_stream::Strong,
@@ -2254,13 +2248,6 @@ impl<'a> Drop for ValueBufferer<'a> {
             bun_ptr::BackRef::from(byte_stream).unpipe_without_deref();
         }
         self.readable_stream_ref.deinit();
-
-        if let Some(mut buffer_stream) = self.js_sink.take() {
-            buffer_stream.detach_self(self.global);
-            // The wrapper is a `Box<JSSink<ArrayBufferSink>>`; dropping it
-            // frees the box and runs `Vec<u8>`'s Drop.
-            drop(buffer_stream);
-        }
     }
 }
 
@@ -2273,7 +2260,6 @@ impl<'a> ValueBufferer<'a> {
         Self {
             ctx,
             on_finished_buffering: on_finish,
-            js_sink: None,
             byte_stream: None,
             readable_stream_ref: Default::default(),
             global,
@@ -2415,7 +2401,7 @@ impl<'a> ValueBufferer<'a> {
         let Some(sink) = Self::take_ctx(args.ptr[args.len - 1]) else {
             return Ok(JSValue::UNDEFINED);
         };
-        sink.handle_resolve_stream(true);
+        sink.handle_resolve_stream(args.ptr[0], true);
         Ok(JSValue::UNDEFINED)
     }
 
@@ -2433,12 +2419,6 @@ impl<'a> ValueBufferer<'a> {
     }
 
     fn handle_reject_stream(&mut self, err: JSValue, is_async: bool) {
-        if let Some(mut wrapper) = self.js_sink.take() {
-            wrapper.detach_self(self.global);
-            // see `Drop` impl — dropping the Box frees the wrapper
-            // and runs `Vec<u8>`'s Drop.
-            drop(wrapper);
-        }
         // `jsc::strong::Optional` owns a GC root; `ptr::read`-duplicating it would
         // double-deinit. Transfer the single owner directly to the callback; the callback
         // (or its returned `ValueError`'s Drop) is responsible for releasing it.
@@ -2446,15 +2426,64 @@ impl<'a> ValueBufferer<'a> {
         (self.on_finished_buffering)(self.ctx, b"", Some(ValueError::JSValue(ref_)), is_async);
     }
 
-    fn handle_resolve_stream(&mut self, is_async: bool) {
-        if let Some(wrapper) = &self.js_sink {
-            let bytes = wrapper.sink.bytes.slice();
+    /// `resolved_value` is what `readableStreamToArrayBuffer` fulfilled with: an
+    /// `ArrayBuffer`, or a `Uint8Array` when the stream yielded a single string
+    /// chunk. It stays rooted for the whole call (reaction argument frame, or
+    /// this frame's stack), and `on_finished_buffering` copies the bytes out.
+    fn handle_resolve_stream(&mut self, resolved_value: JSValue, is_async: bool) {
+        if let Some(array_buffer) = resolved_value.as_array_buffer(self.global) {
+            let bytes = array_buffer.slice();
             bun_core::scoped_log!(BodyValueBufferer, "handleResolveStream {}", bytes.len());
             (self.on_finished_buffering)(self.ctx, bytes, None, is_async);
         } else {
-            bun_core::scoped_log!(BodyValueBufferer, "handleResolveStream no sink");
+            bun_core::scoped_log!(BodyValueBufferer, "handleResolveStream no buffer");
             (self.on_finished_buffering)(self.ctx, b"", None, is_async);
         }
+    }
+
+    /// Buffer a JS-backed stream (`new ReadableStream({...})` or a `type:
+    /// "direct"` stream) through `readableStreamToArrayBuffer` — the same path
+    /// `new Response(stream).arrayBuffer()` takes. Only the JS runtime knows how
+    /// to drive these sources; `byte_stream`'s native pipe cannot.
+    ///
+    /// `stream` is GC-rooted by the caller's `readable_stream_ref`.
+    fn buffer_js_readable_stream(&mut self, stream: ReadableStream) -> crate::Result<()> {
+        let global = self.global;
+
+        let promise_value = global.readable_stream_to_array_buffer(stream.value);
+        if promise_value.is_empty() {
+            // The builtin threw (e.g. the stream yielded a chunk that is neither
+            // a string nor a view); the exception is pending on the VM.
+            return Err(crate::Error::JSError);
+        }
+        promise_value.ensure_still_alive();
+
+        // Unreachable: the C++ wrapper throws a TypeError when the builtin
+        // hands back anything other than a promise, caught by `is_empty` above.
+        let Some(promise) = promise_value.as_any_promise() else {
+            return Err(crate::Error::InvalidStream);
+        };
+        match promise.unwrap(global.vm(), jsc::PromiseUnwrapMode::MarkHandled) {
+            jsc::PromiseResult::Pending => {
+                // The +1 the owner took for this in-flight buffering doubles as
+                // the cell's ref: settling consumes it via `on_finished_buffering`,
+                // and a promise GC'd without settling releases it through
+                // `Bun__NativePromiseContext__destroy`.
+                let cell = crate::api::NativePromiseContext::create(
+                    global,
+                    std::ptr::from_mut::<Self>(self),
+                );
+                promise_value.then_with_value(
+                    global,
+                    cell,
+                    Bun__BodyValueBufferer__onResolveStream,
+                    Bun__BodyValueBufferer__onRejectStream,
+                );
+            }
+            jsc::PromiseResult::Fulfilled(value) => self.handle_resolve_stream(value, false),
+            jsc::PromiseResult::Rejected(err) => self.handle_reject_stream(err, false),
+        }
+        Ok(())
     }
 
     fn buffer_locked_body_value(
@@ -2499,9 +2528,7 @@ impl<'a> ValueBufferer<'a> {
                 | webcore::readable_stream::Source::File(_) => unreachable!(),
                 webcore::readable_stream::Source::JavaScript
                 | webcore::readable_stream::Source::Direct => {
-                    // this is broken right now
-                    // return self.create_js_sink(stream);
-                    return Err(crate::Error::UnsupportedStreamType);
+                    return self.buffer_js_readable_stream(stream);
                 }
                 webcore::readable_stream::Source::Bytes(byte_stream_ptr) => {
                     // BACKREF: see `Source::bytes()` — payload owned by the

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2447,8 +2447,6 @@ impl<'a> ValueBufferer<'a> {
     /// "direct"` stream) through `readableStreamToArrayBuffer` — the same path
     /// `new Response(stream).arrayBuffer()` takes. Only the JS runtime knows how
     /// to drive these sources; `byte_stream`'s native pipe cannot.
-    ///
-    /// `stream` is GC-rooted by the caller's `readable_stream_ref`.
     fn buffer_js_readable_stream(&mut self, stream: ReadableStream) -> crate::Result<()> {
         let global = self.global;
 
@@ -2461,6 +2459,12 @@ impl<'a> ValueBufferer<'a> {
             scope.assert_exception_presence_matches(value.is_empty());
             value
         };
+        // Release the GC root `buffer_locked_body_value` took. The builtin owns
+        // the stream through its own reader now, and whatever drives the source
+        // keeps the returned promise alive. Rooting it here also roots the
+        // promise chain — and so the `NativePromiseContext` cell — forever, so
+        // an abandoned transform could never be collected. See `set_promise`.
+        self.readable_stream_ref.deinit();
         if promise_value.is_empty() {
             // The builtin threw (e.g. the stream yielded a chunk that is neither
             // a string nor a view); the exception is pending on the VM.

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2435,6 +2435,9 @@ impl<'a> ValueBufferer<'a> {
     /// the slice in place while re-entering user JS, which can detach it
     /// (`ArrayBuffer.prototype.transfer`) and free the backing store mid-read.
     fn handle_resolve_stream(&mut self, resolved_value: JSValue, is_async: bool) {
+        // Only the `Source::Bytes` pipe appends to `stream_buffer`, and a bufferer
+        // drives exactly one source, so this is the sole writer on this path.
+        debug_assert!(self.stream_buffer.list.is_empty());
         if let Some(array_buffer) = resolved_value.as_array_buffer(self.global) {
             let _ = self.stream_buffer.write(array_buffer.slice());
         }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2428,17 +2428,19 @@ impl<'a> ValueBufferer<'a> {
 
     /// `resolved_value` is what `readableStreamToArrayBuffer` fulfilled with: an
     /// `ArrayBuffer`, or a `Uint8Array` when the stream yielded a single string
-    /// chunk. It stays rooted for the whole call (reaction argument frame, or
-    /// this frame's stack), and `on_finished_buffering` copies the bytes out.
+    /// chunk.
+    ///
+    /// The bytes are copied into `stream_buffer` first. The single-chunk fast
+    /// path hands back the *user's own* ArrayBuffer, and the consumer tokenizes
+    /// the slice in place while re-entering user JS, which can detach it
+    /// (`ArrayBuffer.prototype.transfer`) and free the backing store mid-read.
     fn handle_resolve_stream(&mut self, resolved_value: JSValue, is_async: bool) {
         if let Some(array_buffer) = resolved_value.as_array_buffer(self.global) {
-            let bytes = array_buffer.slice();
-            bun_core::scoped_log!(BodyValueBufferer, "handleResolveStream {}", bytes.len());
-            (self.on_finished_buffering)(self.ctx, bytes, None, is_async);
-        } else {
-            bun_core::scoped_log!(BodyValueBufferer, "handleResolveStream no buffer");
-            (self.on_finished_buffering)(self.ctx, b"", None, is_async);
+            let _ = self.stream_buffer.write(array_buffer.slice());
         }
+        let bytes = self.stream_buffer.list.as_slice();
+        bun_core::scoped_log!(BodyValueBufferer, "handleResolveStream {}", bytes.len());
+        (self.on_finished_buffering)(self.ctx, bytes, None, is_async);
     }
 
     /// Buffer a JS-backed stream (`new ReadableStream({...})` or a `type:
@@ -2450,7 +2452,15 @@ impl<'a> ValueBufferer<'a> {
     fn buffer_js_readable_stream(&mut self, stream: ReadableStream) -> crate::Result<()> {
         let global = self.global;
 
-        let promise_value = global.readable_stream_to_array_buffer(stream.value);
+        // The builtin's C++ wrapper returns under a `ThrowScope`, so its
+        // simulated throw has to be observed here; a bare `is_empty()` check is
+        // invisible to `validateExceptionChecks` and trips the next scope.
+        let promise_value = {
+            bun_jsc::validation_scope!(scope, global);
+            let value = global.readable_stream_to_array_buffer(stream.value);
+            scope.assert_exception_presence_matches(value.is_empty());
+            value
+        };
         if promise_value.is_empty() {
             // The builtin threw (e.g. the stream yielded a chunk that is neither
             // a string nor a view); the exception is pending on the VM.

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -303,6 +303,202 @@ describe("HTMLRewriter", () => {
     });
   });
 
+  describe("transform() accepts a JavaScript-backed ReadableStream body", () => {
+    // https://github.com/oven-sh/bun/issues/14216
+    // https://github.com/oven-sh/bun/issues/11758
+    const encode = s => new TextEncoder().encode(s);
+
+    function rewriter() {
+      return new HTMLRewriter().on("p", {
+        element(element) {
+          element.setInnerContent("bye");
+        },
+      });
+    }
+
+    function streamOf(...chunks) {
+      return new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+    }
+
+    it("single Uint8Array chunk", async () => {
+      const transformed = rewriter().transform(new Response(streamOf(encode("<p>hi</p>"))));
+      expect(await transformed.text()).toBe("<p>bye</p>");
+    });
+
+    it("single string chunk", async () => {
+      // readableStreamToArrayBuffer hands a single string chunk back as a
+      // Uint8Array view rather than an ArrayBuffer, so this exercises a
+      // different branch than the binary chunk above.
+      const transformed = rewriter().transform(new Response(streamOf("<p>hi</p>")));
+      expect(await transformed.text()).toBe("<p>bye</p>");
+    });
+
+    it("an element split across chunk boundaries", async () => {
+      const transformed = rewriter().transform(
+        new Response(streamOf(encode("<p>h"), encode("i</"), encode("p><p>two</p>"))),
+      );
+      expect(await transformed.text()).toBe("<p>bye</p><p>bye</p>");
+    });
+
+    it("mixed string and binary chunks", async () => {
+      const transformed = rewriter().transform(new Response(streamOf("<p>a</p>", encode("<p>b</p>"))));
+      expect(await transformed.text()).toBe("<p>bye</p><p>bye</p>");
+    });
+
+    it("empty stream", async () => {
+      let endCalls = 0;
+      const transformed = new HTMLRewriter()
+        .onDocument({
+          end() {
+            endCalls++;
+          },
+        })
+        .transform(new Response(streamOf()));
+      expect(await transformed.text()).toBe("");
+      expect(endCalls).toBe(1);
+    });
+
+    it("a direct stream", async () => {
+      const body = new ReadableStream({
+        type: "direct",
+        pull(controller) {
+          controller.write("<p>hi</p>");
+          controller.close();
+        },
+      });
+      expect(await rewriter().transform(new Response(body)).text()).toBe("<p>bye</p>");
+    });
+
+    it("a stream that only produces chunks after transform() returns", async () => {
+      // start() stays pending across transform(), so the rewriter has to take
+      // the asynchronous path instead of buffering everything up front.
+      const { promise: gate, resolve: openGate } = Promise.withResolvers();
+      const body = new ReadableStream({
+        async start(controller) {
+          await gate;
+          controller.enqueue(encode("<p>hi</p>"));
+          controller.close();
+        },
+      });
+      const text = rewriter().transform(new Response(body)).text();
+      openGate();
+      expect(await text).toBe("<p>bye</p>");
+    });
+
+    it("every way of reading the transformed response", async () => {
+      const read = {
+        text: response => response.text(),
+        arrayBuffer: async response => new TextDecoder().decode(await response.arrayBuffer()),
+        bytes: async response => new TextDecoder().decode(await response.bytes()),
+        blob: response => response.blob().then(blob => blob.text()),
+        json: response => response.json().then(value => JSON.stringify(value)),
+        getReader: async response => {
+          const reader = response.body.getReader();
+          const parts = [];
+          for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
+            parts.push(new TextDecoder().decode(chunk.value));
+          }
+          return parts.join("");
+        },
+        readableStreamToText: response => Bun.readableStreamToText(response.body),
+      };
+
+      const html = '<p>hi</p><p data-x="1">there</p>';
+      const expected = '<p>bye</p><p data-x="1">bye</p>';
+      for (const [name, consume] of Object.entries(read)) {
+        const transformed = rewriter().transform(new Response(streamOf(encode(html))));
+        if (name === "json") {
+          // Not valid JSON — but it must fail as a JSON parse error, which
+          // still proves the transformed bytes reached the parser.
+          await expect(consume(transformed)).rejects.toThrow(/JSON/i);
+          continue;
+        }
+        expect({ [name]: await consume(transformed) }).toEqual({ [name]: expected });
+      }
+    });
+
+    it("element handlers observe the streamed document", async () => {
+      const tags = [];
+      const transformed = new HTMLRewriter()
+        .on("*", {
+          element(element) {
+            tags.push(element.tagName);
+          },
+        })
+        .transform(new Response(streamOf(encode("<div><p>hi</p></div>"))));
+      expect(await transformed.text()).toBe("<div><p>hi</p></div>");
+      expect(tags).toEqual(["div", "p"]);
+    });
+
+    it("a stream that errors rejects the transformed body", async () => {
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encode("<p>hi</p>"));
+          controller.error(new Error("upstream boom"));
+        },
+      });
+      const transformed = rewriter().transform(new Response(body));
+      // Must reject rather than resolve with the truncated document.
+      await expect(transformed.text()).rejects.toThrow("upstream boom");
+    });
+
+    it("a stream that errors after transform() returns rejects the transformed body", async () => {
+      const { promise: gate, resolve: openGate } = Promise.withResolvers();
+      const body = new ReadableStream({
+        async start(controller) {
+          await gate;
+          controller.error(new Error("late boom"));
+        },
+      });
+      const text = rewriter().transform(new Response(body)).text();
+      openGate();
+      await expect(text).rejects.toThrow("late boom");
+    });
+
+    it("a chunk that is neither a string nor a view throws", async () => {
+      const transform = () => rewriter().transform(new Response(streamOf(42)));
+      // The underlying TypeError must surface, not "Failed to pipe stream".
+      expect(transform).toThrow(TypeError);
+      expect(transform).not.toThrow("Failed to pipe stream");
+    });
+
+    it("reusing the transformed response's source stream throws", async () => {
+      const response = new Response(streamOf(encode("<p>hi</p>")));
+      expect(await rewriter().transform(response).text()).toBe("<p>bye</p>");
+      expect(() => rewriter().transform(response)).toThrow();
+    });
+
+    it("served over Bun.serve", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          const body = new ReadableStream({
+            start(controller) {
+              controller.enqueue(encode("<b>hello world</b>"));
+              controller.close();
+            },
+          });
+          return new HTMLRewriter()
+            .on("b", {
+              element(element) {
+                element.before("<h1>", { html: true });
+                element.after("</h1>", { html: true });
+                element.removeAndKeepContent();
+              },
+            })
+            .transform(new Response(body, { headers: { "content-type": "text/html" } }));
+        },
+      });
+      const response = await fetch(server.url);
+      expect(await response.text()).toBe("<h1>hello world</h1>");
+    });
+  });
+
   it("HTMLRewriter: async replacement using fetch + Bun.serve", async () => {
     await gcTick();
     let content;
@@ -946,12 +1142,12 @@ const payloads = [
   {
     name: "direct",
     data: getStream("direct", "none"),
-    test: it.todo,
+    test: it,
   },
   {
     name: "default",
     data: getStream("default", "none"),
-    test: it.todo,
+    test: it,
   },
   {
     name: "file",

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -473,6 +473,33 @@ describe("HTMLRewriter", () => {
       expect(() => rewriter().transform(response)).toThrow("Response body already used");
     });
 
+    it("does not rewrite out of the source buffer a handler can detach", async () => {
+      // readableStreamToArrayBuffer's single-chunk fast path returns the user's
+      // own ArrayBuffer. lol-html tokenizes its input in place and dispatches
+      // handlers mid-scan, so a handler that mutates (or transfers, then frees)
+      // that buffer must not be able to reach into the bytes still being parsed.
+      let chunk;
+      const body = new ReadableStream({
+        start(controller) {
+          chunk = encode("<a>x</a><zzz>y</zzz>");
+          controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+      const transformed = new HTMLRewriter()
+        .on("a", {
+          element() {
+            // overwrite "<zzz>" (not yet tokenized) with "<qqq>"
+            chunk.set(encode("qqq"), 9);
+            // and drop the backing store the rewriter would be reading
+            chunk.buffer.transfer();
+            Bun.gc(true);
+          },
+        })
+        .transform(new Response(body));
+      expect(await transformed.text()).toBe("<a>x</a><zzz>y</zzz>");
+    });
+
     // Resolves with "" instead: the `.body` getter builds a ByteStream the
     // producer is never told about, so done() closes it empty. Pre-existing and
     // not specific to JS sources — a fetch body that is still mid-stream when

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,3 +1,4 @@
+import { heapStats } from "bun:jsc";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
@@ -498,6 +499,39 @@ describe("HTMLRewriter", () => {
         })
         .transform(new Response(body));
       expect(await transformed.text()).toBe("<a>x</a><zzz>y</zzz>");
+    });
+
+    it("does not leak a transform whose source stream never settles", async () => {
+      // The bufferer must not hold a Strong to the source: the stream reaches
+      // the promise chain, which reaches the NativePromiseContext cell holding
+      // the sink's refcount, so rooting it means an abandoned transform can
+      // never be collected.
+      const abandon = () => {
+        const body = new ReadableStream({
+          pull() {
+            return new Promise(() => {});
+          },
+        });
+        rewriter().transform(new Response(body));
+      };
+      // BufferOutputSink's ref is released on the event loop, so drain between
+      // collections rather than measuring straight after Bun.gc().
+      const settle = async () => {
+        for (let i = 0; i < 5; i++) {
+          Bun.gc(true);
+          await Bun.sleep(1);
+        }
+      };
+      const live = () => heapStats().objectTypeCounts.Response ?? 0;
+
+      for (let i = 0; i < 10; i++) abandon(); // warm up lazy structures
+      await settle();
+      const before = live();
+      for (let i = 0; i < 200; i++) abandon();
+      await settle();
+      // Pre-fix this grew by exactly 200 (one leaked sink per transform, each
+      // pinning its output Response).
+      expect(live() - before).toBeLessThan(20);
     });
 
     // Resolves with "" instead: the `.body` getter builds a ByteStream the

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -501,6 +501,59 @@ describe("HTMLRewriter", () => {
       expect(await transformed.text()).toBe("<a>x</a><zzz>y</zzz>");
     });
 
+    // The bufferer drops its GC root on the source once the builtin owns it, so
+    // a live transform is kept alive only by whatever can still settle the
+    // stream. That holds because settling needs the controller, and the
+    // controller holds the stream. Each case hides the stream from userland and
+    // collects hard before letting it finish.
+    describe("a source the bufferer no longer roots still completes", () => {
+      const cases = {
+        "controller held only by a timer": () =>
+          new ReadableStream({
+            start(controller) {
+              setTimeout(() => {
+                controller.enqueue(encode("<p>hi</p>"));
+                controller.close();
+              }, 1);
+            },
+          }),
+        "controller escaping to an outer scope": () => {
+          let escaped;
+          const stream = new ReadableStream({
+            start(controller) {
+              escaped = controller;
+            },
+          });
+          queueMicrotask(() => {
+            escaped.enqueue(encode("<p>hi</p>"));
+            escaped.close();
+          });
+          return stream;
+        },
+        "controller reachable only from a pending pull": () =>
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              await Bun.sleep(1);
+              controller.write("<p>hi</p>");
+              controller.close();
+            },
+          }),
+      };
+
+      for (const [name, makeStream] of Object.entries(cases)) {
+        it(name, async () => {
+          const transformed = rewriter().transform(new Response(makeStream()));
+          // Collect aggressively while the source is still in flight.
+          for (let i = 0; i < 3; i++) {
+            Bun.gc(true);
+            await Bun.sleep(1);
+          }
+          expect(await transformed.text()).toBe("<p>bye</p>");
+        });
+      }
+    });
+
     it("does not leak a transform whose source stream never settles", async () => {
       // The bufferer must not hold a Strong to the source: the stream reaches
       // the promise chain, which reaches the NativePromiseContext cell holding

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -470,7 +470,31 @@ describe("HTMLRewriter", () => {
     it("reusing the transformed response's source stream throws", async () => {
       const response = new Response(streamOf(encode("<p>hi</p>")));
       expect(await rewriter().transform(response).text()).toBe("<p>bye</p>");
-      expect(() => rewriter().transform(response)).toThrow();
+      expect(() => rewriter().transform(response)).toThrow("Response body already used");
+    });
+
+    // Resolves with "" instead: the `.body` getter builds a ByteStream the
+    // producer is never told about, so done() closes it empty. Pre-existing and
+    // not specific to JS sources — a fetch body that is still mid-stream when
+    // transform() returns does the same thing on main (#19305, and #6068 for
+    // the Bun.serve shape, which hangs). Un-skip once the output side is fixed.
+    it.todo(".body of a transform whose source is still pending", async () => {
+      const { promise: gate, resolve: openGate } = Promise.withResolvers();
+      const body = new ReadableStream({
+        async start(controller) {
+          await gate;
+          controller.enqueue(encode("<p>hi</p>"));
+          controller.close();
+        },
+      });
+      const transformed = rewriter().transform(new Response(body));
+      const reader = transformed.body.getReader();
+      openGate();
+      const parts = [];
+      for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
+        parts.push(new TextDecoder().decode(chunk.value));
+      }
+      expect(parts.join("")).toBe("<p>bye</p>");
     });
 
     it("served over Bun.serve", async () => {


### PR DESCRIPTION
Fixes #14216
Fixes #11758

### Repro

```js
const body = new ReadableStream({
  start(c) { c.enqueue(new TextEncoder().encode("<p>hi</p>")); c.close(); },
});

new HTMLRewriter()
  .on("p", { element(e) { e.setInnerContent("bye"); } })
  .transform(new Response(body));
// error: Failed to pipe stream  (code: ERR_STREAM_CANNOT_PIPE)
```

`transform()` itself throws, before anything is read. The same body without the rewriter reads fine (`new Response(body).text()`), and the same rewriter accepts string / Blob / `blob.stream()` / `fetch()` bodies. The broken composition is the documented streaming-SSR and middleware shape: build or wrap an HTML body in JS, rewrite it on the way out.

### Cause

`ValueBufferer::buffer_locked_body_value` (`src/runtime/webcore/Body.rs`) matches on the source stream's kind and rejects two of them outright:

```rust
Source::JavaScript | Source::Direct => {
    // this is broken right now
    // return self.create_js_sink(stream);
    return Err(bun_core::err!("UnsupportedStreamType"));
}
```

`HTMLRewriter`'s `BufferOutputSink` is the bufferer's only caller, and it maps every error other than `StreamAlreadyUsed` to `ERR_STREAM_CANNOT_PIPE`. So a bug class the rewriter never supported surfaces as a generic pipe failure that reads like user error. `Source::Bytes` (fetch/file/blob bodies) has a native pipe; `Source::JavaScript` and `Source::Direct` only the JS runtime knows how to drive, which is what the removed `create_js_sink` was trying to work around with an `ArrayBufferSink`.

### Fix

Route those two sources through `readableStreamToArrayBuffer`, the same builtin `new Response(stream).arrayBuffer()` already uses, and feed the resolved bytes to `on_finished_buffering`:

- already-complete stream → the builtin's promise is fulfilled, bytes are delivered synchronously, and `transform()` keeps its synchronous contract (including throwing a handler's error);
- pending stream → settles through `Bun__BodyValueBufferer__onResolveStream` / `onRejectStream`, the promise reactions that were already wired up and registered in `promiseHandlerID` but unreachable. An upstream error therefore rejects the transformed body rather than truncating it, matching #32927's behavior for native bodies.

The pending-promise context is a `NativePromiseContext` cell, so a promise collected without ever settling releases the sink's ref through `Bun__NativePromiseContext__destroy` instead of leaking.

`readableStreamToArrayBuffer` can also throw synchronously (for example a chunk that is neither a string nor a view). That exception is already pending on the VM, so it is now propagated instead of being masked by `ERR_STREAM_CANNOT_PIPE`.

`js_sink` and its `ArrayBufferJSSink` alias were the dead remains of the `create_js_sink` approach being replaced; nothing ever assigned the field.

### Scope: this is the input side only

The rewriter still buffers the whole document before running lol-html, as it always has for every body type. The output side is untouched; #32988 and #32956 are the orthogonal output-side changes, and neither one fixes this arm (both still carry `// this is broken right now`).

One consequence is worth naming, because it is the one thing this PR does *not* get you. A JS stream that is **already complete** when `transform()` returns (the common shape: `start()` enqueues and closes) resolves synchronously, so the transformed body is a plain blob and every consumer works, including `Bun.serve`. A JS stream that is **still pending** at that point now behaves exactly like a native body that is still mid-stream: `.text()` / `.arrayBuffer()` / `.bytes()` / `.blob()` all work, but reading `.body` yields `""` and returning the response straight from `Bun.serve` hangs.

That is not introduced here. Both reproduce on unmodified `main` with a native source — a `fetch()` whose body is still arriving when `transform()` runs:

```js
// raw TCP upstream sends "<p>h" then stalls
const up = await fetch(url);
const out = new HTMLRewriter().on("p", {...}).transform(up);
await out.body.getReader().read();   // main: resolves empty   (#19305)
// Bun.serve(() => out)              // main: hangs            (#6068)
```

So this PR brings JS-backed sources to parity with native ones rather than past them, and #32988 is what closes the remaining gap for both. A `.todo` in the test file records it.

### Three follow-up fixes, each its own commit

The first revision was wrong in three ways. All three were caught by machinery, not by me, and each has a test that fails without its fix:

- **b641742** — `readableStreamToArrayBuffer`'s C++ wrapper returns under a `ThrowScope`, whose destructor calls `simulateThrow()` when returning to native code. Checking the returned `JSValue` for emptiness is a *value* check, invisible to JSC's exception-check validation, so the outstanding need-check tripped the next scope (`asArrayBuffer`'s `ASSERT_NO_PENDING_EXCEPTION`) and aborted the x64-asan lane. Now wrapped in `validation_scope!` with `assert_exception_presence_matches(value.is_empty())`.
- **b641742** — `handle_resolve_stream` handed lol-html a slice borrowed straight from the resolved ArrayBuffer. `toArrayBuffer()`'s single-chunk fast path returns the *user's own* buffer, and lol-html tokenizes in place while dispatching handlers, so a handler could reach into bytes not yet parsed (`<a>x</a><zzz>` came out as `<a>x</a><qqq>`) or transfer the buffer and free it mid-read. Now copied into `stream_buffer` first, as the `Source::Bytes` path already does.
- **b8c5ff6** — `buffer_locked_body_value` roots the source stream, and on this path that root transitively reaches the `NativePromiseContext` cell holding the sink's refcount, so an abandoned transform leaked its whole `BufferOutputSink`. Measured: 200 abandoned transforms → +200 live `Response` objects. Released once the builtin owns the stream, mirroring what `set_promise` already does for `Response.arrayBuffer()` (with a comment citing #13678 for the same reason).

### Verification

Tests land in `test/js/workerd/html-rewriter.test.js` (the existing HTMLRewriter file — this behavior was never correct, so it is not a regression test). 17 new cases cover: single binary chunk, single string chunk (the builtin returns a `Uint8Array` view there, a different branch), an element split across chunk boundaries, mixed string/binary chunks, an empty stream, a `type: "direct"` stream, a stream that only produces after `transform()` returns, all seven consumption paths (`.text()`, `.arrayBuffer()`, `.bytes()`, `.blob()`, `.json()`, `getReader()`, `Bun.readableStreamToText`), element handlers observing the document, a stream that errors (before and after `transform()` returns), a bad chunk surfacing its real `TypeError`, reuse of a consumed source, the `Bun.serve` shape from #11758, plus the detach and leak regressions above.

Every one of them fails on `main`. The two `it.todo("works with payload of type direct" / "default")` cases in that file were todo for exactly this reason and are un-skipped; they pass now.

<details>
<summary>Full suite</summary>

```
$ USE_SYSTEM_BUN=1 bun test test/js/workerd/html-rewriter.test.js -t "JavaScript-backed ReadableStream"
 0 pass / 16 fail

$ bun bd test test/js/workerd/html-rewriter.test.js
 87 pass / 1 todo / 0 fail

$ BUN_JSC_validateExceptionChecks=1 bun bd test test/js/workerd/html-rewriter.test.js
 87 pass / 1 todo / 0 fail

$ bun bd test test/js/workerd/ test/js/web/html/ test/regression/issue/htmlrewriter-additional-bugs.test.ts
 245 pass / 1 skip / 1 todo / 0 fail
```

A note on the leak, since it is the kind of thing that hides: `Bun__NativePromiseContext__destroy` schedules the deref on the event loop, so `Bun.gc(true)` followed by `heapStats()` in the same synchronous turn never observes it. An earlier ad-hoc probe of this exact scenario looked clean for that reason and for the unrelated reason that it only watched for ASAN crashes rather than growth. The committed test drains the loop between collections, and fails with `Received: 200` on the unfixed build.
</details>



---

_Rebased onto be77b65 (main). Conflicts were with #33909 (`bun_core::err!` → per-crate `thiserror::Error` enums) and #33193 (webstreams rewrite in C++); both resolved mechanically — the new `crate::Error` variants and `crate::Result<()>` in my code, and the `readableStreamToArrayBuffer` FFI point is unchanged and still wraps a `ThrowScope`. All 19 new tests pass unmodified and still fail on stock bun._

_This PR still awaits @Jarred-Sumner's steer per [the analysis above](#issuecomment-4884165612) — rebased to keep it reviewable in the meantime._

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 21 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b1acf2727)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [4.71ms]
(pass) HTMLRewriter > error inside element handler [5.56ms]
(pass) HTMLRewriter > error inside element handler (string) [4.46ms]
(pass) HTMLRewriter > fast async error inside element handler [20.75ms]
(pass) HTMLRewriter > slow async error inside element handler [17.77ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [111.30ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [11.14ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [325.70ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the t
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (c9fd3907c)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [0.09ms]
(pass) HTMLRewriter > error inside element handler [0.11ms]
(pass) HTMLRewriter > error inside element handler (string) [0.06ms]
(pass) HTMLRewriter > fast async error inside element handler [12.38ms]
(pass) HTMLRewriter > slow async error inside element handler [1.28ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [9.55ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [0.10ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [6.26ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [2.76ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [1.57ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the transformed response is an errored stream [1.60ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > a read already pending on .body when the upstream fa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b1acf2727)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [4.67ms]
(pass) HTMLRewriter > error inside element handler [6.26ms]
(pass) HTMLRewriter > error inside element handler (string) [4.70ms]
(pass) HTMLRewriter > fast async error inside element handler [21.15ms]
(pass) HTMLRewriter > slow async error inside element handler [17.03ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [110.98ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [11.30ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [327.31ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the t
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 719ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/html_rewriter.rs      |   3 +
 src/runtime/error.rs                  |   3 -
 src/runtime/webcore/Body.rs           | 108 +++++++----
 test/js/workerd/html-rewriter.test.js | 338 +++++++++++++++++++++++++++++++++-
 4 files changed, 415 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/api/html_rewriter.rs           2      3      0
src/runtime/error.rs                       1      2      0
src/runtime/webcore/Body.rs               12     19      0
test/js/workerd/html-rewriter.test.js      4      7      0
```

</details>

<!-- robobun:evidence:end -->