### PR TITLE
Document that a pinned ArrayBuffer's transfer() copies instead of detaching

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -953,6 +953,11 @@ impl JSValue {
     }
     /// `as_array_buffer`, but pins the backing `JSC::ArrayBuffer` first so it
     /// cannot be detached. The pin does not prevent collection.
+    ///
+    /// While pinned, a JS `transfer()`, `structuredClone(v, { transfer: [ab] })`
+    /// or `postMessage(v, [ab])` hands the destination a copy and leaves the
+    /// source attached rather than throwing. See `JSC__JSValue__pinArrayBuffer`
+    /// in bindings.cpp for why. Release the pin with `ArrayBuffer::unpin`.
     pub fn as_pinned_arraybuffer(self, global: &JSGlobalObject) -> Option<ArrayBuffer> {
         if !JSC__JSValue__pinArrayBuffer(self) {
             return None;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3181,10 +3181,24 @@ bool JSC__JSValue__asArrayBuffer(
 }
 
 // Pin/unpin the backing ArrayBuffer of a JSArrayBuffer or JSArrayBufferView so
-// transfer()/detach() throw while a native borrower holds a slice into it.
-// SharedArrayBuffer is never detachable and never moves, so it is left
+// its storage cannot move or be freed while a native borrower holds a slice
+// into it. SharedArrayBuffer is never detachable and never moves, so it is left
 // unpinned rather than rejected. Returns false if `value` has no ArrayBuffer
 // impl.
+//
+// A pin does not make detaching fail, it makes it copy. `pin()` clears
+// `ArrayBuffer::isDetachable()`, and `ArrayBuffer::transferTo()` answers an
+// undetachable buffer by copying the bytes into the destination and reporting
+// success (`if (!isDetachable()) m_contents.copyTo(result)`). So while a borrow
+// is live, `ab.transfer()`, `structuredClone(v, { transfer: [ab] })` and
+// `port.postMessage(v, [ab])` each return normally, give the destination an
+// independent copy, and leave `ab` attached; the bytes being read never move.
+//
+// That departs from ES2024, where transfer() must detach or throw, and from
+// Node, which detaches. It is deliberate: the borrow stays zero-copy in the
+// common case and memory-safe in every case, at the cost of a transfer that
+// silently no-ops for as long as a borrowing op (zlib, fs, crypto, shell,
+// Bun.Image, SQL blob binds, ...) happens to be in flight over that buffer.
 static JSC::ArrayBuffer* arrayBufferImpl(JSC::JSValue value)
 {
     if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value))


### PR DESCRIPTION
## Repro

```js
const zlib = require("zlib");
const ab = new ArrayBuffer(64);
zlib.gzip(new Uint8Array(ab), () => {}); // pins ab's backing store
const nb = ab.transfer();
console.log(ab.detached, ab.byteLength, nb.byteLength);
// bun:  false 64 64   (two live buffers over "moved" memory)
// node: true  0  64
```

Same for `structuredClone(v, { transfer: [ab] })` and `port.postMessage(v, [ab])`.

## Cause

Bun pins an ArrayBuffer's backing store for as long as an in-flight native op
reads its bytes off-thread (`JSC__JSValue__pinArrayBuffer`). `pin()` clears
`JSC::ArrayBuffer::isDetachable()`, and `ArrayBuffer::transferTo()` answers an
undetachable buffer by copying the bytes into the destination and reporting
success:

```cpp
if (!isDetachable()) {
    m_contents.copyTo(result);
    if (!result.m_data)
        return false;
    return true;
}
```

So every detaching entry point returns normally, gives the destination an
independent copy, and leaves the source attached.

The comment above `JSC__JSValue__pinArrayBuffer` said the opposite, that pinning
makes `transfer()`/`detach()` throw. It never has.

## Fix

Comments only, no behavior change. The silent copy is the tradeoff we want: it
keeps the borrow zero-copy in the common case and memory-safe in every case,
where detaching (Node's behavior) would leave the in-flight operation reading
storage the source buffer no longer owns. Document that at the pin site and on
the Rust entry point (`JSValue::as_pinned_arraybuffer`) so the next reader does
not have to re-derive it from JSC.

Existing coverage of the behavior: `test/js/bun/image/image-adversarial.test.ts`
(`OversizeTypedArray input survives .buffer -> transfer() while worker decodes`),
`test/js/bun/md/md-render-callback.test.ts`, and
`test/js/sql/sql-mysql-bind-blob-borrow.test.ts`.

## Note for later

Bun's `structuredClone`/`postMessage` transfer-list check only tests
`isLocked()`, while upstream WebCore tests `!isDetachable()` and throws a
TypeError (`SerializedScriptValue.cpp`, "Step 2: Now that serialization is done,
validate transferable states"). Tightening that to `!isDetachable()` is the one
place this could be made to throw without giving up the pin, if we ever want it.