### PR TITLE
readline: throw ERR_USE_AFTER_CLOSE from write(), pause() and resume() after close()

### DIFF
--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -2702,6 +2702,18 @@ class Readline {
   }
 }
 
+// Bound rather than closed over: a pending question outlives the call, and an
+// inline closure would pin question()'s whole activation until it is answered.
+function onQuestionAbort(signal, reject) {
+  this[kQuestionCancel]();
+  reject($makeAbortError(undefined, { cause: signal.reason }));
+}
+
+function onQuestionAnswer(signal, onAbort, resolve, answer) {
+  signal.removeEventListener("abort", onAbort);
+  resolve(answer);
+}
+
 var PromisesInterface = class Interface extends _Interface {
   // eslint-disable-next-line no-useless-constructor
   constructor(input, output, completer, terminal) {
@@ -2720,15 +2732,9 @@ var PromisesInterface = class Interface extends _Interface {
           reject($makeAbortError(undefined, { cause: signal.reason }));
           return promise;
         }
-        var onAbort = () => {
-          this[kQuestionCancel]();
-          reject($makeAbortError(undefined, { cause: signal.reason }));
-        };
+        var onAbort = onQuestionAbort.bind(this, signal, reject);
         signal.addEventListener("abort", onAbort, { once: true });
-        cb = answer => {
-          signal.removeEventListener("abort", onAbort);
-          resolve(answer);
-        };
+        cb = onQuestionAnswer.bind(undefined, signal, onAbort, resolve);
       }
       this[kQuestion](query, cb);
     } catch (err) {

--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -1403,6 +1403,9 @@ var _Interface = class Interface extends InterfaceConstructor {
    * @returns {void | Interface}
    */
   pause() {
+    if (this.closed) {
+      throw $ERR_USE_AFTER_CLOSE("readline");
+    }
     if (this.paused) return;
     this.input.pause();
     this.paused = true;
@@ -1415,6 +1418,9 @@ var _Interface = class Interface extends InterfaceConstructor {
    * @returns {void | Interface}
    */
   resume() {
+    if (this.closed) {
+      throw $ERR_USE_AFTER_CLOSE("readline");
+    }
     if (!this.paused) return;
     this.input.resume();
     this.paused = false;
@@ -1435,6 +1441,9 @@ var _Interface = class Interface extends InterfaceConstructor {
    * @returns {void}
    */
   write(d, key) {
+    if (this.closed) {
+      throw $ERR_USE_AFTER_CLOSE("readline");
+    }
     if (this.paused) this.resume();
     if (this.terminal) {
       this[kTtyWrite](d, key);
@@ -2719,7 +2728,11 @@ var PromisesInterface = class Interface extends _Interface {
         resolve(answer);
       };
     }
-    this[kQuestion](query, cb);
+    try {
+      this[kQuestion](query, cb);
+    } catch (err) {
+      reject(err);
+    }
     return promise;
   }
 };

--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -2708,27 +2708,28 @@ var PromisesInterface = class Interface extends _Interface {
     super(input, output, completer, terminal);
   }
   question(query, options = kEmptyObject) {
-    var signal = options?.signal;
-    if (signal) {
-      validateAbortSignal(signal, "options.signal");
-      if (signal.aborted) {
-        return PromiseReject($makeAbortError(undefined, { cause: signal.reason }));
-      }
-    }
     const { promise, resolve, reject } = $newPromiseCapability(Promise);
-    var cb = resolve;
-    if (options?.signal) {
-      var onAbort = () => {
-        this[kQuestionCancel]();
-        reject($makeAbortError(undefined, { cause: signal.reason }));
-      };
-      signal.addEventListener("abort", onAbort, { once: true });
-      cb = answer => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(answer);
-      };
-    }
+    // node runs this whole body inside a `new Promise(...)` executor, so every
+    // synchronous throw in here has to surface as a rejection instead.
     try {
+      var cb = resolve;
+      var signal = options?.signal;
+      if (signal) {
+        validateAbortSignal(signal, "options.signal");
+        if (signal.aborted) {
+          reject($makeAbortError(undefined, { cause: signal.reason }));
+          return promise;
+        }
+        var onAbort = () => {
+          this[kQuestionCancel]();
+          reject($makeAbortError(undefined, { cause: signal.reason }));
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        cb = answer => {
+          signal.removeEventListener("abort", onAbort);
+          resolve(answer);
+        };
+      }
       this[kQuestion](query, cb);
     } catch (err) {
       reject(err);

--- a/test/js/node/readline/readline.node.test.ts
+++ b/test/js/node/readline/readline.node.test.ts
@@ -2086,4 +2086,49 @@ describe("readline.createInterface()", () => {
     assert.strictEqual(closed, true);
     assert.strictEqual(rl.closed, true);
   });
+
+  describe("use after close", () => {
+    const useAfterClose = { name: "Error", code: "ERR_USE_AFTER_CLOSE", message: "readline was closed" };
+
+    for (const terminal of [false, true]) {
+      it(`prompt() throws ERR_USE_AFTER_CLOSE (terminal: ${terminal})`, () => {
+        const [rli] = getInterface({ terminal });
+        rli.close();
+        assert.throws(() => rli.prompt(), useAfterClose);
+      });
+
+      it(`write() throws ERR_USE_AFTER_CLOSE (terminal: ${terminal})`, () => {
+        const [rli] = getInterface({ terminal });
+        rli.on("line", () => assert.ok(false, "line should not be emitted after close"));
+        rli.close();
+        assert.throws(() => rli.write("foo\n"), useAfterClose);
+      });
+
+      it(`pause() throws ERR_USE_AFTER_CLOSE (terminal: ${terminal})`, () => {
+        const [rli] = getInterface({ terminal });
+        rli.close();
+        assert.throws(() => rli.pause(), useAfterClose);
+      });
+
+      it(`resume() throws ERR_USE_AFTER_CLOSE (terminal: ${terminal})`, () => {
+        const [rli] = getInterface({ terminal });
+        rli.close();
+        assert.throws(() => rli.resume(), useAfterClose);
+      });
+
+      it(`question() throws ERR_USE_AFTER_CLOSE (terminal: ${terminal})`, () => {
+        const [rli] = getInterface({ terminal });
+        rli.close();
+        assert.throws(() => rli.question("how are you?", () => {}), useAfterClose);
+      });
+    }
+
+    it("close() stays idempotent and setPrompt()/getPrompt() keep working", () => {
+      const [rli] = getInterface({ terminal: false });
+      rli.close();
+      rli.close();
+      rli.setPrompt("$ ");
+      assert.strictEqual(rli.getPrompt(), "$ ");
+    });
+  });
 });

--- a/test/js/node/readline/readline_promises.node.test.ts
+++ b/test/js/node/readline/readline_promises.node.test.ts
@@ -92,4 +92,42 @@ describe("readline/promises.createInterface()", () => {
     assert.strictEqual(closed, true);
     assert.strictEqual(rl.closed, true);
   });
+
+  describe("use after close", () => {
+    const useAfterClose = { name: "Error", code: "ERR_USE_AFTER_CLOSE", message: "readline was closed" };
+
+    function closedInterface() {
+      const fi = new FakeInput();
+      const rl = readlinePromises.createInterface({ input: fi, output: fi });
+      rl.close();
+      return rl;
+    }
+
+    it("question() rejects instead of throwing synchronously", async () => {
+      const rl = closedInterface();
+      const promise = rl.question("how are you?");
+      assert.strictEqual(promise instanceof Promise, true);
+
+      let err: any;
+      let resolved = false;
+      try {
+        await promise;
+        resolved = true;
+      } catch (e) {
+        err = e;
+      }
+      assert.strictEqual(resolved, false);
+      assert.strictEqual(err.name, useAfterClose.name);
+      assert.strictEqual(err.code, useAfterClose.code);
+      assert.strictEqual(err.message, useAfterClose.message);
+    });
+
+    it("prompt(), write(), pause() and resume() throw ERR_USE_AFTER_CLOSE", () => {
+      const rl = closedInterface();
+      assert.throws(() => rl.prompt(), useAfterClose);
+      assert.throws(() => rl.write("foo\n"), useAfterClose);
+      assert.throws(() => rl.pause(), useAfterClose);
+      assert.throws(() => rl.resume(), useAfterClose);
+    });
+  });
 });

--- a/test/js/node/readline/readline_promises.node.test.ts
+++ b/test/js/node/readline/readline_promises.node.test.ts
@@ -20,6 +20,17 @@ class FakeInput extends EventEmitter {
   }
 }
 
+// Awaits a promise that must reject, and hands back the rejection reason.
+async function rejectionOf(promise: Promise<unknown>): Promise<any> {
+  let resolved = false;
+  const err = await promise.then(
+    () => void (resolved = true),
+    (e: any) => e,
+  );
+  assert.strictEqual(resolved, false);
+  return err;
+}
+
 // ----------------------------------------------------------------------------
 // Tests
 // ----------------------------------------------------------------------------
@@ -108,15 +119,7 @@ describe("readline/promises.createInterface()", () => {
       const promise = rl.question("how are you?");
       assert.strictEqual(promise instanceof Promise, true);
 
-      let err: any;
-      let resolved = false;
-      try {
-        await promise;
-        resolved = true;
-      } catch (e) {
-        err = e;
-      }
-      assert.strictEqual(resolved, false);
+      const err = await rejectionOf(promise);
       assert.strictEqual(err.name, useAfterClose.name);
       assert.strictEqual(err.code, useAfterClose.code);
       assert.strictEqual(err.message, useAfterClose.message);
@@ -129,5 +132,20 @@ describe("readline/promises.createInterface()", () => {
       assert.throws(() => rl.pause(), useAfterClose);
       assert.throws(() => rl.resume(), useAfterClose);
     });
+  });
+
+  it("question() rejects rather than throwing when options.signal is not an AbortSignal", async () => {
+    const fi = new FakeInput();
+    const rl = readlinePromises.createInterface({ input: fi, output: fi });
+    try {
+      const promise = rl.question("how are you?", { signal: {} } as any);
+      assert.strictEqual(promise instanceof Promise, true);
+
+      const err = await rejectionOf(promise);
+      assert.strictEqual(err.code, "ERR_INVALID_ARG_TYPE");
+      assert.strictEqual(fi.output, "");
+    } finally {
+      rl.close();
+    }
   });
 });

--- a/test/js/node/test/parallel/test-readline-promises-tab-complete.js
+++ b/test/js/node/test/parallel/test-readline-promises-tab-complete.js
@@ -73,12 +73,12 @@ common.skipIfDumbTerminal();
       rli.on('line', common.mustNotCall());
       for (const character of `${char}\t\t`) {
         fi.emit('data', character);
-        queueMicrotask(() => {
+        queueMicrotask(common.mustCall(() => {
           assert.strictEqual(output, expectations.shift());
           output = '';
-        });
+        }));
       }
-      rli.close();
+      fi.end();
     });
   });
 });
@@ -108,9 +108,9 @@ common.skipIfDumbTerminal();
 
   rli.on('line', common.mustNotCall());
   fi.emit('data', '\t');
-  queueMicrotask(() => {
+  queueMicrotask(common.mustCall(() => {
     assert.match(output, /^Tab completion error:[^]+Error: message/i);
     output = '';
-  });
-  rli.close();
+  }));
+  fi.end();
 }


### PR DESCRIPTION
### Repro

```js
const readline = require("node:readline");
const { PassThrough } = require("node:stream");

const rl = readline.createInterface({ input: new PassThrough(), output: new PassThrough() });
rl.close();

rl.prompt();     // node: throws ERR_USE_AFTER_CLOSE   bun: silent no-op
rl.write("x\n"); // node: throws ERR_USE_AFTER_CLOSE   bun: input silently dropped
rl.pause();      // node: throws ERR_USE_AFTER_CLOSE   bun: silent no-op
rl.resume();     // node: throws ERR_USE_AFTER_CLOSE   bun: silent no-op
```

Node throws `Error [ERR_USE_AFTER_CLOSE]: readline was closed` for all four. Bun only guarded `question()`, so `rl.write()` into a closed interface silently swallowed the line and a re-`prompt()` did nothing. Interactive tools race teardown against late input constantly, and a silent no-op is harder to diagnose than the error node gives you.

### Cause

`src/js/node/readline.ts` was missing the `this.closed` guard node has at the top of `write()`, `pause()` and `resume()`. `prompt()` has no guard of its own in node either, but `close()` calls `pause()` before setting `closed = true`, so a closed interface is always `paused` and `prompt()`'s `if (this.paused) this.resume()` throws through `resume()`. Restoring the three guards restores `prompt()` too.

### Fix

Add the guard to `write()`, `pause()` and `resume()`, in the same position node puts it.

#### `node:readline/promises` `question()`

Second commit. `question()` already inherited the `kQuestion` guard, but Bun builds the promise with `$newPromiseCapability` and then calls into the rest of the body bare, so a synchronous throw escaped instead of rejecting the returned promise. Node wraps the **whole** body in a `new Promise(...)` executor:

```js
question(query, options = kEmptyObject) {
  return new Promise((resolve, reject) => {
    let cb = resolve;
    if (options?.signal) {
      validateAbortSignal(options.signal, 'options.signal');
      ...
```

so `validateAbortSignal` and the already-aborted fast path are absorbed by it too. Moving them inside the try makes all four paths match node:

| | node v26 | bun (before) | bun (after) |
|---|---|---|---|
| closed interface | rejected `ERR_USE_AFTER_CLOSE` | **sync throw** | rejected `ERR_USE_AFTER_CLOSE` |
| invalid `options.signal` | rejected `ERR_INVALID_ARG_TYPE` | **sync throw** | rejected `ERR_INVALID_ARG_TYPE` |
| pre-aborted signal | rejected `ABORT_ERR` | **sync throw `TypeError`** | rejected `ABORT_ERR` |
| late abort | rejected `ABORT_ERR` | rejected `ABORT_ERR` | rejected `ABORT_ERR` |

The pre-aborted row used to go through the bare `PromiseReject = Promise.$reject` capture, which is why it threw `TypeError: |this| is not an object`. Routing it through the capability's `reject` fixes it here as a side effect. The `promisify.custom` path still uses that unbound capture and still reproduces, so #33343 is still needed; I did not touch it.

Third commit, per review: `question()`'s two abort listeners are now root functions bound to the state they need, rather than inline arrows. A pending question outlives the call, so the arrows were pinning the whole activation (`query`, `options`, the promise capability) until it was answered. Same shape as the `onError` / `onData` / `onKeyPress` handlers already bound at the top of this file.

#### `test-readline-promises-tab-complete.js`

Bun's copy of this node test had been changed from upstream's `fi.end()` to `rli.close()`, which closes the interface while an async tab completion is still suspended on `await this.completer(...)`. Its `finally { this.resume(); }` then hits the new guard. That is also what node does:

```
$ node tab-complete-then-close.js
UNHANDLED REJECTION: ERR_USE_AFTER_CLOSE
UNHANDLED REJECTION: ERR_USE_AFTER_CLOSE
output after close: ""
```

So the test was relying on the missing guard. It is restored to upstream (`fi.end()`, plus the `common.mustCall()` wrappers that had been dropped with it); the remaining deltas from upstream are the pre-existing Bun harness adaptations.

### Verification

`test/js/node/readline/readline.node.test.ts` covers `prompt()` / `write()` / `pause()` / `resume()` / `question()` for both `terminal: true` and `terminal: false`, plus that `close()` stays idempotent and `setPrompt()` / `getPrompt()` keep working (node does not guard those). `test/js/node/readline/readline_promises.node.test.ts` covers the `readline/promises` rejections and the four sync throws.

13 of the new assertions fail on the unfixed build and pass with the fix. All 19 `test-readline*` tests under `test/js/node/test/parallel/` pass, as do the `test-repl*` tests and `test/js/node/readline/`.

Matches `node v26.3.0` on every case above.

<details>
<summary>node v26 vs bun, before and after</summary>

```
                node v26          bun (before)      bun (after)
prompt()        ERR_USE_AFTER_CLOSE   ok            ERR_USE_AFTER_CLOSE
write()         ERR_USE_AFTER_CLOSE   ok            ERR_USE_AFTER_CLOSE
pause()         ERR_USE_AFTER_CLOSE   ok            ERR_USE_AFTER_CLOSE
resume()        ERR_USE_AFTER_CLOSE   ok            ERR_USE_AFTER_CLOSE
question()      ERR_USE_AFTER_CLOSE   ERR_USE_AFTER_CLOSE  ERR_USE_AFTER_CLOSE
setPrompt()     ok                    ok            ok
getPrompt()     ok                    ok            ok
close()         ok                    ok            ok
```

</details>

Note for whoever merges: #33343 also appends to `test/js/node/readline/readline_promises.node.test.ts` (a different bug, the unbound `Promise.$reject`). No overlap in `src/`, but the two test files will want a trivial rebase.
