### PR TITLE
orderfile: hand the interactive workloads their stdin under node

### DIFF
--- a/scripts/orderfile/generate.ts
+++ b/scripts/orderfile/generate.ts
@@ -81,6 +81,36 @@ interface Workload {
   env?: Record<string, string>;
 }
 
+export interface RunOptions {
+  env?: Record<string, string | undefined> | undefined;
+  cwd?: string | undefined;
+  input?: string | undefined;
+  timeout?: number | undefined;
+  /** How the command is named in errors. Defaults to the executable. */
+  label?: string | undefined;
+}
+
+/**
+ * Runs a command to completion, throwing if it could not be spawned. Exported so
+ * a test can drive it under node: bun's spawnSync delivers `input` whatever stdin
+ * is, so the wiring below only ever breaks on CI, which builds under node.
+ */
+export function runCommand(cmd: string[], options: RunOptions = {}) {
+  const r = spawnSync(cmd[0]!, cmd.slice(1), {
+    env: { ...process.env, ...options.env },
+    cwd: options.cwd,
+    input: options.input,
+    timeout: options.timeout,
+    // Only a pipe carries `input`: node drops it when stdin is "ignore", and
+    // then an interactive workload reads nothing and waits forever for a line.
+    stdio: [options.input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+    maxBuffer: 1 << 29, // nm prints ~10 MB of symbols
+  });
+  // A timeout arrives here too: spawnSync reports it as an ETIMEDOUT error.
+  if (r.error) throw new Error(`${options.label ?? cmd[0]}: ${r.error.message}`);
+  return r;
+}
+
 export interface GenerateOptions {
   /** Build directory holding the unstripped binary. */
   buildDir: string;
@@ -110,38 +140,15 @@ export function generateOrderFile(options: GenerateOptions): { count: number; ou
     throw new Error(`${bunProfile} not found — build it first (bun run build:release)`);
   }
 
-  interface RunOptions {
-    env?: Record<string, string | undefined> | undefined;
-    cwd?: string | undefined;
-    input?: string | undefined;
-    timeout?: number | undefined;
-    /** How the command is named in errors. Defaults to the executable. */
-    label?: string | undefined;
-  }
-
-  function run(cmd: string[], options: RunOptions = {}) {
-    const r = spawnSync(cmd[0]!, cmd.slice(1), {
-      env: { ...process.env, ...options.env },
-      cwd: options.cwd,
-      input: options.input,
-      timeout: options.timeout,
-      stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: 1 << 29, // nm prints ~10 MB of symbols
-    });
-    // A timeout arrives here too: spawnSync reports it as an ETIMEDOUT error.
-    if (r.error) throw new Error(`${options.label ?? cmd[0]}: ${r.error.message}`);
-    return r;
-  }
-
   const scratch = mkdtempSync(join(tmpdir(), "bun-orderfile-"));
   try {
     // ── Build the tracer and the pty runner ───────────────────────────────────
     const tracer = join(scratch, "pagetrace.so");
     const ptyrun = join(scratch, "ptyrun");
     const cc = process.env.CC || "cc";
-    const build = run([cc, "-O2", "-shared", "-fPIC", "-o", tracer, join(here, "pagetrace.c"), "-ldl"]);
+    const build = runCommand([cc, "-O2", "-shared", "-fPIC", "-o", tracer, join(here, "pagetrace.c"), "-ldl"]);
     if (build.status !== 0) throw new Error(`failed to build the tracer with ${cc}\n${build.stderr}`);
-    const pty = run([cc, "-O2", "-o", ptyrun, join(here, "ptyrun.c"), "-lutil"]);
+    const pty = runCommand([cc, "-O2", "-o", ptyrun, join(here, "ptyrun.c"), "-lutil"]);
     if (pty.status !== 0) throw new Error(`failed to build the pty runner with ${cc}\n${pty.stderr}`);
 
     // ── Representative workloads ──────────────────────────────────────────────
@@ -179,7 +186,10 @@ export function generateOrderFile(options: GenerateOptions): { count: number; ou
       `{ "name": "orderfile-dep", "version": "1.0.0", "main": "index.js" }\n`,
     );
     writeFileSync(join(dependency, "index.js"), `module.exports = 1;\n`);
-    const pack = run([bunProfile, "pm", "pack", "--filename", "dep.tgz"], { cwd: dependency, label: "bun pm pack" });
+    const pack = runCommand([bunProfile, "pm", "pack", "--filename", "dep.tgz"], {
+      cwd: dependency,
+      label: "bun pm pack",
+    });
     if (pack.status !== 0) throw new Error(`could not pack the install fixture\n${pack.stderr}`);
     writeFileSync(
       join(app, "package.json"),
@@ -211,7 +221,7 @@ export function generateOrderFile(options: GenerateOptions): { count: number; ou
       // The tracer loads into the traced process and nowhere else. On a terminal
       // ptyrun is the parent, so it is the one that hands the preload down.
       const preload = workload.tty ? { PTYRUN_PRELOAD: tracer } : { LD_PRELOAD: tracer };
-      const r = run(workload.tty ? [ptyrun, bunProfile, ...workload.args] : [bunProfile, ...workload.args], {
+      const r = runCommand(workload.tty ? [ptyrun, bunProfile, ...workload.args] : [bunProfile, ...workload.args], {
         env: {
           ...preload,
           BUN_PAGETRACE_BIN: bunProfile,
@@ -242,7 +252,7 @@ export function generateOrderFile(options: GenerateOptions): { count: number; ou
 
     // ── Symbol table ──────────────────────────────────────────────────────────
     const nm = process.env.NM || (existsSync("/usr/bin/llvm-nm") ? "llvm-nm" : "nm");
-    const symbols = run([nm, "--defined-only", "-S", "--numeric-sort", bunProfile]);
+    const symbols = runCommand([nm, "--defined-only", "-S", "--numeric-sort", bunProfile]);
     if (symbols.status !== 0) throw new Error(`${nm} failed on ${bunProfile}\n${symbols.stderr}`);
 
     // `t`/`T` only: ordering `.rodata.*` separates constants from the mergeable

--- a/test/js/bun/perf/linker-order.test.ts
+++ b/test/js/bun/perf/linker-order.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
 import { join } from "node:path";
 import {
   mustGenerateOrderFile,
@@ -151,6 +151,42 @@ describe("order file generator", () => {
   it.skipIf(process.platform === "linux")("refuses to run off linux", () => {
     // It is an ELF linker input and the tracer reads /proc/self/maps.
     expect(() => generateOrderFile({ buildDir: "/tmp/build" })).toThrow(/linux/);
+  });
+});
+
+/**
+ * CI builds with `node --experimental-strip-types scripts/build.ts`, so the
+ * workloads are spawned by node's spawnSync, not bun's. Node only delivers
+ * `input` when stdin is a pipe, and silently drops it when stdin is "ignore";
+ * bun delivers it either way, so nothing a developer runs locally notices. The
+ * interactive workloads are the only ones typed anything, and the ~2k tty and
+ * readline functions they exist to trace are unreachable without it.
+ */
+describe.skipIf(process.platform !== "linux" || !nodeExe())("interactive workload stdin", () => {
+  it("reaches the workload when the generator runs under node, as CI does", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        nodeExe()!,
+        "--experimental-strip-types",
+        join(import.meta.dir, "orderfile-workload-fixture.ts"),
+        bunExe(),
+        join(import.meta.dir, "../../../../scripts/orderfile/cli-fixture.js"),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // cli-fixture.js answers `name?` with the first line it is typed and counts
+    // the rest, so "read 0 lines" is what an empty stdin looks like. On a
+    // terminal it is worse: readline waits for a line that never arrives, and
+    // the workload times out instead of returning at all.
+    expect({
+      greeted: stdout.includes("hi world"),
+      read: /read (\d+) lines/.exec(stdout)?.[1],
+      exitCode,
+    }).toEqual({ greeted: true, read: "3", exitCode: 0 });
   });
 });
 

--- a/test/js/bun/perf/linker-order.test.ts
+++ b/test/js/bun/perf/linker-order.test.ts
@@ -176,7 +176,13 @@ describe.skipIf(process.platform !== "linux" || !nodeExe())("interactive workloa
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // node warns about the fixture's module type on every run, so stderr is never
+    // empty; an uncaught error is the part worth reading. It is also how this
+    // notices generate.ts growing TypeScript that node cannot strip, which would
+    // break the real build the same way.
+    const crash = /^\w*Error\b.*/m.exec(stderr)?.[0] ?? null;
 
     // cli-fixture.js answers `name?` with the first line it is typed and counts
     // the rest, so "read 0 lines" is what an empty stdin looks like. On a
@@ -185,8 +191,9 @@ describe.skipIf(process.platform !== "linux" || !nodeExe())("interactive workloa
     expect({
       greeted: stdout.includes("hi world"),
       read: /read (\d+) lines/.exec(stdout)?.[1],
+      crash,
       exitCode,
-    }).toEqual({ greeted: true, read: "3", exitCode: 0 });
+    }).toEqual({ greeted: true, read: "3", crash: null, exitCode: 0 });
   });
 });
 

--- a/test/js/bun/perf/orderfile-workload-fixture.ts
+++ b/test/js/bun/perf/orderfile-workload-fixture.ts
@@ -1,0 +1,18 @@
+// Runs the order file's interactive workload the way a CI build does: under
+// node, through generate.ts's own runner. Prints what the workload wrote, so
+// the test can tell whether it was actually typed its stdin.
+//
+//   node --experimental-strip-types orderfile-workload-fixture.ts <bun> <cli.js>
+import { runCommand } from "../../../../scripts/orderfile/generate.ts";
+
+const [exe, cliFixture] = process.argv.slice(2);
+const result = runCommand([exe!, cliFixture!], {
+  input: "world\none\ntwo\nquit\n",
+  // Well under the real workload timeout: a workload handed no stdin hangs, and
+  // the test should fail rather than sit there.
+  timeout: 30_000,
+  label: "cli workload",
+});
+process.stdout.write(result.stdout.toString());
+// Not process.exit(), which can truncate the write above.
+process.exitCode = result.status ?? 1;


### PR DESCRIPTION
Follow-up to #33345, fixing the `run()` stdin wiring flagged in [this review](https://github.com/oven-sh/bun/pull/33345#discussion_r3524375867).

### The bug

`run()` asks for `input` and for stdin to be `"ignore"` at the same time:

```ts
input: options.input,
stdio: ["ignore", "pipe", "pipe"],
```

Node only delivers `input` when stdin is a pipe. With `"ignore"` it drops it on the floor, no error. Bun's `spawnSync` delivers it either way, which is why `bun run orderfile` works locally and nobody noticed: CI builds with `node --experimental-strip-types scripts/build.ts` (`.buildkite/ci.mjs:595`), so on CI the two interactive workloads are the only ones that are typed anything and they get nothing.

Running the real `cli-fixture.js` through the real `run()` options, once under each runtime:

```
### under NODE (what CI uses):
stdin=ignore  pipe: {"status":0,"read":0,"ms":50}
stdin=ignore  tty : {"err":"ETIMEDOUT","ms":10007}
stdin=pipe    pipe: {"status":0,"read":3,"ms":50}
stdin=pipe    tty : {"status":0,"read":3,"ms":58}

### under BUN (what a dev uses locally):
stdin=ignore  pipe: {"status":0,"read":3,"ms":43}
stdin=ignore  tty : {"status":0,"read":3,"ms":52}
```

So on CI today the pipe workload reads `0` lines, exits `0`, and never drives readline. The tty one is worse: `ptyrun` gets `/dev/null` for stdin, types its `^D` before bun has even started, readline then waits for a line that never arrives, and the workload sits there until `WORKLOAD_TIMEOUT_MS` (120s) kills it. `run()` turns that into a throw, `build.ts` catches it and annotates, and the build ships unordered. Either way the ~2k tty and readline functions those two workloads exist to capture are missing, which is the whole reason they were added.

### The fix

Pipe stdin when there is input to deliver. That is what the rest of the repo already does (`scripts/utils.mjs:246`, `scripts/utils.mjs:358`, `scripts/build/fetch-cli.ts:250`); `generate.ts` was the only site that got it wrong, and I grepped the others to be sure.

`run()` captured nothing from its closure, so it is hoisted to module scope as `runCommand` and exported. That is what lets the test drive it under node, which is the only runtime where any of this is observable.

### Verification

`test/js/bun/perf/linker-order.test.ts` gains a case that spawns `node --experimental-strip-types` on a fixture importing `runCommand`, runs `cli-fixture.js` through it, and checks the fixture was actually typed its input. An in-process test would be useless here: it would run under bun and pass either way.

With stdin reverted to `"ignore"`:

```
  {
    "exitCode": 0,
-   "greeted": true,
-   "read": "3",
+   "greeted": false,
+   "read": "0",
  }
(fail) interactive workload stdin > reaches the workload when the generator runs under node, as CI does
```

and with the fix, `17 pass, 1 skip, 0 fail` for the file. Agents install node 26.3.0 (`scripts/bootstrap.sh`), so the case runs rather than skips.