### PR TITLE
css: scope animation-name to its @keyframes hash in CSS modules (#18921)

### DIFF
--- a/src/css/generics.rs
+++ b/src/css/generics.rs
@@ -445,7 +445,7 @@ mod inherent_bridge {
     bridge_deep_clone!(AnimationName);
 
     use crate::properties::animation::Animation;
-    bridge_eql!(Animation);
+    // `CssEql` for `Animation` via `#[derive(CssEql)]` on the struct.
     bridge_deep_clone!(Animation);
 
     use crate::properties::custom::UAEnvironmentVariable;
@@ -512,6 +512,18 @@ mod inherent_bridge {
 
     use crate::values::easing::EasingFunction;
     bridge_clone_partialeq!(EasingFunction);
+
+    use crate::properties::animation::{
+        AnimationDirection, AnimationFillMode, AnimationIterationCount, AnimationPlayState,
+        AnimationTimeline,
+    };
+    bridge_eql_partialeq!(
+        AnimationIterationCount,
+        AnimationDirection,
+        AnimationPlayState,
+        AnimationFillMode,
+        AnimationTimeline,
+    );
 
     use crate::values::alpha::AlphaValue;
     bridge_clone_partialeq!(AlphaValue);

--- a/src/css/generics.rs
+++ b/src/css/generics.rs
@@ -444,6 +444,10 @@ mod inherent_bridge {
     bridge_hash!(AnimationName);
     bridge_deep_clone!(AnimationName);
 
+    use crate::properties::animation::Animation;
+    bridge_eql!(Animation);
+    bridge_deep_clone!(Animation);
+
     use crate::properties::custom::UAEnvironmentVariable;
     impl CssEql for UAEnvironmentVariable {
         #[inline]

--- a/src/css/properties/animation.rs
+++ b/src/css/properties/animation.rs
@@ -38,9 +38,38 @@ pub struct Animation {
 }
 
 impl Animation {
-    // PropertyFieldMap omitted: `PropertyIdTag::Animation*` variants are not yet
-    // generated (animation longhands are unparsed-only for now). Re-add the
-    // field→PropertyIdTag table once the variants land.
+    // Field-wise (not `#[derive]`) because `AnimationName` carries a raw
+    // `*const [u8]` arena pointer; a derived `PartialEq` would compare by pointer.
+    pub(crate) fn eql(&self, other: &Self) -> bool {
+        self.name.eql(&other.name)
+            && self.duration == other.duration
+            && self.timing_function == other.timing_function
+            && self.iteration_count == other.iteration_count
+            && self.direction == other.direction
+            && self.play_state == other.play_state
+            && self.delay == other.delay
+            && self.fill_mode == other.fill_mode
+            && self.timeline == other.timeline
+    }
+
+    pub(crate) fn deep_clone(&self, bump: &bun_alloc::Arena) -> Self {
+        Animation {
+            name: self.name.deep_clone(bump),
+            duration: self.duration,
+            timing_function: self.timing_function.clone(),
+            iteration_count: self.iteration_count,
+            direction: self.direction,
+            play_state: self.play_state,
+            delay: self.delay,
+            fill_mode: self.fill_mode,
+            timeline: self.timeline.deep_clone(bump),
+        }
+    }
+
+    // PropertyFieldMap omitted: the animation *longhands* (animation-duration,
+    // animation-delay, …) are still unparsed-only, so shorthand→longhand
+    // expansion has nothing to map to yet. Re-add the field→PropertyIdTag table
+    // once those longhand variants land.
 
     pub const VENDOR_PREFIX_MAP: &'static [(&'static str, bool)] = &[
         ("name", true),
@@ -145,68 +174,102 @@ impl Animation {
             AnimationName::String(s) => Some(unsafe { crate::arena_str(*s) }),
         };
 
-        if let Some(name_str) = name_str {
-            if !self.duration.is_zero() || !self.delay.is_zero() {
-                self.duration.to_css(dest)?;
-                dest.write_char(b' ')?;
-            }
+        // Unlike lightningcss — which only emits the components when a name is
+        // present and relies on its declaration handler to never serialize a
+        // name-less shorthand — Bun prints the `Animation` struct directly, so
+        // the components must be emitted even when the name is `none`; otherwise
+        // `animation: 2s` would collapse to `none` and lose its duration. The
+        // keyword-disambiguation checks (a name spelled like a component keyword
+        // forces that component to be shown) only apply when there is a name.
+        let mut wrote_any = false;
+        macro_rules! space {
+            () => {
+                if wrote_any {
+                    dest.write_char(b' ')?;
+                }
+            };
+        }
 
-            if !self.timing_function.is_ease() || EasingFunction::is_ident(name_str) {
-                self.timing_function.to_css(dest)?;
-                dest.write_char(b' ')?;
-            }
+        if !self.duration.is_zero() || !self.delay.is_zero() {
+            space!();
+            self.duration.to_css(dest)?;
+            wrote_any = true;
+        }
 
-            if !self.delay.is_zero() {
-                self.delay.to_css(dest)?;
-                dest.write_char(b' ')?;
-            }
+        if !self.timing_function.is_ease()
+            || name_str.is_some_and(|n| EasingFunction::is_ident(n))
+        {
+            space!();
+            self.timing_function.to_css(dest)?;
+            wrote_any = true;
+        }
 
-            if self.iteration_count != AnimationIterationCount::default()
-                || strings::eql_case_insensitive_ascii(name_str, b"infinite", true)
-            {
-                self.iteration_count.to_css(dest)?;
-                dest.write_char(b' ')?;
-            }
+        if !self.delay.is_zero() {
+            space!();
+            self.delay.to_css(dest)?;
+            wrote_any = true;
+        }
 
-            if self.direction != AnimationDirection::default()
-                || css::parse_utility::parse_string::<AnimationDirection>(
+        if self.iteration_count != AnimationIterationCount::default()
+            || name_str.is_some_and(|n| strings::eql_case_insensitive_ascii(n, b"infinite", true))
+        {
+            space!();
+            self.iteration_count.to_css(dest)?;
+            wrote_any = true;
+        }
+
+        if self.direction != AnimationDirection::default()
+            || name_str.is_some_and(|n| {
+                css::parse_utility::parse_string::<AnimationDirection>(
                     dest.arena,
-                    name_str,
+                    n,
                     AnimationDirection::parse,
                 )
                 .is_ok()
-            {
-                self.direction.to_css(dest)?;
-                dest.write_char(b' ')?;
-            }
+            })
+        {
+            space!();
+            self.direction.to_css(dest)?;
+            wrote_any = true;
+        }
 
-            if self.fill_mode != AnimationFillMode::default()
-                || (!strings::eql_case_insensitive_ascii(name_str, b"none", true)
+        if self.fill_mode != AnimationFillMode::default()
+            || name_str.is_some_and(|n| {
+                !strings::eql_case_insensitive_ascii(n, b"none", true)
                     && css::parse_utility::parse_string::<AnimationFillMode>(
                         dest.arena,
-                        name_str,
+                        n,
                         AnimationFillMode::parse,
                     )
-                    .is_ok())
-            {
-                self.fill_mode.to_css(dest)?;
-                dest.write_char(b' ')?;
-            }
+                    .is_ok()
+            })
+        {
+            space!();
+            self.fill_mode.to_css(dest)?;
+            wrote_any = true;
+        }
 
-            if self.play_state != AnimationPlayState::default()
-                || css::parse_utility::parse_string::<AnimationPlayState>(
+        if self.play_state != AnimationPlayState::default()
+            || name_str.is_some_and(|n| {
+                css::parse_utility::parse_string::<AnimationPlayState>(
                     dest.arena,
-                    name_str,
+                    n,
                     AnimationPlayState::parse,
                 )
                 .is_ok()
-            {
-                self.play_state.to_css(dest)?;
-                dest.write_char(b' ')?;
-            }
+            })
+        {
+            space!();
+            self.play_state.to_css(dest)?;
+            wrote_any = true;
         }
 
-        self.name.to_css(dest)?;
+        // A `none` name is redundant once other components were written, so only
+        // emit the name when it is a real name or nothing else was written.
+        if !matches!(self.name, AnimationName::None) || !wrote_any {
+            space!();
+            self.name.to_css(dest)?;
+        }
 
         if !matches!(self.name, AnimationName::None)
             && self.timeline != AnimationTimeline::default()
@@ -345,7 +408,7 @@ impl AnimationName {
 }
 
 /// A value for the [animation-iteration-count](https://drafts.csswg.org/css-animations/#animation-iteration-count) property.
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum AnimationIterationCount {
     /// The animation will repeat the specified number of times.
     Number(CSSNumber),
@@ -511,6 +574,18 @@ impl AnimationTimeline {
 
     pub fn is_default(&self) -> bool {
         matches!(self, AnimationTimeline::Auto)
+    }
+
+    pub fn deep_clone(&self, _bump: &bun_alloc::Arena) -> Self {
+        match self {
+            AnimationTimeline::Auto => AnimationTimeline::Auto,
+            AnimationTimeline::None => AnimationTimeline::None,
+            // `DashedIdent` is a `Copy` arena-slice pointer.
+            AnimationTimeline::DashedIdent(d) => AnimationTimeline::DashedIdent(*d),
+            AnimationTimeline::Scroll(_) | AnimationTimeline::View(_) => {
+                unreachable!("ScrollTimeline / ViewTimeline are uninstantiated (no parse path)")
+            }
+        }
     }
 }
 

--- a/src/css/properties/animation.rs
+++ b/src/css/properties/animation.rs
@@ -6,6 +6,7 @@ use crate::css_values::length::{LengthPercentage, LengthPercentageOrAuto};
 use crate::css_values::number::{CSSNumber, CSSNumberFns};
 use crate::css_values::size::Size2D;
 use crate::css_values::time::Time;
+use crate::generics::CssEql;
 use crate::{Parser, PrintErr, Printer, SmallList};
 use bun_core::strings;
 
@@ -16,6 +17,7 @@ pub type AnimationList = SmallList<Animation, 1>;
 pub type AnimationNameList = SmallList<AnimationName, 1>;
 
 /// A value for the [animation](https://drafts.csswg.org/css-animations/#animation) shorthand property.
+#[derive(CssEql)]
 pub struct Animation {
     /// The animation name.
     pub name: AnimationName,
@@ -38,20 +40,6 @@ pub struct Animation {
 }
 
 impl Animation {
-    // Field-wise (not `#[derive]`) because `AnimationName` carries a raw
-    // `*const [u8]` arena pointer; a derived `PartialEq` would compare by pointer.
-    pub(crate) fn eql(&self, other: &Self) -> bool {
-        self.name.eql(&other.name)
-            && self.duration == other.duration
-            && self.timing_function == other.timing_function
-            && self.iteration_count == other.iteration_count
-            && self.direction == other.direction
-            && self.play_state == other.play_state
-            && self.delay == other.delay
-            && self.fill_mode == other.fill_mode
-            && self.timeline == other.timeline
-    }
-
     pub(crate) fn deep_clone(&self, bump: &bun_alloc::Arena) -> Self {
         Animation {
             name: self.name.deep_clone(bump),

--- a/src/css/properties/animation.rs
+++ b/src/css/properties/animation.rs
@@ -184,8 +184,7 @@ impl Animation {
             wrote_any = true;
         }
 
-        if !self.timing_function.is_ease() || name_str.is_some_and(|n| EasingFunction::is_ident(n))
-        {
+        if !self.timing_function.is_ease() || name_str.is_some_and(EasingFunction::is_ident) {
             space!();
             self.timing_function.to_css(dest)?;
             wrote_any = true;
@@ -415,9 +414,9 @@ impl AnimationIterationCount {
     }
 
     // Port of `css.DeriveToCss(@This()).toCss`.
-    pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
+    pub fn to_css(self, dest: &mut Printer) -> Result<(), PrintErr> {
         match self {
-            AnimationIterationCount::Number(n) => CSSNumberFns::to_css(*n, dest),
+            AnimationIterationCount::Number(n) => CSSNumberFns::to_css(n, dest),
             AnimationIterationCount::Infinite => dest.write_str(b"infinite"),
         }
     }

--- a/src/css/properties/animation.rs
+++ b/src/css/properties/animation.rs
@@ -184,8 +184,7 @@ impl Animation {
             wrote_any = true;
         }
 
-        if !self.timing_function.is_ease()
-            || name_str.is_some_and(|n| EasingFunction::is_ident(n))
+        if !self.timing_function.is_ease() || name_str.is_some_and(|n| EasingFunction::is_ident(n))
         {
             space!();
             self.timing_function.to_css(dest)?;

--- a/src/css/properties/mod.rs
+++ b/src/css/properties/mod.rs
@@ -302,6 +302,9 @@ mod generic_registrations {
         transform::Translate,
         // transition
         transition::Transition,
+        // animation
+        animation::Animation,
+        animation::AnimationName,
         // ui
         ui::ColorScheme,
         // PropertyId (used as `SmallList<PropertyId, 1>` for `transition-property`)

--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -5823,10 +5823,9 @@ impl Property {
                 }
             }
             PropertyId::Animation(pre) => {
-                if let Ok(c) = css::generic::parse_with_options::<
-                    SmallList<animation::Animation, 1>,
-                >(input, options)
-                {
+                if let Ok(c) = css::generic::parse_with_options::<SmallList<animation::Animation, 1>>(
+                    input, options,
+                ) {
                     if input.expect_exhausted().is_ok() {
                         return Ok(Property::Animation((c, pre)));
                     }

--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -18,6 +18,7 @@ use super::properties_impl;
 
 // Leaf property modules.
 use super::align;
+use super::animation;
 use super::background;
 use super::border;
 use super::border_image;
@@ -245,6 +246,8 @@ pub enum PropertyIdTag {
     TransitionDelay,
     TransitionTimingFunction,
     Transition,
+    Animation,
+    AnimationName,
     Transform,
     TransformOrigin,
     TransformStyle,
@@ -342,6 +345,8 @@ impl PropertyIdTag {
                 | PropertyIdTag::TransitionDelay
                 | PropertyIdTag::TransitionTimingFunction
                 | PropertyIdTag::Transition
+                | PropertyIdTag::Animation
+                | PropertyIdTag::AnimationName
                 | PropertyIdTag::Transform
                 | PropertyIdTag::TransformOrigin
                 | PropertyIdTag::TransformStyle
@@ -401,6 +406,8 @@ impl PropertyIdTag {
             T::TransitionDelay => PrefixFeature::TransitionDelay,
             T::TransitionTimingFunction => PrefixFeature::TransitionTimingFunction,
             T::Transition => PrefixFeature::Transition,
+            T::Animation => PrefixFeature::Animation,
+            T::AnimationName => PrefixFeature::AnimationName,
             T::Transform => PrefixFeature::Transform,
             T::TransformOrigin => PrefixFeature::TransformOrigin,
             T::TransformStyle => PrefixFeature::TransformStyle,
@@ -626,6 +633,8 @@ impl PropertyIdTag {
             PropertyIdTag::TransitionDelay => b"transition-delay",
             PropertyIdTag::TransitionTimingFunction => b"transition-timing-function",
             PropertyIdTag::Transition => b"transition",
+            PropertyIdTag::Animation => b"animation",
+            PropertyIdTag::AnimationName => b"animation-name",
             PropertyIdTag::Transform => b"transform",
             PropertyIdTag::TransformOrigin => b"transform-origin",
             PropertyIdTag::TransformStyle => b"transform-style",
@@ -889,6 +898,8 @@ pub enum PropertyId {
     TransitionDelay(VendorPrefix),
     TransitionTimingFunction(VendorPrefix),
     Transition(VendorPrefix),
+    Animation(VendorPrefix),
+    AnimationName(VendorPrefix),
     Transform(VendorPrefix),
     TransformOrigin(VendorPrefix),
     TransformStyle(VendorPrefix),
@@ -1169,6 +1180,8 @@ impl PropertyId {
             PropertyId::TransitionDelay(..) => PropertyIdTag::TransitionDelay,
             PropertyId::TransitionTimingFunction(..) => PropertyIdTag::TransitionTimingFunction,
             PropertyId::Transition(..) => PropertyIdTag::Transition,
+            PropertyId::Animation(..) => PropertyIdTag::Animation,
+            PropertyId::AnimationName(..) => PropertyIdTag::AnimationName,
             PropertyId::Transform(..) => PropertyIdTag::Transform,
             PropertyId::TransformOrigin(..) => PropertyIdTag::TransformOrigin,
             PropertyId::TransformStyle(..) => PropertyIdTag::TransformStyle,
@@ -1276,6 +1289,8 @@ impl PropertyId {
             | PropertyId::TransitionDelay(p)
             | PropertyId::TransitionTimingFunction(p)
             | PropertyId::Transition(p)
+            | PropertyId::Animation(p)
+            | PropertyId::AnimationName(p)
             | PropertyId::Transform(p)
             | PropertyId::TransformOrigin(p)
             | PropertyId::TransformStyle(p)
@@ -2788,6 +2803,28 @@ impl PropertyId {
             }
             return None;
         }
+        if strings::eql_case_insensitive_ascii_check_length(name, b"animation-name") {
+            let allowed: VendorPrefix = VendorPrefix::NONE
+                | VendorPrefix::WEBKIT
+                | VendorPrefix::MOZ
+                | VendorPrefix::O
+                | VendorPrefix::MS;
+            if allowed.intersects(pre) {
+                return Some(PropertyId::AnimationName(pre));
+            }
+            return None;
+        }
+        if strings::eql_case_insensitive_ascii_check_length(name, b"animation") {
+            let allowed: VendorPrefix = VendorPrefix::NONE
+                | VendorPrefix::WEBKIT
+                | VendorPrefix::MOZ
+                | VendorPrefix::O
+                | VendorPrefix::MS;
+            if allowed.intersects(pre) {
+                return Some(PropertyId::Animation(pre));
+            }
+            return None;
+        }
         if strings::eql_case_insensitive_ascii_check_length(name, b"transform") {
             let allowed: VendorPrefix = VendorPrefix::NONE
                 | VendorPrefix::WEBKIT
@@ -3370,6 +3407,8 @@ pub enum Property {
         ),
     ),
     Transition((SmallList<transition::Transition, 1>, VendorPrefix)),
+    Animation((SmallList<animation::Animation, 1>, VendorPrefix)),
+    AnimationName((SmallList<animation::AnimationName, 1>, VendorPrefix)),
     Transform((transform::TransformList, VendorPrefix)),
     TransformOrigin((position::Position, VendorPrefix)),
     TransformStyle((transform::TransformStyle, VendorPrefix)),
@@ -3635,6 +3674,8 @@ impl Property {
             Property::TransitionDelay(v) => PropertyId::TransitionDelay(v.1),
             Property::TransitionTimingFunction(v) => PropertyId::TransitionTimingFunction(v.1),
             Property::Transition(v) => PropertyId::Transition(v.1),
+            Property::Animation(v) => PropertyId::Animation(v.1),
+            Property::AnimationName(v) => PropertyId::AnimationName(v.1),
             Property::Transform(v) => PropertyId::Transform(v.1),
             Property::TransformOrigin(v) => PropertyId::TransformOrigin(v.1),
             Property::TransformStyle(v) => PropertyId::TransformStyle(v.1),
@@ -3902,6 +3943,8 @@ impl Property {
             Property::TransitionDelay(v) => css::generic::to_css(&v.0, dest),
             Property::TransitionTimingFunction(v) => css::generic::to_css(&v.0, dest),
             Property::Transition(v) => css::generic::to_css(&v.0, dest),
+            Property::Animation(v) => css::generic::to_css(&v.0, dest),
+            Property::AnimationName(v) => css::generic::to_css(&v.0, dest),
             Property::Transform(v) => css::generic::to_css(&v.0, dest),
             Property::TransformOrigin(v) => css::generic::to_css(&v.0, dest),
             Property::TransformStyle(v) => css::generic::to_css(&v.0, dest),
@@ -5779,6 +5822,26 @@ impl Property {
                     }
                 }
             }
+            PropertyId::Animation(pre) => {
+                if let Ok(c) = css::generic::parse_with_options::<
+                    SmallList<animation::Animation, 1>,
+                >(input, options)
+                {
+                    if input.expect_exhausted().is_ok() {
+                        return Ok(Property::Animation((c, pre)));
+                    }
+                }
+            }
+            PropertyId::AnimationName(pre) => {
+                if let Ok(c) = css::generic::parse_with_options::<
+                    SmallList<animation::AnimationName, 1>,
+                >(input, options)
+                {
+                    if input.expect_exhausted().is_ok() {
+                        return Ok(Property::AnimationName((c, pre)));
+                    }
+                }
+            }
             PropertyId::Transform(pre) => {
                 if let Ok(c) =
                     css::generic::parse_with_options::<transform::TransformList>(input, options)
@@ -6752,6 +6815,12 @@ impl Property {
             Property::Transition(v) => {
                 Property::Transition((css::generic::deep_clone(&v.0, arena), v.1))
             }
+            Property::Animation(v) => {
+                Property::Animation((css::generic::deep_clone(&v.0, arena), v.1))
+            }
+            Property::AnimationName(v) => {
+                Property::AnimationName((css::generic::deep_clone(&v.0, arena), v.1))
+            }
             Property::Transform(v) => {
                 Property::Transform((css::generic::deep_clone(&v.0, arena), v.1))
             }
@@ -7280,6 +7349,12 @@ impl Property {
                 css::generic::eql(&a.0, &b.0) && a.1 == b.1
             }
             (Property::Transition(a), Property::Transition(b)) => {
+                css::generic::eql(&a.0, &b.0) && a.1 == b.1
+            }
+            (Property::Animation(a), Property::Animation(b)) => {
+                css::generic::eql(&a.0, &b.0) && a.1 == b.1
+            }
+            (Property::AnimationName(a), Property::AnimationName(b)) => {
                 css::generic::eql(&a.0, &b.0) && a.1 == b.1
             }
             (Property::Transform(a), Property::Transform(b)) => {

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -113,6 +113,7 @@ describe("css", () => {
       "/styles.module.css": `
         .playAnim { animation: anim forwards ease-out 0.25s; }
         .spin { animation-name: rotate; }
+        .quoted { animation-name: "anim"; }
         @keyframes anim { from { opacity: 0 } to { opacity: 1 } }
         @keyframes rotate { to { transform: rotate(360deg) } }
       `,
@@ -135,6 +136,9 @@ describe("css", () => {
 
       // The `animation-name` longhand references the SAME scoped keyframes name.
       expect(css).toContain(`animation-name: ${rotateKeyframes![1]}`);
+
+      // The quoted-string form scopes to the same hash as the ident form.
+      expect(css).toContain(`animation-name: ${animKeyframes![1]}`);
 
       // The bare (unscoped) names must not survive as animation references.
       expect(css).not.toMatch(/animation:[^;]*\banim\b/);

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -100,6 +100,48 @@ describe("css", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/18921
+  // The `animation` shorthand and `animation-name` longhand must scope their
+  // referenced `@keyframes` name to the SAME hashed name the keyframes rule
+  // receives, otherwise the animation is broken.
+  itBundled("css-module/AnimationNameScopedToKeyframes", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(styles.playAnim, styles.spin);
+      `,
+      "/styles.module.css": `
+        .playAnim { animation: anim forwards ease-out 0.25s; }
+        .spin { animation-name: rotate; }
+        @keyframes anim { from { opacity: 0 } to { opacity: 1 } }
+        @keyframes rotate { to { transform: rotate(360deg) } }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      const css = api.readFile("/out/entry.css");
+
+      // Each @keyframes name is scoped (e.g. `anim_<hash>`), not left bare.
+      const animKeyframes = css.match(/@keyframes\s+(anim_[A-Za-z0-9_-]+)\s*\{/);
+      const rotateKeyframes = css.match(/@keyframes\s+(rotate_[A-Za-z0-9_-]+)\s*\{/);
+      expect(animKeyframes, "@keyframes anim should be scoped").not.toBeNull();
+      expect(rotateKeyframes, "@keyframes rotate should be scoped").not.toBeNull();
+
+      // The `animation` shorthand references the SAME scoped keyframes name.
+      const animShorthand = css.match(/animation:\s*([^;]+);/);
+      expect(animShorthand, "animation shorthand should be present").not.toBeNull();
+      expect(animShorthand![1]).toContain(animKeyframes![1]);
+
+      // The `animation-name` longhand references the SAME scoped keyframes name.
+      expect(css).toContain(`animation-name: ${rotateKeyframes![1]}`);
+
+      // The bare (unscoped) names must not survive as animation references.
+      expect(css).not.toMatch(/animation:[^;]*\banim\b/);
+      expect(css).not.toMatch(/animation-name:\s*rotate\b/);
+    },
+  });
+
   itBundled("css-module/ExportsMapMultipleClassesAndComposes", {
     files: {
       "/entry.js": `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7030,6 +7030,33 @@ describe("css tests", () => {
     );
   });
 
+  describe("animation", () => {
+    // The animation name is serialized last, in canonical order.
+    minify_test(".foo { animation: anim 2s }", ".foo{animation:2s anim}");
+    minify_test(".foo { animation: 0.25s ease-out forwards anim }", ".foo{animation:.25s ease-out forwards anim}");
+    minify_test(".foo { animation: none }", ".foo{animation:none}");
+
+    // Name-less shorthands must keep their components (must NOT collapse to
+    // `none`) — a lone trailing `none` is dropped as redundant.
+    minify_test(".foo { animation: 2s }", ".foo{animation:2s}");
+    minify_test(".foo { animation: 2s ease-in-out }", ".foo{animation:2s ease-in-out}");
+    minify_test(
+      ".foo { animation: 3s linear 1s infinite alternate }",
+      ".foo{animation:3s linear 1s infinite alternate}",
+    );
+    minify_test(".foo { animation: 2s none }", ".foo{animation:2s}");
+
+    // Multiple comma-separated animations.
+    minify_test(".foo { animation: spin 1s, 2s slide }", ".foo{animation:1s spin,2s slide}");
+
+    // Vendor-prefixed shorthand.
+    minify_test(".foo { -webkit-animation: spin 1s }", ".foo{-webkit-animation:1s spin}");
+
+    // animation-name longhand.
+    minify_test(".foo { animation-name: foo }", ".foo{animation-name:foo}");
+    minify_test(".foo { animation-name: foo, bar }", ".foo{animation-name:foo,bar}");
+  });
+
   describe("transform", () => {
     minify_test(".foo { transform: translate(2px, 3px)", ".foo{transform:translate(2px,3px)}");
     minify_test(".foo { transform: translate(2px, 0px)", ".foo{transform:translate(2px)}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7045,6 +7045,8 @@ describe("css tests", () => {
       ".foo{animation:3s linear 1s infinite alternate}",
     );
     minify_test(".foo { animation: 2s none }", ".foo{animation:2s}");
+    // 0s duration must still be emitted when a nonzero delay follows.
+    minify_test(".foo { animation: 0s 2s foo }", ".foo{animation:0s 2s foo}");
 
     // Multiple comma-separated animations.
     minify_test(".foo { animation: spin 1s, 2s slide }", ".foo{animation:1s spin,2s slide}");
@@ -7052,9 +7054,20 @@ describe("css tests", () => {
     // Vendor-prefixed shorthand.
     minify_test(".foo { -webkit-animation: spin 1s }", ".foo{-webkit-animation:1s spin}");
 
+    // Timeline component in the shorthand: round-trips a dashed-ident timeline
+    // and drops the default `auto` timeline.
+    minify_test(".foo { animation: 1s spin --my-timeline }", ".foo{animation:1s spin --my-timeline}");
+    minify_test(".foo { animation: 1s spin auto }", ".foo{animation:1s spin}");
+
     // animation-name longhand.
     minify_test(".foo { animation-name: foo }", ".foo{animation-name:foo}");
     minify_test(".foo { animation-name: foo, bar }", ".foo{animation-name:foo,bar}");
+    minify_test('.foo { animation-name: "foo" }', ".foo{animation-name:foo}");
+
+    // CSS-wide keywords must NOT be consumed as an animation name.
+    minify_test(".foo { animation: inherit }", ".foo{animation:inherit}");
+    minify_test(".foo { animation: unset }", ".foo{animation:unset}");
+    minify_test(".foo { animation-name: initial }", ".foo{animation-name:initial}");
   });
 
   describe("transform", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #18921.

In CSS modules, the `animation` shorthand and `animation-name` longhand did not scope their referenced `@keyframes` name to the hashed name the `@keyframes` rule receives. The keyframes *definition* was scoped but the *reference* was not, so the two diverged and the animation silently broke:

```css
/* before */
.playAnim_HASH { animation: anim forwards ease-out .25s; }  /* "anim" not scoped */
@keyframes anim_HASH { /* ... */ }

/* after (matches Lightning CSS / esbuild) */
.playAnim_HASH { animation: .25s ease-out forwards anim_HASH; }
@keyframes anim_HASH { /* ... */ }
```

**Root cause:** `animation`/`animation-name` were never wired into Bun's (hand-maintained) structured CSS property table, so they fell back to `UnparsedProperty` (raw tokens) and their names were emitted verbatim — the CSS-modules scoping that lives in `AnimationName::to_css` was never reached.

**Fix:**

- Wire `animation` (shorthand) and `animation-name` (longhand), including the vendor-prefixed forms, as structured properties, mirroring the existing `transition` property. Their names now flow through the scoping-aware `AnimationName::to_css` and are scoped to match the `@keyframes` rule.
- Fix `Animation::to_css` so a name-less shorthand (e.g. `animation: 3s linear 1s infinite alternate`) keeps its components instead of collapsing to `none`. Bun prints the `Animation` struct directly and, unlike Lightning CSS, has no declaration handler to keep it off that lossy path.

As a side effect, `animation`/`animation-name` are now serialized in canonical form (name last, redundant trailing `none` dropped, numbers normalized) — consistent with how Bun already handles `transition`, and with Lightning CSS and esbuild. All changes are lossless.

### How did you verify your code works?

New tests (each fails on stable Bun, passes with this change):

- `test/bundler/css/css-modules.test.ts` — asserts the `animation` shorthand and `animation-name` longhand reference the same hashed name as their `@keyframes` rule (the exact repro from #18921), and that the unscoped names do not survive.
- `test/js/bun/css/css.test.ts` — an `animation` serialization matrix: canonical ordering, no data loss for name-less shorthands, `none`, vendor prefix, multiple comma-separated animations, and the `animation-name` longhand.

All existing CSS suites pass with the change:

- `test/js/bun/css/css.test.ts`
- `test/bundler/css/css-modules.test.ts`
- `test/bundler/css/view-transition-23600.test.ts`
- `test/bundler/esbuild/css.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
