### PR TITLE
css: fix lab()/oklab() sRGB fallback desaturating boundary colors

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1285,6 +1285,14 @@ where
         return T::from(oklch);
     }
 
+    // Per CSS Color 4, if clipping the origin is already within the JND, use
+    // the clip directly. Without this, colors sitting essentially on the gamut
+    // boundary (e.g. sRGB blue) get desaturated by the chroma search below.
+    let clipped = T::from(current).clip();
+    if delta_eok(clipped, current) < JND {
+        return clipped;
+    }
+
     let mut min: f32 = 0.0;
     let mut max = current.c;
 

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -284,6 +284,26 @@ describe.concurrent('color(input, "ansi") picks the escape for the detected colo
   });
 });
 
+describe("lab()/oklab() sRGB fallback for boundary colors (#33331)", () => {
+  // Reference CIE Lab (D50) for each sRGB color (matches CSS Color 4 to four
+  // decimals). These saturated blues sit on the sRGB gamut boundary, where the
+  // fallback used to desaturate them instead of clipping (#0000ff -> #002cea).
+  const labBlues: [string, string][] = [
+    ["#0000ff", "lab(29.5683% 68.2874 -112.0297)"],
+    ["#0000ee", "lab(27.2497% 64.8129 -106.3296)"],
+    ["#0000cc", "lab(22.5153% 57.7180 -94.6900)"],
+    ["#0000aa", "lab(17.6303% 50.3974 -82.6800)"],
+  ];
+
+  test.each(labBlues)("color(%s via lab) clips to the boundary", (expected, lab) => {
+    expect(color(lab, "hex")).toBe(expected);
+  });
+
+  test("oklab blue is not desaturated", () => {
+    expect(color("oklab(45.2% -0.032 -0.312)", "hex")).toBe("#0200ff");
+  });
+});
+
 // 2^24 color() calls take minutes on debug builds, past the per-test timeout.
 test.skipIf(isDebug)("fuzz ansi256", () => {
   withoutAggressiveGC(() => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -3118,7 +3118,7 @@ describe("css tests", () => {
       `,
       indoc`
         .foo {
-          background: #af5cae linear-gradient(#c65d07, #00807c);
+          background: #af5cae linear-gradient(#c65d07, #00817d);
           background: lab(51.5117% 43.3777 -29.0443) linear-gradient(lab(52.2319% 40.1449 59.9171), lab(47.7776% -34.2947 -7.65904));
         }
       `,


### PR DESCRIPTION
### What

`lab()`/`oklab()` colors whose sRGB conversion lands essentially on the gamut boundary were being desaturated in their sRGB fallback. `lab(29.568% 68.287 -112.029)` is sRGB blue (`#0000ff`), but it compiled to `#002cea`:

```console
$ bun -e 'console.log(Bun.color("lab(29.568% 68.287 -112.029)", "hex"))'
#002cea          # expected #0000ff

$ cat lab.css
a { color: lab(29.568% 68.287 -112.029); }
$ bun build lab.css --minify
a{color:#002cea;color:color(display-p3 .00000346541 -.00000245467 .95958);color:lab(29.568% 68.287 -112.029)}
```

The `display-p3` fallback on the same declaration is correct, and the forward direction (`Bun.color("#0000ff", "lab")`) is exact, so only the `lab -> sRGB` inverse was affected. The worst channel error across a 4096-color sweep was 44/255, all on saturated blues.

### Cause

The raw `lab -> XYZ -> sRGB` conversion for blue is `[0.000003, -0.000002, 0.999991]`: in gamut to within a sub-epsilon green channel. `in_gamut()` is a strict `>= 0.0 && <= 1.0` check, so that `-0.000002` makes it `false`, and `map_gamut` (`src/css/values/color.rs`) runs.

`map_gamut` is a port of the [CSS Color 4 binary-search gamut mapping](https://www.w3.org/TR/css-color-4/#binsearch), but it omits the algorithm's initial clip: before the chroma search, clip the origin and, if `deltaEOK(clip(origin), origin)` is within the just-noticeable-difference, return the clip. For blue `deltaEOK(clip, origin)` is ~0, far under the JND, so it should clip straight to `#0000ff`. Skipping that step sent blue through the OKLCH chroma binary search, which desaturated it to `#002cea`.

### Fix

Add the missing early-out. Colors that only need a sub-epsilon clip now return the clipped value directly; colors genuinely far outside the gamut still go through the chroma search unchanged, so strongly out-of-gamut conversions are untouched.

### Verification

New cases in `test/js/bun/css/color.test.ts` cover `#0000ff`, `#0000ee`, `#0000cc`, `#0000aa` (reference CIE Lab D50, matching CSS Color 4) and the issue's `oklab()` blue. Each fails on the current build and passes with the fix; the four pure blues now match the reference implementation ([color.js](https://colorjs.io)) to the byte.

One existing expectation in `test/js/bun/css/css.test.ts` was the same bug in miniature: `lab(47.7776% -34.2947 -7.65904)` (out of gamut by `-0.125` red, `deltaEOK(clip, origin) = 0.009 < JND`) asserted `#00807c`; the spec-correct clip is `#00817d`, which is what color.js returns. Updated it.

Full `color.test.ts`, `css.test.ts`, and the `relative_color_out_of_gamut` / `color-computed` WPT suites pass unchanged otherwise.

This is independent of #33047 (parsing, output serialization, relative-color folding); that PR does not touch `map_gamut`.
