### PR TITLE
ffi: u32 and i64_fast returns of 2 ** 31 arrive in JS as -2147483648

### DIFF
--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -89,8 +89,11 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 #define TagValueNull             (OtherTag)
 #define NotCellMask  (int64_t)(NumberTag | OtherTag)
 
-#define MAX_INT32 2147483648
-#define MAX_INT52 9007199254740991
+// Smallest and largest values representable as a signed 32-bit integer.
+#define MIN_INT32 -2147483648
+#define MAX_INT32 2147483647
+// Number.MAX_SAFE_INTEGER: the largest integer a double holds exactly.
+#define MAX_SAFE_INTEGER 9007199254740991
 
 // If all bits in the mask are set, this indicates an integer number,
 // if any but not all are set this value is a double precision number.
@@ -349,11 +352,11 @@ static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
-  if (val < MAX_INT32) {
+  if (val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
-  if (val < MAX_INT52) {
+  if (val <= MAX_SAFE_INTEGER) {
     return DOUBLE_TO_JSVALUE((double)val);
   }
 
@@ -361,11 +364,11 @@ static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
 }
 
 static EncodedJSValue INT64_TO_JSVALUE(void* jsGlobalObject, int64_t val) {
-  if (val >= -MAX_INT32 && val <= MAX_INT32) {
+  if (val >= MIN_INT32 && val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
-  if (val >= -MAX_INT52 && val <= MAX_INT52) {
+  if (val >= -MAX_SAFE_INTEGER && val <= MAX_SAFE_INTEGER) {
     return DOUBLE_TO_JSVALUE((double)val);
   }
 

--- a/test/js/bun/ffi/ffi.test.fixture.callback.c
+++ b/test/js/bun/ffi/ffi.test.fixture.callback.c
@@ -91,8 +91,11 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 #define TagValueNull             (OtherTag)
 #define NotCellMask  (int64_t)(NumberTag | OtherTag)
 
-#define MAX_INT32 2147483648
-#define MAX_INT52 9007199254740991
+// Smallest and largest values representable as a signed 32-bit integer.
+#define MIN_INT32 -2147483648
+#define MAX_INT32 2147483647
+// Number.MAX_SAFE_INTEGER: the largest integer a double holds exactly.
+#define MAX_SAFE_INTEGER 9007199254740991
 
 // If all bits in the mask are set, this indicates an integer number,
 // if any but not all are set this value is a double precision number.
@@ -351,11 +354,11 @@ static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
-  if (val < MAX_INT32) {
+  if (val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
-  if (val < MAX_INT52) {
+  if (val <= MAX_SAFE_INTEGER) {
     return DOUBLE_TO_JSVALUE((double)val);
   }
 
@@ -363,11 +366,11 @@ static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
 }
 
 static EncodedJSValue INT64_TO_JSVALUE(void* jsGlobalObject, int64_t val) {
-  if (val >= -MAX_INT32 && val <= MAX_INT32) {
+  if (val >= MIN_INT32 && val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
-  if (val >= -MAX_INT52 && val <= MAX_INT52) {
+  if (val >= -MAX_SAFE_INTEGER && val <= MAX_SAFE_INTEGER) {
     return DOUBLE_TO_JSVALUE((double)val);
   }
 

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -91,8 +91,11 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 #define TagValueNull             (OtherTag)
 #define NotCellMask  (int64_t)(NumberTag | OtherTag)
 
-#define MAX_INT32 2147483648
-#define MAX_INT52 9007199254740991
+// Smallest and largest values representable as a signed 32-bit integer.
+#define MIN_INT32 -2147483648
+#define MAX_INT32 2147483647
+// Number.MAX_SAFE_INTEGER: the largest integer a double holds exactly.
+#define MAX_SAFE_INTEGER 9007199254740991
 
 // If all bits in the mask are set, this indicates an integer number,
 // if any but not all are set this value is a double precision number.
@@ -351,11 +354,11 @@ static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
-  if (val < MAX_INT32) {
+  if (val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
-  if (val < MAX_INT52) {
+  if (val <= MAX_SAFE_INTEGER) {
     return DOUBLE_TO_JSVALUE((double)val);
   }
 
@@ -363,11 +366,11 @@ static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
 }
 
 static EncodedJSValue INT64_TO_JSVALUE(void* jsGlobalObject, int64_t val) {
-  if (val >= -MAX_INT32 && val <= MAX_INT32) {
+  if (val >= MIN_INT32 && val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
-  if (val >= -MAX_INT52 && val <= MAX_INT52) {
+  if (val >= -MAX_SAFE_INTEGER && val <= MAX_SAFE_INTEGER) {
     return DOUBLE_TO_JSVALUE((double)val);
   }
 

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1142,7 +1142,10 @@ describe("integer boxing at the int32 boundary", () => {
         compile.stderr.text(),
         compile.exited,
       ]);
-      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+      // Only the exit code decides: a toolchain is free to warn on stderr.
+      if (exitCode !== 0) {
+        throw new Error(`${compiler} exited with ${exitCode} building echo.c\n${stdout}${stderr}`);
+      }
 
       lib = _dlopen(library, {
         echo_u32: { args: ["u32"], returns: "u32" },

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1089,13 +1089,13 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
 
 // FFI.h boxes a native integer as a JS int32 whenever it fits in one, so 2 ** 31
 // and Number.MAX_SAFE_INTEGER are the values that pick the wrong branch.
-describe("integer boxing at the int32 boundary", () => {
+describe.skipIf(isFFIUnavailable)("integer boxing at the int32 boundary", () => {
   const u32Values = [0, 1, 2147483647, 2147483648, 2147483649, 4294967294, 4294967295];
   const i64Values = [-9007199254740991, -2147483649, -2147483648, -1, 0, 2147483647, 2147483648, 9007199254740991];
   const u64Values = [0, 2147483647, 2147483648, 2147483649, 9007199254740990, 9007199254740991];
 
   // A callback's arguments are boxed by the same macros as a function's return
-  // value, and this needs no C compiler, so it runs wherever bun:ffi does.
+  // value, and this needs no external C compiler, so it covers Windows too.
   it.each([
     ["u32", u32Values],
     ["i64_fast", i64Values],
@@ -1113,7 +1113,9 @@ describe("integer boxing at the int32 boundary", () => {
     expect(received).toEqual(values);
   });
 
-  const compiler = Bun.which("cc") ?? Bun.which("gcc") ?? Bun.which("clang");
+  // `cc -shared -fPIC` is a POSIX invocation; the callback cases above are what
+  // cover Windows.
+  const compiler = isWindows ? undefined : (Bun.which("cc") ?? Bun.which("gcc") ?? Bun.which("clang"));
 
   describe.skipIf(!compiler)("returns", () => {
     let dir;

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1,7 +1,8 @@
-import { afterAll, describe, expect, it } from "bun:test";
-import { existsSync } from "fs";
-import { bunEnv, bunExe, isArm64, isGlibcVersionAtLeast, isWindows, tempDir } from "harness";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, rmSync } from "fs";
+import { bunEnv, bunExe, isArm64, isGlibcVersionAtLeast, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { platform } from "os";
+import { join } from "path";
 
 import {
   dlopen as _dlopen,
@@ -1084,4 +1085,87 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
       expect(lib.symbols.strlen(Buffer.from("bunbun\0", "ascii"))).toBe(6n);
     });
   }
+});
+
+// FFI.h boxes a native integer as a JS int32 whenever it fits in one, so 2 ** 31
+// and Number.MAX_SAFE_INTEGER are the values that pick the wrong branch.
+describe("integer boxing at the int32 boundary", () => {
+  const u32Values = [0, 1, 2147483647, 2147483648, 2147483649, 4294967294, 4294967295];
+  const i64Values = [-9007199254740991, -2147483649, -2147483648, -1, 0, 2147483647, 2147483648, 9007199254740991];
+  const u64Values = [0, 2147483647, 2147483648, 2147483649, 9007199254740990, 9007199254740991];
+
+  // A callback's arguments are boxed by the same macros as a function's return
+  // value, and this needs no C compiler, so it runs wherever bun:ffi does.
+  it.each([
+    ["u32", u32Values],
+    ["i64_fast", i64Values],
+    ["u64_fast", u64Values],
+  ])("passes %s callback arguments to JavaScript unchanged", (type, values) => {
+    const received = [];
+    const callback = new JSCallback(value => void received.push(value), { args: [type], returns: "void" });
+    const call = CFunction({ ptr: callback.ptr, args: [type], returns: "void" });
+    try {
+      for (const value of values) call(value);
+    } finally {
+      call.close();
+      callback.close();
+    }
+    expect(received).toEqual(values);
+  });
+
+  const compiler = Bun.which("cc") ?? Bun.which("gcc") ?? Bun.which("clang");
+
+  describe.skipIf(!compiler)("returns", () => {
+    let dir;
+    let lib;
+
+    beforeAll(async () => {
+      dir = tempDirWithFiles("ffi-int32-boundary", {
+        "echo.c": [
+          "#include <stdint.h>",
+          "uint32_t echo_u32(uint32_t value) { return value; }",
+          "int64_t echo_i64(int64_t value) { return value; }",
+          "uint64_t echo_u64(uint64_t value) { return value; }",
+        ].join("\n"),
+      });
+
+      const library = join(dir, `libecho.${suffix}`);
+      await using compile = Bun.spawn({
+        cmd: [compiler, "-shared", "-fPIC", "-o", library, "echo.c"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        compile.stdout.text(),
+        compile.stderr.text(),
+        compile.exited,
+      ]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+      lib = _dlopen(library, {
+        echo_u32: { args: ["u32"], returns: "u32" },
+        echo_i64: { args: ["i64_fast"], returns: "i64_fast" },
+        echo_u64: { args: ["u64_fast"], returns: "u64_fast" },
+      });
+    });
+
+    afterAll(() => {
+      lib?.close();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("uint32_t", () => {
+      expect(u32Values.map(value => lib.symbols.echo_u32(value))).toEqual(u32Values);
+    });
+
+    it("int64_t", () => {
+      expect(i64Values.map(value => lib.symbols.echo_i64(value))).toEqual(i64Values);
+    });
+
+    it("uint64_t", () => {
+      expect(u64Values.map(value => lib.symbols.echo_u64(value))).toEqual(u64Values);
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

`bun:ffi` corrupts a `u32` return value of exactly `2147483648` (`0x80000000`), handing JavaScript `-2147483648` instead. Every other `uint32_t` round-trips.

```js
// uint32_t echo_u32(uint32_t x) { return x; }
const { symbols } = dlopen(lib, { echo_u32: { args: ["u32"], returns: "u32" } });

symbols.echo_u32(2147483647); // 2147483647
symbols.echo_u32(2147483648); // -2147483648   <- wrong
symbols.echo_u32(2147483649); // 2147483649
```

#### Cause

`FFI.h` defines `MAX_INT32` as `2147483648`, which is `INT32_MAX + 1`:

```c
#define MAX_INT32 2147483648
#define MAX_INT52 9007199254740991
```

`UINT32_TO_JSVALUE` boxes anything `<= MAX_INT32` as an int32, so the one value with only the sign bit set takes the int32 branch and JSC decodes `INT32_MIN`. `INT64_TO_JSVALUE` has the same `val <= MAX_INT32` guard, so `i64_fast` returns of `2 ** 31` corrupt identically (the C cast `(int32_t)2147483648` wraps). `u64_fast` escapes only because `UINT64_TO_JSVALUE` happened to use a strict `<`.

The names are also the other way around one line down: `MAX_INT52` holds `Number.MAX_SAFE_INTEGER` (`2 ** 53 - 1`), and `UINT64_TO_JSVALUE` compares it with a strict `<`, so `u64_fast` returns a `BigInt` for exactly `9007199254740991` while `i64_fast` returns a `number` for the same value.

#### Fix

Name the constants for the values they actually hold, and use the matching comparisons:

```c
#define MIN_INT32 -2147483648
#define MAX_INT32 2147483647
#define MAX_SAFE_INTEGER 9007199254740991
```

`UINT32_TO_JSVALUE`'s existing `val <= MAX_INT32` becomes correct on its own. `UINT64_TO_JSVALUE`'s `val < MAX_INT32` becomes `val <= MAX_INT32` (identical set of values, now readable), its safe-integer bound becomes inclusive, and `INT64_TO_JSVALUE` keeps `INT32_MIN` on the int32 fast path via `MIN_INT32` instead of `-MAX_INT32`.

This is the same change as 099d2dfe8 on the unmerged `ben/fix-ffi-test` branch, which never landed.

#### Relation to #31449

[#31449](https://github.com/oven-sh/bun/pull/31449) contains a fix for the `UINT32_TO_JSVALUE` / `INT64_TO_JSVALUE` half of this, bundled with about ten unrelated FFI fixes. It patches the two comparisons to strict `<` and leaves `MAX_INT32` holding `2 ** 31`; it does not touch the `u64_fast` safe-integer boundary, and its regression test uses `cc()`, which is `skipIf(isASAN)` and therefore never runs in CI. This PR is the FFI.h slice only, root-caused at the constants, with a test that runs everywhere `bun:ffi` does. Happy to close this if #31449 lands first.

Related: [#7007](https://github.com/oven-sh/bun/issues/7007) (the argument direction of the same boundary, already worked around in `src/js/bun/ffi.ts`).

### How did you verify your code works?

Added `integer boxing at the int32 boundary` to `test/js/bun/ffi/ffi.test.js`, covering both directions of the macros:

- `returns` — compiles a three-function shared library and `dlopen`s it, checking `uint32_t`, `int64_t` and `uint64_t` returns across `0`, `2 ** 31 - 1`, `2 ** 31`, `2 ** 31 + 1`, `2 ** 32 - 1`, `±Number.MAX_SAFE_INTEGER`.
- `callback arguments` — a callback's arguments are boxed by the same macros as a function's return value, and that path needs no C compiler, so it also covers Windows, where the compiled-library test is skipped.

All 6 assertions fail on `main` and pass with the fix:

<details>
<summary><code>USE_SYSTEM_BUN=1 bun test test/js/bun/ffi/ffi.test.js -t "int32 boundary"</code> (before)</summary>

```
  [
    0,
    2147483647,
-   2147483648,
+   -2147483648,
    9007199254740991,
  ]
(fail) integer boxing at the int32 boundary > returns > int64_t
(fail) integer boxing at the int32 boundary > returns > uint64_t

 0 pass
 6 fail
```

</details>

```
$ bun bd test test/js/bun/ffi/ffi.test.js
 6 pass
 0 fail
```

The two `ffi.test.fixture.*.c` files in the diff are `viewSource` output, rewritten by the `ffi print` test that already exists in that file.
