### PR TITLE
orderfile: stop a traced process's children from truncating its trace

### DIFF
--- a/scripts/orderfile/pagetrace.c
+++ b/scripts/orderfile/pagetrace.c
@@ -77,28 +77,31 @@ int sigaction(int signum, const struct sigaction *act, struct sigaction *old)
 
 __attribute__((constructor(101))) static void pagetrace_init(void)
 {
-    const char *binary = getenv("BUN_PAGETRACE_BIN");
-    const char *out = getenv("BUN_PAGETRACE_OUT");
-    if (!binary || !out) return;
+    const char *binary_env = getenv("BUN_PAGETRACE_BIN");
+    const char *out_env = getenv("BUN_PAGETRACE_OUT");
+    if (!binary_env || !out_env) return;
+
+    // unsetenv below may invalidate what getenv just returned.
+    char binary[512], out[512];
+    snprintf(binary, sizeof binary, "%s", binary_env);
+    snprintf(out, sizeof out, "%s", out_env);
+
+    // A traced workload execs other programs — `bun install` runs lifecycle
+    // scripts, the cli workload shells out — and LD_PRELOAD is inherited. Take
+    // ourselves out of the environment so no child runs this constructor: one
+    // that maps the same binary (another bun) would arm itself and clobber the
+    // trace this process is still writing. ptyrun hands the preload down to the
+    // one child that should have it, so nothing here depends on inheritance.
+    unsetenv("LD_PRELOAD");
+    unsetenv("BUN_PAGETRACE_BIN");
+    unsetenv("BUN_PAGETRACE_OUT");
 
     long reported = sysconf(_SC_PAGESIZE);
     if (reported > 0) page_size = (uintptr_t)reported;
 
-    size_t bytes = (size_t)(HEADER_WORDS + MAX_HITS) * 8;
-    int fd = open(out, O_CREAT | O_TRUNC | O_RDWR, 0644);
-    if (fd < 0) return;
-    if (ftruncate(fd, (off_t)bytes) != 0) {
-        close(fd);
-        return;
-    }
-    record = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    close(fd);
-    if (record == MAP_FAILED) {
-        record = NULL;
-        return;
-    }
-    record[0] = page_size;
-
+    // Find the regions before creating the output file. A process that is not
+    // the binary under trace has nothing to record, and the file it would
+    // create-and-truncate is the one a live trace is recording into.
     FILE *maps = fopen("/proc/self/maps", "r");
     if (!maps) return;
     char line[1024];
@@ -118,6 +121,21 @@ __attribute__((constructor(101))) static void pagetrace_init(void)
     }
     fclose(maps);
     if (!region_count) return;
+
+    size_t bytes = (size_t)(HEADER_WORDS + MAX_HITS) * 8;
+    int fd = open(out, O_CREAT | O_TRUNC | O_RDWR, 0644);
+    if (fd < 0) return;
+    if (ftruncate(fd, (off_t)bytes) != 0) {
+        close(fd);
+        return;
+    }
+    record = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+    if (record == MAP_FAILED) {
+        record = NULL;
+        return;
+    }
+    record[0] = page_size;
 
     static char altstack[256 * 1024];
     stack_t ss = { .ss_sp = altstack, .ss_size = sizeof altstack, .ss_flags = 0 };

--- a/scripts/orderfile/ptyrun.c
+++ b/scripts/orderfile/ptyrun.c
@@ -11,9 +11,9 @@
 // ours, so a workload looks the same to the caller either way. Exits with the
 // child's status.
 //
-// PTYRUN_PRELOAD becomes the child's LD_PRELOAD. The page tracer has to load
-// into the binary being traced and nowhere else: preloaded here it would create
-// and truncate a trace file for a process it cannot trace.
+// PTYRUN_PRELOAD becomes the child's LD_PRELOAD. The page tracer belongs in the
+// binary being traced and nowhere else, and it drops itself from the environment
+// once loaded, so it is handed down here rather than inherited.
 #define _GNU_SOURCE
 #include <errno.h>
 #include <poll.h>

--- a/test/js/bun/perf/linker-order.test.ts
+++ b/test/js/bun/perf/linker-order.test.ts
@@ -96,6 +96,13 @@ describe("order file generator", () => {
 
 const compiler = process.env.CC || Bun.which("cc") || Bun.which("clang") || Bun.which("gcc");
 
+async function compile(args: string[]) {
+  await using proc = Bun.spawn({ cmd: [compiler!, "-O1", ...args], env: bunEnv, stderr: "pipe" });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+}
+
 /**
  * One of the traced workloads runs on a pseudo-terminal, because bun's stdio,
  * tty and readline code take a path there that a pipe never reaches, and an
@@ -112,13 +119,6 @@ describe.skipIf(process.platform !== "linux" || !compiler)("pty runner", () => {
     `  process.stdin.pause();`,
     `});`,
   ].join("\n");
-
-  async function compile(args: string[]) {
-    await using proc = Bun.spawn({ cmd: [compiler!, "-O1", ...args], env: bunEnv, stderr: "pipe" });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
-  }
 
   async function type(cmd: string[], env: Record<string, string>) {
     await using proc = Bun.spawn({
@@ -154,5 +154,45 @@ describe.skipIf(process.platform !== "linux" || !compiler)("pty runner", () => {
       ptyExit: 0,
       pipeExit: 0,
     });
+  });
+});
+
+/**
+ * The tracer loads into the binary under trace and nowhere else. Every workload
+ * that execs something — `bun install` runs lifecycle scripts, the cli workload
+ * shells out — hands LD_PRELOAD to the child, and a child that created and
+ * truncated the trace file would wipe the pages recorded so far. Those are the
+ * earliest-touched ones, which is to say the hottest.
+ */
+describe.skipIf(process.platform !== "linux" || !compiler)("page tracer", () => {
+  it("keeps the pages it recorded before the traced process execs a child", async () => {
+    using dir = tempDir("pagetrace", { "child.c": "int main(void) { return 0; }\n" });
+    const root = String(dir);
+    const tracer = join(root, "pagetrace.so");
+    const fixture = join(root, "fixture");
+    const child = join(root, "child");
+    const trace = join(root, "trace.bin");
+
+    await compile(["-shared", "-fPIC", "-o", tracer, join(import.meta.dir, "../../../../scripts/orderfile/pagetrace.c"), "-ldl"]); // prettier-ignore
+    await compile(["-o", fixture, join(import.meta.dir, "pagetrace-fixture.c")]);
+    await compile(["-o", child, join(root, "child.c")]);
+
+    // The fixture reads 32 pages of its own .rodata, execs `child` (dynamically
+    // linked, so it inherits LD_PRELOAD), then reads one more.
+    await using proc = Bun.spawn({
+      cmd: [fixture, child],
+      env: { ...bunEnv, LD_PRELOAD: tracer, BUN_PAGETRACE_BIN: fixture, BUN_PAGETRACE_OUT: trace },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "1", stderr: "", exitCode: 0 });
+
+    // Layout: u64 page size, u64 count, then `count` u64 page addresses.
+    const header = new BigUint64Array(await Bun.file(trace).slice(0, 16).arrayBuffer());
+    expect(Number(header[0])).toBeGreaterThan(0);
+    // The 32 pages, the one after, and whatever the fixture's own startup
+    // touched. A child that truncated the file leaves a handful.
+    expect(Number(header[1])).toBeGreaterThanOrEqual(33);
   });
 });

--- a/test/js/bun/perf/pagetrace-fixture.c
+++ b/test/js/bun/perf/pagetrace-fixture.c
@@ -1,0 +1,43 @@
+// Fixture for the scripts/orderfile/pagetrace.c regression test.
+//
+// Reads one byte from each of TOUCHED pages of its own .rodata, execs the
+// dynamically linked program named by argv[1] (which inherits LD_PRELOAD), then
+// reads one more. Under the tracer each of those reads is a recorded page fault,
+// so a child that create-and-truncates the trace file shows up as a collapsed
+// count.
+//
+// The stride is the largest page size linux runs (64 KB on some aarch64 kernels)
+// so the number of distinct pages touched is TOUCHED everywhere.
+//
+//   cc -O2 -o pagetrace-fixture pagetrace-fixture.c
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define STRIDE 65536
+#define TOUCHED 32
+
+// .rodata, not .bss: the tracer protects the binary's text and read-only
+// mappings. volatile so the reads survive -O2.
+static const volatile char blob[(TOUCHED + 1) * STRIDE] = { 1 };
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) return 2;
+
+    unsigned long long sum = 0;
+    for (int i = 0; i < TOUCHED; i++) sum += (unsigned long long)blob[(size_t)i * STRIDE];
+
+    pid_t child = fork();
+    if (child < 0) return 3;
+    if (child == 0) {
+        execl(argv[1], argv[1], (char *)NULL);
+        _exit(127);
+    }
+    int status = 0;
+    if (waitpid(child, &status, 0) != child || status != 0) return 4;
+
+    sum += (unsigned long long)blob[(size_t)TOUCHED * STRIDE];
+    printf("%llu\n", sum);
+    return 0;
+}


### PR DESCRIPTION
Follow-up to #33302, per [this review comment](https://github.com/oven-sh/bun/pull/33302#discussion_r2692766608).

## The bug

`pagetrace.c`'s constructor opened `BUN_PAGETRACE_OUT` with `O_CREAT|O_TRUNC` and `ftruncate`d it *before* reading `/proc/self/maps` to find out whether this process is even the binary under trace:

```c
int fd = open(out, O_CREAT | O_TRUNC | O_RDWR, 0644);   // ← truncates
...
record = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
...
fclose(maps);
if (!region_count) return;                              // ← too late
```

`LD_PRELOAD` and both `BUN_PAGETRACE_*` variables are inherited across `exec`, so any dynamically linked child a workload spawns — a lifecycle script, `/bin/sh`, another bun — re-ran the constructor, zeroed the `MAP_SHARED` trace its parent was still writing into, and only then bailed. The pages lost are the earliest-touched ones, which is to say the hottest.

## The fix

Find the regions first and leave the file alone when there are none. Then drop `LD_PRELOAD` and the two `BUN_PAGETRACE_*` variables from the environment once loaded, so a child that *does* map the same binary (another bun) never arms itself either — the region check alone can't catch that one. `ptyrun` already hands the preload down explicitly via `PTYRUN_PRELOAD` rather than relying on inheritance, so nothing depended on it; its comment is updated to say so.

## Impact today

None, which is why it was still there. No workload currently spawns, and the order file comes out byte-for-byte the same work:

```
                      before fix            after fix
bun -e                2108 pages  +21636    2108 pages  +21636
bun hello.ts          2168 pages    +631    2168 pages    +631
bun server.js         2611 pages   +4809    2611 pages   +4809
bun test              3057 pages   +5174    3057 pages   +5174
bun install            630 pages   +1440     630 pages   +1440
bun install (cached)   540 pages     +83     540 pages     +83
bun cli.js (pipe)     3075 pages   +2024    3075 pages   +2024
bun cli.js (tty)      3348 pages   +2003    3369 pages   +2137   (pty jitter)
```

But `bun install` is one `package.json` away from running a lifecycle script, and the failure is silent: a truncated trace still produces an order file, just one missing the hot core.

## Test

`test/js/bun/perf/pagetrace-fixture.c` reads one byte from each of 32 pages of its own `.rodata`, execs a dynamically linked child, then reads one more. Under the tracer each read is a recorded fault, so the count is the signal:

```
before:  Expected: >= 33   Received: 1
after:   9 pass, 1 skip, 0 fail
```

The stride is 64 KB so the page count is the same on kernels with 16 KB or 64 KB pages. Skipped where there's no C compiler, alongside the existing `ptyrun` test.
