### PR TITLE
Add zip support and streaming append to Bun.Archive

### DIFF
--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -349,6 +349,8 @@ const fastZip = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip
 const storedZip = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip", compress: "store" });
 ```
 
+When `Bun.Archive.write()` is handed an existing `Archive`, its bytes are already packed, so `format` has no effect there; only `compress` still applies, and omitting it inherits the archive's own setting.
+
 The `options` argument accepts:
 
 - `{ format: "tar" | "zip" }` - Container format (default `"tar"`)

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -357,7 +357,6 @@ The `options` argument accepts:
 - `{ compress: "gzip" }` - Gzip the finished tar archive (tar only)
 - `{ compress: "deflate" | "store" }` - Per-entry zip compression (zip only; `"deflate"` is the default)
 - `{ level: number }` - 1-12 for gzip, 1-9 for deflate (default 6)
-- `{ maxMemory: number }` - Bytes buffered before spilling to disk (see below)
 
 ## Appending Entries
 
@@ -387,29 +386,6 @@ Rules:
 - Reading an archive while an `append()` is still pending throws. Await your appends first.
 - If an `append()` rejects, the entry was left half-written: the archive is truncated and can no longer be used.
 - Entries are written with mode `0644` and the current time as their modification time.
-
-## Spilling Large Archives to Disk
-
-While you build an archive, its bytes are buffered in memory. Once they exceed `maxMemory` (64 MB by default), Bun writes the rest to a temporary file instead, so building an archive bigger than RAM does not run you out of memory:
-
-```ts
-// Spill after 8 MB instead of 64 MB
-const archive = new Bun.Archive(undefined, { format: "zip", maxMemory: 8 * 1024 * 1024 });
-
-for await (const path of new Bun.Glob("**/*").scan(".")) {
-  await archive.append(path, Bun.file(path));
-}
-
-// Never materializes the whole archive in memory
-await Bun.Archive.write("everything.zip", archive);
-```
-
-- `maxMemory: Infinity` never spills.
-- `maxMemory: 0` always writes to disk.
-- The temporary file lives in the system temp directory and is removed once the archive is garbage collected. On Linux and macOS it is unlinked the moment it is created, so a crash cannot leave it behind.
-- On Linux and macOS a spilled archive is memory-mapped when it is read back, so `extract()`, `files()`, `Bun.write()`, and `Bun.Archive.write()` stream it from the page cache. On Windows it is read back into memory.
-- `bytes()` always returns a copy of the whole archive, so it defeats the purpose of spilling.
-- `{ compress: "gzip" }` buffers the compressed tar in memory. For archives larger than memory, prefer `format: "zip"` or an uncompressed tar.
 
 ## Examples
 
@@ -514,8 +490,6 @@ type ArchiveOptions = {
   compress?: "gzip" | "deflate" | "store";
   /** Compression level: 1-12 for gzip, 1-9 for deflate (default 6). */
   level?: number;
-  /** Bytes buffered before spilling to a temp file (default 64 MB). */
-  maxMemory?: number;
 };
 
 interface ArchiveExtractOptions {

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -393,14 +393,21 @@ Rules:
 
 ```ts
 const archive = new Bun.Archive(undefined, { format: "zip" });
-const done = Bun.write("everything.zip", new Response(archive.stream()));
+
+const writer = Bun.file("everything.zip").writer();
+const writing = (async () => {
+  for await (const chunk of archive.stream()) writer.write(chunk);
+  await writer.end();
+})();
 
 for await (const path of new Bun.Glob("**/*").scan(".")) {
   await archive.append(path, Bun.file(path)); // parks when the writer falls behind
 }
 archive.end();
-await done;
+await writing;
 ```
+
+Drain the stream incrementally, as above, for the memory bound to hold. A consumer that asks for the whole thing at once, like `new Response(archive.stream()).bytes()`, buffers the entire archive by definition.
 
 Streaming a zip straight to an HTTP client, where the socket provides the backpressure:
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -68,8 +68,11 @@ File contents can be:
 
 - **Strings** - Text content
 - **Blobs** - Binary data
+- **`Bun.file()`** - Read from disk, a chunk at a time
 - **ArrayBufferViews** (such as `Uint8Array`) - Raw bytes
 - **ArrayBuffers** - Raw binary data
+
+`Bun.file()` entries are read synchronously while the constructor runs. To build an archive out of large files without blocking, use [`append()`](#appending-entries) instead.
 
 ```ts
 const data = "binary data";
@@ -477,6 +480,18 @@ async function archiveDirectory(dir: string, compress = false): Promise<Bun.Arch
 
 const archive = await archiveDirectory("./my-project", true);
 await Bun.write("my-project.tar.gz", archive);
+```
+
+For a large directory, `append()` keeps the constructor from blocking and bounds memory:
+
+```ts
+import { Glob } from "bun";
+
+const archive = new Bun.Archive(undefined, { format: "zip" });
+for await (const path of new Glob("**/*").scan("./my-project")) {
+  await archive.append(path, Bun.file(`./my-project/${path}`));
+}
+await Bun.Archive.write("my-project.zip", archive);
 ```
 
 ## Reference

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -424,7 +424,8 @@ Rules:
 - Call `stream()` before appending anything, and only once.
 - Finish with `end()` to close the stream. For any other archive `end()` just seals it, which the first read of its bytes does anyway.
 - A streamed archive's bytes went to the consumer, so `bytes()`, `blob()`, `files()`, and `extract()` throw afterwards.
-- If the consumer cancels, a parked `append()` rejects rather than hanging.
+- If the consumer cancels, a parked `append()` rejects rather than hanging, and a failed `append()` fails the consumer's read rather than leaving it waiting.
+- `compress: "gzip"` is a post-filter over the finished tar, so it cannot be streamed. `stream()` throws on a gzip archive; use `format: "zip"`, whose compression is per-entry.
 
 ## Examples
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -1,9 +1,9 @@
 ---
 title: Archive
-description: Create and extract tar archives with Bun's fast native implementation
+description: Create and extract tar and zip archives with Bun's fast native implementation
 ---
 
-`Bun.Archive` is Bun's native API for tar archives. It creates archives from in-memory data, extracts archives to disk, and reads archive contents without extraction.
+`Bun.Archive` is Bun's native API for tar and zip archives. It creates archives from in-memory data, streams entries into an archive one at a time, extracts archives to disk, and reads archive contents without extraction.
 
 ## Quickstart
 
@@ -18,6 +18,16 @@ const archive = new Bun.Archive({
 
 // Write to disk
 await Bun.write("bundle.tar", archive);
+```
+
+**Build a zip one entry at a time, streaming from disk:**
+
+```ts
+const archive = new Bun.Archive(undefined, { format: "zip" });
+await archive.append("app.js", Bun.file("./dist/app.js"));
+await archive.append("video.mp4", Bun.file("./video.mp4"));
+
+await Bun.Archive.write("bundle.zip", archive);
 ```
 
 **Extract an archive:**
@@ -294,9 +304,26 @@ Supported glob patterns (subset of [Bun.Glob](/docs/api/glob) syntax):
 
 See [Bun.Glob](/docs/api/glob) for the full glob syntax including escaping and advanced patterns.
 
+## Formats
+
+`Bun.Archive` writes tar (the default) and zip. Reading auto-detects tar, tar.gz, and zip, so you never pass a format when you are reading an existing archive.
+
+```ts
+// tar (default)
+const tar = new Bun.Archive({ "hello.txt": "Hello, World!" });
+
+// zip
+const zip = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip" });
+await Bun.write("bundle.zip", zip);
+
+// Reading detects the format from the bytes
+const archive = new Bun.Archive(await Bun.file("bundle.zip").bytes());
+console.log(await archive.files());
+```
+
 ## Compression
 
-Bun.Archive creates uncompressed tar archives by default. Use `{ compress: "gzip" }` to enable gzip compression:
+tar archives are uncompressed unless you pass `{ compress: "gzip" }`, which gzips the finished archive. zip archives deflate each entry by default; pass `{ compress: "store" }` to turn that off.
 
 ```ts
 // Default: uncompressed tar
@@ -311,13 +338,73 @@ const compressed = new Bun.Archive({ "hello.txt": "Hello, World!" }, { compress:
 
 // Gzip with custom level (1-12)
 const maxCompression = new Bun.Archive({ "hello.txt": "Hello, World!" }, { compress: "gzip", level: 12 });
+
+// zip: deflate by default, at level 1-9
+const fastZip = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip", level: 1 });
+
+// zip: no compression
+const storedZip = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip", compress: "store" });
 ```
 
 The `options` argument accepts:
 
-- No options or `undefined` - Uncompressed tar (default)
-- `{ compress: "gzip" }` - Enable gzip compression at level 6
-- `{ compress: "gzip", level: number }` - Gzip with custom level 1-12 (1 = fastest, 12 = smallest)
+- `{ format: "tar" | "zip" }` - Container format (default `"tar"`)
+- `{ compress: "gzip" }` - Gzip the finished tar archive (tar only)
+- `{ compress: "deflate" | "store" }` - Per-entry zip compression (zip only; `"deflate"` is the default)
+- `{ level: number }` - 1-12 for gzip, 1-9 for deflate (default 6)
+- `{ maxMemory: number }` - Bytes buffered before spilling to disk (see below)
+
+## Appending Entries
+
+`append()` adds one more entry to an archive you are building, without holding the entry's contents in memory first. Pass a `Bun.file()` and it streams from disk a chunk at a time, so you can add a file larger than available memory:
+
+```ts
+const archive = new Bun.Archive(undefined, { format: "zip" });
+
+await archive.append("README.md", "# Hello");
+await archive.append("dist/app.js", Bun.file("./dist/app.js"));
+await archive.append("video.mp4", Bun.file("./video.mp4")); // streamed, never buffered
+
+await Bun.Archive.write("bundle.zip", archive);
+```
+
+Appends run in call order, so `Promise.all()` over a list of files produces a deterministic archive:
+
+```ts
+const archive = new Bun.Archive();
+await Promise.all(paths.map(path => archive.append(path, Bun.file(path))));
+```
+
+Rules:
+
+- Only archives you build can be appended to: one created from an object, or from no data at all. Appending to an `Archive` that wraps existing archive data throws.
+- An archive is closed the first time its bytes are read (`bytes()`, `blob()`, `files()`, `extract()`, `Bun.write()`). `append()` after that throws.
+- Reading an archive while an `append()` is still pending throws. Await your appends first.
+- If an `append()` rejects, the entry was left half-written: the archive is truncated and can no longer be used.
+- Entries are written with mode `0644` and the current time as their modification time.
+
+## Spilling Large Archives to Disk
+
+While you build an archive, its bytes are buffered in memory. Once they exceed `maxMemory` (64 MB by default), Bun writes the rest to a temporary file instead, so building an archive bigger than RAM does not run you out of memory:
+
+```ts
+// Spill after 8 MB instead of 64 MB
+const archive = new Bun.Archive(undefined, { format: "zip", maxMemory: 8 * 1024 * 1024 });
+
+for await (const path of new Bun.Glob("**/*").scan(".")) {
+  await archive.append(path, Bun.file(path));
+}
+
+// Never materializes the whole archive in memory
+await Bun.Archive.write("everything.zip", archive);
+```
+
+- `maxMemory: Infinity` never spills.
+- `maxMemory: 0` always writes to disk.
+- The temporary file lives in the system temp directory and is removed once the archive is garbage collected. On Linux and macOS it is unlinked the moment it is created, so a crash cannot leave it behind.
+- On Linux and macOS a spilled archive is memory-mapped when it is read back, so `extract()`, `files()`, `Bun.write()`, and `Bun.Archive.write()` stream it from the page cache. On Windows it is read back into memory.
+- `bytes()` always returns a copy of the whole archive, so it defeats the purpose of spilling.
+- `{ compress: "gzip" }` buffers the compressed tar in memory. For archives larger than memory, prefer `format: "zip"` or an uncompressed tar.
 
 ## Examples
 
@@ -404,10 +491,14 @@ type ArchiveInput =
   | ArrayBufferLike;
 
 type ArchiveOptions = {
-  /** Compression algorithm. Currently only "gzip" is supported. */
-  compress?: "gzip";
-  /** Compression level 1-12 (default 6 when gzip is enabled). */
+  /** Container format to write. Reading auto-detects tar, tar.gz, and zip. */
+  format?: "tar" | "zip";
+  /** "gzip" for tar; "deflate" (default) or "store" for zip. */
+  compress?: "gzip" | "deflate" | "store";
+  /** Compression level: 1-12 for gzip, 1-9 for deflate (default 6). */
   level?: number;
+  /** Bytes buffered before spilling to a temp file (default 64 MB). */
+  maxMemory?: number;
 };
 
 interface ArchiveExtractOptions {
@@ -418,11 +509,17 @@ interface ArchiveExtractOptions {
 class Archive {
   /**
    * Create an Archive from input data
-   * @param data - Files to archive (as object) or existing archive data (as bytes/blob)
-   * @param options - Compression options. Uncompressed by default.
-   *                  Pass { compress: "gzip" } to enable compression.
+   * @param data - Files to archive (as object), existing archive data (as bytes/blob),
+   *               or nothing, for an empty archive to append() to
+   * @param options - Format and compression options. Uncompressed tar by default.
    */
-  constructor(data: ArchiveInput, options?: ArchiveOptions);
+  constructor(data?: ArchiveInput, options?: ArchiveOptions);
+
+  /**
+   * Stream one more entry into an archive that is still being built.
+   * Only valid before the archive's bytes are first read.
+   */
+  append(path: string, data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike): Promise<void>;
 
   /**
    * Extract archive to a directory

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -68,11 +68,11 @@ File contents can be:
 
 - **Strings** - Text content
 - **Blobs** - Binary data
-- **`Bun.file()`** - Read from disk, a chunk at a time
+- **`Bun.file()`** - Read from disk synchronously, in chunks, while the constructor runs
 - **ArrayBufferViews** (such as `Uint8Array`) - Raw bytes
 - **ArrayBuffers** - Raw binary data
 
-`Bun.file()` entries are read synchronously while the constructor runs. To build an archive out of large files without blocking, use [`append()`](#appending-entries) instead.
+A `Bun.file()` entry is never buffered whole, but it does block the constructor. To add large files without blocking, use [`append()`](#appending-entries) instead.
 
 ```ts
 const data = "binary data";

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -387,6 +387,45 @@ Rules:
 - If an `append()` rejects, the entry was left half-written: the archive is truncated and can no longer be used.
 - Entries are written with mode `0644` and the current time as their modification time.
 
+## Streaming Large Archives
+
+`stream()` hands you the archive's bytes as a `ReadableStream` while it is still being built. Reading the stream is what lets the next `append()` make progress: once the stream's queue fills up, an in-flight `append()` parks until the consumer has caught up. A large archive therefore never has to fit in memory.
+
+```ts
+const archive = new Bun.Archive(undefined, { format: "zip" });
+const done = Bun.write("everything.zip", new Response(archive.stream()));
+
+for await (const path of new Bun.Glob("**/*").scan(".")) {
+  await archive.append(path, Bun.file(path)); // parks when the writer falls behind
+}
+archive.end();
+await done;
+```
+
+Streaming a zip straight to an HTTP client, where the socket provides the backpressure:
+
+```ts
+Bun.serve({
+  fetch() {
+    const archive = new Bun.Archive(undefined, { format: "zip" });
+    queueMicrotask(async () => {
+      for (const path of paths) await archive.append(path, Bun.file(path));
+      archive.end();
+    });
+    return new Response(archive.stream(), {
+      headers: { "content-type": "application/zip" },
+    });
+  },
+});
+```
+
+Rules:
+
+- Call `stream()` before appending anything, and only once.
+- Finish with `end()` to close the stream. For any other archive `end()` just seals it, which the first read of its bytes does anyway.
+- A streamed archive's bytes went to the consumer, so `bytes()`, `blob()`, `files()`, and `extract()` throw afterwards.
+- If the consumer cancels, a parked `append()` rejects rather than hanging.
+
 ## Examples
 
 ### Bundle Project Files
@@ -511,6 +550,15 @@ class Archive {
    * Only valid before the archive's bytes are first read.
    */
   append(path: string, data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike): Promise<void>;
+
+  /**
+   * The archive's bytes as they are produced. Reading it is what lets the next
+   * append() make progress, so a large archive never has to fit in memory.
+   */
+  stream(): ReadableStream<Uint8Array>;
+
+  /** Finish the archive, closing its stream() if it has one. */
+  end(): void;
 
   /**
    * Extract archive to a directory

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -360,7 +360,7 @@ The `options` argument accepts:
 
 ## Appending Entries
 
-`append()` adds one more entry to an archive you are building, without holding the entry's contents in memory first. Pass a `Bun.file()` and it streams from disk a chunk at a time, so you can add a file larger than available memory:
+`append()` adds one more entry to an archive you are building, without holding the entry's contents in memory first. Pass a `Bun.file()` and it is read from disk a chunk at a time, so the file's bytes are never buffered whole:
 
 ```ts
 const archive = new Bun.Archive(undefined, { format: "zip" });
@@ -460,7 +460,7 @@ const archive = await archiveDirectory("./my-project", true);
 await Bun.write("my-project.tar.gz", archive);
 ```
 
-For a large directory, `append()` keeps the constructor from blocking and bounds memory:
+For a large directory, `append()` keeps the constructor from blocking:
 
 ```ts
 import { Glob } from "bun";

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -389,7 +389,7 @@ Rules:
 
 ## Streaming Large Archives
 
-`stream()` hands you the archive's bytes as a `ReadableStream` while it is still being built. Reading the stream is what lets the next `append()` make progress: once the stream's queue fills up, an in-flight `append()` parks until the consumer has caught up. A large archive therefore never has to fit in memory.
+`stream()` hands you the archive's bytes as a `ReadableStream` while it is still being built. Reading the stream is what lets the next `append()` make progress: once the stream's queue fills up, an in-flight `append()` parks until the consumer has caught up. A consumer that drains the stream chunk by chunk therefore never has to hold the whole archive in memory.
 
 ```ts
 const archive = new Bun.Archive(undefined, { format: "zip" });
@@ -409,7 +409,7 @@ await writing;
 
 Drain the stream incrementally, as above, for the memory bound to hold. A consumer that asks for the whole thing at once, like `new Response(archive.stream()).bytes()`, buffers the entire archive by definition.
 
-Streaming a zip straight to an HTTP client, where the socket provides the backpressure:
+Streaming a zip straight to an HTTP client, so the client sees bytes before the archive is finished:
 
 ```ts
 Bun.serve({
@@ -426,11 +426,13 @@ Bun.serve({
 });
 ```
 
+A slow client does not currently throttle the `append()`s on this path: the server hands each chunk straight to the socket, which buffers whatever it cannot write yet. The response is still produced incrementally, but peak memory is bounded by the archive, not by the high-water mark.
+
 Rules:
 
 - Call `stream()` before appending anything, and only once.
-- Finish with `end()` to close the stream. For any other archive `end()` just seals it, which the first read of its bytes does anyway.
-- A streamed archive's bytes went to the consumer, so `bytes()`, `blob()`, `files()`, and `extract()` throw afterwards.
+- Finish with `end()` to close the stream. Abandoning a streaming archive without it leaves the consumer waiting, exactly like any `ReadableStream` whose producer never closes it. For any other archive `end()` just seals it, which the first read of its bytes does anyway.
+- A streamed archive's bytes belong to the consumer, so `bytes()`, `blob()`, `files()`, and `extract()` throw.
 - If the consumer cancels, a parked `append()` rejects rather than hanging, and a failed `append()` fails the consumer's read rather than leaving it waiting.
 - `compress: "gzip"` is a post-filter over the finished tar, so it cannot be streamed. `stream()` throws on a gzip archive; use `format: "zip"`, whose compression is per-entry.
 
@@ -560,8 +562,8 @@ class Archive {
   append(path: string, data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike): Promise<void>;
 
   /**
-   * The archive's bytes as they are produced. Reading it is what lets the next
-   * append() make progress, so a large archive never has to fit in memory.
+   * The archive's bytes as they are produced. Draining it chunk by chunk is what
+   * lets the next append() make progress, so the archive need not fit in memory.
    */
   stream(): ReadableStream<Uint8Array>;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9361,8 +9361,9 @@ declare module "bun" {
      * `Archive` wrapping existing archive data throws.
      *
      * Appends are applied in call order. Passing a `Bun.file()` reads it from
-     * disk a chunk at a time, so a file larger than memory can be added. If an
-     * `append()` rejects, the archive is left truncated and can no longer be used.
+     * disk a chunk at a time, so the file's bytes are never buffered whole. If
+     * an `append()` rejects, the archive is left truncated and can no longer be
+     * used.
      *
      * Entries are written with mode `0644` and the current time as their
      * modification time.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9199,7 +9199,10 @@ declare module "bun" {
      *
      * @param path - The file path to write the archive to
      * @param data - The input data for the archive (same as `new Archive()`)
-     * @param options - Optional archive options including compression settings
+     * @param options - Optional archive options including compression settings.
+     *   When `data` is an existing `Archive` its bytes are already packed, so
+     *   `format` has no effect; only `compress` still applies, and omitting it
+     *   inherits the archive's own setting.
      *
      * @returns A promise that resolves when the write is complete
      *

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9397,7 +9397,10 @@ declare module "bun" {
      *
      * Reading the stream is what lets the next `append()` make progress: once the
      * stream's queue is full, an in-flight `append()` parks until the consumer has
-     * caught up. A large archive therefore never has to fit in memory.
+     * caught up. A consumer that drains it chunk by chunk therefore never has to
+     * hold the whole archive in memory. One that asks for all of it at once, like
+     * `new Response(archive.stream()).bytes()`, buffers it by definition, and a
+     * `Bun.serve` response does not currently throttle the `append()`s at all.
      *
      * Call it before appending anything, and finish with `end()` to close the
      * stream. An archive that has been streamed cannot also be read with `bytes()`,

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9403,6 +9403,12 @@ declare module "bun" {
      * stream. An archive that has been streamed cannot also be read with `bytes()`,
      * `blob()`, `files()`, or `extract()`: its bytes went to the consumer.
      *
+     * A failed `append()` fails the consumer's read, and a cancelled consumer
+     * rejects the in-flight `append()`, so neither side is left waiting.
+     *
+     * @throws if the archive uses `compress: "gzip"`, which is a post-filter over
+     *   the finished tar and so cannot be streamed. Use `format: "zip"`.
+     *
      * @example
      * **Stream a zip to a file without holding it in memory:**
      * ```ts

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9373,7 +9373,7 @@ declare module "bun" {
      * @returns A promise that resolves once the entry has been written
      *
      * @example
-     * **Build a zip without holding it in memory:**
+     * **Build a zip one entry at a time:**
      * ```ts
      * const archive = new Bun.Archive(undefined, { format: "zip" });
      * for (const path of paths) {
@@ -9391,6 +9391,56 @@ declare module "bun" {
      * ```
      */
     append(path: string, data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike): Promise<void>;
+
+    /**
+     * The archive's bytes as a `ReadableStream`, produced as entries are appended.
+     *
+     * Reading the stream is what lets the next `append()` make progress: once the
+     * stream's queue is full, an in-flight `append()` parks until the consumer has
+     * caught up. A large archive therefore never has to fit in memory.
+     *
+     * Call it before appending anything, and finish with `end()` to close the
+     * stream. An archive that has been streamed cannot also be read with `bytes()`,
+     * `blob()`, `files()`, or `extract()`: its bytes went to the consumer.
+     *
+     * @example
+     * **Stream a zip to a file without holding it in memory:**
+     * ```ts
+     * const archive = new Bun.Archive(undefined, { format: "zip" });
+     * const done = Bun.write("bundle.zip", new Response(archive.stream()));
+     *
+     * for (const path of paths) {
+     *   await archive.append(path, Bun.file(path));
+     * }
+     * archive.end();
+     * await done;
+     * ```
+     *
+     * @example
+     * **Stream a zip to an HTTP client:**
+     * ```ts
+     * const archive = new Bun.Archive(undefined, { format: "zip" });
+     * queueMicrotask(async () => {
+     *   for (const path of paths) await archive.append(path, Bun.file(path));
+     *   archive.end();
+     * });
+     * return new Response(archive.stream(), {
+     *   headers: { "content-type": "application/zip" },
+     * });
+     * ```
+     */
+    stream(): ReadableStream<Uint8Array>;
+
+    /**
+     * Finish the archive.
+     *
+     * A streamed archive closes its `stream()`. Any other archive is simply sealed,
+     * exactly as the first read of its bytes would do, so calling this is optional
+     * unless you are streaming.
+     *
+     * @throws if an `append()` is still in progress
+     */
+    end(): void;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9413,13 +9413,18 @@ declare module "bun" {
      * **Stream a zip to a file without holding it in memory:**
      * ```ts
      * const archive = new Bun.Archive(undefined, { format: "zip" });
-     * const done = Bun.write("bundle.zip", new Response(archive.stream()));
+     *
+     * const writer = Bun.file("bundle.zip").writer();
+     * const writing = (async () => {
+     *   for await (const chunk of archive.stream()) writer.write(chunk);
+     *   await writer.end();
+     * })();
      *
      * for (const path of paths) {
      *   await archive.append(path, Bun.file(path));
      * }
      * archive.end();
-     * await done;
+     * await writing;
      * ```
      *
      * @example

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8987,15 +8987,27 @@ declare module "bun" {
   type ArchiveInput = Record<string, BlobPart> | Blob | ArrayBufferView | ArrayBufferLike;
 
   /**
-   * Compression format for archive output.
-   * Only `"gzip"` is supported.
+   * Container format written by `new Bun.Archive()`.
+   * Reading auto-detects tar, tar.gz, and zip regardless of this option.
+   *
+   * @default "tar"
    */
-  type ArchiveCompression = "gzip";
+  type ArchiveFormat = "tar" | "zip";
+
+  /**
+   * Compression for archive output.
+   *
+   * - `"gzip"` compresses the finished tar archive (`format: "tar"` only).
+   * - `"deflate"` compresses each zip entry (`format: "zip"` only, the default).
+   * - `"store"` writes zip entries uncompressed (`format: "zip"` only).
+   */
+  type ArchiveCompression = "gzip" | "deflate" | "store";
 
   /**
    * Options for creating an Archive instance.
    *
-   * By default, archives are not compressed. Use `{ compress: "gzip" }` to enable compression.
+   * tar archives are uncompressed unless `{ compress: "gzip" }` is passed.
+   * zip archives deflate each entry unless `{ compress: "store" }` is passed.
    *
    * @example
    * ```ts
@@ -9005,26 +9017,46 @@ declare module "bun" {
    * // Enable gzip with default level (6)
    * new Bun.Archive(data, { compress: "gzip" });
    *
-   * // Specify compression level
-   * new Bun.Archive(data, { compress: "gzip", level: 9 });
+   * // A deflated zip
+   * new Bun.Archive(data, { format: "zip" });
    * ```
    */
   interface ArchiveOptions {
     /**
+     * Container format to write.
+     *
+     * @default "tar"
+     */
+    format?: ArchiveFormat;
+    /**
      * Compression algorithm to use.
-     * Only `"gzip"` is supported.
-     * If not specified, no compression is applied.
+     *
+     * With `format: "tar"` the only valid value is `"gzip"`, and tar archives
+     * are uncompressed when it is omitted.
+     *
+     * With `format: "zip"` the valid values are `"deflate"` (the default) and
+     * `"store"`.
      */
     compress?: ArchiveCompression;
     /**
-     * Compression level (1-12). Only applies when `compress` is set.
-     * - 1: Fastest compression, lowest ratio
-     * - 6: Default balance of speed and ratio
-     * - 12: Best compression ratio, slowest
+     * Compression level. `1` is fastest, the maximum is smallest.
+     *
+     * The range is 1-12 for `"gzip"` and 1-9 for `"deflate"`. Ignored when no
+     * compression is used.
      *
      * @default 6
      */
     level?: number;
+    /**
+     * Bytes of archive output to keep in memory before spilling to a temporary
+     * file. The temporary file is removed when the archive is garbage collected.
+     *
+     * Set to `Infinity` to never spill, or to `0` to always write to disk. Only
+     * applies to archives you build (from an object, or with `append()`).
+     *
+     * @default 64 * 1024 * 1024
+     */
+    maxMemory?: number;
   }
 
   /**
@@ -9064,10 +9096,11 @@ declare module "bun" {
   }
 
   /**
-   * Create and extract tar archives, with optional gzip compression.
+   * Create and extract tar and zip archives.
    *
-   * `Bun.Archive` builds an archive from in-memory data, or wraps an existing
-   * archive so you can extract it to disk or memory.
+   * `Bun.Archive` builds an archive from in-memory data, streams entries into
+   * one with `append()`, or wraps an existing archive so you can extract it to
+   * disk or memory. Reading auto-detects tar, tar.gz, and zip.
    *
    * @example
    * **Create an archive from an object:**
@@ -9156,7 +9189,7 @@ declare module "bun" {
      * const archive = new Bun.Archive(await response.blob());
      * ```
      */
-    constructor(data: ArchiveInput, options?: ArchiveOptions);
+    constructor(data?: ArchiveInput, options?: ArchiveOptions);
 
     /**
      * Create an archive and write it to disk in one operation.
@@ -9324,6 +9357,46 @@ declare module "bun" {
      * ```
      */
     files(glob?: string | readonly string[]): Promise<Map<string, File>>;
+
+    /**
+     * Add one more entry to an archive that is still being built, streaming its
+     * contents rather than buffering them.
+     *
+     * Only archives created from an object, or from no data at all, can be
+     * appended to, and only until their bytes are first read (by `bytes()`,
+     * `blob()`, `files()`, `extract()`, or `Bun.write()`). Appending to an
+     * `Archive` wrapping existing archive data throws.
+     *
+     * Appends are applied in call order. Passing a `Bun.file()` reads it from
+     * disk a chunk at a time, so a file larger than memory can be added. If an
+     * `append()` rejects, the archive is left truncated and can no longer be used.
+     *
+     * Entries are written with mode `0644` and the current time as their
+     * modification time.
+     *
+     * @param path - Path of the entry inside the archive
+     * @param data - Entry contents
+     * @returns A promise that resolves once the entry has been written
+     *
+     * @example
+     * **Build a zip without holding it in memory:**
+     * ```ts
+     * const archive = new Bun.Archive(undefined, { format: "zip" });
+     * for (const path of paths) {
+     *   await archive.append(path, Bun.file(path));
+     * }
+     * await Bun.Archive.write("bundle.zip", archive);
+     * ```
+     *
+     * @example
+     * **Append to an archive seeded from an object:**
+     * ```ts
+     * const archive = new Bun.Archive({ "package.json": pkg });
+     * await archive.append("README.md", "# Hello");
+     * const bytes = await archive.bytes();
+     * ```
+     */
+    append(path: string, data: string | Blob | Bun.ArrayBufferView | ArrayBufferLike): Promise<void>;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9047,16 +9047,6 @@ declare module "bun" {
      * @default 6
      */
     level?: number;
-    /**
-     * Bytes of archive output to keep in memory before spilling to a temporary
-     * file. The temporary file is removed when the archive is garbage collected.
-     *
-     * Set to `Infinity` to never spill, or to `0` to always write to disk. Only
-     * applies to archives you build (from an object, or with `append()`).
-     *
-     * @default 64 * 1024 * 1024
-     */
-    maxMemory?: number;
   }
 
   /**

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -74,6 +74,7 @@ pub mod task_tag {
         ArchiveBlobTask,
         ArchiveWriteTask,
         ArchiveFilesTask,
+        ArchiveAppendTask,
         AsyncGlobWalkTask,
         AsyncImageTask,
         AsyncTransformTask,

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -109,6 +109,8 @@ pub mod lib {
         fn archive_write_set_format_pax_restricted(a: *mut Archive) -> Result;
         fn archive_write_set_format_zip(a: *mut Archive) -> Result;
         fn archive_write_set_bytes_in_last_block(a: *mut Archive, bytes: c_int) -> Result;
+        // Returns the new state (`ARCHIVE_STATE_FATAL`), not an `ARCHIVE_*` code.
+        fn archive_write_fail(a: *mut Archive) -> c_int;
         fn archive_write_zip_set_compression_deflate(a: *mut Archive) -> Result;
         fn archive_write_zip_set_compression_store(a: *mut Archive) -> Result;
         fn archive_write_add_filter_gzip(a: *mut Archive) -> Result;
@@ -395,6 +397,18 @@ pub mod lib {
         pub fn write_close(&self) -> Result {
             // SAFETY: self valid.
             unsafe { archive_write_close(self.as_mut_ptr()) }
+        }
+        /// Put the writer into `ARCHIVE_STATE_FATAL`, so a later
+        /// `archive_write_free` frees it without running a normal close.
+        ///
+        /// `archive_write_free` otherwise calls `archive_write_close`, whose
+        /// `format_finish_entry` pads a half-written entry out to the size its
+        /// header declared (`archive_write_set_format_pax.c`'s
+        /// `__archive_write_nulls(remaining + padding)`), pushing every one of
+        /// those bytes through the client write callback.
+        pub fn write_fail(&self) {
+            // SAFETY: self valid; only mutates the handle's state field.
+            unsafe { archive_write_fail(self.as_mut_ptr()) };
         }
         pub fn write_set_format_pax_restricted(&self) -> Result {
             // SAFETY: self valid.

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -78,6 +78,7 @@ pub mod lib {
         fn archive_read_free(a: *mut Archive) -> Result;
         fn archive_read_support_format_tar(a: *mut Archive) -> Result;
         fn archive_read_support_format_gnutar(a: *mut Archive) -> Result;
+        fn archive_read_support_format_zip(a: *mut Archive) -> Result;
         fn archive_read_support_filter_gzip(a: *mut Archive) -> Result;
         fn archive_read_set_options(a: *mut Archive, opts: *const c_char) -> Result;
         fn archive_read_open_memory(a: *mut Archive, buf: *const c_void, size: usize) -> Result;
@@ -106,6 +107,10 @@ pub mod lib {
         fn archive_write_free(a: *mut Archive) -> Result;
         fn archive_write_close(a: *mut Archive) -> Result;
         fn archive_write_set_format_pax_restricted(a: *mut Archive) -> Result;
+        fn archive_write_set_format_zip(a: *mut Archive) -> Result;
+        fn archive_write_set_bytes_in_last_block(a: *mut Archive, bytes: c_int) -> Result;
+        fn archive_write_zip_set_compression_deflate(a: *mut Archive) -> Result;
+        fn archive_write_zip_set_compression_store(a: *mut Archive) -> Result;
         fn archive_write_add_filter_gzip(a: *mut Archive) -> Result;
         fn archive_write_set_filter_option(
             a: *mut Archive,
@@ -184,6 +189,11 @@ pub mod lib {
             // SAFETY: self valid.
             unsafe { archive_read_support_format_gnutar(self.as_mut_ptr()) }
         }
+        /// Enables both the streamable and the seekable zip readers.
+        pub fn read_support_format_zip(&self) -> Result {
+            // SAFETY: self valid.
+            unsafe { archive_read_support_format_zip(self.as_mut_ptr()) }
+        }
         pub fn read_support_filter_gzip(&self) -> Result {
             // SAFETY: self valid.
             unsafe { archive_read_support_filter_gzip(self.as_mut_ptr()) }
@@ -226,9 +236,17 @@ pub mod lib {
                     result: r,
                 });
             }
-            // SAFETY: on ARCHIVE_OK, libarchive guarantees buff[0..size] is
-            // readable until the next read call on this archive.
-            let bytes = unsafe { core::slice::from_raw_parts(buff.cast::<u8>(), size) };
+            // `zip_read_data_none` signals end-of-entry with ARCHIVE_OK and a
+            // null buffer, and `from_raw_parts` rejects a null pointer even for
+            // a zero-length slice.
+            let bytes: &[u8] = if buff.is_null() || size == 0 {
+                &[]
+            } else {
+                // SAFETY: on ARCHIVE_OK with a non-null buffer, libarchive
+                // guarantees buff[0..size] is readable until the next read call
+                // on this archive.
+                unsafe { core::slice::from_raw_parts(buff.cast::<u8>(), size) }
+            };
             Some(Block {
                 bytes,
                 offset: *offset,
@@ -381,6 +399,27 @@ pub mod lib {
         pub fn write_set_format_pax_restricted(&self) -> Result {
             // SAFETY: self valid.
             unsafe { archive_write_set_format_pax_restricted(self.as_mut_ptr()) }
+        }
+        pub fn write_set_format_zip(&self) -> Result {
+            // SAFETY: self valid.
+            unsafe { archive_write_set_format_zip(self.as_mut_ptr()) }
+        }
+        /// Block size of the final write. Defaults to padding up to
+        /// `bytes_per_block` (10240, what tar wants); pass `1` for formats that
+        /// must not be padded, like zip.
+        pub fn write_set_bytes_in_last_block(&self, bytes: i32) -> Result {
+            // SAFETY: self valid.
+            unsafe { archive_write_set_bytes_in_last_block(self.as_mut_ptr(), bytes) }
+        }
+        /// Per-entry deflate (the zip default when zlib is available).
+        pub fn write_zip_set_compression_deflate(&self) -> Result {
+            // SAFETY: self valid; only meaningful after `write_set_format_zip`.
+            unsafe { archive_write_zip_set_compression_deflate(self.as_mut_ptr()) }
+        }
+        /// Per-entry "stored" (uncompressed) zip entries.
+        pub fn write_zip_set_compression_store(&self) -> Result {
+            // SAFETY: self valid; only meaningful after `write_set_format_zip`.
+            unsafe { archive_write_zip_set_compression_store(self.as_mut_ptr()) }
         }
         pub fn write_add_filter_gzip(&self) -> Result {
             // SAFETY: self valid.
@@ -1142,7 +1181,9 @@ impl BufferReadStream {
         unsafe { &*self.buf }
     }
 
-    pub fn open_read(&mut self) -> lib::Result {
+    /// `zip` additionally enables the zip readers. It is off for `bun install`
+    /// (npm packages are always tarballs) and on for `Bun.Archive`.
+    pub fn open_read(&mut self, zip: bool) -> lib::Result {
         // lib.archive_read_set_open_callback(this.archive, this.);
         // _ = lib.archive_read_set_read_callback(this.archive, archive_read_callback);
         // _ = lib.archive_read_set_seek_callback(this.archive, archive_seek_callback);
@@ -1155,6 +1196,9 @@ impl BufferReadStream {
 
         let _ = archive.read_support_format_tar();
         let _ = archive.read_support_format_gnutar();
+        if zip {
+            let _ = archive.read_support_format_zip();
+        }
         let _ = archive.read_support_filter_gzip();
 
         // Ignore zeroed blocks in the archive, which occurs when multiple tar archives
@@ -1503,6 +1547,8 @@ pub mod archiver {
         pub close_handles: bool,
         pub log: bool,
         pub npm: bool,
+        /// Also accept zip input. Off for `bun install`, on for `Bun.Archive`.
+        pub zip: bool,
     }
 
     impl Default for ExtractOptions {
@@ -1512,6 +1558,7 @@ pub mod archiver {
                 close_handles: true,
                 log: false,
                 npm: false,
+                zip: false,
             }
         }
     }
@@ -1553,7 +1600,7 @@ impl Archiver {
 
         // SAFETY: `file_buffer` outlives `stream` (stack-local, dropped at fn exit).
         let mut stream = unsafe { BufferReadStream::init(file_buffer) };
-        let _ = stream.open_read();
+        let _ = stream.open_read(false);
         let archive = stream.archive;
 
         // Uses the bun_sys directory-fd helpers (open_dir_absolute / open_dir_at).
@@ -1689,7 +1736,7 @@ impl Archiver {
 
         // SAFETY: `file_buffer` outlives `stream` (stack-local, dropped at fn exit).
         let mut stream = unsafe { BufferReadStream::init(file_buffer) };
-        let _ = stream.open_read();
+        let _ = stream.open_read(options.zip);
         let archive = stream.archive;
         let mut count: u32 = 0;
         let dir_fd = dir;

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -41,6 +41,8 @@ pub use bun_jsc::ResolveMessage;
 // ─── compiling submodules (api/ dir) ─────────────────────────────────────────
 #[path = "api/Archive.rs"]
 pub mod archive;
+#[path = "api/archive_builder.rs"]
+pub(crate) mod archive_builder;
 #[path = "api/BunObject.rs"]
 pub mod bun_object;
 #[path = "api/crash_handler_jsc.rs"]

--- a/src/runtime/api/Archive.classes.ts
+++ b/src/runtime/api/Archive.classes.ts
@@ -14,6 +14,10 @@ export default [
       },
     },
     proto: {
+      append: {
+        fn: "append",
+        length: 2,
+      },
       extract: {
         fn: "extract",
         length: 2,

--- a/src/runtime/api/Archive.classes.ts
+++ b/src/runtime/api/Archive.classes.ts
@@ -18,6 +18,14 @@ export default [
         fn: "append",
         length: 2,
       },
+      stream: {
+        fn: "stream",
+        length: 0,
+      },
+      end: {
+        fn: "end",
+        length: 0,
+      },
       extract: {
         fn: "extract",
         length: 2,

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -2,18 +2,29 @@
 //!
 //! An archive created from an object (or from nothing) stays *open* behind a
 //! live libarchive writer until the first read of its bytes, so entries can be
-//! streamed in one at a time with [`Archive::append`].
+//! streamed in one at a time with [`Archive::append`]. [`Archive::stream`]
+//! hands the bytes to a `ReadableStream` as they are produced, and parks an
+//! in-flight append whenever the consumer falls behind.
 
+use core::ffi::c_void;
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::ffi::CString;
 
-use super::archive_builder::{BuildError, Builder, FILETYPE_REGULAR};
+use super::archive_builder::{
+    BuildError, Builder, FILETYPE_REGULAR, STREAM_CHUNK_SIZE, open_entry_file, read_entry_chunk,
+};
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
+use crate::webcore::ByteStream;
+use crate::webcore::ReadableStream;
 use crate::webcore::blob::store::Data as BlobData;
 use crate::webcore::blob::{MAX_SIZE as BLOB_MAX_SIZE, Store as BlobStore, StoreRef};
 use crate::webcore::node_types::PathOrFileDescriptor;
+use crate::webcore::readable_stream::{
+    self, Source as ReadableStreamPtr, Strong as ReadableStreamStrong,
+};
+use crate::webcore::streams;
 use bun_core::zig_string::Slice as ZigStringSlice;
 use bun_core::{self, Output, ZBox};
 use bun_event_loop::{TaskTag, Taskable, task_tag};
@@ -28,6 +39,24 @@ use bun_jsc::{
 use bun_jsc::{StringJsc as _, SysErrorJsc as _};
 use bun_libarchive as libarchive;
 use bun_sys::{self, Fd, FdDirExt as _, FdExt as _, Mode};
+
+/// Bytes queued in a `stream()` before an in-flight `append()` parks and waits
+/// for the consumer to catch up.
+const STREAM_HIGH_WATER_MARK: usize = 1024 * 1024;
+
+/// The `ReadableStream` an archive is being written into.
+struct StreamOut {
+    /// Keeps the JS `ReadableStream` alive, and with it the native source whose
+    /// `context` field `bytes` points at.
+    _held: ReadableStreamStrong,
+    /// The stream's native source, owned by the JS wrapper.
+    bytes: *mut ByteStream,
+    /// Set by [`Archive::on_stream_cancelled`] when the consumer walks away.
+    cancelled: bool,
+    /// An append parked on backpressure, put back on the work pool by
+    /// [`Archive::on_stream_drained`].
+    parked: Option<*mut AppendTask>,
+}
 
 /// Container format written by `new Archive(...)`. Reading auto-detects both.
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
@@ -100,6 +129,9 @@ enum State {
     /// `None` while a work-pool task owns the builder for an in-flight append.
     Building(Option<Builder>),
     Done(StoreRef),
+    /// `end()` handed the archive's bytes to a `stream()` consumer, so there is
+    /// nothing left here to read.
+    Streamed,
     /// An `append()` failed part-way through an entry, so the archive stream is
     /// truncated and can never be completed.
     Failed,
@@ -123,6 +155,8 @@ pub struct Archive {
     queue: RefCell<VecDeque<PendingAppend>>,
     /// True while a work-pool task owns the builder.
     appending: Cell<bool>,
+    /// Set by `stream()`; the archive's bytes go here instead of accumulating.
+    stream: RefCell<Option<StreamOut>>,
 }
 
 // `jsc.Codegen.JSArchive` — codegen already emits `js_Archive`
@@ -141,6 +175,9 @@ impl Archive {
 
     pub fn finalize(self: Box<Self>) {
         jsc::mark_binding();
+        // The stream's source can outlive the archive, and its drain/cancel
+        // handlers point back here. Clear them before the payload goes away.
+        self.clear_stream_handlers();
         drop(self);
         // store.deref() happens via Arc<BlobStore>::drop; an unfinished
         // `Builder` poisons and frees its libarchive writer in `Drop`.
@@ -180,6 +217,7 @@ impl Archive {
                 "entries",
                 builder.as_ref().map_or(0, Builder::entries),
             ),
+            State::Streamed => ("Archive (streamed)".to_string(), "entries", 0),
             State::Failed => ("Archive (failed)".to_string(), "files", 0),
         };
 
@@ -307,6 +345,7 @@ impl Archive {
             options,
             queue: RefCell::new(VecDeque::new()),
             appending: Cell::new(false),
+            stream: RefCell::new(None),
         })
     }
 
@@ -320,6 +359,7 @@ impl Archive {
             let mut state = self.state.borrow_mut();
             match &mut *state {
                 State::Done(store) => return Ok(store.clone()),
+                State::Streamed => return Err(self.throw_streamed(global)),
                 State::Failed => return Err(self.throw_failed(global)),
                 State::Building(slot) => {
                     if slot.is_none() || !self.queue.borrow().is_empty() {
@@ -349,6 +389,12 @@ impl Archive {
         ))
     }
 
+    fn throw_streamed(&self, global: &JSGlobalObject) -> jsc::JsError {
+        global.throw_invalid_arguments(format_args!(
+            "Archive.stream() consumed this archive's bytes; there is nothing left to read"
+        ))
+    }
+
     /// Instance method: archive.append(path, data)
     /// Streams one more entry into an archive that is still open. Resolves when
     /// the entry has been written; rejects (and poisons the archive) on failure.
@@ -362,6 +408,7 @@ impl Archive {
                     "Archive.append() is only available before the archive is read; it cannot append to existing archive data"
                 )));
             }
+            State::Streamed => return Err(self.throw_streamed(global)),
             State::Failed => return Err(self.throw_failed(global)),
             State::Building(_) => {}
         }
@@ -386,6 +433,222 @@ impl Archive {
         Ok(value)
     }
 
+    /// Instance method: archive.stream()
+    /// The archive's bytes as a `ReadableStream`, produced as entries are
+    /// appended. Reading it is what lets the next `append()` make progress.
+    #[bun_jsc::host_fn(method)]
+    pub fn stream(&self, global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        match &*self.state.borrow() {
+            State::Done(_) => {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "Archive.stream() is only available before the archive is read"
+                )));
+            }
+            State::Streamed => return Err(self.throw_streamed(global)),
+            State::Failed => return Err(self.throw_failed(global)),
+            State::Building(slot) => {
+                if slot.is_none() || !self.queue.borrow().is_empty() {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "Archive.stream() cannot start while an append() is in progress"
+                    )));
+                }
+            }
+        }
+        if self.stream.borrow().is_some() {
+            return Err(
+                global.throw_invalid_arguments(format_args!("Archive.stream() was already called"))
+            );
+        }
+
+        // Ownership of the heap-allocated source transfers to the JS wrapper in
+        // `to_readable_stream`; the wrapper's finalizer reclaims it.
+        let source = crate::webcore::byte_stream::Source::new(readable_stream::NewSource {
+            context: ByteStream::default(),
+            global_this: Some(bun_ptr::BackRef::new(global)),
+            ..Default::default()
+        });
+        // SAFETY: freshly heap-allocated, exclusive until handed to JS below.
+        let source = unsafe { &mut *source };
+        source.context.setup();
+        let value = source.to_readable_stream(global)?;
+
+        let bytes: *mut ByteStream = &raw mut source.context;
+        // `&self`-derived, and the handlers only ever form `&Archive`.
+        let this: *mut c_void = core::ptr::from_ref(self).cast_mut().cast();
+        source.drain_handler.set(Some(Archive::on_stream_drained));
+        source.drain_ctx.set(Some(this));
+        source
+            .cancel_handler
+            .set(Some(Archive::on_stream_cancelled));
+        source.cancel_ctx.set(Some(this));
+
+        *self.stream.borrow_mut() = Some(StreamOut {
+            _held: ReadableStreamStrong::init(
+                ReadableStream {
+                    ptr: ReadableStreamPtr::Bytes(bytes),
+                    value,
+                },
+                global,
+            ),
+            bytes,
+            cancelled: false,
+            parked: None,
+        });
+        Ok(value)
+    }
+
+    /// Instance method: archive.end()
+    /// Finish the archive. A streamed archive closes its stream; any other one
+    /// just seals, exactly as the first read of its bytes would.
+    #[bun_jsc::host_fn(method)]
+    pub fn end(&self, global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        if !self.is_streaming() {
+            self.blob_store(global)?;
+            return Ok(JSValue::UNDEFINED);
+        }
+
+        let builder = {
+            let mut state = self.state.borrow_mut();
+            match &mut *state {
+                State::Streamed => return Ok(JSValue::UNDEFINED),
+                State::Failed => return Err(self.throw_failed(global)),
+                State::Done(_) => return Err(self.throw_streamed(global)),
+                State::Building(slot) => {
+                    if slot.is_none() || !self.queue.borrow().is_empty() {
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "Archive.append() is still in progress: await it before end()"
+                        )));
+                    }
+                    slot.take().expect("checked above")
+                }
+            }
+        };
+
+        let tail = match builder.close() {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                *self.state.borrow_mut() = State::Failed;
+                return Err(throw_build_error(global, err));
+            }
+        };
+        *self.state.borrow_mut() = State::Streamed;
+        self.push_to_stream(global, tail, true)?;
+        Ok(JSValue::UNDEFINED)
+    }
+
+    #[inline]
+    fn is_streaming(&self) -> bool {
+        self.stream.borrow().is_some()
+    }
+
+    /// Hand `bytes` to the stream's consumer. `done` closes the stream.
+    ///
+    /// `on_data` can resolve a parked reader and therefore run JS, so the
+    /// `stream` borrow is released first.
+    fn push_to_stream(
+        &self,
+        _global: &JSGlobalObject,
+        bytes: Vec<u8>,
+        done: bool,
+    ) -> Result<(), jsc::JsTerminated> {
+        let Some((source, cancelled)) = self
+            .stream
+            .borrow()
+            .as_ref()
+            .map(|out| (out.bytes, out.cancelled))
+        else {
+            return Ok(());
+        };
+        if cancelled || (bytes.is_empty() && !done) {
+            return Ok(());
+        }
+        let chunk = if done {
+            streams::Result::OwnedAndDone(bytes)
+        } else {
+            streams::Result::Owned(bytes)
+        };
+        // SAFETY: the `StreamOut`'s `_held` roots the JS wrapper that owns the
+        // source this points into, and it is still held (we just read it).
+        unsafe { &*source }.on_data(chunk)
+    }
+
+    /// Whether the consumer is far enough behind to park the next chunk.
+    fn stream_is_backed_up(&self) -> bool {
+        let stream = self.stream.borrow();
+        let Some(out) = stream.as_ref() else {
+            return false;
+        };
+        if out.cancelled {
+            return false;
+        }
+        // SAFETY: see `push_to_stream`.
+        unsafe { &*out.bytes }.buffer.get().len() >= STREAM_HIGH_WATER_MARK
+    }
+
+    fn park_append(&self, task: *mut AppendTask) {
+        if let Some(out) = self.stream.borrow_mut().as_mut() {
+            out.parked = Some(task);
+        }
+    }
+
+    /// The consumer drained the queue, so the parked append can carry on.
+    fn on_stream_drained(ctx: Option<*mut c_void>) {
+        let Some(ctx) = ctx else {
+            return;
+        };
+        // SAFETY: `ctx` is the `*mut Archive` registered in `stream()`. The
+        // handler is cleared in `finalize`, so the payload is alive here.
+        let archive = unsafe { &*ctx.cast::<Archive>() };
+        let parked = archive
+            .stream
+            .borrow_mut()
+            .as_mut()
+            .and_then(|out| out.parked.take());
+        if let Some(task) = parked {
+            AppendTask::schedule(task);
+        }
+    }
+
+    /// The consumer walked away. Resume any parked append so its promise
+    /// settles rather than hanging.
+    fn on_stream_cancelled(ctx: Option<*mut c_void>) {
+        let Some(ctx) = ctx else {
+            return;
+        };
+        // SAFETY: see `on_stream_drained`.
+        let archive = unsafe { &*ctx.cast::<Archive>() };
+        let parked = {
+            let mut stream = archive.stream.borrow_mut();
+            match stream.as_mut() {
+                Some(out) => {
+                    out.cancelled = true;
+                    out.parked.take()
+                }
+                None => None,
+            }
+        };
+        if let Some(task) = parked {
+            // SAFETY: a parked task is owned by the `StreamOut` we just took it
+            // from, and nothing else touches it until it is rescheduled.
+            unsafe { (*task).ctx.cancel() };
+            AppendTask::schedule(task);
+        }
+    }
+
+    fn clear_stream_handlers(&self) {
+        let stream = self.stream.borrow();
+        let Some(out) = stream.as_ref() else {
+            return;
+        };
+        // SAFETY: see `push_to_stream`. `NewSource` is `repr(C)` with `context`
+        // at offset 0, so the source starts at `bytes`.
+        let source = unsafe { &*out.bytes.cast::<crate::webcore::byte_stream::Source>() };
+        source.drain_handler.set(None);
+        source.drain_ctx.set(None);
+        source.cancel_handler.set(None);
+        source.cancel_ctx.set(None);
+    }
+
     /// Start the next queued append, if the builder is free.
     fn pump(&self, global: &JSGlobalObject, this: JSValue) {
         if self.appending.get() {
@@ -397,7 +660,7 @@ impl Archive {
 
         let builder = match &mut *self.state.borrow_mut() {
             State::Building(slot) => slot.take(),
-            State::Done(_) | State::Failed => None,
+            State::Done(_) | State::Streamed | State::Failed => None,
         };
         let Some(builder) = builder else {
             reject_pending(global, job, "Archive is no longer writable");
@@ -412,6 +675,15 @@ impl Archive {
                 path: job.path,
                 source: job.source,
                 mtime: now_seconds(),
+                // Only a streamed archive needs the output drained between
+                // chunks; otherwise the whole entry goes in one step.
+                chunked: self.is_streaming(),
+                started: false,
+                written: 0,
+                total: 0,
+                file: None,
+                buf: Vec::new(),
+                done: false,
                 result: Ok(()),
             },
             job.promise,
@@ -475,6 +747,8 @@ fn build_error_to_js(global: &JSGlobalObject, err: BuildError) -> JSValue {
         BuildError::EntryChangedSize => global.create_error_instance(format_args!(
             "Bun.Archive: the file changed size while it was being added"
         )),
+        BuildError::StreamCancelled => global
+            .create_error_instance(format_args!("Bun.Archive: the stream() consumer cancelled")),
         BuildError::Libarchive(stage) => {
             global.create_error_instance(format_args!("Failed to create archive: {stage}"))
         }
@@ -1068,12 +1342,28 @@ impl PromiseResult {
 ///   - `run` — runs on thread pool, stores result in `self`
 ///   - `run_from_js` — returns value to resolve/reject
 ///   - `Drop` — cleanup
+/// What `AsyncTask` does once `step_from_js` returns.
+pub enum Step {
+    /// Put the task back on the work pool for another `run()`.
+    Reschedule,
+    /// Leave the task alive and untouched; something else will reschedule it.
+    Parked,
+    /// Settle the task's promise and drop it.
+    Settle(PromiseResult),
+}
+
 pub trait TaskContext: Send {
     /// Dispatch tag for this context's `AsyncTask<Self>` variant.
     const TAG: TaskTag;
     /// Runs on thread pool. Stores its result on `self`.
     fn run(&mut self);
     fn run_from_js(&mut self, global: &JSGlobalObject) -> JsResult<PromiseResult>;
+    /// What to do on the JS thread after one `run()`. A context that can be
+    /// resumed overrides this; the default settles on the first pass. `task` is
+    /// the owning `AsyncTask<Self>`, which a resumable context parks.
+    fn step_from_js(&mut self, global: &JSGlobalObject, _task: *mut c_void) -> JsResult<Step> {
+        Ok(Step::Settle(self.run_from_js(global)?))
+    }
     /// Runs once this task's own promise has settled. A context that settles
     /// *other* promises does it here, so its own rejection is observed first.
     fn after_settled(&mut self, _global: &JSGlobalObject) {}
@@ -1173,27 +1463,43 @@ impl<C: TaskContext> AsyncTask<C> {
     // not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn run_from_js(this: *mut Self) -> Result<(), bun_jsc::JsTerminated> {
-        // SAFETY: see fn-level safety contract.
-        let mut owned = unsafe { bun_core::heap::take(this) };
-        owned.keep_alive.unref(bun_io::js_vm_ctx());
-
-        // `defer { ctx.deinit; destroy(this) }` — handled by `owned: Box<Self>` dropping at scope
-        // exit (ctx implements Drop).
-
         let vm = VirtualMachine::get();
         if vm.is_shutting_down() {
+            // SAFETY: see fn-level safety contract.
+            let mut owned = unsafe { bun_core::heap::take(this) };
+            owned.keep_alive.unref(bun_io::js_vm_ctx());
             return Ok(());
         }
 
         let global = vm.global();
-        let promise = owned.promise.swap();
-        let result = match owned.ctx.run_from_js(global) {
-            Ok(r) => r,
+        // SAFETY: `this` is the live allocation from `create`; only this thread
+        // touches it between the work-pool callback and here.
+        let step = unsafe { (*this).ctx.step_from_js(global, this.cast()) };
+
+        // Ownership is only taken on the paths that settle: a rescheduled or
+        // parked task stays alive, and keeps the event loop alive with it.
+        let result = match step {
+            Ok(Step::Reschedule) => {
+                Self::schedule(this);
+                return Ok(());
+            }
+            Ok(Step::Parked) => return Ok(()),
+            Ok(Step::Settle(result)) => result,
             Err(e) => {
+                // SAFETY: see above.
+                let mut owned = unsafe { bun_core::heap::take(this) };
+                owned.keep_alive.unref(bun_io::js_vm_ctx());
+                let promise = owned.promise.swap();
                 // JSError means exception is already pending
                 return promise.reject(global, Ok(global.take_exception(e)));
             }
         };
+
+        // SAFETY: see above. `defer { ctx.deinit; destroy(this) }` — handled by
+        // `owned: Box<Self>` dropping at scope exit (ctx implements Drop).
+        let mut owned = unsafe { bun_core::heap::take(this) };
+        owned.keep_alive.unref(bun_io::js_vm_ctx());
+        let promise = owned.promise.swap();
         result.fulfill(global, promise)?;
         owned.ctx.after_settled(global);
         Ok(())
@@ -1742,30 +2048,44 @@ pub struct AppendContext {
     path: ZBox,
     source: AppendSource,
     mtime: i64,
+    /// Write the entry a chunk at a time, so the JS thread can drain the output
+    /// into the stream in between. Off when nothing is consuming the archive.
+    chunked: bool,
+    /// Whether the entry's header has been written.
+    started: bool,
+    /// Body bytes written so far, of `total`.
+    written: u64,
+    total: u64,
+    /// A file-backed source's open handle, carried across chunks.
+    file: Option<bun_sys::File>,
+    /// Scratch for a file-backed source's chunk.
+    buf: Vec<u8>,
+    done: bool,
     result: Result<(), BuildError>,
 }
 
-// SAFETY: `archive` is a JSC handle that is created, read and dropped only on
-// the JS thread; `run` (the work-pool half) never touches it. Everything else
-// in the context is `Send`.
-unsafe impl Send for AppendContext {}
+impl AppendContext {
+    /// Give up: the stream's consumer cancelled.
+    fn cancel(&mut self) {
+        if self.result.is_ok() {
+            self.result = Err(BuildError::StreamCancelled);
+        }
+        self.done = true;
+    }
 
-impl TaskContext for AppendContext {
-    const TAG: TaskTag = task_tag::ArchiveAppendTask;
-
-    fn run(&mut self) {
+    /// Write the whole entry in one go. The non-streaming path.
+    fn write_whole(&mut self) -> Result<(), BuildError> {
         let AppendContext {
             builder,
             path,
             source,
             mtime,
-            result,
             ..
         } = self;
         let Some(builder) = builder.as_mut() else {
-            return;
+            return Ok(());
         };
-        *result = match source {
+        match source {
             AppendSource::Bytes(data) => builder.add_bytes(path, data, *mtime),
             AppendSource::Store { store, offset, len } => {
                 let view = store.shared_view();
@@ -1778,7 +2098,103 @@ impl TaskContext for AppendContext {
                 offset,
                 len,
             } => builder.add_file(path, source_path, *offset, *len, *mtime),
-        };
+        }
+    }
+
+    /// Write the next chunk of the entry. The streaming path.
+    fn write_chunk(&mut self) -> Result<(), BuildError> {
+        if !self.started {
+            self.total = match &self.source {
+                AppendSource::Bytes(data) => data.len() as u64,
+                AppendSource::Store { store, offset, len } => {
+                    let view = store.shared_view();
+                    let offset = (*offset).min(view.len());
+                    (offset.saturating_add(*len).min(view.len()) - offset) as u64
+                }
+                AppendSource::File {
+                    path: source_path,
+                    offset,
+                    len,
+                } => {
+                    let (file, size) = open_entry_file(source_path, *offset, *len)?;
+                    self.file = Some(file);
+                    size
+                }
+            };
+            let builder = self.builder.as_mut().expect("builder held by the task");
+            builder.begin_entry(&self.path, self.total, self.mtime)?;
+            self.started = true;
+        }
+
+        if self.written >= self.total {
+            self.builder
+                .as_mut()
+                .expect("builder held by the task")
+                .end_entry()?;
+            self.done = true;
+            return Ok(());
+        }
+
+        let remaining = self.total - self.written;
+        let take = remaining.min(STREAM_CHUNK_SIZE as u64);
+
+        let AppendContext {
+            builder,
+            source,
+            written,
+            file,
+            buf,
+            ..
+        } = self;
+        let builder = builder.as_mut().expect("builder held by the task");
+        match source {
+            AppendSource::Bytes(data) => {
+                let start = *written as usize;
+                let end = start + take as usize;
+                builder.write_body(&data[start..end])?;
+                *written += take;
+            }
+            AppendSource::Store { store, offset, len } => {
+                let view = store.shared_view();
+                let base = (*offset).min(view.len());
+                let end_of_view = base.saturating_add(*len).min(view.len());
+                let start = base + *written as usize;
+                let end = (start + take as usize).min(end_of_view);
+                builder.write_body(&view[start..end])?;
+                *written += (end - start) as u64;
+            }
+            AppendSource::File { .. } => {
+                let file = file.as_ref().expect("file opened on the first chunk");
+                if buf.len() < take as usize {
+                    buf.resize(take as usize, 0);
+                }
+                let read = read_entry_chunk(file, &mut buf[..take as usize], remaining)?;
+                builder.write_body(&buf[..read])?;
+                *written += read as u64;
+            }
+        }
+        Ok(())
+    }
+}
+
+// SAFETY: `archive` is a JSC handle that is created, read and dropped only on
+// the JS thread; `run` (the work-pool half) never touches it. Everything else
+// in the context is `Send`.
+unsafe impl Send for AppendContext {}
+
+impl TaskContext for AppendContext {
+    const TAG: TaskTag = task_tag::ArchiveAppendTask;
+
+    fn run(&mut self) {
+        if self.done || self.result.is_err() || self.builder.is_none() {
+            return;
+        }
+        if self.chunked {
+            self.result = self.write_chunk();
+        } else {
+            self.result = self.write_whole();
+            self.done = true;
+        }
     }
 
     fn run_from_js(&mut self, global: &JSGlobalObject) -> JsResult<PromiseResult> {
@@ -1796,6 +2212,36 @@ impl TaskContext for AppendContext {
             Ok(()) => PromiseResult::Resolve(JSValue::UNDEFINED),
             Err(err) => PromiseResult::Reject(build_error_to_js(global, err)),
         })
+    }
+
+    fn step_from_js(&mut self, global: &JSGlobalObject, task: *mut c_void) -> JsResult<Step> {
+        let this = self.archive.get();
+        let Some(archive) = this.as_class_ref::<Archive>() else {
+            return Ok(Step::Settle(PromiseResult::Resolve(JSValue::UNDEFINED)));
+        };
+
+        // Hand whatever the writer produced to the consumer before deciding
+        // whether there is room for more.
+        if self.chunked && self.result.is_ok() {
+            let produced = self
+                .builder
+                .as_mut()
+                .map(Builder::take_output)
+                .unwrap_or_default();
+            archive.push_to_stream(global, produced, false)?;
+        }
+
+        if self.result.is_err() || self.done {
+            return Ok(Step::Settle(self.run_from_js(global)?));
+        }
+
+        if archive.stream_is_backed_up() {
+            // SAFETY: `task` is the `*mut AsyncTask<Self>` that owns us; the
+            // drain/cancel handler is the only thing that touches it again.
+            archive.park_append(task.cast::<AppendTask>());
+            return Ok(Step::Parked);
+        }
+        Ok(Step::Reschedule)
     }
 
     /// Reject the appends that were queued behind this one, now that its own

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -294,11 +294,9 @@ impl Archive {
         // For plain objects, open a writer and pack the object's entries into it.
         if data_arg.is_object() {
             let mut builder = open_builder(global, options)?;
-            if let Err(err) = add_object_entries(global, &mut builder, data_arg) {
-                // A JS exception from property iteration: the builder's `Drop`
-                // closes the writer and removes any spill file.
-                return Err(err);
-            }
+            // On a JS exception from property iteration the builder's `Drop`
+            // closes the writer and removes any spill file.
+            add_object_entries(global, &mut builder, data_arg)?;
             return Ok(Archive::new(State::Building(Some(builder)), options));
         }
 
@@ -468,7 +466,7 @@ fn reject_pending(global: &JSGlobalObject, job: PendingAppend, message: &str) {
 
 /// Seconds since the epoch, for entry mtimes.
 fn now_seconds() -> i64 {
-    i64::try_from(bun_core::time::milli_timestamp() / 1000).unwrap_or(0)
+    bun_core::time::timestamp()
 }
 
 fn open_builder(global: &JSGlobalObject, options: Options) -> JsResult<Builder> {
@@ -852,7 +850,10 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
 
     // For Archive instances, use options override or archive's compression settings
     if let Some(archive) = data_arg.as_class_ref::<Archive>() {
-        let gzip = options.compress.gzip().or(archive.options.compress.gzip());
+        let gzip = options
+            .compress
+            .gzip()
+            .or_else(|| archive.options.compress.gzip());
         return start_write_task(
             global,
             WriteData::Store(archive.blob_store(global)?),

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -474,30 +474,24 @@ fn open_builder(global: &JSGlobalObject, options: Options) -> JsResult<Builder> 
     Builder::open(options).map_err(|err| throw_build_error(global, err))
 }
 
-fn throw_build_error(global: &JSGlobalObject, err: BuildError) -> jsc::JsError {
-    match err {
-        BuildError::Sys(sys_err) => global.throw_value(sys_err.to_js(global)),
-        BuildError::OutOfMemory => global.throw_value(global.create_out_of_memory_error()),
-        BuildError::EntryChangedSize => global.throw_invalid_arguments(format_args!(
-            "Archive.append: the file changed size while it was being added"
-        )),
-        BuildError::Libarchive(stage) => {
-            global.throw_invalid_arguments(format_args!("Failed to create archive: {stage}"))
-        }
-    }
-}
-
+/// The constructor, `Archive.write()`, and `append()` all reach these, so the
+/// messages name the class rather than one method.
 fn build_error_to_js(global: &JSGlobalObject, err: BuildError) -> JSValue {
     match err {
         BuildError::Sys(sys_err) => sys_err.to_js(global),
         BuildError::OutOfMemory => global.create_out_of_memory_error(),
         BuildError::EntryChangedSize => global.create_error_instance(format_args!(
-            "Archive.append: the file changed size while it was being added"
+            "Bun.Archive: the file changed size while it was being added"
         )),
         BuildError::Libarchive(stage) => {
             global.create_error_instance(format_args!("Failed to create archive: {stage}"))
         }
     }
+}
+
+#[inline]
+fn throw_build_error(global: &JSGlobalObject, err: BuildError) -> jsc::JsError {
+    global.throw_value(build_error_to_js(global, err))
 }
 
 /// Turn a closed builder's output into a `Blob.Store`.

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -541,7 +541,10 @@ impl Archive {
             Ok(bytes) => bytes,
             Err(err) => {
                 *self.state.borrow_mut() = State::Failed;
-                return Err(throw_build_error(global, err));
+                // The consumer is waiting on a close that will never come.
+                let error = build_error_to_js(global, err);
+                self.error_stream(global, error)?;
+                return Err(global.throw_value(error));
             }
         };
         *self.state.borrow_mut() = State::Streamed;

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -85,6 +85,10 @@ impl Default for GzipOptions {
 pub(crate) struct Options {
     pub format: Format,
     pub compress: Compression,
+    /// Whether `compress` came from the caller. `Compression::Store` and
+    /// `Deflate` both have no gzip post-filter, so `Archive.write()` cannot
+    /// tell an explicit "no gzip" from an omitted option without this.
+    pub compress_given: bool,
     pub max_memory: u64,
 }
 
@@ -93,6 +97,7 @@ impl Default for Options {
         Self {
             format: Format::Tar,
             compress: Compression::None,
+            compress_given: false,
             max_memory: DEFAULT_MAX_MEMORY,
         }
     }
@@ -376,11 +381,7 @@ impl Archive {
             )));
         }
         let path_slice = path_arg.to_slice(global)?;
-        if path_slice.slice().is_empty() {
-            return Err(global
-                .throw_invalid_arguments(format_args!("Archive.append: path must not be empty")));
-        }
-        let path = ZBox::from_bytes(path_slice.slice());
+        let path = entry_path(global, path_slice.slice())?;
         let source = parse_append_source(global, data_arg)?;
 
         let promise = JSPromiseStrong::init(global);
@@ -558,6 +559,7 @@ fn parse_archive_options(global: &JSGlobalObject, options_arg: JSValue) -> JsRes
         };
     }
 
+    options.compress_given = options_arg.get_truthy(global, "compress")?.is_some();
     options.compress = parse_compression(global, options_arg, options.format)?;
 
     if let Some(max_memory_val) = options_arg.get_truthy(global, "maxMemory")? {
@@ -685,7 +687,7 @@ fn add_object_entries(
         }
 
         let key_slice = key.to_utf8();
-        let path = ZBox::from_bytes(key_slice.slice());
+        let path = entry_path(global, key_slice.slice())?;
 
         // `Bun.file()` has no bytes in memory; stream it off disk.
         if let Some(blob) = blob_from_js(value) {
@@ -708,6 +710,23 @@ fn add_object_entries(
     }
 
     Ok(())
+}
+
+/// libarchive takes entry names as NUL-terminated C strings, so an embedded NUL
+/// would silently truncate the name (`"a\0b.txt"` becomes `"a"`).
+fn entry_path(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<ZBox> {
+    if bytes.is_empty() {
+        return Err(
+            global.throw_invalid_arguments(format_args!("Bun.Archive: path must not be empty"))
+        );
+    }
+    if bytes.contains(&0) {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "Bun.Archive: path must not contain a NUL byte: {}",
+            bun_core::fmt::quote(bytes),
+        )));
+    }
+    Ok(ZBox::from_bytes(bytes))
 }
 
 /// Where a file-backed blob's bytes live on disk. `None` for an in-memory blob,
@@ -850,10 +869,13 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
 
     // For Archive instances, use options override or archive's compression settings
     if let Some(archive) = data_arg.as_class_ref::<Archive>() {
-        let gzip = options
-            .compress
-            .gzip()
-            .or_else(|| archive.options.compress.gzip());
+        // `format`/`compress` cannot change an archive that is already built,
+        // but an explicit `compress` still decides whether to gzip the result.
+        let gzip = if options.compress_given {
+            options.compress.gzip()
+        } else {
+            archive.options.compress.gzip()
+        };
         return start_write_task(
             global,
             WriteData::Store(archive.blob_store(global)?),

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1392,10 +1392,6 @@ impl PromiseResult {
     }
 }
 
-/// Context must provide:
-///   - `run` — runs on thread pool, stores result in `self`
-///   - `run_from_js` — returns value to resolve/reject
-///   - `Drop` — cleanup
 /// What `AsyncTask` does once `step_from_js` returns.
 pub enum Step {
     /// Put the task back on the work pool for another `run()`.
@@ -1406,6 +1402,10 @@ pub enum Step {
     Settle(PromiseResult),
 }
 
+/// Context must provide:
+///   - `run` — runs on thread pool, stores result in `self`
+///   - `run_from_js` — returns value to resolve/reject
+///   - `Drop` — cleanup
 pub trait TaskContext: Send {
     /// Dispatch tag for this context's `AsyncTask<Self>` variant.
     const TAG: TaskTag;

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -689,7 +689,19 @@ fn add_object_entries(
         let key_slice = key.to_utf8();
         let path = ZBox::from_bytes(key_slice.slice());
 
-        // Use a view for Blob/ArrayBuffer, convert for strings.
+        // `Bun.file()` has no bytes in memory; stream it off disk.
+        if let Some(blob) = blob_from_js(value) {
+            if let Some(store) = blob.store.get().as_ref() {
+                if let Some(file) = file_backed_source(global, blob, store)? {
+                    builder
+                        .add_file(&path, &file.path, file.offset, file.len, mtime)
+                        .map_err(|err| throw_build_error(global, err))?;
+                    continue;
+                }
+            }
+        }
+
+        // Use a view for in-memory Blob/ArrayBuffer, convert for strings.
         let data_slice = get_entry_data(global, value)?;
 
         builder
@@ -698,6 +710,42 @@ fn add_object_entries(
     }
 
     Ok(())
+}
+
+/// Where a file-backed blob's bytes live on disk. `None` for an in-memory blob,
+/// whose bytes both archive paths read directly instead.
+struct FileBackedSource {
+    path: ZBox,
+    offset: u64,
+    len: Option<u64>,
+}
+
+fn file_backed_source(
+    global: &JSGlobalObject,
+    blob: &Blob,
+    store: &StoreRef,
+) -> JsResult<Option<FileBackedSource>> {
+    match &store.data {
+        BlobData::Bytes(_) => Ok(None),
+        BlobData::File(file) => match &file.pathlike {
+            PathOrFileDescriptor::Path(path) => {
+                // A file-backed blob's size stays `MAX_SIZE` until something
+                // stats it; only a `.slice()` gives a real window to honour.
+                let declared = blob.size.get();
+                Ok(Some(FileBackedSource {
+                    path: ZBox::from_bytes(path.slice()),
+                    offset: blob.offset.get(),
+                    len: (declared < BLOB_MAX_SIZE).then_some(declared),
+                }))
+            }
+            PathOrFileDescriptor::Fd(_) => Err(global.throw_invalid_arguments(format_args!(
+                "Bun.Archive: file descriptor-backed files are not supported; read the bytes first"
+            ))),
+        },
+        BlobData::S3(_) => Err(global.throw_invalid_arguments(format_args!(
+            "Bun.Archive: S3 files are not supported; await file.bytes() first"
+        ))),
+    }
 }
 
 /// Returns data as a ZigString.Slice (handles ownership automatically via deinit)
@@ -752,38 +800,22 @@ fn parse_append_source(global: &JSGlobalObject, value: JSValue) -> JsResult<Appe
         let Some(store) = blob.store.get().as_ref().cloned() else {
             return Ok(AppendSource::Bytes(Vec::new()));
         };
-        match &store.data {
-            BlobData::Bytes(_) => {
-                let view = store.shared_view();
-                let offset = usize::try_from(blob.offset.get())
-                    .unwrap_or(usize::MAX)
-                    .min(view.len());
-                let len = usize::try_from(blob.size.get())
-                    .unwrap_or(usize::MAX)
-                    .min(view.len() - offset);
-                return Ok(AppendSource::Store { store, offset, len });
-            }
-            BlobData::File(file) => match &file.pathlike {
-                PathOrFileDescriptor::Path(path) => {
-                    let declared = blob.size.get();
-                    return Ok(AppendSource::File {
-                        path: ZBox::from_bytes(path.slice()),
-                        offset: blob.offset.get(),
-                        len: (declared < BLOB_MAX_SIZE).then_some(declared),
-                    });
-                }
-                PathOrFileDescriptor::Fd(_) => {
-                    return Err(global.throw_invalid_arguments(format_args!(
-                        "Archive.append: file descriptor-backed files are not supported; read the bytes first"
-                    )));
-                }
-            },
-            BlobData::S3(_) => {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Archive.append: S3 files are not supported; await file.bytes() first"
-                )));
-            }
+        if let Some(file) = file_backed_source(global, blob, &store)? {
+            return Ok(AppendSource::File {
+                path: file.path,
+                offset: file.offset,
+                len: file.len,
+            });
         }
+        // In-memory: hold a ref on the store instead of copying its bytes.
+        let view = store.shared_view();
+        let offset = usize::try_from(blob.offset.get())
+            .unwrap_or(usize::MAX)
+            .min(view.len());
+        let len = usize::try_from(blob.size.get())
+            .unwrap_or(usize::MAX)
+            .min(view.len() - offset);
+        return Ok(AppendSource::Store { store, offset, len });
     }
 
     if let Some(array_buffer) = value.as_array_buffer(global) {

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -2,19 +2,15 @@
 //!
 //! An archive created from an object (or from nothing) stays *open* behind a
 //! live libarchive writer until the first read of its bytes, so entries can be
-//! streamed in one at a time with [`Archive::append`]. The writer's output is
-//! buffered in memory up to `maxMemory` bytes and spills to a temporary file
-//! beyond that, which keeps peak memory bounded for archives larger than RAM.
+//! streamed in one at a time with [`Archive::append`].
 
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::ffi::CString;
 
-use super::archive_builder::{BuildError, Builder, FILETYPE_REGULAR, SinkOutput};
+use super::archive_builder::{BuildError, Builder, FILETYPE_REGULAR};
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
-#[cfg(unix)]
-use crate::webcore::BlobStoreExt as _;
 use crate::webcore::blob::store::Data as BlobData;
 use crate::webcore::blob::{MAX_SIZE as BLOB_MAX_SIZE, Store as BlobStore, StoreRef};
 use crate::webcore::node_types::PathOrFileDescriptor;
@@ -32,9 +28,6 @@ use bun_jsc::{
 use bun_jsc::{StringJsc as _, SysErrorJsc as _};
 use bun_libarchive as libarchive;
 use bun_sys::{self, Fd, FdDirExt as _, FdExt as _, Mode};
-
-/// Bytes of archive output held in memory before spilling to a temporary file.
-const DEFAULT_MAX_MEMORY: u64 = 64 * 1024 * 1024;
 
 /// Container format written by `new Archive(...)`. Reading auto-detects both.
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
@@ -89,7 +82,6 @@ pub(crate) struct Options {
     /// `Deflate` both have no gzip post-filter, so `Archive.write()` cannot
     /// tell an explicit "no gzip" from an omitted option without this.
     pub compress_given: bool,
-    pub max_memory: u64,
 }
 
 impl Default for Options {
@@ -98,7 +90,6 @@ impl Default for Options {
             format: Format::Tar,
             compress: Compression::None,
             compress_given: false,
-            max_memory: DEFAULT_MAX_MEMORY,
         }
     }
 }
@@ -269,7 +260,6 @@ impl Archive {
     /// - format: "tar" | "zip" - Container format (default "tar")
     /// - compress: "gzip" (tar) | "deflate" | "store" (zip)
     /// - level: number - Compression level
-    /// - maxMemory: number - Bytes buffered before spilling to a temp file
     // NOTE: `#[bun_jsc::host_fn]` has no `constructor` kind yet; the
     // `JsClass` derive emits a `constructor` shim that calls this directly.
     pub fn constructor(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<Box<Archive>> {
@@ -342,8 +332,8 @@ impl Archive {
             }
         };
 
-        let store = match builder.close().and_then(output_to_store) {
-            Ok(store) => store,
+        let store = match builder.close() {
+            Ok(bytes) => BlobStore::init(bytes),
             Err(err) => {
                 *self.state.borrow_mut() = State::Failed;
                 return Err(throw_build_error(global, err));
@@ -496,37 +486,7 @@ fn throw_build_error(global: &JSGlobalObject, err: BuildError) -> jsc::JsError {
     global.throw_value(build_error_to_js(global, err))
 }
 
-/// Turn a closed builder's output into a `Blob.Store`.
-///
-/// A spilled archive is memory-mapped copy-on-write on POSIX, so reading it
-/// back (`extract()`, `Bun.write()`, `files()`) streams from the page cache
-/// instead of allocating a second copy. Windows has no mapping helper in
-/// `bun_sys`, so it reads the file back into memory.
-fn output_to_store(output: SinkOutput) -> Result<StoreRef, BuildError> {
-    match output {
-        SinkOutput::Memory(bytes) => Ok(BlobStore::init(bytes)),
-        SinkOutput::Spilled(file) => {
-            #[cfg(unix)]
-            {
-                if file.len() == 0 {
-                    return Ok(BlobStore::init(Vec::new()));
-                }
-                let mapping = file.mmap()?;
-                // The mapping owns the pages; dropping `file` closes the
-                // descriptor of the already-unlinked temp file.
-                drop(file);
-                Ok(BlobStore::init_mmap(mapping))
-            }
-            #[cfg(not(unix))]
-            {
-                let bytes = file.read_to_vec()?;
-                Ok(BlobStore::init(bytes))
-            }
-        }
-    }
-}
-
-/// Parse `{ format, compress, level, maxMemory }`.
+/// Parse `{ format, compress, level }`.
 fn parse_archive_options(global: &JSGlobalObject, options_arg: JSValue) -> JsResult<Options> {
     let mut options = Options::default();
     if options_arg.is_empty() || options_arg.is_undefined_or_null() {
@@ -560,25 +520,6 @@ fn parse_archive_options(global: &JSGlobalObject, options_arg: JSValue) -> JsRes
     let compress_val = options_arg.get_truthy(global, "compress")?;
     options.compress_given = compress_val.is_some();
     options.compress = parse_compression(global, options_arg, compress_val, options.format)?;
-
-    if let Some(max_memory_val) = options_arg.get_truthy(global, "maxMemory")? {
-        if !max_memory_val.is_number() {
-            return Err(
-                global.throw_invalid_arguments(format_args!("Archive: maxMemory must be a number"))
-            );
-        }
-        let max_memory = max_memory_val.as_number();
-        if max_memory.is_nan() || max_memory < 0.0 {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Archive: maxMemory must be a non-negative number"
-            )));
-        }
-        options.max_memory = if max_memory.is_infinite() {
-            u64::MAX
-        } else {
-            max_memory as u64
-        };
-    }
 
     Ok(options)
 }
@@ -930,13 +871,12 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
     if data_arg.is_object() {
         let mut builder = open_builder(global, options)?;
         add_object_entries(global, &mut builder, data_arg)?;
-        let store = builder
+        let bytes = builder
             .close()
-            .and_then(output_to_store)
             .map_err(|err| throw_build_error(global, err))?;
         return start_write_task(
             global,
-            WriteData::Store(store),
+            WriteData::Owned(bytes),
             path_slice.slice(),
             options.compress.gzip(),
         );

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -282,12 +282,17 @@ impl Archive {
             return Ok(Archive::new(State::Building(Some(builder)), options));
         }
 
-        // For Blob/Archive, ref the existing store (zero-copy)
+        // For a Blob, ref the existing store (zero-copy). An empty Blob has no
+        // store at all, and is still archive data: it must not fall through to
+        // the object form below and be packed as an empty object literal.
         if let Some(blob) = blob_from_js(data_arg) {
-            if let Some(store) = blob.store.get().as_ref() {
-                // StoreRef::clone == store.ref()
-                return Ok(Archive::new(State::Done(store.clone()), options));
-            }
+            // StoreRef::clone == store.ref()
+            let store = blob
+                .store
+                .get()
+                .as_ref()
+                .map_or_else(|| BlobStore::init(Vec::new()), StoreRef::clone);
+            return Ok(Archive::new(State::Done(store), options));
         }
 
         // For ArrayBuffer/TypedArray, copy the data
@@ -439,8 +444,9 @@ impl Archive {
                 self.pump(global, this);
             }
             None => {
+                // The queue is drained in `AppendContext::after_settled`, once
+                // this append's own rejection has been delivered.
                 *self.state.borrow_mut() = State::Failed;
-                self.drain_queue(global);
             }
         }
     }
@@ -553,8 +559,11 @@ fn parse_archive_options(global: &JSGlobalObject, options_arg: JSValue) -> JsRes
         };
     }
 
-    options.compress_given = options_arg.get_truthy(global, "compress")?.is_some();
-    options.compress = parse_compression(global, options_arg, options.format)?;
+    // One `[[Get]]`: a getter or Proxy trap on `compress` must not be able to
+    // return different values to `compress_given` and `compress`.
+    let compress_val = options_arg.get_truthy(global, "compress")?;
+    options.compress_given = compress_val.is_some();
+    options.compress = parse_compression(global, options_arg, compress_val, options.format)?;
 
     if let Some(max_memory_val) = options_arg.get_truthy(global, "maxMemory")? {
         if !max_memory_val.is_number() {
@@ -581,9 +590,9 @@ fn parse_archive_options(global: &JSGlobalObject, options_arg: JSValue) -> JsRes
 fn parse_compression(
     global: &JSGlobalObject,
     options_arg: JSValue,
+    compress: Option<JSValue>,
     format: Format,
 ) -> JsResult<Compression> {
-    let compress = options_arg.get_truthy(global, "compress")?;
     let Some(compress_val) = compress else {
         // zip entries are deflated by default, matching every other zip writer;
         // tar is uncompressed unless asked otherwise.
@@ -1109,6 +1118,9 @@ pub trait TaskContext: Send {
     /// Runs on thread pool. Stores its result on `self`.
     fn run(&mut self);
     fn run_from_js(&mut self, global: &JSGlobalObject) -> JsResult<PromiseResult>;
+    /// Runs once this task's own promise has settled. A context that settles
+    /// *other* promises does it here, so its own rejection is observed first.
+    fn after_settled(&mut self, _global: &JSGlobalObject) {}
 }
 
 /// Generic async task that handles all the boilerplate for thread pool tasks.
@@ -1226,7 +1238,9 @@ impl<C: TaskContext> AsyncTask<C> {
                 return promise.reject(global, Ok(global.take_exception(e)));
             }
         };
-        result.fulfill(global, promise)
+        result.fulfill(global, promise)?;
+        owned.ctx.after_settled(global);
+        Ok(())
     }
 }
 
@@ -1826,6 +1840,17 @@ impl TaskContext for AppendContext {
             Ok(()) => PromiseResult::Resolve(JSValue::UNDEFINED),
             Err(err) => PromiseResult::Reject(build_error_to_js(global, err)),
         })
+    }
+
+    /// Reject the appends that were queued behind this one, now that its own
+    /// rejection has been delivered. `Promise.all()` over a list of appends
+    /// therefore reports the entry that actually failed, not the cascade.
+    fn after_settled(&mut self, global: &JSGlobalObject) {
+        if let Some(archive) = self.archive.get().as_class_ref::<Archive>() {
+            if matches!(&*archive.state.borrow(), State::Failed) {
+                archive.drain_queue(global);
+            }
+        }
     }
 }
 

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1,10 +1,23 @@
-//! `Bun.Archive` — tar/tgz pack + extract over libarchive.
+//! `Bun.Archive` — tar/tar.gz/zip pack + extract over libarchive.
+//!
+//! An archive created from an object (or from nothing) stays *open* behind a
+//! live libarchive writer until the first read of its bytes, so entries can be
+//! streamed in one at a time with [`Archive::append`]. The writer's output is
+//! buffered in memory up to `maxMemory` bytes and spills to a temporary file
+//! beyond that, which keeps peak memory bounded for archives larger than RAM.
 
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::ffi::CString;
 
+use super::archive_builder::{BuildError, Builder, FILETYPE_REGULAR, SinkOutput};
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
-use crate::webcore::blob::{Store as BlobStore, StoreRef};
+#[cfg(unix)]
+use crate::webcore::BlobStoreExt as _;
+use crate::webcore::blob::store::Data as BlobData;
+use crate::webcore::blob::{MAX_SIZE as BLOB_MAX_SIZE, Store as BlobStore, StoreRef};
+use crate::webcore::node_types::PathOrFileDescriptor;
 use bun_core::zig_string::Slice as ZigStringSlice;
 use bun_core::{self, Output, ZBox};
 use bun_event_loop::{TaskTag, Taskable, task_tag};
@@ -20,16 +33,40 @@ use bun_jsc::{StringJsc as _, SysErrorJsc as _};
 use bun_libarchive as libarchive;
 use bun_sys::{self, Fd, FdDirExt as _, FdExt as _, Mode};
 
-/// libarchive `AE_IFREG` (== `S_IFREG`). The Rust `bun_libarchive::lib` port
-/// does not yet expose `FileType`, so mirror the constant locally.
-const FILETYPE_REGULAR: u32 = 0o100000;
+/// Bytes of archive output held in memory before spilling to a temporary file.
+const DEFAULT_MAX_MEMORY: u64 = 64 * 1024 * 1024;
 
-/// Compression options for the archive
+/// Container format written by `new Archive(...)`. Reading auto-detects both.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum Format {
+    #[default]
+    Tar,
+    Zip,
+}
+
+/// How the archive's bytes are compressed.
 #[derive(Clone, Copy, Default)]
 pub(crate) enum Compression {
     #[default]
     None,
+    /// tar: gzip the finished archive (libdeflate, levels 1-12).
     Gzip(GzipOptions),
+    /// zip: per-entry deflate (zlib, levels 1-9).
+    Deflate(u8),
+    /// zip: per-entry "stored", i.e. no compression.
+    Store,
+}
+
+impl Compression {
+    /// The post-filter applied to the finished archive bytes, if any. Only tar
+    /// has one: zip compresses each entry as libarchive writes it.
+    #[inline]
+    fn gzip(self) -> Option<GzipOptions> {
+        match self {
+            Compression::Gzip(options) => Some(options),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -44,23 +81,52 @@ impl Default for GzipOptions {
     }
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct Options {
+    pub format: Format,
+    pub compress: Compression,
+    pub max_memory: u64,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            format: Format::Tar,
+            compress: Compression::None,
+            max_memory: DEFAULT_MAX_MEMORY,
+        }
+    }
+}
+
+/// An archive is either still being written to, finished (its bytes live in a
+/// `Blob.Store`), or poisoned by a failed `append()`.
+enum State {
+    /// `None` while a work-pool task owns the builder for an in-flight append.
+    Building(Option<Builder>),
+    Done(StoreRef),
+    /// An `append()` failed part-way through an entry, so the archive stream is
+    /// truncated and can never be completed.
+    Failed,
+}
+
+/// One `append()` call waiting for the in-flight one to finish. Appends are
+/// serialized because a single libarchive writer owns the output stream.
+struct PendingAppend {
+    path: ZBox,
+    source: AppendSource,
+    promise: JSPromiseStrong,
+}
+
 // Hand-written JS class glue (not the `#[bun_jsc::JsClass]` derive): Archive
 // needs a custom `finalize` and no constructor, which the proc-macro does not
 // expose.
 #[repr(C)]
 pub struct Archive {
-    /// The underlying data for the archive - uses Blob.Store for thread-safe ref counting
-    store: StoreRef,
-    /// Compression settings for this archive
-    compress: Compression,
-}
-
-impl Archive {
-    /// Borrow the backing `StoreRef`.
-    #[inline]
-    pub fn store_ref(&self) -> &StoreRef {
-        &self.store
-    }
+    state: RefCell<State>,
+    options: Options,
+    queue: RefCell<VecDeque<PendingAppend>>,
+    /// True while a work-pool task owns the builder.
+    appending: Cell<bool>,
 }
 
 // `jsc.Codegen.JSArchive` — codegen already emits `js_Archive`
@@ -80,7 +146,8 @@ impl Archive {
     pub fn finalize(self: Box<Self>) {
         jsc::mark_binding();
         drop(self);
-        // store.deref() happens via Arc<BlobStore>::drop
+        // store.deref() happens via Arc<BlobStore>::drop; an unfinished
+        // `Builder` closes and removes its spill file in `Drop`.
     }
 
     /// Pretty-print for console.log
@@ -93,30 +160,50 @@ impl Archive {
         F: bun_jsc::ConsoleFormatter,
         W: core::fmt::Write,
     {
-        let data = self.store.shared_view();
         let fmt_err = |_: core::fmt::Error| crate::Error::FormatError;
+        let size_options = bun_core::fmt::SizeFormatterOptions::default();
 
-        writeln!(
-            writer,
-            "Archive ({}) {{",
-            bun_core::fmt::size(data.len(), bun_core::fmt::SizeFormatterOptions::default()),
-        )
-        .map_err(fmt_err)?;
+        // Reading an unfinished archive would have to close its writer, so
+        // report the entries written so far instead of parsing the bytes back.
+        let (header, label, count) = match &*self.state.borrow() {
+            State::Done(store) => {
+                let data = store.shared_view();
+                (
+                    format!(
+                        "Archive ({})",
+                        bun_core::fmt::size(data.len(), size_options)
+                    ),
+                    "files",
+                    count_files_in_archive(data),
+                )
+            }
+            State::Building(builder) => (
+                // No size: libarchive holds a whole block back, so the sink's
+                // byte count says nothing useful until the archive is closed.
+                "Archive (open)".to_string(),
+                "entries",
+                builder.as_ref().map_or(0, Builder::entries),
+            ),
+            State::Failed => ("Archive (failed)".to_string(), "files", 0),
+        };
 
+        writeln!(writer, "{header} {{").map_err(fmt_err)?;
         {
             let mut formatter = formatter.indented();
             formatter.write_indent(writer).map_err(fmt_err)?;
             write!(
                 writer,
-                "{}",
-                Output::pretty_fmt::<ENABLE_ANSI_COLORS>("<r>files<d>:<r> "),
+                "{}{}{}",
+                Output::pretty_fmt::<ENABLE_ANSI_COLORS>("<r>"),
+                label,
+                Output::pretty_fmt::<ENABLE_ANSI_COLORS>("<d>:<r> "),
             )
             .map_err(fmt_err)?;
             formatter
                 .print_as::<W, ENABLE_ANSI_COLORS>(
                     jsc::FormatTag::Double,
                     writer,
-                    JSValue::js_number(f64::from(count_files_in_archive(data))),
+                    JSValue::js_number(f64::from(count)),
                     jsc::JSType::NumberObject,
                 )
                 .map_err(|_| crate::Error::JSError)?;
@@ -129,10 +216,11 @@ impl Archive {
     }
 }
 
-/// Configure archive for reading tar/tar.gz
+/// Configure archive for reading tar/tar.gz/zip
 fn configure_archive_reader(archive: &libarchive::lib::Archive) {
     let _ = archive.read_support_format_tar();
     let _ = archive.read_support_format_gnutar();
+    let _ = archive.read_support_format_zip();
     let _ = archive.read_support_filter_gzip();
     let _ = archive.read_set_options(c"read_concatenated_archives");
 }
@@ -167,118 +255,399 @@ fn count_files_in_archive(data: &[u8]) -> u32 {
 }
 
 impl Archive {
-    /// Constructor: new Archive(data, options?)
+    /// Constructor: new Archive(data?, options?)
     /// Creates an Archive from either:
     /// - An object { [path: string]: Blob | string | ArrayBufferView | ArrayBufferLike }
     /// - A Blob, ArrayBufferView, or ArrayBufferLike (assumes it's already a valid archive)
+    /// - Nothing, producing an empty archive to `append()` to
     /// Options:
-    /// - compress: "gzip" - Enable gzip compression
-    /// - level: number (1-12) - Compression level (default 6)
-    /// When no options are provided, no compression is applied
+    /// - format: "tar" | "zip" - Container format (default "tar")
+    /// - compress: "gzip" (tar) | "deflate" | "store" (zip)
+    /// - level: number - Compression level
+    /// - maxMemory: number - Bytes buffered before spilling to a temp file
     // NOTE: `#[bun_jsc::host_fn]` has no `constructor` kind yet; the
     // `JsClass` derive emits a `constructor` shim that calls this directly.
     pub fn constructor(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<Box<Archive>> {
         let [data_arg, options_arg] = callframe.arguments_as_array::<2>();
-        if data_arg.is_empty() {
-            return Err(
-                global.throw_invalid_arguments(format_args!("new Archive() requires an argument"))
-            );
-        }
+        let options = parse_archive_options(global, options_arg)?;
 
-        // Parse compression options
-        let compress = parse_compression_options(global, options_arg)?;
+        // An omitted argument opens an empty archive to append to.
+        if data_arg.is_empty() || data_arg.is_undefined() {
+            let builder = open_builder(global, options)?;
+            return Ok(Archive::new(State::Building(Some(builder)), options));
+        }
 
         // For Blob/Archive, ref the existing store (zero-copy)
         if let Some(blob) = blob_from_js(data_arg) {
             if let Some(store) = blob.store.get().as_ref() {
                 // StoreRef::clone == store.ref()
-                return Ok(Box::new(Archive {
-                    store: store.clone(),
-                    compress,
-                }));
+                return Ok(Archive::new(State::Done(store.clone()), options));
             }
         }
 
         // For ArrayBuffer/TypedArray, copy the data
         if let Some(array_buffer) = data_arg.as_array_buffer(global) {
             let data: Vec<u8> = array_buffer.slice().to_vec();
-            return Ok(create_archive(data, compress));
+            return Ok(Archive::new(State::Done(BlobStore::init(data)), options));
         }
 
-        // For plain objects, build a tarball
+        // For plain objects, open a writer and pack the object's entries into it.
         if data_arg.is_object() {
-            let data = build_tarball_from_object(global, data_arg)?;
-            return Ok(create_archive(data, compress));
+            let mut builder = open_builder(global, options)?;
+            if let Err(err) = add_object_entries(global, &mut builder, data_arg) {
+                // A JS exception from property iteration: the builder's `Drop`
+                // closes the writer and removes any spill file.
+                return Err(err);
+            }
+            return Ok(Archive::new(State::Building(Some(builder)), options));
         }
 
         Err(global.throw_invalid_arguments(format_args!(
             "Expected an object, Blob, TypedArray, or ArrayBuffer"
         )))
     }
-}
 
-/// Parse compression options from JS value
-/// Returns .none if no compression specified, caller must handle defaults
-fn parse_compression_options(
-    global: &JSGlobalObject,
-    options_arg: JSValue,
-) -> JsResult<Compression> {
-    // No options provided means no compression (caller handles defaults)
-    if options_arg.is_undefined_or_null() {
-        return Ok(Compression::None);
+    fn new(state: State, options: Options) -> Box<Archive> {
+        Box::new(Archive {
+            state: RefCell::new(state),
+            options,
+            queue: RefCell::new(VecDeque::new()),
+            appending: Cell::new(false),
+        })
     }
 
+    /// The finished archive bytes, closing the writer on first use.
+    ///
+    /// Also the entry point `Bun.write(path, archive)` reaches through
+    /// `Blob::write_file_internal`, so it must leave the `Archive` in a state
+    /// where every other read works too.
+    pub fn blob_store(&self, global: &JSGlobalObject) -> JsResult<StoreRef> {
+        let builder = {
+            let mut state = self.state.borrow_mut();
+            match &mut *state {
+                State::Done(store) => return Ok(store.clone()),
+                State::Failed => return Err(self.throw_failed(global)),
+                State::Building(slot) => {
+                    if slot.is_none() || !self.queue.borrow().is_empty() {
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "Archive.append() is still in progress: await it before reading the archive"
+                        )));
+                    }
+                    slot.take().expect("checked above")
+                }
+            }
+        };
+
+        let store = match builder.close().and_then(output_to_store) {
+            Ok(store) => store,
+            Err(err) => {
+                *self.state.borrow_mut() = State::Failed;
+                return Err(throw_build_error(global, err));
+            }
+        };
+        *self.state.borrow_mut() = State::Done(store.clone());
+        Ok(store)
+    }
+
+    fn throw_failed(&self, global: &JSGlobalObject) -> jsc::JsError {
+        global.throw_invalid_arguments(format_args!(
+            "Archive.append() failed earlier, so this archive can no longer be used"
+        ))
+    }
+
+    /// Instance method: archive.append(path, data)
+    /// Streams one more entry into an archive that is still open. Resolves when
+    /// the entry has been written; rejects (and poisons the archive) on failure.
+    #[bun_jsc::host_fn(method)]
+    pub fn append(&self, global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let [path_arg, data_arg] = callframe.arguments_as_array::<2>();
+
+        match &*self.state.borrow() {
+            State::Done(_) => {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "Archive.append() is only available before the archive is read; it cannot append to existing archive data"
+                )));
+            }
+            State::Failed => return Err(self.throw_failed(global)),
+            State::Building(_) => {}
+        }
+
+        if !path_arg.is_string() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Archive.append: first argument must be a string path"
+            )));
+        }
+        let path_slice = path_arg.to_slice(global)?;
+        if path_slice.slice().is_empty() {
+            return Err(global
+                .throw_invalid_arguments(format_args!("Archive.append: path must not be empty")));
+        }
+        let path = ZBox::from_bytes(path_slice.slice());
+        let source = parse_append_source(global, data_arg)?;
+
+        let promise = JSPromiseStrong::init(global);
+        let value = promise.value();
+        self.queue.borrow_mut().push_back(PendingAppend {
+            path,
+            source,
+            promise,
+        });
+        self.pump(global, callframe.this());
+        Ok(value)
+    }
+
+    /// Start the next queued append, if the builder is free.
+    fn pump(&self, global: &JSGlobalObject, this: JSValue) {
+        if self.appending.get() {
+            return;
+        }
+        let Some(job) = self.queue.borrow_mut().pop_front() else {
+            return;
+        };
+
+        let builder = match &mut *self.state.borrow_mut() {
+            State::Building(slot) => slot.take(),
+            State::Done(_) | State::Failed => None,
+        };
+        let Some(builder) = builder else {
+            reject_pending(global, job, "Archive is no longer writable");
+            return;
+        };
+
+        let task = AppendTask::create_with_promise(
+            global,
+            AppendContext {
+                archive: jsc::Strong::create(this, global),
+                builder: Some(builder),
+                path: job.path,
+                source: job.source,
+                mtime: now_seconds(),
+                result: Ok(()),
+            },
+            job.promise,
+        );
+        self.appending.set(true);
+        AppendTask::schedule(task);
+    }
+
+    /// Called on the JS thread once an append task finishes: take the builder
+    /// back and start the next queued entry.
+    fn finish_append(&self, global: &JSGlobalObject, this: JSValue, builder: Option<Builder>) {
+        self.appending.set(false);
+        match builder {
+            Some(builder) => {
+                *self.state.borrow_mut() = State::Building(Some(builder));
+                self.pump(global, this);
+            }
+            None => {
+                *self.state.borrow_mut() = State::Failed;
+                self.drain_queue(global);
+            }
+        }
+    }
+
+    fn drain_queue(&self, global: &JSGlobalObject) {
+        loop {
+            let Some(job) = self.queue.borrow_mut().pop_front() else {
+                return;
+            };
+            reject_pending(
+                global,
+                job,
+                "Archive.append() failed earlier, so this archive can no longer be used",
+            );
+        }
+    }
+}
+
+fn reject_pending(global: &JSGlobalObject, job: PendingAppend, message: &str) {
+    let mut promise = job.promise;
+    let error = global.create_error_instance(format_args!("{message}"));
+    let _ = promise.swap().reject(global, Ok(error));
+}
+
+/// Seconds since the epoch, for entry mtimes.
+fn now_seconds() -> i64 {
+    i64::try_from(bun_core::time::milli_timestamp() / 1000).unwrap_or(0)
+}
+
+fn open_builder(global: &JSGlobalObject, options: Options) -> JsResult<Builder> {
+    Builder::open(options).map_err(|err| throw_build_error(global, err))
+}
+
+fn throw_build_error(global: &JSGlobalObject, err: BuildError) -> jsc::JsError {
+    match err {
+        BuildError::Sys(sys_err) => global.throw_value(sys_err.to_js(global)),
+        BuildError::OutOfMemory => global.throw_value(global.create_out_of_memory_error()),
+        BuildError::EntryChangedSize => global.throw_invalid_arguments(format_args!(
+            "Archive.append: the file changed size while it was being added"
+        )),
+        BuildError::Libarchive(stage) => {
+            global.throw_invalid_arguments(format_args!("Failed to create archive: {stage}"))
+        }
+    }
+}
+
+fn build_error_to_js(global: &JSGlobalObject, err: BuildError) -> JSValue {
+    match err {
+        BuildError::Sys(sys_err) => sys_err.to_js(global),
+        BuildError::OutOfMemory => global.create_out_of_memory_error(),
+        BuildError::EntryChangedSize => global.create_error_instance(format_args!(
+            "Archive.append: the file changed size while it was being added"
+        )),
+        BuildError::Libarchive(stage) => {
+            global.create_error_instance(format_args!("Failed to create archive: {stage}"))
+        }
+    }
+}
+
+/// Turn a closed builder's output into a `Blob.Store`.
+///
+/// A spilled archive is memory-mapped copy-on-write on POSIX, so reading it
+/// back (`extract()`, `Bun.write()`, `files()`) streams from the page cache
+/// instead of allocating a second copy. Windows has no mapping helper in
+/// `bun_sys`, so it reads the file back into memory.
+fn output_to_store(output: SinkOutput) -> Result<StoreRef, BuildError> {
+    match output {
+        SinkOutput::Memory(bytes) => Ok(BlobStore::init(bytes)),
+        SinkOutput::Spilled(file) => {
+            #[cfg(unix)]
+            {
+                if file.len() == 0 {
+                    return Ok(BlobStore::init(Vec::new()));
+                }
+                let mapping = file.mmap()?;
+                // The mapping owns the pages; dropping `file` closes the
+                // descriptor of the already-unlinked temp file.
+                drop(file);
+                Ok(BlobStore::init_mmap(mapping))
+            }
+            #[cfg(not(unix))]
+            {
+                let bytes = file.read_to_vec()?;
+                Ok(BlobStore::init(bytes))
+            }
+        }
+    }
+}
+
+/// Parse `{ format, compress, level, maxMemory }`.
+fn parse_archive_options(global: &JSGlobalObject, options_arg: JSValue) -> JsResult<Options> {
+    let mut options = Options::default();
+    if options_arg.is_empty() || options_arg.is_undefined_or_null() {
+        return Ok(options);
+    }
     if !options_arg.is_object() {
         return Err(
             global.throw_invalid_arguments(format_args!("Archive: options must be an object"))
         );
     }
 
-    // Check for compress option
-    if let Some(compress_val) = options_arg.get_truthy(global, "compress")? {
-        // compress must be "gzip"
-        if !compress_val.is_string() {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Archive: compress option must be a string"
-            )));
+    if let Some(format_val) = options_arg.get_truthy(global, "format")? {
+        if !format_val.is_string() {
+            return Err(global
+                .throw_invalid_arguments(format_args!("Archive: format option must be a string")));
         }
-
-        let compress_str = compress_val.to_slice(global)?;
-        // Drop handles compress_str.deinit()
-
-        if compress_str.slice() != b"gzip" {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Archive: compress option must be \"gzip\""
-            )));
-        }
-
-        // Parse level option (1-12, default 6)
-        let mut level: u8 = 6;
-        if let Some(level_val) = options_arg.get_truthy(global, "level")? {
-            if !level_val.is_number() {
-                return Err(
-                    global.throw_invalid_arguments(format_args!("Archive: level must be a number"))
-                );
-            }
-            let level_num = level_val.to_int64();
-            if level_num < 1 || level_num > 12 {
+        let format_str = format_val.to_slice(global)?;
+        options.format = match format_str.slice() {
+            b"tar" => Format::Tar,
+            b"zip" => Format::Zip,
+            _ => {
                 return Err(global.throw_invalid_arguments(format_args!(
-                    "Archive: level must be between 1 and 12"
+                    "Archive: format must be \"tar\" or \"zip\""
                 )));
             }
-            level = u8::try_from(level_num).expect("int cast");
-        }
-
-        return Ok(Compression::Gzip(GzipOptions { level }));
+        };
     }
 
-    // No compress option specified in options object means no compression
-    Ok(Compression::None)
+    options.compress = parse_compression(global, options_arg, options.format)?;
+
+    if let Some(max_memory_val) = options_arg.get_truthy(global, "maxMemory")? {
+        if !max_memory_val.is_number() {
+            return Err(
+                global.throw_invalid_arguments(format_args!("Archive: maxMemory must be a number"))
+            );
+        }
+        let max_memory = max_memory_val.as_number();
+        if max_memory.is_nan() || max_memory < 0.0 {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Archive: maxMemory must be a non-negative number"
+            )));
+        }
+        options.max_memory = if max_memory.is_infinite() {
+            u64::MAX
+        } else {
+            max_memory as u64
+        };
+    }
+
+    Ok(options)
 }
 
-fn create_archive(data: Vec<u8>, compress: Compression) -> Box<Archive> {
-    let store = BlobStore::init(data);
-    Box::new(Archive { store, compress })
+fn parse_compression(
+    global: &JSGlobalObject,
+    options_arg: JSValue,
+    format: Format,
+) -> JsResult<Compression> {
+    let compress = options_arg.get_truthy(global, "compress")?;
+    let Some(compress_val) = compress else {
+        // zip entries are deflated by default, matching every other zip writer;
+        // tar is uncompressed unless asked otherwise.
+        return Ok(match format {
+            Format::Tar => Compression::None,
+            Format::Zip => Compression::Deflate(parse_level(global, options_arg, 1, 9, 6)?),
+        });
+    };
+    if !compress_val.is_string() {
+        return Err(global
+            .throw_invalid_arguments(format_args!("Archive: compress option must be a string")));
+    }
+    let compress_str = compress_val.to_slice(global)?;
+
+    match (format, compress_str.slice()) {
+        (Format::Tar, b"gzip") => Ok(Compression::Gzip(GzipOptions {
+            level: parse_level(global, options_arg, 1, 12, 6)?,
+        })),
+        (Format::Zip, b"deflate") => {
+            Ok(Compression::Deflate(parse_level(global, options_arg, 1, 9, 6)?))
+        }
+        (Format::Zip, b"store") => Ok(Compression::Store),
+        (Format::Tar, b"deflate" | b"store") => Err(global.throw_invalid_arguments(format_args!(
+            "Archive: compress: \"{}\" requires format: \"zip\"",
+            bstr::BStr::new(compress_str.slice()),
+        ))),
+        (Format::Zip, b"gzip") => Err(global.throw_invalid_arguments(format_args!(
+            "Archive: compress: \"gzip\" is not supported with format: \"zip\"; use \"deflate\" or \"store\""
+        ))),
+        (Format::Tar, _) => Err(global.throw_invalid_arguments(format_args!(
+            "Archive: compress option must be \"gzip\""
+        ))),
+        (Format::Zip, _) => Err(global.throw_invalid_arguments(format_args!(
+            "Archive: compress option must be \"deflate\" or \"store\""
+        ))),
+    }
+}
+
+fn parse_level(
+    global: &JSGlobalObject,
+    options_arg: JSValue,
+    min: i64,
+    max: i64,
+    default: u8,
+) -> JsResult<u8> {
+    let Some(level_val) = options_arg.get_truthy(global, "level")? else {
+        return Ok(default);
+    };
+    if !level_val.is_number() {
+        return Err(global.throw_invalid_arguments(format_args!("Archive: level must be a number")));
+    }
+    let level = level_val.to_int64();
+    if level < min || level > max {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "Archive: level must be between {min} and {max}"
+        )));
+    }
+    Ok(u8::try_from(level).expect("int cast"))
 }
 
 /// `JSValue::as_::<Blob>()` shim — kept as a free fn. Returns a shared
@@ -289,49 +658,18 @@ fn blob_from_js(value: JSValue) -> Option<&'static Blob> {
     value.as_class_ref::<Blob>()
 }
 
-/// Shared helper that builds tarball bytes from a JS object
-fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<Vec<u8>> {
-    use libarchive::lib;
-
+/// Write every `{ path: contents }` pair of a JS object into `builder`.
+fn add_object_entries(
+    global: &JSGlobalObject,
+    builder: &mut Builder,
+    obj: JSValue,
+) -> JsResult<()> {
     let Some(js_obj) = obj.get_object() else {
         return Err(global.throw_invalid_arguments(format_args!("Expected an object")));
     };
 
-    // Set up archive first
-    let mut growing_buffer = lib::GrowingBuffer::init();
-    // errdefer growing_buffer.deinit() — handled by Drop on Vec<u8>
+    let mtime = now_seconds();
 
-    let archive = lib::WriteArchive::new();
-    let archive_ref: &lib::Archive = &archive;
-
-    if archive_ref.write_set_format_pax_restricted() != lib::Result::Ok {
-        return Err(global.throw_invalid_arguments(format_args!(
-            "Failed to create tarball: ArchiveFormatError"
-        )));
-    }
-
-    // `archive` is a live `archive_write_new()` handle (see `Archive::write_new`
-    // above); `growing_buffer` is stack-local and outlives all callback invocations
-    // (the archive is closed before this fn returns).
-    let open_rc = lib::archive_write_open2(
-        &archive,
-        (&raw mut growing_buffer).cast(),
-        Some(lib::GrowingBuffer::open_callback),
-        Some(lib::GrowingBuffer::write_callback),
-        Some(lib::GrowingBuffer::close_callback),
-        None,
-    );
-    if open_rc != 0 {
-        return Err(global
-            .throw_invalid_arguments(format_args!("Failed to create tarball: ArchiveOpenError")));
-    }
-
-    let entry = lib::OwnedEntry::new();
-    let entry_ref: &lib::Entry = &entry;
-
-    let now_secs: isize = isize::try_from(bun_core::time::milli_timestamp() / 1000).unwrap_or(0);
-
-    // Iterate over object properties and write directly to archive
     let mut iter = jsc::JSPropertyIterator::init(
         global,
         js_obj,
@@ -348,68 +686,24 @@ fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<
             continue;
         }
 
-        // Get the key as a null-terminated string
         let key_slice = key.to_utf8();
-        let key_str = ZBox::from_vec_with_nul(key_slice.slice().to_vec());
-        // defer free(key_str)/key_slice.deinit() — handled by Drop
+        let path = ZBox::from_bytes(key_slice.slice());
 
-        // Get data - use view for Blob/ArrayBuffer, convert for strings
+        // Use a view for Blob/ArrayBuffer, convert for strings.
         let data_slice = get_entry_data(global, value)?;
-        // defer data_slice.deinit() — handled by Drop
 
-        // Write entry to archive
-        let data = data_slice.slice();
-        let _ = entry_ref.clear();
-        // Same platform split as `pack_command::add_archive_entry`: the process
-        // locale is always "C", so libarchive's locale-keyed pax writer is only
-        // lossless with raw bytes on POSIX and with the UTF-8 form on Windows.
-        #[cfg(windows)]
-        entry_ref.set_pathname_utf8(key_str.as_zstr());
-        #[cfg(not(windows))]
-        entry_ref.set_pathname(key_str.as_zstr());
-        entry_ref.set_size(i64::try_from(data.len()).expect("int cast"));
-        entry_ref.set_filetype(FILETYPE_REGULAR);
-        entry_ref.set_perm(0o644);
-        entry_ref.set_mtime(now_secs, 0);
-
-        // `Warn` means the header was still written (libarchive fell back to a
-        // per-entry binary hdrcharset for a name its locale machinery could not
-        // convert); only `Failed`/`Fatal` mean no header was produced.
-        if !archive_ref.write_header(entry_ref).succeeded() {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Failed to create tarball: ArchiveHeaderError"
-            )));
-        }
-        if archive_ref.write_data(data) < 0 {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Failed to create tarball: ArchiveWriteError"
-            )));
-        }
-        if archive_ref.write_finish_entry() != lib::Result::Ok {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Failed to create tarball: ArchiveFinishEntryError"
-            )));
-        }
+        builder
+            .add_bytes(&path, data_slice.slice(), mtime)
+            .map_err(|err| throw_build_error(global, err))?;
     }
 
-    if archive_ref.write_close() != lib::Result::Ok {
-        return Err(global
-            .throw_invalid_arguments(format_args!("Failed to create tarball: ArchiveCloseError")));
-    }
-
-    match growing_buffer.to_owned_slice() {
-        Ok(v) => Ok(v),
-        Err(_) => {
-            Err(global
-                .throw_invalid_arguments(format_args!("Failed to create tarball: OutOfMemory")))
-        }
-    }
+    Ok(())
 }
 
 /// Returns data as a ZigString.Slice (handles ownership automatically via deinit)
 fn get_entry_data(global: &JSGlobalObject, value: JSValue) -> JsResult<ZigStringSlice> {
     // For Blob, use sharedView (no copy needed). The backing store outlives
-    // the returned slice for the duration of the caller's tarball build.
+    // the returned slice for the duration of the caller's archive build.
     if let Some(blob) = blob_from_js(value) {
         return Ok(ZigStringSlice::from_utf8_never_free(blob.shared_view()));
     }
@@ -423,11 +717,87 @@ fn get_entry_data(global: &JSGlobalObject, value: JSValue) -> JsResult<ZigString
     value.to_slice(global)
 }
 
+/// Where one `append()`ed entry's bytes come from. Every variant is `Send`: the
+/// bytes are copied, the `Blob.Store` is atomically refcounted, or the data is
+/// streamed from a path on the work-pool thread.
+pub(crate) enum AppendSource {
+    Bytes(Vec<u8>),
+    /// An in-memory Blob: hold a ref instead of copying.
+    Store {
+        store: StoreRef,
+        offset: usize,
+        len: usize,
+    },
+    /// A `Bun.file()`: streamed from disk a chunk at a time.
+    File {
+        path: ZBox,
+        offset: u64,
+        len: Option<u64>,
+    },
+}
+
+fn parse_append_source(global: &JSGlobalObject, value: JSValue) -> JsResult<AppendSource> {
+    if value.is_empty() {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "Archive.append requires 2 arguments (path, data)"
+        )));
+    }
+
+    if value.is_string() {
+        let slice = value.to_slice(global)?;
+        return Ok(AppendSource::Bytes(slice.slice().to_vec()));
+    }
+
+    if let Some(blob) = blob_from_js(value) {
+        let Some(store) = blob.store.get().as_ref().cloned() else {
+            return Ok(AppendSource::Bytes(Vec::new()));
+        };
+        match &store.data {
+            BlobData::Bytes(_) => {
+                let view = store.shared_view();
+                let offset = usize::try_from(blob.offset.get())
+                    .unwrap_or(usize::MAX)
+                    .min(view.len());
+                let len = usize::try_from(blob.size.get())
+                    .unwrap_or(usize::MAX)
+                    .min(view.len() - offset);
+                return Ok(AppendSource::Store { store, offset, len });
+            }
+            BlobData::File(file) => match &file.pathlike {
+                PathOrFileDescriptor::Path(path) => {
+                    let declared = blob.size.get();
+                    return Ok(AppendSource::File {
+                        path: ZBox::from_bytes(path.slice()),
+                        offset: blob.offset.get(),
+                        len: (declared < BLOB_MAX_SIZE).then_some(declared),
+                    });
+                }
+                PathOrFileDescriptor::Fd(_) => {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "Archive.append: file descriptor-backed files are not supported; read the bytes first"
+                    )));
+                }
+            },
+            BlobData::S3(_) => {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "Archive.append: S3 files are not supported; await file.bytes() first"
+                )));
+            }
+        }
+    }
+
+    if let Some(array_buffer) = value.as_array_buffer(global) {
+        return Ok(AppendSource::Bytes(array_buffer.slice().to_vec()));
+    }
+
+    Err(global.throw_invalid_arguments(format_args!(
+        "Archive.append: expected a string, Blob, TypedArray, or ArrayBuffer"
+    )))
+}
+
 /// Static method: Archive.write(path, data, options?)
 /// Creates and writes an archive to disk in one operation.
 /// For Archive instances, uses the archive's compression settings unless overridden by options.
-/// Options:
-///   - gzip: { level?: number } - Override compression settings
 #[bun_jsc::host_fn]
 pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
     let [path_arg, data_arg, options_arg] = callframe.arguments_as_array::<3>();
@@ -446,21 +816,16 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
 
     let path_slice = path_arg.to_slice(global)?;
 
-    // Parse options for compression override
-    let options_compress = parse_compression_options(global, options_arg)?;
+    let options = parse_archive_options(global, options_arg)?;
 
     // For Archive instances, use options override or archive's compression settings
     if let Some(archive) = data_arg.as_class_ref::<Archive>() {
-        let compress = if !matches!(options_compress, Compression::None) {
-            options_compress
-        } else {
-            archive.compress
-        };
+        let gzip = options.compress.gzip().or(archive.options.compress.gzip());
         return start_write_task(
             global,
-            WriteData::Store(archive.store.clone()),
+            WriteData::Store(archive.blob_store(global)?),
             path_slice.slice(),
-            compress,
+            gzip,
         );
     }
 
@@ -471,7 +836,7 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
                 global,
                 WriteData::Store(store.clone()),
                 path_slice.slice(),
-                options_compress,
+                options.compress.gzip(),
             );
         }
     }
@@ -483,18 +848,23 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
             global,
             WriteData::Owned(data),
             path_slice.slice(),
-            options_compress,
+            options.compress.gzip(),
         );
     }
 
-    // For plain objects, build a tarball with options compression
+    // For plain objects, pack them and write the result
     if data_arg.is_object() {
-        let data = build_tarball_from_object(global, data_arg)?;
+        let mut builder = open_builder(global, options)?;
+        add_object_entries(global, &mut builder, data_arg)?;
+        let store = builder
+            .close()
+            .and_then(output_to_store)
+            .map_err(|err| throw_build_error(global, err))?;
         return start_write_task(
             global,
-            WriteData::Owned(data),
+            WriteData::Store(store),
             path_slice.slice(),
-            options_compress,
+            options.compress.gzip(),
         );
     }
 
@@ -537,7 +907,8 @@ impl Archive {
             }
         }
 
-        start_extract_task(global, &self.store, path_slice.slice(), glob_patterns)
+        let store = self.blob_store(global)?;
+        start_extract_task(global, &store, path_slice.slice(), glob_patterns)
     }
 }
 
@@ -617,14 +988,26 @@ impl Archive {
     /// Returns Promise<Blob> with the archive data (compressed if gzip was set in options)
     #[bun_jsc::host_fn(method)]
     pub fn blob(&self, global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-        start_blob_task(global, &self.store, self.compress, BlobOutputType::Blob)
+        let store = self.blob_store(global)?;
+        start_blob_task(
+            global,
+            &store,
+            self.options.compress.gzip(),
+            BlobOutputType::Blob,
+        )
     }
 
     /// Instance method: archive.bytes()
     /// Returns Promise<Uint8Array> with the archive data (compressed if gzip was set in options)
     #[bun_jsc::host_fn(method)]
     pub fn bytes(&self, global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-        start_blob_task(global, &self.store, self.compress, BlobOutputType::Bytes)
+        let store = self.blob_store(global)?;
+        start_blob_task(
+            global,
+            &store,
+            self.options.compress.gzip(),
+            BlobOutputType::Bytes,
+        )
     }
 
     /// Instance method: archive.files(glob?)
@@ -640,7 +1023,8 @@ impl Archive {
             glob_patterns = parse_pattern_arg(global, glob_arg, b"Archive.files", b"glob")?;
         }
 
-        start_files_task(global, &self.store, glob_patterns)
+        let store = self.blob_store(global)?;
+        start_files_task(global, &store, glob_patterns)
     }
 }
 
@@ -693,7 +1077,16 @@ impl<C: TaskContext> Taskable for AsyncTask<C> {
 }
 
 impl<C: TaskContext> AsyncTask<C> {
+    #[inline]
     fn create(global: &JSGlobalObject, ctx: C) -> Result<*mut Self, bun_alloc::AllocError> {
+        Ok(Self::create_with_promise(
+            global,
+            ctx,
+            JSPromiseStrong::init(global),
+        ))
+    }
+
+    fn create_with_promise(global: &JSGlobalObject, ctx: C, promise: JSPromiseStrong) -> *mut Self {
         // `bun_vm_ptr()` returns `*mut VirtualMachine` with write provenance; valid for
         // process lifetime. Do NOT launder `bun_vm()` (a `&VirtualMachine`) through
         // `*const _ as *mut _` — that derives a writeable pointer from a shared
@@ -701,7 +1094,7 @@ impl<C: TaskContext> AsyncTask<C> {
         let vm: *mut VirtualMachine = global.bun_vm_ptr();
         let this = Box::new(AsyncTask {
             ctx,
-            promise: JSPromiseStrong::init(global),
+            promise,
             vm,
             task: WorkPoolTask {
                 callback: Self::run_callback,
@@ -714,7 +1107,7 @@ impl<C: TaskContext> AsyncTask<C> {
         // SAFETY: raw was just produced by heap::alloc; not yet shared. Keep the event
         // loop alive until `run_from_js` unrefs after the threadpool work completes.
         unsafe { (*raw).keep_alive.ref_(bun_io::js_vm_ctx()) };
-        Ok(raw)
+        raw
     }
 
     fn schedule(this: *mut Self) {
@@ -855,6 +1248,7 @@ impl ExtractContext {
                 close_handles: true,
                 log: false,
                 npm: false,
+                zip: true,
             },
         ) {
             Ok(c) => c,
@@ -915,7 +1309,7 @@ enum BlobResult {
 
 pub struct BlobContext {
     store: StoreRef,
-    compress: Compression,
+    gzip: Option<GzipOptions>,
     output_type: BlobOutputType,
     result: BlobResult,
 }
@@ -924,12 +1318,12 @@ impl TaskContext for BlobContext {
     const TAG: TaskTag = task_tag::ArchiveBlobTask;
 
     fn run(&mut self) {
-        self.result = match &self.compress {
-            Compression::Gzip(opts) => match compress_gzip(self.store.shared_view(), opts.level) {
+        self.result = match &self.gzip {
+            Some(opts) => match compress_gzip(self.store.shared_view(), opts.level) {
                 Ok(data) => BlobResult::Compressed(data),
                 Err(e) => BlobResult::Err(e.into()),
             },
-            Compression::None => BlobResult::Uncompressed,
+            None => BlobResult::Uncompressed,
         };
     }
 
@@ -985,7 +1379,7 @@ pub type BlobTask = AsyncTask<BlobContext>;
 fn start_blob_task(
     global: &JSGlobalObject,
     store: &StoreRef,
-    compress: Compression,
+    gzip: Option<GzipOptions>,
     output_type: BlobOutputType,
 ) -> JsResult<JSValue> {
     let store = store.clone();
@@ -995,7 +1389,7 @@ fn start_blob_task(
         global,
         BlobContext {
             store,
-            compress,
+            gzip,
             output_type,
             result: BlobResult::Uncompressed,
         },
@@ -1028,7 +1422,7 @@ enum WriteData {
 pub struct WriteContext {
     data: WriteData,
     path: ZBox,
-    compress: Compression,
+    gzip: Option<GzipOptions>,
     result: WriteResult,
 }
 
@@ -1057,17 +1451,17 @@ impl WriteContext {
             WriteData::Store(s) => s.shared_view(),
         };
         let compressed_buf;
-        let data_to_write: &[u8] = match &self.compress {
-            Compression::Gzip(opts) => {
+        let data_to_write: &[u8] = match &self.gzip {
+            Some(opts) => {
                 compressed_buf = match compress_gzip(source_data, opts.level) {
                     Ok(v) => v,
                     Err(e) => return WriteResult::Err(e.into()),
                 };
                 &compressed_buf
             }
-            Compression::None => source_data,
+            None => source_data,
         };
-        // `defer if (compress != .none) free(data_to_write)` — handled by `compressed_buf: Vec<u8>` Drop.
+        // `defer if (gzip) free(data_to_write)` — handled by `compressed_buf: Vec<u8>` Drop.
 
         let file = match bun_sys::File::openat(
             Fd::cwd(),
@@ -1092,9 +1486,9 @@ fn start_write_task(
     global: &JSGlobalObject,
     data: WriteData,
     path: &[u8],
-    compress: Compression,
+    gzip: Option<GzipOptions>,
 ) -> JsResult<JSValue> {
-    let path_z = ZBox::from_vec_with_nul(path.to_vec());
+    let path_z = ZBox::from_bytes(path);
 
     // Ref store if using store reference — already done by caller via Arc::clone into WriteData::Store.
     // errdefer store.deref / free(data.owned) — handled by WriteData Drop on early return.
@@ -1104,7 +1498,7 @@ fn start_write_task(
         WriteContext {
             data,
             path: path_z,
-            compress,
+            gzip,
             result: WriteResult::Success,
         },
     )?;
@@ -1314,6 +1708,79 @@ fn start_files_task(
     FilesTask::schedule(task);
     Ok(promise_js)
 }
+
+// ============================================================================
+// Append task
+// ============================================================================
+
+pub struct AppendContext {
+    /// Roots the owning `Archive` JS object so its payload outlives the task.
+    /// Only touched on the JS thread (`run_from_js`).
+    archive: jsc::Strong,
+    /// Moved out of the `Archive` for the duration of the task and handed back
+    /// in `run_from_js`. `None` once handed back.
+    builder: Option<Builder>,
+    path: ZBox,
+    source: AppendSource,
+    mtime: i64,
+    result: Result<(), BuildError>,
+}
+
+// SAFETY: `archive` is a JSC handle that is created, read and dropped only on
+// the JS thread; `run` (the work-pool half) never touches it. Everything else
+// in the context is `Send`.
+unsafe impl Send for AppendContext {}
+
+impl TaskContext for AppendContext {
+    const TAG: TaskTag = task_tag::ArchiveAppendTask;
+
+    fn run(&mut self) {
+        let AppendContext {
+            builder,
+            path,
+            source,
+            mtime,
+            result,
+            ..
+        } = self;
+        let Some(builder) = builder.as_mut() else {
+            return;
+        };
+        *result = match source {
+            AppendSource::Bytes(data) => builder.add_bytes(path, data, *mtime),
+            AppendSource::Store { store, offset, len } => {
+                let view = store.shared_view();
+                let offset = (*offset).min(view.len());
+                let end = offset.saturating_add(*len).min(view.len());
+                builder.add_bytes(path, &view[offset..end], *mtime)
+            }
+            AppendSource::File {
+                path: source_path,
+                offset,
+                len,
+            } => builder.add_file(path, source_path, *offset, *len, *mtime),
+        };
+    }
+
+    fn run_from_js(&mut self, global: &JSGlobalObject) -> JsResult<PromiseResult> {
+        let failed = self.result.is_err();
+        // A failed entry leaves a truncated stream behind: drop the builder so
+        // the archive can never be completed.
+        let builder = if failed { None } else { self.builder.take() };
+
+        let this = self.archive.get();
+        if let Some(archive) = this.as_class_ref::<Archive>() {
+            archive.finish_append(global, this, builder);
+        }
+
+        Ok(match core::mem::replace(&mut self.result, Ok(())) {
+            Ok(()) => PromiseResult::Resolve(JSValue::UNDEFINED),
+            Err(err) => PromiseResult::Reject(build_error_to_js(global, err)),
+        })
+    }
+}
+
+pub type AppendTask = AsyncTask<AppendContext>;
 
 // ============================================================================
 // Helpers

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -459,6 +459,13 @@ impl Archive {
                 global.throw_invalid_arguments(format_args!("Archive.stream() was already called"))
             );
         }
+        // gzip is a post-filter over the finished bytes, and nothing post-filters
+        // what goes to the stream. Say so rather than emit a raw tar.
+        if self.options.compress.gzip().is_some() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Archive.stream() does not support compress: \"gzip\"; use format: \"zip\", or read the archive with bytes()"
+            )));
+        }
 
         // Ownership of the heap-allocated source transfers to the JS wrapper in
         // `to_readable_stream`; the wrapper's finalizer reclaims it.
@@ -570,6 +577,37 @@ impl Archive {
         // SAFETY: the `StreamOut`'s `_held` roots the JS wrapper that owns the
         // source this points into, and it is still held (we just read it).
         unsafe { &*source }.on_data(chunk)
+    }
+
+    /// Fail the stream's consumer, so a read that is waiting on bytes which will
+    /// never come rejects instead of hanging.
+    fn error_stream(
+        &self,
+        global: &JSGlobalObject,
+        error: JSValue,
+    ) -> Result<(), jsc::JsTerminated> {
+        let Some((source, cancelled)) = self
+            .stream
+            .borrow()
+            .as_ref()
+            .map(|out| (out.bytes, out.cancelled))
+        else {
+            return Ok(());
+        };
+        if cancelled {
+            return Ok(());
+        }
+        let err = streams::StreamError::JSValue(jsc::strong::Optional::create(error, global));
+        // SAFETY: see `push_to_stream`.
+        unsafe { &*source }.on_data(streams::Result::Err(err))
+    }
+
+    /// Whether the consumer has walked away.
+    fn stream_cancelled(&self) -> bool {
+        self.stream
+            .borrow()
+            .as_ref()
+            .is_some_and(|out| out.cancelled)
     }
 
     /// Whether the consumer is far enough behind to park the next chunk.
@@ -2220,6 +2258,12 @@ impl TaskContext for AppendContext {
             return Ok(Step::Settle(PromiseResult::Resolve(JSValue::UNDEFINED)));
         };
 
+        // The consumer walked away while we were on the work pool: stop now
+        // rather than write out chunks nobody will read.
+        if self.chunked && self.result.is_ok() && archive.stream_cancelled() {
+            self.cancel();
+        }
+
         // Hand whatever the writer produced to the consumer before deciding
         // whether there is room for more.
         if self.chunked && self.result.is_ok() {
@@ -2232,7 +2276,15 @@ impl TaskContext for AppendContext {
         }
 
         if self.result.is_err() || self.done {
-            return Ok(Step::Settle(self.run_from_js(global)?));
+            let settled = self.run_from_js(global)?;
+            // A failed append leaves the consumer waiting on bytes that will
+            // never come. Fail its read instead of hanging it.
+            if let PromiseResult::Reject(error) = settled {
+                if archive.is_streaming() {
+                    archive.error_stream(global, error)?;
+                }
+            }
+            return Ok(Step::Settle(settled));
         }
 
         if archive.stream_is_backed_up() {

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -282,17 +282,13 @@ impl Archive {
             return Ok(Archive::new(State::Building(Some(builder)), options));
         }
 
-        // For a Blob, ref the existing store (zero-copy). An empty Blob has no
-        // store at all, and is still archive data: it must not fall through to
-        // the object form below and be packed as an empty object literal.
+        // A Blob is archive data, even when it has no store at all: it must not
+        // fall through to the object form below and be packed as an empty object.
         if let Some(blob) = blob_from_js(data_arg) {
-            // StoreRef::clone == store.ref()
-            let store = blob
-                .store
-                .get()
-                .as_ref()
-                .map_or_else(|| BlobStore::init(Vec::new()), StoreRef::clone);
-            return Ok(Archive::new(State::Done(store), options));
+            return Ok(Archive::new(
+                State::Done(archive_store_from_blob(blob)),
+                options,
+            ));
         }
 
         // For ArrayBuffer/TypedArray, copy the data
@@ -653,6 +649,28 @@ fn parse_level(
     Ok(u8::try_from(level).expect("int cast"))
 }
 
+/// The archive bytes a Blob stands for.
+///
+/// Sharing the store is zero-copy, but it is only the same bytes when the Blob
+/// spans its whole store: `blob.slice(0, 512)` sees a window of it, and the
+/// window is what the archive is made of.
+fn archive_store_from_blob(blob: &Blob) -> StoreRef {
+    let Some(store) = blob.store.get().as_ref().cloned() else {
+        return BlobStore::init(Vec::new());
+    };
+    // File- and S3-backed stores have no bytes to window into; they are passed
+    // through as-is, the way `Bun.write()` consumes them.
+    if !matches!(store.data, BlobData::Bytes(_)) {
+        return store;
+    }
+    let view = blob.shared_view();
+    if view.len() == store.shared_view().len() {
+        // StoreRef::clone == store.ref()
+        return store;
+    }
+    BlobStore::init(view.to_vec())
+}
+
 /// `JSValue::as_::<Blob>()` shim — kept as a free fn. Returns a shared
 /// borrow (BACKREF: m_ctx payload kept live by the JSC cell rooted by `value`
 /// on the caller's stack) so callers don't open-code `unsafe { &*ptr }`.
@@ -889,14 +907,12 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
 
     // For Blobs, use store reference with options compression
     if let Some(blob) = blob_from_js(data_arg) {
-        if let Some(store) = blob.store.get().as_ref() {
-            return start_write_task(
-                global,
-                WriteData::Store(store.clone()),
-                path_slice.slice(),
-                options.compress.gzip(),
-            );
-        }
+        return start_write_task(
+            global,
+            WriteData::Store(archive_store_from_blob(blob)),
+            path_slice.slice(),
+            options.compress.gzip(),
+        );
     }
 
     // For ArrayBuffer/TypedArray, copy the data with options compression

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -143,7 +143,7 @@ impl Archive {
         jsc::mark_binding();
         drop(self);
         // store.deref() happens via Arc<BlobStore>::drop; an unfinished
-        // `Builder` closes and removes its spill file in `Drop`.
+        // `Builder` poisons and frees its libarchive writer in `Drop`.
     }
 
     /// Pretty-print for console.log
@@ -291,7 +291,7 @@ impl Archive {
         if data_arg.is_object() {
             let mut builder = open_builder(global, options)?;
             // On a JS exception from property iteration the builder's `Drop`
-            // closes the writer and removes any spill file.
+            // poisons the writer, so no partial output is flushed.
             add_object_entries(global, &mut builder, data_arg)?;
             return Ok(Archive::new(State::Building(Some(builder)), options));
         }

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -362,6 +362,12 @@ impl Archive {
                 State::Streamed => return Err(self.throw_streamed(global)),
                 State::Failed => return Err(self.throw_failed(global)),
                 State::Building(slot) => {
+                    // stream() owns the output. Closing the builder here would
+                    // hand these bytes to the caller and leave the consumer
+                    // waiting on an end-of-stream that never arrives.
+                    if self.is_streaming() {
+                        return Err(self.throw_streamed(global));
+                    }
                     if slot.is_none() || !self.queue.borrow().is_empty() {
                         return Err(global.throw_invalid_arguments(format_args!(
                             "Archive.append() is still in progress: await it before reading the archive"
@@ -391,7 +397,7 @@ impl Archive {
 
     fn throw_streamed(&self, global: &JSGlobalObject) -> jsc::JsError {
         global.throw_invalid_arguments(format_args!(
-            "Archive.stream() consumed this archive's bytes; there is nothing left to read"
+            "Archive.stream() owns this archive's bytes; there is nothing left to read"
         ))
     }
 
@@ -620,7 +626,14 @@ impl Archive {
             return false;
         }
         // SAFETY: see `push_to_stream`.
-        unsafe { &*out.bytes }.buffer.get().len() >= STREAM_HIGH_WATER_MARK
+        let bytes = unsafe { &*out.bytes };
+        // A `buffer_action` consumer (`new Response(stream).bytes()`) accumulates
+        // into `buffer` and never drains it, so parking against its length would
+        // park forever: only the push this task would make can unpark it.
+        if bytes.buffer_action.get().is_some() {
+            return false;
+        }
+        bytes.buffer.get().len() >= STREAM_HIGH_WATER_MARK
     }
 
     fn park_append(&self, task: *mut AppendTask) {

--- a/src/runtime/api/archive_builder.rs
+++ b/src/runtime/api/archive_builder.rs
@@ -1,12 +1,11 @@
-//! The incremental side of `Bun.Archive`: a live libarchive writer whose
-//! output spills from memory to a temporary file once it grows past
-//! `maxMemory`, plus the entry sources `Archive.append()` can stream from.
+//! The incremental side of `Bun.Archive`: a live libarchive writer whose output
+//! accumulates in a [`Sink`], plus the entry sources `Archive.append()` can
+//! stream from.
 
 use core::ffi::{c_int, c_void};
 
 use bun_core::ZBox;
 use bun_libarchive::lib;
-use bun_resolver::fs::{FileSystem, RealFS};
 use bun_sys;
 
 use super::archive::{Compression, Format, Options};
@@ -30,7 +29,7 @@ const STREAM_CHUNK_SIZE: usize = 256 * 1024;
 pub(crate) enum BuildError {
     /// A libarchive call failed; the payload is the stage that failed.
     Libarchive(&'static str),
-    /// An I/O error while spilling output, or while reading a file entry.
+    /// An I/O error while reading a file entry.
     Sys(bun_sys::Error),
     OutOfMemory,
     /// A file shrank between `stat` and the end of the copy loop, so fewer
@@ -45,185 +44,32 @@ impl From<bun_sys::Error> for BuildError {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Spill sink
+// Sink
 // ──────────────────────────────────────────────────────────────────────────
 
-/// The temporary file an oversized archive spills into.
-///
-/// On POSIX the file is unlinked the instant it is created, so a crash can
-/// never leave it behind and nothing has to clean it up; the open descriptor
-/// keeps the inode alive. Windows cannot unlink an open file, so the path is
-/// kept and removed once the descriptor closes.
-pub(crate) struct SpillFile {
-    file: Option<bun_sys::File>,
-    path: ZBox,
-    len: u64,
-}
-
-impl SpillFile {
-    fn create() -> Result<SpillFile, bun_sys::Error> {
-        // `PathBuffer` is ~96 KB on Windows, so take it from the pool rather
-        // than the stack.
-        let mut name_buf = bun_paths::path_buffer_pool::get();
-        let name = FileSystem::tmpname(b"bun-archive", &mut name_buf[..], bun_core::fast_random())
-            .map_err(|_| bun_sys::Error::new(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open))?;
-        let joined = bun_paths::resolve_path::join_abs_string_z::<bun_paths::platform::Auto>(
-            RealFS::platform_temp_dir(),
-            &[name.as_bytes()],
-        );
-        #[allow(unused_mut)]
-        let mut path = ZBox::from_bytes(joined.as_bytes());
-        let file = bun_sys::File::open(
-            path.as_zstr(),
-            bun_sys::O::CREAT | bun_sys::O::EXCL | bun_sys::O::RDWR | bun_sys::O::CLOEXEC,
-            0o600,
-        )?;
-
-        // POSIX: drop the name now so a crash cannot leave the file behind. The
-        // open descriptor keeps the inode alive. If the unlink fails, keep the
-        // path so `Drop` removes it instead.
-        #[cfg(unix)]
-        if bun_sys::unlink(path.as_zstr()).is_ok() {
-            path = ZBox::from_bytes(b"");
-        }
-
-        Ok(SpillFile {
-            file: Some(file),
-            path,
-            len: 0,
-        })
-    }
-
-    fn write(&mut self, data: &[u8]) -> Result<(), bun_sys::Error> {
-        let Some(file) = &self.file else {
-            return Err(bun_sys::Error::new(bun_sys::E::EBADF, bun_sys::Tag::write));
-        };
-        file.write_all(data)?;
-        self.len += data.len() as u64;
-        Ok(())
-    }
-
-    #[cfg(unix)]
-    #[inline]
-    pub(crate) fn len(&self) -> u64 {
-        self.len
-    }
-
-    /// Read the whole spill file back into memory. Only needed on platforms
-    /// without a `bun_sys` file-mapping helper.
-    #[cfg(not(unix))]
-    pub(crate) fn read_to_vec(&self) -> Result<Vec<u8>, bun_sys::Error> {
-        let Some(file) = &self.file else {
-            return Err(bun_sys::Error::new(bun_sys::E::EBADF, bun_sys::Tag::read));
-        };
-        bun_sys::set_file_offset(file.fd(), 0)?;
-        let len = usize::try_from(self.len).unwrap_or(usize::MAX);
-        let mut out: Vec<u8> = Vec::new();
-        out.try_reserve_exact(len)
-            .map_err(|_| bun_sys::Error::new(bun_sys::E::ENOMEM, bun_sys::Tag::read))?;
-        out.resize(len, 0);
-        let mut read = 0usize;
-        while read < len {
-            let n = file.read_all(&mut out[read..])?;
-            if n == 0 {
-                break;
-            }
-            read += n;
-        }
-        out.truncate(read);
-        Ok(out)
-    }
-
-    /// Map the spill file copy-on-write. The caller owns the mapping and must
-    /// release it with `munmap` (`Blob.Store::init_mmap` wires that up).
-    #[cfg(unix)]
-    pub(crate) fn mmap(&self) -> Result<&'static mut [u8], bun_sys::Error> {
-        let Some(file) = &self.file else {
-            return Err(bun_sys::Error::new(bun_sys::E::EBADF, bun_sys::Tag::mmap));
-        };
-        let len = usize::try_from(self.len)
-            .map_err(|_| bun_sys::Error::new(bun_sys::E::EINVAL, bun_sys::Tag::mmap))?;
-        let ptr = bun_sys::mmap(
-            core::ptr::null_mut(),
-            len,
-            libc::PROT_READ | libc::PROT_WRITE,
-            libc::MAP_PRIVATE,
-            file.fd(),
-            0,
-        )?;
-        // SAFETY: `mmap` returned a mapping of exactly `len` readable bytes.
-        Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
-    }
-
-    /// Close the descriptor and remove the backing file. A no-op for the path
-    /// on POSIX, where it was unlinked at creation.
-    fn discard(&mut self) {
-        drop(self.file.take());
-        if !self.path.is_empty() {
-            let _ = bun_sys::unlink(self.path.as_zstr());
-            self.path = ZBox::from_bytes(b"");
-        }
-    }
-}
-
-impl Drop for SpillFile {
-    fn drop(&mut self) {
-        self.discard();
-    }
-}
-
-/// What a finished [`Builder`] produced.
-pub(crate) enum SinkOutput {
-    Memory(Vec<u8>),
-    Spilled(SpillFile),
-}
-
-/// libarchive's write sink: buffers in memory until the archive would exceed
-/// `max_memory` bytes, then streams everything to a [`SpillFile`].
-pub(crate) struct SpillSink {
-    max_memory: u64,
+/// Where libarchive's output goes. Bytes accumulate here until the owning
+/// `Archive` takes them, either all at once when the archive is read, or a
+/// chunk at a time when it is being streamed.
+pub(crate) struct Sink {
     buf: Vec<u8>,
-    spill: Option<SpillFile>,
     /// Set by the write callback, which can only report failure as `-1`.
     error: Option<BuildError>,
 }
 
-impl SpillSink {
-    fn new(max_memory: u64) -> SpillSink {
-        SpillSink {
-            max_memory,
+impl Sink {
+    fn new() -> Sink {
+        Sink {
             buf: Vec::new(),
-            spill: None,
             error: None,
         }
     }
 
     fn push(&mut self, data: &[u8]) -> Result<(), BuildError> {
-        if let Some(spill) = &mut self.spill {
-            spill.write(data)?;
-            return Ok(());
-        }
-        if self.buf.len() as u64 + data.len() as u64 > self.max_memory {
-            let mut spill = SpillFile::create()?;
-            spill.write(&self.buf)?;
-            // Release the buffer's capacity, not just its length.
-            self.buf = Vec::new();
-            spill.write(data)?;
-            self.spill = Some(spill);
-            return Ok(());
-        }
         self.buf
             .try_reserve(data.len())
             .map_err(|_| BuildError::OutOfMemory)?;
         self.buf.extend_from_slice(data);
         Ok(())
-    }
-
-    fn take_output(&mut self) -> SinkOutput {
-        match self.spill.take() {
-            Some(file) => SinkOutput::Spilled(file),
-            None => SinkOutput::Memory(core::mem::take(&mut self.buf)),
-        }
     }
 
     unsafe extern "C" fn open_callback(_a: *mut lib::Archive, _client_data: *mut c_void) -> c_int {
@@ -236,9 +82,9 @@ impl SpillSink {
         buff: *const c_void,
         length: usize,
     ) -> lib::la_ssize_t {
-        // SAFETY: `client_data` is the `*mut SpillSink` registered with
+        // SAFETY: `client_data` is the `*mut Sink` registered with
         // `archive_write_open2`; libarchive never calls back concurrently.
-        let this = unsafe { bun_core::callback_ctx::<SpillSink>(client_data) };
+        let this = unsafe { bun_core::callback_ctx::<Sink>(client_data) };
         if buff.is_null() || length == 0 {
             return 0;
         }
@@ -271,9 +117,9 @@ pub(crate) struct Builder {
     /// `Option` only so `Drop` can free the archive (which flushes through the
     /// write callback) before the sink it writes into is destroyed.
     archive: Option<lib::WriteArchive>,
-    /// Heap-owned `SpillSink`; this pointer is what libarchive hands back to
-    /// the write callback. Destroyed by `Drop`, after `archive`.
-    sink: *mut SpillSink,
+    /// Heap-owned `Sink`; this pointer is what libarchive hands back to the
+    /// write callback. Destroyed by `Drop`, after `archive`.
+    sink: *mut Sink,
     entry: lib::OwnedEntry,
     entries: u32,
     closed: bool,
@@ -292,8 +138,8 @@ impl Drop for Builder {
                 // Without poisoning it, `archive_write_free` runs a normal close,
                 // and closing while an entry is half-written makes tar pad that
                 // entry out to its declared size: a failed `append()` of a 600 MB
-                // file would write 600 MB of NULs into the sink (spilling them to
-                // a temp file) before the promise settles.
+                // file would write 600 MB of NULs into the sink before the
+                // promise settles.
                 archive.write_fail();
             }
         }
@@ -308,7 +154,7 @@ impl Drop for Builder {
 
 impl Builder {
     pub(crate) fn open(options: Options) -> Result<Builder, BuildError> {
-        let sink = bun_core::heap::into_raw(Box::new(SpillSink::new(options.max_memory)));
+        let sink = bun_core::heap::into_raw(Box::new(Sink::new()));
         // From here on `sink` is owned by the `Builder` we return, or freed on
         // the error paths below.
         let guard = scopeguard::guard((), |()| {
@@ -323,9 +169,9 @@ impl Builder {
         let rc = lib::archive_write_open2(
             &archive,
             sink.cast(),
-            Some(SpillSink::open_callback),
-            Some(SpillSink::write_callback),
-            Some(SpillSink::close_callback),
+            Some(Sink::open_callback),
+            Some(Sink::write_callback),
+            Some(Sink::close_callback),
             None,
         );
         if rc != 0 {
@@ -349,7 +195,7 @@ impl Builder {
     }
 
     #[inline]
-    fn sink_mut(&mut self) -> &mut SpillSink {
+    fn sink_mut(&mut self) -> &mut Sink {
         // SAFETY: see `sink`; `&mut self` proves no other borrow is live.
         unsafe { &mut *self.sink }
     }
@@ -359,7 +205,7 @@ impl Builder {
         self.entries
     }
 
-    /// Prefer the sink's own error (a spill `write()` failure) over the generic
+    /// Prefer the sink's own error (an allocation failure) over the generic
     /// libarchive stage error, since the sink is the real cause.
     fn fail(&mut self, stage: &'static str) -> BuildError {
         self.sink_mut()
@@ -472,14 +318,14 @@ impl Builder {
     }
 
     /// Close the writer and take its output. Consumes the builder.
-    pub(crate) fn close(mut self) -> Result<SinkOutput, BuildError> {
+    pub(crate) fn close(mut self) -> Result<Vec<u8>, BuildError> {
         if !self.closed {
             if self.archive().write_close() != lib::Result::Ok {
                 return Err(self.fail("ArchiveCloseError"));
             }
             self.closed = true;
         }
-        Ok(self.sink_mut().take_output())
+        Ok(core::mem::take(&mut self.sink_mut().buf))
     }
 }
 

--- a/src/runtime/api/archive_builder.rs
+++ b/src/runtime/api/archive_builder.rs
@@ -1,0 +1,506 @@
+//! The incremental side of `Bun.Archive`: a live libarchive writer whose
+//! output spills from memory to a temporary file once it grows past
+//! `maxMemory`, plus the entry sources `Archive.append()` can stream from.
+
+use core::ffi::{c_int, c_void};
+
+use bun_core::ZBox;
+use bun_libarchive::lib;
+use bun_paths::PathBuffer;
+use bun_resolver::fs::{FileSystem, RealFS};
+use bun_sys;
+
+use super::archive::{Compression, Format, Options};
+
+/// libarchive `AE_IFREG` (== `S_IFREG`). The Rust `bun_libarchive::lib` port
+/// does not yet expose `FileType`, so mirror the constant locally.
+pub(crate) const FILETYPE_REGULAR: u32 = 0o100000;
+
+/// Permission bits given to entries added through the object form or
+/// `append()`.
+const DEFAULT_ENTRY_PERM: u32 = 0o644;
+
+/// Bytes read from disk at a time when streaming a file-backed entry.
+const STREAM_CHUNK_SIZE: usize = 256 * 1024;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Errors
+// ──────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub(crate) enum BuildError {
+    /// A libarchive call failed; the payload is the stage that failed.
+    Libarchive(&'static str),
+    /// An I/O error while spilling output, or while reading a file entry.
+    Sys(bun_sys::Error),
+    OutOfMemory,
+    /// A file shrank between `stat` and the end of the copy loop, so fewer
+    /// bytes were written than the entry header declares.
+    EntryChangedSize,
+}
+
+impl From<bun_sys::Error> for BuildError {
+    fn from(err: bun_sys::Error) -> Self {
+        BuildError::Sys(err)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Spill sink
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The temporary file an oversized archive spills into.
+///
+/// On POSIX the file is unlinked the instant it is created, so a crash can
+/// never leave it behind and nothing has to clean it up; the open descriptor
+/// keeps the inode alive. Windows cannot unlink an open file, so the path is
+/// kept and removed once the descriptor closes.
+pub(crate) struct SpillFile {
+    file: Option<bun_sys::File>,
+    path: ZBox,
+    len: u64,
+}
+
+impl SpillFile {
+    fn create() -> Result<SpillFile, bun_sys::Error> {
+        let mut name_buf = PathBuffer::uninit();
+        let name = FileSystem::tmpname(
+            b"bun-archive",
+            name_buf.0.as_mut_slice(),
+            bun_core::fast_random(),
+        )
+        .map_err(|_| bun_sys::Error::new(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open))?;
+        let joined = bun_paths::resolve_path::join_abs_string_z::<bun_paths::platform::Auto>(
+            RealFS::platform_temp_dir(),
+            &[name.as_bytes()],
+        );
+        let path = ZBox::from_bytes(joined.as_bytes());
+        let file = bun_sys::File::open(
+            path.as_zstr(),
+            bun_sys::O::CREAT | bun_sys::O::EXCL | bun_sys::O::RDWR | bun_sys::O::CLOEXEC,
+            0o600,
+        )?;
+
+        #[cfg(unix)]
+        {
+            let _ = bun_sys::unlink(path.as_zstr());
+            return Ok(SpillFile {
+                file: Some(file),
+                path: ZBox::from_bytes(b""),
+                len: 0,
+            });
+        }
+        #[cfg(not(unix))]
+        Ok(SpillFile {
+            file: Some(file),
+            path,
+            len: 0,
+        })
+    }
+
+    fn write(&mut self, data: &[u8]) -> Result<(), bun_sys::Error> {
+        let Some(file) = &self.file else {
+            return Err(bun_sys::Error::new(bun_sys::E::EBADF, bun_sys::Tag::write));
+        };
+        file.write_all(data)?;
+        self.len += data.len() as u64;
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[inline]
+    pub(crate) fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Read the whole spill file back into memory. Only needed on platforms
+    /// without a `bun_sys` file-mapping helper.
+    #[cfg(not(unix))]
+    pub(crate) fn read_to_vec(&self) -> Result<Vec<u8>, bun_sys::Error> {
+        let Some(file) = &self.file else {
+            return Err(bun_sys::Error::new(bun_sys::E::EBADF, bun_sys::Tag::read));
+        };
+        bun_sys::set_file_offset(file.fd(), 0)?;
+        let len = usize::try_from(self.len).unwrap_or(usize::MAX);
+        let mut out: Vec<u8> = Vec::new();
+        out.try_reserve_exact(len)
+            .map_err(|_| bun_sys::Error::new(bun_sys::E::ENOMEM, bun_sys::Tag::read))?;
+        out.resize(len, 0);
+        let mut read = 0usize;
+        while read < len {
+            let n = file.read_all(&mut out[read..])?;
+            if n == 0 {
+                break;
+            }
+            read += n;
+        }
+        out.truncate(read);
+        Ok(out)
+    }
+
+    /// Map the spill file copy-on-write. The caller owns the mapping and must
+    /// release it with `munmap` (`Blob.Store::init_mmap` wires that up).
+    #[cfg(unix)]
+    pub(crate) fn mmap(&self) -> Result<&'static mut [u8], bun_sys::Error> {
+        let Some(file) = &self.file else {
+            return Err(bun_sys::Error::new(bun_sys::E::EBADF, bun_sys::Tag::mmap));
+        };
+        let len = usize::try_from(self.len)
+            .map_err(|_| bun_sys::Error::new(bun_sys::E::EINVAL, bun_sys::Tag::mmap))?;
+        let ptr = bun_sys::mmap(
+            core::ptr::null_mut(),
+            len,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE,
+            file.fd(),
+            0,
+        )?;
+        // SAFETY: `mmap` returned a mapping of exactly `len` readable bytes.
+        Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
+    }
+
+    /// Close the descriptor and remove the backing file. A no-op for the path
+    /// on POSIX, where it was unlinked at creation.
+    fn discard(&mut self) {
+        drop(self.file.take());
+        if !self.path.is_empty() {
+            let _ = bun_sys::unlink(self.path.as_zstr());
+            self.path = ZBox::from_bytes(b"");
+        }
+    }
+}
+
+impl Drop for SpillFile {
+    fn drop(&mut self) {
+        self.discard();
+    }
+}
+
+/// What a finished [`Builder`] produced.
+pub(crate) enum SinkOutput {
+    Memory(Vec<u8>),
+    Spilled(SpillFile),
+}
+
+/// libarchive's write sink: buffers in memory until the archive would exceed
+/// `max_memory` bytes, then streams everything to a [`SpillFile`].
+pub(crate) struct SpillSink {
+    max_memory: u64,
+    buf: Vec<u8>,
+    spill: Option<SpillFile>,
+    /// Set by the write callback, which can only report failure as `-1`.
+    error: Option<BuildError>,
+}
+
+impl SpillSink {
+    fn new(max_memory: u64) -> SpillSink {
+        SpillSink {
+            max_memory,
+            buf: Vec::new(),
+            spill: None,
+            error: None,
+        }
+    }
+
+    fn push(&mut self, data: &[u8]) -> Result<(), BuildError> {
+        if let Some(spill) = &mut self.spill {
+            spill.write(data)?;
+            return Ok(());
+        }
+        if self.buf.len() as u64 + data.len() as u64 > self.max_memory {
+            let mut spill = SpillFile::create()?;
+            spill.write(&self.buf)?;
+            // Release the buffer's capacity, not just its length.
+            self.buf = Vec::new();
+            spill.write(data)?;
+            self.spill = Some(spill);
+            return Ok(());
+        }
+        self.buf
+            .try_reserve(data.len())
+            .map_err(|_| BuildError::OutOfMemory)?;
+        self.buf.extend_from_slice(data);
+        Ok(())
+    }
+
+    fn take_output(&mut self) -> SinkOutput {
+        match self.spill.take() {
+            Some(file) => SinkOutput::Spilled(file),
+            None => SinkOutput::Memory(core::mem::take(&mut self.buf)),
+        }
+    }
+
+    unsafe extern "C" fn open_callback(_a: *mut lib::Archive, _client_data: *mut c_void) -> c_int {
+        0
+    }
+
+    unsafe extern "C" fn write_callback(
+        _a: *mut lib::Archive,
+        client_data: *mut c_void,
+        buff: *const c_void,
+        length: usize,
+    ) -> lib::la_ssize_t {
+        // SAFETY: `client_data` is the `*mut SpillSink` registered with
+        // `archive_write_open2`; libarchive never calls back concurrently.
+        let this = unsafe { bun_core::callback_ctx::<SpillSink>(client_data) };
+        if buff.is_null() || length == 0 {
+            return 0;
+        }
+        // SAFETY: libarchive guarantees `buff[0..length]` is readable here.
+        let data = unsafe { core::slice::from_raw_parts(buff.cast::<u8>(), length) };
+        match this.push(data) {
+            Ok(()) => lib::la_ssize_t::try_from(length).expect("int cast"),
+            Err(err) => {
+                this.error = Some(err);
+                -1
+            }
+        }
+    }
+
+    unsafe extern "C" fn close_callback(_a: *mut lib::Archive, _client_data: *mut c_void) -> c_int {
+        0
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Builder
+// ──────────────────────────────────────────────────────────────────────────
+
+/// A live libarchive writer plus the sink it writes into.
+///
+/// Exactly one thread owns a `Builder` at a time: the owning `Archive` hands
+/// it to a work-pool task for the duration of an `append()` and takes it back
+/// when the task finishes on the JS thread.
+pub(crate) struct Builder {
+    /// `Option` only so `Drop` can free the archive (which flushes through the
+    /// write callback) before the sink it writes into is destroyed.
+    archive: Option<lib::WriteArchive>,
+    /// Heap-owned `SpillSink`; this pointer is what libarchive hands back to
+    /// the write callback. Destroyed by `Drop`, after `archive`.
+    sink: *mut SpillSink,
+    entry: lib::OwnedEntry,
+    entries: u32,
+    closed: bool,
+}
+
+// SAFETY: the libarchive handles and the sink are uniquely owned by the
+// `Builder`. It is moved between the JS thread and one work-pool thread, never
+// shared: the owning `Archive` relinquishes it for the duration of a task.
+unsafe impl Send for Builder {}
+
+impl Drop for Builder {
+    fn drop(&mut self) {
+        // `archive_write_free` can flush buffered bytes through the write
+        // callback, which writes into `*sink`: free the archive first.
+        drop(self.archive.take());
+        // SAFETY: `sink` is the `heap::into_raw` allocation made in `open`,
+        // destroyed exactly once here.
+        unsafe { bun_core::heap::destroy(self.sink) };
+    }
+}
+
+impl Builder {
+    pub(crate) fn open(options: Options) -> Result<Builder, BuildError> {
+        let sink = bun_core::heap::into_raw(Box::new(SpillSink::new(options.max_memory)));
+        // From here on `sink` is owned by the `Builder` we return, or freed on
+        // the error paths below.
+        let guard = scopeguard::guard((), |()| {
+            // SAFETY: `sink` is still the sole owner of the allocation; this
+            // only runs when we return `Err` before constructing the `Builder`.
+            unsafe { bun_core::heap::destroy(sink) };
+        });
+
+        let archive = lib::WriteArchive::new();
+        configure_writer(&archive, options)?;
+
+        let rc = lib::archive_write_open2(
+            &archive,
+            sink.cast(),
+            Some(SpillSink::open_callback),
+            Some(SpillSink::write_callback),
+            Some(SpillSink::close_callback),
+            None,
+        );
+        if rc != 0 {
+            return Err(BuildError::Libarchive("ArchiveOpenError"));
+        }
+
+        scopeguard::ScopeGuard::into_inner(guard);
+        Ok(Builder {
+            archive: Some(archive),
+            sink,
+            entry: lib::OwnedEntry::new(),
+            entries: 0,
+            closed: false,
+        })
+    }
+
+    #[inline]
+    fn archive(&self) -> &lib::Archive {
+        // Only `Drop` takes the handle out.
+        self.archive.as_ref().expect("builder archive taken")
+    }
+
+    #[inline]
+    fn sink_mut(&mut self) -> &mut SpillSink {
+        // SAFETY: see `sink`; `&mut self` proves no other borrow is live.
+        unsafe { &mut *self.sink }
+    }
+
+    #[inline]
+    pub(crate) fn entries(&self) -> u32 {
+        self.entries
+    }
+
+    /// Prefer the sink's own error (a spill `write()` failure) over the generic
+    /// libarchive stage error, since the sink is the real cause.
+    fn fail(&mut self, stage: &'static str) -> BuildError {
+        self.sink_mut()
+            .error
+            .take()
+            .unwrap_or(BuildError::Libarchive(stage))
+    }
+
+    fn write_header(&mut self, path: &ZBox, size: u64, mtime: i64) -> Result<(), BuildError> {
+        let size = i64::try_from(size).map_err(|_| BuildError::EntryChangedSize)?;
+        let entry = &self.entry;
+        let _ = entry.clear();
+        // Same platform split as `pack_command::add_archive_entry`: the process
+        // locale is always "C", so libarchive's locale-keyed writers are only
+        // lossless with raw bytes on POSIX and with the UTF-8 form on Windows.
+        #[cfg(windows)]
+        entry.set_pathname_utf8(path.as_zstr());
+        #[cfg(not(windows))]
+        entry.set_pathname(path.as_zstr());
+        entry.set_size(size);
+        entry.set_filetype(FILETYPE_REGULAR);
+        entry.set_perm(DEFAULT_ENTRY_PERM);
+        entry.set_mtime(isize::try_from(mtime).unwrap_or(0), 0);
+
+        // `Warn` still wrote a header (libarchive fell back to a per-entry
+        // binary hdrcharset); only `Failed`/`Fatal` mean no header was produced.
+        if !self.archive().write_header(entry).succeeded() {
+            return Err(self.fail("ArchiveHeaderError"));
+        }
+        Ok(())
+    }
+
+    fn write_data(&mut self, data: &[u8]) -> Result<(), BuildError> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        if self.archive().write_data(data) < 0 {
+            return Err(self.fail("ArchiveWriteError"));
+        }
+        Ok(())
+    }
+
+    fn finish_entry(&mut self) -> Result<(), BuildError> {
+        if self.archive().write_finish_entry() != lib::Result::Ok {
+            return Err(self.fail("ArchiveFinishEntryError"));
+        }
+        self.entries += 1;
+        Ok(())
+    }
+
+    /// Write one complete entry whose bytes are already in memory.
+    pub(crate) fn add_bytes(
+        &mut self,
+        path: &ZBox,
+        data: &[u8],
+        mtime: i64,
+    ) -> Result<(), BuildError> {
+        self.write_header(path, data.len() as u64, mtime)?;
+        self.write_data(data)?;
+        self.finish_entry()
+    }
+
+    /// Write one entry by streaming `len` bytes out of `source`, starting at
+    /// `offset`, never holding more than [`STREAM_CHUNK_SIZE`] of it at once.
+    pub(crate) fn add_file(
+        &mut self,
+        path: &ZBox,
+        source: &ZBox,
+        offset: u64,
+        max_len: Option<u64>,
+        mtime: i64,
+    ) -> Result<(), BuildError> {
+        let file = bun_sys::File::open(source.as_zstr(), bun_sys::O::RDONLY, 0)?;
+        let file_size = u64::try_from(bun_sys::fstat(file.fd())?.st_size).unwrap_or(0);
+        let start = offset.min(file_size);
+        let available = file_size - start;
+        let len = max_len.map_or(available, |l| l.min(available));
+
+        if start > 0 {
+            bun_sys::set_file_offset(file.fd(), start)?;
+        }
+
+        self.write_header(path, len, mtime)?;
+
+        let mut buf = vec![0u8; STREAM_CHUNK_SIZE.min(usize::try_from(len).unwrap_or(usize::MAX))];
+        let mut remaining = len;
+        while remaining > 0 {
+            let want = usize::try_from(remaining)
+                .unwrap_or(usize::MAX)
+                .min(buf.len());
+            let read = file.read_all(&mut buf[..want])?;
+            if read == 0 {
+                return Err(BuildError::EntryChangedSize);
+            }
+            self.write_data(&buf[..read])?;
+            remaining -= read as u64;
+        }
+
+        self.finish_entry()
+    }
+
+    /// Close the writer and take its output. Consumes the builder.
+    pub(crate) fn close(mut self) -> Result<SinkOutput, BuildError> {
+        if !self.closed {
+            self.closed = true;
+            if self.archive().write_close() != lib::Result::Ok {
+                return Err(self.fail("ArchiveCloseError"));
+            }
+        }
+        Ok(self.sink_mut().take_output())
+    }
+}
+
+/// Apply `options` to a fresh `archive_write_new()` handle.
+fn configure_writer(archive: &lib::Archive, options: Options) -> Result<(), BuildError> {
+    match options.format {
+        Format::Tar => {
+            if archive.write_set_format_pax_restricted() != lib::Result::Ok {
+                return Err(BuildError::Libarchive("ArchiveFormatError"));
+            }
+        }
+        Format::Zip => {
+            if archive.write_set_format_zip() != lib::Result::Ok {
+                return Err(BuildError::Libarchive("ArchiveFormatError"));
+            }
+            // Without this libarchive zero-pads the output up to its 10240-byte
+            // default block, so a 200-byte zip would be written as 10 KB.
+            if archive.write_set_bytes_in_last_block(1) != lib::Result::Ok {
+                return Err(BuildError::Libarchive("ArchiveFormatError"));
+            }
+            match options.compress {
+                Compression::Store => {
+                    if archive.write_zip_set_compression_store() != lib::Result::Ok {
+                        return Err(BuildError::Libarchive("ArchiveFormatError"));
+                    }
+                }
+                Compression::Deflate(level) => {
+                    if archive.write_zip_set_compression_deflate() != lib::Result::Ok {
+                        return Err(BuildError::Libarchive("ArchiveFormatError"));
+                    }
+                    let option = ZBox::from_bytes(format!("zip:compression-level={level}"));
+                    if !archive.write_set_options(option.as_zstr()).succeeded() {
+                        return Err(BuildError::Libarchive("ArchiveFormatError"));
+                    }
+                }
+                Compression::None | Compression::Gzip(_) => {}
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/runtime/api/archive_builder.rs
+++ b/src/runtime/api/archive_builder.rs
@@ -6,7 +6,6 @@ use core::ffi::{c_int, c_void};
 
 use bun_core::ZBox;
 use bun_libarchive::lib;
-use bun_paths::PathBuffer;
 use bun_resolver::fs::{FileSystem, RealFS};
 use bun_sys;
 
@@ -63,13 +62,11 @@ pub(crate) struct SpillFile {
 
 impl SpillFile {
     fn create() -> Result<SpillFile, bun_sys::Error> {
-        let mut name_buf = PathBuffer::uninit();
-        let name = FileSystem::tmpname(
-            b"bun-archive",
-            name_buf.0.as_mut_slice(),
-            bun_core::fast_random(),
-        )
-        .map_err(|_| bun_sys::Error::new(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open))?;
+        // `PathBuffer` is ~96 KB on Windows, so take it from the pool rather
+        // than the stack.
+        let mut name_buf = bun_paths::path_buffer_pool::get();
+        let name = FileSystem::tmpname(b"bun-archive", &mut name_buf[..], bun_core::fast_random())
+            .map_err(|_| bun_sys::Error::new(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open))?;
         let joined = bun_paths::resolve_path::join_abs_string_z::<bun_paths::platform::Auto>(
             RealFS::platform_temp_dir(),
             &[name.as_bytes()],

--- a/src/runtime/api/archive_builder.rs
+++ b/src/runtime/api/archive_builder.rs
@@ -18,8 +18,9 @@ pub(crate) const FILETYPE_REGULAR: u32 = 0o100000;
 /// `append()`.
 const DEFAULT_ENTRY_PERM: u32 = 0o644;
 
-/// Bytes read from disk at a time when streaming a file-backed entry.
-const STREAM_CHUNK_SIZE: usize = 256 * 1024;
+/// Bytes of an entry written per step. Also how much of a file-backed entry is
+/// read from disk at a time.
+pub(crate) const STREAM_CHUNK_SIZE: usize = 256 * 1024;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Errors
@@ -35,6 +36,8 @@ pub(crate) enum BuildError {
     /// A file shrank between `stat` and the end of the copy loop, so fewer
     /// bytes were written than the entry header declares.
     EntryChangedSize,
+    /// The `stream()` consumer cancelled, so there is nowhere left to write.
+    StreamCancelled,
 }
 
 impl From<bun_sys::Error> for BuildError {
@@ -262,6 +265,41 @@ impl Builder {
         Ok(())
     }
 
+    /// Take the output produced so far, leaving the sink empty.
+    #[inline]
+    pub(crate) fn take_output(&mut self) -> Vec<u8> {
+        core::mem::take(&mut self.sink_mut().buf)
+    }
+
+    // ── Resumable entry ────────────────────────────────────────────────────
+    //
+    // `begin_entry` / `write_body` / `end_entry` let an entry be written a chunk
+    // at a time, so the work can be handed back to the JS thread in between. The
+    // all-at-once helpers below are those three calls in a loop.
+
+    /// Write an entry's header, declaring a body of `size` bytes.
+    #[inline]
+    pub(crate) fn begin_entry(
+        &mut self,
+        path: &ZBox,
+        size: u64,
+        mtime: i64,
+    ) -> Result<(), BuildError> {
+        self.write_header(path, size, mtime)
+    }
+
+    /// Write the next slice of the current entry's body.
+    #[inline]
+    pub(crate) fn write_body(&mut self, data: &[u8]) -> Result<(), BuildError> {
+        self.write_data(data)
+    }
+
+    /// Close the current entry, whose body must be fully written.
+    #[inline]
+    pub(crate) fn end_entry(&mut self) -> Result<(), BuildError> {
+        self.finish_entry()
+    }
+
     /// Write one complete entry whose bytes are already in memory.
     pub(crate) fn add_bytes(
         &mut self,
@@ -284,37 +322,18 @@ impl Builder {
         max_len: Option<u64>,
         mtime: i64,
     ) -> Result<(), BuildError> {
-        let file = bun_sys::File::open(
-            source.as_zstr(),
-            bun_sys::O::RDONLY | bun_sys::O::CLOEXEC,
-            0,
-        )?;
-        let file_size = u64::try_from(bun_sys::fstat(file.fd())?.st_size).unwrap_or(0);
-        let start = offset.min(file_size);
-        let available = file_size - start;
-        let len = max_len.map_or(available, |l| l.min(available));
-
-        if start > 0 {
-            bun_sys::set_file_offset(file.fd(), start)?;
-        }
-
-        self.write_header(path, len, mtime)?;
+        let (file, len) = open_entry_file(source, offset, max_len)?;
+        self.begin_entry(path, len, mtime)?;
 
         let mut buf = vec![0u8; STREAM_CHUNK_SIZE.min(usize::try_from(len).unwrap_or(usize::MAX))];
         let mut remaining = len;
         while remaining > 0 {
-            let want = usize::try_from(remaining)
-                .unwrap_or(usize::MAX)
-                .min(buf.len());
-            let read = file.read_all(&mut buf[..want])?;
-            if read == 0 {
-                return Err(BuildError::EntryChangedSize);
-            }
-            self.write_data(&buf[..read])?;
+            let read = read_entry_chunk(&file, &mut buf, remaining)?;
+            self.write_body(&buf[..read])?;
             remaining -= read as u64;
         }
 
-        self.finish_entry()
+        self.end_entry()
     }
 
     /// Close the writer and take its output. Consumes the builder.
@@ -327,6 +346,47 @@ impl Builder {
         }
         Ok(core::mem::take(&mut self.sink_mut().buf))
     }
+}
+
+/// Open a file-backed entry's source and work out how many of its bytes the
+/// entry covers, seeking to `offset`.
+pub(crate) fn open_entry_file(
+    source: &ZBox,
+    offset: u64,
+    max_len: Option<u64>,
+) -> Result<(bun_sys::File, u64), BuildError> {
+    let file = bun_sys::File::open(
+        source.as_zstr(),
+        bun_sys::O::RDONLY | bun_sys::O::CLOEXEC,
+        0,
+    )?;
+    let file_size = u64::try_from(bun_sys::fstat(file.fd())?.st_size).unwrap_or(0);
+    let start = offset.min(file_size);
+    let available = file_size - start;
+    let len = max_len.map_or(available, |l| l.min(available));
+
+    if start > 0 {
+        bun_sys::set_file_offset(file.fd(), start)?;
+    }
+    Ok((file, len))
+}
+
+/// Read the next slice of a file-backed entry, at most `remaining` bytes.
+pub(crate) fn read_entry_chunk(
+    file: &bun_sys::File,
+    buf: &mut [u8],
+    remaining: u64,
+) -> Result<usize, BuildError> {
+    let want = usize::try_from(remaining)
+        .unwrap_or(usize::MAX)
+        .min(buf.len());
+    let read = file.read_all(&mut buf[..want])?;
+    if read == 0 {
+        // The file shrank between `fstat` and here, so the entry can no longer
+        // match the size its header declares.
+        return Err(BuildError::EntryChangedSize);
+    }
+    Ok(read)
 }
 
 /// Apply `options` to a fresh `archive_write_new()` handle.

--- a/src/runtime/api/archive_builder.rs
+++ b/src/runtime/api/archive_builder.rs
@@ -392,12 +392,18 @@ impl Builder {
         Ok(())
     }
 
-    fn write_data(&mut self, data: &[u8]) -> Result<(), BuildError> {
-        if data.is_empty() {
-            return Ok(());
-        }
-        if self.archive().write_data(data) < 0 {
-            return Err(self.fail("ArchiveWriteError"));
+    /// `archive_write_data` clamps its length to `INT_MAX` and returns the count
+    /// it actually took, so a single call cannot be assumed to consume the whole
+    /// slice: an entry over 2 GiB would otherwise be silently NUL-padded out to
+    /// the size its header declared.
+    fn write_data(&mut self, mut data: &[u8]) -> Result<(), BuildError> {
+        while !data.is_empty() {
+            let written = self.archive().write_data(data);
+            if written <= 0 {
+                return Err(self.fail("ArchiveWriteError"));
+            }
+            let written = usize::try_from(written).expect("int cast").min(data.len());
+            data = &data[written..];
         }
         Ok(())
     }

--- a/src/runtime/api/archive_builder.rs
+++ b/src/runtime/api/archive_builder.rs
@@ -290,7 +290,18 @@ unsafe impl Send for Builder {}
 
 impl Drop for Builder {
     fn drop(&mut self) {
-        // `archive_write_free` can flush buffered bytes through the write
+        if let Some(archive) = &self.archive {
+            if !self.closed {
+                // This writer is being abandoned, so its output is thrown away.
+                // Without poisoning it, `archive_write_free` runs a normal close,
+                // and closing while an entry is half-written makes tar pad that
+                // entry out to its declared size: a failed `append()` of a 600 MB
+                // file would write 600 MB of NULs into the sink (spilling them to
+                // a temp file) before the promise settles.
+                archive.write_fail();
+            }
+        }
+        // `archive_write_free` can still flush buffered bytes through the write
         // callback, which writes into `*sink`: free the archive first.
         drop(self.archive.take());
         // SAFETY: `sink` is the `heap::into_raw` allocation made in `open`,
@@ -425,7 +436,11 @@ impl Builder {
         max_len: Option<u64>,
         mtime: i64,
     ) -> Result<(), BuildError> {
-        let file = bun_sys::File::open(source.as_zstr(), bun_sys::O::RDONLY, 0)?;
+        let file = bun_sys::File::open(
+            source.as_zstr(),
+            bun_sys::O::RDONLY | bun_sys::O::CLOEXEC,
+            0,
+        )?;
         let file_size = u64::try_from(bun_sys::fstat(file.fd())?.st_size).unwrap_or(0);
         let start = offset.min(file_size);
         let available = file_size - start;

--- a/src/runtime/api/archive_builder.rs
+++ b/src/runtime/api/archive_builder.rs
@@ -71,23 +71,22 @@ impl SpillFile {
             RealFS::platform_temp_dir(),
             &[name.as_bytes()],
         );
-        let path = ZBox::from_bytes(joined.as_bytes());
+        #[allow(unused_mut)]
+        let mut path = ZBox::from_bytes(joined.as_bytes());
         let file = bun_sys::File::open(
             path.as_zstr(),
             bun_sys::O::CREAT | bun_sys::O::EXCL | bun_sys::O::RDWR | bun_sys::O::CLOEXEC,
             0o600,
         )?;
 
+        // POSIX: drop the name now so a crash cannot leave the file behind. The
+        // open descriptor keeps the inode alive. If the unlink fails, keep the
+        // path so `Drop` removes it instead.
         #[cfg(unix)]
-        {
-            let _ = bun_sys::unlink(path.as_zstr());
-            return Ok(SpillFile {
-                file: Some(file),
-                path: ZBox::from_bytes(b""),
-                len: 0,
-            });
+        if bun_sys::unlink(path.as_zstr()).is_ok() {
+            path = ZBox::from_bytes(b"");
         }
-        #[cfg(not(unix))]
+
         Ok(SpillFile {
             file: Some(file),
             path,
@@ -469,10 +468,10 @@ impl Builder {
     /// Close the writer and take its output. Consumes the builder.
     pub(crate) fn close(mut self) -> Result<SinkOutput, BuildError> {
         if !self.closed {
-            self.closed = true;
             if self.archive().write_close() != lib::Result::Ok {
                 return Err(self.fail("ArchiveCloseError"));
             }
+            self.closed = true;
         }
         Ok(self.sink_mut().take_output())
     }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -77,8 +77,9 @@ macro_rules! __fs_pat {
 // (high-tier owns them all; grouped by source module)
 
 use crate::api::archive::{
-    AsyncTask as ArchiveAsyncTask, BlobTask as ArchiveBlobTask, ExtractTask as ArchiveExtractTask,
-    FilesTask as ArchiveFilesTask, WriteTask as ArchiveWriteTask,
+    AppendTask as ArchiveAppendTask, AsyncTask as ArchiveAsyncTask, BlobTask as ArchiveBlobTask,
+    ExtractTask as ArchiveExtractTask, FilesTask as ArchiveFilesTask,
+    WriteTask as ArchiveWriteTask,
 };
 
 use crate::shell::builtins::{
@@ -283,6 +284,9 @@ pub fn run_task(
         }
         task_tag::ArchiveWriteTask => {
             ArchiveAsyncTask::run_from_js(cast_ptr!(ArchiveWriteTask))?;
+        }
+        task_tag::ArchiveAppendTask => {
+            ArchiveAsyncTask::run_from_js(cast_ptr!(ArchiveAppendTask))?;
         }
         task_tag::ArchiveFilesTask => {
             ArchiveAsyncTask::run_from_js(cast_ptr!(ArchiveFilesTask))?;
@@ -584,7 +588,7 @@ fn run_task_cold(task: Task) {
 /// Compile-time guard that the arm count above tracks
 /// `bun_event_loop::task_tag::COUNT`. Bump when adding a variant.
 const _: () = assert!(
-    task_tag::COUNT == 97,
+    task_tag::COUNT == 98,
     "dispatch::run_task arm count out of sync with bun_event_loop::task_tag",
 );
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5321,7 +5321,7 @@ pub fn write_file_internal(
 
         // Check for Archive - allows Bun.write() and S3 writes to accept Archive instances
         if let Some(archive) = data.as_class_ref::<Archive>() {
-            break 'brk Blob::init_with_store(archive.store_ref().clone(), global_this);
+            break 'brk Blob::init_with_store(archive.blob_store(global_this)?, global_this);
         }
 
         break 'brk Blob::get::<false, false>(global_this, data)?;

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -171,11 +171,12 @@ describe("Bun.Archive", () => {
       expect(archive).toBeInstanceOf(Bun.Archive);
     });
 
-    test("throws with no arguments", () => {
-      expect(() => {
-        // @ts-expect-error - testing runtime behavior
-        new Bun.Archive();
-      }).toThrow();
+    test("creates an empty, appendable archive with no arguments", async () => {
+      const archive = new Bun.Archive();
+      expect(archive).toBeInstanceOf(Bun.Archive);
+
+      await archive.append("a.txt", "a");
+      expect((await archive.files()).size).toBe(1);
     });
 
     test("throws with invalid input type (number)", () => {
@@ -1904,6 +1905,300 @@ describe("Bun.Archive", () => {
       const readArchive = new Bun.Archive(await bunFile.bytes());
       const files = await readArchive.files();
       expect(await files.get("test.txt")!.text()).toBe("test content");
+    });
+  });
+
+  describe("zip format", () => {
+    test("writes a zip with the PK local file header magic", async () => {
+      const archive = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip" });
+      const bytes = await archive.bytes();
+
+      expect(Array.from(bytes.subarray(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04]);
+    });
+
+    // libarchive zero-pads writes up to its 10240-byte default block, which is
+    // what tar wants and what a zip must not have.
+    test("is not padded to libarchive's block size", async () => {
+      const empty = await new Bun.Archive(undefined, { format: "zip" }).bytes();
+      expect(empty.length).toBe(22); // just the end-of-central-directory record
+
+      const small = await new Bun.Archive({ "a.txt": "a" }, { format: "zip" }).bytes();
+      expect(small.length).toBeLessThan(1024);
+
+      // tar keeps its block padding.
+      expect((await new Bun.Archive({ "a.txt": "a" }).bytes()).length).toBe(10240);
+    });
+
+    test("round-trips through files()", async () => {
+      const zip = await new Bun.Archive(
+        {
+          "hello.txt": "Hello, World!",
+          "nested/data.json": JSON.stringify({ foo: "bar" }),
+        },
+        { format: "zip" },
+      ).bytes();
+
+      const files = await new Bun.Archive(zip).files();
+      expect([...files.keys()].sort()).toEqual(["hello.txt", "nested/data.json"]);
+      expect(await files.get("hello.txt")!.text()).toBe("Hello, World!");
+      expect(await files.get("nested/data.json")!.text()).toBe(JSON.stringify({ foo: "bar" }));
+    });
+
+    test("extracts to disk", async () => {
+      using dir = tempDir("archive-zip-extract", {});
+      const zip = await new Bun.Archive({ "a.txt": "a", "dir/b.txt": "b" }, { format: "zip" }).bytes();
+
+      const count = await new Bun.Archive(zip).extract(String(dir));
+      expect(count).toBeGreaterThanOrEqual(2);
+      expect(await Bun.file(join(String(dir), "a.txt")).text()).toBe("a");
+      expect(await Bun.file(join(String(dir), "dir", "b.txt")).text()).toBe("b");
+    });
+
+    // libarchive's stored-zip reader signals end-of-entry with ARCHIVE_OK and a
+    // null data block, which used to trip a null-pointer slice in extract().
+    test("extracts an uncompressed (stored) zip", async () => {
+      using dir = tempDir("archive-zip-stored-extract", {});
+      const zip = await new Bun.Archive({ "c.txt": "stored entry" }, { format: "zip", compress: "store" }).bytes();
+
+      const count = await new Bun.Archive(zip).extract(String(dir));
+      expect(count).toBe(1);
+      expect(await Bun.file(join(String(dir), "c.txt")).text()).toBe("stored entry");
+    });
+
+    test("deflate is the default and store is larger", async () => {
+      const content = "compress me ".repeat(4096);
+      const deflated = await new Bun.Archive({ "big.txt": content }, { format: "zip" }).bytes();
+      const stored = await new Bun.Archive({ "big.txt": content }, { format: "zip", compress: "store" }).bytes();
+
+      expect(deflated.length).toBeLessThan(stored.length);
+      expect(stored.length).toBeGreaterThan(content.length);
+
+      // Both are still readable.
+      for (const bytes of [deflated, stored]) {
+        const files = await new Bun.Archive(bytes).files();
+        expect(await files.get("big.txt")!.text()).toBe(content);
+      }
+    });
+
+    test("deflate level affects compression ratio", async () => {
+      const content = Buffer.alloc(256 * 1024, "abcdefghij").toString();
+      const level1 = await new Bun.Archive({ "big.txt": content }, { format: "zip", level: 1 }).bytes();
+      const level9 = await new Bun.Archive({ "big.txt": content }, { format: "zip", level: 9 }).bytes();
+
+      expect(level9.length).toBeLessThanOrEqual(level1.length);
+    });
+
+    test("the zip the real unzip(1) would read is also what Bun reads back", async () => {
+      using dir = tempDir("archive-zip-write", {});
+      const path = join(String(dir), "out.zip");
+      await Bun.Archive.write(path, { "x.txt": "x" }, { format: "zip" });
+
+      const bytes = await Bun.file(path).bytes();
+      expect(Array.from(bytes.subarray(0, 2))).toEqual([0x50, 0x4b]);
+      const files = await new Bun.Archive(bytes).files();
+      expect(await files.get("x.txt")!.text()).toBe("x");
+    });
+
+    test("rejects gzip with zip and deflate with tar", () => {
+      expect(() => new Bun.Archive({ "a.txt": "a" }, { format: "zip", compress: "gzip" })).toThrow();
+      // @ts-expect-error - deflate requires format: "zip"
+      expect(() => new Bun.Archive({ "a.txt": "a" }, { compress: "deflate" })).toThrow();
+      // @ts-expect-error - unknown format
+      expect(() => new Bun.Archive({ "a.txt": "a" }, { format: "7z" })).toThrow();
+    });
+  });
+
+  describe("archive.append()", () => {
+    test("appends to an empty archive", async () => {
+      const archive = new Bun.Archive();
+      await archive.append("hello.txt", "Hello, World!");
+      await archive.append("bytes.bin", new Uint8Array([1, 2, 3]));
+      await archive.append("blob.txt", new Blob(["from a blob"]));
+
+      const files = await archive.files();
+      expect([...files.keys()].sort()).toEqual(["blob.txt", "bytes.bin", "hello.txt"]);
+      expect(await files.get("hello.txt")!.text()).toBe("Hello, World!");
+      expect(await files.get("blob.txt")!.text()).toBe("from a blob");
+      expect(new Uint8Array(await files.get("bytes.bin")!.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
+    });
+
+    test("appends on top of the object form", async () => {
+      const archive = new Bun.Archive({ "package.json": "{}" });
+      await archive.append("README.md", "# Hello");
+
+      const files = await archive.files();
+      expect([...files.keys()].sort()).toEqual(["README.md", "package.json"]);
+    });
+
+    test("appends into a zip", async () => {
+      const archive = new Bun.Archive(undefined, { format: "zip" });
+      await archive.append("a.txt", "a");
+      await archive.append("b.txt", "b");
+
+      const bytes = await archive.bytes();
+      expect(Array.from(bytes.subarray(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04]);
+      const files = await new Bun.Archive(bytes).files();
+      expect(await files.get("b.txt")!.text()).toBe("b");
+    });
+
+    test("streams a Bun.file() from disk", async () => {
+      using dir = tempDir("archive-append-file", { "source.bin": "" });
+      const sourcePath = join(String(dir), "source.bin");
+      const content = Buffer.alloc(3 * 1024 * 1024, "xyz");
+      await Bun.write(sourcePath, content);
+
+      const archive = new Bun.Archive();
+      await archive.append("copied.bin", Bun.file(sourcePath));
+
+      const files = await archive.files();
+      const copied = Buffer.from(await files.get("copied.bin")!.arrayBuffer());
+      expect(copied.length).toBe(content.length);
+      expect(copied.equals(content)).toBe(true);
+    });
+
+    test("respects a sliced Bun.file()", async () => {
+      using dir = tempDir("archive-append-slice", { "source.txt": "0123456789" });
+      const sourcePath = join(String(dir), "source.txt");
+
+      const archive = new Bun.Archive();
+      await archive.append("slice.txt", Bun.file(sourcePath).slice(2, 6));
+
+      const files = await archive.files();
+      expect(await files.get("slice.txt")!.text()).toBe("2345");
+    });
+
+    test("preserves order under Promise.all", async () => {
+      const archive = new Bun.Archive();
+      await Promise.all(Array.from({ length: 16 }, (_, i) => archive.append(`f${i}.txt`, String(i))));
+
+      const files = await archive.files();
+      expect([...files.keys()]).toEqual(Array.from({ length: 16 }, (_, i) => `f${i}.txt`));
+    });
+
+    test("throws after the archive has been read", async () => {
+      const archive = new Bun.Archive({ "a.txt": "a" });
+      await archive.bytes();
+
+      expect(() => archive.append("b.txt", "b")).toThrow(/cannot append to existing archive data/);
+    });
+
+    test("throws on an archive created from existing data", async () => {
+      const tar = await new Bun.Archive({ "a.txt": "a" }).bytes();
+      const archive = new Bun.Archive(tar);
+
+      expect(() => archive.append("b.txt", "b")).toThrow();
+    });
+
+    test("throws when reading while an append is still pending", async () => {
+      const archive = new Bun.Archive();
+      const pending = archive.append("a.txt", "a");
+
+      expect(() => archive.bytes()).toThrow(/still in progress/);
+      await pending;
+      expect((await archive.bytes()).length).toBeGreaterThan(0);
+    });
+
+    test("rejects a missing Bun.file() and poisons the archive", async () => {
+      using dir = tempDir("archive-append-missing", {});
+      const archive = new Bun.Archive();
+      await archive.append("ok.txt", "ok");
+
+      await expect(archive.append("gone.bin", Bun.file(join(String(dir), "nope.bin")))).rejects.toThrow(
+        /ENOENT|no such file/i,
+      );
+      // The entry was half-written, so every later read fails too.
+      expect(() => archive.bytes()).toThrow(/can no longer be used/);
+    });
+
+    test("rejects every queued append once one fails", async () => {
+      using dir = tempDir("archive-append-queue-fail", {});
+      const archive = new Bun.Archive();
+
+      // Both settle in the same turn, so attach handlers before awaiting either.
+      const [failing, queued] = await Promise.allSettled([
+        archive.append("gone.bin", Bun.file(join(String(dir), "nope.bin"))),
+        archive.append("never.txt", "never"),
+      ]);
+
+      expect(failing.status).toBe("rejected");
+      expect((failing as PromiseRejectedResult).reason.message).toMatch(/ENOENT|no such file/i);
+      expect(queued.status).toBe("rejected");
+      expect((queued as PromiseRejectedResult).reason.message).toMatch(/can no longer be used/);
+    });
+
+    test("rejects a non-string path", () => {
+      const archive = new Bun.Archive();
+      // @ts-expect-error - path must be a string
+      expect(() => archive.append(123, "a")).toThrow();
+      expect(() => archive.append("", "a")).toThrow();
+    });
+
+    test("rejects unsupported entry data", () => {
+      const archive = new Bun.Archive();
+      // @ts-expect-error - numbers are not valid entry data
+      expect(() => archive.append("a.txt", 123)).toThrow();
+    });
+  });
+
+  describe("spilling to disk", () => {
+    // Spilled output goes to a temp file and is mapped back in, so it has to
+    // describe exactly the same archive as the purely in-memory path.
+    test("maxMemory: 0 produces the same archive as the in-memory path", async () => {
+      const files = { "a.txt": "a".repeat(5000), "b.txt": "b".repeat(5000) };
+      const spilled = await new Bun.Archive(files, { maxMemory: 0 }).bytes();
+      const buffered = await new Bun.Archive(files, { maxMemory: Infinity }).bytes();
+
+      expect(spilled.length).toBe(buffered.length);
+      const entries = await new Bun.Archive(spilled).files();
+      expect([...entries.keys()]).toEqual(["a.txt", "b.txt"]);
+      expect(await entries.get("a.txt")!.text()).toBe(files["a.txt"]);
+      expect(await entries.get("b.txt")!.text()).toBe(files["b.txt"]);
+    });
+
+    test("a spilled archive still extracts, lists, and writes", async () => {
+      using dir = tempDir("archive-spill", {});
+      const archive = new Bun.Archive(undefined, { format: "zip", maxMemory: 0 });
+      await archive.append("a.txt", "a");
+      await archive.append("dir/b.txt", "b");
+
+      const files = await archive.files();
+      expect([...files.keys()].sort()).toEqual(["a.txt", "dir/b.txt"]);
+
+      const out = join(String(dir), "out.zip");
+      await Bun.Archive.write(out, archive);
+      expect(await Bun.file(out).exists()).toBe(true);
+
+      const extractDir = join(String(dir), "extracted");
+      expect(await new Bun.Archive(await Bun.file(out).bytes()).extract(extractDir)).toBeGreaterThanOrEqual(2);
+      expect(await Bun.file(join(extractDir, "a.txt")).text()).toBe("a");
+    });
+
+    test("Bun.write accepts a spilled archive", async () => {
+      using dir = tempDir("archive-spill-write", {});
+      const out = join(String(dir), "out.tar");
+      const archive = new Bun.Archive({ "a.txt": "hello" }, { maxMemory: 0 });
+
+      await Bun.write(out, archive);
+      const files = await new Bun.Archive(await Bun.file(out).bytes()).files();
+      expect(await files.get("a.txt")!.text()).toBe("hello");
+    });
+
+    test("a 12MB archive spills and round-trips", async () => {
+      const chunk = Buffer.alloc(1024 * 1024, "z").toString();
+      const archive = new Bun.Archive(undefined, { maxMemory: 1024 * 1024 });
+      for (let i = 0; i < 12; i++) {
+        await archive.append(`chunk-${i}.txt`, chunk);
+      }
+
+      const files = await archive.files();
+      expect(files.size).toBe(12);
+      expect((await files.get("chunk-11.txt")!.text()).length).toBe(chunk.length);
+    });
+
+    test("rejects an invalid maxMemory", () => {
+      expect(() => new Bun.Archive({}, { maxMemory: -1 })).toThrow();
+      // @ts-expect-error - maxMemory must be a number
+      expect(() => new Bun.Archive({}, { maxMemory: "lots" })).toThrow();
     });
   });
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -2212,7 +2212,7 @@ describe("Bun.Archive", () => {
     // Abandoning a libarchive writer mid-entry makes its normal close pad the
     // entry out to the size its header declared, pushing every NUL byte through
     // the sink: a failed append of a 600MB file used to write 600MB of zeros to
-    // a throwaway spill file before the promise settled.
+    // a throwaway buffer before the promise settled.
     // Skipped on macOS: the trick below needs fstat(dir).st_size > 0 so the read
     // loop runs at least once, and POSIX leaves a directory's st_size undefined.
     test.skipIf(isWindows || isMacOS)("a source that fails mid-read does not pad the entry out", async () => {
@@ -2275,68 +2275,6 @@ describe("Bun.Archive", () => {
       const archive = new Bun.Archive();
       // @ts-expect-error - numbers are not valid entry data
       expect(() => archive.append("a.txt", 123)).toThrow();
-    });
-  });
-
-  describe.concurrent("spilling to disk", () => {
-    // Spilled output goes to a temp file and is mapped back in, so it has to
-    // describe exactly the same archive as the purely in-memory path.
-    test("maxMemory: 0 produces the same archive as the in-memory path", async () => {
-      const files = { "a.txt": Buffer.alloc(5000, "a").toString(), "b.txt": Buffer.alloc(5000, "b").toString() };
-      const spilled = await new Bun.Archive(files, { maxMemory: 0 }).bytes();
-      const buffered = await new Bun.Archive(files, { maxMemory: Infinity }).bytes();
-
-      expect(spilled.length).toBe(buffered.length);
-      const entries = await new Bun.Archive(spilled).files();
-      expect([...entries.keys()]).toEqual(["a.txt", "b.txt"]);
-      expect(await entries.get("a.txt")!.text()).toBe(files["a.txt"]);
-      expect(await entries.get("b.txt")!.text()).toBe(files["b.txt"]);
-    });
-
-    test("a spilled archive still extracts, lists, and writes", async () => {
-      using dir = tempDir("archive-spill", {});
-      const archive = new Bun.Archive(undefined, { format: "zip", maxMemory: 0 });
-      await archive.append("a.txt", "a");
-      await archive.append("dir/b.txt", "b");
-
-      const files = await archive.files();
-      expect([...files.keys()].sort()).toEqual(["a.txt", "dir/b.txt"]);
-
-      const out = join(String(dir), "out.zip");
-      await Bun.Archive.write(out, archive);
-      expect(await Bun.file(out).exists()).toBe(true);
-
-      const extractDir = join(String(dir), "extracted");
-      expect(await new Bun.Archive(await Bun.file(out).bytes()).extract(extractDir)).toBeGreaterThanOrEqual(2);
-      expect(await Bun.file(join(extractDir, "a.txt")).text()).toBe("a");
-    });
-
-    test("Bun.write accepts a spilled archive", async () => {
-      using dir = tempDir("archive-spill-write", {});
-      const out = join(String(dir), "out.tar");
-      const archive = new Bun.Archive({ "a.txt": "hello" }, { maxMemory: 0 });
-
-      await Bun.write(out, archive);
-      const files = await new Bun.Archive(await Bun.file(out).bytes()).files();
-      expect(await files.get("a.txt")!.text()).toBe("hello");
-    });
-
-    test("a 12MB archive spills and round-trips", async () => {
-      const chunk = Buffer.alloc(1024 * 1024, "z").toString();
-      const archive = new Bun.Archive(undefined, { maxMemory: 1024 * 1024 });
-      for (let i = 0; i < 12; i++) {
-        await archive.append(`chunk-${i}.txt`, chunk);
-      }
-
-      const files = await archive.files();
-      expect(files.size).toBe(12);
-      expect((await files.get("chunk-11.txt")!.text()).length).toBe(chunk.length);
-    });
-
-    test("rejects an invalid maxMemory", () => {
-      expect(() => new Bun.Archive({}, { maxMemory: -1 })).toThrow();
-      // @ts-expect-error - maxMemory must be a number
-      expect(() => new Bun.Archive({}, { maxMemory: "lots" })).toThrow();
     });
   });
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1043,6 +1043,24 @@ describe("Bun.Archive", () => {
       }).toThrow();
     });
 
+    // Store/deflate have no gzip post-filter, so an explicit `compress` has to be
+    // distinguishable from an omitted one.
+    test("an explicit compress overrides the archive's gzip, an omitted one inherits it", async () => {
+      using dir = tempDir("archive-write-compress-override", {});
+      const gzipMagic = async (p: string) => Array.from((await Bun.file(p).bytes()).subarray(0, 2));
+
+      const inherited = join(String(dir), "inherited.tar.gz");
+      await Bun.Archive.write(inherited, new Bun.Archive({ "f.txt": "x" }, { compress: "gzip" }));
+      expect(await gzipMagic(inherited)).toEqual([0x1f, 0x8b]);
+
+      const overridden = join(String(dir), "overridden.tar");
+      await Bun.Archive.write(overridden, new Bun.Archive({ "f.txt": "x" }, { compress: "gzip" }), {
+        format: "zip",
+        compress: "store",
+      });
+      expect(await gzipMagic(overridden)).not.toEqual([0x1f, 0x8b]);
+    });
+
     test("throws with invalid gzip option", async () => {
       using dir = tempDir("archive-write-invalid-gzip", {});
       const archivePath = join(String(dir), "test.tar");
@@ -1908,7 +1926,7 @@ describe("Bun.Archive", () => {
     });
   });
 
-  describe("Bun.file() entries", () => {
+  describe.concurrent("Bun.file() entries", () => {
     test("the object form streams a Bun.file() instead of writing an empty entry", async () => {
       using dir = tempDir("archive-objform-file", {
         "a.txt": "from disk",
@@ -1952,7 +1970,7 @@ describe("Bun.Archive", () => {
     });
   });
 
-  describe("zip format", () => {
+  describe.concurrent("zip format", () => {
     test("writes a zip with the PK local file header magic", async () => {
       const archive = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip" });
       const bytes = await archive.bytes();
@@ -2010,7 +2028,7 @@ describe("Bun.Archive", () => {
     });
 
     test("deflate is the default and store is larger", async () => {
-      const content = "compress me ".repeat(4096);
+      const content = Buffer.alloc(48 * 1024, "compress me ").toString();
       const deflated = await new Bun.Archive({ "big.txt": content }, { format: "zip" }).bytes();
       const stored = await new Bun.Archive({ "big.txt": content }, { format: "zip", compress: "store" }).bytes();
 
@@ -2052,7 +2070,7 @@ describe("Bun.Archive", () => {
     });
   });
 
-  describe("archive.append()", () => {
+  describe.concurrent("archive.append()", () => {
     test("appends to an empty archive", async () => {
       const archive = new Bun.Archive();
       await archive.append("hello.txt", "Hello, World!");
@@ -2177,6 +2195,13 @@ describe("Bun.Archive", () => {
       expect(() => archive.append("", "a")).toThrow();
     });
 
+    // libarchive takes entry names as NUL-terminated C strings, so "a\0b.txt"
+    // would silently become "a".
+    test("rejects an entry path with an embedded NUL", () => {
+      expect(() => new Bun.Archive().append("foo\u0000bar.txt", "x")).toThrow(/NUL byte/);
+      expect(() => new Bun.Archive({ "baz\u0000qux.txt": "y" })).toThrow(/NUL byte/);
+    });
+
     test("rejects unsupported entry data", () => {
       const archive = new Bun.Archive();
       // @ts-expect-error - numbers are not valid entry data
@@ -2184,11 +2209,11 @@ describe("Bun.Archive", () => {
     });
   });
 
-  describe("spilling to disk", () => {
+  describe.concurrent("spilling to disk", () => {
     // Spilled output goes to a temp file and is mapped back in, so it has to
     // describe exactly the same archive as the purely in-memory path.
     test("maxMemory: 0 produces the same archive as the in-memory path", async () => {
-      const files = { "a.txt": "a".repeat(5000), "b.txt": "b".repeat(5000) };
+      const files = { "a.txt": Buffer.alloc(5000, "a").toString(), "b.txt": Buffer.alloc(5000, "b").toString() };
       const spilled = await new Bun.Archive(files, { maxMemory: 0 }).bytes();
       const buffered = await new Bun.Archive(files, { maxMemory: Infinity }).bytes();
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -2278,6 +2278,111 @@ describe("Bun.Archive", () => {
     });
   });
 
+  describe.concurrent("archive.stream()", () => {
+    test("streams a tar as it is appended", async () => {
+      const archive = new Bun.Archive();
+      const reading = new Response(archive.stream()).bytes();
+
+      await archive.append("a.txt", "hello");
+      await archive.append("b.txt", "world");
+      archive.end();
+
+      const tar = await reading;
+      const files = await new Bun.Archive(tar).files();
+      expect([...files.keys()].sort()).toEqual(["a.txt", "b.txt"]);
+      expect(await files.get("b.txt")!.text()).toBe("world");
+    });
+
+    test("streams a zip", async () => {
+      const archive = new Bun.Archive(undefined, { format: "zip" });
+      const reading = new Response(archive.stream()).bytes();
+
+      await archive.append("x.txt", "x");
+      archive.end();
+
+      const zip = await reading;
+      expect(Array.from(zip.subarray(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04]);
+      expect(await (await new Bun.Archive(zip).files()).get("x.txt")!.text()).toBe("x");
+    });
+
+    // The whole point: the producer is throttled by whoever is reading.
+    test("parks an append while the consumer is behind", async () => {
+      const chunk = Buffer.alloc(2 * 1024 * 1024, "z"); // larger than the high-water mark
+      const archive = new Bun.Archive(undefined, { format: "zip", compress: "store" });
+      const reader = archive.stream().getReader();
+
+      let appended = 0;
+      const appending = (async () => {
+        for (let i = 0; i < 8; i++) {
+          await archive.append(`f${i}.bin`, chunk);
+          appended = i + 1;
+        }
+        archive.end();
+      })();
+
+      // Nothing is reading, so the appends cannot get ahead of the queue.
+      await Bun.sleep(20);
+      expect(appended).toBeLessThan(8);
+
+      let total = 0;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value!.length;
+      }
+      await appending;
+
+      expect(appended).toBe(8);
+      expect(total).toBeGreaterThan(8 * chunk.length);
+    });
+
+    test("a cancelled consumer rejects the parked append", async () => {
+      const chunk = Buffer.alloc(2 * 1024 * 1024, "z");
+      const archive = new Bun.Archive();
+      const reader = archive.stream().getReader();
+
+      const pending = archive.append("big.bin", chunk);
+      await Bun.sleep(20);
+      await reader.cancel();
+
+      await expect(pending).rejects.toThrow(/consumer cancelled/);
+    });
+
+    test("a streamed archive has nothing left to read", async () => {
+      const archive = new Bun.Archive();
+      const reading = new Response(archive.stream()).bytes();
+      await archive.append("a.txt", "a");
+      archive.end();
+      await reading;
+
+      expect(() => archive.bytes()).toThrow(/nothing left to read/);
+      expect(() => archive.append("b.txt", "b")).toThrow(/nothing left to read/);
+    });
+
+    test("rejects a second stream(), and one started mid-append", async () => {
+      const archive = new Bun.Archive();
+      archive.stream();
+      expect(() => archive.stream()).toThrow(/already called/);
+
+      const other = new Bun.Archive();
+      const pending = other.append("a.txt", "a");
+      expect(() => other.stream()).toThrow(/in progress/);
+      await pending;
+    });
+
+    test("rejects stream() on an archive built from existing data", async () => {
+      const tar = await new Bun.Archive({ "a.txt": "a" }).bytes();
+      expect(() => new Bun.Archive(tar).stream()).toThrow(/before the archive is read/);
+    });
+
+    test("end() on a non-streamed archive just seals it", async () => {
+      const archive = new Bun.Archive({ "a.txt": "a" });
+      archive.end();
+      expect((await archive.files()).size).toBe(1);
+      expect(() => archive.append("b.txt", "b")).toThrow();
+    });
+  });
+
   describe("TypeScript types", () => {
     test("valid archive options", () => {
       const files = { "hello.txt": "Hello, World!" };

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -2278,7 +2278,7 @@ describe("Bun.Archive", () => {
     });
   });
 
-  describe.concurrent("archive.stream()", () => {
+  describe("archive.stream()", () => {
     test("streams a tar as it is appended", async () => {
       const archive = new Bun.Archive();
       const reading = new Response(archive.stream()).bytes();
@@ -2305,6 +2305,12 @@ describe("Bun.Archive", () => {
       expect(await (await new Bun.Archive(zip).files()).get("x.txt")!.text()).toBe("x");
     });
 
+    // Yield to the event loop n times. Not a delay: it gives the work pool
+    // that many chances to make progress, which is what we are asserting about.
+    const barriers = async (n: number) => {
+      for (let i = 0; i < n; i++) await Bun.sleep(0);
+    };
+
     // The whole point: the producer is throttled by whoever is reading.
     test("parks an append while the consumer is behind", async () => {
       const chunk = Buffer.alloc(2 * 1024 * 1024, "z"); // larger than the high-water mark
@@ -2320,8 +2326,9 @@ describe("Bun.Archive", () => {
         archive.end();
       })();
 
-      // Nothing is reading, so the appends cannot get ahead of the queue.
-      await Bun.sleep(20);
+      // Nothing is reading, so the appends cannot finish however long we spin.
+      const raced = await Promise.race([appending.then(() => "finished"), barriers(500).then(() => "stalled")]);
+      expect(raced).toBe("stalled");
       expect(appended).toBeLessThan(8);
 
       let total = 0;
@@ -2336,16 +2343,44 @@ describe("Bun.Archive", () => {
       expect(total).toBeGreaterThan(8 * chunk.length);
     });
 
-    test("a cancelled consumer rejects the parked append", async () => {
+    // Whether the append is parked or still on the work pool, a cancelled
+    // consumer has to settle it rather than leave it running or hanging.
+    test.each([0, 1, 8])("a cancelled consumer rejects the append (after %i barriers)", async n => {
       const chunk = Buffer.alloc(2 * 1024 * 1024, "z");
       const archive = new Bun.Archive();
       const reader = archive.stream().getReader();
 
       const pending = archive.append("big.bin", chunk);
-      await Bun.sleep(20);
+      await barriers(n);
       await reader.cancel();
 
       await expect(pending).rejects.toThrow(/consumer cancelled/);
+    });
+
+    // Without this the consumer waits forever on bytes that will never come.
+    test("a failed append fails the consumer's read", async () => {
+      using dir = tempDir("archive-stream-fail", {});
+      const archive = new Bun.Archive();
+      const reading = new Response(archive.stream()).bytes();
+
+      // Both reject in the same turn, so attach handlers before awaiting either.
+      const [append, consumer] = await Promise.allSettled([
+        archive.append("gone.bin", Bun.file(join(String(dir), "nope.bin"))),
+        reading,
+      ]);
+
+      expect(append.status).toBe("rejected");
+      expect((append as PromiseRejectedResult).reason.message).toMatch(/ENOENT|no such file/i);
+      expect(consumer.status).toBe("rejected");
+      expect((consumer as PromiseRejectedResult).reason.message).toMatch(/ENOENT|no such file/i);
+    });
+
+    // gzip is a post-filter over the finished bytes, and nothing post-filters
+    // what goes to the stream, so it must not silently emit a raw tar.
+    test("rejects stream() on a gzip archive", () => {
+      expect(() => new Bun.Archive(undefined, { compress: "gzip" }).stream()).toThrow(
+        /does not support compress: "gzip"/,
+      );
     });
 
     test("a streamed archive has nothing left to read", async () => {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -2172,6 +2172,20 @@ describe("Bun.Archive", () => {
       expect(() => archive.bytes()).toThrow(/can no longer be used/);
     });
 
+    // Abandoning a libarchive writer mid-entry makes its normal close pad the
+    // entry out to the size its header declared, pushing every NUL byte through
+    // the sink: a failed append of a 600MB file used to write 600MB of zeros to
+    // a throwaway spill file before the promise settled.
+    test.skipIf(isWindows)("a source that fails mid-read does not pad the entry out", async () => {
+      using dir = tempDir("archive-append-unreadable", {});
+      const archive = new Bun.Archive();
+
+      // A directory: open() and fstat() succeed, so the entry header is written
+      // with the directory's size, and then read() fails with EISDIR.
+      await expect(archive.append("d.bin", Bun.file(String(dir)))).rejects.toThrow(/EISDIR|directory/i);
+      expect(() => archive.bytes()).toThrow(/can no longer be used/);
+    });
+
     test("rejects every queued append once one fails", async () => {
       using dir = tempDir("archive-append-queue-fail", {});
       const archive = new Bun.Archive();

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -2379,6 +2379,41 @@ describe("Bun.Archive", () => {
       expect((consumer as PromiseRejectedResult).reason.message).toMatch(/ENOENT|no such file/i);
     });
 
+    // The sibling of the test above: a getReader() consumer leaves ByteStream by a
+    // different branch than the buffered one, and it has already taken a chunk, so
+    // the failure arrives after the stream has started producing.
+    test("a failed append fails a getReader() consumer that already took a chunk", async () => {
+      using dir = tempDir("archive-stream-fail-reader", {});
+      const archive = new Bun.Archive();
+      const reader = archive.stream().getReader();
+
+      const gotChunk = Promise.withResolvers<void>();
+      let received = 0;
+      const consuming = (async () => {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) return "clean done";
+          received += value.length;
+          gotChunk.resolve();
+        }
+      })();
+
+      await archive.append("ok.txt", Buffer.alloc(64 * 1024, "a"));
+      await gotChunk.promise; // the consumer is past its first read
+      expect(received).toBeGreaterThan(0);
+
+      const [append, consumer] = await Promise.allSettled([
+        archive.append("gone.bin", Bun.file(join(String(dir), "nope.bin"))),
+        consuming,
+      ]);
+
+      expect(append.status).toBe("rejected");
+      expect((append as PromiseRejectedResult).reason.message).toMatch(/ENOENT|no such file/i);
+      // Not a clean `done`: that would hand back a truncated archive.
+      expect(consumer.status).toBe("rejected");
+      expect((consumer as PromiseRejectedResult).reason.message).toMatch(/ENOENT|no such file/i);
+    });
+
     // gzip is a post-filter over the finished bytes, and nothing post-filters
     // what goes to the stream, so it must not silently emit a raw tar.
     test("rejects stream() on a gzip archive", () => {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -2186,6 +2186,22 @@ describe("Bun.Archive", () => {
       expect(() => archive.bytes()).toThrow(/can no longer be used/);
     });
 
+    // Promise.all() rejects with whichever rejection settles first, so the
+    // failing append has to be delivered before the cascade it triggers,
+    // otherwise the docs' recommended pattern reports "failed earlier" and
+    // hides the ENOENT.
+    test("Promise.all over appends reports the entry that actually failed", async () => {
+      using dir = tempDir("archive-append-all", {});
+      const archive = new Bun.Archive();
+
+      await expect(
+        Promise.all([
+          archive.append("gone.bin", Bun.file(join(String(dir), "nope.bin"))),
+          archive.append("later.txt", "x"),
+        ]),
+      ).rejects.toThrow(/ENOENT|no such file/i);
+    });
+
     test("rejects every queued append once one fails", async () => {
       using dir = tempDir("archive-append-queue-fail", {});
       const archive = new Bun.Archive();

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
 import { existsSync, readdirSync, rmSync } from "node:fs";
 import { join } from "path";
 
@@ -2213,7 +2213,9 @@ describe("Bun.Archive", () => {
     // entry out to the size its header declared, pushing every NUL byte through
     // the sink: a failed append of a 600MB file used to write 600MB of zeros to
     // a throwaway spill file before the promise settled.
-    test.skipIf(isWindows)("a source that fails mid-read does not pad the entry out", async () => {
+    // Skipped on macOS: the trick below needs fstat(dir).st_size > 0 so the read
+    // loop runs at least once, and POSIX leaves a directory's st_size undefined.
+    test.skipIf(isWindows || isMacOS)("a source that fails mid-read does not pad the entry out", async () => {
       using dir = tempDir("archive-append-unreadable", {});
       const archive = new Bun.Archive();
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -2381,8 +2381,9 @@ describe("Bun.Archive", () => {
 
     // The sibling of the test above: a getReader() consumer leaves ByteStream by a
     // different branch than the buffered one, and it has already taken a chunk, so
-    // the failure arrives after the stream has started producing.
-    test("a failed append fails a getReader() consumer that already took a chunk", async () => {
+    // the failure arrives after the stream has started producing. The awaiting loop
+    // body is the point: the consumer is between reads when the append fails.
+    test.each([false, true])("a failed append fails a getReader() consumer (awaiting body: %p)", async awaits => {
       using dir = tempDir("archive-stream-fail-reader", {});
       const archive = new Bun.Archive();
       const reader = archive.stream().getReader();
@@ -2395,6 +2396,7 @@ describe("Bun.Archive", () => {
           if (done) return "clean done";
           received += value.length;
           gotChunk.resolve();
+          if (awaits) await barriers(1);
         }
       })();
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1926,6 +1926,43 @@ describe("Bun.Archive", () => {
     });
   });
 
+  describe.concurrent("Blob input", () => {
+    // Sharing the Blob's store is only the same bytes when the Blob spans the
+    // whole store; a slice sees a window of it.
+    test("a sliced Blob archives its window, not its parent", async () => {
+      using dir = tempDir("archive-blob-slice", {});
+      const tar = await new Bun.Archive({ "a.txt": "a", "b.txt": "b" }).bytes();
+      const blob = new Blob([tar]);
+
+      expect((await new Bun.Archive(blob.slice(0, 512)).bytes()).length).toBe(512);
+      expect((await new Bun.Archive(blob.slice(512)).bytes()).length).toBe(tar.length - 512);
+
+      const out = join(String(dir), "sliced.tar");
+      await Bun.Archive.write(out, blob.slice(0, 512));
+      expect(await Bun.file(out).size).toBe(512);
+    });
+
+    test("an unsliced Blob round-trips", async () => {
+      const tar = await new Bun.Archive({ "a.txt": "a", "b.txt": "b" }).bytes();
+      const archive = new Bun.Archive(new Blob([tar]));
+
+      expect((await archive.bytes()).length).toBe(tar.length);
+      expect([...(await archive.files()).keys()].sort()).toEqual(["a.txt", "b.txt"]);
+    });
+
+    // An empty Blob has no store at all, and must not be mistaken for an object
+    // literal: it is empty archive data, exactly like an empty Uint8Array.
+    test("an empty Blob is empty archive data, not an empty object", async () => {
+      expect((await new Bun.Archive(new Blob([])).bytes()).length).toBe(0);
+      expect((await new Bun.Archive(new Uint8Array(0)).bytes()).length).toBe(0);
+
+      // Zero bytes is not a valid archive, so reading its entries fails the
+      // same way for both.
+      await expect(new Bun.Archive(new Blob([])).files()).rejects.toThrow(/Unrecognized archive format/);
+      await expect(new Bun.Archive(new Uint8Array(0)).files()).rejects.toThrow(/Unrecognized archive format/);
+    });
+  });
+
   describe.concurrent("Bun.file() entries", () => {
     test("the object form streams a Bun.file() instead of writing an empty entry", async () => {
       using dir = tempDir("archive-objform-file", {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -2099,11 +2099,15 @@ describe("Bun.Archive", () => {
     });
 
     test("rejects gzip with zip and deflate with tar", () => {
-      expect(() => new Bun.Archive({ "a.txt": "a" }, { format: "zip", compress: "gzip" })).toThrow();
+      expect(() => new Bun.Archive({ "a.txt": "a" }, { format: "zip", compress: "gzip" })).toThrow(
+        /compress: "gzip" is not supported with format: "zip"/,
+      );
       // @ts-expect-error - deflate requires format: "zip"
-      expect(() => new Bun.Archive({ "a.txt": "a" }, { compress: "deflate" })).toThrow();
+      expect(() => new Bun.Archive({ "a.txt": "a" }, { compress: "deflate" })).toThrow(
+        /compress: "deflate" requires format: "zip"/,
+      );
       // @ts-expect-error - unknown format
-      expect(() => new Bun.Archive({ "a.txt": "a" }, { format: "7z" })).toThrow();
+      expect(() => new Bun.Archive({ "a.txt": "a" }, { format: "7z" })).toThrow(/format must be "tar" or "zip"/);
     });
   });
 
@@ -2185,7 +2189,7 @@ describe("Bun.Archive", () => {
       const tar = await new Bun.Archive({ "a.txt": "a" }).bytes();
       const archive = new Bun.Archive(tar);
 
-      expect(() => archive.append("b.txt", "b")).toThrow();
+      expect(() => archive.append("b.txt", "b")).toThrow(/cannot append to existing archive data/);
     });
 
     test("throws when reading while an append is still pending", async () => {
@@ -2257,11 +2261,11 @@ describe("Bun.Archive", () => {
       expect((queued as PromiseRejectedResult).reason.message).toMatch(/can no longer be used/);
     });
 
-    test("rejects a non-string path", () => {
+    test("rejects a non-string path, and an empty one", () => {
       const archive = new Bun.Archive();
       // @ts-expect-error - path must be a string
-      expect(() => archive.append(123, "a")).toThrow();
-      expect(() => archive.append("", "a")).toThrow();
+      expect(() => archive.append(123, "a")).toThrow(/first argument must be a string path/);
+      expect(() => archive.append("", "a")).toThrow(/path must not be empty/);
     });
 
     // libarchive takes entry names as NUL-terminated C strings, so "a\0b.txt"
@@ -2274,7 +2278,7 @@ describe("Bun.Archive", () => {
     test("rejects unsupported entry data", () => {
       const archive = new Bun.Archive();
       // @ts-expect-error - numbers are not valid entry data
-      expect(() => archive.append("a.txt", 123)).toThrow();
+      expect(() => archive.append("a.txt", 123)).toThrow(/expected a string, Blob, TypedArray, or ArrayBuffer/);
     });
   });
 
@@ -2394,6 +2398,60 @@ describe("Bun.Archive", () => {
       expect(() => archive.append("b.txt", "b")).toThrow(/nothing left to read/);
     });
 
+    // `new Response(stream).bytes()` attaches a buffer_action, which accumulates
+    // into the ByteStream's buffer rather than draining it. Treating that buffer
+    // as a queue depth parked the append against a number that only ever grows.
+    test("an entry past the high-water mark still reaches a buffered consumer", async () => {
+      const archive = new Bun.Archive();
+      const reading = new Response(archive.stream()).bytes();
+
+      const big = Buffer.alloc(2 * 1024 * 1024, "z"); // > STREAM_HIGH_WATER_MARK
+      await archive.append("big.bin", big);
+      archive.end();
+
+      const files = await new Bun.Archive(await reading).files();
+      expect(Buffer.from(await files.get("big.bin")!.arrayBuffer()).equals(big)).toBe(true);
+    });
+
+    // The pattern the docs recommend for writing a large archive to disk.
+    test("streams into a FileSink a chunk at a time", async () => {
+      using dir = tempDir("archive-stream-sink", {});
+      const out = join(String(dir), "out.zip");
+      const archive = new Bun.Archive(undefined, { format: "zip" });
+
+      const writer = Bun.file(out).writer();
+      const writing = (async () => {
+        for await (const chunk of archive.stream()) writer.write(chunk);
+        await writer.end();
+      })();
+
+      await archive.append("a.txt", "a");
+      await archive.append("big.bin", Buffer.alloc(2 * 1024 * 1024, "z"));
+      archive.end();
+      await writing;
+
+      const files = await new Bun.Archive(await Bun.file(out).bytes()).files();
+      expect([...files.keys()].sort()).toEqual(["a.txt", "big.bin"]);
+      expect(await files.get("a.txt")!.text()).toBe("a");
+      expect((await files.get("big.bin")!.arrayBuffer()).byteLength).toBe(2 * 1024 * 1024);
+    });
+
+    // Closing the builder out from under the stream would hand these bytes to
+    // the caller and leave the consumer waiting on an end that never comes.
+    test("reading a streaming archive throws instead of stranding the consumer", async () => {
+      const archive = new Bun.Archive();
+      const reading = new Response(archive.stream()).bytes();
+
+      expect(() => archive.bytes()).toThrow(/nothing left to read/);
+      expect(() => archive.blob()).toThrow(/nothing left to read/);
+
+      // Nothing was consumed, so the stream still finishes normally.
+      await archive.append("a.txt", "a");
+      archive.end();
+      const files = await new Bun.Archive(await reading).files();
+      expect(await files.get("a.txt")!.text()).toBe("a");
+    });
+
     test("rejects a second stream(), and one started mid-append", async () => {
       const archive = new Bun.Archive();
       archive.stream();
@@ -2414,7 +2472,7 @@ describe("Bun.Archive", () => {
       const archive = new Bun.Archive({ "a.txt": "a" });
       archive.end();
       expect((await archive.files()).size).toBe(1);
-      expect(() => archive.append("b.txt", "b")).toThrow();
+      expect(() => archive.append("b.txt", "b")).toThrow(/only available before the archive is read/);
     });
   });
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1908,6 +1908,50 @@ describe("Bun.Archive", () => {
     });
   });
 
+  describe("Bun.file() entries", () => {
+    test("the object form streams a Bun.file() instead of writing an empty entry", async () => {
+      using dir = tempDir("archive-objform-file", {
+        "a.txt": "from disk",
+        "b.json": JSON.stringify({ n: 1 }),
+      });
+
+      const archive = new Bun.Archive({
+        "a.txt": Bun.file(join(String(dir), "a.txt")),
+        "b.json": Bun.file(join(String(dir), "b.json")),
+        "inline.txt": "inline",
+      });
+
+      const files = await archive.files();
+      expect(await files.get("a.txt")!.text()).toBe("from disk");
+      expect(await files.get("b.json")!.text()).toBe(JSON.stringify({ n: 1 }));
+      expect(await files.get("inline.txt")!.text()).toBe("inline");
+    });
+
+    test("the object form honors a sliced Bun.file()", async () => {
+      using dir = tempDir("archive-objform-slice", { "a.txt": "0123456789" });
+
+      const archive = new Bun.Archive({ "s.txt": Bun.file(join(String(dir), "a.txt")).slice(2, 6) });
+      expect(await (await archive.files()).get("s.txt")!.text()).toBe("2345");
+    });
+
+    test("Archive.write() streams Bun.file() entries too", async () => {
+      using dir = tempDir("archive-objform-write", { "src.txt": "streamed" });
+      const out = join(String(dir), "out.tar");
+
+      await Bun.Archive.write(out, { "src.txt": Bun.file(join(String(dir), "src.txt")) });
+
+      const files = await new Bun.Archive(await Bun.file(out).bytes()).files();
+      expect(await files.get("src.txt")!.text()).toBe("streamed");
+    });
+
+    test("a missing Bun.file() throws rather than writing an empty entry", () => {
+      using dir = tempDir("archive-objform-missing", {});
+      expect(() => new Bun.Archive({ "gone.txt": Bun.file(join(String(dir), "gone.txt")) })).toThrow(
+        /ENOENT|no such file/i,
+      );
+    });
+  });
+
   describe("zip format", () => {
     test("writes a zip with the PK local file header magic", async () => {
       const archive = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip" });


### PR DESCRIPTION
Fixes #27077
Fixes #28459

`Bun.Archive` could only write tar, and an archive had to be built entirely in memory before any of it could be read, so packing anything bigger than RAM was impossible.

## `format: "zip"`

```ts
const archive = new Bun.Archive({ "hello.txt": "Hello, World!" }, { format: "zip" });
await Bun.write("bundle.zip", archive);
```

Per-entry deflate is the default (levels 1-9); `compress: "store"` writes them uncompressed. Reading auto-detects zip alongside tar and tar.gz, so `extract()`, `files()`, and the glob filters work on zip input with no option at all. libarchive already compiled its zip reader and writer in, only the bindings were missing.

## `archive.append(path, data)`

An archive from `new Archive(object)` (or from no argument) now keeps its libarchive writer open until its bytes are first read, instead of closing it in the constructor.

```ts
const archive = new Bun.Archive(undefined, { format: "zip" });
for await (const path of new Bun.Glob("**/*").scan(".")) {
  await archive.append(path, Bun.file(path)); // copied off disk in 256 KB chunks
}
await Bun.Archive.write("everything.zip", archive);
```

Appends are serialized through a FIFO onto the work pool, so `Promise.all()` over a list of files still produces a deterministic archive. Reading an archive closes it; `append()` after that, or on an `Archive` wrapping existing archive data, throws.

## `archive.stream()`

The bytes come out as a `ReadableStream` while the archive is still being written, and the consumer's reads are what let the next `append()` make progress. Once the stream's queue passes its high-water mark, an in-flight `append()` parks mid-entry and its work-pool task resumes on the stream's drain. A large archive never has to fit in memory.

```ts
const archive = new Bun.Archive(undefined, { format: "zip" });

const writer = Bun.file("everything.zip").writer();
const writing = (async () => {
  for await (const chunk of archive.stream()) writer.write(chunk);
  await writer.end();
})();

for await (const path of new Bun.Glob("**/*").scan(".")) {
  await archive.append(path, Bun.file(path)); // parks when the writer falls behind
}
archive.end();
await writing;
```

Streaming a zip straight to an HTTP client, so it sees bytes before the archive is finished:

```ts
Bun.serve({
  fetch() {
    const archive = new Bun.Archive(undefined, { format: "zip" });
    queueMicrotask(async () => {
      for (const path of paths) await archive.append(path, Bun.file(path));
      archive.end();
    });
    return new Response(archive.stream(), {
      headers: { "content-type": "application/zip" },
    });
  },
});
```

A slow client does not throttle the `append()`s on this path: `RequestContext` attaches the `ByteStream`'s pipe and drains its buffer, after which every chunk goes straight to `resp.write()` and the buffer length stays 0, so `stream_is_backed_up()` never trips. Measured with a client that reads nothing: all 20 appends of an 80 MB archive still finish, and uSockets holds what the client has not taken. The response is still produced incrementally; wiring `resp.write()`'s backpressure back into the `ByteStream` is a `RequestContext` change, not this one. The docs say so rather than claiming a bound that is not there.

Memory is flat in the size of the archive. Draining the stream incrementally, under a debug + ASAN build (which has a large fixed floor of its own):

| archive | peak RSS delta |
|---|---|
| 200 MB | 187 MB |
| 400 MB | 194 MB |
| 800 MB | 199 MB |

Quadrupling the archive costs 12 MB. That bound is the incremental-drain case. A consumer that asks for the whole thing at once, like `new Response(archive.stream()).bytes()`, buffers it all by definition, and the `Bun.serve` path above does not throttle at all; the docs say both.

An `append()` is split into resumable steps, so a long one yields to the event loop between chunks instead of holding the writer for the whole file. If the consumer cancels, a parked `append()` rejects rather than hanging; if an `append()` fails, the consumer's read fails with the same error rather than waiting forever. `compress: "gzip"` is a post-filter over the finished tar (libdeflate has no streaming API), so `stream()` throws on a gzip archive and points at `format: "zip"`, whose compression is per-entry.

## Bugs this turned up

**A latent null-pointer slice.** `lib::Archive::next()` did `slice::from_raw_parts(buff, size)` unconditionally on `ARCHIVE_OK`. libarchive's stored-zip reader signals end-of-entry with `ARCHIVE_OK` and `*buff = NULL, *size = 0` ([`zip_read_data_none`](https://github.com/libarchive/libarchive/blob/master/libarchive/archive_read_support_format_zip.c#L1666-L1673)), which tar never produced. Extracting an uncompressed zip aborted:

```
panic: unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be
aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
  <bun_libarchive::lib::Archive>::next                 src/libarchive/lib.rs:237
  <bun_libarchive::lib::Archive>::read_data_into_fd    src/libarchive/lib.rs:282
  <bun_libarchive::Archiver>::extract_to_dir           src/libarchive/lib.rs:2211
```

**Entries over 2 GiB were silently corrupted.** `archive_write_data` clamps its length to `INT_MAX` and returns the count it actually took, so one call cannot be assumed to consume the whole slice. Writing a single `INT_MAX + 1024` byte entry produced an archive whose last 1024 bytes read back as NULs: libarchive padded the body out to the size the header declared. It is now a loop over the return value.

**Block padding.** libarchive zero-pads writes up to its 10240-byte default block, which is what tar wants and what a zip must not have: every zip came out 10 KB minimum with trailing zeros. The zip writer sets `bytes_in_last_block = 1`; an empty zip is the canonical 22 bytes again, and tar keeps its padding.

**Abandoning a writer mid-entry wrote out the whole entry.** `archive_write_free` runs a normal close, and closing with a half-written entry makes the format pad that entry to its declared size. A failed `append()` of a 600 MB file wrote 600 MB of NULs into the sink before the promise settled, blocking the JS thread for 494 ms. `Drop` now calls `archive_write_fail` first, which puts the handle in `ARCHIVE_STATE_FATAL` so the close is skipped: 4 MB and 94 ms.

**An embedded NUL truncated an entry's path.** `"a\0b.txt"` was archived as `a`. Rejected up front now, along with the empty path.

**A sliced `Bun.file()` archived its parent's bytes.** `Bun.file(p).slice(4, 8)` ignored the window and wrote the whole file.

## `Bun.file()` in the object form

The second commit fixes #28459: `new Bun.Archive({ "a.txt": Bun.file(p) })` wrote a 0-byte entry, because the constructor read the blob with `shared_view()`, which is empty for a file-backed store. It now takes the same streaming path `append()` uses, so the file is copied off disk a chunk at a time rather than read wholly into memory. A missing file throws instead of silently archiving nothing. This overlaps with #28460, which fixes the same issue by reading the file into memory; I went this way because `append()` needed the streaming path anyway and leaving the object form broken inside this diff would have been strange. Happy to drop the commit if #28460 lands first.

## Verification

```
bun bd test test/js/bun/archive.test.ts        153 pass, 1 skip, 0 fail   (debug + ASAN)
bun bd test test/cli/install/bun-pack.test.ts   74 pass, 0 fail
bun run rust:check-all                          10 ok, 0 failed
```

Interop, both directions: `unzip -t` and python's `zipfile` read and verify our output (deflated and stored), and we read and extract theirs. `bun install`'s tarball extraction is untouched, the zip reader is opt-in via `ExtractOptions.zip`, off there and on for `Bun.Archive`.

## Two `Bun.write` bugs the docs walked into

Neither is this PR's to fix, but both shaped the docs, and the second one looks worth a separate issue. On stock 1.4.0, with no archive code involved:

```js
const mk = () => new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("hello")); c.close(); } });

await Bun.write(path, mk());                  // writes 23 bytes: "[object ReadableStream]"
await Bun.write(path, new Response(mk()));    // never settles
```

The first is #31689. The second I have not found an issue for, and it is the pattern an earlier revision of these docs recommended. The docs now pump into a `Bun.file(path).writer()` instead, which works and keeps the memory bound.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/archive.test.ts

<!-- robobun:evidence:end -->