### PR TITLE
ffi: toArrayBuffer/toBuffer throw RangeError instead of aborting on a huge byteLength

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -1,4 +1,4 @@
-use core::ffi::{c_uint, c_void};
+use core::ffi::c_void;
 use core::ptr;
 
 use crate as jsc;
@@ -155,9 +155,10 @@ impl ArrayBuffer {
         self.value.unpin_array_buffer();
     }
 
-    // require('buffer').kMaxLength.
+    // The largest byte length JavaScriptCore backs an ArrayBuffer with
+    // (`MAX_ARRAY_BUFFER_SIZE`), exposed to JS as `require('buffer').kMaxLength`.
     // keep in sync with Bun::Buffer::kMaxLength
-    pub const MAX_SIZE: c_uint = c_uint::MAX;
+    pub const MAX_SIZE: usize = 1 << 32;
 
     // 4 MB or so is pretty good for mmap()
     const MMAP_THRESHOLD: usize = 1024 * 1024 * 4;
@@ -424,8 +425,8 @@ impl ArrayBuffer {
 
     pub fn from_bytes(bytes: &mut [u8], typed_array_type: JSType) -> ArrayBuffer {
         ArrayBuffer {
-            len: u32::try_from(bytes.len()).expect("int cast") as usize,
-            byte_len: u32::try_from(bytes.len()).expect("int cast") as usize,
+            len: bytes.len(),
+            byte_len: bytes.len(),
             typed_array_type,
             ptr: bytes.as_mut_ptr(),
             ..Default::default()
@@ -446,8 +447,8 @@ impl ArrayBuffer {
         // this is an FFI hand-off, not a leak.
         let ptr = bun_core::heap::into_raw(bytes).cast::<u8>();
         ArrayBuffer {
-            len: u32::try_from(len).expect("int cast") as usize,
-            byte_len: u32::try_from(len).expect("int cast") as usize,
+            len,
+            byte_len: len,
             typed_array_type,
             ptr,
             ..Default::default()

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -80,14 +80,18 @@ pub(crate) fn new_cstring(
     byte_offset: Option<JSValue>,
     length_value: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    match get_ptr_slice(global_this, value, byte_offset, length_value) {
-        ValueOrError::Err(err) => Ok(err),
-        ValueOrError::Slice(ptr, len) => {
-            // SAFETY: ptr/len point to FFI-owned memory whose lifetime the caller guarantees.
-            let bytes = unsafe { core::slice::from_raw_parts(ptr, len) };
-            jsc::bun_string_jsc::create_utf8_for_js(global_this, bytes)
-        }
-    }
+    // A C string's JS representation is capped by `WTF::String::MaxLength` in code
+    // units, which a UTF-8 byte count does not map onto; only the address is bounded.
+    let (ptr, len) = get_ptr_slice(
+        global_this,
+        value,
+        byte_offset,
+        length_value,
+        MAX_ADDRESSABLE_MEMORY,
+    )?;
+    // SAFETY: ptr/len point to FFI-owned memory whose lifetime the caller guarantees.
+    let bytes = unsafe { core::slice::from_raw_parts(ptr, len) };
+    jsc::bun_string_jsc::create_utf8_for_js(global_this, bytes)
 }
 
 // DOMJIT fast-path descriptor + slow-path host fn, represented here as a const
@@ -484,35 +488,30 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
     JSValue::from_ptr_address(addr)
 }
 
-/// `union(enum)` → Rust enum.
-/// `Slice` carries a raw (ptr, len) because it points at caller-owned FFI memory
-/// of unknown lifetime.
+/// Decodes the `(ptr, byteOffset, byteLength)` triple the `bun:ffi` view
+/// constructors accept into a raw (ptr, len) pair pointing at caller-owned FFI
+/// memory of unknown lifetime. `max_byte_length` is the largest `byteLength` the
+/// caller's result object can represent; anything past it is a `RangeError`.
 // Consumer audit: `new_cstring` copies the bytes into a JS string;
 // `to_array_buffer` wraps the pointer with the caller's optional finalizer and
 // never frees it from Rust; `to_buffer` does the same when a finalizer is
 // given, but WITHOUT one it falls back to `JSValue::create_buffer`, which
 // installs `MarkedArrayBuffer_deallocator` and `mi_free`s the caller-owned
 // slice on GC — free-foreign-memory footgun, see PR #31753.
-enum ValueOrError {
-    Err(JSValue),
-    Slice(*mut u8, usize),
-}
-
 fn get_ptr_slice(
     global_this: &JSGlobalObject,
     value: JSValue,
     byte_offset: Option<JSValue>,
     byte_length: Option<JSValue>,
-) -> ValueOrError {
+    max_byte_length: usize,
+) -> JsResult<(*mut u8, usize)> {
     if !value.is_number() || value.as_number() < 0.0 || value.as_number() > usize::MAX as f64 {
-        return ValueOrError::Err(
-            global_this.to_invalid_arguments(format_args!("ptr must be a number.")),
-        );
+        return Err(global_this.throw_invalid_arguments(format_args!("ptr must be a number.")));
     }
 
     let num = value.as_ptr_address();
     if num == 0 {
-        return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+        return Err(global_this.throw_invalid_arguments(format_args!(
             "ptr cannot be zero, that would segfault Bun :("
         )));
     }
@@ -529,69 +528,81 @@ fn get_ptr_slice(
             }
 
             if addr == 0 {
-                return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+                return Err(global_this.throw_invalid_arguments(format_args!(
                     "ptr cannot be zero, that would segfault Bun :("
                 )));
             }
 
             if !byte_off.as_number().is_finite() {
-                return ValueOrError::Err(
-                    global_this.to_invalid_arguments(format_args!("ptr must be a finite number.")),
-                );
+                return Err(global_this
+                    .throw_invalid_arguments(format_args!("ptr must be a finite number.")));
             }
         } else if !byte_off.is_empty_or_undefined_or_null() {
             // do nothing
         } else {
-            return ValueOrError::Err(
-                global_this.to_invalid_arguments(format_args!("Expected number for byteOffset")),
+            return Err(
+                global_this.throw_invalid_arguments(format_args!("Expected number for byteOffset"))
             );
         }
     }
 
     if addr == 0xDEADBEEF || addr == 0xaaaaaaaa || addr == 0xAAAAAAAA {
-        return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+        return Err(global_this.throw_invalid_arguments(format_args!(
             "ptr to invalid memory, that would segfault Bun :("
         )));
     }
 
-    if let Some(value_length) = byte_length {
-        if !value_length.is_empty_or_undefined_or_null() {
+    let explicit_length = byte_length.filter(|len| !len.is_empty_or_undefined_or_null());
+    let length_i = match explicit_length {
+        Some(value_length) => {
             if !value_length.is_number() {
-                return ValueOrError::Err(
-                    global_this.to_invalid_arguments(format_args!("length must be a number.")),
+                return Err(
+                    global_this.throw_invalid_arguments(format_args!("length must be a number."))
                 );
             }
 
             if value_length.as_number() == 0.0 {
-                return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+                return Err(global_this.throw_invalid_arguments(format_args!(
                     "length must be > 0. This usually means a bug in your code."
                 )));
             }
 
             let length_i = value_length.to_int64();
             if length_i < 0 {
-                return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
+                return Err(global_this.throw_invalid_arguments(format_args!(
                     "length must be > 0. This usually means a bug in your code."
                 )));
             }
 
-            if length_i > i64::try_from(MAX_ADDRESSABLE_MEMORY).expect("int cast") {
-                return ValueOrError::Err(global_this.to_invalid_arguments(format_args!(
-                    "length exceeds max addressable memory. This usually means a bug in your code."
-                )));
-            }
-
-            let length = usize::try_from(length_i).expect("int cast");
-            return ValueOrError::Slice(addr as *mut u8, length);
+            length_i
         }
+        // Scan for the NUL terminator. The scanned length is bounded too: a C
+        // string longer than the result object can represent aborts inside JSC.
+        None => {
+            // SAFETY: caller asserts `addr` points at a NUL-terminated C string.
+            let len = unsafe { bun_core::ffi::cstr(addr as *const core::ffi::c_char) }
+                .to_bytes()
+                .len();
+            i64::try_from(len).expect("int cast")
+        }
+    };
+
+    let max = i64::try_from(max_byte_length).expect("int cast");
+    if length_i > max {
+        return Err(global_this.throw_range_error(
+            length_i,
+            jsc::RangeErrorOptions {
+                field_name: b"byteLength",
+                max,
+                ..Default::default()
+            },
+        ));
     }
 
-    // Scan for the NUL terminator.
-    // SAFETY: caller asserts `addr` points at a NUL-terminated C string.
-    let len = unsafe { bun_core::ffi::cstr(addr as *const core::ffi::c_char) }
-        .to_bytes()
-        .len();
-    ValueOrError::Slice(addr as *mut u8, len)
+    Ok((
+        addr as *mut u8,
+        usize::try_from(length_i).expect("int cast"),
+    ))
 }
 
 fn get_cptr(value: JSValue) -> Option<usize> {
@@ -619,55 +630,58 @@ pub(crate) fn to_array_buffer(
     finalization_ctx_or_ptr: Option<JSValue>,
     finalization_callback: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    match get_ptr_slice(global_this, value, byte_offset, value_length) {
-        ValueOrError::Err(erro) => Ok(erro),
-        ValueOrError::Slice(ptr, len) => {
-            let mut callback: jsc::JSTypedArrayBytesDeallocator = None;
-            let mut ctx: Option<*mut c_void> = None;
-            if let Some(callback_value) = finalization_callback {
-                if let Some(callback_ptr) = get_cptr(callback_value) {
-                    // SAFETY: user-supplied raw fn pointer address.
-                    callback = unsafe { deallocator_from_addr(callback_ptr) };
+    let (ptr, len) = get_ptr_slice(
+        global_this,
+        value,
+        byte_offset,
+        value_length,
+        ArrayBuffer::MAX_SIZE,
+    )?;
 
-                    if let Some(ctx_value) = finalization_ctx_or_ptr {
-                        if let Some(ctx_ptr) = get_cptr(ctx_value) {
-                            ctx = Some(ctx_ptr as *mut c_void);
-                        } else if !ctx_value.is_undefined_or_null() {
-                            return Ok(global_this.to_invalid_arguments(format_args!(
-                                "Expected user data to be a C pointer (number or BigInt)"
-                            )));
-                        }
-                    }
-                } else if !callback_value.is_empty_or_undefined_or_null() {
-                    return Ok(global_this.to_invalid_arguments(format_args!(
-                        "Expected callback to be a C pointer (number or BigInt)"
-                    )));
-                }
-            } else if let Some(callback_value) = finalization_ctx_or_ptr {
-                if let Some(callback_ptr) = get_cptr(callback_value) {
-                    // SAFETY: user-supplied raw fn pointer address.
-                    callback = unsafe { deallocator_from_addr(callback_ptr) };
-                } else if !callback_value.is_empty_or_undefined_or_null() {
-                    return Ok(global_this.to_invalid_arguments(format_args!(
-                        "Expected callback to be a C pointer (number or BigInt)"
+    let mut callback: jsc::JSTypedArrayBytesDeallocator = None;
+    let mut ctx: Option<*mut c_void> = None;
+    if let Some(callback_value) = finalization_callback {
+        if let Some(callback_ptr) = get_cptr(callback_value) {
+            // SAFETY: user-supplied raw fn pointer address.
+            callback = unsafe { deallocator_from_addr(callback_ptr) };
+
+            if let Some(ctx_value) = finalization_ctx_or_ptr {
+                if let Some(ctx_ptr) = get_cptr(ctx_value) {
+                    ctx = Some(ctx_ptr as *mut c_void);
+                } else if !ctx_value.is_undefined_or_null() {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected user data to be a C pointer (number or BigInt)"
                     )));
                 }
             }
-
-            // SAFETY: ptr/len came from get_ptr_slice; FFI-owned memory. The
-            // `bun:ffi` user asserts the pointer stays valid for the object's
-            // lifetime and that their finalization callback/ctx pair, if
-            // provided, is sound to invoke once at GC — `toArrayBuffer(ptr,
-            // ...)` is an inherently trusting FFI API.
-            unsafe {
-                let slice = core::slice::from_raw_parts_mut(ptr, len);
-                ArrayBuffer::from_bytes(slice, jsc::JSType::ArrayBuffer).to_js_with_context(
-                    global_this,
-                    ctx.unwrap_or(core::ptr::null_mut()),
-                    callback,
-                )
-            }
+        } else if !callback_value.is_empty_or_undefined_or_null() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected callback to be a C pointer (number or BigInt)"
+            )));
         }
+    } else if let Some(callback_value) = finalization_ctx_or_ptr {
+        if let Some(callback_ptr) = get_cptr(callback_value) {
+            // SAFETY: user-supplied raw fn pointer address.
+            callback = unsafe { deallocator_from_addr(callback_ptr) };
+        } else if !callback_value.is_empty_or_undefined_or_null() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected callback to be a C pointer (number or BigInt)"
+            )));
+        }
+    }
+
+    // SAFETY: ptr/len came from get_ptr_slice; FFI-owned memory. The
+    // `bun:ffi` user asserts the pointer stays valid for the object's
+    // lifetime and that their finalization callback/ctx pair, if
+    // provided, is sound to invoke once at GC — `toArrayBuffer(ptr,
+    // ...)` is an inherently trusting FFI API.
+    unsafe {
+        let slice = core::slice::from_raw_parts_mut(ptr, len);
+        ArrayBuffer::from_bytes(slice, jsc::JSType::ArrayBuffer).to_js_with_context(
+            global_this,
+            ctx.unwrap_or(core::ptr::null_mut()),
+            callback,
+        )
     }
 }
 
@@ -679,57 +693,60 @@ pub(crate) fn to_buffer(
     finalization_ctx_or_ptr: Option<JSValue>,
     finalization_callback: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    match get_ptr_slice(global_this, value, byte_offset, value_length) {
-        ValueOrError::Err(err) => Ok(err),
-        ValueOrError::Slice(ptr, len) => {
-            let mut callback: jsc::JSTypedArrayBytesDeallocator = None;
-            let mut ctx: Option<*mut c_void> = None;
-            if let Some(callback_value) = finalization_callback {
-                if let Some(callback_ptr) = get_cptr(callback_value) {
-                    // SAFETY: user-supplied raw fn pointer address.
-                    callback = unsafe { deallocator_from_addr(callback_ptr) };
+    let (ptr, len) = get_ptr_slice(
+        global_this,
+        value,
+        byte_offset,
+        value_length,
+        ArrayBuffer::MAX_SIZE,
+    )?;
 
-                    if let Some(ctx_value) = finalization_ctx_or_ptr {
-                        if let Some(ctx_ptr) = get_cptr(ctx_value) {
-                            ctx = Some(ctx_ptr as *mut c_void);
-                        } else if !ctx_value.is_empty_or_undefined_or_null() {
-                            return Ok(global_this.to_invalid_arguments(format_args!(
-                                "Expected user data to be a C pointer (number or BigInt)"
-                            )));
-                        }
-                    }
-                } else if !callback_value.is_empty_or_undefined_or_null() {
-                    return Ok(global_this.to_invalid_arguments(format_args!(
-                        "Expected callback to be a C pointer (number or BigInt)"
-                    )));
-                }
-            } else if let Some(callback_value) = finalization_ctx_or_ptr {
-                if let Some(callback_ptr) = get_cptr(callback_value) {
-                    // SAFETY: user-supplied raw fn pointer address.
-                    callback = unsafe { deallocator_from_addr(callback_ptr) };
-                } else if !callback_value.is_empty_or_undefined_or_null() {
-                    return Ok(global_this.to_invalid_arguments(format_args!(
-                        "Expected callback to be a C pointer (number or BigInt)"
+    let mut callback: jsc::JSTypedArrayBytesDeallocator = None;
+    let mut ctx: Option<*mut c_void> = None;
+    if let Some(callback_value) = finalization_callback {
+        if let Some(callback_ptr) = get_cptr(callback_value) {
+            // SAFETY: user-supplied raw fn pointer address.
+            callback = unsafe { deallocator_from_addr(callback_ptr) };
+
+            if let Some(ctx_value) = finalization_ctx_or_ptr {
+                if let Some(ctx_ptr) = get_cptr(ctx_value) {
+                    ctx = Some(ctx_ptr as *mut c_void);
+                } else if !ctx_value.is_empty_or_undefined_or_null() {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Expected user data to be a C pointer (number or BigInt)"
                     )));
                 }
             }
-
-            // SAFETY: ptr/len came from get_ptr_slice; FFI-owned memory.
-            let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
-            if callback.is_some() || ctx.is_some() {
-                return Ok(create_buffer_with_ctx(
-                    global_this,
-                    slice,
-                    ctx.unwrap_or(core::ptr::null_mut()),
-                    callback,
-                ));
-            }
-
-            // `JSValue::create_buffer` installs `MarkedArrayBuffer_deallocator` so
-            // the slice is `mi_free`d on GC (including the free-foreign-memory footgun).
-            Ok(JSValue::create_buffer(global_this, slice))
+        } else if !callback_value.is_empty_or_undefined_or_null() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected callback to be a C pointer (number or BigInt)"
+            )));
+        }
+    } else if let Some(callback_value) = finalization_ctx_or_ptr {
+        if let Some(callback_ptr) = get_cptr(callback_value) {
+            // SAFETY: user-supplied raw fn pointer address.
+            callback = unsafe { deallocator_from_addr(callback_ptr) };
+        } else if !callback_value.is_empty_or_undefined_or_null() {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected callback to be a C pointer (number or BigInt)"
+            )));
         }
     }
+
+    // SAFETY: ptr/len came from get_ptr_slice; FFI-owned memory.
+    let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
+    if callback.is_some() || ctx.is_some() {
+        return Ok(create_buffer_with_ctx(
+            global_this,
+            slice,
+            ctx.unwrap_or(core::ptr::null_mut()),
+            callback,
+        ));
+    }
+
+    // `JSValue::create_buffer` installs `MarkedArrayBuffer_deallocator` so
+    // the slice is `mi_free`d on GC (including the free-foreign-memory footgun).
+    Ok(JSValue::create_buffer(global_this, slice))
 }
 
 pub(crate) fn getter(global_object: &JSGlobalObject, _: &JSObject) -> JSValue {

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -537,8 +537,8 @@ fn get_ptr_slice(
                 return Err(global_this
                     .throw_invalid_arguments(format_args!("ptr must be a finite number.")));
             }
-        } else if !byte_off.is_empty_or_undefined_or_null() {
-            // do nothing
+        } else if byte_off.is_empty_or_undefined_or_null() {
+            // an omitted byteOffset leaves `addr` alone
         } else {
             return Err(
                 global_this.throw_invalid_arguments(format_args!("Expected number for byteOffset"))

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -707,6 +707,82 @@ it.skipIf(!isWindows || isFFIUnavailable)("dlopen accepts non-ASCII library path
   });
 });
 
+// `expect(fn).toThrow()` is satisfied by a *returned* Error, so spell the
+// difference out: these used to hand the caller an Error object as the result.
+it("toArrayBuffer and toBuffer throw argument errors instead of returning them", () => {
+  const address = ptr(new Uint8Array(8));
+  const outcome = view => {
+    try {
+      const result = view();
+      return `returned ${result instanceof Error ? result.constructor.name : typeof result}`;
+    } catch (error) {
+      return `threw ${error.constructor.name}: ${error.message}`;
+    }
+  };
+
+  expect([
+    outcome(() => toArrayBuffer(0)),
+    outcome(() => toBuffer(0)),
+    outcome(() => toArrayBuffer(address, 0, 0)),
+    outcome(() => toBuffer(address, 0, -1)),
+    outcome(() => toArrayBuffer(address, 0, 8, "not a pointer")),
+    outcome(() => toBuffer(address, 0, 8, "not a pointer")),
+  ]).toEqual([
+    "threw TypeError: ptr cannot be zero, that would segfault Bun :(",
+    "threw TypeError: ptr cannot be zero, that would segfault Bun :(",
+    "threw TypeError: length must be > 0. This usually means a bug in your code.",
+    "threw TypeError: length must be > 0. This usually means a bug in your code.",
+    "threw TypeError: Expected callback to be a C pointer (number or BigInt)",
+    "threw TypeError: Expected callback to be a C pointer (number or BigInt)",
+  ]);
+});
+
+// A byteLength JSC cannot back an ArrayBuffer with used to abort the process:
+// toArrayBuffer panicked on an int cast, toBuffer tripped a JSC RELEASE_ASSERT.
+it("toArrayBuffer and toBuffer reject a byteLength past the max ArrayBuffer size", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { ptr, toArrayBuffer, toBuffer } from "bun:ffi";
+      const address = ptr(new Uint8Array(64));
+      for (const [name, view] of [["toArrayBuffer", toArrayBuffer], ["toBuffer", toBuffer]]) {
+        for (const byteLength of [2 ** 32 + 1, 2 ** 33, Number.MAX_SAFE_INTEGER]) {
+          try {
+            view(address, 0, byteLength);
+            console.log(name, byteLength, "did not throw");
+          } catch (e) {
+            console.log(name, e.constructor.name, e.code, e.message);
+          }
+        }
+      }
+      // exactly MAX_ARRAY_BUFFER_SIZE is what new ArrayBuffer(2 ** 32) accepts.
+      // Held alive so neither view's backing store is finalized before exit.
+      globalThis.views = [toArrayBuffer(address, 0, 2 ** 32), toBuffer(address, 0, 2 ** 32)];
+      console.log("at the limit", globalThis.views[0].byteLength, globalThis.views[1].byteLength);`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const outOfRange = "is out of range. It must be <= 4294967296. Received";
+  expect({ stdout: stdout.split("\n"), stderr, exitCode }).toEqual({
+    stdout: [
+      `toArrayBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 4294967297`,
+      `toArrayBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 8589934592`,
+      `toArrayBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 9007199254740991`,
+      `toBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 4294967297`,
+      `toBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 8589934592`,
+      `toBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 9007199254740991`,
+      "at the limit 4294967296 4294967296",
+      "",
+    ],
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 it('suffix does not start with a "."', () => {
   expect(suffix).not.toMatch(/^\./);
 });

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -737,6 +737,28 @@ it("toArrayBuffer and toBuffer throw argument errors instead of returning them",
   ]);
 });
 
+// An omitted byteOffset used to be the error case and a non-number the
+// silently-ignored one, so CString#arrayBuffer (byteOffset defaults to
+// undefined) cached a TypeError as its ArrayBuffer.
+it("toArrayBuffer accepts an omitted byteOffset and rejects a non-number one", () => {
+  const bytes = new Uint8Array(16);
+  bytes.set(Buffer.from("hi\0"));
+  const address = ptr(bytes);
+
+  expect(toArrayBuffer(address, undefined, 8).byteLength).toBe(8);
+  expect(toArrayBuffer(address, null, 8).byteLength).toBe(8);
+  expect(() => toArrayBuffer(address, "garbage", 8)).toThrow("Expected number for byteOffset");
+  expect(() => toArrayBuffer(address, {}, 8)).toThrow("Expected number for byteOffset");
+
+  const arrayBuffer = new CString(address).arrayBuffer;
+  expect(arrayBuffer).toBeInstanceOf(ArrayBuffer);
+  expect(new TextDecoder().decode(arrayBuffer)).toBe("hi");
+
+  // the view aliases `bytes`, which also keeps it reachable across the decode
+  new Uint8Array(arrayBuffer)[0] = "H".charCodeAt(0);
+  expect(bytes[0]).toBe("H".charCodeAt(0));
+});
+
 // A byteLength JSC cannot back an ArrayBuffer with used to abort the process:
 // toArrayBuffer panicked on an int cast, toBuffer tripped a JSC RELEASE_ASSERT.
 it("toArrayBuffer and toBuffer reject a byteLength past the max ArrayBuffer size", async () => {
@@ -745,7 +767,8 @@ it("toArrayBuffer and toBuffer reject a byteLength past the max ArrayBuffer size
       bunExe(),
       "-e",
       `import { ptr, toArrayBuffer, toBuffer } from "bun:ffi";
-      const address = ptr(new Uint8Array(64));
+      const backing = new Uint8Array(64);
+      const address = ptr(backing);
       for (const [name, view] of [["toArrayBuffer", toArrayBuffer], ["toBuffer", toBuffer]]) {
         for (const byteLength of [2 ** 32 + 1, 2 ** 33, Number.MAX_SAFE_INTEGER]) {
           try {
@@ -757,17 +780,18 @@ it("toArrayBuffer and toBuffer reject a byteLength past the max ArrayBuffer size
         }
       }
       // exactly MAX_ARRAY_BUFFER_SIZE is what new ArrayBuffer(2 ** 32) accepts.
-      // Held alive so neither view's backing store is finalized before exit.
-      globalThis.views = [toArrayBuffer(address, 0, 2 ** 32), toBuffer(address, 0, 2 ** 32)];
-      console.log("at the limit", globalThis.views[0].byteLength, globalThis.views[1].byteLength);`,
+      // Only toArrayBuffer holds a view here: toBuffer without a finalizer installs
+      // a deallocator that frees a pointer it does not own, which VM teardown runs.
+      console.log("at the limit", toArrayBuffer(address, 0, 2 ** 32).byteLength, backing.length);`,
     ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // stderr is drained, not asserted: ASAN and debug builds emit benign warnings.
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const outOfRange = "is out of range. It must be <= 4294967296. Received";
-  expect({ stdout: stdout.split("\n"), stderr, exitCode }).toEqual({
+  expect({ stdout: stdout.split("\n"), exitCode }).toEqual({
     stdout: [
       `toArrayBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 4294967297`,
       `toArrayBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 8589934592`,
@@ -775,10 +799,9 @@ it("toArrayBuffer and toBuffer reject a byteLength past the max ArrayBuffer size
       `toBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 4294967297`,
       `toBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 8589934592`,
       `toBuffer RangeError ERR_OUT_OF_RANGE The value of "byteLength" ${outOfRange} 9007199254740991`,
-      "at the limit 4294967296 4294967296",
+      "at the limit 4294967296 64",
       "",
     ],
-    stderr: "",
     exitCode: 0,
   });
 });


### PR DESCRIPTION
## Repro

```js
import { ptr, toArrayBuffer } from "bun:ffi";
toArrayBuffer(ptr(new Uint8Array(64)), 0, 2 ** 32);
```

```
panic: int cast: TryFromIntError(PosOverflow)
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

An uncatchable `SIGABRT`. `toBuffer` aborts the same way past `2 ** 32`, silently, by tripping `RELEASE_ASSERT(m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE)` inside JSC. Both are reachable from an entirely in-contract FFI call: `mmap` a region bigger than 4 GiB through `dlopen`'d libc and ask for a view of it.

## Cause

`ArrayBuffer::from_bytes` narrowed the length through `u32::try_from(bytes.len()).expect("int cast")`, a leftover from when the descriptor's `len`/`byte_len` were `u32`. They are `usize` now, and the C ABI they mirror (`Bun__ArrayBuffer`, `size_t len; size_t byte_len;`) has always been 64-bit, so the cast did nothing except panic. Past that, `bun:ffi` never bounded the user-supplied `byteLength` against the largest buffer JSC can back, so a length in `(2^32, 2^56)` sailed into JSC and hit the release assert.

JSC's `MAX_ARRAY_BUFFER_SIZE` is `1ull << 32` inclusive on 64-bit (`PageCount.h`), which is also `Bun::Buffer::kMaxLength`, also `require("buffer").kMaxLength`, and also exactly what `new ArrayBuffer(2 ** 32)` accepts today.

## Fix

- Drop the narrowing casts in `ArrayBuffer::from_bytes` / `from_owned_bytes`.
- Bound the byteLength in the FFI layer and throw `RangeError [ERR_OUT_OF_RANGE]` past `MAX_ARRAY_BUFFER_SIZE`, matching what every other Buffer entry point already does. The bound covers the NUL-scan path (no explicit `byteLength`) as well. A caller with a larger mapping can now catch the error and window the view.
- `ArrayBuffer::MAX_SIZE` is documented as `kMaxLength` but held `u32::MAX`, one below the real limit. Correct it and use it. Its one other consumer is `node:crypto`'s `MAX_POSSIBLE_LENGTH = min(MAX_SIZE, i32::MAX)`, which is `i32::MAX` either way.
- `CString` keeps the address bound: its result is capped by `WTF::String::MaxLength` in code units, which a UTF-8 byte count does not map onto, so `MAX_ARRAY_BUFFER_SIZE` would be the wrong number there.

`get_ptr_slice` handed its validation failures back as `Error` objects *in the return slot* rather than throwing them, so a new `RangeError` would have been uncatchable (`toArrayBuffer(0)` returned a `TypeError` object where an `ArrayBuffer` was expected). They throw now, as do the finalizer-argument checks in `toArrayBuffer`/`toBuffer`. One user-visible consequence: a `returns: "cstring"` symbol whose C function hands back one of the sentinel addresses (`0xDEADBEEF`, `0xAAAAAAAA`) now throws from the call instead of yielding a `CString` whose text is the error message.

Removing the cast widens slightly beyond FFI: the ~15 other callers of `ArrayBuffer::from_bytes` (`Blob.arrayBuffer()` on a >4 GiB file being the only realistic one) previously panicked on such a length and now reach JSC's own release assert. Abort either way, no new correctness hole, and every one of them hands the descriptor straight to a `to_js*` sink rather than reading the length back.

## Also: an omitted byteOffset was the error case

While restructuring `get_ptr_slice` it turned out its two `byteOffset` arms are inverted, which `ptr()` a few lines up gets right:

```
toArrayBuffer(p, undefined, 8)  -> TypeError: Expected number for byteOffset
toArrayBuffer(p, null, 8)       -> TypeError: Expected number for byteOffset
toArrayBuffer(p, "garbage", 8)  -> ok, bad offset silently ignored
```

Nullish meant "error" and a non-number meant "ignore it". `CString.prototype.arrayBuffer` passes a `byteOffset` that defaults to `undefined`, so it has been handing back (and caching) a `TypeError` where an `ArrayBuffer` belongs. Swapping the arms fixes both, and it has to happen here: converting these errors from returned to thrown would otherwise turn that into a throw on a valid call.


## Verification

`2 ** 32` keeps working, `2 ** 32 + 1` throws, against a real 6 GiB anonymous mapping:

<details>
<summary>dlopen + mmap</summary>

```js
import { dlopen, read, toArrayBuffer } from "bun:ffi";
const libc = dlopen("libc.so.6", {
  mmap: { args: ["ptr", "usize", "i32", "i32", "i32", "i64"], returns: "ptr" },
});
const SIX_GIB = 6 * 1024 ** 3;
const base = libc.symbols.mmap(null, SIX_GIB, 3, 0x22, -1, 0);

for (const byteLength of [2 ** 32 - 1, 2 ** 32, 5 * 2 ** 30, SIX_GIB]) {
  try {
    console.log(byteLength, "->", toArrayBuffer(base, 0, byteLength).byteLength);
  } catch (e) {
    console.log(byteLength, "->", `${e.constructor.name}: ${e.message}`);
  }
}

const view = new Uint8Array(toArrayBuffer(base, 0, 2 ** 32));
view[0] = 7;
console.log("write-through:", read.u8(base, 0));
```

```
4294967295 -> 4294967295
4294967296 -> 4294967296
5368709120 -> RangeError: The value of "byteLength" is out of range. It must be <= 4294967296. Received 5368709120
6442450944 -> RangeError: The value of "byteLength" is out of range. It must be <= 4294967296. Received 6442450944
write-through: 7
```

</details>

Three tests in `test/js/bun/ffi/ffi.test.js`, all of which fail on the released binary (`USE_SYSTEM_BUN=1 bun test`, the byteLength one by aborting the child) and pass on `bun bd test`. The byteLength test pins both ends of the boundary: `2 ** 32` succeeds, `2 ** 32 + 1` through `Number.MAX_SAFE_INTEGER` throw for both entry points.

Note for reviewers: #32260 touches the `byteOffset` lines of `get_ptr_slice` for an unrelated negative-offset panic, so expect a small conflict if both land.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/ffi.test.js

<!-- robobun:evidence:end -->