### PR TITLE
color: unmark the lab round-trip test as failing

### DIFF
--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -442,15 +442,27 @@ describe("css string output parses back to the same color", () => {
     expect(color("#000000", "hsl")).toBe("hsl(0, 0%, 0%)");
   });
 
-  test("lab output is CSS that Bun can parse back", () => {
-    for (const input of [...inputs, "#808080", "lime", "rebeccapurple"]) {
-      expect(color(color(input, "lab") as string, "hex")).not.toBeNull();
+  // #0000ff is https://github.com/oven-sh/bun/issues/33331; the cube sweep below
+  // steps over 255, so it never reaches pure blue.
+  test("lab round-trips", () => {
+    for (const input of [...inputs, "#808080", "lime", "rebeccapurple", "#0000ff"]) {
+      expect(color(color(input, "lab") as string, "hex")).toBe(color(input, "hex"));
     }
   });
 
-  // https://github.com/oven-sh/bun/issues/33331
-  test.failing("lab round-trips", () => {
-    expect(color(color("#0000ff", "lab") as string, "hex")).toBe("#0000ff");
+  test("lab round-trips across the color cube", () => {
+    withoutAggressiveGC(() => {
+      for (let r = 0; r < 256; r += 37) {
+        for (let g = 0; g < 256; g += 53) {
+          for (let b = 0; b < 256; b += 61) {
+            const back = color(color({ r, g, b }, "lab") as string, "hex");
+            if (back !== color({ r, g, b }, "hex")) {
+              throw new Error(`lab(${r},${g},${b}) round-tripped to ${back}`);
+            }
+          }
+        }
+      }
+    });
   });
 
   // The forward direction is exact, so the inverse is the broken one. It goes


### PR DESCRIPTION
`test/js/bun/css/color.test.ts` fails on `main`:

```
✗ css string output parses back to the same color > lab round-trips
  ^ this test is marked as failing but it passed. Remove `.failing` if tested behavior now works
```

## Cause

`test.failing("lab round-trips")` was added in #33328 pinned to #33331 (`lab()` colors on the sRGB gamut boundary were desaturated: `#0000ff` round-tripped to `#002cea`). #33333 fixed that conversion by adding the CSS Color 4 initial clip to `map_gamut`, but left the marker behind, so the test now passes and the runner flags it.

## Fix

Drop the marker. The test asserted one color and sat next to `lab output is CSS that Bun can parse back`, which looped over eight inputs with the weaker `not.toBeNull()` check, so this folds them into one: the round-trip over the same input list the `hsl round-trips` twin uses, plus `#0000ff`, and a cube sweep mirroring `hsl round-trips across the color cube`. The not-null assertion is subsumed (`toBe(color(input, "hex"))` cannot pass on `null`).

`#0000ff` stays an explicit case because the cube sweep steps by 61 and never reaches 255.

## Verification

```
bun bd test test/js/bun/css/color.test.ts
972 pass, 1 skip, 0 fail
```

Both tests are load-bearing. Reverting #33333's `map_gamut` clip turns them red along with the five cases that PR added:

```
(fail) lab()/oklab() sRGB fallback for boundary colors (#33331) > color(#0000ff via lab) clips to the boundary
(fail) lab()/oklab() sRGB fallback for boundary colors (#33331) > color(#0000ee via lab) clips to the boundary
(fail) lab()/oklab() sRGB fallback for boundary colors (#33331) > color(#0000cc via lab) clips to the boundary
(fail) lab()/oklab() sRGB fallback for boundary colors (#33331) > color(#0000aa via lab) clips to the boundary
(fail) lab()/oklab() sRGB fallback for boundary colors (#33331) > oklab blue is not desaturated
(fail) css string output parses back to the same color > lab round-trips
(fail) css string output parses back to the same color > lab round-trips across the color cube
```

The round-trip is exact now, not just for the colors asserted here. #33331 reported 15 of 4096 colors wrong with a worst channel error of 44/255; sweeping ~930k colors on the current build finds zero mismatches:

<details>
<summary>sweep</summary>

```js
function sweep(name, rs, gs, bs) {
  let bad = 0, total = 0;
  for (let r = 0; r < 256; r += rs) for (let g = 0; g < 256; g += gs) for (let b = 0; b < 256; b += bs) {
    total++;
    if (Bun.color(Bun.color({ r, g, b }, "lab"), "hex") !== Bun.color({ r, g, b }, "hex")) bad++;
  }
  console.log(`${name}: ${bad}/${total} mismatched`);
}
sweep("step 17 (the sweep from #33331)", 17, 17, 17);
sweep("step 5", 5, 5, 5);
sweep("every r,g; 6 blues", 1, 1, 51);
sweep("6 reds; every g,b", 51, 1, 1);
```

```
step 17 (the sweep from #33331): 0/4096 mismatched
step 5: 0/140608 mismatched
every r,g; 6 blues: 0/393216 mismatched
6 reds; every g,b: 0/393216 mismatched
```

</details>

The step-17 sweep costs ~1s on a debug build, so the committed cube test uses the coarser steps of its `hsl` twin (~29ms). Those steps still catch the regression, as the fail-before run above shows.

Closes #33331. The conversion fix landed in #33333; this is the marker it left behind.