### PR TITLE
resolve: make relative `options.paths` entries absolute

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1426,12 +1426,46 @@ pub fn bun_resolve_sync_with_paths(
     };
     let source_str = scopeguard::guard(source_str, |s| s.deref());
 
+    // The resolver walks each entry as a directory, which requires it to be
+    // absolute. Node resolves relative entries against the cwd too, via the
+    // `path.resolve()` at the top of `Module._nodeModulePaths`.
+    let mut abs_bufs: Vec<Vec<u8>> = Vec::new();
+    let mut abs_paths: Vec<BunString> = Vec::with_capacity(paths.len());
+    {
+        use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
+        let top_level_dir = global.bun_vm().top_level_dir();
+        let mut join_buf = bun_paths::path_buffer_pool::get();
+        for path in paths {
+            let utf8 = path.to_utf8_without_ref();
+            if bun_paths::is_absolute(utf8.slice()) {
+                abs_paths.push(*path);
+                continue;
+            }
+            // `None` means the joined path does not fit in MAX_PATH_BYTES, so it
+            // cannot name a real directory either. Dropping the entry is the only
+            // option: the resolver would assert on the relative original.
+            let Some(abs) = join_abs_string_buf_checked::<platform::Auto>(
+                top_level_dir,
+                join_buf.as_mut_slice(),
+                &[utf8.slice()],
+            ) else {
+                continue;
+            };
+            abs_bufs.push(abs.to_vec());
+            // Borrowed, not cloned: `abs_bufs` owns the bytes until this function
+            // returns, and its elements' heap buffers never move.
+            abs_paths.push(BunString::borrow_utf8(abs_bufs.last().unwrap()));
+        }
+    }
+
     // SAFETY: bun_vm() returns the live thread-local VM for a Bun-owned global.
     let bun_vm = global.bun_vm().as_mut();
     debug_assert!(bun_vm.transpiler.resolver.custom_dir_paths.is_none());
-    // SAFETY: `paths` borrows C++-owned BunStrings valid for the duration of
-    // this synchronous resolve call; lifetime is erased for the resolver slot.
-    bun_vm.transpiler.resolver.custom_dir_paths = Some(unsafe { bun_ptr::detach_lifetime(paths) });
+    // SAFETY: `abs_paths` borrows the C++-owned BunStrings and `abs_bufs`, both
+    // valid for the duration of this synchronous resolve call; lifetime is
+    // erased for the resolver slot.
+    bun_vm.transpiler.resolver.custom_dir_paths =
+        Some(unsafe { bun_ptr::detach_lifetime(abs_paths.as_slice()) });
     scopeguard::defer! {
         // SAFETY: same VM pointer; called before returning to C++.
         global.bun_vm().as_mut().transpiler.resolver.custom_dir_paths = None;

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { isModuleResolveFilenameSlowPathEnabled } from "bun:internal-for-testing";
 import { expect, it, mock } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, ospath, tempDir } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import Module from "node:module";
 import { tmpdir } from "node:os";
@@ -230,6 +230,54 @@ it('import("bun") works', async () => {
 
 it("require.resolve with empty options object", () => {
   expect(require.resolve(import.meta.path + String(""), {})).toBe(import.meta.path);
+});
+
+it("require.resolve resolves relative options.paths against the cwd", async () => {
+  using dir = tempDir("resolve-relative-paths", {
+    "node_modules/dummy-pkg/package.json": JSON.stringify({ name: "dummy-pkg", main: "index.js" }),
+    "node_modules/dummy-pkg/index.js": "module.exports = 1;",
+    "sub/target.js": "module.exports = 2;",
+    "fixture.js": `
+      const Module = require("node:module");
+      const path = require("node:path");
+      const rel = p => path.relative(process.cwd(), p).replaceAll(path.sep, "/");
+      // Non-string entries are coerced, so these end up as relative paths too.
+      const coerced = [-5.0, 4.736300735651323, -769908.0822694495, -1000000000.0];
+      console.log(rel(require.resolve("dummy-pkg", { paths: ["sub"] })));
+      console.log(rel(require.resolve("dummy-pkg", { paths: ["./sub"] })));
+      console.log(rel(require.resolve("dummy-pkg", { paths: [""] })));
+      console.log(rel(require.resolve("dummy-pkg", { paths: ["does-not-exist"] })));
+      console.log(rel(require.resolve("dummy-pkg", { paths: coerced })));
+      console.log(rel(require.resolve("./target.js", { paths: ["sub"] })));
+      console.log(rel(Module._resolveFilename("dummy-pkg", null, false, { paths: ["sub"] })));
+      // Absolute entries are passed through untouched, including ones too long to
+      // join: the resolver falls back to the nearest existing parent directory.
+      const tooLong = path.join(process.cwd(), Buffer.alloc(8000, "a").toString());
+      console.log(rel(require.resolve("dummy-pkg", { paths: [tooLong] })));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(normalizeBunSnapshot(stdout, String(dir))).toMatchInlineSnapshot(`
+    "node_modules/dummy-pkg/index.js
+    node_modules/dummy-pkg/index.js
+    node_modules/dummy-pkg/index.js
+    node_modules/dummy-pkg/index.js
+    node_modules/dummy-pkg/index.js
+    sub/target.js
+    node_modules/dummy-pkg/index.js
+    node_modules/dummy-pkg/index.js"
+  `);
+  expect(exitCode).toBe(0);
 });
 
 it("dynamically import bun", async () => {


### PR DESCRIPTION
### What's the problem?

`require.resolve(id, { paths })` and `Module._resolveFilename(id, parent, isMain, { paths })` pass each `paths` entry straight through to the resolver, which walks it as a lookup directory. `Resolver::dir_info_cached` requires an absolute path and asserts on anything else, so a relative entry aborted the process:

```console
$ bun -e 'require.resolve("some-pkg", { paths: ["sub"] })'
panic: cannot resolve DirInfo for non-absolute path: sub
```

That's a plain `assert!`, not a `debug_assert!`, so it aborts release builds too. Node accepts relative entries here and resolves them against the cwd:

```console
$ node -e 'console.log(require.resolve("foo", { paths: ["sub"] }))'
/tmp/t/node_modules/foo/index.js
```

Non-string entries reach the same assert, because the C++ side coerces them with `toWTFString()` first, so `{ paths: [-5] }` arrives as the relative path `"-5"`. That's how a fuzzer found it.

### What's the fix?

Make the entries absolute in `bun_resolve_sync_with_paths` (the single funnel both C++ call sites go through) before they are published to `Resolver::custom_dir_paths`, mirroring the `path.resolve(from)` at the top of Node's `Module._nodeModulePaths`.

Entries that are already absolute are passed through untouched, so the resolver's existing "walk up to the nearest existing parent" fallback still handles absolute paths too long to fit in `MAX_PATH_BYTES`. An entry that cannot be joined into a path buffer is dropped: it cannot name a real directory, and the relative original would re-trip the assert.

### Behavior

Checked against Node 26 in a directory containing `node_modules/foo` and an empty `sub/`:

| `paths` entry | node | bun before | bun after |
| --- | --- | --- | --- |
| `"sub"` | `…/node_modules/foo/index.js` | **panic** | `…/node_modules/foo/index.js` |
| `"./sub"` | `…/node_modules/foo/index.js` | **panic** | `…/node_modules/foo/index.js` |
| `""` | `…/node_modules/foo/index.js` | **panic** | `…/node_modules/foo/index.js` |
| `"."` | `…/node_modules/foo/index.js` | **panic** | `…/node_modules/foo/index.js` |
| `-5` | `ERR_INVALID_ARG_TYPE` | **panic** | `…/node_modules/foo/index.js` |
| `"/abs/sub"` | `…/node_modules/foo/index.js` | `…/node_modules/foo/index.js` | `…/node_modules/foo/index.js` |

Numbers still resolve rather than throwing: Bun coerces `paths` entries to strings today, and this PR only stops the abort. Tightening that to Node's `ERR_INVALID_ARG_TYPE` is a separate compat change.

### Test

`test/js/bun/resolve/import-meta.test.js` spawns a fixture covering relative, dot-relative, empty-string, nonexistent, and coerced-number entries, a relative specifier resolved against a relative `paths` entry, the `Module._resolveFilename` entry point, and an absolute entry too long to join. It fails with `USE_SYSTEM_BUN=1` (the subprocess dies with `SIGABRT`), and deleting either half of the fix breaks it.