### PR TITLE
node:vm: give SourceTextModule an empty import.meta by default

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3951,6 +3951,15 @@ JSC::JSObject* GlobalObject::moduleLoaderCreateImportMetaProperties(JSGlobalObje
     JSModuleRecord* record,
     RefPtr<JSC::ScriptFetcher>)
 {
+    // vm.SourceTextModule: Node leaves import.meta empty unless options.initializeImportMeta fills it.
+    if (record) {
+        if (auto* provider = record->sourceCode().provider()) {
+            auto* fetcher = provider->sourceOrigin().fetcher();
+            if (fetcher && fetcher->fetcherType() == JSC::ScriptFetcher::Type::NodeVM)
+                return JSC::constructEmptyObject(globalObject->vm(), globalObject->nullPrototypeObjectStructure());
+        }
+    }
+
     return Zig::ImportMetaObject::create(globalObject, key);
 }
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import {
   compileFunction,
   constants,
@@ -1972,5 +1972,115 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
     const position = Number(match![1]);
     expect(position).toBeGreaterThan(INT32_MAX - 100);
     expect(position).toBeLessThanOrEqual(INT32_MAX);
+  });
+});
+
+describe("node:vm SourceTextModule import.meta", () => {
+  // A SourceTextModule identifier ("vm:module(0)" by default) is not a module
+  // path, so there is nothing to derive import.meta from. Node leaves it empty
+  // and lets the host populate it through options.initializeImportMeta. Bun used
+  // to synthesize url/dirname/filename and a working resolve() from the
+  // identifier, which let sandboxed code resolve against the host filesystem.
+  const metaSource =
+    "export const meta = {" +
+    " ownKeys: Reflect.ownKeys(import.meta)," +
+    " nullProto: Object.getPrototypeOf(import.meta) === null," +
+    " url: String(import.meta.url)," +
+    " dirname: String(import.meta.dirname)," +
+    " filename: String(import.meta.filename)," +
+    " resolve: typeof import.meta.resolve," +
+    " require: typeof import.meta.require," +
+    " custom: String(import.meta.custom) };";
+
+  const empty = {
+    ownKeys: [],
+    nullProto: true,
+    url: "undefined",
+    dirname: "undefined",
+    filename: "undefined",
+    resolve: "undefined",
+    require: "undefined",
+    custom: "undefined",
+  };
+
+  test("is empty by default and only initializeImportMeta populates it", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const src = ${JSON.stringify(metaSource)};
+      const results = {};
+
+      async function run(label, options) {
+        const m = new vm.SourceTextModule(src, options);
+        await m.link(() => { throw new Error("unexpected import"); });
+        await m.evaluate();
+        results[label] = m.namespace.meta;
+      }
+
+      await run("default", undefined);
+      await run("identifier", { identifier: "file:///real/path.mjs" });
+      await run("contextified", { context: vm.createContext({}) });
+      await run("initializeImportMeta", { initializeImportMeta: meta => { meta.custom = "set"; } });
+      console.log(JSON.stringify(results));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      default: empty,
+      identifier: empty,
+      contextified: empty,
+      initializeImportMeta: { ...empty, ownKeys: ["custom"], custom: "set" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("modules dynamically imported by a SourceTextModule still get a real import.meta", async () => {
+    using dir = tempDir("vm-module-import-meta", {
+      "dep.mjs": `export const info = {
+        url: import.meta.url,
+        resolve: typeof import.meta.resolve,
+        dirname: typeof import.meta.dirname,
+      };`,
+      "main.mjs": `
+        import vm from "node:vm";
+        const src = 'const dep = await import("./dep.mjs");' +
+          ' export const inner = { vmUrl: String(import.meta.url),' +
+          ' depUrlIsFileUrl: dep.info.url.startsWith("file://") && dep.info.url.endsWith("/dep.mjs"),' +
+          ' depResolve: dep.info.resolve, depDirname: dep.info.dirname };';
+        const m = new vm.SourceTextModule(src, {
+          importModuleDynamically: specifier => import(new URL(specifier, import.meta.url).href),
+        });
+        await m.link(() => { throw new Error("unexpected static import"); });
+        await m.evaluate();
+        console.log(JSON.stringify(m.namespace.inner));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      vmUrl: "undefined",
+      depUrlIsFileUrl: true,
+      depResolve: "function",
+      depDirname: "string",
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Repro

```js
import vm from "node:vm";
const m = new vm.SourceTextModule(`export const meta = {
  url: import.meta.url,
  resolve: typeof import.meta.resolve,
};`);
await m.link(() => {});
await m.evaluate();
console.log(m.namespace.meta);
```

```
node: { url: undefined, resolve: 'undefined' }
bun:  { url: "file:///vm:module(0)", resolve: "function" }
```

With `identifier: "file:///real/path.mjs"` it gets worse: bun reports
`url: "file:///file:///real/path.mjs"`. `import.meta.dirname` / `filename` /
`require` are synthesized the same way, and the installed `resolve()` resolves
against that made-up base, i.e. against the host filesystem from inside what is
supposed to be a sandbox.

## Cause

`GlobalObject::moduleLoaderCreateImportMetaProperties` built a real
`ImportMetaObject` from the module key. For a `vm.SourceTextModule` that key is
the identifier, which defaults to `vm:module(N)` and is not a module path, so
there is nothing to derive import.meta from.

Node leaves a VM module's import.meta empty and lets the host populate it
through `options.initializeImportMeta`. Bun already did that for *contextified*
vm modules, but only by accident: `NodeVMGlobalObject`'s method table leaves the
`moduleLoaderCreateImportMetaProperties` hook null, so JSC falls back to
`constructEmptyObject(vm, nullPrototypeObjectStructure())`. Modules evaluated in
the main context went through the hook and got the fabricated object.

## Fix

Return that same empty null-prototype object when the module record's source
origin carries a `NodeVMScriptFetcher` (the marker that says "this source was
compiled by node:vm"). `options.initializeImportMeta` still populates it, and
modules dynamically imported *by* a vm module still go through the default
loader and keep a real import.meta.

## Verification

`test/js/node/vm/vm.test.ts` gains two tests. The first covers the default,
custom-`identifier`, contextified, and `initializeImportMeta` cases; the second
pins the negative contract that a real module dynamically imported from a vm
module keeps its `url` / `resolve` / `dirname`. Both fail on `main` and pass
with the fix.

Node's own `test/js/node/test/parallel/test-vm-module-*.js` suite still passes
(its `test-vm-module-import-meta.js` already asserted
`Reflect.ownKeys(import.meta)` deep-equals `['prop']`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->