### PR TITLE
build: trace bun install and an interactive CLI for the symbol order file

### DIFF
--- a/scripts/orderfile/cli-fixture.js
+++ b/scripts/orderfile/cli-fixture.js
@@ -1,0 +1,30 @@
+// The interactive workload for scripts/orderfile/generate.ts. Reads stdin,
+// writes stdout, drives readline. Traced twice: once on a pipe, once on a
+// terminal (ptyrun.c), which is the only way to reach isatty, the window size,
+// raw mode, and readline's line editor with its cursor escapes.
+//
+// Fed "world\none\ntwo\nquit\n". `quit` is what makes it exit, so it never has
+// to wait for an end-of-input that a terminal may not deliver.
+const { createInterface } = require("node:readline");
+
+const terminal = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+process.stdout.write(`tty=${terminal} ${process.stdout.columns ?? 0}x${process.stdout.rows ?? 0}\n`);
+process.stdout.write(Buffer.alloc(8192, 0x2e)); // more than one write's worth
+if (terminal) {
+  process.stdout.write(`\ncolors=${process.stdout.hasColors?.(256)}\n`);
+  process.stdin.setRawMode(true);
+  process.stdin.setRawMode(false);
+}
+
+const rl = createInterface({ input: process.stdin, output: process.stdout, terminal, prompt: "> " });
+let lines = 0;
+rl.question("\nname? ", name => {
+  process.stdout.write(`hi ${name.trim()}\n`);
+  rl.on("line", line => {
+    process.stdout.write(`${++lines}: ${line.trim()}\n`);
+    if (line.trim() === "quit") return rl.close();
+    rl.prompt();
+  });
+  rl.prompt();
+});
+rl.on("close", () => process.stdout.write(`read ${lines} lines\n`));

--- a/scripts/orderfile/generate.ts
+++ b/scripts/orderfile/generate.ts
@@ -17,6 +17,10 @@
  * order. Symbols lld cannot find are ignored, so the file degrades gracefully
  * as code moves.
  *
+ * One workload runs under `ptyrun.c`, on a pseudo-terminal: bun's stdio, tty
+ * and readline code is a different path on a terminal than on a pipe, and the
+ * functions it reaches are ~2k that no other workload touches.
+ *
  * The file is never committed. Release builds generate it from their own pass-1
  * binary and relink against it; canary builds inherit the last successful
  * build's file and re-publish it (scripts/build/ci.ts — inheritOrderFile /
@@ -39,7 +43,7 @@
  * the tracer depends on /proc/self/maps.
  */
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -55,6 +59,27 @@ const here = dirname(fileURLToPath(import.meta.url));
  * functions, so anything this low means the tracer or the symbol table broke.
  */
 const MIN_FUNCTIONS = 4000;
+
+/**
+ * A workload that blows through this is hung — an interactive one waiting on an
+ * end-of-input that never comes, say — and a release build must not hang with it.
+ */
+const WORKLOAD_TIMEOUT_MS = 120_000;
+
+/** Typed into cli-fixture.js. `quit` is what makes it exit. */
+const CLI_INPUT = "world\none\ntwo\nquit\n";
+
+interface Workload {
+  name: string;
+  args: string[];
+  /** Working directory for the traced process. */
+  cwd?: string;
+  /** Typed into stdin; on a terminal it arrives as keystrokes. */
+  input?: string;
+  /** Run on a pseudo-terminal rather than pipes (see ptyrun.c). */
+  tty?: boolean;
+  env?: Record<string, string>;
+}
 
 export interface GenerateOptions {
   /** Build directory holding the unstripped binary. */
@@ -85,23 +110,39 @@ export function generateOrderFile(options: GenerateOptions): { count: number; ou
     throw new Error(`${bunProfile} not found — build it first (bun run build:release)`);
   }
 
-  function run(cmd: string[], env?: Record<string, string | undefined>) {
+  interface RunOptions {
+    env?: Record<string, string | undefined>;
+    cwd?: string;
+    input?: string;
+    timeout?: number;
+    /** How the command is named in errors. Defaults to the executable. */
+    label?: string;
+  }
+
+  function run(cmd: string[], options: RunOptions = {}) {
     const r = spawnSync(cmd[0]!, cmd.slice(1), {
-      env: { ...process.env, ...env },
+      env: { ...process.env, ...options.env },
+      cwd: options.cwd,
+      input: options.input,
+      timeout: options.timeout,
       stdio: ["ignore", "pipe", "pipe"],
       maxBuffer: 1 << 29, // nm prints ~10 MB of symbols
     });
-    if (r.error) throw r.error;
+    // A timeout arrives here too: spawnSync reports it as an ETIMEDOUT error.
+    if (r.error) throw new Error(`${options.label ?? cmd[0]}: ${r.error.message}`);
     return r;
   }
 
   const scratch = mkdtempSync(join(tmpdir(), "bun-orderfile-"));
   try {
-    // ── Build the tracer ──────────────────────────────────────────────────────
+    // ── Build the tracer and the pty runner ───────────────────────────────────
     const tracer = join(scratch, "pagetrace.so");
+    const ptyrun = join(scratch, "ptyrun");
     const cc = process.env.CC || "cc";
     const build = run([cc, "-O2", "-shared", "-fPIC", "-o", tracer, join(here, "pagetrace.c"), "-ldl"]);
     if (build.status !== 0) throw new Error(`failed to build the tracer with ${cc}\n${build.stderr}`);
+    const pty = run([cc, "-O2", "-o", ptyrun, join(here, "ptyrun.c"), "-lutil"]);
+    if (pty.status !== 0) throw new Error(`failed to build the pty runner with ${cc}\n${pty.stderr}`);
 
     // ── Representative workloads ──────────────────────────────────────────────
     // Order matters: earlier workloads get the densest placement, so the plain
@@ -122,22 +163,66 @@ export function generateOrderFile(options: GenerateOptions): { count: number; ou
       join(fixtures, "tests", "example.test.ts"),
       `import { expect, test } from "bun:test";\ntest("passes", () => { expect(1).toBe(1); });\n`,
     );
+    // Reads stdin, writes stdout, drives readline — run once on a pipe and once
+    // on a terminal.
+    copyFileSync(join(here, "cli-fixture.js"), join(fixtures, "cli.js"));
 
-    const workloads: { name: string; args: string[] }[] = [
+    // `bun install`, offline: the one dependency is a tarball packed by the binary
+    // we are about to trace, so a slow registry cannot cost a release its order
+    // file. The rest is the real path — lockfile, extraction, node_modules.
+    const dependency = join(fixtures, "dep");
+    const app = join(fixtures, "app");
+    mkdirSync(dependency);
+    mkdirSync(app);
+    writeFileSync(
+      join(dependency, "package.json"),
+      `{ "name": "orderfile-dep", "version": "1.0.0", "main": "index.js" }\n`,
+    );
+    writeFileSync(join(dependency, "index.js"), `module.exports = 1;\n`);
+    const pack = run([bunProfile, "pm", "pack", "--filename", "dep.tgz"], { cwd: dependency, label: "bun pm pack" });
+    if (pack.status !== 0) throw new Error(`could not pack the install fixture\n${pack.stderr}`);
+    writeFileSync(
+      join(app, "package.json"),
+      `{ "name": "orderfile-app", "version": "0.0.0", ` +
+        `"dependencies": { "orderfile-dep": "file:../dep/dep.tgz" } }\n`,
+    );
+    const installEnv = { BUN_INSTALL_CACHE_DIR: join(scratch, "install-cache") };
+
+    const workloads: Workload[] = [
       { name: "bun -e", args: ["-e", "console.log(1)"] },
       { name: "bun hello.ts", args: [join(fixtures, "hello.ts")] },
       { name: "bun server.js", args: [join(fixtures, "server.js")] },
       { name: "bun test", args: ["test", join(fixtures, "tests", "example.test.ts")] },
+      { name: "bun install", args: ["install"], cwd: app, env: installEnv },
+      { name: "bun install (cached)", args: ["install"], cwd: app, env: installEnv },
+      { name: "bun cli.js (pipe)", args: [join(fixtures, "cli.js")], input: CLI_INPUT },
+      {
+        name: "bun cli.js (tty)",
+        args: [join(fixtures, "cli.js")],
+        input: CLI_INPUT,
+        tty: true,
+        env: { TERM: "xterm-256color" },
+      },
     ];
 
     const traces: { name: string; pageSize: number; pages: BigUint64Array }[] = [];
     for (const [i, workload] of workloads.entries()) {
       const out = join(scratch, `trace-${i}.bin`);
-      const r = run([bunProfile, ...workload.args], {
-        LD_PRELOAD: tracer,
-        BUN_PAGETRACE_BIN: bunProfile,
-        BUN_PAGETRACE_OUT: out,
-        BUN_DEBUG_QUIET_LOGS: "1",
+      // The tracer loads into the traced process and nowhere else. On a terminal
+      // ptyrun is the parent, so it is the one that hands the preload down.
+      const preload = workload.tty ? { PTYRUN_PRELOAD: tracer } : { LD_PRELOAD: tracer };
+      const r = run(workload.tty ? [ptyrun, bunProfile, ...workload.args] : [bunProfile, ...workload.args], {
+        env: {
+          ...preload,
+          BUN_PAGETRACE_BIN: bunProfile,
+          BUN_PAGETRACE_OUT: out,
+          BUN_DEBUG_QUIET_LOGS: "1",
+          ...workload.env,
+        },
+        cwd: workload.cwd,
+        input: workload.input,
+        timeout: WORKLOAD_TIMEOUT_MS,
+        label: `workload "${workload.name}"`,
       });
       if (r.status !== 0) throw new Error(`workload "${workload.name}" exited ${r.status}\n${r.stderr}`);
 
@@ -210,7 +295,7 @@ export function generateOrderFile(options: GenerateOptions): { count: number; ou
           order.push(name);
         }
       }
-      log(`  ${trace.name.padEnd(16)} ${visited.size} pages touched, +${order.length - before} functions`);
+      log(`  ${trace.name.padEnd(21)} ${visited.size} pages touched, +${order.length - before} functions`);
     }
 
     if (order.length < minFunctions) {

--- a/scripts/orderfile/ptyrun.c
+++ b/scripts/orderfile/ptyrun.c
@@ -1,0 +1,84 @@
+// Runs a command on a pseudo-terminal, used by scripts/orderfile/generate.ts.
+//
+// bun takes a different path on a terminal than on a pipe — isatty, TIOCGWINSZ,
+// raw mode, readline's line editor and its cursor escapes — and nothing but a
+// real pty reaches it. So one workload runs under this.
+//
+//   cc -O2 -o ptyrun ptyrun.c -lutil
+//   printf 'hi\n' | ./ptyrun bun cli.js
+//
+// Our stdin is typed into the terminal and the child's output is forwarded to
+// ours, so a workload looks the same to the caller either way. Exits with the
+// child's status.
+//
+// PTYRUN_PRELOAD becomes the child's LD_PRELOAD. The page tracer has to load
+// into the binary being traced and nowhere else: preloaded here it would create
+// and truncate a trace file for a process it cannot trace.
+#define _GNU_SOURCE
+#include <errno.h>
+#include <poll.h>
+#include <pty.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define EOT 4 // ^D: how a terminal says end-of-input
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: ptyrun <command> [args...]\n");
+        return 2;
+    }
+
+    struct winsize window = { .ws_row = 24, .ws_col = 80 };
+    int master = -1;
+    pid_t child = forkpty(&master, NULL, NULL, &window);
+    if (child < 0) {
+        perror("forkpty");
+        return 2;
+    }
+    if (child == 0) {
+        const char *preload = getenv("PTYRUN_PRELOAD");
+        if (preload && *preload) setenv("LD_PRELOAD", preload, 1);
+        execvp(argv[1], &argv[1]);
+        perror(argv[1]);
+        _exit(127);
+    }
+
+    // Drain the child's output — a full pty buffer would block it — and type
+    // whatever arrives on our stdin into the terminal.
+    char buffer[8192];
+    struct pollfd fds[2] = { { .fd = master, .events = POLLIN }, { .fd = STDIN_FILENO, .events = POLLIN } };
+    for (;;) {
+        if (poll(fds, 2, -1) < 0) {
+            if (errno == EINTR) continue;
+            break;
+        }
+        if (fds[0].revents) {
+            ssize_t n = read(master, buffer, sizeof buffer);
+            if (n <= 0) break; // EIO once the child has closed its side
+            if (write(STDOUT_FILENO, buffer, (size_t)n) < 0) break;
+        }
+        if (fds[1].revents) {
+            ssize_t n = read(STDIN_FILENO, buffer, sizeof buffer);
+            if (n > 0) {
+                if (write(master, buffer, (size_t)n) < 0) break;
+            } else {
+                // Out of input. Closing the master instead would SIGHUP the child.
+                char eof = EOT;
+                fds[1].fd = -1;
+                if (write(master, &eof, 1) < 0) break;
+            }
+        }
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) < 0) {
+        perror("waitpid");
+        return 2;
+    }
+    return WIFEXITED(status) ? WEXITSTATUS(status) : 1;
+}

--- a/test/js/bun/perf/linker-order.test.ts
+++ b/test/js/bun/perf/linker-order.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 import type { Config } from "../../../../scripts/build/config.ts";
 import { linkDepends, linkerFlags, orderFilePath, usesOrderFile } from "../../../../scripts/build/flags.ts";
@@ -90,5 +91,68 @@ describe("order file generator", () => {
   it.skipIf(process.platform === "linux")("refuses to run off linux", () => {
     // It is an ELF linker input and the tracer reads /proc/self/maps.
     expect(() => generateOrderFile({ buildDir: "/tmp/build" })).toThrow(/linux/);
+  });
+});
+
+const compiler = process.env.CC || Bun.which("cc") || Bun.which("clang") || Bun.which("gcc");
+
+/**
+ * One of the traced workloads runs on a pseudo-terminal, because bun's stdio,
+ * tty and readline code take a path there that a pipe never reaches, and an
+ * order file that missed it would leave all of that scattered. `ptyrun.c` is
+ * what provides the terminal.
+ */
+describe.skipIf(process.platform !== "linux" || !compiler)("pty runner", () => {
+  /** Reports what the process sees on its stdio, plus the one line it was typed. */
+  const probe = [
+    `process.stdin.once("data", data => {`,
+    `  const tty = Boolean(process.stdin.isTTY && process.stdout.isTTY);`,
+    `  const fields = [tty, process.stdout.columns ?? 0, process.env.LD_PRELOAD ?? "none", data.toString().trim()];`,
+    `  process.stdout.write(fields.join(" ") + "\\n");`,
+    `  process.stdin.pause();`,
+    `});`,
+  ].join("\n");
+
+  async function compile(args: string[]) {
+    await using proc = Bun.spawn({ cmd: [compiler!, "-O1", ...args], env: bunEnv, stderr: "pipe" });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  async function type(cmd: string[], env: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd,
+      env: { ...bunEnv, ...env },
+      stdin: new Blob(["hi\n"]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // A terminal echoes back what it was typed and turns \n into \r\n, so the
+    // probe's own line is the last one.
+    const lines = stdout.replaceAll("\r", "").trim().split("\n");
+    return { line: lines.at(-1), stderr, exitCode };
+  }
+
+  it("runs the child on a terminal, and hands it the preload it was given", async () => {
+    using dir = tempDir("ptyrun", { "empty.c": "int ptyrun_nothing;\n" });
+    const ptyrun = join(String(dir), "ptyrun");
+    // Somewhere for LD_PRELOAD to point that is real but does nothing. In a
+    // trace this is the page tracer, which has to load into the traced binary
+    // and not into ptyrun.
+    const preload = join(String(dir), "empty.so");
+    await compile(["-o", ptyrun, join(import.meta.dir, "../../../../scripts/orderfile/ptyrun.c"), "-lutil"]);
+    await compile(["-shared", "-fPIC", "-o", preload, join(String(dir), "empty.c")]);
+
+    const pty = await type([ptyrun, bunExe(), "-e", probe], { PTYRUN_PRELOAD: preload });
+    const pipe = await type([bunExe(), "-e", probe], {});
+
+    expect({ pty: pty.line, pipe: pipe.line, ptyExit: pty.exitCode, pipeExit: pipe.exitCode }).toEqual({
+      pty: `true 80 ${preload} hi`,
+      pipe: "false 0 none hi",
+      ptyExit: 0,
+      pipeExit: 0,
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #33302. The `--symbol-ordering-file` packs the functions a run executes to the front of `.text`. It was traced from four workloads (`bun -e`, a script, `Bun.serve`, `bun test`), which left two large chunks of what people actually run scattered across the binary: `bun install`, and anything attached to a terminal.

### What the new workloads add

Measured on a linux-x64 release build (`bun run orderfile`), counting only functions no earlier workload had already touched:

| workload | pages touched | new functions |
| --- | --- | --- |
| `bun -e` | 2,187 | 22,456 |
| `bun hello.ts` | 2,250 | 680 |
| `bun server.js` | 2,689 | 5,224 |
| `bun test` | 3,153 | 5,065 |
| **`bun install`** | 636 | **1,471** |
| **`bun install` (cached)** | 545 | **64** |
| **`bun cli.js` (pipe)** | 3,144 | **2,014** |
| **`bun cli.js` (tty)** | 3,463 | **2,193** |

33,428 functions before, 39,167 after.

### `bun install`

Offline by construction: the app's one dependency is a tarball that `bun pm pack` produces from a fixture, packed by the very binary being traced. A slow or unreachable registry must not be able to cost a release its order file. It still walks the real path (manifest, lockfile, tarball extraction, node_modules linking), and it runs a second time because a re-install that finds everything already in place is the common one.

It touches far fewer pages than the runtime workloads because it never starts JavaScriptCore, but 1,471 of the functions it does touch were in nobody else's trace.

### The interactive CLI

`scripts/orderfile/cli-fixture.js` reads stdin, writes stdout, and drives `node:readline`. It is traced twice:

- on a pipe, fed `world\none\ntwo\nquit\n` on stdin
- on a pseudo-terminal, typed the same thing

The terminal run is the point: `isatty`, `TIOCGWINSZ`, raw mode, and readline's line editor with its cursor escapes are 2,193 functions that the pipe run never reaches, even after everything above it.

`scripts/orderfile/ptyrun.c` is what provides the terminal: `forkpty`, relay our stdin in as keystrokes, drain the child's output so a full pty buffer cannot block it, exit with its status. `PTYRUN_PRELOAD` becomes the child's `LD_PRELOAD`, because the page tracer has to load into the binary being traced and not into the helper that spawns it.

The fixture exits on `quit` rather than on end-of-input, so it never waits for an EOF a terminal might not deliver. Workloads now also run under a 120s timeout, so an interactive one that does hang fails the trace instead of hanging the release.

### Placement

The four existing workloads still run first, and the order file is first-touch order with dedup, so the functions that land at the very front of `.text` are the same ones as before. The first 1,000 entries (what `verifyOrderFileApplied` samples) are byte-identical across a before/after run.

### Verification

```
$ bun run orderfile
  bun -e                2187 pages touched, +22456 functions
  bun hello.ts          2250 pages touched, +680 functions
  bun server.js         2689 pages touched, +5224 functions
  bun test              3153 pages touched, +5065 functions
  bun install           636 pages touched, +1471 functions
  bun install (cached)  545 pages touched, +64 functions
  bun cli.js (pipe)     3144 pages touched, +2014 functions
  bun cli.js (tty)      3463 pages touched, +2193 functions
wrote build/release/linker.order (39167 functions)
```

`test/js/bun/perf/linker-order.test.ts` gains a check on the new C helper, since a pty that silently degrades to a pipe would quietly drop 2,193 functions from the file: it compiles `ptyrun.c`, runs bun under it, and asserts the child sees `isTTY`, an 80 column window, and the preload it was handed, while the same command on a pipe sees none of it.

```
$ bun bd test test/js/bun/perf/linker-order.test.ts
 8 pass
 1 skip
 0 fail
```