### PR TITLE
net: don't reject when disposing a server that never listened

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3190,6 +3190,13 @@ Server.prototype.close = function close(callback) {
 };
 
 Server.prototype[Symbol.asyncDispose] = function () {
+  // Disposing a server that never listened is a no-op, so `await using` cannot replace the
+  // error that kept listen() from succeeding with ERR_SERVER_NOT_RUNNING.
+  // https://github.com/nodejs/node/blob/b59def5e8113/lib/net.js#L2636
+  if (!this._handle) {
+    return Promise.$resolve();
+  }
+
   const { resolve, reject, promise } = Promise.withResolvers();
   this.close(function (err, ...args) {
     if (err) reject(err);

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -2,6 +2,8 @@ import { realpathSync } from "fs";
 import { AddressInfo, createServer, Server, Socket } from "net";
 import { createTest } from "node-harness";
 import { once } from "node:events";
+import { createServer as createHttpServer } from "node:http";
+import { Server as TLSServer } from "node:tls";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -567,5 +569,82 @@ describe("net.createServer events", () => {
     } finally {
       server.close();
     }
+  });
+});
+
+describe("net.Server[Symbol.asyncDispose]", () => {
+  async function listen(server: Server, port: number): Promise<void> {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    server.once("error", reject);
+    server.listen(port, resolve);
+    try {
+      await promise;
+    } finally {
+      server.removeListener("error", reject);
+    }
+  }
+
+  function settle(promise: Promise<unknown>): Promise<unknown> {
+    return promise.then(
+      () => null,
+      (error: unknown) => error,
+    );
+  }
+
+  it("resolves when the server never listened", async () => {
+    const server = new Server();
+    expect(server.listening).toBe(false);
+    expect(await settle(server[Symbol.asyncDispose]())).toBeNull();
+  });
+
+  it("resolves when the server is already closed", async () => {
+    const server = new Server();
+    await listen(server, 0);
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    server.close(err => (err ? reject(err) : resolve()));
+    await promise;
+
+    expect(server.listening).toBe(false);
+    expect(await settle(server[Symbol.asyncDispose]())).toBeNull();
+  });
+
+  it("closes a listening server", async () => {
+    const server = new Server();
+    await listen(server, 0);
+    const closed = once(server, "close");
+
+    expect(await settle(server[Symbol.asyncDispose]())).toBeNull();
+    await closed;
+    expect(server.listening).toBe(false);
+    expect(server.address()).toBeNull();
+  });
+
+  it("does not replace a failed listen() with ERR_SERVER_NOT_RUNNING under `await using`", async () => {
+    await using blocker = createServer();
+    await listen(blocker, 0);
+    const { port } = blocker.address() as AddressInfo;
+
+    async function takeTheBusyPort() {
+      await using server = createServer();
+      await listen(server, port);
+    }
+
+    const error = await settle(takeTheBusyPort());
+    expect(error).not.toBeInstanceOf(SuppressedError);
+    expect(error).toMatchObject({ code: "EADDRINUSE" });
+  });
+
+  it("tls.Server inherits the guard", async () => {
+    const server = new TLSServer();
+    expect(server.listening).toBe(false);
+    expect(await settle(server[Symbol.asyncDispose]())).toBeNull();
+  });
+
+  // node only guards on net.Server; its http.Server dispose still rejects for a server that
+  // never listened. https://github.com/nodejs/node/blob/b59def5e8113/lib/_http_server.js#L677
+  it("http.Server still rejects with ERR_SERVER_NOT_RUNNING, like node", async () => {
+    const error = await settle(createHttpServer()[Symbol.asyncDispose]());
+    expect(error).toMatchObject({ code: "ERR_SERVER_NOT_RUNNING" });
   });
 });


### PR DESCRIPTION
### Repro

```js
import net from "node:net";

const blocker = net.createServer();
await new Promise(r => blocker.listen(0, r));
const { port } = blocker.address();

try {
  await (async () => {
    await using srv = net.createServer();
    await new Promise((resolve, reject) => {
      srv.once("error", reject);
      srv.listen(port, resolve); // EADDRINUSE
    });
  })();
} catch (e) {
  console.log(e.name, e.code); // node: Error EADDRINUSE
                               // bun:  SuppressedError undefined
}
```

Bun buries the real error inside `SuppressedError(error=ERR_SERVER_NOT_RUNNING, suppressed=EADDRINUSE)`, so `err.code === "EADDRINUSE"` handling breaks and logs point at the wrong failure.

### Cause

`net.Server.prototype[Symbol.asyncDispose]` calls `close()` unconditionally:

```js
Server.prototype[Symbol.asyncDispose] = function () {
  const { resolve, reject, promise } = Promise.withResolvers();
  this.close(function (err, ...args) { ... });
  return promise;
};
```

`Server.prototype.close(cb)` invokes `cb($ERR_SERVER_NOT_RUNNING())` when `this._handle` is null, so disposing a server that never listened always rejects. Since the whole point of `await using` is to be safe when setup failed, the dispose rejection replaces the error that prevented `listen()` from succeeding.

Node guards on the handle and makes dispose a no-op in that case ([lib/net.js#L2636](https://github.com/nodejs/node/blob/b59def5e8113/lib/net.js#L2636)):

```js
Server.prototype[SymbolAsyncDispose] = async function() {
  if (!this._handle) {
    return;
  }
  await FunctionPrototypeCall(promisify(this.close), this);
};
```

### Fix

Add the same `!this._handle` guard. `tls.Server` extends `net.Server` and doesn't override the method, so it inherits the fix.

Scope notes:

- `http.Server` has its own `[Symbol.asyncDispose]` with no guard, and Node's `http.Server` also rejects with `ERR_SERVER_NOT_RUNNING` ([lib/_http_server.js#L677](https://github.com/nodejs/node/blob/b59def5e8113/lib/_http_server.js#L677)). Bun already matches, so it is left alone. A test pins that asymmetry.
- `dgram.Socket[Symbol.asyncDispose]` already has the equivalent guard. `net` was the only one missing it.

Node's own `test/js/node/test/parallel/test-net-server-async-dispose.mjs` has a case for this ("should resolve even if the server is already closed") but never caught it: the `it` callback resolves before its `server.listen` callback ever runs, so the assertions are vacuous.

### Verification

All behaviour below matches `node v26.3.0`:

| case | before | after |
| --- | --- | --- |
| `net.Server` never listened | rejects `ERR_SERVER_NOT_RUNNING` | resolves |
| `net.Server` already closed | rejects `ERR_SERVER_NOT_RUNNING` | resolves |
| `tls.Server` never listened | rejects `ERR_SERVER_NOT_RUNNING` | resolves |
| `await using` + `EADDRINUSE` | `SuppressedError` | `Error` with `code: "EADDRINUSE"` |
| `net.Server` listening | closes | closes |
| `http.Server` never listened | rejects `ERR_SERVER_NOT_RUNNING` | rejects `ERR_SERVER_NOT_RUNNING` |

New tests live alongside the existing `net.Server` coverage in `test/js/node/net/node-net-server.test.ts`. 4 of the 6 fail on the released binary and pass with this change; the other 2 are the positive close path and the `http.Server` negative contract.