### PR TITLE
console: throw on non-object this in console.write instead of crashing

### DIFF
--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -116,6 +116,8 @@ export function asyncIterator(this: Console) {
 }
 
 export function write(this: Console, input) {
+  if (!$isObject(this)) throw $ERR_INVALID_THIS("Console");
+
   var writer = $getByIdDirectPrivate(this, "writer");
   if (!writer) {
     var length = $toLength(input?.length ?? 0);

--- a/test/js/bun/console/console-write.test.ts
+++ b/test/js/bun/console/console-write.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("console.write rejects a non-object this", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+for (const value of [1766, true, "str", Symbol("s"), 10n, undefined, null]) {
+  let code;
+  try {
+    console.write.call(value);
+  } catch (e) {
+    code = e.code;
+  }
+  if (code !== "ERR_INVALID_THIS") {
+    throw new Error(\`expected ERR_INVALID_THIS for \${String(value)}, got \${code}\`);
+  }
+}
+
+console.write.call({}, "x");
+console.write("ok");
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "xok",
+    exitCode: 0,
+    signalCode: null,
+  });
+});


### PR DESCRIPTION
### What

`console.write` crashes when called with a `this` that is not an object:

```js
console.write.call(1766);
```

```
panic(main thread): Segmentation fault at address 0x0
```

Debug builds trip the assertion first:

```
ASSERTION FAILED: isCell()
JSCJSValue.h(1043) : JSCell *JSC::JSValue::asCell() const
```

Found by Fuzzilli, which reached it through its `explore` harness probing `console.write`.

### Why

`write` in `src/js/builtins/ConsoleObject.ts` caches its `Bun.stdout.writer()` as a private field on the receiver:

```js
var writer = $getByIdDirectPrivate(this, "writer");
if (!writer) {
  ...
  $putByIdDirectPrivate(this, "writer", writer);
}
```

Nothing validates `this`. The read is harmless on a primitive (it just returns `undefined`), but that then takes us straight into the write, and `$putByIdDirectPrivate` requires an object base: it reaches `asObject()` -> `asCell()` with no type check.

So every non-object receiver lands in undefined behavior:

| `this`                       | before                              |
| ---------------------------- | ----------------------------------- |
| number, boolean              | `isCell()` assertion / segfault     |
| string, symbol, bigint       | `cell->isObjectSlow()` assertion    |
| `undefined`, `null`          | `TypeError: undefined is not an object (evaluating 'writer')` |

The `undefined`/`null` cases happened to be safe because the *read* throws first, synthesizing a prototype, so they never reach the write. That also explains the unhelpful message they produced.

### Fix

Guard the receiver before touching the private field:

```js
if (!$isObject(this)) throw $ERR_INVALID_THIS("Console");
```

`$isObject` lowers to `JSValue::isObject()` (`isCell() && asCell()->isObject()`), which is exactly the precondition `$putByIdDirectPrivate` needs. All seven receivers above now throw `ERR_INVALID_THIS`, including `undefined`/`null`, which get a clearer message than before.

Functions and plain objects still work as receivers, so nothing that used to write anything changes behavior: `console.write.call({}, "x")` keeps writing `x`.

### Scope

I checked the rest of the class. Three other builtins write a private field onto `this` from a user-reachable prototype method, and all three already validate:

- `ReadableStream.prototype.getReader` -> `$isReadableStream(this)`
- `ReadableByteStreamController.prototype.byobRequest` -> `$isReadableByteStreamController(this)`
- `CompressionStream.prototype.readable` / `writable` -> `$inheritsCompressionStream(this)`

Everything else in `src/js/builtins/` that calls `$putByIdDirectPrivate(this, ...)` is an `initialize*` / `privateInitialize*` constructor body, where `this` is always an object. `console.write` was the only unguarded site.

The read-only siblings (`ByteLengthQueuingStrategy.prototype.highWaterMark`, `CountQueuingStrategy.prototype.highWaterMark`) only use `$getByIdDirectPrivate`, which is safe on primitives, and they already throw a `TypeError` on the resulting `undefined`.

### Test

`test/js/bun/console/console-write.test.ts` spawns a fixture that calls `console.write.call(...)` with each of the seven receivers, asserts `ERR_INVALID_THIS`, then checks that an ordinary object receiver and the real `console` still write. It asserts `signalCode: null` so a crash can't pass.

Fails on the unfixed build (`SIGSEGV`, empty stdout), passes with this change. The `test/js/bun/console/`, `test/js/node/console/` and `test/js/web/console/` suites are green (104 pass, 1 pre-existing skip).
