### PR TITLE
node:vm: evaluate SourceTextModule graphs in spec depth-first post-order

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -344,16 +344,18 @@ void NodeVMModule::prepareGraphForEvaluation(JSGlobalObject* globalObject, uint3
     visited.add(this);
     stack.append(Frame { this, 0 });
 
-    // A callback threw. record->evaluate() never runs, so the records of the
-    // modules that were waiting on it stay Linked and reconcileEvaluationState()
-    // leaves their wrappers linked -- free to evaluate later on top of a
-    // dependency that never produced its exports. Error everything that
-    // transitively imports the thrower, found by walking importer edges.
+    // A callback threw, so record->evaluate() never runs and nothing in the graph
+    // has evaluated. Error the thrower and everything that transitively imports
+    // it, found by walking importer edges back from it. The stack alone is not
+    // that set: post-order pops a cycle member as soon as its own requests are
+    // done, which can happen before a sibling of a still-stacked cycle member
+    // throws. `visited` is not it either: a module that does not import the
+    // thrower is untouched by the failure and has to stay evaluable.
     //
-    // The stack is not that set: post-order pops a cycle member as soon as its
-    // own requests are done, which can happen before a sibling of a still-stacked
-    // cycle member throws. Nor is `visited`: a module that does not import the
-    // thrower is untouched by the failure and must stay evaluable.
+    // The error is recorded on the module record as well as the wrapper, the way
+    // innerModuleEvaluation does for an abrupt completion. A wrapper-only error
+    // leaves the record Linked, so a module outside the walk (a sibling the
+    // failure cut short) would evaluate straight through it and run its body.
     auto propagateEvaluationError = [&](NodeVMModule* thrower) {
         JSC::Exception* exception = scope.exception();
         if (!exception) [[unlikely]]
@@ -380,6 +382,12 @@ void NodeVMModule::prepareGraphForEvaluation(JSGlobalObject* globalObject, uint3
             if (module->status() != Status::Errored) {
                 module->status(Status::Errored);
                 module->m_evaluationException.set(vm, module, exception);
+            }
+            if (auto* sourceTextModule = dynamicDowncast<NodeVMSourceTextModule>(module)) {
+                if (JSC::JSModuleRecord* record = sourceTextModule->moduleRecordIfExists(); record && !record->evaluationError()) {
+                    record->setStatus(JSC::CyclicModuleRecord::Status::Evaluated);
+                    record->setEvaluationError(vm, exception->value());
+                }
             }
             if (auto iter = importers.find(module); iter != importers.end())
                 worklist.appendVector(iter->value);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -344,25 +344,46 @@ void NodeVMModule::prepareGraphForEvaluation(JSGlobalObject* globalObject, uint3
     visited.add(this);
     stack.append(Frame { this, 0 });
 
-    // A callback threw. record->evaluate() will never run, so the records of the
-    // modules still on the stack stay Linked and reconcileEvaluationState() would
-    // leave their wrappers linked -- and happily evaluate them later on top of a
-    // dependency that never produced its exports. Post-order means everything
-    // still on the stack transitively imports the thrower, which is exactly the
-    // set innerModuleEvaluation errors out of its own DFS stack.
+    // A callback threw. record->evaluate() never runs, so the records of the
+    // modules that were waiting on it stay Linked and reconcileEvaluationState()
+    // leaves their wrappers linked -- free to evaluate later on top of a
+    // dependency that never produced its exports. Error everything that
+    // transitively imports the thrower, found by walking importer edges.
+    //
+    // The stack is not that set: post-order pops a cycle member as soon as its
+    // own requests are done, which can happen before a sibling of a still-stacked
+    // cycle member throws. Nor is `visited`: a module that does not import the
+    // thrower is untouched by the failure and must stay evaluable.
     auto propagateEvaluationError = [&](NodeVMModule* thrower) {
         JSC::Exception* exception = scope.exception();
         if (!exception) [[unlikely]]
             return;
-        auto markErrored = [&](NodeVMModule* module) {
-            if (module->status() == Status::Errored)
-                return;
-            module->status(Status::Errored);
-            module->m_evaluationException.set(vm, module, exception);
-        };
-        markErrored(thrower);
-        for (const Frame& frame : stack)
-            markErrored(frame.module);
+
+        WTF::HashMap<NodeVMModule*, WTF::Vector<NodeVMModule*>> importers;
+        for (NodeVMModule* module : visited) {
+            for (const NodeVMModuleRequest& request : module->moduleRequests()) {
+                auto iter = module->m_resolveCache.find(request.specifier());
+                if (iter == module->m_resolveCache.end())
+                    continue;
+                if (auto* dependency = dynamicDowncast<NodeVMModule>(iter->value.get()))
+                    importers.add(dependency, WTF::Vector<NodeVMModule*> {}).iterator->value.append(module);
+            }
+        }
+
+        WTF::HashSet<NodeVMModule*> errored;
+        WTF::Vector<NodeVMModule*, 16> worklist;
+        worklist.append(thrower);
+        while (!worklist.isEmpty()) {
+            NodeVMModule* module = worklist.takeLast();
+            if (!errored.add(module).isNewEntry)
+                continue;
+            if (module->status() != Status::Errored) {
+                module->status(Status::Errored);
+                module->m_evaluationException.set(vm, module, exception);
+            }
+            if (auto iter = importers.find(module); iter != importers.end())
+                worklist.appendVector(iter->value);
+        }
     };
 
     while (!stack.isEmpty()) {

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -344,6 +344,27 @@ void NodeVMModule::prepareGraphForEvaluation(JSGlobalObject* globalObject, uint3
     visited.add(this);
     stack.append(Frame { this, 0 });
 
+    // A callback threw. record->evaluate() will never run, so the records of the
+    // modules still on the stack stay Linked and reconcileEvaluationState() would
+    // leave their wrappers linked -- and happily evaluate them later on top of a
+    // dependency that never produced its exports. Post-order means everything
+    // still on the stack transitively imports the thrower, which is exactly the
+    // set innerModuleEvaluation errors out of its own DFS stack.
+    auto propagateEvaluationError = [&](NodeVMModule* thrower) {
+        JSC::Exception* exception = scope.exception();
+        if (!exception) [[unlikely]]
+            return;
+        auto markErrored = [&](NodeVMModule* module) {
+            if (module->status() == Status::Errored)
+                return;
+            module->status(Status::Errored);
+            module->m_evaluationException.set(vm, module, exception);
+        };
+        markErrored(thrower);
+        for (const Frame& frame : stack)
+            markErrored(frame.module);
+    };
+
     while (!stack.isEmpty()) {
         NodeVMModule* module = stack.last().module;
         const WTF::Vector<NodeVMModuleRequest>& requests = module->moduleRequests();
@@ -365,15 +386,18 @@ void NodeVMModule::prepareGraphForEvaluation(JSGlobalObject* globalObject, uint3
         if (auto* syntheticModule = dynamicDowncast<NodeVMSyntheticModule>(module)) {
             if (module->status() == Status::Unlinked) {
                 syntheticModule->link(globalObject, nullptr, nullptr, jsUndefined());
-                RETURN_IF_EXCEPTION(scope, );
+                if (scope.exception()) [[unlikely]]
+                    return propagateEvaluationError(module);
             }
             if (module->status() == Status::Linked) {
                 module->evaluate(globalObject, timeout, breakOnSigint);
-                RETURN_IF_EXCEPTION(scope, );
+                if (scope.exception()) [[unlikely]]
+                    return propagateEvaluationError(module);
             }
         } else if (auto* sourceTextModule = dynamicDowncast<NodeVMSourceTextModule>(module)) {
             sourceTextModule->initializeImportMeta(globalObject);
-            RETURN_IF_EXCEPTION(scope, );
+            if (scope.exception()) [[unlikely]]
+                return propagateEvaluationError(module);
         }
     }
 }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -54,7 +54,10 @@ void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeou
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
-    if (m_status != Status::Evaluating)
+    // Only a module that has not reached a terminal state of its own can still
+    // learn something from its record: the root's evaluate() already wrote its
+    // own status, and dependencies sit at Linked until their record moves.
+    if (m_status != Status::Linked && m_status != Status::Evaluating)
         return;
 
     auto* sourceTextThis = dynamicDowncast<NodeVMSourceTextModule>(this);
@@ -63,14 +66,25 @@ void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 
     // JSModuleRecord is a CyclicModuleRecord; no downcast machinery needed.
     JSC::JSModuleRecord* cyclic = sourceTextThis->moduleRecordIfExists();
-    if (!cyclic || cyclic->status() != JSC::CyclicModuleRecord::Status::Evaluated)
+    if (!cyclic)
         return;
 
-    if (JSValue error = cyclic->evaluationError(); error && !error.isEmpty()) {
-        status(Status::Errored);
-        m_evaluationException.set(vm, this, JSC::Exception::create(vm, error));
-    } else {
-        status(Status::Evaluated);
+    using RecordStatus = JSC::CyclicModuleRecord::Status;
+    switch (cyclic->status()) {
+    case RecordStatus::Evaluating:
+    case RecordStatus::EvaluatingAsync:
+        status(Status::Evaluating);
+        break;
+    case RecordStatus::Evaluated:
+        if (JSValue error = cyclic->evaluationError(); error && !error.isEmpty()) {
+            status(Status::Errored);
+            m_evaluationException.set(vm, this, JSC::Exception::create(vm, error));
+        } else {
+            status(Status::Evaluated);
+        }
+        break;
+    default:
+        break;
     }
 }
 
@@ -117,7 +131,11 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
                 return {};
             }
         }
-        return m_evaluationResult.get();
+        // A dependency evaluated as part of a root's graph never created a
+        // capability promise of its own; vm.ts resolves an already-evaluated
+        // module with undefined, so the value here is only a placeholder.
+        JSValue evaluationResult = m_evaluationResult.get();
+        return evaluationResult ? evaluationResult : jsUndefined();
     }
 
     auto* sourceTextThis = dynamicDowncast<NodeVMSourceTextModule>(this);
@@ -162,13 +180,12 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     auto run = [&] {
         if (sourceTextThis) {
             status(Status::Evaluating);
-            evaluateDependencies(globalObject, record, timeout, breakOnSigint);
+            prepareGraphForEvaluation(globalObject, timeout, breakOnSigint);
             RETURN_IF_EXCEPTION(scope, );
-            sourceTextThis->initializeImportMeta(globalObject);
-            RETURN_IF_EXCEPTION(scope, );
-            // Spec-style Evaluate(): returns the capability promise that
-            // settles when (possibly async, for top-level await) evaluation
-            // finishes. Errors are stored on the record, not thrown.
+            // Spec-style Evaluate(): walks the whole graph in depth-first
+            // post-order and returns the capability promise that settles when
+            // (possibly async, for top-level await) evaluation finishes.
+            // Errors are stored on the record, not thrown.
             result = record->evaluate(globalObject);
             RETURN_IF_EXCEPTION(scope, );
         } else if (syntheticThis) {
@@ -301,35 +318,62 @@ NodeVMModule::NodeVMModule(JSC::VM& vm, JSC::Structure* structure, WTF::String i
 {
 }
 
-void NodeVMModule::evaluateDependencies(JSGlobalObject* globalObject, AbstractModuleRecord* record, uint32_t timeout, bool breakOnSigint)
+// record->evaluate() walks the whole graph itself in the spec's depth-first
+// post-order, so a dependency must not be evaluated beforehand: that makes the
+// dependency the root of the DFS and rotates the evaluation order of every cycle
+// it sits on. Only what JSC cannot see is applied here first: a
+// SyntheticModuleRecord evaluates to undefined in JSC (the user's evaluation
+// steps hang off the wrapper) and import.meta is a wrapper-side callback.
+//
+// Iterative like the other graph walks here: a deep import chain would overflow
+// the native stack before record->evaluate() reaches its isSafeToRecurse() guard
+// and throws a catchable RangeError.
+void NodeVMModule::prepareGraphForEvaluation(JSGlobalObject* globalObject, uint32_t timeout, bool breakOnSigint)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    for (const auto& request : record->requestedModules()) {
-        if (auto iter = m_resolveCache.find(request.m_specifier.string()); iter != m_resolveCache.end()) {
-            auto* dependency = uncheckedDowncast<NodeVMModule>(iter->value.get());
-            RELEASE_ASSERT(dependency != nullptr);
+    struct Frame {
+        NodeVMModule* module;
+        unsigned nextRequest;
+    };
 
-            if (dependency->status() == Status::Unlinked) {
-                if (auto* syntheticDependency = dynamicDowncast<NodeVMSyntheticModule>(dependency)) {
-                    syntheticDependency->link(globalObject, nullptr, nullptr, jsUndefined());
-                    RETURN_IF_EXCEPTION(scope, );
-                }
-            }
+    WTF::HashSet<NodeVMModule*> visited;
+    WTF::Vector<Frame, 16> stack;
 
-            if (dependency->status() == Status::Linked) {
-                JSValue dependencyResult = dependency->evaluate(globalObject, timeout, breakOnSigint);
+    visited.add(this);
+    stack.append(Frame { this, 0 });
+
+    while (!stack.isEmpty()) {
+        NodeVMModule* module = stack.last().module;
+        const WTF::Vector<NodeVMModuleRequest>& requests = module->moduleRequests();
+
+        if (unsigned index = stack.last().nextRequest; index < requests.size()) {
+            stack.last().nextRequest = index + 1;
+            auto iter = module->m_resolveCache.find(requests[index].specifier());
+            if (iter == module->m_resolveCache.end())
+                continue;
+            if (auto* dependency = dynamicDowncast<NodeVMModule>(iter->value.get()); dependency && visited.add(dependency).isNewEntry)
+                stack.append(Frame { dependency, 0 });
+            continue;
+        }
+
+        stack.removeLast();
+
+        // Post-order: a module is prepared after its dependencies, the order
+        // record->evaluate() will run the bodies in.
+        if (auto* syntheticModule = dynamicDowncast<NodeVMSyntheticModule>(module)) {
+            if (module->status() == Status::Unlinked) {
+                syntheticModule->link(globalObject, nullptr, nullptr, jsUndefined());
                 RETURN_IF_EXCEPTION(scope, );
-                // Source text dependencies evaluate via the spec-style
-                // Evaluate() and return a capability promise. A still-pending
-                // promise means the dependency uses top-level await; the
-                // root record's evaluate() drives the async machinery to
-                // completion and the wrapper status reconciles lazily
-                // (reconcileEvaluationState), so a pending result is fine
-                // here.
-                UNUSED_PARAM(dependencyResult);
             }
+            if (module->status() == Status::Linked) {
+                module->evaluate(globalObject, timeout, breakOnSigint);
+                RETURN_IF_EXCEPTION(scope, );
+            }
+        } else if (auto* sourceTextModule = dynamicDowncast<NodeVMSourceTextModule>(module)) {
+            sourceTextModule->initializeImportMeta(globalObject);
+            RETURN_IF_EXCEPTION(scope, );
         }
     }
 }

--- a/src/jsc/bindings/NodeVMModule.h
+++ b/src/jsc/bindings/NodeVMModule.h
@@ -66,9 +66,10 @@ public:
 
     JSValue evaluate(JSGlobalObject* globalObject, uint32_t timeout, bool breakOnSigint);
 
-    // For top-level-await modules JSC finishes evaluation asynchronously
-    // (record status EvaluatingAsync -> Evaluated); pull the final state into
-    // m_status/m_evaluationException once the record has settled.
+    // record->evaluate() advances the records of the whole graph without
+    // telling their wrappers, and for top-level await it finishes
+    // asynchronously (record status EvaluatingAsync -> Evaluated). Pull the
+    // record's state into m_status/m_evaluationException on demand.
     void reconcileEvaluationState(JSC::VM& vm);
 
     bool hasAsyncGraph() const;
@@ -89,7 +90,7 @@ protected:
 
     NodeVMModule(JSC::VM& vm, JSC::Structure* structure, WTF::String identifier, JSValue context, JSValue moduleWrapper);
 
-    void evaluateDependencies(JSGlobalObject* globalObject, AbstractModuleRecord* record, uint32_t timeout, bool breakOnSigint);
+    void prepareGraphForEvaluation(JSGlobalObject* globalObject, uint32_t timeout, bool breakOnSigint);
 
     DECLARE_EXPORT_INFO;
     DECLARE_VISIT_CHILDREN;

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -535,13 +535,19 @@ void NodeVMSourceTextModule::initializeImportMeta(JSGlobalObject* globalObject)
         return;
     }
 
-    CallData callData = JSC::getCallData(m_initializeImportMeta.get());
+    // The callback runs at most once per module: a module shared by two roots
+    // is walked again when the second root is prepared for evaluation, but its
+    // import.meta was already populated.
+    JSValue callback = m_initializeImportMeta.get();
+    m_initializeImportMeta.clear();
+
+    CallData callData = JSC::getCallData(callback);
 
     MarkedArgumentBuffer args;
     args.append(metaValue);
     args.append(m_moduleWrapper.get());
 
-    JSC::call(globalObject, m_initializeImportMeta.get(), callData, jsUndefined(), args);
+    JSC::call(globalObject, callback, callData, jsUndefined(), args);
     scope.release();
 }
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -8,6 +8,8 @@ import {
   runInNewContext,
   runInThisContext,
   Script,
+  SourceTextModule,
+  SyntheticModule,
 } from "node:vm";
 
 function capture(_: any, _1?: any) {}
@@ -1175,5 +1177,151 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("ab=B ba=A");
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("node:vm SourceTextModule graph evaluation order", () => {
+  // A module graph is evaluated in depth-first post-order, dependencies first
+  // (https://tc39.es/ecma262/#sec-innermoduleevaluation). Evaluating each
+  // dependency before its importer used to make the innermost dependency the
+  // root of the DFS, which rotates the evaluation order of any cycle it sits
+  // on and puts legal cyclic bindings in the TDZ when their importer runs.
+  async function linkGraph(modules: Record<string, SourceTextModule | SyntheticModule>, rootIdentifier = "A") {
+    const root = modules[rootIdentifier] as SourceTextModule;
+    await root.link(specifier => modules[specifier]);
+    return root;
+  }
+
+  test("a two-module cycle runs the dependency's body before the importer's", async () => {
+    const context = createContext({ order: [] as string[] });
+    const modules = {
+      A: new SourceTextModule(`import { v } from "B"; order.push("A"); export const a = v + 1;`, {
+        identifier: "A",
+        context,
+      }),
+      B: new SourceTextModule(`import "A"; order.push("B"); export const v = 1;`, { identifier: "B", context }),
+    };
+
+    const root = await linkGraph(modules);
+    await root.evaluate();
+
+    expect(context.order).toEqual(["B", "A"]);
+    expect(modules.A.namespace.a).toBe(2);
+    expect([modules.A.status, modules.B.status]).toEqual(["evaluated", "evaluated"]);
+  });
+
+  test("a three-module cycle runs bodies in depth-first post-order", async () => {
+    const context = createContext({ order: [] as string[] });
+    const modules = {
+      A: new SourceTextModule(`import "B"; order.push("A");`, { identifier: "A", context }),
+      B: new SourceTextModule(`import "C"; order.push("B");`, { identifier: "B", context }),
+      C: new SourceTextModule(`import "A"; order.push("C");`, { identifier: "C", context }),
+    };
+
+    const root = await linkGraph(modules);
+    await root.evaluate();
+
+    expect(context.order).toEqual(["C", "B", "A"]);
+  });
+
+  test("an acyclic diamond runs each body once, dependencies first", async () => {
+    const context = createContext({ order: [] as string[] });
+    const modules = {
+      A: new SourceTextModule(`import "B"; import "C"; order.push("A");`, { identifier: "A", context }),
+      B: new SourceTextModule(`import "D"; order.push("B");`, { identifier: "B", context }),
+      C: new SourceTextModule(`import "D"; order.push("C");`, { identifier: "C", context }),
+      D: new SourceTextModule(`order.push("D");`, { identifier: "D", context }),
+    };
+
+    const root = await linkGraph(modules);
+    await root.evaluate();
+
+    expect(context.order).toEqual(["D", "B", "C", "A"]);
+  });
+
+  test("a synthetic dependency of a cyclic graph runs its evaluation steps first", async () => {
+    const context = createContext({ order: [] as string[] });
+    const S: SyntheticModule = new SyntheticModule(
+      ["x"],
+      () => {
+        context.order.push("S");
+        S.setExport("x", 7);
+      },
+      { identifier: "S", context },
+    );
+    const modules = {
+      A: new SourceTextModule(`import "B"; import { x } from "S"; order.push("A" + x);`, { identifier: "A", context }),
+      B: new SourceTextModule(`import "A"; order.push("B");`, { identifier: "B", context }),
+      S,
+    };
+
+    const root = await linkGraph(modules);
+    await root.evaluate();
+
+    expect(context.order).toEqual(["S", "B", "A7"]);
+  });
+
+  test("import.meta is initialized for every module in a cycle before any body runs", async () => {
+    const context = createContext({ order: [] as string[] });
+    const initialized: string[] = [];
+    const sourceText = (identifier: string, source: string) =>
+      new SourceTextModule(source, {
+        identifier,
+        context,
+        initializeImportMeta(meta, module) {
+          initialized.push(module.identifier);
+          (meta as any).id = identifier;
+        },
+      });
+    const modules = {
+      A: sourceText("A", `import "B"; order.push(import.meta.id);`),
+      B: sourceText("B", `import "A"; order.push(import.meta.id);`),
+    };
+
+    const root = await linkGraph(modules);
+    await root.evaluate();
+
+    expect(context.order).toEqual(["B", "A"]);
+    expect(initialized).toEqual(["B", "A"]);
+  });
+
+  test("a module shared by two roots is evaluated once and its import.meta initialized once", async () => {
+    const context = createContext({ order: [] as string[] });
+    const initialized: string[] = [];
+    const shared = new SourceTextModule(`order.push(import.meta.id);`, {
+      identifier: "shared",
+      context,
+      initializeImportMeta(meta, module) {
+        initialized.push(module.identifier);
+        (meta as any).id = "shared";
+      },
+    });
+    const roots = ["root1", "root2"].map(
+      identifier => new SourceTextModule(`import "shared"; order.push("${identifier}");`, { identifier, context }),
+    );
+
+    for (const root of roots) {
+      await root.link(() => shared);
+      await root.evaluate();
+    }
+
+    expect(context.order).toEqual(["shared", "root1", "root2"]);
+    expect(initialized).toEqual(["shared"]);
+    expect(shared.status).toBe("evaluated");
+  });
+
+  test("a cycle that throws errors every module on the cycle with the same error", async () => {
+    const context = createContext({});
+    const modules = {
+      A: new SourceTextModule(`import "B"; export const a = 1;`, { identifier: "A", context }),
+      B: new SourceTextModule(`import "A"; throw new Error("boom");`, { identifier: "B", context }),
+    };
+
+    const root = await linkGraph(modules);
+    await expect(root.evaluate()).rejects.toThrow("boom");
+
+    expect([modules.A.status, modules.B.status]).toEqual(["errored", "errored"]);
+    expect(modules.A.error).toBe(modules.B.error);
+    expect(modules.A.error.message).toBe("boom");
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1371,6 +1371,57 @@ describe("node:vm SourceTextModule graph evaluation order", () => {
     await expect(modules.B.evaluate()).rejects.toThrow("meta boom");
   });
 
+  test("a module the failure never reached cannot evaluate through an errored dependency", async () => {
+    const context = createContext({ order: [] as string[] });
+    const modules = {
+      A: new SourceTextModule(`import "B"; import "C"; order.push("A");`, { identifier: "A", context }),
+      B: new SourceTextModule(`import "D"; order.push("B");`, { identifier: "B", context }),
+      C: new SourceTextModule(`import "D"; order.push("C");`, { identifier: "C", context }),
+      D: new SourceTextModule(`import.meta.x; order.push("D");`, {
+        identifier: "D",
+        context,
+        initializeImportMeta() {
+          throw new Error("never reached");
+        },
+      }),
+    };
+
+    const root = await linkGraph(modules);
+    await expect(root.evaluate()).rejects.toThrow("never reached");
+
+    // C was never walked (the failure cut A's request list short), so like node
+    // it stays linked. Evaluating it must still fail on D rather than run D's
+    // body: the error lives on D's record, not just its wrapper.
+    expect([modules.A.status, modules.B.status, modules.D.status]).toEqual(["errored", "errored", "errored"]);
+    expect(modules.C.status).toBe("linked");
+    await expect(modules.C.evaluate()).rejects.toThrow("never reached");
+    expect(context.order).toEqual([]);
+  });
+
+  test("an unreached module cannot evaluate through an errored intermediate", async () => {
+    const context = createContext({ order: [] as string[] });
+    const S = new SyntheticModule(
+      ["x"],
+      () => {
+        throw new Error("via boom");
+      },
+      { identifier: "S", context },
+    );
+    const modules = {
+      A: new SourceTextModule(`import "B"; import "C"; order.push("A");`, { identifier: "A", context }),
+      B: new SourceTextModule(`import { x } from "S"; order.push("B" + x);`, { identifier: "B", context }),
+      C: new SourceTextModule(`import "B"; order.push("C");`, { identifier: "C", context }),
+      S,
+    };
+
+    const root = await linkGraph(modules);
+    await expect(root.evaluate()).rejects.toThrow("via boom");
+
+    expect(modules.B.status).toBe("errored");
+    await expect(modules.C.evaluate()).rejects.toThrow("via boom");
+    expect(context.order).toEqual([]);
+  });
+
   test("import.meta is initialized for every module in a cycle before any body runs", async () => {
     const context = createContext({ order: [] as string[] });
     const initialized: string[] = [];

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1239,6 +1239,12 @@ describe("node:vm SourceTextModule graph evaluation order", () => {
     expect(context.order).toEqual(["D", "B", "C", "A"]);
   });
 
+  // JSC's SyntheticModuleRecord evaluates to undefined and offers no hook for a
+  // user callback, so a SyntheticModule's evaluation steps cannot run at their
+  // DFS position the way V8 runs them. Bun runs every synthetic callback before
+  // record->evaluate() runs any body, so node orders this ["B","S","A7"] while
+  // bun orders it ["S","B","A7"]. Only the relative order of a synthetic's side
+  // effects differs; its exports are always set before any importer reads them.
   test("a synthetic dependency of a cyclic graph runs its evaluation steps first", async () => {
     const context = createContext({ order: [] as string[] });
     const S: SyntheticModule = new SyntheticModule(
@@ -1259,6 +1265,51 @@ describe("node:vm SourceTextModule graph evaluation order", () => {
     await root.evaluate();
 
     expect(context.order).toEqual(["S", "B", "A7"]);
+  });
+
+  test("a synthetic dependency that throws errors every module importing it", async () => {
+    const context = createContext({});
+    const S = new SyntheticModule(
+      [],
+      () => {
+        throw new Error("synthetic boom");
+      },
+      { identifier: "S", context },
+    );
+    const modules = {
+      A: new SourceTextModule(`import "B"; export const a = 1;`, { identifier: "A", context }),
+      B: new SourceTextModule(`import "S"; export const b = 2;`, { identifier: "B", context }),
+      S,
+    };
+
+    const root = await linkGraph(modules);
+    await expect(root.evaluate()).rejects.toThrow("synthetic boom");
+
+    // B transitively imports S, so it must not be left evaluable on top of a
+    // dependency that never produced its exports.
+    expect([modules.A.status, modules.B.status, S.status]).toEqual(["errored", "errored", "errored"]);
+    expect(modules.B.error.message).toBe("synthetic boom");
+    await expect(modules.B.evaluate()).rejects.toThrow("synthetic boom");
+  });
+
+  test("an initializeImportMeta that throws errors the module and its importers", async () => {
+    const context = createContext({});
+    const modules = {
+      A: new SourceTextModule(`import "B"; export const a = 1;`, { identifier: "A", context }),
+      B: new SourceTextModule(`import.meta.x; export const b = 2;`, {
+        identifier: "B",
+        context,
+        initializeImportMeta() {
+          throw new Error("meta boom");
+        },
+      }),
+    };
+
+    const root = await linkGraph(modules);
+    await expect(root.evaluate()).rejects.toThrow("meta boom");
+
+    expect([modules.A.status, modules.B.status]).toEqual(["errored", "errored"]);
+    await expect(modules.B.evaluate()).rejects.toThrow("meta boom");
   });
 
   test("import.meta is initialized for every module in a cycle before any body runs", async () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1292,6 +1292,65 @@ describe("node:vm SourceTextModule graph evaluation order", () => {
     await expect(modules.B.evaluate()).rejects.toThrow("synthetic boom");
   });
 
+  test("a cycle member popped before a throwing synthetic is still errored", async () => {
+    const context = createContext({ order: [] as string[] });
+    const S = new SyntheticModule(
+      ["x"],
+      () => {
+        throw new Error("cycle boom");
+      },
+      { identifier: "S", context },
+    );
+    const modules = {
+      A: new SourceTextModule(`import "B"; order.push("A");`, { identifier: "A", context }),
+      B: new SourceTextModule(`import "C"; import { x } from "S"; order.push("B" + x);`, { identifier: "B", context }),
+      C: new SourceTextModule(`import "B"; order.push("C");`, { identifier: "C", context }),
+      S,
+    };
+
+    const root = await linkGraph(modules);
+    await expect(root.evaluate()).rejects.toThrow("cycle boom");
+
+    // C sits in a cycle with B and so transitively imports S, even though the
+    // post-order walk pops C before it ever reaches S.
+    expect([modules.A.status, modules.B.status, modules.C.status, S.status]).toEqual([
+      "errored",
+      "errored",
+      "errored",
+      "errored",
+    ]);
+    await expect(modules.C.evaluate()).rejects.toThrow("cycle boom");
+    expect(context.order).toEqual([]);
+  });
+
+  test("a sibling that does not import a throwing synthetic stays evaluable", async () => {
+    const context = createContext({ order: [] as string[] });
+    const S = new SyntheticModule(
+      [],
+      () => {
+        throw new Error("sibling boom");
+      },
+      { identifier: "S", context },
+    );
+    const modules = {
+      A: new SourceTextModule(`import "B"; import "S"; order.push("A");`, { identifier: "A", context }),
+      B: new SourceTextModule(`order.push("B"); export const b = 5;`, { identifier: "B", context }),
+      S,
+    };
+
+    const root = await linkGraph(modules);
+    await expect(root.evaluate()).rejects.toThrow("sibling boom");
+
+    // B has no dependency on S, so erroring it would be wrong. Its body has not
+    // run yet either (synthetic steps run before any body), so it reads "linked"
+    // where node reads "evaluated" -- it evaluates on demand instead.
+    expect(modules.A.status).toBe("errored");
+    expect(modules.B.status).toBe("linked");
+    await modules.B.evaluate();
+    expect(modules.B.namespace.b).toBe(5);
+    expect(context.order).toEqual(["B"]);
+  });
+
   test("an initializeImportMeta that throws errors the module and its importers", async () => {
     const context = createContext({});
     const modules = {


### PR DESCRIPTION
`vm.SourceTextModule` evaluated cyclic module graphs in the wrong order: the importing module's body ran before its dependency's, so a legal ESM cycle threw a TDZ `ReferenceError` and left both modules `errored`.

### Repro

```js
const vm = require("node:vm");
const src = {
  // classic legal cycle
  A: `import { v } from "B"; export const a = v + 1;`,
  B: `import "A"; export const v = 1;`,
};
const mods = {
  A: new vm.SourceTextModule(src.A, { identifier: "A" }),
  B: new vm.SourceTextModule(src.B, { identifier: "B" }),
};
await mods.A.link(spec => mods[spec]);
await mods.A.evaluate();
console.log(mods.A.namespace.a);
```

```
# node --experimental-vm-modules, and bun's own file-based ESM
2

# bun 1.4.0
ReferenceError: Cannot access 'v' before initialization.
# ...and mods.A.status === mods.B.status === "errored"
```

A three-module cycle `A -> B -> C -> A` runs its bodies `B > A > C` where the spec ([InnerModuleEvaluation](https://tc39.es/ecma262/#sec-innermoduleevaluation)), node, and bun's own file-based ESM all run `C > B > A`. Acyclic graphs were ordered correctly.

### Cause

`NodeVMModule::evaluate()` evaluated every dependency before the importing module, and each of those calls drove JSC's spec-style `CyclicModuleRecord::evaluate()` on the dependency's own record. `record->evaluate()` already walks the whole graph in depth-first post-order, so pre-evaluating a dependency makes *it* the root of the DFS, which rotates the post-order of any cycle it sits on.

The pre-walk existed only because JSC evaluates a `SyntheticModuleRecord` to `undefined` without running anything, so a `vm.SyntheticModule`'s evaluation steps live on bun's wrapper rather than on the record.

### Fix

Let the root's `record->evaluate()` drive the whole graph, and pre-walk only to apply the two things JSC cannot see: a synthetic module's evaluation steps, and the `initializeImportMeta` callback. Both now run for every reachable module, in post-order, before any body executes.

Dependency wrappers no longer evaluate themselves, so their status is pulled from their record on demand (`reconcileEvaluationState`): a module the DFS never reaches stays `linked`, one it is currently inside reads `evaluating`, and a finished one reads `evaluated` / `errored`. `initializeImportMeta` is now one-shot per module so a module shared by two roots doesn't see it twice.

### Known divergence

JSC's `SyntheticModuleRecord::evaluate()` returns `undefined` with no hook for a user callback, so a `vm.SyntheticModule`'s evaluation steps cannot run at their DFS position the way V8 runs them. They run in the pre-walk instead, before any module body. Two consequences, both noted in comments next to the affected tests:

- For `A -> [B, S]` where `S` is synthetic, node's side-effect order is `B, S, A` and bun's is `S, B, A`. A synthetic's exports are always set before any importer reads them, so only the relative order of its own side effects differs. (Before this PR bun produced `A, B, S` here, reading the export before it was set.)
- If a synthetic's evaluation steps throw, a sibling that does not import it stays `linked` rather than `evaluated`, because no body had run yet. It still evaluates successfully on a later `evaluate()`. (Modules that *do* transitively import the thrower are errored, matching node.)

Closing either gap needs a WebKit change.

### Verification

New tests in `test/js/node/vm/vm.test.ts` (`node:vm SourceTextModule graph evaluation order`) cover the two-module cycle, a three-module cycle, an acyclic diamond, a synthetic dependency of a cyclic graph, `import.meta` across a cycle, a module shared by two roots, and a cycle that throws. Four of the seven fail on `main`.

All 97 `test/js/node/test/parallel/test-vm-*` tests pass, including every `test-vm-module-*`.

<details>
<summary>Differential probe against <code>node --experimental-vm-modules</code> (identical output after the fix)</summary>

```
1 tla-dep order: ["B","A"] A: evaluated B: evaluated
2 tla-cycle order: ["B","A"] A: evaluated B: evaluated
3 dep re-evaluate: ["B","A"] result: undefined B: evaluated
4 deep chain threw: RangeError Maximum call stack size exceeded
5 dynamic import in cycle: ["B","A","dyn","D9"]
6 threw: nope | A: errored B: errored C: linked
7 afterEvaluate: ["B","A","tick"]
```

Before the fix bun printed `["A","B"]` for 2 and `["A","dyn","D9","B"]` for 5.

Case 4 is a behavior change worth calling out: a very deep linear import chain now throws the same catchable `RangeError` node throws, at the same depth (a 2000-module chain evaluates, 3000 throws on both). It used to evaluate because each module got its own shallow `record->evaluate()` rather than one deep DFS.

</details>