### PR TITLE
test: spec-driven deep-equality matrix for assert, util and Bun.deepEquals

### DIFF
--- a/test/js/bun/bun-object/deep-equals.spec.ts
+++ b/test/js/bun/bun-object/deep-equals.spec.ts
@@ -77,3 +77,55 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     });
   });
 });
+
+// The cases documented at https://bun.sh/docs/api/utils#bun-deepequals as the
+// differences between the default and strict modes.
+describe("Bun.deepEquals strict mode", () => {
+  it("ignores an extra undefined property only when not strict", () => {
+    const a = { entries: [1, 2] };
+    const b = { entries: [1, 2], extra: undefined };
+    expect(Bun.deepEquals(a, b)).toBe(true);
+    expect(Bun.deepEquals(a, b, true)).toBe(false);
+  });
+
+  it("distinguishes a missing property from an undefined one", () => {
+    expect(Bun.deepEquals({}, { a: undefined })).toBe(true);
+    expect(Bun.deepEquals({}, { a: undefined }, true)).toBe(false);
+  });
+
+  it("distinguishes a missing array element from an undefined one", () => {
+    expect(Bun.deepEquals(["asdf"], ["asdf", undefined])).toBe(true);
+    expect(Bun.deepEquals(["asdf"], ["asdf", undefined], true)).toBe(false);
+  });
+
+  it("distinguishes a hole from an undefined element", () => {
+    expect(Bun.deepEquals([, 1], [undefined, 1])).toBe(true);
+    expect(Bun.deepEquals([, 1], [undefined, 1], true)).toBe(false);
+  });
+
+  it("distinguishes a class instance from an object literal", () => {
+    class Foo {
+      a = 1;
+    }
+    expect(Bun.deepEquals(new Foo(), { a: 1 })).toBe(true);
+    expect(Bun.deepEquals(new Foo(), { a: 1 }, true)).toBe(false);
+  });
+
+  it("is symmetric", () => {
+    const a = { entries: [1, 2] };
+    const b = { entries: [1, 2], extra: undefined };
+    expect(Bun.deepEquals(b, a)).toBe(true);
+    expect(Bun.deepEquals(b, a, true)).toBe(false);
+  });
+
+  it("recurses into nested values", () => {
+    expect(Bun.deepEquals({ a: { b: 1 } }, { a: { b: 1, c: undefined } })).toBe(true);
+    expect(Bun.deepEquals({ a: { b: 1 } }, { a: { b: 1, c: undefined } }, true)).toBe(false);
+  });
+
+  // Matches Node's util.isDeepStrictEqual, which rejects a null prototype
+  // against Object.prototype.
+  it.failing("distinguishes a null-prototype object from an object literal", () => {
+    expect(Bun.deepEquals(Object.create(null), {}, true)).toBe(false);
+  });
+});

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -425,7 +425,14 @@ const cases: Case[] = [
     strictBug: "reports equal",
     looseBug: "reports equal",
   },
-  { name: "a WeakMap and a WeakSet", a: () => new WeakMap(), b: () => new WeakSet(), strict: false, loose: false },
+  {
+    name: "a WeakMap and a WeakSet",
+    a: () => new WeakMap(),
+    b: () => new WeakSet(),
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
 
   // Typed arrays and buffers.
   {

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -405,7 +405,8 @@ const cases: Case[] = [
   { name: "sets holding -0 and 0", a: () => new Set([-0]), b: () => new Set([0]), strict: true, loose: true },
   { name: "sets holding NaN", a: () => new Set([NaN]), b: () => new Set([NaN]), strict: true, loose: true },
 
-  // WeakMap/WeakSet are compared by reference, never structurally.
+  // "WeakMap and WeakSet instances are not compared structurally. They are only
+  // equal if they reference the same object." -- nodejs.org/api/assert.html
   {
     name: "two empty WeakMaps",
     a: () => new WeakMap(),
@@ -424,15 +425,7 @@ const cases: Case[] = [
     strictBug: "reports equal",
     looseBug: "reports equal",
   },
-  {
-    name: "two resolved promises",
-    a: () => Promise.resolve(1),
-    b: () => Promise.resolve(1),
-    strict: false,
-    loose: false,
-    strictBug: "reports equal",
-    looseBug: "reports equal",
-  },
+  { name: "a WeakMap and a WeakSet", a: () => new WeakMap(), b: () => new WeakSet(), strict: false, loose: false },
 
   // Typed arrays and buffers.
   {

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -72,10 +72,29 @@ function argumentsObject(...values: unknown[]) {
 }
 
 const cases: Case[] = [
-  // Numbers and boxed primitives.
+  // Loose mode compares primitives with ==, strict mode with Object.is.
   { name: "0 and -0", a: () => 0, b: () => -0, strict: false, loose: true, looseBug: "reports not equal" },
   { name: "NaN and NaN", a: () => NaN, b: () => NaN, strict: true, loose: true },
   { name: "[0] and [-0]", a: () => [0], b: () => [-0], strict: false, loose: true, looseBug: "reports not equal" },
+  { name: "'1' and 1", a: () => "1", b: () => 1, strict: false, loose: true, looseBug: "reports not equal" },
+  { name: "['1'] and [1]", a: () => ["1"], b: () => [1], strict: false, loose: true, looseBug: "reports not equal" },
+  {
+    name: "'+00000000' and false",
+    a: () => "+00000000",
+    b: () => false,
+    strict: false,
+    loose: true,
+    looseBug: "reports not equal",
+  },
+  { name: "'' and false", a: () => "", b: () => false, strict: false, loose: true, looseBug: "reports not equal" },
+  {
+    name: "null and undefined",
+    a: () => null,
+    b: () => undefined,
+    strict: false,
+    loose: true,
+    looseBug: "reports not equal",
+  },
   {
     name: "{ a: -0 } and { a: 0 }",
     a: () => ({ a: -0 }),
@@ -555,37 +574,34 @@ function caught(fn: () => void): (Error & { code?: string }) | null {
   }
 }
 
-describe("assert.deepStrictEqual", () => {
-  for (const testCase of cases) {
-    const label = `${testCase.strict ? "accepts" : "rejects"} ${testCase.name}`;
-    const run = testCase.strictBug ? test.failing : test;
-    run(testCase.strictBug ? `${label} (Bun ${testCase.strictBug})` : label, () => {
-      const error = caught(() => assert.deepStrictEqual(testCase.a(), testCase.b()));
-      if (testCase.strict) {
-        expect(error?.message ?? null).toBeNull();
-      } else {
-        expect(error?.code).toBe("ERR_ASSERTION");
-      }
-      expect(caught(() => assert.notDeepStrictEqual(testCase.a(), testCase.b())) === null).toBe(!testCase.strict);
-    });
-  }
-});
+function describeMatrix(
+  suite: string,
+  mode: "strict" | "loose",
+  bugField: "strictBug" | "looseBug",
+  equal: (actual: unknown, expected: unknown) => void,
+  notEqual: (actual: unknown, expected: unknown) => void,
+) {
+  describe(suite, () => {
+    for (const testCase of cases) {
+      const expected = testCase[mode];
+      const bug = testCase[bugField];
+      const label = `${expected ? "accepts" : "rejects"} ${testCase.name}`;
+      const run = bug ? test.failing : test;
+      run(bug ? `${label} (Bun ${bug})` : label, () => {
+        const error = caught(() => equal(testCase.a(), testCase.b()));
+        if (expected) {
+          expect(error?.message ?? null).toBeNull();
+        } else {
+          expect(error?.code).toBe("ERR_ASSERTION");
+        }
+        expect(caught(() => notEqual(testCase.a(), testCase.b())) === null).toBe(!expected);
+      });
+    }
+  });
+}
 
-describe("assert.deepEqual", () => {
-  for (const testCase of cases) {
-    const label = `${testCase.loose ? "accepts" : "rejects"} ${testCase.name}`;
-    const run = testCase.looseBug ? test.failing : test;
-    run(testCase.looseBug ? `${label} (Bun ${testCase.looseBug})` : label, () => {
-      const error = caught(() => assert.deepEqual(testCase.a(), testCase.b()));
-      if (testCase.loose) {
-        expect(error?.message ?? null).toBeNull();
-      } else {
-        expect(error?.code).toBe("ERR_ASSERTION");
-      }
-      expect(caught(() => assert.notDeepEqual(testCase.a(), testCase.b())) === null).toBe(!testCase.loose);
-    });
-  }
-});
+describeMatrix("assert.deepStrictEqual", "strict", "strictBug", assert.deepStrictEqual, assert.notDeepStrictEqual);
+describeMatrix("assert.deepEqual", "loose", "looseBug", assert.deepEqual, assert.notDeepEqual);
 
 describe("util.isDeepStrictEqual", () => {
   for (const testCase of cases) {

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -1,0 +1,635 @@
+// Deep-equality matrix for node:assert and node:util.
+// Expectations come from the documented semantics of assert.deepStrictEqual/deepEqual,
+// cross-checked against Node.js. Cases Bun gets wrong today are marked `test.failing`.
+import { describe, expect, test } from "bun:test";
+import assert from "node:assert";
+import util from "node:util";
+
+type Thunk = () => unknown;
+
+interface Case {
+  name: string;
+  /** Thunks so that every test gets freshly constructed operands. */
+  a: Thunk;
+  b: Thunk;
+  /** Whether assert.deepStrictEqual(a, b) should succeed. */
+  strict: boolean;
+  /** Whether assert.deepEqual(a, b) should succeed. */
+  loose: boolean;
+  /** Set when Bun disagrees with `strict`; the text says what Bun does instead. */
+  strictBug?: string;
+  /** Set when Bun disagrees with `loose`; the text says what Bun does instead. */
+  looseBug?: string;
+}
+
+const sym = Symbol("shared");
+
+class WithPrototypeGetter {
+  get a() {
+    return 1;
+  }
+}
+
+function anonymousClassInstance() {
+  return new (class {
+    a = 1;
+  })();
+}
+
+function sameNameClassInstance() {
+  return new (class Shared {
+    a = 1;
+  })();
+}
+
+function nonEnumerable() {
+  const object = {};
+  Object.defineProperty(object, "hidden", { value: 1, enumerable: false });
+  return object;
+}
+
+function withExtraProperty<T extends object>(value: T): T {
+  return Object.assign(value, { extra: 1 });
+}
+
+function selfReferencingObject() {
+  const object: Record<string, unknown> = {};
+  object.self = object;
+  return object;
+}
+
+function selfReferencingArray() {
+  const array: unknown[] = [];
+  array.push(array);
+  return array;
+}
+
+function argumentsObject(...values: unknown[]) {
+  return (function () {
+    // eslint-disable-next-line prefer-rest-params
+    return arguments;
+  })(...values);
+}
+
+const cases: Case[] = [
+  // Numbers and boxed primitives.
+  { name: "0 and -0", a: () => 0, b: () => -0, strict: false, loose: true, looseBug: "reports not equal" },
+  { name: "NaN and NaN", a: () => NaN, b: () => NaN, strict: true, loose: true },
+  { name: "[0] and [-0]", a: () => [0], b: () => [-0], strict: false, loose: true, looseBug: "reports not equal" },
+  {
+    name: "{ a: -0 } and { a: 0 }",
+    a: () => ({ a: -0 }),
+    b: () => ({ a: 0 }),
+    strict: false,
+    loose: true,
+    looseBug: "reports not equal",
+  },
+  { name: "1n and 1", a: () => 1n, b: () => 1, strict: false, loose: true, looseBug: "reports not equal" },
+  { name: "new String('a') and 'a'", a: () => new String("a"), b: () => "a", strict: false, loose: false },
+  { name: "two boxed equal strings", a: () => new String("a"), b: () => new String("a"), strict: true, loose: true },
+  { name: "two boxed equal numbers", a: () => new Number(1), b: () => new Number(1), strict: true, loose: true },
+  { name: "boxed -0 and boxed 0", a: () => new Number(-0), b: () => new Number(0), strict: false, loose: false },
+  { name: "two boxed booleans", a: () => new Boolean(true), b: () => new Boolean(true), strict: true, loose: true },
+  {
+    name: "two boxed symbols",
+    a: () => Object(Symbol.iterator),
+    b: () => Object(Symbol.iterator),
+    strict: true,
+    loose: true,
+  },
+  { name: "two boxed bigints", a: () => Object(1n), b: () => Object(1n), strict: true, loose: true },
+
+  // Undefined-valued and missing properties. Both modes compare own key counts.
+  {
+    name: "{} and { a: undefined }",
+    a: () => ({}),
+    b: () => ({ a: undefined }),
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+  {
+    name: "{ a: undefined } and { b: undefined }",
+    a: () => ({ a: undefined }),
+    b: () => ({ b: undefined }),
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+  {
+    name: "{ a: { b: undefined } } and { a: {} }",
+    a: () => ({ a: { b: undefined } }),
+    b: () => ({ a: {} }),
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+  {
+    name: "[1] and [1, undefined]",
+    a: () => [1],
+    b: () => [1, undefined],
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+  {
+    name: "a hole and an explicit undefined",
+    a: () => [, 1],
+    b: () => [undefined, 1],
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+
+  // Prototypes.
+  {
+    name: "a null-prototype object and {}",
+    a: () => Object.create(null),
+    b: () => ({}),
+    strict: false,
+    loose: true,
+    strictBug: "reports equal",
+  },
+  {
+    name: "two null-prototype objects with the same keys",
+    a: () => Object.assign(Object.create(null), { a: 1 }),
+    b: () => Object.assign(Object.create(null), { a: 1 }),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "a class instance and an object literal",
+    a: () =>
+      new (class Foo {
+        a = 1;
+      })(),
+    b: () => ({ a: 1 }),
+    strict: false,
+    loose: true,
+  },
+  {
+    name: "instances of two differently named classes",
+    a: () =>
+      new (class A {
+        a = 1;
+      })(),
+    b: () =>
+      new (class B {
+        a = 1;
+      })(),
+    strict: false,
+    loose: true,
+  },
+  {
+    name: "instances of two distinct anonymous classes",
+    a: anonymousClassInstance,
+    b: anonymousClassInstance,
+    strict: false,
+    loose: true,
+    strictBug: "matches classes by name, so reports equal",
+  },
+  {
+    name: "instances of two distinct identically named classes",
+    a: sameNameClassInstance,
+    b: sameNameClassInstance,
+    strict: false,
+    loose: true,
+    strictBug: "matches classes by name, so reports equal",
+  },
+  {
+    name: "an Array subclass instance and an array",
+    a: () => new (class extends Array {})(),
+    b: () => [],
+    strict: false,
+    loose: true,
+    strictBug: "reports equal",
+  },
+  {
+    name: "[] and Object.create(Array.prototype)",
+    a: () => [],
+    b: () => Object.create(Array.prototype),
+    strict: false,
+    loose: false,
+  },
+
+  // Symbol keys: compared in strict mode, ignored in loose mode.
+  {
+    name: "{ [sym]: 1 } and {}",
+    a: () => ({ [sym]: 1 }),
+    b: () => ({}),
+    strict: false,
+    loose: true,
+    looseBug: "reports not equal",
+  },
+  {
+    name: "two objects sharing a symbol key",
+    a: () => ({ [sym]: 1 }),
+    b: () => ({ [sym]: 1 }),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "distinct symbols with the same description",
+    a: () => ({ [Symbol("s")]: 1 }),
+    b: () => ({ [Symbol("s")]: 1 }),
+    strict: false,
+    loose: true,
+    looseBug: "reports not equal",
+  },
+
+  // Only own enumerable properties participate.
+  { name: "a non-enumerable own property and {}", a: nonEnumerable, b: () => ({}), strict: true, loose: true },
+  {
+    name: "a getter and a data property",
+    a: () => ({
+      get a() {
+        return 1;
+      },
+    }),
+    b: () => ({ a: 1 }),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "instances whose only property is a prototype getter",
+    a: () => new WithPrototypeGetter(),
+    b: () => new WithPrototypeGetter(),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "a frozen and a non-frozen object",
+    a: () => Object.freeze({ a: 1 }),
+    b: () => ({ a: 1 }),
+    strict: true,
+    loose: true,
+  },
+
+  // Date.
+  { name: "two equal dates", a: () => new Date(0), b: () => new Date(0), strict: true, loose: true },
+  { name: "two different dates", a: () => new Date(0), b: () => new Date(1), strict: false, loose: false },
+  {
+    name: "a date with an extra own property",
+    a: () => withExtraProperty(new Date(0)),
+    b: () => new Date(0),
+    strict: false,
+    loose: false,
+    strictBug: "reports equal",
+    looseBug: "reports equal",
+  },
+
+  // RegExp.
+  { name: "two equal regexps", a: () => /a/g, b: () => /a/g, strict: true, loose: true },
+  { name: "regexps with different flags", a: () => /a/g, b: () => /a/i, strict: false, loose: false },
+  {
+    name: "regexps with different lastIndex",
+    a: () => Object.assign(/a/g, { lastIndex: 3 }),
+    b: () => /a/g,
+    strict: false,
+    loose: false,
+    strictBug: "reports equal",
+    looseBug: "reports equal",
+  },
+
+  // Error.
+  {
+    name: "two errors with the same message",
+    a: () => new Error("x"),
+    b: () => new Error("x"),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "errors with different messages",
+    a: () => new Error("x"),
+    b: () => new Error("y"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "an Error and a TypeError",
+    a: () => new Error("x"),
+    b: () => new TypeError("x"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "an error with an extra own property",
+    a: () => withExtraProperty(new Error("x")),
+    b: () => new Error("x"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "errors with different causes",
+    a: () => new Error("x", { cause: 1 }),
+    b: () => new Error("x", { cause: 2 }),
+    strict: false,
+    loose: false,
+  },
+
+  // Map and Set.
+  {
+    name: "maps with different insertion order",
+    a: () =>
+      new Map([
+        [1, 1],
+        [2, 2],
+      ]),
+    b: () =>
+      new Map([
+        [2, 2],
+        [1, 1],
+      ]),
+    strict: true,
+    loose: true,
+  },
+  { name: "maps keyed by NaN", a: () => new Map([[NaN, 1]]), b: () => new Map([[NaN, 1]]), strict: true, loose: true },
+  {
+    name: "maps keyed by -0 and 0",
+    a: () => new Map([[-0, 1]]),
+    b: () => new Map([[0, 1]]),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "maps keyed by deep-equal objects",
+    a: () => new Map([[{ a: 1 }, 1]]),
+    b: () => new Map([[{ a: 1 }, 1]]),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "maps keyed by different objects",
+    a: () => new Map([[{ a: 1 }, 1]]),
+    b: () => new Map([[{ a: 2 }, 1]]),
+    strict: false,
+    loose: false,
+  },
+  { name: "maps of different size", a: () => new Map([[1, 1]]), b: () => new Map(), strict: false, loose: false },
+  {
+    name: "a map with an extra own property",
+    a: () => withExtraProperty(new Map()),
+    b: () => new Map(),
+    strict: false,
+    loose: false,
+    strictBug: "reports equal",
+    looseBug: "reports equal",
+  },
+  {
+    name: "sets holding deep-equal objects",
+    a: () => new Set([{ a: 1 }]),
+    b: () => new Set([{ a: 1 }]),
+    strict: true,
+    loose: true,
+  },
+  { name: "sets holding -0 and 0", a: () => new Set([-0]), b: () => new Set([0]), strict: true, loose: true },
+  { name: "sets holding NaN", a: () => new Set([NaN]), b: () => new Set([NaN]), strict: true, loose: true },
+
+  // WeakMap/WeakSet are compared by reference, never structurally.
+  {
+    name: "two empty WeakMaps",
+    a: () => new WeakMap(),
+    b: () => new WeakMap(),
+    strict: false,
+    loose: false,
+    strictBug: "reports equal",
+    looseBug: "reports equal",
+  },
+  {
+    name: "two empty WeakSets",
+    a: () => new WeakSet(),
+    b: () => new WeakSet(),
+    strict: false,
+    loose: false,
+    strictBug: "reports equal",
+    looseBug: "reports equal",
+  },
+  {
+    name: "two resolved promises",
+    a: () => Promise.resolve(1),
+    b: () => Promise.resolve(1),
+    strict: false,
+    loose: false,
+    strictBug: "reports equal",
+    looseBug: "reports equal",
+  },
+
+  // Typed arrays and buffers.
+  {
+    name: "a Uint8Array and an Int8Array with the same bytes",
+    a: () => new Uint8Array([1]),
+    b: () => new Int8Array([1]),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "two equal Uint8Arrays",
+    a: () => new Uint8Array([1, 2]),
+    b: () => new Uint8Array([1, 2]),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "Float64Arrays holding NaN",
+    a: () => new Float64Array([NaN]),
+    b: () => new Float64Array([NaN]),
+    strict: true,
+    loose: false,
+  },
+  {
+    name: "Float64Arrays holding -0 and 0",
+    a: () => new Float64Array([-0]),
+    b: () => new Float64Array([0]),
+    strict: false,
+    loose: true,
+  },
+  {
+    name: "ArrayBuffers of the same length",
+    a: () => new ArrayBuffer(2),
+    b: () => new ArrayBuffer(2),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "ArrayBuffers of different length",
+    a: () => new ArrayBuffer(2),
+    b: () => new ArrayBuffer(3),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "DataViews of the same length",
+    a: () => new DataView(new ArrayBuffer(2)),
+    b: () => new DataView(new ArrayBuffer(2)),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "a Buffer and a Uint8Array with the same bytes",
+    a: () => Buffer.from([1]),
+    b: () => new Uint8Array([1]),
+    strict: false,
+    loose: true,
+    strictBug: "reports equal",
+  },
+  {
+    name: "a typed array with an extra own property",
+    a: () => withExtraProperty(new Uint8Array([1])),
+    b: () => new Uint8Array([1]),
+    strict: false,
+    loose: false,
+    strictBug: "reports equal",
+    looseBug: "reports equal",
+  },
+
+  // Arrays.
+  { name: "[1] and { 0: 1 }", a: () => [1], b: () => ({ 0: 1 }), strict: false, loose: false },
+  {
+    name: "an array with an extra own property",
+    a: () => withExtraProperty([1]),
+    b: () => [1],
+    strict: false,
+    loose: false,
+    strictBug: "reports equal",
+    looseBug: "reports equal",
+  },
+  { name: "arrays of different length", a: () => [1, 2], b: () => [1], strict: false, loose: false },
+  { name: "'a' and ['a']", a: () => "a", b: () => ["a"], strict: false, loose: false },
+
+  // Cycles.
+  {
+    name: "two self-referencing objects",
+    a: selfReferencingObject,
+    b: selfReferencingObject,
+    strict: true,
+    loose: true,
+  },
+  { name: "two self-referencing arrays", a: selfReferencingArray, b: selfReferencingArray, strict: true, loose: true },
+  {
+    name: "a cycle and a finitely nested object",
+    a: selfReferencingObject,
+    b: () => ({ self: { self: {} } }),
+    strict: false,
+    loose: false,
+  },
+
+  // Miscellaneous.
+  {
+    name: "different Symbol.toStringTag values",
+    a: () => ({ [Symbol.toStringTag]: "a" }),
+    b: () => ({ [Symbol.toStringTag]: "b" }),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "two references to the same function",
+    a: () => globalThis.isNaN,
+    b: () => globalThis.isNaN,
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "two distinct functions with the same source",
+    a: () => () => {},
+    b: () => () => {},
+    strict: false,
+    loose: false,
+  },
+  { name: "an arguments object and an array", a: () => argumentsObject(1), b: () => [1], strict: false, loose: false },
+  {
+    name: "two equal arguments objects",
+    a: () => argumentsObject(1),
+    b: () => argumentsObject(1),
+    strict: true,
+    loose: true,
+  },
+];
+
+function caught(fn: () => void): (Error & { code?: string }) | null {
+  try {
+    fn();
+    return null;
+  } catch (error) {
+    return error as Error & { code?: string };
+  }
+}
+
+describe("assert.deepStrictEqual", () => {
+  for (const testCase of cases) {
+    const label = `${testCase.strict ? "accepts" : "rejects"} ${testCase.name}`;
+    const run = testCase.strictBug ? test.failing : test;
+    run(testCase.strictBug ? `${label} (Bun ${testCase.strictBug})` : label, () => {
+      const error = caught(() => assert.deepStrictEqual(testCase.a(), testCase.b()));
+      if (testCase.strict) {
+        expect(error?.message ?? null).toBeNull();
+      } else {
+        expect(error?.code).toBe("ERR_ASSERTION");
+      }
+      expect(caught(() => assert.notDeepStrictEqual(testCase.a(), testCase.b())) === null).toBe(!testCase.strict);
+    });
+  }
+});
+
+describe("assert.deepEqual", () => {
+  for (const testCase of cases) {
+    const label = `${testCase.loose ? "accepts" : "rejects"} ${testCase.name}`;
+    const run = testCase.looseBug ? test.failing : test;
+    run(testCase.looseBug ? `${label} (Bun ${testCase.looseBug})` : label, () => {
+      const error = caught(() => assert.deepEqual(testCase.a(), testCase.b()));
+      if (testCase.loose) {
+        expect(error?.message ?? null).toBeNull();
+      } else {
+        expect(error?.code).toBe("ERR_ASSERTION");
+      }
+      expect(caught(() => assert.notDeepEqual(testCase.a(), testCase.b())) === null).toBe(!testCase.loose);
+    });
+  }
+});
+
+describe("util.isDeepStrictEqual", () => {
+  for (const testCase of cases) {
+    const label = `${testCase.name} is ${testCase.strict ? "" : "not "}deep-strict-equal`;
+    const run = testCase.strictBug ? test.failing : test;
+    run(testCase.strictBug ? `${label} (Bun ${testCase.strictBug})` : label, () => {
+      expect(util.isDeepStrictEqual(testCase.a(), testCase.b())).toBe(testCase.strict);
+    });
+  }
+
+  test("never throws on exotic input", () => {
+    expect(util.isDeepStrictEqual(undefined, undefined)).toBe(true);
+    expect(util.isDeepStrictEqual(null, undefined)).toBe(false);
+    expect(util.isDeepStrictEqual(Object.create(null), Object.create(null))).toBe(true);
+  });
+});
+
+describe("AssertionError", () => {
+  test("deepStrictEqual reports actual, expected and operator", () => {
+    const error = caught(() => assert.deepStrictEqual({ a: 1 }, { a: 2 })) as any;
+    expect(error).not.toBeNull();
+    expect(error.name).toBe("AssertionError");
+    expect(error.code).toBe("ERR_ASSERTION");
+    expect(error.operator).toBe("deepStrictEqual");
+    expect(error.actual).toEqual({ a: 1 });
+    expect(error.expected).toEqual({ a: 2 });
+    expect(error.generatedMessage).toBe(true);
+  });
+
+  test("notDeepStrictEqual reports its own operator", () => {
+    const error = caught(() => assert.notDeepStrictEqual({ a: 1 }, { a: 1 })) as any;
+    expect(error.operator).toBe("notDeepStrictEqual");
+    expect(error.code).toBe("ERR_ASSERTION");
+  });
+
+  test("a string message is used instead of generating one", () => {
+    const error = caught(() => assert.deepStrictEqual(1, 2, "nope")) as any;
+    expect(error.message.startsWith("nope")).toBe(true);
+    expect(error.generatedMessage).toBe(false);
+  });
+
+  test("an Error message is thrown as-is", () => {
+    const custom = new RangeError("custom");
+    const error = caught(() => assert.deepStrictEqual(1, 2, custom));
+    expect(error).toBe(custom);
+  });
+});


### PR DESCRIPTION
## What

`util.isDeepStrictEqual` had **zero** tests anywhere in `test/`. `assert.deepStrictEqual` / `assert.deepEqual` were covered by fewer than 20 assertions scattered across unrelated files, and Node's own deep-equality suite was never ported. All three route to the same native comparison, so the gap hid real divergences.

This adds a table of ~80 operand pairs, each run through `assert.deepStrictEqual`, `assert.notDeepStrictEqual`, `assert.deepEqual`, `assert.notDeepEqual` and `util.isDeepStrictEqual` (251 tests). Expectations were written from the documented semantics and cross-checked against Node, not read off Bun's current output.

Also added:
- `AssertionError` shape: `actual`, `expected`, `operator`, `generatedMessage`, and the `message`-as-Error path.
- The strict-vs-default distinctions that `Bun.deepEquals` documents, which previously had no test that actually differed between the two modes.

## Divergences it found

Every case below is marked `test.failing`, so CI stays green and the test reports the moment the behavior is corrected.

Strict mode (`deepStrictEqual` / `isDeepStrictEqual`), 13 cases:

| case | expected | Bun |
| --- | --- | --- |
| `Object.create(null)` vs `{}` | not equal | equal |
| two distinct anonymous classes | not equal | equal |
| two distinct classes sharing a name | not equal | equal |
| `class extends Array` instance vs `[]` | not equal | equal |
| `Buffer.from([1])` vs `new Uint8Array([1])` | not equal | equal |
| extra own property on a `Date`/`RegExp`/`Map`/typed array/array | not equal | equal |
| `RegExp` with a different `lastIndex` | not equal | equal |
| two `WeakMap`s, two `WeakSet`s | not equal | equal |

Class identity looks like the common root: Bun appears to match constructors by name rather than by identity, which is why two distinct anonymous classes (both named `""`) compare equal.

Loose mode (`deepEqual`), 20 cases. Node's loose mode still compares own key counts and still uses `==` for primitives:

| case | expected | Bun |
| --- | --- | --- |
| `0` vs `-0`, `1n` vs `1`, `'1'` vs `1`, `''` vs `false`, `'+00000000'` vs `false`, `null` vs `undefined` | equal | not equal |
| `{}` vs `{ a: undefined }` (and array/nested variants) | not equal | equal |
| a hole vs an explicit `undefined` | not equal | equal |
| symbol-keyed properties | ignored | compared |
| a `WeakMap` vs a `WeakSet` | not equal | equal |
| plus the 8 strict cases above, which are also loose divergences | | |

## Related issues

Not fixed here, but the repros are now covered as `test.failing` rows:

- #29030 `assert.deepStrictEqual({}, Object.create(null))` does not throw.
- #23877 `assert.deepEqual('+00000000', false)` throws.

## Verification

```
bun bd test test/js/node/assert/deep-equal.test.ts test/js/bun/bun-object/deep-equals.spec.ts
295 pass, 2 skip, 0 fail
```

No `src/` changes.
