### PR TITLE
worker_threads: stop dropping falsy receiveMessageOnPort messages

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -72,7 +72,7 @@ const isMainThread = Bun.isMainThread;
 const {
   0: _workerData,
   1: _threadId,
-  2: _receiveMessageOnPort,
+  2: receiveMessageOnPort,
   3: environmentData,
   4: _threadName,
   5: _isMessagePortActive,
@@ -84,7 +84,7 @@ const {
 } = $cpp("Worker.cpp", "createNodeWorkerThreadsBinding") as [
   unknown,
   number,
-  (port: unknown) => unknown,
+  (port: MessagePort) => { message: unknown } | undefined,
   Map<unknown, unknown>,
   string,
   (port: unknown) => boolean,
@@ -734,13 +734,6 @@ if (
   workerData = workerData.data;
   if (stdioPorts) setupWorkerStdio(stdioPorts);
   if (controlPort) messaging.setupMainThreadPort(controlPort, _setEntryEvaluatedHook);
-}
-function receiveMessageOnPort(port: MessagePort) {
-  let res = _receiveMessageOnPort(port);
-  if (!res) return undefined;
-  return {
-    message: res,
-  };
 }
 
 // TODO: parent port emulation is not complete

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -366,18 +366,18 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
     dispatchEvent(event.event);
 }
 
-JSValue MessagePort::tryTakeMessage(JSGlobalObject* lexicalGlobalObject)
+std::optional<JSValue> MessagePort::tryTakeMessage(JSGlobalObject* lexicalGlobalObject)
 {
     if (!isEntangled())
-        return jsUndefined();
+        return std::nullopt;
 
     auto* context = scriptExecutionContext();
     if (!context)
-        return jsUndefined();
+        return std::nullopt;
 
     auto message = m_pipe->takeOne(m_side);
     if (!message)
-        return jsUndefined();
+        return std::nullopt;
 
     auto ports = MessagePort::entanglePorts(*context, WTF::move(message->transferredPorts));
     return message->message.releaseNonNull()->deserialize(*lexicalGlobalObject, lexicalGlobalObject, WTF::move(ports), SerializationErrorMode::NonThrowing);

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -106,7 +106,9 @@ public:
     void dispatchEvent(Event&) final;
 
     // node:worker_threads receiveMessageOnPort — synchronous single pop.
-    JSValue tryTakeMessage(JSGlobalObject*);
+    // std::nullopt means nothing was dequeued; a dequeued message may itself
+    // be undefined, so the two cannot be conflated.
+    std::optional<JSValue> tryTakeMessage(JSGlobalObject*);
 
     bool hasPendingActivity() const;
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -750,11 +750,8 @@ JSC_DEFINE_HOST_FUNCTION(jsReceiveMessageOnPort, (JSGlobalObject * lexicalGlobal
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (callFrame->argumentCount() < 1) {
-        throwTypeError(lexicalGlobalObject, scope, "receiveMessageOnPort needs 1 argument"_s);
-        return {};
-    }
-
+    // A missing argument reads back as jsUndefined(), which falls through to the
+    // same ERR_INVALID_ARG_TYPE node throws for it.
     auto port = callFrame->argument(0);
 
     if (!port.isObject()) {

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -41,6 +41,7 @@
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/JSMap.h>
 #include <JavaScriptCore/JSModuleLoader.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include "MessageEvent.h"
 #include "BunWorkerGlobalScope.h"
 #include "CloseEvent.h"
@@ -761,7 +762,17 @@ JSC_DEFINE_HOST_FUNCTION(jsReceiveMessageOnPort, (JSGlobalObject * lexicalGlobal
     }
 
     if (auto* messagePort = dynamicDowncast<JSMessagePort>(port)) {
-        RELEASE_AND_RETURN(scope, JSC::JSValue::encode(messagePort->wrapped().tryTakeMessage(lexicalGlobalObject)));
+        auto message = messagePort->wrapped().tryTakeMessage(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!message)
+            return JSC::JSValue::encode(jsUndefined());
+
+        // The payload is wrapped in `{ message }` so that a falsy (or
+        // undefined) message is distinguishable from an empty queue.
+        JSObject* envelope = constructEmptyObject(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        envelope->putDirect(vm, vm.propertyNames->message, *message);
+        return JSC::JSValue::encode(envelope);
     } else if (dynamicDowncast<JSBroadcastChannel>(port)) {
         // TODO: support broadcast channels
         return JSC::JSValue::encode(jsUndefined());

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,5 @@
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -21,6 +22,10 @@ import wt, {
   Worker,
   workerData,
 } from "worker_threads";
+
+// Many of these tests spawn nested workers or whole bun subprocesses that each
+// spawn workers, which the 5s default does not cover on a debug/ASAN build.
+setDefaultTimeout(isDebug ? 90_000 : 10_000);
 
 test("support eval in worker", async () => {
   const worker = new Worker(`postMessage(1 + 1)`, {
@@ -413,9 +418,6 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
-// The fixture spawns six workers that each parse 100 MiB of source, which the
-// default 5s budget cannot cover on a debug/ASAN build (~27s there, ~2s in
-// release). The sizes are load-bearing: they keep RSS growth above the noise.
 test("eval does not leak source code", async () => {
   const proc = Bun.spawn({
     cmd: [bunExe(), "eval-source-leak-fixture.js"],
@@ -428,7 +430,7 @@ test("eval does not leak source code", async () => {
   const errors = await proc.stderr.text();
   if (errors.length > 0) throw new Error(errors);
   expect(proc.exitCode).toBe(0);
-}, 120_000);
+});
 
 describe("captured stdio backpressure", () => {
   // node flow control (lib/internal/worker/io.js): a writev batch's callback is

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -252,6 +252,21 @@ test("receiveMessageOnPort works as FIFO", () => {
   }
 }, 9999999);
 
+// https://github.com/oven-sh/bun/issues/26501
+test("receiveMessageOnPort preserves a queue of interleaved falsy and truthy messages", () => {
+  const { port1, port2 } = new MessageChannel();
+
+  const values = [undefined, null, 0, 1, false, true, "", "hello world"];
+  for (const value of values) port1.postMessage(value);
+
+  const received = values.map(() => receiveMessageOnPort(port2));
+  expect(received).toStrictEqual(values.map(message => ({ message })));
+  expect(receiveMessageOnPort(port2)).toBeUndefined();
+
+  port1.close();
+  port2.close();
+});
+
 test("receiveMessageOnPort does not drop falsy messages", () => {
   const { port1, port2 } = new MessageChannel();
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -252,6 +252,48 @@ test("receiveMessageOnPort works as FIFO", () => {
   }
 }, 9999999);
 
+test("receiveMessageOnPort does not drop falsy messages", () => {
+  const { port1, port2 } = new MessageChannel();
+
+  port1.postMessage(0);
+  port1.postMessage(1);
+  port1.postMessage(2);
+
+  expect([receiveMessageOnPort(port2), receiveMessageOnPort(port2), receiveMessageOnPort(port2)]).toStrictEqual([
+    { message: 0 },
+    { message: 1 },
+    { message: 2 },
+  ]);
+  expect(receiveMessageOnPort(port2)).toBeUndefined();
+
+  port1.close();
+  port2.close();
+});
+
+// A popped message is gone from the queue, so reporting a falsy one as "queue
+// empty" loses it. The envelope is what distinguishes the two cases.
+test.each([
+  ["0", 0],
+  ["-0", -0],
+  ["an empty string", ""],
+  ["false", false],
+  ["null", null],
+  ["undefined", undefined],
+  ["NaN", NaN],
+  ["0n", 0n],
+])("receiveMessageOnPort returns an envelope for %s", (_label, value) => {
+  const { port1, port2 } = new MessageChannel();
+  port1.postMessage(value);
+
+  const received = receiveMessageOnPort(port2);
+  expect(received).toStrictEqual({ message: value });
+  expect(Object.hasOwn(received!, "message")).toBe(true);
+  expect(receiveMessageOnPort(port2)).toBeUndefined();
+
+  port1.close();
+  port2.close();
+});
+
 test("you can override globalThis.postMessage", async () => {
   const worker = new Worker(new URL("./worker-override-postMessage.js", import.meta.url));
   const message = await new Promise(resolve => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -252,6 +252,22 @@ test("receiveMessageOnPort works as FIFO", () => {
   }
 }, 9999999);
 
+test("receiveMessageOnPort rejects arguments that are not a MessagePort", () => {
+  const call = receiveMessageOnPort as (...args: unknown[]) => unknown;
+
+  for (const args of [[], [undefined], [null], [0], [-1], [""], [{}], [[]]]) {
+    let error: any;
+    try {
+      call(...args);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(error.message).toBe('The "port" argument must be a MessagePort instance');
+  }
+});
+
 // https://github.com/oven-sh/bun/issues/26501
 test("receiveMessageOnPort preserves a queue of interleaved falsy and truthy messages", () => {
   const { port1, port2 } = new MessageChannel();
@@ -409,7 +425,10 @@ test("eval does not leak source code", async () => {
   const errors = await proc.stderr.text();
   if (errors.length > 0) throw new Error(errors);
   expect(proc.exitCode).toBe(0);
-});
+  // The fixture spawns six workers that each parse 100 MiB of source, which the
+  // default 5s budget cannot cover on a debug/ASAN build (~27s there, ~2s in
+  // release). The sizes are load-bearing: they keep RSS growth above the noise.
+}, 120_000);
 
 describe("captured stdio backpressure", () => {
   // node flow control (lib/internal/worker/io.js): a writev batch's callback is

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -413,6 +413,9 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
+// The fixture spawns six workers that each parse 100 MiB of source, which the
+// default 5s budget cannot cover on a debug/ASAN build (~27s there, ~2s in
+// release). The sizes are load-bearing: they keep RSS growth above the noise.
 test("eval does not leak source code", async () => {
   const proc = Bun.spawn({
     cmd: [bunExe(), "eval-source-leak-fixture.js"],
@@ -425,9 +428,6 @@ test("eval does not leak source code", async () => {
   const errors = await proc.stderr.text();
   if (errors.length > 0) throw new Error(errors);
   expect(proc.exitCode).toBe(0);
-  // The fixture spawns six workers that each parse 100 MiB of source, which the
-  // default 5s budget cannot cover on a debug/ASAN build (~27s there, ~2s in
-  // release). The sizes are load-bearing: they keep RSS growth above the noise.
 }, 120_000);
 
 describe("captured stdio backpressure", () => {


### PR DESCRIPTION
Fixes #26501

## Repro

```js
const { MessageChannel, receiveMessageOnPort } = require("worker_threads");
const { port1, port2 } = new MessageChannel();
port2.postMessage(0);
port2.postMessage(1);

receiveMessageOnPort(port1); // node: { message: 0 }   bun: undefined  <- the 0 is gone
receiveMessageOnPort(port1); // node: { message: 1 }   bun: { message: 1 }
```

Every falsy payload (`0`, `""`, `false`, `null`, `undefined`, `NaN`, `0n`, `-0`) is popped off the queue and then reported as "queue empty", so the message is silently destroyed. `receiveMessageOnPort` is the synchronous drain used by worker pools and `Atomics.wait`-style request/response protocols, where `0` meaning success/index is routine; it presents as "the worker never answered".

## Cause

`MessagePort::tryTakeMessage` returned `jsUndefined()` for an empty queue *and* for the deserialized message, collapsing the two cases into one value. The `node:worker_threads` wrapper therefore had to guess with JS truthiness:

```ts
let res = _receiveMessageOnPort(port);
if (!res) return undefined;
return { message: res };
```

No JS-side check can recover the distinction once it has been lost. Narrowing the guard to `res === undefined || res === null` (as #27880 does) still drops a queued `null` and a queued `undefined`, which node reports as `{ message: null }` and `{ message: undefined }`.

## Fix

`tryTakeMessage` now returns `std::optional<JSValue>`, with `std::nullopt` reserved for "nothing dequeued", and `jsReceiveMessageOnPort` builds the `{ message }` envelope where emptiness is actually known. The JS wrapper is gone; the host function already carries the right name and arity, so it is exported directly.

Exporting the host function directly makes its `argumentCount() < 1` guard reachable for the first time (the wrapper always forwarded one argument), and that guard threw a bare `TypeError`. A missing argument already reads back as `jsUndefined()`, so the guard is deleted and a zero-arg call lands on the same `ERR_INVALID_ARG_TYPE` node throws. There is a test for the code and message.

## Rebase

Main had added a `threadName` / `internal/worker/messaging` / captured-stdio block immediately before the deleted JS wrapper; the resolution keeps main's new block and drops the wrapper. The binding destructure auto-merged.

## Debug-build timeout in the same file

Worker startup under a debug/ASAN build is slow enough that several tests in `worker_threads.test.ts` (including ones newly landed on main) cannot finish inside the 5s default. This PR adds a single `setDefaultTimeout(isDebug ? 90_000 : 10_000)` at the top of the file, matching the pattern used elsewhere in `test/js/`, rather than a per-test override. Release timing is effectively unchanged.

## Verification

`test/js/node/worker_threads/worker_threads.test.ts` gains the queue from #26501, the FIFO-with-`0` repro, a case per falsy value, and the argument-validation coverage. All 10 falsy-message tests fail on `main` and pass with the fix. The whole file is green under `bun bd test` (100 passing).

Differential against node v26 for a queue of `0, "", false, null, undefined, NaN, 1, {a:1}`:

```
node: envelope(0) | envelope() | envelope(false) | envelope(null) | envelope(undefined) | envelope(NaN) | envelope(1) | envelope([object Object]) | EMPTY
bun:  envelope(0) | envelope() | envelope(false) | envelope(null) | envelope(undefined) | envelope(NaN) | envelope(1) | envelope([object Object]) | EMPTY
```

`test/js/web/workers/message-port-pipe.test.ts` (13 tests) and node's own `test/parallel/test-worker-message-port-receive-message.js` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ad9d799ab)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1729.39ms]
(pass) all worker_threads module properties are present [25.48ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [25.72ms]
(pass) all worker_threads worker instance properties are present [161.21ms]
(pass) threadId module and worker property is consistent [199.10ms]
(pass) receiveMessageOnPort works across threads [1664.10ms]
(pass) receiveMessageOnPort works as FIFO [14.61ms]
(pass) receiveMessageOnPort rejects arguments that are not a MessagePort [12.53ms]
279 | 
280 |   const values = [undefined, null, 0, 1, false, true, "", "hello world"];
281 |   for (const
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/worker_threads/worker_threads.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'markAsUncloneable' not found in module 'node:worker_threads'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [168.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ad9d799ab)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1747.69ms]
(pass) all worker_threads module properties are present [25.21ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [25.23ms]
(pass) all worker_threads worker instance properties are present [162.18ms]
(pass) threadId module and worker property is consistent [204.20ms]
(pass) receiveMessageOnPort works across threads [1714.59ms]
(pass) receiveMessageOnPort works as FIFO [13.94ms]
(pass) receiveMessageOnPort rejects arguments that are not a MessagePort [13.16ms]
(pass) receiveMessageOnPort preserves a queue of interleaved falsy and truthy messages [9.96ms]
(pass) re
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ad9d799ab9
  features     (none)

22 deps, 106 codegen, 1168 objects in 817ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [14.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] gen ErrorCode+*.h
[5/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[6/1231] fetch picohttpparser
[picohttpparser] up to date
[7/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      | 11 +--
 src/jsc/bindings/webcore/MessagePort.cpp           |  8 +--
 src/jsc/bindings/webcore/MessagePort.h             |  4 +-
 src/jsc/bindings/webcore/Worker.cpp                | 20 ++++--
 test/js/node/worker_threads/worker_threads.test.ts | 80 +++++++++++++++++++++-
 5 files changed, 102 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/worker_threads.ts                           3      3      0
src/jsc/bindings/webcore/MessagePort.cpp                1      1      0
src/jsc/bindings/webcore/MessagePort.h                  1      1      0
src/jsc/bindings/webcore/Worker.cpp                     3      4      0
test/js/node/worker_threads/worker_threads.test.ts      6      9      0
```

</details>

<!-- robobun:evidence:end -->