### PR TITLE
fix unsound pointer provenance in WeakPtr, ObjectPool and the JSON tape

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1104,17 +1104,25 @@ unsafe impl Send for ObjectJSON {}
 unsafe impl Sync for ObjectJSON {}
 
 impl ObjectJSON {
-    /// `tape` must be the document's [`JsonTape`] and outlive this node.
+    /// `tape` must be the document's [`JsonTape`], and must outlive this node.
+    ///
+    /// # Safety
+    /// `tape` must carry the tape allocation's own provenance — the parser's
+    /// `NonNull<JsonTape>` — **not** a `&JsonTape`/`&mut JsonTape` reborrow of
+    /// it. The parser keeps appending to the tape after this node is built
+    /// (sibling properties, the enclosing object, later strings), and each of
+    /// those writes would invalidate a reborrow-derived pointer, making every
+    /// later [`properties`](Self::properties) read UB.
     #[inline]
-    pub fn new(
-        tape: &JsonTape,
+    pub unsafe fn new(
+        tape: core::ptr::NonNull<JsonTape>,
         first: u32,
         count: u32,
         is_single_line: bool,
         close_brace_loc: crate::Loc,
     ) -> Self {
         ObjectJSON {
-            tape: core::ptr::NonNull::from(tape),
+            tape,
             first,
             count,
             close_brace_loc,
@@ -1165,17 +1173,20 @@ unsafe impl Send for ArrayJSON {}
 unsafe impl Sync for ArrayJSON {}
 
 impl ArrayJSON {
-    /// `tape` must be the document's [`JsonTape`] and outlive this node.
+    /// `tape` must be the document's [`JsonTape`], and must outlive this node.
+    ///
+    /// # Safety
+    /// Same provenance contract as [`ObjectJSON::new`].
     #[inline]
-    pub fn new(
-        tape: &JsonTape,
+    pub unsafe fn new(
+        tape: core::ptr::NonNull<JsonTape>,
         first: u32,
         count: u32,
         is_single_line: bool,
         close_bracket_loc: crate::Loc,
     ) -> Self {
         ArrayJSON {
-            tape: core::ptr::NonNull::from(tape),
+            tape,
             first,
             count,
             close_bracket_loc,
@@ -2598,3 +2609,133 @@ impl Import {
 }
 
 pub use G::Class;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tests
+//
+// Run under Miri (`bun run rust:miri -p bun_ast`): the JSON tape hands `(first,
+// count)` spans to nodes that hold a raw `NonNull<JsonTape>` and read through
+// it long after parsing appended more rows, so Tree Borrows is what proves the
+// stored pointer survives those writes.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod json_tape_tests {
+    use super::*;
+    use crate::Loc;
+    use core::ptr::NonNull;
+
+    fn prop(key: Str, value: JsonValue) -> PropertyJSON {
+        PropertyJSON {
+            key,
+            key_loc: Loc::EMPTY,
+            value,
+        }
+    }
+
+    /// Mirrors `Parser`'s ownership: the tape is a heap allocation the parser
+    /// holds as a `NonNull` and reaches only through that pointer, handing the
+    /// same pointer to every node it builds.
+    struct TapeOwner(NonNull<JsonTape>);
+
+    impl TapeOwner {
+        fn new() -> Self {
+            TapeOwner(
+                NonNull::new(bun_core::heap::into_raw(Box::new(JsonTape::empty())))
+                    .expect("non-null"),
+            )
+        }
+        fn ptr(&self) -> NonNull<JsonTape> {
+            self.0
+        }
+        /// `Parser::tape_mut` — a fresh reborrow of the root pointer per call.
+        #[allow(clippy::mut_from_ref)]
+        fn get(&self) -> &mut JsonTape {
+            // SAFETY: sole owner; each call hands out one short-lived borrow.
+            unsafe { &mut *self.0.as_ptr() }
+        }
+    }
+
+    impl Drop for TapeOwner {
+        fn drop(&mut self) {
+            // SAFETY: sole owner of a `Box`-allocated tape.
+            drop(unsafe { bun_core::heap::take(self.0.as_ptr()) });
+        }
+    }
+
+    /// The parser keeps appending to the tape while it builds enclosing nodes.
+    /// Mirrors `{"a": {"b": null}}`: the inner object's node is built first,
+    /// then the outer object allocates a key and appends its own rows — writes
+    /// the inner node must survive, because `properties()` is read afterwards.
+    #[test]
+    fn object_json_survives_later_tape_writes() {
+        let tape = TapeOwner::new();
+
+        // Inner `{"b": null}`.
+        let kb = tape.get().alloc_str(b"b");
+        let (first, count) = tape.get().append_props(&[prop(kb, JsonValue::Null)], &[]);
+        // SAFETY: the tape's own pointer, as `Parser` passes it.
+        let inner = unsafe { ObjectJSON::new(tape.ptr(), first, count, true, Loc::EMPTY) };
+
+        // The parse continues: another string, then the outer object's rows.
+        let ka = tape.get().alloc_str(b"a");
+        let (first, count) = tape.get().append_props(&[prop(ka, JsonValue::Null)], &[]);
+        // SAFETY: as above.
+        let outer = unsafe { ObjectJSON::new(tape.ptr(), first, count, true, Loc::EMPTY) };
+
+        // Post-parse reads, after every one of those writes.
+        assert_eq!(inner.properties().len(), 1);
+        assert_eq!(inner.properties()[0].key.slice(), b"b");
+        assert_eq!(outer.properties().len(), 1);
+        assert_eq!(outer.properties()[0].key.slice(), b"a");
+        assert!(inner.get(b"b").is_some());
+        assert!(inner.get(b"nope").is_none());
+    }
+
+    #[test]
+    fn array_json_survives_later_tape_writes() {
+        let tape = TapeOwner::new();
+
+        let (first, count) = tape.get().append_items(&[JsonValue::Null], &[]);
+        // SAFETY: the tape's own pointer, as `Parser` passes it.
+        let inner = unsafe { ArrayJSON::new(tape.ptr(), first, count, true, Loc::EMPTY) };
+
+        let (first, count) = tape.get().append_items(&[JsonValue::Boolean(true)], &[]);
+        // SAFETY: as above.
+        let outer = unsafe { ArrayJSON::new(tape.ptr(), first, count, true, Loc::EMPTY) };
+
+        assert_eq!(inner.items().len(), 1);
+        assert!(matches!(inner.items()[0], JsonValue::Null));
+        assert_eq!(outer.items().len(), 1);
+        assert!(matches!(outer.items()[0], JsonValue::Boolean(true)));
+    }
+
+    /// An empty span must not dereference the tape at all.
+    #[test]
+    fn zero_count_spans_do_not_read_the_tape() {
+        let tape = TapeOwner::new();
+        // SAFETY: the tape's own pointer.
+        let o = unsafe { ObjectJSON::new(tape.ptr(), 0, 0, true, Loc::EMPTY) };
+        // SAFETY: as above.
+        let a = unsafe { ArrayJSON::new(tape.ptr(), 0, 0, true, Loc::EMPTY) };
+        assert!(o.properties().is_empty());
+        assert_eq!(o.value_locs(), Some(&[][..]));
+        assert!(a.items().is_empty());
+        assert_eq!(a.item_locs(), Some(&[][..]));
+    }
+
+    /// `alloc_str` hands out `Str`s pointing into chunks that must stay put as
+    /// later strings spill into new chunks.
+    #[test]
+    fn alloc_str_chunks_never_move() {
+        let tape = TapeOwner::new();
+        let a = tape.get().alloc_str(b"first");
+        // Force a fresh chunk: bigger than what is left in the current one.
+        let big = vec![b'x'; JsonTape::STR_CHUNK + 1];
+        let b = tape.get().alloc_str(&big);
+        let c = tape.get().alloc_str(b"third");
+        assert_eq!(a.slice(), b"first");
+        assert_eq!(b.slice(), &big[..]);
+        assert_eq!(c.slice(), b"third");
+    }
+}

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1025,6 +1025,19 @@ impl JsonTape {
         }
     }
 
+    /// The tape allocation's own pointer, for [`ObjectJSON::new`] /
+    /// [`ArrayJSON::new`].
+    ///
+    /// Takes `&mut self` so the result can never be a shared reborrow: the
+    /// parser keeps writing through this pointer for the rest of the parse, and
+    /// a `&JsonTape`-derived pointer is frozen and has no permission to do that.
+    /// Build the pointer with this rather than a bare `NonNull::from`, so the
+    /// borrow it is derived from cannot silently be the wrong one.
+    #[inline]
+    pub fn root_ptr(&mut self) -> core::ptr::NonNull<JsonTape> {
+        core::ptr::NonNull::from(self)
+    }
+
     #[inline]
     fn alloc(&self) -> TapeAlloc {
         *self.props.allocator()
@@ -2737,5 +2750,34 @@ mod json_tape_tests {
         assert_eq!(a.slice(), b"first");
         assert_eq!(b.slice(), &big[..]);
         assert_eq!(c.slice(), b"third");
+    }
+
+    /// `Parser::new`'s arena arm roots the tape at the `&mut JsonTape` the
+    /// allocator hands back, not at a `Box::into_raw`. Writes through that root
+    /// must still be permitted: a shared reborrow here is frozen, so every
+    /// `append_props` the parse performs afterwards would be UB. This is the
+    /// shape the bundler's JSON imports take.
+    #[test]
+    fn tape_rooted_at_a_mutable_borrow_still_accepts_writes() {
+        let mut owner = JsonTape::empty();
+        // `root_ptr` takes `&mut self`, exactly as `arena.alloc(..)` yields.
+        let tape_ptr = owner.root_ptr();
+        // From here on reach the tape only through `tape_ptr`, as the parser does.
+        // SAFETY: `tape_ptr` roots the tape; `owner` is untouched until it drops.
+        let tape = |p: NonNull<JsonTape>| -> &mut JsonTape { unsafe { &mut *p.as_ptr() } };
+
+        let kb = tape(tape_ptr).alloc_str(b"b");
+        let (first, count) = tape(tape_ptr).append_props(&[prop(kb, JsonValue::Null)], &[]);
+        // SAFETY: the tape's own pointer.
+        let inner = unsafe { ObjectJSON::new(tape_ptr, first, count, true, Loc::EMPTY) };
+
+        // The parse keeps appending after the node is built.
+        let ka = tape(tape_ptr).alloc_str(b"a");
+        let (first, count) = tape(tape_ptr).append_props(&[prop(ka, JsonValue::Null)], &[]);
+        // SAFETY: as above.
+        let outer = unsafe { ObjectJSON::new(tape_ptr, first, count, true, Loc::EMPTY) };
+
+        assert_eq!(inner.properties()[0].key.slice(), b"b");
+        assert_eq!(outer.properties()[0].key.slice(), b"a");
     }
 }

--- a/src/bun_core/debug.rs
+++ b/src/bun_core/debug.rs
@@ -275,6 +275,13 @@ pub(crate) const PC_OFFSET: usize = StackIterator::PC_OFFSET;
 /// trace is returned rather than an empty one — a noisier trace beats none.
 #[inline(never)]
 pub(crate) fn capture_current(first_address: Option<usize>, out: &mut [usize]) -> usize {
+    // Miri can neither execute `frame_address`'s inline asm nor follow the
+    // frame-pointer chain it returns. An empty trace keeps the debug-only
+    // `StoredTrace` captures on the refcount paths interpretable. `cfg!` rather
+    // than `#[cfg]` so the walk below stays compiled (and `PC_OFFSET` live).
+    if cfg!(miri) {
+        return 0;
+    }
     #[cfg(windows)]
     let n = {
         let cap = out.len().min(u16::MAX as usize) as u32;

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2984,6 +2984,13 @@ pub fn capture_stack_trace(begin: usize, addrs: &mut [usize]) -> usize {
 /// silently degrades to the full untrimmed trace.
 #[inline(always)]
 pub fn return_address() -> usize {
+    // Miri cannot execute `frame_address`'s inline asm, and an address read out
+    // of a register is not a pointer it can dereference. 0 = "no trim", the
+    // same value the arches without an asm! mapping return. `cfg!` rather than
+    // `#[cfg]` so the read below stays compiled (and `PC_OFFSET` live).
+    if cfg!(miri) {
+        return 0;
+    }
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         let fp = debug::frame_address();

--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -288,7 +288,7 @@ impl<T: ObjectPoolType, const TS: bool, const MAX: usize, S> ObjectPoolTrait
 /// node is returned to its pool.
 pub struct PoolGuard<'a, T: ObjectPoolType + 'static> {
     node: *mut Node<T>,
-    release: unsafe fn(&mut Node<T>),
+    release: unsafe fn(*mut Node<T>),
     _marker: PhantomData<&'a mut T>,
 }
 
@@ -318,7 +318,7 @@ impl<'a, T: ObjectPoolType> Drop for PoolGuard<'a, T> {
         // to the pool's free list. `data` is initialized: either `T::INIT` is
         // `Some` (so `get_node` wrote it), or the guard's `DerefMut` already
         // proved initialization to the borrow checker before any read.
-        unsafe { (self.release)(&mut *self.node) };
+        unsafe { (self.release)(self.node) };
     }
 }
 
@@ -369,7 +369,7 @@ where
         }));
         // SAFETY: `new_node` is a freshly heap-allocated `Node<T>` we exclusively
         // own, and `data` was initialized to `pooled` just above.
-        unsafe { Self::release(&mut *new_node) };
+        unsafe { Self::release(new_node) };
     }
 
     pub fn get_if_exists() -> Option<*mut Node<T>> {
@@ -453,19 +453,37 @@ where
         }
     }
 
-    /// `value` must point to the `data` field of a live `Node<T>` previously
-    /// handed out by this pool (e.g. via `first()`).
-    pub fn release_value(value: &mut T) {
-        // SAFETY: `value` points to the `data` field of a live `Node<T>`.
+    /// Return the node owning `value` to the pool's free list (or free it if
+    /// the pool is full).
+    ///
+    /// Takes a raw `*mut T` for the same reason [`Self::release`] does: a full
+    /// pool frees the `Node<T>` that `value` points into, which would be UB
+    /// through a live `&mut` function argument. A `&mut value` reborrow also
+    /// does not carry whole-parent provenance, which `from_field_ptr!` requires.
+    ///
+    /// # Safety
+    ///
+    /// `value` must point to the initialized `data` field of a live,
+    /// exclusively-owned `Node<T>` previously handed out by this pool (e.g. via
+    /// [`Self::first`]), carrying that node's provenance. Ownership transfers
+    /// back to the pool.
+    pub unsafe fn release_value(value: *mut T) {
+        // SAFETY: caller contract — `value` is the `data` field of a live node
+        // and carries its provenance.
         let node = unsafe { bun_core::from_field_ptr!(Node<T>, data, value) };
-        // SAFETY: `node` is the parent of the `data` field, exclusively owned.
-        // `data` is initialized: the caller handed us `&mut T`, which is only
-        // possible to form (without UB on the caller's side) if `data` holds a
-        // valid `T`.
-        unsafe { Self::release(&mut *node) };
+        // SAFETY: caller contract — `node` is live, exclusively owned, and its
+        // `data` is initialized.
+        unsafe { Self::release(node) };
     }
 
     /// Return a node to the pool's free list (or free it if the pool is full).
+    ///
+    /// Takes a raw `*mut Node<T>`, not `&mut Node<T>`: when the pool is already
+    /// at `MAX_COUNT` this frees the node, and freeing an allocation that a live
+    /// `&mut` **function argument** points into is UB (the reference is
+    /// protected for the whole call). Same reason
+    /// [`CellRefCounted::deref`](bun_ptr::CellRefCounted::deref) takes a raw
+    /// pointer.
     ///
     /// # Safety
     ///
@@ -476,8 +494,8 @@ where
     /// `assume_init_drop()` on teardown — releasing a node that was obtained
     /// from `get_node()` with `T::INIT == None` and never written is UB.
     /// Ownership transfers back to the pool's free list.
-    pub unsafe fn release(node: &mut Node<T>) {
-        let node_ptr: *mut Node<T> = node;
+    pub unsafe fn release(node: *mut Node<T>) {
+        debug_assert!(!node.is_null());
         let overflowed = Self::data(|cell| {
             let mut d = cell.borrow_mut();
             if MAX_COUNT > 0 && d.count >= MAX_COUNT {
@@ -496,15 +514,17 @@ where
             }
 
             if d.loaded {
-                d.list.prepend(node);
+                // SAFETY: caller contract — `node` is live and exclusively
+                // owned; the list takes ownership of it here.
+                d.list.prepend(unsafe { &mut *node });
             } else {
-                d.list = SinglyLinkedList { first: node_ptr };
+                d.list = SinglyLinkedList { first: node };
                 d.loaded = true;
             }
             false
         });
         if overflowed {
-            Self::destroy_node(node_ptr);
+            Self::destroy_node(node);
         }
     }
 
@@ -648,5 +668,315 @@ impl ObjectPoolType for bun_core::MutableString {
     #[inline]
     fn reset(&mut self) {
         bun_core::MutableString::reset(self);
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tests
+//
+// Run under Miri (`bun run rust:miri -p bun_collections`): the free list hands
+// raw `*mut Node<T>` back and forth across `Box::into_raw`/`heap::take`, so
+// Tree Borrows is what proves no node is reused after free or double-dropped.
+//
+// `object_pool!` names its storage struct `__ObjectPoolStorage` unconditionally,
+// so each pool needs its own module.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Mutex, MutexGuard, PoisonError};
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+    static RESETS: AtomicUsize = AtomicUsize::new(0);
+
+    /// `DROPS`/`RESETS` are process-wide but libtest runs `#[test]`s on parallel
+    /// threads, so every test asserting on them holds this for its duration.
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn serial() -> MutexGuard<'static, ()> {
+        SERIAL.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn drops() -> usize {
+        DROPS.load(Ordering::SeqCst)
+    }
+
+    fn resets() -> usize {
+        RESETS.load(Ordering::SeqCst)
+    }
+
+    /// Owns a heap allocation so a missed `assume_init_drop` leaks (Miri's
+    /// leak check catches it) and a double drop is a double free.
+    #[derive(Debug)]
+    struct Tracked(Box<u32>);
+
+    impl Drop for Tracked {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl ObjectPoolType for Tracked {
+        const INIT: Option<fn() -> Result<Self, Error>> = Some(|| Ok(Tracked(Box::new(0))));
+        fn reset(&mut self) {
+            RESETS.fetch_add(1, Ordering::SeqCst);
+            *self.0 = 0;
+        }
+    }
+
+    // ── SinglyLinkedList ──────────────────────────────────────────────────
+
+    #[test]
+    fn singly_linked_list_push_pop() {
+        let mut list: SinglyLinkedList<u32> = SinglyLinkedList::default();
+        assert_eq!(list.len(), 0);
+        assert!(list.pop_first().is_none());
+
+        let mut nodes: Vec<Box<Node<u32>>> = (0..3)
+            .map(|i| {
+                Box::new(Node {
+                    next: ptr::null_mut(),
+                    data: MaybeUninit::new(i),
+                })
+            })
+            .collect();
+        for n in nodes.iter_mut() {
+            list.prepend(n);
+        }
+        assert_eq!(list.len(), 3);
+
+        // LIFO: last prepended comes out first.
+        for expect in (0..3).rev() {
+            let node = list.pop_first().expect("node");
+            // SAFETY: `data` was initialized above; the node is still owned by
+            // the `nodes` vec, which outlives the list.
+            assert_eq!(unsafe { *(*node).data_ref() }, expect);
+        }
+        assert!(list.pop_first().is_none());
+        // Nothing was handed to the list's `Drop` (it is empty), so `nodes`
+        // still owns every allocation.
+        core::mem::forget(list);
+    }
+
+    #[test]
+    fn singly_linked_list_remove_and_walk() {
+        let mut list: SinglyLinkedList<u32> = SinglyLinkedList::default();
+        let mut nodes: Vec<Box<Node<u32>>> = (0..4)
+            .map(|i| {
+                Box::new(Node {
+                    next: ptr::null_mut(),
+                    data: MaybeUninit::new(i),
+                })
+            })
+            .collect();
+        for n in nodes.iter_mut() {
+            list.prepend(n);
+        }
+
+        // Head is node 3; remove a middle node (1) and the head.
+        list.remove(&nodes[1]);
+        assert_eq!(list.len(), 3);
+        let head = nodes[3].as_ref();
+        list.remove(head);
+        assert_eq!(list.len(), 2);
+
+        // SAFETY: list is non-empty, so `first` is live.
+        assert_eq!(unsafe { (*list.first).count_children() }, 1);
+        // SAFETY: `first` is live and in the list.
+        let last = unsafe { (*list.first).find_last() };
+        // SAFETY: `last` is the tail node, still owned by `nodes`.
+        assert_eq!(unsafe { *(*last).data_ref() }, 0);
+
+        core::mem::forget(list);
+    }
+
+    /// The list owns whatever is still on it at `Drop` — dropping it must run
+    /// each element's destructor exactly once and free each node.
+    #[test]
+    fn singly_linked_list_drop_frees_nodes() {
+        let _serial = serial();
+        let before = drops();
+        let mut list: SinglyLinkedList<Tracked> = SinglyLinkedList::default();
+        for i in 0..3 {
+            let node = bun_core::heap::into_raw(Box::new(Node {
+                next: ptr::null_mut(),
+                data: MaybeUninit::new(Tracked(Box::new(i))),
+            }));
+            // SAFETY: freshly allocated and exclusively owned; ownership moves
+            // to the list, whose `Drop` frees it.
+            list.prepend(unsafe { &mut *node });
+        }
+        drop(list);
+        assert_eq!(drops(), before + 3);
+    }
+
+    // ── ObjectPool: recycling ─────────────────────────────────────────────
+
+    // `object_pool!` emits a `pub` storage struct; unreachable from a
+    // private test module, which `unreachable_pub` would otherwise flag.
+    #[allow(unreachable_pub)]
+    mod recycle {
+        use super::*;
+        crate::object_pool!(pub Pool: Tracked, threadsafe, 0);
+
+        #[test]
+        fn pool_recycles_the_same_node() {
+            let _serial = serial();
+            let before = drops();
+            let resets_before = resets();
+
+            let first_ptr = {
+                let mut guard = Pool::get();
+                *guard.0 = 11;
+                guard.node_ptr()
+            }; // guard drop → node returns to the free list
+
+            // Reuse: same allocation, `reset()` ran, value cleared.
+            let mut guard = Pool::get();
+            assert_eq!(guard.node_ptr(), first_ptr);
+            assert_eq!(resets(), resets_before + 1);
+            assert_eq!(*guard.0, 0);
+            *guard.0 = 22;
+            assert_eq!(*guard.0, 22);
+            drop(guard);
+
+            // Nothing was destroyed: the free list still owns the node.
+            assert_eq!(drops(), before);
+
+            Pool::delete_all();
+            assert_eq!(drops(), before + 1);
+        }
+    }
+
+    // ── ObjectPool: MAX_COUNT overflow frees instead of caching ───────────
+
+    // `object_pool!` emits a `pub` storage struct; unreachable from a
+    // private test module, which `unreachable_pub` would otherwise flag.
+    #[allow(unreachable_pub)]
+    mod capped {
+        use super::*;
+        crate::object_pool!(pub Pool: Tracked, threadsafe, 1);
+
+        #[test]
+        fn pool_over_max_count_destroys_the_node() {
+            let _serial = serial();
+            let before = drops();
+
+            let a = Pool::get();
+            let b = Pool::get();
+            assert_ne!(a.node_ptr(), b.node_ptr());
+            assert!(!Pool::full());
+
+            drop(a); // cached (count 0 → 1)
+            assert!(Pool::full());
+            assert_eq!(drops(), before);
+
+            drop(b); // pool full → destroyed
+            assert_eq!(drops(), before + 1);
+
+            Pool::delete_all();
+            assert_eq!(drops(), before + 2);
+        }
+    }
+
+    // ── ObjectPool: push / get_if_exists ──────────────────────────────────
+
+    // `object_pool!` emits a `pub` storage struct; unreachable from a
+    // private test module, which `unreachable_pub` would otherwise flag.
+    #[allow(unreachable_pub)]
+    mod push_get {
+        use super::*;
+        crate::object_pool!(pub Pool: Tracked, threadsafe, 0);
+
+        #[test]
+        fn push_then_get_if_exists() {
+            let _serial = serial();
+            let before = drops();
+            // Nothing cached yet: `get_if_exists` must not allocate.
+            assert!(Pool::get_if_exists().is_none());
+
+            Pool::push(Tracked(Box::new(5)));
+            let node = Pool::get_if_exists().expect("pushed node");
+            // SAFETY: `node` was just popped; `push` initialized `data`, and
+            // `get_if_exists` already ran `reset()` on it.
+            assert_eq!(unsafe { *(*node).data_ref().0 }, 0);
+            // The pool is empty again — the node is ours.
+            assert!(Pool::get_if_exists().is_none());
+
+            // Hand it back, then tear the pool down. Miri's leak check is what
+            // proves `delete_all` actually frees the node it reclaimed.
+            // SAFETY: `node` came from this pool and `data` is initialized.
+            unsafe { Pool::release(node) };
+            assert_eq!(drops(), before);
+            Pool::delete_all();
+            assert_eq!(drops(), before + 1);
+        }
+    }
+
+    // ── ObjectPool: `first()` + `release_value()` container_of round-trip ──
+
+    // `object_pool!` emits a `pub` storage struct; unreachable from a
+    // private test module, which `unreachable_pub` would otherwise flag.
+    #[allow(unreachable_pub)]
+    mod field_ptr {
+        use super::*;
+        crate::object_pool!(pub Pool: Tracked, threadsafe, 0);
+
+        #[test]
+        fn first_then_release_value_round_trips_through_the_data_field() {
+            let _serial = serial();
+            let before = drops();
+            let value: *mut Tracked = Pool::first();
+            // SAFETY: `first()` hands out the `data` field of a live node whose
+            // `T::INIT` already wrote a valid `Tracked`.
+            unsafe { *(*value).0 = 7 };
+            // `release_value` recovers the node via `offset_of!(Node<T>, data)`.
+            // SAFETY: `value` is that node's `data` field, carrying its provenance.
+            unsafe { Pool::release_value(value) };
+
+            // The node is back on the free list, unharmed and reusable.
+            let guard = Pool::get();
+            assert_eq!(*guard.0, 0, "reset() ran on reuse");
+            drop(guard);
+
+            Pool::delete_all();
+            assert_eq!(drops(), before + 1);
+        }
+    }
+
+    // ── ObjectPool: `release_value()` on a full pool frees the node ────────
+
+    // `object_pool!` emits a `pub` storage struct; unreachable from a
+    // private test module, which `unreachable_pub` would otherwise flag.
+    #[allow(unreachable_pub)]
+    mod field_ptr_capped {
+        use super::*;
+        crate::object_pool!(pub Pool: Tracked, threadsafe, 1);
+
+        /// The overflow path frees the very `Node<T>` that `value` points into.
+        /// Taking `*mut T` is what makes that sound: a `&mut T` argument is
+        /// protected for the whole call, and Tree Borrows rejects deallocating
+        /// an allocation a protected reference points into.
+        #[test]
+        fn release_value_on_a_full_pool_frees_the_node() {
+            let _serial = serial();
+            let before = drops();
+
+            // Fill the pool (MAX_COUNT = 1), then overflow it through `first()`.
+            let cached = Pool::get();
+            let overflow: *mut Tracked = Pool::first();
+            drop(cached);
+            assert!(Pool::full());
+
+            // SAFETY: `overflow` is the `data` field of a live node this pool
+            // handed out, carrying its provenance.
+            unsafe { Pool::release_value(overflow) };
+            assert_eq!(drops(), before + 1, "the overflowing node was freed");
+
+            Pool::delete_all();
+            assert_eq!(drops(), before + 2);
+        }
     }
 }

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1155,8 +1155,16 @@ fn start_queued_task(
     // Note: AsyncHttp is byte-copied here
     // since the original stays valid (real owner is `http`, copy is the
     // HTTP-thread working set).
-    let cloned = bun_core::heap::release(cloned);
-    in_flight.push(NonNull::from(&*cloned).cast::<crate::ThreadlocalAsyncHttp<'static>>());
+    //
+    // `in_flight` keeps the allocation's own pointer, not a `&*cloned`
+    // reborrow of it: the writes below go through `cloned`, and a shared
+    // reborrow would be frozen by the first of them.
+    let cloned_ptr = bun_core::heap::into_raw(cloned);
+    let cloned_nn = NonNull::new(cloned_ptr).expect("freshly leaked Box is non-null");
+    in_flight.push(cloned_nn.cast::<crate::ThreadlocalAsyncHttp<'static>>());
+    // SAFETY: freshly leaked; this thread is its sole owner until the request
+    // completes and `in_flight` gives the pointer back.
+    let cloned = unsafe { &mut *cloned_ptr };
     cloned.async_http.real = NonNull::new(http);
     // Clear stale queue pointers - the clone inherited http.next and http.task.node.next
     // which may point to other AsyncHTTP structs that could be freed before the callback

--- a/src/http/zlib.rs
+++ b/src/http/zlib.rs
@@ -31,13 +31,20 @@ mod buffer_pool {
         BufferPool::first().cast::<MutableString>()
     }
 
-    pub fn put(mutable: &mut MutableString) {
-        mutable.reset();
-        // SAFETY: `mutable` was returned by `get()`; `#[repr(transparent)]`
-        // makes the `MutableString → PooledMutableString` reinterpret sound.
-        // `release_value` recovers the parent node via `offset_of`.
-        let pooled = unsafe { &mut *std::ptr::from_mut(mutable).cast::<PooledMutableString>() };
-        BufferPool::release_value(pooled);
+    /// # Safety
+    ///
+    /// `mutable` must be a pointer previously returned by [`get`] and not yet
+    /// returned to the pool. A raw pointer, not `&mut MutableString`: a full
+    /// pool frees the node this points into, which would be UB through a live
+    /// `&mut` function argument.
+    pub unsafe fn put(mutable: *mut MutableString) {
+        // SAFETY: caller contract — `mutable` is a live pooled buffer.
+        unsafe { (*mutable).reset() };
+        // SAFETY: caller contract. `#[repr(transparent)]` makes the
+        // `MutableString → PooledMutableString` reinterpret sound, and the cast
+        // keeps the node's provenance, which `release_value` needs to recover
+        // the parent node via `offset_of`.
+        unsafe { BufferPool::release_value(mutable.cast::<PooledMutableString>()) };
     }
 }
 pub use buffer_pool::{get, put};

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1811,7 +1811,7 @@ pub mod formatter {
                 // SAFETY: `node` was obtained from `Pool::get_node()` and is
                 // exclusively owned by this formatter; `Map::INIT` is `Some`,
                 // so `data` is initialized. Ownership returns to the pool.
-                unsafe { visited::Pool::release(node.as_mut()) };
+                unsafe { visited::Pool::release(node.as_ptr()) };
             }
         }
     }

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -427,15 +427,7 @@ fn parse_to_rows(
         let root = Expr::init(
             // SAFETY: the tape's own pointer; `ParsedJson` keeps it alive, and
             // an empty span never dereferences it anyway.
-            unsafe {
-                E::ObjectJSON::new(
-                    core::ptr::NonNull::from(&mut *tape),
-                    0,
-                    0,
-                    true,
-                    bun_ast::Loc::EMPTY,
-                )
-            },
+            unsafe { E::ObjectJSON::new(tape.root_ptr(), 0, 0, true, bun_ast::Loc::EMPTY) },
             bun_ast::Loc { start: 0 },
         );
         return Ok(ParsedJson {
@@ -462,15 +454,7 @@ fn parse_to_rows_in(
         return Ok(Expr::init(
             // SAFETY: the arena-allocated tape's own pointer; it lives until the
             // arena resets, and an empty span never dereferences it anyway.
-            unsafe {
-                E::ObjectJSON::new(
-                    core::ptr::NonNull::from(tape),
-                    0,
-                    0,
-                    true,
-                    bun_ast::Loc::EMPTY,
-                )
-            },
+            unsafe { E::ObjectJSON::new(tape.root_ptr(), 0, 0, true, bun_ast::Loc::EMPTY) },
             bun_ast::Loc { start: 0 },
         ));
     }

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -423,9 +423,19 @@ fn parse_to_rows(
     opts: JSONOptions,
 ) -> Result<ParsedJson, bun_core::Error> {
     if source.contents.is_empty() {
-        let tape = Box::new(E::JsonTape::empty());
+        let mut tape = Box::new(E::JsonTape::empty());
         let root = Expr::init(
-            E::ObjectJSON::new(&tape, 0, 0, true, bun_ast::Loc::EMPTY),
+            // SAFETY: the tape's own pointer; `ParsedJson` keeps it alive, and
+            // an empty span never dereferences it anyway.
+            unsafe {
+                E::ObjectJSON::new(
+                    core::ptr::NonNull::from(&mut *tape),
+                    0,
+                    0,
+                    true,
+                    bun_ast::Loc::EMPTY,
+                )
+            },
             bun_ast::Loc { start: 0 },
         );
         return Ok(ParsedJson {
@@ -450,7 +460,17 @@ fn parse_to_rows_in(
     if source.contents.is_empty() {
         let tape = arena.alloc(E::JsonTape::empty_in(tape_alloc));
         return Ok(Expr::init(
-            E::ObjectJSON::new(tape, 0, 0, true, bun_ast::Loc::EMPTY),
+            // SAFETY: the arena-allocated tape's own pointer; it lives until the
+            // arena resets, and an empty span never dereferences it anyway.
+            unsafe {
+                E::ObjectJSON::new(
+                    core::ptr::NonNull::from(tape),
+                    0,
+                    0,
+                    true,
+                    bun_ast::Loc::EMPTY,
+                )
+            },
             bun_ast::Loc { start: 0 },
         ));
     }

--- a/src/parsers/json_stage2.rs
+++ b/src/parsers/json_stage2.rs
@@ -93,16 +93,16 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
         opts: JSONOptions,
         tape_alloc: E::TapeAlloc,
     ) -> Self {
+        // `root_ptr` both times: it takes `&mut JsonTape`, so neither arm can
+        // hand `tape` a frozen, shared-reborrow pointer. The parser writes
+        // through `tape` for the rest of the parse.
         let (tape, tape_owned) = match tape_alloc {
-            E::TapeAlloc::Global => (
-                core::ptr::NonNull::from(Box::leak(Box::new(E::JsonTape::empty()))),
-                true,
-            ),
+            E::TapeAlloc::Global => (Box::leak(Box::new(E::JsonTape::empty())).root_ptr(), true),
             E::TapeAlloc::Arena(arena) => {
                 // SAFETY: the caller's arena (lifetime-erased) outlives the parse and the AST.
                 let arena: &Bump = unsafe { arena.as_ref() };
                 (
-                    core::ptr::NonNull::from(&*arena.alloc(E::JsonTape::empty_in(tape_alloc))),
+                    arena.alloc(E::JsonTape::empty_in(tape_alloc)).root_ptr(),
                     false,
                 )
             }

--- a/src/parsers/json_stage2.rs
+++ b/src/parsers/json_stage2.rs
@@ -389,15 +389,20 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
         }
     }
 
+    /// The tape allocation's own pointer, for the nodes that store it.
+    ///
+    /// Not a `&JsonTape`: parsing keeps appending to the tape after a node is
+    /// built, and every such write invalidates a pointer derived from a shared
+    /// reborrow (see [`E::ObjectJSON::new`]).
     #[inline]
-    fn tape_ref(&self) -> &'a E::JsonTape {
-        // SAFETY: allocated in `Parser::new`; the caller keeps it alive for the AST's lifetime.
-        unsafe { self.tape.expect("the tape was already taken").as_ref() }
+    fn tape_ptr(&self) -> core::ptr::NonNull<E::JsonTape> {
+        self.tape.expect("the tape was already taken")
     }
 
     #[inline]
     fn tape_mut(&mut self) -> &mut E::JsonTape {
-        // SAFETY: see `tape_ref`; exclusively owned until `take_tape`.
+        // SAFETY: allocated in `Parser::new` and exclusively owned until
+        // `take_tape`; a fresh reborrow of the root pointer per call.
         unsafe { self.tape.expect("the tape was already taken").as_mut() }
     }
 
@@ -702,7 +707,9 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
         }
         let (first, count) = self.push_items_block(mark);
         Ok(Expr::init(
-            E::ArrayJSON::new(self.tape_ref(), first, count, is_single_line, close_loc),
+            // SAFETY: `tape_ptr` is the tape allocation's own pointer, and the
+            // tape outlives the AST (`take_tape` hands it to the caller).
+            unsafe { E::ArrayJSON::new(self.tape_ptr(), first, count, is_single_line, close_loc) },
             loc,
         ))
     }
@@ -830,7 +837,8 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
 
         let (first, count) = self.push_props_block(mark);
         Ok(Expr::init(
-            E::ObjectJSON::new(self.tape_ref(), first, count, is_single_line, close_loc),
+            // SAFETY: see `parse_array`.
+            unsafe { E::ObjectJSON::new(self.tape_ptr(), first, count, is_single_line, close_loc) },
             loc,
         ))
     }

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -1284,3 +1284,334 @@ fn offset_of_ref_count_ts<T: ThreadSafeRefCounted>() -> usize {
 // compile-time assertion in `RefPtr`. Replaced by `AnyRefCounted` trait bound.
 
 bun_core::declare_scope!(ref_count, hidden);
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tests
+//
+// Run under Miri (`bun run rust:miri -p bun_ptr`): every path here walks raw
+// pointers through `Box::into_raw` / `heap::take`, so Tree Borrows is what
+// proves the ref/deref/destructor handoff does not alias or use-after-free.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::AtomicUsize;
+    use std::sync::{Mutex, MutexGuard, PoisonError};
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    /// `DROPS` is process-wide but libtest runs `#[test]`s on parallel threads,
+    /// so every test asserting on it holds this for its duration.
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn serial() -> MutexGuard<'static, ()> {
+        SERIAL.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn drops() -> usize {
+        DROPS.load(Ordering::SeqCst)
+    }
+
+    // ── RefCount (single-threaded) ────────────────────────────────────────
+
+    struct Thing {
+        ref_count: RefCount<Thing>,
+        payload: Box<u32>,
+    }
+
+    impl Thing {
+        fn new(payload: u32) -> *mut Thing {
+            bun_core::heap::into_raw(Box::new(Thing {
+                ref_count: RefCount::init(),
+                payload: Box::new(payload),
+            }))
+        }
+    }
+
+    impl Drop for Thing {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl RefCounted for Thing {
+        type DestructorCtx = ();
+        unsafe fn get_ref_count(this: *mut Self) -> *mut RefCount<Self> {
+            // SAFETY: caller contract — `this` is in-bounds of a `Thing`
+            // allocation. Pure field projection, no read.
+            unsafe { &raw mut (*this).ref_count }
+        }
+        unsafe fn destructor(this: *mut Self, _: ()) {
+            // SAFETY: caller contract — refcount hit zero, sole owner.
+            drop(unsafe { bun_core::heap::take(this) });
+        }
+    }
+
+    #[test]
+    fn ref_count_ref_deref_destroys_at_zero() {
+        let _serial = serial();
+        let before = drops();
+        let t = Thing::new(7);
+        // SAFETY: `t` is live with one ref.
+        unsafe {
+            RefCount::<Thing>::ref_(t);
+            assert_eq!((*RefCounted::get_ref_count(t)).get(), 2);
+            RefCount::<Thing>::deref(t);
+            assert!((*RefCounted::get_ref_count(t)).has_one_ref());
+            assert_eq!(*(*t).payload, 7);
+            // Last ref: runs `destructor`, freeing the allocation.
+            RefCount::<Thing>::deref(t);
+        }
+        assert_eq!(drops(), before + 1);
+    }
+
+    #[test]
+    fn ref_count_init_exact_refs() {
+        let _serial = serial();
+        let before = drops();
+        let t = bun_core::heap::into_raw(Box::new(Thing {
+            ref_count: RefCount::init_exact_refs(3),
+            payload: Box::new(1),
+        }));
+        // SAFETY: `t` is live with three refs; exactly three derefs destroy it.
+        unsafe {
+            RefCount::<Thing>::deref(t);
+            RefCount::<Thing>::deref(t);
+            assert_eq!(drops(), before);
+            RefCount::<Thing>::deref(t);
+        }
+        assert_eq!(drops(), before + 1);
+    }
+
+    #[test]
+    fn ref_ptr_round_trip() {
+        let _serial = serial();
+        let before = drops();
+        let p = RefPtr::new(Thing {
+            ref_count: RefCount::init(),
+            payload: Box::new(42),
+        });
+        assert_eq!(*p.data().payload, 42);
+
+        let q = p.dupe_ref();
+        let r = p.clone();
+        assert_eq!(p.as_ptr(), q.as_ptr());
+        assert_eq!(p.as_ptr(), r.as_ptr());
+        r.deref();
+        q.deref();
+        assert_eq!(drops(), before);
+
+        // `leak` hands the ref off without decrementing; `from_raw` takes it back.
+        let raw = p.leak();
+        // SAFETY: `raw` still owns the ref `p` gave up.
+        let p = unsafe { RefPtr::from_raw(raw) };
+        assert_eq!(*p.payload, 42);
+        p.deref();
+        assert_eq!(drops(), before + 1);
+    }
+
+    #[test]
+    fn scoped_ref_releases_on_drop() {
+        let _serial = serial();
+        let before = drops();
+        let t = Thing::new(3);
+        {
+            // SAFETY: `t` is live; the guard's ref keeps it alive for the scope.
+            let _g = unsafe { ScopedRef::new(t) };
+            // SAFETY: two refs outstanding.
+            assert_eq!(unsafe { (*RefCounted::get_ref_count(t)).get() }, 2);
+        }
+        // SAFETY: the original ref is still outstanding.
+        assert!(unsafe { (*RefCounted::get_ref_count(t)).has_one_ref() });
+        // SAFETY: releasing the last ref.
+        unsafe { RefCount::<Thing>::deref(t) };
+        assert_eq!(drops(), before + 1);
+    }
+
+    #[test]
+    fn scoped_ref_adopt_consumes_caller_ref() {
+        let _serial = serial();
+        let before = drops();
+        let t = Thing::new(3);
+        // SAFETY: `t` is live and we own the one ref the guard will consume.
+        drop(unsafe { ScopedRef::adopt(t) });
+        assert_eq!(drops(), before + 1);
+    }
+
+    #[test]
+    fn finalize_js_box_releases_one_ref() {
+        let _serial = serial();
+        let before = drops();
+        let t = Thing::new(9);
+        // SAFETY: `t` is live; simulate the codegen handing `finalize` a Box.
+        let boxed: Box<Thing> = unsafe { bun_core::heap::take(t) };
+        let seen = std::cell::Cell::new(0u32);
+        finalize_js_box(boxed, |thing: &Thing| seen.set(*thing.payload));
+        assert_eq!(seen.get(), 9);
+        assert_eq!(drops(), before + 1);
+    }
+
+    #[test]
+    fn clear_without_destructor_skips_drop() {
+        let _serial = serial();
+        let before = drops();
+        let t = Thing::new(1);
+        // SAFETY: `t` is live.
+        unsafe { (*RefCounted::get_ref_count(t)).clear_without_destructor() };
+        // SAFETY: we now own the allocation outright; free it by hand.
+        drop(unsafe { bun_core::heap::take(t) });
+        assert_eq!(drops(), before + 1);
+    }
+
+    // ── ThreadSafeRefCount (atomic, cross-thread) ─────────────────────────
+
+    struct Shared {
+        ref_count: ThreadSafeRefCount<Shared>,
+        payload: Box<u32>,
+    }
+
+    impl Drop for Shared {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl ThreadSafeRefCounted for Shared {
+        unsafe fn get_ref_count(this: *mut Self) -> *mut ThreadSafeRefCount<Self> {
+            // SAFETY: caller contract — pure field projection, no read.
+            unsafe { &raw mut (*this).ref_count }
+        }
+    }
+
+    /// `*mut Shared` is not `Send`; the refcount is what makes sharing it sound.
+    #[derive(Clone, Copy)]
+    struct SendPtr(*mut Shared);
+    // SAFETY: `Shared`'s payload is only read across threads, and every thread
+    // holds its own ref for the duration (taken before spawn).
+    unsafe impl Send for SendPtr {}
+
+    #[test]
+    fn thread_safe_ref_count_cross_thread_destroy() {
+        let _serial = serial();
+        let before = drops();
+        let s = bun_core::heap::into_raw(Box::new(Shared {
+            ref_count: ThreadSafeRefCount::init(),
+            payload: Box::new(5),
+        }));
+
+        const N: usize = 4;
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            // SAFETY: `s` is live and we hold a ref while handing one out.
+            unsafe { ThreadSafeRefCount::<Shared>::ref_(s) };
+            let p = SendPtr(s);
+            handles.push(std::thread::spawn(move || {
+                let p = p;
+                // SAFETY: this thread owns one ref, so `*p.0` is live.
+                unsafe {
+                    assert_eq!(*(*p.0).payload, 5);
+                    ThreadSafeRefCount::<Shared>::deref(p.0);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(drops(), before);
+        // SAFETY: the initial ref; last one out runs `destructor`.
+        unsafe { ThreadSafeRefCount::<Shared>::deref(s) };
+        assert_eq!(drops(), before + 1);
+    }
+
+    #[test]
+    fn thread_safe_release_defers_destruction() {
+        let _serial = serial();
+        let before = drops();
+        let s = bun_core::heap::into_raw(Box::new(Shared {
+            ref_count: ThreadSafeRefCount::init_exact_refs(2),
+            payload: Box::new(8),
+        }));
+        // SAFETY: `s` is live with two refs.
+        unsafe {
+            assert!(!ThreadSafeRefCount::<Shared>::release(s));
+            assert_eq!(drops(), before);
+            // 1 → 0: `release` reports sole ownership but runs no destructor.
+            assert!(ThreadSafeRefCount::<Shared>::release(s));
+            assert_eq!(drops(), before);
+            drop(bun_core::heap::take(s));
+        }
+        assert_eq!(drops(), before + 1);
+    }
+
+    // ── CellRefCounted ────────────────────────────────────────────────────
+
+    struct Light {
+        ref_count: Cell<u32>,
+        payload: Box<u32>,
+    }
+
+    impl Drop for Light {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    // SAFETY: every `*mut Light` reaching `deref` came from `Box::into_raw`,
+    // which the default `destroy` reclaims.
+    unsafe impl CellRefCounted for Light {
+        fn ref_count(&self) -> &Cell<u32> {
+            &self.ref_count
+        }
+        unsafe fn ref_count_raw<'a>(this: *const Self) -> &'a Cell<u32> {
+            // SAFETY: caller contract — `this` is live. Field projection only;
+            // no whole-struct `&Self` is formed.
+            unsafe { &*(&raw const (*this).ref_count) }
+        }
+    }
+
+    #[test]
+    fn cell_ref_counted_destroys_at_zero() {
+        let _serial = serial();
+        let before = drops();
+        let l = bun_core::heap::into_raw(Box::new(Light {
+            ref_count: Cell::new(1),
+            payload: Box::new(11),
+        }));
+        // SAFETY: `l` is live.
+        unsafe {
+            (*l).ref_();
+            assert_eq!((*l).ref_count.get(), 2);
+            CellRefCounted::deref(l);
+            assert_eq!(*(*l).payload, 11);
+            assert_eq!(drops(), before);
+            CellRefCounted::deref(l);
+        }
+        assert_eq!(drops(), before + 1);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn type_base_name_strips_module_path() {
+        assert_eq!(type_base_name("a::b::Foo"), "Foo");
+        assert_eq!(type_base_name("a::b::Foo<c::Bar>"), "Foo<c::Bar>");
+        assert_eq!(type_base_name("Foo"), "Foo");
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn offset_of_ref_count_probes_uninit_without_reading() {
+        // `get_ref_count` must be a pure projection: this probes it against a
+        // `MaybeUninit<Thing>`, so any read of `*base` is an uninit read Miri
+        // would reject.
+        assert_eq!(
+            offset_of_ref_count::<Thing>(),
+            core::mem::offset_of!(Thing, ref_count)
+        );
+        assert_eq!(
+            offset_of_ref_count_ts::<Shared>(),
+            core::mem::offset_of!(Shared, ref_count)
+        );
+    }
+}

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -71,6 +71,17 @@ pub trait HasWeakPtrData {
 /// contents can be freed, but the object itself is not destroyed until all
 /// `WeakPtr`s are released. Even if the allocation is present, `WeakPtr<T>::get`
 /// will return `None` after the inner contents are freed.
+///
+/// # Provenance
+/// A `WeakPtr` is a **shared** handle: the owner keeps using the object through
+/// its own pointer, and several `WeakPtr`s may coexist. The stored pointer must
+/// therefore carry the allocation's own provenance (`Box::into_raw` /
+/// `heap::into_raw`), which is why [`init_ref`](Self::init_ref) takes `*mut T`
+/// rather than `&mut T`. Deriving it from a `&mut T` reborrow instead makes the
+/// next write through any *other* pointer to the object a foreign write that
+/// invalidates the handle, so every later `get`/`deref` is UB. This mirrors
+/// [`ThisPtr::new`](crate::ThisPtr::new) and
+/// [`ParentRef::from_raw_mut`](crate::ParentRef::from_raw_mut).
 pub struct WeakPtr<T: HasWeakPtrData> {
     // Intentionally a raw pointer, not `std::sync::Weak<T>`: this file *is*
     // the definition of the intrusive weak pointer, with liveness tracked by
@@ -83,13 +94,24 @@ pub type Data = WeakPtrData;
 impl<T: HasWeakPtrData> WeakPtr<T> {
     pub const EMPTY: Self = Self { raw_ptr: None };
 
-    pub fn init_ref(req: &mut T) -> Self {
-        // SAFETY: `req` is a valid &mut T, so the allocation is live.
-        let d = unsafe { &mut *T::weak_ptr_data(req) };
+    /// Take a weak reference to `this`, incrementing its weak count.
+    ///
+    /// # Safety
+    /// `this` must be non-null and point to a live, not-yet-finalized `T`.
+    /// It must carry the provenance of the whole allocation (as produced by
+    /// `bun_core::heap::into_raw` / `Box::into_raw`), **not** a reborrow of a
+    /// `&mut T` — see the [type-level note](WeakPtr#provenance).
+    pub unsafe fn init_ref(this: *mut T) -> Self {
+        debug_assert!(!this.is_null());
+        // SAFETY: caller contract — `this` points to a live `T`. Projecting
+        // straight to the embedded field means no whole-struct `&mut T` is
+        // formed, so `this`'s provenance reaches the stored pointer intact.
+        let d = unsafe { &mut *T::weak_ptr_data(this) };
         debug_assert!(!d.finalized());
         d.set_reference_count(d.reference_count() + 1);
         Self {
-            raw_ptr: Some(NonNull::from(req)),
+            // SAFETY: caller contract — `this` is non-null.
+            raw_ptr: Some(unsafe { NonNull::new_unchecked(this) }),
         }
     }
 
@@ -101,6 +123,12 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
         }
     }
 
+    /// Borrow the pointee, or `None` once the owner has finalized it (which
+    /// also releases this handle's weak ref).
+    ///
+    /// The returned `&mut T` is a fresh reborrow of the allocation pointer, so
+    /// it must not overlap any other borrow of the same object — including one
+    /// handed out by a second `WeakPtr`. Finish with it before the next `get`.
     pub fn get(&mut self) -> Option<&mut T> {
         if let Some(value) = self.raw_ptr {
             // SAFETY: allocation is live while any WeakPtr holds it (see above).
@@ -118,16 +146,18 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
     /// `value` must equal `self.raw_ptr.unwrap()` and point to a live
     /// allocation whose embedded `WeakPtrData` has `reference_count > 0`.
     unsafe fn deref_internal(&mut self, value: NonNull<T>) {
+        self.raw_ptr = None;
         // SAFETY: caller guarantees `value` points to a live allocation;
         // projecting to the embedded `WeakPtrData` field.
         let weak_data = unsafe { &mut *T::weak_ptr_data(value.as_ptr()) };
-        self.raw_ptr = None;
         let count = weak_data.reference_count() - 1;
         weak_data.set_reference_count(count);
-        if weak_data.finalized() && count == 0 {
+        let finalized = weak_data.finalized();
+        if finalized && count == 0 {
             // The allocation came from `heap::alloc` (via `Box::new`).
             // SAFETY: this is the last reference and the owner has finalized,
-            // so we hold the only pointer to a `Box`-allocated `T`.
+            // so we hold the only pointer to a `Box`-allocated `T`. `weak_data`
+            // is dead here, so freeing through `value` disturbs no live borrow.
             drop(unsafe { bun_core::heap::take(value.as_ptr()) });
         }
     }
@@ -136,5 +166,178 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
 impl<T: HasWeakPtrData> Default for WeakPtr<T> {
     fn default() -> Self {
         Self::EMPTY
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Mutex, MutexGuard, PoisonError};
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    /// `DROPS` is process-wide but libtest runs `#[test]`s on parallel threads,
+    /// so every test asserting on it holds this for its duration.
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn serial() -> MutexGuard<'static, ()> {
+        SERIAL.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn drops() -> usize {
+        DROPS.load(Ordering::SeqCst)
+    }
+
+    struct Owner {
+        weak: WeakPtrData,
+        /// Inline (not behind a `Box`) so writing it is a write into the
+        /// `Owner` allocation itself — the access a stale handle trips on.
+        payload: u32,
+        /// Proves the allocation is actually freed rather than merely leaked.
+        _heap: Box<u32>,
+    }
+
+    impl Drop for Owner {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl HasWeakPtrData for Owner {
+        unsafe fn weak_ptr_data(this: *mut Self) -> *mut WeakPtrData {
+            // SAFETY: caller contract — pure field projection, no read.
+            unsafe { &raw mut (*this).weak }
+        }
+    }
+
+    fn new_owner(payload: u32) -> *mut Owner {
+        bun_core::heap::into_raw(Box::new(Owner {
+            weak: WeakPtrData::EMPTY,
+            payload,
+            _heap: Box::new(payload),
+        }))
+    }
+
+    #[test]
+    fn bit_layout() {
+        let mut d = WeakPtrData::EMPTY;
+        assert_eq!(d.reference_count(), 0);
+        assert!(!d.finalized());
+
+        d.set_reference_count(5);
+        assert_eq!(d.reference_count(), 5);
+        assert!(!d.finalized());
+
+        d.set_finalized(true);
+        assert!(d.finalized());
+        // Setting the count must not clobber the finalized bit, and vice versa.
+        assert_eq!(d.reference_count(), 5);
+        d.set_reference_count(WeakPtrData::REF_MASK);
+        assert_eq!(d.reference_count(), WeakPtrData::REF_MASK);
+        assert!(d.finalized());
+
+        d.set_finalized(false);
+        assert_eq!(d.reference_count(), WeakPtrData::REF_MASK);
+    }
+
+    #[test]
+    fn on_finalize_reports_last_ref() {
+        let mut d = WeakPtrData::EMPTY;
+        assert!(d.on_finalize());
+
+        let mut d = WeakPtrData::EMPTY;
+        d.set_reference_count(1);
+        assert!(!d.on_finalize());
+    }
+
+    /// Finalizing with a live `WeakPtr` keeps the allocation; the last
+    /// `deref` frees it.
+    #[test]
+    fn weak_ptr_outlives_finalize_then_frees() {
+        let _serial = serial();
+        let before = drops();
+        let raw = new_owner(4);
+        // SAFETY: `raw` is a freshly leaked Box; live and not finalized.
+        let mut weak = unsafe { WeakPtr::init_ref(raw) };
+        assert_eq!(weak.get().map(|o| o.payload), Some(4));
+
+        // Owner finalizes its contents: not the last ref, so the allocation stays.
+        // SAFETY: `raw` is live.
+        assert!(!unsafe { (*Owner::weak_ptr_data(raw)).on_finalize() });
+        assert_eq!(drops(), before);
+
+        // `get` on a finalized owner releases the ref and reports `None`, which
+        // is the last ref, so `deref_internal` frees the allocation.
+        assert!(weak.get().is_none());
+        assert_eq!(drops(), before + 1);
+        // The handle is now empty: a second `get`/`deref` must be a no-op.
+        assert!(weak.get().is_none());
+        weak.deref();
+    }
+
+    /// `deref` before finalize leaves the allocation to the owner.
+    #[test]
+    fn weak_ptr_deref_before_finalize_leaves_owner_in_charge() {
+        let _serial = serial();
+        let before = drops();
+        let raw = new_owner(6);
+        // SAFETY: `raw` is a freshly leaked Box; live and not finalized.
+        let mut weak = unsafe { WeakPtr::init_ref(raw) };
+        weak.deref();
+        assert_eq!(drops(), before);
+        // SAFETY: no weak refs remain; the owner frees its own allocation.
+        drop(unsafe { bun_core::heap::take(raw) });
+        assert_eq!(drops(), before + 1);
+    }
+
+    /// The owner keeps mutating the object through its own pointer while the
+    /// handle is live — the shape every in-tree caller has (`RequestContext`
+    /// holds a `WeakPtr<Request>` while JS mutates the `Request`). A handle
+    /// built from a `&mut T` reborrow is invalidated by that foreign write.
+    #[test]
+    fn weak_ptr_survives_owner_writes_through_its_own_pointer() {
+        let _serial = serial();
+        let before = drops();
+        let raw = new_owner(1);
+        // SAFETY: `raw` is a freshly leaked Box; live and not finalized.
+        let mut weak = unsafe { WeakPtr::init_ref(raw) };
+
+        for i in 2..5u32 {
+            // SAFETY: `raw` is live; the owner writes through its own pointer.
+            // This is a foreign write for any handle built from a reborrow.
+            unsafe { (*raw).payload = i };
+            assert_eq!(weak.get().map(|o| o.payload), Some(i));
+        }
+
+        weak.deref();
+        // SAFETY: no weak refs remain.
+        drop(unsafe { bun_core::heap::take(raw) });
+        assert_eq!(drops(), before + 1);
+    }
+
+    /// Several weak refs: only the one that takes the count to zero *after*
+    /// finalize frees the allocation. Creating the second handle writes the
+    /// weak count, which must not invalidate the first.
+    #[test]
+    fn weak_ptr_many_refs_last_one_frees() {
+        let _serial = serial();
+        let before = drops();
+        let raw = new_owner(2);
+        // SAFETY: `raw` is a freshly leaked Box; live and not finalized.
+        let mut a = unsafe { WeakPtr::init_ref(raw) };
+        // SAFETY: see above.
+        let mut b = unsafe { WeakPtr::init_ref(raw) };
+        // SAFETY: `raw` is live.
+        assert_eq!(unsafe { (*Owner::weak_ptr_data(raw)).reference_count() }, 2);
+        assert_eq!(a.get().map(|o| o.payload), Some(2));
+        assert_eq!(b.get().map(|o| o.payload), Some(2));
+
+        // SAFETY: `raw` is live.
+        assert!(!unsafe { (*Owner::weak_ptr_data(raw)).on_finalize() });
+        a.deref();
+        assert_eq!(drops(), before);
+        b.deref();
+        assert_eq!(drops(), before + 1);
     }
 }

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -603,10 +603,15 @@ impl<'a> RouteLoader<'a> {
 
         // /index.js
         if route.full_hash == INDEX_ROUTE_HASH {
-            let new_route = Box::new(route);
-            // SAFETY: Box contents have stable address; never removed from all_routes until consumed by load_all
-            self.index = Some(NonNull::from(&*new_route));
-            self.all_routes.push(new_route);
+            // Park the `Box` first, then derive `index` from it, and from a
+            // `&mut`: moving a `Box` retags it, so a pointer taken before the
+            // move is a stale sibling of the one `all_routes` owns, and a `&*`
+            // downgrade would freeze the tag.
+            self.all_routes.push(Box::new(route));
+            let parked = self.all_routes.last_mut().expect("just pushed");
+            // Box contents have a stable address; never removed from
+            // `all_routes` until consumed by `load_all`.
+            self.index = Some(NonNull::from(&mut **parked));
             return;
         }
 

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -603,10 +603,12 @@ impl<'a> RouteLoader<'a> {
 
         // /index.js
         if route.full_hash == INDEX_ROUTE_HASH {
-            // Park the `Box` first, then derive `index` from it, and from a
-            // `&mut`: moving a `Box` retags it, so a pointer taken before the
-            // move is a stale sibling of the one `all_routes` owns, and a `&*`
-            // downgrade would freeze the tag.
+            // Derived from a `&mut`, not a `&*` downgrade: `NonNull::from(&T)`
+            // yields a frozen tag. Today `index` is only read through (`match_`
+            // takes `as_ref()`), so the old spelling was not live UB, but it was
+            // one write away from it. The static arm below needs no such change:
+            // `&raw const *box` forms no reference at all. Parking the `Box`
+            // before deriving is belt-and-braces.
             self.all_routes.push(Box::new(route));
             let parked = self.all_routes.last_mut().expect("just pushed");
             // Box contents have a stable address; never removed from

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -309,21 +309,19 @@ where
 // downcast through the codegen stub so the call sites type-check; the stub
 // returns `None` until codegen lands.
 //
-/// # Safety
-/// `from_js` returns the C++-owned cell pointer for `value`. The caller must
-/// guarantee that:
-/// - no other Rust `&mut Response` aliasing this cell is live for the
-///   lifetime of the returned reference, and
-/// - `value` is kept GC-rooted (ensure_still_alive / protect()) for as long
-///   as the returned reference is used, so the JSC-owned allocation outlives
-///   the borrow.
+/// The C++-owned cell pointer for `value`, or `None` if it is not a `Response`.
+///
+/// Returns a raw pointer rather than `&mut Response` so it keeps the wrapper
+/// allocation's provenance: `RequestContext::set_response` stores it in a
+/// `WeakPtr<Response>`, which outlives any reborrow and is read again after
+/// the Response has been written through other pointers.
+///
+/// Callers must keep `value` GC-rooted (ensure_still_alive / protect()) for as
+/// long as they use the pointer, so the JSC-owned allocation outlives it, and
+/// must not form two overlapping `&mut Response` from it.
 #[inline]
-unsafe fn as_response(value: JSValue) -> Option<&'static mut Response> {
-    response::from_js(value).map(|p| {
-        // SAFETY: see the fn-level safety doc — caller guarantees no live
-        // aliasing `&mut Response` and keeps `value` GC-rooted for the borrow.
-        unsafe { &mut *p.cast::<Response>() }
-    })
+fn as_response(value: JSValue) -> Option<*mut Response> {
+    response::from_js(value).map(|p| p.cast::<Response>())
 }
 
 // ─── sibling-subtree shims ───────────────────────────────────────────────────
@@ -750,13 +748,13 @@ where
             return;
         }
 
-        // SAFETY: sole `&mut Response` for this cell in scope; `value` is
-        // protect()'d immediately below and stored in `response_jsvalue`.
-        let Some(response) = (unsafe { as_response(value) }) else {
+        let Some(response) = as_response(value) else {
             ctx.render_missing_invalid_response(value);
             return;
         };
-        if ctx.reject_unsendable_response(response) {
+        // SAFETY: `response` is the live cell pointer; `value` is rooted by the
+        // caller's frame and protect()'d below.
+        if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
             return;
         }
         ctx.response_jsvalue = value;
@@ -775,7 +773,8 @@ where
             return;
         }
 
-        ctx.render(response);
+        // SAFETY: `response` is the live, protect()'d cell pointer.
+        unsafe { ctx.render(response) };
     }
 
     pub fn should_render_missing(&self) -> bool {
@@ -2447,7 +2446,7 @@ where
         // SAFETY: pair is a stack local threaded through cork user-data.
         let pair = unsafe { &mut *pair };
         let this = &mut *pair.this;
-        let response = &mut *pair.response;
+        let response_ptr = pair.response;
         if this.resp.is_none() {
             return;
         }
@@ -2456,7 +2455,11 @@ where
         // Always this.renderMetadata() before sending the content-length or transfer-encoding header so status is sent first
 
         let resp = this.resp.expect("infallible: resp bound");
-        this.set_response(response);
+        // SAFETY: `response_ptr` is the live, GC-rooted cell pointer the
+        // constructing frame put in the pair; it carries the cell's provenance.
+        unsafe { this.set_response(response_ptr) };
+        // SAFETY: sole `&mut Response` for this cell in this frame.
+        let response = unsafe { &mut *response_ptr };
 
         // `render` drops the body for a null-body status on GET, so HEAD must
         // not derive framing from that body (or the user headers) either
@@ -2575,13 +2578,18 @@ where
                     ); // TODO: properly propagate exception upwards
                     return;
                 }
+                // Size the blob *before* `render_metadata()`: it re-fetches the
+                // Response from `response_weakref`, so no borrow of the Response
+                // (here, `blob`) may still be live across it. Nothing is written
+                // to the socket in between, so the wire output is unchanged.
+                blob.resolve_size();
+                let blob_size = blob.size.get();
                 this.render_metadata();
 
-                blob.resolve_size();
-                if blob.size.get() == crate::webcore::blob::MAX_SIZE {
+                if blob_size == crate::webcore::blob::MAX_SIZE {
                     resp.write_header_int(b"content-length", 0);
                 } else {
-                    resp.write_header_int(b"content-length", blob.size.get() as u64);
+                    resp.write_header_int(b"content-length", blob_size as u64);
                 }
                 this.end_without_body(this.should_close_connection());
             }
@@ -2644,11 +2652,11 @@ where
             return;
         }
 
-        // SAFETY: sole `&mut Response` for this cell in scope;
-        // `response_value` is rooted via ensure_still_alive() / protect()
-        // below for the duration of the borrow.
-        if let Some(response) = unsafe { as_response(response_value) } {
-            if ctx.reject_unsendable_response(response) {
+        // `response_value` is rooted via ensure_still_alive() / protect() below
+        // for as long as `response` is used.
+        if let Some(response) = as_response(response_value) {
+            // SAFETY: `response` is the live, rooted cell pointer.
+            if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
                 return;
             }
             ctx.response_jsvalue = response_value;
@@ -2664,7 +2672,9 @@ where
                 }
                 return;
             } else {
-                let body_value = response.get_body_value();
+                // SAFETY: sole `&mut Response` for this cell in scope; the
+                // borrow ends before `render` reborrows the same pointer.
+                let body_value = unsafe { (*response).get_body_value() };
                 body_value.to_blob_if_possible();
 
                 match body_value {
@@ -2680,7 +2690,8 @@ where
                     }
                     _ => {}
                 }
-                ctx.render(response);
+                // SAFETY: `response` is the live, rooted cell pointer.
+                unsafe { ctx.render(response) };
             }
             return;
         }
@@ -2714,15 +2725,15 @@ where
                         ctx.render_missing_invalid_response(fulfilled_value);
                         return;
                     }
-                    // SAFETY: sole `&mut Response` for this cell in scope;
                     // `fulfilled_value` is rooted via ensure_still_alive() /
-                    // protect() below for the duration of the borrow.
-                    let Some(response) = (unsafe { as_response(fulfilled_value) }) else {
+                    // protect() below for as long as `response` is used.
+                    let Some(response) = as_response(fulfilled_value) else {
                         ctx.render_missing_invalid_response(fulfilled_value);
                         return;
                     };
 
-                    if ctx.reject_unsendable_response(response) {
+                    // SAFETY: `response` is the live, rooted cell pointer.
+                    if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
                         return;
                     }
 
@@ -2739,7 +2750,9 @@ where
                         }
                         return;
                     }
-                    let body_value = response.get_body_value();
+                    // SAFETY: sole `&mut Response` for this cell in scope; the
+                    // borrow ends before `render` reborrows the same pointer.
+                    let body_value = unsafe { (*response).get_body_value() };
                     body_value.to_blob_if_possible();
                     match body_value {
                         Body::Value::Blob(blob) => {
@@ -2754,7 +2767,8 @@ where
                         }
                         _ => {}
                     }
-                    ctx.render(response);
+                    // SAFETY: `response` is the live, rooted cell pointer.
+                    unsafe { ctx.render(response) };
                     return;
                 }
                 jsc::PromiseResult::Rejected(err) => {
@@ -3351,8 +3365,10 @@ where
     /// `false` when the Response can be written. A status outside `100..=999`
     /// has no HTTP status line, so the Response can never reach the client:
     /// report it like a thrown error rather than writing an unparseable one.
-    fn reject_unsendable_response(&mut self, response: &Response) -> bool {
-        let status = response.status_code();
+    ///
+    /// Takes the status, not the Response: `run_error_handler` below runs user
+    /// JS, which may write through the cell pointer the caller holds.
+    fn reject_unsendable_response(&mut self, status: u16) -> bool {
         if HTTPStatusText::is_sendable(status) {
             return false;
         }
@@ -3454,14 +3470,15 @@ where
                     } else if let Some(promise) = result.as_any_promise() {
                         Self::process_on_error_promise(self, result, promise, value, status);
                         return;
-                    // SAFETY: sole `&mut Response` for this cell in scope;
                     // `result` is GC-rooted by `_keep` (EnsureStillAlive)
                     // across the render() call.
-                    } else if let Some(response) = unsafe { as_response(result) } {
+                    } else if let Some(response) = as_response(result) {
                         // An unsendable Response from the error handler itself
                         // falls through to the default error page below.
-                        if HTTPStatusText::is_sendable(response.status_code()) {
-                            self.render(response);
+                        // SAFETY: `response` is the live, rooted cell pointer.
+                        if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                            // SAFETY: as above.
+                            unsafe { self.render(response) };
                             return;
                         }
                     }
@@ -3505,15 +3522,15 @@ where
                     return;
                 }
 
-                // SAFETY: sole `&mut Response` for this cell in scope;
-                // `fulfilled_value` is rooted via ensure_still_alive() below
-                // for the duration of the borrow.
-                let Some(response) = (unsafe { as_response(fulfilled_value) }) else {
+                // `fulfilled_value` is rooted via ensure_still_alive() below for
+                // as long as `response` is used.
+                let Some(response) = as_response(fulfilled_value) else {
                     ctx.finish_running_error_handler(value, status);
                     return;
                 };
 
-                if !HTTPStatusText::is_sendable(response.status_code()) {
+                // SAFETY: `response` is the live, rooted cell pointer.
+                if !HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
                     ctx.finish_running_error_handler(value, status);
                     return;
                 }
@@ -3522,7 +3539,9 @@ where
                 ctx.response_jsvalue.ensure_still_alive();
                 ctx.flags.set_response_protected(false);
 
-                let body_value = response.get_body_value();
+                // SAFETY: sole `&mut Response` for this cell in scope; the
+                // borrow ends before `render` reborrows the same pointer.
+                let body_value = unsafe { (*response).get_body_value() };
                 body_value.to_blob_if_possible();
                 match body_value {
                     Body::Value::Blob(blob) => {
@@ -3537,7 +3556,8 @@ where
                     }
                     _ => {}
                 }
-                ctx.render(response);
+                // SAFETY: `response` is the live, rooted cell pointer.
+                unsafe { ctx.render(response) };
                 return;
             }
             jsc::PromiseResult::Rejected(err) => {
@@ -3769,24 +3789,34 @@ where
     /// Replace the tracked Response. Drops the previous weak ref (if any)
     /// before taking a new one so the old Response's allocation can be
     /// freed once its own strong refs go to zero.
-    fn set_response(&mut self, response: &mut Response) {
+    ///
+    /// # Safety
+    /// `response` must be the live JS wrapper's cell pointer (as returned by
+    /// [`as_response`]), carrying the allocation's provenance — `WeakPtr` keeps
+    /// it past any reborrow.
+    unsafe fn set_response(&mut self, response: *mut Response) {
         if self
             .response_weakref
             .get()
             .map(std::ptr::from_mut::<Response>)
-            == Some(std::ptr::from_mut(response))
+            == Some(response)
         {
             return;
         }
         self.response_weakref.deref();
-        self.response_weakref = response::WeakRef::init_ref(response);
+        // SAFETY: caller contract — `response` is live and root-provenanced.
+        self.response_weakref = unsafe { response::WeakRef::init_ref(response) };
     }
 
-    pub fn render(&mut self, response: &mut Response) {
+    /// # Safety
+    /// Same contract as [`Self::set_response`].
+    pub unsafe fn render(&mut self, response: *mut Response) {
         ctx_log!("render");
-        self.set_response(response);
+        // SAFETY: caller contract.
+        unsafe { self.set_response(response) };
 
-        if HTTPStatusText::is_null_body(response.status_code()) {
+        // SAFETY: caller contract — `response` is live.
+        if HTTPStatusText::is_null_body(unsafe { (*response).status_code() }) {
             self.do_render_blob();
             return;
         }
@@ -4252,7 +4282,10 @@ pub struct HeaderResponseSizePair<'a, ThisServer, const SSL: bool, const DBG: bo
 
 pub struct HeaderResponsePair<'a, ThisServer, const SSL: bool, const DBG: bool, const H3: bool> {
     pub this: &'a mut RequestContext<ThisServer, SSL, DBG, H3>,
-    pub response: &'a mut Response,
+    /// The JS wrapper's cell pointer, not a `&mut Response`: the receiving
+    /// frame hands it to `set_response`, which stores it in a `WeakPtr` that
+    /// outlives any reborrow. The cell is GC-rooted by the constructing frame.
+    pub response: *mut Response,
 }
 
 pub struct PathnameFormatter<'a, ThisServer, const SSL: bool, const DBG: bool, const H3: bool> {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -741,8 +741,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 Some(signal_ref),
                 body_hive,
             )));
-        // SAFETY: freshly allocated; uniquely owned here.
-        ctx_mut.request_weakref = bun_ptr::WeakPtr::init_ref(unsafe { &mut *request_object });
+        // SAFETY: freshly leaked from `heap::into_raw`, so `request_object`
+        // carries the allocation's provenance, as `init_ref` requires.
+        ctx_mut.request_weakref = unsafe { bun_ptr::WeakPtr::init_ref(request_object) };
 
         // (H3 eager-url/header population is unreachable on this path.)
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -222,8 +222,9 @@ where
     }
     #[inline]
     fn set_request_weakref(&mut self, req: *mut Request) {
-        // SAFETY: req is a freshly-boxed Request; live for the request duration.
-        self.request_weakref = bun_ptr::WeakPtr::<Request>::init_ref(unsafe { &mut *req });
+        // SAFETY: `req` is a freshly-boxed Request (live for the request
+        // duration) still carrying its `heap::into_raw` provenance.
+        self.request_weakref = unsafe { bun_ptr::WeakPtr::<Request>::init_ref(req) };
     }
     #[inline]
     fn clear_req(&mut self) {
@@ -3071,11 +3072,15 @@ where
             Some(signal_for_req),
             body_hive,
         ));
-        let request_object: &mut Request =
-            // SAFETY: leak so the ctx (which outlives this stack frame) can
-            // hold the borrow; Request is freed via ctx.deinit's request_weakref.
-            unsafe { &mut *bun_core::heap::into_raw(request_object_box) };
-        ctx.set_request_weakref(request_object);
+        // Leak so the ctx (which outlives this stack frame) can hold the
+        // pointer; Request is freed via ctx.deinit's request_weakref. The weak
+        // handle takes the raw pointer, not a reborrow of `request_object`:
+        // writes through `request_object` below would otherwise invalidate it.
+        let request_object_ptr: *mut Request = bun_core::heap::into_raw(request_object_box);
+        ctx.set_request_weakref(request_object_ptr);
+        // SAFETY: freshly leaked; no other borrow of the Request is live, and
+        // the weak handle only reborrows when `get()` is called.
+        let request_object: &mut Request = unsafe { &mut *request_object_ptr };
 
         // The lazy `getRequest()` path that backs Request.url / .headers
         // is `*uws.Request`-typed; for HTTP/3 we populate both eagerly so
@@ -3317,15 +3322,21 @@ where
             body_hive,
         ));
         ctx.upgrade_context = Some(upgrade_ctx);
-        let request_object: &mut Request =
-            // SAFETY: leaked so the ctx (which outlives this stack frame) can
-            // hold the borrow; freed via ctx.deinit's request_weakref.
-            unsafe { &mut *bun_core::heap::into_raw(request_object_box) };
-        ctx.request_weakref = bun_ptr::WeakPtr::<Request>::init_ref(request_object);
+        // Leaked so the ctx (which outlives this stack frame) can hold the
+        // pointer; freed via ctx.deinit's request_weakref. Everything below
+        // goes through this raw pointer rather than a `&mut Request` reborrow:
+        // the weak handle and the deferred `detach_request` both alias it.
+        let request_object_ptr: *mut Request = bun_core::heap::into_raw(request_object_box);
+        // SAFETY: freshly leaked, so it carries the allocation's provenance.
+        ctx.request_weakref = unsafe { bun_ptr::WeakPtr::<Request>::init_ref(request_object_ptr) };
 
         // We keep the Request object alive for the duration of the request so that we can remove the pointer to the UWS request object.
         let global = this.global();
-        let args = [request_object.to_js(&global), this.js_value_assert_alive()];
+        // SAFETY: `request_object_ptr` is live; no other borrow is outstanding.
+        let args = [
+            unsafe { (*request_object_ptr).to_js(&global) },
+            this.js_value_assert_alive(),
+        ];
         let request_value = args[0];
         request_value.ensure_still_alive();
 
@@ -3337,11 +3348,12 @@ where
             Ok(v) => v,
             Err(err) => global.take_exception(err),
         };
-        let request_object_ptr: *mut Request = request_object;
+        // Its own copy, so the closure's capture does not pin `request_object_ptr`.
+        let detach_ptr = request_object_ptr;
         scopeguard::defer! {
             // uWS request will not live longer than this function
-            // SAFETY: see request_object above.
-            unsafe { (*request_object_ptr).request_context.detach_request() };
+            // SAFETY: see request_object_ptr above.
+            unsafe { (*detach_ptr).request_context.detach_request() };
         }
 
         // SAFETY: self_ptr is live for the request's duration; the &mut held
@@ -3362,7 +3374,9 @@ where
 
         ctx.to_async(
             std::ptr::from_mut::<uws::Request>(req).cast::<c_void>(),
-            request_object,
+            // SAFETY: `request_object_ptr` is live (the ctx's weakref owns it)
+            // and no other borrow of the Request is outstanding here.
+            unsafe { &mut *request_object_ptr },
         );
     }
 

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -394,7 +394,7 @@ impl Drop for Formatter<'_> {
                 let data = node.as_mut().data.assume_init_mut();
                 *data = core::mem::take(&mut self.map);
                 data.clear();
-                visited::Pool::release(node.as_mut());
+                visited::Pool::release(node.as_ptr());
             }
         }
     }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1985,7 +1985,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             debug_assert!(self.pooled_buffer.is_none());
         }
 
-        if let Some(mut pooled) = self.pooled_buffer {
+        if let Some(pooled) = self.pooled_buffer {
             self.buffer.clear();
             if self.buffer.capacity() > 64 * 1024 {
                 self.buffer.clear_and_free();
@@ -2001,7 +2001,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             // SAFETY: `pooled` was obtained from `ByteListPool::get_node` and is
             // exclusively owned by this stream; `data` was rewritten just above,
             // so it is initialized. Ownership returns to the pool.
-            unsafe { ByteListPool::release(pooled.as_mut()) };
+            unsafe { ByteListPool::release(pooled.as_ptr()) };
         } else if self.buffer.capacity() == 0 {
             //
         } else if FeatureFlags::HTTP_BUFFER_POOLING && !ByteListPool::full() {

--- a/test/internal/frozen-nonnull-reborrow.test.ts
+++ b/test/internal/frozen-nonnull-reborrow.test.ts
@@ -1,0 +1,74 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../scripts/glob-sources.ts";
+
+// `NonNull::from(&*expr)` is always a bug waiting to happen.
+//
+// The `&*` takes something that derefs to `&mut T` (a `Box`, a `&mut T`, an
+// arena's `alloc()` return) and downgrades it to `&T`, so `NonNull::from` picks
+// the `From<&T>` impl. Under Tree Borrows the resulting tag is *frozen*: it may
+// be read through, never written through. Code that stores such a pointer and
+// later writes through it — or keeps it while something writes through the
+// original `&mut` — is UB.
+//
+// Three of these existed, all storing the pointer past the borrow that produced
+// it:
+//
+//   - `Parser::new`'s arena arm froze the `JsonTape` root, so every later
+//     `tape_mut()` write through it was UB (bundler JSON imports).
+//   - `RouteLoader::append_route` froze the `/index.js` route pointer *and*
+//     derived it before moving the `Box` into `all_routes`.
+//   - `start_queued_task` froze the in-flight HTTP pointer, then immediately
+//     wrote through the `&mut` it came from.
+//
+// If you need a raw pointer that outlives the borrow, take it from the
+// allocation itself: `NonNull::from(&mut *x)`, `heap::into_raw(boxed)`, or a
+// `fn root_ptr(&mut self) -> NonNull<Self>` helper. Derive it *after* any move
+// of the owning `Box` — moving a `Box` retags it, and a pointer taken before
+// the move is a stale sibling of the one the new owner holds.
+//
+// Sibling guard: test/internal/unsound-erased-box.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `NonNull::from(&*` — optionally qualified (`core::ptr::NonNull`, `ptr::NonNull`).
+// `&\s*\*` so rustfmt-introduced whitespace still matches. Does not match
+// `NonNull::from(&mut *x)`, which is the correct spelling.
+const FROZEN_REBORROW = /NonNull::from\(\s*&\s*\*/g;
+
+const offenders: string[] = [];
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including this file's siblings)
+  // don't count.
+  const stripped = content.replace(/^\s*\/\/.*$/gm, "");
+  for (const line of stripped.split("\n")) {
+    FROZEN_REBORROW.lastIndex = 0;
+    if (FROZEN_REBORROW.test(line)) offenders.push(`${source}: ${line.trim()}`);
+  }
+}
+
+test("NonNull::from(&*x) — frozen reborrow stored past its borrow", () => {
+  expect(offenders).toEqual([]);
+});

--- a/test/internal/frozen-nonnull-reborrow.test.ts
+++ b/test/internal/frozen-nonnull-reborrow.test.ts
@@ -53,12 +53,14 @@ const tracked: Set<string> | null = (() => {
 const FROZEN_REBORROW = /NonNull::from\(\s*&\s*\*/g;
 
 const offenders: string[] = [];
+let scanned = 0;
 for (const abs of rustSources) {
   const source = path.relative(root, abs).replaceAll(path.sep, "/");
   // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
   // its canonical path.
   if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
   if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
   const content = await file(abs).text();
   // Strip full-line comments so prose mentions (including this file's siblings)
   // don't count.
@@ -68,6 +70,13 @@ for (const abs of rustSources) {
     if (FROZEN_REBORROW.test(line)) offenders.push(`${source}: ${line.trim()}`);
   }
 }
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing (e.g. a
+  // symlinked checkout root) and leaving nothing to scan, which would make the
+  // ban below pass vacuously. Same guard as unsound-erased-box.test.ts.
+  expect(scanned).toBeGreaterThan(0);
+});
 
 test("NonNull::from(&*x) — frozen reborrow stored past its borrow", () => {
   expect(offenders).toEqual([]);


### PR DESCRIPTION
Fixes #31974.

Seven `unsafe` sites build a long-lived raw pointer out of a short-lived reference, or free memory that a live `&mut` argument points into. Miri reports UB on all of them under the aliasing model the repo already runs (`-Zmiri-tree-borrows`, `bun run rust:miri`).

## Repro

Each is a regression test added in this PR. They fail under Miri on the unfixed code and pass with the fix:

```
MIRIFLAGS="-Zmiri-tree-borrows" cargo miri test -p bun_ptr         weak_ptr
MIRIFLAGS="-Zmiri-tree-borrows" cargo miri test -p bun_collections pool
MIRIFLAGS="-Zmiri-tree-borrows" cargo miri test -p bun_ast         json_tape
```

<details>
<summary>Miri output on the unfixed code</summary>

```
error: Undefined Behavior: reborrow through <143109> at alloc49028[0xc] is forbidden
   --> src/ptr/weak_ptr.rs:123:34
    = help: the accessed tag <143109> has state Disabled which forbids this reborrow
help: the accessed tag <143109> later transitioned to Disabled due to a foreign write access

error: Undefined Behavior: deallocation through <3135142> ... is forbidden
   --> src/collections/pool.rs:537:13
    = help: the allocation of the accessed tag also contains the strongly protected tag <3134897>
    = help: the strongly protected tag <3134897> disallows deallocations
help: the strongly protected tag <3134897> was created here, in the initial state Reserved
   --> src/collections/pool.rs:479:27
    |
479 |     pub unsafe fn release(node: &mut Node<T>) {
    |                           ^^^^

error: Undefined Behavior: deallocation through <187832> at alloc63184 is forbidden
   --> src/collections/pool.rs:558:13
    = help: the strongly protected tag <187832> disallows deallocations
help: the strongly protected tag <187832> was created here, in the initial state Reserved
   --> src/collections/pool.rs:470:33
    |
470 |     pub unsafe fn release_value(value: &mut T) {
    |                                 ^^^^^

error: Undefined Behavior: reborrow through <209070> at alloc55442[0x18] is forbidden
   --> src/ast/e.rs (ObjectJSON::properties)
help: the accessed tag <209070> later transitioned to Disabled due to a foreign write access
```
</details>

## Cause

**`bun_ptr::WeakPtr::init_ref`** took `&mut T` and stored `NonNull::from(req)`. `WeakPtr` is a *shared* handle: the owner keeps using the object through its own pointer, and several handles may coexist. Any such write is foreign to the stored tag, so the handle is invalidated and every later `get()`/`deref()` is UB. In-tree this is `RequestContext` holding a `WeakPtr<Request>` while JS mutates the `Request`. `ThisPtr::new`, `ParentRef::from_raw_mut` and `RefPtr::init_ref` in the same crate already take raw pointers for exactly this reason; `WeakPtr` was the odd one out.

**`bun_collections::ObjectPool::release`** took `&mut Node<T>` and, when the pool is already at `MAX_COUNT`, freed that node. Deallocating an allocation that a live `&mut` *function argument* points into is UB — the reference is protected for the whole call. Every capped pool (`BodyPool`, `ByteListPool`, zlib's `BufferPool`, the console/test-runner `visited::Pool`, `StringVoidMapPool`) reaches this on overflow. `CellRefCounted::deref` already documents the same lesson and takes a raw pointer.

**`ObjectPool::release_value`** had the identical defect one layer up: it took `&mut T`, recovered the parent node with `from_field_ptr!`, and handed it to `release` — so a full pool frees the allocation its own protected argument points into. `bun_http::zlib::put` (its only caller) inherited it, because `put`'s `&mut MutableString` is protected for the same call.

**`E::ObjectJSON::new` / `E::ArrayJSON::new`** stored a `NonNull<JsonTape>` derived from a `&JsonTape`, but the parser keeps appending to the tape after a node is built (sibling properties, the enclosing object, later strings). Parsing `{"a": {"b": 1}}` therefore makes every later read of the inner object's `properties()` UB. The parser already holds the tape as a `NonNull<JsonTape>` and only laundered it through `tape_ref()`.

**`Parser::new`'s arena arm** built the tape pointer as `NonNull::from(&*arena.alloc(..))`. `MimallocArena::alloc` returns `&mut T`, so the `&*` reborrowed it down to `&JsonTape` and `NonNull::from` picked `From<&T>` — a frozen, read-only tag. Every later `tape_mut()` write goes through it, and `tape_ptr()` handed it to `ObjectJSON::new`, whose contract this PR had just written to forbid exactly that. Reached by the bundler's JSON/JSONC imports (`parse_json_into_arena`). The `Global` arm used `Box::leak`, which yields `&mut`, so it was sound — which is why the first round of tests was green. Caught in review by @claude.

**Two more `NonNull::from(&*x)`.** Once the arena arm turned up, the same shape appeared twice more. They are not equally bad, and the PR does not claim they are:

- `start_queued_task` pushed a frozen pointer into `in_flight` and then *immediately wrote through the `&mut` it came from*. A foreign write disables the frozen child outright, and a disabled tag forbids even reads, so every later use of that `in_flight` entry is UB. This one is live.
- `RouteLoader::append_route` froze the `/index.js` route pointer. `index` happens to be read-only today (`match_` only takes `as_ref()`), and a frozen tag still permits reads, so this was **not** live UB — it was one write away from it. Fixed as hardening, not as a bug. (Thanks @claude for catching that I had overclaimed it.) The static-route arm right below needs no change: `&raw const *box` is a place projection that forms no reference, so it never freezes anything.

## Fix

All of them take the allocation's own pointer instead of a reborrow of it:

- `WeakPtr::init_ref(this: *mut T)`, with the provenance contract spelled out on the type. Callers in `server/` already had the raw pointer in hand.
- `ObjectPool::release(node: *mut Node<T>)`, matching `destroy_node`.
- `ObjectPool::release_value(value: *mut T)` as an `unsafe fn`, mirroring `release`; `zlib::put(mutable: *mut MutableString)` follows.
- `ObjectJSON::new(tape: NonNull<JsonTape>)` / `ArrayJSON::new(..)`; the parser passes `self.tape_ptr()`, and the now-unused `tape_ref()` is deleted.
- `JsonTape::root_ptr(&mut self)` is the only way to build that pointer, so neither arm of `Parser::new` can silently derive it from a shared borrow again.
- `RouteLoader::append_route` derives `index` from `&mut **parked`; `start_queued_task` keeps the `heap::into_raw` pointer. Neither is Miri-provable — `bun_router`/`bun_http` are not in the Miri crate set — so these two rest on the analysis above plus a `fetch` smoke over the client path, not on a failing test.
- `test/internal/frozen-nonnull-reborrow.test.ts` bans `NonNull::from(&*x)` outright, in the same genre as `unsound-erased-box.test.ts`. No inventory file: there are zero occurrences left, so the rule is simply "don't write it". It also asserts it scanned a non-empty set of sources, so the ban cannot pass vacuously if the realpath/tracked filters over-fire.

Because the `Response` weak handle now hands out *live* reborrows, `do_render_head_response`'s blob arm had to stop holding one across `render_metadata()` (which re-fetches the Response from the same handle): the blob is sized before the call instead of after. Nothing is written to the socket in between, so the wire output is unchanged. `reject_unsendable_response` takes the status rather than `&Response` for the same reason — `run_error_handler` runs user JS that can write through the caller's cell pointer.

`bun_core::return_address` and `debug::capture_current` read `rbp` via inline asm and walk the frame-pointer chain, neither of which Miri can execute. They short-circuit on `cfg!(miri)` — this is what had left `ref_count.rs` (91 `unsafe`, 0 tests) untestable.

## Verification

- `bun run rust:miri` — 145 tests, green. `bun_ptr` goes from 2 to 20 tests (`RefCount`, `ThreadSafeRefCount` across real threads, `RefPtr`, `ScopedRef`, `CellRefCounted`, `WeakPtr`), `bun_collections` gains 8 (`ObjectPool`, `SinglyLinkedList`, `PoolGuard`, the `first()`/`release_value()` `container_of` round-trip, and `release_value` on a *full* pool — the overflow path that frees the node the argument points into) and `bun_ast` 4 (`JsonTape` spans, `alloc_str` chunk stability). Miri's leak check is what proves `delete_all` actually frees what it reclaims.
- `cargo clippy --workspace --no-deps` and `cargo check --workspace` clean.
- `bun bd test test/js/bun/jsonc/ test/js/bun/json5/` — 802 pass, 0 fail.
- `bun bd test test/js/bun/http/serve.test.ts` — 238 pass, including the `Response.error()` suite that covers `reject_unsendable_response`. The 4 failures (`requestIP > v6`, root-range port, `#6583`, `/bun:info` loopback) reproduce on the released binary in this container and are environmental.
- `bun bd test test/js/bun/console/ test/js/bun/test/expect/ test/regression/issue/18413.test.ts` — pass (the pooled `pretty_format` / console formatter and the zlib buffer pool's neighbourhood).
- `test/js/web/streams/streams.test.js` — 134 pass; the 2 failures (`Bun.file().stream() read text from large file`, `handles exceptions during empty stream creation`) reproduce on a debug build of `main` with `src/` stashed, so they are not a regression.
- HEAD framing checked by hand across file / string / blob / explicit-content-length / 204 / stream bodies, against both HEAD and GET, to confirm the `resolve_size()` reorder is behaviour-preserving.

## Not fixed here

`RequestContext`'s render path has other places that hold a `&mut Response` across a call that re-enters `response_weakref.get()`. They were all unsound before this PR too (the handle's tag was already stale), and untangling them is a separate cleanup. This PR fixes the primitive and the one site it touches.

`bun_http::zlib::{get, put}` and `ObjectPool::{first, release_value}` still have no production callers. This PR makes the unchecked contract `unsafe` rather than safe, which closes the hole #31974 reports; #31978 proposes deleting the surface outright instead, which remains the better end state.



