### PR TITLE
webstreams: trim pipeTo's per-chunk deferral and drain queued chunks in place

### DIFF
--- a/bench/snippets/webstreams-throughput.mjs
+++ b/bench/snippets/webstreams-throughput.mjs
@@ -79,7 +79,9 @@ const drain = async rs => {
 const SHARED_CHUNK_SCENARIOS = new Set([
   "reader.read() loop (shared chunk)",
   "for await (shared chunk)",
+  "readMany loop (shared chunk)",
   "pipeTo(WritableStream) (shared chunk)",
+  "pipeTo(WritableStream, HWM 16) (shared chunk)",
   "pipeThrough(TransformStream) (shared chunk)",
   "tee + drain both (shared chunk)",
 ]);
@@ -87,6 +89,16 @@ const SHARED_CHUNK_SCENARIOS = new Set([
 const scenarios = {
   "reader.read() loop (shared chunk)": () => drain(byteSource()),
   "reader.read() loop (fresh buffers)": () => drain(freshSource()),
+  // readMany drains whatever is queued per call: the batching consumer's machinery cost.
+  "readMany loop (shared chunk)": async () => {
+    const reader = byteSource().getReader();
+    let n = 0;
+    while (true) {
+      const r = await reader.readMany();
+      if (r.done) return n;
+      for (const v of r.value) n += v.byteLength;
+    }
+  },
   "for await (shared chunk)": async () => {
     let n = 0;
     for await (const c of byteSource()) n += c.length;
@@ -105,6 +117,22 @@ const scenarios = {
           n += c.length;
         },
       }),
+    );
+    return n;
+  },
+  // A destination with capacity: the pipe can move already-queued chunks without
+  // waiting out a writer-ready round trip per chunk.
+  "pipeTo(WritableStream, HWM 16) (shared chunk)": async () => {
+    let n = 0;
+    await byteSource().pipeTo(
+      new WritableStream(
+        {
+          write(c) {
+            n += c.length;
+          },
+        },
+        new CountQueuingStrategy({ highWaterMark: 16 }),
+      ),
     );
     return n;
   },

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -486,7 +486,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onPipeChunkDeferredWrite, (JSGlobal
             if (!next)
                 break;
             // The dequeue can run the source's pull(): re-check before touching the writer.
-            if (op->m_finalized || op->m_shuttingDown || op->m_writer.get() != writer)
+            // A dequeued chunk must still be written if a shutdown merely began (the
+            // shutdown waits on m_currentWrite); only a finalized op or a replaced writer
+            // makes the write invalid.
+            if (op->m_finalized || op->m_writer.get() != writer)
                 break;
             auto* nextWrite = writableStreamDefaultWriterWrite(globalObject, writer, next);
             if (catchScope.exception()) [[unlikely]]
@@ -618,10 +621,11 @@ void pipeToReadRequestChunkSteps(JSGlobalObject* globalObject, JSStreamPipeToOpe
     auto* context = InternalFieldTuple::create(vm, globalObject->internalFieldTupleStructure(), op, writePromise);
     queuePipeReactionJob(vm, globalObject, runtime->onPipeChunkDeferredWrite(), chunk, context);
     publishPipeWrite(globalObject, op, writePromise);
+    RETURN_IF_EXCEPTION(scope, );
     // A shutdown that is waiting on m_currentWrite re-checks it when its reaction fires.
     if (op->m_shuttingDown)
         return;
-    WebCore::registerPipeReaction(globalObject, writer->m_readyPromise.get(), runtime->onPipeWriterReadyFulfilled(), nullptr, op);
+    RELEASE_AND_RETURN(scope, WebCore::registerPipeReaction(globalObject, writer->m_readyPromise.get(), runtime->onPipeWriterReadyFulfilled(), nullptr, op));
 }
 
 void pipeToReadRequestCloseSteps(JSGlobalObject* globalObject, JSStreamPipeToOperation* op)

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -118,6 +118,16 @@ static void queuePipeReactionJob(JSC::VM& vm, JSGlobalObject* globalObject, JSFu
     vm.queueMicrotask(WTF::move(task));
 }
 
+// Publish a write for the shutdown paths: m_currentWrite is the newest write, and every
+// write gets the settled reaction that re-checks the pipe's state.
+static void publishPipeWrite(JSGlobalObject* globalObject, JSStreamPipeToOperation* op, JSPromise* writePromise)
+{
+    auto& vm = getVM(globalObject);
+    op->m_currentWrite.set(vm, op, writePromise);
+    auto* settledHandler = JSStreamsRuntime::from(globalObject)->onPipeWriteSettled();
+    registerPipeReaction(globalObject, writePromise, settledHandler, settledHandler, op);
+}
+
 // One tick of the read/write loop: backpressure first, then at most one read.
 static void pipeToLoopStep(JSGlobalObject* globalObject, JSStreamPipeToOperation* op)
 {
@@ -432,23 +442,69 @@ WEB_STREAMS_DEFINE_PIPE_REACTION_TRAMPOLINE(onPipeWritesFinishedForShutdown, onW
 #undef WEB_STREAMS_DEFINE_PIPE_REACTION_TRAMPOLINE
 #undef WEB_STREAMS_DEFINE_PIPE_REACTION_TRAMPOLINE_WITH_VALUE
 
-// [reaction-convention] the deferred sink write. context = InternalFieldTuple{op, chunk};
-// the result promise it was registered with (op->m_currentWrite) adopts the write promise.
+// [reaction-convention] the deferred sink write, queued as a plain job (no result
+// capability, so any throw must settle the published promise itself). argument(0) = the
+// chunk; context = InternalFieldTuple{op, the promise published as m_currentWrite}, which
+// adopts the real write's settlement. After the head write, chunks the source already has
+// queued are written in place while the destination reports capacity: no read request, no
+// extra microtask per chunk. The dequeue and the write both run user JS, so every guard is
+// re-established around each of them.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onPipeChunkDeferredWrite, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* context = dynamicDowncast<InternalFieldTuple>(callFrame->argument(1));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
     auto* op = dynamicDowncast<JSStreamPipeToOperation>(context->getInternalField(0));
     if (!op) [[unlikely]]
         return JSValue::encode(jsUndefined());
-    if (op->m_finalized)
-        return JSValue::encode(jsUndefined());
-    auto* writePromise = writableStreamDefaultWriterWrite(globalObject, op->m_writer.get(), context->getInternalField(1));
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(writePromise);
+    auto* trackingPromise = uncheckedDowncast<JSPromise>(context->getInternalField(1));
+    do {
+        if (op->m_finalized) {
+            resolvePromise(globalObject, trackingPromise, jsUndefined());
+            break;
+        }
+        auto* writePromise = writableStreamDefaultWriterWrite(globalObject, op->m_writer.get(), callFrame->argument(0));
+        if (catchScope.exception()) [[unlikely]]
+            break;
+        writePromise->performPromiseThenWithContext(vm, globalObject, jsUndefined(), jsUndefined(), trackingPromise, jsUndefined());
+        if (catchScope.exception()) [[unlikely]]
+            break;
+
+        while (!op->m_finalized && !op->m_shuttingDown) {
+            auto* writer = op->m_writer.get();
+            auto desiredSize = writableStreamDefaultWriterGetDesiredSize(writer);
+            if (!desiredSize || *desiredSize <= 0)
+                break;
+            auto* reader = op->m_reader.get();
+            if (!reader)
+                break;
+            JSValue next = readableStreamDefaultReaderTryReadFromQueue(globalObject, reader);
+            if (catchScope.exception()) [[unlikely]]
+                break;
+            if (!next)
+                break;
+            // The dequeue can run the source's pull(): re-check before touching the writer.
+            if (op->m_finalized || op->m_shuttingDown || op->m_writer.get() != writer)
+                break;
+            auto* nextWrite = writableStreamDefaultWriterWrite(globalObject, writer, next);
+            if (catchScope.exception()) [[unlikely]]
+                break;
+            publishPipeWrite(globalObject, op, nextWrite);
+            if (catchScope.exception()) [[unlikely]]
+                break;
+        }
+    } while (false);
+    if (catchScope.exception()) [[unlikely]] {
+        JSValue error = takeAbruptCompletion(globalObject, catchScope);
+        if (error.isEmpty())
+            return JSValue::encode(jsUndefined());
+        // The shutdown paths wait on the published m_currentWrite: never leave it pending.
+        if (trackingPromise->status() == JSPromise::Status::Pending)
+            rejectPromise(globalObject, trackingPromise, error);
+    }
+    return JSValue::encode(jsUndefined());
 }
 
 // [reaction-convention] shutdown-action settlement. The context is the op cell; the
@@ -555,17 +611,13 @@ void pipeToReadRequestChunkSteps(JSGlobalObject* globalObject, JSStreamPipeToOpe
         return;
     auto* writer = op->m_writer.get();
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    // The sink write is deferred by one reaction so an enqueue() inside the source never
+    // The sink write is deferred by one microtask so an enqueue() inside the source never
     // synchronously reenters the destination's write algorithm. m_currentWrite is the deferred
     // write's promise, so a shutdown that must drain the pending writes still waits for it.
-    auto* deferred = promiseFulfilledWith(globalObject, JSC::jsUndefined());
-    RETURN_IF_EXCEPTION(scope, );
     auto* writePromise = JSPromise::create(vm, globalObject->promiseStructure());
-    auto* context = InternalFieldTuple::create(vm, globalObject->internalFieldTupleStructure(), op, chunk);
-    deferred->performPromiseThenWithContext(vm, globalObject, runtime->onPipeChunkDeferredWrite(), jsUndefined(), writePromise, context);
-    op->m_currentWrite.set(vm, op, writePromise);
-    auto* settledHandler = runtime->onPipeWriteSettled();
-    WebCore::registerPipeReaction(globalObject, writePromise, settledHandler, settledHandler, op);
+    auto* context = InternalFieldTuple::create(vm, globalObject->internalFieldTupleStructure(), op, writePromise);
+    queuePipeReactionJob(vm, globalObject, runtime->onPipeChunkDeferredWrite(), chunk, context);
+    publishPipeWrite(globalObject, op, writePromise);
     // A shutdown that is waiting on m_currentWrite re-checks it when its reaction fires.
     if (op->m_shuttingDown)
         return;

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -102,8 +102,8 @@ class JSDirectStreamController;
     V(onAsyncIteratorRejectMicrotask)
 
 // owner: JSStreamPipeToOperation.cpp. context = the JSStreamPipeToOperation, EXCEPT
-// onPipeChunkDeferredWrite, whose context is an InternalFieldTuple{op, chunk} (the pipe's
-// read-request chunk steps defer the sink write by one reaction).
+// onPipeChunkDeferredWrite, whose context is an InternalFieldTuple{op, m_currentWrite
+// promise} and whose argument is the chunk (the pipe's deferred sink write job).
 // onPipeWriteSettled is registered as BOTH the fulfillment and the rejection handler of
 // every write-request promise (the pipe must react to every one).
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_PIPE(V) \

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1986,7 +1986,6 @@ it("readMany batches the pipelined pull's chunk with the delivered one", async (
   expect(wakes).toEqual(["c1", "c2", "c3,c4", "c5,c6"]);
 });
 
-
 // A chunk the pipe has already dequeued when a shutdown begins must still be written to the
 // destination (the shutdown waits for pending writes); it must not vanish.
 // https://github.com/oven-sh/bun/pull/33329

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1985,3 +1985,37 @@ it("readMany batches the pipelined pull's chunk with the delivered one", async (
   }
   expect(wakes).toEqual(["c1", "c2", "c3,c4", "c5,c6"]);
 });
+
+
+// A chunk the pipe has already dequeued when a shutdown begins must still be written to the
+// destination (the shutdown waits for pending writes); it must not vanish.
+// https://github.com/oven-sh/bun/pull/33329
+it("pipeTo writes an already-dequeued chunk when the signal aborts mid-drain", async () => {
+  const ac = new AbortController();
+  let pulls = 0;
+  const written = [];
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue("a");
+      c.enqueue("b");
+      c.enqueue("c");
+    },
+    pull() {
+      if (++pulls === 1) ac.abort(new Error("stop"));
+    },
+  });
+  const ws = new WritableStream(
+    {
+      write(chunk) {
+        written.push(chunk);
+      },
+    },
+    new CountQueuingStrategy({ highWaterMark: 16 }),
+  );
+  const outcome = await rs.pipeTo(ws, { signal: ac.signal }).then(
+    () => "fulfilled",
+    e => "rejected:" + e.message,
+  );
+  // Node 26 agrees byte-for-byte: every dequeued chunk is written before the abort finishes.
+  expect({ outcome, written }).toEqual({ outcome: "rejected:stop", written: ["a", "b", "c"] });
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1925,7 +1925,6 @@ describe("text consumers reject strings over the string allocation limit", () =>
   });
 });
 
-
 // A source pull() that runs inside the pipe's in-place drain and synchronously errors the
 // destination and aborts the pipe's signal must not touch the released writer afterwards.
 // https://github.com/oven-sh/bun/pull/33193
@@ -1965,7 +1964,6 @@ it("pipeTo survives a pull() that errors the destination and aborts mid-drain", 
     ),
   ).toBe("rejected:Error");
 });
-
 
 // For a pull-driven source, readMany must return chunks the pull pipeline enqueued while the
 // previous wake settled (the drain runs after the controller's follow-up pull, not before).

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1924,3 +1924,66 @@ describe("text consumers reject strings over the string allocation limit", () =>
     expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "Out of memory", exitCode: 0 });
   });
 });
+
+
+// A source pull() that runs inside the pipe's in-place drain and synchronously errors the
+// destination and aborts the pipe's signal must not touch the released writer afterwards.
+// https://github.com/oven-sh/bun/pull/33193
+it("pipeTo survives a pull() that errors the destination and aborts mid-drain", async () => {
+  const ac = new AbortController();
+  let sinkController;
+  let pulls = 0;
+  const readable = new ReadableStream({
+    start(c) {
+      c.enqueue("a");
+      c.enqueue("b");
+      c.enqueue("c");
+    },
+    pull(c) {
+      pulls++;
+      if (pulls === 1) {
+        sinkController.error(new Error("dest dead"));
+        ac.abort(new Error("stop"));
+        return;
+      }
+      c.enqueue("d");
+    },
+  });
+  const writable = new WritableStream(
+    {
+      start(c) {
+        sinkController = c;
+      },
+      write() {},
+    },
+    new CountQueuingStrategy({ highWaterMark: 16 }),
+  );
+  expect(
+    await readable.pipeTo(writable, { signal: ac.signal, preventAbort: true, preventCancel: true }).then(
+      () => "fulfilled",
+      e => `rejected:${e.constructor.name}`,
+    ),
+  ).toBe("rejected:Error");
+});
+
+
+// For a pull-driven source, readMany must return chunks the pull pipeline enqueued while the
+// previous wake settled (the drain runs after the controller's follow-up pull, not before).
+it("readMany batches the pipelined pull's chunk with the delivered one", async () => {
+  let pulls = 0;
+  const rs = new ReadableStream({
+    pull(c) {
+      pulls++;
+      if (pulls <= 6) c.enqueue("c" + pulls);
+      else c.close();
+    },
+  });
+  const reader = rs.getReader();
+  const wakes = [];
+  while (true) {
+    const r = await reader.readMany();
+    if (r.done) break;
+    wakes.push(r.value.join(","));
+  }
+  expect(wakes).toEqual(["c1", "c2", "c3,c4", "c5,c6"]);
+});


### PR DESCRIPTION
### What

Follow-up to the Web Streams C++ rewrite (#33193), on the `pipeTo` chunk path:

- The per-chunk sink write keeps its one-microtask deferral (an `enqueue()` inside the source must never reenter the destination's write algorithm synchronously), but the deferral now rides the promise-free internal job queue instead of allocating a pre-fulfilled promise + `InternalFieldTuple` + reaction per chunk.
- Inside that job — a safe re-entrancy point — the pipe now **drains chunks the source already has queued** straight into the writer while the destination reports capacity (`desiredSize > 0`), so destinations with `highWaterMark > 1` no longer pay a read request and a writer-ready round trip per queued chunk.
- Hardening that came out of pre-merge review of this diff: the promise published as `m_currentWrite` adopts the real write's settlement (rejections included) and is settled on **every** path out of the deferred job (a throw can no longer leave a shutdown waiting forever), and the drain re-validates the operation and writer after every call into user JS (a `pull()` that errors the destination and aborts the signal mid-drain reaches `finalize()` synchronously).

### Benchmarks

Interleaved A/B (this branch vs its merge base on `main`), one process per run, medians of 10, `bench/snippets/webstreams-throughput.mjs`:

| scenario (shared chunk, M chunks/s) | main | this PR | delta |
|---|---|---|---|
| `pipeTo(WritableStream)`, HWM 16 | 0.75 | **0.84** | **+12%** |
| `pipeTo(WritableStream)`, default HWM | 0.71 | 0.73 | +3% (≈ noise) |
| `reader.read()` loop | 1.74 | 1.75 | ±0 |
| `for await` | 1.60 | 1.58 | ±0 |
| `readMany` loop | 1.39 | 1.31 | ±0 (untouched code; this is the box's noise floor) |

With the default `highWaterMark` of 1 a write is always in flight before a second chunk can be drained, so the win there is allocation-only (one promise + one reaction + one tuple fewer per chunk), which does not move wall clock; the drain is what pays off for `highWaterMark > 1`.

### What was tried and deliberately not shipped

A `readMany` "optimization" (settling its result promise straight from a dedicated read request instead of an intermediate `{value, done}` object + promise + reaction) turned out to **regress `readMany`'s batching**: the promise reaction it removed is what makes the drain run *after* the controller's pipelined follow-up pull, so pull-driven sources went from 2 chunks per wake to 1 (measured on both this branch's draft and `main`). It was reverted, and that batching contract is now pinned by a regression test so it can't be lost silently again.

### Tests

- New: `pipeTo` mid-drain abort/error scenario (crashed a draft of this change); `readMany` pull-pipelining batching.
- WPT streams (1402 subtests incl. all piping suites) + `streams.test.js` + `bun/stream/` + `body-stream` + async-iterator + `node/stream`: 10,824 pass / 0 fail on this branch.
