### PR TITLE
Drain the microtask checkpoint after unhandledRejection handlers run

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -155,13 +155,9 @@ function applyHandlers(handlers, emitter, args) {
 }
 
 function addCatch(emitter, thenable, type, args) {
-  // `emit` is swapped per-instance (and on the prototype by the static
-  // `captureRejections` setter), so an emitter can reach here with capture
-  // turned off for it specifically. Re-read the flag the way node does.
+  // The prototype may hold the capturing emit while this instance opted out.
   if (!emitter[kCapture]) return;
-  // Any thenable counts, not just a real Promise. Per Promises/A+ `then` may be
-  // a getter, and reading it exactly once is observable, so cache it and let a
-  // throwing getter surface as an 'error' event.
+  // Promises/A+: `then` may be a getter, so read it once; a throw is an 'error' event.
   try {
     const then = thenable.then;
     if (typeof then === "function") {
@@ -277,8 +273,6 @@ const emitWithRejectionCapture = function emit(type, ...args) {
         result = handler.$apply(this, args);
         break;
     }
-    // Not just promises: any thenable the handler returns participates in
-    // rejection capture. `addCatch` duck-types `then`.
     if (result !== undefined && result !== null) {
       addCatch(this, result, type, args);
     }
@@ -970,9 +964,8 @@ Object.defineProperties(EventEmitter, {
       validateBoolean(value, "EventEmitter.captureRejections");
 
       EventEmitterPrototype[kCapture] = value;
-      // Emitters whose constructor never ran (`inherits()` without a super call) have
-      // no own `emit`, so the capturing variant reaches them through the prototype.
-      // Only swap our own function: a userland `emit` patch has to survive a toggle.
+      // Reaches emitters with no own `emit` (constructor never ran). Swap only our own
+      // function so a userland `emit` patch survives a toggle.
       const emit = EventEmitterPrototype.emit;
       if (emit === emitWithoutRejectionCapture || emit === emitWithRejectionCapture) {
         EventEmitterPrototype.emit = value ? emitWithRejectionCapture : emitWithoutRejectionCapture;

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -970,10 +970,9 @@ Object.defineProperties(EventEmitter, {
       validateBoolean(value, "EventEmitter.captureRejections");
 
       EventEmitterPrototype[kCapture] = value;
-      // Emitters whose constructor never ran (`inherits()` without a super call)
-      // have no own `emit`, so the capturing variant has to reach them through
-      // the prototype. Only ever swap out our own function: node's setter leaves
-      // `emit` alone, so a userland patch has to survive a toggle.
+      // Emitters whose constructor never ran (`inherits()` without a super call) have
+      // no own `emit`, so the capturing variant reaches them through the prototype.
+      // Only swap our own function: a userland `emit` patch has to survive a toggle.
       const emit = EventEmitterPrototype.emit;
       if (emit === emitWithoutRejectionCapture || emit === emitWithRejectionCapture) {
         EventEmitterPrototype.emit = value ? emitWithRejectionCapture : emitWithoutRejectionCapture;

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -970,11 +970,14 @@ Object.defineProperties(EventEmitter, {
       validateBoolean(value, "EventEmitter.captureRejections");
 
       EventEmitterPrototype[kCapture] = value;
-      // Instances that never ran the EventEmitter constructor (`inherits()`
-      // without a super call) have no own `emit`, so the capturing variant has
-      // to reach them through the prototype. `addCatch` re-checks `kCapture`,
-      // so emitters that opted out still skip capture.
-      EventEmitterPrototype.emit = value ? emitWithRejectionCapture : emitWithoutRejectionCapture;
+      // Emitters whose constructor never ran (`inherits()` without a super call)
+      // have no own `emit`, so the capturing variant has to reach them through
+      // the prototype. Only ever swap out our own function: node's setter leaves
+      // `emit` alone, so a userland patch has to survive a toggle.
+      const emit = EventEmitterPrototype.emit;
+      if (emit === emitWithoutRejectionCapture || emit === emitWithRejectionCapture) {
+        EventEmitterPrototype.emit = value ? emitWithRejectionCapture : emitWithoutRejectionCapture;
+      }
     },
     enumerable: true,
   },

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -154,11 +154,25 @@ function applyHandlers(handlers, emitter, args) {
   }
 }
 
-function addCatch(emitter, promise, type, args) {
-  promise.then(undefined, function (err) {
-    // The callback is called with nextTick to avoid a follow-up rejection from this promise.
-    process.nextTick(emitUnhandledRejectionOrErr, emitter, err, type, args);
-  });
+function addCatch(emitter, thenable, type, args) {
+  // `emit` is swapped per-instance (and on the prototype by the static
+  // `captureRejections` setter), so an emitter can reach here with capture
+  // turned off for it specifically. Re-read the flag the way node does.
+  if (!emitter[kCapture]) return;
+  // Any thenable counts, not just a real Promise. Per Promises/A+ `then` may be
+  // a getter, and reading it exactly once is observable, so cache it and let a
+  // throwing getter surface as an 'error' event.
+  try {
+    const then = thenable.then;
+    if (typeof then === "function") {
+      then.$call(thenable, undefined, function (err) {
+        // The callback is called with nextTick to avoid a follow-up rejection from this promise.
+        process.nextTick(emitUnhandledRejectionOrErr, emitter, err, type, args);
+      });
+    }
+  } catch (err) {
+    emitter.emit("error", err);
+  }
 }
 
 function emitUnhandledRejectionOrErr(emitter, err, type, args) {
@@ -263,7 +277,9 @@ const emitWithRejectionCapture = function emit(type, ...args) {
         result = handler.$apply(this, args);
         break;
     }
-    if (result !== undefined && $isPromise(result)) {
+    // Not just promises: any thenable the handler returns participates in
+    // rejection capture. `addCatch` duck-types `then`.
+    if (result !== undefined && result !== null) {
       addCatch(this, result, type, args);
     }
     return true;
@@ -291,7 +307,7 @@ const emitWithRejectionCapture = function emit(type, ...args) {
         result = listener.$apply(this, args);
         break;
     }
-    if (result !== undefined && $isPromise(result)) {
+    if (result !== undefined && result !== null) {
       addCatch(this, result, type, args);
     }
   }
@@ -954,6 +970,11 @@ Object.defineProperties(EventEmitter, {
       validateBoolean(value, "EventEmitter.captureRejections");
 
       EventEmitterPrototype[kCapture] = value;
+      // Instances that never ran the EventEmitter constructor (`inherits()`
+      // without a super call) have no own `emit`, so the capturing variant has
+      // to reach them through the prototype. `addCatch` re-checks `kCapture`,
+      // so emitters that opted out still skip capture.
+      EventEmitterPrototype.emit = value ? emitWithRejectionCapture : emitWithoutRejectionCapture;
     },
     enumerable: true,
   },

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1113,6 +1113,12 @@ impl JSGlobalObject {
         crate::from_js_host_call_generic(self, || JSC__JSGlobalObject__handleRejectedPromises(self))
     }
 
+    /// Whether [`Self::handle_rejected_promises`] still has `unhandledRejection`
+    /// notifications to deliver.
+    pub fn has_pending_rejected_promises(&self) -> bool {
+        JSC__JSGlobalObject__hasPendingRejectedPromises(self)
+    }
+
     // The `readableStreamTo*` consumers throw `ERR_INVALID_ARG_TYPE` when
     // `value` is not a `ReadableStream` and propagate what the consumer throws.
     pub fn readable_stream_to_array_buffer(&self, value: JSValue) -> JsResult<JSValue> {
@@ -1536,6 +1542,8 @@ unsafe extern "C" {
     safe fn JSC__JSGlobalObject__generateHeapSnapshot(this: &JSGlobalObject) -> JSValue;
 
     safe fn JSC__JSGlobalObject__handleRejectedPromises(this: &JSGlobalObject);
+
+    safe fn JSC__JSGlobalObject__hasPendingRejectedPromises(this: &JSGlobalObject) -> bool;
 
     safe fn ZigGlobalObject__readableStreamToArrayBuffer(
         this: &JSGlobalObject,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1681,16 +1681,24 @@ impl VirtualMachine {
                 dispatch = true;
             }
 
+            // A `beforeExit` listener is user JS and can reject a promise. Notify it
+            // (and run what the handler schedules) before concluding the loop is idle.
+            if self.event_loop_mut().drain_rejected_promises().is_err() {
+                return;
+            }
+            if self.is_event_loop_alive() {
+                continue;
+            }
+
             // Same guards as on entry: a fatal throw or a stop requested during
             // the inner drain must not re-dispatch. The main-thread case already
             // hard-exits via `exit_on_uncaught_exception`; this covers workers.
             if dispatch && self.unhandled_error_counter == 0 && self.script_allowed() {
                 ExitHandler::dispatch_on_before_exit(self);
                 dispatch = false;
-
-                if self.is_event_loop_alive() {
-                    continue;
-                }
+                // The listener just ran may have scheduled work or rejected; the
+                // next pass picks up both.
+                continue;
             }
 
             break;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2145,9 +2145,9 @@ pub struct RuntimeHooks {
     pub auto_tick: unsafe fn(vm: *mut VirtualMachine),
     /// `eventLoop().autoTickActive()` — like `auto_tick` but only sleeps in
     /// the uSockets loop while it has active handles.
-    /// Separate slot because the body skips `runImminentGCTimer` /
-    /// `handleRejectedPromises` and falls through to `tickWithoutIdle` when
-    /// idle — folding it into `auto_tick` would change shutdown semantics.
+    /// Separate slot because the body skips `runImminentGCTimer` and falls
+    /// through to `tickWithoutIdle` when idle — folding it into `auto_tick`
+    /// would change shutdown semantics.
     pub auto_tick_active: unsafe fn(vm: *mut VirtualMachine),
     /// `printException` / `printErrorlikeObject` — formats `value` (or its
     /// wrapped `JSC::Exception`) to stderr via `ConsoleObject::Formatter`.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1696,8 +1696,6 @@ impl VirtualMachine {
             if dispatch && self.unhandled_error_counter == 0 && self.script_allowed() {
                 ExitHandler::dispatch_on_before_exit(self);
                 dispatch = false;
-                // The listener just ran may have scheduled work or rejected; the
-                // next pass picks up both.
                 continue;
             }
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -331,6 +331,7 @@ public:
     uint8_t drainMicrotasks();
 
     void handleRejectedPromises();
+    bool hasPendingRejectedPromises() const { return !m_aboutToBeNotifiedRejectedPromises.isEmpty(); }
     ALWAYS_INLINE void initGeneratedLazyClasses();
 
     template<typename Visitor>

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4129,6 +4129,11 @@ void JSC__JSGlobalObject__handleRejectedPromises(JSC::JSGlobalObject* arg0)
     return uncheckedDowncast<Zig::GlobalObject>(arg0)->handleRejectedPromises();
 }
 
+bool JSC__JSGlobalObject__hasPendingRejectedPromises(JSC::JSGlobalObject* arg0)
+{
+    return uncheckedDowncast<Zig::GlobalObject>(arg0)->hasPendingRejectedPromises();
+}
+
 #pragma mark - JSC::JSValue
 
 JSC::JSString* JSC__JSValue__asString(JSC::EncodedJSValue JSValue0)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -166,6 +166,7 @@ CPP_DECL JSC::EncodedJSValue JSC__JSGlobalObject__createAggregateError(JSC::JSGl
 CPP_DECL void JSC__JSGlobalObject__deleteModuleRegistryEntry(JSC::JSGlobalObject* arg0, const EncodedSlice* arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSGlobalObject__generateHeapSnapshot(JSC::JSGlobalObject* arg0);
 CPP_DECL void JSC__JSGlobalObject__handleRejectedPromises(JSC::JSGlobalObject* arg0);
+CPP_DECL bool JSC__JSGlobalObject__hasPendingRejectedPromises(JSC::JSGlobalObject* arg0);
 CPP_DECL void JSC__JSGlobalObject__addGc(JSC::JSGlobalObject* globalObject);
 CPP_DECL double JSC__JSGlobalObject__jsDateNow(JSC::JSGlobalObject* globalObject);
 CPP_DECL void JSC__JSGlobalObject__queueMicrotaskJob(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, JSC::EncodedJSValue JSValue2, JSC::EncodedJSValue JSValue3);

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -818,22 +818,16 @@ impl EventLoop {
         self.drain_rejected_promises()
     }
 
-    /// Deliver pending `unhandledRejection` notifications, then re-enter the
-    /// `nextTick` + microtask checkpoint the handlers may have filled.
-    ///
-    /// Node's `processTicksAndRejections` loops back into that checkpoint after
-    /// `processPromiseRejections()`. Returning without it drops anything a
-    /// handler scheduled behind an `await`, and the loop sees no pending work.
+    /// Deliver pending `unhandledRejection` notifications, then drain the `nextTick` +
+    /// microtask checkpoint the handlers filled, as node's `processTicksAndRejections`
+    /// does; otherwise work a handler schedules behind an `await` is lost.
     /// `Err(Stopped)` is the VM's termination, taken at this loop-level boundary.
     pub fn drain_rejected_promises(&mut self) -> Result<(), Stopped> {
-        // Note: reshaped for borrowck — `vm_ref()` is `&'static`, so these
-        // borrows detach from `&self` and survive the `&mut self` calls below.
-        let global = self.vm_ref().global();
-        let global_vm = self.vm_ref().jsc_vm();
-
-        while global.has_pending_rejected_promises() {
-            global.handle_rejected_promises().map_err(|_| Stopped)?;
-            self.drain_microtasks_with_global(global, global_vm)?;
+        while self.global_ref().has_pending_rejected_promises() {
+            self.global_ref()
+                .handle_rejected_promises()
+                .map_err(|_| Stopped)?;
+            self.drain_microtasks()?;
         }
         Ok(())
     }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -815,9 +815,27 @@ impl EventLoop {
             self.tick_concurrent();
         }
 
-        self.global_ref()
-            .handle_rejected_promises()
-            .map_err(|_| Stopped)
+        self.drain_rejected_promises()
+    }
+
+    /// Deliver pending `unhandledRejection` notifications, then re-enter the
+    /// `nextTick` + microtask checkpoint the handlers may have filled.
+    ///
+    /// Node's `processTicksAndRejections` loops back into that checkpoint after
+    /// `processPromiseRejections()`. Returning without it drops anything a
+    /// handler scheduled behind an `await`, and the loop sees no pending work.
+    /// `Err(Stopped)` is the VM's termination, taken at this loop-level boundary.
+    pub fn drain_rejected_promises(&mut self) -> Result<(), Stopped> {
+        // Note: reshaped for borrowck — `vm_ref()` is `&'static`, so these
+        // borrows detach from `&self` and survive the `&mut self` calls below.
+        let global = self.vm_ref().global();
+        let global_vm = self.vm_ref().jsc_vm();
+
+        while global.has_pending_rejected_promises() {
+            global.handle_rejected_promises().map_err(|_| Stopped)?;
+            self.drain_microtasks_with_global(global, global_vm)?;
+        }
+        Ok(())
     }
 
     /// Tick the task queue without draining microtasks afterward.

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1555,7 +1555,7 @@ impl Run<'_> {
         }
 
         vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
-        let _ = vm.global().handle_rejected_promises();
+        let _ = vm.event_loop_ref().drain_rejected_promises();
         // The loop stopped on an uncaught error: Node's fatal-exception exit, not a drain.
         if vm.unhandled_error_counter > 0 {
             vm.exit_handler.requested = true;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1237,9 +1237,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };
-    // A timer or I/O callback above may have rejected a promise. Notify it here
-    // (node notifies inside the same phase) so the handler runs, and whatever it
-    // schedules is visible before the caller re-checks `is_event_loop_alive()`.
+    // A timer or I/O callback above may have rejected a promise; node notifies it in
+    // the same phase, so what the handler schedules is visible to the liveness check.
     // SAFETY: `el` is the live per-thread event loop.
     let _ = unsafe { (*el).drain_rejected_promises() };
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1026,8 +1026,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         // Still run the post-poll hooks.
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
-        // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
-        let _ = unsafe { (*(*vm).global).handle_rejected_promises() };
+        // SAFETY: `el` is the live per-thread event loop.
+        let _ = unsafe { (*el).drain_rejected_promises() };
         return;
     }
 
@@ -1114,15 +1114,14 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };
-    // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
-    let _ = unsafe { (*(*vm).global).handle_rejected_promises() };
+    // SAFETY: `el` is the live per-thread event loop.
+    let _ = unsafe { (*el).drain_rejected_promises() };
 }
 
 /// `eventLoop().autoTickActive()`. Same shape as
-/// [`auto_tick`] but: no `runImminentGCTimer`, no `handleRejectedPromises` at
-/// the tail, and no debug sleep-timer logging. Used by `bun_main` /
-/// `on_before_exit` drain loops where blocking when the loop is idle would
-/// hang shutdown.
+/// [`auto_tick`] but: no `runImminentGCTimer` and no debug sleep-timer logging.
+/// Used by `bun_main` / `on_before_exit` drain loops where blocking when the
+/// loop is idle would hang shutdown.
 ///
 /// # Safety
 /// `vm` is the live per-thread VM.
@@ -1173,6 +1172,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
         unsafe { (*loop_).tick_without_idle() };
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
+        // SAFETY: `el` is the live per-thread event loop.
+        let _ = unsafe { (*el).drain_rejected_promises() };
         return;
     }
 
@@ -1236,6 +1237,11 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };
+    // A timer or I/O callback above may have rejected a promise. Notify it here
+    // (node notifies inside the same phase) so the handler runs, and whatever it
+    // schedules is visible before the caller re-checks `is_event_loop_alive()`.
+    // SAFETY: `el` is the live per-thread event loop.
+    let _ = unsafe { (*el).drain_rejected_promises() };
 }
 
 /// `printException` / `printErrorlikeObject` — formats `value` to stderr via

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -785,6 +785,97 @@ describe("EventEmitter captureRejections", () => {
 
     expect(handled).toEqual(null);
   });
+
+  test("it captures a thenable returned from a handler", async () => {
+    const myEmitter = new EventEmitter({ captureRejections: true });
+    const { promise, resolve } = Promise.withResolvers<any>();
+    myEmitter.on("error", resolve);
+
+    myEmitter.on("action", () => ({
+      then(resolved: unknown, rejected: (err: unknown) => void) {
+        expect(resolved).toBeUndefined();
+        rejected(new Error("boom"));
+      },
+    }));
+    myEmitter.emit("action");
+
+    expect((await promise).message).toBe("boom");
+  });
+
+  test("a throwing `then` getter surfaces as an error event", async () => {
+    const myEmitter = new EventEmitter({ captureRejections: true });
+    const { promise, resolve } = Promise.withResolvers<any>();
+    myEmitter.on("error", resolve);
+
+    myEmitter.on("action", () => {
+      const obj = {};
+      Object.defineProperty(obj, "then", {
+        get() {
+          throw new Error("boom");
+        },
+      });
+      return obj;
+    });
+    myEmitter.emit("action");
+
+    expect((await promise).message).toBe("boom");
+  });
+
+  // `EventEmitter.captureRejections` is process-global, so each case below runs
+  // in its own process.
+  test("it captures rejections on an emitter whose constructor never ran", async () => {
+    // `inherits()` without a super() call leaves no own `emit`, so the capturing
+    // variant has to reach the instance through the prototype.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const EventEmitter = require("node:events");
+          const { inherits } = require("node:util");
+          function NoConstructor() {}
+          inherits(NoConstructor, EventEmitter);
+
+          EventEmitter.captureRejections = true;
+          const ee = new NoConstructor();
+          ee.on("error", err => console.log("error:" + err.message));
+          ee.on("action", async () => { throw new Error("boom"); });
+          ee.emit("action");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "error:boom", stderr: "", exitCode: 0 });
+  });
+
+  test("it does not capture on an emitter constructed before captureRejections was enabled", async () => {
+    // The emitter kept its own `captureRejections: false`, so flipping the
+    // global flag afterwards must not start capturing for it.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const EventEmitter = require("node:events");
+          const ee = new EventEmitter();
+          EventEmitter.captureRejections = true;
+
+          process.on("unhandledRejection", err => console.log("unhandled:" + err.message));
+          ee.on("error", () => console.log("error-handler"));
+          ee.on("action", async () => { throw new Error("boom"); });
+          ee.emit("action");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "unhandled:boom", stderr: "", exitCode: 0 });
+  });
 });
 
 const waysOfCreating = [

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -876,6 +876,44 @@ describe("EventEmitter captureRejections", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "unhandled:boom", stderr: "", exitCode: 0 });
   });
+
+  test("toggling captureRejections leaves a userland prototype emit patch alone", async () => {
+    // node's setter only flips the flag, so a patched `EventEmitter.prototype.emit`
+    // (what APM/tracing libraries install) has to survive a toggle.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const EventEmitter = require("node:events");
+          const original = EventEmitter.prototype.emit;
+          const seen = [];
+          EventEmitter.prototype.emit = function patched(...args) {
+            seen.push(args[0]);
+            return original.apply(this, args);
+          };
+
+          EventEmitter.captureRejections = true;
+          EventEmitter.captureRejections = false;
+
+          const ee = new EventEmitter();
+          let handled = false;
+          ee.on("x", () => { handled = true; });
+          ee.emit("x");
+          console.log(JSON.stringify({ seen, handled }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: `{"seen":["x"],"handled":true}`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });
 
 const waysOfCreating = [

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -84,3 +84,101 @@ describe("process.on", () => {
     expect(result2.exitCode).toBe(0);
   });
 });
+
+describe.concurrent("process.on('unhandledRejection')", () => {
+  it("keeps the process alive for work the handler schedules after a microtask hop", async () => {
+    // The handler only reaches setTimeout after one nextTick/microtask hop, which
+    // is what `await` compiles to. That checkpoint has to drain before the loop
+    // decides it has no work left, or the timers never run.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.on("unhandledRejection", reason => {
+            if (reason === "a") Promise.resolve().then(() => setTimeout(() => console.log("then"), 1));
+            if (reason === "b") queueMicrotask(() => setTimeout(() => console.log("queueMicrotask"), 1));
+            if (reason === "c") process.nextTick(() => setTimeout(() => console.log("nextTick"), 1));
+          });
+          Promise.reject("a");
+          Promise.reject("b");
+          Promise.reject("c");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // nextTick drains before the microtask queue, so its timer is armed first.
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "nextTick\nthen\nqueueMicrotask",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("runs before beforeExit when the rejection comes from a timer", async () => {
+    // The rejection lands in the timer phase, after the last thing keeping the
+    // loop alive is gone. Node notifies it inside that phase, so the handler
+    // still gets to schedule work and `beforeExit` observes the real state.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const log = [];
+          process.on("beforeExit", () => {
+            log.push("beforeExit");
+            console.log(log.join(","));
+          });
+          process.on("unhandledRejection", () => {
+            log.push("handler");
+            Promise.resolve().then(() => setTimeout(() => log.push("recovered"), 1));
+          });
+          setTimeout(() => {
+            Promise.reject(new Error("late"));
+          }, 1);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "handler,recovered,beforeExit",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("runs for a rejection raised by a beforeExit listener", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          let n = 0;
+          process.on("beforeExit", () => {
+            console.log("beforeExit#" + ++n);
+            if (n === 1) Promise.reject(new Error("from beforeExit"));
+          });
+          process.on("unhandledRejection", () => {
+            console.log("handler");
+            Promise.resolve().then(() => setTimeout(() => console.log("recovered"), 1));
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "beforeExit#1\nhandler\nrecovered\nbeforeExit#2",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Repro

```js
process.on("unhandledRejection", () => {
  // any microtask hop — which is what `await` compiles to
  Promise.resolve().then(() => setTimeout(() => console.log("recovered"), 10));
});
Promise.reject(new Error("x"));
```

```
node: recovered
bun:  (nothing, exits 0)
```

`process.nextTick` and `queueMicrotask` are dropped the same way. Scheduling the timer *directly* in the handler works, so only the hop is affected.

It matters because `unhandledRejection` handlers are where apps flush a logger, write a crash report, or start a graceful shutdown, and almost all of that code awaits something before scheduling a continuation.

## Cause

An `unhandledRejection` handler is user JS that can queue microtasks and nextTicks. Node loops back into its checkpoint afterwards:

```js
do {
  while ((tock = queue.shift()) !== null) { /* nextTick */ }
  runMicrotasks();
} while (!queue.isEmpty() || processPromiseRejections());
```

Bun's `handleRejectedPromises()` emits the event and returns straight to the `is_event_loop_alive()` check. The handler's microtask is still sitting in the queue, which `is_event_loop_alive()` does not count, so the loop exits and the work never runs.

A second gap in the same family: `auto_tick_active` (the timer + poll phase that `bun run`'s main loop and `on_before_exit` drive) had no rejection handling at its tail at all. A rejection raised by a timer callback was therefore notified only after `beforeExit`, from the exit path, with no loop iteration left. That dropped even a *directly* scheduled `setTimeout`, and emitted `unhandledRejection` after `beforeExit` instead of before it.

## Fix

`EventLoop::drain_rejected_promises()`: notify pending rejections, then drain the nextTick + microtask checkpoint they filled, repeating while the drain produces new rejections. It returns `Result<(), Stopped>` like the rest of the loop-level code on main, so a VM termination met inside a handler propagates instead of being swallowed. Used at the tail of `EventLoop::tick_turn`, `auto_tick`, `auto_tick_active`, and in `on_before_exit`'s drain loop, so whatever a handler schedules is visible before liveness is re-checked.

The new `hasPendingRejectedPromises()` binding keeps the common path to a single `isEmpty()` read: when nothing rejected, no drain runs.

Emission order within a batch is unchanged (all handlers, then one checkpoint), matching node.

## Verification

Differential against node v26. All of these produce byte-identical output with the fix and were wrong before it:

| rejection raised | handler schedules | before | after / node |
| --- | --- | --- | --- |
| module top level | `setTimeout` behind `.then()` | *nothing* | `recovered` |
| module top level | `setTimeout` behind `queueMicrotask` | *nothing* | `queueMicrotask` |
| module top level | `setTimeout` behind `nextTick` | *nothing* | `nextTick` |
| `setTimeout` callback | `setTimeout` behind `.then()` | *nothing* | `handler`, `recovered` |
| `setTimeout` callback | `setTimeout` directly | `beforeExit` only | `handler`, `timer-from-handler`, `beforeExit` |
| `setTimeout` callback | nothing | `beforeExit`, `handler` | `handler`, `beforeExit` |
| `beforeExit` listener | `setTimeout` behind `.then()` | *nothing* | `handler`, `recovered`, `beforeExit#2` |

Three of those are the new cases in `test/js/node/process/process-on.test.ts`; they fail on `main` and pass with the fix.

<details>
<summary>Suites run against the debug build</summary>

No new failures in:

- `test/js/node/process/process-on.test.ts`
- `test/js/node/process/process.test.js` (including `delivers many unhandledRejections in order`, which pins batch ordering)
- `test/js/node/process/process-nexttick.test.js`
- `test/js/node/test/parallel/test-promises-unhandled-rejections.js` and the seven other `test-promise-unhandled-*` files
- `test/js/web/workers/worker.test.ts`
- `test/js/web/timers/{setTimeout,setInterval,setImmediate}.test.js`
- `test/js/node/timers/node-timers.test.ts`
- `test/js/bun/cron/in-process-cron.test.ts`
- `test/js/bun/http/serve.test.ts`, `test/js/web/streams/streams.test.js`, `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`

`bun run rust:check-all` passes on all 10 targets.

Pre-existing failures in this container, unrelated and reproducible without the change: the timer RSS-leak fixtures gate on `process.execPath.includes("bun-asan")`, which is false for `bun-debug`, so the 192 MB ASAN threshold never applies (a release build measures a 2.0 MB delta); a few `serve.test.ts` cases need IPv6 / a non-root uid.

</details>


## Second fix: `captureRejections`

Fixing the event loop made `test/js/node/test/parallel/test-event-capture-rejections.js` fail. That test is a chain of twelve stages, each handing off with `process.nextTick` from inside an `unhandledRejection` handler, so on `main` it silently stopped after its third stage and still exited 0. With the chain repaired the remaining nine stages run for the first time and hit three pre-existing `captureRejections` gaps, all reproducible on released bun:

| | bun 1.4.0 | node |
| --- | --- | --- |
| handler returns a thenable (not a real `Promise`) | rejection dropped silently | `error` event |
| `then` getter throws | rejection dropped silently | `error` event |
| `inherits(X, EventEmitter)` with no `super()`, global `captureRejections = true` | `unhandledRejection` | `error` event |

In `src/js/node/events.ts`:

- `addCatch` only attached to real promises (`$isPromise(result)`). Node duck-types `then`. Reading `then` is observable (Promises/A+ allows a getter), so it is read once and a throwing getter becomes an `error` event.
- `emit` is swapped *per instance* in the constructor, so an emitter built by `inherits()` without a `super()` call keeps the non-capturing `emit` regardless of the global flag. The static `captureRejections` setter now swaps the prototype's `emit` too.
- That swap alone would over-capture: an emitter constructed while the flag was off owns `kCapture = false` and has no own `emit`, so flipping the flag later would start capturing it, which node does not do. `addCatch` now re-checks `kCapture`, as node does.

That prototype swap only ever replaces one of the two internal emit functions. Node's setter leaves `emit` alone, so a userland patch of `EventEmitter.prototype.emit` (what APM and tracing libraries install) has to survive a toggle of the flag.

Five tests in `test/js/node/events/event-emitter.test.ts`; three fail on `main`, and two are negative tests for the guards above (each fails if its guard is deleted). `test-event-capture-rejections.js` now runs all twelve stages and exits 0.

## Rebase notes

Rebased across a large stretch of main. Two resolutions changed code rather than just context:

- **`Stopped` model.** Main's `tick()` became `tick_turn() -> Result<(), Stopped>`, and `handle_rejected_promises()` / `drain_microtasks()` now return `Result`s. `drain_rejected_promises()` adopts the same signature and uses `?` throughout; the `auto_tick` / `auto_tick_active` / `Run::start` call sites discard it with `let _ =` exactly as main does for the call it replaces, and `on_before_exit` returns on `Err`, matching the `script_allowed()` returns main added around it (#34639).
- **`on_before_exit` guards.** Main now skips `beforeExit` after a fatal throw and stops the drain on a termination request. The rejection drain is inserted at the point the loop goes idle, ahead of those guards, so they still gate the re-dispatch.
- **Two dispatch sites in `events.ts`.** #34519 split `emitWithRejectionCapture` into a single-listener fast path and an array path, each with its own `$isPromise` check. Auto-merge only updated one; the other is updated by hand so a thenable is captured regardless of listener count. `test-event-capture-rejections.js` covers both shapes.

Everything else merged cleanly. Verified on the new base: `process-on.test.ts` + `event-emitter.test.ts` 86/86, `test-event-capture-rejections.js` all 12 stages, 56 upstream `test-event*` / `test-promise*` files, the 7 node-differential repros byte-identical, `rust:check-all` 12/12 targets, and the 6 expected fail-before failures against released bun.

## Note on #33354

#33354 changes *when* a rejection is emitted (moving the scan into `EventLoop::exit()` so it lands before anything the rejecting callback scheduled). This PR changes what happens *after* the handler runs. They are independent and do not conflict textually, but whichever lands second should have `handle_rejected_promises_after_tick()` call `drain_rejected_promises()` rather than `global_ref().handle_rejected_promises()`, otherwise the checkpoint is skipped for rejections reported from `exit()`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 9 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts test/js/node/process/process-on.test.ts
bun test v1.4.1 (861e9ae04)

test/js/node/process/process-on.test.ts:
(pass) process.on > when called from the main thread [380.02ms]
 [245ms]  bundle  1 modules
[2.77s] compile  ./out
(pass) process.on > should work inside --compile [3413.51ms]
[macro] call initialize
Bundled 1 module in 451ms

  out.ts  8 bytes  (entry point)

(pass) process.on > should work inside a macro [813.28ms]
144 |       env: bunEnv,
145 |       stdout: "pipe",
146 |       stderr: "pipe",
147 |     });
148 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
149 |     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
                                                              ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "handler,recovered,beforeExit",
+   "stdout": "beforeExit",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/b
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (792f4a752)

test/js/node/process/process-on.test.ts:
(pass) process.on > when called from the main thread [7.85ms]
  [28ms]  bundle  1 modules
 [419ms] compile  ./out
(pass) process.on > should work inside --compile [502.78ms]
Bundled 1 module in 57ms

  out.ts  8 bytes  (entry point)

(pass) process.on > should work inside a macro [109.31ms]
(pass) process.on('unhandledRejection') > runs for a rejection raised by a beforeExit listener [8.44ms]
(pass) process.on('unhandledRejection') > runs before beforeExit when the rejection comes from a timer [9.45ms]
(pass) process.on('unhandledRejection') > keeps the process alive for work the handler schedules after a microtask hop [11.33ms]

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [0.04ms]
(pass) node:events > once [1.07ms]
(pass) node:events > once (abort) [0.32ms]
(pass) node:events > once (two events in same tick) [10.39ms]
(pass) node:events > once removes the listener afterwards [0.87ms]
(pass) node:events > once is an async function [0.03ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [0.25ms]
(pass) node
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts test/js/node/process/process-on.test.ts
bun test v1.4.1 (861e9ae04)

test/js/node/process/process-on.test.ts:
(pass) process.on > when called from the main thread [397.51ms]
 [303ms]  bundle  1 modules
[1.929s] compile  ./out
(pass) process.on > should work inside --compile [2591.54ms]
[macro] call initialize
Bundled 1 module in 349ms

  out.ts  8 bytes  (entry point)

(pass) process.on > should work inside a macro [705.56ms]
(pass) process.on('unhandledRejection') > runs for a rejection raised by a beforeExit listener [285.98ms]
(pass) process.on('unhandledRejection') > runs before beforeExit when the rejection comes from a timer [304.45ms]
(pass) process.on('unhandledRejection') > keeps the process alive for work the handler schedules after a microtask hop [462.41ms]

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [2.21ms]
(pass) node:events > once [38.89ms]
(pass) node:events > once (abort) [11.78ms]
(pass) node:events > once (two events in same tick) 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 926ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 242 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (7641ms)
Bundle modules (174ms)
Postprocesss modules (1096ms)
Bundle Functions (496ms)
Generate Code (62ms)

[9.48s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/events.ts                     |  30 +++++--
 src/jsc/JSGlobalObject.rs                 |   8 ++
 src/jsc/VirtualMachine.rs                 |  20 +++--
 src/jsc/bindings/ZigGlobalObject.h        |   1 +
 src/jsc/bindings/bindings.cpp             |   5 ++
 src/jsc/bindings/headers.h                |   1 +
 src/jsc/event_loop.rs                     |  18 ++++-
 src/runtime/cli/run_command.rs            |   2 +-
 src/runtime/jsc_hooks.rs                  |  21 +++--
 test/js/node/events/event-emitter.test.ts | 129 ++++++++++++++++++++++++++++++
 test/js/node/process/process-on.test.ts   |  98 +++++++++++++++++++++++
 11 files changed, 307 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 9

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/events.ts                          9     10      0
src/jsc/JSGlobalObject.rs                      1      2      0
src/jsc/VirtualMachine.rs                      4      4      0
src/jsc/bindings/ZigGlobalObject.h             1      1      0
src/jsc/bindings/bindings.cpp                  1      1      0
src/jsc/bindings/headers.h                     1      1      0
src/jsc/event_loop.rs                          3      3      0
src/runtime/cli/run_command.rs                 2      1      0
src/runtime/jsc_hooks.rs                       5      5      0
test/js/node/events/event-emitter.test.ts      2      3      0
test/js/node/process/process-on.test.ts        1      1      0
```

</details>

<!-- robobun:evidence:end -->