### PR TITLE
Emit unhandledRejection at the end of the tick that created it

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1146,14 +1146,14 @@ impl JSGlobalObject {
         self.bun_vm_unsafe().cast::<VirtualMachine>()
     }
 
-    pub fn handle_rejected_promises(&self) {
+    /// Returns whether an `unhandledRejection` handler ran.
+    pub fn handle_rejected_promises(&self) -> bool {
         // JSC__JSGlobalObject__handleRejectedPromises catches and reports its
         // own exceptions; the only thing that escapes is a TerminationException
         // (worker terminate() or process.exit()), and the request flag may
         // already be cleared by the time we observe it. Nothing actionable here.
-        let _ = crate::from_js_host_call_generic(self, || {
-            JSC__JSGlobalObject__handleRejectedPromises(self)
-        });
+        crate::from_js_host_call_generic(self, || JSC__JSGlobalObject__handleRejectedPromises(self))
+            .unwrap_or(false)
     }
 
     pub fn readable_stream_to_array_buffer(&self, value: JSValue) -> JSValue {
@@ -1677,7 +1677,7 @@ unsafe extern "C" {
     ) -> JSValue;
     safe fn JSC__JSGlobalObject__generateHeapSnapshot(this: &JSGlobalObject) -> JSValue;
 
-    safe fn JSC__JSGlobalObject__handleRejectedPromises(this: &JSGlobalObject);
+    safe fn JSC__JSGlobalObject__handleRejectedPromises(this: &JSGlobalObject) -> bool;
 
     safe fn ZigGlobalObject__readableStreamToArrayBuffer(
         this: &JSGlobalObject,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3215,11 +3215,12 @@ void GlobalObject::queueTaskConcurrently(WebCore::EventLoopTask* task)
 
 extern "C" void Bun__handleRejectedPromise(Zig::GlobalObject* JSGlobalObject, JSC::JSPromise* promise);
 
-void GlobalObject::handleRejectedPromises()
+bool GlobalObject::handleRejectedPromises()
 {
     if (m_aboutToBeNotifiedRejectedPromises.isEmpty()) [[likely]]
-        return;
+        return false;
 
+    bool notifiedAny = false;
     JSC::VM& virtual_machine = vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(virtual_machine);
     do {
@@ -3240,11 +3241,12 @@ void GlobalObject::handleRejectedPromises()
             if (promise->isHandled())
                 continue;
             inflight.index = i + 1;
+            notifiedAny = true;
 
             Bun__handleRejectedPromise(this, promise);
             if (auto ex = scope.exception()) {
                 if (virtual_machine.isTerminationException(ex)) [[unlikely]]
-                    return;
+                    return false;
                 (void)scope.tryClearException();
                 this->reportUncaughtExceptionAtEventLoop(this, ex);
             }
@@ -3252,6 +3254,10 @@ void GlobalObject::handleRejectedPromises()
         // An unhandledRejection handler may itself reject a promise; loop
         // until the list stays empty.
     } while (!m_aboutToBeNotifiedRejectedPromises.isEmpty());
+
+    // Whether a handler ran, so the caller can re-drain the microtask queue the
+    // handler may have pushed onto (Node's `processTicksAndRejections` loop).
+    return notifiedAny;
 }
 
 DEFINE_VISIT_CHILDREN(GlobalObject);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -344,7 +344,8 @@ public:
 
     uint8_t drainMicrotasks();
 
-    void handleRejectedPromises();
+    // Returns whether an `unhandledRejection` handler ran.
+    bool handleRejectedPromises();
     ALWAYS_INLINE void initGeneratedLazyClasses();
 
     template<typename Visitor>

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3831,7 +3831,7 @@ JSC::EncodedJSValue JSC__JSGlobalObject__generateHeapSnapshot(JSC::JSGlobalObjec
 // Rust -> C++ boundary function).
 __attribute__((__always_inline__)) JSC::VM* JSC__JSGlobalObject__vm(JSC::JSGlobalObject* arg0) { return &arg0->vm(); };
 
-void JSC__JSGlobalObject__handleRejectedPromises(JSC::JSGlobalObject* arg0)
+bool JSC__JSGlobalObject__handleRejectedPromises(JSC::JSGlobalObject* arg0)
 {
     return uncheckedDowncast<Zig::GlobalObject>(arg0)->handleRejectedPromises();
 }

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -182,7 +182,7 @@ CPP_DECL void JSC__JSGlobalObject__createSyntheticModule_(JSC::JSGlobalObject* a
 CPP_DECL void JSC__JSGlobalObject__deleteModuleRegistryEntry(JSC::JSGlobalObject* arg0, ZigString* arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSGlobalObject__generateHeapSnapshot(JSC::JSGlobalObject* arg0);
 CPP_DECL JSC::EncodedJSValue JSC__JSGlobalObject__getCachedObject(JSC::JSGlobalObject* arg0, const ZigString* arg1);
-CPP_DECL void JSC__JSGlobalObject__handleRejectedPromises(JSC::JSGlobalObject* arg0);
+CPP_DECL bool JSC__JSGlobalObject__handleRejectedPromises(JSC::JSGlobalObject* arg0);
 CPP_DECL JSC::EncodedJSValue JSC__JSGlobalObject__putCachedObject(JSC::JSGlobalObject* arg0, const ZigString* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__JSGlobalObject__addGc(JSC::JSGlobalObject* globalObject);
 CPP_DECL void JSC__JSGlobalObject__queueMicrotaskJob(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, JSC::EncodedJSValue JSValue2, JSC::EncodedJSValue JSValue3);

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -247,11 +247,33 @@ impl EventLoop {
         let count = self.entered_event_loop_count;
         bun_core::scoped_log!(EventLoop, "exit() = {}", count - 1);
 
-        if count == 1 && !self.vm_ref().is_inside_deferred_task_queue.get() {
-            let _ = self.drain_microtasks();
-        }
+        let drained = count == 1
+            && !self.vm_ref().is_inside_deferred_task_queue.get()
+            && self.drain_microtasks().is_ok();
 
         self.entered_event_loop_count -= 1;
+        if drained {
+            self.handle_rejected_promises_after_tick();
+        }
+    }
+
+    /// The tail of a macrotask callback, once its microtasks have drained:
+    /// report what it left unhandled before anything it scheduled runs. Node
+    /// does this from `processTicksAndRejections`, which its timer and
+    /// immediate queues run after every callback.
+    ///
+    /// Only valid once the enter/exit counter is back at 0: the handler is
+    /// user JS, and its own `enter()`/`exit()` must see depth 0 to drain.
+    fn handle_rejected_promises_after_tick(&mut self) {
+        debug_assert_eq!(self.entered_event_loop_count, 0);
+        // spawnSync's isolated loop shares this VM and global object; running
+        // JS on it is forbidden, which is also why `drain_microtasks` bails.
+        if self.vm_ref().suppress_microtask_drain.get() {
+            return;
+        }
+        // `global_ref()` hands back a `'static` reference, so no borrow of the
+        // loop spans the `unhandledRejection` handler, which re-enters it.
+        self.global_ref().handle_rejected_promises();
     }
 
     /// `enter()` now, `exit()` on drop. Takes the raw VM-owned pointer so the
@@ -275,7 +297,8 @@ impl EventLoop {
         bun_core::scoped_log!(EventLoop, "exit() = {}", count - 1);
 
         let inside_deferred = self.vm_ref().is_inside_deferred_task_queue.get();
-        let result = if allow_drain_microtask && count == 1 && !inside_deferred {
+        let drained = allow_drain_microtask && count == 1 && !inside_deferred;
+        let result = if drained {
             self.drain_microtasks()
         } else {
             Ok(())
@@ -285,6 +308,9 @@ impl EventLoop {
         // decremented.
         if result.is_ok() {
             self.entered_event_loop_count -= 1;
+            if drained {
+                self.handle_rejected_promises_after_tick();
+            }
         }
         result
     }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -247,33 +247,11 @@ impl EventLoop {
         let count = self.entered_event_loop_count;
         bun_core::scoped_log!(EventLoop, "exit() = {}", count - 1);
 
-        let drained = count == 1
-            && !self.vm_ref().is_inside_deferred_task_queue.get()
-            && self.drain_microtasks().is_ok();
+        if count == 1 && !self.vm_ref().is_inside_deferred_task_queue.get() {
+            let _ = self.drain_microtasks();
+        }
 
         self.entered_event_loop_count -= 1;
-        if drained {
-            self.handle_rejected_promises_after_tick();
-        }
-    }
-
-    /// The tail of a macrotask callback, once its microtasks have drained:
-    /// report what it left unhandled before anything it scheduled runs. Node
-    /// does this from `processTicksAndRejections`, which its timer and
-    /// immediate queues run after every callback.
-    ///
-    /// Only valid once the enter/exit counter is back at 0: the handler is
-    /// user JS, and its own `enter()`/`exit()` must see depth 0 to drain.
-    fn handle_rejected_promises_after_tick(&mut self) {
-        debug_assert_eq!(self.entered_event_loop_count, 0);
-        // spawnSync's isolated loop shares this VM and global object; running
-        // JS on it is forbidden, which is also why `drain_microtasks` bails.
-        if self.vm_ref().suppress_microtask_drain.get() {
-            return;
-        }
-        // `global_ref()` hands back a `'static` reference, so no borrow of the
-        // loop spans the `unhandledRejection` handler, which re-enters it.
-        self.global_ref().handle_rejected_promises();
     }
 
     /// `enter()` now, `exit()` on drop. Takes the raw VM-owned pointer so the
@@ -297,8 +275,7 @@ impl EventLoop {
         bun_core::scoped_log!(EventLoop, "exit() = {}", count - 1);
 
         let inside_deferred = self.vm_ref().is_inside_deferred_task_queue.get();
-        let drained = allow_drain_microtask && count == 1 && !inside_deferred;
-        let result = if drained {
+        let result = if allow_drain_microtask && count == 1 && !inside_deferred {
             self.drain_microtasks()
         } else {
             Ok(())
@@ -308,9 +285,6 @@ impl EventLoop {
         // decremented.
         if result.is_ok() {
             self.entered_event_loop_count -= 1;
-            if drained {
-                self.handle_rejected_promises_after_tick();
-            }
         }
         result
     }
@@ -387,6 +361,45 @@ impl EventLoop {
         if self.entered_event_loop_count == 0 && !self.vm_ref().is_inside_deferred_task_queue.get()
         {
             let _ = self.drain_microtasks();
+        }
+    }
+
+    /// Report what the timer or immediate callback that just finished left
+    /// unhandled, then drain whatever its `unhandledRejection` handler queued,
+    /// so both land before the next macrotask. Node does this from
+    /// `processTicksAndRejections`, a `do { drain } while (rejections)` loop its
+    /// timer and immediate queues run after every callback.
+    ///
+    /// Only the two batch-drain phases call this. `exit()` looks like the same
+    /// hook but is not: native code also uses it to re-enter JS from inside a JS
+    /// turn (`Interpreter::finish`), where reporting a rejection that the caller
+    /// is about to handle would be wrong.
+    ///
+    /// # Safety
+    /// `loop_` must be the live per-thread `EventLoop`, called right after the
+    /// `exit()` that ends one callback.
+    pub unsafe fn handle_rejected_promises_after_tick(loop_: *mut EventLoop) {
+        // The handler is user JS and re-enters this same `EventLoop`
+        // (`setImmediate` -> `enqueue_immediate_task`), so read the guard
+        // through the raw place and hold no borrow of `*loop_` across it.
+        // SAFETY: per fn contract — `loop_` is live.
+        if unsafe { (*loop_).entered_event_loop_count } != 0 {
+            return;
+        }
+        // SAFETY: per fn contract; both accessors hand back `'static` refs that
+        // detach from `*loop_`.
+        let (global, vm) = unsafe { ((*loop_).global_ref(), (*loop_).vm_ref()) };
+        // spawnSync's isolated loop shares this VM and global object; running JS
+        // on it is forbidden, which is also why `drain_microtasks` bails.
+        if vm.is_inside_deferred_task_queue.get() || vm.suppress_microtask_drain.get() {
+            return;
+        }
+        while global.handle_rejected_promises() {
+            // SAFETY: per fn contract. The handler returned before we get here,
+            // so this short-lived `&mut` spans no re-entrant JS of its own.
+            if unsafe { (*loop_).drain_microtasks() }.is_err() {
+                return;
+            }
         }
     }
 

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -375,6 +375,9 @@ impl EventLoop {
     /// turn (`Interpreter::finish`), where reporting a rejection that the caller
     /// is about to handle would be wrong.
     ///
+    /// The caller must have drained the callback's microtasks first: a promise
+    /// whose `.catch()` is still queued is not unhandled yet.
+    ///
     /// # Safety
     /// `loop_` must be the live per-thread `EventLoop`, called right after the
     /// `exit()` that ends one callback.
@@ -869,6 +872,11 @@ impl EventLoop {
         if exception_thrown {
             // SAFETY: as above.
             unsafe { (*this).maybe_drain_microtasks() };
+            // A throwing callback skips its own checkpoint, so its rejections are
+            // reported here instead — still ahead of the timer phase, which is
+            // where Node reports them too.
+            // SAFETY: as above.
+            unsafe { Self::handle_rejected_promises_after_tick(this) };
         }
 
         // SAFETY: as above; this read MUST observe pushes JS made during the

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -859,16 +859,19 @@ impl EventLoop {
 
         let mut exception_thrown = false;
         for task in to_run_now.iter() {
+            // `|=`, not `=`: a task that threw owes the batch tail a checkpoint,
+            // and a later task that returns early (cleared, unref'd, stale
+            // generation) must not erase that.
             // SAFETY: ImmediateObject pointers are kept alive by the JS heap
             // until `runImmediateTask` consumes them; `virtual_machine` is the
             // live owning VM per caller contract.
-            exception_thrown = unsafe { __bun_run_immediate_task(*task, virtual_machine) };
+            exception_thrown |= unsafe { __bun_run_immediate_task(*task, virtual_machine) };
         }
         // Re-escape `this` after the re-entrant loop so nothing about `*this`
         // is carried across it.
         let this: *mut Self = core::hint::black_box(this);
 
-        // make sure microtasks are drained if the last task had an exception
+        // make sure microtasks are drained if any task had an exception
         if exception_thrown {
             // SAFETY: as above.
             unsafe { (*this).maybe_drain_microtasks() };

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -431,8 +431,13 @@ impl TimerObjectInternals {
         {
             return true;
         }
-        // SAFETY: `vm` is live; `event_loop()` yields the live per-thread loop.
-        unsafe { EventLoop::handle_rejected_promises_after_tick((*vm).event_loop()) };
+        // A callback that threw leaves its microtasks un-drained (Node marks the
+        // callback scope failed and skips the checkpoint). `tick_immediate_tasks`
+        // runs both at the end of the batch instead.
+        if !exception_thrown {
+            // SAFETY: `vm` is live; `event_loop()` yields the live per-thread loop.
+            unsafe { EventLoop::handle_rejected_promises_after_tick((*vm).event_loop()) };
+        }
 
         exception_thrown
     }
@@ -690,6 +695,7 @@ impl TimerObjectInternals {
         // SAFETY: `vm` is live; see `enter()` note above.
         unsafe { (*(*vm).event_loop()).exit() };
         // SAFETY: `vm` is live; `event_loop()` yields the live per-thread loop.
+        // `exit` above already drained this callback's microtasks.
         unsafe { EventLoop::handle_rejected_promises_after_tick((*vm).event_loop()) };
     }
 

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -11,6 +11,7 @@
 use bun_core::{Timespec, TimespecMockMode};
 
 use crate::jsc::JsCell;
+use crate::jsc::event_loop::EventLoop;
 use crate::jsc::{
     Debugger, JSGlobalObject, JSValue, JsRef, JsResult, ScriptExecutionStatus,
     generated::{JSImmediate, JSTimeout},
@@ -430,6 +431,8 @@ impl TimerObjectInternals {
         {
             return true;
         }
+        // SAFETY: `vm` is live; `event_loop()` yields the live per-thread loop.
+        unsafe { EventLoop::handle_rejected_promises_after_tick((*vm).event_loop()) };
 
         exception_thrown
     }
@@ -686,6 +689,8 @@ impl TimerObjectInternals {
 
         // SAFETY: `vm` is live; see `enter()` note above.
         unsafe { (*(*vm).event_loop()).exit() };
+        // SAFETY: `vm` is live; `event_loop()` yields the live per-thread loop.
+        unsafe { EventLoop::handle_rejected_promises_after_tick((*vm).event_loop()) };
     }
 
     /// A `setTimeout` whose

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -957,12 +957,13 @@ describe.concurrent(() => {
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
-  // Node reports unhandled rejections at the end of the callback that created
-  // them (processTicksAndRejections), so the event always precedes anything
-  // that callback scheduled, and anything already queued behind it.
+  // Node reports unhandled rejections at the end of the timer/immediate callback
+  // that created them (processTicksAndRejections), so the event precedes
+  // anything that callback scheduled and anything already queued behind it, and
+  // work the handler itself queues runs before the next macrotask too.
   it.each([
     [
-      "timer scheduled by the rejecting setImmediate",
+      "the timer scheduled by the rejecting setImmediate",
       `setImmediate(() => {
          Promise.reject(new Error("x"));
          setTimeout(() => log("later timer"), 0);
@@ -970,7 +971,7 @@ describe.concurrent(() => {
       ["unhandledRejection", "later timer"],
     ],
     [
-      "setImmediate queued behind the rejecting setImmediate",
+      "the setImmediate queued behind the rejecting setImmediate",
       `setImmediate(() => {
          Promise.reject(new Error("x"));
        });
@@ -978,7 +979,7 @@ describe.concurrent(() => {
       ["unhandledRejection", "second immediate"],
     ],
     [
-      "timer already scheduled when a setImmediate rejects",
+      "the timer already scheduled when a setImmediate rejects",
       `setTimeout(() => log("pending timer"), 5);
        setImmediate(() => {
          Promise.reject(new Error("x"));
@@ -988,7 +989,7 @@ describe.concurrent(() => {
     [
       // Both timers are overdue by the time the loop first drains them, so they
       // fire in a single batch and the rejection must split them.
-      "timer due in the same batch as the rejecting timer",
+      "the timer due in the same batch as the rejecting timer",
       `setTimeout(() => log("second timer"), 30);
        setTimeout(() => {
          Promise.reject(new Error("x"));
@@ -996,29 +997,7 @@ describe.concurrent(() => {
        for (const until = Date.now() + 60; Date.now() < until; );`,
       ["unhandledRejection", "second timer"],
     ],
-    [
-      // Same, for a rejection created in the poll phase: the socket handler
-      // stalls long enough that its own timer is due when the drain runs.
-      "timer due when a socket data handler rejects",
-      `const net = require("net");
-       const server = net.createServer(socket => {
-         socket.on("data", () => {
-           Promise.reject(new Error("x"));
-           setTimeout(() => {
-             log("later timer");
-             socket.end();
-             server.close();
-           }, 0);
-           for (const until = Date.now() + 10; Date.now() < until; );
-         });
-       });
-       server.listen(0, () => {
-         const client = net.connect(server.address().port, () => client.write("hi"));
-         client.on("error", () => {});
-       });`,
-      ["unhandledRejection", "later timer"],
-    ],
-  ])("unhandledRejection is emitted before the %s", async (_name, body, expected) => {
+  ])("unhandledRejection is emitted before %s", async (_name, body, expected) => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -1034,6 +1013,30 @@ describe.concurrent(() => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
       stdout: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("drains process.nextTick queued by the unhandledRejection handler before the next macrotask", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("unhandledRejection", () => {
+           console.log("unhandledRejection");
+           process.nextTick(() => console.log("nextTick from handler"));
+         });
+         setImmediate(() => Promise.reject(new Error("x")));
+         setImmediate(() => console.log("second immediate"));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+      stdout: ["unhandledRejection", "nextTick from handler", "second immediate"],
       stderr: "",
       exitCode: 0,
     });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -957,6 +957,88 @@ describe.concurrent(() => {
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
+  // Node reports unhandled rejections at the end of the callback that created
+  // them (processTicksAndRejections), so the event always precedes anything
+  // that callback scheduled, and anything already queued behind it.
+  it.each([
+    [
+      "timer scheduled by the rejecting setImmediate",
+      `setImmediate(() => {
+         Promise.reject(new Error("x"));
+         setTimeout(() => log("later timer"), 0);
+       });`,
+      ["unhandledRejection", "later timer"],
+    ],
+    [
+      "setImmediate queued behind the rejecting setImmediate",
+      `setImmediate(() => {
+         Promise.reject(new Error("x"));
+       });
+       setImmediate(() => log("second immediate"));`,
+      ["unhandledRejection", "second immediate"],
+    ],
+    [
+      "timer already scheduled when a setImmediate rejects",
+      `setTimeout(() => log("pending timer"), 5);
+       setImmediate(() => {
+         Promise.reject(new Error("x"));
+       });`,
+      ["unhandledRejection", "pending timer"],
+    ],
+    [
+      // Both timers are overdue by the time the loop first drains them, so they
+      // fire in a single batch and the rejection must split them.
+      "timer due in the same batch as the rejecting timer",
+      `setTimeout(() => log("second timer"), 30);
+       setTimeout(() => {
+         Promise.reject(new Error("x"));
+       }, 10);
+       for (const until = Date.now() + 60; Date.now() < until; );`,
+      ["unhandledRejection", "second timer"],
+    ],
+    [
+      // Same, for a rejection created in the poll phase: the socket handler
+      // stalls long enough that its own timer is due when the drain runs.
+      "timer due when a socket data handler rejects",
+      `const net = require("net");
+       const server = net.createServer(socket => {
+         socket.on("data", () => {
+           Promise.reject(new Error("x"));
+           setTimeout(() => {
+             log("later timer");
+             socket.end();
+             server.close();
+           }, 0);
+           for (const until = Date.now() + 10; Date.now() < until; );
+         });
+       });
+       server.listen(0, () => {
+         const client = net.connect(server.address().port, () => client.write("hi"));
+         client.on("error", () => {});
+       });`,
+      ["unhandledRejection", "later timer"],
+    ],
+  ])("unhandledRejection is emitted before the %s", async (_name, body, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const log = line => console.log(line);
+         process.on("unhandledRejection", () => log("unhandledRejection"));
+         ${body}`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+      stdout: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it("aborts when the uncaughtException handler throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")], {
       stderr: "pipe",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1042,6 +1042,71 @@ describe.concurrent(() => {
     });
   });
 
+  // A callback that throws skips its own checkpoint, so its microtasks and
+  // rejections are held until the immediate batch drains. Scanning at the throw
+  // site instead would report a promise whose .catch() is merely queued.
+  it.each([
+    [
+      "reports nothing when a queued microtask handles the rejection",
+      `setImmediate(() => {
+         const p = Promise.reject(new Error("x"));
+         queueMicrotask(() => p.catch(() => {}));
+         throw new Error("boom");
+       });
+       process.on("rejectionHandled", () => console.log("rejectionHandled"));`,
+      ["uncaughtException"],
+    ],
+    [
+      "reports the rejection before the timer the callback scheduled",
+      `setImmediate(() => {
+         Promise.reject(new Error("x"));
+         setTimeout(() => console.log("later timer"), 0);
+         throw new Error("boom");
+       });`,
+      ["uncaughtException", "unhandledRejection", "later timer"],
+    ],
+    [
+      "defers the rejection past the immediate queued behind it",
+      `setImmediate(() => {
+         Promise.reject(new Error("x"));
+         throw new Error("boom");
+       });
+       setImmediate(() => console.log("second immediate"));`,
+      ["uncaughtException", "second immediate", "unhandledRejection"],
+    ],
+    [
+      // `tick_immediate_tasks` routes on the *last* task's outcome, so pin the
+      // case where an earlier immediate succeeded and the throw ends the batch.
+      "reports the rejection when the throw ends a batch that started clean",
+      `setImmediate(() => console.log("first immediate"));
+       setImmediate(() => {
+         Promise.reject(new Error("x"));
+         setTimeout(() => console.log("later timer"), 0);
+         throw new Error("boom");
+       });`,
+      ["first immediate", "uncaughtException", "unhandledRejection", "later timer"],
+    ],
+  ])("a throwing setImmediate %s", async (_name, body, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("uncaughtException", () => console.log("uncaughtException"));
+         process.on("unhandledRejection", () => console.log("unhandledRejection"));
+         ${body}`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+      stdout: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it("aborts when the uncaughtException handler throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")], {
       stderr: "pipe",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1075,8 +1075,8 @@ describe.concurrent(() => {
       ["uncaughtException", "second immediate", "unhandledRejection"],
     ],
     [
-      // `tick_immediate_tasks` routes on the *last* task's outcome, so pin the
-      // case where an earlier immediate succeeded and the throw ends the batch.
+      // `tick_immediate_tasks` tracks whether *any* task threw, so pin both the
+      // throw-ends-the-batch case and a later task that returns without running.
       "reports the rejection when the throw ends a batch that started clean",
       `setImmediate(() => console.log("first immediate"));
        setImmediate(() => {
@@ -1085,6 +1085,18 @@ describe.concurrent(() => {
          throw new Error("boom");
        });`,
       ["first immediate", "uncaughtException", "unhandledRejection", "later timer"],
+    ],
+    [
+      "reports the rejection when it clears the immediate queued behind it",
+      `var cleared;
+       setImmediate(() => {
+         Promise.reject(new Error("x"));
+         setTimeout(() => console.log("later timer"), 0);
+         clearImmediate(cleared);
+         throw new Error("boom");
+       });
+       cleared = setImmediate(() => console.log("never runs"));`,
+      ["uncaughtException", "unhandledRejection", "later timer"],
     ],
   ])("a throwing setImmediate %s", async (_name, body, expected) => {
     await using proc = Bun.spawn({


### PR DESCRIPTION
## Repro

```js
setImmediate(() => {
  Promise.reject(new Error("x")); // never handled
  setTimeout(() => console.log("later timer"), 0);
});
process.on("unhandledRejection", () => console.log("unhandledRejection"));
```

```
node: unhandledRejection, later timer
bun:  later timer, unhandledRejection
```

Without an `unhandledRejection` handler, node prints the error and exits before `later timer` runs; Bun runs the timer first.

## Cause

Node reports unhandled rejections from `processTicksAndRejections`, which its timer and immediate queues run after every callback. So a rejection is always delivered before anything that callback scheduled, and before anything already queued behind it.

Bun only scanned at the tail of `autoTick`, after the poll and timer phases, so everything the callback scheduled got to run first. The timer case looked correct only by accident: a `setTimeout(…, 0)` created inside a timer callback is not due within the same drain, so the tail scan beat it. Once a sibling timer is already due, the same reordering shows up.

## Fix

Run the scan at the end of each timer and immediate callback, which is where node's `runNextTicks()` sits. `handleRejectedPromises()` now reports whether a handler ran, so the caller can re-drain the microtask queue the handler may have pushed onto, mirroring node's `do { drain } while (processPromiseRejections())`.

Two placements that look right but aren't:

- **`EventLoop::exit()`**, even though that is where the callback's microtasks already drain. `exit()` is also how native code re-enters JS from inside a JS turn: `Interpreter::finish()` calls it while `ShellPromise.then()` is mid-flight, between `rej(potentialError)` and the `super.then()` that handles it. Scanning there reports a rejection the caller is about to handle. The enter/exit counter cannot tell the two apart, so only the two batch-drain phases call the new hook.
- **The throw site of a callback that threw.** `exit_maybe_drain_microtasks(false)` deliberately skips the drain there, so the scan would see a promise whose `.catch()` is merely queued and report it. Node marks the failed callback's scope and skips its checkpoint entirely, running it once the immediate batch drains, which is what keeps the `timers-immediate-exception` fixture's nextTicks deferred past the next immediate. This does the same.

## Verification

Differential against node v26, comparing emission order. All of these were wrong before this change:

| rejection created in | competing work | before | after / node |
| --- | --- | --- | --- |
| `setImmediate` | `setTimeout(…, 0)` scheduled by it | `later timer`, `unhandledRejection` | `unhandledRejection`, `later timer` |
| `setImmediate` | sibling `setImmediate` queued behind it | `second immediate`, `unhandledRejection` | `unhandledRejection`, `second immediate` |
| `setImmediate` | `setTimeout(…, 5)` already scheduled | `5ms timer`, `unhandledRejection` | `unhandledRejection`, `5ms timer` |
| `setTimeout` | sibling timer due in the same drain | `second timer`, `unhandledRejection` | `unhandledRejection`, `second timer` |
| `setImmediate` | `process.nextTick` queued **by the handler** | nextTick never ran at all | `unhandledRejection`, `nextTick from handler`, `second immediate` |
| a **throwing** `setImmediate` | `setTimeout(…, 0)` scheduled by it | `later timer`, `unhandledRejection` | `uncaughtException`, `unhandledRejection`, `later timer` |
| a **throwing** `setImmediate` ending a batch that started clean | `first immediate`, `later timer`, `unhandledRejection` | `first immediate`, `uncaughtException`, `unhandledRejection`, `later timer` |
| a **throwing** `setImmediate` that `clearImmediate`s its sibling | `later timer`, `unhandledRejection` | `uncaughtException`, `unhandledRejection`, `later timer` |

Plus two cases that already matched node on `main` and are pinned so the checkpoint placement can't drift:

| a **throwing** `setImmediate` whose rejection is `.catch()`ed by a queued microtask | reports nothing (`uncaughtException` only) |
| a **throwing** `setImmediate` with a sibling immediate behind it | `uncaughtException`, `second immediate`, `unhandledRejection` |

All ten are cases in `test/js/node/process/process.test.js`; the eight in the first table fail on `main`.

Also re-checked against node and unchanged by this PR: rejections from `process.nextTick`, `queueMicrotask`, module top level, `fs.readFile` callbacks, a `setTimeout` scheduling another `setTimeout`, a `setTimeout` scheduling a `setImmediate`, a `setImmediate` scheduling another `setImmediate`, and `nextTick` queued from the rejecting callback (still delivered before the rejection).

### Known gap, not addressed here

A rejection created in the **poll phase** (e.g. a socket `data` handler) is still reported after an already-due timer. Pre-existing; the natural hook is `exit()`, which is unusable for the reason above.

<details>
<summary>Suites run against the debug build (no new failures vs. main)</summary>

- `test/js/node/process/process.test.js`
- `test/js/node/timers/` (including node's `timers-immediate-exception` fixture, which pins the deferred-checkpoint behaviour)
- `test/js/bun/shell/commands/` (the suite an earlier revision of this PR broke)
- `test/js/web/timers/`, `test/js/node/timers.promises/`
- `test/js/web/streams/streams.test.js`, `test/js/bun/http/serve.test.ts`
- `test/js/bun/test/` (bun's own test-runner suite)
- node's `test/parallel/test-promise*-unhandled-*.js`, `test-promises-unhandled-rejections.js`, `test-microtask-queue-run-immediate.js`, `test-timers-immediate.js`

The pre-existing failures in those suites (`bunshell ls > permission denied directory` — the container runs as root, `server.requestIP > v6`, `expect.assertions DOES fail the test, …`, …) reproduce identically with `src/` reverted to `main`.

</details>



