### PR TITLE
build: pin -C metadata so bun's crates keep stable symbol names

### DIFF
--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -188,6 +188,7 @@ Split CI modes: `rust-only` (lolhtml+codegen+cargo → libbun_rust.a), `cpp-only
 | `source.ts`                    | `Dependency` types, `resolveDep()`, fetch/configure/build emission                                                      |
 | `codegen.ts`                   | Code generation steps, `emitCodegen()`, `CodegenOutputs`                                                                |
 | `rust.ts`                      | `cargo build` step, `emitRust()`, `rustLibPath()`, cross-compile matrix                                                 |
+| `rustc-metadata-shim.rs`       | `RUSTC_WORKSPACE_WRAPPER` — pins `-C metadata` so our crates' symbol names survive a dependency-graph edit              |
 | `cargo-config.ts`              | Generates the git-ignored `.cargo/config.toml` (per-target `linker` from `cfg.hostCxx`)                                 |
 | `bun.ts`                       | `emitBun()` — assembles deps+codegen+rust+compile+link                                                                  |
 | `shims.ts`                     | Platform/toolchain workaround dylibs, `emitShims()`                                                                     |

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -180,6 +180,14 @@ export function rustLibPath(cfg: Config): string {
   return resolve(rustTargetDir(cfg), rustTarget(cfg), subdir, `${cfg.libPrefix}bun_rust${cfg.libSuffix}`);
 }
 
+/** The `RUSTC_WORKSPACE_WRAPPER` source — see its module doc for why it exists. */
+const metadataShimSource = resolve(import.meta.dirname, "rustc-metadata-shim.rs");
+
+/** Where the compiled wrapper lands. A HOST executable — cargo spawns it. */
+function metadataShimPath(cfg: Config): string {
+  return resolve(cfg.buildDir, `rustc-metadata-shim${cfg.host.exeSuffix}`);
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // Ninja rules
 // ───────────────────────────────────────────────────────────────────────────
@@ -202,6 +210,27 @@ export function registerRustRules(n: Ninja, cfg: Config): void {
 
   if (cfg.cargo === undefined) return; // emitRust() asserts with a hint
   const stream = `${cfg.jsRuntime} ${q(streamPath)} rust`;
+
+  // `RUSTC_WORKSPACE_WRAPPER` — pins `-C metadata` so our crates keep the same
+  // v0 symbol names across builds (rustc-metadata-shim.rs has the why).
+  //
+  // A bare `rustc` builds it: the wrapper has to exist before cargo runs, so it
+  // can't be a workspace member, and one host `.rs` is cheaper than a second
+  // cargo invocation. `rustc` sits next to `cargo` on both rustup and distro
+  // installs — the same assumption findRustup() already makes.
+  //
+  // Its own link step needs a linker, and rustc's default (`cc`) isn't on every
+  // CI image. Point it at the clang tools.ts resolved, with the lld that ships
+  // beside it — or at the MSVC linker on a Windows host, mirroring what the
+  // cargo env sets for the dep graph's host artifacts.
+  const rustc = join(dirname(cfg.cargo), `rustc${cfg.host.exeSuffix}`);
+  const shimLinkFlags = hostWin
+    ? [`-Clinker=${cfg.msvcLinker ?? cfg.ld}`]
+    : [`-Clinker=${cfg.hostCc}`, "-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Qunused-arguments"];
+  n.rule("rustc_metadata_shim", {
+    command: `${q(rustc)} --edition 2024 -Copt-level=2 ${quoteArgs(shimLinkFlags, hostWin)} -o $out $in`,
+    description: "rustc → $out",
+  });
 
   // Cargo build for `bun_bin`. Runs from repo root (workspace `Cargo.toml`
   // lives there). Env passed via stream.ts `--env=K=V`.
@@ -364,6 +393,16 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   const tier3 = rustTargetIsTier3(triple);
   const profile = cargoProfile(cfg);
   const lib = rustLibPath(cfg);
+
+  // ─── `-C metadata` pin ───
+  // An implicit input of every cargo edge below, so it's on disk before cargo
+  // tries to spawn it.
+  const metadataShim = metadataShimPath(cfg);
+  n.build({
+    outputs: [metadataShim],
+    rule: "rustc_metadata_shim",
+    inputs: [metadataShimSource],
+  });
 
   // ─── Build args ───
   const args: string[] = [
@@ -653,6 +692,19 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   // ─── Environment ───
   const env: Record<string, string> = {
     CARGO_TERM_COLOR: "always",
+    // Pin `-C metadata` for the workspace's own crates so their v0 symbol names
+    // survive a dependency-graph edit. Cargo folds every dependency's
+    // `-C metadata` into a unit's own, and rustc hashes that into the `Cs…`
+    // disambiguator each symbol carries — so one new dep anywhere below a crate
+    // renames everything above it. `bun_runtime` depends on ~100 workspace
+    // crates, which is why it was renamed by nearly every commit. See
+    // rustc-metadata-shim.rs.
+    //
+    // `_WORKSPACE_` rather than plain `RUSTC_WRAPPER`: cargo applies it to
+    // workspace members only, which is exactly the set whose names we care
+    // about, and leaves registry crates on cargo's collision-proof hash.
+    // `cargo clippy` sets this variable itself, so it keeps working.
+    RUSTC_WORKSPACE_WRAPPER: metadataShim,
     // `include!(concat!(env!("BUN_CODEGEN_DIR"), "/generated_*.rs"))` and
     // `include_bytes!` in `bun_js_parser`/`bun_runtime` resolve against this.
     // Set in cargo's env so it reaches every crate's `rustc` invocation
@@ -861,7 +913,7 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
       // workspace manifest if any path-dep's `Cargo.toml` is missing.
       // shimDest: rebuilt when a sibling build dir (other arch/profile)
       // overwrote the shared exe.
-      implicitInputs: [cfg.cargo, ...inputs.rustSources, ...inputs.vendorStamps, shimDest],
+      implicitInputs: [cfg.cargo, metadataShim, ...inputs.rustSources, ...inputs.vendorStamps, shimDest],
       vars: {
         cwd: cfg.cwd,
         args: quoteArgs(shimArgs, hostWin),
@@ -898,7 +950,14 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     // so depending on those orders the codegen step before cargo without
     // ninja needing to know the `.rs` paths. vendorStamps orders the
     // lol-html source fetch before cargo resolves the path dep.
-    implicitInputs: [cfg.cargo, ...inputs.rustSources, ...inputs.codegenInputs, ...inputs.vendorStamps, ...shimInputs],
+    implicitInputs: [
+      cfg.cargo,
+      metadataShim,
+      ...inputs.rustSources,
+      ...inputs.codegenInputs,
+      ...inputs.vendorStamps,
+      ...shimInputs,
+    ],
     orderOnlyInputs: inputs.codegenOrderOnly,
     vars: {
       cwd: cfg.cwd,

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -211,24 +211,31 @@ export function registerRustRules(n: Ninja, cfg: Config): void {
   if (cfg.cargo === undefined) return; // emitRust() asserts with a hint
   const stream = `${cfg.jsRuntime} ${q(streamPath)} rust`;
 
+  const rustup = findRustup(cfg);
+  // Toolchain self-heal, prepended to anything that invokes a rustup proxy —
+  // see the rust_build_cross comment below for what it repairs and why it's a
+  // ~70ms no-op otherwise.
+  const repair =
+    rustup !== undefined && cfg.rustToolchain !== undefined
+      ? `${stream} --console $env ${q(rustup)} toolchain install ${cfg.rustToolchain} --force --component rust-src $rust_target_arg && `
+      : "";
+
   // `RUSTC_WORKSPACE_WRAPPER` — pins `-C metadata` so our crates keep the same
-  // v0 symbol names across builds (rustc-metadata-shim.rs has the why).
-  //
-  // A bare `rustc` builds it: the wrapper has to exist before cargo runs, so it
-  // can't be a workspace member, and one host `.rs` is cheaper than a second
-  // cargo invocation. `rustc` sits next to `cargo` on both rustup and distro
-  // installs — the same assumption findRustup() already makes.
-  //
-  // Its own link step needs a linker, and rustc's default (`cc`) isn't on every
-  // CI image. Point it at the clang tools.ts resolved, with the lld that ships
-  // beside it — or at the MSVC linker on a Windows host, mirroring what the
-  // cargo env sets for the dep graph's host artifacts.
+  // v0 symbol names across builds (rustc-metadata-shim.rs has the why). A bare
+  // `rustc` builds it: it must exist before cargo runs, so it can't be a
+  // workspace member. That makes it the build's first rustup-proxy call, hence
+  // the repair above: a partially installed toolchain has no host `rust-std`
+  // for it to link against. `-Clinker`: rustc's default `cc` isn't on every CI
+  // image, so use the clang tools.ts resolved (MSVC's link.exe on a Windows
+  // host), same as the cargo env picks for the dep graph's host artifacts.
   const rustc = join(dirname(cfg.cargo), `rustc${cfg.host.exeSuffix}`);
-  const shimLinkFlags = hostWin
+  const shimLink = hostWin
     ? [`-Clinker=${cfg.msvcLinker ?? cfg.ld}`]
-    : [`-Clinker=${cfg.hostCc}`, "-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Qunused-arguments"];
+    : [`-Clinker=${cfg.hostCc}`, "-Clink-arg=-fuse-ld=lld"];
+  const shimCmd = `${repair}${q(rustc)} --edition 2024 -Copt-level=2 ${quoteArgs(shimLink, hostWin)} -o $out $in`;
   n.rule("rustc_metadata_shim", {
-    command: `${q(rustc)} --edition 2024 -Copt-level=2 ${quoteArgs(shimLinkFlags, hostWin)} -o $out $in`,
+    // ninja spawns via CreateProcess, so `&&` needs a shell — same as rust_build_cross.
+    command: hostWin && repair !== "" ? `cmd /c "${shimCmd}"` : shimCmd,
     description: "rustc → $out",
   });
 
@@ -324,11 +331,8 @@ export function registerRustRules(n: Ninja, cfg: Config): void {
     });
   }
 
-  const rustup = findRustup(cfg);
-  if (rustup !== undefined && cfg.rustToolchain !== undefined) {
-    const chain =
-      `${stream} --console $env ${q(rustup)} toolchain install ${cfg.rustToolchain} --force --component rust-src $rust_target_arg && ` +
-      `${stream} --console --cwd=$cwd $env ${q(cfg.cargo)} build $args`;
+  if (repair !== "") {
+    const chain = `${repair}${stream} --console --cwd=$cwd $env ${q(cfg.cargo)} build $args`;
     n.rule("rust_build_cross", {
       command: hostWin ? `cmd /c "${chain}"` : chain,
       description: "cargo bun_bin → $label ($rust_target_arg)",
@@ -394,15 +398,10 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   const profile = cargoProfile(cfg);
   const lib = rustLibPath(cfg);
 
-  // ─── `-C metadata` pin ───
-  // An implicit input of every cargo edge below, so it's on disk before cargo
-  // tries to spawn it.
+  // Implicit input of every cargo edge below, so it's on disk before cargo
+  // tries to spawn it. Emitted after `env` is built (the rule's toolchain
+  // repair wants it).
   const metadataShim = metadataShimPath(cfg);
-  n.build({
-    outputs: [metadataShim],
-    rule: "rustc_metadata_shim",
-    inputs: [metadataShimSource],
-  });
 
   // ─── Build args ───
   const args: string[] = [
@@ -692,18 +691,11 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   // ─── Environment ───
   const env: Record<string, string> = {
     CARGO_TERM_COLOR: "always",
-    // Pin `-C metadata` for the workspace's own crates so their v0 symbol names
-    // survive a dependency-graph edit. Cargo folds every dependency's
-    // `-C metadata` into a unit's own, and rustc hashes that into the `Cs…`
-    // disambiguator each symbol carries — so one new dep anywhere below a crate
-    // renames everything above it. `bun_runtime` depends on ~100 workspace
-    // crates, which is why it was renamed by nearly every commit. See
-    // rustc-metadata-shim.rs.
-    //
-    // `_WORKSPACE_` rather than plain `RUSTC_WRAPPER`: cargo applies it to
-    // workspace members only, which is exactly the set whose names we care
-    // about, and leaves registry crates on cargo's collision-proof hash.
-    // `cargo clippy` sets this variable itself, so it keeps working.
+    // Pins `-C metadata` for our own crates so their v0 symbol names survive a
+    // dependency-graph edit — rustc-metadata-shim.rs has the why. `_WORKSPACE_`
+    // rather than plain `RUSTC_WRAPPER`: cargo applies it to workspace members
+    // only, leaving registry crates on its collision-proof hash. `cargo clippy`
+    // sets this variable itself, so it keeps working.
     RUSTC_WORKSPACE_WRAPPER: metadataShim,
     // `include!(concat!(env!("BUN_CODEGEN_DIR"), "/generated_*.rs"))` and
     // `include_bytes!` in `bun_js_parser`/`bun_runtime` resolve against this.
@@ -815,6 +807,18 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     env.CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS = "true";
   }
   if (rustflags.length > 0) env.CARGO_ENCODED_RUSTFLAGS = rustflags.join("\x1f");
+
+  const envArgs = Object.entries(env)
+    .map(([k, v]) => `--env=${k}=${quote(v, hostWin)}`)
+    .join(" ");
+
+  // ─── `-C metadata` pin ───
+  n.build({
+    outputs: [metadataShim],
+    rule: "rustc_metadata_shim",
+    inputs: [metadataShimSource],
+    vars: { env: envArgs },
+  });
 
   // ─── Windows .bin/ shim PE ───
   // Builds `src/install/windows-shim/bun_shim_impl.rs` as a freestanding release PE and wires the artifact into `include_bytes!`. Without this step `include_bytes!` embeds the
@@ -964,9 +968,7 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
       args: quoteArgs(args, hostWin),
       ...(useCrossRule ? { rust_target_arg: tier3 ? "" : `--target ${triple}` } : {}),
       label: `${cfg.libPrefix}bun_rust${cfg.libSuffix}`,
-      env: Object.entries(env)
-        .map(([k, v]) => `--env=${k}=${quote(v, hostWin)}`)
-        .join(" "),
+      env: envArgs,
     },
   });
   n.phony("bun-rust", [lib]);

--- a/scripts/build/rustc-metadata-shim.rs
+++ b/scripts/build/rustc-metadata-shim.rs
@@ -1,31 +1,22 @@
-//! `RUSTC_WORKSPACE_WRAPPER` for the bun workspace: pin `-C metadata` so our
-//! crates keep the same v0 symbol names from one build to the next.
+//! `RUSTC_WORKSPACE_WRAPPER`: replace cargo's `-C metadata` with the package
+//! name, so bun's crates keep the same v0 symbol names from build to build.
 //!
-//! Cargo derives a unit's `-C metadata` from, among other things, the
-//! `-C metadata` of every dependency it has (`compute_metadata` in
-//! `compilation_files.rs`). rustc hashes that value into the `StableCrateId`
-//! that every v0 symbol carries: the `Cs…` in
-//! `_RNvNtNtCs4EG9u9StnXu_11bun_runtime3cli7command15boot_standalone`. So a
-//! dependency-edge edit *anywhere below a crate* renames every symbol that
-//! crate defines. `bun_runtime` sits at the top of the dependency cone (direct
-//! deps on ~100 workspace crates), so it is renamed by almost every commit,
-//! while leaves like `bun_core` never move. Nothing is wrong with the binary —
-//! but anything that matches symbol names across two builds silently loses the
-//! crate: lld `--symbol-ordering-file` reuse, sccache hits, symbolicating an
-//! old profile against a new binary.
+//! Cargo mixes the `-C metadata` of every dependency into a unit's own, and
+//! rustc hashes that into the `StableCrateId` every v0 symbol carries — the
+//! `Cs…` in `_RNvNtNtCs4EG9u9StnXu_11bun_runtime3cli7command15boot_standalone`.
+//! A dependency-edge edit *anywhere below a crate* therefore renames every
+//! symbol that crate defines. `bun_runtime` has ~100 direct workspace deps, so
+//! it was renamed by nearly every commit, and anything matching symbol names
+//! across two builds silently lost it: lld `--symbol-ordering-file` reuse,
+//! sccache hits, symbolicating an old profile against a new binary.
 //!
-//! There is no cargo knob for this, and rustc sorts/dedups/hashes *every*
-//! `-C metadata` it is handed, so an extra one from RUSTFLAGS cannot shadow
-//! cargo's. Rewriting the value before rustc sees it is the only lever.
+//! rustc hashes *every* `-C metadata` it is handed, so an extra one from
+//! RUSTFLAGS can't shadow cargo's — rewriting it here is the only lever.
 //!
-//! The replacement keeps everything in cargo's hash that identifies this
-//! compilation unit — package, version, features, target, crate types — and
-//! drops only the dependency hash. Symbols stay unique because rustc mixes the
-//! crate name into `StableCrateId` independently of `-C metadata`, and no two
-//! workspace packages share a name.
-//!
-//! Built by `scripts/build/rust.ts` with a bare `rustc`; it is not a workspace
-//! member (it has to exist before cargo runs).
+//! The package name alone keeps symbols unique: rustc mixes the crate name into
+//! `StableCrateId` on top of this, no two workspace packages share a name, and
+//! cargo applies this wrapper to workspace members only — registry crates, where
+//! two versions of one name can coexist, keep cargo's hash.
 
 use std::env;
 use std::ffi::OsString;
@@ -38,92 +29,21 @@ fn main() {
         std::process::exit(1);
     };
 
-    let args: Vec<OsString> = argv.collect();
-    let args = rewrite_metadata(&args, &pin(&args));
-    run(&rustc, &args);
-}
-
-/// Replace the value of cargo's `-C metadata=<hash>` with `pin`.
-///
-/// Cargo emits it as two arguments (`-C`, `metadata=…`); the one-argument
-/// spelling is handled too in case a RUSTFLAG ever uses it. Invocations
-/// without one (cargo's `-vV` / `--print` probes) pass straight through.
-fn rewrite_metadata(args: &[OsString], pin: &str) -> Vec<OsString> {
-    let mut out: Vec<OsString> = Vec::with_capacity(args.len());
-    let mut i = 0;
-    while i < args.len() {
-        let arg = args[i].to_string_lossy();
-        let next_is_metadata =
-            i + 1 < args.len() && args[i + 1].to_string_lossy().starts_with("metadata=");
-        if arg == "-C" && next_is_metadata {
-            out.push(OsString::from("-C"));
-            out.push(OsString::from(format!("metadata={pin}")));
-            i += 2;
-            continue;
-        }
-        if arg.starts_with("-Cmetadata=") {
-            out.push(OsString::from(format!("-Cmetadata={pin}")));
-            i += 1;
-            continue;
-        }
-        out.push(args[i].clone());
-        i += 1;
-    }
-    out
-}
-
-/// The unit's identity, stable across dependency-graph edits.
-///
-/// Package name and version come from cargo's per-invocation env; target,
-/// crate types and features come off the command line. Sorted so argument
-/// order can never change the result.
-fn pin(args: &[OsString]) -> String {
-    let scan: Vec<String> = args
-        .iter()
-        .map(|a| a.to_string_lossy().into_owned())
+    // Cargo emits `-C` and `metadata=<hash>` as two arguments, and nothing else
+    // it passes starts with `metadata=`. Invocations with none at all (cargo's
+    // `-vV` / `--print` probes) fall through untouched.
+    let pin = format!(
+        "metadata=bun.{}",
+        env::var("CARGO_PKG_NAME").unwrap_or_default()
+    );
+    let args: Vec<OsString> = argv
+        .map(|arg| match arg.to_str() {
+            Some(a) if a.starts_with("metadata=") => OsString::from(pin.as_str()),
+            _ => arg,
+        })
         .collect();
-    let mut target: Option<String> = None;
-    let mut crate_types: Vec<String> = Vec::new();
-    let mut features: Vec<String> = Vec::new();
 
-    let mut i = 0;
-    while i < scan.len() {
-        if let Some(v) = value_of(&scan, &mut i, "--target") {
-            target = Some(v);
-        } else if let Some(v) = value_of(&scan, &mut i, "--crate-type") {
-            crate_types.push(v);
-        } else if let Some(v) = value_of(&scan, &mut i, "--cfg") {
-            if let Some(f) = v.strip_prefix("feature=") {
-                features.push(f.trim_matches('"').to_string());
-            }
-        }
-        i += 1;
-    }
-
-    crate_types.sort();
-    features.sort();
-    features.dedup();
-    format!(
-        "bun/{}@{}/{}/{}/{}",
-        env::var("CARGO_PKG_NAME").unwrap_or_default(),
-        env::var("CARGO_PKG_VERSION").unwrap_or_default(),
-        target.as_deref().unwrap_or("host"),
-        crate_types.join("+"),
-        features.join(","),
-    )
-}
-
-/// `--flag value` and `--flag=value`, but never `--flag-something`. Advances
-/// `i` past the value when it was a separate argument.
-fn value_of(scan: &[String], i: &mut usize, flag: &str) -> Option<String> {
-    let arg = scan[*i].as_str();
-    let rest = arg.strip_prefix(flag)?;
-    if rest.is_empty() {
-        let value = scan.get(*i + 1)?.clone();
-        *i += 1;
-        return Some(value);
-    }
-    rest.strip_prefix('=').map(str::to_string)
+    run(&rustc, &args)
 }
 
 #[cfg(unix)]
@@ -131,10 +51,10 @@ fn run(rustc: &OsString, args: &[OsString]) -> ! {
     use std::os::unix::process::CommandExt;
     let err = Command::new(rustc).args(args).exec();
     eprintln!(
-        "rustc-metadata-shim: failed to exec {}: {err}",
+        "rustc-metadata-shim: cannot exec {}: {err}",
         rustc.to_string_lossy()
     );
-    std::process::exit(1);
+    std::process::exit(1)
 }
 
 #[cfg(not(unix))]
@@ -143,10 +63,10 @@ fn run(rustc: &OsString, args: &[OsString]) -> ! {
         Ok(status) => std::process::exit(status.code().unwrap_or(1)),
         Err(err) => {
             eprintln!(
-                "rustc-metadata-shim: failed to run {}: {err}",
+                "rustc-metadata-shim: cannot run {}: {err}",
                 rustc.to_string_lossy()
             );
-            std::process::exit(1);
+            std::process::exit(1)
         }
     }
 }

--- a/scripts/build/rustc-metadata-shim.rs
+++ b/scripts/build/rustc-metadata-shim.rs
@@ -1,0 +1,152 @@
+//! `RUSTC_WORKSPACE_WRAPPER` for the bun workspace: pin `-C metadata` so our
+//! crates keep the same v0 symbol names from one build to the next.
+//!
+//! Cargo derives a unit's `-C metadata` from, among other things, the
+//! `-C metadata` of every dependency it has (`compute_metadata` in
+//! `compilation_files.rs`). rustc hashes that value into the `StableCrateId`
+//! that every v0 symbol carries: the `Cs…` in
+//! `_RNvNtNtCs4EG9u9StnXu_11bun_runtime3cli7command15boot_standalone`. So a
+//! dependency-edge edit *anywhere below a crate* renames every symbol that
+//! crate defines. `bun_runtime` sits at the top of the dependency cone (direct
+//! deps on ~100 workspace crates), so it is renamed by almost every commit,
+//! while leaves like `bun_core` never move. Nothing is wrong with the binary —
+//! but anything that matches symbol names across two builds silently loses the
+//! crate: lld `--symbol-ordering-file` reuse, sccache hits, symbolicating an
+//! old profile against a new binary.
+//!
+//! There is no cargo knob for this, and rustc sorts/dedups/hashes *every*
+//! `-C metadata` it is handed, so an extra one from RUSTFLAGS cannot shadow
+//! cargo's. Rewriting the value before rustc sees it is the only lever.
+//!
+//! The replacement keeps everything in cargo's hash that identifies this
+//! compilation unit — package, version, features, target, crate types — and
+//! drops only the dependency hash. Symbols stay unique because rustc mixes the
+//! crate name into `StableCrateId` independently of `-C metadata`, and no two
+//! workspace packages share a name.
+//!
+//! Built by `scripts/build/rust.ts` with a bare `rustc`; it is not a workspace
+//! member (it has to exist before cargo runs).
+
+use std::env;
+use std::ffi::OsString;
+use std::process::Command;
+
+fn main() {
+    let mut argv = env::args_os().skip(1);
+    let Some(rustc) = argv.next() else {
+        eprintln!("rustc-metadata-shim: expected rustc's path as the first argument");
+        std::process::exit(1);
+    };
+
+    let args: Vec<OsString> = argv.collect();
+    let args = rewrite_metadata(&args, &pin(&args));
+    run(&rustc, &args);
+}
+
+/// Replace the value of cargo's `-C metadata=<hash>` with `pin`.
+///
+/// Cargo emits it as two arguments (`-C`, `metadata=…`); the one-argument
+/// spelling is handled too in case a RUSTFLAG ever uses it. Invocations
+/// without one (cargo's `-vV` / `--print` probes) pass straight through.
+fn rewrite_metadata(args: &[OsString], pin: &str) -> Vec<OsString> {
+    let mut out: Vec<OsString> = Vec::with_capacity(args.len());
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].to_string_lossy();
+        let next_is_metadata =
+            i + 1 < args.len() && args[i + 1].to_string_lossy().starts_with("metadata=");
+        if arg == "-C" && next_is_metadata {
+            out.push(OsString::from("-C"));
+            out.push(OsString::from(format!("metadata={pin}")));
+            i += 2;
+            continue;
+        }
+        if arg.starts_with("-Cmetadata=") {
+            out.push(OsString::from(format!("-Cmetadata={pin}")));
+            i += 1;
+            continue;
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    out
+}
+
+/// The unit's identity, stable across dependency-graph edits.
+///
+/// Package name and version come from cargo's per-invocation env; target,
+/// crate types and features come off the command line. Sorted so argument
+/// order can never change the result.
+fn pin(args: &[OsString]) -> String {
+    let scan: Vec<String> = args
+        .iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    let mut target: Option<String> = None;
+    let mut crate_types: Vec<String> = Vec::new();
+    let mut features: Vec<String> = Vec::new();
+
+    let mut i = 0;
+    while i < scan.len() {
+        if let Some(v) = value_of(&scan, &mut i, "--target") {
+            target = Some(v);
+        } else if let Some(v) = value_of(&scan, &mut i, "--crate-type") {
+            crate_types.push(v);
+        } else if let Some(v) = value_of(&scan, &mut i, "--cfg") {
+            if let Some(f) = v.strip_prefix("feature=") {
+                features.push(f.trim_matches('"').to_string());
+            }
+        }
+        i += 1;
+    }
+
+    crate_types.sort();
+    features.sort();
+    features.dedup();
+    format!(
+        "bun/{}@{}/{}/{}/{}",
+        env::var("CARGO_PKG_NAME").unwrap_or_default(),
+        env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+        target.as_deref().unwrap_or("host"),
+        crate_types.join("+"),
+        features.join(","),
+    )
+}
+
+/// `--flag value` and `--flag=value`, but never `--flag-something`. Advances
+/// `i` past the value when it was a separate argument.
+fn value_of(scan: &[String], i: &mut usize, flag: &str) -> Option<String> {
+    let arg = scan[*i].as_str();
+    let rest = arg.strip_prefix(flag)?;
+    if rest.is_empty() {
+        let value = scan.get(*i + 1)?.clone();
+        *i += 1;
+        return Some(value);
+    }
+    rest.strip_prefix('=').map(str::to_string)
+}
+
+#[cfg(unix)]
+fn run(rustc: &OsString, args: &[OsString]) -> ! {
+    use std::os::unix::process::CommandExt;
+    let err = Command::new(rustc).args(args).exec();
+    eprintln!(
+        "rustc-metadata-shim: failed to exec {}: {err}",
+        rustc.to_string_lossy()
+    );
+    std::process::exit(1);
+}
+
+#[cfg(not(unix))]
+fn run(rustc: &OsString, args: &[OsString]) -> ! {
+    match Command::new(rustc).args(args).status() {
+        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+        Err(err) => {
+            eprintln!(
+                "rustc-metadata-shim: failed to run {}: {err}",
+                rustc.to_string_lossy()
+            );
+            std::process::exit(1);
+        }
+    }
+}

--- a/test/internal/rustc-metadata-shim.test.ts
+++ b/test/internal/rustc-metadata-shim.test.ts
@@ -9,17 +9,19 @@
  * renamed by nearly every commit.
  *
  * The graph assertion is configure-time only and runs everywhere. The
- * behavioural ones compile the wrapper, so they need a rust toolchain.
+ * behavioural ones drive the wrapper `bun bd` already built, so they need a
+ * build directory; CI's test lanes run a downloaded binary and skip them. (The
+ * build-rust lanes are what prove the wrapper compiles and cargo runs through
+ * it on every platform — no need to rebuild it from a test.)
  */
 import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { join } from "node:path";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 import { resolveConfig, type Toolchain } from "../../scripts/build/config.ts";
 import { Ninja } from "../../scripts/build/ninja.ts";
 import { emitRust, registerRustRules } from "../../scripts/build/rust.ts";
-
-const shimSource = join(import.meta.dirname, "..", "..", "scripts", "build", "rustc-metadata-shim.rs");
 
 test("the wrapper is built before cargo and reaches its env", () => {
   /** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
@@ -73,30 +75,20 @@ test("the wrapper is built before cargo and reaches its env", () => {
   expect(cargoEdge!.split("|")[1]).toContain("rustc-metadata-shim");
 });
 
-// Compiling the wrapper needs rustc. It sits next to cargo on both rustup and
-// distro installs — the same assumption registerRustRules() makes.
-const rustc = Bun.which("rustc");
+// emitRust() drops the wrapper in the build directory, which is where the bun
+// under test lives when it came from `bun bd`. A downloaded binary has no build
+// directory next to it, so CI's test lanes skip: they have no business invoking
+// a rust toolchain, and on a rustup proxy the first call downloads a channel.
+const shim = join(dirname(process.execPath), `rustc-metadata-shim${isWindows ? ".exe" : ""}`);
 
-describe.skipIf(rustc === null)("rustc metadata shim", () => {
-  let shim = "";
+describe.skipIf(!existsSync(shim))("rustc metadata shim", () => {
   let fakeRustc = "";
 
-  beforeAll(async () => {
+  beforeAll(() => {
     // Not disposed: bun:test has no `using` for suite-scoped fixtures, and the
     // OS reaps its own temp dir.
-    const dir = String(
-      tempDir("rustc-metadata-shim", { "fake-rustc.ts": `console.log(process.argv.slice(2).join("\\n"))` }),
-    );
-    shim = join(dir, "shim");
-    fakeRustc = join(dir, "fake-rustc.ts");
-
-    await using proc = Bun.spawn({
-      cmd: [rustc!, "--edition", "2024", "-Copt-level=0", "-o", shim, shimSource],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    const dir = tempDir("rustc-metadata-shim", { "fake-rustc.ts": `console.log(process.argv.slice(2).join("\\n"))` });
+    fakeRustc = join(String(dir), "fake-rustc.ts");
   });
 
   /** Run the wrapper; returns the argv it would have handed the real rustc. */

--- a/test/internal/rustc-metadata-shim.test.ts
+++ b/test/internal/rustc-metadata-shim.test.ts
@@ -1,0 +1,198 @@
+/**
+ * `RUSTC_WORKSPACE_WRAPPER` regression tests — scripts/build/rustc-metadata-shim.rs
+ * and its wiring in scripts/build/rust.ts.
+ *
+ * Cargo folds the `-C metadata` of every dependency into a unit's own, and rustc
+ * hashes that into the `Cs…` disambiguator every v0 symbol carries. Without the
+ * wrapper, a dependency-edge edit anywhere below a crate renames every symbol
+ * that crate defines — `bun_runtime`, at the top of the dependency cone, gets
+ * renamed by nearly every commit. The wrapper replaces the value with one that
+ * depends only on the unit's own identity.
+ *
+ * The graph assertions are configure-time only and run everywhere. The
+ * behavioural ones compile the wrapper, so they need a rust toolchain.
+ */
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+import { type Config, type PartialConfig, resolveConfig, type Toolchain } from "../../scripts/build/config.ts";
+import { Ninja } from "../../scripts/build/ninja.ts";
+import { emitRust, registerRustRules } from "../../scripts/build/rust.ts";
+
+const shimSource = join(import.meta.dirname, "..", "..", "scripts", "build", "rustc-metadata-shim.rs");
+
+/** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
+function mockToolchain(): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: "/fake/rust/bin/cargo",
+    cargoHome: "/fake/.cargo",
+    rustupHome: "/fake/.rustup",
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+}
+
+/** The ninja graph `emitRust` produces for a plain linux build. */
+function rustGraph(partial: PartialConfig = {}): string {
+  const cfg: Config = resolveConfig({ os: "linux", arch: "x64", buildType: "Debug", ...partial }, mockToolchain());
+  const n = new Ninja({ buildDir: cfg.buildDir });
+  registerRustRules(n, cfg);
+  emitRust(n, cfg, { codegenInputs: [], codegenOrderOnly: [], rustSources: [], vendorStamps: [] });
+  return n.toString();
+}
+
+describe("rustc metadata shim: build graph", () => {
+  test("the wrapper is built from its source and reaches cargo's env", () => {
+    const graph = rustGraph();
+    expect(graph).toContain("rule rustc_metadata_shim");
+    expect(graph).toMatch(/^build rustc-metadata-shim: rustc_metadata_shim \S*rustc-metadata-shim\.rs$/m);
+    // `_WORKSPACE_`, not plain RUSTC_WRAPPER: registry crates keep cargo's
+    // collision-proof hash, only our own crates get a pinned one.
+    expect(graph).toContain("--env=RUSTC_WORKSPACE_WRAPPER=");
+    expect(graph).not.toContain("--env=RUSTC_WRAPPER=");
+  });
+
+  test("cargo cannot run before the wrapper exists", () => {
+    // ninja wraps long build lines with a trailing `$`; join them back up.
+    const cargoEdge = rustGraph()
+      .replace(/\$\n\s+/g, " ")
+      .split("\n")
+      .find(line => line.startsWith("build ") && line.includes("libbun_rust.a:"));
+    expect(cargoEdge).toBeDefined();
+    // Implicit inputs come after the `|`.
+    expect(cargoEdge!.split("|")[1]).toContain("rustc-metadata-shim");
+  });
+});
+
+// Compiling the wrapper needs rustc. It sits next to cargo on both rustup and
+// distro installs — the same assumption registerRustRules() makes.
+const rustc = Bun.which("rustc");
+
+describe.skipIf(rustc === null)("rustc metadata shim: rewriting", () => {
+  /** Compile the wrapper, next to a fake `rustc` that just echoes its argv. */
+  async function compileShim(dir: string) {
+    const shim = join(dir, "shim");
+    await using proc = Bun.spawn({
+      cmd: [rustc!, "--edition", "2024", "-Copt-level=0", "-o", shim, shimSource],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    return shim;
+  }
+
+  /** Run the wrapper; returns the argv it would have handed the real rustc. */
+  async function argvFor(dir: string, shim: string, args: string[], pkg = "bun_runtime") {
+    await using proc = Bun.spawn({
+      // The wrapper's first argument is always rustc's path — that's cargo's contract.
+      cmd: [shim, bunExe(), join(dir, "fake-rustc.ts"), ...args],
+      env: { ...bunEnv, CARGO_PKG_NAME: pkg, CARGO_PKG_VERSION: "0.0.0" },
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    return stdout.split("\n").filter(Boolean);
+  }
+
+  /** The `-C metadata=…` value the wrapper handed down. */
+  function metadataOf(argv: string[]): string | undefined {
+    for (let i = 0; i + 1 < argv.length; i++) {
+      if (argv[i] === "-C" && argv[i + 1]!.startsWith("metadata=")) return argv[i + 1]!.slice("metadata=".length);
+    }
+    return undefined;
+  }
+
+  function fixture() {
+    return tempDir("rustc-metadata-shim", {
+      "fake-rustc.ts": `console.log(process.argv.slice(2).join("\\n"));`,
+    });
+  }
+
+  const unit = [
+    "--crate-name",
+    "bun_runtime",
+    "--edition=2024",
+    "--crate-type",
+    "lib",
+    "--cfg",
+    'feature="default"',
+    "--target",
+    "x86_64-unknown-linux-gnu",
+  ];
+  const pinned = "bun/bun_runtime@0.0.0/x86_64-unknown-linux-gnu/lib/default";
+
+  test("two dependency-graph states collapse to the same metadata", async () => {
+    using dir = fixture();
+    const shim = await compileShim(String(dir));
+    // The only difference is cargo's dependency hash — exactly what moves when a
+    // crate anywhere below this one gains or loses a dependency.
+    const before = await argvFor(String(dir), shim, [...unit, "-C", "metadata=4e6e51e9e0da5e6b"]);
+    const after = await argvFor(String(dir), shim, [...unit, "-C", "metadata=9c1d0ab7735ffd12"]);
+
+    expect(metadataOf(before)).toBe(pinned);
+    expect(metadataOf(after)).toBe(pinned);
+  });
+
+  test("distinct units keep distinct metadata", async () => {
+    using dir = fixture();
+    const shim = await compileShim(String(dir));
+    const pin = async (args: string[], pkg?: string) => metadataOf(await argvFor(String(dir), shim, args, pkg));
+
+    const runtime = await pin([...unit, "-C", "metadata=aaaa"]);
+    const core = await pin([...unit, "-C", "metadata=aaaa"], "bun_core");
+    const features = await pin([...unit, "--cfg", 'feature="show_crash_trace"', "-C", "metadata=aaaa"]);
+    // Build scripts compile for the host, so no `--target` reaches rustc.
+    const buildScript = await pin(
+      ["--crate-name", "build_script_build", "--crate-type", "bin", "-C", "metadata=aaaa"],
+      "bun_core",
+    );
+
+    expect(runtime).toBe(pinned);
+    expect(buildScript).toBe("bun/bun_core@0.0.0/host/bin/");
+    expect(new Set([runtime, core, features, buildScript]).size).toBe(4);
+  });
+
+  test("only -C metadata is rewritten; everything else passes through", async () => {
+    using dir = fixture();
+    const shim = await compileShim(String(dir));
+    const args = [...unit, "-C", "extra-filename=-4e6e51e9e0da5e6b", "-C", "metadata=4e6e51e9e0da5e6b", "lib.rs"];
+
+    // `extra-filename` keys cargo's on-disk artifact names — leaving it alone is
+    // what keeps two dependency-graph states from clobbering each other's rlibs.
+    expect(await argvFor(String(dir), shim, args)).toEqual(
+      args.map(arg => (arg === "metadata=4e6e51e9e0da5e6b" ? `metadata=${pinned}` : arg)),
+    );
+  });
+
+  test("an invocation without -C metadata passes through untouched", async () => {
+    using dir = fixture();
+    const shim = await compileShim(String(dir));
+    // cargo probes the wrapper with `-vV` / `--print` before it compiles anything.
+    expect(await argvFor(String(dir), shim, ["-vV"])).toEqual(["-vV"]);
+    expect(await argvFor(String(dir), shim, ["--print", "cfg"])).toEqual(["--print", "cfg"]);
+  });
+});

--- a/test/internal/rustc-metadata-shim.test.ts
+++ b/test/internal/rustc-metadata-shim.test.ts
@@ -99,8 +99,11 @@ describe.skipIf(!existsSync(shim))("rustc metadata shim", () => {
       env: { ...bunEnv, CARGO_PKG_NAME: pkg },
       stderr: "pipe",
     });
+    // stderr is drained so the pipe can't fill, but not asserted empty — a debug
+    // or ASAN bun writes benign noise there. It does carry the wrapper's own
+    // failure message, so surface it when the exit code is wrong.
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    if (exitCode !== 0) throw new Error(`wrapper exited ${exitCode}\n${stderr}`);
     return stdout.split("\n").filter(Boolean);
   }
 

--- a/test/internal/rustc-metadata-shim.test.ts
+++ b/test/internal/rustc-metadata-shim.test.ts
@@ -1,30 +1,29 @@
 /**
- * `RUSTC_WORKSPACE_WRAPPER` regression tests — scripts/build/rustc-metadata-shim.rs
+ * Regression tests for the `-C metadata` pin — scripts/build/rustc-metadata-shim.rs
  * and its wiring in scripts/build/rust.ts.
  *
  * Cargo folds the `-C metadata` of every dependency into a unit's own, and rustc
  * hashes that into the `Cs…` disambiguator every v0 symbol carries. Without the
  * wrapper, a dependency-edge edit anywhere below a crate renames every symbol
- * that crate defines — `bun_runtime`, at the top of the dependency cone, gets
- * renamed by nearly every commit. The wrapper replaces the value with one that
- * depends only on the unit's own identity.
+ * that crate defines — `bun_runtime`, with ~100 direct workspace deps, was
+ * renamed by nearly every commit.
  *
- * The graph assertions are configure-time only and run everywhere. The
+ * The graph assertion is configure-time only and runs everywhere. The
  * behavioural ones compile the wrapper, so they need a rust toolchain.
  */
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
-import { type Config, type PartialConfig, resolveConfig, type Toolchain } from "../../scripts/build/config.ts";
+import { resolveConfig, type Toolchain } from "../../scripts/build/config.ts";
 import { Ninja } from "../../scripts/build/ninja.ts";
 import { emitRust, registerRustRules } from "../../scripts/build/rust.ts";
 
 const shimSource = join(import.meta.dirname, "..", "..", "scripts", "build", "rustc-metadata-shim.rs");
 
-/** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
-function mockToolchain(): Toolchain {
-  return {
+test("the wrapper is built before cargo and reaches its env", () => {
+  /** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
+  const toolchain: Toolchain = {
     cc: "/fake/llvm/bin/clang",
     cxx: "/fake/llvm/bin/clang++",
     clangVersion: "21.1.8",
@@ -53,146 +52,90 @@ function mockToolchain(): Toolchain {
     mt: undefined,
     nasm: undefined,
   };
-}
-
-/** The ninja graph `emitRust` produces for a plain linux build. */
-function rustGraph(partial: PartialConfig = {}): string {
-  const cfg: Config = resolveConfig({ os: "linux", arch: "x64", buildType: "Debug", ...partial }, mockToolchain());
+  const cfg = resolveConfig({ os: "linux", arch: "x64", buildType: "Debug" }, toolchain);
   const n = new Ninja({ buildDir: cfg.buildDir });
   registerRustRules(n, cfg);
   emitRust(n, cfg, { codegenInputs: [], codegenOrderOnly: [], rustSources: [], vendorStamps: [] });
-  return n.toString();
-}
+  // ninja wraps long build lines with a trailing `$`; join them back up.
+  const graph = n.toString().replace(/\$\n\s+/g, " ");
 
-describe("rustc metadata shim: build graph", () => {
-  test("the wrapper is built from its source and reaches cargo's env", () => {
-    const graph = rustGraph();
-    expect(graph).toContain("rule rustc_metadata_shim");
-    expect(graph).toMatch(/^build rustc-metadata-shim: rustc_metadata_shim \S*rustc-metadata-shim\.rs$/m);
-    // `_WORKSPACE_`, not plain RUSTC_WRAPPER: registry crates keep cargo's
-    // collision-proof hash, only our own crates get a pinned one.
-    expect(graph).toContain("--env=RUSTC_WORKSPACE_WRAPPER=");
-    expect(graph).not.toContain("--env=RUSTC_WRAPPER=");
-  });
+  // `.exe` on a Windows host: the wrapper is a host executable, and the host
+  // isn't the linux target asked for above.
+  expect(graph).toMatch(/^build rustc-metadata-shim(\.exe)?: rustc_metadata_shim \S*rustc-metadata-shim\.rs\b/m);
+  // `_WORKSPACE_`, not plain RUSTC_WRAPPER: registry crates keep cargo's
+  // collision-proof hash, only our own crates get a pinned one.
+  expect(graph).toContain("--env=RUSTC_WORKSPACE_WRAPPER=");
+  expect(graph).not.toContain("--env=RUSTC_WRAPPER=");
 
-  test("cargo cannot run before the wrapper exists", () => {
-    // ninja wraps long build lines with a trailing `$`; join them back up.
-    const cargoEdge = rustGraph()
-      .replace(/\$\n\s+/g, " ")
-      .split("\n")
-      .find(line => line.startsWith("build ") && line.includes("libbun_rust.a:"));
-    expect(cargoEdge).toBeDefined();
-    // Implicit inputs come after the `|`.
-    expect(cargoEdge!.split("|")[1]).toContain("rustc-metadata-shim");
-  });
+  const cargoEdge = graph.split("\n").find(line => line.startsWith("build ") && line.includes("libbun_rust.a:"));
+  expect(cargoEdge).toBeDefined();
+  // Implicit inputs come after the `|` — cargo can't run before the wrapper exists.
+  expect(cargoEdge!.split("|")[1]).toContain("rustc-metadata-shim");
 });
 
 // Compiling the wrapper needs rustc. It sits next to cargo on both rustup and
 // distro installs — the same assumption registerRustRules() makes.
 const rustc = Bun.which("rustc");
 
-describe.skipIf(rustc === null)("rustc metadata shim: rewriting", () => {
-  /** Compile the wrapper, next to a fake `rustc` that just echoes its argv. */
-  async function compileShim(dir: string) {
-    const shim = join(dir, "shim");
+describe.skipIf(rustc === null)("rustc metadata shim", () => {
+  let shim = "";
+  let fakeRustc = "";
+
+  beforeAll(async () => {
+    // Not disposed: bun:test has no `using` for suite-scoped fixtures, and the
+    // OS reaps its own temp dir.
+    const dir = String(
+      tempDir("rustc-metadata-shim", { "fake-rustc.ts": `console.log(process.argv.slice(2).join("\\n"))` }),
+    );
+    shim = join(dir, "shim");
+    fakeRustc = join(dir, "fake-rustc.ts");
+
     await using proc = Bun.spawn({
       cmd: [rustc!, "--edition", "2024", "-Copt-level=0", "-o", shim, shimSource],
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
-    return shim;
-  }
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
 
   /** Run the wrapper; returns the argv it would have handed the real rustc. */
-  async function argvFor(dir: string, shim: string, args: string[], pkg = "bun_runtime") {
+  async function argvFor(args: string[], pkg = "bun_runtime") {
     await using proc = Bun.spawn({
       // The wrapper's first argument is always rustc's path — that's cargo's contract.
-      cmd: [shim, bunExe(), join(dir, "fake-rustc.ts"), ...args],
-      env: { ...bunEnv, CARGO_PKG_NAME: pkg, CARGO_PKG_VERSION: "0.0.0" },
+      cmd: [shim, bunExe(), fakeRustc, ...args],
+      env: { ...bunEnv, CARGO_PKG_NAME: pkg },
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
     return stdout.split("\n").filter(Boolean);
   }
 
-  /** The `-C metadata=…` value the wrapper handed down. */
-  function metadataOf(argv: string[]): string | undefined {
-    for (let i = 0; i + 1 < argv.length; i++) {
-      if (argv[i] === "-C" && argv[i + 1]!.startsWith("metadata=")) return argv[i + 1]!.slice("metadata=".length);
-    }
-    return undefined;
-  }
-
-  function fixture() {
-    return tempDir("rustc-metadata-shim", {
-      "fake-rustc.ts": `console.log(process.argv.slice(2).join("\\n"));`,
-    });
-  }
-
-  const unit = [
-    "--crate-name",
-    "bun_runtime",
-    "--edition=2024",
-    "--crate-type",
-    "lib",
-    "--cfg",
-    'feature="default"',
-    "--target",
-    "x86_64-unknown-linux-gnu",
-  ];
-  const pinned = "bun/bun_runtime@0.0.0/x86_64-unknown-linux-gnu/lib/default";
+  const unit = ["--crate-name", "bun_runtime", "--crate-type", "lib", "--target", "x86_64-unknown-linux-gnu"];
 
   test("two dependency-graph states collapse to the same metadata", async () => {
-    using dir = fixture();
-    const shim = await compileShim(String(dir));
     // The only difference is cargo's dependency hash — exactly what moves when a
-    // crate anywhere below this one gains or loses a dependency.
-    const before = await argvFor(String(dir), shim, [...unit, "-C", "metadata=4e6e51e9e0da5e6b"]);
-    const after = await argvFor(String(dir), shim, [...unit, "-C", "metadata=9c1d0ab7735ffd12"]);
+    // crate anywhere below this one gains or loses a dependency. `extra-filename`
+    // must survive: it keys cargo's on-disk artifact names.
+    const before = [...unit, "-C", "extra-filename=-4e6e51e9e0da5e6b", "-C", "metadata=4e6e51e9e0da5e6b", "lib.rs"];
+    const after = [...unit, "-C", "extra-filename=-9c1d0ab7735ffd12", "-C", "metadata=9c1d0ab7735ffd12", "lib.rs"];
 
-    expect(metadataOf(before)).toBe(pinned);
-    expect(metadataOf(after)).toBe(pinned);
+    expect(await argvFor(before)).toEqual(
+      before.map(arg => (arg.startsWith("metadata=") ? "metadata=bun.bun_runtime" : arg)),
+    );
+    expect(await argvFor(after)).toEqual(
+      after.map(arg => (arg.startsWith("metadata=") ? "metadata=bun.bun_runtime" : arg)),
+    );
   });
 
-  test("distinct units keep distinct metadata", async () => {
-    using dir = fixture();
-    const shim = await compileShim(String(dir));
-    const pin = async (args: string[], pkg?: string) => metadataOf(await argvFor(String(dir), shim, args, pkg));
-
-    const runtime = await pin([...unit, "-C", "metadata=aaaa"]);
-    const core = await pin([...unit, "-C", "metadata=aaaa"], "bun_core");
-    const features = await pin([...unit, "--cfg", 'feature="show_crash_trace"', "-C", "metadata=aaaa"]);
-    // Build scripts compile for the host, so no `--target` reaches rustc.
-    const buildScript = await pin(
-      ["--crate-name", "build_script_build", "--crate-type", "bin", "-C", "metadata=aaaa"],
-      "bun_core",
-    );
-
-    expect(runtime).toBe(pinned);
-    expect(buildScript).toBe("bun/bun_core@0.0.0/host/bin/");
-    expect(new Set([runtime, core, features, buildScript]).size).toBe(4);
-  });
-
-  test("only -C metadata is rewritten; everything else passes through", async () => {
-    using dir = fixture();
-    const shim = await compileShim(String(dir));
-    const args = [...unit, "-C", "extra-filename=-4e6e51e9e0da5e6b", "-C", "metadata=4e6e51e9e0da5e6b", "lib.rs"];
-
-    // `extra-filename` keys cargo's on-disk artifact names — leaving it alone is
-    // what keeps two dependency-graph states from clobbering each other's rlibs.
-    expect(await argvFor(String(dir), shim, args)).toEqual(
-      args.map(arg => (arg === "metadata=4e6e51e9e0da5e6b" ? `metadata=${pinned}` : arg)),
-    );
+  test("distinct packages keep distinct metadata", async () => {
+    expect(await argvFor([...unit, "-C", "metadata=aaaa"], "bun_core")).toContain("metadata=bun.bun_core");
   });
 
   test("an invocation without -C metadata passes through untouched", async () => {
-    using dir = fixture();
-    const shim = await compileShim(String(dir));
     // cargo probes the wrapper with `-vV` / `--print` before it compiles anything.
-    expect(await argvFor(String(dir), shim, ["-vV"])).toEqual(["-vV"]);
-    expect(await argvFor(String(dir), shim, ["--print", "cfg"])).toEqual(["--print", "cfg"]);
+    expect(await argvFor(["-vV"])).toEqual(["-vV"]);
+    expect(await argvFor(["--print", "cfg"])).toEqual(["--print", "cfg"]);
   });
 });

--- a/test/internal/rustc-metadata-shim.test.ts
+++ b/test/internal/rustc-metadata-shim.test.ts
@@ -114,7 +114,7 @@ describe.skipIf(rustc === null)("rustc metadata shim", () => {
 
   const unit = ["--crate-name", "bun_runtime", "--crate-type", "lib", "--target", "x86_64-unknown-linux-gnu"];
 
-  test("two dependency-graph states collapse to the same metadata", async () => {
+  test.concurrent("two dependency-graph states collapse to the same metadata", async () => {
     // The only difference is cargo's dependency hash — exactly what moves when a
     // crate anywhere below this one gains or loses a dependency. `extra-filename`
     // must survive: it keys cargo's on-disk artifact names.
@@ -129,11 +129,11 @@ describe.skipIf(rustc === null)("rustc metadata shim", () => {
     );
   });
 
-  test("distinct packages keep distinct metadata", async () => {
+  test.concurrent("distinct packages keep distinct metadata", async () => {
     expect(await argvFor([...unit, "-C", "metadata=aaaa"], "bun_core")).toContain("metadata=bun.bun_core");
   });
 
-  test("an invocation without -C metadata passes through untouched", async () => {
+  test.concurrent("an invocation without -C metadata passes through untouched", async () => {
     // cargo probes the wrapper with `-vV` / `--print` before it compiles anything.
     expect(await argvFor(["-vV"])).toEqual(["-vV"]);
     expect(await argvFor(["--print", "cfg"])).toEqual(["--print", "cfg"]);


### PR DESCRIPTION
`bun_runtime`'s Rust symbol disambiguator changes on nearly every build, so a symbol like

```
_RNvNtNtCs4EG9u9StnXu_11bun_runtime3cli7command15boot_standalone
```

does not exist under that name in the next build. Nothing is wrong with the shipped binary, but anything keyed on symbol names *across* two builds silently loses the crate: reusing an lld `--symbol-ordering-file` from an earlier build, sccache hits, and symbolicating an old profile against a new binary.

## Cause

Cargo's `-C metadata` for a unit mixes in the sorted `-C metadata` of every one of its dependencies (`compute_metadata` in `compilation_files.rs`), and rustc hashes `-C metadata` into the `StableCrateId` that every v0 symbol carries. So a dependency-edge edit *anywhere below a crate* renames every symbol that crate defines.

`bun_runtime` has direct dependencies on ~100 workspace crates, so it is renamed by almost every commit. `bun_core`, `bun_bunfig` and `bun_js_parser` sit near the bottom of the graph and so never move. It is not `build.rs`, the git sha, or the workspace version: RUSTFLAGS and the profile are deliberately excluded from `-C metadata` (cargo hashes them into `-C extra-filename` only), and `-C metadata` is computed before any build script runs.

Concretely, between two adjacent canary builds `bun_sql_jsc` dropped its `bun_wyhash` dependency. That rotated `bun_sql_jsc`'s `-C metadata`, which rotated `bun_runtime`'s and `bun_rust`'s.

## Fix

A `RUSTC_WORKSPACE_WRAPPER` (`scripts/build/rustc-metadata-shim.rs`) replaces cargo's value with one derived only from the unit's own identity:

```
bun/bun_runtime@0.0.0/x86_64-unknown-linux-gnu/lib/default
```

That is everything in cargo's hash that identifies the compilation unit (package, version, target, crate types, features), minus the dependency hash that churns. Symbols stay unique because rustc mixes the crate name into `StableCrateId` independently of `-C metadata`, and no two workspace packages share a name.

Notes on the shape of the fix:

- **`_WORKSPACE_`, not plain `RUSTC_WRAPPER`.** Cargo applies it to workspace members only, which is exactly the set whose names we care about; registry crates (where two versions of one crate name can coexist) keep cargo's collision-proof hash. `cargo clippy` sets this variable itself, so it keeps working.
- **A wrapper is the only lever.** Cargo has no knob for this, and rustc sorts/dedups/hashes *every* `-C metadata` it is handed, so an extra one from RUSTFLAGS does not shadow cargo's — verified, it produces a third value that still rotates.
- **`-C extra-filename` is left alone**, so cargo's on-disk artifact names stay unique across dependency-graph states.
- It is built by a bare `rustc` rather than cargo: the wrapper has to exist before cargo runs, so it can't be a workspace member, and one host `.rs` is cheaper than a second cargo invocation. `rustc` sits next to `cargo`, the same assumption `findRustup()` already makes.

One-time cost: the wrapper's path is part of cargo's fingerprint for workspace members, so the first build after this lands recompiles bun's own crates.

## Verification

Re-applying the exact `bun_sql_jsc` dependency edit on a debug linux-x64 build:

| crate | unpinned (before → after) | pinned |
| --- | --- | --- |
| `bun_runtime` | `CsduDwerHUqXv` → `CscY7r8IXUlgZ` | unchanged |
| `bun_sql_jsc` | `Cs9HsfIadT9o5` → `Cs1w60FSEQOrU` | unchanged |
| `bun_core` | `CsbzcMvzFcEb5` → `CsbzcMvzFcEb5` | unchanged |

<details>
<summary>Commands</summary>

```sh
# with and without the bun_wyhash edge on bun_sql_jsc
ninja -C build/debug bun-rust
llvm-nm --defined-only build/debug/rust-target/x86_64-unknown-linux-gnu/debug/libbun_rust.a \
  | grep -oE 'Cs[A-Za-z0-9]+_11bun_runtime\b' | sort -u
```

</details>

`bun bd` links and runs, and the binary carries exactly one `bun_runtime` disambiguator.

`test/internal/rustc-metadata-shim.test.ts` covers the ninja wiring (everywhere) and the wrapper's rewriting (where rustc is available): two different cargo metadata hashes collapse to the same pinned value, distinct units keep distinct values, `-C extra-filename` and every other argument pass through, and an invocation with no `-C metadata` (cargo's `-vV` / `--print` probes) is untouched.
