### PR TITLE
jsc: make VirtualMachine::event_loop_handle atomic for the cross-thread wakeup path

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -231,7 +231,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let vm_ptr = global.bun_vm_ptr();
         let vm = global.bun_vm().as_mut();
 
-        debug_assert!(vm.event_loop_handle.is_some());
+        debug_assert!(!vm.event_loop_handle_ptr().is_null());
 
         // Decode all BunString inputs into UTF-8 slices. The underlying
         // JavaScript strings may be Latin1 or UTF-16; `String.to_utf8()` either

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -178,7 +178,10 @@ pub struct VirtualMachine {
     /// both types are owned by `bun_runtime` (forward dep). Access goes through
     /// [`RuntimeHooks::timer_insert`] / [`RuntimeHooks::body_value_hive_ref`].
     pub runtime_state: *mut c_void,
-    pub event_loop_handle: Option<*mut PlatformEventLoop>,
+    /// Per-VM platform event loop (uws `Loop` on POSIX, libuv on Windows);
+    /// null = unset. Atomic: producer threads read it on the cross-thread
+    /// `wakeup()` path while the JS thread may rewrite it (spawnSync).
+    pub event_loop_handle: core::sync::atomic::AtomicPtr<PlatformEventLoop>,
     /// Pending `unref` count drained by the event-loop thread. Atomic because
     /// `KeepAlive::unref_on_next_tick_concurrently` increments it from OTHER
     /// threads.
@@ -876,23 +879,46 @@ impl VirtualMachine {
         unsafe { &mut *self.uws_loop() }
     }
 
+    /// Acquire-load the per-VM platform event loop pointer (null before
+    /// `ensure_waker()`). Safe from any thread: the cross-thread `wakeup()`
+    /// path reads it this way and hands it straight to the thread-safe
+    /// `us_wakeup_loop` extern without forming a `&mut Loop`.
+    #[inline(always)]
+    pub fn event_loop_handle_ptr(&self) -> *mut PlatformEventLoop {
+        self.event_loop_handle
+            .load(core::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Release-store the per-VM platform event loop pointer. JS-thread-only
+    /// writers (`ensure_waker`, spawnSync prepare/cleanup, `Bun.serve` init);
+    /// Release pairs with the Acquire load in [`Self::event_loop_handle_ptr`].
+    #[inline(always)]
+    pub fn set_event_loop_handle_ptr(&self, handle: *mut PlatformEventLoop) {
+        self.event_loop_handle
+            .store(handle, core::sync::atomic::Ordering::Release);
+    }
+
     /// Safe `&mut PlatformEventLoop` accessor for `event_loop_handle` (the
     /// uws loop on POSIX, libuv loop on Windows). `None` only before
-    /// `ensure_waker()` runs. Consolidates the open-coded raw deref of
-    /// `self.event_loop_handle.unwrap()` at the `EventLoop::tick*` /
-    /// `update_counts` call sites into one SAFETY block.
+    /// `ensure_waker()` runs. Consolidates the open-coded raw deref at the
+    /// `EventLoop::tick*` / `update_counts` call sites into one SAFETY block.
     ///
-    /// Same single-JS-thread soundness contract as [`Self::uws_loop_mut`] —
-    /// the `PlatformEventLoop` is a separate heap allocation (uws/uv-owned),
-    /// so the returned `&mut` cannot alias any field of `self`.
+    /// JS-thread-only — forms `&mut PlatformEventLoop`. Cross-thread callers
+    /// (`wakeup()`) MUST use [`Self::event_loop_handle_ptr`] instead. The
+    /// `PlatformEventLoop` is a separate heap allocation (uws/uv-owned), so
+    /// the returned `&mut` cannot alias any field of `self`.
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
     pub fn platform_loop_opt(&self) -> Option<&mut PlatformEventLoop> {
-        // SAFETY: when `Some`, `event_loop_handle` was set in `init()` /
+        // SAFETY: when non-null, `event_loop_handle` was set in `init()` /
         // `ensure_waker()` to the live per-VM uws/uv loop and remains valid
-        // for the VM lifetime. Single-JS-thread invariant per `unsafe impl
-        // Sync` — only the owning JS thread reborrows mutably.
-        self.event_loop_handle.map(|h| unsafe { &mut *h })
+        // for the VM lifetime. JS-thread-only per `unsafe impl Sync`.
+        let handle = self.event_loop_handle_ptr();
+        if handle.is_null() {
+            None
+        } else {
+            Some(unsafe { &mut *handle })
+        }
     }
 
     /// Read-then-zero `pending_unref_counter`. `swap(0)` so a concurrent
@@ -1007,19 +1033,21 @@ impl VirtualMachine {
 
     /// Per-callback hot path: `drain_microtasks_with_global` calls
     /// `uws_loop_mut()` (→ this) every time the microtask queue drains, and
-    /// the only call site there is already gated on
-    /// `event_loop_handle.is_some()`.
+    /// the only call site there is already gated on a non-null
+    /// `event_loop_handle`.
     #[inline(always)]
     pub fn uws_loop(&self) -> *mut uws::Loop {
         #[cfg(unix)]
         {
-            debug_assert!(
-                self.event_loop_handle.is_some(),
-                "uws event_loop_handle is null"
-            );
-            // SAFETY: set in `init()` on the JS thread before any host_fn /
+            // Relaxed (not Acquire): this is a JS-thread-only hot path and the
+            // only writer is the JS thread, so program order already makes its
+            // own store visible. Set in `init()` before any host_fn /
             // event-loop tick runs; never cleared while the VM is live.
-            unsafe { self.event_loop_handle.unwrap_unchecked() }
+            let handle = self
+                .event_loop_handle
+                .load(core::sync::atomic::Ordering::Relaxed);
+            debug_assert!(!handle.is_null(), "uws event_loop_handle is null");
+            handle
         }
         #[cfg(not(unix))]
         {
@@ -3138,16 +3166,9 @@ impl VirtualMachine {
 
     /// Returns this VM's libuv event loop handle (must already be initialized).
     pub fn uv_loop(&self) -> *mut Async::Loop {
-        #[cfg(debug_assertions)]
-        {
-            return self
-                .event_loop_handle
-                .expect("libuv event_loop_handle is null");
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            self.event_loop_handle.unwrap()
-        }
+        let handle = self.event_loop_handle_ptr();
+        assert!(!handle.is_null(), "libuv event_loop_handle is null");
+        handle
     }
 
     /// Whether TLS certificate verification is enforced, from the cached override or the env loader.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -910,13 +910,13 @@ impl VirtualMachine {
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
     pub fn platform_loop_opt(&self) -> Option<&mut PlatformEventLoop> {
-        // SAFETY: when non-null, `event_loop_handle` was set in `init()` /
-        // `ensure_waker()` to the live per-VM uws/uv loop and remains valid
-        // for the VM lifetime. JS-thread-only per `unsafe impl Sync`.
         let handle = self.event_loop_handle_ptr();
         if handle.is_null() {
             None
         } else {
+            // SAFETY: non-null `event_loop_handle` was set in `init()` /
+            // `ensure_waker()` to the live per-VM uws/uv loop and remains
+            // valid for the VM lifetime. JS-thread-only per `unsafe impl Sync`.
             Some(unsafe { &mut *handle })
         }
     }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -957,8 +957,13 @@ impl EventLoop {
         #[cfg(windows)]
         {
             if let Some(loop_) = self.uws_loop {
-                // SAFETY: uws_loop is a valid live uws::Loop handle
-                unsafe { (*loop_.as_ptr()).wakeup() };
+                // Cross-thread, like the POSIX arm: call the thread-safe
+                // `us_wakeup_loop` extern on the raw pointer, not
+                // `WindowsLoop::wakeup(&mut self)` whose autoref would form a
+                // second `&mut Loop` to the singleton (mirrors `WindowsWaker`).
+                // SAFETY: `loop_` is the live per-VM uws loop; the extern
+                // routes to the thread-safe `uv_async_send`.
+                unsafe { uws::us_wakeup_loop(loop_.as_ptr()) };
             }
             return;
         }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -339,7 +339,7 @@ impl EventLoop {
         // Guard on `event_loop_handle` being set, but drain via `uws_loop_mut()`:
         // on Windows the uSockets loop (`uws::Loop::get()`) is NOT
         // `event_loop_handle` (which is the libuv loop).
-        if vm.event_loop_handle.is_some() {
+        if !vm.event_loop_handle_ptr().is_null() {
             vm.uws_loop_mut().drain_quic_if_necessary();
         }
 
@@ -562,9 +562,18 @@ impl EventLoop {
         let vm = self.virtual_machine.expect("virtual_machine").as_ptr();
         // SAFETY: `virtual_machine` is set in `VirtualMachine::init()` to the
         // owning per-thread singleton; non-null and live for the VM lifetime.
-        // `addr_of!` projects to the field place without forming an
-        // intermediate `&VirtualMachine` that would assert no-alias.
-        unsafe { core::ptr::addr_of!((*vm).event_loop_handle).read() }.expect("event_loop_handle")
+        // JS-thread-only (libuv completion callbacks), and only the JS thread
+        // writes `event_loop_handle`, so reading it here races nothing.
+        // `AtomicPtr<T>` has the same layout as `*mut T`; read the bytes via
+        // the raw field projection to avoid an intermediate `&VirtualMachine`
+        // (a caller may hold `&mut`).
+        let handle = unsafe {
+            core::ptr::addr_of!((*vm).event_loop_handle)
+                .cast::<*mut crate::PlatformEventLoop>()
+                .read()
+        };
+        assert!(!handle.is_null(), "event_loop_handle");
+        handle
     }
 
     pub fn usockets_loop(&self) -> *mut uws::Loop {
@@ -580,9 +589,12 @@ impl EventLoop {
         }
         #[cfg(not(windows))]
         {
-            self.vm_ref().event_loop_handle.expect(
-                "usockets_loop: event_loop_handle not initialized (call ensure_waker first)",
-            )
+            let handle = self.vm_ref().event_loop_handle_ptr();
+            assert!(
+                !handle.is_null(),
+                "usockets_loop: event_loop_handle not initialized (call ensure_waker first)"
+            );
+            handle
         }
     }
 
@@ -856,14 +868,19 @@ impl EventLoop {
 
     pub fn ensure_waker(&mut self) {
         jsc::mark_binding();
-        if self.vm_ref().event_loop_handle.is_none() {
+        if self.vm_ref().event_loop_handle_ptr().is_null() {
             #[cfg(windows)]
             {
                 self.uws_loop = NonNull::new(uws::Loop::get());
             }
             let vm = self.vm();
-            // SAFETY: `vm` is the live owning VM.
-            unsafe { (*vm).event_loop_handle = Some(Async::Loop::get()) };
+            // SAFETY: `vm` is the live owning VM; Release-store pairs with the
+            // Acquire load on the cross-thread `wakeup()` path.
+            unsafe {
+                (*vm)
+                    .event_loop_handle
+                    .store(Async::Loop::get(), Ordering::Release)
+            };
             // Route through raw addr_of to avoid stacked-borrow
             // aliasing of the embedded field with its parent.
             // SAFETY: `vm` is the live owning VM; gc_controller is embedded.
@@ -947,12 +964,17 @@ impl EventLoop {
         }
         #[cfg(not(windows))]
         {
-            // Route through the single audited `platform_loop_opt()` accessor
-            // (set-once `Option<*mut>` deref) instead of open-coding the raw
-            // `(*event_loop_handle).wakeup()` here. Same `&mut Loop` is formed
-            // either way (autoref), so no soundness change vs the prior code.
-            if let Some(loop_) = self.vm_ref().platform_loop_opt() {
-                loop_.wakeup();
+            // Cross-thread: producer threads (HTTP client, work pool, waiters)
+            // reach here via `enqueue_task_concurrent`/`ref_concurrently`.
+            // Acquire-load the loop pointer and call the thread-safe
+            // `us_wakeup_loop` extern directly — forming a `&mut Loop` (as the
+            // JS-thread `platform_loop_opt()` does) would alias the loop the
+            // JS thread owns. Mirrors `HTTPThread::wakeup`.
+            let loop_ = self.vm_ref().event_loop_handle_ptr();
+            if !loop_.is_null() {
+                // SAFETY: `loop_` is the live per-VM uws loop; `us_wakeup_loop`
+                // is a thread-safe eventfd/pipe write (see uws_sys/Loop.rs).
+                unsafe { uws::us_wakeup_loop(loop_) };
             }
         }
     }
@@ -1379,7 +1401,7 @@ pub(crate) fn __bun_spawn_sync_event_loop_tick_tasks_only(el: *mut ()) {
 pub(crate) fn __bun_spawn_sync_vm_get_event_loop_handle(
     vm: *mut (),
 ) -> bun_event_loop::SpawnSyncEventLoop::VmEventLoopHandle {
-    vm_from_ptr(vm).event_loop_handle.and_then(NonNull::new)
+    NonNull::new(vm_from_ptr(vm).event_loop_handle_ptr())
 }
 
 #[unsafe(no_mangle)]
@@ -1387,7 +1409,7 @@ pub(crate) fn __bun_spawn_sync_vm_set_event_loop_handle(
     vm: *mut (),
     h: bun_event_loop::SpawnSyncEventLoop::VmEventLoopHandle,
 ) {
-    vm_from_ptr(vm).event_loop_handle = h.map(NonNull::as_ptr);
+    vm_from_ptr(vm).set_event_loop_handle_ptr(h.map_or(core::ptr::null_mut(), NonNull::as_ptr));
 }
 
 #[unsafe(no_mangle)]

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4900,8 +4900,7 @@ impl Resolver {
                 Async::posix_event_loop::poll_tag::DNS_RESOLVER,
                 self.as_ctx_ptr().cast::<()>(),
             );
-            // SAFETY: `event_loop_handle` is set once VM is initialized; live for VM lifetime.
-            let loop_ = unsafe { &mut *self.vm().event_loop_handle.unwrap() };
+            let loop_ = self.vm().platform_loop_opt().expect("event_loop_handle");
             // SAFETY: single-JS-thread; the `&mut PollsMap` borrow does not span
             // any re-entrant call (`FilePoll::register` is a syscall wrapper).
             let polls = unsafe { self.polls.get_mut() };

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1709,7 +1709,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.listener = Some(socket);
         // SAFETY: `vm_mut()` is the process-static `*mut VirtualMachine` (non-null
         // for the server's lifetime); single-threaded JS context.
-        unsafe { (*self.vm_mut()).event_loop_handle = Some(bun_io::Loop::get()) };
+        unsafe { (*self.vm_mut()).set_event_loop_handle_ptr(bun_io::Loop::get()) };
         if !SSL {
             // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
             let fd = bun_opaque::opaque_deref_mut(socket).socket().fd();
@@ -2809,8 +2809,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             }
                             if !this_ref.config.http1 {
                                 // SAFETY: per-thread VM singleton; no aliasing `&mut`.
-                                jsc::VirtualMachine::get().as_mut().event_loop_handle =
-                                    Some(bun_io::Loop::get());
+                                jsc::VirtualMachine::get()
+                                    .as_mut()
+                                    .set_event_loop_handle_ptr(bun_io::Loop::get());
                             }
                         }
                     }

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -311,9 +311,11 @@ impl<'a> GlobalJS<'a> {
             return &*vm.uv_loop();
         }
         #[cfg(not(windows))]
-        // SAFETY: `event_loop_handle` is set during VM init and never freed before the VM.
-        unsafe {
-            &*vm.event_loop_handle.expect("event_loop_handle is null")
+        {
+            let handle = vm.event_loop_handle_ptr();
+            assert!(!handle.is_null(), "event_loop_handle is null");
+            // SAFETY: set during VM init, never freed before the VM; JS thread.
+            unsafe { &*handle }
         }
     }
 

--- a/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
+++ b/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
@@ -158,4 +158,47 @@ describe.concurrent("spawnSync isolated event loop", () => {
     expect(stdout).not.toContain("FAIL");
     expect(exitCode).toBe(0);
   });
+
+  // spawnSync swaps the VM's event_loop_handle (prepare/cleanup) while async
+  // I/O already in flight keeps its producer thread (the HTTP client thread)
+  // calling wakeup() cross-thread. Exercises that concurrency and that the
+  // main loop resumes and completes every request after the swap.
+  test("async I/O in flight survives concurrent spawnSync loop-handle swaps", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+        const url = "http://localhost:" + server.port + "/";
+        let ok = 0;
+        for (let round = 0; round < 4; round++) {
+          const inflight = [];
+          for (let i = 0; i < 24; i++) inflight.push(fetch(url).then(r => r.text()));
+          // Swap event_loop_handle repeatedly while the fetches are in flight.
+          for (let i = 0; i < 3; i++) {
+            const r = Bun.spawnSync({ cmd: ["echo", "x"], env: process.env });
+            if (r.exitCode !== 0) { console.log("FAIL: spawnSync exit " + r.exitCode); process.exit(2); }
+          }
+          for (const body of await Promise.all(inflight)) {
+            if (body !== "ok") { console.log("FAIL: fetch body " + JSON.stringify(body)); process.exit(3); }
+            ok++;
+          }
+        }
+        server.stop(true);
+        console.log("SUCCESS:" + ok);
+        process.exit(0);
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+    expect(stdout).toContain("SUCCESS:96");
+    expect(stdout).not.toContain("FAIL");
+  });
 });


### PR DESCRIPTION
### What

`VirtualMachine::event_loop_handle` was a plain `Option<*mut PlatformEventLoop>` (src/jsc/VirtualMachine.rs) read from non-JS producer threads on the wakeup path while the JS thread could concurrently rewrite it.

Read path (POSIX):

```
EventLoop::enqueue_task_concurrent / ref_concurrently / unref_concurrently   // producer threads
  -> EventLoop::wakeup()                                                       // src/jsc/event_loop.rs
     -> VirtualMachine::platform_loop_opt()   // plain non-atomic read + &mut PlatformEventLoop from &self
        -> loop_.wakeup()                      // Loop::wakeup(&mut self)
```

Write path (JS thread): `ensure_waker()` sets it during VM setup, and the spawnSync prepare/cleanup swap rewrites it at runtime (`__bun_spawn_sync_vm_set_event_loop_handle`), so it is not set-once.

Two defects:
1. An unsynchronized read on a producer thread concurrent with the non-atomic write on the JS thread (during a spawnSync window) is a data race / UB.
2. The POSIX path formed `&mut PlatformEventLoop` from `&self` on producer threads. `src/uws_sys/Loop.rs` documents that cross-thread callers holding only a `*mut Loop` must not form `&mut Loop` (two producer threads would create aliasing `&mut` to the singleton); the established pattern is `HTTPThread::wakeup`, which calls the raw `us_wakeup_loop` extern.

### Impact

Benign on supported targets (which is why this was filed rather than crashing in the wild): `Option<*mut T>` is niche-optimized to one machine word so the read cannot tear, `us_wakeup_loop` is a thread-safe eventfd/pipe write, and waking the old-vs-new (both valid) loop during a spawnSync swap is harmless. It is still formally UB.

### Fix

- Make `event_loop_handle` an `AtomicPtr<PlatformEventLoop>` (null = unset).
- Release-store at the writers (`ensure_waker`, the spawnSync FFI setter, `Bun.serve` listen init); Acquire-load in the new `event_loop_handle_ptr()` accessor.
- `EventLoop::wakeup()` now calls the thread-safe `us_wakeup_loop` extern on the raw loop pointer instead of forming `&mut Loop`, on both the POSIX arm (Acquire-loading `event_loop_handle`) and the Windows arm (the set-once `uws_loop`), mirroring `HTTPThread::wakeup` and `WindowsWaker::wake`.
- The JS-thread-only `platform_loop_opt()` keeps returning `&mut PlatformEventLoop` for the `tick` / `run` / `update_counts` call sites. The hot `uws_loop()` path uses a Relaxed load since its only writer is the JS thread.

No behavioral change: this is a memory-model correctness fix.

### Testing

This race has no runtime symptom on supported targets (single-word pointer, thread-safe wakeup), so a fail-before reproducer is not possible: ASAN (the debug build) does not detect data races, and JSC is not buildable under ThreadSanitizer. The added test in `test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts` is a concurrency / no-regression guard: it drives concurrent in-flight `fetch()` (producer-thread wakeups) across repeated `Bun.spawnSync` event-loop-handle swaps and asserts every request completes. It passes on both the unfixed and fixed builds (8/8 iterations on the unfixed binary, ~25ms each), so it documents the scenario and guards against regressions rather than proving the race.

Verified:
- `bun bd` (linux x64) builds; the full `spawnsync-isolated-event-loop` file passes (5/5).
- `cargo check` clean on `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc` for `bun_jsc`, `bun_runtime`, `bun_http_jsc` (the change touches cfg-gated unix / Windows branches).

### Related

Complements #32071, which made the neighbouring `is_shutting_down` and `event_loop` fields on the same struct atomic for the same reason; `event_loop_handle` was the remaining non-atomic field on that path. The two overlap textually in `VirtualMachine.rs` (both add atomic fields and the atomic import), so whichever lands second will rebase.

Closes #33313
