### PR TITLE
Keep response headers with empty values in fetch()

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1958,14 +1958,17 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void*
 
         for (size_t j = 0; j < end; j++) {
             PicoHTTPHeader header = pico_headers.ptr[j];
-            if (header.value.len == 0 || header.name.len == 0)
+            // An empty name is picohttpparser's obs-fold continuation marker, not a header.
+            // An empty value is a valid zero-length field value (RFC 9110 section 5.5).
+            if (header.name.len == 0)
                 continue;
 
             StringView nameView = StringView(std::span { reinterpret_cast<const char*>(header.name.ptr), header.name.len });
 
             std::span<Latin1Character> data;
             auto value = String::createUninitialized(header.value.len, data);
-            memcpy(data.data(), header.value.ptr, header.value.len);
+            if (header.value.len > 0)
+                memcpy(data.data(), header.value.ptr, header.value.len);
 
             HTTPHeaderName name;
 
@@ -1977,8 +1980,8 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void*
             } else {
                 // the case where we do not need to clone the name
                 // when the header name is already present in the list
-                // we don't have that information here, so map.setUncommonHeaderCloneName exists
-                map.setUncommonHeaderCloneName(nameView, value);
+                // we don't have that information here, so map.addUncommonHeaderCloneName exists
+                map.addUncommonHeaderCloneName(nameView, value);
             }
         }
 
@@ -2007,7 +2010,7 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
         if (WebCore::findHTTPHeaderName(nameView, name)) {
             map.add(name, WTF::move(value));
         } else {
-            map.setUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
         }
     }
     headers->setInternalHeaders(WTF::move(map));
@@ -2032,7 +2035,7 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
         if (WebCore::findHTTPHeaderName(nameView, hn)) {
             map.add(hn, WTF::move(value));
         } else {
-            map.setUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
         }
     });
     headers->setInternalHeaders(WTF::move(map));

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -177,7 +177,22 @@ void HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
         m_uncommonHeaders[index].value = value;
 }
 
-void HTTPHeaderMap::setUncommonHeaderCloneName(const StringView name, const String& value)
+// Repeated field lines combine into one comma-separated value (RFC 9110 section 5.3),
+// matching what `add(HTTPHeaderName, ...)` already does for well-known names.
+void HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
+{
+    auto index = m_uncommonHeaders.findIf([&](auto& header) {
+        return equalIgnoringASCIICase(header.key, name);
+    });
+    if (index == notFound)
+        m_uncommonHeaders.append(UncommonHeader { name, value });
+    else
+        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+}
+
+// `addUncommonHeader` for callers whose `name` borrows a buffer that will not outlive the
+// map. It is copied only when a new entry is appended; combining reuses the stored name.
+void HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
@@ -188,7 +203,7 @@ void HTTPHeaderMap::setUncommonHeaderCloneName(const StringView name, const Stri
         memcpy(ptr.data(), name.span8().data(), name.length());
         m_uncommonHeaders.append(UncommonHeader { nameCopy, value });
     } else
-        m_uncommonHeaders[index].value = value;
+        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
 }
 
 void HTTPHeaderMap::add(const String& name, const String& value)
@@ -198,13 +213,7 @@ void HTTPHeaderMap::add(const String& name, const String& value)
         add(headerName, value);
         return;
     }
-    auto index = m_uncommonHeaders.findIf([&](auto& header) {
-        return equalIgnoringASCIICase(header.key, name);
-    });
-    if (index == notFound)
-        m_uncommonHeaders.append(UncommonHeader { name, value });
-    else
-        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+    addUncommonHeader(name, value);
 }
 
 void HTTPHeaderMap::append(const String& name, const String& value)

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -270,7 +270,8 @@ public:
     template<class Encoder> void encode(Encoder &) const;
     template<class Decoder> [[nodiscard]] static bool decode(Decoder &, HTTPHeaderMap &);
     void setUncommonHeader(const String &name, const String &value);
-    void setUncommonHeaderCloneName(const StringView name, const String &value);
+    void addUncommonHeader(const String &name, const String &value);
+    void addUncommonHeaderCloneName(const StringView name, const String &value);
 
 private:
     WEBCORE_EXPORT String getUncommonHeader(const StringView name) const;

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -1,4 +1,46 @@
 import { expect, test } from "bun:test";
+import net from "node:net";
+
+// RFC 9110 section 5.3: repeated field lines combine into one comma-separated value.
+// Raw socket client because `new Headers()` already combines before anything is sent.
+test("repeated request headers are combined, not replaced", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch: req => Response.json(Object.fromEntries(req.headers)),
+  });
+
+  await using socket = net.connect(server.port, "127.0.0.1", () =>
+    socket.write(
+      "GET / HTTP/1.1\r\n" +
+        "Host: x\r\n" +
+        // well-known name: already combined before this test
+        "vary: a\r\n" +
+        "vary: b\r\n" +
+        // uncommon name: used to keep only the last value
+        "x-uncommon: a\r\n" +
+        "x-uncommon: b\r\n" +
+        // an empty repeat must not erase the value that came before it
+        "x-keep: HIT\r\n" +
+        "x-keep:\r\n" +
+        "Connection: close\r\n" +
+        "\r\n",
+    ),
+  );
+
+  let raw = "";
+  socket.on("data", chunk => (raw += chunk));
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  socket.on("close", () => resolve());
+  socket.on("error", reject);
+  await promise;
+
+  const body = JSON.parse(raw.slice(raw.indexOf("\r\n\r\n") + 4));
+  expect({ vary: body.vary, uncommon: body["x-uncommon"], keep: body["x-keep"] }).toEqual({
+    vary: "a, b",
+    uncommon: "a, b",
+    keep: "HIT, ",
+  });
+});
 
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -233,6 +233,33 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     );
   });
 
+  // RFC 9110 section 5.5: a zero-length field value is valid and distinct from an absent header.
+  test("GET: response header with an empty value is preserved", async () => {
+    await withH2Server(
+      (_req, res) => {
+        res.writeHead(200, { "x-empty": "", "x-after": "1" });
+        res.end("ok");
+      },
+      async url => {
+        await using proc = await spawnFetch(`
+          const res = await fetch(${JSON.stringify(url)} + "/empty-header", {
+            tls: { rejectUnauthorized: false },
+          });
+          const body = await res.text();
+          console.log(JSON.stringify({
+            empty: res.headers.get("x-empty"),
+            after: res.headers.get("x-after"),
+            body,
+          }));
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual({ empty: "", after: "1", body: "ok" });
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
   test("POST: request body is delivered as DATA frames", async () => {
     await withH2Server(
       (req, res) => {

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -17,6 +17,7 @@ beforeAll(async () => {
     http1: false,
     routes: {
       "/hello": () => new Response("hello over h3", { headers: { "x-proto": "h3" } }),
+      "/empty-header": () => new Response("ok", { headers: { "x-empty": "", "x-after": "1" } }),
       "/echo": async req => {
         const body = await req.bytes();
         return new Response(body, {
@@ -415,6 +416,13 @@ describe("fetch protocol: http3", () => {
     for (const [name, value] of Object.entries(sent)) {
       expect(got[name.toLowerCase()]).toBe(value);
     }
+  });
+
+  // RFC 9110 section 5.5: a zero-length field value is valid and distinct from an absent header.
+  test("response header with an empty value is preserved", async () => {
+    const res = await fetch(`${base}/empty-header`, h3);
+    expect(await res.text()).toBe("ok");
+    expect([res.headers.get("x-empty"), res.headers.get("x-after")]).toEqual(["", "1"]);
   });
 
   test("response consumed as blob / bytes", async () => {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1552,6 +1552,100 @@ describe("Headers", () => {
     expect(headers.get("content-type")).toBe(null);
     gc();
   });
+
+  // RFC 9110 section 5.5 permits zero-length field values. "present but empty" and
+  // "absent" are different things, so the fetch client must not drop such headers.
+  it("keeps response headers with empty values", async () => {
+    const { promise, resolve } = Promise.withResolvers<AddressInfo>();
+    await using server = net
+      .createServer(socket => {
+        socket.on("error", () => {});
+        socket.once("data", () => {
+          socket.write(
+            "HTTP/1.1 200 OK\r\n" +
+              // no OWS after the colon, uncommon header name
+              "x-empty:\r\n" +
+              // OWS after the colon, well-known header name
+              "vary: \r\n" +
+              "x-after: 1\r\n" +
+              "content-length: 0\r\n" +
+              "\r\n",
+          );
+          socket.end();
+        });
+      })
+      .listen(0, "127.0.0.1", () => resolve(server.address() as AddressInfo));
+    const { port } = await promise;
+
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(res.headers.toJSON()).toEqual({
+      "x-empty": "",
+      "vary": "",
+      "x-after": "1",
+      "content-length": "0",
+    });
+    expect([res.headers.has("x-empty"), res.headers.get("x-empty")]).toEqual([true, ""]);
+    expect([res.headers.has("vary"), res.headers.get("vary")]).toEqual([true, ""]);
+    expect([...res.headers]).toEqual([
+      ["content-length", "0"],
+      ["vary", ""],
+      ["x-after", "1"],
+      ["x-empty", ""],
+    ]);
+    expect(res.status).toBe(200);
+  });
+
+  // RFC 9110 section 5.3: repeated field lines combine into one comma-separated value.
+  it("combines repeated response headers instead of replacing them", async () => {
+    const { promise, resolve } = Promise.withResolvers<AddressInfo>();
+    await using server = net
+      .createServer(socket => {
+        socket.on("error", () => {});
+        socket.once("data", () => {
+          socket.write(
+            "HTTP/1.1 200 OK\r\n" +
+              // well-known name: already combined before this change
+              "vary: a\r\n" +
+              "vary: b\r\n" +
+              // uncommon name: used to keep only the last value
+              "x-uncommon: a\r\n" +
+              "x-uncommon: b\r\n" +
+              // an empty repeat must not erase the value that came before it
+              "x-keep: HIT\r\n" +
+              "x-keep:\r\n" +
+              "content-length: 0\r\n" +
+              "\r\n",
+          );
+          socket.end();
+        });
+      })
+      .listen(0, "127.0.0.1", () => resolve(server.address() as AddressInfo));
+    const { port } = await promise;
+
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(res.headers.toJSON()).toEqual({
+      "vary": "a, b",
+      "x-uncommon": "a, b",
+      "x-keep": "HIT, ",
+      "content-length": "0",
+    });
+  });
+
+  it("round-trips an empty header value through Bun.serve", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response(JSON.stringify(req.headers.get("x-empty-req")), {
+          headers: { "x-empty-res": "", "x-after": "1" },
+        });
+      },
+    });
+
+    const res = await fetch(server.url, { headers: { "x-empty-req": "" } });
+    // The request side already round-trips an empty value; the response side is the fix.
+    expect(await res.text()).toBe(`""`);
+    expect([res.headers.get("x-empty-res"), res.headers.get("x-after")]).toEqual(["", "1"]);
+  });
 });
 
 it("body nullable", async () => {


### PR DESCRIPTION
## Repro

A server that replies with a zero-length field value:

```js
// raw response:  HTTP/1.1 200 OK\r\nx-empty:\r\nx-after: 1\r\ncontent-length: 0\r\n\r\n
const res = await fetch(url);
res.headers.has("x-empty"); // node/curl: true ("")    bun: false
```

The header never existed as far as `response.headers` was concerned. RFC 9110 section 5.5 permits zero-length field values (`field-value = *field-content`), and "present but empty" is a different thing from "absent": presence-only flags (`x-cache:`, `x-robots-tag:`), tracing headers set to `""` to mean "sampled, no parent", and signature schemes that canonicalize a named header list all depend on the distinction. `Bun.serve` already both sends and parses such headers; only the fetch client dropped them.

## Cause

`WebCore__FetchHeaders__createFromPicoHeaders_` skipped them outright:

```cpp
if (header.value.len == 0 || header.name.len == 0)
    continue;
```

This is the single funnel for fetch response headers, so HTTP/1, HTTP/2 and HTTP/3 were all affected. The `name.len == 0` half is load-bearing (picohttpparser uses a null name as its obs-fold continuation marker) and stays.

Removing the `value.len == 0` half exposed a second defect in the same loop. Duplicate header names that are **not** well-known went through `setUncommonHeaderCloneName`, which *replaces* the stored value, while well-known names go through `HTTPHeaderMap::add` and *combine* with `", "` per RFC 9110 section 5.3. So once empty values were allowed through:

```
x-keep: HIT
x-keep:
```

would have yielded `""`, losing `HIT`, where node yields `"HIT, "`. The two changes are entangled: the empty-value fix cannot land on its own without regressing that case.

The same replace-instead-of-combine defect is in the server request paths (`createFromUWS`, `createFromH3`), where it already loses data today — `x-uncommon: a` / `x-uncommon: b` reports just `b`, and the `x-keep` case above already reports `""`.

## Fix

- Allow zero-length field values through the fetch client's response header conversion, and guard the `memcpy` (`String::createUninitialized(0, …)` hands back a null span), matching the sibling conversions.
- Extract `HTTPHeaderMap::addUncommonHeader` out of `HTTPHeaderMap::add`, and rename `setUncommonHeaderCloneName` to `addUncommonHeaderCloneName`, both combining on a duplicate name like the well-known path already does. Repoint the three wire-to-`FetchHeaders` conversions at them. `setUncommonHeader` stays (`HTTPHeaderMap::set` needs overwrite semantics).

`set-cookie` and `cookie` are unaffected: both are well-known names and keep their existing handling (separate list, and `"; "` respectively).

## Verification

New tests, each failing on `main` and passing with this change:

| test | file |
| --- | --- |
| empty value preserved over HTTP/1 (raw socket) | `test/js/web/fetch/fetch.test.ts` |
| empty value preserved over HTTP/2 | `test/js/web/fetch/fetch-http2-client.test.ts` |
| empty value preserved over HTTP/3 | `test/js/web/fetch/fetch-http3-client.test.ts` |
| repeated response headers combine, empty repeat does not erase | `test/js/web/fetch/fetch.test.ts` |
| repeated request headers combine | `test/js/bun/http/bun-serve-headers.test.ts` |
| empty value round-trips through `Bun.serve` | `test/js/web/fetch/fetch.test.ts` |

The HTTP/1 test covers both the well-known (`vary:`) and uncommon (`x-empty:`) branches of the conversion, with and without optional whitespace after the colon, and asserts `has()`, `get()`, `toJSON()` and iteration.

<details>
<summary>Before and after, on a raw response carrying repeated and empty-valued headers</summary>

Raw response:

```
HTTP/1.1 200 OK
x-uncommon: a
x-uncommon: b
x-keep: HIT
x-keep:
vary: a
vary: b
etag: keep
etag:
content-length: 0
```

```
bun (before): {"vary":"a, b","etag":"keep",   "x-uncommon":"b",   "x-keep":"HIT",  "content-length":"0"}
bun (after):  {"vary":"a, b","etag":"keep, ", "x-uncommon":"a, b","x-keep":"HIT, ","content-length":"0"}
node:         {"vary":"a, b","etag":"keep, ", "x-uncommon":"a, b","x-keep":"HIT, ","content-length":"0"}
```

</details>

I diffed the full set of failing tests in `test/js/web/fetch/fetch.test.ts` with and without the patch: the only difference is the new tests flipping from fail to pass. `serve.test.ts`, `bun-server.test.ts`, the HTTP/2 and HTTP/3 client suites and the header-focused suites show no new failures.

## Note on overlap

#31321 also touches `HTTPHeaderMap` but in the other direction (JS `Headers` out to the wire, emitting one line per value instead of a comma-joined one). The two are complementary; whichever lands second needs a small rebase.
