### PR TITLE
bundler: keep wrapped ESM dependencies in their import position

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -3163,29 +3163,6 @@ impl<'a> LinkerContext<'a> {
                 // This depends on the "__esm" symbol and declares the "init_foo" symbol
                 // for similar reasons to the CommonJS closure above.
 
-                // Count async dependencies to determine if we need __promiseAll
-                let mut async_import_count: usize = 0;
-                {
-                    let import_records =
-                        self.graph.ast.items_import_records()[source_index as usize].as_slice();
-                    let meta_flags = self.graph.meta.items_flags();
-
-                    for record in import_records {
-                        if !record.source_index.is_valid() {
-                            continue;
-                        }
-                        let other_flags = meta_flags[record.source_index.get() as usize];
-                        if other_flags.is_async_or_has_async_dependency {
-                            async_import_count += 1;
-                            if async_import_count >= 2 {
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                let needs_promise_all = async_import_count >= 2;
-
                 let esm_parts: &[u32] = if wrapper_ref.is_valid()
                     && self.options.output_format != Format::InternalBakeDev
                 {
@@ -3194,25 +3171,9 @@ impl<'a> LinkerContext<'a> {
                     &[]
                 };
 
-                let promise_all_parts: &[u32] = if needs_promise_all
-                    && wrapper_ref.is_valid()
-                    && self.options.output_format != Format::InternalBakeDev
-                {
-                    self.top_level_symbols_to_parts_for_runtime(self.promise_all_runtime_ref)
-                } else {
-                    &[]
-                };
-
-                // generate a dummy part that depends on the "__esm" and optionally "__promiseAll" symbols
-                let mut dependencies =
-                    DependencyList::init_capacity(esm_parts.len() + promise_all_parts.len());
+                // generate a dummy part that depends on the "__esm" symbol
+                let mut dependencies = DependencyList::init_capacity(esm_parts.len());
                 for &part in esm_parts {
-                    dependencies.append_assume_capacity(Dependency {
-                        part_index: part,
-                        source_index: bun_ast::Index::RUNTIME,
-                    });
-                }
-                for &part in promise_all_parts {
                     dependencies.append_assume_capacity(Dependency {
                         part_index: part,
                         source_index: bun_ast::Index::RUNTIME,
@@ -3251,19 +3212,6 @@ impl<'a> LinkerContext<'a> {
                             crate::Index::RUNTIME,
                         )
                         .expect("OOM");
-
-                    // Only mark __promiseAll as used if we have multiple async dependencies
-                    if needs_promise_all {
-                        self.graph
-                            .generate_symbol_import_and_use(
-                                source_index,
-                                part_index,
-                                self.promise_all_runtime_ref,
-                                1,
-                                crate::Index::RUNTIME,
-                            )
-                            .expect("OOM");
-                    }
                 }
             }
             WrapKind::None => {}
@@ -4178,17 +4126,15 @@ pub struct StmtList {
 
 pub struct InsideWrapperPrefix {
     pub(crate) stmts: Vec<Stmt>,
-    pub(crate) sync_dependencies_end: usize,
-    // if true it will exist at `sync_dependencies_end`
-    pub(crate) has_async_dependency: bool,
+    /// Set only while the last statement is an `await init_…()` the next async dependency can merge into.
+    async_dependency_index: Option<usize>,
 }
 
 impl InsideWrapperPrefix {
     fn init() -> Self {
         Self {
             stmts: Vec::new(),
-            sync_dependencies_end: 0,
-            has_async_dependency: false,
+            async_dependency_index: None,
         }
     }
 
@@ -4196,34 +4142,35 @@ impl InsideWrapperPrefix {
 
     pub(crate) fn reset(&mut self) {
         self.stmts.clear();
-        self.sync_dependencies_end = 0;
-        self.has_async_dependency = false;
+        self.async_dependency_index = None;
     }
 }
 
 impl InsideWrapperPrefix {
     pub(crate) fn append_non_dependency(&mut self, stmt: Stmt) -> Result<(), AllocError> {
         self.stmts.push(stmt);
+        self.async_dependency_index = None;
         Ok(())
     }
 
     pub(crate) fn append_non_dependency_slice(&mut self, stmts: &[Stmt]) -> Result<(), AllocError> {
+        if stmts.is_empty() {
+            return Ok(());
+        }
         self.stmts.extend_from_slice(stmts);
+        self.async_dependency_index = None;
         Ok(())
     }
 
     fn append_sync_dependency(&mut self, call_expr: Expr) -> Result<(), AllocError> {
-        self.stmts.insert(
-            self.sync_dependencies_end,
-            Stmt::alloc(
-                S::SExpr {
-                    value: call_expr,
-                    ..Default::default()
-                },
-                call_expr.loc,
-            ),
-        );
-        self.sync_dependencies_end += 1;
+        self.stmts.push(Stmt::alloc(
+            S::SExpr {
+                value: call_expr,
+                ..Default::default()
+            },
+            call_expr.loc,
+        ));
+        self.async_dependency_index = None;
         Ok(())
     }
 
@@ -4232,25 +4179,23 @@ impl InsideWrapperPrefix {
         call_expr: Expr,
         promise_all_ref: Ref,
     ) -> Result<(), AllocError> {
-        if !self.has_async_dependency {
-            self.has_async_dependency = true;
-            self.stmts.insert(
-                self.sync_dependencies_end,
-                Stmt::alloc(
-                    S::SExpr {
-                        value: Expr::init(E::Await { value: call_expr }, Loc::EMPTY),
-                        ..Default::default()
-                    },
-                    Loc::EMPTY,
-                ),
-            );
+        let Some(async_dependency_index) = self.async_dependency_index else {
+            self.async_dependency_index = Some(self.stmts.len());
+            self.stmts.push(Stmt::alloc(
+                S::SExpr {
+                    value: Expr::init(E::Await { value: call_expr }, Loc::EMPTY),
+                    ..Default::default()
+                },
+                Loc::EMPTY,
+            ));
             return Ok(());
-        }
+        };
+        debug_assert_eq!(async_dependency_index + 1, self.stmts.len());
 
         // Note: deep AST mutation chain — `s_expr_mut`/`e_await_mut`/
         // `e_call_mut`/`e_array_mut` return `Option`; `.unwrap()` panics on
         // shape mismatch.
-        let mut first_dep_call_expr = self.stmts[self.sync_dependencies_end]
+        let mut first_dep_call_expr = self.stmts[async_dependency_index]
             .data
             .s_expr_mut()
             .unwrap()
@@ -4313,7 +4258,7 @@ impl InsideWrapperPrefix {
             );
 
             // replace the `await init_` expr with `await __promiseAll`
-            self.stmts[self.sync_dependencies_end] = Stmt::alloc(
+            self.stmts[async_dependency_index] = Stmt::alloc(
                 S::SExpr {
                     value: Expr::init(
                         E::Await {

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -843,10 +843,13 @@ pub(crate) fn scan_imports_and_exports(
             );
 
             let parts_len = col_ref!(parts_list)[id].len() as usize;
+            // Per file, not per part: `InsideWrapperPrefix` batches across all of a file's parts.
+            let mut async_dependency_count: u32 = 0;
             for part_index in 0..parts_len {
                 let mut to_esm_uses: u32 = 0;
                 let mut to_common_js_uses: u32 = 0;
                 let mut runtime_require_uses: u32 = 0;
+                let mut promise_all_uses: u32 = 0;
 
                 // Imports of wrapped files must depend on the wrapper
                 // Iterate by index so each iteration re-borrows
@@ -961,6 +964,16 @@ pub(crate) fn scan_imports_and_exports(
                     let other_flags = col_ref!(flags)[other_id];
                     let other_export_kind = col_ref!(exports_kind)[other_id];
                     let other_source_index = other_id as u32;
+
+                    if other_flags.wrap == WrapKind::Esm
+                        && kind == ImportKind::Stmt
+                        && other_flags.is_async_or_has_async_dependency
+                    {
+                        async_dependency_count += 1;
+                        if async_dependency_count >= 2 {
+                            promise_all_uses += 1;
+                        }
+                    }
 
                     if other_flags.wrap != WrapKind::None {
                         // Depend on the automatically-generated require wrapper symbol
@@ -1092,6 +1105,14 @@ pub(crate) fn scan_imports_and_exports(
                 }
 
                 if output_format != Format::InternalBakeDev {
+                    // Adjacent async dependencies are awaited together through "__promiseAll"
+                    this.graph.generate_runtime_symbol_import_and_use(
+                        source_index,
+                        Index::part(part_index as u32),
+                        b"__promiseAll",
+                        promise_all_uses,
+                    )?;
+
                     // If there's an ES6 import of a CommonJS module, then we're going to need the
                     // "__toESM" symbol from the runtime to wrap the result of "require()"
                     this.graph.generate_runtime_symbol_import_and_use(

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2632,6 +2632,116 @@ describe("bundler", () => {
       stdout: "",
     },
   });
+  // A dynamic import forces the ESM modules it shares with the entry into lazy
+  // `__esm` wrappers. Calling those wrappers must not jump ahead of a CommonJS
+  // module the entry imported first.
+  itBundled("edgecase/WrappedESMDependencyKeepsImportOrder", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import "./a.cjs";
+        import "./b.mjs";
+        await import("./c.mjs");
+      `,
+      "/a.cjs": /* js */ `
+        console.log("a cjs");
+        module.exports = {};
+      `,
+      "/b.mjs": /* js */ `
+        console.log("b esm");
+      `,
+      "/c.mjs": /* js */ `
+        import "./b.mjs";
+        console.log("c esm");
+      `,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: `
+        a cjs
+        b esm
+        c esm
+      `,
+    },
+    onAfterBundle(api) {
+      const entry = api.readFile("out.js").split("// entry.mjs")[1];
+      expect(entry.indexOf("require_a()")).toBeLessThan(entry.indexOf("init_b()"));
+    },
+  });
+  itBundled("edgecase/WrappedESMDependencyKeepsImportOrderReversed", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import "./b.mjs";
+        import "./a.cjs";
+        await import("./c.mjs");
+      `,
+      "/a.cjs": /* js */ `
+        console.log("a cjs");
+        module.exports = {};
+      `,
+      "/b.mjs": /* js */ `
+        console.log("b esm");
+      `,
+      "/c.mjs": /* js */ `
+        import "./b.mjs";
+        console.log("c esm");
+      `,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: `
+        b esm
+        a cjs
+        c esm
+      `,
+    },
+  });
+  // Adjacent async dependencies still batch into one `__promiseAll`, but the
+  // CommonJS module imported before them keeps its slot.
+  itBundled("edgecase/WrappedESMAsyncDependenciesKeepImportOrder", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import "./a.cjs";
+        import "./x.mjs";
+        import "./y.mjs";
+        await import("./c.mjs");
+      `,
+      "/a.cjs": /* js */ `
+        console.log("a cjs");
+        module.exports = {};
+      `,
+      "/x.mjs": /* js */ `
+        await 0;
+        console.log("x esm");
+      `,
+      "/y.mjs": /* js */ `
+        await 0;
+        console.log("y esm");
+      `,
+      "/c.mjs": /* js */ `
+        import "./x.mjs";
+        import "./y.mjs";
+        console.log("c esm");
+      `,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: `
+        a cjs
+        x esm
+        y esm
+        c esm
+      `,
+    },
+    onAfterBundle(api) {
+      const entry = api.readFile("out.js").split("// entry.mjs")[1];
+      expect(entry.indexOf("require_a()")).toBeLessThan(entry.indexOf("__promiseAll("));
+      expect(entry).toContain("init_x()");
+      expect(entry).toContain("init_y()");
+    },
+  });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {
     files: {
       "/entry.ts": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2738,8 +2738,7 @@ describe("bundler", () => {
     onAfterBundle(api) {
       const entry = api.readFile("out.js").split("// entry.mjs")[1];
       expect(entry.indexOf("require_a()")).toBeLessThan(entry.indexOf("__promiseAll("));
-      expect(entry).toContain("init_x()");
-      expect(entry).toContain("init_y()");
+      expect(entry).toMatch(/__promiseAll\(\s*\[\s*init_x\(\),\s*init_y\(\)\s*\]\)/);
     },
   });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2665,7 +2665,7 @@ describe("bundler", () => {
     },
     onAfterBundle(api) {
       const entry = api.readFile("out.js").split("// entry.mjs")[1];
-      expect(entry.indexOf("require_a()")).toBeLessThan(entry.indexOf("init_b()"));
+      expect(entry).toMatch(/require_a\(\)[\s\S]*init_b\(\)/);
     },
   });
   itBundled("edgecase/WrappedESMDependencyKeepsImportOrderReversed", {
@@ -2695,6 +2695,10 @@ describe("bundler", () => {
         a cjs
         c esm
       `,
+    },
+    onAfterBundle(api) {
+      const entry = api.readFile("out.js").split("// entry.mjs")[1];
+      expect(entry).toMatch(/init_b\(\)[\s\S]*require_a\(\)/);
     },
   });
   // Adjacent async dependencies still batch into one `__promiseAll`, but the
@@ -2737,8 +2741,7 @@ describe("bundler", () => {
     },
     onAfterBundle(api) {
       const entry = api.readFile("out.js").split("// entry.mjs")[1];
-      expect(entry.indexOf("require_a()")).toBeLessThan(entry.indexOf("__promiseAll("));
-      expect(entry).toMatch(/__promiseAll\(\s*\[\s*init_x\(\),\s*init_y\(\)\s*\]\)/);
+      expect(entry).toMatch(/require_a\(\)[\s\S]*__promiseAll\(\s*\[\s*init_x\(\),\s*init_y\(\)\s*\]\)/);
     },
   });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -428,4 +428,82 @@ describe("bundler", () => {
       expect(bundled).not.toMatch(/await\s+__promiseAll\s*\(/);
     },
   });
+
+  // The entry point is never wrapped, so nothing used to mark __promiseAll as
+  // live even though its two adjacent async imports batch into a call to it.
+  itBundled("bundler/__promiseAll is included when an unwrapped entry batches async imports", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import "./x.mjs";
+        import "./y.mjs";
+        await import("./dx.mjs");
+        await import("./dy.mjs");
+      `,
+      "/x.mjs": /* js */ `
+        await 0;
+        console.log("x");
+      `,
+      "/y.mjs": /* js */ `
+        await 0;
+        console.log("y");
+      `,
+      "/dx.mjs": /* js */ `
+        import "./x.mjs";
+        console.log("dx");
+      `,
+      "/dy.mjs": /* js */ `
+        import "./y.mjs";
+        console.log("dy");
+      `,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: `
+        x
+        y
+        dx
+        dy
+      `,
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(/await\s+__promiseAll\s*\(\s*\[/);
+      expect(bundled).toContain("var __promiseAll = ");
+    },
+  });
+
+  itBundled("bundler/__promiseAll is tree-shaken when async deps are only reached by import()", {
+    files: {
+      "/entry.mjs": /* js */ `
+        await import("./w.mjs");
+      `,
+      "/w.mjs": /* js */ `
+        await import("./x.mjs");
+        await import("./y.mjs");
+        console.log("w");
+      `,
+      "/x.mjs": /* js */ `
+        await 0;
+        console.log("x");
+      `,
+      "/y.mjs": /* js */ `
+        await 0;
+        console.log("y");
+      `,
+    },
+    format: "esm",
+    target: "bun",
+    run: {
+      stdout: `
+        x
+        y
+        w
+      `,
+    },
+    onAfterBundle(api) {
+      // Dynamic imports never batch, so the helper can never be referenced.
+      expect(api.readFile("out.js")).not.toContain("__promiseAll");
+    },
+  });
 });


### PR DESCRIPTION
## Repro

```js
// entry.mjs
import "./a.cjs";        // must evaluate first
import "./b.mjs";        // also a static dep of the dynamically-imported ./c.mjs
await import("./c.mjs");

// a.cjs  -> console.log("a cjs"); module.exports = {};
// b.mjs  -> console.log("b esm");
// c.mjs  -> import "./b.mjs"; console.log("c esm");
```

`node entry.mjs`, `bun entry.mjs` and `esbuild --bundle` all print `a cjs / b esm / c esm`.
`bun build` printed `b esm / a cjs / c esm`.

The dynamic import forces `b.mjs` into a lazy `__esm` wrapper, and the `init_b()` call
was hoisted above the CommonJS module the entry imported first:

```js
// entry.mjs  (before)
init_b();
var import_a = __toESM(require_a(), 1);
await Promise.resolve().then(() => (init_c(), exports_c));
```

Without the dynamic import `b.mjs` is never wrapped, so nothing is hoisted and the
order is right. That is why this only shows up in built artifacts of code that is
correct everywhere else.

## Cause

`InsideWrapperPrefix` (`src/bundler/LinkerContext.rs`) kept a `sync_dependencies_end`
cursor and **inserted** each `init_x()` call at it, while CommonJS `var ns = require_x()`
statements, `__reExport(...)` calls and the `"use strict"` directive were **pushed** at
the back. Dependency calls therefore always won, whatever the source order. The cursor
existed so that consecutive async dependencies stay adjacent and can be merged into one
`await __promiseAll([...])`.

esbuild's `shouldRemoveImportExportStmt` appends both kinds to `insideWrapperPrefix` in
statement order, which is where the reference output comes from.

## Fix

Append every statement in source order. Track the index of a trailing
`await init_x()` statement instead of a cursor, and merge an incoming async dependency
into it only while it is still the last statement; appending anything else clears it.
Adjacent async dependencies still batch:

```js
// entry.mjs  (after)
var import_a = __toESM(require_a(), 1);
await __promiseAll([init_x(), init_y()]);
await init_c().then(() => exports_c);
```

While auditing that batching, a second bug: `__promiseAll` was only marked live inside
`create_wrapper_for_file`'s `WrapKind::Esm` arm, but an **unwrapped** file batches async
dependencies too. An entry point with two adjacent async imports emitted a call to a
symbol that was never included:

```
ReferenceError: __promiseAll is not defined
```

Reproduces on stock 1.4.0, independent of the ordering bug. The symbol is now marked
live in `scan_imports_and_exports`, alongside `__toESM` and `__toCommonJS`, from the
second async statement-import of a file onwards. Since that predicate now matches the
emit site, graphs whose async dependencies are only reachable through `import()` no
longer carry the unused helper.

This second bug was later found independently in #36189, which proposed the same
`scan_imports_and_exports` change on its own and was closed in favour of this PR.

## Verification

`bun build` output for the repro is now byte-identical to esbuild's. Same for the
async-dependency variant, checked against `node`, the Bun runtime and esbuild.

With `--splitting` the shared ESM dep moves into its own chunk and is pulled in by a
hoisted `import` statement; esbuild does exactly the same thing, so that case is
unchanged.

New tests, each failing before and passing after:

- `edgecase/WrappedESMDependencyKeepsImportOrder`
- `edgecase/WrappedESMDependencyKeepsImportOrderReversed`
- `edgecase/WrappedESMAsyncDependenciesKeepImportOrder`
- `bundler/__promiseAll is included when an unwrapped entry batches async imports`
- `bundler/__promiseAll is tree-shaken when async deps are only reached by import()`

<details>
<summary>Suites run (debug build)</summary>

All of `test/bundler/` plus `test/bake/dev/` and
`test/regression/issue/cyclic-imports-async-bundler.test.js`. The only failures are
identical on an unmodified `main` build: `bundler_compile` / `bun-build-api` /
`native-plugin` / `cli` fail on a debug-only `debug warn: hintSourcePagesDontNeed`
stderr line or a 180s timeout, and `bake/dev/production.test.ts` has two 5s timeouts.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->
