### PR TITLE
spawn: clamp subprocess reads to the remaining maxBuffer budget

### DIFF
--- a/src/io/MaxBuf.rs
+++ b/src/io/MaxBuf.rs
@@ -20,12 +20,9 @@ pub struct MaxBuf {
     // (once both are cleared, it is freed)
 }
 
-/// How far past `maxBuffer` a reader may buffer before it notices.
-///
-/// The read that trips the limit is the one that overshoots it, so the
-/// overshoot is bounded by the read size. Node reads child stdio in 64 KB
-/// chunks and its `spawnSync` contract relies on the allowance being nonzero:
-/// `stdout` is documented to exceed `maxBuffer` by up to one read.
+/// How far the read that crosses `maxBuffer` may overshoot it: one Node-sized
+/// stdio read. Must stay nonzero, Node's `spawnSync` documents `stdout`
+/// exceeding `maxBuffer` by up to one read.
 const OVERREAD_ALLOWANCE: u64 = 64 * 1024;
 
 // TODO(refactor): LIFETIMES.tsv classifies the caller fields (Subprocess.{stdout,stderr}_maxbuf,
@@ -139,14 +136,9 @@ impl MaxBuf {
         remaining < 0 && this.owned_by_subprocess.get()
     }
 
-    /// Trims `buf` so the read that trips `maxBuffer` cannot buffer more than
-    /// `OVERREAD_ALLOWANCE` bytes past the limit. Readers fill a 256 KB scratch
-    /// buffer (or whatever spare capacity they have) from a socketpair whose
-    /// receive buffer dwarfs Node's 64 KB read size, so an unclamped read
-    /// overshoots by hundreds of KB.
-    ///
-    /// Never returns an empty slice: a zero-length read is indistinguishable
-    /// from EOF.
+    /// Trims `buf` to the remaining budget plus `OVERREAD_ALLOWANCE`: unclamped,
+    /// a 256 KB scratch read off a socketpair overshoots `maxBuffer` by hundreds
+    /// of KB. Never empties a non-empty `buf` (that would read as EOF).
     pub fn clamp_read_buf(this: Option<NonNull<MaxBuf>>, buf: &mut [u8]) -> &mut [u8] {
         let Some(this) = this else {
             return buf;

--- a/src/io/MaxBuf.rs
+++ b/src/io/MaxBuf.rs
@@ -20,6 +20,14 @@ pub struct MaxBuf {
     // (once both are cleared, it is freed)
 }
 
+/// How far past `maxBuffer` a reader may buffer before it notices.
+///
+/// The read that trips the limit is the one that overshoots it, so the
+/// overshoot is bounded by the read size. Node reads child stdio in 64 KB
+/// chunks and its `spawnSync` contract relies on the allowance being nonzero:
+/// `stdout` is documented to exceed `maxBuffer` by up to one read.
+const OVERREAD_ALLOWANCE: u64 = 64 * 1024;
+
 // TODO(refactor): LIFETIMES.tsv classifies the caller fields (Subprocess.{stdout,stderr}_maxbuf,
 // {Posix,Windows}BufferedReader.maxbuf) as SHARED → Option<Arc<MaxBuf>>. The fn params below
 // (`ptr: &mut Option<NonNull<MaxBuf>>`, `value: Option<NonNull<MaxBuf>>`) and the hand-rolled
@@ -129,6 +137,25 @@ impl MaxBuf {
         let remaining = this.remaining_bytes.get().checked_sub(delta).unwrap_or(-1);
         this.remaining_bytes.set(remaining);
         remaining < 0 && this.owned_by_subprocess.get()
+    }
+
+    /// Trims `buf` so the read that trips `maxBuffer` cannot buffer more than
+    /// `OVERREAD_ALLOWANCE` bytes past the limit. Readers fill a 256 KB scratch
+    /// buffer (or whatever spare capacity they have) from a socketpair whose
+    /// receive buffer dwarfs Node's 64 KB read size, so an unclamped read
+    /// overshoots by hundreds of KB.
+    ///
+    /// Never returns an empty slice: a zero-length read is indistinguishable
+    /// from EOF.
+    pub fn clamp_read_buf(this: Option<NonNull<MaxBuf>>, buf: &mut [u8]) -> &mut [u8] {
+        let Some(this) = this else {
+            return buf;
+        };
+        let remaining = u64::try_from(Self::live(&this).remaining_bytes.get()).unwrap_or(0);
+        let limit =
+            usize::try_from(remaining.saturating_add(OVERREAD_ALLOWANCE)).unwrap_or(usize::MAX);
+        let len = buf.len().min(limit);
+        &mut buf[..len]
     }
 }
 

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -664,7 +664,9 @@ impl PosixBufferedReader {
             if parent._buffer.capacity() == 0 {
                 // Use stack buffer for streaming — per-loop scratch buffer;
                 // single-threaded event loop (see `EventLoopCtx::pipe_read_buffer_mut`).
+                let maxbuf = parent.maxbuf;
                 let stack_buffer = parent.vtable.event_loop().pipe_read_buffer_mut();
+                let stack_buffer = MaxBuf::clamp_read_buf(maxbuf, stack_buffer);
 
                 match sys::read_nonblocking(fd, stack_buffer) {
                     sys::Result::Ok(bytes_read) => {
@@ -710,11 +712,13 @@ impl PosixBufferedReader {
                     }
                 }
             } else {
+                let maxbuf = parent.maxbuf;
                 parent._buffer.reserve(16 * 1024);
                 let buf_len = {
                     // SAFETY: sys::read_nonblocking writes only initialized bytes into
                     // the prefix it reports; commit_spare exposes exactly that prefix.
                     let buf = unsafe { bun_core::vec::spare_bytes_mut(&mut parent._buffer) };
+                    let buf = MaxBuf::clamp_read_buf(maxbuf, buf);
                     let buf_len = buf.len();
                     match sys::read_nonblocking(fd, buf) {
                         sys::Result::Ok(bytes_read) => {
@@ -864,6 +868,7 @@ impl PosixBufferedReader {
                 let mut head_start = 0usize; // index into stack_buffer where the unwritten head begins
                 while stack_buffer_len - head_start > 16 * 1024 {
                     let buf = &mut event_loop.pipe_read_buffer_mut()[head_start..];
+                    let buf = MaxBuf::clamp_read_buf(parent.maxbuf, buf);
 
                     match sys_fn(fd, buf, parent._offset) {
                         sys::Result::Ok(bytes_read) => {
@@ -972,7 +977,9 @@ impl PosixBufferedReader {
             // Avoid a 16 KB dynamic memory allocation when the buffer might very well be empty.
             // Per-loop scratch buffer; single-threaded event loop (see
             // `EventLoopCtx::pipe_read_buffer_mut`).
+            let maxbuf = parent.maxbuf;
             let stack_buffer = parent.vtable.event_loop().pipe_read_buffer_mut();
+            let stack_buffer = MaxBuf::clamp_read_buf(maxbuf, stack_buffer);
 
             // Unlike the block of code following this one, only handle the non-streaming case.
             debug_assert!(!streaming);
@@ -1018,9 +1025,11 @@ impl PosixBufferedReader {
         }
 
         loop {
+            let maxbuf = parent.maxbuf;
             parent._buffer.reserve(16 * 1024);
             // SAFETY: writing into spare capacity; commit after syscall reports bytes written.
             let buf = unsafe { bun_core::vec::spare_bytes_mut(&mut parent._buffer) };
+            let buf = MaxBuf::clamp_read_buf(maxbuf, buf);
 
             match sys_fn(fd, buf, parent._offset) {
                 sys::Result::Ok(bytes_read) => {
@@ -1340,9 +1349,13 @@ impl WindowsBufferedReader {
         suggested_size: usize,
     ) -> &mut [u8] {
         self.flags.insert(WindowsFlags::HAS_INFLIGHT_READ);
+        // Spare capacity grows well past `suggested_size`, so an unclamped read
+        // overshoots `maxBuffer` by however much the buffer had room for.
+        let maxbuf = self.maxbuf;
         self._buffer.reserve(suggested_size);
         // SAFETY: returning spare capacity for libuv to write into; len updated in on_read.
-        unsafe { bun_core::vec::spare_bytes_mut(&mut self._buffer) }
+        let buf = unsafe { bun_core::vec::spare_bytes_mut(&mut self._buffer) };
+        MaxBuf::clamp_read_buf(maxbuf, buf)
     }
 
     pub fn start_with_current_pipe(&mut self) -> sys::Result<()> {

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -53,10 +53,9 @@ describe("yes is killed", () => {
 
 describe("maxBuffer caps the buffer while the child is still writing", () => {
   const maxBuffer = 1024;
-  // Nothing that lands after the limit trips is buffered, so the result can
-  // only overshoot by the read that tripped it. Reads are clamped to the
-  // remaining budget plus Node's 64 KB stdio read size, which is the same
-  // bound Node gives spawnSync.
+  // The result can only overshoot by the read that tripped the limit, and reads
+  // are clamped to the remaining budget plus Node's 64 KB stdio read size. That
+  // is the same bound Node gives spawnSync.
   const bound = maxBuffer + 64 * 1024;
 
   // `killSignal: 0` sends no signal at all, so the child outlives the kill and

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -54,9 +54,10 @@ describe("yes is killed", () => {
 describe("maxBuffer caps the buffer while the child is still writing", () => {
   const maxBuffer = 1024;
   // Nothing that lands after the limit trips is buffered, so the result can
-  // only overshoot by the read that tripped it: one pipe scratch buffer.
-  // (Node bounds spawnSync the same way, at its 64 KB read size.)
-  const bound = maxBuffer + 256 * 1024;
+  // only overshoot by the read that tripped it. Reads are clamped to the
+  // remaining budget plus Node's 64 KB stdio read size, which is the same
+  // bound Node gives spawnSync.
+  const bound = maxBuffer + 64 * 1024;
 
   // `killSignal: 0` sends no signal at all, so the child outlives the kill and
   // keeps writing for as long as Bun keeps reading. A child that merely
@@ -77,6 +78,8 @@ describe("maxBuffer caps the buffer while the child is still writing", () => {
       stdio: ["ignore", "pipe", "pipe"],
     });
     expect(proc.exitedDueToMaxBuffer).toBe(true);
+    // Above maxBuffer: the read that trips the limit is still buffered.
+    expect(proc.stdout.length).toBeGreaterThan(maxBuffer);
     expect(proc.stdout.length).toBeLessThanOrEqual(bound);
     expect(proc.stderr.length).toBe(0);
   });
@@ -89,6 +92,7 @@ describe("maxBuffer caps the buffer while the child is still writing", () => {
     });
     await proc.exited;
     const stdout = await proc.stdout.bytes();
+    expect(stdout.length).toBeGreaterThan(maxBuffer);
     expect(stdout.length).toBeLessThanOrEqual(bound);
   });
 });


### PR DESCRIPTION
## Repro

```js
const firehose = `
  const { writeSync } = require("fs");
  const chunk = Buffer.alloc(1024 * 1024, 97);
  for (let i = 0; i < 8; i++) { try { writeSync(1, chunk); } catch { break; } }
`;
const proc = Bun.spawnSync([process.execPath, "-e", firehose], {
  maxBuffer: 1024,
  killSignal: 0,
  stdio: ["ignore", "pipe", "pipe"],
});
console.log(proc.stdout.length); // 219264, sometimes 262144
```

Node caps the same case at 65536 + maxBuffer.

## Cause

Subprocess stdio is an `AF_UNIX` `SOCK_STREAM` socketpair, whose receive buffer defaults to 208 KB (`net.core.rmem_default`), and the reader drains it into a 256 KB scratch buffer (`PIPE_READ_BUFFER_SIZE`) without consulting the remaining budget. `maxBuffer` is charged after each read, so the read that trips the limit is the one that overshoots it, and that read could pull hundreds of KB.

Node reads child stdio in 64 KB chunks, which is why its overshoot is bounded at 64 KB.

## Fix

`MaxBuf::clamp_read_buf` trims each read buffer to the remaining budget plus a 64 KB allowance, applied at every read site in the POSIX reader (blocking-pipe and `read_with_fn` paths, streaming and buffered) and at the Windows reader's single buffer-allocation choke point.

The allowance has to stay nonzero. Node's `spawnSync` contract documents `stdout` exceeding `maxBuffer` by up to one read (`test-child-process-spawnsync-maxbuf.js` asserts the full 15-byte output comes back with `maxBuffer: 1`), and a zero-length read would be indistinguishable from EOF.

The resulting bound is exact: the final read is clamped to `remaining + 64 KB` and `total_before = maxBuffer - remaining`, so the buffer never holds more than `maxBuffer + 64 KB`.

## Verification

`maxBuffer: 1024`, child firehosing stdout, 8 runs of each:

| | before | after |
|---|---|---|
| `Bun.spawnSync` | 219264 (once 262144) | 66560 |
| `Bun.spawn` | 219264 | 66560 |

`66560 = 1024 + 65536`, hit exactly every run.

`test/js/bun/spawn/spawn-maxbuf.test.ts` tightens the existing bound from `maxBuffer + 256 KB` to `maxBuffer + 64 KB` and adds a `> maxBuffer` assertion so the overflow path is provably exercised. It fails on `main` (219264 / 262144 vs `<= 66560`) and passes with this change.

Node compat suites pass unchanged: `test-child-process-spawnsync-maxbuf`, `-execsync-maxbuf`, `-execfilesync-maxbuf`, `-exec-maxbuf`, `-execfile-maxbuf`, plus `spawn.test.ts`, `spawnSync.test.ts`, `child-process-exec.test.ts` (149 pass, 0 fail) and `shell-blocking-pipe.test.ts`.

<details>
<summary>Pre-existing failures in the same file, unaffected</summary>

`yes is killed > Bun.spawn` and `> Bun.spawnSync` assert `Date.now()` deltas under 100 ms and take ~120 ms in a debug + ASAN build. They fail identically on unmodified `main`.
</details>