### PR TITLE
test: fix the flaky out-of-memory assertion in tls-syscall-fault.test.ts

### DIFF
--- a/test/js/node/tls/tls-syscall-fault.test.ts
+++ b/test/js/node/tls/tls-syscall-fault.test.ts
@@ -20,6 +20,10 @@ afterEach(() => fault.clear());
 // stream; anything past "ARMED" means a TLS socket survived the failed
 // allocation and reached its read loop.
 const OOM_FIXTURE_MARKERS = ["ARMED", "READ DATA", "CLOSED", "CLIENT ERROR"];
+// How `CrashReason::OutOfMemory` is phrased depends on whether a crash report is
+// being generated, and CI configures that per job (BUN_CRASH_REPORT_URL is only
+// set when its remap server came up). Match either phrasing.
+const OOM_CRASH_MESSAGES = ["Bun ran out of memory", "Bun has run out of memory"];
 test.skipIf(!fault.available())(
   "a failed per-loop TLS buffer allocation reports out of memory instead of faulting inside SSL_read",
   async () => {
@@ -30,7 +34,7 @@ test.skipIf(!fault.available())(
       stderr: "pipe",
     });
     const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const outOfMemory = stderr.includes("Bun ran out of memory");
+    const outOfMemory = OOM_CRASH_MESSAGES.some(message => stderr.includes(message));
     expect({
       markers: stdout
         .split("\n")


### PR DESCRIPTION
### What does this PR do?

`test/js/node/tls/tls-syscall-fault.test.ts` fails on the `x64-asan` lane on some jobs and passes on others. It is not a real failure, and it is not a race: the assertion depends on an environment variable CI sets conditionally.

#### Cause

The test decides whether the child reported OOM with a single literal:

```js
const outOfMemory = stderr.includes("Bun ran out of memory");
```

That string comes from `Display for CrashReason` (`src/crash_handler/lib.rs:691`), which is printed on the `panic(main thread): {reason}` line. But for `CrashReason::OutOfMemory` that line is deliberately suppressed when a crash report is being generated:

```rust
if !matches!(reason, CrashReason::OutOfMemory) || debug_trace {
    // panic(main thread): {reason}
}
```

In that mode the child prints the banner instead (`src/crash_handler/lib.rs:1208`):

```
oh no: Bun has run out of memory.
```

`debug_trace` is false when `is_reporting_enabled()` is true, and `is_reporting_enabled()` returns true as soon as `BUN_CRASH_REPORT_URL` is set. The CI runner sets it only when its crash-report remap server came up (`scripts/runner.node.mjs:1326`):

```js
...(typeof remapPort == "number"
  ? { BUN_CRASH_REPORT_URL: `http://localhost:${remapPort}` }
  : { BUN_ENABLE_CRASH_REPORTING: "0" }),
```

so the same test passes or fails depending on the job. Locally there is no remap server, which is why it always passes during development.

`OutOfMemory` is the only `CrashReason` whose `panic:` line is conditional, so this is the only test that can be bitten by it. `test/cli/run/run-crash-handler.test.ts:196` already special-cases it for exactly this reason:

```js
if (approach !== "outOfMemory") {
  expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
} else {
  expect(stderr.toLowerCase()).toContain("out of memory");
}
```

#### Fix

Match either phrasing. Both are the same `CrashReason::OutOfMemory`, and which one prints is not what this test is about.

```js
const OOM_CRASH_MESSAGES = ["Bun ran out of memory", "Bun has run out of memory"];
...
const outOfMemory = OOM_CRASH_MESSAGES.some(message => stderr.includes(message));
```

The crash handler's two messages are left alone: they are deliberately different registers (a short reason on the `panic:` line, a full sentence in the report banner), and unifying them would change user-facing output for no user benefit.

### How did you verify your code works?

`BUN_CRASH_REPORT_URL` reproduces the CI job that fails, since `bunEnv` spreads `process.env`:

<details>
<summary>Before, on <code>main</code></summary>

```
$ BUN_CRASH_REPORT_URL=http://localhost:1 bun bd test test/js/node/tls/tls-syscall-fault.test.ts -t "reports out of memory"

+ oh no: Bun has run out of memory.
...
- Expected  - 2
+ Received  + 21
(fail) a failed per-loop TLS buffer allocation reports out of memory instead of faulting inside SSL_read

 0 pass
 1 fail
```

</details>

After, both modes:

```
$ BUN_CRASH_REPORT_URL=http://localhost:1 bun bd test test/js/node/tls/tls-syscall-fault.test.ts
 11 pass
 0 fail

$ bun bd test test/js/node/tls/tls-syscall-fault.test.ts
 11 pass
 0 fail
```

Seen failing on build [#68424](https://buildkite.com/bun/bun/builds/68424) and build [#68416](https://buildkite.com/bun/bun/builds/68416), on two unrelated branches. The test arrived in #33326.
