### PR TITLE
util: styleText honors its options argument, debuglog exposes enabled

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -245,6 +245,12 @@ var toUSVString = input => {
   return (input + "").toWellFormed();
 };
 
+// internal/streams/utils pulls in the whole stream machinery and
+// internal/util/colors requires node:tty, so neither is loaded until a caller
+// actually asks styleText to look at a stream.
+let lazyStreamUtils;
+let lazyUtilColors;
+
 function styleText(format, text, options) {
   const validateStream = options?.validateStream ?? true;
 
@@ -257,11 +263,13 @@ function styleText(format, text, options) {
   let skipColorize = false;
   if (validateStream) {
     const stream = options?.stream ?? process.stdout;
-    const { isReadableStream, isWritableStream, isNodeStream } = require("internal/streams/utils");
+    lazyStreamUtils ??= require("internal/streams/utils");
+    const { isReadableStream, isWritableStream, isNodeStream } = lazyStreamUtils;
     if (!isReadableStream(stream) && !isWritableStream(stream) && !isNodeStream(stream)) {
       throw $ERR_INVALID_ARG_TYPE("stream", ["ReadableStream", "WritableStream", "Stream"], stream);
     }
-    skipColorize = !require("internal/util/colors").shouldColorize(stream);
+    lazyUtilColors ??= require("internal/util/colors");
+    skipColorize = !lazyUtilColors.shouldColorize(stream);
   }
 
   const formatArray = $isJSArray(format) ? format : [format];

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -3,7 +3,7 @@ const types = require("node:util/types");
 /** @type {import('node-inspect-extracted')} */
 const utl = require("internal/util/inspect");
 const { promisify } = require("internal/promisify");
-const { validateString, validateOneOf, validateBoolean } = require("internal/validators");
+const { validateString, validateOneOf, validateBoolean, validateObject } = require("internal/validators");
 const { MIMEType, MIMEParams } = require("internal/util/mime");
 const { deprecate } = require("internal/util/deprecate");
 
@@ -60,21 +60,53 @@ function emitWarningIfNeeded(set) {
   }
 }
 
-function debuglog(set) {
-  set = set.toUpperCase();
+function debuglogImpl(enabled, set) {
   if (!debugs[set]) {
-    if (debugEnvRegex.test(set)) {
-      var pid = process.pid;
+    let impl;
+    if (enabled) {
+      const pid = process.pid;
       emitWarningIfNeeded(set);
-      debugs[set] = function () {
-        var msg = format.$apply(cjs_exports, arguments);
+      impl = function debug() {
+        const msg = format.$apply(cjs_exports, arguments);
         console.error("%s %d: %s", set, pid, msg);
       };
     } else {
-      debugs[set] = function () {};
+      impl = function debug() {};
     }
+    Object.defineProperty(impl, "enabled", {
+      __proto__: null,
+      value: enabled,
+      configurable: true,
+      enumerable: true,
+    });
+    debugs[set] = impl;
   }
   return debugs[set];
+}
+
+function debuglog(set, cb) {
+  set = set.toUpperCase();
+  const enabled = debugEnvRegex.test(set);
+  // The implementation is created eagerly so that the NODE_DEBUG=http warning
+  // is emitted when node:http requires this, the way node:_http_client does.
+  const impl = debuglogImpl(enabled, set);
+  let notified = false;
+  const logger = function debuglogWrapper() {
+    if (!notified) {
+      notified = true;
+      if (typeof cb === "function") cb(impl);
+    }
+    return impl.$apply(undefined, arguments);
+  };
+  Object.defineProperty(logger, "enabled", {
+    __proto__: null,
+    get() {
+      return enabled;
+    },
+    configurable: true,
+    enumerable: true,
+  });
+  return logger;
 }
 
 function isBoolean(arg) {
@@ -213,30 +245,41 @@ var toUSVString = input => {
   return (input + "").toWellFormed();
 };
 
-function styleText(format, text) {
+function styleText(format, text, options) {
+  const validateStream = options?.validateStream ?? true;
+
   validateString(text, "text");
+  if (options !== undefined) {
+    validateObject(options, "options");
+  }
+  validateBoolean(validateStream, "options.validateStream");
 
-  if ($isJSArray(format)) {
-    let left = "";
-    let right = "";
-    for (const key of format) {
-      const formatCodes = inspect.colors[key];
-      if (formatCodes == null) {
-        validateOneOf(key, "format", ObjectKeys(inspect.colors));
-      }
-      left += `\u001b[${formatCodes[0]}m`;
-      right = `\u001b[${formatCodes[1]}m${right}`;
+  let skipColorize = false;
+  if (validateStream) {
+    const stream = options?.stream ?? process.stdout;
+    const { isReadableStream, isWritableStream, isNodeStream } = require("internal/streams/utils");
+    if (!isReadableStream(stream) && !isWritableStream(stream) && !isNodeStream(stream)) {
+      throw $ERR_INVALID_ARG_TYPE("stream", ["ReadableStream", "WritableStream", "Stream"], stream);
     }
-
-    return `${left}${text}${right}`;
+    skipColorize = !require("internal/util/colors").shouldColorize(stream);
   }
 
-  let formatCodes = inspect.colors[format];
+  const formatArray = $isJSArray(format) ? format : [format];
 
-  if (formatCodes == null) {
-    validateOneOf(format, "format", ObjectKeys(inspect.colors));
+  let left = "";
+  let right = "";
+  for (const key of formatArray) {
+    if (key === "none") continue;
+    const formatCodes = inspect.colors[key];
+    if (formatCodes == null) {
+      validateOneOf(key, "format", ObjectKeys(inspect.colors));
+    }
+    if (skipColorize) continue;
+    left += `\u001b[${formatCodes[0]}m`;
+    right = `\u001b[${formatCodes[1]}m${right}`;
   }
-  return `\u001b[${formatCodes[0]}m${text}\u001b[${formatCodes[1]}m`;
+
+  return skipColorize ? text : `${left}${text}${right}`;
 }
 
 function getSystemErrorName(err: any) {

--- a/test/js/node/test/parallel/test-util-styletext.js
+++ b/test/js/node/test/parallel/test-util-styletext.js
@@ -31,13 +31,28 @@ assert.throws(() => {
   code: 'ERR_INVALID_ARG_VALUE',
 });
 
-assert.strictEqual(util.styleText('red', 'test'), '\u001b[31mtest\u001b[39m');
+// styleText only colorizes when the target stream can show colors.
+const raw = { validateStream: false };
 
-assert.strictEqual(util.styleText(['bold', 'red'], 'test'), '\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m');
-assert.strictEqual(util.styleText(['bold', 'red'], 'test'), util.styleText('bold', util.styleText('red', 'test')));
+assert.strictEqual(util.styleText('red', 'test', raw), '\u001b[31mtest\u001b[39m');
+
+assert.strictEqual(util.styleText(['bold', 'red'], 'test', raw), '\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m');
+assert.strictEqual(util.styleText(['bold', 'red'], 'test', raw),
+                   util.styleText('bold', util.styleText('red', 'test', raw), raw));
 
 assert.throws(() => {
   util.styleText(['invalid'], 'text');
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
 });
+
+assert.throws(() => {
+  util.styleText('red', 'text', { stream: {} });
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// does not throw
+util.styleText('red', 'text', { stream: {}, validateStream: false });
+
+assert.strictEqual(util.styleText('none', 'test'), 'test');

--- a/test/js/node/util/debuglog.test.ts
+++ b/test/js/node/util/debuglog.test.ts
@@ -89,8 +89,8 @@ describe("util.debuglog", () => {
 
   test("a non-function callback is ignored", async () => {
     const result = await run(`require("util").debuglog("ignored", 42)("x");`, "ignored");
-    expect(result.exitCode).toBe(0);
     expect(result.stderr.trim()).toMatch(/^IGNORED \d+: x$/);
+    expect(result.exitCode).toBe(0);
   });
 
   test("NODE_DEBUG=http warns that it can expose sensitive data", async () => {

--- a/test/js/node/util/debuglog.test.ts
+++ b/test/js/node/util/debuglog.test.ts
@@ -1,0 +1,98 @@
+// https://nodejs.org/api/util.html#utildebuglogsection-callback
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import util from "node:util";
+
+async function run(script: string, nodeDebug?: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: nodeDebug === undefined ? bunEnv : { ...bunEnv, NODE_DEBUG: nodeDebug },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("util.debuglog", () => {
+  test("returns a function exposing an enumerable `enabled` boolean", () => {
+    const log = util.debuglog("never-enabled-section");
+    expect(typeof log).toBe("function");
+    expect(log.enabled).toBe(false);
+    expect(Object.keys(log)).toEqual(["enabled"]);
+  });
+
+  test("util.debug is util.debuglog", () => {
+    expect(util.debug).toBe(util.debuglog);
+  });
+
+  test("a disabled section writes nothing", async () => {
+    const result = await run(`require("util").debuglog("quiet")("hello");`);
+    expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
+
+  test("an enabled section writes SECTION pid: message to stderr", async () => {
+    const { stderr, exitCode } = await run(
+      `const log = require("util").debuglog("noisy");
+       process.stdout.write(String(log.enabled));
+       log("hello %s", "world");`,
+      "noisy",
+    );
+    expect(stderr).toContain("NOISY");
+    expect(stderr).toContain("hello world");
+    expect(stderr.trim()).toMatch(/^NOISY \d+: hello world$/);
+    expect(exitCode).toBe(0);
+  });
+
+  test("enabled reflects NODE_DEBUG", async () => {
+    const script = `const util = require("util");
+      process.stdout.write(JSON.stringify([util.debuglog("a").enabled, util.debuglog("b").enabled]));`;
+    const results = await Promise.all([run(script, "a"), run(script, "b"), run(script, "a,b"), run(script)]);
+    expect(results.map(r => r.stdout)).toEqual(["[true,false]", "[false,true]", "[true,true]", "[false,false]"]);
+  });
+
+  test("section matching is case-insensitive and supports wildcards", async () => {
+    const script = `const util = require("util");
+      process.stdout.write(JSON.stringify([util.debuglog("FOO").enabled, util.debuglog("foobar").enabled]));`;
+    const results = await Promise.all([run(script, "foo"), run(script, "foo*")]);
+    expect(results.map(r => r.stdout)).toEqual(["[true,false]", "[true,true]"]);
+  });
+
+  test("the callback runs once, on the first call, with the logging function", async () => {
+    const { stdout, exitCode } = await run(
+      `const util = require("util");
+       const seen = [];
+       const log = util.debuglog("cb", fn => seen.push(typeof fn));
+       const beforeFirstCall = seen.length;
+       log("one");
+       log("two");
+       process.stdout.write(JSON.stringify({ beforeFirstCall, seen }));`,
+      "cb",
+    );
+    expect(stdout).toBe(`{"beforeFirstCall":0,"seen":["function"]}`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("the logging function handed to the callback also reports enabled", async () => {
+    const { stdout } = await run(
+      `const util = require("util");
+       let enabled;
+       util.debuglog("cb2", fn => { enabled = fn.enabled; })("x");
+       process.stdout.write(String(enabled));`,
+      "cb2",
+    );
+    expect(stdout).toBe("true");
+  });
+
+  test("a non-function callback is ignored", async () => {
+    const result = await run(`require("util").debuglog("ignored", 42)("x");`, "ignored");
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr.trim()).toMatch(/^IGNORED \d+: x$/);
+  });
+
+  test("NODE_DEBUG=http warns that it can expose sensitive data", async () => {
+    const { stderr, exitCode } = await run(`require("util").debuglog("http");`, "http");
+    expect(stderr).toContain("can expose sensitive data");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/util/debuglog.test.ts
+++ b/test/js/node/util/debuglog.test.ts
@@ -6,7 +6,8 @@ import util from "node:util";
 async function run(script: string, nodeDebug?: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
-    env: nodeDebug === undefined ? bunEnv : { ...bunEnv, NODE_DEBUG: nodeDebug },
+    // Always set the key so an ambient NODE_DEBUG cannot leak into the child.
+    env: { ...bunEnv, NODE_DEBUG: nodeDebug },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -15,10 +16,12 @@ async function run(script: string, nodeDebug?: string) {
 }
 
 describe("util.debuglog", () => {
+  // The value of `enabled` depends on this process's NODE_DEBUG, so the true and
+  // false cases live in the subprocess tests below.
   test("returns a function exposing an enumerable `enabled` boolean", () => {
-    const log = util.debuglog("never-enabled-section");
+    const log = util.debuglog("some-section");
     expect(typeof log).toBe("function");
-    expect(log.enabled).toBe(false);
+    expect(typeof log.enabled).toBe("boolean");
     expect(Object.keys(log)).toEqual(["enabled"]);
   });
 

--- a/test/js/node/util/debuglog.test.ts
+++ b/test/js/node/util/debuglog.test.ts
@@ -29,12 +29,12 @@ describe("util.debuglog", () => {
     expect(util.debug).toBe(util.debuglog);
   });
 
-  test("a disabled section writes nothing", async () => {
+  test.concurrent("a disabled section writes nothing", async () => {
     const result = await run(`require("util").debuglog("quiet")("hello");`);
     expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
   });
 
-  test("an enabled section writes SECTION pid: message to stderr", async () => {
+  test.concurrent("an enabled section writes SECTION pid: message to stderr", async () => {
     const { stdout, stderr, exitCode } = await run(
       `const log = require("util").debuglog("noisy");
        process.stdout.write(String(log.enabled));
@@ -46,21 +46,21 @@ describe("util.debuglog", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("enabled reflects NODE_DEBUG", async () => {
+  test.concurrent("enabled reflects NODE_DEBUG", async () => {
     const script = `const util = require("util");
       process.stdout.write(JSON.stringify([util.debuglog("a").enabled, util.debuglog("b").enabled]));`;
     const results = await Promise.all([run(script, "a"), run(script, "b"), run(script, "a,b"), run(script)]);
     expect(results.map(r => r.stdout)).toEqual(["[true,false]", "[false,true]", "[true,true]", "[false,false]"]);
   });
 
-  test("section matching is case-insensitive and supports wildcards", async () => {
+  test.concurrent("section matching is case-insensitive and supports wildcards", async () => {
     const script = `const util = require("util");
       process.stdout.write(JSON.stringify([util.debuglog("FOO").enabled, util.debuglog("foobar").enabled]));`;
     const results = await Promise.all([run(script, "foo"), run(script, "foo*")]);
     expect(results.map(r => r.stdout)).toEqual(["[true,false]", "[true,true]"]);
   });
 
-  test("the callback runs once, on the first call, with the logging function", async () => {
+  test.concurrent("the callback runs once, on the first call, with the logging function", async () => {
     const { stdout, exitCode } = await run(
       `const util = require("util");
        const seen = [];
@@ -75,7 +75,7 @@ describe("util.debuglog", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("the logging function handed to the callback also reports enabled", async () => {
+  test.concurrent("the logging function handed to the callback also reports enabled", async () => {
     const { stdout } = await run(
       `const util = require("util");
        let enabled;
@@ -86,13 +86,13 @@ describe("util.debuglog", () => {
     expect(stdout).toBe("true");
   });
 
-  test("a non-function callback is ignored", async () => {
+  test.concurrent("a non-function callback is ignored", async () => {
     const result = await run(`require("util").debuglog("ignored", 42)("x");`, "ignored");
     expect(result.stderr.trim()).toMatch(/^IGNORED \d+: x$/);
     expect(result.exitCode).toBe(0);
   });
 
-  test("NODE_DEBUG=http warns that it can expose sensitive data", async () => {
+  test.concurrent("NODE_DEBUG=http warns that it can expose sensitive data", async () => {
     const { stderr, exitCode } = await run(`require("util").debuglog("http");`, "http");
     expect(stderr).toContain("can expose sensitive data");
     expect(exitCode).toBe(0);

--- a/test/js/node/util/debuglog.test.ts
+++ b/test/js/node/util/debuglog.test.ts
@@ -35,14 +35,13 @@ describe("util.debuglog", () => {
   });
 
   test("an enabled section writes SECTION pid: message to stderr", async () => {
-    const { stderr, exitCode } = await run(
+    const { stdout, stderr, exitCode } = await run(
       `const log = require("util").debuglog("noisy");
        process.stdout.write(String(log.enabled));
        log("hello %s", "world");`,
       "noisy",
     );
-    expect(stderr).toContain("NOISY");
-    expect(stderr).toContain("hello world");
+    expect(stdout).toBe("true");
     expect(stderr.trim()).toMatch(/^NOISY \d+: hello world$/);
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/util/style-text.test.ts
+++ b/test/js/node/util/style-text.test.ts
@@ -153,7 +153,7 @@ describe("util.styleText", () => {
   describe("the default stream is process.stdout", () => {
     const script = `process.stdout.write(JSON.stringify(require("util").styleText("red", "test")));`;
 
-    test("a piped stdout gets no escape codes", async () => {
+    test.concurrent("a piped stdout gets no escape codes", async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", script],
         env: bunEnv,
@@ -164,7 +164,7 @@ describe("util.styleText", () => {
       expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({ stdout: `"test"`, stderr: "", exitCode: 0 });
     });
 
-    test("FORCE_COLOR turns the codes back on", async () => {
+    test.concurrent("FORCE_COLOR turns the codes back on", async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", script],
         env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: undefined },

--- a/test/js/node/util/style-text.test.ts
+++ b/test/js/node/util/style-text.test.ts
@@ -124,7 +124,7 @@ describe("util.styleText", () => {
     const cleared = { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: undefined, NODE_DISABLE_COLORS: undefined };
     const colorized = JSON.stringify("\u001b[36mhi\u001b[39m");
 
-    test.each([
+    test.concurrent.each([
       ["NO_COLOR", { NO_COLOR: "1" }, `"hi"`],
       ["NODE_DISABLE_COLORS", { NODE_DISABLE_COLORS: "1" }, `"hi"`],
       ["FORCE_COLOR", { FORCE_COLOR: "1" }, colorized],

--- a/test/js/node/util/style-text.test.ts
+++ b/test/js/node/util/style-text.test.ts
@@ -1,5 +1,5 @@
 // https://nodejs.org/api/util.html#utilstyletextformat-text-options
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { Writable } from "node:stream";
 import util from "node:util";
@@ -15,6 +15,16 @@ function colorCapableStream() {
   stream.getColorDepth = () => 24;
   return stream;
 }
+
+// FORCE_COLOR short-circuits the stream check, so the in-process cases below
+// would answer to the ambient environment rather than to the stream they pass.
+const ambientForceColor = process.env.FORCE_COLOR;
+beforeAll(() => {
+  delete process.env.FORCE_COLOR;
+});
+afterAll(() => {
+  if (ambientForceColor !== undefined) process.env.FORCE_COLOR = ambientForceColor;
+});
 
 describe("util.styleText", () => {
   test("wraps the text in the format's open and close codes", () => {

--- a/test/js/node/util/style-text.test.ts
+++ b/test/js/node/util/style-text.test.ts
@@ -75,6 +75,16 @@ describe("util.styleText", () => {
       expect(util.styleText("red", "x", { stream: new Writable() })).toBe("x");
     });
 
+    // https://github.com/oven-sh/bun/issues/25736
+    test("honors a bare isTTY flag on a stream with no getColorDepth", () => {
+      const tty: any = new Writable();
+      tty.isTTY = true;
+      const notTty: any = new Writable();
+      notTty.isTTY = false;
+      expect(util.styleText("bgYellow", "TTY", { stream: tty })).toBe("\u001b[43mTTY\u001b[49m");
+      expect(util.styleText("bgYellow", "No TTY", { stream: notTty })).toBe("No TTY");
+    });
+
     test("accepts web streams", () => {
       expect(util.styleText("red", "x", { stream: new WritableStream() as any })).toBe("x");
       expect(util.styleText("red", "x", { stream: new ReadableStream() as any })).toBe("x");
@@ -98,6 +108,36 @@ describe("util.styleText", () => {
   test.failing("restores the outer format after a nested one closes", () => {
     const nested = "A" + util.styleText("blue", "B", raw) + "C";
     expect(util.styleText("red", nested, raw)).toBe("\u001b[31mA\u001b[34mB\u001b[31mC\u001b[39m");
+  });
+
+  // https://github.com/oven-sh/bun/issues/20129
+  describe("the color environment variables", () => {
+    // A stream that claims to be a TTY and defers to the real color detection,
+    // so the env vars are the only thing deciding the outcome.
+    const script = `
+      const { Writable } = require("node:stream");
+      const stream = new Writable();
+      stream.isTTY = true;
+      stream.getColorDepth = require("node:tty").WriteStream.prototype.getColorDepth;
+      process.stdout.write(JSON.stringify(require("util").styleText("cyan", "hi", { stream })));
+    `;
+    const cleared = { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: undefined, NODE_DISABLE_COLORS: undefined };
+    const colorized = JSON.stringify("\u001b[36mhi\u001b[39m");
+
+    test.each([
+      ["NO_COLOR", { NO_COLOR: "1" }, `"hi"`],
+      ["NODE_DISABLE_COLORS", { NODE_DISABLE_COLORS: "1" }, `"hi"`],
+      ["FORCE_COLOR", { FORCE_COLOR: "1" }, colorized],
+    ])("%s decides whether a TTY stream gets colors", async (_name, env, expected) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...cleared, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({ stdout: expected, stderr: "", exitCode: 0 });
+    });
   });
 
   describe("the default stream is process.stdout", () => {

--- a/test/js/node/util/style-text.test.ts
+++ b/test/js/node/util/style-text.test.ts
@@ -1,0 +1,132 @@
+// https://nodejs.org/api/util.html#utilstyletextformat-text-options
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { Writable } from "node:stream";
+import util from "node:util";
+
+// styleText only emits escape codes when the target stream can show them, so
+// every in-process case has to name a stream or opt out of the check. The
+// default-stream behavior is covered by subprocesses further down.
+const raw = { validateStream: false } as const;
+
+function colorCapableStream() {
+  const stream: any = new Writable();
+  stream.isTTY = true;
+  stream.getColorDepth = () => 24;
+  return stream;
+}
+
+describe("util.styleText", () => {
+  test("wraps the text in the format's open and close codes", () => {
+    expect(util.styleText("red", "test", raw)).toBe("\u001b[31mtest\u001b[39m");
+    expect(util.styleText("bold", "test", raw)).toBe("\u001b[1mtest\u001b[22m");
+  });
+
+  test("applies an array of formats from the outside in", () => {
+    expect(util.styleText(["bold", "red"], "test", raw)).toBe("\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m");
+    expect(util.styleText(["bold", "red"], "test", raw)).toBe(
+      util.styleText("bold", util.styleText("red", "test", raw), raw),
+    );
+  });
+
+  test("accepts the color aliases", () => {
+    expect(util.styleText("grey", "t", raw)).toBe(util.styleText("gray", "t", raw));
+    expect(util.styleText("bgGrey", "t", raw)).toBe(util.styleText("bgGray", "t", raw));
+    expect(util.styleText("blackBright", "t", raw)).toBe(util.styleText("gray", "t", raw));
+    expect(util.styleText("faint", "t", raw)).toBe(util.styleText("dim", "t", raw));
+  });
+
+  test("the 'none' format leaves the text untouched", () => {
+    expect(util.styleText("none", "test")).toBe("test");
+    expect(util.styleText(["none"], "test", raw)).toBe("test");
+    expect(util.styleText(["none", "red"], "test", raw)).toBe("\u001b[31mtest\u001b[39m");
+  });
+
+  test("rejects an unknown format", () => {
+    expect(() => util.styleText("invalid", "text")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+    expect(() => util.styleText(["invalid"], "text")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+    expect(() => util.styleText(["red", "invalid"], "text")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+  });
+
+  test.each([undefined, null, false, 5n, 5, Symbol("s"), () => {}, {}])("rejects %p as a format", invalid => {
+    expect(() => util.styleText(invalid as any, "test")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+  });
+
+  test.each([undefined, null, false, 5n, 5, Symbol("s"), () => {}, {}])("rejects %p as text", invalid => {
+    expect(() => util.styleText("red", invalid as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+  });
+
+  test("validates the options object", () => {
+    expect(() => util.styleText("red", "x", 5 as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => util.styleText("red", "x", null as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => util.styleText("red", "x", { validateStream: "yes" } as any)).toThrowWithCode(
+      TypeError,
+      "ERR_INVALID_ARG_TYPE",
+    );
+  });
+
+  describe("options.stream", () => {
+    test("colorizes when the stream supports colors", () => {
+      expect(util.styleText("red", "x", { stream: colorCapableStream() })).toBe("\u001b[31mx\u001b[39m");
+      expect(util.styleText(["red"], "x", { stream: colorCapableStream() })).toBe("\u001b[31mx\u001b[39m");
+    });
+
+    test("leaves the text alone when the stream is not a TTY", () => {
+      expect(util.styleText("red", "x", { stream: new Writable() })).toBe("x");
+    });
+
+    test("accepts web streams", () => {
+      expect(util.styleText("red", "x", { stream: new WritableStream() as any })).toBe("x");
+      expect(util.styleText("red", "x", { stream: new ReadableStream() as any })).toBe("x");
+    });
+
+    test("rejects anything that is not a stream", () => {
+      expect(() => util.styleText("red", "x", { stream: {} as any })).toThrowWithCode(
+        TypeError,
+        "ERR_INVALID_ARG_TYPE",
+      );
+      expect(() => util.styleText("red", "x", { stream: 1 as any })).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    });
+
+    test("skips the stream check entirely when validateStream is false", () => {
+      expect(util.styleText("red", "x", { stream: {} as any, validateStream: false })).toBe("\u001b[31mx\u001b[39m");
+    });
+  });
+
+  // Node restores the enclosing color when a nested styleText closes, instead of
+  // emitting a plain reset. Bun emits the reset, so 'C' below loses its color.
+  test.failing("restores the outer format after a nested one closes", () => {
+    const nested = "A" + util.styleText("blue", "B", raw) + "C";
+    expect(util.styleText("red", nested, raw)).toBe("\u001b[31mA\u001b[34mB\u001b[31mC\u001b[39m");
+  });
+
+  describe("the default stream is process.stdout", () => {
+    const script = `process.stdout.write(JSON.stringify(require("util").styleText("red", "test")));`;
+
+    test("a piped stdout gets no escape codes", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({ stdout: `"test"`, stderr: "", exitCode: 0 });
+    });
+
+    test("FORCE_COLOR turns the codes back on", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: undefined },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({
+        stdout: JSON.stringify("\u001b[31mtest\u001b[39m"),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+});

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -342,9 +342,11 @@ describe("util", () => {
   });
 
   it("multiplecolors", () => {
-    expect(util.styleText(["bold", "red"], "test")).toBe("\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m");
-    expect(util.styleText("bold", "test")).toBe("\u001b[1mtest\u001b[22m");
-    expect(util.styleText("red", "test")).toBe("\u001b[31mtest\u001b[39m");
+    // styleText only colorizes when the stream supports it, so opt out of the check.
+    const raw = { validateStream: false };
+    expect(util.styleText(["bold", "red"], "test", raw)).toBe("\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m");
+    expect(util.styleText("bold", "test", raw)).toBe("\u001b[1mtest\u001b[22m");
+    expect(util.styleText("red", "test", raw)).toBe("\u001b[31mtest\u001b[39m");
   });
 
   it("styleText", () => {
@@ -376,7 +378,7 @@ describe("util", () => {
       },
     );
 
-    assert.strictEqual(util.styleText("red", "test"), "\u001b[31mtest\u001b[39m");
+    assert.strictEqual(util.styleText("red", "test", { validateStream: false }), "\u001b[31mtest\u001b[39m");
   });
 
   describe("getSystemErrorName", () => {


### PR DESCRIPTION
Fixes #25736
Fixes #20129

## Overlap with #30985

@alii opened #30985 in May with the same `styleText` fix plus nested-style restoration. It is still green but now conflicts with main. I did not know about it when I opened this. Happy to close this in favour of a rebased #30985, or to land this and add the nested-style handling on top. Maintainer's call. This PR also fixes `debuglog`, which #30985 does not touch.

## Repro

`util.styleText` ignored its third argument and always emitted escape codes, so redirecting a program's output wrote the escapes into the file:

```console
$ bun -e 'process.stdout.write(require("util").styleText("red", "hello"))' | xxd | head -1
00000000: 1b5b 3331 6d68 656c 6c6f 1b5b 3339 6d    .[31mhello.[39m

$ node -e 'process.stdout.write(require("util").styleText("red", "hello"))' | xxd | head -1
00000000: 6865 6c6c 6f                             hello
```

Same cause as #25736 (an `isTTY: false` stream still gets colors) and #20129 (`NO_COLOR`, `NODE_DISABLE_COLORS` and `FORCE_COLOR` are ignored).

`util.debuglog` was missing its documented `enabled` property and ignored its callback argument:

```console
$ bun -e 'console.log(require("util").debuglog("x").enabled)'
undefined
```

## Cause

`styleText` was written before the options parameter existed, so it never consulted the target stream. `src/js/internal/util/colors.ts` already exports the `shouldColorize(stream)` helper Node uses for exactly this, it was just never called. `'none'` was also rejected as an unknown format.

`debuglog` returned the cached per-section implementation directly, so there was nowhere to hang `enabled`, and the second parameter was never read.

## Fix

`styleText(format, text, options)` now follows [the documented contract](https://nodejs.org/api/util.html#utilstyletextformat-text-options), reading the options the same way `lib/util.js` does:

- `options.validateStream` (default `true`) checks that `options.stream` (default `process.stdout`) is a readable, writable or node stream, throwing `ERR_INVALID_ARG_TYPE` otherwise, and skips colorizing when the stream cannot show colors.
- `options.validateStream: false` always colorizes, which is the escape hatch Node's own tests use.
- `'none'` is accepted and contributes no codes.
- `NO_COLOR`, `NODE_DISABLE_COLORS` and `FORCE_COLOR` are honored, via the existing `shouldColorize`.

`debuglog(section, callback)` now returns a wrapper carrying an enumerable `enabled` getter, and invokes `callback` once with the logging function the first time the logger is called. The implementation is still created eagerly so that `NODE_DEBUG=http` keeps emitting its sensitive-data warning when `node:http` loads, which `test-http-debug.js` relies on.

## Verification

New `test/js/node/util/style-text.test.ts` (30 tests) and `test/js/node/util/debuglog.test.ts` (11 tests), written against the Node docs: format application and aliases, `none`, the full argument-validation matrix, every `options.stream` shape including the `isTTY` repro from #25736, the `NO_COLOR`/`NODE_DISABLE_COLORS`/`FORCE_COLOR` matrix from #20129, and the default-stream behavior in piped subprocesses. The debuglog tests cover `enabled`, `NODE_DEBUG` matching (lists, wildcards, case), the stderr output shape, the callback, and the http warning. Both files pass with `NODE_DEBUG='*'` or `FORCE_COLOR=1` set in the ambient environment.

The two existing `styleText` assertions in `util.test.js` and the ported `test-util-styletext.js` now pass `{ validateStream: false }`, which is exactly what upstream's current `test-util-styletext.js` does.

Not implemented here, and marked `test.failing`: Node also restores the enclosing color when a nested `styleText` closes, so `styleText('red', 'A' + styleText('blue', 'B') + 'C')` keeps `C` red. Bun emits a plain reset. #30985 has an implementation of this.

```
bun bd test test/js/node/util/     564 pass, 0 fail (excluding two pre-existing debug-build timeouts in parseArgs)
bun bd test/js/node/test/parallel/test-util-*.js    all pass
bun bd test/js/node/test/parallel/test-http-debug.js    pass
```
