### PR TITLE
node:fs: stop writeFile from truncating files opened with a non-truncating flag

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1446,6 +1446,12 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: Abort
   return totalBytesWritten;
 }
 
+// The only flag spellings whose `open` truncates. `r+` & co. overwrite in place,
+// so resizing the file down to the bytes we wrote would destroy the rest of it.
+function flagTruncates(flag): boolean {
+  return flag === "w" || flag === "w+" || flag === "wx" || flag === "wx+" || flag === "xw" || flag === "xw+";
+}
+
 async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, flag, mode) {
   let encoding;
   let signal: AbortSignal | null = null;
@@ -1491,7 +1497,7 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
 
   // Handle cleanup outside of try-catch
   if (mustClose) {
-    if (typeof flag === "string" && !flag.includes("a")) {
+    if (flagTruncates(flag)) {
       try {
         await fs.ftruncate(fdOrPath, totalBytesWritten);
       } catch {}

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7430,7 +7430,11 @@ impl NodeFS {
         let fd = match &args.file {
             PathOrFileDescriptor::Path(p) => {
                 let path = p.slice_z_with_force_copy::<true>(pathbuf);
-                match sys::openat(args.dirfd, path, args.flag.as_int(), args.mode) {
+                // O_TRUNC is dropped on purpose: leaving the existing blocks
+                // allocated makes repeatedly rewriting a large file cheaper. The
+                // `ftruncate` after the write sets the final size instead.
+                let flags = args.flag.as_int() & !sys::O::TRUNC;
+                match sys::openat(args.dirfd, path, flags, args.mode) {
                     Err(err) => return Err(err.with_path(p.slice())),
                     Ok(fd) => fd,
                 }
@@ -7508,9 +7512,9 @@ impl NodeFS {
 
         // https://github.com/oven-sh/bun/issues/2931
         // https://github.com/oven-sh/bun/issues/10222
-        // Only resize when the flags asked to truncate: `r+` & co. overwrite in
-        // place, and Node never resizes a descriptor it was handed. This also
-        // undoes any over-allocation from the preallocate above.
+        // Resize only when the flags asked to truncate (the open above dropped
+        // O_TRUNC): `r+` & co. overwrite in place, and Node never resizes a
+        // descriptor it was handed.
         if (args.flag.as_int() & sys::O::TRUNC) != 0
             && matches!(args.file, PathOrFileDescriptor::Path(_))
         {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7430,10 +7430,13 @@ impl NodeFS {
         let fd = match &args.file {
             PathOrFileDescriptor::Path(p) => {
                 let path = p.slice_z_with_force_copy::<true>(pathbuf);
-                // O_TRUNC is dropped on purpose: leaving the existing blocks
-                // allocated makes repeatedly rewriting a large file cheaper. The
-                // `ftruncate` after the write sets the final size instead.
-                let flags = args.flag.as_int() & !sys::O::TRUNC;
+                // O_TRUNC is dropped on purpose: keeping the existing blocks
+                // allocated makes rewriting a large file cheaper, and the resize
+                // below sets the final size. O_APPEND writes at EOF, so it keeps it.
+                let mut flags = args.flag.as_int();
+                if (flags & sys::O::APPEND) == 0 {
+                    flags &= !sys::O::TRUNC;
+                }
                 match sys::openat(args.dirfd, path, flags, args.mode) {
                     Err(err) => return Err(err.with_path(p.slice())),
                     Ok(fd) => fd,
@@ -7494,9 +7497,16 @@ impl NodeFS {
             }
         }
 
+        // A write error is held back rather than returned, so the resize below
+        // still runs: a partial write must not leave the old tail sitting behind
+        // the bytes that did land.
+        let mut write_err: Option<sys::Error> = None;
         while !buf.is_empty() {
             match sys::write(fd, buf) {
-                Err(err) => return Err(err),
+                Err(err) => {
+                    write_err = Some(err);
+                    break;
+                }
                 Ok(amt) => {
                     buf = &buf[amt..];
                     #[cfg(not(windows))]
@@ -7528,6 +7538,10 @@ impl NodeFS {
             {
                 let _ = Syscall::ftruncate(fd, (written as u64 & ((1u64 << 63) - 1)) as i64);
             }
+        }
+
+        if let Some(err) = write_err {
+            return Err(err);
         }
 
         if args.flush {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7458,11 +7458,25 @@ impl NodeFS {
         // Worthwhile after 6 MB at least on ext4 linux
         if PREALLOCATE_SUPPORTED && buf.len() >= PREALLOCATE_LENGTH {
             'preallocate: {
-                let offset: usize = if matches!(args.file, PathOrFileDescriptor::Path(_)) {
-                    // on mac, it's relatively positioned
+                let is_path = matches!(args.file, PathOrFileDescriptor::Path(_));
+                // Preallocating grows the file, so skip it when the kernel picks
+                // the write offset at write() time: an O_APPEND write would land
+                // after the grown end, leaving a hole where the data belongs.
+                let appends = if is_path {
+                    (args.flag.as_int() & sys::O::APPEND) != 0
+                } else {
+                    // `flag` is the option, not how the caller opened this fd.
+                    match sys::get_fcntl_flags(fd) {
+                        Ok(open_flags) => (open_flags as c_int & sys::O::APPEND) != 0,
+                        Err(_) => break 'preallocate,
+                    }
+                };
+                if appends {
+                    break 'preallocate;
+                }
+                let offset: usize = if is_path {
                     0
                 } else {
-                    // on linux, it's absolutely positioned
                     match Syscall::lseek(fd, 0, libc::SEEK_CUR) {
                         Err(_) => break 'preallocate,
                         Ok(pos) => usize::try_from(pos).expect("int cast"),
@@ -7494,9 +7508,11 @@ impl NodeFS {
 
         // https://github.com/oven-sh/bun/issues/2931
         // https://github.com/oven-sh/bun/issues/10222
-        // Only truncate if we're not appending and writing to a path
-        if (args.flag.as_int() & sys::O::APPEND) == 0
-            && !matches!(args.file, PathOrFileDescriptor::Fd(_))
+        // Only resize when the flags asked to truncate: `r+` & co. overwrite in
+        // place, and Node never resizes a descriptor it was handed. This also
+        // undoes any over-allocation from the preallocate above.
+        if (args.flag.as_int() & sys::O::TRUNC) != 0
+            && matches!(args.file, PathOrFileDescriptor::Path(_))
         {
             // If this errors, we silently ignore it.
             // Not all files are seekable (and thus, not all files can be truncated).

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1702,7 +1702,7 @@ impl FileSystemFlags {
     /// Open file for reading. An exception occurs if the file does not exist.
     pub const R: Self = Self(O::RDONLY);
     /// Open file for writing. The file is created (if it does not exist) or truncated (if it exists).
-    pub const W: Self = Self(O::WRONLY | O::CREAT);
+    pub const W: Self = Self(O::TRUNC | O::CREAT | O::WRONLY);
 
     #[inline]
     pub fn as_int(self) -> c_int {

--- a/test/js/node/fs/fs-writeFile-write-error-fixture.js
+++ b/test/js/node/fs/fs-writeFile-write-error-fixture.js
@@ -1,0 +1,23 @@
+// Run under `ulimit -f 1` (a 512 byte RLIMIT_FSIZE) so the write loop fails
+// partway through with EFBIG. Handling SIGXFSZ keeps the default terminate
+// action from killing us before write() can return the error.
+const fs = require("fs");
+process.on("SIGXFSZ", () => {});
+
+const [path, flag] = process.argv.slice(2);
+let code = "none";
+try {
+  fs.writeFileSync(path, Buffer.alloc(1000, "A"), flag === "default" ? undefined : { flag });
+} catch (e) {
+  code = e.code;
+}
+
+const contents = fs.readFileSync(path);
+console.log(
+  JSON.stringify({
+    code,
+    size: contents.length,
+    written: contents.filter(b => b === 0x41).length,
+    stale: contents.filter(b => b === 0x42).length,
+  }),
+);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -590,8 +590,10 @@ describe("writeFile with a non-truncating flag", () => {
   });
 
   // O_APPEND writes land at the end of the file, so O_TRUNC has to empty it at
-  // open rather than afterwards.
-  it("writeFileSync with a numeric O_APPEND|O_TRUNC flag empties the file first", () => {
+  // open rather than afterwards. Skipped on Windows: openat() there picks its
+  // NtCreateFile disposition from O_WRONLY and ignores O_TRUNC, so this already
+  // yields "0123456789ZZ" on main. Separate bug, separate fix.
+  it.skipIf(isWindows)("writeFileSync with a numeric O_APPEND|O_TRUNC flag empties the file first", () => {
     const path = join(tmpdirSync(), "append-truncating.txt");
     writeFileSync(path, "0123456789");
     writeFileSync(path, "ZZ", {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -588,6 +588,52 @@ describe("writeFile with a non-truncating flag", () => {
     writeFileSync(path, "ZZ", { flag });
     expect(readFileSync(path, "utf8")).toBe("ZZ");
   });
+
+  // O_APPEND writes land at the end of the file, so O_TRUNC has to empty it at
+  // open rather than afterwards.
+  it("writeFileSync with a numeric O_APPEND|O_TRUNC flag empties the file first", () => {
+    const path = join(tmpdirSync(), "append-truncating.txt");
+    writeFileSync(path, "0123456789");
+    writeFileSync(path, "ZZ", {
+      flag: constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | constants.O_TRUNC,
+    });
+    expect(readFileSync(path, "utf8")).toBe("ZZ");
+  });
+});
+
+// A write that dies partway through must not leave the old tail sitting behind
+// the bytes that did land. RLIMIT_FSIZE makes write() fail with EFBIG after 512
+// bytes, which `ulimit -f 1` sets for the child.
+describe.skipIf(isWindows)("writeFileSync when the write fails partway", () => {
+  const fixture = join(import.meta.dir, "fs-writeFile-write-error-fixture.js");
+
+  async function runUnderFileSizeLimit(path: string, flag: string) {
+    writeFileSync(path, Buffer.alloc(2000, "B"));
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", `ulimit -f 1; exec "$0" "$1" "$2" "$3"`, bunExe(), fixture, path, flag],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderrHasError: stderr.includes("error:"), exitCode }).toEqual({ stderrHasError: false, exitCode: 0 });
+    return JSON.parse(stdout);
+  }
+
+  it.each(["default", "w", "w+"])("with flag %p the file holds only what was written", async flag => {
+    const path = join(tmpdirSync(), "write-error.bin");
+    const { code, size, written, stale } = await runUnderFileSizeLimit(path, flag);
+    expect({ code, stale, sizeIsOnlyWrittenBytes: size === written }).toEqual({
+      code: "EFBIG",
+      stale: 0,
+      sizeIsOnlyWrittenBytes: true,
+    });
+  });
+
+  it("with flag 'r+' the rest of the file survives", async () => {
+    const path = join(tmpdirSync(), "write-error-in-place.bin");
+    const { code, size, stale } = await runUnderFileSizeLimit(path, "r+");
+    expect({ code, size, stale }).toEqual({ code: "EFBIG", size: 2000, stale: 1488 });
+  });
 });
 
 // Writes at or above the preallocate threshold take the fallocate() path, which

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -503,6 +503,102 @@ it("writeFileSync NOT in append SHOULD truncate the file", () => {
   }
 });
 
+describe("writeFile with a non-truncating flag", () => {
+  const flags = ["r+", "rs+", constants.O_RDWR];
+
+  it.each(flags)("writeFileSync with flag %p overwrites in place", flag => {
+    const path = join(tmpdirSync(), "in-place.txt");
+    writeFileSync(path, "0123456789");
+    writeFileSync(path, "ZZ", { flag });
+    expect(readFileSync(path, "utf8")).toBe("ZZ23456789");
+  });
+
+  it.each(flags)("promises.writeFile with flag %p overwrites in place", async flag => {
+    const path = join(tmpdirSync(), "in-place.txt");
+    writeFileSync(path, "0123456789");
+    await promises.writeFile(path, "ZZ", { flag });
+    expect(readFileSync(path, "utf8")).toBe("ZZ23456789");
+  });
+
+  it.each(flags)("fs.writeFile with flag %p overwrites in place", async flag => {
+    const path = join(tmpdirSync(), "in-place.txt");
+    writeFileSync(path, "0123456789");
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    fs.writeFile(path, "ZZ", { flag }, err => (err ? reject(err) : resolve()));
+    await promise;
+    expect(readFileSync(path, "utf8")).toBe("ZZ23456789");
+  });
+
+  it("writeFileSync on a file descriptor does not truncate", () => {
+    const path = join(tmpdirSync(), "in-place-fd.txt");
+    writeFileSync(path, "0123456789");
+    const fd = openSync(path, "r+");
+    try {
+      writeFileSync(fd, "ZZ");
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(path, "utf8")).toBe("ZZ23456789");
+  });
+
+  it.each(["w", "w+"])("writeFileSync with flag %p still truncates", flag => {
+    const path = join(tmpdirSync(), "truncating.txt");
+    writeFileSync(path, "0123456789");
+    writeFileSync(path, "ZZ", { flag });
+    expect(readFileSync(path, "utf8")).toBe("ZZ");
+  });
+});
+
+// Writes at or above the preallocate threshold take the fallocate() path, which
+// grows the file before the data lands. O_APPEND then writes past the grown end,
+// leaving a hole of zeroes where the data belongs.
+describe("writeFile with a preallocate-sized buffer", () => {
+  const big = Buffer.alloc(3 * 1024 * 1024, "A");
+
+  it("appends with flag 'a'", () => {
+    const path = join(tmpdirSync(), "append-big.bin");
+    writeFileSync(path, "HEADER");
+    writeFileSync(path, big, { flag: "a" });
+    const out = readFileSync(path);
+    expect(out.subarray(0, 6).toString()).toBe("HEADER");
+    expect(out.indexOf(0)).toBe(-1);
+    expect(out.length).toBe(6 + big.length);
+  });
+
+  it("appends through a file descriptor opened with 'a'", () => {
+    const path = join(tmpdirSync(), "append-big-fd.bin");
+    writeFileSync(path, "HEADER");
+    const fd = openSync(path, "a");
+    try {
+      writeFileSync(fd, big);
+    } finally {
+      closeSync(fd);
+    }
+    const out = readFileSync(path);
+    expect(out.subarray(0, 6).toString()).toBe("HEADER");
+    expect(out.indexOf(0)).toBe(-1);
+    expect(out.length).toBe(6 + big.length);
+  });
+
+  it("keeps the tail of a larger file with flag 'r+'", () => {
+    const path = join(tmpdirSync(), "in-place-big.bin");
+    writeFileSync(path, Buffer.alloc(4 * 1024 * 1024, "B"));
+    writeFileSync(path, big, { flag: "r+" });
+    const out = readFileSync(path);
+    expect(out.subarray(0, big.length).equals(big)).toBe(true);
+    expect(out.indexOf("B")).toBe(big.length);
+    expect(out.length).toBe(4 * 1024 * 1024);
+  });
+
+  it("truncates a larger file with the default flag", () => {
+    const path = join(tmpdirSync(), "truncating-big.bin");
+    writeFileSync(path, Buffer.alloc(4 * 1024 * 1024, "B"));
+    writeFileSync(path, big);
+    const out = readFileSync(path);
+    expect(out.equals(big)).toBe(true);
+  });
+});
+
 describe("copyFileSync", () => {
   it("should work for files < 128 KB", () => {
     const tempdir = tmpdirTestMkdir();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -529,6 +529,47 @@ describe("writeFile with a non-truncating flag", () => {
     expect(readFileSync(path, "utf8")).toBe("ZZ23456789");
   });
 
+  // An iterable `data` takes a separate slow path in fs.promises, with its own
+  // truncate.
+  it.each(["r+", "rs+"])("promises.writeFile of an async iterable with flag %p overwrites in place", async flag => {
+    const path = join(tmpdirSync(), "in-place-async-iter.txt");
+    writeFileSync(path, "0123456789");
+    await promises.writeFile(
+      path,
+      (async function* () {
+        yield "ZZ";
+      })(),
+      { flag },
+    );
+    expect(readFileSync(path, "utf8")).toBe("ZZ23456789");
+  });
+
+  it.each(["r+", "rs+"])("promises.writeFile of a sync iterable with flag %p overwrites in place", async flag => {
+    const path = join(tmpdirSync(), "in-place-sync-iter.txt");
+    writeFileSync(path, "0123456789");
+    await promises.writeFile(
+      path,
+      (function* () {
+        yield "ZZ";
+      })(),
+      { flag },
+    );
+    expect(readFileSync(path, "utf8")).toBe("ZZ23456789");
+  });
+
+  it.each(["w", "w+"])("promises.writeFile of an async iterable with flag %p still truncates", async flag => {
+    const path = join(tmpdirSync(), "truncating-async-iter.txt");
+    writeFileSync(path, "0123456789");
+    await promises.writeFile(
+      path,
+      (async function* () {
+        yield "ZZ";
+      })(),
+      { flag },
+    );
+    expect(readFileSync(path, "utf8")).toBe("ZZ");
+  });
+
   it("writeFileSync on a file descriptor does not truncate", () => {
     const path = join(tmpdirSync(), "in-place-fd.txt");
     writeFileSync(path, "0123456789");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -604,9 +604,11 @@ describe("writeFile with a non-truncating flag", () => {
 });
 
 // A write that dies partway through must not leave the old tail sitting behind
-// the bytes that did land. RLIMIT_FSIZE makes write() fail with EFBIG after 512
-// bytes, which `ulimit -f 1` sets for the child.
-describe.skipIf(isWindows)("writeFileSync when the write fails partway", () => {
+// the bytes that did land. `ulimit -f 1` gives the child a 512 byte RLIMIT_FSIZE,
+// and Linux's generic_write_checks() then clamps the write to the limit and fails
+// the next one with EFBIG. Linux-only: BSD kernels reject the whole write instead,
+// so the byte split is not portable.
+describe.skipIf(!isLinux)("writeFileSync when the write fails partway", () => {
   const fixture = join(import.meta.dir, "fs-writeFile-write-error-fixture.js");
 
   async function runUnderFileSizeLimit(path: string, flag: string) {
@@ -631,10 +633,11 @@ describe.skipIf(isWindows)("writeFileSync when the write fails partway", () => {
     });
   });
 
+  // 512 new bytes over the head, the other 1488 untouched, and no resize.
   it("with flag 'r+' the rest of the file survives", async () => {
     const path = join(tmpdirSync(), "write-error-in-place.bin");
-    const { code, size, stale } = await runUnderFileSizeLimit(path, "r+");
-    expect({ code, size, stale }).toEqual({ code: "EFBIG", size: 2000, stale: 1488 });
+    const { code, size, written, stale } = await runUnderFileSizeLimit(path, "r+");
+    expect({ code, size, written, stale }).toEqual({ code: "EFBIG", size: 2000, written: 512, stale: 1488 });
   });
 });
 


### PR DESCRIPTION
## Repro

```js
const fs = require("fs");
fs.writeFileSync("f.txt", "0123456789");
fs.writeFileSync("f.txt", "ZZ", { flag: "r+" }); // r+ = read/write, no truncation
fs.readFileSync("f.txt", "utf8");
// node: "ZZ23456789"      bun: "ZZ"
```

`flag: "r+"` is the documented way to patch a region of an existing file in place. On Bun the rest of the file is silently destroyed, and the call succeeds. The same happens with `"rs+"`, `"sr+"`, and a numeric `O_RDWR`, across `writeFileSync`, `fs.writeFile` and `fs.promises.writeFile` (including its iterable slow path). `FileHandle.writeFile` was already correct.

Two more data bugs turned up next to it.

```js
// 1. append + preallocate, linux
fs.writeFileSync("f.bin", "HEADER");
fs.writeFileSync("f.bin", Buffer.alloc(3 * 1024 * 1024, "A"), { flag: "a" });
// node: 3145734 bytes, no zeroes
// bun:  6291456 bytes, 3145722 zeroes between HEADER and the data

// 2. a write that fails partway (here via RLIMIT_FSIZE; ENOSPC/EIO do the same)
fs.writeFileSync("f.txt", Buffer.alloc(2000, "B"));
fs.writeFileSync("f.txt", Buffer.alloc(1000, "A")); // dies at 512 bytes with EFBIG
// node: 512 bytes, all new
// bun:  2000 bytes, 512 new + 1488 stale
```

## Cause

`NodeFS::write_file_with_path_buffer` opens the path, writes, then runs `ftruncate(fd, written)` (`SetEndOfFile` on Windows) on every non-append write. The `ftruncate` is how a truncating write actually truncates: `open()` is deliberately given no `O_TRUNC` so the file's existing blocks stay allocated, which makes repeatedly rewriting a large file cheaper. Three things went wrong with that:

- The guard was "not appending", so it also fired for `r+`, `rs+`, `sr+` and numeric `O_RDWR`, which are supposed to overwrite in place.
- The `ftruncate` only ran on the success path, so a write that died partway left the old tail sitting behind the bytes that did land.
- `fallocate()` preallocation (writes at or above 2 MB) grows the file, but an `O_APPEND` write takes its offset from the end of the file at `write()` time, so the data landed past the grown end with a hole of zeroes in front of it. This hit `flag: "a"`/`"a+"`/`"as"` on a path, and `writeFileSync(fd, ...)` on a descriptor opened for append.

`fs.promises.writeFile` routes iterable `data` to a separate JS slow path (`writeFileAsyncIterator`) that has its own copy of the truncate, gated on `!flag.includes("a")`. Same bug, same flags.

## Fix

- `FileSystemFlags::W` now includes `O_TRUNC`, matching its own doc comment and the `"w"` entry in `FILE_SYSTEM_FLAGS_MAP`. It is the flag's meaning, not what reaches `open()`.
- `write_file_with_path_buffer` masks `O_TRUNC` out of the flags it passes to `open()` explicitly, and resizes afterwards only when the flag carries `O_TRUNC`. A caller-supplied descriptor is still never resized. `O_APPEND` keeps its `O_TRUNC`, since an append lands at EOF and the kernel has to empty the file at open for the offsets to come out right (the block-reuse win does not apply to an append anyway).
- The write loop's error is held back until after the resize, so a partial write leaves only what it wrote. The `flush` fsync is still skipped on error.
- `writeFileAsyncIterator` gates its `ftruncate` on the same rule, via the six flag spellings node maps to `O_TRUNC`.
- Preallocation is skipped when the kernel picks the write offset: `args.flag` answers that for a path, `fcntl(F_GETFL)` for a descriptor (the `flag` option is not how the caller opened it).

The syscalls for `w` are unchanged; `r+` simply stops issuing the `ftruncate`:

```
          w                 w+                r+
main      ftruncate(2)      ftruncate(2)      ftruncate(2)   <- data loss
this PR   ftruncate(2)      ftruncate(2)      -
node      - (O_TRUNC)       - (O_TRUNC)       -
```

## Verification

`test/js/node/fs/fs.test.ts` gains 25 tests: `r+`/`rs+`/numeric `O_RDWR` across `writeFileSync`, `fs.writeFile`, `promises.writeFile` and `promises.writeFile` of a sync/async iterable; the preallocate-sized append cases (path and fd); a write that fails partway under `RLIMIT_FSIZE` (Linux only: the 512-byte partial write before `EFBIG` is `generic_write_checks()`'s clamp, BSD rejects the whole write); and guards that `w`, `w+`, numeric `O_APPEND|O_TRUNC`, the default flag and a caller's descriptor keep their existing behaviour. 17 of them fail on `main`.

Also diffed against Node across a 62-case matrix (every flag string, six numeric flag combinations, path and fd, iterable and buffer data, writes above and below the 2 MB preallocate threshold, pre-existing files larger and smaller than the write). `main` differs from Node in 19 of them; with this change all 62 match byte for byte.

<details>
<summary>matrix diff, main vs node</summary>

```
< small flag=r+: len=10 head="ZZ23456789"       > small flag=r+: len=2 head="ZZ"
< small flag=rs+: len=10 head="ZZ23456789"      > small flag=rs+: len=2 head="ZZ"
< small flag=sr+: len=10 head="ZZ23456789"      > small flag=sr+: len=2 head="ZZ"
< big flag=r+: len=4194304                      > big flag=r+: len=3145728
< bigOnSmall flag=a: len=3145734 zeros=0        > bigOnSmall flag=a: len=6291456 zeros=3145722
< bigOnSmall flag=a+: len=3145734 zeros=0       > bigOnSmall flag=a+: len=6291456 zeros=3145722
< bigOnSmall flag=as: len=3145734 zeros=0       > bigOnSmall flag=as: len=6291456 zeros=3145722
< fd bigOnSmall open=a: len=3145734 zeros=0     > fd bigOnSmall open=a: len=6291456 zeros=3145722
< fd bigOnSmall open=a+: len=3145734 zeros=0    > fd bigOnSmall open=a+: len=6291456 zeros=3145722
< numeric O_RDWR: len=10 head="ZZ23456789"      > numeric O_RDWR: len=2 head="ZZ"
< numeric O_WRONLY|O_CREAT: len=10              > numeric O_WRONLY|O_CREAT: len=2
< numeric-big O_WRONLY|O_CREAT|O_APPEND: zeros=0          > ...: len=6291456 zeros=3145722
< numeric-big O_WRONLY|O_CREAT|O_APPEND|O_TRUNC: zeros=0  > ...: len=6291456 zeros=3145728
< async iterable flag=r+: "ZZ23456789"          > async iterable flag=r+: "ZZ"
< async iterable flag=rs+: "ZZ23456789"         > async iterable flag=rs+: "ZZ"
< async iterable flag=sr+: "ZZ23456789"         > async iterable flag=sr+: "ZZ"
< sync iterable flag=r+: "ZZ23456789"           > sync iterable flag=r+: "ZZ"
< sync iterable flag=rs+: "ZZ23456789"          > sync iterable flag=rs+: "ZZ"
< sync iterable flag=sr+: "ZZ23456789"          > sync iterable flag=sr+: "ZZ"
```

</details>

Node's own `test-fs-write-file*`, `test-fs-append-file*` and `test-fs-promises-writefile*` parallel tests still pass, and `bun run rust:check-all` is green on all 10 targets so the Windows `SetEndOfFile` branch and the `fcntl` call still compile everywhere.


### One case skipped on Windows

`openat` on Windows derives its `NtCreateFile` disposition from `O_WRONLY`, never from `O_TRUNC`:

```rust
let overwrite = (flags & O::WRONLY) != 0 && (flags & O::APPEND) == 0;
```

libuv keys it off `O_CREAT|O_EXCL|O_TRUNC` instead, so Bun diverges there in a few ways that have nothing to do with this writer: a numeric `O_APPEND|O_TRUNC` open never empties the file, `fs.openSync(path, "w+")` never truncates, and a numeric `O_WRONLY|O_CREAT` truncates when it should not. The `O_APPEND|O_TRUNC` test is `skipIf(isWindows)` for that reason; the behaviour there is `"0123456789ZZ"` on `main` and on this branch alike, so nothing regressed. Happy to fix the disposition mapping in a follow-up if that is wanted, it is a wider change than this PR.



### Known follow-up

`preallocate_file` calls `fallocate(fd, 0, offset, len)` with mode 0, which grows the file. If `write()` then fails partway on a flag that does not truncate, nothing sizes the file back and the fallocate-grown zero tail survives. `main` behaves identically (its write error returned before the resize), so nothing regresses here, and the trigger is narrow: `fallocate` accounts for space and quota up front, so `ENOSPC`/`EDQUOT` cannot fire afterwards, and `RLIMIT_FSIZE` fails the `fallocate` itself before it can grow anything. That leaves `EIO` off a bad block, which is not something a test can reach.

The clean fix is `FALLOC_FL_KEEP_SIZE`, which also covers the descriptor case (the resize never runs for a caller's fd, so gating preallocation on `O_TRUNC` would only close half of it). It is left out of this PR because `preallocate_file` has six callers across libarchive, `Bun.write`, copy_file, the transpiler cache and tarball extraction, and re-moding it deserves its own reasoning per caller.
