### PR TITLE
tls: report out of memory instead of segfaulting when the loop's TLS buffer cannot be allocated

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -18,6 +18,7 @@
 #if (defined(LIBUS_USE_OPENSSL) || defined(LIBUS_USE_WOLFSSL))
 
 #include "internal/internal.h"
+#include "internal/fault_inject.h"
 #include "libusockets.h"
 #include <string.h>
 #include <limits.h>
@@ -674,15 +675,29 @@ static struct loop_ssl_data *ssl_set_loop_data(struct us_socket_t *s) {
   return loop_ssl_data;
 }
 
+/* The loop's shared TLS plaintext buffer. Split out so the fault injector can
+ * fail this one allocation: a 512 KiB malloc only returns NULL where the OS
+ * does not overcommit, which is the only place the crash was ever seen. */
+static char *ssl_alloc_read_output(void) {
+#if defined(LIBUS_SOCKET_FAULT_INJECTION) && LIBUS_SOCKET_FAULT_INJECTION
+  ssize_t injected = 0;
+  int unused = 0;
+  if (US_FAULT_CHECK(US_FAULT_SSL_LOOP_BUFFER, -1, injected, unused)) return NULL;
+#endif
+  return us_malloc(LIBUS_RECV_BUFFER_LENGTH + LIBUS_RECV_BUFFER_PADDING * 2);
+}
+
 void us_internal_init_loop_ssl_data(struct us_loop_t *loop) {
   if (!loop->data.ssl_data) {
     struct loop_ssl_data *loop_ssl_data = us_calloc(1, sizeof(struct loop_ssl_data));
-    loop_ssl_data->ssl_read_output =
-        us_malloc(LIBUS_RECV_BUFFER_LENGTH + LIBUS_RECV_BUFFER_PADDING * 2);
+    if (!loop_ssl_data) Bun__outOfMemory();
+    loop_ssl_data->ssl_read_output = ssl_alloc_read_output();
+    if (!loop_ssl_data->ssl_read_output) Bun__outOfMemory();
 
     OPENSSL_init_ssl(0, NULL);
 
     loop_ssl_data->shared_biom = BIO_meth_new(BIO_TYPE_MEM, "µS BIO");
+    if (!loop_ssl_data->shared_biom) Bun__outOfMemory();
     BIO_meth_set_create(loop_ssl_data->shared_biom, BIO_s_custom_create);
     BIO_meth_set_write(loop_ssl_data->shared_biom, BIO_s_custom_write);
     BIO_meth_set_read(loop_ssl_data->shared_biom, BIO_s_custom_read);
@@ -690,6 +705,7 @@ void us_internal_init_loop_ssl_data(struct us_loop_t *loop) {
 
     loop_ssl_data->shared_rbio = BIO_new(loop_ssl_data->shared_biom);
     loop_ssl_data->shared_wbio = BIO_new(loop_ssl_data->shared_biom);
+    if (!loop_ssl_data->shared_rbio || !loop_ssl_data->shared_wbio) Bun__outOfMemory();
     BIO_set_data(loop_ssl_data->shared_rbio, loop_ssl_data);
     BIO_set_data(loop_ssl_data->shared_wbio, loop_ssl_data);
 
@@ -707,6 +723,9 @@ void us_internal_free_loop_ssl_data(struct us_loop_t *loop) {
     BIO_free(loop_ssl_data->shared_wbio);
     BIO_meth_free(loop_ssl_data->shared_biom);
     us_free(loop_ssl_data);
+    /* us_internal_init_loop_ssl_data's guard reads this: leaving it dangling
+     * would hand a freed loop_ssl_data back to the next TLS socket. */
+    loop->data.ssl_data = NULL;
   }
 }
 

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -1,5 +1,7 @@
 /*
- * Socket syscall fault injection for the bsd_* wrapper layer.
+ * Fault injection for the bsd_* syscall wrappers, plus the one allocation
+ * whose failure path is otherwise unreachable on an overcommitting kernel
+ * (US_FAULT_SSL_LOOP_BUFFER).
  *
  * Compiled in only when LIBUS_SOCKET_FAULT_INJECTION is defined (controlled
  * by the `socketFaultInjection` Config field). When compiled out,
@@ -37,6 +39,10 @@ enum us_fault_syscall {
     US_FAULT_SOCKET,
     US_FAULT_CLOSE,
     US_FAULT_SHUTDOWN,
+    /* Not a syscall: the per-loop TLS plaintext buffer allocated once by
+     * us_internal_init_loop_ssl_data. Only US_FAULT_ERRNO applies — there is
+     * no byte count to clamp and no zero return to fake. */
+    US_FAULT_SSL_LOOP_BUFFER,
     US_FAULT_COUNT
 };
 

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -71,6 +71,10 @@ void us_internal_loop_update_pending_ready_polls(struct us_loop_t *loop,
 extern void __attribute__((__noreturn__)) Bun__panic(const char *message, size_t length);
 #define BUN_PANIC(message) Bun__panic(message, sizeof(message) - 1)
 
+/* Reports "Bun ran out of memory" through the crash handler and aborts. For
+ * allocations this library has no way to fail gracefully from. */
+extern void __attribute__((__noreturn__)) Bun__outOfMemory(void);
+
 #ifdef _WIN32
 #define IS_EINTR(rc) (rc == SOCKET_ERROR && WSAGetLastError() == WSAEINTR)
 #define LIBUS_ERR WSAGetLastError()

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -73,6 +73,9 @@ void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct
     loop->data.sweep_timer_count = 0;
     loop->data.recv_buf = malloc(LIBUS_RECV_BUFFER_LENGTH + LIBUS_RECV_BUFFER_PADDING * 2);
     loop->data.send_buf = malloc(LIBUS_SEND_BUFFER_LENGTH);
+    /* Every read on this loop writes into recv_buf; a NULL here makes each one
+     * fail with EFAULT for the life of the process. */
+    if (!loop->data.recv_buf || !loop->data.send_buf) Bun__outOfMemory();
     loop->data.pre_cb = pre_cb;
     loop->data.post_cb = post_cb;
     loop->data.wakeup_async = us_internal_create_async(loop, 1, 0);

--- a/src/bun_bin/phase_c_exports.rs
+++ b/src/bun_bin/phase_c_exports.rs
@@ -74,6 +74,13 @@ pub(crate) extern "C" fn Bun__panic(msg: *const u8, len: usize) -> ! {
     bun_core::output::panic(format_args!("{}", bstr::BStr::new(bytes)));
 }
 
+/// Out-of-memory entry point for C callers (bun-usockets) that cannot
+/// propagate an allocation failure. Same crash report as `handle_oom`.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn Bun__outOfMemory() -> ! {
+    bun_core::out_of_memory()
+}
+
 // REAL: now provided by bun_jsc (src/jsc/array_buffer.rs).
 // MarkedArrayBuffer_deallocator
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -276,8 +276,20 @@ export const setSocketOptions: setSocketOptionsFn = $newRustFunction(
   3,
 );
 
-/** Only the syscalls instrumented in bsd.c; arming anything else is rejected. */
-export type SocketFaultSyscall = "recv" | "send" | "writev" | "sendmsg" | "recvmsg" | "connect" | "accept";
+/**
+ * The syscalls instrumented in bsd.c, plus "ssl_loop_buffer" — not a syscall,
+ * but the per-loop TLS plaintext buffer allocation, whose failure path is
+ * unreachable on an overcommitting kernel. Arming anything else is rejected.
+ */
+export type SocketFaultSyscall =
+  | "recv"
+  | "send"
+  | "writev"
+  | "sendmsg"
+  | "recvmsg"
+  | "connect"
+  | "accept"
+  | "ssl_loop_buffer";
 
 export type SocketFaultRule = {
   syscall: SocketFaultSyscall;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -316,7 +316,7 @@ export type SocketFaultRule = {
   after?: number;
   /** fire this many times then disarm; -1 = forever. Default 1. */
   repeat?: number;
-  /** match only this fd; -1 (default) = any */
+  /** match only this fd; -1 (default) = any. Rejected for "ssl_loop_buffer", which has no fd. */
   fd?: number;
 };
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4967,13 +4967,23 @@ pub mod testing_apis {
                 )));
             }
 
+            // ssl_loop_buffer is an allocation, not a socket operation: its hook
+            // passes fd = -1, so a rule pinned to a descriptor would arm and then
+            // silently never fire.
+            let target_fd = get_i32("fd", -1)?;
+            if syscall == fi::SSL_LOOP_BUFFER && target_fd != -1 {
+                return Err(global.throw(format_args!(
+                    "rule.fd is not supported for syscall \"ssl_loop_buffer\""
+                )));
+            }
+
             let rule = fi::UsFaultRule {
                 action,
                 errno_value,
                 clamp_bytes,
                 after_n_calls: get_i32("after", 0)?,
                 repeat: get_i32("repeat", 1)?,
-                target_fd: get_i32("fd", -1)?,
+                target_fd,
             };
 
             // SAFETY: rule is a valid stack pointer for the duration of the call.

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4876,11 +4876,13 @@ pub mod testing_apis {
                 fi::CONNECT
             } else if syscall_str.eql_comptime(b"accept") {
                 fi::ACCEPT
+            } else if syscall_str.eql_comptime(b"ssl_loop_buffer") {
+                fi::SSL_LOOP_BUFFER
             } else {
                 // socket/close/shutdown have enum slots but no bsd.c hooks;
                 // accepting them would arm rules that can never fire.
                 return Err(global.throw(format_args!(
-                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept"
+                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, ssl_loop_buffer"
                 )));
             };
 

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -407,6 +407,9 @@ pub mod fault_inject {
     pub const SOCKET: c_int = 7;
     pub const CLOSE: c_int = 8;
     pub const SHUTDOWN: c_int = 9;
+    /// Not a syscall: the per-loop TLS plaintext buffer allocation in
+    /// `us_internal_init_loop_ssl_data`.
+    pub const SSL_LOOP_BUFFER: c_int = 10;
 
     pub const ACTION_NONE: c_int = 0;
     pub const ACTION_ERRNO: c_int = 1;

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -46,6 +46,18 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
     expect(fault.set({ syscall: "ssl_loop_buffer", action: "errno", errno: "ENOMEM" })).toBe(true);
   });
 
+  // ssl_loop_buffer's hook is an allocation, so it checks with fd = -1; a rule
+  // pinned to a descriptor would arm and then silently never fire.
+  test("set() rejects 'fd' for ssl_loop_buffer, which has no descriptor", () => {
+    expect(() => fault.set({ syscall: "ssl_loop_buffer", action: "errno", errno: "ENOMEM", fd: 3 })).toThrow(
+      /rule\.fd is not supported for syscall "ssl_loop_buffer"/,
+    );
+    // -1 is the default "any" sentinel and stays accepted.
+    expect(fault.set({ syscall: "ssl_loop_buffer", action: "errno", errno: "ENOMEM", fd: -1 })).toBe(true);
+    // Descriptor-pinned rules still work for the real syscalls.
+    expect(fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", fd: 3 })).toBe(true);
+  });
+
   test("set() rejects unknown errno name", () => {
     expect(() => fault.set({ syscall: "recv", action: "errno", errno: "ENOSUCHERR" as any })).toThrow(
       /unknown errno name/,

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -21,9 +21,10 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   });
 
   // Only recv/send have a byte count to clamp; arming "short" on any other
-  // syscall used to succeed silently and never fire.
+  // syscall used to succeed silently and never fire. ssl_loop_buffer is an
+  // allocation, so it has no byte count either.
   test("set() rejects 'short' for syscalls that cannot clamp a byte count", () => {
-    for (const syscall of ["writev", "sendmsg", "recvmsg", "connect", "accept"] as const) {
+    for (const syscall of ["writev", "sendmsg", "recvmsg", "connect", "accept", "ssl_loop_buffer"] as const) {
       expect(() => fault.set({ syscall, action: "short", bytes: 1 })).toThrow(/only supported for syscall/);
     }
     expect(fault.set({ syscall: "recv", action: "short", bytes: 1 })).toBe(true);
@@ -33,12 +34,16 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   // A zero return only means something for the data syscalls (EOF on the read
   // side, backpressure on the write side); connect's wrapper returns errno.
   test("set() rejects 'zero' for syscalls with no zero-return semantics", () => {
-    for (const syscall of ["connect", "accept"] as const) {
+    for (const syscall of ["connect", "accept", "ssl_loop_buffer"] as const) {
       expect(() => fault.set({ syscall, action: "zero" })).toThrow(/only supported for syscall/);
     }
     for (const syscall of ["recv", "send", "writev", "sendmsg", "recvmsg"] as const) {
       expect(fault.set({ syscall, action: "zero" })).toBe(true);
     }
+  });
+
+  test("set() accepts ssl_loop_buffer with action 'errno'", () => {
+    expect(fault.set({ syscall: "ssl_loop_buffer", action: "errno", errno: "ENOMEM" })).toBe(true);
   });
 
   test("set() rejects unknown errno name", () => {

--- a/test/js/node/tls/tls-loop-buffer-oom-fixture.ts
+++ b/test/js/node/tls/tls-loop-buffer-oom-fixture.ts
@@ -1,0 +1,48 @@
+// Fixture for the out-of-memory path of the per-loop TLS plaintext buffer.
+//
+// us_internal_init_loop_ssl_data() allocates one 512 KiB buffer per event loop,
+// lazily, on the loop's first TLS socket. A NULL return used to go unnoticed:
+// every later SSL_read handed BoringSSL `NULL + LIBUS_RECV_BUFFER_PADDING` as
+// its plaintext destination and memcpy faulted on the first record of
+// application data. malloc() of 512 KiB effectively never returns NULL on an
+// overcommitting kernel, so the fault injector is the only way here from a
+// test; on Windows it is a routine failure.
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { tls as certs } from "harness";
+import tls from "node:tls";
+import type { AddressInfo } from "node:net";
+
+if (!fault.available()) throw new Error("socket fault injection is not available in this build");
+
+// Nothing in this process has attached a TLS socket yet, so the next attach is
+// the one that allocates the loop's buffer.
+fault.set({ syscall: "ssl_loop_buffer", action: "errno", errno: "ENOMEM" });
+console.log("ARMED");
+
+const server = tls.createServer({ key: certs.key, cert: certs.cert }, socket => {
+  socket.on("error", () => {});
+  // Comfortably more than 256 bytes: memcpy only reaches the
+  // destination-alignment path that the crash reports point at for copies
+  // larger than 8 vector registers' worth.
+  socket.write(Buffer.alloc(4096, 0x61));
+});
+server.on("error", () => {});
+
+server.listen(0, "127.0.0.1", () => {
+  const { port } = server.address() as AddressInfo;
+  const client = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+  client.on("error", () => {
+    console.log("CLIENT ERROR");
+    process.exit(0);
+  });
+  // Either of these means the allocation failure went unreported: the process
+  // was supposed to abort before a TLS socket could reach its read loop.
+  client.on("data", () => {
+    console.log("READ DATA");
+    process.exit(0);
+  });
+  client.on("close", () => {
+    console.log("CLOSED");
+    process.exit(0);
+  });
+});

--- a/test/js/node/tls/tls-syscall-fault.test.ts
+++ b/test/js/node/tls/tls-syscall-fault.test.ts
@@ -1,12 +1,50 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { afterEach, describe, expect, test } from "bun:test";
-import { tls as certs, isWindows } from "harness";
+import { bunEnv, bunExe, tls as certs, isWindows } from "harness";
 import { once } from "node:events";
+import { join } from "node:path";
 import tls from "node:tls";
 
 const skip = !fault.available() || isWindows;
 
 afterEach(() => fault.clear());
+
+// The loop's shared TLS plaintext buffer is one lazy 512 KiB malloc, and its
+// NULL return used to be ignored: SSL_read then wrote to
+// `NULL + LIBUS_RECV_BUFFER_PADDING`. Runs in a child because the allocation
+// happens once per event loop, on its first TLS socket. No isWindows skip —
+// the unchecked allocation is exactly the one that fails there.
+//
+// Every marker the fixture can print. A crashing debug build symbolizes its
+// backtrace onto stdout, so match the fixture's lines rather than the whole
+// stream; anything past "ARMED" means a TLS socket survived the failed
+// allocation and reached its read loop.
+const OOM_FIXTURE_MARKERS = ["ARMED", "READ DATA", "CLOSED", "CLIENT ERROR"];
+test.skipIf(!fault.available())(
+  "a failed per-loop TLS buffer allocation reports out of memory instead of faulting inside SSL_read",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "tls-loop-buffer-oom-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const outOfMemory = stderr.includes("Bun ran out of memory");
+    expect({
+      markers: stdout
+        .split("\n")
+        .map(line => line.trim())
+        .filter(line => OOM_FIXTURE_MARKERS.includes(line)),
+      outOfMemory,
+      // Only populated when the assertion is about to fail, so the diff shows why.
+      stderrTail: outOfMemory ? "" : stderr.slice(-2000),
+    }).toEqual({ markers: ["ARMED"], outOfMemory: true, stderrTail: "" });
+  },
+  // Symbolizing the crash backtrace of a debug/ASAN binary takes several
+  // seconds on its own, well past the default per-test budget.
+  60_000,
+);
 
 async function connectedTLSPair(onServerSocket?: (s: tls.TLSSocket) => void) {
   const server = tls.createServer({ key: certs.key, cert: certs.cert });


### PR DESCRIPTION
Fixes a `Segmentation fault at address 0x00000040` (sometimes `0x00000030`) reported from Windows x64 builds, crashing inside boringssl's record copy from uSockets' TLS read loop:

```
memcpy                            src/vctools/crt/vcruntime/src/string/amd64/memcpy.asm
bssl::OPENSSL_memcpy              vendor/boringssl/crypto/internal.h:868
SSL_peek                          vendor/boringssl/ssl/ssl_lib.cc:947
SSL_read                          vendor/boringssl/ssl/ssl_lib.cc:918
us_internal_ssl_on_data           packages/bun-usockets/src/crypto/openssl.c:1797
us_internal_dispatch_ready_poll   packages/bun-usockets/src/loop.c:600
uv__fast_poll_process_poll_req    vendor/libuv/src/win/poll.c:208
uv_run                            vendor/libuv/src/win/core.c:737
```

## Cause

`us_internal_init_loop_ssl_data` (`openssl.c:677`) allocates one 512 KiB plaintext buffer per event loop, lazily, on the loop's first TLS socket, and never checked the result:

```c
loop_ssl_data->ssl_read_output =
    us_malloc(LIBUS_RECV_BUFFER_LENGTH + LIBUS_RECV_BUFFER_PADDING * 2);
```

With `ssl_read_output == NULL`, every later `SSL_read` hands boringssl

```c
loop_ssl_data->ssl_read_output + LIBUS_RECV_BUFFER_PADDING + read
```

as its plaintext destination, so the first record of application data memcpy's to `NULL + 32`. `SSL_peek`'s `OPENSSL_memcpy(buf, ...)` at `ssl_lib.cc:947` is the write, and the access violation confirms it is a write fault.

`0x30`/`0x40` rather than `0x20` is memcpy's destination-alignment preamble (`dst += VEC_SIZE; dst &= ~(VEC_SIZE - 1)`), which moves the first faulting store for copies larger than eight vector registers. Measured on the copy sizes a real TLS record produces:

| memcpy variant | first faulting store for `dst = NULL + 32` |
| --- | --- |
| 32-byte vectors (AVX) | `0x40` |
| 16-byte vectors (SSE) | `0x30` |

So the two strikingly stable fault addresses are just CPU dispatch across the affected machines, and `read` is always `0`: the crash is always the connection's first record of application data.

Only Windows reports it because Linux and macOS overcommit, so a 512 KiB `malloc` there effectively never returns NULL. Windows fails the commit cleanly, and the loop's much smaller `us_calloc` still succeeds out of an already-committed page, leaving exactly the observed shape: a valid `loop_ssl_data` whose `ssl_read_output` is NULL.

## Fix

- Null-check the buffer allocation, the `us_calloc` of `loop_ssl_data`, and the `BIO_meth_new`/`BIO_new` calls beside them, and route the failure through Bun's out-of-memory crash path (`Bun__outOfMemory`, new C entry point next to `Bun__panic`). The process now dies with `Bun ran out of memory` and a stack trace that names the allocation, instead of faulting on the first TLS byte.
- Apply the same check to the sibling site: `recv_buf`/`send_buf` in `us_internal_loop_data_init` are the same unchecked `malloc(LIBUS_RECV_BUFFER_LENGTH + LIBUS_RECV_BUFFER_PADDING * 2)`. A NULL `recv_buf` does not fault, it makes every read on the loop fail with `EFAULT` for the life of the process, which is worse to diagnose.
- `us_internal_free_loop_ssl_data` left `loop->data.ssl_data` dangling, which defeats the `if (!loop->data.ssl_data)` guard the init function relies on. It now clears the field.

A 512 KiB `malloc` effectively never returns NULL on an overcommitting kernel, so the failure path needs the existing socket fault injector to be reachable from a test. This adds an `ssl_loop_buffer` rule to it, which like the rest of the injector is compiled out of release builds.

## Verification

The new test spawns a child that arms `ssl_loop_buffer` before its first TLS socket and asserts it reports out of memory rather than reaching a read loop.

Reverting only `if (!loop_ssl_data->ssl_read_output) Bun__outOfMemory();` reproduces the reported crash exactly, on Linux, from that same fixture: same fault address, same frames, same boringssl source lines.

<details>
<summary>Reproduction on the unfixed build (<code>bun bd</code>, ASAN)</summary>

```
==19592==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000040
==19592==The signal is caused by a WRITE memory access.
==19592==Hint: address points to the zero page.
    #0 __memcpy_evex_unaligned_erms
    #1 bssl::OPENSSL_memcpy(void*, void const*, unsigned long) vendor/boringssl/crypto/internal.h:868:10
    #2 SSL_peek vendor/boringssl/ssl/ssl_lib.cc:947:3
    #3 SSL_read vendor/boringssl/ssl/ssl_lib.cc:918:13
    #4 us_internal_ssl_on_data packages/bun-usockets/src/crypto/openssl.c:1847:21
    #5 us_internal_dispatch_ready_poll packages/bun-usockets/src/loop.c:625:38
```

With the fix:

```
panic(main thread): Bun ran out of memory
Bun__outOfMemory              src/bun_bin/phase_c_exports.rs:81:5
us_internal_init_loop_ssl_data packages/bun-usockets/src/crypto/openssl.c:696:42
us_internal_ssl_attach        packages/bun-usockets/src/crypto/openssl.c:1275:3
```

</details>

`test/js/node/tls/tls-syscall-fault.test.ts` (11 pass), `test/js/bun/util/socket-fault-injection.test.ts` (15 pass), plus `socket-syscall-fault`, `serve-syscall-fault` and `fetch-syscall-fault` (19 pass) are green. The three failures in `test/js/node/tls/` on this machine are pre-existing: two also fail on an unmodified 1.4.0, and `tls.connect should ignore invalid NODE_EXTRA_CA_CERTS` takes 5.75s, just over the 5s local default (CI triples the per-test timeout for ASAN builds).

## Teardown audit

The report also asked whether a socket can reach `us_internal_ssl_on_data` after its loop's SSL data has been freed. `us_internal_free_loop_ssl_data` is only reachable from `us_loop_free`, and the only loop Bun frees today is `SpawnSyncEventLoop`'s, which never has a TLS socket attached (its `loop->data.ssl_data` is always NULL, so the free is a no-op). So that is not the cause here.

It is worth noting separately that the libuv `us_loop_free` (`eventing/libuv.c:201-206`) calls `us_internal_loop_data_free(loop)` and *then* runs `uv_run(loop->uv_loop, UV_RUN_NOWAIT)`, which is a full libuv iteration that can dispatch socket poll callbacks into the just-freed `recv_buf` and `ssl_data`. The POSIX `us_loop_free` (`eventing/epoll_kqueue.c:56-60`) has no such window. It is unreachable today for the reason above, so it is left out of this PR rather than changing loop teardown ordering without a test that can exercise it.
