### PR TITLE
readline: reject instead of throwing when question() gets an aborted signal

### DIFF
--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -30,7 +30,7 @@ const {
 const { dirname, isAbsolute, join, parse, resolve } = require("node:path");
 
 const PromisePrototypeThen = $Promise.prototype.$then;
-const PromiseReject = Promise.$reject;
+const PromiseReject = Promise.$reject.bind(Promise);
 
 async function checkPaths(src, dest, opts) {
   if (opts.filter && !(await opts.filter(src, dest))) {

--- a/src/js/internal/primordials.js
+++ b/src/js/internal/primordials.js
@@ -95,7 +95,7 @@ const arrayToSafePromiseIterable = (promises, mapFn) =>
         new Promise((a, b) => PromisePrototypeThen.$call(mapFn == null ? promise : mapFn(promise, i), a, b)),
     ),
   );
-const PromiseAll = Promise.all;
+const PromiseAll = Promise.all.bind(Promise);
 const PromiseResolve = Promise.$resolve.bind(Promise);
 const SafePromiseAll = (promises, mapFn) => PromiseAll(arrayToSafePromiseIterable(promises, mapFn));
 // Shared scheduler for SafePromiseAllReturnVoid/ReturnArrayLike: `returnVal`

--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -43,7 +43,7 @@ const {
 
 const internalGetStringWidth = $newCppFunction("stringWidth.cpp", "jsFunctionBunStringWidth", 1);
 
-const PromiseReject = Promise.$reject;
+const PromiseReject = Promise.$reject.bind(Promise);
 
 var isWritable;
 

--- a/test/js/node/readline/readline_promises.node.test.ts
+++ b/test/js/node/readline/readline_promises.node.test.ts
@@ -1,6 +1,8 @@
 import { createTest } from "node-harness";
 import { EventEmitter } from "node:events";
+import readline from "node:readline";
 import readlinePromises from "node:readline/promises";
+import { promisify } from "node:util";
 const { describe, it, expect, createDoneDotAll, createCallCheckCtx, assert } = createTest(import.meta.path);
 
 // ----------------------------------------------------------------------------
@@ -91,5 +93,65 @@ describe("readline/promises.createInterface()", () => {
 
     assert.strictEqual(closed, true);
     assert.strictEqual(rl.closed, true);
+  });
+});
+
+describe("readline question() with an aborted signal", () => {
+  async function rejection(promise: Promise<unknown>) {
+    return await promise.then(
+      () => {
+        throw new Error("question() resolved, expected it to reject");
+      },
+      (err: any) => err,
+    );
+  }
+
+  it("rejects instead of throwing synchronously", async () => {
+    const fi = new FakeInput();
+    using rl = readlinePromises.createInterface({ input: fi, output: fi });
+
+    const reason = new Error("cancelled before the prompt");
+    const promise = rl.question("Question?", { signal: AbortSignal.abort(reason) });
+    expect(promise).toBeInstanceOf(Promise);
+
+    const error = await rejection(promise);
+    expect({ name: error.name, code: error.code, cause: error.cause }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      cause: reason,
+    });
+    // the prompt is never written when the signal is already aborted
+    expect(fi.output).toBe("");
+  });
+
+  it("rejects instead of throwing synchronously through util.promisify", async () => {
+    const fi = new FakeInput();
+    using rl = readline.createInterface({ input: fi, output: fi });
+    const question = promisify(rl.question);
+
+    const reason = new Error("cancelled before the prompt");
+    const promise = question.call(rl, "Question?", { signal: AbortSignal.abort(reason) });
+    expect(promise).toBeInstanceOf(Promise);
+
+    const error = await rejection(promise);
+    expect({ name: error.name, code: error.code, cause: error.cause }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      cause: reason,
+    });
+    expect(fi.output).toBe("");
+  });
+
+  it("rejects when the signal aborts after the question was asked", async () => {
+    const fi = new FakeInput();
+    using rl = readlinePromises.createInterface({ input: fi, output: fi });
+
+    const controller = new AbortController();
+    const promise = rl.question("Question?", { signal: controller.signal });
+    expect(fi.output).toBe("Question?");
+    controller.abort();
+
+    const error = await rejection(promise);
+    expect({ name: error.name, code: error.code }).toEqual({ name: "AbortError", code: "ABORT_ERR" });
   });
 });


### PR DESCRIPTION
### Repro

```js
import { createInterface } from "node:readline/promises";
const rl = createInterface({ input: process.stdin, output: process.stdout });
rl.question("q", { signal: AbortSignal.abort() }).catch(e => console.log(e.code));
```

node prints `ABORT_ERR`. Bun throws synchronously before `.catch` is ever attached:

```
TypeError: |this| is not an object
```

Passing an already-aborted signal is the normal shape of cancellation-aware code (a request cancelled before the prompt is reached), and an async API that throws synchronously takes the caller down with it.

### Cause

`src/js/node/readline.ts` captured `Promise.reject` detached from its receiver:

```js
const PromiseReject = Promise.$reject;
```

`Promise.reject` builds its result with `NewPromiseCapability(this)`, so calling it bare leaves `this` undefined and it throws `|this| is not an object`. The two call sites are the already-aborted fast paths of `Interface.prototype.question[util.promisify.custom]` and the `node:readline/promises` `Interface#question`. A signal that aborts *later* goes through `new Promise(...)`/`$newPromiseCapability`, which is why only the pre-aborted path was broken.

### Fix

Bind the receiver, matching the ten other `Promise.$reject` / `$resolve` / `withResolvers` captures already in `src/js`:

```js
const PromiseReject = Promise.$reject.bind(Promise);
```

Two sibling captures had the same shape and are bound in the same commit:

- `src/js/internal/fs/cp.ts` — `PromiseReject` in `pathExistsRejected`, which would replace a real `stat()` error with the same `TypeError`.
- `src/js/internal/primordials.js` — `PromiseAll`, which made `SafePromiseAll` throw on every call (`PromiseResolve` on the next line was already bound).

### Verification

Three cases added to `test/js/node/readline/readline_promises.node.test.ts`: `node:readline/promises` `question()`, the `util.promisify(rl.question)` path, and a signal that aborts after the question was asked. All three match node (`AbortError` / `ABORT_ERR`, `cause` preserved, no prompt written for the pre-aborted case).

The first two fail on the unfixed build with `TypeError: |this| is not an object` and pass with the fix.