### PR TITLE
Error the Bun.file() stream when read() fails instead of hanging the pull promise

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -59,6 +59,10 @@ pub struct FileReader {
     pub event_loop: Cell<EventLoopHandle>,
     pub lazy: JsCell<Lazy>,
     pub buffered: JsCell<Vec<u8>>,
+    /// A reader error that arrived with no armed `pending` read to settle it —
+    /// every error from the synchronous `read()` inside `on_pull` lands here.
+    /// The next `on_pull` takes it and errors the stream instead of reading on.
+    pub read_error: JsCell<Option<sys::Error>>,
     pub read_inside_on_pull: JsCell<ReadDuringJSOnPullResult>,
     /// Read-only after construction.
     pub highwater_mark: usize,
@@ -83,6 +87,7 @@ impl Default for FileReader {
             event_loop: Cell::new(EventLoopHandle::init(core::ptr::null_mut())),
             lazy: JsCell::new(Lazy::None),
             buffered: JsCell::new(Vec::new()),
+            read_error: JsCell::new(None),
             read_inside_on_pull: JsCell::new(ReadDuringJSOnPullResult::None),
             highwater_mark: 16384,
             flowing: Cell::new(true),
@@ -865,6 +870,10 @@ impl FileReader {
             }
         }
 
+        if let Some(err) = self.read_error.replace(None) {
+            return streams::Result::Err(streams::StreamError::Error(err));
+        }
+
         if self.reader().is_done() {
             return streams::Result::Done;
         }
@@ -910,6 +919,10 @@ impl FileReader {
                             value: array,
                             len: amount_read as u64, // @truncate
                         });
+                    }
+
+                    if let Some(err) = self.read_error.replace(None) {
+                        return streams::Result::Err(streams::StreamError::Error(err));
                     }
 
                     if self.reader().is_done() {
@@ -1047,16 +1060,24 @@ impl FileReader {
             self.buffered.set(Vec::new());
         }
 
-        self.pending.with_mut(|p| {
-            p.result = streams::Result::Err(streams::StreamError::Error(err));
-        });
         // Pin across `p.run()`: it runs user JS, and anything there that
         // reaches on_reader_done would drop the across-read ref and let a GC
         // free this box before the `waiting_for_on_reader_done` read below.
         let parent = self.parent();
         // SAFETY: see `parent()`.
         unsafe { (*parent).increment_count() };
-        self.pending.with_mut(|p| p.run());
+
+        if self.pending.get().state == streams::PendingState::Pending {
+            self.pending.with_mut(|p| {
+                p.result = streams::Result::Err(streams::StreamError::Error(err));
+            });
+            self.pending.with_mut(|p| p.run());
+        } else {
+            // Nothing to settle: the failing read ran synchronously inside
+            // `on_pull`, or landed between pulls. `p.run()` would no-op and the
+            // pull promise would never settle, so hand it to the next `on_pull`.
+            self.read_error.set(Some(err));
+        }
 
         if self.waiting_for_on_reader_done.get() && !self.done.get() {
             self.waiting_for_on_reader_done.set(false);

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -59,9 +59,9 @@ pub struct FileReader {
     pub event_loop: Cell<EventLoopHandle>,
     pub lazy: JsCell<Lazy>,
     pub buffered: JsCell<Vec<u8>>,
-    /// A reader error that arrived with no armed `pending` read to settle it —
-    /// every error from the synchronous `read()` inside `on_pull` lands here.
-    /// The next `on_pull` takes it and errors the stream instead of reading on.
+    /// A reader error that arrived with no armed `pending` read to settle it.
+    /// Every error from the synchronous `read()` inside `on_pull` lands here;
+    /// the next `on_pull` takes it and errors the stream instead of reading on.
     pub read_error: JsCell<Option<sys::Error>>,
     pub read_inside_on_pull: JsCell<ReadDuringJSOnPullResult>,
     /// Read-only after construction.

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -7,9 +7,9 @@ import {
   readableStreamToText,
 } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
-import { createReadStream, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { closeSync, createReadStream, openSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 it("TransformStream", async () => {
@@ -1422,6 +1422,65 @@ it("Bun.file().stream() read text from large file", async () => {
   } finally {
     unlinkSync(tmpfile);
   }
+});
+
+// On POSIX a file is read synchronously inside the stream's pull, so a failing
+// read(2) arrives with no pending read to reject. It used to be dropped, and
+// the pull promise then never settled. Windows reads files through libuv, so
+// the error always had a pending read waiting for it.
+describe.skipIf(isWindows)("Bun.file().stream() surfaces read() errors", () => {
+  // read(2) on /proc/self/mem fails with EIO: nothing is mapped at address 0.
+  const eioPath = "/proc/self/mem";
+  const itEIO = isLinux ? it : it.skip;
+
+  async function expectReadError(promise, code) {
+    const err = await promise.then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe(code);
+    return err;
+  }
+
+  itEIO("for await rejects with the read error", async () => {
+    const chunks = [];
+    await expectReadError(
+      (async () => {
+        for await (const chunk of Bun.file(eioPath).stream()) chunks.push(chunk);
+      })(),
+      "EIO",
+    );
+    expect(chunks).toHaveLength(0);
+  });
+
+  itEIO("getReader().read() rejects with the read error", async () => {
+    await expectReadError(Bun.file(eioPath).stream().getReader().read(), "EIO");
+  });
+
+  itEIO("pipeTo() rejects with the read error", async () => {
+    await expectReadError(
+      Bun.file(eioPath)
+        .stream()
+        .pipeTo(new WritableStream({ write() {} })),
+      "EIO",
+    );
+  });
+
+  itEIO("Bun.file().text() reports the same read error", async () => {
+    const err = await expectReadError(Bun.file(eioPath).text(), "EIO");
+    expect(err.syscall).toBe("read");
+  });
+
+  it("a stream over a write-only fd rejects with EBADF", async () => {
+    using dir = tempDir("file-stream-read-error", { "x.bin": "hello" });
+    const fd = openSync(join(String(dir), "x.bin"), "w");
+    try {
+      await expectReadError(Bun.file(fd).stream().getReader().read(), "EBADF");
+    } finally {
+      closeSync(fd);
+    }
+  });
 });
 
 it("fs.createReadStream(filename) should be able to break inside async loop", async () => {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1424,10 +1424,9 @@ it("Bun.file().stream() read text from large file", async () => {
   }
 });
 
-// On POSIX a file is read synchronously inside the stream's pull, so a failing
-// read(2) arrives with no pending read to reject. It used to be dropped, and
-// the pull promise then never settled. Windows reads files through libuv, so
-// the error always had a pending read waiting for it.
+// A POSIX file is read synchronously inside the stream's pull, so a failing
+// read(2) arrives with no pending read to reject. Windows reads files through
+// libuv, where the error always lands on a pending read.
 describe.skipIf(isWindows)("Bun.file().stream() surfaces read() errors", () => {
   // read(2) on /proc/self/mem fails with EIO: nothing is mapped at address 0.
   const eioPath = "/proc/self/mem";


### PR DESCRIPTION
## Repro

`Bun.file(path).stream()` hangs forever when `read(2)` on the file fails. Every other read path on the same file surfaces the error.

```js
// read(2) on /proc/self/mem returns EIO: nothing is mapped at address 0.
for await (const chunk of Bun.file("/proc/self/mem").stream()) {}
console.log("done"); // never reached
```

```
text()                         rejected: EIO
arrayBuffer()                  rejected: EIO
fs.promises.readFile           rejected: EIO
fs.createReadStream            rejected: EIO
stream() for-await             NEVER-SETTLES
stream() getReader().read()    NEVER-SETTLES
stream() pipeTo                NEVER-SETTLES
```

Any `strace -f -e inject=read:error=EIO:when=3 bun stream-it.ts` style injection reproduces it too; `/proc/self/mem` just needs no tooling. This is the normal failure mode of real storage (bad sectors, NFS/FUSE, removable media), and it silently hangs whatever awaited the stream: a request handler, a queue worker.

## Cause

`FileReader::on_reader_error` delivers the error only through `self.pending`:

```rust
self.pending.with_mut(|p| p.result = streams::Result::Err(..));
self.pending.with_mut(|p| p.run());
```

`Pending::run()` returns immediately unless `state == Pending`, and `pending` is armed only when a previous `on_pull` returned `Result::Pending`. On POSIX a regular file is read synchronously inside `on_pull` (`read_inside_on_pull = Js(buffer)` → `reader().read()`), so at error time `pending.state` is `None`: `p.run()` no-ops and the error is dropped. `on_pull` then sees `amount_read == 0`, `is_done() == false`, and returns `Result::Pending`. With no poll registered and no read in flight, nothing will ever settle it.

Windows reads files through libuv, so the error always arrives with a pending read to reject; this is POSIX-only.

## Fix

Keep a `read_error` slot on `FileReader`. `on_reader_error` settles `pending` when it is armed, and otherwise stashes the error. `on_pull` takes it at the two points where the stream would otherwise wait: before issuing a new read, and after a synchronous read that produced nothing. Both sites return `streams::Result::Err`, which `process_result` already turns into a rejected pull promise, so the stream errors.

Taking the error before issuing a new read is what keeps the stash from going stale: once a read fails, the stream terminates with that error rather than retrying the broken fd.

Buffered bytes still win over the error, so a read that fails part-way delivers what it read, then errors on the next pull.

## Verification

Added to `test/js/web/streams/streams.test.js`: the three stream legs (`for await`, `getReader().read()`, `pipeTo`) must reject with `EIO`, `Bun.file().text()` must keep reporting the same error, and a stream over a write-only fd must reject with `EBADF` (the same non-retryable read-error path, and the case that also covers macOS).

<details>
<summary>Before / after</summary>

`USE_SYSTEM_BUN=1 bun test` (1.4.0):

```
(fail) for await rejects with the read error [5000.01ms]
  ^ this test timed out after 5000ms.
(fail) getReader().read() rejects with the read error [5000.00ms]
  ^ this test timed out after 5000ms.
(fail) pipeTo() rejects with the read error [5000.00ms]
  ^ this test timed out after 5000ms.
(pass) Bun.file().text() reports the same read error [1.43ms]
(fail) a stream over a write-only fd rejects with EBADF [5000.00ms]
  ^ this test timed out after 5000ms.
```

`bun bd test`:

```
(pass) for await rejects with the read error [31.41ms]
(pass) getReader().read() rejects with the read error [5.32ms]
(pass) pipeTo() rejects with the read error [8.21ms]
(pass) Bun.file().text() reports the same read error [5.98ms]
(pass) a stream over a write-only fd rejects with EBADF [29.54ms]
```

`streams.test.js` in full: 141 pass, 0 fail. `spawn.test.ts` (the other `FileReader` consumer, via subprocess stdout): 129 pass, 0 fail.

</details>

